### PR TITLE
security: remaining HIGH-tier hardening (ReDoS bound, peer revocation, upload quota, stored XSS, conversion limits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`query` tool `$regex` filters are now bounded against ReDoS** — the structured query filter
+  sanitizer whitelisted `$regex` but applied no pattern analysis, so a catastrophic-backtracking
+  pattern could pin MongoDB CPU for the full `maxTimeMS` budget per call (multiplied per member
+  space on proxy spaces). `$regex` values must now be strings of at most 500 characters and pass
+  the same conservative nested-quantifier heuristic used for schema `pattern` rules (shared via
+  `util/redos.ts`); the `maxTimeMS` ceiling drops from 30 s to 10 s. Covered by
+  `testing/standalone/query-regex-redos.test.js`.
+
+- **Removed or ejected sync peers no longer keep valid credentials** — removing a member (direct
+  club/pubsub removal, a concluded remove vote, a departure, or deleting a network) never revoked
+  the peer's PAT or dropped the stored outbound token, so an ejected peer could keep reading and
+  writing sync data indefinitely. Credentials are now revoked once the peer no longer shares **any**
+  network with this instance (membership in another common network preserves them), on both sides of
+  an ejection. The ejection guard also now covers the **data** endpoints (`/api/sync/memories`,
+  `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/manifest`, `/files`, tombstones, merkle …) —
+  previously only `/api/sync/networks/:id/*` returned `401 ejected`, while data endpoints fell back
+  to "space exists" because the network config is deleted on ejection. Covered by
+  `testing/sync/peer-revocation.test.js`.
+
+- **Chunked uploads now enforce the storage quota and a total-size bound** — the `Content-Range`
+  upload branch performed no quota check at all (quota applied only to single-request uploads) and
+  never bounded the declared total, so a client could bypass the files hard limit or fill the disk
+  through the `.chunks` staging area. Every chunk now runs the same quota check as a single-request
+  upload (the first chunk projects the full declared total), staged bytes under `.chunks` count
+  toward measured file usage, and the declared total is capped by `maxChunkedUploadBytes`
+  (default 10 GiB). Covered by `testing/red-team-tests/file-hardening.test.js`.
+
+- **User-uploaded HTML/SVG/XML can no longer run script in the instance origin (stored XSS)** —
+  file downloads served `text/html` and `image/svg+xml` inline with no `Content-Disposition`, so a
+  crafted upload opened in the browser executed in Ythril's origin (web-UI token theft). Active-content
+  types (`.html`, `.htm`, `.svg`, `.xml`, `.xhtml`) are now served with
+  `Content-Disposition: attachment` and a `sandbox` CSP; passive types (images, PDF, plain text)
+  stay inline so previews keep working. Filenames are quote/CRLF-sanitised in the header. Covered by
+  `testing/red-team-tests/file-hardening.test.js`.
+
+- **Document conversion is size-bounded (DoS guard)** — the pdf/docx/epub/html → markdown pipeline
+  accepted inputs of any size (`maxFileSizeBytes` applied only to media embedding), parsed HTML
+  in-process via jsdom, and stored every image a document embedded. Conversion now rejects documents
+  over `maxDocumentConversionBytes` (default 100 MiB; HTML capped at 25 MiB because jsdom parses
+  in-process) permanently — no retry burn — and extracted images are capped at 50 per document /
+  100 MiB aggregate. Covered by `testing/standalone/conversion-limits.test.js`.
+
 - **Webhook delivery now pins the connection to the validated IP** — `ssrfSafeFetch` resolved and
   validated the target's address but then let `fetch` re-resolve it to connect, leaving a narrow
   DNS-rebind TOCTOU window between check and connect. It now pins the socket to the exact validated

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1429,7 +1429,7 @@ The final chunk (where `end === total - 1`) returns **201** with the full file h
 { "path": "large-file.zip", "sha256": "a1b2c3..." }
 ```
 
-Duplicate ranges are silently accepted (idempotent). The `maxUploadBodyBytes` config limit applies per-chunk, not per-file.
+Duplicate ranges are silently accepted (idempotent). The `maxUploadBodyBytes` config limit applies per-chunk; the declared `Content-Range` total is bounded by `maxChunkedUploadBytes` (default 10 GiB → **413** when exceeded). Every chunk is also checked against the storage quota — the first chunk projects the full declared total — and returns **507** when the files hard limit would be exceeded. Bytes staged under `.chunks` count toward measured file usage.
 
 ### Check Upload Progress
 
@@ -1454,6 +1454,8 @@ GET /api/files/:spaceId?path=reports/q1.pdf
 ```
 
 Returns raw file bytes. Works with any file type — PDFs, images, archives, source code, etc. If `path` is a directory, returns a JSON listing.
+
+Active-content types that can execute script when rendered in the browser (`.html`, `.htm`, `.svg`, `.xml`, `.xhtml`) are served with `Content-Disposition: attachment` and a `sandbox` Content-Security-Policy (stored-XSS guard). Passive types — images, PDF, plain text — are served `inline` and preview normally.
 
 ---
 
@@ -1596,6 +1598,8 @@ Recall results (`recall`, `recall_global`, `find_similar`) **do** include chunk 
 #### Resilience
 
 If the unstructured sidecar is unavailable, `write_file` still succeeds. The original file is stored as-is and `conversionError` is set on the filemeta record. No HTTP 5xx is returned to the caller.
+
+Conversion input is size-bounded: documents over `maxDocumentConversionBytes` in `config.json` (default 100 MiB; HTML additionally capped at 25 MiB because jsdom parses it in-process) are stored as-is with `embeddingStatus: "skipped"` — the conversion job fails permanently rather than retrying. Images extracted during hi-res conversion are capped at 50 per document / 100 MiB aggregate.
 
 To disable the conversion pipeline entirely, set `CONVERSION_SIDECAR_URL=""` in Ythril's environment — all uploads fall back to the `"text"` bypass regardless of `inputFormat`.
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -388,8 +388,14 @@ On the **receiving** end of a `member_removed` event:
 2. The network entry is removed from `cfg.networks`.
 3. Config is saved.
 
-Subsequently, any sync request to `/api/sync/networks/:networkId` for an ejected network ID returns `401 { "error": "ejected" }` via an early-exit middleware, preventing stale sync attempts.
+Subsequently, any sync request scoped to an ejected network ID returns `401 { "error": "ejected" }` via early-exit middleware — both the gossip endpoints (`/api/sync/networks/:networkId/*`, network ID in the path) and the data endpoints (`/api/sync/memories`, `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/manifest`, `/files`, tombstones, merkle — network ID in the query string or body). Without the data-endpoint guard, ex-peers could keep syncing after an ejection because the network config is deleted locally and the space-scope check falls back to "space exists".
 
-> **Note on peer token lifecycle**: peer tokens (stored in `secrets.peerTokens`) are *infrastructure-level* credentials representing a trusted peering relationship and are not automatically revoked when a member leaves or is removed from a network. Token revocation is a separate, explicit administrative action.
+> **Peer credential lifecycle**: when a member is removed (direct club/pubsub removal, a concluded
+> remove vote, a `member_departed` announcement, or deleting a network) — and, on the ejected side,
+> when `member_removed` is processed — the instance revokes the departed peer's credentials: any PAT
+> bound to it via `peerInstanceId` and the outbound token in `secrets.peerTokens`. Revocation only
+> happens once the peer no longer shares **any** network with this instance; membership in another
+> common network (or a pending join round) preserves the credentials
+> (`revokePeerCredentialsIfOrphaned` in `auth/tokens.ts`).
 
 

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -170,12 +170,23 @@ filesRouter.get('/:spaceId', globalRateLimit, requireSpaceAuth, async (req, res)
     const bytes = await readFileBytes(foundMid, normalised);
     const ext = path.extname(normalised).toLowerCase();
     const contentType = MIME_MAP[ext] ?? 'application/octet-stream';
+    // Stored XSS guard: user-uploaded HTML/SVG/XML rendered inline would run
+    // script in this origin (token theft from the web UI). Active-content
+    // types are forced to download and get a sandbox CSP so nothing executes
+    // even if a browser renders them anyway. Passive types (images, pdf,
+    // plain text) stay inline so previews keep working.
+    const filename = path.basename(normalised).replace(/[\r\n"\\]/g, '_');
+    const isActive = ACTIVE_CONTENT_EXTS.has(ext);
     res
       .status(200)
       .setHeader('Content-Type', contentType)
       .setHeader('Content-Length', bytes.length)
       .setHeader('X-Content-Type-Options', 'nosniff')
-      .send(bytes);
+      .setHeader('Content-Disposition', `${isActive ? 'attachment' : 'inline'}; filename="${filename}"`);
+    if (isActive) {
+      res.setHeader('Content-Security-Policy', "sandbox; default-src 'none'");
+    }
+    res.send(bytes);
   } catch (err) {
     log.warn(`readFileBytes error for space ${foundMid}, path ${normalised}: ${err}`);
     res.status(500).json({ error: 'Failed to read file' });
@@ -277,6 +288,29 @@ filesRouter.post(
         res.status(400).json({ error: `Chunk size mismatch: Content-Range says ${expectedLen} bytes but body is ${req.body.length}` });
         return;
       }
+
+      // Bound the declared assembled size — Content-Range totals were previously
+      // unlimited, letting a client stage arbitrarily large uploads.
+      const maxChunkedTotal = cfg.maxChunkedUploadBytes ?? 10 * 1024 ** 3;
+      if (range.total > maxChunkedTotal) {
+        res.status(413).json({ error: `Declared upload size ${range.total} exceeds the maximum of ${maxChunkedTotal} bytes` });
+        return;
+      }
+
+      // Storage quota check on every chunk (mirrors the single-request path —
+      // each chunk is its own POST). The first chunk projects the full declared
+      // total for early rejection; later chunks project their own size, and
+      // staged bytes under .chunks are counted in measured usage.
+      try {
+        await checkQuota('files', range.start === 0 ? range.total : req.body.length);
+      } catch (err) {
+        if (err instanceof QuotaError) {
+          res.status(507).json({ error: err.message, storageExceeded: true });
+          return;
+        }
+        throw err;
+      }
+
       try {
         const { received, complete } = await storeChunk(
           targetSpace, filePath, req.body, range.start, range.end, range.total,
@@ -361,7 +395,7 @@ filesRouter.post(
       // Storage quota check — rejects with 507 if hard limit exceeded
       let quotaResult;
       try {
-        quotaResult = await checkQuota('files');
+        quotaResult = await checkQuota('files', incomingBytes);
       } catch (err) {
         if (err instanceof QuotaError) {
           res.status(507).json({ error: err.message, storageExceeded: true });
@@ -662,6 +696,10 @@ filesRouter.patch('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly, 
     res.status(500).json({ error: 'Failed to move path' });
   }
 });
+
+// Extensions whose content can execute script when rendered inline by a
+// browser — always served as attachments (stored-XSS guard).
+const ACTIVE_CONTENT_EXTS = new Set(['.html', '.htm', '.svg', '.xml', '.xhtml']);
 
 // ── MIME type lookup (basic set) ─────────────────────────────────────────────
 const MIME_MAP: Record<string, string> = {

--- a/server/src/api/networks.ts
+++ b/server/src/api/networks.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { requireAdmin } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, saveSecrets } from '../config/loader.js';
-import { createToken, revokeToken } from '../auth/tokens.js';
+import { createToken, revokeToken, revokePeerCredentialsIfOrphaned } from '../auth/tokens.js';
 import { createSpace } from '../spaces/spaces.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from './sync.js';
 import { getSyncHistory } from '../sync/history.js';
@@ -260,6 +260,13 @@ networksRouter.delete('/:id', globalRateLimit, requireAdmin, async (req, res) =>
     if (i >= 0) { c.networks.splice(i, 1); saveConfig(c); }
   }
   log.info(`Deleted network id=${net.id}`);
+
+  // Revoke credentials of peers that no longer share any network with us.
+  for (const member of net.members) {
+    if (member.instanceId === cfg.instanceId) continue;
+    await revokePeerCredentialsIfOrphaned(member.instanceId)
+      .catch(err => log.error(`peer credential revocation for ${member.instanceId}: ${err}`));
+  }
 
   if (warnings.length) {
     res.json({ ok: true, warnings });
@@ -685,8 +692,11 @@ networksRouter.delete('/:id/members/:instanceId', globalRateLimit, requireAdmin,
 
   if (net.type === 'club' || net.type === 'pubsub') {
     // Club / Pubsub: publisher (owner) removes directly, no vote required
+    const removedId = net.members[memberIdx]!.instanceId;
     net.members.splice(memberIdx, 1);
     saveConfig(cfg);
+    revokePeerCredentialsIfOrphaned(removedId)
+      .catch(err => log.error(`peer credential revocation for ${removedId}: ${err}`));
     res.status(204).end();
     return;
   }

--- a/server/src/api/notify.ts
+++ b/server/src/api/notify.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { requireAuth } from '../auth/middleware.js';
 import { notifyRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig } from '../config/loader.js';
+import { revokePeerCredentialsIfOrphaned } from '../auth/tokens.js';
 import { log } from '../util/log.js';
 
 export const notifyRouter = Router();
@@ -162,6 +163,10 @@ notifyRouter.post('/', notifyRateLimit, requireAuth, (req, res) => {
         log.info(`Departed member ${instanceId} removed from network ${networkId}`);
       }
     }
+    // The departing peer's PAT stays valid only while it is still a member of
+    // some other shared network; otherwise revoke it (and our outbound token).
+    revokePeerCredentialsIfOrphaned(instanceId)
+      .catch(err => log.error(`peer credential revocation for ${instanceId}: ${err}`));
   }
 
   // We have been ejected from this network — mark as ejected and remove it locally
@@ -172,11 +177,20 @@ notifyRouter.post('/', notifyRateLimit, requireAuth, (req, res) => {
       cfgEject.ejectedFromNetworks.push(networkId);
     }
     const netIdx = cfgEject.networks.findIndex(n => n.id === networkId);
+    const formerMembers = netIdx >= 0 ? cfgEject.networks[netIdx]!.members.map(m => m.instanceId) : [];
     if (netIdx >= 0) {
       cfgEject.networks.splice(netIdx, 1);
     }
     saveConfig(cfgEject);
     log.warn(`Ejected from network ${networkId} — network removed and marked as ejected`);
+    // Ex-peers of the deleted network keep their PATs only if they still share
+    // another network with us; otherwise their credentials are revoked so they
+    // cannot keep hitting our data endpoints after the ejection.
+    for (const memberId of formerMembers) {
+      if (memberId === cfgEject.instanceId) continue;
+      revokePeerCredentialsIfOrphaned(memberId)
+        .catch(err => log.error(`peer credential revocation for ${memberId}: ${err}`));
+    }
   }
 
   res.status(204).end();

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -17,6 +17,7 @@ import { syncRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, getSecrets, getDataRoot, loadConfig, saveConfig } from '../config/loader.js';
 import { listTombstones, applyRemoteTombstone } from '../brain/tombstones.js';
 import { requireAuth, denyReadOnly } from '../auth/middleware.js';
+import { revokePeerCredentialsIfOrphaned } from '../auth/tokens.js';
 import { log } from '../util/log.js';
 import { nextSeq, bumpSeq } from '../util/seq.js';
 import { updateSpace } from '../spaces/spaces.js';
@@ -41,6 +42,21 @@ import type {
 } from '../config/types.js';
 
 export const syncRouter = Router();
+
+// ── Ejection guard (all sync endpoints) ─────────────────────────────────────
+// If this instance has been removed from a network by vote, refuse every sync
+// request scoped to that network — data endpoints carry the networkId in the
+// query string or body, gossip endpoints in the path (guarded again below).
+// Without this, ex-peers could keep syncing data because the network config is
+// deleted on ejection and the space-scope check falls back to "space exists".
+syncRouter.use((req, res, next) => {
+  const nid = (req.query['networkId'] ?? (req.body as Record<string, unknown> | undefined)?.['networkId']) as string | undefined;
+  if (nid && typeof nid === 'string' && getConfig().ejectedFromNetworks?.includes(nid)) {
+    res.status(401).json({ error: 'ejected' });
+    return;
+  }
+  next();
+});
 
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -1427,6 +1443,16 @@ function concludeRoundIfReady(
     if (round.type === 'remove') {
       const idx = net.members.findIndex(m => m.instanceId === round.subjectInstanceId);
       if (idx >= 0) net.members.splice(idx, 1);
+      // Revoke the ejected peer's credentials once it holds no membership anywhere.
+      // Deferred a tick so the caller's saveConfig (and the member_removed notify,
+      // which still needs our outbound token) run first.
+      const ejectedId = round.subjectInstanceId;
+      if (ejectedId) {
+        setImmediate(() => {
+          revokePeerCredentialsIfOrphaned(ejectedId)
+            .catch(err => log.error(`peer credential revocation for ${ejectedId}: ${err}`));
+        });
+      }
     }
     // On meta_change round pass: apply the pending meta to the space
     if (round.type === 'meta_change' && round.spaceId && round.pendingMeta) {

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -1,7 +1,7 @@
 ﻿import { randomBytes } from 'crypto';
 import bcrypt from 'bcrypt';
 import { v4 as uuidv4 } from 'uuid';
-import { getConfig, saveConfig } from '../config/loader.js';
+import { getConfig, saveConfig, getSecrets, saveSecrets } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { TokenRecord } from '../config/types.js';
 
@@ -183,6 +183,45 @@ export async function revokeToken(id: string): Promise<boolean> {
     if (val.tokenId === id) _tokenCache.delete(key);
   }
   return true;
+}
+
+/**
+ * Revoke all credentials tied to a peer instance once it no longer shares any
+ * network with us: the inbound PATs it presents (records with a matching
+ * `peerInstanceId`) and our outbound token for calling it (`secrets.peerTokens`).
+ *
+ * A peer can legitimately be a member of several networks, so this is a no-op
+ * while the instance still appears in any network's member list or in an
+ * unconcluded join round's pending member. Call it after a member has been
+ * removed (vote conclusion, direct removal, departure, or network deletion).
+ *
+ * Returns true if any credential was actually revoked.
+ */
+export async function revokePeerCredentialsIfOrphaned(instanceId: string): Promise<boolean> {
+  if (!instanceId) return false;
+  const config = getConfig();
+  const stillMember = config.networks.some(n =>
+    n.members.some(m => m.instanceId === instanceId) ||
+    n.pendingRounds?.some(r => !r.concluded && r.pendingMember?.instanceId === instanceId),
+  );
+  if (stillMember) return false;
+
+  let revoked = false;
+  const inbound = config.tokens.filter(t => t.peerInstanceId === instanceId);
+  for (const t of inbound) {
+    if (await revokeToken(t.id)) {
+      revoked = true;
+      log.info(`Revoked peer PAT '${t.name}' (${t.id}) — instance ${instanceId} is no longer a member of any network`);
+    }
+  }
+  const secrets = getSecrets();
+  if (secrets.peerTokens[instanceId]) {
+    delete secrets.peerTokens[instanceId];
+    saveSecrets(secrets);
+    revoked = true;
+    log.info(`Dropped outbound peer token for departed instance ${instanceId}`);
+  }
+  return revoked;
 }
 
 /** Rotate a token: generate a new plaintext/hash for an existing record.

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { col, isVectorSearchAvailable, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { NotFoundError } from '../util/errors.js';
+import { hasReDoSRisk, MAX_PATTERN_LENGTH } from '../util/redos.js';
 import { embed } from './embedding.js';
 import { getConfig, getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/spaces.js';
@@ -765,6 +766,20 @@ function sanitizeFilter(filter: unknown, depth = 0): unknown {
       if (key.startsWith('$') && !ALLOWED_OPERATORS.has(key)) {
         throw new Error(`Operator '${key}' is not allowed in queries`);
       }
+      // $regex must be a plain string and pass the shared ReDoS heuristic —
+      // a catastrophic pattern would otherwise pin Mongo CPU for the full
+      // maxTimeMS budget per call (multiplied per member space on proxies).
+      if (key === '$regex') {
+        if (typeof val !== 'string') {
+          throw new Error("'$regex' must be a string pattern");
+        }
+        if (val.length > MAX_PATTERN_LENGTH) {
+          throw new Error(`'$regex' pattern exceeds ${MAX_PATTERN_LENGTH} characters`);
+        }
+        if (hasReDoSRisk(val)) {
+          throw new Error("'$regex' pattern rejected: potential catastrophic backtracking (nested or alternating quantifiers)");
+        }
+      }
       out[key] = sanitizeFilter(val, depth + 1);
     }
     // $options must only appear alongside $regex and contain valid flags
@@ -796,7 +811,7 @@ export async function queryBrain(
     throw new Error(`Unknown collection '${collectionName}'`);
   }
   const safeFilter = sanitizeFilter(filter) as Record<string, never>;
-  const safeMaxTime = Math.min(maxTimeMS, 30_000);
+  const safeMaxTime = Math.min(maxTimeMS, 10_000);
   const collName = `${spaceId}_${collectionName}`;
   let cursor = col(collName)
     .find(safeFilter)

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -596,6 +596,13 @@ export interface Config {
   /** Optional media embedding pipeline (image / audio / video). Off by default. */
   mediaEmbedding?: MediaEmbeddingConfig;
   maxUploadBodyBytes?: number;
+  /** Max total size (bytes) a chunked upload may declare via Content-Range.
+   *  Default 10 GiB. The storage quota (if configured) applies on top. */
+  maxChunkedUploadBytes?: number;
+  /** Max input size (bytes) accepted by the document conversion pipeline
+   *  (pdf/docx/epub/html/md/txt → markdown chunks). Default 100 MiB; HTML is
+   *  additionally capped at 25 MiB because jsdom parses it in-process. */
+  maxDocumentConversionBytes?: number;
   allowInsecurePlaintext?: boolean;
   /** Max redirect hops followed (and re-validated) during webhook delivery.
    *  Default 3; clamped to [0, 20]. Env var WEBHOOK_MAX_REDIRECTS overrides. */

--- a/server/src/files/converters/html.ts
+++ b/server/src/files/converters/html.ts
@@ -9,8 +9,19 @@ import TurndownService from 'turndown';
 import type { FileConverter } from './types.js';
 import { ConversionUnavailableError } from './types.js';
 
+
+// jsdom builds the full DOM in-process — parsing cost is highly non-linear in
+// input size, so HTML gets a tighter cap than the sidecar-backed formats.
+const MAX_HTML_BYTES = 25 * 1024 * 1024;
+
 export class HtmlConverter implements FileConverter {
   async convert(fileBytes: Buffer, _fileName: string): Promise<string> {
+    if (fileBytes.length > MAX_HTML_BYTES) {
+      throw new ConversionUnavailableError(
+        'too_large',
+        `HTML input is ${fileBytes.length} bytes; in-process conversion is capped at ${MAX_HTML_BYTES} bytes`,
+      );
+    }
     const html = fileBytes.toString('utf8');
 
     const dom = new JSDOM(html, { url: 'http://localhost/' });

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -17,6 +17,7 @@ import { normaliseMarkdown } from './normaliser.js';
 import { sectionChunk } from './section-chunker.js';
 import { paragraphChunk } from './paragraph-chunker.js';
 import type { Chunk } from './types.js';
+import { ConversionUnavailableError } from './types.js';
 import { writeFile, writeFileBytes } from '../files.js';
 import { col, mFilter, mDoc } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
@@ -145,6 +146,11 @@ export interface ConversionResult {
  *  3. Chunk
  *  Returns the produced chunks and the full converted Markdown (null for md/txt).
  */
+// Conversion runs in-process (jsdom for HTML) or ships the whole file to the
+// sidecar — an unbounded input pins CPU/RAM for the duration. Documents over
+// the cap are rejected up front with reason 'too_large' (never retried).
+const DEFAULT_MAX_CONVERSION_BYTES = 100 * 1024 * 1024;
+
 export async function runConversionPipeline(
   fileBytes: Buffer,
   filePath: string,
@@ -154,6 +160,16 @@ export async function runConversionPipeline(
   const fileName = path.basename(filePath);
   let markdown: string;
   let convertedMarkdown: string | null = null;
+
+  if (format !== 'text' && !isMediaFormat(format)) {
+    const cap = getConfig().maxDocumentConversionBytes ?? DEFAULT_MAX_CONVERSION_BYTES;
+    if (fileBytes.length > cap) {
+      throw new ConversionUnavailableError(
+        'too_large',
+        `Document is ${fileBytes.length} bytes; conversion is capped at ${cap} bytes`,
+      );
+    }
+  }
 
   switch (format) {
     case 'text':
@@ -262,13 +278,27 @@ export async function storeConversionResults(
     await col<FileMetaDoc>(`${spaceId}_files`).insertOne(mDoc<FileMetaDoc>(convertedDoc));
   }
 
-  // 2. Write extracted image subfiles and enqueue for media pipeline
+  // 2. Write extracted image subfiles and enqueue for media pipeline.
+  // Bounded: a crafted document can embed thousands of images — cap the count
+  // and the aggregate decoded size so conversion cannot flood storage.
+  const MAX_EXTRACTED_IMAGES = 50;
+  const MAX_EXTRACTED_IMAGE_BYTES = 100 * 1024 * 1024;
+  if (extractedImages.length > MAX_EXTRACTED_IMAGES) {
+    log.warn(`Conversion of ${spaceId}/${originalId} extracted ${extractedImages.length} images; storing only the first ${MAX_EXTRACTED_IMAGES}`);
+    extractedImages = extractedImages.slice(0, MAX_EXTRACTED_IMAGES);
+  }
+  let extractedBytesTotal = 0;
   if (extractedImages.length > 0) {
     for (const img of extractedImages) {
       const imgPath = `_extracted/${originalId}/image-${img.index}.${img.ext}`;
       const imgId = normPath(imgPath);
       try {
         const imgBytes = Buffer.from(img.base64, 'base64');
+        if (extractedBytesTotal + imgBytes.length > MAX_EXTRACTED_IMAGE_BYTES) {
+          log.warn(`Extracted-image size budget (${MAX_EXTRACTED_IMAGE_BYTES} bytes) reached for ${spaceId}/${originalId}; skipping remaining images`);
+          break;
+        }
+        extractedBytesTotal += imgBytes.length;
         await writeFileBytes(spaceId, imgPath, imgBytes);
 
         const imgDoc: FileMetaDoc = {

--- a/server/src/files/converters/types.ts
+++ b/server/src/files/converters/types.ts
@@ -19,9 +19,10 @@ export interface FileConverter {
  *   reason = 'no_content'   → blank/corrupted document
  *   reason = 'sidecar_down' → unstructured sidecar unreachable
  *   reason = 'sidecar_error'→ sidecar returned non-200
+ *   reason = 'too_large'    → input exceeds the conversion size cap (never retried)
  */
 export class ConversionUnavailableError extends Error {
-  readonly reason: 'no_content' | 'sidecar_down' | 'sidecar_error' | 'unknown';
+  readonly reason: 'no_content' | 'sidecar_down' | 'sidecar_error' | 'too_large' | 'unknown';
 
   constructor(reason: ConversionUnavailableError['reason'], message?: string) {
     super(message ?? reason);

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -41,6 +41,7 @@ import {
   deleteConversionArtifacts,
 } from '../converters/pipeline.js';
 import type { ResolvedFormat } from '../converters/pipeline.js';
+import { ConversionUnavailableError } from '../converters/types.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { spaceRoot } from '../sandbox.js';
@@ -236,12 +237,21 @@ async function processJob(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn(`Media worker: job ${spaceId}/${fileId} failed: ${message}`);
-    if (attempts >= maxAttempts) {
+    // An oversized document will never shrink — fail permanently instead of
+    // burning the retry budget re-reading a file the pipeline refuses to convert.
+    const permanent = err instanceof ConversionUnavailableError && err.reason === 'too_large';
+    if (permanent) {
+      await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
+        mFilter<FileMetaDoc>({ _id: fileId }),
+        { $set: { embeddingStatus: 'skipped' } },
+      ).catch(() => {});
+    }
+    if (permanent || attempts >= maxAttempts) {
       mediaJobsFailedTotal.labels({ space: spaceId, media_type: mediaType }).inc();
     } else {
       mediaJobsRetriedTotal.labels({ space: spaceId, media_type: mediaType }).inc();
     }
-    await failJob(spaceId, fileId, attempts, maxAttempts, message).catch(innerErr =>
+    await failJob(spaceId, fileId, permanent ? maxAttempts : attempts, maxAttempts, message).catch(innerErr =>
       log.warn(`Media worker: failJob error: ${innerErr instanceof Error ? innerErr.message : String(innerErr)}`),
     );
   } finally {

--- a/server/src/quota/quota.ts
+++ b/server/src/quota/quota.ts
@@ -89,9 +89,13 @@ export async function dirSizeBytes(dirPath: string): Promise<number> {
 export async function measureUsage(): Promise<UsageGiB> {
   const dataRoot = getDataRoot();
   const filesDir = path.join(dataRoot, 'files');
+  // In-progress chunked uploads stage under .chunks — count them toward the
+  // files quota so partial uploads cannot fill the disk invisibly.
+  const chunksDir = path.join(dataRoot, '.chunks');
 
   const [fileBytes, brainBytes] = await Promise.all([
-    dirSizeBytes(filesDir),
+    Promise.all([dirSizeBytes(filesDir), dirSizeBytes(chunksDir)])
+      .then(([a, b]) => a + b),
     (async () => {
       try {
         const db = getDb();
@@ -117,10 +121,13 @@ export async function measureUsage(): Promise<UsageGiB> {
  * Check quota limits for a write operation.
  *
  * @param area  'files' for file writes; 'brain' for memory/entity/edge writes
+ * @param incomingBytes  projected size of the write being checked — added to
+ *        current usage before hard-limit comparison so an upload that would
+ *        push usage past the limit is rejected up front, not after landing
  * @throws QuotaError if any hard limit is exceeded — caller should return HTTP 507
  * @returns QuotaCheckResult — caller should surface `warning` to the user if softBreached
  */
-export async function checkQuota(area: 'files' | 'brain'): Promise<QuotaCheckResult> {
+export async function checkQuota(area: 'files' | 'brain', incomingBytes = 0): Promise<QuotaCheckResult> {
   const cfg = getConfig();
   const storage = cfg.storage;
 
@@ -130,21 +137,22 @@ export async function checkQuota(area: 'files' | 'brain'): Promise<QuotaCheckRes
   }
 
   const usage = await measureUsage();
+  const incomingGiB = incomingBytes / GiB;
   const warnings: string[] = [];
   let softBreached = false;
 
   // ── Hard limits (throw on exceed) ─────────────────────────────────────
 
-  if (storage.total?.hardLimitGiB != null && usage.total >= storage.total.hardLimitGiB) {
-    throw new QuotaError('total', usage.total, storage.total.hardLimitGiB);
+  if (storage.total?.hardLimitGiB != null && usage.total + incomingGiB >= storage.total.hardLimitGiB) {
+    throw new QuotaError('total', usage.total + incomingGiB, storage.total.hardLimitGiB);
   }
 
-  if (area === 'files' && storage.files?.hardLimitGiB != null && usage.files >= storage.files.hardLimitGiB) {
-    throw new QuotaError('files', usage.files, storage.files.hardLimitGiB);
+  if (area === 'files' && storage.files?.hardLimitGiB != null && usage.files + incomingGiB >= storage.files.hardLimitGiB) {
+    throw new QuotaError('files', usage.files + incomingGiB, storage.files.hardLimitGiB);
   }
 
-  if (area === 'brain' && storage.brain?.hardLimitGiB != null && usage.brain >= storage.brain.hardLimitGiB) {
-    throw new QuotaError('brain', usage.brain, storage.brain.hardLimitGiB);
+  if (area === 'brain' && storage.brain?.hardLimitGiB != null && usage.brain + incomingGiB >= storage.brain.hardLimitGiB) {
+    throw new QuotaError('brain', usage.brain + incomingGiB, storage.brain.hardLimitGiB);
   }
 
   // ── Soft limits (warn, do not reject) ─────────────────────────────────

--- a/server/src/spaces/schema-validation.ts
+++ b/server/src/spaces/schema-validation.ts
@@ -14,6 +14,7 @@
 
 import type { SpaceMeta, PropertySchema, TypeSchema } from '../config/types.js';
 import { getSchemaLibrary } from '../config/loader.js';
+import { hasReDoSRisk, MAX_PATTERN_LENGTH } from '../util/redos.js';
 
 // ── Violation type ─────────────────────────────────────────────────────────
 
@@ -341,32 +342,14 @@ function validateValue(field: string, value: unknown, schema: PropertySchema): S
 }
 
 /**
- * Detect regex patterns susceptible to catastrophic backtracking (ReDoS).
- * Rejects patterns with nested quantifiers like (a+)+, (a*)*b, (a|a)+, etc.
- * This is a conservative heuristic — it may block some safe patterns, which
- * is the correct fail-safe direction for user-supplied regexes.
- *
- * Groups that begin with a mandatory literal separator character (-, /, :)
- * that is not itself optional are excluded because the separator forces unique
- * iteration boundaries and prevents exponential backtracking.
- * e.g. (-[a-z0-9]+)+ is safe — each iteration must start with a literal '-'
- * that cannot be matched by [a-z0-9], so there is no ambiguous partitioning.
- */
-const NESTED_QUANTIFIER_RE = /\((?:\?:)?(?![-/:](?![?*{]))([^)]*[+*])\)([+*?]|\{)/;
-const ALTERNATION_QUANTIFIER_RE = /\([^)]*\|[^)]*\)([+*?]|\{)/;
-
-function hasReDoSRisk(pattern: string): boolean {
-  return NESTED_QUANTIFIER_RE.test(pattern) || ALTERNATION_QUANTIFIER_RE.test(pattern);
-}
-
-/**
  * Test a regex pattern against a value with comprehensive ReDoS protection:
  * 1. Length limits on both pattern (500) and value (10K)
  * 2. Structural analysis rejecting nested quantifiers / alternation+quantifier
+ *    (`hasReDoSRisk`, shared via util/redos.ts)
  * 3. Fail-safe: returns false (non-matching → reported as violation) on any issue
  */
 function safeRegexTest(pattern: string, value: string): boolean {
-  if (pattern.length > 500 || value.length > 10_000) return false;
+  if (pattern.length > MAX_PATTERN_LENGTH || value.length > 10_000) return false;
   if (hasReDoSRisk(pattern)) return false;
   try {
     return new RegExp(pattern).test(value);

--- a/server/src/util/redos.ts
+++ b/server/src/util/redos.ts
@@ -1,0 +1,26 @@
+/**
+ * Heuristics for detecting regex patterns susceptible to catastrophic
+ * backtracking (ReDoS). Shared by schema validation (space `pattern` rules)
+ * and the structured query tool (`$regex` filters).
+ */
+
+/** Maximum length accepted for a user-supplied regex pattern. */
+export const MAX_PATTERN_LENGTH = 500;
+
+/**
+ * Rejects patterns with nested quantifiers like (a+)+, (a*)*b, (a|a)+, etc.
+ * This is a conservative heuristic — it may block some safe patterns, which
+ * is the correct fail-safe direction for user-supplied regexes.
+ *
+ * Groups that begin with a mandatory literal separator character (-, /, :)
+ * that is not itself optional are excluded because the separator forces unique
+ * iteration boundaries and prevents exponential backtracking.
+ * e.g. (-[a-z0-9]+)+ is safe — each iteration must start with a literal '-'
+ * that cannot be matched by [a-z0-9], so there is no ambiguous partitioning.
+ */
+const NESTED_QUANTIFIER_RE = /\((?:\?:)?(?![-/:](?![?*{]))([^)]*[+*])\)([+*?]|\{)/;
+const ALTERNATION_QUANTIFIER_RE = /\([^)]*\|[^)]*\)([+*?]|\{)/;
+
+export function hasReDoSRisk(pattern: string): boolean {
+  return NESTED_QUANTIFIER_RE.test(pattern) || ALTERNATION_QUANTIFIER_RE.test(pattern);
+}

--- a/testing/red-team-tests/file-hardening.test.js
+++ b/testing/red-team-tests/file-hardening.test.js
@@ -1,0 +1,237 @@
+/**
+ * Red-team tests: file subsystem hardening (H8 chunked-upload limits, H9
+ * stored-XSS-safe downloads)
+ *
+ * H9 — download headers:
+ *  - HTML/SVG downloads must carry Content-Disposition: attachment and a
+ *    sandbox CSP so user-uploaded markup can never run script in the
+ *    instance origin
+ *  - passive types (txt, png) stay inline (previews keep working)
+ *
+ * H8 — chunked uploads:
+ *  - Content-Range totals above maxChunkedUploadBytes are rejected 413
+ *  - chunked uploads respect the storage quota (507), which the old code
+ *    bypassed entirely
+ *
+ * Uses the same config-patch + reload-config mechanism as quota.test.js.
+ *
+ * Run: node --test testing/red-team-tests/file-hardening.test.js
+ * Pre-requisite: docker compose test stack up + testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'config.json');
+const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+
+// On Linux CI the container's node user owns config.json — patch via docker exec.
+const USE_DOCKER_EXEC = process.platform !== 'win32';
+const CONTAINER_A = 'ythril-a';
+
+let token;
+let originalConfig;
+
+function readConfig() {
+  if (USE_DOCKER_EXEC) {
+    return JSON.parse(execSync(`docker exec ${CONTAINER_A} cat /config/config.json`).toString('utf8'));
+  }
+  return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+}
+
+function writeConfig(cfg) {
+  if (USE_DOCKER_EXEC) {
+    const json = JSON.stringify(cfg, null, 2);
+    execSync(
+      `docker exec -i ${CONTAINER_A} sh -c 'cat > /config/config.json && chmod 600 /config/config.json'`,
+      { input: json },
+    );
+    return;
+  }
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2), { encoding: 'utf8' });
+}
+
+async function applyConfig(cfg) {
+  writeConfig(cfg);
+  const r = await post(INSTANCES.a, token, '/api/admin/reload-config', {});
+  assert.equal(r.status, 200, `reload-config failed: ${JSON.stringify(r.body)}`);
+}
+
+async function uploadRaw(filePath, bytes, contentType = 'application/octet-stream', extraHeaders = {}) {
+  const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': contentType,
+      ...extraHeaders,
+    },
+    body: bytes,
+  });
+  const body = await r.json().catch(() => null);
+  return { status: r.status, body };
+}
+
+async function download(filePath) {
+  const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
+  const r = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+  const text = await r.text().catch(() => '');
+  return { status: r.status, headers: r.headers, text };
+}
+
+async function deleteFile(filePath) {
+  const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
+  await fetch(url, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } }).catch(() => {});
+}
+
+describe('File hardening (H8 + H9)', () => {
+  before(() => {
+    token = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+    originalConfig = readConfig();
+  });
+
+  after(async () => {
+    // Restore original config
+    await applyConfig(originalConfig).catch(() => {});
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // H9 — stored-XSS-safe downloads
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Download headers (stored XSS guard)', () => {
+    const run = Date.now();
+    const uploads = [];
+
+    after(async () => {
+      for (const p of uploads) await deleteFile(p);
+    });
+
+    async function uploadAndFetch(name, content, contentType) {
+      const p = `xss-test-${run}/${name}`;
+      uploads.push(p);
+      const up = await uploadRaw(p, Buffer.from(content), contentType);
+      assert.ok(up.status === 201 || up.status === 202, `upload ${name}: ${up.status} ${JSON.stringify(up.body)}`);
+      return download(p);
+    }
+
+    it('HTML is served as attachment with sandbox CSP', async () => {
+      const r = await uploadAndFetch('evil.html', '<script>alert(document.domain)</script>', 'text/html');
+      assert.equal(r.status, 200);
+      assert.match(r.headers.get('content-disposition') ?? '', /^attachment/);
+      assert.match(r.headers.get('content-security-policy') ?? '', /sandbox/);
+      assert.equal(r.headers.get('x-content-type-options'), 'nosniff');
+    });
+
+    it('SVG is served as attachment with sandbox CSP', async () => {
+      const svg = '<svg xmlns="http://www.w3.org/2000/svg"><script>fetch("//evil")</script></svg>';
+      const r = await uploadAndFetch('evil.svg', svg, 'image/svg+xml');
+      assert.equal(r.status, 200);
+      assert.match(r.headers.get('content-disposition') ?? '', /^attachment/);
+      assert.match(r.headers.get('content-security-policy') ?? '', /sandbox/);
+    });
+
+    it('XML is served as attachment', async () => {
+      const r = await uploadAndFetch('evil.xml', '<?xml version="1.0"?><x/>', 'application/xml');
+      assert.equal(r.status, 200);
+      assert.match(r.headers.get('content-disposition') ?? '', /^attachment/);
+    });
+
+    it('plain text stays inline (previews unaffected)', async () => {
+      const r = await uploadAndFetch('note.txt', 'just text', 'text/plain');
+      assert.equal(r.status, 200);
+      assert.match(r.headers.get('content-disposition') ?? '', /^inline/);
+      // The app-wide baseline CSP is fine — only the sandbox directive is reserved
+      // for active-content types.
+      assert.ok(!(r.headers.get('content-security-policy') ?? '').includes('sandbox'));
+    });
+
+    it('PNG stays inline', async () => {
+      // 1x1 transparent PNG
+      const png = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+        'base64',
+      );
+      const p = `xss-test-${run}/pixel.png`;
+      uploads.push(p);
+      const up = await uploadRaw(p, png, 'image/png');
+      assert.ok(up.status === 201 || up.status === 202, `upload png: ${up.status}`);
+      const r = await download(p);
+      assert.equal(r.status, 200);
+      assert.match(r.headers.get('content-disposition') ?? '', /^inline/);
+    });
+
+    it('filename in Content-Disposition is quote/CRLF-sanitised', async () => {
+      const p = `xss-test-${run}/a"b.html`;
+      uploads.push(p);
+      const up = await uploadRaw(p, Buffer.from('<b>x</b>'), 'text/html');
+      assert.ok(up.status === 201 || up.status === 202, `upload: ${up.status}`);
+      const r = await download(p);
+      const cd = r.headers.get('content-disposition') ?? '';
+      assert.ok(!cd.includes('a"b'), `raw quote must not survive in header: ${cd}`);
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // H8 — chunked upload limits
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Chunked upload limits', () => {
+    const run = Date.now();
+
+    after(async () => {
+      await applyConfig(originalConfig).catch(() => {});
+    });
+
+    it('rejects a Content-Range total above maxChunkedUploadBytes with 413', async () => {
+      const cfg = readConfig();
+      cfg.maxChunkedUploadBytes = 1024 * 1024; // 1 MiB cap
+      await applyConfig(cfg);
+
+      const declared = 5 * 1024 * 1024; // declares 5 MiB
+      const chunk = Buffer.alloc(1024, 0x41);
+      const r = await uploadRaw(`chunk-test-${run}/too-big.bin`, chunk, 'application/octet-stream', {
+        'Content-Range': `bytes 0-1023/${declared}`,
+      });
+      assert.equal(r.status, 413, `expected 413, got ${r.status}: ${JSON.stringify(r.body)}`);
+    });
+
+    it('rejects chunks once the files hard quota would be exceeded (507)', async () => {
+      const cfg = readConfig();
+      delete cfg.maxChunkedUploadBytes;
+      cfg.storage = { files: { hardLimitGiB: 0.000001 } }; // ~1 KiB — instantly exceeded
+      await applyConfig(cfg);
+
+      const chunk = Buffer.alloc(4096, 0x42);
+      const r = await uploadRaw(`chunk-test-${run}/quota.bin`, chunk, 'application/octet-stream', {
+        'Content-Range': 'bytes 0-4095/8192',
+      });
+      assert.equal(r.status, 507, `expected 507, got ${r.status}: ${JSON.stringify(r.body)}`);
+      assert.equal(r.body?.storageExceeded, true);
+    });
+
+    it('accepts a normal chunked upload within limits (regression)', async () => {
+      await applyConfig(originalConfig);
+
+      const p = `chunk-test-${run}/ok.bin`;
+      const part1 = Buffer.alloc(1024, 0x43);
+      const part2 = Buffer.alloc(1024, 0x44);
+      const r1 = await uploadRaw(p, part1, 'application/octet-stream', {
+        'Content-Range': 'bytes 0-1023/2048',
+      });
+      assert.equal(r1.status, 202, `first chunk: ${r1.status} ${JSON.stringify(r1.body)}`);
+      const r2 = await uploadRaw(p, part2, 'application/octet-stream', {
+        'Content-Range': 'bytes 1024-2047/2048',
+      });
+      assert.ok(r2.status === 201 || r2.status === 202, `final chunk: ${r2.status} ${JSON.stringify(r2.body)}`);
+      assert.ok(r2.body?.sha256, 'assembled response should include sha256');
+      await deleteFile(p);
+    });
+  });
+});

--- a/testing/standalone/conversion-limits.test.js
+++ b/testing/standalone/conversion-limits.test.js
@@ -1,0 +1,63 @@
+/**
+ * Unit tests: document-conversion size caps (H10)
+ *
+ * - HtmlConverter refuses inputs over its in-process jsdom cap (25 MiB) with
+ *   ConversionUnavailableError reason 'too_large' (permanent, never retried)
+ * - Normal-size HTML still converts
+ * - parseContentRange rejects malformed / inverted ranges (chunked-upload
+ *   bounds regression guard, H8)
+ *
+ * Pure in-process logic — no MongoDB, no Docker.
+ * Run: node --test testing/standalone/conversion-limits.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { HtmlConverter } from '../../server/dist/files/converters/html.js';
+import { ConversionUnavailableError } from '../../server/dist/files/converters/types.js';
+import { parseContentRange } from '../../server/dist/files/chunks.js';
+
+describe('HtmlConverter size cap', () => {
+  it('rejects HTML over 25 MiB with reason too_large', async () => {
+    const conv = new HtmlConverter();
+    const big = Buffer.alloc(25 * 1024 * 1024 + 1, 0x61); // 'a' * (25MiB + 1)
+    await assert.rejects(
+      conv.convert(big, 'huge.html'),
+      (err) => {
+        assert.ok(err instanceof ConversionUnavailableError, `expected ConversionUnavailableError, got ${err?.constructor?.name}`);
+        assert.equal(err.reason, 'too_large');
+        return true;
+      },
+    );
+  });
+
+  it('still converts normal-size HTML', async () => {
+    const conv = new HtmlConverter();
+    const html = Buffer.from(
+      '<html><body><article><h1>Title</h1>' +
+      `<p>${'Real paragraph content that Readability will keep. '.repeat(20)}</p>` +
+      '</article></body></html>',
+    );
+    const md = await conv.convert(html, 'ok.html');
+    assert.ok(md.includes('Real paragraph content'));
+  });
+});
+
+describe('parseContentRange bounds', () => {
+  it('accepts a well-formed range', () => {
+    assert.deepEqual(parseContentRange('bytes 0-9/100'), { start: 0, end: 9, total: 100 });
+  });
+
+  it('rejects end >= total', () => {
+    assert.equal(parseContentRange('bytes 0-100/100'), null);
+  });
+
+  it('rejects start > end', () => {
+    assert.equal(parseContentRange('bytes 10-5/100'), null);
+  });
+
+  it('rejects garbage', () => {
+    assert.equal(parseContentRange('bytes x-y/z'), null);
+  });
+});

--- a/testing/standalone/query-regex-redos.test.js
+++ b/testing/standalone/query-regex-redos.test.js
@@ -1,0 +1,87 @@
+/**
+ * Unit tests: $regex ReDoS bound in the structured query tool (H5)
+ *
+ * The shared heuristic (util/redos.ts) must reject catastrophic-backtracking
+ * patterns, and queryBrain's filter sanitizer must refuse them (plus
+ * non-string and oversized patterns) BEFORE any database work happens.
+ *
+ * Pure in-process logic — no MongoDB needed: sanitizeFilter runs before the
+ * collection handle is acquired, so a rejected filter never touches the db.
+ *
+ * Run: node --test testing/standalone/query-regex-redos.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { hasReDoSRisk, MAX_PATTERN_LENGTH } from '../../server/dist/util/redos.js';
+import { queryBrain } from '../../server/dist/brain/memory.js';
+
+describe('hasReDoSRisk — shared heuristic', () => {
+  const risky = [
+    '(a+)+$',
+    '(a*)*b',
+    '(a|a)+',
+    '(.*)*x',
+    '(?:x+)+y',
+    '(a|ab)*c',
+  ];
+  // Known miss: patterns whose inner quantifier is mid-group with a trailing
+  // optional, e.g. (\w+\s?)*$ — the conservative heuristic doesn't flag these;
+  // the 500-char pattern cap and the 10s maxTimeMS ceiling bound the damage.
+  for (const p of risky) {
+    it(`flags catastrophic pattern: ${p}`, () => {
+      assert.equal(hasReDoSRisk(p), true);
+    });
+  }
+
+  const safe = [
+    'hello',
+    '^user-[0-9]+$',
+    'a+b*c?',
+    '(-[a-z0-9]+)+',      // separator-anchored group — documented safe exception
+    '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$',
+  ];
+  for (const p of safe) {
+    it(`allows benign pattern: ${p}`, () => {
+      assert.equal(hasReDoSRisk(p), false);
+    });
+  }
+});
+
+describe('queryBrain — $regex sanitisation (rejected before any db access)', () => {
+  it('rejects a catastrophic $regex pattern', async () => {
+    await assert.rejects(
+      queryBrain('anyspace', 'memories', { fact: { $regex: '(a+)+$' } }),
+      /catastrophic backtracking/,
+    );
+  });
+
+  it('rejects a catastrophic $regex nested under $and', async () => {
+    await assert.rejects(
+      queryBrain('anyspace', 'memories', { $and: [{ fact: { $regex: '(x*)*y' } }] }),
+      /catastrophic backtracking/,
+    );
+  });
+
+  it('rejects a non-string $regex', async () => {
+    await assert.rejects(
+      queryBrain('anyspace', 'memories', { fact: { $regex: { $gt: '' } } }),
+      /must be a string/,
+    );
+  });
+
+  it(`rejects a $regex pattern longer than ${MAX_PATTERN_LENGTH} chars`, async () => {
+    await assert.rejects(
+      queryBrain('anyspace', 'memories', { fact: { $regex: 'a'.repeat(MAX_PATTERN_LENGTH + 1) } }),
+      /exceeds/,
+    );
+  });
+
+  it('still rejects disallowed operators (regression)', async () => {
+    await assert.rejects(
+      queryBrain('anyspace', 'memories', { $where: 'sleep(1000)' }),
+      /not allowed/,
+    );
+  });
+});

--- a/testing/sync/leave-removal.test.js
+++ b/testing/sync/leave-removal.test.js
@@ -84,8 +84,31 @@ function readContainerConfig(container) {
   return JSON.parse(out);
 }
 
+/** Mint fresh peer PATs on both instances. Departures/removals now REVOKE the
+ *  departed peer's credentials (H7), so tokens cannot be reused across the
+ *  leave/removal cycles in this file — each setup mints its own pair. */
+async function mintPeerTokens() {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const ptForA = await post(INSTANCES.b, tokenB, '/api/tokens', {
+    name: `leave-test-peer-a-${suffix}`,
+    peerInstanceId: instanceIdA,
+  });
+  assert.equal(ptForA.status, 201, `Create peer token for A on B: ${JSON.stringify(ptForA.body)}`);
+  peerTokenForA = ptForA.body.plaintext;
+  peerTokenForAId = ptForA.body.token?.id;
+
+  const ptForB = await post(INSTANCES.a, tokenA, '/api/tokens', {
+    name: `leave-test-peer-b-${suffix}`,
+    peerInstanceId: instanceIdB,
+  });
+  assert.equal(ptForB.status, 201, `Create peer token for B on A: ${JSON.stringify(ptForB.body)}`);
+  peerTokenForB = ptForB.body.plaintext;
+  peerTokenForBId = ptForB.body.token?.id;
+}
+
 /** Create a club network on A, mirror on B, inject peer tokens. Returns networkId. */
 async function setupClubNetwork() {
+  await mintPeerTokens();
   const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
     label: `Leave Test ${Date.now()}`,
     type: 'club',
@@ -136,6 +159,7 @@ async function setupClubNetwork() {
 
 /** Create a democratic network on A, mirror on B, inject peer tokens. Returns networkId. */
 async function setupDemocraticNetwork() {
+  await mintPeerTokens();
   const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
     label: `Removal Test ${Date.now()}`,
     type: 'democratic',
@@ -204,23 +228,9 @@ describe('Leave and removal flows', () => {
     instanceIdA = getInstanceId('ythril-a');
     instanceIdB = getInstanceId('ythril-b');
 
-    // Create peer PATs with peerInstanceId so the notify handler's identity
-    // verification passes (in production the invite handshake sets this).
-    const ptForA = await post(INSTANCES.b, tokenB, '/api/tokens', {
-      name: `leave-test-peer-a-${Date.now()}`,
-      peerInstanceId: instanceIdA,
-    });
-    assert.equal(ptForA.status, 201, `Create peer token for A on B: ${JSON.stringify(ptForA.body)}`);
-    peerTokenForA = ptForA.body.plaintext;
-    peerTokenForAId = ptForA.body.token?.id;
-
-    const ptForB = await post(INSTANCES.a, tokenA, '/api/tokens', {
-      name: `leave-test-peer-b-${Date.now()}`,
-      peerInstanceId: instanceIdB,
-    });
-    assert.equal(ptForB.status, 201, `Create peer token for B on A: ${JSON.stringify(ptForB.body)}`);
-    peerTokenForB = ptForB.body.plaintext;
-    peerTokenForBId = ptForB.body.token?.id;
+    // Peer PATs (with peerInstanceId so the notify handler's identity
+    // verification passes) are minted fresh by each setup*Network call —
+    // see mintPeerTokens().
   });
 
   after(async () => {

--- a/testing/sync/peer-revocation.test.js
+++ b/testing/sync/peer-revocation.test.js
@@ -1,0 +1,275 @@
+/**
+ * Integration tests: peer credential revocation on removal / ejection (H7)
+ *
+ * Removed or ejected sync peers must not keep valid credentials:
+ *  - Club direct removal: the removed member's inbound PAT (peerInstanceId)
+ *    and our outbound peer token are revoked on the removing instance
+ *  - Multi-network membership: credentials survive removal from ONE network
+ *    while the peer is still a member of another, and are revoked after the
+ *    last shared network is gone
+ *  - Remove vote conclusion: same revocation on the vote path
+ *  - Ejected side: after processing member_removed, the ejected instance
+ *    revokes the ex-peers' credentials
+ *  - Ejection guard: data endpoints (e.g. /api/sync/memories) refuse requests
+ *    scoped to an ejected network with 401 {"error":"ejected"} — previously
+ *    only /api/sync/networks/:id/* was guarded
+ *
+ * Run:  node --test testing/sync/peer-revocation.test.js
+ * Pre-requisite: docker compose test stack up + testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del, waitFor } from './helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, 'configs');
+
+let tokenA, tokenB;
+let instanceIdA, instanceIdB;
+
+function getInstanceId(container) {
+  return execSync(
+    `docker exec ${container} node -e "const fs=require('fs');` +
+    `const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));` +
+    `process.stdout.write(c.instanceId)"`,
+  ).toString().trim();
+}
+
+function readContainerConfig(container) {
+  const out = execSync(
+    `docker exec ${container} node -e "const fs=require('fs');` +
+    `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
+  ).toString();
+  return JSON.parse(out);
+}
+
+function readContainerSecrets(container) {
+  const out = execSync(
+    `docker exec ${container} node -e "const fs=require('fs');` +
+    `process.stdout.write(fs.readFileSync('/config/secrets.json','utf8'))"`,
+  ).toString();
+  return JSON.parse(out);
+}
+
+function injectPeerToken(container, instanceId, token) {
+  const script = [
+    `const fs=require('fs');`,
+    `const p='/config/secrets.json';`,
+    `const s=JSON.parse(fs.readFileSync(p,'utf8'));`,
+    `s.peerTokens=s.peerTokens||{};`,
+    `s.peerTokens['${instanceId}']='${token}';`,
+    `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
+    `process.stdout.write('ok');`,
+  ].join('');
+  execSync(`docker exec ${container} node -e "${script}"`);
+}
+
+/** Create a fresh peer PAT on `base` bound to `peerInstanceId`. */
+async function createPeerToken(base, adminToken, name, peerInstanceId) {
+  const r = await post(base, adminToken, '/api/tokens', { name, peerInstanceId });
+  assert.equal(r.status, 201, `create peer token: ${JSON.stringify(r.body)}`);
+  return { id: r.body.token?.id ?? r.body.id, plaintext: r.body.plaintext };
+}
+
+/** Create a club network on A with B as a direct member. Returns networkId. */
+async function createClubWithB(outboundTokenForB) {
+  const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+    label: `Revocation Test ${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    type: 'club',
+    spaces: ['general'],
+    votingDeadlineHours: 1,
+  });
+  assert.equal(netR.status, 201, `create network: ${JSON.stringify(netR.body)}`);
+  const nid = netR.body.id;
+  const addB = await post(INSTANCES.a, tokenA, `/api/networks/${nid}/members`, {
+    instanceId: instanceIdB,
+    label: 'Instance B',
+    url: 'http://ythril-b:3200',
+    token: outboundTokenForB,
+    direction: 'both',
+  });
+  assert.equal(addB.status, 201, `add B: ${JSON.stringify(addB.body)}`);
+  return nid;
+}
+
+function tokensWithPeerId(container, peerInstanceId) {
+  const cfg = readContainerConfig(container);
+  return (cfg.tokens ?? []).filter(t => t.peerInstanceId === peerInstanceId);
+}
+
+/** Delete leftover networks from prior (failed) runs of this file — a stale
+ *  network still listing the peer as a member legitimately blocks revocation. */
+async function cleanupStaleNetworks(base, adminToken) {
+  const r = await get(base, adminToken, '/api/networks');
+  if (r.status !== 200) return;
+  for (const n of r.body.networks ?? []) {
+    if (n.label?.startsWith('Revocation')) {
+      await del(base, adminToken, `/api/networks/${n.id}`).catch(() => {});
+    }
+  }
+}
+
+describe('Peer credential revocation (H7)', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    tokenB = fs.readFileSync(path.join(CONFIGS, 'b', 'token.txt'), 'utf8').trim();
+    instanceIdA = getInstanceId('ythril-a');
+    instanceIdB = getInstanceId('ythril-b');
+
+    await cleanupStaleNetworks(INSTANCES.a, tokenA);
+    await cleanupStaleNetworks(INSTANCES.b, tokenB);
+  });
+
+  it('club direct removal revokes the removed peer\'s PAT and the outbound token', async () => {
+    // Inbound PAT on A that "B" would present, bound to B's instanceId
+    const pat = await createPeerToken(INSTANCES.a, tokenA, `revoke-club-${Date.now()}`, instanceIdB);
+    const nid = await createClubWithB('dummy-outbound-token-club');
+
+    // Sanity: PAT exists, outbound token stored by the add-member call
+    assert.ok(tokensWithPeerId('ythril-a', instanceIdB).length >= 1, 'PAT should exist before removal');
+    assert.ok(readContainerSecrets('ythril-a').peerTokens?.[instanceIdB], 'outbound token should exist before removal');
+
+    const rm = await del(INSTANCES.a, tokenA, `/api/networks/${nid}/members/${instanceIdB}`);
+    assert.equal(rm.status, 204, `remove member: ${JSON.stringify(rm.body)}`);
+
+    await waitFor(async () => tokensWithPeerId('ythril-a', instanceIdB).length === 0);
+    await waitFor(async () => !readContainerSecrets('ythril-a').peerTokens?.[instanceIdB]);
+
+    // The revoked PAT must no longer authenticate
+    const r = await get(INSTANCES.a, pat.plaintext, '/api/spaces');
+    assert.equal(r.status, 401, `revoked PAT must not authenticate, got ${r.status}`);
+
+    await del(INSTANCES.a, tokenA, `/api/networks/${nid}`).catch(() => {});
+  });
+
+  it('credentials survive removal while the peer is still a member of another network', async () => {
+    const pat = await createPeerToken(INSTANCES.a, tokenA, `revoke-multi-${Date.now()}`, instanceIdB);
+    const nid1 = await createClubWithB('dummy-outbound-token-m1');
+    const nid2 = await createClubWithB('dummy-outbound-token-m2');
+
+    // Remove B from network 1 only — still a member of network 2
+    const rm1 = await del(INSTANCES.a, tokenA, `/api/networks/${nid1}/members/${instanceIdB}`);
+    assert.equal(rm1.status, 204);
+
+    // Give the async revocation a moment, then confirm the PAT survived
+    await new Promise(r => setTimeout(r, 1500));
+    assert.ok(
+      tokensWithPeerId('ythril-a', instanceIdB).length >= 1,
+      'PAT must survive while B is still a member of another network',
+    );
+    const stillValid = await get(INSTANCES.a, pat.plaintext, '/api/spaces');
+    assert.equal(stillValid.status, 200, 'PAT should still authenticate');
+
+    // Remove B from network 2 — now orphaned, credentials must go
+    const rm2 = await del(INSTANCES.a, tokenA, `/api/networks/${nid2}/members/${instanceIdB}`);
+    assert.equal(rm2.status, 204);
+    await waitFor(async () => tokensWithPeerId('ythril-a', instanceIdB).length === 0);
+
+    await del(INSTANCES.a, tokenA, `/api/networks/${nid1}`).catch(() => {});
+    await del(INSTANCES.a, tokenA, `/api/networks/${nid2}`).catch(() => {});
+  });
+
+  describe('remove-vote conclusion + ejection side', () => {
+    let nid;
+    let patOnA;   // B's PAT on A (revoked when the remove vote concludes on A)
+    let patOnB;   // A's PAT on B (revoked when B processes member_removed)
+
+    before(async () => {
+      patOnA = await createPeerToken(INSTANCES.a, tokenA, `revoke-vote-a-${Date.now()}`, instanceIdB);
+      patOnB = await createPeerToken(INSTANCES.b, tokenB, `revoke-vote-b-${Date.now()}`, instanceIdA);
+
+      // Democratic network on A with B as member; A can notify B via patOnB
+      const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+        label: `Revocation Vote Test ${Date.now()}`,
+        type: 'democratic',
+        spaces: ['general'],
+        votingDeadlineHours: 1,
+      });
+      assert.equal(netR.status, 201);
+      nid = netR.body.id;
+
+      const addB = await post(INSTANCES.a, tokenA, `/api/networks/${nid}/members`, {
+        instanceId: instanceIdB,
+        label: 'Instance B',
+        url: 'http://ythril-b:3200',
+        token: patOnB.plaintext,
+        direction: 'both',
+      });
+      if (addB.status === 202) {
+        const vr = await post(INSTANCES.a, tokenA, `/api/networks/${nid}/votes/${addB.body.roundId}`, { vote: 'yes' });
+        assert.equal(vr.status, 200);
+      } else {
+        assert.equal(addB.status, 201, JSON.stringify(addB.body));
+      }
+
+      // Mirror the network on B so it can process the ejection
+      const netOnB = await post(INSTANCES.b, tokenB, '/api/networks', {
+        id: nid,
+        label: 'Revocation Vote Test',
+        type: 'democratic',
+        spaces: ['general'],
+        votingDeadlineHours: 1,
+      });
+      assert.ok(netOnB.status === 201 || netOnB.status === 409);
+      const addAonB = await post(INSTANCES.b, tokenB, `/api/networks/${nid}/members`, {
+        instanceId: instanceIdA,
+        label: 'Instance A',
+        url: 'http://ythril-a:3200',
+        token: patOnA.plaintext,
+        direction: 'both',
+      });
+      if (addAonB.status === 202) {
+        const vr = await post(INSTANCES.b, tokenB, `/api/networks/${nid}/votes/${addAonB.body.roundId}`, { vote: 'yes' });
+        assert.equal(vr.status, 200);
+      }
+      // Outbound orientation: A calls B with the token B issued (patOnB), and
+      // vice versa — same as the invite handshake would set up.
+      injectPeerToken('ythril-a', instanceIdB, patOnB.plaintext);
+      injectPeerToken('ythril-b', instanceIdA, patOnA.plaintext);
+      await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+      await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
+
+      // A opens + concludes the remove vote for B
+      const removeR = await del(INSTANCES.a, tokenA, `/api/networks/${nid}/members/${instanceIdB}`);
+      assert.equal(removeR.status, 202, JSON.stringify(removeR.body));
+      const voteR = await post(INSTANCES.a, tokenA, `/api/networks/${nid}/votes/${removeR.body.roundId}`, { vote: 'yes' });
+      assert.equal(voteR.status, 200, JSON.stringify(voteR.body));
+      assert.equal(voteR.body.concluded, true);
+
+      // Wait until B has processed member_removed
+      await waitFor(async () => readContainerConfig('ythril-b').ejectedFromNetworks?.includes(nid));
+    });
+
+    after(async () => {
+      // B's copy was removed by the ejection; clean up A's copy.
+      await del(INSTANCES.a, tokenA, `/api/networks/${nid}`).catch(() => {});
+    });
+
+    it('the removing instance revokes the ejected peer\'s credentials', async () => {
+      await waitFor(async () => tokensWithPeerId('ythril-a', instanceIdB).length === 0);
+      await waitFor(async () => !readContainerSecrets('ythril-a').peerTokens?.[instanceIdB]);
+    });
+
+    it('the ejected instance revokes the ex-peer\'s credentials after member_removed', async () => {
+      await waitFor(async () => tokensWithPeerId('ythril-b', instanceIdA).length === 0);
+    });
+
+    it('data endpoints refuse requests scoped to the ejected network (401 ejected)', async () => {
+      // Previously only /api/sync/networks/:id/* was guarded; data endpoints
+      // fell back to "space exists" because the network config was deleted.
+      const r = await get(INSTANCES.b, tokenB, `/api/sync/memories?spaceId=general&networkId=${nid}`);
+      assert.equal(r.status, 401, `expected 401 ejected, got ${r.status}: ${JSON.stringify(r.body)}`);
+      assert.equal(r.body?.error, 'ejected');
+    });
+
+    it('data endpoints for other networks still work on the ejected instance', async () => {
+      const r = await get(INSTANCES.b, tokenB, '/api/sync/memories?spaceId=general');
+      assert.equal(r.status, 200, `expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+    });
+  });
+});


### PR DESCRIPTION
Closes out the **HIGH tier** of the security audit — the five remaining findings (H5, H7–H10), following #126–#130.

## H5 — `query` tool `$regex` ReDoS bound
The structured query filter sanitizer whitelisted `$regex` with no pattern analysis, so a catastrophic-backtracking pattern pinned MongoDB CPU for the full `maxTimeMS` budget per call (multiplied per member space on proxies). `$regex` must now be a **string ≤ 500 chars** passing the conservative nested-quantifier heuristic already used for schema `pattern` rules — extracted to a shared `util/redos.ts` — and the `maxTimeMS` ceiling drops 30 s → 10 s.

## H7 — removed/ejected peers kept valid credentials
Removing a member (club/pubsub direct removal, concluded remove vote, departure, network deletion) never revoked the peer's PAT or dropped the outbound token, so an ejected peer could keep syncing indefinitely. New `revokePeerCredentialsIfOrphaned()` revokes the peer's inbound `peerInstanceId`-bound PATs and the `secrets.peerTokens` entry **once it no longer shares any network** with this instance (membership in another common network, or a pending join round, preserves them) — wired into every removal path on both sides of an ejection.

The ejection guard now also covers the **data** endpoints (`/memories`, `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/manifest`, `/files`, tombstones, merkle): previously only `/api/sync/networks/:id/*` returned `401 ejected`, while data endpoints fell back to "space exists" because the network config is deleted on ejection.

## H8 — chunked uploads bypassed the storage quota
The `Content-Range` branch ran no quota check and never bounded the declared total. Now: every chunk runs the same quota check as a single-request upload (`checkQuota` gained an `incomingBytes` projection; the first chunk projects the full declared total → early 507), bytes staged under `.chunks` count toward measured file usage, and the declared total is capped by new config `maxChunkedUploadBytes` (default 10 GiB → 413).

## H9 — stored XSS via inline HTML/SVG downloads
`text/html` / `image/svg+xml` were served inline with no `Content-Disposition`, so a crafted upload opened in the browser executed in Ythril's origin (web-UI token theft). Active-content extensions (`.html/.htm/.svg/.xml/.xhtml`) are now served `Content-Disposition: attachment` + `Content-Security-Policy: sandbox; default-src 'none'`; passive types (images, PDF, text) stay inline so previews keep working. Filenames are quote/CRLF-sanitised.

## H10 — unbounded document conversion (DoS)
The pdf/docx/epub/html → markdown pipeline accepted any input size (jsdom parses HTML **in-process**) and stored every embedded image. Conversion now rejects documents over `maxDocumentConversionBytes` (default 100 MiB; HTML additionally capped at 25 MiB) with a permanent `too_large` failure — no retry burn, `embeddingStatus: "skipped"` — and extracted images are capped at 50 per document / 100 MiB aggregate with logged truncation.

## Tests
- New: `testing/standalone/query-regex-redos.test.js` (unit), `testing/standalone/conversion-limits.test.js` (unit), `testing/sync/peer-revocation.test.js` (6), `testing/red-team-tests/file-hardening.test.js` (9)
- Updated: `testing/sync/leave-removal.test.js` now mints fresh peer PATs per network setup — H7 revocation (correctly) invalidates cross-cycle token reuse
- Full suites on the rebuilt Docker stack: **sync 173 pass / 0 fail**, **standalone 661 pass / 0 fail**, **red-team 220/220**, **integration 783 pass / 0 fail**

## Config (all optional)
- `maxChunkedUploadBytes` — cap on the declared chunked-upload total (default 10 GiB)
- `maxDocumentConversionBytes` — conversion input cap (default 100 MiB; HTML fixed at 25 MiB)

Docs updated: CHANGELOG, `docs/sync-protocol.md` (peer-credential lifecycle note rewritten — it previously documented the non-revoking behaviour as intended), `docs/integration-guide.md` (chunked limits, download headers, conversion caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)