### PR TITLE
security: server-guard hardening (trust-proxy default, pagination clamp, rate-limit kill-switch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`trust proxy` now defaults to `false` (was hardcoded to `1`).** The default compose
+  deployment is exposed directly with no reverse proxy, so trusting the first hop meant
+  `req.ip` came from the client-supplied `X-Forwarded-For` header — attacker-controllable.
+  That let a client rotate `X-Forwarded-For` to defeat every rate limiter (including the only
+  throttle in front of admin TOTP verification) and to forge client IPs in the audit log.
+  `req.ip` is now derived from the socket by default. **Behavior change:** if you run behind
+  a reverse proxy (nginx/Traefik/ingress), set the new `trustProxy` config key — or the
+  `TRUST_PROXY` env var — to the **exact number of proxy hops** (e.g. `1`), not `true`.
+  Accepts Express's native values (`false` | hop count | `'loopback'` | CIDR list).
+- **`?limit`/`?skip` on brain list endpoints are clamped.** A non-numeric value
+  (`?limit=abc`) previously became `NaN` and flowed unbounded into MongoDB. Values are now
+  coerced to a safe bounded integer, the list helpers clamp internally as defense-in-depth,
+  and proxy-space results are re-limited to the requested page size.
+- **Rate-limit kill-switches (`SKIP_*_RATE_LIMIT`) are ignored in production.** These test-only
+  env vars are now honoured outside `NODE_ENV=production` only, so a leaked flag can't silently
+  disable rate limiting on a live deployment. A loud warning is logged at startup if one is set.
+
 ### Fixed
 
 - **Legacy tokens are no longer silently invalidated on upgrade** — a startup/reload migration

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -190,6 +190,7 @@ DEBUG=1 docker compose up
 | `PORT` | `3200` | HTTP listen port |
 | `DEBUG` | (unset) | Set to `1` for verbose logging |
 | `METRICS_TOKEN` | (unset) | When set, `GET /metrics` requires this exact value as a Bearer token — the recommended path for Prometheus scrape configs. If unset, the endpoint falls back to requiring a valid admin PAT. |
+| `TRUST_PROXY` | `false` | Express `trust proxy` setting (overrides the `trustProxy` config key). Default `false` — `req.ip` comes from the socket. **Set this when running behind a reverse proxy**, to the exact number of proxy hops (e.g. `1`), *not* `true` (which trusts the whole `X-Forwarded-For` chain and is client-spoofable). Also accepts `loopback` or a comma-separated CIDR/IP list. Rate limiting and the audit log key on `req.ip`, so a wrong value here is a security setting. |
 
 ### Data Persistence
 

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -19,6 +19,7 @@ import { col, mFilter, mDoc } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { needsReindex, clearReindexFlag } from '../spaces/spaces.js';
 import { log } from '../util/log.js';
+import { parseLimit, parseSkip, capPage } from '../util/pagination.js';
 import { checkQuota, QuotaError } from '../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget, findSpace, isProxySpace, isStrictLinkage } from '../spaces/proxy.js';
 import { validateEntity, validateEdge, validateMemory, validateChrono, resolveMetaRefs, getAllowedChronoTypes, type SchemaViolation } from '../spaces/schema-validation.js';
@@ -214,12 +215,12 @@ brainRouter.get('/:spaceId/memories', globalRateLimit, requireSpaceAuth, async (
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const limit = Math.min(Number(req.query['limit'] ?? 100), 500);
-  const skip = Number(req.query['skip'] ?? 0);
+  const limit = parseLimit(req.query['limit'], 100, 500);
+  const skip = parseSkip(req.query['skip']);
   const filter = buildMemoryFilter(req.query as Record<string, unknown>);
   const memberIds = resolveMemberSpaces(spaceId);
   const all = (await Promise.all(memberIds.map(mid => listMemories(mid, filter, limit, skip)))).flat();
-  res.json({ memories: all, limit, skip });
+  res.json({ memories: capPage(all, limit), limit, skip });
 });
 
 // GET /api/brain/:spaceId/memories/:id — get single memory
@@ -378,12 +379,12 @@ brainRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth, 
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const limit = Math.min(Number(req.query['limit'] ?? 100), 500);
-  const skip = Number(req.query['skip'] ?? 0);
+  const limit = parseLimit(req.query['limit'], 100, 500);
+  const skip = parseSkip(req.query['skip']);
   const filter = buildMemoryFilter(req.query as Record<string, unknown>);
   const memberIds = resolveMemberSpaces(spaceId);
   const all = (await Promise.all(memberIds.map(mid => listMemories(mid, filter, limit, skip)))).flat();
-  res.json({ memories: all, limit, skip });
+  res.json({ memories: capPage(all, limit), limit, skip });
 });
 
 // DELETE /api/brain/spaces/:spaceId/memories/:id
