### PR TITLE
feat(mcp): semantic duplicate detection on remember and upsert_entity

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5323,6 +5323,21 @@ Content-Type: application/json
 }
 ```
 
+### Duplicate Detection on Insert
+
+The `remember` and `upsert_entity` tools run a **semantic near-duplicate check** before storing, using the same embedding the new record is stored with — so it costs one extra ANN vector search, not a re-embed. When a highly similar record already exists, the tool's response flags it (id, a short summary, and the cosine score) so an agent can update or merge the existing record instead of accumulating redundant ones:
+
+```text
+Stored memory (seq 1284, ID 7f3c…).
+⚠️ Possible duplicate — 1 existing memory is highly similar: "The Vault service stores secrets and rotates auth tokens" (ID 9a1b…, 0.97). This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.
+```
+
+- **The write always succeeds** — the check is advisory, never blocking. It also never fails an insert: if vector search is unavailable or the space needs reindexing, the check is silently skipped.
+- **Default on** for both tools. Pass `checkDuplicates: false` to skip it, or `dupeThreshold` (0–1, default ~0.92) to tune sensitivity — lower flags looser matches.
+- For `upsert_entity` the check fires only on a **new insert** (no `id`, or an `id` that does not yet exist), not on updates.
+- Because `$vectorSearch` has indexing latency, a record inserted moments earlier may not yet be visible to the check — duplicates are detected against the already-indexed corpus.
+- Not applied by `bulk_write` (it would add a search per item); use single-item `remember`/`upsert_entity` when you want duplicate feedback.
+
 ### Example: recall
 
 ```json

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -4,6 +4,7 @@ import { nextSeq } from '../util/seq.js';
 import { embed } from './embedding.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
+import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './memory.js';
 import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc } from '../config/types.js';
 
 /** A backlink entry describing an item that references a given entity. */
