### PR TITLE
security: auth surface hardening (query-token scope, TOTP replay, OIDC alg pinning, MCP admin gate, token prefix, seed gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A `?token=` query parameter is now accepted only on the SSE endpoints** — the Bearer-token
+  query-string fallback exists because the browser `EventSource` API cannot set headers, but it was
+  wired into the shared auth path and therefore honoured on **every route and every method**. A token
+  in a query string leaks into access logs, proxy logs, browser history and `Referer` headers, so it
+  is now accepted only on `GET /api/about/logs/stream` and `GET /mcp` (the two SSE streams).
+  Everything else requires the `Authorization` header. **Breaking** for any integration that passed
+  `?token=` to a REST route — switch it to the header.
+
+- **TOTP codes are single-use** — a code stayed valid for its whole ±1-step window (up to 90 s), so a
+  code captured in transit (proxy log, shoulder-surf, phished operator) could be replayed — precisely
+  the window an attacker with a stolen admin PAT needs to disable MFA. The highest consumed step is
+  now recorded (`totpLastStep` in `secrets.json`) and a code is accepted only for a step strictly
+  greater than it. Note: this makes the "test your authenticator" call on `POST /api/mfa/verify`
+  consume the code, so a code entered there cannot immediately be reused for a gated action — wait
+  for the next one.
+
+- **OIDC ID-token signature algorithms are pinned** — `jwtVerify` ran with no `algorithms` option, so
+  the accepted set was an implicit consequence of jose's JWKS resolver rather than stated policy. It
+  is now an explicit asymmetric allow-list (RS/PS/ES/EdDSA), narrowable per deployment via
+  `oidc.allowedAlgorithms` (e.g. `["RS256"]`). To be precise about the scope: jose already refuses
+  symmetric JWKS keys, so the classic HS/RS confusion attack was **not** reachable — this is defence
+  in depth, not a fix for an exploitable hole. Covered by `testing/standalone/oidc-alg-pinning.test.js`.
+
+- **The instance-level MCP tools now require an admin token** — `list_peers` (full peer topology:
+  instance IDs, URLs, network membership) and `sync_now` (drives outbound connections to every peer)
+  had no admin gate, though their REST equivalents under `/api/networks*` are all `requireAdmin`. Any
+  space-scoped token could enumerate the network and trigger syncs. Both are now admin-only, enforced
+  in the dispatcher and hidden from `tools/list` for non-admin tokens.
+
+- **`POST /api/conflicts/seed` is admin-gated** — this test fixture fabricates conflict records that
+  the UI presents as genuine sync conflicts with an attacker-chosen peer label, and whose resolution
+  actions move/overwrite files. It sat on the plain authenticated router, so any space-scoped token
+  could inject them.
+
+- **Token lookup prefixes now carry their intended entropy** — the stored `prefix` (a pre-filter for
+  the bcrypt scan) was `plaintext.slice(0, 8)` = the literal `ythril_` plus **one** random character,
+  despite a comment claiming 62^8. Roughly 1/62 of all tokens shared a bucket, so a large deployment
+  ran many bcrypt compares per request. It is now taken from the random part (offset 7). Records
+  still holding the old format keep authenticating and are migrated on first use — no token is
+  invalidated, no re-issue needed.
+
 - **`query` tool `$regex` filters are now bounded against ReDoS** — the structured query filter
   sanitizer whitelisted `$regex` but applied no pattern analysis, so a catastrophic-backtracking
   pattern could pin MongoDB CPU for the full `maxTimeMS` budget per call (multiplied per member

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -373,6 +373,8 @@ Authorization: Bearer ythril_<base62-encoded-token>
 
 Tokens are created during first-run setup or via `POST /api/tokens`. The plaintext token is shown **once** — store it securely.
 
+> **The token must travel in the header.** A `?token=…` query parameter is accepted **only** on the two SSE streams — `GET /api/about/logs/stream` and `GET /mcp` — because the browser `EventSource` API cannot set headers. On every other route a query-string token is ignored and the request returns `401`. Query strings end up in access logs, proxy logs, browser history, and `Referer` headers, which is why the fallback is not available API-wide.
+
 ### Token Scoping
 
 | Token Type | Access |
@@ -3609,6 +3611,11 @@ Scan the `otpauth` URI as a QR code in any TOTP app.
 > (disabling) require a current TOTP code in the `X-TOTP-Code` header — a stolen admin PAT alone
 > cannot replace or remove the second factor. First-time enrolment (MFA off) needs no code. If the
 > authenticator is lost, remove `totpSecret` from `secrets.json` on the host to recover.
+>
+> **Codes are single-use.** A TOTP code is accepted once; replaying it — including within the ±1-step
+> (up to 90 s) clock-skew window it would otherwise still match — is refused. `POST /api/mfa/verify`
+> consumes the code too, so a code you tested there cannot immediately be reused for a gated call:
+> wait for your authenticator to roll to the next one.
 
 ---
 
@@ -5027,7 +5034,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`recall`, `query`, `get_stats`, `get_space_meta`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `list_peers`, `traverse`) work normally.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`recall`, `query`, `get_stats`, `get_space_meta`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -5133,8 +5140,13 @@ Content-Type: application/json
 | `move_file` | Move or rename a file/directory |
 | `update_space` | Update space label and/or description (admin only) |
 | `wipe_space` | Wipe all or specific collection types from the space (admin only) |
-| `list_peers` | List all configured peer instances |
-| `sync_now` | Trigger immediate sync (all networks or specific peer) |
+| `list_peers` | List all configured peer instances (admin only) |
+| `sync_now` | Trigger immediate sync (all networks or specific peer) (admin only) |
+
+> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, and `wipe_space` require an `admin`
+> token: the first two are instance-level (they expose the whole peer topology and drive outbound
+> connections to every peer) and have no space scoping. They are hidden from `tools/list` for
+> non-admin tokens and rejected if called directly.
 
 ### Example: remember
 
@@ -5471,6 +5483,7 @@ Add an `oidc` block to `config.json`:
 | `clientId` | Yes | OAuth2 client ID registered at the IdP. |
 | `audience` | No | Expected `aud` claim. Defaults to `clientId`. |
 | `scopes` | No | Scopes to request. Defaults to `["openid", "profile", "email"]`. |
+| `allowedAlgorithms` | No | JWS algorithms accepted when verifying ID tokens. Defaults to the asymmetric set `RS256/384/512`, `PS256/384/512`, `ES256/384/512`, `EdDSA`. Use it to **narrow** verification to what your IdP actually signs with (e.g. `["RS256"]`). |
 | `claimMapping` | No | Maps IdP claims to Ythril permissions (see below). |
 | `enforceForBrowser` | No | When `true`, the browser SPA rejects cached PAT sessions and always forces a fresh OIDC login. PATs continue to work for API / MCP bearer-header requests. Default: `false`. |
 | `postLogoutRedirectUri` | No | URI the IdP should redirect to after `end_session`. Passed as `post_logout_redirect_uri`. Defaults to `{origin}/login`. |

--- a/server/src/api/conflicts.ts
+++ b/server/src/api/conflicts.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import fs from 'fs/promises';
 import path from 'path';
-import { requireAuth } from '../auth/middleware.js';
+import { requireAuth, requireAdmin, denyReadOnly } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { col, mFilter, mDoc } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
@@ -276,8 +276,14 @@ conflictsRouter.post('/bulk-resolve', globalRateLimit, requireAuth, async (req, 
   }
 });
 
