### PR TITLE
security: files/brain hardening (symlink TOCTOU, chunk coverage, path decode, proto-pollution, query projection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **File paths are re-checked against symlink escapes before every filesystem operation** — the
+  sandbox boundary check was purely lexical (string prefix), so a symlink component anywhere along a
+  path could point outside the space root while the string still looked contained — a TOCTOU that a
+  recursive directory delete would follow out of the sandbox. Every read/write/delete/move/list now
+  canonicalises the path with `realpath` (walking to the nearest existing ancestor for not-yet-created
+  files) and re-asserts the real location is inside the space root; the recursive-delete endpoint does
+  the same before `fs.rm`. (M1)
+
+- **Chunked uploads verify full, non-overlapping coverage before assembly** — `assembleChunks` only
+  checked the aggregate byte count, so a set of chunks with a gap and a compensating overlap could
+  report "complete" and assemble into silently corrupt content. Assembly now verifies the chunks tile
+  `[0, total)` exactly (contiguous, no gaps, no overlaps) before writing, and the returned sha256 is
+  computed from the same buffers that are written in order — the previous hash was produced by a
+  `data` listener racing `stream.pipeline`, so it could cover a different byte view than the file on
+  disk. (M11)
+
+- **File paths are no longer double-URL-decoded** — `resolveSafePath` ran `decodeURIComponent` on a
+  value the HTTP layer had already decoded once. A filename containing a literal `%` (e.g. `50%.png`)
+  therefore threw `URIError` → HTTP 500, and the on-disk path could diverge from the file-meta `_id`.
+  The redundant decode is removed; the disk path now matches the stored `_id` byte-for-byte. (L3)
+
+- **Prototype-polluting property keys are rejected in entity-merge resolution** — `applyResolutions`
+  wrote resolved property values through a computed index; a `__proto__` / `constructor` / `prototype`
+  key would mutate the object prototype instead of adding a data property. Such keys are now skipped.
+  (Impact was limited — merge values are scalars — but it removes the footgun from a path that assigns
+  user/peer-supplied keys.) (L4)
+
+- **The `query` tool no longer silently discards a caller's projection** — the mandatory
+  `embedding`-vector exclusion was applied as a second `.project()` call, which in the MongoDB driver
+  *replaces* the first, dropping any projection the caller supplied. The exclusion is now merged with
+  the caller's projection (respecting MongoDB's inclusion/exclusion rules), and an explicit request to
+  include `embedding` is still stripped so the vector can never leak. (L5)
+
 - **Sync data endpoints now verify network membership, not just space scope** — a peer-bound token
   was authorised against the calling token's space allow-list alone, so two networks sharing a space
   but with **disjoint membership** leaked into each other: a member of network X could read/write that

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -40,7 +40,7 @@ import {
   getUploadReceived,
 } from '../files/chunks.js';
 import { checkQuota, QuotaError } from '../quota/quota.js';
-import { resolveSafePath, spaceRoot } from '../files/sandbox.js';
+import { resolveSafePath, assertNoSymlinkEscape, spaceRoot } from '../files/sandbox.js';
 import { col, mFilter, mDoc } from '../db/mongo.js';
 import type { FileTombstoneDoc, FileMetaDoc } from '../config/types.js';
 import { upsertFileMeta, deleteFileMeta, deleteFileMetaByPrefix, renameFileMeta, renameFileMetaByPrefix } from '../files/file-meta.js';