@@ -635,15 +636,15 @@ brainRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAuth, 
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const limit = Math.min(Number(req.query['limit'] ?? 50), 500);
-  const skip = Number(req.query['skip'] ?? 0);
+  const limit = parseLimit(req.query['limit'], 50, 500);
+  const skip = parseSkip(req.query['skip']);
   const filter: Record<string, unknown> = {};
   if (typeof req.query['name'] === 'string') filter['name'] = req.query['name'];
   if (typeof req.query['type'] === 'string') filter['type'] = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
   const memberIds = resolveMemberSpaces(spaceId);
   const all = (await Promise.all(memberIds.map(mid => listEntities(mid, filter, limit, skip)))).flat();
-  res.json({ entities: all, limit, skip });
+  res.json({ entities: capPage(all, limit), limit, skip });
 });
 
 // GET /api/brain/spaces/:spaceId/entities/by-ids?ids=id1,id2,... — batch fetch up to 100 entities by ID
@@ -925,8 +926,8 @@ brainRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const limit = Math.min(Number(req.query['limit'] ?? 50), 200);
-  const skip = Number(req.query['skip'] ?? 0);
+  const limit = parseLimit(req.query['limit'], 50, 200);
+  const skip = parseSkip(req.query['skip']);
   const filter: { from?: string; to?: string; label?: string } = {};
   if (typeof req.query['from'] === 'string') filter.from = req.query['from'];
   if (typeof req.query['to'] === 'string') filter.to = req.query['to'];
@@ -945,7 +946,7 @@ brainRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     }));
   }
   const enriched = all.map(e => ({ ...e, fromName: nameMap.get(e.from), toName: nameMap.get(e.to) }));
-  res.json({ edges: enriched, limit, skip });
+  res.json({ edges: capPage(enriched, limit), limit, skip });
 });
 
 // GET /api/brain/spaces/:spaceId/edges/:id
@@ -1315,8 +1316,8 @@ brainRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, as
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const limit = Math.min(Number(req.query['limit'] ?? 50), 500);
-  const skip = Number(req.query['skip'] ?? 0);
+  const limit = parseLimit(req.query['limit'], 50, 500);
+  const skip = parseSkip(req.query['skip']);
   const filter: ChronoFilter = {};
   if (typeof req.query['status'] === 'string') filter.status = req.query['status'];
   if (typeof req.query['type'] === 'string') filter.type = req.query['type'];
@@ -1343,7 +1344,7 @@ brainRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, as
 
   const memberIds = resolveMemberSpaces(spaceId);
   const all = (await Promise.all(memberIds.map(mid => listChrono(mid, filter, limit, skip)))).flat();
-  res.json({ chrono: all, limit, skip });
+  res.json({ chrono: capPage(all, limit), limit, skip });
 });
 
 // DELETE /api/brain/spaces/:spaceId/chrono/:id
@@ -1389,8 +1390,8 @@ brainRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, asy
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const limit = Math.min(Number(req.query['limit'] ?? 50), 200);
-  const skip = Number(req.query['skip'] ?? 0);
+  const limit = parseLimit(req.query['limit'], 50, 200);
+  const skip = parseSkip(req.query['skip']);
   // By default exclude chunk records (parentFileId set) so the file manager only shows
   // top-level files. Pass ?includeChunks=true to see all records (e.g. for debugging).
   const includeChunks = req.query['includeChunks'] === 'true';
@@ -1407,7 +1408,7 @@ brainRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, asy
       .limit(limit)
       .toArray(),
   ))).flat();
-  res.json({ files: all, limit, skip });
+  res.json({ files: capPage(all, limit), limit, skip });
 });
 
 // DELETE /api/brain/spaces/:spaceId/files — delete file metadata record by path (does NOT delete the file on disk)

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -56,14 +56,46 @@ const clientDist =
   process.env['CLIENT_DIST'] ??
   path.resolve(__dirname, '..', '..', 'client', 'dist', 'browser');
 
