### PR TITLE
security: harden multi-brain sync governance (vote forgery, signing, tombstone forgery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cryptographically signed governance votes** — every brain now owns a persistent Ed25519 signing
+  keypair (private half in `secrets.json`, public half in `config.json`, generated at setup / first
+  boot). Each governance vote cast is signed over a canonical message binding `network | round |
+  subject | voter | vote`, and the signature travels with the cast. Peers publish and pin each
+  other's public keys via member gossip (trust-on-first-use; a later attempt to change a pinned key
+  is refused). Because a signed cast can be verified by anyone, votes now **relay safely through
+  intermediate nodes** — restoring braintree governance for trees deeper than a single hop, which the
+  own-cast-only forgery fix had limited. A new per-network `requireSignedVotes` flag (settable on
+  create/update, default off) enforces strict mode once every member has published a key: unsigned or
+  invalid casts are then rejected outright. Default (compatibility) mode verifies signed casts and
+  relays them, while still accepting an unsigned cast only directly from its own voter — so signing
+  rolls out to existing networks without a flag day. New tests: `testing/standalone/vote-signing.test.js`
+  (20 unit cases) and `testing/sync/vote-signing.test.js` (signed cast + key distribution + safe relay
+  of a third-party signed cast, tampered cast rejected).
+
+### Security
+
+- **Sync: forged tombstones can no longer delete another instance's data** — `applyRemoteTombstone`
+  authorised a deletion purely on `localDoc.author.instanceId === tombstone.instanceId`, both of which
+  are attacker-controlled, so a member could forge a tombstone with `instanceId` set to a victim
+  instance and delete that victim's authored memories/entities/edges/chrono across the network. The
+  deletion is now bound to the authenticated peer: a tombstone may delete a document only when its
+  issuer matches the delivering peer's identity (`peerInstanceId`, set on production peer tokens) or
+  the caller is a trusted local/admin token. A tombstone relayed by a third party on behalf of another
+  author is refused; the author's own tombstone reaches each peer first-hand on direct sync. New
+  red-team test `testing/sync/tombstone-forgery.test.js`; the pubsub tombstone test now uses a
+  production-style bound peer token.
+
+- **Sync governance: vote forgery via the gossip pull path is now rejected** — during a sync cycle a
+  node pulls open vote rounds from each peer and merged the vote casts it received. The merge trusted
+  the `instanceId` on each cast, so a single malicious member could serve a fabricated round
+  pre-stuffed with forged `yes` votes attributed to every other member and drive a `remove` /
+  `space_deletion` / braintree `join` round to conclusion without real quorum — ejecting members or
+  destroying a remote space. The pull-merge (`server/src/sync/engine.ts`) now accepts only a peer's
+  **own** vote (`peerCast.instanceId === member.instanceId`), matching the authenticated POST vote
+  path; each member's vote reaches quorum first-hand because governance networks sync with every
+  member. Additionally, braintree conclusion (`server/src/api/sync.ts`) no longer trusts a
+  peer-supplied `requiredVoters` **set**: it recomputes the ancestor chain from the local topology
+  (anchored on the proposer node), so the set cannot be shrunk to `[attacker]`. Covered by a new
+  red-team integration test `testing/sync/vote-forgery.test.js`; the full governance/vote/braintree/
+  pubsub/democratic/closed suite continues to pass.
+
 ---
 
 ## [1.4.4] — 2026-07-07

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Brains can form **networks** to sync selected spaces. Five network types define 
 
 Sync uses watermark-based incremental replication with SHA-256 file manifests, Merkle verification, and conflict detection with four resolution strategies (keep-local, keep-incoming, keep-both, save-to-space).
 
+Membership changes are decided by **cryptographically signed votes**: each brain holds a persistent Ed25519 keypair and signs every governance vote cast; peers pin each other's public keys on first contact. Signatures let votes relay safely through intermediate nodes (multi-hop braintree trees) and make it impossible for one member to forge another's vote. Set `requireSignedVotes` on a network to reject any unsigned vote once all members have published keys. Tombstone-based deletions are likewise bound to the authenticated peer, so a member cannot forge a tombstone to delete another instance's data.
+
 ### Security & Auth
 
 - **PAT tokens** (`ythril_*`) with bcrypt-hashed storage, per-space scope, read-only mode, and expiry dates

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -164,7 +164,7 @@ npm run test:sync
 npm run test:down
 ```
 
-Covers: closed-network sync, braintree governance, democratic voting, pubsub topology, gossip exchange, conflict detection, file sync, entity/edge sync, fork/merge, Merkle verification, vote propagation, direction enforcement, leave/removal.
+Covers: closed-network sync, braintree governance, democratic voting, pubsub topology, gossip exchange, conflict detection, file sync, entity/edge sync, fork/merge, Merkle verification, vote propagation, vote signing &amp; safe relay, vote forgery rejection, tombstone forgery rejection, direction enforcement, leave/removal.
 
 ### Red-team tests
 
@@ -306,7 +306,7 @@ Ythril is designed for ISO 27001-class environments. Security is not a phase —
 
 - **Validate at the boundary, trust internally.** Every public endpoint validates input with Zod schemas before any logic runs. Internal function calls between modules do not re-validate.
 - **Defence in depth.** A single control is never the only thing standing between an attacker and a breach. Input validation, SSRF checks, path-traversal guards, rate limits, and audit logging each operate independently.
-- **Cryptographic choices are non-negotiable.** AES-256-GCM for secrets at rest. RSA-4096-OAEP for invite payloads. bcrypt cost-12 for token hashes. HMAC-SHA256 for webhook signatures. `crypto.timingSafeEqual` for all constant-time comparisons. No weaker alternatives.
+- **Cryptographic choices are non-negotiable.** AES-256-GCM for secrets at rest. RSA-4096-OAEP for invite payloads. Ed25519 for governance vote-cast signatures. bcrypt cost-12 for token hashes. HMAC-SHA256 for webhook signatures. `crypto.timingSafeEqual` for all constant-time comparisons. No weaker alternatives.
 - **No dynamic evaluation.** No `eval()`, no `Function()` constructors, no template-string code generation. User input never reaches a code path that interprets it as executable.
 - **Secrets never appear in logs.** The log-redaction layer strips tokens, passwords, and keys before they reach stdout. Red-team tests verify this.
 - **SSRF protection is mandatory** for any feature that makes outbound HTTP requests using user-supplied URLs. Resolve the hostname, reject private/link-local/loopback ranges, reject non-HTTP(S) schemes. The `validateUrl()` utility exists for this — use it.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2891,11 +2891,14 @@ POST /api/networks
   "type": "closed",
   "spaces": ["general"],
   "votingDeadlineHours": 24,
-  "syncSchedule": "*/5 * * * *"
+  "syncSchedule": "*/5 * * * *",
+  "requireSignedVotes": false
 }
 ```
 
 **Network types**: `closed` (unanimous vote), `democratic` (majority), `club` (proposer only), `braintree` (tree hierarchy), `pubsub` (auto-join publisher/subscriber, push-only).
+
+**`requireSignedVotes`** (optional, default `false`): when `true`, governance vote casts must carry a valid Ed25519 signature from the voting member (strict mode). Leave it off until every member has synced at least once so their signing keys are published; then enable it (also settable via `PATCH`) to reject any unsigned or forged vote. See [Sync Protocol → Signed vote casts](sync-protocol.md).
 
 **Response** `201`: the created network object.
 
@@ -2918,7 +2921,7 @@ PATCH /api/networks/:id
 ```
 
 ```json