@@ -15,6 +16,8 @@ export interface BacklinkEntry {
 export interface UpsertResult {
   entity: EntityDoc;
   warning?: string;
+  /** Near-duplicate entities surfaced by an opt-in insert-time similarity check. */
+  similar?: SimilarMatch[];
 }
 
 function authorRef() {
@@ -59,6 +62,7 @@ export async function upsertEntity(
   properties: Record<string, string | number | boolean> = {},
   description?: string,
   id?: string,
+  opts?: DupeCheckOpts,
 ): Promise<UpsertResult> {
   const collection = col<EntityDoc>(`${spaceId}_entities`);
 
@@ -103,6 +107,14 @@ export async function upsertEntity(
     }
   }
 
+  // Opt-in insert-time duplicate check, using the freshly computed vector
+  // BEFORE insert so it can never self-match.
+  let similar: SimilarMatch[] | undefined;
+  if (opts?.checkDuplicates && embeddingFields.embedding) {
+    const hits = await checkDuplicates(spaceId, 'entity', embeddingFields.embedding, opts.dupeThreshold, opts.dupeTopK);
+    if (hits.length > 0) similar = hits;
+  }
+
   const doc: EntityDoc = {
     _id: id ?? uuidv4(),
     spaceId,
@@ -118,7 +130,7 @@ export async function upsertEntity(
   };
   if (description !== undefined) doc.description = description;
   await collection.insertOne(mDoc<EntityDoc>(doc));
-  return { entity: doc, warning };
+  return { entity: doc, warning, similar };
 }
 
 /**

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -116,10 +116,20 @@ export async function remember(
   properties?: Record<string, string | number | boolean>,
   entityNames?: string[],
   type?: string,
-): Promise<MemoryDoc> {
+  opts?: DupeCheckOpts,
+): Promise<MemoryDoc & { similar?: SimilarMatch[] }> {
   const names = entityNames ?? await resolveEntityNames(spaceId, entityIds);
   const embedText = memoryEmbedText(fact, tags, names, description, properties);
   const embResult = await embed(embedText);
+
+  // Opt-in insert-time duplicate check, using the freshly computed vector
+  // BEFORE insert so it can never self-match.
+  let similar: SimilarMatch[] | undefined;
+  if (opts?.checkDuplicates) {
+    const hits = await checkDuplicates(spaceId, 'memory', embResult.vector, opts.dupeThreshold, opts.dupeTopK);
+    if (hits.length > 0) similar = hits;
+  }
+
   const seq = await nextSeq(spaceId);
   const now = new Date().toISOString();
   const doc: MemoryDoc = {
@@ -140,7 +150,7 @@ export async function remember(
   if (description !== undefined) doc.description = description;
   if (properties !== undefined) doc.properties = properties;
   await col<MemoryDoc>(`${spaceId}_memories`).insertOne(mDoc<MemoryDoc>(doc));
-  return doc;
+  return similar ? { ...doc, similar } : doc;
 }
 
 export type RecallKnowledgeType = 'memory' | 'entity' | 'edge' | 'chrono' | 'file';
@@ -296,6 +306,66 @@ export async function recall(
   await enrichFileChunksWithParent(spaceId, final);
 
   return final;
+}
+
+// ── Insert-time duplicate detection ──────────────────────────────────────────
+
+/** A near-duplicate surfaced by an insert-time similarity check. */
+export interface SimilarMatch {
+  _id: string;
+  type: RecallKnowledgeType;
+  score: number;
+  summary: string;
+}
+
+/** Default cosine-similarity threshold at/above which an insert is flagged as a likely duplicate. */
+export const DEFAULT_DUPE_THRESHOLD = 0.92;
+const DEFAULT_DUPE_TOPK = 3;
+
+/** Options controlling the optional insert-time duplicate check on remember/upsertEntity. */
+export interface DupeCheckOpts {
+  checkDuplicates?: boolean;
+  dupeThreshold?: number;
+  dupeTopK?: number;
+}
+
+/** One-line human summary of a recall result, for duplicate feedback. */
+function summariseRecall(r: RecallResult): string {
+  switch (r.type) {
+    case 'memory': return r.fact.length > 120 ? `${r.fact.slice(0, 117)}…` : r.fact;
+    case 'entity': return `${r.name} (${r.entityType})`;
+    case 'edge': return `${r.from} → ${r.label} → ${r.to}`;
+    case 'chrono': return r.title;
+    case 'file': return r.path;
+  }
+}
+
+/**
+ * Insert-time near-duplicate check: run an ANN vector search with a freshly
+ * computed embedding and return existing records of the same type scoring at or
+ * above `threshold`. Best-effort — returns `[]` (never throws) when vector
+ * search is unavailable, the space needs reindexing, or the search fails, so it
+ * can never block a write. Passes no tags/filter, keeping the search on the fast
+ * ANN path. Supply `excludeId` to drop a self-match when called post-insert.
+ */
+export async function checkDuplicates(
+  spaceId: string,
+  type: RecallKnowledgeType,
+  vector: number[],
+  threshold = DEFAULT_DUPE_THRESHOLD,
+  topK = DEFAULT_DUPE_TOPK,
+  excludeId?: string,
+): Promise<SimilarMatch[]> {
+  if (!vector || vector.length === 0) return [];
+  if (!isVectorSearchAvailable() || needsReindex(spaceId)) return [];
+  try {
+    const hits = await recallByType(spaceId, type, vector, topK);
+    return hits
+      .filter(h => h._id !== excludeId && (h.score ?? 0) >= threshold)
+      .map(h => ({ _id: h._id, type: h.type, score: h.score, summary: summariseRecall(h) }));
+  } catch {
+    return [];
+  }
 }
 
 /** Maps knowledge types to their MongoDB collection suffixes. */

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -194,6 +194,8 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
             additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
           },
           targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+          checkDuplicates: { type: 'boolean', description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar memory already exists, the response flags it (id + summary + score) so you can update it instead of creating a redundant one. The memory is still stored regardless. Set false to skip the check.' },
+          dupeThreshold: { type: 'number', description: 'Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.' },
         },
         required: ['space', 'fact'],
       },
@@ -399,6 +401,8 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
             additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
           },
           targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+          checkDuplicates: { type: 'boolean', description: 'On a NEW entity insert (no id / unknown id), run a semantic near-duplicate check first (default true). Flags highly similar existing entities (id + summary + score) so you can merge or update instead of creating a duplicate. Does not fire on updates. Set false to skip.' },
+          dupeThreshold: { type: 'number', description: 'Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.' },
         },
         required: ['space', 'name', 'type'],
       },
@@ -955,8 +959,15 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
           }
 
           const resolvedNames = entityNames.filter(n => !unresolvedNames.includes(n));
-          const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames);
+          // Insert-time duplicate check defaults ON for the interactive remember tool.
+          const remDupeCheck = a['checkDuplicates'] !== false;
+          const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
+          const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames, undefined,
+            { checkDuplicates: remDupeCheck, dupeThreshold: remDupeThreshold });
           const warnings: string[] = [];
+          if (mem.similar && mem.similar.length > 0) {
+            warnings.push(`⚠️ Possible duplicate — ${mem.similar.length} existing memor${mem.similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${mem.similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.`);
+          }
           if (unresolvedNames.length > 0) {
             warnings.push(`⚠️ Unresolved entity names (not linked — create them first): ${unresolvedNames.map(n => `'${n}'`).join(', ')}`);
           }