-// POST /api/conflicts/seed — seed a conflict record (for testing)
-conflictsRouter.post('/seed', globalRateLimit, requireAuth, async (req, res) => {
+// POST /api/conflicts/seed — seed a conflict record (test support)
+//
+// This fabricates a conflict record that the UI presents as a genuine sync
+// conflict with a named peer, and whose resolution actions move/overwrite files.
+// It is a test fixture, not a product feature, so it is admin-gated: any
+// space-scoped token could previously inject conflicts (with an attacker-chosen
+// `peerInstanceLabel`) into any space it could read.
+conflictsRouter.post('/seed', globalRateLimit, requireAdmin, denyReadOnly, async (req, res) => {
   try {
     const { _id, spaceId, originalPath, conflictPath, peerInstanceId, peerInstanceLabel, detectedAt } = req.body ?? {};
     if (!_id || !spaceId || !originalPath || !conflictPath) {

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -63,12 +63,34 @@ export function denyReadOnly(req: Request, res: Response, next: NextFunction): v
   next();
 }
 
+/**
+ * Endpoints where a `?token=` query parameter is accepted in place of the
+ * Authorization header. Only the SSE streams qualify: the browser `EventSource`
+ * API cannot set headers, so there is no alternative there.
+ *
+ * A token in a query string leaks into access logs, proxy logs, browser history
+ * and `Referer` headers, so the fallback must NOT be available instance-wide —
+ * it previously was, on every route and every method.
+ */
+const QUERY_TOKEN_PATHS = new Set([
+  '/api/about/logs/stream',  // audit-log live tail (EventSource)
+  '/mcp',                    // MCP SSE transport (EventSource)
+]);
+
+function allowsQueryToken(req: Request): boolean {
+  if (req.method !== 'GET') return false;
+  const pathOnly = (req.originalUrl.split('?')[0] ?? '').replace(/\/+$/, '');
+  return QUERY_TOKEN_PATHS.has(pathOnly || '/');
+}
+
 function extractBearer(req: Request): string | null {
   const auth = req.headers.authorization;
   if (auth && auth.startsWith('Bearer ')) return auth.slice('Bearer '.length).trim();
-  // Fallback: query parameter (used by EventSource / SSE which cannot set headers)
-  const queryToken = req.query['token'];
-  if (typeof queryToken === 'string' && queryToken.trim()) return queryToken.trim();
+  // Fallback: query parameter — SSE endpoints only (EventSource cannot set headers)
+  if (allowsQueryToken(req)) {
+    const queryToken = req.query['token'];
+    if (typeof queryToken === 'string' && queryToken.trim()) return queryToken.trim();
+  }
   return null;
 }
 

--- a/server/src/auth/oidc.ts
+++ b/server/src/auth/oidc.ts
@@ -17,6 +17,27 @@ import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { OidcConfig, OidcClaimRule, OidcClaimMapping } from '../config/types.js';
 
+/**
+ * JWS algorithms accepted for OIDC ID tokens unless `oidc.allowedAlgorithms`
+ * narrows them. Asymmetric only: an IdP signs with its private key and publishes
+ * the public half via JWKS.
+ *
+ * Note on the threat model: jose's JWKS resolver already refuses symmetric keys
+ * ("Unsupported alg value for a JSON Web Key Set"), so the classic HS/RS
+ * confusion attack was NOT reachable here even without this option. What pinning
+ * buys is (a) the accepted set becomes explicit policy rather than a side effect
+ * of the resolver's behaviour — it cannot silently widen if that behaviour
+ * changes — and (b) operators can narrow it to exactly what their IdP signs with
+ * (`allowedAlgorithms: ["RS256"]`), so an alg the IdP never uses is rejected
+ * outright.
+ */
+export const DEFAULT_OIDC_ALGORITHMS = [
+  'RS256', 'RS384', 'RS512',
+  'PS256', 'PS384', 'PS512',
+  'ES256', 'ES384', 'ES512',
+  'EdDSA',
+];
+
 // ── OIDC URL validation ───────────────────────────────────────────────────
 // Unlike the full isSsrfSafeUrl check (designed for user-supplied peer URLs),
 // this allows private IPs and loopback because internal IdPs (e.g. Keycloak on
@@ -243,9 +264,11 @@ export async function validateOidcJwt(bearer: string): Promise<OidcTokenRecord |
 
     const audience = oidcCfg.audience ?? oidcCfg.clientId;
 
+    // Pin the accepted signature algorithms (see DEFAULT_OIDC_ALGORITHMS).
     const { payload } = await jwtVerify(bearer, jwks, {
       issuer: discovery.issuer,
       audience,
+      algorithms: oidcCfg.allowedAlgorithms ?? DEFAULT_OIDC_ALGORITHMS,
     });
 
     // ── Map claims → permissions (fail-closed) ────────────────────────────

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -7,6 +7,8 @@ import type { TokenRecord } from '../config/types.js';
 
 const BCRYPT_ROUNDS = 12;
 const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const TOKEN_PREFIX = 'ythril_';
+const PREFIX_LOOKUP_LENGTH = 8;
 
 function toBase62(bytes: Buffer): string {
   let num = BigInt('0x' + bytes.toString('hex'));
@@ -22,7 +24,26 @@ function toBase62(bytes: Buffer): string {
 
 /** Generate a new PAT plaintext: `ythril_<base62(32 random bytes)>` */
 export function generateToken(): string {
-  return `ythril_${toBase62(randomBytes(32))}`;
+  return `${TOKEN_PREFIX}${toBase62(randomBytes(32))}`;
+}
+
+/**
+ * Lookup prefix for a plaintext token: 8 chars taken from the RANDOM part,
+ * i.e. AFTER the literal `ythril_`.
+ *
+ * The prefix is a pre-filter for the bcrypt scan, so it wants entropy. Slicing
+ * from offset 0 captured `ythril_` + a single random char — about 1 char of
+ * entropy, so ~1/62 of all tokens shared a bucket and a large deployment ran
+ * many bcrypt compares per auth (and the value leaked nothing useful either
+ * way). Slicing from offset 7 gives the intended 62^8.
+ */
+function tokenPrefix(plaintext: string): string {
+  return plaintext.slice(TOKEN_PREFIX.length, TOKEN_PREFIX.length + PREFIX_LOOKUP_LENGTH);
+}
+
+/** The pre-fix format used before the entropy fix — still matched on lookup. */
+function legacyTokenPrefix(plaintext: string): string {
+  return plaintext.slice(0, PREFIX_LOOKUP_LENGTH);
 }
 
 /** Hash a plaintext token for storage */
@@ -75,16 +96,17 @@ export async function findMatchingToken(
   }
 
   // Prefix-filtered path: only bcrypt-compare records whose prefix matches.
-  // `prefix` is the first 8 chars of the plaintext token, stored in the record
-  // at creation time — this allows O(small n) pre-filtering so we virtually
-  // never run more than 1 bcrypt compare.
-  const prefix = plaintext.slice(0, 8);
-  const candidates = config.tokens.filter(t => t.prefix === prefix);
+  // Records may carry either prefix format (see tokenPrefix) — match both, then
+  // self-heal the record to the current format on a successful verify.
+  const prefix = tokenPrefix(plaintext);
+  const legacyPrefix = legacyTokenPrefix(plaintext);
+  const candidates = config.tokens.filter(t => t.prefix === prefix || t.prefix === legacyPrefix);
 
   for (const record of candidates) {
     const ok = await verifyToken(plaintext, record.hash);
     if (!ok) continue;
     if (record.expiresAt && new Date(record.expiresAt) < new Date()) continue;
+    healPrefix(config, record, prefix);
     _tokenCache.set(plaintext, { tokenId: record.id, expiresAt: Date.now() + CACHE_TTL_MS });
     return record;
   }
@@ -100,15 +122,21 @@ export async function findMatchingToken(
     const ok = await verifyToken(plaintext, record.hash);
     if (!ok) continue;
     if (record.expiresAt && new Date(record.expiresAt) < new Date()) continue;
-    record.prefix = prefix; // self-heal
-    try {
-      saveConfig(config);
-      log.info(`Backfilled prefix for legacy token '${record.name}' (${record.id}) on first use.`);
-    } catch { /* best-effort — will persist on the next config save */ }
+    healPrefix(config, record, prefix);
     _tokenCache.set(plaintext, { tokenId: record.id, expiresAt: Date.now() + CACHE_TTL_MS });
     return record;
   }
   return null;
+}
+
+/** Rewrite a record's prefix to the current format (best-effort persist). */
+function healPrefix(config: ReturnType<typeof getConfig>, record: TokenRecord, prefix: string): void {
+  if (record.prefix === prefix) return;
+  record.prefix = prefix;
+  try {
+    saveConfig(config);
+    log.info(`Migrated lookup prefix for token '${record.name}' (${record.id}) on first use.`);
+  } catch { /* best-effort — will persist on the next config save */ }
 }
 
 /** Update lastUsed timestamp for a token (best-effort, non-blocking).
@@ -140,7 +168,7 @@ export async function createToken(opts: {
     id: uuidv4(),
     name: opts.name,
     hash,
-    prefix: plaintext.slice(0, 8),
+    prefix: tokenPrefix(plaintext),
     createdAt: new Date().toISOString(),
     lastUsed: null,
     expiresAt: opts.expiresAt ?? null,
@@ -235,7 +263,7 @@ export async function regenerateToken(id: string): Promise<string | null> {
   const plaintext = generateToken();
   const hash = await hashToken(plaintext);
   config.tokens[idx]!.hash = hash;
-  config.tokens[idx]!.prefix = plaintext.slice(0, 8);
+  config.tokens[idx]!.prefix = tokenPrefix(plaintext);
   saveConfig(config);
   // Evict any cached entry for the old plaintext by scanning the cache
   for (const [key, val] of _tokenCache) {

--- a/server/src/auth/totp.ts
+++ b/server/src/auth/totp.ts
@@ -66,6 +66,8 @@ export function enableMfa(issuer: string, label: string): { secret: string; otpa
   const otpauth = generateURI({ issuer, label, secret });
   const secrets = getSecrets();
   secrets.totpSecret = secret;
+  // A fresh secret has no consumed steps — clear any counter from a prior enrolment.
+  delete secrets.totpLastStep;
   saveSecrets(secrets);
   return { secret, otpauth };
 }
@@ -74,27 +76,50 @@ export function enableMfa(issuer: string, label: string): { secret: string; otpa
 export function disableMfa(): void {
   const secrets = getSecrets();
   delete secrets.totpSecret;
+  delete secrets.totpLastStep;
   saveSecrets(secrets);
 }
+
+const TOTP_STEP_SECONDS = 30;
 
 /**
  * Verify a 6-digit TOTP code against the stored secret.
  * Returns false if MFA is not enabled or the code is wrong.
- * Checks current step ±1 (30 s window) using crypto.timingSafeEqual
- * to prevent timing side-channel attacks.
+ *
+ * Checks the current step ±1 (30 s window) using crypto.timingSafeEqual to
+ * prevent timing side-channel attacks, then enforces **single use**: the
+ * matched step must be strictly greater than the highest step already consumed
+ * (`secrets.totpLastStep`). Without this, a code captured in transit — from a
+ * proxy log, a shoulder-surf, or a phished operator — stays replayable for the
+ * remainder of its up-to-90 s validity window, which is exactly the window an
+ * attacker with a stolen admin PAT needs to disable MFA.
  */
 export function verifyMfaCode(code: string): boolean {
-  const { totpSecret } = getSecrets();
+  const secrets = getSecrets();
+  const { totpSecret } = secrets;
   if (!totpSecret) return false;
 
   const normalizedCode = Buffer.from(code.padStart(6, '0').slice(0, 6));
   const now = Math.floor(Date.now() / 1000);
 
-  // Always iterate all windows to prevent timing leakage of which window matched
+  // Always iterate all windows to prevent timing leakage of which window matched.
+  // `matchedStep` records WHICH step matched so it can be burned below.
   let matched = 0;
-  for (const offset of [-30, 0, 30]) {
-    const expected = Buffer.from(computeTotp(totpSecret, now + offset));
-    matched |= crypto.timingSafeEqual(normalizedCode, expected) ? 1 : 0;
+  let matchedStep = -1;
+  for (const offset of [-TOTP_STEP_SECONDS, 0, TOTP_STEP_SECONDS]) {
+    const epoch = now + offset;
+    const expected = Buffer.from(computeTotp(totpSecret, epoch));
+    const isMatch = crypto.timingSafeEqual(normalizedCode, expected);
+    matched |= isMatch ? 1 : 0;
+    if (isMatch) matchedStep = Math.floor(epoch / TOTP_STEP_SECONDS);
   }
-  return matched === 1;
+  if (matched !== 1 || matchedStep < 0) return false;
+
+  // Replay guard: refuse a step at or below the last consumed one.
+  const lastStep = secrets.totpLastStep ?? -1;
+  if (matchedStep <= lastStep) return false;
+
+  secrets.totpLastStep = matchedStep;
+  saveSecrets(secrets);
+  return true;
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -529,6 +529,11 @@ export interface OidcConfig {
   /** Scopes to request during the authorization code flow.
    *  Defaults to ["openid", "profile", "email"]. */
   scopes?: string[];
+  /** JWS algorithms accepted when verifying ID tokens. Defaults to the
+   *  asymmetric set in `DEFAULT_OIDC_ALGORITHMS` (RS/PS/ES/EdDSA). Override only
+   *  to NARROW it (e.g. ["RS256"]); adding an HMAC alg would let anyone holding
+   *  the shared secret mint tokens. */
+  allowedAlgorithms?: string[];
   /** Maps IdP JWT claims to Ythril permission flags. */
   claimMapping?: OidcClaimMapping;
   /**
@@ -642,6 +647,10 @@ export interface OAuthClientRecord {
 export interface SecretsFile {
   peerTokens: Record<string, string>;
   totpSecret?: string;              // base32 TOTP secret; absent = MFA disabled
+  /** Highest TOTP step counter already consumed. A code is accepted only for a
+   *  step strictly greater than this, so a code observed in transit cannot be
+   *  replayed within its ±1-step validity window. Reset when MFA is re-enrolled. */
+  totpLastStep?: number;
   webhookEncryptionKey?: string;    // hex-encoded AES-256 key for webhook secret encryption
   signingPrivateKey?: string;       // Ed25519 private key (PKCS8 PEM) for signing governance votes
   /**

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -96,6 +96,17 @@ const MUTATING_TOOLS = new Set([
   'bulk_write',
 ]);
 
+/**
+ * Tools that require an admin token. `list_peers` exposes the full peer
+ * topology (instance IDs, URLs, network membership) and `sync_now` drives
+ * outbound connections to every peer — both are instance-level operations with
+ * no space scoping, so a plain space-scoped token must not reach them. The REST
+ * equivalents (`/api/networks*`) are all `requireAdmin`; this closes the gap.
+ */
+const ADMIN_TOOLS = new Set([
+  'list_peers', 'sync_now', 'update_space', 'wipe_space',
+]);
+
 /** Tools that require a non-empty `space` parameter in global-mode tool calls.
  * When adding a new tool, update this set and the allTools schema accordingly. */
 const SPACE_REQUIRED_TOOLS = new Set([
@@ -773,7 +784,10 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
   ];
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: readOnly ? allTools.filter(t => !MUTATING_TOOLS.has(t.name)) : allTools,
+    tools: allTools.filter(t =>
+      !(readOnly && MUTATING_TOOLS.has(t.name)) &&
+      !(!isAdmin && ADMIN_TOOLS.has(t.name)),
+    ),
   }));
 
   // ── tools/call ────────────────────────────────────────────────────────────
@@ -785,6 +799,15 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
     if (readOnly && MUTATING_TOOLS.has(name)) {
       return {
         content: [{ type: 'text' as const, text: 'Error: this token has read-only access' }],
+        isError: true,
+      };
+    }
+
+    // Block instance-level tools for non-admin tokens (filtering them out of
+    // tools/list is advisory — the dispatcher is the enforcement point).
+    if (!isAdmin && ADMIN_TOOLS.has(name)) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: tool '${name}' requires an admin token` }],
         isError: true,
       };
     }

--- a/testing/red-team-tests/auth-surface-hardening.test.js
+++ b/testing/red-team-tests/auth-surface-hardening.test.js
@@ -1,0 +1,393 @@
+/**
+ * Red-team tests: auth surface hardening (M2, M8, M9, L1, L2)
+ *
+ * M2 — the `?token=` query-param fallback is accepted ONLY on the SSE endpoints
+ *      (EventSource cannot set headers). On every other route a query token must
+ *      be ignored → 401, so a token cannot be smuggled through access logs,
+ *      proxy logs, or a Referer header.
+ * M8 — a TOTP code is single-use: replaying a code that is still inside its
+ *      ±1-step validity window must be refused.
+ * M9 — the instance-level MCP tools (`list_peers`, `sync_now`) require an admin
+ *      token: they expose the peer topology / drive outbound sync and have no
+ *      space scoping.
+ * L1 — the token lookup `prefix` is taken from the RANDOM part of the token
+ *      (offset 7), not `ythril_` + 1 char; records still carrying the old
+ *      format keep authenticating and are migrated on first use.
+ * L2 — POST /api/conflicts/seed (a test fixture that fabricates conflict
+ *      records) is admin-gated.
+ *
+ * Run: node --test testing/red-team-tests/auth-surface-hardening.test.js
+ * Pre-requisite: test stack up + testing/sync/setup.js. MFA must start disabled
+ * on instance A.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let adminToken;
+
+before(() => {
+  adminToken = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+});
+
+function readContainerConfig(container = 'ythril-a') {
+  const out = execSync(
+    `docker exec ${container} node -e "const fs=require('fs');` +
+    `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
+  ).toString();
+  return JSON.parse(out);
+}
+
+// ── M2 — query-param token accepted on SSE endpoints only ────────────────────
+
+describe('M2 — ?token= is accepted only on the SSE endpoints', () => {
+  /** Request with the token ONLY in the query string (no Authorization header). */
+  async function queryTokenGet(pathAndQuery) {
+    const sep = pathAndQuery.includes('?') ? '&' : '?';
+    const r = await fetch(`${INSTANCES.a}${pathAndQuery}${sep}token=${encodeURIComponent(adminToken)}`);
+    return r.status;
+  }
+
+  const BLOCKED = [
+    '/api/spaces',
+    '/api/tokens',
+    '/api/networks',
+    '/api/brain/general/memories',
+    '/api/files/general?path=.',
+    '/api/about',
+  ];
+
+  for (const route of BLOCKED) {
+    it(`rejects a query-param token on ${route}`, async () => {
+      const status = await queryTokenGet(route);
+      assert.equal(status, 401, `VULNERABILITY: ${route} accepted a token from the query string`);
+    });
+  }
+
+  it('rejects a query-param token on a mutating (POST) route', async () => {
+    const r = await fetch(`${INSTANCES.a}/api/spaces?token=${encodeURIComponent(adminToken)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: `qt-${RUN}`, label: 'Should not be created' }),
+    });
+    assert.equal(r.status, 401, 'VULNERABILITY: POST accepted a token from the query string');
+  });
+
+  it('still accepts a query-param token on the log-stream SSE endpoint (EventSource)', async () => {
+    // The SSE stream never ends — abort as soon as headers arrive.
+    const ac = new AbortController();
+    const r = await fetch(
+      `${INSTANCES.a}/api/about/logs/stream?token=${encodeURIComponent(adminToken)}`,
+      { signal: ac.signal },
+    );
+    const status = r.status;
+    const ctype = r.headers.get('content-type') ?? '';
+    ac.abort();
+    assert.equal(status, 200, 'the audit-log EventSource must keep working');
+    assert.match(ctype, /text\/event-stream/);
+  });
+
+  it('the Authorization header still works everywhere (regression)', async () => {
+    const r = await get(INSTANCES.a, adminToken, '/api/spaces');
+    assert.equal(r.status, 200);
+  });
+});
+
+// ── M9 — instance-level MCP tools require admin ──────────────────────────────
+
+describe('M9 — list_peers / sync_now require an admin token', () => {
+  const spaceId = `m9-${RUN}`;
+  let plainToken;
+  const tokenIds = [];
+
+  before(async () => {
+    await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'M9' });
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', {
+      name: `m9-plain-${RUN}`,
+      spaces: [spaceId],
+    });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    plainToken = t.body.plaintext;
+    if (t.body.token?.id) tokenIds.push(t.body.token.id);
+  });
+
+  after(async () => {
+    for (const id of tokenIds) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+    await fetch(`${INSTANCES.a}/api/spaces/${spaceId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true }),
+    }).catch(() => {});
+  });
+
+  async function mcp(token, body) {
+    const r = await fetch(`${INSTANCES.a}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, ...body }),
+    });
+    return { status: r.status, text: await r.text() };
+  }
+
+  const callTool = (token, name, args = {}) =>
+    mcp(token, { method: 'tools/call', params: { name, arguments: args } });
+
+  it('list_peers via a non-admin token is refused', async () => {
+    const r = await callTool(plainToken, 'list_peers');
+    assert.match(r.text, /requires an admin token/i,
+      `VULNERABILITY: non-admin token reached list_peers: ${r.text.slice(0, 300)}`);
+  });
+
+  it('sync_now via a non-admin token is refused', async () => {
+    const r = await callTool(plainToken, 'sync_now');
+    assert.match(r.text, /requires an admin token/i,
+      `VULNERABILITY: non-admin token reached sync_now: ${r.text.slice(0, 300)}`);
+  });
+
+  it('tools/list hides the admin-only tools from a non-admin token', async () => {
+    const r = await mcp(plainToken, { method: 'tools/list', params: {} });
+    assert.ok(!/"name"\s*:\s*"list_peers"/.test(r.text), 'list_peers must not be advertised to a non-admin token');
+    assert.ok(!/"name"\s*:\s*"sync_now"/.test(r.text), 'sync_now must not be advertised to a non-admin token');
+  });
+
+  it('an admin token can still call list_peers (regression)', async () => {
+    const r = await callTool(adminToken, 'list_peers');
+    assert.ok(!/requires an admin token/i.test(r.text), `admin must retain access: ${r.text.slice(0, 300)}`);
+  });
+});
+
+// ── L1 — token lookup prefix entropy ─────────────────────────────────────────
+
+describe('L1 — token lookup prefix comes from the random part of the token', () => {
+  const tokenIds = [];
+
+  after(async () => {
+    for (const id of tokenIds) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+  });
+
+  it('a new token stores prefix = plaintext.slice(7, 15), not "ythril_" + 1 char', async () => {
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `l1-${RUN}` });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    const plaintext = t.body.plaintext;
+    const id = t.body.token?.id;
+    if (id) tokenIds.push(id);
+
+    const record = readContainerConfig().tokens.find(x => x.id === id);
+    assert.ok(record, 'token record should exist');
+    assert.equal(record.prefix, plaintext.slice(7, 15));
+    assert.ok(!record.prefix.startsWith('ythril_'), 'prefix must not be the constant literal');
+  });
+
+  it('a record still carrying the OLD prefix format authenticates and is migrated', async () => {
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `l1-legacy-${RUN}` });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    const plaintext = t.body.plaintext;
+    const id = t.body.token?.id;
+    if (id) tokenIds.push(id);
+
+    // Rewrite the record to the pre-fix format, as an upgraded deployment has it.
+    const oldPrefix = plaintext.slice(0, 8);
+    execSync(
+      `docker exec ythril-a node -e "const fs=require('fs');const p='/config/config.json';` +
+      `const c=JSON.parse(fs.readFileSync(p,'utf8'));` +
+      `const t=c.tokens.find(t=>t.id==='${id}');t.prefix='${oldPrefix}';` +
+      `fs.writeFileSync(p,JSON.stringify(c,null,2),{mode:0o600})"`,
+    );
+    const reload = await post(INSTANCES.a, adminToken, '/api/admin/reload-config', {});
+    assert.equal(reload.status, 200, JSON.stringify(reload.body));
+
+    // It must still authenticate …
+    const r = await get(INSTANCES.a, plaintext, '/api/spaces');
+    assert.equal(r.status, 200, 'a token with the old prefix format must keep working');
+
+    // … and be migrated to the new format on that first use.
+    const record = readContainerConfig().tokens.find(x => x.id === id);
+    assert.equal(record.prefix, plaintext.slice(7, 15), 'prefix should be migrated on first use');
+  });
+});
+
+// ── L2 — conflicts/seed is admin-gated ───────────────────────────────────────
+
+describe('L2 — POST /api/conflicts/seed requires an admin token', () => {
+  const spaceId = `l2-${RUN}`;
+  let plainToken;
+  const tokenIds = [];
+
+  before(async () => {
+    await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'L2' });
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', {
+      name: `l2-plain-${RUN}`,
+      spaces: [spaceId],
+    });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    plainToken = t.body.plaintext;
+    if (t.body.token?.id) tokenIds.push(t.body.token.id);
+  });
+
+  after(async () => {
+    for (const id of tokenIds) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+    await fetch(`${INSTANCES.a}/api/spaces/${spaceId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true }),
+    }).catch(() => {});
+  });
+
+  const seedBody = () => ({
+    _id: `seed-${RUN}-${Math.random().toString(36).slice(2, 8)}`,
+    spaceId,
+    originalPath: 'notes.md',
+    conflictPath: 'notes.conflict.md',
+    peerInstanceId: 'attacker',
+    peerInstanceLabel: 'Totally Legit Peer',
+  });
+
+  it('a space-scoped non-admin token cannot fabricate a conflict record', async () => {
+    const r = await post(INSTANCES.a, plainToken, '/api/conflicts/seed', seedBody());
+    assert.equal(r.status, 403, `VULNERABILITY: non-admin token seeded a conflict (${r.status})`);
+  });
+
+  it('an admin token can still seed (regression — the tests depend on it)', async () => {
+    const r = await post(INSTANCES.a, adminToken, '/api/conflicts/seed', seedBody());
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+  });
+});
+
+// ── M8 — TOTP codes are single-use ───────────────────────────────────────────
+
+describe('M8 — a TOTP code cannot be replayed inside its validity window', () => {
+  let secret;
+
+  // Break-glass disable: remove totpSecret from secrets.json + restart.
+  // (Once MFA is on, reload-config itself demands a code.)
+  function disableMfaViaRestart() {
+    execSync(
+      `docker exec ythril-a node -e "const fs=require('fs');const p='/config/secrets.json';` +
+      `const s=JSON.parse(fs.readFileSync(p,'utf8'));delete s.totpSecret;delete s.totpLastStep;` +
+      `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600})"`,
+    );
+    execSync('docker restart ythril-a', { stdio: 'ignore' });
+    const sleep1s = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
+    for (let i = 0; i < 45; i++) {
+      try {
+        if (execSync('docker inspect -f "{{.State.Health.Status}}" ythril-a').toString().trim() === 'healthy') return;
+      } catch { /* container mid-restart */ }
+      sleep1s();
+    }
+  }
+
+  /** After a restart the keep-alive pool still holds sockets to the dead process,
+   *  so the first request can surface as ECONNRESET. Drive one through until the
+   *  API answers cleanly. */
+  async function waitForApi() {
+    for (let i = 0; i < 30; i++) {
+      try {
+        const r = await fetch(`${INSTANCES.a}/health`);
+        if (r.ok) return;
+      } catch { /* stale socket / still booting */ }
+      await new Promise(res => setTimeout(res, 500));
+    }
+    throw new Error('instance A did not come back after restart');
+  }
+
+  // RFC 6238 TOTP (SHA-1, 30 s, 6 digits) — mirrors server/src/auth/totp.ts
+  const BASE32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  function base32Decode(input) {
+    let bits = '';
+    for (const c of input.toUpperCase().replace(/=+$/, '')) {
+      const v = BASE32.indexOf(c);
+      if (v === -1) continue;
+      bits += v.toString(2).padStart(5, '0');
+    }
+    const bytes = new Uint8Array(Math.floor(bits.length / 8));
+    for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(bits.slice(i * 8, i * 8 + 8), 2);
+    return Buffer.from(bytes);
+  }
+  function totp(sec, epoch = Math.floor(Date.now() / 1000)) {
+    const buf = Buffer.alloc(8);
+    buf.writeBigUInt64BE(BigInt(Math.floor(epoch / 30)));
+    const hmac = crypto.createHmac('sha1', base32Decode(sec)).update(buf).digest();
+    const off = hmac[hmac.length - 1] & 0x0f;
+    const code = (((hmac[off] & 0x7f) << 24) | (hmac[off + 1] << 16) | (hmac[off + 2] << 8) | hmac[off + 3]) % 1e6;
+    return code.toString().padStart(6, '0');
+  }
+
+  before(async () => {
+    disableMfaViaRestart();
+    await waitForApi();
+    const setup = await post(INSTANCES.a, adminToken, '/api/mfa/setup', {});
+    assert.equal(setup.status, 201, `enable MFA: ${JSON.stringify(setup.body)}`);
+    secret = setup.body.secret;
+    assert.ok(secret, 'setup should return the base32 secret');
+  });
+
+  after(() => {
+    disableMfaViaRestart();
+  });
+
+  it('a fresh code verifies, and the SAME code is refused on replay', async () => {
+    const code = totp(secret);
+
+    const first = await post(INSTANCES.a, adminToken, '/api/mfa/verify', { code });
+    assert.equal(first.status, 200, JSON.stringify(first.body));
+    assert.equal(first.body.valid, true, 'a fresh code must verify');
+
+    const replay = await post(INSTANCES.a, adminToken, '/api/mfa/verify', { code });
+    assert.equal(replay.status, 200, JSON.stringify(replay.body));
+    assert.equal(
+      replay.body.valid, false,
+      'VULNERABILITY: the same TOTP code verified twice — a captured code stays replayable for up to 90 s',
+    );
+  });
+
+  it('a code from an ALREADY-CONSUMED earlier step is refused (window replay)', async () => {
+    // The previous step's code is normally still valid (±1 window). After a
+    // later step has been consumed, it must be rejected as stale.
+    const prevStepCode = totp(secret, Math.floor(Date.now() / 1000) - 30);
+    const r = await post(INSTANCES.a, adminToken, '/api/mfa/verify', { code: prevStepCode });
+    assert.equal(r.body.valid, false, 'a code from a step at/below the last consumed one must be refused');
+  });
+
+  it('an MFA-gated route accepts a fresh code but not its replay', async () => {
+    // /api/admin/reload-config is requireAdminMfa — a real gated action.
+    // The CURRENT step was already burned by the tests above, so take the NEXT
+    // step's code: it is inside the +1 skew window (hence valid) and its step is
+    // above the last consumed one (hence not a replay). Avoids a 30 s wait.
+    const code = totp(secret, Math.floor(Date.now() / 1000) + 30);
+    const first = await fetch(`${INSTANCES.a}/api/admin/reload-config`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+        'x-totp-code': code,
+      },
+      body: '{}',
+    });
+    assert.equal(first.status, 200, 'a fresh code must pass the MFA gate');
+
+    const replay = await fetch(`${INSTANCES.a}/api/admin/reload-config`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+        'x-totp-code': code,
+      },
+      body: '{}',
+    });
+    assert.equal(replay.status, 403, 'VULNERABILITY: a replayed TOTP code passed the MFA gate');
+  });
+});