+/**
+ * Resolve the Express `trust proxy` setting from the TRUST_PROXY env var (takes
+ * precedence) or `config.trustProxy`. Defaults to `false` so a directly-exposed
+ * deployment derives `req.ip` from the socket, not a spoofable X-Forwarded-For.
+ */
+function resolveTrustProxy(): boolean | number | string {
+  let raw: unknown = process.env['TRUST_PROXY'];
+  if (raw === undefined) {
+    try { raw = getConfig().trustProxy; } catch { raw = undefined; } // config not loaded on first run
+  }
+  if (raw === undefined || raw === null || raw === false || raw === '') return false;
+  if (raw === true) return true;
+  if (typeof raw === 'number') return raw;
+  if (Array.isArray(raw)) return raw.join(',');
+  if (typeof raw === 'string') {
+    const s = raw.trim();
+    if (s === 'true') return true;
+    if (s === 'false' || s === '') return false;
+    if (/^\d+$/.test(s)) return Number(s);
+    return s; // 'loopback' or a comma-separated CIDR/IP list — Express parses these
+  }
+  return false;
+}
+
 export function createApp() {
   const app = express();
 
   // ── Proxy trust ──────────────────────────────────────────────────────────
-  // Trust the first proxy hop (Traefik / nginx) so req.ip reflects the real
-  // client address.  Without this, rate-limit and audit log all share the
-  // Docker-gateway IP.
-  app.set('trust proxy', 1);
+  // Default false: the server is exposed directly in the default deployment, so
+  // req.ip must come from the socket. Trusting a client-supplied X-Forwarded-For
+  // would let an attacker spoof the IP that rate limiting and the audit log key
+  // on — bypassing the only throttle in front of admin TOTP. Set trustProxy to
+  // the exact hop count only when a known reverse proxy terminates connections.
+  const trustProxy = resolveTrustProxy();
+  app.set('trust proxy', trustProxy);
+  if (trustProxy === true) {
+    log.warn('trust proxy = true trusts the ENTIRE X-Forwarded-For chain (client-spoofable). Set it to the exact proxy hop count instead.');
+  } else {
+    log.debug(`trust proxy = ${JSON.stringify(trustProxy)}`);
+  }
 
   // ── Request body parsers ─────────────────────────────────────────────────
   app.use(express.json({ limit: '10mb' }));

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { col, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
+import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
 import { getConfig } from '../config/loader.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
@@ -191,8 +192,8 @@ export async function listChrono(
   return col<ChronoEntry>(`${spaceId}_chrono`)
     .find(mFilter<ChronoEntry>(query))
     .sort({ createdAt: -1 })
-    .skip(skip)
-    .limit(limit)
+    .skip(parseSkip(skip))
+    .limit(parseLimit(limit, 20, 1000))
     .toArray() as Promise<ChronoEntry[]>;
 }
 

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { col, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
+import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
@@ -157,8 +158,8 @@ export async function listEdges(
   return col<EdgeDoc>(`${spaceId}_edges`)
     .find(mFilter<EdgeDoc>(q))
     .sort({ seq: -1, createdAt: -1, _id: -1 })
-    .skip(skip)
-    .limit(limit)
+    .skip(parseSkip(skip))
+    .limit(parseLimit(limit, 20, 1000))
     .toArray() as Promise<EdgeDoc[]>;
 }
 

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { col, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
+import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
@@ -255,8 +256,8 @@ export async function listEntities(
 ): Promise<EntityDoc[]> {
   return col<EntityDoc>(`${spaceId}_entities`)
     .find(mFilter<EntityDoc>({ ...filter, spaceId }))
-    .skip(skip)
-    .limit(limit)
+    .skip(parseSkip(skip))
+    .limit(parseLimit(limit, 20, 1000))
     .toArray() as Promise<EntityDoc[]>;
 }
 

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { col, isVectorSearchAvailable, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
+import { parseLimit, parseSkip } from '../util/pagination.js';
 import { NotFoundError } from '../util/errors.js';
 import { hasReDoSRisk, MAX_PATTERN_LENGTH } from '../util/redos.js';
 import { embed } from './embedding.js';
@@ -775,8 +776,8 @@ export async function listMemories(
     .find(mFilter<MemoryDoc>(filter))
     .project({ embedding: 0 })
     .sort({ createdAt: -1 })
-    .skip(skip)
-    .limit(limit)
+    .skip(parseSkip(skip))
+    .limit(parseLimit(limit, 20, 1000))
     .toArray();
 }
 

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -669,6 +669,17 @@ export interface Config {
    *  additionally capped at 25 MiB because jsdom parses it in-process. */
   maxDocumentConversionBytes?: number;
   allowInsecurePlaintext?: boolean;
+  /**
+   * Express `trust proxy` setting. Default `false` — the out-of-the-box compose
+   * deployment is exposed directly, so `req.ip` must come from the socket, not a
+   * client-supplied X-Forwarded-For (which would let an attacker spoof the IP
+   * that rate limiting and the audit log key on). Set to the exact number of
+   * proxy hops (NOT `true`) only when a known reverse proxy terminates client
+   * connections. Accepts Express's native values: boolean | hop count |
+   * 'loopback' | a comma-separated CIDR/IP list. Overridable via the
+   * TRUST_PROXY environment variable.
+   */
+  trustProxy?: boolean | number | string | string[];
   /** Max redirect hops followed (and re-validated) during webhook delivery.
    *  Default 3; clamped to [0, 20]. Env var WEBHOOK_MAX_REDIRECTS overrides. */
   webhookMaxRedirects?: number;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -112,6 +112,9 @@ async function main(): Promise<void> {
     startMediaEmbeddingWorker();
   }
 
+  const { warnRateLimitBypass } = await import('./rate-limit/middleware.js');
+  warnRateLimitBypass();
+
   const app = createApp();
   const server = createServer(app);
 

--- a/server/src/rate-limit/middleware.ts
+++ b/server/src/rate-limit/middleware.ts
@@ -1,6 +1,28 @@
 import rateLimit from 'express-rate-limit';
 import { log } from '../util/log.js';
 
+/**
+ * The `SKIP_*_RATE_LIMIT` kill-switches exist only for the test harness. They are
+ * honoured **outside production only**, so a leaked env var (copy-pasted compose,
+ * shared `.env`) can never silently disable rate limiting on a live deployment —
+ * the limiters are the only throttle in front of admin TOTP verification.
+ */
+function skipRateLimit(envKey: string): boolean {
+  return process.env['NODE_ENV'] !== 'production' && process.env[envKey] === 'true';
+}
+
+/** Log a loud warning at startup when a rate-limit kill-switch is set. */
+export function warnRateLimitBypass(): void {
+  const set = ['SKIP_AUTH_RATE_LIMIT', 'SKIP_GLOBAL_RATE_LIMIT', 'SKIP_SYNC_RATE_LIMIT']
+    .filter(f => process.env[f] === 'true');
+  if (set.length === 0) return;
+  if (process.env['NODE_ENV'] === 'production') {
+    log.warn(`SECURITY: rate-limit kill-switch(es) set but IGNORED in production: ${set.join(', ')}. Remove them from the environment.`);
+  } else {
+    log.warn(`Rate limiting DISABLED via ${set.join(', ')} (non-production only).`);
+  }
+}
+
 /** 10 requests/minute per IP — used for auth-sensitive endpoints (setup, login) */
 export const authRateLimit = rateLimit({
   windowMs: 60_000,
@@ -15,7 +37,7 @@ export const authRateLimit = rateLimit({
   // Allow test infrastructure to disable this limit on A/B instances so
   // parallel test suites don't exhaust the window. Instance C omits this env
   // so rate-limit tests on C still exercise the real 429 behaviour.
-  skip: () => process.env['SKIP_AUTH_RATE_LIMIT'] === 'true',
+  skip: () => skipRateLimit('SKIP_AUTH_RATE_LIMIT'),
 });
 
 /** 60 requests/minute per IP — used for notification and setup endpoints */
@@ -45,7 +67,7 @@ export const globalRateLimit = rateLimit({
   // Allow test infrastructure to disable this limit on A/B instances so
   // parallel test suites don't exhaust the window on the same IP. Instance C
   // omits this env so rate-limit tests can exercise the real 429 behaviour.
-  skip: () => process.env['SKIP_GLOBAL_RATE_LIMIT'] === 'true',
+  skip: () => skipRateLimit('SKIP_GLOBAL_RATE_LIMIT'),
 });
 
 /** 2000 requests/minute per IP — machine-to-machine sync endpoints.
@@ -61,7 +83,7 @@ export const syncRateLimit = rateLimit({
     log.warn(`syncRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
     res.status(options.statusCode).json(options.message);
   },
-  skip: () => process.env['SKIP_SYNC_RATE_LIMIT'] === 'true',
+  skip: () => skipRateLimit('SKIP_SYNC_RATE_LIMIT'),
 });
 
 /** 5 requests/minute per IP — destructive bulk operations (memory wipe) */
@@ -75,5 +97,5 @@ export const bulkWipeRateLimit = rateLimit({
     log.warn(`bulkWipeRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
     res.status(options.statusCode).json(options.message);
   },
-  skip: () => process.env['SKIP_GLOBAL_RATE_LIMIT'] === 'true',
+  skip: () => skipRateLimit('SKIP_GLOBAL_RATE_LIMIT'),
 });

--- a/server/src/util/pagination.ts
+++ b/server/src/util/pagination.ts
@@ -1,0 +1,35 @@
+/**
+ * Safe pagination-parameter parsing for list endpoints.
+ *
+ * `Number('abc')` is `NaN` and `Math.min(NaN, max)` is `NaN`, which flows
+ * unbounded into MongoDB `.limit()`. These helpers coerce to a bounded integer
+ * so a garbage or out-of-range `?limit=`/`?skip=` can never produce an
+ * unbounded or degenerate query.
+ */
+
+/** Parse a `limit` query value into an integer in `[1, max]`, falling back to `def` on garbage. */
+export function parseLimit(raw: unknown, def: number, max: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return def;
+  return Math.min(Math.max(Math.trunc(n), 1), max);
+}
+
+/** Parse a `skip` query value into a non-negative integer (0 on garbage/negative). */
+export function parseSkip(raw: unknown): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.trunc(n);
+}
+
+/**
+ * Cap a merged, cross-space (proxy) list result to `limit`. Each member space is
+ * already limited to `limit`, so a proxy of N members can return up to N × limit
+ * rows; this bounds the response to the requested page size. Only re-sorts (by
+ * `createdAt` desc) when it actually overflows, so single-space results — already
+ * sorted and limited by the query — are returned untouched.
+ */
+export function capPage<T>(rows: T[], limit: number): T[] {
+  if (rows.length <= limit) return rows;
+  const ts = (r: T) => String((r as { createdAt?: string }).createdAt ?? '');
+  return [...rows].sort((a, b) => ts(b).localeCompare(ts(a))).slice(0, limit);
+}

--- a/testing/integration/pagination-and-trust-proxy.test.js
+++ b/testing/integration/pagination-and-trust-proxy.test.js
@@ -1,0 +1,115 @@
+/**
+ * Integration tests: pagination clamp (S4) + trust-proxy default (S1)
+ *
+ * S4 — a garbage/out-of-range ?limit=/?skip= must be coerced to a safe bounded
+ *      value, never NaN/unbounded.
+ * S1 — with trustProxy default (false, as the test stack runs it), a client
+ *      X-Forwarded-For must NOT influence req.ip — verified via the audit log,
+ *      which records the client IP on every write.
+ *
+ * Run: node --test testing/integration/pagination-and-trust-proxy.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `pgtrust-${RUN}`;
+const SPOOFED_IP = '203.0.113.99';
+
+let tokenA;
+function token() { return tokenA; }
+
+async function raw(method, urlPath, { body, headers } = {}) {
+  const r = await fetch(`${INSTANCES.a}${urlPath}`, {
+    method,
+    headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json', ...(headers ?? {}) },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  let parsed = null;
+  try { parsed = await r.json(); } catch { /* no body */ }
+  return { status: r.status, body: parsed };
+}
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const r = await post(INSTANCES.a, token(), '/api/spaces', { id: SPACE, label: `PgTrust ${RUN}` });
+  assert.equal(r.status, 201, `create space: ${JSON.stringify(r.body)}`);
+  for (let i = 0; i < 3; i++) {
+    await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, { fact: `pagination memory ${i} ${RUN}` });
+  }
+});
+
+after(async () => {
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, { method: 'DELETE', headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ confirm: true }) }).catch(() => {});
+});
+
+describe('Pagination clamp (S4)', () => {
+  it('non-numeric ?limit=abc is coerced to the default, not NaN/unbounded', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=abc`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.ok(Array.isArray(r.body.memories));
+    assert.equal(r.body.memories.length, 3, 'returns all 3 (default applied)');
+  });
+
+  it('?limit=1 returns exactly one', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=1`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.memories.length, 1);
+  });
+
+  it('negative ?limit=-5 is clamped to >= 1', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=-5`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.memories.length, 1, 'clamped to minimum 1');
+  });
+
+  it('huge ?limit=1e9 does not error and stays bounded', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=1e9`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.memories.length, 3);
+  });
+
+  it('non-numeric ?skip=abc is treated as 0', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?skip=abc&limit=100`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.memories.length, 3, 'skip=abc → 0, all returned');
+  });
+
+  it('?skip=2 skips two', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?skip=2&limit=100`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.memories.length, 1);
+  });
+});
+
+describe('Trust proxy default (S1)', () => {
+  it('a spoofed X-Forwarded-For does not become the audited client IP', async () => {
+    // An audited write carrying a spoofed forwarded-for header.
+    const w = await raw('POST', `/api/brain/${SPACE}/memories`, {
+      body: { fact: `trust-proxy probe ${RUN}` },
+      headers: { 'X-Forwarded-For': SPOOFED_IP },
+    });
+    assert.equal(w.status, 201, JSON.stringify(w.body));
+
+    // Audit writes are fire-and-forget — poll until entries for this space appear.
+    let entries = [];
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      const a = await get(INSTANCES.a, token(), `/api/admin/audit-log?spaceId=${SPACE}&limit=100`);
+      entries = a.body?.entries ?? a.body?.logs ?? [];
+      if (entries.length > 0) break;
+      await new Promise(r => setTimeout(r, 500));
+    }
+    assert.ok(entries.length > 0, 'audit entries recorded for the test space');
+    // With trustProxy=false, req.ip is the socket address — never the spoofed header.
+    const spoofed = entries.filter(e => e.ip === SPOOFED_IP);
+    assert.equal(spoofed.length, 0, `no audit entry should carry the spoofed X-Forwarded-For IP (found ${spoofed.length})`);
+  });
+});


### PR DESCRIPTION
## Summary

Three server-side guard fixes from the post-audit backlog (`SECURITY-TODO` S1, S4, S6) — the documented "server guards" batch.

## S1 — `trust proxy` defaults to `false` (HIGH)

`server/src/app.ts` hardcoded `app.set('trust proxy', 1)`, but the default compose deployment is exposed directly with **no reverse proxy**. So `req.ip` was derived from the client-supplied `X-Forwarded-For` header — meaning a client could:
- rotate `X-Forwarded-For` per request to present a fresh source IP and **defeat every rate limiter**, including the only throttle in front of admin TOTP verification (a 6-digit code with no lockout); and
- **forge client IPs in the append-only audit log**.

Now `req.ip` comes from the socket by default. Trust-proxy is configurable via a new `trustProxy` config key or the `TRUST_PROXY` env var (env wins), accepting Express's native values (`false` | hop count | `'loopback'` | CIDR list). Setting it to `true` logs a warning (it trusts the whole chain).

**⚠️ Behavior change** (flagged in `CHANGELOG.md`): deployments behind a reverse proxy should set `TRUST_PROXY`/`trustProxy` to the **exact hop count** (e.g. `1`), not `true`. Documented in the integration-guide env-var table.

## S4 — pagination params are clamped (LOW)

`?limit=abc` → `Number('abc')` → `NaN` → `Math.min(NaN, 500)` → `NaN`, which flowed unbounded into MongoDB `.limit()`. New `parseLimit`/`parseSkip` coerce to a bounded integer at all 6 brain list sites; the `list*` helpers clamp internally (defense-in-depth for non-REST callers); and proxy-space fan-out results are re-limited to the page size (`capPage`) instead of returning up to N×limit rows.

## S6 — rate-limit kill-switches ignored in production (LOW)

`SKIP_*_RATE_LIMIT` are test-only env vars. They're now honoured **only when `NODE_ENV !== 'production'`**, so a leaked flag (copy-pasted compose, shared `.env`) can't silently disable rate limiting on a live deployment. A loud warning logs at startup if one is set. Safe for the harness (it runs `NODE_ENV=test`).

## Testing

- New `testing/integration/pagination-and-trust-proxy.test.js` — **7 cases, green**: `?limit=abc`/`-5`/`1e9`/`skip=abc` clamping, exact-page behavior, and **a spoofed `X-Forwarded-For` never becomes the audited client IP** (S1, verified via the audit log).
- Regression: `brain.test.js` (175, list endpoints) and `token-brute-force.test.js` (rate limiting still enforced) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)