-{ "syncSchedule": "*/10 * * * *", "label": "Renamed" }
+{ "syncSchedule": "*/10 * * * *", "label": "Renamed", "requireSignedVotes": true }
 ```
 
 ---
@@ -3513,9 +3516,9 @@ GET /api/sync/merkle?spaceId=general&networkId=net-uuid
 ### Gossip Endpoints
 
 - `GET /api/sync/networks/:networkId/members` returns current member view (sensitive fields stripped).
-- `POST /api/sync/networks/:networkId/members` accepts member updates for gossip propagation.
+- `POST /api/sync/networks/:networkId/members` accepts member updates for gossip propagation. The `self` record carries the sender's `signingPublicKey`, which the receiver pins trust-on-first-use for verifying that member's signed votes.
 - `GET /api/sync/networks/:networkId/votes` returns open rounds.
-- `POST /api/sync/networks/:networkId/votes/:roundId` relays `{ vote: "yes" | "veto", instanceId }`.
+- `POST /api/sync/networks/:networkId/votes/:roundId` relays `{ vote: "yes" | "veto", instanceId, sig?, castAt? }`. A cast bearing a valid `sig` (Ed25519 over `ythril-vote:v1|network|round|subject|voter|vote`) is accepted from any relaying peer; an unsigned cast is accepted only directly from its own voter. Returns `403` if the cast is rejected. See [Sync Protocol → Signed vote casts](sync-protocol.md).
 
 If this instance has been ejected from a network, `/api/sync/networks/:networkId/*` returns `401` with `{ "error": "ejected" }`.
 

--- a/docs/network-types.md
+++ b/docs/network-types.md
@@ -42,6 +42,12 @@ A brain's spaces are isolated from each other. A network is scoped to specific s
 
 ---
 
+## Vote integrity
+
+Regardless of type, every governance vote is **cryptographically signed**. Each brain holds a persistent Ed25519 keypair and signs each vote it casts; peers pin one another's public keys on first contact. A signed vote can be verified by any brain, so votes relay safely across intermediate nodes (important for deep Braintree trees) and no member can forge a vote on another member's behalf. A network can be switched to strict mode (`requireSignedVotes`) to reject any unsigned vote once all members have published keys. See the [Sync Protocol](sync-protocol.md) for the wire-level detail.
+
+---
+
 ## Closed network
 
 All members must vote yes for any join or removal. A single no blocks it. For a solo member (one device), every action is instant self-approval.

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -110,15 +110,18 @@ With `?full=true` the full document payload is embedded in the paginated list re
 
 Tombstones are fetched before documents so that a deletion that arrived at the peer applies before the engine could accidentally re-insert the same document that was just deleted. After tombstones are applied, items appearing in the list with a `deletedAt` field are skipped (they're stubs that the tombstone phase already handled).
 
-### Tombstone author guard
+### Tombstone deletion authorisation
 
-When `applyRemoteTombstone` processes an incoming tombstone it compares `tombstone.instanceId` (the instance that issued the delete) with `localDoc.author.instanceId` (the instance that created the document). If they differ, the local document is **not deleted**. This prevents a remote deletion from destroying locally-authored content — critical for pubsub subscribers and braintree leaves that may have their own data alongside pushed content.
+When `applyRemoteTombstone` processes an incoming tombstone it must satisfy **two** conditions before deleting the underlying document:
 
-Documents without `author` metadata (legacy, pre-author-field data) are deleted unconditionally since authorship cannot be determined.
+1. **Author match** — `tombstone.instanceId` (the issuer of the delete) must equal `localDoc.author.instanceId` (the instance that created the document). A tombstone can only delete a document authored by its own issuer.
+2. **Issuer proof** — because `tombstone.instanceId` is attacker-controllable, matching it against the author is not enough on its own. The delete is authorised only when the tombstone was delivered by the issuer itself — the authenticated peer's identity (`peerInstanceId`, carried on production peer tokens; or `member.instanceId` on the pull path) equals the issuer — or the caller is a trusted local/admin token. A tombstone relayed by a third party on behalf of another author is **refused**; the authoring peer's own tombstone reaches each member first-hand on direct sync.
+
+Together this prevents a member from forging a tombstone with `instanceId` set to a victim instance in order to delete the victim's content across the network. Documents without `author` metadata (legacy, pre-author-field data) are deleted unconditionally since authorship cannot be determined.
 
 ### Document ID collision safety
 
-All document `_id` values (`memories`, `entities`, `edges`, `chrono`) are **UUIDv4** — 122 bits of cryptographic randomness from Node.js `uuid` v4. The probability of two independent instances generating the same `_id` is astronomically low (~2.7 × 10⁻²⁰ after 1 billion documents). In practice, a publisher's tombstone targeting `_id = X` will never match a subscriber-created document because the subscriber's documents will always have different UUIDv4 identifiers. The tombstone author guard is a defence-in-depth layer on top of this structural guarantee.
+All document `_id` values (`memories`, `entities`, `edges`, `chrono`) are **UUIDv4** — 122 bits of cryptographic randomness from Node.js `uuid` v4. The probability of two independent instances generating the same `_id` is astronomically low (~2.7 × 10⁻²⁰ after 1 billion documents). In practice, a publisher's tombstone targeting `_id = X` will never match a subscriber-created document because the subscriber's documents will always have different UUIDv4 identifiers. The tombstone deletion-authorisation checks are a defence-in-depth layer on top of this structural guarantee.
 
 ### `lastSeqReceived` update
 
@@ -322,9 +325,22 @@ The `self` field in the `POST` response carries the receiver's own identity so t
 | Method | Path | Body | Returns |
 |--------|------|------|---------|
 | `GET` | `/api/sync/networks/:networkId/votes` | — | `{ rounds[VoteRound] }` |
-| `POST` | `/api/sync/networks/:networkId/votes/:roundId` | `{ vote: 'yes'\|'veto', instanceId }` | `200 { status:'ok' }` \| `404` |
+| `POST` | `/api/sync/networks/:networkId/votes/:roundId` | `{ vote: 'yes'\|'veto', instanceId, sig?, castAt? }` | `200 { status:'ok' }` \| `403` \| `404` |
 
 Sensitive fields (`inviteKeyHash`, `pendingMember.tokenHash`) are stripped from `GET` responses before sending to peers.
+
+### Signed vote casts
+
+Each brain holds a persistent **Ed25519 keypair** (private key in `secrets.json` as `signingPrivateKey`, public key in `config.json` as `signingPublicKey`, generated at setup / first boot). When an instance casts its own vote it signs the canonical message `ythril-vote:v1|<networkId>|<roundId>|<subjectInstanceId>|<voterInstanceId>|<vote>`; the base64 signature travels with the cast as `VoteCast.sig`.
+
+Public keys are distributed and **pinned trust-on-first-use** via the member-gossip `self` record (`NetworkMember.signingPublicKey`); a later attempt to change a member's pinned key is refused.
+
+A receiver accepts a cast when:
+
+- its signature verifies against the voter's pinned key — accepted from **any** reporting peer, which is what makes multi-hop vote relay (deep braintree trees) safe; or
+- the network is not in strict mode (`requireSignedVotes` unset) **and** the cast is reported directly by its own voter (the unsigned-compatibility path — a peer may never relay an unsigned cast on another member's behalf).
+
+With `requireSignedVotes: true` on the network, only signed-and-verified casts are accepted. Enable it once every member has published a key.
 
 ---
 
@@ -332,13 +348,13 @@ Sensitive fields (`inviteKeyHash`, `pendingMember.tokenHash`) are stripped from 
 
 After the gossip (member identity) exchange, the engine runs a vote propagation pass with each peer:
 
-1. **Push casts** — for each open local vote round, each known vote cast is relayed to the peer via `POST /api/sync/networks/:networkId/votes/:roundId { vote, instanceId }`. If the peer does not yet have the round (404), the push is silently skipped — the round will arrive on the peer's next pull cycle.
+1. **Push casts** — for each open local vote round, each known vote cast is relayed to the peer via `POST /api/sync/networks/:networkId/votes/:roundId { vote, instanceId, sig, castAt }`, forwarding the voter's signature so the peer can verify and relay it onward. If the peer does not yet have the round (404), the push is silently skipped — the round will arrive on the peer's next pull cycle.
 
 2. **Pull rounds** — `GET /api/sync/networks/:networkId/votes` fetches the peer's open rounds. For each round:
    - **New round**: if the round does not exist locally, it is adopted into `pendingRounds` (with an empty `votes` array); votes are then merged in the same pass.
-   - **Vote merge**: for each cast from the peer's round, if the cast is not already present locally it is added. If the same voter's cast differs (e.g., updated from `yes` to `veto`), the local cast is replaced.
+   - **Vote merge**: each cast from the peer's round is accepted only if it passes the signature/own-cast check above (a forged cast attributed to another member is dropped). The cast — including its signature — is stored verbatim so it can be relayed onward unchanged. If the same voter's cast changes (e.g., `yes` → `veto`), the local cast is replaced.
 
-3. **Round conclusion** — after all merges, `concludeRoundIfReady` is evaluated for every open local round. Unanimous-type networks (closed, braintree) require every listed remote member to have individually cast `yes`; a single outstanding member prevents conclusion. Democratic networks use a simple majority count. Club networks conclude on the first `yes`.
+3. **Round conclusion** — after all merges, `concludeRoundIfReady` is evaluated for every open local round. Unanimous-type networks (closed, braintree) require every listed remote member to have individually cast `yes`; a single outstanding member prevents conclusion. For **braintree** rounds the required-voter set (ancestor path) is recomputed from the local topology at conclusion, never trusted from the adopted round, so a peer cannot shrink it. Democratic networks use a simple majority count. Club networks conclude on the first `yes`.
 
 4. **Side effects** — if a `space_deletion` round concludes with zero vetoes, the space is removed from the local instance asynchronously.
 

--- a/server/src/api/networks.ts
+++ b/server/src/api/networks.ts
@@ -17,10 +17,24 @@ import { createToken, revokeToken } from '../auth/tokens.js';
 import { createSpace } from '../spaces/spaces.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from './sync.js';
 import { getSyncHistory } from '../sync/history.js';
+import { buildBraintreeAncestors } from '../util/braintree.js';
+import { signOwnVoteCast, getSigningPublicKey } from '../util/signing.js';
 import { log } from '../util/log.js';
-import type { NetworkConfig, NetworkMember, VoteRound } from '../config/types.js';
+import type { NetworkConfig, NetworkMember, VoteRound, VoteCast } from '../config/types.js';
 
 export const networksRouter = Router();
+
+/** Build this instance's own vote cast, signed when a signing key is available. */
+function makeSignedOwnCast(networkId: string, round: VoteRound, instanceId: string, vote: 'yes' | 'veto'): VoteCast {
+  const sig = signOwnVoteCast({
+    networkId,
+    roundId: round.roundId,
+    subjectInstanceId: round.subjectInstanceId,
+    instanceId,
+    vote,
+  });
+  return { instanceId, vote, castAt: new Date().toISOString(), ...(sig ? { sig } : {}) };
+}
 
 const BCRYPT_ROUNDS = 12;
 
@@ -45,6 +59,7 @@ const CreateNetworkBody = z.object({
   votingDeadlineHours: z.number().int().min(1).max(72).default(24),
   syncSchedule: z.string().optional(),
   merkle: z.boolean().optional(),
+  requireSignedVotes: z.boolean().optional(),  // strict mode: reject unsigned governance votes
   myParentInstanceId: z.string().optional(),  // braintree: this instance's parent in the tree (omit → root)
 });
 
