### PR TITLE
security: auth/authz hardening (MCP proxy scope, MFA gating, token-mint scope, OIDC fail-closed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **MCP proxy spaces no longer bypass member-space token scope** — an MCP call targeting a proxy space
+  checked the token only against the *proxy* space id, then fanned reads/writes out to the member
+  spaces with no further check. A token scoped solely to a proxy (especially a `proxyFor: ['*']`
+  wildcard) could therefore reach spaces it was never granted — the whole instance in the wildcard
+  case. The MCP dispatcher now requires the token to hold **every** member space (mirroring
+  `requireSpaceAuth` on the REST layer) before any proxy fan-out.
+
+- **MFA setup/disable now require a current TOTP code once MFA is enabled** — `POST /api/mfa/setup`
+  (rotate) and `DELETE /api/mfa` (disable) were gated only by `requireAdmin`, so a stolen admin PAT
+  could silently overwrite or remove the second factor it was meant to be protected by. Both now use
+  `requireAdminMfa`: first-time enrolment still needs no code (MFA is off), but rotating or disabling
+  an *enabled* factor requires a valid code. Break-glass recovery when the authenticator is lost is
+  removing `totpSecret` from `secrets.json` on the host.
+
+- **Token minting cannot escalate scope** — `POST /api/tokens` applied no relationship between the
+  new token's scope and the creating token's. A *space-restricted* admin token could mint an
+  `admin: true` token with no `spaces` (= all spaces) and escalate to unrestricted admin. A
+  space-restricted creator may now only mint tokens confined to a subset of its own spaces; an
+  unrestricted admin is unaffected.
+
+- **OIDC now fails closed for unmatched tokens (behaviour change)** — a JWT that matched neither the
+  `admin` nor the `readOnly` claim rule was granted `readOnly: undefined` (read-write) and
+  `spaces: undefined` (ALL spaces), so any principal able to obtain an audience-matching token from a
+  shared realm got full read-write access to every space. Such tokens are now accepted with
+  **read-only access to no spaces**; a configured-but-missing `spaces` claim likewise yields an empty
+  allow-list rather than all spaces. **Action required:** if you relied on the permissive default,
+  grant access explicitly via `claimMapping` rules (or set `requireMatch: true` to reject unmatched
+  tokens outright). Covered by `testing/standalone/oidc-claim-mapping.test.js` and
+  `testing/red-team-tests/auth-escalation.test.js`.
+
 - **SSRF guard hardened against alternate host encodings and DNS-based bypasses** — the outbound-URL
   validator (`util/ssrf.ts`) previously inspected only the literal hostname string, so a blocked
   address supplied in a non-standard encoding — decimal/hex/octal integer (`http://2130706433/`),

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -172,7 +172,7 @@ Covers: closed-network sync, braintree governance, democratic voting, pubsub top
 npm run test:redteam
 ```
 
-Attack simulations: auth bypass, path traversal, MongoDB injection ($options injection, operator whitelist), space boundary, oversized payload, invite replay, SSRF (IPv4/IPv6, alternate host encodings, network members), sequence injection, mass assignment, token brute-force, sync scope bypass, MCP security (token hygiene, input validation, operator injection), direction enforcement, space rename.
+Attack simulations: auth bypass, path traversal, MongoDB injection ($options injection, operator whitelist), space boundary, oversized payload, invite replay, SSRF (IPv4/IPv6, alternate host encodings, network members), sequence injection, mass assignment, token brute-force, sync scope bypass, MCP security (token hygiene, input validation, operator injection), auth escalation (MCP proxy member-space scope, MFA setup/disable gating, token-minting scope), direction enforcement, space rename.
 
 ### Run everything
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3577,6 +3577,11 @@ POST /api/mfa/setup
 
 Scan the `otpauth` URI as a QR code in any TOTP app.
 
+> When MFA is **already enabled**, `POST /api/mfa/setup` (rotating the secret) and `DELETE /api/mfa`
+> (disabling) require a current TOTP code in the `X-TOTP-Code` header — a stolen admin PAT alone
+> cannot replace or remove the second factor. First-time enrolment (MFA off) needs no code. If the
+> authenticator is lost, remove `totpSecret` from `secrets.json` on the host to recover.
+
 ---
 
 ### Verify OTP Code
@@ -5398,6 +5403,13 @@ Add an `oidc` block to `config.json`:
 Each rule has:
 - `claim` — dot-notation path inside the JWT payload (e.g. `"realm_access.roles"`).
 - `value` (optional) — the claim must equal this value, or be an array containing it. When omitted, the claim simply needs to be truthy.
+
+**Fail-closed defaults.** A validly-signed JWT that matches **neither** the `admin` nor the `readOnly`
+rule is accepted but granted **read-only access to no spaces** — grant access explicitly through the
+rules above. (Previously such a token received read-write access to *all* spaces.) When a `spaces`
+mapping is configured but the claim is missing or not a string array, the allow-list is empty (deny),
+never "all spaces". Set `requireMatch: true` in `claimMapping` to reject unmatched tokens outright
+with `401` instead of accepting them with no access.
 
 ### Bearer Token Dispatch
 

--- a/server/src/api/mfa.ts
+++ b/server/src/api/mfa.ts
@@ -3,10 +3,13 @@
  *
  * Route prefix: /api/mfa
  *
- * All routes require an admin PAT. Enroll/disable do NOT require an existing
- * TOTP code (bootstrap problem — you can't provide a code before you have the
- * secret, and you must be able to disable MFA if you lose your authenticator
- * via a deliberate admin API call).
+ * All routes require an admin PAT. When MFA is ALREADY enabled, `setup` (rotate)
+ * and `disable` additionally require a current TOTP code (via requireAdminMfa) —
+ * otherwise a stolen admin PAT could silently overwrite or remove the second
+ * factor it is meant to be protected by. When MFA is not yet enabled,
+ * requireAdminMfa is equivalent to requireAdmin (no code needed), so first-time
+ * enrolment works without a code. Break-glass recovery when the authenticator is
+ * lost is an operator action: remove `totpSecret` from secrets.json on disk.
  *
  * GET  /api/mfa/status          — { enabled: boolean }
  * POST /api/mfa/setup           — generate & store secret; returns { secret, otpauth }
@@ -15,7 +18,7 @@
  */
 
 import { Router } from 'express';
-import { requireAdmin } from '../auth/middleware.js';
+import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { enableMfa, disableMfa, isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { getConfig } from '../config/loader.js';
@@ -31,10 +34,11 @@ mfaRouter.get('/status', globalRateLimit, requireAdmin, (_req, res) => {
 });
 
 // POST /api/mfa/setup — generate and store a new TOTP secret.
-// Safe to call again (rotates the secret).  Must confirm with a valid code
-// from the new secret before the secret is considered active (handled client-
-// side: show QR, ask user to enter code, then hit /verify).
-mfaRouter.post('/setup', authRateLimit, requireAdmin, (_req, res) => {
+// Rotating an already-enabled secret requires a current TOTP code (requireAdminMfa),
+// so a stolen admin PAT cannot silently replace the second factor. Must confirm
+// with a valid code from the new secret before it is considered active (handled
+// client-side: show QR, ask user to enter code, then hit /verify).
+mfaRouter.post('/setup', authRateLimit, requireAdminMfa, (_req, res) => {
   const cfg = getConfig();
   const issuer = 'Ythril';
   const account = cfg.instanceLabel || 'brain';
@@ -58,11 +62,10 @@ mfaRouter.post('/verify', authRateLimit, requireAdmin, (req, res) => {
   res.json({ valid: ok });
 });
 
-// DELETE /api/mfa — disable MFA.  Does NOT require a TOTP code on purpose:
-// this is the emergency recovery path when an admin loses their authenticator.
-// Physical access to the config + a valid admin PAT is sufficient proof of
-// identity for the disable operation.
-mfaRouter.delete('/', authRateLimit, requireAdmin, (_req, res) => {
+// DELETE /api/mfa — disable MFA. Requires a current TOTP code (requireAdminMfa)
+// so a stolen admin PAT cannot turn the second factor off. If the authenticator
+// is lost, recover by removing `totpSecret` from secrets.json on the host.
+mfaRouter.delete('/', authRateLimit, requireAdminMfa, (_req, res) => {
   if (!isMfaEnabled()) {
     res.status(409).json({ error: 'MFA is not enabled' });
     return;

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -43,6 +43,28 @@ tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
     res.status(400).json({ error: 'A schemaLibrary token cannot have admin or space access' });
     return;
   }
+
+  // Privilege-escalation guard: a space-restricted creator (its token carries a
+  // `spaces` allow-list) may only mint tokens confined to a SUBSET of its own
+  // spaces. Without this, a token scoped to space A could mint an unrestricted
+  // token (no `spaces` = all spaces, `admin: true`) and defeat its own scoping.
+  // An unrestricted creator (no `spaces`) may mint any scope.
+  const creatorSpaces = req.authToken?.spaces;
+  if (creatorSpaces) {
+    if (schemaLibrary) {
+      // schemaLibrary tokens have no space access — always within any scope.
+    } else if (!spaces) {
+      res.status(403).json({ error: 'A space-restricted token cannot create an unrestricted (all-spaces) token' });
+      return;
+    } else {
+      const outside = spaces.filter(s => !creatorSpaces.includes(s));
+      if (outside.length > 0) {
+        res.status(403).json({ error: `Cannot grant access to space(s) outside your own scope: ${outside.join(', ')}` });
+        return;
+      }
+    }
+  }
+
   // schemaLibrary tokens are always read-only and have no space access
   const effectiveReadOnly = schemaLibrary ? true : (readOnly ?? false);
   const effectiveSpaces = schemaLibrary ? [] : spaces;

--- a/server/src/auth/oidc.ts
+++ b/server/src/auth/oidc.ts
@@ -15,7 +15,7 @@ import { createRemoteJWKSet, jwtVerify } from 'jose';
 import type { JWTPayload } from 'jose';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
-import type { OidcConfig, OidcClaimRule } from '../config/types.js';
+import type { OidcConfig, OidcClaimRule, OidcClaimMapping } from '../config/types.js';
 
 // ── OIDC URL validation ───────────────────────────────────────────────────
 // Unlike the full isSsrfSafeUrl check (designed for user-supplied peer URLs),
@@ -183,6 +183,50 @@ export function getOidcConfig(): OidcConfig | null {
   return cfg.oidc;
 }
 
+export interface OidcPermissions {
+  admin: boolean;
+  readOnly: boolean | undefined;
+  spaces: string[] | undefined;
+  /** True when the token matched the admin or readOnly claim rule. */
+  matched: boolean;
+}
+
+/**
+ * Map OIDC JWT claims to Ythril permissions — **fail closed**.
+ *
+ * A token that matches NEITHER the admin nor the readOnly rule receives
+ * read-only access to NO spaces. Previously such a token was granted
+ * `readOnly: undefined` (i.e. read-write) and `spaces: undefined` (i.e. ALL
+ * spaces), so any principal able to obtain an audience-matching JWT from a
+ * shared realm got full read-write access to every space. Access must now be
+ * granted explicitly via claim rules.
+ *
+ * When a `spaces` mapping is configured but the claim is missing or not an
+ * array, the allow-list is empty (deny) rather than undefined (all spaces).
+ */
+export function mapOidcClaims(payload: JWTPayload, mapping: OidcClaimMapping): OidcPermissions {
+  const admin = mapping.admin ? evaluateClaimRule(payload, mapping.admin) : false;
+  const readOnlyMatched = mapping.readOnly ? evaluateClaimRule(payload, mapping.readOnly) : false;
+  const matched = admin || readOnlyMatched;
+
+  let spaces: string[] | undefined;
+  if (mapping.spaces) {
+    const raw = resolveClaim(payload, mapping.spaces.claim);
+    spaces = Array.isArray(raw) ? raw.filter((s): s is string => typeof s === 'string') : [];
+  }
+
+  if (!matched) {
+    return { admin: false, readOnly: true, spaces: [], matched: false };
+  }
+
+  return {
+    admin,
+    readOnly: readOnlyMatched ? true : undefined,
+    spaces,
+    matched: true,
+  };
+}
+
 /**
  * Validate a JWT bearer token against the configured OIDC provider.
  *
@@ -204,28 +248,18 @@ export async function validateOidcJwt(bearer: string): Promise<OidcTokenRecord |
       audience,
     });
 
-    // ── Map claims → permissions ──────────────────────────────────────────
+    // ── Map claims → permissions (fail-closed) ────────────────────────────
     const mapping = oidcCfg.claimMapping ?? {};
-
-    const admin = mapping.admin ? evaluateClaimRule(payload, mapping.admin) : false;
-    const readOnly = mapping.readOnly ? evaluateClaimRule(payload, mapping.readOnly) : undefined;
+    const perms = mapOidcClaims(payload, mapping);
 
     // ── requireMatch guard ────────────────────────────────────────────────
     // When requireMatch is true, reject any token that matches neither the
     // admin nor the readOnly rule.  This prevents KC-authenticated users
     // who hold a valid audience-matched token (e.g. via SSO from a shared
     // realm) from accessing the instance without an explicit role assignment.
-    if (mapping.requireMatch && !admin && !readOnly) {
+    if (mapping.requireMatch && !perms.matched) {
       log.warn('OIDC JWT rejected: requireMatch is enabled and no claim rule matched');
       return null;
-    }
-
-    let spaces: string[] | undefined;
-    if (mapping.spaces) {
-      const raw = resolveClaim(payload, mapping.spaces.claim);
-      if (Array.isArray(raw)) {
-        spaces = raw.filter((s): s is string => typeof s === 'string');
-      }
     }
 
     // ── Derive display name ────────────────────────────────────────────────
@@ -244,9 +278,9 @@ export async function validateOidcJwt(bearer: string): Promise<OidcTokenRecord |
       createdAt,
       lastUsed: null,
       expiresAt,
-      admin,
-      readOnly: readOnly === true ? true : undefined,
-      spaces,
+      admin: perms.admin,
+      readOnly: perms.readOnly,
+      spaces: perms.spaces,
       source: 'oidc',
     };
   } catch (err) {

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -801,6 +801,19 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
       if (tokenSpaces && !tokenSpaces.includes(rawSpace)) {
         return { content: [{ type: 'text' as const, text: `Error: token does not have access to space '${rawSpace}'` }], isError: true };
       }
+      // Proxy fan-out scope check: a proxy space aggregates reads across (and
+      // routes writes to) its member spaces. The token must hold EVERY member
+      // space — mirroring requireSpaceAuth on the REST layer — otherwise a token
+      // scoped only to the proxy (especially a `proxyFor: ['*']` wildcard) could
+      // read/write member spaces it was never granted. For a non-proxy space
+      // resolveMemberSpaces returns [rawSpace], so this is a no-op there.
+      if (tokenSpaces) {
+        const members = resolveMemberSpaces(rawSpace);
+        const missing = members.filter(m => !tokenSpaces.includes(m));
+        if (missing.length > 0) {
+          return { content: [{ type: 'text' as const, text: `Error: token does not have access to member space(s) of '${rawSpace}': ${missing.join(', ')}` }], isError: true };
+        }
+      }
     }
     const callSpace = rawSpace;
 

--- a/testing/red-team-tests/auth-escalation.test.js
+++ b/testing/red-team-tests/auth-escalation.test.js
@@ -1,0 +1,172 @@
+/**
+ * Red-team tests: auth / authorization escalation guards.
+ *
+ * H1 — MCP proxy fan-out cannot exceed the token's member-space scope.
+ *      A token scoped only to a proxy space must NOT reach the proxy's member
+ *      spaces via MCP (a wildcard `proxyFor: ['*']` token would otherwise reach
+ *      the whole instance).
+ * H2 — MFA setup/disable cannot be performed with just an admin PAT once MFA is
+ *      enabled: rotating or removing the second factor requires a current TOTP
+ *      code (otherwise a stolen admin PAT neutralises MFA).
+ * H3 — A space-restricted admin token cannot mint an unrestricted (all-spaces)
+ *      token, nor a token scoped to spaces outside its own allow-list.
+ *
+ * Run: node --test testing/red-team-tests/auth-escalation.test.js
+ * Pre-requisite: the test stack is up (docker compose ... up) and tokens
+ * provisioned (testing/sync/setup.js). MFA must start disabled on instance A.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let adminToken;
+
+async function mcpCall(token, name, args) {
+  const r = await fetch(`${INSTANCES.a}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }),
+  });
+  return { status: r.status, text: await r.text() };
+}
+
+before(() => {
+  adminToken = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+});
+
+// ── H1 — MCP proxy fan-out scope ─────────────────────────────────────────────
+
+describe('H1 — MCP proxy space cannot exceed member-space token scope', () => {
+  const spaceA = `esc-a-${RUN}`;
+  const spaceB = `esc-b-${RUN}`;
+  const proxyId = `esc-proxy-${RUN}`;
+  let proxyOnlyToken, fullToken;
+  const tokenIds = [];
+
+  before(async () => {
+    await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceA, label: 'Esc A' });
+    await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceB, label: 'Esc B' });
+    const p = await post(INSTANCES.a, adminToken, '/api/spaces', { id: proxyId, label: 'Esc Proxy', proxyFor: [spaceA, spaceB] });
+    assert.equal(p.status, 201, `create proxy: ${JSON.stringify(p.body)}`);
+
+    const t1 = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `esc-proxy-only-${RUN}`, spaces: [proxyId] });
+    assert.equal(t1.status, 201, JSON.stringify(t1.body));
+    proxyOnlyToken = t1.body.plaintext; tokenIds.push(t1.body.token.id);
+
+    const t2 = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `esc-full-${RUN}`, spaces: [proxyId, spaceA, spaceB] });
+    assert.equal(t2.status, 201, JSON.stringify(t2.body));
+    fullToken = t2.body.plaintext; tokenIds.push(t2.body.token.id);
+  });
+
+  after(async () => {
+    for (const id of tokenIds) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+    for (const id of [proxyId, spaceA, spaceB]) await delWithBody(INSTANCES.a, adminToken, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  });
+
+  it('a proxy-only token is DENIED access to the proxy\'s member spaces', async () => {
+    const r = await mcpCall(proxyOnlyToken, 'get_stats', { space: proxyId });
+    assert.equal(r.status, 200);
+    assert.match(r.text, /member space/i,
+      `VULNERABILITY: proxy-only token reached member spaces via MCP. Response: ${r.text.slice(0, 300)}`);
+  });
+
+  it('a token scoped to all member spaces IS allowed', async () => {
+    const r = await mcpCall(fullToken, 'get_stats', { space: proxyId });
+    assert.equal(r.status, 200);
+    assert.doesNotMatch(r.text, /does not have access to member space/i,
+      `Regression: full-scope token was wrongly denied. Response: ${r.text.slice(0, 300)}`);
+  });
+});
+
+// ── H3 — token-minting privilege escalation ──────────────────────────────────
+
+describe('H3 — space-restricted admin cannot mint a broader token', () => {
+  let restrictedAdmin;
+  const tokenIds = [];
+
+  before(async () => {
+    // A space-restricted admin token (admin over 'general' only).
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `esc-restricted-admin-${RUN}`, admin: true, spaces: ['general'] });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    restrictedAdmin = t.body.plaintext; tokenIds.push(t.body.token.id);
+  });
+
+  after(async () => {
+    for (const id of tokenIds) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+  });
+
+  it('cannot mint an unrestricted (all-spaces) token', async () => {
+    const r = await post(INSTANCES.a, restrictedAdmin, '/api/tokens', { name: `esc-escalate-all-${RUN}`, admin: true });
+    if (r.status === 201 && r.body?.token?.id) tokenIds.push(r.body.token.id); // clean up if it slipped through
+    assert.equal(r.status, 403, `VULNERABILITY: restricted admin minted an all-spaces token (got ${r.status}: ${JSON.stringify(r.body)})`);
+  });
+
+  it('cannot mint a token scoped to a space outside its own allow-list', async () => {
+    const r = await post(INSTANCES.a, restrictedAdmin, '/api/tokens', { name: `esc-escalate-other-${RUN}`, spaces: ['esc-outside-scope'] });
+    if (r.status === 201 && r.body?.token?.id) tokenIds.push(r.body.token.id);
+    assert.equal(r.status, 403, `VULNERABILITY: restricted admin granted access outside its scope (got ${r.status}: ${JSON.stringify(r.body)})`);
+  });
+
+  it('CAN mint a token scoped to a subset of its own spaces (control)', async () => {
+    const r = await post(INSTANCES.a, restrictedAdmin, '/api/tokens', { name: `esc-subset-${RUN}`, spaces: ['general'] });
+    assert.equal(r.status, 201, `Regression: restricted admin could not mint an in-scope token: ${JSON.stringify(r.body)}`);
+    if (r.body?.token?.id) tokenIds.push(r.body.token.id);
+  });
+});
+
+// ── H2 — MFA setup/disable require a current code once enabled ────────────────
+
+describe('H2 — MFA cannot be rotated/disabled with just an admin PAT once enabled', () => {
+  // Once MFA is enabled, /api/admin/reload-config ALSO requires a TOTP code, so
+  // we cannot reload our way out of it. Disabling MFA in test cleanup is done the
+  // documented break-glass way: remove `totpSecret` from secrets.json on disk and
+  // restart, which reloads the (now MFA-off) config from disk. Code-free and
+  // reliable — no TOTP generation needed.
+  function disableMfaViaRestart() {
+    execSync(`docker exec ythril-a node -e "const fs=require('fs');const p='/config/secrets.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));delete s.totpSecret;fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600})"`);
+    execSync('docker restart ythril-a', { stdio: 'ignore' });
+    const sleep1s = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
+    for (let i = 0; i < 45; i++) {
+      try {
+        if (execSync('docker inspect -f "{{.State.Health.Status}}" ythril-a').toString().trim() === 'healthy') return;
+      } catch { /* container mid-restart */ }
+      sleep1s();
+    }
+  }
+
+  before(async () => {
+    disableMfaViaRestart();                       // ensure a clean (MFA-off) start
+    const setup = await post(INSTANCES.a, adminToken, '/api/mfa/setup', {});  // first-time enrol needs no code
+    assert.equal(setup.status, 201, `enable MFA: ${JSON.stringify(setup.body)}`);
+    const status = await get(INSTANCES.a, adminToken, '/api/mfa/status');
+    assert.equal(status.body.enabled, true, 'MFA should be enabled after setup');
+  });
+
+  after(() => {
+    disableMfaViaRestart();
+  });
+
+  it('POST /api/mfa/setup (rotate) with only an admin PAT is rejected once MFA is enabled', async () => {
+    const r = await post(INSTANCES.a, adminToken, '/api/mfa/setup', {});
+    assert.equal(r.status, 403, `VULNERABILITY: MFA secret rotated without a code (got ${r.status}: ${JSON.stringify(r.body)})`);
+    assert.equal(r.body.error, 'MFA_REQUIRED');
+  });
+
+  it('DELETE /api/mfa with only an admin PAT is rejected once MFA is enabled', async () => {
+    const r = await del(INSTANCES.a, adminToken, '/api/mfa');
+    assert.equal(r.status, 403, `VULNERABILITY: MFA disabled without a code (got ${r.status}: ${JSON.stringify(r.body)})`);
+  });
+});