@@ -317,8 +317,9 @@ filesRouter.post(
         );
 
         if (complete) {
-          // Assemble final file
+          // Assemble final file (symlink-checked before writing the target).
           const absTarget = resolveSafePath(targetSpace, filePath);
+          await assertNoSymlinkEscape(targetSpace, absTarget);
           const sha256 = await assembleChunks(targetSpace, filePath, range.total, absTarget);
           await upsertFileMeta(targetSpace, filePath, range.total).catch(err => {
             log.warn(`upsertFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
@@ -569,6 +570,9 @@ filesRouter.delete('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly,
   let absPath: string;
   try {
     absPath = resolveSafePath(targetSpace, filePath);
+    // Symlink-aware boundary re-check before a recursive delete: the lexical
+    // path may stay under the root while a symlink component points outside it.
+    await assertNoSymlinkEscape(targetSpace, absPath);
   } catch (err) {
     res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
     return;

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -813,18 +813,51 @@ export async function queryBrain(
   const safeFilter = sanitizeFilter(filter) as Record<string, never>;
   const safeMaxTime = Math.min(maxTimeMS, 10_000);
   const collName = `${spaceId}_${collectionName}`;
-  let cursor = col(collName)
+  const cursor = col(collName)
     .find(safeFilter)
     .maxTimeMS(safeMaxTime)
     // Deterministic newest-first ordering keeps recent writes visible under
     // the default limit even when historical datasets grow large.
     .sort({ seq: -1, updatedAt: -1, createdAt: -1, _id: -1 })
-    .limit(Math.min(limit, 100));
-
-  if (projection) {
-    cursor = cursor.project(projection as Record<string, never>);
-  }
-  // Always exclude embedding vectors from query results
-  cursor = cursor.project({ embedding: 0 });
+    .limit(Math.min(limit, 100))
+    // The embedding vector is never returned. This is MERGED with the caller's
+    // projection rather than applied as a second `.project()` — a second call
+    // replaces the first in the MongoDB driver, which previously discarded the
+    // caller's projection entirely.
+    .project(mergeEmbeddingExclusion(projection) as Record<string, never>);
   return cursor.toArray();
+}
+
+/**
+ * Merge the mandatory `embedding` exclusion with a caller-supplied projection.
+ *
+ * MongoDB forbids mixing inclusion and exclusion (except for `_id`), so we
+ * cannot blindly add `embedding: 0` to an inclusion projection:
+ *  - No projection → `{ embedding: 0 }`.
+ *  - Inclusion projection (`{ field: 1 }`) → embedding is already excluded by
+ *    omission; we just strip any explicit `embedding: 1` so the vector can never
+ *    be opted back in.
+ *  - Exclusion projection (`{ field: 0 }`) → add `embedding: 0`.
+ */
+export function mergeEmbeddingExclusion(
+  projection?: Record<string, unknown>,
+): Record<string, 0 | 1> {
+  if (!projection || Object.keys(projection).length === 0) {
+    return { embedding: 0 };
+  }
+  // Inclusion vs exclusion is decided by the non-_id fields.
+  const isInclusion = Object.entries(projection)
+    .some(([k, v]) => k !== '_id' && (v === 1 || v === true));
+
+  const out: Record<string, 0 | 1> = {};
+  if (isInclusion) {
+    for (const [k, v] of Object.entries(projection)) {
+      if (k === 'embedding') continue; // never allow the vector to be included
+      out[k] = (v === 1 || v === true) ? 1 : 0;
+    }
+  } else {
+    for (const k of Object.keys(projection)) out[k] = 0;
+    out['embedding'] = 0;
+  }
+  return out;
 }

--- a/server/src/brain/merge.ts
+++ b/server/src/brain/merge.ts
@@ -245,7 +245,25 @@ async function detectDuplicateEdges(
 // ── Resolution application ─────────────────────────────────────────────────
 
 /**
+ * Property keys that must never be written through a computed index, or they
+ * would mutate the object prototype instead of adding a data property.
+ */
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** True when `key` is safe to assign as a plain data property. */
+function isSafeKey(key: string): boolean {
+  return !PROTO_KEYS.has(key);
+}
+
+/**
  * Apply resolved property values and return the final merged properties.
+ *
+ * Prototype-polluting keys (`__proto__`, `constructor`, `prototype`) are
+ * rejected before assignment. Object spread copies data properties (it does not
+ * invoke the `__proto__` setter), so the danger is only the computed
+ * `result[key] = value` writes below — which `isSafeKey` guards. Merge property
+ * values are only scalars today, so the blast radius was small, but this keeps
+ * the pattern out of a path that assigns user/peer-supplied keys.
  */
 export function applyResolutions(
   survivorProps: Record<string, string | number | boolean>,
@@ -257,11 +275,19 @@ export function applyResolutions(
 
   // Apply absorbed-only properties
   for (const p of absorbedOnly) {
+    if (!isSafeKey(p.key)) {
+      log.warn(`merge: skipping prototype-polluting property key '${p.key}'`);
+      continue;
+    }
     result[p.key] = p.value as string | number | boolean;
   }
 
   // Apply conflict resolutions
   for (const c of conflicts) {
+    if (!isSafeKey(c.key)) {
+      log.warn(`merge: skipping prototype-polluting property key '${c.key}'`);
+      continue;
+    }
     const resolution = c.resolution!;
     if (resolution === 'survivor') {
       // Keep survivor value (already in result)

--- a/server/src/files/chunks.ts
+++ b/server/src/files/chunks.ts
@@ -7,10 +7,9 @@
  */
 
 import fs from 'fs/promises';
-import { createReadStream, createWriteStream } from 'fs';
+import { createWriteStream } from 'fs';
 import path from 'path';
 import { createHash } from 'crypto';
-import { pipeline } from 'stream/promises';
 import { getDataRoot } from '../config/loader.js';
 import { log } from '../util/log.js';
 
@@ -86,6 +85,18 @@ export async function storeChunk(
  * Assemble all chunks into the target file.
  * Returns the sha256 of the assembled file.
  * Cleans up the chunk directory after assembly.
+ *
+ * Before writing anything, the chunks are verified to tile `[0, total)`
+ * exactly — contiguous, no gaps, no overlaps, summing to `total`. Previously
+ * only the aggregate byte count was checked (in storeChunk), so a set of
+ * chunks with a gap and a compensating overlap could report "complete" and
+ * assemble into silently corrupt content.
+ *
+ * The sha256 is computed from the same buffers that are written, in order, so
+ * it always matches the file on disk. The prior implementation hashed via a
+ * `data` listener attached alongside `stream.pipeline`, which put the stream in
+ * flowing mode and raced the pipeline's own consumption — the hash could cover
+ * a different byte view than what was written.
  */
 export async function assembleChunks(
   spaceId: string,
@@ -96,31 +107,51 @@ export async function assembleChunks(
   const id = uploadId(spaceId, filePath, total);
   const dir = uploadDir(spaceId, id);
 
-  // List and sort chunk files by their start offset
+  // List and sort chunk files by their start offset.
   const entries = await fs.readdir(dir);
   const chunkFiles = entries
     .filter(n => n.endsWith('.bin'))
     .map(n => ({ name: n, start: parseInt(n.replace('.bin', ''), 10) }))
+    .filter(c => Number.isInteger(c.start) && c.start >= 0)
     .sort((a, b) => a.start - b.start);
 
-  // Ensure target directory exists
+  // Verify the chunks tile [0, total) exactly before touching the target file.
+  let expected = 0;
+  const sized: { name: string; size: number }[] = [];
+  for (const cf of chunkFiles) {
+    if (cf.start !== expected) {
+      throw new RangeError(
+        `Chunk coverage error for '${filePath}': expected a chunk at offset ${expected}, ` +
+        `found one at ${cf.start} (gap or overlap).`,
+      );
+    }
+    const st = await fs.stat(path.join(dir, cf.name));
+    sized.push({ name: cf.name, size: st.size });
+    expected += st.size;
+  }
+  if (expected !== total) {
+    throw new RangeError(
+      `Chunk coverage error for '${filePath}': assembled size ${expected} does not match ` +
+      `the declared total ${total}.`,
+    );
+  }
+
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
 
-  // Assemble into target file
+  // Assemble sequentially: read each chunk, hash it, then write it. One chunk is
+  // held in memory at a time (chunk size is bounded by the upload body limit).
   const hash = createHash('sha256');
   const out = createWriteStream(targetPath);
-
   try {
-    for (const cf of chunkFiles) {
-      const chunkPath = path.join(dir, cf.name);
-      const rs = createReadStream(chunkPath);
-      rs.on('data', (chunk) => hash.update(chunk));
-      await pipeline(rs, out, { end: false });
+    for (const cf of sized) {
+      const buf = await fs.readFile(path.join(dir, cf.name));
+      hash.update(buf);
+      await new Promise<void>((resolve, reject) => {
+        out.write(buf, err => (err ? reject(err) : resolve()));
+      });
     }
-
-    out.end();
     await new Promise<void>((resolve, reject) => {
-      out.on('finish', resolve);
+      out.end(() => resolve());
       out.on('error', reject);
     });
   } catch (err) {

--- a/server/src/files/files.ts
+++ b/server/src/files/files.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { createHash } from 'crypto';
-import { resolveSafePath, spaceRoot } from './sandbox.js';
+import { resolveSafePathChecked, spaceRoot } from './sandbox.js';
 import { getConfig, getDataRoot } from '../config/loader.js';
 
 export interface FileEntry {
@@ -18,20 +18,20 @@ export async function ensureSpaceFilesDir(spaceId: string): Promise<void> {
 
 /** Read a text file — rejects if it's a directory or doesn't exist */
 export async function readFile(spaceId: string, filePath: string): Promise<string> {
-  const abs = resolveSafePath(spaceId, filePath);
+  const abs = await resolveSafePathChecked(spaceId, filePath);
   const content = await fs.readFile(abs, 'utf8');
   return content;
 }
 
 /** Read a file as a Buffer (for binary files) */
 export async function readFileBytes(spaceId: string, filePath: string): Promise<Buffer> {
-  const abs = resolveSafePath(spaceId, filePath);
+  const abs = await resolveSafePathChecked(spaceId, filePath);
   return fs.readFile(abs);
 }
 
 /** Write a text file, creating parent directories as needed */
 export async function writeFile(spaceId: string, filePath: string, content: string): Promise<{ sha256: string }> {
-  const abs = resolveSafePath(spaceId, filePath);
+  const abs = await resolveSafePathChecked(spaceId, filePath);
   await fs.mkdir(path.dirname(abs), { recursive: true });
   await fs.writeFile(abs, content, 'utf8');
   const sha256 = createHash('sha256').update(content, 'utf8').digest('hex');
@@ -44,7 +44,7 @@ export async function writeFileBytes(
   filePath: string,
   data: Buffer,
 ): Promise<{ sha256: string }> {
-  const abs = resolveSafePath(spaceId, filePath);
+  const abs = await resolveSafePathChecked(spaceId, filePath);
   await fs.mkdir(path.dirname(abs), { recursive: true });
   await fs.writeFile(abs, data);
   const sha256 = createHash('sha256').update(data).digest('hex');
@@ -53,7 +53,7 @@ export async function writeFileBytes(
 
 /** List entries in a directory (non-recursive) */
 export async function listDir(spaceId: string, dirPath: string): Promise<FileEntry[]> {
-  const abs = resolveSafePath(spaceId, dirPath);
+  const abs = await resolveSafePathChecked(spaceId, dirPath);
   const entries = await fs.readdir(abs, { withFileTypes: true });
   const result: FileEntry[] = [];
   for (const e of entries) {
@@ -75,13 +75,13 @@ export async function listDir(spaceId: string, dirPath: string): Promise<FileEnt
 
 /** Delete a file (not a directory) */
 export async function deleteFile(spaceId: string, filePath: string): Promise<void> {
-  const abs = resolveSafePath(spaceId, filePath);
+  const abs = await resolveSafePathChecked(spaceId, filePath);
   await fs.unlink(abs);
 }
 
 /** Create a directory (including parents) */
 export async function createDir(spaceId: string, dirPath: string): Promise<void> {
-  const abs = resolveSafePath(spaceId, dirPath);
+  const abs = await resolveSafePathChecked(spaceId, dirPath);
   await fs.mkdir(abs, { recursive: true });
 }
 
@@ -91,8 +91,8 @@ export async function moveFile(
   srcPath: string,
   dstPath: string,
 ): Promise<void> {
-  const srcAbs = resolveSafePath(spaceId, srcPath);
-  const dstAbs = resolveSafePath(spaceId, dstPath);
+  const srcAbs = await resolveSafePathChecked(spaceId, srcPath);
+  const dstAbs = await resolveSafePathChecked(spaceId, dstPath);
   await fs.mkdir(path.dirname(dstAbs), { recursive: true });
   await fs.rename(srcAbs, dstAbs);
 }

--- a/server/src/files/sandbox.ts
+++ b/server/src/files/sandbox.ts
@@ -1,51 +1,121 @@
 import path from 'path';
+import fs from 'fs/promises';
 import { getDataRoot } from '../config/loader.js';
 
 /**
- * Resolve a user-supplied path within a space's data directory.
+ * Resolve a user-supplied path within a space's data directory (LEXICAL check).
  *
  * Security hardening:
- * 1. URL-decode to prevent %2F / %00 traversal
- * 2. Unicode NFC normalization to prevent homoglyph traversal
- * 3. Null-byte rejection
- * 4. Strip leading slashes (browser filenames often start with /)
- * 5. path.resolve against the space data root
- * 6. Strict prefix check — must remain under the space root
+ * 1. Unicode NFC normalization to prevent homoglyph traversal
+ * 2. Null-byte rejection
+ * 3. Strip leading slashes (browser filenames often start with /)
+ * 4. path.resolve against the space data root
+ * 5. Strict prefix check — must remain under the space root
+ *
+ * NOTE: this does NOT URL-decode. The HTTP layer (Express) already decodes
+ * query/route params exactly once, and the file-meta `_id` is derived from the
+ * same once-decoded string. A second `decodeURIComponent` here double-decoded
+ * the path — corrupting any filename containing a literal `%` (e.g. `50%.png`
+ * threw `URIError` → HTTP 500) and diverging the on-disk path from the DB `_id`.
+ * Callers that receive a raw HTTP value must not pre-decode it either.
+ *
+ * This is a purely lexical check. It does not follow symlinks — use
+ * {@link assertNoSymlinkEscape} (async) before an actual filesystem operation
+ * to close the symlink TOCTOU.
  *
  * @returns The absolute safe path
  * @throws RangeError if the path attempts to escape the space root
  */
 export function resolveSafePath(spaceId: string, userPath: string): string {
-  const dataRoot = getDataRoot();
-  const spaceRoot = path.resolve(dataRoot, 'files', spaceId);
+  const spaceRootDir = spaceRoot(spaceId);
 
-  // 1. URL-decode (may throw URIError on malformed input — propagate as 400)
-  const decoded = decodeURIComponent(userPath);
+  // 1. Unicode NFC normalization
+  const normalized = userPath.normalize('NFC');
 
-  // 2. Unicode NFC normalization
-  const normalized = decoded.normalize('NFC');
-
-  // 3. Strip any null bytes
+  // 2. Reject null bytes
   if (normalized.includes('\x00')) {
     throw new RangeError('Path contains null bytes');
   }
 
-  // 4. Strip leading slashes so browser-supplied filenames like
+  // 3. Strip any leading slashes so browser-supplied filenames like
   //    '/Screenshot 2024.png' are treated as relative.  An absolute path
   //    passed directly to path.resolve() would silently discard spaceRoot,
   //    causing the prefix check below to fire as a false-positive traversal.
   const relative = normalized.replace(/^\/+/, '');
 
-  // 5. Resolve to absolute
-  const resolved = path.resolve(spaceRoot, relative);
+  // 4. Resolve to absolute
+  const resolved = path.resolve(spaceRootDir, relative);
 
-  // 6. Prefix check — must start with spaceRoot + separator
-  const boundary = spaceRoot.endsWith(path.sep) ? spaceRoot : spaceRoot + path.sep;
-  if (!resolved.startsWith(boundary) && resolved !== spaceRoot) {
+  // 5. Prefix check — must start with spaceRoot + separator
+  if (!isWithin(spaceRootDir, resolved)) {
     throw new RangeError(`Path traversal attempt: '${userPath}'`);
   }
 
   return resolved;
+}
+
+/** True when `candidate` is the boundary itself or lies beneath it. */
+function isWithin(boundaryDir: string, candidate: string): boolean {
+  const boundary = boundaryDir.endsWith(path.sep) ? boundaryDir : boundaryDir + path.sep;
+  return candidate === boundaryDir || candidate.startsWith(boundary);
+}
+
+/**
+ * Symlink-aware boundary check: canonicalises `absPath` (following symlinks) and
+ * asserts the real location is still inside the space root's real location.
+ *
+ * The lexical {@link resolveSafePath} guarantees the *string* stays under the
+ * root, but a symlink anywhere along the path can still point outside it — the
+ * classic TOCTOU that turns a recursive delete or a write into an escape. Since
+ * the target (or intermediate directories) may not exist yet, this walks up to
+ * the nearest existing ancestor, realpaths that, and re-appends the
+ * not-yet-created suffix (which cannot contain a symlink precisely because it
+ * does not exist).
+ *
+ * Call this before every real filesystem operation on a user-controlled path.
+ *
+ * @throws RangeError if the real path escapes the space root
+ */
+export async function assertNoSymlinkEscape(spaceId: string, absPath: string): Promise<void> {
+  const rootDir = spaceRoot(spaceId);
+
+  let realRoot: string;
+  try {
+    realRoot = await fs.realpath(rootDir);
+  } catch {
+    // The space directory does not exist yet — there is nothing to escape into.
+    return;
+  }
+
+  let probe = absPath;
+  // Bounded walk up to the nearest existing ancestor.
+  for (let i = 0; i < 4096; i++) {
+    try {
+      const realProbe = await fs.realpath(probe);
+      const suffix = path.relative(probe, absPath); // '' when probe === absPath
+      const realFull = suffix ? path.resolve(realProbe, suffix) : realProbe;
+      if (!isWithin(realRoot, realFull)) {
+        throw new RangeError(`Path escapes the space root via a symlink: '${absPath}'`);
+      }
+      return;
+    } catch (err) {
+      if (err instanceof RangeError) throw err;
+      // ENOENT (or similar) — this ancestor does not exist; step up one level.
+      const parent = path.dirname(probe);
+      if (parent === probe) return; // reached the filesystem root without any existing ancestor
+      probe = parent;
+    }
+  }
+}
+
+/**
+ * Convenience: lexical resolve + symlink-aware check in one call, for the
+ * filesystem helpers. Returns the absolute (lexical) path to operate on.
+ */
+export async function resolveSafePathChecked(spaceId: string, userPath: string): Promise<string> {
+  const abs = resolveSafePath(spaceId, userPath);
+  await assertNoSymlinkEscape(spaceId, abs);
+  return abs;
 }
 
 /** Return the absolute data root for a space's files */

--- a/testing/red-team-tests/file-hardening.test.js
+++ b/testing/red-team-tests/file-hardening.test.js
@@ -234,4 +234,27 @@ describe('File hardening (H8 + H9)', () => {
       await deleteFile(p);
     });
   });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // L3 — a filename with a literal % round-trips (no double URL-decode)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Literal % in filenames (L3)', () => {
+    const run = Date.now();
+
+    it('uploads and downloads a file named with a literal % (previously 500)', async () => {
+      const p = `pct-test-${run}/50%.png`;
+      // Before the fix, resolveSafePath ran decodeURIComponent again on the
+      // already-decoded path — '50%.png' → URIError → HTTP 500.
+      const up = await uploadRaw(p, Buffer.from('percent'), 'application/octet-stream');
+      assert.ok(up.status === 201 || up.status === 202, `upload: ${up.status} ${JSON.stringify(up.body)}`);
+
+      const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(p)}`;
+      const r = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+      const body = await r.text();
+      assert.equal(r.status, 200, `download of a %-named file must not 500: got ${r.status}`);
+      assert.equal(body, 'percent');
+      await deleteFile(p);
+    });
+  });
 });

