### PR TITLE
feat(recall): graph-traversal augmented recall (traverse parameter)

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -692,6 +692,7 @@ Available as both:
 | `types` | — | all types | Restrict result knowledge types |
 | `minScore` | — | none | Filter out low-similarity matches |
 | `filter` | — | none | Property equality/comparison filter (see below) |
+| `traverse` | — | `0` | Graph-expansion depth (integer 0–5). `0` = classic recall; > 0 follows edges from each match (see [Graph-Augmented Recall](#graph-augmented-recall-traverse-parameter)) |
 
 **Response** `200`:
 
@@ -705,6 +706,69 @@ Available as both:
 ```
 
 Searches **all knowledge types** (memories, entities, edges, chrono entries, and files) using the built-in embedding model and MongoDB Atlas `$vectorSearch`. Results are ranked by vector similarity across all types and include a `type` discriminator field. No extra configuration needed.
+
+#### Graph-Augmented Recall (`traverse` parameter)
+
+By default `recall` returns matches in isolation — the knowledge-graph edges between records are not consulted. Set `traverse` to an integer between `1` and `5` to follow the graph outward from every match: for each seed, the server walks edges (in **both** directions) up to `traverse` hops and returns the connected entities alongside the matches. This turns semantic search into context-aware retrieval — "recall the Vault service **and everything connected to it**" in one call, instead of a recall followed by manual `traverse`/`query` calls.
+
+`traverse: 0` (the default) is behaviourally identical to classic recall and returns the classic response shape above. When `traverse > 0` the response shape changes: each result is annotated, and a `traverseDepth` field is added.
+
+```json
+{
+  "query": "authentication token scoping",
+  "types": ["entity"],
+  "traverse": 2
+}
+```
+
+**Response** `200` (when `traverse > 0`):
+
+```json
+{
+  "results": [
+    {
+      "score": 0.91,
+      "source": "recall",
+      "hops": 0,
+      "path": [],
+      "spaceId": "adrs",
+      "type": "entity",
+      "record": { "_id": "adr-0042", "name": "Token Scoping", "type": "decision" }
+    },
+    {
+      "score": null,
+      "source": "traverse",
+      "hops": 1,
+      "path": [{ "from": "adr-0042", "label": "implements", "to": "adr-0079" }],
+      "spaceId": "adrs",
+      "type": "entity",
+      "record": { "_id": "adr-0079", "name": "Vault Integration", "type": "decision" }
+    }
+  ],
+  "count": 2,
+  "traverseDepth": 2
+}
+```
+
+Per-result annotations:
+
+| Field | Meaning |
+|-------|---------|
+| `source` | `"recall"` for a direct semantic match (seed), `"traverse"` for a record reached via the graph |
+| `hops` | Distance from the nearest seed — `0` for a seed, `1` for a direct neighbour, etc. |
+| `path` | The edge chain connecting this record to its seed (`[]` for seeds). Each element is `{ from, label, to }` |
+| `score` | Vector similarity for seeds; `null` for traversal-reached records (they were not ranked by the search) |
+| `record` | Seed records carry the full recall result; traversal records carry the reached **entity** document |
+
+**Guard rails:**
+
+- **Depth cap:** `traverse` must be `0`–`5`. A value of `6` or higher (or a negative/non-integer value) returns `400` — it is rejected, not clamped.
+- **Result cap:** the combined output (seeds + traversal) is capped at `topK × (traverse + 1) × 4`. On dense graphs the traversal is truncated to this budget, preferring lower-hop records.
+- **Cycle-safe:** each record is visited once, so a circular graph (A→B→C→A) never loops or produces duplicates. A record reachable by multiple paths keeps its **shortest** path.
+- **Space-scoped:** traversal stays within the spaces the calling token may access. An edge pointing at a record in a space the token cannot see (or at an id that is not an entity) is silently skipped — no data and no `403` leak.
+- Only **entities** are returned by traversal (edges connect entities); memories, chrono entries, and files still appear as seeds when they match semantically.
+
+**Performance:** traversal issues roughly two batched (`$in`) MongoDB queries per hop, not one query per node. Even so, `traverse > 2` on a densely-connected graph can fan out quickly — pair it with `filter`, `tags`, or a low `topK` to keep the seed set (and therefore the traversal frontier) tight.
 
 #### Prefiltered Recall (`filter` parameter)
 

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -6,7 +6,7 @@ import { globalRateLimit, bulkWipeRateLimit } from '../rate-limit/middleware.js'
 import { NotFoundError } from '../util/errors.js';
 import { listMemories, deleteMemory, countMemories, bulkDeleteMemories, remember, updateMemory, queryBrain, findSimilar, recall, validateFilterExpression, type RecallKnowledgeType, type FilterExpression } from '../brain/memory.js';
 import { listEntities, deleteEntity, upsertEntity, getEntityById, updateEntityById, bulkDeleteEntities, findEntitiesByName, findEntityBacklinks } from '../brain/entities.js';
-import { listEdges, deleteEdge, upsertEdge, getEdgeById, updateEdgeById, bulkDeleteEdges, traverseGraph } from '../brain/edges.js';
+import { listEdges, deleteEdge, upsertEdge, getEdgeById, updateEdgeById, bulkDeleteEdges, traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE } from '../brain/edges.js';
 import { computeMergePlan, applyResolutions, executeMerge, validateResolution, type PropertyResolution } from '../brain/merge.js';
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../brain/delete-fields.js';
 /** Regex that matches a UUID v4 (case-insensitive). */
@@ -1507,6 +1507,20 @@ brainRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, as
   }
 });
 
+/** One entry in a graph-augmented recall response (traverse > 0). */
+interface RecallTraverseItem {
+  /** Vector similarity score for seeds; null for traversal-reached records. */
+  score: number | null;
+  source: 'recall' | 'traverse';
+  /** 0 = seed, 1 = one edge away, etc. */
+  hops: number;
+  /** Edge chain connecting this record to its seed (empty for seeds). */
+  path: { from: string; label: string; to: string }[];
+  spaceId: string;
+  type: string;
+  record: unknown;
+}
+
 // POST /api/brain/spaces/:spaceId/recall — semantic vector search by natural language query
 brainRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
@@ -1515,7 +1529,7 @@ brainRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, a
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const { query, topK, types, minScore, filter } = req.body ?? {};
+  const { query, topK, types, minScore, filter, traverse } = req.body ?? {};
   if (!query || typeof query !== 'string' || !query.trim()) {
     res.status(400).json({ error: 'query must be a non-empty string' });
     return;
@@ -1523,6 +1537,17 @@ brainRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, a
   const safeTopK = typeof topK === 'number' ? Math.min(Math.max(topK, 1), 100) : 10;
   const safeTypes = Array.isArray(types) ? types.filter((t: unknown): t is RecallKnowledgeType => typeof t === 'string') : undefined;
   const safeMinScore = typeof minScore === 'number' ? minScore : undefined;
+
+  // Graph-traversal expansion depth. 0 (default) = classic recall, unchanged.
+  // Rejected rather than clamped past the cap so an obviously-wrong depth surfaces.
+  let safeTraverse = 0;
+  if (traverse != null) {
+    if (typeof traverse !== 'number' || !Number.isInteger(traverse) || traverse < 0 || traverse > MAX_RECALL_TRAVERSE) {
+      res.status(400).json({ error: `traverse must be an integer between 0 and ${MAX_RECALL_TRAVERSE}` });
+      return;
+    }
+    safeTraverse = traverse;
+  }
 
   let safeFilter: FilterExpression | undefined;
   if (filter != null) {
@@ -1544,8 +1569,26 @@ brainRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, a
       memberIds.map(mid => recall(mid, query.trim(), safeTopK, undefined, safeTypes, undefined, safeMinScore, safeFilter)),
     )).flat();
     all.sort((x, y) => (y.score ?? 0) - (x.score ?? 0));
-    const results = all.slice(0, safeTopK);
-    res.json({ results, count: results.length });
+    const seeds = all.slice(0, safeTopK);
+
+    if (safeTraverse === 0) {
+      res.json({ results: seeds, count: seeds.length });
+      return;
+    }
+
+    // Graph-augmented recall: expand seeds along edges, cap the combined output.
+    const totalCap = safeTopK * (safeTraverse + 1) * 4;
+    const neighbours = await traverseRecallSeeds(
+      memberIds,
+      seeds.map(s => ({ _id: s._id, spaceId: s.spaceId })),
+      safeTraverse,
+      Math.max(0, totalCap - seeds.length),
+    );
+    const results: RecallTraverseItem[] = [
+      ...seeds.map(s => ({ score: s.score, source: 'recall' as const, hops: 0, path: [], spaceId: s.spaceId, type: s.type, record: s })),
+      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity' as const, record: n.record })),
+    ];
+    res.json({ results, count: results.length, traverseDepth: safeTraverse });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(400).json({ error: msg });

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -432,3 +432,121 @@ export async function traverseGraph(
 
   return { nodes: resultNodes, edges: resultEdges, truncated: false };
 }
+
+// ── Recall-augmenting traversal ──────────────────────────────────────────────
+
+/** Hard cap on the `traverse` depth accepted by graph-augmented recall. */
+export const MAX_RECALL_TRAVERSE = 5;
+
+/** A neighbour reached by following the edge graph out from a recall seed set. */
+export interface SeedTraverseNeighbor {
+  _id: string;
+  spaceId: string;
+  /** Hop distance from the nearest seed (1 = directly connected to a seed). */
+  hops: number;
+  /** Edge chain connecting the nearest seed to this neighbour (shortest path). */
+  path: { from: string; label: string; to: string }[];
+  /** Hydrated entity document (embedding stripped). */
+  record: EntityDoc;
+}
+
+/**
+ * Multi-source, depth-limited BFS over the edge graph of a SINGLE space, seeded
+ * from a set of recall-match IDs. Follows edges in BOTH directions, records the
+ * shortest path to each neighbour (BFS visit order guarantees shortest-first),
+ * and detects cycles via a visited set so a circular graph never loops or
+ * duplicates. Neighbours are hydrated as entities within THIS space only — an
+ * edge pointing at an id absent from the space (e.g. a cross-space edge to a
+ * space the caller can't see) yields no neighbour and is silently skipped.
+ * Batched `$in` lookups keep this to ~2 queries per hop regardless of fan-out.
+ */
+export async function traverseFromSeeds(
+  spaceId: string,
+  seedIds: string[],
+  maxDepth: number,
+  limit: number,
+): Promise<SeedTraverseNeighbor[]> {
+  if (seedIds.length === 0 || maxDepth < 1 || limit < 1) return [];
+
+  const visited = new Set<string>(seedIds);
+  const pathTo = new Map<string, { from: string; label: string; to: string }[]>();
+  for (const id of seedIds) pathTo.set(id, []);
+
+  let frontier: string[] = [...new Set(seedIds)];
+  let frontierSet = new Set<string>(frontier);
+  let depth = 0;
+  const results: SeedTraverseNeighbor[] = [];
+
+  while (frontier.length > 0 && depth < maxDepth) {
+    const edges = await col<EdgeDoc>(`${spaceId}_edges`)
+      .find(mFilter<EdgeDoc>({ $or: [{ from: { $in: frontier } }, { to: { $in: frontier } }] }))
+      .toArray() as EdgeDoc[];
+
+    const newNeighborIds: string[] = [];
+    for (const edge of edges) {
+      // Same-level edge (both ends already in the frontier) — introduces no new node.
+      if (frontierSet.has(edge.from) && frontierSet.has(edge.to)) continue;
+      const frontierEnd = frontierSet.has(edge.from) ? edge.from : edge.to;
+      const neighborId = frontierEnd === edge.from ? edge.to : edge.from;
+      if (visited.has(neighborId)) continue;
+      visited.add(neighborId);
+      pathTo.set(neighborId, [...(pathTo.get(frontierEnd) ?? []), { from: edge.from, label: edge.label, to: edge.to }]);
+      newNeighborIds.push(neighborId);
+    }
+
+    if (newNeighborIds.length === 0) break;
+
+    const entities = await col<EntityDoc>(`${spaceId}_entities`)
+      .find(mFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId }))
+      .project({ embedding: 0 })
+      .toArray() as EntityDoc[];
+    const entityMap = new Map<string, EntityDoc>();
+    for (const e of entities) entityMap.set(e._id, e);
+
+    const nextFrontier: string[] = [];
+    for (const neighborId of newNeighborIds) {
+      const entity = entityMap.get(neighborId);
+      if (!entity) continue; // not an entity in this space (e.g. cross-space edge target) — skip
+      results.push({ _id: entity._id, spaceId, hops: depth + 1, path: pathTo.get(neighborId) ?? [], record: entity });
+      if (results.length >= limit) return results;
+      nextFrontier.push(neighborId);
+    }
+
+    frontier = nextFrontier;
+    frontierSet = new Set<string>(frontier);
+    depth++;
+  }
+
+  return results;
+}
+
+/**
+ * Expand a set of recall seeds into their graph neighbours across the caller's
+ * authorized spaces. Seeds are grouped by space (only spaces in `memberIds` are
+ * traversed — the cross-space access guard), each space is BFS-expanded via
+ * `traverseFromSeeds`, and the merged neighbours are truncated to `limit` with
+ * lower-hop results preferred. Never touches a space outside `memberIds`.
+ */
+export async function traverseRecallSeeds(
+  memberIds: string[],
+  seeds: { _id: string; spaceId: string }[],
+  maxDepth: number,
+  limit: number,
+): Promise<SeedTraverseNeighbor[]> {
+  if (seeds.length === 0 || maxDepth < 1 || limit < 1) return [];
+  const allowed = new Set(memberIds);
+  const bySpace = new Map<string, string[]>();
+  for (const s of seeds) {
+    if (!allowed.has(s.spaceId)) continue;
+    const arr = bySpace.get(s.spaceId) ?? [];
+    arr.push(s._id);
+    bySpace.set(s.spaceId, arr);
+  }
+
+  const collected: SeedTraverseNeighbor[] = [];
+  for (const [sid, ids] of bySpace) {
+    collected.push(...await traverseFromSeeds(sid, ids, maxDepth, limit));
+  }
+  collected.sort((a, b) => a.hops - b.hops); // prefer lower-hop neighbours when truncating
+  return collected.slice(0, limit);
+}

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -17,7 +17,7 @@ import { updateSpace, wipeSpace, WIPE_COLLECTION_TYPES, type WipeCollectionType 
 import { remember, recall, recallGlobal, findSimilar, queryBrain, updateMemory, deleteMemory, validateFilterExpression, type RecallKnowledgeType, type RecallResult, type FilterExpression } from '../brain/memory.js';
 import { col, mFilter, mDoc } from '../db/mongo.js';
 import { upsertEntity, updateEntityById, findEntitiesByName } from '../brain/entities.js';
-import { upsertEdge, traverseGraph, updateEdgeById } from '../brain/edges.js';
+import { upsertEdge, traverseGraph, updateEdgeById, traverseRecallSeeds, MAX_RECALL_TRAVERSE } from '../brain/edges.js';
 import { computeMergePlan, applyResolutions, executeMerge, validateResolution, type PropertyResolution } from '../brain/merge.js';
 import { validateDeleteFields } from '../brain/delete-fields.js';
 
@@ -85,6 +85,31 @@ function toRecallRecord(r: RecallResult): Record<string, unknown> {
     case 'file':
       return { ...common, path: r.path, ...(r.sizeBytes !== undefined ? { sizeBytes: r.sizeBytes } : {}), ...(r.parentFileId !== undefined ? { parentFileId: r.parentFileId } : {}), ...(r.chunkIndex !== undefined ? { chunkIndex: r.chunkIndex } : {}), ...(r.headingText !== undefined ? { headingText: r.headingText } : {}), ...(r.content !== undefined ? { content: r.content } : {}) };
   }
+}
+
+/** Build the `record` object for a traversal-reached entity (embedding already excluded). */
+function entityDocToRecord(e: import('../config/types.js').EntityDoc): Record<string, unknown> {
+  const rec: Record<string, unknown> = { _id: e._id, name: e.name, type: e.type };
+  if (e.createdAt !== undefined) rec['createdAt'] = e.createdAt;
+  if (e.updatedAt !== undefined) rec['updatedAt'] = e.updatedAt;
+  if (e.seq !== undefined) rec['seq'] = e.seq;
+  if (e.tags !== undefined) rec['tags'] = e.tags;
+  if (e.description !== undefined) rec['description'] = e.description;
+  if (e.properties !== undefined) rec['properties'] = e.properties;
+  if (e.embeddingModel !== undefined) rec['embeddingModel'] = e.embeddingModel;
+  return rec;
+}
+
+/** One entry in a graph-augmented recall response (traverse > 0). */
+interface McpRecallTraverseItem {
+  score: number | null;
+  source: 'recall' | 'traverse';
+  hops: number;
+  path: { from: string; label: string; to: string }[];
+  spaceId: string;
+  type: string;
+  matchedText: string;
+  record: Record<string, unknown>;
 }
 
 const MUTATING_TOOLS = new Set([
@@ -196,6 +221,12 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
           minScore: {
             type: 'number',
             description: 'Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded.',
+          },
+          traverse: {
+            type: 'number',
+            minimum: 0,
+            maximum: 5,
+            description: 'Optional graph expansion depth (integer 0–5, default 0). When > 0, each semantic match is expanded along knowledge-graph edges up to this many hops, and the connected entities are returned alongside the matches. Each result is annotated with source ("recall" or "traverse"), hops (0 = seed), and path (the connecting edge chain). Use with filter/tags to narrow the seed set — traverse > 2 on dense graphs can be slow. Example: recall "auth token scoping" with traverse: 1 returns the matching records plus everything one edge away.',
           },
           filter: {
             type: 'object',
@@ -953,6 +984,15 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
             : undefined;
           const minScore = typeof a['minScore'] === 'number' ? a['minScore'] : undefined;
 
+          // Graph-traversal expansion depth. 0 (default) = classic recall, unchanged.
+          let traverse = 0;
+          if (a['traverse'] != null) {
+            if (typeof a['traverse'] !== 'number' || !Number.isInteger(a['traverse']) || a['traverse'] < 0 || a['traverse'] > MAX_RECALL_TRAVERSE) {
+              throw new Error(`traverse must be an integer between 0 and ${MAX_RECALL_TRAVERSE}`);
+            }
+            traverse = a['traverse'];
+          }
+
           let filter: FilterExpression | undefined;
           if (a['filter'] != null) {
             if (typeof a['filter'] !== 'object' || Array.isArray(a['filter'])) {
@@ -963,42 +1003,48 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
             filter = a['filter'] as FilterExpression;
           }
 
+          // Resolve the seed set and the authorized space set (same guard for both).
+          let seeds: RecallResult[];
+          let traverseSpaces: string[];
           if (callSpace) {
-            // Search specific space
             const memberIds = resolveMemberSpaces(callSpace);
             const all = (await Promise.all(memberIds.map(mid => recall(mid, query, topK, tags, types, minPerType, minScore, filter)))).flat();
             all.sort((x, y) => (y.score ?? 0) - (x.score ?? 0));
-            const results = all.slice(0, topK);
-            const output = {
-              results: results.map(r => ({
-                score: r.score,
-                spaceId: r.spaceId,
-                type: r.type,
-                matchedText: r.matchedText ?? formatRecallSummary(r),
-                record: toRecallRecord(r),
-              })),
-              count: results.length,
-            };
-            return {
-              content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
-            };
+            seeds = all.slice(0, topK);
+            traverseSpaces = memberIds;
           } else {
-            // Cross-space search across all accessible spaces
-            const results = await recallGlobal(accessibleSpaceIds, query, topK, tags, types, minPerType, minScore, filter);
+            seeds = await recallGlobal(accessibleSpaceIds, query, topK, tags, types, minPerType, minScore, filter);
+            traverseSpaces = accessibleSpaceIds;
+          }
+
+          if (traverse === 0) {
             const output = {
-              results: results.map(r => ({
+              results: seeds.map(r => ({
                 score: r.score,
                 spaceId: r.spaceId,
                 type: r.type,
                 matchedText: r.matchedText ?? formatRecallSummary(r),
                 record: toRecallRecord(r),
               })),
-              count: results.length,
+              count: seeds.length,
             };
-            return {
-              content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
-            };
+            return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
           }
+
+          // Graph-augmented recall: expand seeds along edges, cap the combined output.
+          const totalCap = topK * (traverse + 1) * 4;
+          const neighbours = await traverseRecallSeeds(
+            traverseSpaces,
+            seeds.map(s => ({ _id: s._id, spaceId: s.spaceId })),
+            traverse,
+            Math.max(0, totalCap - seeds.length),
+          );
+          const results: McpRecallTraverseItem[] = [
+            ...seeds.map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, matchedText: r.matchedText ?? formatRecallSummary(r), record: toRecallRecord(r) })),
+            ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity', matchedText: `${n.record.name} (${n.record.type})`, record: entityDocToRecord(n.record) })),
+          ];
+          const output = { results, count: results.length, traverseDepth: traverse };
+          return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
         }
 
         case 'find_similar': {

--- a/testing/integration/recall-traverse.test.js
+++ b/testing/integration/recall-traverse.test.js
@@ -1,0 +1,380 @@
+/**
+ * Integration tests: Graph-traversal augmented recall (`traverse` parameter)
+ *
+ * Covers the 011 acceptance criteria:
+ *  - traverse: 0 is behaviourally identical to classic recall (backward compat)
+ *  - traverse: 1 returns seeds AND their directly-connected neighbours (any direction)
+ *  - each traversal result carries source: "traverse", hops, and a connecting path
+ *  - traverse: 2 reaches two-hop neighbours with hops: 2 and a 2-edge path
+ *  - a circular graph (A→B→C→A) does not loop or duplicate records
+ *  - an edge to a record absent from the space is silently skipped (the same
+ *    hydration guard that makes cross-space edges to inaccessible spaces safe)
+ *  - traverse: 6 is rejected with 400 (exceeds the server cap); non-int / negative too
+ *  - total result count is bounded by the configured cap on a dense graph
+ *  - the MCP recall tool accepts traverse and returns annotated results
+ *
+ * Seeding model: the recall SEED entity is written via the brain API so it is
+ * embedded and $vectorSearch-visible; graph NEIGHBOURS are written via the sync
+ * endpoint (no embedding) because they are reached structurally, not by vector
+ * search — which also guarantees the seed set is deterministic (only the seed is
+ * indexed).
+ *
+ * Run: node --test testing/integration/recall-traverse.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `traverse-test-${RUN}`;        // chain + cycle + skip graph
+const SPACE_DENSE = `traverse-dense-${RUN}`; // hub-and-spoke graph for the cap test
+
+let tokenA;
+let embeddingAvailable = false;
+let seedAId = null;   // brain-API-assigned _id of the chain seed entity
+let seedHId = null;   // brain-API-assigned _id of the dense hub entity
+
+// Fixed neighbour IDs (written via sync, so we control them)
+const entB = `trav-B-${RUN}`;
+const entC = `trav-C-${RUN}`;
+const entD = `trav-D-${RUN}`;
+const ghost = `trav-ghost-${RUN}`; // referenced by an edge but never created as an entity
+const DENSE_LEAVES = Array.from({ length: 30 }, (_, i) => `dense-leaf-${i}-${RUN}`);
+
+function token() { return tokenA; }
+
+/** True if `edge` connects x and y in either orientation (edge iteration order is not deterministic). */
+function edgeConnects(edge, x, y) {
+  return (edge.from === x && edge.to === y) || (edge.from === y && edge.to === x);
+}
+
+async function ensureReindexed(baseUrl, tok) {
+  const { body: spacesBody } = await get(baseUrl, tok, '/api/spaces');
+  for (const space of spacesBody?.spaces ?? []) {
+    const { body: statusBody } = await get(baseUrl, tok, `/api/brain/spaces/${space.id}/reindex-status`);
+    if (statusBody?.needsReindex) {
+      await post(baseUrl, tok, `/api/brain/spaces/${space.id}/reindex`, {});
+    }
+  }
+}
+
+async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host, port, path: '/mcp', method: 'GET', headers: { Authorization: `Bearer ${authToken}`, Accept: 'text/event-stream' } },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(Object.assign(new Error(`MCP SSE open failed: ${res.statusCode}`), { statusCode: res.statusCode }));
+          return;
+        }
+        let buffer = '';
+        let sessionId = null;
+        const pendingMessages = [];
+        const waiters = [];
+        res.setEncoding('utf8');
+        res.on('data', chunk => {
+          buffer += chunk;
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() ?? '';
+          for (const part of parts) {
+            if (!part.trim()) continue;
+            let eventType = 'message';
+            let data = '';
+            for (const line of part.split('\n')) {
+              if (line.startsWith('event:')) eventType = line.slice(6).trim();
+              else if (line.startsWith('data:')) data = line.slice(5).trim();
+            }
+            if (eventType === 'endpoint') {
+              const m = data.match(/sessionId=([^&\s]+)/);
+              if (m) sessionId = m[1];
+            } else if (eventType === 'message' && data) {
+              try {
+                const parsed2 = JSON.parse(data);
+                const waiter = waiters.shift();
+                if (waiter) waiter(parsed2);
+                else pendingMessages.push(parsed2);
+              } catch { /* non-JSON */ }
+            }
+          }
+        });
+        const deadline = Date.now() + timeoutMs;
+        const poll = setInterval(() => {
+          if (sessionId) { clearInterval(poll); resolve({ callTool, close }); }
+          else if (Date.now() > deadline) { clearInterval(poll); reject(new Error('MCP session did not receive endpoint event')); }
+        }, 50);
+
+        async function postJsonRpc(body) {
+          return new Promise((res2, rej2) => {
+            const waiterTimeout = setTimeout(() => rej2(new Error('MCP tool call timed out')), timeoutMs);
+            if (pendingMessages.length > 0) { clearTimeout(waiterTimeout); res2(pendingMessages.shift()); return; }
+            waiters.push(msg => { clearTimeout(waiterTimeout); res2(msg); });
+            const postData = JSON.stringify(body);
+            const pr = http.request(
+              { host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(postData), Authorization: `Bearer ${authToken}` } },
+              pres => {
+                let txt = '';
+                pres.setEncoding('utf8');
+                pres.on('data', c => { txt += c; });
+                pres.on('end', () => {
+                  if (pres.statusCode !== 202 && pres.statusCode !== 200) { clearTimeout(waiterTimeout); rej2(new Error(`MCP POST failed: ${pres.statusCode} ${txt}`)); }
+                });
+              },
+            );
+            pr.on('error', rej2);
+            pr.write(postData);
+            pr.end();
+          });
+        }
+        async function callTool(name, args = {}) {
+          const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } });
+          return rpc?.result ?? rpc;
+        }
+        function close() { req.destroy(); }
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Poll $vectorSearch on `space` until every id in `ids` appears in unfiltered recall. */
+async function waitForIndexed(space, ids, timeoutMs = 30_000) {
+  const pending = new Set(ids);
+  const deadline = Date.now() + timeoutMs;
+  while (pending.size > 0 && Date.now() < deadline) {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${space}/recall`, { query: 'indexing probe query', types: ['entity'], topK: 100 });
+    if (r.status === 200 && Array.isArray(r.body.results)) {
+      for (const result of r.body.results) pending.delete(result._id);
+    }
+    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
+  }
+  if (pending.size > 0) throw new Error(`Timed out waiting for indexing of: ${[...pending].join(', ')}`);
+}
+
+async function syncEntity(space, id, name, seq) {
+  const { post: syncPost } = await import('../sync/helpers.js');
+  const now = new Date().toISOString();
+  await syncPost(INSTANCES.a, token(), `/api/sync/entities?spaceId=${space}`, {
+    _id: id, spaceId: space, name, type: 'service', tags: [],
+    seq, author: { instanceId: 'test', instanceLabel: 'Test' }, createdAt: now, updatedAt: now,
+  });
+}
+
+async function syncEdge(space, from, to, label, seq) {
+  const { post: syncPost } = await import('../sync/helpers.js');
+  const now = new Date().toISOString();
+  await syncPost(INSTANCES.a, token(), `/api/sync/edges?spaceId=${space}`, {
+    _id: `edge-${from}-${to}-${RUN}`, spaceId: space, from, to, label,
+    seq, author: { instanceId: 'test', instanceLabel: 'Test' }, createdAt: now, updatedAt: now,
+  });
+}
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+
+  for (const [id, label] of [[SPACE, `Traverse Test ${RUN}`], [SPACE_DENSE, `Traverse Dense ${RUN}`]]) {
+    const r = await post(INSTANCES.a, token(), '/api/spaces', { id, label });
+    assert.equal(r.status, 201, `Failed to create space ${id}: ${JSON.stringify(r.body)}`);
+  }
+  await ensureReindexed(INSTANCES.a, token());
+
+  // Chain seed A — written via the brain API so it is embedded + searchable.
+  const seedA = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, {
+    name: `Vault Secret Service ${RUN}`, type: 'service',
+    description: 'Vault secret storage service handling authentication token scoping and rotation',
+    tags: [], properties: {},
+  });
+  embeddingAvailable = seedA.status === 201;
+  seedAId = seedA.body?._id ?? null;
+
+  // Dense hub H — also embedded/searchable, distinct topic so it never co-matches A.
+  const seedH = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE_DENSE}/entities`, {
+    name: `Telemetry Aggregator ${RUN}`, type: 'service',
+    description: 'Telemetry aggregation pipeline collecting metrics from many downstream collectors',
+    tags: [], properties: {},
+  });
+  seedHId = seedH.body?._id ?? null;
+
+  let seq = Date.now();
+  // Chain neighbours B, C, D (sync — not embedded, reached structurally only).
+  for (const [id, name] of [[entB, 'B'], [entC, 'C'], [entD, 'D']]) {
+    await syncEntity(SPACE, id, `TravEnt-${name}-${RUN}`, seq++);
+  }
+  // Edges (traversal is bidirectional):
+  //   A→B (depends_on), B→C (depends_on)  → chain: B at hop 1, C at hop 2
+  //   A→D (references)                    → branch: D at hop 1
+  //   B→A (cycles_back)                   → the A→B→A cycle from the acceptance criteria
+  //   A→ghost (references)                → dangling: ghost is never created, must be skipped
+  // The cycle uses B→A (not C→A) so it does not shortcut C to a 1-hop neighbour.
+  if (seedAId) {
+    await syncEdge(SPACE, seedAId, entB, 'depends_on', seq++);
+    await syncEdge(SPACE, entB, entC, 'depends_on', seq++);
+    await syncEdge(SPACE, seedAId, entD, 'references', seq++);
+    await syncEdge(SPACE, entB, seedAId, 'cycles_back', seq++);
+    await syncEdge(SPACE, seedAId, ghost, 'references', seq++);
+  }
+
+  // Dense graph: hub H → 30 leaves (all one hop away).
+  for (const leaf of DENSE_LEAVES) await syncEntity(SPACE_DENSE, leaf, `Leaf-${leaf}`, seq++);
+  if (seedHId) for (const leaf of DENSE_LEAVES) await syncEdge(SPACE_DENSE, seedHId, leaf, 'feeds', seq++);
+
+  if (embeddingAvailable && seedAId) await waitForIndexed(SPACE, [seedAId]);
+  if (embeddingAvailable && seedHId) await waitForIndexed(SPACE_DENSE, [seedHId]);
+});
+
+after(async () => {
+  for (const space of [SPACE, SPACE_DENSE]) {
+    await fetch(`${INSTANCES.a}/api/spaces/${space}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true }),
+    }).catch(() => {});
+  }
+});
+
+// ── Validation (no embedding required) ───────────────────────────────────────
+
+describe('Recall traverse — input validation', () => {
+  it('traverse: 6 (over cap) returns 400', async () => {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: 'anything', traverse: 6 });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /traverse/);
+  });
+  it('traverse: -1 (negative) returns 400', async () => {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: 'anything', traverse: -1 });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+  });
+  it('traverse: 2.5 (non-integer) returns 400', async () => {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: 'anything', traverse: 2.5 });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+  });
+});
+
+// ── Behaviour (embedding required) ───────────────────────────────────────────
+
+describe('Recall traverse — graph expansion', () => {
+  const q = 'authentication token scoping vault';
+
+  it('traverse: 0 is identical to classic recall (backward compat)', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: q, types: ['entity'], traverse: 0 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.traverseDepth, undefined, 'classic response must not carry traverseDepth');
+    assert.ok(Array.isArray(r.body.results));
+    const seed = r.body.results.find(x => x._id === seedAId);
+    assert.ok(seed, 'seed entity must be recalled');
+    assert.equal(seed.source, undefined, 'classic results must not carry a source annotation');
+    assert.equal(typeof seed.score, 'number');
+  });
+
+  it('traverse: 1 returns the seed plus its direct neighbours, annotated', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: q, types: ['entity'], topK: 10, traverse: 1 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.traverseDepth, 1);
+
+    const byId = new Map(r.body.results.map(x => [x._id ?? x.record?._id, x]));
+    const seed = r.body.results.find(x => x.source === 'recall' && x.record?._id === seedAId);
+    assert.ok(seed, 'seed present as source recall');
+    assert.equal(seed.hops, 0);
+    assert.deepEqual(seed.path, []);
+
+    const b = r.body.results.find(x => x.record?._id === entB);
+    const d = r.body.results.find(x => x.record?._id === entD);
+    assert.ok(b && d, 'both direct neighbours B and D returned');
+    for (const [n, id] of [[b, entB], [d, entD]]) {
+      assert.equal(n.source, 'traverse');
+      assert.equal(n.hops, 1);
+      assert.equal(n.score, null, 'traversal-only results have null score');
+      assert.equal(n.type, 'entity');
+      assert.equal(n.path.length, 1, 'one-hop neighbour has a one-edge path');
+      assert.ok(edgeConnects(n.path[0], seedAId, id), `path edge connects seed and ${id}`);
+    }
+    assert.ok(!byId.has(entC), 'two-hop neighbour C must NOT appear at depth 1');
+    assert.ok(!r.body.results.some(x => (x.record?._id ?? x._id) === ghost), 'dangling edge target must be skipped');
+  });
+
+  it('traverse: 2 reaches the two-hop neighbour with a two-edge path', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: q, types: ['entity'], topK: 10, traverse: 2 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const c = r.body.results.find(x => x.record?._id === entC);
+    assert.ok(c, 'two-hop neighbour C returned at depth 2');
+    assert.equal(c.hops, 2);
+    assert.equal(c.path.length, 2, 'two-hop neighbour has a two-edge path');
+    assert.ok(edgeConnects(c.path[0], seedAId, entB), 'path hop 1 connects seed and B');
+    assert.ok(edgeConnects(c.path[1], entB, entC), 'path hop 2 connects B and C');
+  });
+
+  it('a cycle does not loop or duplicate records', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    // C→A closes a cycle. Depth 3 would revisit A without cycle detection.
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: q, types: ['entity'], topK: 10, traverse: 3 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const ids = r.body.results.map(x => x.record?._id ?? x._id);
+    const unique = new Set(ids);
+    assert.equal(ids.length, unique.size, `no duplicate records (got ${JSON.stringify(ids)})`);
+    const seedOccurrences = ids.filter(id => id === seedAId).length;
+    assert.equal(seedOccurrences, 1, 'the seed appears exactly once despite the cycle');
+  });
+});
+
+// ── Result cap (embedding required) ──────────────────────────────────────────
+
+describe('Recall traverse — result cap', () => {
+  it('caps the combined output on a dense graph', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    // topK 1, traverse 1 → cap = 1 * (1+1) * 4 = 8. Hub has 30 leaves at hop 1,
+    // so truncation MUST engage: exactly 1 seed + 7 neighbours = 8.
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE_DENSE}/recall`, {
+      query: 'telemetry metrics aggregation collectors', types: ['entity'], topK: 1, traverse: 1,
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.ok(r.body.count <= 8, `count ${r.body.count} must be within the cap of 8`);
+    assert.equal(r.body.count, 8, 'dense graph should fill exactly to the cap');
+    const seedCount = r.body.results.filter(x => x.source === 'recall').length;
+    assert.equal(seedCount, 1, 'exactly one seed');
+  });
+});
+
+// ── MCP surface (embedding required) ─────────────────────────────────────────
+
+describe('Recall traverse — MCP tool', () => {
+  it('MCP recall accepts traverse and returns annotated results', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    let session;
+    try {
+      session = await openMcpSession(token());
+    } catch (e) {
+      return t.skip(`MCP session unavailable: ${e.message}`);
+    }
+    try {
+      const result = await session.callTool('recall', { space: SPACE, query: 'authentication token scoping vault', types: ['entity'], traverse: 1 });
+      const text = result?.content?.[0]?.text;
+      assert.ok(text, 'MCP recall returned text content');
+      const output = JSON.parse(text);
+      assert.equal(output.traverseDepth, 1);
+      const seed = output.results.find(x => x.source === 'recall');
+      assert.ok(seed, 'seed annotated as source recall');
+      const neighbour = output.results.find(x => x.source === 'traverse' && x.record?._id === entB);
+      assert.ok(neighbour, 'neighbour B reached via traverse');
+      assert.equal(neighbour.hops, 1);
+      assert.ok(edgeConnects(neighbour.path[0], seedAId, entB), 'MCP neighbour path connects seed and B');
+    } finally {
+      session.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional **`traverse`** parameter (integer `0`–`5`) to `recall` — REST (`POST /api/brain/spaces/:spaceId/recall`) and the `recall` MCP tool. When `traverse > 0`, each semantic match is expanded along knowledge-graph edges up to N hops, and the connected entities are returned alongside the matches. This turns semantic search into context-aware retrieval — *"recall the Vault service **and everything connected to it**"* in a single call, instead of a recall followed by manual `traverse`/`query` calls.

Implements the local `011` backlog issue (graph-traversal augmented recall).

## Behaviour

- **`traverse: 0` (default) is unchanged** — classic recall, classic response shape. Backward compatible.
- When `traverse > 0`, the response shape changes: each result is annotated with `source` (`recall` seed vs `traverse` neighbour), `hops` (0 = seed), and `path` (the connecting edge chain), and a `traverseDepth` field is added. Traversal-only records have `score: null`.

```jsonc
{
  "query": "authentication token scoping",
  "types": ["entity"],
  "traverse": 2
}
// →
{
  "results": [
    { "score": 0.91, "source": "recall",   "hops": 0, "path": [], "type": "entity", "record": { ... } },
    { "score": null, "source": "traverse", "hops": 1,
      "path": [{ "from": "adr-0042", "label": "implements", "to": "adr-0079" }], "type": "entity", "record": { ... } }
  ],
  "count": 2,
  "traverseDepth": 2
}
```

## Implementation

- `brain/edges.ts` — new `traverseFromSeeds` (bidirectional, cycle-safe, multi-source BFS over one space with shortest-path tracking and batched `$in` lookups — ~2 queries per hop) and `traverseRecallSeeds` (groups seeds by space, expands each, merges + caps). Reuses the existing `traverseGraph` patterns; `traverseGraph` itself is untouched.
- `api/brain.ts` and `mcp/router.ts` — parse/validate `traverse`, run the augmented flow when > 0. The MCP dispatcher's two branches (single-space vs cross-space) were unified so seed resolution and traversal aren't duplicated.

## Guard rails

- **Depth** must be `0`–`5`; `6`+ / negative / non-integer is **rejected** (`400` REST, tool error MCP), not clamped.
- **Result cap:** combined output ≤ `topK × (traverse + 1) × 4`, lower hops preferred when truncating.
- **Cycle-safe:** each record visited once; `A→B→A` never loops or duplicates; shortest path kept.
- **Space-scoped:** traversal stays within the token's authorized spaces; an edge pointing at an inaccessible space (or a non-entity id) is silently skipped — no `403` leak.

## Testing

- New `testing/integration/recall-traverse.test.js` — **9 cases, all green**, covering every acceptance criterion: validation (`6`/`-1`/`2.5` → 400), backward-compat (`traverse: 0`), 1-hop and 2-hop expansion with path/hops annotation, cycle safety, dangling-edge skip, the result cap on a dense 30-leaf hub, and the MCP tool path.
- Existing `recall-filter` suite (21 cases) still green — no regression to classic recall.

## Docs

- Integration guide recall section: new **Graph-Augmented Recall** subsection (parameter, response shape, per-result annotations, guard rails, performance guidance) + a `traverse` row in the recall parameter table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)