--- a/testing/standalone/oidc-claim-mapping.test.js
+++ b/testing/standalone/oidc-claim-mapping.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit tests: OIDC claim → permission mapping (auth/oidc.ts mapOidcClaims)
+ *
+ * Regression guard for the fail-open finding: a token that matched no claim rule
+ * used to be granted read-write access to ALL spaces. It must now fail closed —
+ * read-only, no spaces.
+ *
+ * Pure in-process logic — no IdP, no network, no config. Run with:
+ *   node --test testing/standalone/oidc-claim-mapping.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapOidcClaims } from '../../server/dist/auth/oidc.js';
+
+const ADMIN_RULE = { claim: 'role', value: 'admin' };
+const RO_RULE = { claim: 'role', value: 'viewer' };
+const SPACES_RULE = { claim: 'ythril_spaces' };
+
+describe('mapOidcClaims — fail closed for unmatched tokens', () => {
+  it('empty mapping → read-only, no spaces (fail closed)', () => {
+    const p = mapOidcClaims({ sub: 'u' }, {});
+    assert.equal(p.admin, false);
+    assert.equal(p.readOnly, true);
+    assert.deepEqual(p.spaces, []);
+    assert.equal(p.matched, false);
+  });
+
+  it('rules configured but none match → read-only, no spaces', () => {
+    const p = mapOidcClaims({ role: 'something-else' }, { admin: ADMIN_RULE, readOnly: RO_RULE });
+    assert.equal(p.admin, false);
+    assert.equal(p.readOnly, true);
+    assert.deepEqual(p.spaces, []);
+    assert.equal(p.matched, false);
+  });
+
+  it('unmatched token with a spaces claim still gets NO spaces (fail closed overrides)', () => {
+    const p = mapOidcClaims({ role: 'nope', ythril_spaces: ['secret'] }, { admin: ADMIN_RULE, spaces: SPACES_RULE });
+    assert.equal(p.matched, false);
+    assert.equal(p.readOnly, true);
+    assert.deepEqual(p.spaces, [], 'an unmatched token must not receive spaces from its claim');
+  });
+});
+
+describe('mapOidcClaims — matched tokens', () => {
+  it('admin rule match → admin, writable (readOnly undefined)', () => {
+    const p = mapOidcClaims({ role: 'admin' }, { admin: ADMIN_RULE });
+    assert.equal(p.admin, true);
+    assert.equal(p.readOnly, undefined);
+    assert.equal(p.matched, true);
+    assert.equal(p.spaces, undefined, 'no spaces mapping → unrestricted (all spaces)');
+  });
+
+  it('readOnly rule match → read-only', () => {
+    const p = mapOidcClaims({ role: 'viewer' }, { admin: ADMIN_RULE, readOnly: RO_RULE });
+    assert.equal(p.admin, false);
+    assert.equal(p.readOnly, true);
+    assert.equal(p.matched, true);
+  });
+
+  it('matched admin + spaces claim (array) → that allow-list', () => {
+    const p = mapOidcClaims({ role: 'admin', ythril_spaces: ['a', 'b', 3, 'c'] }, { admin: ADMIN_RULE, spaces: SPACES_RULE });
+    assert.equal(p.admin, true);
+    assert.deepEqual(p.spaces, ['a', 'b', 'c'], 'non-string entries are dropped');
+  });
+
+  it('matched admin + spaces mapping configured but claim missing → [] (deny), not all spaces', () => {
+    const p = mapOidcClaims({ role: 'admin' }, { admin: ADMIN_RULE, spaces: SPACES_RULE });
+    assert.equal(p.admin, true);
+    assert.deepEqual(p.spaces, [], 'configured-but-missing spaces claim must deny, not grant all');
+  });
+
+  it('matched admin, NO spaces mapping → undefined (unrestricted)', () => {
+    const p = mapOidcClaims({ role: 'admin' }, { admin: ADMIN_RULE });
+    assert.equal(p.spaces, undefined);
+  });
+});

