### PR TITLE
test: harden container config reads against saveConfig write races

### DIFF
--- a/testing/red-team-tests/auth-surface-hardening.test.js
+++ b/testing/red-team-tests/auth-surface-hardening.test.js
@@ -28,7 +28,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del } from '../sync/helpers.js';
+import { INSTANCES, post, get, del, dockerExec } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -41,7 +41,7 @@ before(() => {
 });
 
 function readContainerConfig(container = 'ythril-a') {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
   ).toString();
@@ -201,7 +201,7 @@ describe('L1 — token lookup prefix comes from the random part of the token', (
 
     // Rewrite the record to the pre-fix format, as an upgraded deployment has it.
     const oldPrefix = plaintext.slice(0, 8);
-    execSync(
+    dockerExec(
       `docker exec ythril-a node -e "const fs=require('fs');const p='/config/config.json';` +
       `const c=JSON.parse(fs.readFileSync(p,'utf8'));` +
       `const t=c.tokens.find(t=>t.id==='${id}');t.prefix='${oldPrefix}';` +
@@ -275,7 +275,7 @@ describe('M8 — a TOTP code cannot be replayed inside its validity window', () 
   // Break-glass disable: remove totpSecret from secrets.json + restart.
   // (Once MFA is on, reload-config itself demands a code.)
   function disableMfaViaRestart() {
-    execSync(
+    dockerExec(
       `docker exec ythril-a node -e "const fs=require('fs');const p='/config/secrets.json';` +
       `const s=JSON.parse(fs.readFileSync(p,'utf8'));delete s.totpSecret;delete s.totpLastStep;` +
       `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600})"`,

--- a/testing/red-team-tests/sync-medium-hardening.test.js
+++ b/testing/red-team-tests/sync-medium-hardening.test.js
@@ -22,12 +22,11 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del } from '../sync/helpers.js';
+import { INSTANCES, post, get, del, dockerExec } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -37,7 +36,7 @@ let adminToken;
 let instanceIdA;
 
 function getInstanceId(container = 'ythril-a') {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(JSON.parse(fs.readFileSync('/config/config.json','utf8')).instanceId)"`,
   ).toString().trim();

--- a/testing/sync/braintree-governance.test.js
+++ b/testing/sync/braintree-governance.test.js
@@ -17,11 +17,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, delWithBody, waitFor, triggerSync } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del, delWithBody, waitFor, triggerSync } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -37,7 +36,7 @@ let testSpaceId;
 // ── helpers ─────────────────────────────────────────────────────────────────
 
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));` +
     `process.stdout.write(c.instanceId)"`,
@@ -54,11 +53,11 @@ function injectPeerToken(container, instanceId, token) {
     `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 function readContainerConfig(container) {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
   ).toString();

--- a/testing/sync/closed-network.test.js
+++ b/testing/sync/closed-network.test.js
@@ -9,9 +9,8 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import {
+import { dockerExec,
   INSTANCES,
   post, get, del, delWithBody, triggerSync, waitFor,
 } from './helpers.js';
@@ -31,7 +30,7 @@ function loadTokens() {
 
 /** Read instanceId from a container's config.json */
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
   ).toString().trim();
 }
@@ -47,7 +46,7 @@ s.peerTokens['${instanceId}'] = '${token}';
 fs.writeFileSync(p, JSON.stringify(s, null, 2), { mode: 0o600 });
 process.stdout.write('ok');
 `.replace(/\n/g, ' ');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 // ── Setup ────────────────────────────────────────────────────────────────────

--- a/testing/sync/fork.test.js
+++ b/testing/sync/fork.test.js
@@ -19,11 +19,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -32,7 +31,7 @@ const CONFIGS = path.join(__dirname, 'configs');
 
 /** Read a container's full config.json and return parsed object. */
 function readContainerConfig(container) {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
   ).toString();
@@ -221,7 +220,7 @@ describe('Off-grid / fork', () => {
 
     before(async () => {
       // Discover instance ID of ythril-a
-      instanceIdA = execSync(
+      instanceIdA = dockerExec(
         `docker exec ythril-a node -e "const fs=require('fs');` +
         `const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));` +
         `process.stdout.write(c.instanceId)"`,

--- a/testing/sync/gossip.test.js
+++ b/testing/sync/gossip.test.js
@@ -20,11 +20,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, delWithBody, reqJson, triggerSync, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del, delWithBody, reqJson, triggerSync, waitFor } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -49,12 +48,12 @@ s.peerTokens['${instanceId}'] = '${token}';
 fs.writeFileSync(p, JSON.stringify(s, null, 2), { mode: 0o600 });
 process.stdout.write('ok');
 `.replace(/\n/g, ' ');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 /** Read instanceId from a container's config.json */
 function getInstanceId(container) {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
   ).toString().trim();
   return out;
@@ -62,7 +61,7 @@ function getInstanceId(container) {
 
 /** Read instanceLabel from a container's config.json */
 function getInstanceLabel(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceLabel)"`,
   ).toString().trim();
 }

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -3,6 +3,51 @@
  * Assumes instances are running at http://localhost:320{0,1,2}.
  */
 
+import { execSync } from 'node:child_process';
+
+/** Synchronous sleep (these container-config readers are called synchronously). */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Run a `docker exec` command, retrying on transient failure.
+ *
+ * The server persists config.json via an atomic temp-file + rename. Across a
+ * Docker bind mount (notably Docker Desktop on Windows), that rename has a brief
+ * non-atomic window where a concurrent read can observe the file as missing
+ * (ENOENT) or half-written. Because the sync engine calls saveConfig frequently
+ * (watermarks, gossip merges), a test that reads a container's config via
+ * `docker exec` can race a write — so we retry to ride out the window.
+ */
+export function dockerExec(cmd, { retries = 10, delayMs = 150 } = {}) {
+  let lastErr;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+    } catch (err) {
+      lastErr = err;
+      if (i < retries) sleepSync(delayMs);
+    }
+  }
+  throw lastErr;
+}
+
+/** Read and parse a container's /config/config.json (resilient to write races). */
+export function readContainerConfig(container) {
+  return JSON.parse(dockerExec(`docker exec ${container} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`));
+}
+
+/** Read and parse a container's /config/secrets.json (resilient to write races). */
+export function readContainerSecrets(container) {
+  return JSON.parse(dockerExec(`docker exec ${container} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/secrets.json','utf8'))"`));
+}
+
+/** Read a container's instanceId from its config (resilient to write races). */
+export function getInstanceId(container) {
+  return dockerExec(`docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`).trim();
+}
+
 export const INSTANCES = {
   a: 'http://127.0.0.1:3200',
   b: 'http://127.0.0.1:3201',

--- a/testing/sync/leave-removal.test.js
+++ b/testing/sync/leave-removal.test.js
@@ -17,11 +17,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, reqJson, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del, reqJson, waitFor } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -36,7 +35,7 @@ let instanceIdA, instanceIdB;
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));` +
     `process.stdout.write(c.instanceId)"`,
@@ -53,7 +52,7 @@ function injectPeerToken(container, instanceId, token) {
     `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 /** Tag a token record in the container's config.tokens[] with peerInstanceId.
@@ -73,11 +72,11 @@ function tagPeerToken(container, tokenId, peerInstanceId) {
     `fs.writeFileSync(p,JSON.stringify(c,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 function readContainerConfig(container) {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
   ).toString();

--- a/testing/sync/merkle.test.js
+++ b/testing/sync/merkle.test.js
@@ -18,11 +18,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, waitFor, triggerSync } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del, waitFor, triggerSync } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -32,7 +31,7 @@ const HEX64 = /^[0-9a-f]{64}$/;
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));` +
     `process.stdout.write(c.instanceId)"`,
@@ -49,7 +48,7 @@ function injectPeerToken(container, instanceId, token) {
     `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 /** Call /api/sync/merkle as a normal PAT-authenticated request (self-check). */

--- a/testing/sync/peer-revocation.test.js
+++ b/testing/sync/peer-revocation.test.js
@@ -20,11 +20,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del, waitFor } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -33,7 +32,7 @@ let tokenA, tokenB;
 let instanceIdA, instanceIdB;
 
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));` +
     `process.stdout.write(c.instanceId)"`,
@@ -41,7 +40,7 @@ function getInstanceId(container) {
 }
 
 function readContainerConfig(container) {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
   ).toString();
@@ -49,7 +48,7 @@ function readContainerConfig(container) {
 }
 
 function readContainerSecrets(container) {
-  const out = execSync(
+  const out = dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');` +
     `process.stdout.write(fs.readFileSync('/config/secrets.json','utf8'))"`,
   ).toString();
@@ -66,7 +65,7 @@ function injectPeerToken(container, instanceId, token) {
     `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 /** Create a fresh peer PAT on `base` bound to `peerInstanceId`. */

--- a/testing/sync/pubsub-topology.test.js
+++ b/testing/sync/pubsub-topology.test.js
@@ -11,11 +11,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import {
+import { dockerExec,
   INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, waitFor,
 } from './helpers.js';
 
@@ -24,7 +23,7 @@ const CONFIGS = path.join(__dirname, 'configs');
 
 /** Read a container's real instanceId (a uuid) from its config. */
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
   ).toString().trim();
 }

--- a/testing/sync/tombstone-forgery.test.js
+++ b/testing/sync/tombstone-forgery.test.js
@@ -22,20 +22,15 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, delWithBody } from './helpers.js';
+import { INSTANCES, post, get, del, delWithBody, getInstanceId } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
 
 let tokenA, tokenB, instanceIdA, instanceIdB, peerTokenForB, networkId, testSpaceId;
-
-function getInstanceId(c) {
-  return execSync(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
-}
 
 describe('Forged tombstone cross-instance deletion is refused', () => {
   before(async () => {

--- a/testing/sync/vote-forgery.test.js
+++ b/testing/sync/vote-forgery.test.js
@@ -22,11 +22,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, del, delWithBody, triggerSync, waitFor } from './helpers.js';
+import { INSTANCES, post, del, delWithBody, triggerSync, waitFor, dockerExec, readContainerConfig, getInstanceId } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -35,12 +34,6 @@ let tokenA, tokenB;
 let instanceIdA, instanceIdB;
 let peerTokenForA, peerTokenForB;
 let networkId, testSpaceId;
-
-function getInstanceId(container) {
-  return execSync(
-    `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
-  ).toString().trim();
-}
 
 function injectPeerToken(container, instanceId, token) {
   const script = [
@@ -52,14 +45,7 @@ function injectPeerToken(container, instanceId, token) {
     `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
-}
-
-function readContainerConfig(container) {
-  const out = execSync(
-    `docker exec ${container} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`,
-  ).toString();
-  return JSON.parse(out);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 /** Inject a fabricated vote round into a container's network config. */
@@ -75,7 +61,7 @@ function injectRound(container, netId, round) {
     `fs.writeFileSync(p,JSON.stringify(c,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 describe('Vote forgery via gossip pull is rejected', () => {

--- a/testing/sync/vote-key-rotation.test.js
+++ b/testing/sync/vote-key-rotation.test.js
@@ -14,11 +14,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, put, del, delWithBody, triggerSync, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, put, del, delWithBody, triggerSync, waitFor } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -26,11 +25,11 @@ const CONFIGS = path.join(__dirname, 'configs');
 let tokenA, tokenB, instanceIdA, instanceIdB, peerTokenForA, peerTokenForB, networkId, testSpaceId;
 
 function getInstanceId(c) {
-  return execSync(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
+  return dockerExec(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
 }
 function injectPeerToken(c, id, tok) {
   const s = `const fs=require('fs');const p='/config/secrets.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));s.peerTokens=s.peerTokens||{};s.peerTokens['${id}']='${tok}';fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});process.stdout.write('ok');`;
-  execSync(`docker exec ${c} node -e "${s}"`);
+  dockerExec(`docker exec ${c} node -e "${s}"`);
 }
 async function pinnedKeyForA() {
   const net = await get(INSTANCES.b, tokenB, `/api/networks/${networkId}`);

--- a/testing/sync/vote-propagation.test.js
+++ b/testing/sync/vote-propagation.test.js
@@ -22,11 +22,10 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, delWithBody, reqJson, triggerSync, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, get, del, delWithBody, reqJson, triggerSync, waitFor } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -41,7 +40,7 @@ let testSpaceId;
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function getInstanceId(container) {
-  return execSync(
+  return dockerExec(
     `docker exec ${container} node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(c.instanceId)"`,
   ).toString().trim();
 }
@@ -56,7 +55,7 @@ function injectPeerToken(container, instanceId, token) {
     `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
     `process.stdout.write('ok');`,
   ].join('');
-  execSync(`docker exec ${container} node -e "${script}"`);
+  dockerExec(`docker exec ${container} node -e "${script}"`);
 }
 
 /** Open a join round on an instance for a fake candidate. Returns { roundId, candidateId }. */

--- a/testing/sync/vote-signing.test.js
+++ b/testing/sync/vote-signing.test.js
@@ -16,11 +16,10 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, del, delWithBody, triggerSync, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, del, delWithBody, triggerSync, waitFor } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -28,19 +27,19 @@ const CONFIGS = path.join(__dirname, 'configs');
 let tokenA, tokenB, instanceIdA, instanceIdB, peerTokenForA, peerTokenForB, networkId, testSpaceId;
 
 function getInstanceId(c) {
-  return execSync(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
+  return dockerExec(`docker exec ${c} node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('/config/config.json','utf8'));process.stdout.write(j.instanceId)"`).toString().trim();
 }
 function injectPeerToken(c, id, tok) {
   const s = `const fs=require('fs');const p='/config/secrets.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));s.peerTokens=s.peerTokens||{};s.peerTokens['${id}']='${tok}';fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});process.stdout.write('ok');`;
-  execSync(`docker exec ${c} node -e "${s}"`);
+  dockerExec(`docker exec ${c} node -e "${s}"`);
 }
 function readConfig(c) {
-  return JSON.parse(execSync(`docker exec ${c} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`).toString());
+  return JSON.parse(dockerExec(`docker exec ${c} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`).toString());
 }
 /** Mutate a container's config.json for a network via a base64-encoded JS patch fn body. */
 function patchNetwork(c, netId, patchB64) {
   const s = `const fs=require('fs');const p='/config/config.json';const cfg=JSON.parse(fs.readFileSync(p,'utf8'));const n=cfg.networks.find(x=>x.id==='${netId}');const patch=new Function('n','cfg',Buffer.from('${patchB64}','base64').toString('utf8'));patch(n,cfg);fs.writeFileSync(p,JSON.stringify(cfg,null,2),{mode:0o600});process.stdout.write('ok');`;
-  execSync(`docker exec ${c} node -e "${s}"`);
+  dockerExec(`docker exec ${c} node -e "${s}"`);
 }
 function patch(c, netId, fnBody) {
   patchNetwork(c, netId, Buffer.from(fnBody, 'utf8').toString('base64'));


### PR DESCRIPTION
## Summary

Fixes a reproducible, **order-dependent** failure in the sync suite — `vote-forgery.test.js › "A ignores a forged yes-vote served by malicious peer B"` — that surfaced when running the full test suite. Test-harness only; **no product code change**.

## Root cause

The test reads a container's `/config/config.json` via `docker exec … readFileSync(...)` while the server is persisting it. `saveConfig` writes atomically (temp file → rename), but across a Docker bind mount (Docker Desktop on Windows) that rename has a brief window where a concurrent read observes **`ENOENT`**. The sync engine calls `saveConfig` frequently (watermarks, gossip merges), so a config read done *during active sync* races a write.

- vote-forgery is uniquely exposed: it reads config in the **test body**, inside a `waitFor` loop, while **repeatedly triggering sync** — maximum concurrent-write pressure.
- **Passes in isolation** (little background write activity), **fails in the full sync sequence** (many networks accumulate → frequent `saveConfig`). Every *other* sync test with the same read pattern passed in the same run, which is the signature of a timing race, not a logic bug.

This is unrelated to any recent feature work — the test is from #127 and the failure is a Docker-on-Windows bind-mount + atomic-rename interaction.

## Fix

- Add a resilient `dockerExec` + `readContainerConfig` / `readContainerSecrets` / `getInstanceId` to `testing/sync/helpers.js`. `dockerExec` **retries on transient failure** (up to ~1.5s) to ride out the rename window.
- Route **every** container config read/write through it across the **13 sync tests + 2 red-team tests** (`docker restart`/`docker inspect` stay `execSync`). Because the failure is a race, the whole class is fixed — not just the one test that happened to flake.

## Verification

- **Sync suite:** 173/174, **0 failures** — vote-forgery now passes within the full sequence (previously the only failure).
- **Red-team suite:** 253/253, **0 failures** (run sequentially, as `test:redteam` does).
- All files `node --check`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)