### PR TITLE
security: sync-layer hardening (network-membership check, seq-poisoning guard, Merkle content hashing, invite binding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Sync data endpoints now verify network membership, not just space scope** — a peer-bound token
+  was authorised against the calling token's space allow-list alone, so two networks sharing a space
+  but with **disjoint membership** leaked into each other: a member of network X could read/write that
+  space by naming network Y (which it does not belong to). A token carrying a `peerInstanceId` may now
+  reach a space only through a network that peer is actually a member of. Manually-provisioned peer
+  tokens and asymmetric (single-side-configured) networks are unaffected — they fall back to plain
+  token-space scoping. (M3)
+
+- **Sync sequence-counter poisoning is bounded** — every ingested document advances the space's `seq`
+  counter (so local writes always sort above synced ones). A peer could push a single document with a
+  `seq` near the protocol ceiling (2^50), dragging the counter there; once local writes reach the
+  ceiling, peers reject them and the space silently loses the ability to sync new writes. Documents
+  whose `seq` falls within a reserved band below the ceiling (`MAX_INGEST_SEQ = 2^50 − 2^40`) are now
+  refused on every ingest path (single upsert → 400, batch → dropped with a warning, engine pull →
+  skipped), and `bumpSeq` clamps the advance as a backstop. The bound is absolute rather than relative
+  to the current counter, so it never false-positives on a legitimate high-volume space syncing to a
+  fresh peer. (M5)
+
+- **Merkle verification now hashes document content** — leaves were
+  `SHA-256("doc:<type>:<id>:<seq>")`, so a peer serving *altered* content under the same `_id`/`seq`
+  produced the same root: divergence detection caught missing or version-skewed documents but never
+  tampered ones. Leaves now include a canonical content hash (keys sorted, embedding vectors excluded
+  so peers running different models don't false-positive). Files were already content-hashed. Merkle
+  remains advisory (opt-in per network; a mismatch is reported, not blocking). Covered by
+  `testing/standalone/merkle-content-hash.test.js`. (M6)
+
+- **Invite reparent bundles are bound to their target instance** — a braintree *reparent* invite
+  rewrites one existing member's record (including its inbound `tokenHash`) at finalize. `apply` never
+  compared the applying `instanceId` to the session's reparent target, so a holder of a reparent
+  bundle could apply as an unrelated instance and have finalize hand them the victim's member record —
+  a member takeover. `apply` (and finalize, as a TOCTOU backstop) now refuse a mismatch, and the
+  normal join path re-checks membership at finalize. A new optional `expectedInstanceId` on
+  `POST /api/invite/generate` pins any invite to a single instance so a leaked bundle can't be
+  redeemed by someone else. (M10)
+
 - **A `?token=` query parameter is now accepted only on the SSE endpoints** — the Bearer-token
   query-string fallback exists because the browser `EventSource` API cannot set headers, but it was
   wired into the shared auth path and therefore honoured on **every route and every method**. A token

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3300,6 +3300,13 @@ Authorization: Bearer <admin-token>
 { "networkId": "net-uuid" }
 ```
 
+Optional fields:
+
+| Field | Purpose |
+|---|---|
+| `expectedInstanceId` | Pin the invite to one `instanceId`. Only that instance may `apply` the bundle — a leaked or forwarded invite link cannot be redeemed by anyone else. |
+| `reparentInstanceId` | Braintree reparent (not a new join): move this already-existing member under this instance. The invite is bound to that `instanceId` — applying it as any other instance is refused, so a reparent bundle cannot seize a different member's record. |
+
 **Response** `201`:
 
 ```json
@@ -3542,6 +3549,8 @@ GET /api/sync/merkle?spaceId=general&networkId=net-uuid
   "networkId": "net-uuid"
 }
 ```
+
+Each brain-document leaf hashes the document's **content** (canonical JSON, keys sorted, embedding vectors excluded so peers running different embedding models don't diverge), not just its `_id`/`seq` — so a mismatch detects tampered content, not only missing or version-skewed documents. File leaves hash the file's SHA-256. The check is advisory: a root mismatch is reported as `MERKLE_DIVERGENCE`, it does not block sync.
 
 ### Gossip Endpoints
 

--- a/server/src/api/invite.ts
+++ b/server/src/api/invite.ts
@@ -81,6 +81,8 @@ interface HandshakeSession {
   /** When set, this session is a braintree reparent, not a new join.
    *  The instanceId of the grandchild being temporarily re-parented. */
   reparentInstanceId?: string;
+  /** When set, only this instanceId may apply the invite (optional pinning). */
+  expectedInstanceId?: string;
 }
 
 const _sessions = new Map<string, HandshakeSession>();
@@ -103,6 +105,9 @@ const GenerateBody = z.object({
   /** When set, this invite is a braintree reparent — not a new join.
    *  The target must already be a member whose parent is offline. */
   reparentInstanceId: z.string().uuid().optional(),
+  /** Optional: pin the invite to one instanceId. Only that instance may apply it,
+   *  so a leaked/forwarded bundle cannot be redeemed by someone else. */
+  expectedInstanceId: z.string().uuid().optional(),
 });
 
 const INVITE_SSRF_SAFE_URL = z.string().url().refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE });
@@ -164,7 +169,7 @@ inviteRouter.post('/generate', globalRateLimit, requireAdmin, async (req, res) =
   const parsed = GenerateBody.safeParse(req.body);
   if (!parsed.success) { res.status(400).json({ error: parsed.error.message }); return; }
 
-  const { networkId, reparentInstanceId } = parsed.data;
+  const { networkId, reparentInstanceId, expectedInstanceId } = parsed.data;
   const cfg = getConfig();
   const net = cfg.networks.find(n => n.id === networkId);
   if (!net) { res.status(404).json({ error: 'Network not found' }); return; }
@@ -204,6 +209,7 @@ inviteRouter.post('/generate', globalRateLimit, requireAdmin, async (req, res) =
     publicKeyPem: publicKey as string,
     expiresAt,
     reparentInstanceId,
+    expectedInstanceId,
   });
 
   log.info(`Invite handshake generated for network ${networkId} (session ${sessionKey})${
@@ -251,13 +257,35 @@ inviteRouter.post('/apply', authRateLimit, async (req, res) => {
   const net = cfg.networks.find(n => n.id === networkId);
   if (!net) { res.status(404).json({ error: 'Network not found' }); return; }
 
-  // Ensure the joining instance is not already a member — unless this is a reparent session
-  // targeting exactly that instance (the grandchild re-applying under a new parent).
-  if (net.members.some(m => m.instanceId === instanceId)) {
-    if (!session.reparentInstanceId || session.reparentInstanceId !== instanceId) {
-      res.status(409).json({ error: 'Instance is already a member of this network' });
+  // ── Reparent sessions are bound to their target ──────────────────────────
+  // A reparent invite exists to move ONE specific member (the grandchild whose
+  // parent went offline) under this instance. finalize() rewrites that member's
+  // record — including its tokenHash. Without this check the applier's identity
+  // was never compared to the session's target, so ANY holder of a reparent
+  // bundle could apply as an unrelated instanceId and have finalize hand them
+  // the victim's member record: its inbound tokenHash replaced by the
+  // attacker's, i.e. a member takeover.
+  if (session.reparentInstanceId) {
+    if (instanceId !== session.reparentInstanceId) {
+      res.status(403).json({ error: 'This invite is a reparent for a different instance' });
       return;
     }
+    if (!net.members.some(m => m.instanceId === instanceId)) {
+      res.status(409).json({ error: 'Reparent target is not a member of this network' });
+      return;
+    }
+  } else if (net.members.some(m => m.instanceId === instanceId)) {
+    res.status(409).json({ error: 'Instance is already a member of this network' });
+    return;
+  }
+
+  // Optional pinning: when the inviter named the instance this bundle is for,
+  // only that instance may use it. An invite bundle is a bearer credential, so
+  // without pinning anyone who obtains it (forwarded link, shoulder-surfed QR)
+  // can join in place of the intended peer.
+  if (session.expectedInstanceId && instanceId !== session.expectedInstanceId) {
+    res.status(403).json({ error: 'This invite is pinned to a different instanceId' });
+    return;
   }
 
   // Validate the peer's RSA public key is parseable and exactly 4096-bit
@@ -356,6 +384,12 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
   if (session.reparentInstanceId) {
     // ── Reparent path ───────────────────────────────────────────────────────
     // Update the existing member record instead of creating a new one.
+    // /apply already bound the applier to the session's target; re-assert it here
+    // so the record being rewritten is always the one the applier authenticated as.
+    if (instanceId !== session.reparentInstanceId) {
+      res.status(403).json({ error: 'Reparent session does not match the applying instance' });
+      return;
+    }
     const target = net.members.find(m => m.instanceId === session.reparentInstanceId);
     if (!target) {
       res.status(400).json({ error: 'Reparent target member not found — was it removed?' });
@@ -387,6 +421,13 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
     responseStatus = 'reparented';
   } else {
     // ── Normal join path ────────────────────────────────────────────────────
+    // Re-check membership: /apply ran this check, but two handshakes for the
+    // same instance could interleave between apply and finalize and add the
+    // member twice.
+    if (net.members.some(m => m.instanceId === instanceId)) {
+      res.status(409).json({ error: 'Instance is already a member of this network' });
+      return;
+    }
     const newMember: NetworkMember = {
       instanceId,
       label: instanceLabel,

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -19,7 +19,7 @@ import { listTombstones, applyRemoteTombstone } from '../brain/tombstones.js';
 import { requireAuth, denyReadOnly } from '../auth/middleware.js';
 import { revokePeerCredentialsIfOrphaned } from '../auth/tokens.js';
 import { log } from '../util/log.js';
-import { nextSeq, bumpSeq } from '../util/seq.js';
+import { nextSeq, bumpSeq, isSeqImplausible, MAX_INGEST_SEQ } from '../util/seq.js';
 import { updateSpace } from '../spaces/spaces.js';
 import { isStrictLinkage } from '../spaces/proxy.js';
 import { getAllowedChronoTypes } from '../spaces/schema-validation.js';
@@ -288,20 +288,86 @@ async function forkChainDepth(spaceId: string, docId: string | undefined): Promi
 }
 
 /**
- * Returns true if:
- *  1. The calling token (if space-scoped) includes spaceId in its allowlist, AND
- *  2. The spaceId is valid for the given networkId (or exists locally if no networkId).
- *
- * @param tokenSpaces - the `spaces` field from req.authToken (undefined = full-access token)
+ * Refuse a document whose `seq` is implausibly far ahead of the space counter
+ * (see util/seq.ts — MAX_INGEST_SEQ). Responds 400 and returns true when rejected.
  */
-function spaceAllowed(spaceId: string, networkId?: string, tokenSpaces?: string[]): boolean {
+function rejectImplausibleSeq(
+  spaceId: string,
+  seq: number,
+  res: import('express').Response,
+  peerInstanceId?: string,
+): boolean {
+  if (!isSeqImplausible(seq)) return false;
+  log.warn(
+    `Refused document with implausible seq ${seq} for space '${spaceId}' ` +
+    `from peer '${peerInstanceId ?? 'unknown'}' (max ingest seq ${MAX_INGEST_SEQ}).`,
+  );
+  res.status(400).json({ error: `seq ${seq} is too close to the protocol ceiling and was refused` });
+  return true;
+}
+
+/** The peer identity bound to a production peer PAT (set by the invite handshake). */
+function callerPeerId(authToken: Record<string, unknown> | undefined): string | undefined {
+  const v = authToken?.['peerInstanceId'];
+  return typeof v === 'string' && v ? v : undefined;
+}
+
+/**
+ * Networks (local view) in which `peerInstanceId` is a member.
+ *
+ * An EMPTY result means the token is bound to a peer we do not list as a member
+ * anywhere. That happens for manually-provisioned peer tokens and for
+ * single-side-configured (asymmetric) networks, where the sender holds the
+ * network config and we do not. Those callers fall back to plain token-space
+ * scoping — see spaceAllowed.
+ */
+function peerMemberNetworks(peerInstanceId: string) {
+  return getConfig().networks.filter(n => n.members.some(m => m.instanceId === peerInstanceId));
+}
+
+/**
+ * Returns true if the caller may touch `spaceId` (optionally within `networkId`).
+ *
+ * Checks, in order:
+ *  1. Token space scope (a space-scoped token may only touch its own spaces).
+ *  2. **Network membership** — a peer-bound token may only reach spaces shared
+ *     through a network that peer is actually a member of. Space scope alone is
+ *     not enough: two networks with overlapping spaces but disjoint membership
+ *     would otherwise leak into each other (a peer of network X reading a space
+ *     that X and Y both carry, while being no member of Y).
+ *  3. The space is actually shared by that network.
+ *
+ * Local/admin tokens (no `peerInstanceId`) keep the previous behaviour — they
+ * are this instance's own credentials, not a remote peer's.
+ */
+function spaceAllowed(
+  spaceId: string,
+  networkId: string | undefined,
+  tokenSpaces: string[] | undefined,
+  authToken?: Record<string, unknown>,
+): boolean {
   const cfg = getConfig();
   // Enforce token-level space scope before any network check
   if (tokenSpaces && !tokenSpaces.includes(spaceId)) return false;
+
+  const peerId = callerPeerId(authToken);
+  if (peerId) {
+    const memberNets = peerMemberNetworks(peerId);
+    if (memberNets.length > 0) {
+      // A known peer: it may only reach spaces via networks it belongs to.
+      const usable = networkId
+        ? memberNets.filter(n => n.id === networkId)
+        : memberNets;
+      return usable.some(n => n.spaces.includes(spaceId));
+    }
+    // Unknown peer (manual token / asymmetric network): fall through to the
+    // legacy space-existence check below — the token's own scope still applies.
+  }
+
   // If no networkId given, allow any known space
   if (!networkId) return cfg.spaces.some(s => s.id === spaceId);
   const net = cfg.networks.find(n => n.id === networkId);
-  // networkId not found locally â€” fall back to checking the space exists.
+  // networkId not found locally — fall back to checking the space exists.
   // This handles asymmetric networks where the caller has the network config
   // but the recipient does not (e.g. single-side configured networks).
   if (!net) return cfg.spaces.some(s => s.id === spaceId);
@@ -312,14 +378,27 @@ function spaceAllowed(spaceId: string, networkId?: string, tokenSpaces?: string[
  * For directional networks (braintree, pubsub), reject inbound writes from
  * members whose direction is 'push'. Direction is stored from THIS instance's
  * perspective:
- *   direction='push'  â†’ we push TO them â†’ they must NOT push to us
- *   direction='pull'  â†’ we pull FROM them â†’ they may push to us (data source)
- *   direction='both'  â†’ bidirectional â†’ accept
+ *   direction='push'  → we push TO them → they must NOT push to us
+ *   direction='pull'  → we pull FROM them → they may push to us (data source)
+ *   direction='both'  → bidirectional → accept
+ *
+ * Enforcement is against an IDENTIFIED member: the peer token carries a
+ * server-issued `peerInstanceId` (set by the invite handshake) that is matched
+ * against the member list. This covers the real case — a push-only subscriber
+ * or child trying to write back to its publisher/parent, where that peer IS a
+ * member with direction='push' on this side, so it is blocked.
+ *
+ * A token with NO `peerInstanceId` is intentionally NOT blocked here: in a
+ * braintree tree the receiver does not list its parent as a member at all, and
+ * manually-provisioned peer tokens legitimately omit `peerInstanceId`, so a
+ * blanket refusal would break those topologies. `peerInstanceId` is issued
+ * server-side and cannot be self-declared, so an attacker cannot forge a
+ * matching identity to bypass the check either.
  *
  * Returns true if the write should be REJECTED (403).
  */
 function isDirectionalWriteBlocked(networkId: string | undefined, authToken: Record<string, unknown> | undefined): boolean {
-  const peerInstanceId = authToken && typeof authToken['peerInstanceId'] === 'string' ? authToken['peerInstanceId'] : undefined;
+  const peerInstanceId = callerPeerId(authToken);
   if (!networkId || !peerInstanceId) return false;
   const cfg = getConfig();
   const net = cfg.networks.find(n => n.id === networkId);
@@ -327,7 +406,7 @@ function isDirectionalWriteBlocked(networkId: string | undefined, authToken: Rec
   if (net.type !== 'braintree' && net.type !== 'pubsub') return false;
   const member = net.members.find(m => m.instanceId === peerInstanceId);
   if (!member) return false;
-  // direction='push' means WE push to THEM â€” they should not be writing to us
+  // direction='push' means WE push to THEM — they should not be writing to us
   return member.direction === 'push';
 }
 
@@ -344,7 +423,7 @@ syncRouter.get('/memories', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId, sinceSeq = '0', limit = '100', cursor, full: fullParam } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const sinceVal = cursor ? decodeCursor(cursor) : parseInt(sinceSeq, 10);
     const pageSize = Math.min(parseInt(limit, 10) || 100, 500);
@@ -390,7 +469,7 @@ syncRouter.get('/memories/:id', syncRateLimit, requireAuth, async (req, res) => 
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const doc = await col<MemoryDoc>(`${spaceId}_memories`).findOne(mFilter<MemoryDoc>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
@@ -410,7 +489,7 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingMemoryDoc.safeParse(req.body);
@@ -419,6 +498,7 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
       return;
     }
     const incoming = parsed.data as MemoryDoc;
+    if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
 
     // Check for tombstone â€” if a tombstone with >= seq exists, skip
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
@@ -496,7 +576,7 @@ syncRouter.get('/entities', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId, sinceSeq = '0', limit = '100', cursor, full: fullParam } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const sinceVal = cursor ? decodeCursor(cursor) : parseInt(sinceSeq, 10);
     const pageSize = Math.min(parseInt(limit, 10) || 100, 500);
@@ -533,7 +613,7 @@ syncRouter.get('/entities/:id', syncRateLimit, requireAuth, async (req, res) => 
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const doc = await col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
@@ -547,7 +627,7 @@ syncRouter.post('/entities', syncRateLimit, requireAuth, denyReadOnly, async (re
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingEntityDoc.safeParse(req.body);
@@ -556,6 +636,7 @@ syncRouter.post('/entities', syncRateLimit, requireAuth, denyReadOnly, async (re
       return;
     }
     const incoming = parsed.data as EntityDoc;
+    if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
 
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
       .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'entity' })) as TombstoneDoc | null;
@@ -594,7 +675,7 @@ syncRouter.get('/edges', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId, sinceSeq = '0', limit = '100', cursor, full: fullParam } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const sinceVal = cursor ? decodeCursor(cursor) : parseInt(sinceSeq, 10);
     const pageSize = Math.min(parseInt(limit, 10) || 100, 500);
@@ -631,7 +712,7 @@ syncRouter.get('/edges/:id', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const doc = await col<EdgeDoc>(`${spaceId}_edges`).findOne(mFilter<EdgeDoc>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
@@ -645,7 +726,7 @@ syncRouter.post('/edges', syncRateLimit, requireAuth, denyReadOnly, async (req, 
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingEdgeDoc.safeParse(req.body);
@@ -654,6 +735,7 @@ syncRouter.post('/edges', syncRateLimit, requireAuth, denyReadOnly, async (req, 
       return;
     }
     const incoming = parsed.data as EdgeDoc;
+    if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
 
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
       .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'edge' })) as TombstoneDoc | null;
@@ -693,7 +775,7 @@ syncRouter.get('/chrono', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId, sinceSeq = '0', limit = '100', cursor, full: fullParam } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const sinceVal = cursor ? decodeCursor(cursor) : parseInt(sinceSeq, 10);
     const pageSize = Math.min(parseInt(limit, 10) || 100, 500);
@@ -730,7 +812,7 @@ syncRouter.get('/chrono/:id', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const doc = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(mFilter<ChronoEntry>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
@@ -744,7 +826,7 @@ syncRouter.post('/chrono', syncRateLimit, requireAuth, denyReadOnly, async (req,
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingChronoDoc.safeParse(req.body);
@@ -753,6 +835,7 @@ syncRouter.post('/chrono', syncRateLimit, requireAuth, denyReadOnly, async (req,
       return;
     }
     const incoming = parsed.data as ChronoEntry;
+    if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
     const allowedChronoTypes = getAllowedChronoTypes(getConfig().spaces.find(s => s.id === spaceId)?.meta);
     if (!allowedChronoTypes.has(incoming.type)) {
       res.status(400).json({ error: `\`type\` must be one of: ${[...allowedChronoTypes].join(', ')}` });
@@ -803,18 +886,37 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const body = req.body as { memories?: unknown[]; entities?: unknown[]; edges?: unknown[]; chrono?: unknown[] };
-    const memories = (Array.isArray(body?.memories) ? body.memories.slice(0, 500) : [])
+    const memoriesRaw = (Array.isArray(body?.memories) ? body.memories.slice(0, 500) : [])
       .flatMap(m => { const r = IncomingMemoryDoc.safeParse(m); return r.success ? [r.data as MemoryDoc] : []; });
-    const entities = (Array.isArray(body?.entities) ? body.entities.slice(0, 500) : [])
+    const entitiesRaw = (Array.isArray(body?.entities) ? body.entities.slice(0, 500) : [])
       .flatMap(e => { const r = IncomingEntityDoc.safeParse(e); return r.success ? [r.data as EntityDoc] : []; });
-    const edges = (Array.isArray(body?.edges) ? body.edges.slice(0, 500) : [])
+    const edgesRaw = (Array.isArray(body?.edges) ? body.edges.slice(0, 500) : [])
       .flatMap(e => { const r = IncomingEdgeDoc.safeParse(e); return r.success ? [r.data as EdgeDoc] : []; });
-    const chrono = (Array.isArray(body?.chrono) ? body.chrono.slice(0, 500) : [])
+    const chronoRaw = (Array.isArray(body?.chrono) ? body.chrono.slice(0, 500) : [])
       .flatMap(c => { const r = IncomingChronoDoc.safeParse(c); return r.success ? [r.data as ChronoEntry] : []; });
+
+    // Drop documents whose seq is too close to the protocol ceiling — one such
+    // doc would otherwise drag the counter toward it via the bumpSeq below (see
+    // util/seq.ts). Batch ingest already skips invalid documents silently, so
+    // these are dropped with a warning, not fatal.
+    const plausible = <T extends { seq: number; _id: string }>(docs: T[], kind: string): T[] =>
+      docs.filter(d => {
+        if (!isSeqImplausible(d.seq)) return true;
+        log.warn(
+          `batch-upsert: dropped ${kind} '${d._id}' with implausible seq ${d.seq} ` +
+          `for space '${spaceId}' (max ingest seq ${MAX_INGEST_SEQ}) from peer ` +
+          `'${callerPeerId(req.authToken as Record<string, unknown>) ?? 'unknown'}'.`,
+        );
+        return false;
+      });
+    const memories = plausible(memoriesRaw, 'memory');
+    const entities = plausible(entitiesRaw, 'entity');
+    const edges = plausible(edgesRaw, 'edge');
+    const chrono = plausible(chronoRaw, 'chrono');
 
     // â”€â”€ Memories â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     const memStats = { inserted: 0, updated: 0, forked: 0, skipped: 0, tombstoned: 0 };
@@ -939,7 +1041,7 @@ syncRouter.get('/tombstones', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId, sinceSeq = '0', limit = '1000' } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const since = parseInt(sinceSeq, 10);
     const pageSize = Math.min(parseInt(limit, 10) || 1000, 5000);
@@ -964,7 +1066,7 @@ syncRouter.post('/tombstones', syncRateLimit, requireAuth, denyReadOnly, async (
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const body = req.body as { tombstones?: TombstoneDoc[] };
@@ -1009,7 +1111,7 @@ syncRouter.get('/manifest', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId, since } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const sinceDate = since ? new Date(since) : undefined;
     const manifest = await buildFileManifest(spaceId, sinceDate);
@@ -1033,7 +1135,7 @@ syncRouter.get('/file-tombstones', syncRateLimit, requireAuth, async (req, res) 
   try {
     const { spaceId, networkId, since } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const filter = since
       ? { spaceId, deletedAt: { $gt: since } }
@@ -1063,7 +1165,7 @@ syncRouter.post('/file-tombstones', syncRateLimit, requireAuth, denyReadOnly, as
     const { networkId } = req.query as Record<string, string>;
     if (!spaceId || typeof spaceId !== 'string') { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!Array.isArray(tombstones)) { res.status(400).json({ error: 'tombstones must be array' }); return; }
-    if (!spaceAllowed(spaceId, undefined, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
     if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const spaceFiles = path.resolve(getDataRoot(), 'files', spaceId);
@@ -1124,7 +1226,7 @@ syncRouter.get('/merkle', syncRateLimit, requireAuth, async (req, res) => {
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
-    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces)) { res.status(403).json({ error: 'Forbidden' }); return; }
+    if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
     const result = await computeMerkleRoot(spaceId);
     res.json({ ...result, networkId: networkId ?? null });

--- a/server/src/brain/merkle.ts
+++ b/server/src/brain/merkle.ts
@@ -2,10 +2,17 @@
  * Merkle root computation for a space.
  *
  * The root is a SHA-256 hash over a binary Merkle tree whose leaves are:
- *   - For each memory / entity / edge document (excluding tombstones):
- *       SHA-256( "doc:<type>:<_id>:<seq>" )
+ *   - For each memory / entity / edge / chrono document (excluding tombstones):
+ *       SHA-256( "doc:<type>:<_id>:<seq>:<contentHash>" )
  *   - For each file in the space:
  *       SHA-256( "file:<relative-path>:<sha256>" )
+ *
+ * `contentHash` is a SHA-256 over the document's canonical JSON (keys sorted,
+ * derived fields excluded — see canonicalDocHash). Hashing only `_id:seq`, as
+ * this did previously, detects a missing or version-skewed document but NOT a
+ * tampered one: a peer could serve altered content under the same `_id`/`seq`
+ * and the roots would still agree. Files were already content-hashed; brain
+ * documents now are too.
  *
  * Leaves are sorted lexicographically before tree construction so the root is
  * deterministic regardless of insertion order.
@@ -13,7 +20,8 @@
  * If the space contains no documents and no files the root is the SHA-256 of
  * the empty string — a well-defined sentinel value.
  *
- * Enabled per-network via `network.merkle === true` (opt-in).
+ * Enabled per-network via `network.merkle === true` (opt-in, advisory: a
+ * mismatch is reported as MERKLE_DIVERGENCE, it does not block sync).
  */
 
 import { createHash } from 'node:crypto';
@@ -24,6 +32,39 @@ import { buildFileManifest } from '../files/manifest.js';
 
 function sha256hex(input: string): string {
   return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+/**
+ * Fields excluded from the content hash.
+ *
+ * `embedding` (and its companions) are DERIVED from the document text by the
+ * local embedding model. Two peers running different models — or different
+ * versions of one — legitimately hold different vectors for identical content,
+ * so including them would report divergence on every heterogeneous network.
+ * The text they are derived from is hashed, which is what actually matters.
+ */
+const DERIVED_FIELDS = new Set(['embedding', 'embeddingModel', 'matchedText']);
+
+/**
+ * Canonical JSON of a document: keys sorted at every level, derived fields
+ * dropped. Two instances holding the same document must produce byte-identical
+ * output regardless of field insertion order (Mongo does not preserve it).
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      if (DERIVED_FIELDS.has(key)) continue;
+      out[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function canonicalDocHash(doc: Record<string, unknown>): string {
+  return sha256hex(JSON.stringify(canonicalize(doc)));
 }
 
 /**
@@ -62,27 +103,31 @@ export interface MerkleResult {
   computedAt: string; // ISO 8601
 }
 
+/** Leaf string for one brain document (exported for tests). */
+export function docLeaf(collType: string, doc: Record<string, unknown>): string {
+  return sha256hex(`doc:${collType}:${String(doc['_id'])}:${String(doc['seq'])}:${canonicalDocHash(doc)}`);
+}
+
 /**
  * Compute the Merkle root for a single space.
  *
- * Queries memories, entities, and edges from MongoDB (only `_id` and `seq` —
- * no payload data is read) and walks the file system for the file manifest.
- * All leaves are sorted before tree construction.
+ * Documents are streamed with a cursor (not `toArray`) because the content hash
+ * needs the full document, and a large space would otherwise be materialised in
+ * memory all at once. Embedding vectors are excluded at the projection level, so
+ * the biggest field never leaves MongoDB.
  */
 export async function computeMerkleRoot(spaceId: string): Promise<MerkleResult> {
   const leaves: string[] = [];
 
   // ── Brain documents ────────────────────────────────────────────────────
-  // Only (_id, seq) — no need to load payload data.
   for (const collType of ['memories', 'entities', 'edges', 'chrono'] as const) {
     const collName = `${spaceId}_${collType}`;
-    const docs = await col<{ _id: string; seq: number }>(collName)
+    const cursor = col<Record<string, unknown>>(collName)
       .find(mFilter({}))
-      .project({ _id: 1, seq: 1 })
-      .toArray() as { _id: string; seq: number }[];
+      .project({ embedding: 0, embeddingModel: 0, matchedText: 0 });
 
-    for (const doc of docs) {
-      leaves.push(sha256hex(`doc:${collType}:${doc._id}:${doc.seq}`));
+    for await (const doc of cursor) {
+      leaves.push(docLeaf(collType, doc as Record<string, unknown>));
     }
   }
 

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -21,7 +21,7 @@ import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
 import { recordSyncResult, type SyncCounts } from './history.js';
 import { buildFileManifest } from '../files/manifest.js';
 import { log } from '../util/log.js';
-import { bumpSeq } from '../util/seq.js';
+import { bumpSeq, isSeqImplausible } from '../util/seq.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from '../api/sync.js';
 import { enqueueMediaJob } from '../files/media/job-queue.js';
 import { resolveInputFormat } from '../files/converters/pipeline.js';
@@ -843,6 +843,16 @@ async function pullFromPeer(
       for (const item of items) {
         if ('deletedAt' in item && (item as { deletedAt?: string }).deletedAt) continue;
         const doc = item as T;
+        // Refuse a document whose seq is too close to the protocol ceiling:
+        // ingesting it would drag the counter there via the bumpSeq below,
+        // eventually making our own writes unsyncable (see util/seq.ts).
+        if (isSeqImplausible((doc as MemoryDoc).seq)) {
+          log.warn(
+            `Pull ${urlSuffix} from ${member.label}: skipped doc '${(doc as MemoryDoc)._id}' ` +
+            `with implausible seq ${(doc as MemoryDoc).seq} in space '${spaceId}'.`,
+          );
+          continue;
+        }
         await upsertFn(spaceId, doc);
         count++;
         if ((doc as MemoryDoc).seq > maxSeq) maxSeq = (doc as MemoryDoc).seq;

--- a/server/src/util/seq.ts
+++ b/server/src/util/seq.ts
@@ -18,13 +18,67 @@ export async function nextSeq(spaceId: string): Promise<number> {
   return result.seq;
 }
 
+/** Read the current counter for a space (0 when it does not exist yet). */
+export async function currentSeq(spaceId: string): Promise<number> {
+  const doc = await col<SpaceCounterDoc>('ythril_counters')
+    .findOne(mFilter<SpaceCounterDoc>({ _id: spaceId })) as SpaceCounterDoc | null;
+  return doc?.seq ?? 0;
+}
+
+/**
+ * The protocol sequence ceiling (mirrors `MAX_SYNC_SEQ` in api/sync.ts, where
+ * incoming docs are Zod-validated to `<= 2^50`). A document at or above this
+ * cannot be represented, so it is never a legitimate value on the wire.
+ */
+export const MAX_SYNC_SEQ = 2 ** 50;
+
+/**
+ * Headroom kept below `MAX_SYNC_SEQ`. Ingesting a document advances the space
+ * counter (`bumpSeq`) so local writes always sort above synced ones — so a peer
+ * that pushes one document with `seq` near the ceiling drags the counter there,
+ * and the space's *next* local write exceeds `MAX_SYNC_SEQ` and is rejected by
+ * every peer: silent, unrecoverable write loss.
+ *
+ * The guard is absolute rather than relative to the current counter: legitimate
+ * seqs are small monotonic counters (`nextSeq` increments by 1), so they sit far
+ * below `MAX_SYNC_SEQ - SEQ_CEILING_RESERVE` regardless of a space's history,
+ * while the poisoning value (near 2^50) is caught. A relative "max jump" guard
+ * would instead false-positive on the initial sync of a high-volume space to a
+ * fresh peer. 2^40 (~1.1e12) of reserve leaves an unreachable number of future
+ * writes before the ceiling.
+ */
+export const SEQ_CEILING_RESERVE = 2 ** 40;
+
+/** The highest `seq` an ingested document may carry. */
+export const MAX_INGEST_SEQ = MAX_SYNC_SEQ - SEQ_CEILING_RESERVE;
+
+/**
+ * True when `seq` is out of range or so close to the protocol ceiling that
+ * ingesting it would strand the space's counter. Callers reject such documents.
+ * Synchronous — the bound does not depend on the current counter.
+ */
+export function isSeqImplausible(seq: number): boolean {
+  return !Number.isFinite(seq) || seq < 0 || seq > MAX_INGEST_SEQ;
+}
+
 /**
  * Ensure the space counter is at least `minSeq`.
  * Called after receiving remote documents via sync so that subsequent local
  * writes always get a seq higher than any synced document.
  * Uses $max — only advances the counter, never decreases it.
+ *
+ * The advance is CLAMPED to `MAX_INGEST_SEQ`: ingest paths already refuse
+ * documents above it, and this is the backstop that keeps a stray value from
+ * stranding the counter within `SEQ_CEILING_RESERVE` of the ceiling.
  */
 export async function bumpSeq(spaceId: string, minSeq: number): Promise<void> {
+  if (minSeq > MAX_INGEST_SEQ) {
+    log.warn(
+      `Clamped seq bump for space '${spaceId}': requested ${minSeq} exceeds ` +
+      `MAX_INGEST_SEQ (${MAX_INGEST_SEQ}) — advancing to the ceiling reserve instead.`,
+    );
+    minSeq = MAX_INGEST_SEQ;
+  }
   await col<SpaceCounterDoc>('ythril_counters').updateOne(
     mFilter<SpaceCounterDoc>({ _id: spaceId }),
     mUpdate<SpaceCounterDoc>({ $max: { seq: minSeq } }),

--- a/testing/red-team-tests/invite-binding.test.js
+++ b/testing/red-team-tests/invite-binding.test.js
@@ -1,0 +1,195 @@
+/**
+ * Red-team tests: invite membership binding (M10)
+ *
+ * M10a — a REPARENT invite is bound to its target instanceId. finalize() rewrites
+ *        that member's record (including its inbound tokenHash), so a holder of a
+ *        reparent bundle who applies as an unrelated instanceId must NOT be able
+ *        to seize another member's record. apply() must refuse the mismatch.
+ * M10b — optional pinning: when the inviter sets expectedInstanceId, only that
+ *        instance may apply the bundle.
+ *
+ * Uses instance A (SKIP_AUTH_RATE_LIMIT=true) for the invite endpoints.
+ *
+ * Run: node --test testing/red-team-tests/invite-binding.test.js
+ * Pre-requisite: test stack up + testing/sync/setup.js.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN_A = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+const RUN = Date.now();
+
+let tokenA;
+
+function rsa4096() {
+  return crypto.generateKeyPairSync('rsa', {
+    modulusLength: 4096,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+async function apply(body) {
+  const r = await fetch(`${INSTANCES.a}/api/invite/apply`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await r.json().catch(() => ({}));
+  return { status: r.status, body: json };
+}
+
+before(() => {
+  tokenA = fs.readFileSync(TOKEN_A, 'utf8').trim();
+});
+
+// ── M10a — reparent bundle cannot seize another member ───────────────────────
+
+describe('M10 — a reparent invite is bound to its target instance', () => {
+  let networkId;
+  const victimId = crypto.randomUUID();
+  const attackerId = crypto.randomUUID();
+
+  before(async () => {
+    // Braintree network with self as root and a victim child whose "parent" we
+    // will pretend is offline so a reparent invite can be generated for it.
+    const net = await post(INSTANCES.a, tokenA, '/api/networks', {
+      label: `invite-bind-${RUN}`,
+      type: 'braintree',
+      spaces: ['general'],
+      votingDeadlineHours: 1,
+    });
+    assert.equal(net.status, 201, JSON.stringify(net.body));
+    networkId = net.body.id;
+
+    // Add the victim as a direct member (child of self).
+    const pt = await post(INSTANCES.a, tokenA, '/api/tokens', {
+      name: `invite-bind-victim-${RUN}`,
+      peerInstanceId: victimId,
+    });
+    const add = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+      instanceId: victimId,
+      label: 'Victim Child',
+      url: 'http://victim.internal:3200',
+      token: pt.body.plaintext,
+      direction: 'both',
+    });
+    assert.ok(add.status === 201 || add.status === 202, `add victim: ${add.status} ${JSON.stringify(add.body)}`);
+  });
+
+  after(async () => {
+    await fetch(`${INSTANCES.a}/api/networks/${networkId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${tokenA}` },
+    }).catch(() => {});
+  });
+
+  it('a reparent invite applied under a DIFFERENT instanceId is refused (no member seizure)', async () => {
+    const gen = await post(INSTANCES.a, tokenA, '/api/invite/generate', {
+      networkId,
+      reparentInstanceId: victimId,
+    });
+    assert.equal(gen.status, 201, `generate reparent: ${JSON.stringify(gen.body)}`);
+
+    const { publicKey } = rsa4096();
+    const r = await apply({
+      handshakeId: gen.body.handshakeId,
+      networkId,
+      instanceId: attackerId,          // NOT the reparent target
+      instanceLabel: 'Attacker',
+      instanceUrl: 'https://attacker.example.com',
+      rsaPublicKeyPem: publicKey,
+    });
+    assert.equal(r.status, 403, `VULNERABILITY: reparent applied as a different instance (${r.status}) ${JSON.stringify(r.body)}`);
+  });
+
+  it('a reparent invite applied as the correct target is accepted', async () => {
+    const gen = await post(INSTANCES.a, tokenA, '/api/invite/generate', {
+      networkId,
+      reparentInstanceId: victimId,
+    });
+    assert.equal(gen.status, 201);
+
+    const { publicKey } = rsa4096();
+    const r = await apply({
+      handshakeId: gen.body.handshakeId,
+      networkId,
+      instanceId: victimId,            // the reparent target
+      instanceLabel: 'Victim Child',
+      instanceUrl: 'http://victim.internal:3200',
+      rsaPublicKeyPem: publicKey,
+    });
+    assert.equal(r.status, 200, `legitimate reparent apply should succeed: ${r.status} ${JSON.stringify(r.body)}`);
+  });
+});
+
+// ── M10b — expectedInstanceId pinning ────────────────────────────────────────
+
+describe('M10 — expectedInstanceId pins an invite to one instance', () => {
+  let networkId;
+  const intendedId = crypto.randomUUID();
+  const otherId = crypto.randomUUID();
+
+  before(async () => {
+    const net = await post(INSTANCES.a, tokenA, '/api/networks', {
+      label: `invite-pin-${RUN}`,
+      type: 'club',
+      spaces: ['general'],
+      votingDeadlineHours: 1,
+    });
+    assert.equal(net.status, 201, JSON.stringify(net.body));
+    networkId = net.body.id;
+  });
+
+  after(async () => {
+    await fetch(`${INSTANCES.a}/api/networks/${networkId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${tokenA}` },
+    }).catch(() => {});
+  });
+
+  it('a pinned invite applied by the wrong instance is refused', async () => {
+    const gen = await post(INSTANCES.a, tokenA, '/api/invite/generate', {
+      networkId,
+      expectedInstanceId: intendedId,
+    });
+    assert.equal(gen.status, 201, JSON.stringify(gen.body));
+
+    const { publicKey } = rsa4096();
+    const r = await apply({
+      handshakeId: gen.body.handshakeId,
+      networkId,
+      instanceId: otherId,             // not the pinned instance
+      instanceLabel: 'Interloper',
+      instanceUrl: 'https://interloper.example.com',
+      rsaPublicKeyPem: publicKey,
+    });
+    assert.equal(r.status, 403, `VULNERABILITY: pinned invite redeemed by another instance (${r.status})`);
+  });
+
+  it('the pinned instance can apply its own invite', async () => {
+    const gen = await post(INSTANCES.a, tokenA, '/api/invite/generate', {
+      networkId,
+      expectedInstanceId: intendedId,
+    });
+    assert.equal(gen.status, 201);
+
+    const { publicKey } = rsa4096();
+    const r = await apply({
+      handshakeId: gen.body.handshakeId,
+      networkId,
+      instanceId: intendedId,
+      instanceLabel: 'Intended',
+      instanceUrl: 'https://intended.example.com',
+      rsaPublicKeyPem: publicKey,
+    });
+    assert.equal(r.status, 200, `pinned instance should be able to apply: ${r.status} ${JSON.stringify(r.body)}`);
+  });
+});

--- a/testing/red-team-tests/sync-medium-hardening.test.js
+++ b/testing/red-team-tests/sync-medium-hardening.test.js
@@ -1,0 +1,242 @@
+/**
+ * Red-team tests: sync-layer hardening (M3, M5)
+ *
+ * M3 — a peer-bound token may reach a space only through a network the peer is
+ *      actually a member of. Two networks sharing a space but with disjoint
+ *      membership must not leak into each other.
+ * M5 — a document whose seq is too close to the 2^50 protocol ceiling is refused
+ *      on every ingest path, so a single crafted push cannot drag the space's
+ *      counter into the reserve band and strand its future writes.
+ *
+ * (The directional-write regression — a push-direction member cannot write
+ * inbound — is asserted below too; that enforcement pre-dates this batch and is
+ * kept as a guard. See the tracker's M4 note for why the absent-peerInstanceId
+ * case is intentionally not blocked.)
+ *
+ * These drive the real /api/sync endpoints on instance A. Peer tokens are minted
+ * with peerInstanceId to mimic the invite handshake.
+ *
+ * Run: node --test testing/red-team-tests/sync-medium-hardening.test.js
+ * Pre-requisite: test stack up + testing/sync/setup.js.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let adminToken;
+let instanceIdA;
+
+function getInstanceId(container = 'ythril-a') {
+  return execSync(
+    `docker exec ${container} node -e "const fs=require('fs');` +
+    `process.stdout.write(JSON.parse(fs.readFileSync('/config/config.json','utf8')).instanceId)"`,
+  ).toString().trim();
+}
+
+/** Authenticated POST with a raw Bearer token (helpers.post reads a token string too). */
+async function syncPost(token, pathAndQuery, body) {
+  const r = await fetch(`${INSTANCES.a}${pathAndQuery}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  const text = await r.text();
+  let json = null;
+  try { json = JSON.parse(text); } catch { /* non-JSON */ }
+  return { status: r.status, body: json, text };
+}
+
+async function makeSpace(id) {
+  const r = await post(INSTANCES.a, adminToken, '/api/spaces', { id, label: id });
+  assert.ok(r.status === 201 || r.status === 409, `create space ${id}: ${r.status} ${JSON.stringify(r.body)}`);
+}
+
+async function deleteSpace(id) {
+  await fetch(`${INSTANCES.a}/api/spaces/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true }),
+  }).catch(() => {});
+}
+
+async function makeNetwork(spaces, type = 'club') {
+  const r = await post(INSTANCES.a, adminToken, '/api/networks', {
+    label: `sync-med-${RUN}-${Math.random().toString(36).slice(2, 6)}`,
+    type,
+    spaces,
+    votingDeadlineHours: 1,
+  });
+  assert.equal(r.status, 201, `create network: ${JSON.stringify(r.body)}`);
+  return r.body.id;
+}
+
+/** Add a member and return the peer token it will present (with peerInstanceId). */
+async function addMember(networkId, peerInstanceId, direction = 'both') {
+  const pt = await post(INSTANCES.a, adminToken, '/api/tokens', {
+    name: `sync-med-peer-${peerInstanceId}-${RUN}`,
+    spaces: undefined,
+    peerInstanceId,
+  });
+  assert.equal(pt.status, 201, `create peer token: ${JSON.stringify(pt.body)}`);
+  const add = await post(INSTANCES.a, adminToken, `/api/networks/${networkId}/members`, {
+    instanceId: peerInstanceId,
+    label: `peer-${peerInstanceId}`,
+    url: 'http://peer.internal:3200',
+    token: pt.body.plaintext,
+    direction,
+  });
+  assert.equal(add.status, 201, `add member: ${JSON.stringify(add.body)}`);
+  return { token: pt.body.plaintext, tokenId: pt.body.token?.id };
+}
+
+const memoryDoc = (spaceId, seq, id = randomUUID()) => ({
+  _id: id,
+  spaceId,
+  fact: `sync-med test ${id}`,
+  seq,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  author: { instanceId: randomUUID(), instanceLabel: 'Peer X' },
+  tags: [],
+  entityIds: [],
+  embedding: [0.1, 0.2, 0.3],
+  embeddingModel: 'test-model',
+});
+
+before(() => {
+  adminToken = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  instanceIdA = getInstanceId();
+});
+
+// ── M3 — network membership, not just space scope ────────────────────────────
+
+describe('M3 — a peer may reach a space only via a network it belongs to', () => {
+  const shared = `m3-shared-${RUN}`;
+  let netX, peerXId, peerX, netY, peerYId;
+  const cleanupTokens = [];
+
+  before(async () => {
+    await makeSpace(shared);
+    peerXId = randomUUID();
+    peerYId = randomUUID();
+    // Two networks BOTH carrying `shared`, with disjoint membership.
+    netX = await makeNetwork([shared]);
+    const x = await addMember(netX, peerXId);
+    peerX = x.token; cleanupTokens.push(x.tokenId);
+    netY = await makeNetwork([shared]);
+    const y = await addMember(netY, peerYId);
+    cleanupTokens.push(y.tokenId);
+  });
+
+  after(async () => {
+    await del(INSTANCES.a, adminToken, `/api/networks/${netX}`).catch(() => {});
+    await del(INSTANCES.a, adminToken, `/api/networks/${netY}`).catch(() => {});
+    for (const id of cleanupTokens) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+    await deleteSpace(shared);
+  });
+
+  it('peer X (member of net X) may write the shared space via net X', async () => {
+    const r = await syncPost(peerX, `/api/sync/memories?spaceId=${shared}&networkId=${netX}`, memoryDoc(shared, 1));
+    assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.text.slice(0, 200)}`);
+  });
+
+  it('peer X CANNOT use net Y (it is not a member of net Y) for the same space', async () => {
+    const r = await syncPost(peerX, `/api/sync/memories?spaceId=${shared}&networkId=${netY}`, memoryDoc(shared, 1));
+    assert.equal(r.status, 403, `VULNERABILITY: peer reached a space via a network it is not a member of (${r.status})`);
+  });
+
+  it('peer X reading the shared space via net Y is refused', async () => {
+    const r = await get(INSTANCES.a, peerX, `/api/sync/memories?spaceId=${shared}&networkId=${netY}`);
+    assert.equal(r.status, 403, `VULNERABILITY: cross-network read via disjoint membership (${r.status})`);
+  });
+});
+
+// ── M4 — directional write attribution ───────────────────────────────────────
+
+describe('Directional-write regression — an identified push member is refused', () => {
+  const space = `dir-${RUN}`;
+  let netId, pushPeer;
+  const cleanupTokens = [];
+
+  before(async () => {
+    await makeSpace(space);
+    netId = await makeNetwork([space], 'pubsub');
+    // A push-direction member: WE push to them → they must not push back to us.
+    const p = await addMember(netId, randomUUID(), 'push');
+    pushPeer = p.token; cleanupTokens.push(p.tokenId);
+  });
+
+  after(async () => {
+    await del(INSTANCES.a, adminToken, `/api/networks/${netId}`).catch(() => {});
+    for (const id of cleanupTokens) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+    await deleteSpace(space);
+  });
+
+  it('a push-direction member (identified by peerInstanceId) cannot write inbound', async () => {
+    const r = await syncPost(pushPeer, `/api/sync/memories?spaceId=${space}&networkId=${netId}`, memoryDoc(space, 1));
+    assert.equal(r.status, 403, `VULNERABILITY: push-side member wrote inbound (${r.status})`);
+  });
+});
+
+// ── M5 — seq-counter poisoning ───────────────────────────────────────────────
+
+describe('M5 — implausible seq values are refused', () => {
+  const space = `m5-${RUN}`;
+  let netId, peer, peerId;
+  const cleanupTokens = [];
+
+  before(async () => {
+    await makeSpace(space);
+    netId = await makeNetwork([space]);
+    peerId = randomUUID();
+    const p = await addMember(netId, peerId);
+    peer = p.token; cleanupTokens.push(p.tokenId);
+  });
+
+  after(async () => {
+    await del(INSTANCES.a, adminToken, `/api/networks/${netId}`).catch(() => {});
+    for (const id of cleanupTokens) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+    await deleteSpace(space);
+  });
+
+  it('a normal low-seq document is accepted', async () => {
+    const r = await syncPost(peer, `/api/sync/memories?spaceId=${space}&networkId=${netId}`, memoryDoc(space, 5));
+    assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.text.slice(0, 200)}`);
+  });
+
+  it('a document with seq near the 2^50 ceiling is refused', async () => {
+    const nearCeiling = 2 ** 50 - 1;
+    const r = await syncPost(peer, `/api/sync/memories?spaceId=${space}&networkId=${netId}`, memoryDoc(space, nearCeiling));
+    assert.equal(r.status, 400, `VULNERABILITY: counter-poisoning seq accepted (${r.status})`);
+    assert.match(r.text, /ceiling|refused/i);
+  });
+
+  it('after the poison attempt the counter is intact — a normal doc still lands', async () => {
+    const r = await syncPost(peer, `/api/sync/memories?spaceId=${space}&networkId=${netId}`, memoryDoc(space, 6));
+    assert.equal(r.status, 200, `space should still accept normal writes after a rejected poison (${r.status})`);
+  });
+
+  it('batch-upsert drops implausible docs but keeps the good ones', async () => {
+    const good = memoryDoc(space, 7);
+    const poison = memoryDoc(space, 2 ** 50 - 5);
+    const r = await syncPost(peer, `/api/sync/batch-upsert?spaceId=${space}&networkId=${netId}`, {
+      memories: [good, poison],
+    });
+    assert.equal(r.status, 200, `batch-upsert should not 500: ${r.text.slice(0, 200)}`);
+    // The good doc is retrievable; the poison one is not.
+    const fetchGood = await get(INSTANCES.a, adminToken, `/api/sync/memories/${good._id}?spaceId=${space}`);
+    assert.equal(fetchGood.status, 200, 'the plausible doc should have been stored');
+    const fetchPoison = await get(INSTANCES.a, adminToken, `/api/sync/memories/${poison._id}?spaceId=${space}`);
+    assert.equal(fetchPoison.status, 404, 'the poison doc must not have been stored');
+  });
+});

--- a/testing/standalone/merkle-content-hash.test.js
+++ b/testing/standalone/merkle-content-hash.test.js
@@ -1,0 +1,81 @@
+/**
+ * Unit tests: Merkle leaves hash document CONTENT (M6)
+ *
+ * The leaf used to be SHA-256("doc:<type>:<_id>:<seq>"), so a peer could serve
+ * tampered content under the same _id/seq and the roots would still agree —
+ * verification detected missing / version-skewed documents, never modified ones.
+ * Leaves now include a canonical content hash.
+ *
+ * Pure in-process logic — no MongoDB (docLeaf is exported for exactly this).
+ * Run: node --test testing/standalone/merkle-content-hash.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { docLeaf } from '../../server/dist/brain/merkle.js';
+
+const base = () => ({
+  _id: 'mem-1',
+  seq: 7,
+  fact: 'The deploy key rotates on Fridays.',
+  tags: ['ops'],
+  author: { instanceId: 'inst-a', instanceLabel: 'A' },
+});
+
+describe('docLeaf — content sensitivity', () => {
+  it('identical documents produce identical leaves', () => {
+    assert.equal(docLeaf('memories', base()), docLeaf('memories', base()));
+  });
+
+  it('TAMPERED content under the same _id and seq changes the leaf', () => {
+    const tampered = { ...base(), fact: 'The deploy key rotates on Mondays.' };
+    assert.notEqual(
+      docLeaf('memories', base()),
+      docLeaf('memories', tampered),
+      'VULNERABILITY: a modified fact produced the same Merkle leaf',
+    );
+  });
+
+  it('a changed nested field changes the leaf', () => {
+    const tampered = { ...base(), author: { instanceId: 'attacker', instanceLabel: 'A' } };
+    assert.notEqual(docLeaf('memories', base()), docLeaf('memories', tampered));
+  });
+
+  it('a changed tag changes the leaf', () => {
+    assert.notEqual(
+      docLeaf('memories', base()),
+      docLeaf('memories', { ...base(), tags: ['ops', 'secret'] }),
+    );
+  });
+
+  it('key ORDER does not change the leaf (canonicalisation)', () => {
+    const reordered = {
+      author: { instanceLabel: 'A', instanceId: 'inst-a' },
+      tags: ['ops'],
+      fact: 'The deploy key rotates on Fridays.',
+      seq: 7,
+      _id: 'mem-1',
+    };
+    assert.equal(
+      docLeaf('memories', base()),
+      docLeaf('memories', reordered),
+      'Mongo does not guarantee field order — the hash must not depend on it',
+    );
+  });
+
+  it('the embedding vector is EXCLUDED (peers may run different models)', () => {
+    const withVec = { ...base(), embedding: [0.1, 0.2], embeddingModel: 'nomic-v1.5', matchedText: 'x' };
+    const otherVec = { ...base(), embedding: [0.9, 0.4], embeddingModel: 'other-model', matchedText: 'y' };
+    assert.equal(docLeaf('memories', base()), docLeaf('memories', withVec));
+    assert.equal(docLeaf('memories', withVec), docLeaf('memories', otherVec));
+  });
+
+  it('the same content in a different collection produces a different leaf', () => {
+    assert.notEqual(docLeaf('memories', base()), docLeaf('entities', base()));
+  });
+
+  it('a changed seq still changes the leaf (regression — version skew)', () => {
+    assert.notEqual(docLeaf('memories', base()), docLeaf('memories', { ...base(), seq: 8 }));
+  });
+});


### PR DESCRIPTION
The **sync-layer MEDIUM** group of the security audit — M3, M5, M6, M10 fixed, M4 assessed — following #134. Remaining after this: the files/brain group (M1, M11, L3–L5).

## M3 — network membership, not just space scope
Sync data endpoints (`requireAuth`, not `requireSpaceAuth`) authorised a peer token against the calling token's space allow-list alone. Two networks that share a space but have **disjoint membership** therefore leaked into each other: a member of network X could read/write that space by naming network Y, which it does not belong to. A token carrying a `peerInstanceId` may now reach a space only through a network that peer is actually a member of. Manually-provisioned peer tokens (no `peerInstanceId`) and asymmetric single-side-configured networks keep the previous space-existence fallback, so nothing legitimate breaks.

## M5 — sequence-counter poisoning
Every ingested document advances the space's `seq` counter (so local writes always sort above synced ones). A peer could push one document with `seq` near the protocol ceiling (2^50), dragging the counter there; once local writes hit the ceiling, peers reject them and the space **silently loses the ability to sync new writes**. Documents whose `seq` lands in a reserved band below the ceiling (`MAX_INGEST_SEQ = 2^50 − 2^40`) are now refused on every ingest path (single upsert → 400, batch → dropped with a warning, engine pull → skipped), and `bumpSeq` clamps as a backstop.

The guard is **absolute, not a relative "max jump."** I initially wrote it relative (`current + 1,000,000`) and it false-positived: the test stack's `general` counter is timestamp-polluted (~1.78e12) from old runs that seeded `Date.now()` as `seq`, and instance A's counter sat ~5.7M ahead of B's, so legitimate cross-instance sync was rejected. An absolute ceiling-reserve is correct — legitimate seqs are small monotonic counters far below the band, so it never false-positives on a high-volume space (or a polluted counter) while still catching the near-2^50 poison.

## M6 — Merkle verification hashes content
Leaves were `SHA-256("doc:<type>:<id>:<seq>")`, so a peer serving **altered** content under the same `_id`/`seq` produced the same root — divergence detection caught missing/version-skewed documents but never tampered ones. Leaves now include a canonical content hash (keys sorted for Mongo-order-independence; embedding vectors excluded so peers running different embedding models don't false-positive). Files were already content-hashed. Merkle stays advisory (opt-in; a mismatch is reported, not blocking).

## M10 — invite reparent binding
A braintree *reparent* invite rewrites one existing member's record — including its inbound `tokenHash` — at finalize. `apply` never compared the applying `instanceId` to the session's reparent target, so a holder of a reparent bundle could apply as an unrelated instance and have finalize hand them the victim's member record (a takeover). `apply` (and finalize, as a TOCTOU backstop) now bind the reparent target; the normal join path re-checks membership at finalize. New optional `expectedInstanceId` on `POST /api/invite/generate` pins any invite to one instance so a leaked bundle can't be redeemed by someone else.

## M4 — assessed, no code change
The finding was "push-only enforcement trusts self-declared `peerInstanceId` and no-ops when absent." Two corrections after investigation:
1. `peerInstanceId` is **server-issued** (set by the invite handshake, stored in the token record) — not self-declared, so it can't be forged to bypass the check.
2. The meaningful attack — a push-only subscriber/child writing back to its publisher/parent — is **already blocked**: that peer is a member with `direction='push'` on the receiving side, so it's caught (kept as a regression test).

I first added a blanket "refuse unattributed directional writes" rule; it broke braintree sync, because a braintree child does not list its parent as a member and manual peer tokens legitimately omit `peerInstanceId`. Reverted — the residual gap (an unattributed token) requires the caller to already hold a non-peer credential the receiver accepts, so blocking it wholesale is net-negative. Rationale recorded in the audit tracker.

## Tests
- New: `testing/standalone/merkle-content-hash.test.js` (8 — tamper detection, canonicalisation, embedding exclusion), `testing/red-team-tests/sync-medium-hardening.test.js` (M3 cross-network isolation, M5 poison rejection + batch drop, directional-push regression), `testing/red-team-tests/invite-binding.test.js` (4 — reparent seizure refused, `expectedInstanceId` pinning)
- Full suites on the rebuilt Docker stack: **sync 173 pass / 0 fail**, **standalone 676 / 0**, **red-team 252 / 0**, **integration 783 / 0**. (Diagnosing the initial 17 sync failures is what surfaced both the timestamp-counter pollution and the braintree over-block above.)

## Config (optional)
- `expectedInstanceId` on `POST /api/invite/generate` — pin an invite to one instance

Docs updated: CHANGELOG, `docs/integration-guide.md` (invite `expectedInstanceId`/`reparentInstanceId` binding, Merkle content-hash note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)