@@ -1359,8 +1370,16 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
             return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(entSchemaViolations, null, 2)}` }], isError: true };
           }
 
-          const { entity, warning } = await upsertEntity(wt.target, eName, eType, tags, props, description, rawId);
+          // Insert-time duplicate check defaults ON for the interactive upsert tool
+          // (only fires on inserts, not updates — see upsertEntity).
+          const entDupeCheck = a['checkDuplicates'] !== false;
+          const entDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
+          const { entity, warning, similar } = await upsertEntity(wt.target, eName, eType, tags, props, description, rawId,
+            { checkDuplicates: entDupeCheck, dupeThreshold: entDupeThreshold });
           let msg = `Entity '${entity.name}' (${entity.type}) upserted (ID ${entity._id}).${warning ? `\n⚠️ ${warning}` : ''}`;
+          if (similar && similar.length > 0) {
+            msg += `\n⚠️ Possible duplicate — ${similar.length} existing entit${similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. Pass checkDuplicates:false to skip, or provide the existing id to update it instead.`;
+          }
           // Schema warnings (reuse violations from pre-write check)
           if (entMeta?.validationMode === 'warn') {
             for (const v of entSchemaViolations) msg += `\n⚠️ Schema: ${v.field} — ${v.reason}`;

--- a/testing/integration/dupe-detection.test.js
+++ b/testing/integration/dupe-detection.test.js
@@ -1,0 +1,199 @@
+/**
+ * Integration tests: Insert-time semantic duplicate detection
+ *
+ * Covers the F4 feature — the `remember` and `upsert_entity` MCP tools run an
+ * opt-in (default-on) near-duplicate check using the freshly computed embedding
+ * and flag highly similar existing records in the response:
+ *  - remember a near-identical memory → response flags the existing one
+ *  - remember a clearly distinct memory → no duplicate flag
+ *  - remember with checkDuplicates:false → no flag even for a duplicate
+ *  - upsert_entity a semantically duplicate entity → response flags the existing one
+ *  - the write always succeeds regardless (the check is advisory)
+ *
+ * Duplicates are only visible once the original is $vectorSearch-indexed, so the
+ * original is written and waited-for before the duplicate is inserted.
+ *
+ * Run: node --test testing/integration/dupe-detection.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `dupe-test-${RUN}`;
+
+let tokenA;
+let embeddingAvailable = false;
+
+function token() { return tokenA; }
+function idFrom(text) { const m = /ID ([0-9a-f-]{36})/.exec(text ?? ''); return m ? m[1] : null; }
+
+async function ensureReindexed(baseUrl, tok) {
+  const { body } = await get(baseUrl, tok, '/api/spaces');
+  for (const space of body?.spaces ?? []) {
+    const { body: st } = await get(baseUrl, tok, `/api/brain/spaces/${space.id}/reindex-status`);
+    if (st?.needsReindex) await post(baseUrl, tok, `/api/brain/spaces/${space.id}/reindex`, {});
+  }
+}
+
+async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host, port, path: '/mcp', method: 'GET', headers: { Authorization: `Bearer ${authToken}`, Accept: 'text/event-stream' } },
+      (res) => {
+        if (res.statusCode !== 200) { res.resume(); reject(Object.assign(new Error(`MCP SSE open failed: ${res.statusCode}`), { statusCode: res.statusCode })); return; }
+        let buffer = '';
+        let sessionId = null;
+        const pendingMessages = [];
+        const waiters = [];
+        res.setEncoding('utf8');
+        res.on('data', chunk => {
+          buffer += chunk;
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() ?? '';
+          for (const part of parts) {
+            if (!part.trim()) continue;
+            let eventType = 'message';
+            let data = '';
+            for (const line of part.split('\n')) {
+              if (line.startsWith('event:')) eventType = line.slice(6).trim();
+              else if (line.startsWith('data:')) data = line.slice(5).trim();
+            }
+            if (eventType === 'endpoint') { const m = data.match(/sessionId=([^&\s]+)/); if (m) sessionId = m[1]; }
+            else if (eventType === 'message' && data) {
+              try { const p = JSON.parse(data); const w = waiters.shift(); if (w) w(p); else pendingMessages.push(p); } catch { /* non-JSON */ }
+            }
+          }
+        });
+        const deadline = Date.now() + timeoutMs;
+        const poll = setInterval(() => {
+          if (sessionId) { clearInterval(poll); resolve({ callTool, close }); }
+          else if (Date.now() > deadline) { clearInterval(poll); reject(new Error('MCP session did not receive endpoint event')); }
+        }, 50);
+        async function postJsonRpc(body) {
+          return new Promise((res2, rej2) => {
+            const wt = setTimeout(() => rej2(new Error('MCP tool call timed out')), timeoutMs);
+            if (pendingMessages.length > 0) { clearTimeout(wt); res2(pendingMessages.shift()); return; }
+            waiters.push(msg => { clearTimeout(wt); res2(msg); });
+            const postData = JSON.stringify(body);
+            const pr = http.request(
+              { host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(postData), Authorization: `Bearer ${authToken}` } },
+              pres => { let t = ''; pres.setEncoding('utf8'); pres.on('data', c => { t += c; }); pres.on('end', () => { if (pres.statusCode !== 202 && pres.statusCode !== 200) { clearTimeout(wt); rej2(new Error(`MCP POST failed: ${pres.statusCode} ${t}`)); } }); },
+            );
+            pr.on('error', rej2); pr.write(postData); pr.end();
+          });
+        }
+        async function callTool(name, args = {}) {
+          const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } });
+          return rpc?.result ?? rpc;
+        }
+        function close() { req.destroy(); }
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Poll $vectorSearch until every id appears in unfiltered recall for `types`. */
+async function waitForIndexed(ids, types, timeoutMs = 30_000) {
+  const pending = new Set(ids);
+  const deadline = Date.now() + timeoutMs;
+  while (pending.size > 0 && Date.now() < deadline) {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: 'indexing probe query', types, topK: 100 });
+    if (r.status === 200 && Array.isArray(r.body.results)) for (const x of r.body.results) pending.delete(x._id);
+    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
+  }
+  if (pending.size > 0) throw new Error(`Timed out waiting for indexing of: ${[...pending].join(', ')}`);
+}
+
+let session;
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const r = await post(INSTANCES.a, token(), '/api/spaces', { id: SPACE, label: `Dupe Test ${RUN}` });
+  assert.equal(r.status, 201, `Failed to create space: ${JSON.stringify(r.body)}`);
+  await ensureReindexed(INSTANCES.a, token());
+  // Probe embedding availability
+  const probe = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, { name: `__dupe-probe-${RUN}__`, type: 'probe', description: 'probe', tags: [] });
+  embeddingAvailable = probe.status === 201;
+  session = await openMcpSession(token());
+});
+
+after(async () => {
+  try { session?.close(); } catch { /* ignore */ }
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, { method: 'DELETE', headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ confirm: true }) }).catch(() => {});
+});
+
+describe('Duplicate detection — remember', () => {
+  it('flags a near-identical memory as a possible duplicate', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const first = 'The Vault service stores secrets and rotates authentication tokens on a schedule.';
+    const dup = 'The Vault service stores secrets and rotates authentication tokens on a fixed schedule.';
+
+    const r1 = await session.callTool('remember', { space: SPACE, fact: first });
+    const id1 = idFrom(r1?.content?.[0]?.text);
+    assert.ok(id1, `first remember returned an id: ${r1?.content?.[0]?.text}`);
+    await waitForIndexed([id1], ['memory']);
+
+    const r2 = await session.callTool('remember', { space: SPACE, fact: dup });
+    const text2 = r2?.content?.[0]?.text ?? '';
+    assert.match(text2, /Possible duplicate/, `expected a duplicate flag, got: ${text2}`);
+    assert.ok(text2.includes(id1), `duplicate flag should name the existing memory ${id1}: ${text2}`);
+    // The write still succeeds.
+    assert.ok(idFrom(text2) && idFrom(text2) !== id1, 'the near-duplicate is still stored as a new memory');
+  });
+
+  it('does not flag a clearly distinct memory', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const r = await session.callTool('remember', { space: SPACE, fact: 'Ripe bananas are a yellow tropical fruit rich in potassium.' });
+    const text = r?.content?.[0]?.text ?? '';
+    assert.ok(idFrom(text), 'distinct memory stored');
+    assert.doesNotMatch(text, /Possible duplicate/, `distinct memory should not be flagged: ${text}`);
+  });
+
+  it('skips the check when checkDuplicates:false', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const dup = 'The Vault service stores secrets and rotates authentication tokens on a schedule.';
+    const r = await session.callTool('remember', { space: SPACE, fact: dup, checkDuplicates: false });
+    const text = r?.content?.[0]?.text ?? '';
+    assert.ok(idFrom(text), 'memory stored');
+    assert.doesNotMatch(text, /Possible duplicate/, `checkDuplicates:false must skip the flag: ${text}`);
+  });
+});
+
+describe('Duplicate detection — upsert_entity', () => {
+  it('flags a semantically duplicate entity insert', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const desc = 'Central telemetry aggregation pipeline collecting metrics from downstream collectors.';
+    const r1 = await session.callTool('upsert_entity', { space: SPACE, name: `Telemetry Aggregator ${RUN}`, type: 'service', description: desc });
+    const id1 = idFrom(r1?.content?.[0]?.text);
+    assert.ok(id1, `first upsert returned an id: ${r1?.content?.[0]?.text}`);
+    await waitForIndexed([id1], ['entity']);
+
+    // Different name (avoids the exact-name warning), same semantics → semantic dup.
+    const r2 = await session.callTool('upsert_entity', { space: SPACE, name: `Telemetry Collector Aggregation ${RUN}`, type: 'service', description: desc });
+    const text2 = r2?.content?.[0]?.text ?? '';
+    assert.match(text2, /Possible duplicate/, `expected a duplicate flag, got: ${text2}`);
+    assert.ok(text2.includes(id1), `duplicate flag should name the existing entity ${id1}: ${text2}`);
+  });
+
+  it('skips the check when checkDuplicates:false', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    const desc = 'Central telemetry aggregation pipeline collecting metrics from downstream collectors.';
+    const r = await session.callTool('upsert_entity', { space: SPACE, name: `Telemetry Something Else ${RUN}`, type: 'service', description: desc, checkDuplicates: false });
+    const text = r?.content?.[0]?.text ?? '';
+    assert.doesNotMatch(text, /Possible duplicate/, `checkDuplicates:false must skip the flag: ${text}`);
+  });
+});


### PR DESCRIPTION
## Summary

The **`remember`** and **`upsert_entity`** MCP tools now run an opt-in (default-on) **semantic near-duplicate check** before storing. It reuses the record's freshly computed embedding — one extra ANN vector search, no re-embed — and when a highly similar record already exists, the tool response flags it (id, short summary, cosine score) so an agent can update or merge the existing record instead of accumulating redundant ones.

Implements the local `F4` backlog item (semantic duplicate feedback on insert).

## Behaviour

```text
Stored memory (seq 1284, ID 7f3c…).
⚠️ Possible duplicate — 1 existing memory is highly similar: "The Vault service stores secrets and rotates auth tokens" (ID 9a1b…, 0.97). This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.
```

- **Advisory, never blocking** — the write always succeeds. The check also never fails an insert: if vector search is unavailable or the space needs reindexing, it is silently skipped.
- **Default on** for both tools; `checkDuplicates: false` skips it, `dupeThreshold` (0–1, default ~0.92) tunes sensitivity.
- **`upsert_entity`** runs it only on a **new insert** (no `id` / unknown `id`), not on updates.
- **`bulk_write` does not run it** (it would add a search per item) and **REST write paths are unchanged** — this is scoped to the interactive MCP tools where the feedback is most useful. REST parity is a possible follow-up.
- Because `$vectorSearch` has indexing latency, a record inserted moments earlier may not yet be visible to the check; duplicates are detected against the already-indexed corpus.

## Implementation

- `brain/memory.ts` — new `checkDuplicates()` + `SimilarMatch` / `DupeCheckOpts`. It runs `recallByType` with **no tags/filter** (fast ANN path), filters to scores ≥ threshold, and is fully guarded (`isVectorSearchAvailable()` / `needsReindex()` / try-catch → `[]`), so it can never block or fail a write.
- Threaded through `remember()` and `upsertEntity()` via an **optional trailing `opts` arg** and an **optional `similar` return field** — backward compatible; existing callers (REST, `bulk_write`) are unaffected because the flag defaults off at the function level and is enabled only by the two MCP tool handlers.
- The check runs **pre-insert** using the just-computed vector, so it can never self-match.

## Testing

- New `testing/integration/dupe-detection.test.js` — **5 cases, all green**: near-identical memory flagged (names the existing record), distinct memory not flagged, `checkDuplicates:false` skips, semantically-duplicate entity insert flagged, and the entity opt-out.
- Regression: `brain.test.js` (175) and `mcp-tools.test.js` (85) suites pass — no impact on existing write paths or MCP tools.

## Docs

- Integration guide MCP section: new **Duplicate Detection on Insert** subsection (behaviour, response example, the `checkDuplicates`/`dupeThreshold` args, and the indexing-latency and bulk-write caveats), plus the two tool-schema descriptions.

## Notes / follow-ups

- REST `POST /memories` and `POST /entities` parity (the REST memory path is inline, not via `remember()`), a per-space default in `SpaceMeta`, and enabling it opt-in for `bulk_write` are natural follow-ups, deliberately out of scope to keep this PR tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)