--- a/testing/standalone/oidc.test.js
+++ b/testing/standalone/oidc.test.js
@@ -702,7 +702,7 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
 
     try {
       const issuerUrl = `http://127.0.0.1:${serverPort}`;
-      // requireMatch absent — default permissive behaviour
+      // requireMatch absent — unmatched tokens are accepted but fail closed
       writeFullConfig({ ...makeOidcConfig(), issuerUrl, audience: 'ythril' });
       loaderMod.loadConfig();
       oidcMod.clearOidcCache();
@@ -720,9 +720,12 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
         .sign(privateKey);
 
       const record = await oidcMod.validateOidcJwt(token);
+      // Fail-closed: an unmatched token is accepted (requireMatch is absent) but
+      // granted read-only access to NO spaces — not the old read-write, all-spaces default.
       assert.ok(record !== null, 'unmatched token should be accepted when requireMatch is absent');
       assert.equal(record.admin, false);
-      assert.equal(record.readOnly, undefined);
+      assert.equal(record.readOnly, true, 'unmatched token must be read-only (fail closed)');
+      assert.deepEqual(record.spaces, [], 'unmatched token must have no space access (fail closed)');
     } finally {
       await new Promise(resolve => server.close(resolve));
       writeFullConfig(makeOidcConfig());


### PR DESCRIPTION
## Summary

Closes four HIGH-severity authorization findings from the security audit. All are self-contained auth/authz fixes. Validated on the Docker stack (red-team integration) plus standalone unit tests.

## H1 — MCP proxy fan-out bypassed member-space scope
`server/src/mcp/router.ts`

An MCP call on a proxy space checked the token only against the *proxy* space id, then fanned reads/writes out to the member spaces with no further check. A token scoped solely to a proxy — especially a `proxyFor: ['*']` wildcard — could reach spaces it was never granted (**the whole instance** in the wildcard case). The dispatcher now requires the token to hold **every** member space before any fan-out, mirroring `requireSpaceAuth` on the REST layer. A single guard covers all ~30 fan-out sites.

## H2 — MFA setup/disable weren't TOTP-gated
`server/src/api/mfa.ts`

`POST /api/mfa/setup` (rotate) and `DELETE /api/mfa` (disable) were gated only by `requireAdmin`, so a stolen admin PAT could silently overwrite or remove the second factor it was meant to be protected by. Both now use `requireAdminMfa`: first-time enrolment needs no code (MFA is off), but rotating/disabling an **enabled** factor requires a current TOTP code. Break-glass recovery is removing `totpSecret` from `secrets.json` on the host.

## H3 — Token minting could escalate scope
`server/src/api/tokens.ts`

`POST /api/tokens` applied no relationship between the new token's scope and the creator's, so a **space-restricted** admin token could mint an `admin: true` token with no `spaces` (= all spaces) and escalate to unrestricted admin. A restricted creator may now only mint tokens confined to a subset of its own spaces; an unrestricted admin is unaffected.

## H4 — OIDC failed open ⚠️ behaviour change
`server/src/auth/oidc.ts`

A validly-signed JWT that matched **neither** the `admin` nor `readOnly` rule was granted `readOnly: undefined` (read-write) and `spaces: undefined` (**all** spaces), so any principal able to obtain an audience-matching token from a shared realm got full read-write access to every space. Claim mapping is extracted into a testable `mapOidcClaims()` and now **fails closed** — unmatched tokens get **read-only, no spaces**; a configured-but-missing `spaces` claim yields an empty allow-list, never "all spaces".

> **Action required for OIDC deployments relying on the permissive default:** grant access explicitly via `claimMapping` rules, or set `requireMatch: true` to reject unmatched tokens outright.

## Tests
- `testing/red-team-tests/auth-escalation.test.js` — H1 (proxy-only token denied member access; full-scope token allowed), H2 (setup/disable rejected without a code once enabled), H3 (restricted admin cannot mint all-spaces or out-of-scope tokens; subset allowed).
- `testing/standalone/oidc-claim-mapping.test.js` — H4 fail-closed matrix (8 cases).
- Existing `testing/standalone/oidc.test.js` updated for the fail-closed default.

## Notes
- Fourth PR in the security audit series (after #126 SSRF, #127 sync governance, both merged). Independent subsystem; no overlap with those.
- Remaining audit items are MEDIUM/LOW (see the running tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)