--- a/testing/standalone/oidc-alg-pinning.test.js
+++ b/testing/standalone/oidc-alg-pinning.test.js
@@ -1,0 +1,107 @@
+/**
+ * Unit tests: OIDC signature-algorithm pinning (M7)
+ *
+ * `jwtVerify` was called without an `algorithms` option, so the accepted set was
+ * whatever jose's JWKS resolver happened to allow, rather than explicit policy.
+ *
+ * Scope note (verified below, not assumed): jose's JWKS resolver ALREADY refuses
+ * symmetric keys, so the classic HS/RS confusion attack was never reachable here.
+ * Pinning is defence in depth — it makes the accepted set explicit (it cannot
+ * widen silently if the resolver's behaviour changes) and lets an operator narrow
+ * verification to exactly what their IdP signs with (`allowedAlgorithms`).
+ *
+ * Pure in-process logic — no IdP, no network. Run:
+ *   node --test testing/standalone/oidc-alg-pinning.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SignJWT, jwtVerify, createLocalJWKSet, generateSecret, generateKeyPair, exportJWK,
+} from 'jose';
+import { DEFAULT_OIDC_ALGORITHMS } from '../../server/dist/auth/oidc.js';
+
+const ISSUER = 'https://issuer.example.com';
+const AUDIENCE = 'ythril';
+
+describe('DEFAULT_OIDC_ALGORITHMS', () => {
+  it('contains only asymmetric algorithms', () => {
+    for (const alg of DEFAULT_OIDC_ALGORITHMS) {
+      assert.match(alg, /^(RS|PS|ES)(256|384|512)$|^EdDSA$/, `unexpected algorithm in the default set: ${alg}`);
+    }
+  });
+
+  it('excludes every HMAC algorithm', () => {
+    for (const alg of ['HS256', 'HS384', 'HS512']) {
+      assert.ok(!DEFAULT_OIDC_ALGORITHMS.includes(alg), `${alg} must not be accepted`);
+    }
+  });
+
+  it('excludes the "none" algorithm', () => {
+    assert.ok(!DEFAULT_OIDC_ALGORITHMS.includes('none'));
+    assert.ok(!DEFAULT_OIDC_ALGORITHMS.includes('None'));
+  });
+
+  it('includes RS256 (what essentially every OIDC IdP signs with)', () => {
+    assert.ok(DEFAULT_OIDC_ALGORITHMS.includes('RS256'));
+  });
+});
+
+describe('symmetric keys are refused at the JWKS layer (pre-existing guard)', () => {
+  it('an HS256 token against an oct JWKS key is rejected even with no algorithms option', async () => {
+    const secret = await generateSecret('HS256', { extractable: true });
+    const jwk = await exportJWK(secret);
+    jwk.kid = 'sym-1';
+    jwk.alg = 'HS256';
+    const jwks = createLocalJWKSet({ keys: [jwk] });
+
+    const token = await new SignJWT({ sub: 'attacker', role: 'admin' })
+      .setProtectedHeader({ alg: 'HS256', kid: 'sym-1' })
+      .setIssuer(ISSUER).setAudience(AUDIENCE)
+      .setIssuedAt().setExpirationTime('1h')
+      .sign(secret);
+
+    // Documents WHY the HS-confusion vector was not exploitable: jose stops it
+    // before any algorithm policy is consulted. If this ever starts passing, the
+    // `algorithms` pin below is the thing standing between it and an admin token.
+    await assert.rejects(
+      () => jwtVerify(token, jwks, { issuer: ISSUER, audience: AUDIENCE }),
+      /Unsupported "alg" value for a JSON Web Key Set/,
+    );
+  });
+});
+
+describe('pinning narrows the accepted set (what the fix buys)', () => {
+  let esToken, esJwks;
+
+  before(async () => {
+    const { privateKey, publicKey } = await generateKeyPair('ES256', { extractable: true });
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = 'ec-1';
+    esJwks = createLocalJWKSet({ keys: [jwk] });
+
+    esToken = await new SignJWT({ sub: 'user', role: 'admin' })
+      .setProtectedHeader({ alg: 'ES256', kid: 'ec-1' })
+      .setIssuer(ISSUER).setAudience(AUDIENCE)
+      .setIssuedAt().setExpirationTime('1h')
+      .sign(privateKey);
+  });
+
+  it('an ES256 token is accepted under the default set', async () => {
+    const { payload } = await jwtVerify(esToken, esJwks, {
+      issuer: ISSUER, audience: AUDIENCE, algorithms: DEFAULT_OIDC_ALGORITHMS,
+    });
+    assert.equal(payload.sub, 'user');
+  });
+
+  it('the same token is refused when the operator narrows to ["RS256"]', async () => {
+    await assert.rejects(
+      () => jwtVerify(esToken, esJwks, {
+        issuer: ISSUER, audience: AUDIENCE, algorithms: ['RS256'],
+      }),
+      /alg/i,
+      'allowedAlgorithms must be able to reject an algorithm the IdP never uses',
+    );
+  });
+});


### PR DESCRIPTION
The **auth/authz MEDIUM+LOW** group of the security audit (M2, M7, M8, M9, L1, L2), following #133 which closed the HIGH tier. The remaining MEDIUM/LOW items split into a sync group (M3–M6, M10) and a files/brain group (M1, M11, L3–L5) — separate PRs.

## ⚠️ Breaking: `?token=` is no longer accepted on REST routes (M2)

The query-string token fallback exists because the browser `EventSource` API cannot set headers — but it lived in the shared auth path and was therefore honoured on **every route and every method**. Query strings land in access logs, proxy logs, browser history and `Referer` headers, so a token passed that way is effectively logged in plaintext across the request path.

It is now accepted **only** on the two SSE streams: `GET /api/about/logs/stream` and `GET /mcp`. Everywhere else a query token is ignored → `401`. The only in-tree consumer (the audit-log EventSource in the web UI) is unaffected. **If an external integration passes `?token=` to a REST route, it must move the token to the `Authorization` header.**

## M8 — TOTP codes are single-use

A code stayed valid for its whole ±1-step window (up to 90 s), so a code captured in transit — proxy log, shoulder-surf, phished operator — could be replayed. That is exactly the window an attacker with a stolen admin PAT needs to disable MFA (the thing #128 hardened). The highest consumed step is now recorded (`totpLastStep` in `secrets.json`) and a code is accepted only for a strictly greater step.

Side effect worth knowing: `POST /api/mfa/verify` ("test your authenticator") consumes the code too, so a code tested there can't immediately be reused for a gated call — documented in the integration guide.

## M7 — OIDC algorithm pinning (**severity corrected down**)

`jwtVerify` ran with no `algorithms` option. The audit item assumed this allowed HS/RS confusion. **Writing the test disproved that**: jose's JWKS resolver already refuses symmetric keys (`Unsupported "alg" value for a JSON Web Key Set`), so the attack was never reachable. Rather than assert a vulnerability that doesn't exist, the test now proves both directions — the pre-existing guard, *and* what pinning actually buys:

- the accepted set becomes explicit policy instead of a side effect of resolver behaviour (it can't silently widen if that behaviour changes), and
- operators can narrow verification to exactly what their IdP signs with, via the new `oidc.allowedAlgorithms` (e.g. `["RS256"]`).

Defence in depth, not a fix for an exploitable hole — and the CHANGELOG says so.

## M9 — instance-level MCP tools require admin

`list_peers` (full peer topology: instance IDs, URLs, network membership) and `sync_now` (drives outbound connections to every peer) had no admin gate, though every REST equivalent under `/api/networks*` is `requireAdmin`. Any space-scoped token could enumerate the network and trigger syncs. Both are now admin-only — enforced centrally in the dispatcher (with `update_space`/`wipe_space`, whose inline checks this generalises) and hidden from `tools/list` for non-admin tokens.

## L1 — token lookup prefix entropy

The stored `prefix` (a pre-filter for the bcrypt scan) was `plaintext.slice(0, 8)` — the literal `ythril_` plus **one** random char, despite a comment claiming `62^8`. About 1/62 of all tokens shared a bucket, so a large deployment ran many bcrypt compares per request. It now comes from the random part (offset 7). Lookup matches **both** formats and migrates the record on first successful auth, so no existing token is invalidated and no re-issue is needed (consistent with #131, which removed the token-deleting migration).

## L2 — `POST /api/conflicts/seed` is admin-gated

A test fixture that fabricates conflict records — presented in the UI as genuine sync conflicts with an attacker-chosen `peerInstanceLabel`, and whose resolution actions move/overwrite files — sat on the plain authenticated router. Now `requireAdmin` + `denyReadOnly`.

## Tests

- New: `testing/red-team-tests/auth-surface-hardening.test.js` (20 — query-token blocked on REST/POST but working on SSE, TOTP replay refused on both `/mfa/verify` and a real MFA-gated route, MCP admin gate + `tools/list` filtering, prefix format + old-format migration, seed gate)
- New: `testing/standalone/oidc-alg-pinning.test.js` (7)
- Full suites on the rebuilt Docker stack: **red-team 240/240**, **integration 783 pass / 0 fail**, **standalone 668 pass / 0 fail**, **sync 173 pass / 0 fail**

## Config (all optional)

- `oidc.allowedAlgorithms` — narrow the accepted ID-token signature algorithms

Docs updated: CHANGELOG, `docs/integration-guide.md` (header-only auth note, TOTP single-use note, `allowedAlgorithms` row, MCP admin-only tools — the read-only tool list wrongly implied `list_peers` was reachable by any token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)