@@ -65,6 +80,7 @@ const CastVoteBody = z.object({
 const UpdateNetworkBody = z.object({
   syncSchedule: z.string().optional(),
   label: z.string().min(1).max(200).optional(),
+  requireSignedVotes: z.boolean().optional(),
 });
 
 const JoinRemoteBody = z.object({
@@ -161,7 +177,7 @@ networksRouter.post('/', globalRateLimit, requireAdmin, async (req, res) => {
     const parsed = CreateNetworkBody.safeParse(req.body);
     if (!parsed.success) { res.status(400).json({ error: parsed.error.message }); return; }
 
-    const { id: presetId, label, type, spaces, votingDeadlineHours, syncSchedule, merkle, myParentInstanceId } = parsed.data;
+    const { id: presetId, label, type, spaces, votingDeadlineHours, syncSchedule, merkle, requireSignedVotes, myParentInstanceId } = parsed.data;
     const cfg = getConfig();
 
     // Validate spaces exist
@@ -185,6 +201,7 @@ networksRouter.post('/', globalRateLimit, requireAdmin, async (req, res) => {
       votingDeadlineHours,
       syncSchedule,
       merkle,
+      ...(requireSignedVotes ? { requireSignedVotes: true } : {}),
       myParentInstanceId: type === 'braintree' ? myParentInstanceId : undefined,
       members: [],
       pendingRounds: [],
@@ -269,6 +286,7 @@ networksRouter.patch('/:id', globalRateLimit, requireAdmin, (req, res) => {
     }).catch(err => log.warn(`Failed to reschedule sync for ${net!.id}: ${err}`));
   }
   if (parsed.data.label) net.label = parsed.data.label;
+  if (parsed.data.requireSignedVotes !== undefined) net.requireSignedVotes = parsed.data.requireSignedVotes;
 
   saveConfig(cfg);
   log.info(`Updated network ${net.id}`);
@@ -492,40 +510,6 @@ networksRouter.post('/join-remote', globalRateLimit, requireAdmin, async (req, r
   }
 });
 
-// ── Braintree governance helpers ────────────────────────────────────────────
-
-/**
- * Compute the list of instance IDs that must vote yes for a Braintree governance action.
- *
- * Walks from `startId` upward through `parentInstanceId` on network members.
- * When the walk reaches `selfId` it continues via `net.myParentInstanceId` (the recorded
- * parent of this instance).  Returns the path from `startId` up to (and including) the root.
- *
- * For a JOIN round: call with startId = selfId (the inviting node is this server).
- * For a REMOVE round: call with startId = subject.parentInstanceId (the subject's direct parent).
- */
-function buildBraintreeAncestors(
-  net: NetworkConfig,
-  selfId: string,
-  startId: string,
-): string[] {
-  const path: string[] = [];
-  const visited = new Set<string>();
-  let cur: string | undefined = startId;
-  while (cur && !visited.has(cur)) {
-    path.push(cur);
-    visited.add(cur);
-    if (cur === selfId) {
-      cur = net.myParentInstanceId;   // continue upward via this instance's declared parent
-    } else {
-      const m = net.members.find(m => m.instanceId === cur);
-      if (!m) break;                  // chain incomplete; stop here
-      cur = m.parentInstanceId;
-    }
-  }
-  return path;
-}
-
 // ── POST /api/networks/:id/members — add a peer member ────────────────────
 
 networksRouter.post('/:id/members', globalRateLimit, requireAdmin, async (req, res) => {
@@ -626,7 +610,7 @@ networksRouter.post('/:id/members', globalRateLimit, requireAdmin, async (req, r
     };
     freshNet.pendingRounds.push(round);
     // Auto-cast this instance's yes vote (proposer implicitly approves their own proposal)
-    round.votes.push({ instanceId: freshCfg.instanceId, vote: 'yes', castAt: new Date().toISOString() });
+    round.votes.push(makeSignedOwnCast(freshNet.id, round, freshCfg.instanceId, 'yes'));
     const secrets = getSecrets();
     secrets.peerTokens[instanceId] = token;
     saveSecrets(secrets);
@@ -708,7 +692,7 @@ networksRouter.delete('/:id/members/:instanceId', globalRateLimit, requireAdmin,
   net.pendingRounds.push(removeRound);
   // Auto-cast this instance's yes vote if we are a required voter
   if (requiredVoters.includes(cfg.instanceId)) {
-    removeRound.votes.push({ instanceId: cfg.instanceId, vote: 'yes', castAt: new Date().toISOString() });
+    removeRound.votes.push(makeSignedOwnCast(net.id, removeRound, cfg.instanceId, 'yes'));
   }
   const immediatePassed = concludeRoundIfReady(net, removeRound);
   if (immediatePassed) {
@@ -863,7 +847,7 @@ networksRouter.post('/:id/votes/:roundId', globalRateLimit, requireAdmin, (req, 
 
     const instanceId = cfg.instanceId;
     const existing = round.votes.findIndex(v => v.instanceId === instanceId);
-    const cast = { instanceId, vote: parsed.data.vote, castAt: new Date().toISOString() };
+    const cast = makeSignedOwnCast(net.id, round, instanceId, parsed.data.vote);
     if (existing >= 0) { round.votes[existing] = cast; }
     else { round.votes.push(cast); }
 

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -24,6 +24,8 @@ import { isStrictLinkage } from '../spaces/proxy.js';
 import { getAllowedChronoTypes } from '../spaces/schema-validation.js';
 import { buildFileManifest } from '../files/manifest.js';
 import { computeMerkleRoot } from '../brain/merkle.js';
+import { buildBraintreeAncestors } from '../util/braintree.js';
+import { acceptVoteCast, getSigningPublicKey, pinMemberSigningKey } from '../util/signing.js';
 import { emitWebhookEvent } from '../webhooks/dispatcher.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -964,7 +966,13 @@ syncRouter.post('/tombstones', syncRateLimit, requireAuth, denyReadOnly, async (
     const parsed = schema.safeParse(tombstones);
     if (!parsed.success) { res.status(400).json({ error: 'Invalid tombstone format' }); return; }
 
-    await Promise.all(parsed.data.map(t => applyRemoteTombstone(t)));
+    // A peer token may only delete content it authored (peerInstanceId === tombstone issuer);
+    // a trusted local/admin token (no peerInstanceId) may relay any tombstone.
+    const callerPeerId = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string | undefined;
+    const trustedRelay = !callerPeerId && req.authToken?.admin === true;
+    await Promise.all(parsed.data.map(t =>
+      applyRemoteTombstone(t as TombstoneDoc, { peerInstanceId: callerPeerId, trustedRelay }),
+    ));
     res.status(200).json({ applied: parsed.data.length });
   } catch (err) {
     log.error(`sync POST tombstones: ${err}`);
@@ -1187,13 +1195,16 @@ syncRouter.post('/networks/:networkId/members', syncRateLimit, requireAuth, deny
     if (freshNet) {
       const idx = freshNet.members.findIndex(m => m.instanceId === incoming.instanceId);
       if (idx >= 0) {
-        freshNet.members[idx] = {
+        const updated = {
           ...freshNet.members[idx]!,
           label: incoming.label ?? freshNet.members[idx]!.label,
           url: incoming.url ?? freshNet.members[idx]!.url,
           children: incoming.children ?? freshNet.members[idx]!.children,
           lastSyncAt: new Date().toISOString(),
         };
+        // Trust-on-first-use: pin the member's signing key the first time we see it.
+        pinMemberSigningKey(updated, incoming.signingPublicKey);
+        freshNet.members[idx] = updated;
         saveConfig(fresh);
       }
     }
@@ -1202,6 +1213,8 @@ syncRouter.post('/networks/:networkId/members', syncRateLimit, requireAuth, deny
     const selfUrl = process.env['INSTANCE_URL'] ?? '';
     const selfRecord: Record<string, unknown> = { instanceId: cfg.instanceId, label: cfg.instanceLabel };
     if (selfUrl) selfRecord['url'] = selfUrl;
+    const ownSigningKey = getSigningPublicKey();
+    if (ownSigningKey) selfRecord['signingPublicKey'] = ownSigningKey;
     res.status(200).json({ status: 'ok', self: selfRecord });
   } catch (err) {
     log.error(`sync POST members: ${err}`);
@@ -1242,17 +1255,9 @@ syncRouter.get('/networks/:networkId/votes', syncRateLimit, requireAuth, async (
  */
 syncRouter.post('/networks/:networkId/votes/:roundId', syncRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
-    const body = req.body as { vote: string; instanceId: string };
+    const body = req.body as { vote: string; instanceId: string; sig?: string; castAt?: string };
     if (!body?.vote || !body?.instanceId || !['yes', 'veto'].includes(body.vote)) {
       res.status(400).json({ error: 'vote (yes|veto) and instanceId required' });
-      return;
-    }
-
-    // Vote forgery prevention: a peer token may only cast votes on behalf of its own instanceId.
-    // Tokens without peerInstanceId (admin/local) may relay votes on behalf of any instanceId.
-    const callerPeerId = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string | undefined;
-    if (callerPeerId && callerPeerId !== body.instanceId) {
-      res.status(403).json({ error: 'Token is not authorized to cast votes on behalf of this instanceId' });
       return;
     }
 
@@ -1263,9 +1268,25 @@ syncRouter.post('/networks/:networkId/votes/:roundId', syncRateLimit, requireAut
     const round = net.pendingRounds.find(r => r.roundId === req.params['roundId'] && !r.concluded);
     if (!round) { res.status(404).json({ error: 'Round not found or concluded' }); return; }
 
+    // Vote forgery prevention. A signed cast is accepted from any reporter (its
+    // signature proves the voter cast it). An unsigned cast is accepted only from
+    // its own voter — a peer token may only relay its own instanceId; admin/local
+    // tokens (no peerInstanceId) may relay any unsigned cast (compat).
+    const callerPeerId = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string | undefined;
+    const cast = {
+      instanceId: body.instanceId,
+      vote: body.vote as 'yes' | 'veto',
+      castAt: typeof body.castAt === 'string' ? body.castAt : new Date().toISOString(),
+      ...(typeof body.sig === 'string' && body.sig ? { sig: body.sig } : {}),
+    };
+    const decision = acceptVoteCast(net, round, cast, callerPeerId ?? body.instanceId);
+    if (!decision.accept) {
+      res.status(403).json({ error: `Vote rejected: ${decision.reason}` });
+      return;
+    }
+
     // Deduplicate: replace existing vote from this instance if present
     const existing = round.votes.findIndex(v => v.instanceId === body.instanceId);
-    const cast = { instanceId: body.instanceId, vote: body.vote as 'yes' | 'veto', castAt: new Date().toISOString() };
     if (existing >= 0) { round.votes[existing] = cast; }
     else { round.votes.push(cast); }
 
@@ -1311,6 +1332,31 @@ syncRouter.post('/networks/:networkId/votes/:roundId', syncRateLimit, requireAut
 
 // â”€â”€ Vote conclusion logic â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
+/**
+ * Recompute the braintree ancestor voter set for a round from this instance's
+ * own view of the tree, so conclusion never depends on a peer-supplied
+ * `requiredVoters` *set*. Returns null for round types that are not
+ * ancestor-gated (space_deletion / meta_change) or when no anchor is available —
+ * the caller then falls back to requiring every member to vote yes.
+ *
+ * The round's `requiredVoters[0]` is the anchor node the proposer computed the
+ * chain from (the inviting node for a join, the subject's parent for a remove).
+ * We trust only that single anchor and recompute the FULL chain from it against
+ * our local topology. This exactly reproduces the proposer's set for legitimate
+ * rounds, but a peer cannot SHRINK the required set: anchoring on `[attacker]`
+ * still recomputes the real ancestor chain from the attacker up to the root, so
+ * every genuine ancestor must still vote yes.
+ */
+function localBraintreeRequiredVoters(
+  net: import('../config/types.js').NetworkConfig,
+  round: import('../config/types.js').VoteRound,
+): string[] | null {
+  if (round.type !== 'join' && round.type !== 'remove') return null;
+  const anchor = round.requiredVoters?.[0];
+  if (!anchor) return null;
+  return buildBraintreeAncestors(net, getConfig().instanceId, anchor);
+}
+
 function concludeRoundIfReady(
   net: import('../config/types.js').NetworkConfig,
   round: import('../config/types.js').VoteRound,
@@ -1339,19 +1385,27 @@ function concludeRoundIfReady(
     case 'closed':
       passed = allRemoteVotedYes;
       break;
-    case 'braintree':
-      if (round.requiredVoters && round.requiredVoters.length > 0) {
-        // Only the designated ancestors (path from inviting node to root) must vote yes.
-        // The subject itself is excluded from the required set.
-        const relevant = round.requiredVoters.filter(id => id !== round.subjectInstanceId);
+    case 'braintree': {
+      // SECURITY: recompute the ancestor voter set from the LOCAL topology rather
+      // than trusting `round.requiredVoters`. Once a round is adopted via gossip,
+      // that field is attacker-controllable — a malicious peer could shrink it to
+      // `[attacker]` and, with its own (authentic) yes vote, force a join/remove/
+      // space_deletion to conclude on the victim. The local recomputation yields
+      // the same set for legitimate rounds and cannot be shrunk by a peer.
+      const localRequired = localBraintreeRequiredVoters(net, round);
+      if (localRequired && localRequired.length > 0) {
+        const relevant = localRequired.filter(id => id !== round.subjectInstanceId);
         passed = relevant.every(id =>
           round.votes.some(c => c.instanceId === id && c.vote === 'yes'),
         );
       } else {
-        // Fallback for rounds created before requiredVoters was introduced
+        // No locally-derivable ancestor set (e.g. space_deletion / meta_change, a
+        // pre-requiredVoters round, or an incomplete local tree view): fall back to
+        // requiring EVERY current member to have voted yes — never fewer.
         passed = allRemoteVotedYes;
       }
       break;
+    }
     case 'democratic':
       passed = (voters.length === 0 && yesCount > 0) || (yesCount > voters.length / 2 && vetoCount === 0);
       break;

--- a/server/src/brain/tombstones.ts
+++ b/server/src/brain/tombstones.ts
@@ -1,5 +1,15 @@
 import { col, mFilter, mDoc, mUpdate } from '../db/mongo.js';
+import { log } from '../util/log.js';
 import type { TombstoneDoc } from '../config/types.js';
+
+/** Context for authorising a remote tombstone's deletion of a local document. */
+export interface TombstoneAuth {
+  /** instanceId of the authenticated peer that delivered this tombstone
+   *  (the peer we pulled from, or the caller of POST /tombstones). */
+  peerInstanceId?: string;
+  /** True when the caller is a trusted local/admin token (no peer identity). */
+  trustedRelay?: boolean;
+}
 
 /** List tombstones with seq greater than the given watermark */
 export async function listTombstones(
@@ -18,7 +28,7 @@ export async function listTombstones(
 }
 
 /** Write a tombstone received from a peer (only if local seq is lower or doc doesn't exist) */
-export async function applyRemoteTombstone(tombstone: TombstoneDoc): Promise<void> {
+export async function applyRemoteTombstone(tombstone: TombstoneDoc, auth: TombstoneAuth = {}): Promise<void> {
   const { spaceId, _id, type, seq } = tombstone;
 
   // Idempotent upsert — only insert if not present or remote seq is higher
@@ -46,12 +56,31 @@ export async function applyRemoteTombstone(tombstone: TombstoneDoc): Promise<voi
   const targetColl = collMap[type];
   if (targetColl) {
     const localDoc = await col(targetColl).findOne(mFilter({ _id })) as { author?: { instanceId?: string } } | null;
-    // If the local doc has an author and it doesn't match the tombstone issuer, skip deletion.
-    // Documents without author metadata (legacy) are deleted as before.
-    if (localDoc?.author?.instanceId && tombstone.instanceId &&
-        localDoc.author.instanceId !== tombstone.instanceId) {
-      return;
+    if (localDoc?.author?.instanceId) {
+      const issuer = tombstone.instanceId;
+      // The tombstone may only delete a document authored by its own issuer.
+      if (localDoc.author.instanceId !== issuer) return;
+
+      // SECURITY: `issuer` is attacker-controllable, so matching it against the
+      // doc's author is not enough — a malicious peer could forge a tombstone
+      // with `instanceId` set to a victim instance to delete that victim's data.
+      // Require proof that the delete is authorised: either the tombstone was
+      // delivered directly by its issuer (the authenticated peer IS the author),
+      // or it came from a trusted local/admin token. A tombstone relayed by a
+      // third party on behalf of another author is refused; the authoring peer's
+      // own tombstone reaches us first-hand on direct sync.
+      const authorised =
+        auth.trustedRelay === true ||
+        (auth.peerInstanceId !== undefined && auth.peerInstanceId === issuer);
+      if (!authorised) {
+        log.warn(
+          `Refusing tombstone for doc '${_id}' (${type}) in space '${spaceId}': issuer '${issuer}' ` +
+          `is not the delivering peer '${auth.peerInstanceId ?? '-'}' — possible cross-instance delete forgery`,
+        );
+        return;
+      }
     }
+    // Documents without author metadata (legacy) carry nothing to protect — delete as before.
     await col(targetColl).deleteOne(mFilter({ _id }));
   }
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -416,12 +416,20 @@ export interface NetworkMember {
   originalParentInstanceId?: string;
   children?: string[];       // instanceIds of direct children (braintree)
   skipTlsVerify?: boolean;   // non-default; UI shows security warning when true
+  /** Ed25519 public key (SPKI PEM) used to verify this member's signed vote casts.
+   *  Trust-on-first-use: pinned the first time we learn it via member gossip / invite;
+   *  a later attempt to change it to a different key is rejected. */
+  signingPublicKey?: string;
 }
 
 export interface VoteCast {
   instanceId: string;
   vote: VoteValue;
   castAt: string;            // ISO8601
+  /** Base64 Ed25519 signature by `instanceId` over the canonical vote message
+   *  (see util/signing.ts). Present on casts created by signing-capable brains;
+   *  absent on legacy/unsigned casts (accepted only via the own-cast path). */
+  sig?: string;
 }
 
 export interface VoteRound {
@@ -455,6 +463,12 @@ export interface NetworkConfig {
   spaceMap?: Record<string, string>;
   votingDeadlineHours: number;
   merkle?: boolean;
+  /** When true, governance vote casts must carry a valid Ed25519 signature from
+   *  the voting member (verified against its pinned signingPublicKey). Enable
+   *  once every member has published a signing key. Default (false/undefined)
+   *  runs in compatibility mode: signed casts are verified and relay-safe, while
+   *  unsigned casts are accepted only directly from the voter (never relayed). */
+  requireSignedVotes?: boolean;
   members: NetworkMember[];
   pendingRounds: VoteRound[];
   syncSchedule?: string;     // cron expression; omit = manual only
@@ -565,6 +579,10 @@ export interface Config {
   instanceId: string;
   instanceLabel: string;
   publicUrl?: string;         // optional canonical public URL for this brain instance
+  /** Ed25519 public signing key (SPKI PEM) for this instance. Published to peers
+   *  so they can verify our signed governance vote casts. Private half is in
+   *  secrets.json. Generated on first startup after setup. */
+  signingPublicKey?: string;
   tokens: TokenRecord[];
   spaces: SpaceConfig[];
   networks: NetworkConfig[];
@@ -592,6 +610,7 @@ export interface SecretsFile {
   peerTokens: Record<string, string>;
   totpSecret?: string;              // base32 TOTP secret; absent = MFA disabled
   webhookEncryptionKey?: string;    // hex-encoded AES-256 key for webhook secret encryption
+  signingPrivateKey?: string;       // Ed25519 private key (PKCS8 PEM) for signing governance votes
   /**
    * Media embedding provider credentials. Stored here (0o600) instead of
    * config.json so API keys are never world-readable. Env vars

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -51,6 +51,13 @@ async function main(): Promise<void> {
       }
     }
 
+    // Ensure this instance has a persistent Ed25519 signing keypair for governance
+    // vote signatures. Generated once (no-op on subsequent boots).
+    {
+      const { ensureInstanceKeypair } = await import('./util/signing.js');
+      ensureInstanceKeypair();
+    }
+
     // TLS warning: if non-loopback binding and plaintext allowed
     const { getConfig } = await import('./config/loader.js');
     const cfg = getConfig();

--- a/server/src/setup/routes.ts
+++ b/server/src/setup/routes.ts
@@ -4,6 +4,7 @@ import { authRateLimit } from '../rate-limit/middleware.js';
 import { configExists, saveConfig, saveSecrets, loadSecrets, loadConfig } from '../config/loader.js';
 import { ensureGeneralSpace } from '../spaces/spaces.js';
 import { createToken } from '../auth/tokens.js';
+import { ensureInstanceKeypair } from '../util/signing.js';
 import { log } from '../util/log.js';
 import type { Config, SecretsFile } from '../config/types.js';
 
@@ -112,6 +113,7 @@ setupRouter.post('/', authRateLimit, async (req, res) => {
   await saveSecrets(secrets);
   loadConfig();
   loadSecrets();
+  ensureInstanceKeypair();
 
   try {
     await ensureGeneralSpace();
@@ -175,6 +177,7 @@ setupRouter.post('/json', authRateLimit, async (req, res) => {
   await saveSecrets(secrets);
   loadConfig();
   loadSecrets();
+  ensureInstanceKeypair();
 
   try {
     await ensureGeneralSpace();

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -50,6 +50,7 @@ import { getDataRoot } from '../config/loader.js';
 import { createHash } from 'node:crypto';
 import { resolveSafePath } from '../files/sandbox.js';
 import { deleteFileMeta, upsertFileMeta } from '../files/file-meta.js';
+import { acceptVoteCast, getSigningPublicKey, pinMemberSigningKey } from '../util/signing.js';
 import { v4 as uuidv4 } from 'uuid';
 
 // Timeout for every outbound fetch to a peer.
@@ -547,6 +548,8 @@ async function gossipWithPeer(
         .map(m => m.instanceId),
     };
     if (selfUrl) selfRecord['url'] = selfUrl;
+    const ownSigningKey = getSigningPublicKey();
+    if (ownSigningKey) selfRecord['signingPublicKey'] = ownSigningKey;
     const resp = await fetch(`${base}/members`, {
       ...opts(),
       method: 'POST',
@@ -566,6 +569,7 @@ async function gossipWithPeer(
               let changed = false;
               if (peerSelf.url && peerSelf.url !== local.url) { local.url = peerSelf.url; changed = true; }
               if (peerSelf.label && peerSelf.label !== local.label) { local.label = peerSelf.label; changed = true; }
+              if (pinMemberSigningKey(local, peerSelf.signingPublicKey)) changed = true;
               if (changed) {
                 log.info(`Gossip: updated ${member.label} via self-piggyback (${net.id})`);
                 saveConfig(freshCfg);
@@ -617,6 +621,7 @@ async function gossipWithPeer(
         local.children = peerRecord.children;
         updated = true;
       }
+      if (pinMemberSigningKey(local, peerRecord.signingPublicKey)) updated = true;
       if (updated) {
         log.info(`Gossip: updated member ${local.label} (${local.instanceId}) in network ${net.id}`);
         changed = true;
@@ -658,7 +663,9 @@ async function propagateVotesWithPeer(
         await fetch(`${base}/votes/${encodeURIComponent(round.roundId)}`, {
           ...opts(),
           method: 'POST',
-          body: JSON.stringify({ vote: cast.vote, instanceId: cast.instanceId }),
+          // Forward the signature (and castAt) so the peer can verify and, when
+          // valid, relay this cast onward — signed casts are relay-safe.
+          body: JSON.stringify({ vote: cast.vote, instanceId: cast.instanceId, sig: cast.sig, castAt: cast.castAt }),
         }).catch(err => log.warn(`Vote push (${round.roundId}) to ${member.label}: ${err}`));
       }
     }
@@ -699,12 +706,29 @@ async function propagateVotesWithPeer(
       }
       if (local.concluded) continue;
 
-      // Merge vote casts
+      // Merge vote casts.
+      //
+      // SECURITY: a signed cast is accepted from any reporter (its signature
+      // proves the voter cast it, so multi-hop relay is safe); an unsigned cast
+      // is accepted only when the reporting peer IS the voter. This blocks the
+      // forgery where a malicious peer serves a round pre-stuffed with `yes`
+      // votes forged for other members, while allowing signed votes to relay
+      // through intermediate nodes (deep braintree trees).
       for (const peerCast of (peerRound.votes ?? []) as VoteCast[]) {
         if (!peerCast.instanceId || !['yes', 'veto'].includes(peerCast.vote)) continue;
+        const decision = acceptVoteCast(freshNet, local, peerCast, member.instanceId);
+        if (!decision.accept) {
+          log.warn(
+            `Vote gossip: rejecting cast for '${peerCast.instanceId}' relayed by '${member.instanceId}' ` +
+            `(round ${peerRound.roundId}) — ${decision.reason}`,
+          );
+          continue;
+        }
         const idx = local.votes.findIndex(v => v.instanceId === peerCast.instanceId);
         if (idx >= 0) {
-          if (local.votes[idx]!.vote !== peerCast.vote) {
+          // Only replace if the new cast changes the vote value; preserve the
+          // signature that came with it.
+          if (local.votes[idx]!.vote !== peerCast.vote || local.votes[idx]!.sig !== peerCast.sig) {
             local.votes[idx] = peerCast;
             changed = true;
           }
@@ -781,7 +805,11 @@ async function pullFromPeer(
     if (resp.ok) {
       const data = await resp.json() as { memories?: TombstoneDoc[]; entities?: TombstoneDoc[]; edges?: TombstoneDoc[]; chrono?: TombstoneDoc[] };
       const all = [...(data.memories ?? []), ...(data.entities ?? []), ...(data.edges ?? []), ...(data.chrono ?? [])];
-      for (const t of all) { await applyRemoteTombstone(t); }
+      // The peer we pulled from is the authenticated source. Its own tombstones
+      // (issuer === member) are authorised; a tombstone it relays on behalf of a
+      // third author is refused here and applied instead when we sync directly
+      // with that author.
+      for (const t of all) { await applyRemoteTombstone(t, { peerInstanceId: member.instanceId }); }
     }
   } catch (err) {
     log.warn(`pullFromPeer tombstones from ${member.label}: ${err}`);

--- a/server/src/util/braintree.ts
+++ b/server/src/util/braintree.ts
@@ -1,0 +1,45 @@
+/**
+ * Braintree topology helper.
+ *
+ * Extracted into a shared, dependency-free module so both the network
+ * governance API (round creation) and the sync engine (round conclusion) can
+ * compute the ancestor voter set from the SAME source of truth. Conclusion must
+ * recompute this locally rather than trust a peer-supplied `requiredVoters`,
+ * which is attacker-controllable once a round is adopted via gossip.
+ */
+
+import type { NetworkConfig } from '../config/types.js';
+
+/**
+ * Compute the list of instance IDs that must vote yes for a Braintree governance
+ * action.
+ *
+ * Walks from `startId` upward through `parentInstanceId` on network members.
+ * When the walk reaches `selfId` it continues via `net.myParentInstanceId` (the
+ * recorded parent of this instance). Returns the path from `startId` up to (and
+ * including) the root.
+ *
+ * For a JOIN round: startId = the inviting node (the pending member's parent).
+ * For a REMOVE round: startId = the subject's direct parent.
+ */
+export function buildBraintreeAncestors(
+  net: NetworkConfig,
+  selfId: string,
+  startId: string,
+): string[] {
+  const path: string[] = [];
+  const visited = new Set<string>();
+  let cur: string | undefined = startId;
+  while (cur && !visited.has(cur)) {
+    path.push(cur);
+    visited.add(cur);
+    if (cur === selfId) {
+      cur = net.myParentInstanceId; // continue upward via this instance's declared parent
+    } else {
+      const m = net.members.find(m => m.instanceId === cur);
+      if (!m) break; // chain incomplete; stop here
+      cur = m.parentInstanceId;
+    }
+  }
+  return path;
+}

--- a/server/src/util/signing.ts
+++ b/server/src/util/signing.ts
@@ -1,0 +1,227 @@
+/**
+ * Instance signing keys and vote-cast signatures.
+ *
+ * Each brain owns a persistent Ed25519 keypair: the private key lives in
+ * secrets.json (never leaves the box), the public key lives in config.json and
+ * is published to peers via the member-gossip `self` record (trust-on-first-use
+ * pinning — see NetworkMember.signingPublicKey).
+ *
+ * A vote cast is signed ONCE by the voting instance over a canonical message
+ * that binds the network, round, subject, voter and vote value. The signature
+ * travels with the cast, so ANY node can verify a cast regardless of which peer
+ * relayed it. This is what makes multi-hop vote relay safe: a relayed cast is
+ * accepted only if its signature verifies against the voter's pinned key, so a
+ * peer can neither forge another member's vote nor tamper with a relayed one.
+ *
+ * Ed25519 is used (not RSA): tiny keys/signatures, deterministic, no digest
+ * configuration, and `crypto.sign(null, …)` / `crypto.verify(null, …)` operate
+ * directly on the message.
+ */
+
+import crypto from 'node:crypto';
+import { getConfig, saveConfig, getSecrets, saveSecrets } from '../config/loader.js';
+import { log } from '../util/log.js';
+import type { NetworkConfig, NetworkMember, VoteRound, VoteCast } from '../config/types.js';
+
+export interface InstanceKeypair {
+  publicKeyPem: string;
+  privateKeyPem: string;
+}
+
+/** Generate a fresh Ed25519 instance keypair (SPKI/PKCS8 PEM). */
+export function generateInstanceKeypair(): InstanceKeypair {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  return {
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+  };
+}
+
+/**
+ * Canonical message signed for a vote cast. Binding all five fields prevents a
+ * signature from being replayed onto a different network, round, subject, voter
+ * or vote value.
+ */
+export function voteCastMessage(params: {
+  networkId: string;
+  roundId: string;
+  subjectInstanceId: string;
+  instanceId: string;
+  vote: string;
+}): string {
+  return [
+    'ythril-vote:v1',
+    params.networkId,
+    params.roundId,
+    params.subjectInstanceId,
+    params.instanceId,
+    params.vote,
+  ].join('|');
+}
+
+/** Sign a message with an Ed25519 private key PEM; returns base64. Empty on failure. */
+export function signMessage(privateKeyPem: string, message: string): string {
+  try {
+    const key = crypto.createPrivateKey(privateKeyPem);
+    return crypto.sign(null, Buffer.from(message, 'utf8'), key).toString('base64');
+  } catch (err) {
+    log.warn(`signMessage failed: ${err instanceof Error ? err.message : String(err)}`);
+    return '';
+  }
+}
+
+/** Verify a base64 Ed25519 signature over `message` against a public key PEM. */
+export function verifyMessage(publicKeyPem: string, message: string, sigB64: string): boolean {
+  if (!publicKeyPem || !sigB64) return false;
+  try {
+    const key = crypto.createPublicKey(publicKeyPem);
+    return crypto.verify(null, Buffer.from(message, 'utf8'), key, Buffer.from(sigB64, 'base64'));
+  } catch {
+    return false;
+  }
+}
+
+// ── Instance keypair lifecycle ───────────────────────────────────────────────
+
+/**
+ * Ensure this instance has a persistent signing keypair. Generates one on first
+ * call (private key → secrets.json, public key → config.json) and is a no-op
+ * afterwards. Safe to call at startup and after setup. Returns the keypair, or
+ * null if config/secrets are not yet available (pre-setup).
+ */
+export function ensureInstanceKeypair(): InstanceKeypair | null {
+  let cfg;
+  try {
+    cfg = getConfig();
+  } catch {
+    return null; // config not loaded yet (pre-setup)
+  }
+  const secrets = getSecrets();
+
+  const havePriv = typeof secrets.signingPrivateKey === 'string' && secrets.signingPrivateKey.length > 0;
+  const havePub = typeof cfg.signingPublicKey === 'string' && cfg.signingPublicKey.length > 0;
+  if (havePriv && havePub) {
+    return { publicKeyPem: cfg.signingPublicKey!, privateKeyPem: secrets.signingPrivateKey! };
+  }
+
+  const kp = generateInstanceKeypair();
+  secrets.signingPrivateKey = kp.privateKeyPem;
+  saveSecrets(secrets);
+  cfg.signingPublicKey = kp.publicKeyPem;
+  saveConfig(cfg);
+  log.info('Generated persistent Ed25519 instance signing keypair.');
+  return kp;
+}
+
+/** Return this instance's signing keypair, or null if not yet initialised. */
+export function getInstanceKeypair(): InstanceKeypair | null {
+  let cfg;
+  try {
+    cfg = getConfig();
+  } catch {
+    return null;
+  }
+  const secrets = getSecrets();
+  if (!secrets.signingPrivateKey || !cfg.signingPublicKey) return null;
+  return { publicKeyPem: cfg.signingPublicKey, privateKeyPem: secrets.signingPrivateKey };
+}
+
+/** This instance's own public signing key (PEM), or undefined if not initialised. */
+export function getSigningPublicKey(): string | undefined {
+  try {
+    return getConfig().signingPublicKey;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Sign a vote cast for THIS instance. Returns a base64 signature, or '' when no
+ * keypair is available (the cast then travels unsigned and is accepted by peers
+ * only via the own-cast compatibility path, not by relay).
+ */
+export function signOwnVoteCast(params: {
+  networkId: string;
+  roundId: string;
+  subjectInstanceId: string;
+  instanceId: string;
+  vote: string;
+}): string {
+  const kp = getInstanceKeypair();
+  if (!kp) return '';
+  return signMessage(kp.privateKeyPem, voteCastMessage(params));
+}
+
+// ── Key distribution (trust-on-first-use) ────────────────────────────────────
+
+/**
+ * Pin a member's signing public key on first sight (TOFU). Sets it when absent;
+ * a later attempt to change it to a DIFFERENT key is refused and logged — this
+ * prevents a peer from rotating another member's key to impersonate it. Returns
+ * true when the member record was modified.
+ */
+export function pinMemberSigningKey(member: NetworkMember, incomingKey: string | undefined): boolean {
+  if (!incomingKey || typeof incomingKey !== 'string') return false;
+  if (!member.signingPublicKey) {
+    member.signingPublicKey = incomingKey;
+    return true;
+  }
+  if (member.signingPublicKey !== incomingKey) {
+    log.warn(
+      `TOFU: refusing to change pinned signing key for member '${member.instanceId}' — ignoring new key`,
+    );
+  }
+  return false;
+}
+
+// ── Vote-cast verification & relay acceptance ────────────────────────────────
+
+/** Resolve the pinned signing public key for a voter within a network. */
+function voterPublicKey(net: NetworkConfig, voterInstanceId: string): string | undefined {
+  let selfId: string | undefined;
+  try { selfId = getConfig().instanceId; } catch { selfId = undefined; }
+  if (voterInstanceId === selfId) return getSigningPublicKey();
+  return net.members.find(m => m.instanceId === voterInstanceId)?.signingPublicKey;
+}
+
+/** True if the cast carries a valid signature from its claimed voter. */
+export function isVoteCastSignatureValid(net: NetworkConfig, round: VoteRound, cast: VoteCast): boolean {
+  if (!cast.sig) return false;
+  const pub = voterPublicKey(net, cast.instanceId);
+  if (!pub) return false;
+  return verifyMessage(pub, voteCastMessage({
+    networkId: net.id,
+    roundId: round.roundId,
+    subjectInstanceId: round.subjectInstanceId,
+    instanceId: cast.instanceId,
+    vote: cast.vote,
+  }), cast.sig);
+}
+
+/**
+ * Decide whether to accept a vote cast that arrived from `reportingInstanceId`
+ * (the authenticated peer that reported it — the sync peer we pulled from, or
+ * the caller of the vote-relay endpoint).
+ *
+ *  - A cast with a valid signature is accepted from ANY reporter — this is what
+ *    makes multi-hop relay safe (deep braintree trees).
+ *  - In strict mode (`net.requireSignedVotes`), an unsigned or invalid cast is
+ *    rejected outright.
+ *  - Otherwise (compatibility mode, the default), an unsigned cast is accepted
+ *    only when reported directly by its own voter — never relayed on behalf of
+ *    another instance. This is the pre-signing forgery guard, preserved so that
+ *    signing rolls out without breaking not-yet-upgraded peers.
+ */
+export function acceptVoteCast(
+  net: NetworkConfig,
+  round: VoteRound,
+  cast: VoteCast,
+  reportingInstanceId: string | undefined,
+): { accept: boolean; reason?: string } {
+  if (isVoteCastSignatureValid(net, round, cast)) return { accept: true };
+  if (net.requireSignedVotes) {
+    return { accept: false, reason: 'unsigned or invalid signature (network requires signed votes)' };
+  }
+  if (reportingInstanceId && cast.instanceId === reportingInstanceId) return { accept: true };
+  return { accept: false, reason: 'unsigned vote relayed on behalf of another instance' };
+}

--- a/testing/standalone/vote-signing.test.js
+++ b/testing/standalone/vote-signing.test.js
@@ -1,0 +1,157 @@
+/**
+ * Unit tests: governance vote-cast signing & relay acceptance (util/signing.ts)
+ *
+ * Pure in-process crypto — no MongoDB, no Docker, no config loaded. Run with:
+ *   node --test testing/standalone/vote-signing.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  generateInstanceKeypair,
+  voteCastMessage,
+  signMessage,
+  verifyMessage,
+  isVoteCastSignatureValid,
+  acceptVoteCast,
+} from '../../server/dist/util/signing.js';
+
+const NET_ID = 'net-1';
+const ROUND = { roundId: 'round-1', subjectInstanceId: 'subject-X' };
+
+const A = generateInstanceKeypair();
+const B = generateInstanceKeypair();
+
+function signedCast(kp, instanceId, vote, over = {}) {
+  const msg = voteCastMessage({
+    networkId: over.networkId ?? NET_ID,
+    roundId: over.roundId ?? ROUND.roundId,
+    subjectInstanceId: over.subjectInstanceId ?? ROUND.subjectInstanceId,
+    instanceId,
+    vote: over.voteInSig ?? vote,
+  });
+  return { instanceId, vote, castAt: '2026-07-10T00:00:00.000Z', sig: signMessage(kp.privateKeyPem, msg) };
+}
+
+function net(extra = {}) {
+  return {
+    id: NET_ID,
+    members: [
+      { instanceId: 'A', signingPublicKey: A.publicKeyPem },
+      { instanceId: 'B', signingPublicKey: B.publicKeyPem },
+      { instanceId: 'C' }, // no key pinned yet
+    ],
+    ...extra,
+  };
+}
+
+describe('sign / verify primitives', () => {
+  it('round-trips a signature', () => {
+    const msg = voteCastMessage({ networkId: NET_ID, roundId: 'r', subjectInstanceId: 's', instanceId: 'A', vote: 'yes' });
+    const sig = signMessage(A.privateKeyPem, msg);
+    assert.ok(sig.length > 0);
+    assert.equal(verifyMessage(A.publicKeyPem, msg, sig), true);
+  });
+
+  it('fails on a tampered message', () => {
+    const sig = signMessage(A.privateKeyPem, 'hello');
+    assert.equal(verifyMessage(A.publicKeyPem, 'hello!', sig), false);
+  });
+
+  it('fails against the wrong key', () => {
+    const msg = 'x';
+    const sig = signMessage(A.privateKeyPem, msg);
+    assert.equal(verifyMessage(B.publicKeyPem, msg, sig), false);
+  });
+
+  it('fails on garbage signature / empty inputs', () => {
+    assert.equal(verifyMessage(A.publicKeyPem, 'x', 'not-base64-sig'), false);
+    assert.equal(verifyMessage('', 'x', 'AAAA'), false);
+    assert.equal(verifyMessage(A.publicKeyPem, 'x', ''), false);
+  });
+
+  it('binds every field — changing any changes the message', () => {
+    const base = { networkId: 'n', roundId: 'r', subjectInstanceId: 's', instanceId: 'i', vote: 'yes' };
+    const m = voteCastMessage(base);
+    for (const k of Object.keys(base)) {
+      assert.notEqual(voteCastMessage({ ...base, [k]: base[k] + 'X' }), m, `field ${k} must be bound`);
+    }
+  });
+});
+
+describe('isVoteCastSignatureValid', () => {
+  it('accepts a correctly signed cast against the pinned key', () => {
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, signedCast(A, 'A', 'yes')), true);
+  });
+  it('rejects when the vote value was tampered after signing', () => {
+    const c = signedCast(A, 'A', 'yes');
+    c.vote = 'veto'; // signature was over "yes"
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, c), false);
+  });
+  it('rejects a signature bound to a different round', () => {
+    const c = signedCast(A, 'A', 'yes', { roundId: 'other-round' });
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, c), false);
+  });
+  it('rejects a signature bound to a different network', () => {
+    const c = signedCast(A, 'A', 'yes', { networkId: 'other-net' });
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, c), false);
+  });
+  it('rejects when signer key does not match claimed voter (A signs, claims to be B)', () => {
+    const c = signedCast(A, 'B', 'yes'); // signed with A's key, instanceId=B → verified against B's key
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, c), false);
+  });
+  it('rejects when no key is pinned for the voter', () => {
+    const c = signedCast(A, 'C', 'yes'); // C has no pinned key
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, c), false);
+  });
+  it('rejects an unsigned cast', () => {
+    assert.equal(isVoteCastSignatureValid(net(), ROUND, { instanceId: 'A', vote: 'yes', castAt: 'x' }), false);
+  });
+});
+
+describe('acceptVoteCast — compatibility mode (default)', () => {
+  const n = net();
+  it('accepts a valid signed cast relayed by ANY peer (relay-safe)', () => {
+    const c = signedCast(A, 'A', 'yes');
+    assert.equal(acceptVoteCast(n, ROUND, c, 'B').accept, true, 'relayed by B');
+    assert.equal(acceptVoteCast(n, ROUND, c, 'someone-else').accept, true);
+  });
+  it('accepts an unsigned cast reported directly by its voter', () => {
+    const c = { instanceId: 'A', vote: 'yes', castAt: 'x' };
+    assert.equal(acceptVoteCast(n, ROUND, c, 'A').accept, true);
+  });
+  it('rejects an unsigned cast relayed on behalf of another instance (forgery)', () => {
+    const c = { instanceId: 'A', vote: 'yes', castAt: 'x' };
+    const d = acceptVoteCast(n, ROUND, c, 'B');
+    assert.equal(d.accept, false);
+    assert.match(d.reason, /unsigned vote relayed/);
+  });
+  it('rejects an invalid signature relayed by another instance', () => {
+    const c = signedCast(A, 'A', 'yes');
+    c.vote = 'veto'; // invalidates signature
+    assert.equal(acceptVoteCast(n, ROUND, c, 'B').accept, false);
+  });
+  it('accepts an invalid-signature cast reported by its own voter (falls back to own-cast)', () => {
+    const c = signedCast(A, 'A', 'yes');
+    c.sig = 'garbage';
+    assert.equal(acceptVoteCast(n, ROUND, c, 'A').accept, true);
+  });
+});
+
+describe('acceptVoteCast — strict mode (requireSignedVotes)', () => {
+  const n = net({ requireSignedVotes: true });
+  it('accepts a valid signed cast from any reporter', () => {
+    assert.equal(acceptVoteCast(n, ROUND, signedCast(A, 'A', 'yes'), 'B').accept, true);
+  });
+  it('rejects an unsigned cast even from its own voter', () => {
+    const d = acceptVoteCast(n, ROUND, { instanceId: 'A', vote: 'yes', castAt: 'x' }, 'A');
+    assert.equal(d.accept, false);
+    assert.match(d.reason, /requires signed votes/);
+  });
+  it('rejects an invalid signature even from its own voter', () => {
+    const c = signedCast(A, 'A', 'yes');
+    c.sig = 'garbage';
+    assert.equal(acceptVoteCast(n, ROUND, c, 'A').accept, false);
+  });
+});

--- a/testing/sync/README.md
+++ b/testing/sync/README.md
@@ -36,6 +36,9 @@
    node --test testing/sync/leave-removal.test.js
    node --test testing/sync/merkle.test.js
    node --test testing/sync/vote-propagation.test.js
+   node --test testing/sync/vote-forgery.test.js
+   node --test testing/sync/vote-signing.test.js
+   node --test testing/sync/tombstone-forgery.test.js
    ```
    Or run all:
    ```
@@ -105,6 +108,19 @@
 - After A triggers sync with B, A merges B's vote casts into the shared round
 - A round concludes locally once all remote voters have cast yes (unanimous types) or threshold is met
 
+### Tombstone forgery (a ↔ b, red-team)
+- A authors a memory; malicious B, using its own bound peer token, POSTs a tombstone forged as instance A to delete it
+- A must refuse the deletion (issuer ≠ delivering peer), so the memory survives; a trusted admin tombstone still deletes — regression guard for the forged-tombstone-deletion fix
+
+### Vote forgery (a ↔ b, red-team)
+- A malicious peer B serves a fabricated `remove` round carrying a `yes` vote forged on behalf of A
+- After A pulls from B, A must ignore the forged cast (a peer may only report its own vote), so the round does not conclude and B is not ejected — regression guard for the gossip vote-forgery fix
+
+### Vote signing (a ↔ b)
+- A vote cast created via the API carries an Ed25519 signature, and that signature survives propagation to a peer intact
+- Peers pin each other's signing public keys via member gossip (trust-on-first-use)
+- A validly-signed cast from a third instance is accepted even when relayed by a different peer (safe multi-hop relay); a tampered relayed cast is rejected
+
 ### Conflict
 - Write the same memory ID on A and B simultaneously (requires manual seq injection)
 - Sync A→B; verify fork exists on B
@@ -170,6 +186,9 @@ testing/sync/
   leave-removal.test.js
   merkle.test.js
   vote-propagation.test.js
+  vote-forgery.test.js
+  vote-signing.test.js
+  tombstone-forgery.test.js
   configs/
     a/                           — populated by setup.js
     b/

--- a/testing/sync/pubsub-topology.test.js
+++ b/testing/sync/pubsub-topology.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -21,9 +22,17 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
 
+/** Read a container's real instanceId (a uuid) from its config. */
+function getInstanceId(container) {
+  return execSync(
+    `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
+  ).toString().trim();
+}
+
 let tokenA, tokenB;
 let networkId;
 let testSpaceId;
+let instanceIdA;
 
 describe('Pub/Sub topology (A -> B subscriber)', () => {
   before(async () => {
@@ -45,8 +54,12 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     assert.equal(r.status, 201, `Create pubsub network: ${JSON.stringify(r.body)}`);
     networkId = r.body.id;
 
-    // Create a peer token on B for A to use when pushing
-    const bPeer = await postRetry429(INSTANCES.b, tokenB, '/api/tokens', { name: 'pubsub-peer-a' });
+    // Create a peer token on B for A to use when pushing. Bind it to A's real
+    // instanceId (peerInstanceId) so it represents a production peer token — the
+    // subscriber authorises publisher tombstones by matching this identity against
+    // the tombstone issuer.
+    instanceIdA = getInstanceId('ythril-a');
+    const bPeer = await postRetry429(INSTANCES.b, tokenB, '/api/tokens', { name: 'pubsub-peer-a', peerInstanceId: instanceIdA });
     assert.equal(bPeer.status, 201, `Create peer token on B: ${JSON.stringify(bPeer.body)}`);
 
     const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {

--- a/testing/sync/tombstone-forgery.test.js
+++ b/testing/sync/tombstone-forgery.test.js
@@ -1,0 +1,116 @@
+/**
+ * Red-team integration test: forged-tombstone cross-instance data deletion.
+ *
+ * Threat: a member forges a tombstone whose `instanceId` is set to a VICTIM
+ * instance and pushes it to a peer. Before the fix, `applyRemoteTombstone`
+ * authorised the delete purely on `localDoc.author.instanceId === tombstone.instanceId`
+ * — both attacker-controlled — so the forger could delete the victim's authored
+ * memories/entities/edges/chrono across the network.
+ *
+ * The fix binds the deletion to the authenticated peer: a tombstone may delete a
+ * document only when its issuer matches the delivering peer's identity
+ * (peerInstanceId) or the caller is a trusted local/admin token.
+ *
+ * Scenario (A <-> B, closed): A authors a memory. Malicious B, using its OWN
+ * bound peer token, POSTs a tombstone forged as instance A to delete A's memory.
+ * A must refuse the deletion. A control shows a trusted (admin) tombstone still
+ * deletes, so the endpoint is not simply broken.
+ *
+ * Run:  node --test testing/sync/tombstone-forgery.test.js
+ * Pre-requisite: docker compose -f docker-compose.test.yml up && node testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del, delWithBody } from './helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, 'configs');
+
+let tokenA, tokenB, instanceIdA, instanceIdB, peerTokenForB, networkId, testSpaceId;
+
+function getInstanceId(c) {
+  return execSync(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
+}
+
+describe('Forged tombstone cross-instance deletion is refused', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    tokenB = fs.readFileSync(path.join(CONFIGS, 'b', 'token.txt'), 'utf8').trim();
+    instanceIdA = getInstanceId('ythril-a');
+    instanceIdB = getInstanceId('ythril-b');
+
+    testSpaceId = `tomb-forgery-${Date.now()}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: testSpaceId, label: 'Tombstone Forgery Test Space' });
+
+    // A closed network on A with B as a member, holding a peer token BOUND to B's
+    // real instanceId — exactly what a production invite handshake issues.
+    const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+      label: `Tomb Forgery ${Date.now()}`, type: 'closed', spaces: [testSpaceId], votingDeadlineHours: 1,
+    });
+    assert.equal(netR.status, 201, JSON.stringify(netR.body));
+    networkId = netR.body.id;
+
+    const bTok = await post(INSTANCES.a, tokenA, '/api/tokens', { name: `tf-peer-b-${Date.now()}`, peerInstanceId: instanceIdB });
+    assert.equal(bTok.status, 201, JSON.stringify(bTok.body));
+    peerTokenForB = bTok.body.plaintext;
+
+    const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+      instanceId: instanceIdB, label: 'Instance B', url: 'http://ythril-b:3200', token: peerTokenForB, direction: 'both',
+    });
+    if (addB.status === 202) await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${addB.body.roundId}`, { vote: 'yes' });
+  });
+
+  after(async () => {
+    if (networkId) await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    if (testSpaceId) await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+  });
+
+  it('B cannot delete A-authored content by forging a tombstone as A', async () => {
+    // A authors a memory (author.instanceId = A).
+    const w = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+      fact: 'A-authored memory that B must not be able to delete', tags: ['victim'],
+    });
+    assert.equal(w.status, 201, JSON.stringify(w.body));
+    const victimId = w.body._id ?? w.body.id;
+
+    // Malicious B pushes a tombstone FORGED as instance A, authenticated with B's
+    // own bound peer token (peerInstanceId = B).
+    const forged = await post(INSTANCES.a, peerTokenForB, `/api/sync/tombstones?spaceId=${testSpaceId}&networkId=${networkId}`, {
+      tombstones: [{
+        _id: victimId, type: 'memory', spaceId: testSpaceId,
+        deletedAt: new Date().toISOString(), instanceId: instanceIdA, seq: Date.now() + 1_000_000,
+      }],
+    });
+    // The endpoint accepts the tombstone document (records it) but must NOT delete.
+    assert.equal(forged.status, 200, JSON.stringify(forged.body));
+
+    // The victim memory must still exist.
+    const check = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${victimId}`);
+    assert.equal(check.status, 200, 'VULNERABILITY: forged tombstone deleted A-authored content');
+  });
+
+  it('a trusted (admin) tombstone for the same author still deletes — endpoint is not simply broken', async () => {
+    const w = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+      fact: 'A-authored memory deleted via a trusted admin tombstone', tags: ['control'],
+    });
+    assert.equal(w.status, 201, JSON.stringify(w.body));
+    const id = w.body._id ?? w.body.id;
+
+    // A's admin token has no peerInstanceId → trusted relay → deletion authorised.
+    const t = await post(INSTANCES.a, tokenA, `/api/sync/tombstones?spaceId=${testSpaceId}&networkId=${networkId}`, {
+      tombstones: [{
+        _id: id, type: 'memory', spaceId: testSpaceId,
+        deletedAt: new Date().toISOString(), instanceId: instanceIdA, seq: Date.now() + 2_000_000,
+      }],
+    });
+    assert.equal(t.status, 200, JSON.stringify(t.body));
+
+    const check = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${id}`);
+    assert.equal(check.status, 404, 'trusted admin tombstone should have deleted the memory');
+  });
+});

--- a/testing/sync/vote-forgery.test.js
+++ b/testing/sync/vote-forgery.test.js
@@ -1,0 +1,185 @@
+/**
+ * Red-team integration test: vote forgery via the gossip pull path.
+ *
+ * Threat: a single malicious network member serves a fabricated vote round via
+ * GET /api/sync/networks/:id/votes, pre-stuffed with `yes` casts forged on behalf
+ * of OTHER members who never voted. Before the fix, the victim merged those
+ * forged casts on pull and `concludeRoundIfReady` would conclude the round —
+ * ejecting members / deleting spaces without real quorum.
+ *
+ * The fix (server/src/sync/engine.ts) accepts only a peer's OWN vote during the
+ * pull-merge (`peerCast.instanceId === member.instanceId`), so a forged cast
+ * attributed to another instance is ignored and the round never concludes.
+ *
+ * Scenario: closed network with members A and B. B (malicious) injects a
+ * `remove` round for subject B, carrying a forged `yes` vote attributed to A.
+ * A pulls from B. A must NOT accept the forged A-vote, so the round must not
+ * conclude and B must remain in A's member list.
+ *
+ * Run:  node --test testing/sync/vote-forgery.test.js
+ * Pre-requisite: docker compose -f docker-compose.test.yml up && node testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, del, delWithBody, triggerSync, waitFor } from './helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, 'configs');
+
+let tokenA, tokenB;
+let instanceIdA, instanceIdB;
+let peerTokenForA, peerTokenForB;
+let networkId, testSpaceId;
+
+function getInstanceId(container) {
+  return execSync(
+    `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
+  ).toString().trim();
+}
+
+function injectPeerToken(container, instanceId, token) {
+  const script = [
+    `const fs=require('fs');`,
+    `const p='/config/secrets.json';`,
+    `const s=JSON.parse(fs.readFileSync(p,'utf8'));`,
+    `s.peerTokens=s.peerTokens||{};`,
+    `s.peerTokens['${instanceId}']='${token}';`,
+    `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
+    `process.stdout.write('ok');`,
+  ].join('');
+  execSync(`docker exec ${container} node -e "${script}"`);
+}
+
+function readContainerConfig(container) {
+  const out = execSync(
+    `docker exec ${container} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
+  ).toString();
+  return JSON.parse(out);
+}
+
+/** Inject a fabricated vote round into a container's network config. */
+function injectRound(container, netId, round) {
+  const payload = Buffer.from(JSON.stringify(round)).toString('base64');
+  const script = [
+    `const fs=require('fs');`,
+    `const p='/config/config.json';`,
+    `const c=JSON.parse(fs.readFileSync(p,'utf8'));`,
+    `const n=c.networks.find(x=>x.id==='${netId}');`,
+    `n.pendingRounds=n.pendingRounds||[];`,
+    `n.pendingRounds.push(JSON.parse(Buffer.from('${payload}','base64').toString('utf8')));`,
+    `fs.writeFileSync(p,JSON.stringify(c,null,2),{mode:0o600});`,
+    `process.stdout.write('ok');`,
+  ].join('');
+  execSync(`docker exec ${container} node -e "${script}"`);
+}
+
+describe('Vote forgery via gossip pull is rejected', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    tokenB = fs.readFileSync(path.join(CONFIGS, 'b', 'token.txt'), 'utf8').trim();
+    instanceIdA = getInstanceId('ythril-a');
+    instanceIdB = getInstanceId('ythril-b');
+
+    testSpaceId = `vote-forgery-${Date.now()}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: testSpaceId, label: 'Vote Forgery Test Space' });
+    await post(INSTANCES.b, tokenB, '/api/spaces', { id: testSpaceId, label: 'Vote Forgery Test Space' });
+
+    const ptForA = await post(INSTANCES.b, tokenB, '/api/tokens', { name: `vf-peer-a-${Date.now()}` });
+    peerTokenForA = ptForA.body.plaintext;
+    const ptForB = await post(INSTANCES.a, tokenA, '/api/tokens', { name: `vf-peer-b-${Date.now()}` });
+    peerTokenForB = ptForB.body.plaintext;
+
+    const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+      label: `Vote Forgery ${Date.now()}`,
+      type: 'closed',
+      spaces: [testSpaceId],
+      votingDeadlineHours: 1,
+    });
+    assert.equal(netR.status, 201, `Create network: ${JSON.stringify(netR.body)}`);
+    networkId = netR.body.id;
+
+    const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+      instanceId: instanceIdB, label: 'Instance B', url: 'http://ythril-b:3200', token: peerTokenForA, direction: 'both',
+    });
+    if (addB.status === 202) {
+      await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${addB.body.roundId}`, { vote: 'yes' });
+    }
+
+    const netOnB = await post(INSTANCES.b, tokenB, '/api/networks', {
+      id: networkId, label: 'Vote Forgery', type: 'closed', spaces: [testSpaceId], votingDeadlineHours: 1,
+    });
+    assert.ok(netOnB.status === 201 || netOnB.status === 409, `Create net on B: ${JSON.stringify(netOnB.body)}`);
+    const addAonB = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/members`, {
+      instanceId: instanceIdA, label: 'Instance A', url: 'http://ythril-a:3200', token: peerTokenForB, direction: 'both',
+    });
+    if (addAonB.status === 202) {
+      await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/votes/${addAonB.body.roundId}`, { vote: 'yes' });
+    }
+
+    injectPeerToken('ythril-a', instanceIdB, peerTokenForA);
+    injectPeerToken('ythril-b', instanceIdA, peerTokenForB);
+    await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+    await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
+  });
+
+  after(async () => {
+    if (networkId) {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+      await del(INSTANCES.b, tokenB, `/api/networks/${networkId}`).catch(() => {});
+      await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+      await delWithBody(INSTANCES.b, tokenB, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+    }
+  });
+
+  it('A ignores a forged yes-vote (attributed to A) served by malicious peer B', async () => {
+    // Sanity: B is currently a member on A.
+    const before = readContainerConfig('ythril-a').networks.find(n => n.id === networkId);
+    assert.ok(before.members.some(m => m.instanceId === instanceIdB), 'Precondition: B is a member on A');
+
+    // Malicious B injects a remove round (subject = B) carrying a FORGED yes vote
+    // attributed to A. If A trusts relayed casts, this concludes and A removes B.
+    const forgedRoundId = `forged-${Date.now()}`;
+    injectRound('ythril-b', networkId, {
+      roundId: forgedRoundId,
+      type: 'remove',
+      subjectInstanceId: instanceIdB,
+      subjectLabel: 'Instance B',
+      subjectUrl: 'http://ythril-b:3200',
+      deadline: new Date(Date.now() + 3_600_000).toISOString(),
+      openedAt: new Date().toISOString(),
+      votes: [{ instanceId: instanceIdA, vote: 'yes', castAt: new Date().toISOString() }],
+    });
+    await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
+
+    // A pulls from B (gossip). Repeat a couple of times to be sure the round was seen.
+    await triggerSync(INSTANCES.a, tokenA, networkId);
+    await triggerSync(INSTANCES.a, tokenA, networkId);
+
+    // Give A a moment to persist, then assert the forgery had no effect.
+    await waitFor(async () => {
+      const netA = readContainerConfig('ythril-a').networks.find(n => n.id === networkId);
+      // B must still be a member (round did not conclude and remove it).
+      return !!netA && netA.members.some(m => m.instanceId === instanceIdB);
+    }, 8_000).catch(() => {});
+
+    const netA = readContainerConfig('ythril-a').networks.find(n => n.id === networkId);
+    assert.ok(
+      netA.members.some(m => m.instanceId === instanceIdB),
+      'VULNERABILITY: forged vote concluded a remove round — B was ejected from A',
+    );
+
+    const adopted = netA.pendingRounds?.find(r => r.roundId === forgedRoundId);
+    if (adopted) {
+      assert.ok(
+        !adopted.votes?.some(v => v.instanceId === instanceIdA),
+        'VULNERABILITY: A adopted a forged vote attributed to itself',
+      );
+      assert.ok(!adopted.concluded, 'VULNERABILITY: forged round concluded on A');
+    }
+  });
+});

--- a/testing/sync/vote-signing.test.js
+++ b/testing/sync/vote-signing.test.js
@@ -1,0 +1,195 @@
+/**
+ * Integration tests: signed governance votes + safe relay.
+ *
+ * Proves the end-to-end wiring of the vote-signing feature:
+ *  1. A vote cast created via the API carries an Ed25519 signature, and that
+ *     signature survives propagation to a peer unchanged.
+ *  2. Signing public keys distribute between peers via member gossip (TOFU pin).
+ *  3. A VALID signed cast from a third instance (C) is accepted even when relayed
+ *     by a different peer (B) — the multi-hop relay that plain own-cast-only
+ *     rejected. A TAMPERED relayed cast is rejected.
+ *
+ * Run:  node --test testing/sync/vote-signing.test.js
+ * Pre-requisite: docker compose -f docker-compose.test.yml up && node testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, del, delWithBody, triggerSync, waitFor } from './helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, 'configs');
+
+let tokenA, tokenB, instanceIdA, instanceIdB, peerTokenForA, peerTokenForB, networkId, testSpaceId;
+
+function getInstanceId(c) {
+  return execSync(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
+}
+function injectPeerToken(c, id, tok) {
+  const s = `const fs=require('fs');const p='/config/secrets.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));s.peerTokens=s.peerTokens||{};s.peerTokens['${id}']='${tok}';fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});process.stdout.write('ok');`;
+  execSync(`docker exec ${c} node -e "${s}"`);
+}
+function readConfig(c) {
+  return JSON.parse(execSync(`docker exec ${c} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`).toString());
+}
+/** Mutate a container's config.json for a network via a base64-encoded JS patch fn body. */
+function patchNetwork(c, netId, patchB64) {
+  const s = `const fs=require('fs');const p='/config/config.json';const cfg=JSON.parse(fs.readFileSync(p,'utf8'));const n=cfg.networks.find(x=>x.id==='${netId}');const patch=new Function('n','cfg',Buffer.from('${patchB64}','base64').toString('utf8'));patch(n,cfg);fs.writeFileSync(p,JSON.stringify(cfg,null,2),{mode:0o600});process.stdout.write('ok');`;
+  execSync(`docker exec ${c} node -e "${s}"`);
+}
+function patch(c, netId, fnBody) {
+  patchNetwork(c, netId, Buffer.from(fnBody, 'utf8').toString('base64'));
+}
+
+function voteMsg({ networkId, roundId, subjectInstanceId, instanceId, vote }) {
+  return ['ythril-vote:v1', networkId, roundId, subjectInstanceId, instanceId, vote].join('|');
+}
+function ed25519() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  return {
+    pub: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    priv: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+  };
+}
+function signCast(priv, fields) {
+  return crypto.sign(null, Buffer.from(voteMsg(fields), 'utf8'), crypto.createPrivateKey(priv)).toString('base64');
+}
+
+describe('Signed governance votes and safe relay', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    tokenB = fs.readFileSync(path.join(CONFIGS, 'b', 'token.txt'), 'utf8').trim();
+    instanceIdA = getInstanceId('ythril-a');
+    instanceIdB = getInstanceId('ythril-b');
+
+    testSpaceId = `vote-signing-${Date.now()}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: testSpaceId, label: 'Vote Signing Test Space' });
+    await post(INSTANCES.b, tokenB, '/api/spaces', { id: testSpaceId, label: 'Vote Signing Test Space' });
+
+    peerTokenForA = (await post(INSTANCES.b, tokenB, '/api/tokens', { name: `vs-a-${Date.now()}` })).body.plaintext;
+    peerTokenForB = (await post(INSTANCES.a, tokenA, '/api/tokens', { name: `vs-b-${Date.now()}` })).body.plaintext;
+
+    const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+      label: `Vote Signing ${Date.now()}`, type: 'closed', spaces: [testSpaceId], votingDeadlineHours: 1,
+    });
+    assert.equal(netR.status, 201, JSON.stringify(netR.body));
+    networkId = netR.body.id;
+
+    const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+      instanceId: instanceIdB, label: 'Instance B', url: 'http://ythril-b:3200', token: peerTokenForA, direction: 'both',
+    });
+    if (addB.status === 202) await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${addB.body.roundId}`, { vote: 'yes' });
+
+    const netOnB = await post(INSTANCES.b, tokenB, '/api/networks', {
+      id: networkId, label: 'Vote Signing', type: 'closed', spaces: [testSpaceId], votingDeadlineHours: 1,
+    });
+    assert.ok(netOnB.status === 201 || netOnB.status === 409, JSON.stringify(netOnB.body));
+    const addAonB = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/members`, {
+      instanceId: instanceIdA, label: 'Instance A', url: 'http://ythril-a:3200', token: peerTokenForB, direction: 'both',
+    });
+    if (addAonB.status === 202) await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/votes/${addAonB.body.roundId}`, { vote: 'yes' });
+
+    injectPeerToken('ythril-a', instanceIdB, peerTokenForA);
+    injectPeerToken('ythril-b', instanceIdA, peerTokenForB);
+    await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+    await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
+  });
+
+  after(async () => {
+    if (networkId) {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+      await del(INSTANCES.b, tokenB, `/api/networks/${networkId}`).catch(() => {});
+      await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+      await delWithBody(INSTANCES.b, tokenB, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+    }
+  });
+
+  it('A vote cast is signed, and the signature propagates to B intact', async () => {
+    // Open a join round on A and cast A's vote (now signed).
+    const cand = `sig-cand-${Date.now()}`;
+    const open = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+      instanceId: cand, label: 'Sig Candidate', url: 'http://vote-sign.internal:3200', token: `ythril_sig_${cand}`, direction: 'both',
+    });
+    assert.equal(open.status, 202, JSON.stringify(open.body));
+    const roundId = open.body.roundId;
+    const vr = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${roundId}`, { vote: 'yes' });
+    assert.ok([200, 201].includes(vr.status), JSON.stringify(vr.body));
+
+    // A's own cast must carry a signature.
+    const roundOnA = readConfig('ythril-a').networks.find(n => n.id === networkId).pendingRounds.find(r => r.roundId === roundId);
+    const aCast = roundOnA.votes.find(v => v.instanceId === instanceIdA);
+    assert.ok(aCast?.sig, 'A\'s vote cast must be signed');
+
+    // Propagate to B and confirm the signature survived unchanged.
+    await triggerSync(INSTANCES.b, tokenB, networkId);
+    await waitFor(async () => {
+      const rb = readConfig('ythril-b').networks.find(n => n.id === networkId)?.pendingRounds.find(r => r.roundId === roundId);
+      const bCast = rb?.votes?.find(v => v.instanceId === instanceIdA);
+      return bCast?.sig === aCast.sig;
+    }, 10_000);
+  });
+
+  it('peers pin each other\'s signing public keys via gossip', async () => {
+    await triggerSync(INSTANCES.a, tokenA, networkId);
+    await triggerSync(INSTANCES.b, tokenB, networkId);
+    await waitFor(async () => {
+      const aSeesB = readConfig('ythril-a').networks.find(n => n.id === networkId)?.members.find(m => m.instanceId === instanceIdB)?.signingPublicKey;
+      const bSeesA = readConfig('ythril-b').networks.find(n => n.id === networkId)?.members.find(m => m.instanceId === instanceIdA)?.signingPublicKey;
+      return !!aSeesB && !!bSeesA;
+    }, 12_000);
+  });
+
+  it('a VALID signed cast from a third instance is accepted when relayed by B; a tampered one is rejected', async () => {
+    // Virtual third instance C with its own keypair, pinned as a member on A.
+    const C = ed25519();
+    const instanceIdC = `virt-c-${Date.now()}`;
+    patch('ythril-a', networkId, `n.members.push({instanceId:${JSON.stringify(instanceIdC)},label:'Virtual C',url:'http://virtual-c.internal:3200',tokenHash:'x',direction:'both',signingPublicKey:${JSON.stringify(C.pub)}});`);
+    await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+
+    // Two rounds injected on B (which A will pull): one with a VALID C-signature,
+    // one where the vote value was tampered after signing. Subject is a ghost id so
+    // nothing is actually removed even if a round concluded.
+    const validRid = `relay-ok-${Date.now()}`;
+    const tamperRid = `relay-bad-${Date.now()}`;
+    const ghost = 'ghost-subject';
+    const validSig = signCast(C.priv, { networkId, roundId: validRid, subjectInstanceId: ghost, instanceId: instanceIdC, vote: 'yes' });
+    const tamperSig = signCast(C.priv, { networkId, roundId: tamperRid, subjectInstanceId: ghost, instanceId: instanceIdC, vote: 'yes' });
+    const deadline = new Date(Date.now() + 3_600_000).toISOString();
+    const mkRound = (rid, vote, sig) => ({
+      roundId: rid, type: 'remove', subjectInstanceId: ghost, subjectLabel: 'Ghost', subjectUrl: 'http://ghost.internal:3200',
+      deadline, openedAt: new Date().toISOString(),
+      votes: [{ instanceId: instanceIdC, vote, castAt: new Date().toISOString(), sig }],
+    });
+    patch('ythril-b', networkId, `n.pendingRounds=n.pendingRounds||[];n.pendingRounds.push(${JSON.stringify(mkRound(validRid, 'yes', validSig))});n.pendingRounds.push(${JSON.stringify(mkRound(tamperRid, 'veto', tamperSig))});`);
+    await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
+
+    // A pulls from B (relay).
+    await triggerSync(INSTANCES.a, tokenA, networkId);
+    await triggerSync(INSTANCES.a, tokenA, networkId);
+
+    await waitFor(async () => {
+      const nets = readConfig('ythril-a').networks.find(n => n.id === networkId);
+      const ok = nets?.pendingRounds?.find(r => r.roundId === validRid);
+      return ok?.votes?.some(v => v.instanceId === instanceIdC && v.vote === 'yes');
+    }, 12_000);
+
+    const netA = readConfig('ythril-a').networks.find(n => n.id === networkId);
+    const validRound = netA.pendingRounds.find(r => r.roundId === validRid);
+    assert.ok(
+      validRound?.votes?.some(v => v.instanceId === instanceIdC && v.sig === validSig),
+      'A must accept C\'s validly-signed cast relayed by B (safe multi-hop relay)',
+    );
+    const tamperRound = netA.pendingRounds.find(r => r.roundId === tamperRid);
+    if (tamperRound) {
+      assert.ok(
+        !tamperRound.votes?.some(v => v.instanceId === instanceIdC),
+        'A must reject a tampered (vote value != signed value) relayed cast',
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes three trust-model gaps in the peer-to-peer sync layer, all exploitable by an authenticated network member. Validated against the 4-instance Docker test stack (full sync suite) plus standalone unit tests.

## 1. Vote forgery via the gossip pull path
`sync/engine.ts`, `api/sync.ts`, `util/braintree.ts`

During a sync cycle a node pulls open vote rounds from each peer and merged the casts it received, **trusting the `instanceId`** on each. A single malicious member could serve a fabricated round pre-stuffed with forged `yes` votes attributed to every other member and drive a `remove` / `space_deletion` / braintree `join` to conclusion **without real quorum** — ejecting members or destroying a remote space.

- Pull-merge now accepts only a peer's **own** cast (or a validly-signed one, below).
- Braintree conclusion recomputes `requiredVoters` from **local topology** (anchored on the proposer) instead of trusting the adopted round, so the required-voter set cannot be shrunk to `[attacker]`.

## 2. Signed governance votes (new capability)
`util/signing.ts`

- Persistent **Ed25519** instance keypair (private → `secrets.json`, public → `config.json`), generated at setup/boot.
- Vote casts are signed over `network | round | subject | voter | vote`; the signature travels with the cast. Peers pin each other's public keys **trust-on-first-use** via member gossip.
- A signed cast verifies for **any** relayer, making multi-hop vote relay safe (restores deep braintree governance).
- Per-network `requireSignedVotes` enforces strict mode; default compatibility mode keeps existing networks working (unsigned own-casts still accepted, so signing rolls out without a flag day).

## 3. Forged-tombstone data deletion
`brain/tombstones.ts`

`applyRemoteTombstone` authorised deletes purely on the attacker-controlled `tombstone.instanceId`, letting a member forge a tombstone as a victim and delete the victim's authored memories/entities/edges/chrono across the network. Deletion is now bound to the authenticated peer (`peerInstanceId` / trusted admin); a third-party-relayed tombstone for another author is refused.

## Tests

- `testing/standalone/vote-signing.test.js` (20 unit cases)
- `testing/sync/{vote-forgery,vote-signing,tombstone-forgery}.test.js`
- The pubsub tombstone test now uses a production-style **bound** peer token (`peerInstanceId`), matching what the invite handshake issues.

## Notes

- Part of a security audit. A sibling PR (`security/ssrf-hardening`) covers the SSRF findings; the two touch overlapping doc files, so whichever merges second may need a trivial doc conflict resolution.
- Independent of the SSRF PR — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)