--- a/testing/standalone/files-brain-hardening.test.js
+++ b/testing/standalone/files-brain-hardening.test.js
@@ -1,0 +1,242 @@
+/**
+ * Unit tests: files/brain hardening (M1, M11, L3, L4, L5)
+ *
+ * M1  — assertNoSymlinkEscape follows symlinks and refuses a path whose real
+ *       location escapes the space root (the lexical check cannot see this).
+ * M11 — assembleChunks verifies the chunks tile [0, total) exactly (no gap,
+ *       no overlap) and its sha256 matches the assembled bytes.
+ * L3  — resolveSafePath no longer URL-decodes: a filename with a literal '%'
+ *       resolves without throwing and stays byte-identical to the DB _id.
+ * L4  — applyResolutions rejects prototype-polluting property keys.
+ * L5  — mergeEmbeddingExclusion merges the embedding exclusion with the caller's
+ *       projection instead of discarding it, and never lets the vector through.
+ *
+ * Pure in-process logic. sandbox/chunks read DATA_ROOT from the env, which this
+ * test points at a temp dir. Run:
+ *   node --test testing/standalone/files-brain-hardening.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+// DATA_ROOT must be set before importing modules that read it at call time.
+const TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'ythril-fb-'));
+process.env.DATA_ROOT = TMP;
+
+const { resolveSafePath, assertNoSymlinkEscape, spaceRoot } =
+  await import('../../server/dist/files/sandbox.js');
+const { assembleChunks, uploadId, storeChunk } =
+  await import('../../server/dist/files/chunks.js');
+const { applyResolutions } = await import('../../server/dist/brain/merge.js');
+const { mergeEmbeddingExclusion } = await import('../../server/dist/brain/memory.js');
+
+const SPACE = 'fbtest';
+
+// ── L3 — no URL-decode in resolveSafePath ────────────────────────────────────
+
+describe('L3 — resolveSafePath does not URL-decode', () => {
+  it('a filename with a literal % resolves without throwing', () => {
+    // decodeURIComponent('50%.png') throws URIError → the old code 500'd.
+    const abs = resolveSafePath(SPACE, '50%.png');
+    assert.ok(abs.endsWith(`${path.sep}50%.png`), abs);
+  });
+
+  it('the resolved basename is byte-identical to the input (matches the DB _id)', () => {
+    const abs = resolveSafePath(SPACE, 'a%2Fb.png'); // %2F stays literal, not decoded to '/'
+    assert.equal(path.basename(abs), 'a%2Fb.png');
+  });
+
+  it('still blocks lexical traversal', () => {
+    assert.throws(() => resolveSafePath(SPACE, '../../etc/passwd'), /traversal/i);
+  });
+
+  it('still rejects null bytes', () => {
+    assert.throws(() => resolveSafePath(SPACE, 'a\x00b'), /null/i);
+  });
+});
+
+// ── M1 — symlink escape detection ────────────────────────────────────────────
+
+describe('M1 — assertNoSymlinkEscape follows symlinks', () => {
+  const root = spaceRoot(SPACE);
+  let outsideDir;
+
+  before(async () => {
+    await fs.mkdir(root, { recursive: true });
+    outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ythril-outside-'));
+    await fs.writeFile(path.join(outsideDir, 'secret.txt'), 'top secret');
+  });
+
+  after(async () => {
+    await fs.rm(outsideDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('accepts a normal path inside the root', async () => {
+    const abs = resolveSafePath(SPACE, 'docs/note.txt');
+    await assert.doesNotReject(() => assertNoSymlinkEscape(SPACE, abs));
+  });
+
+  it('refuses a path that reaches outside via a symlinked directory', async () => {
+    // root/evil -> <outsideDir>. Lexically root/evil/secret.txt is "inside".
+    const link = path.join(root, 'evil');
+    await fs.rm(link, { recursive: true, force: true }).catch(() => {});
+    try {
+      await fs.symlink(outsideDir, link, 'dir');
+    } catch (err) {
+      // Windows without symlink privilege — skip rather than fail.
+      if (err.code === 'EPERM' || err.code === 'ENOSYS') return;
+      throw err;
+    }
+    const abs = resolveSafePath(SPACE, 'evil/secret.txt');
+    await assert.rejects(() => assertNoSymlinkEscape(SPACE, abs), /symlink/i);
+  });
+
+  it('refuses a symlinked FILE that points outside the root', async () => {
+    const link = path.join(root, 'link-to-secret.txt');
+    await fs.rm(link, { force: true }).catch(() => {});
+    try {
+      await fs.symlink(path.join(outsideDir, 'secret.txt'), link, 'file');
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'ENOSYS') return;
+      throw err;
+    }
+    const abs = resolveSafePath(SPACE, 'link-to-secret.txt');
+    await assert.rejects(() => assertNoSymlinkEscape(SPACE, abs), /symlink/i);
+  });
+});
+
+// ── M11 — chunk assembly coverage + hash ─────────────────────────────────────
+
+describe('M11 — assembleChunks verifies coverage and hashes correctly', () => {
+  const filePath = 'big.bin';
+
+  async function seedChunks(space, parts) {
+    // parts: array of { start, buf }
+    for (const p of parts) {
+      await storeChunk(space, filePath, p.buf, p.start, p.start + p.buf.length - 1, TOTAL);
+    }
+  }
+  const A = Buffer.alloc(1000, 0x41);
+  const B = Buffer.alloc(1000, 0x42);
+  const C = Buffer.alloc(500, 0x43);
+  const TOTAL = A.length + B.length + C.length; // 2500
+
+  it('assembles contiguous chunks and the sha256 matches the bytes', async () => {
+    const space = 'm11-ok';
+    await fs.mkdir(spaceRoot(space), { recursive: true });
+    await seedChunks(space, [
+      { start: 0, buf: A },
+      { start: 1000, buf: B },
+      { start: 2000, buf: C },
+    ]);
+    const target = path.join(spaceRoot(space), filePath);
+    const sha = await assembleChunks(space, filePath, TOTAL, target);
+
+    const written = await fs.readFile(target);
+    assert.equal(written.length, TOTAL);
+    assert.equal(sha, createHash('sha256').update(Buffer.concat([A, B, C])).digest('hex'));
+  });
+
+  it('refuses assembly when a chunk is missing (gap)', async () => {
+    const space = 'm11-gap';
+    await fs.mkdir(spaceRoot(space), { recursive: true });
+    // 0..999 and 2000..2499 present; 1000..1999 missing.
+    await seedChunks(space, [
+      { start: 0, buf: A },
+      { start: 2000, buf: C },
+    ]);
+    const target = path.join(spaceRoot(space), filePath);
+    await assert.rejects(() => assembleChunks(space, filePath, TOTAL, target), /coverage/i);
+  });
+
+  it('refuses assembly when chunks overlap', async () => {
+    const space = 'm11-overlap';
+    await fs.mkdir(spaceRoot(space), { recursive: true });
+    // 0..999 and 500..1499 overlap.
+    await seedChunks(space, [
+      { start: 0, buf: A },
+      { start: 500, buf: B },
+    ]);
+    const target = path.join(spaceRoot(space), filePath);
+    await assert.rejects(() => assembleChunks(space, filePath, TOTAL, target), /coverage/i);
+  });
+});
+
+// ── L4 — prototype-pollution reject in applyResolutions ──────────────────────
+
+describe('L4 — applyResolutions rejects prototype-polluting keys', () => {
+  it('does not pollute Object.prototype via a __proto__ absorbed-only key', () => {
+    const result = applyResolutions(
+      { safe: 'a' },
+      {},
+      [],
+      [{ key: '__proto__', value: 'polluted' }],
+    );
+    assert.equal({}.polluted, undefined, 'Object.prototype must not be polluted');
+    assert.equal(result.safe, 'a');
+    assert.ok(!('__proto__' in result) || result.__proto__ !== 'polluted');
+  });
+
+  it('does not pollute via a constructor conflict key', () => {
+    const result = applyResolutions(
+      {},
+      {},
+      [{ key: 'constructor', type: 'string', survivorValue: 'x', absorbedValue: 'y', resolution: 'absorbed' }],
+      [],
+    );
+    assert.equal(typeof {}.constructor, 'function', 'constructor must remain the Object constructor');
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(result, 'constructor'),
+      'the constructor key must be skipped, not written as an own property',
+    );
+  });
+
+  it('still applies normal property resolutions', () => {
+    const result = applyResolutions(
+      { keep: 1 },
+      {},
+      [{ key: 'color', type: 'string', survivorValue: 'red', absorbedValue: 'blue', resolution: 'absorbed' }],
+      [{ key: 'extra', value: 'added' }],
+    );
+    assert.equal(result.keep, 1);
+    assert.equal(result.color, 'blue');
+    assert.equal(result.extra, 'added');
+  });
+});
+
+// ── L5 — projection merge ────────────────────────────────────────────────────
+
+describe('L5 — mergeEmbeddingExclusion preserves the caller projection', () => {
+  it('no projection → excludes embedding only', () => {
+    assert.deepEqual(mergeEmbeddingExclusion(undefined), { embedding: 0 });
+    assert.deepEqual(mergeEmbeddingExclusion({}), { embedding: 0 });
+  });
+
+  it('inclusion projection is preserved (embedding excluded by omission)', () => {
+    const out = mergeEmbeddingExclusion({ fact: 1, tags: 1 });
+    assert.deepEqual(out, { fact: 1, tags: 1 });
+    assert.ok(!('embedding' in out) || out.embedding === 0);
+  });
+
+  it('exclusion projection keeps the caller fields AND adds embedding: 0', () => {
+    const out = mergeEmbeddingExclusion({ createdAt: 0 });
+    assert.deepEqual(out, { createdAt: 0, embedding: 0 });
+  });
+
+  it('an explicit embedding inclusion is stripped (vector can never leak)', () => {
+    const out = mergeEmbeddingExclusion({ fact: 1, embedding: 1 });
+    assert.equal(out.embedding, undefined, 'embedding must not be included even if requested');
+    assert.equal(out.fact, 1);
+  });
+
+  it('_id exclusion alongside inclusion is respected', () => {
+    const out = mergeEmbeddingExclusion({ _id: 0, fact: 1 });
+    assert.equal(out.fact, 1);
+    assert.equal(out._id, 0);
+  });
+});


### PR DESCRIPTION
The **final MEDIUM+LOW group** of the security audit — the files/brain items (M1, M11, L3, L4, L5), following #135. With this, **every CRITICAL/HIGH/MEDIUM/LOW item in the audit is fixed or assessed.**

## M1 — symlink TOCTOU in the file sandbox
`resolveSafePath` guaranteed only that the path *string* stayed under the space root. A symlink component anywhere along the path could still point outside it — the classic time-of-check/time-of-use that a recursive directory delete would happily follow out of the sandbox. New `assertNoSymlinkEscape` canonicalises the path with `realpath` (walking up to the nearest existing ancestor for not-yet-created files, then re-appending the non-existent suffix, which cannot contain a symlink) and re-asserts the real location is inside the space root. It runs before every read / write / delete / move / list (via `resolveSafePathChecked`) and before the recursive-delete endpoint's `fs.rm`.

## M11 — chunked-upload coverage + hash race
`assembleChunks` only checked the aggregate byte count, so a set of chunks with a gap and a compensating overlap could report "complete" and assemble into **silently corrupt** content. Assembly now verifies the chunks tile `[0, total)` exactly (contiguous, no gaps, no overlaps) before writing anything. The returned sha256 is computed from the same buffers written in order — the previous hash came from a `data` listener attached alongside `stream.pipeline`, which put the stream in flowing mode and raced the pipeline's own consumption, so it could cover a different byte view than the file on disk.

## L3 — double URL-decode
`resolveSafePath` ran `decodeURIComponent` on a value the HTTP layer had already decoded once. A filename with a literal `%` (e.g. `50%.png`) therefore threw `URIError` → HTTP 500, and the on-disk path could diverge from the file-meta `_id` (which is derived from the once-decoded string). The redundant decode is removed; the disk path now matches the stored `_id` byte-for-byte, and `%`-named files round-trip.

## L4 — prototype pollution in entity-merge resolution
`applyResolutions` wrote resolved property values through a computed index; a `__proto__` / `constructor` / `prototype` key would mutate the object prototype instead of adding a data property. Those keys are now skipped. (Impact was limited — merge values are scalars — but it removes the footgun from a path that assigns user/peer-supplied keys.)

## L5 — `query` tool discarded the caller's projection
The mandatory `embedding`-vector exclusion was applied as a **second** `.project()` call, which in the MongoDB driver *replaces* the first — silently dropping any projection the caller supplied. The exclusion is now merged with the caller's projection (respecting MongoDB's inclusion/exclusion rules: an inclusion projection already omits the vector; an exclusion projection gets `embedding: 0` added), and an explicit request to include `embedding` is still stripped so the vector can never leak.

## Tests
- New: `testing/standalone/files-brain-hardening.test.js` (18 — symlink escape via a symlinked dir/file, chunk gap/overlap rejection + sha256 correctness, `%`-filename resolution, proto-key rejection, projection merge). `testing/red-team-tests/file-hardening.test.js` gains a `%`-filename HTTP round-trip.
- Full suites on the rebuilt Docker stack, each run in isolation: **standalone 694 / 0 fail** (incl. the 18 new), **integration 783 / 0**, **red-team 251 / 0**, **sync 172 / 0** (both the auth-escalation MFA test and the vote-signing relay test are pre-existing load-flakes — they restart/stress the shared container under a full parallel run and pass cleanly in isolation; neither touches files/brain code).

Docs: CHANGELOG. (No API surface change — L3 fixes a 500, the rest are internal hardening; L5 makes the documented `projection` parameter actually take effect.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)