### PR TITLE
security: SSRF-safe sync connections + peer-URL re-validation (S2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Sync connections are now SSRF-validated at connection time, and peer URL rewrites
+  are re-validated.** Peer URLs were validated only at admission, but a peer can rewrite
+  its own stored URL after admission (via gossip or the member self-update endpoint) with
+  no re-check, and the sync engine connected with a bare `fetch` (no DNS pin). An
+  admitted-but-malicious member could therefore point itself at `http://169.254.169.254/`
+  (cloud IMDS), loopback, or an internal host, and the victim would connect there with peer
+  auth headers attached. All 15 outbound sync connections now go through an SSRF-safe fetch
+  (DNS-resolve → pin the socket to the validated IP → re-validate each redirect), and the
+  three URL-merge paths re-validate before persisting. **Same-host / LAN deployments** whose
+  peers use private addresses set the new `allowPrivatePeers` config key (or the
+  `SYNC_ALLOW_PRIVATE_PEERS` env var); even then, crown-jewel addresses (loopback,
+  link-local/IMDS, unspecified) stay blocked. Covered by `testing/red-team-tests/sync-peer-ssrf.test.js`
+  and `testing/standalone/peer-ssrf-policy.test.js`.
+
 - **`trust proxy` now defaults to `false` (was hardcoded to `1`).** The default compose
   deployment is exposed directly with no reverse proxy, so trusting the first hop meant
   `req.ip` came from the client-supplied `X-Forwarded-For` header — attacker-controllable.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -191,6 +191,7 @@ DEBUG=1 docker compose up
 | `DEBUG` | (unset) | Set to `1` for verbose logging |
 | `METRICS_TOKEN` | (unset) | When set, `GET /metrics` requires this exact value as a Bearer token — the recommended path for Prometheus scrape configs. If unset, the endpoint falls back to requiring a valid admin PAT. |
 | `TRUST_PROXY` | `false` | Express `trust proxy` setting (overrides the `trustProxy` config key). Default `false` — `req.ip` comes from the socket. **Set this when running behind a reverse proxy**, to the exact number of proxy hops (e.g. `1`), *not* `true` (which trusts the whole `X-Forwarded-For` chain and is client-spoofable). Also accepts `loopback` or a comma-separated CIDR/IP list. Rate limiting and the audit log key on `req.ip`, so a wrong value here is a security setting. |
+| `SYNC_ALLOW_PRIVATE_PEERS` | `false` | Allow sync **peer URLs** to resolve to private/reserved addresses (RFC-1918, CGNAT, IPv6 ULA) — for same-host or LAN networks (overrides the `allowPrivatePeers` config key). Default `false`: sync connects only to public peers, and any peer that tries to move its URL onto a private address is refused. Even when `true`, crown-jewel addresses (loopback, link-local / cloud IMDS `169.254.169.254`, unspecified) stay blocked. |
 
 ### Data Persistence
 

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -19,6 +19,7 @@ import { listTombstones, applyRemoteTombstone } from '../brain/tombstones.js';
 import { requireAuth, denyReadOnly } from '../auth/middleware.js';
 import { revokePeerCredentialsIfOrphaned } from '../auth/tokens.js';
 import { log } from '../util/log.js';
+import { isPeerUrlAllowed } from '../sync/peer-fetch.js';
 import { nextSeq, bumpSeq, isSeqImplausible, MAX_INGEST_SEQ } from '../util/seq.js';
 import { updateSpace } from '../spaces/spaces.js';
 import { isStrictLinkage } from '../spaces/proxy.js';
@@ -1313,10 +1314,17 @@ syncRouter.post('/networks/:networkId/members', syncRateLimit, requireAuth, deny
     if (freshNet) {
       const idx = freshNet.members.findIndex(m => m.instanceId === incoming.instanceId);
       if (idx >= 0) {
+        // Re-validate a peer-supplied URL before accepting it — a peer must not be
+        // able to move itself onto a blocked/internal address post-admission (SSRF).
+        let nextUrl = freshNet.members[idx]!.url;
+        if (incoming.url && incoming.url !== nextUrl) {
+          if (isPeerUrlAllowed(incoming.url)) nextUrl = incoming.url;
+          else log.warn(`Member self-update: rejected unsafe URL from ${incoming.instanceId}: ${incoming.url}`);
+        }
         const updated = {
           ...freshNet.members[idx]!,
           label: incoming.label ?? freshNet.members[idx]!.label,
-          url: incoming.url ?? freshNet.members[idx]!.url,
+          url: nextUrl,
           children: incoming.children ?? freshNet.members[idx]!.children,
           lastSyncAt: new Date().toISOString(),
         };

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -696,6 +696,13 @@ export interface Config {
   audit?: AuditConfig;
   /** Optional background semantic-duplicate scanner. Off by default. */
   dupeScanner?: DupeScannerConfig;
+  /**
+   * Allow sync peers to live on private/reserved addresses (RFC-1918, CGNAT,
+   * IPv6 ULA) — for same-host or LAN deployments. Default false (public peers
+   * only). Even when true, crown-jewel addresses (loopback, link-local/IMDS,
+   * unspecified) stay blocked. Overridable via SYNC_ALLOW_PRIVATE_PEERS.
+   */
+  allowPrivatePeers?: boolean;
   /** Dynamically-registered OAuth clients (RFC 7591) for the MCP browser
    *  authorization flow. Populated automatically when a client registers; not
    *  meant to be hand-edited. See mcp/oauth.ts. */

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -22,6 +22,7 @@ import { recordSyncResult, type SyncCounts } from './history.js';
 import { buildFileManifest } from '../files/manifest.js';
 import { log } from '../util/log.js';
 import { bumpSeq, isSeqImplausible } from '../util/seq.js';
+import { peerSafeFetch, isPeerUrlAllowed } from './peer-fetch.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from '../api/sync.js';
 import { enqueueMediaJob } from '../files/media/job-queue.js';
 import { resolveInputFormat } from '../files/converters/pipeline.js';
@@ -405,7 +406,7 @@ async function runSyncForMember(
   // In parallel, warm our own local MongoDB collections.
   {
     const _tw = Date.now();
-    const peerWarm = fetch(`${member.url}/api/sync/warm`, {
+    const peerWarm = peerSafeFetch(`${member.url}/api/sync/warm`, {
       ...fetchOpts(),
       method: 'POST',
       body: JSON.stringify({ networkId: net.id, spaces: net.spaces }),
@@ -552,7 +553,7 @@ async function gossipWithPeer(
     if (ownSigningKey) selfRecord['signingPublicKey'] = ownSigningKey;
     const ownRotation = getSigningKeyRotation();
     if (ownRotation) selfRecord['signingKeyRotation'] = ownRotation;
-    const resp = await fetch(`${base}/members`, {
+    const resp = await peerSafeFetch(`${base}/members`, {
       ...opts(),
       method: 'POST',
       body: JSON.stringify(selfRecord),
@@ -569,7 +570,10 @@ async function gossipWithPeer(
             const local = freshNet.members.find(m => m.instanceId === member.instanceId);
             if (local) {
               let changed = false;
-              if (peerSelf.url && peerSelf.url !== local.url) { local.url = peerSelf.url; changed = true; }
+              if (peerSelf.url && peerSelf.url !== local.url) {
+                if (isPeerUrlAllowed(peerSelf.url)) { local.url = peerSelf.url; changed = true; }
+                else log.warn(`Gossip: rejected unsafe self-URL from ${member.label} (${member.instanceId}): ${peerSelf.url}`);
+              }
               if (peerSelf.label && peerSelf.label !== local.label) { local.label = peerSelf.label; changed = true; }
               if (pinMemberSigningKey(local, peerSelf.signingPublicKey, peerSelf.signingKeyRotation)) changed = true;
               if (changed) {
@@ -589,7 +593,7 @@ async function gossipWithPeer(
 
   // 2. Pull peer's member view and merge into our config
   try {
-    const resp = await fetch(`${base}/members`, opts());
+    const resp = await peerSafeFetch(`${base}/members`, opts());
     if (!resp.ok) {
       log.warn(`Gossip pull from ${member.label}: HTTP ${resp.status}`);
       return;
@@ -610,7 +614,7 @@ async function gossipWithPeer(
       if (!local) continue; // unknown member — do not auto-add
       // Merge: only update mutable identity fields (url, label, children)
       let updated = false;
-      if (peerRecord.url && peerRecord.url !== local.url) {
+      if (peerRecord.url && peerRecord.url !== local.url && isPeerUrlAllowed(peerRecord.url)) {
         local.url = peerRecord.url;
         updated = true;
       }
@@ -662,7 +666,7 @@ async function propagateVotesWithPeer(
     const roundsToPush = localNet?.pendingRounds ?? [];
     for (const round of roundsToPush) {
       for (const cast of round.votes) {
-        await fetch(`${base}/votes/${encodeURIComponent(round.roundId)}`, {
+        await peerSafeFetch(`${base}/votes/${encodeURIComponent(round.roundId)}`, {
           ...opts(),
           method: 'POST',
           // Forward the signature (and castAt) so the peer can verify and, when
@@ -677,7 +681,7 @@ async function propagateVotesWithPeer(
 
   // 2. Pull peer's open rounds; create new ones locally and merge vote casts
   try {
-    const resp = await fetch(`${base}/votes`, opts());
+    const resp = await peerSafeFetch(`${base}/votes`, opts());
     if (!resp.ok) {
       log.warn(`Vote pull from ${member.label}: HTTP ${resp.status}`);
       return;
@@ -803,7 +807,7 @@ async function pullFromPeer(
   // Pull tombstones first — so deletions apply before we potentially upsert deleted docs
   try {
     const tombsUrl = `${member.url}/api/sync/tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}&sinceSeq=${sinceSeq}`;
-    const resp = await fetch(tombsUrl, opts());
+    const resp = await peerSafeFetch(tombsUrl, opts());
     if (resp.ok) {
       const data = await resp.json() as { memories?: TombstoneDoc[]; entities?: TombstoneDoc[]; edges?: TombstoneDoc[]; chrono?: TombstoneDoc[] };
       const all = [...(data.memories ?? []), ...(data.entities ?? []), ...(data.edges ?? []), ...(data.chrono ?? [])];
@@ -835,7 +839,7 @@ async function pullFromPeer(
         spaceId: remoteSpaceId, networkId, sinceSeq: String(sinceSeq), limit: '200', full: 'true',
         ...(cur ? { cursor: cur } : {}),
       });
-      const resp = await fetch(`${member.url}/api/sync/${urlSuffix}?${params}`, batchOpts());
+      const resp = await peerSafeFetch(`${member.url}/api/sync/${urlSuffix}?${params}`, batchOpts());
       if (!resp.ok) { log.warn(`Pull ${urlSuffix} from ${member.label} returned ${resp.status}`); break; }
       const { items, nextCursor } = await resp.json() as {
         items: (T | { _id: string; seq: number; deletedAt: string })[]; nextCursor: string | null;
@@ -928,7 +932,7 @@ async function pushToPeer(
     while (true) {
       const page = await listTombstones(spaceId, tsCursor, 500);
       if (page.length === 0) break;
-      const resp = await fetch(tsEndpoint, {
+      const resp = await peerSafeFetch(tsEndpoint, {
         ...opts(),
         method: 'POST',
         body: JSON.stringify({ tombstones: page }),
@@ -968,7 +972,7 @@ async function pushToPeer(
         .limit(PUSH_BATCH_SIZE)
         .toArray() as T[];
       if (batch.length === 0) break;
-      const resp = await fetch(batchEndpoint, {
+      const resp = await peerSafeFetch(batchEndpoint, {
         ...batchOpts(), method: 'POST',
         body: JSON.stringify({ [payloadKey]: batch }),
       });
@@ -1032,7 +1036,7 @@ async function syncFiles(
     // Fetch tombstones before the manifest so that files deleted on the peer
     // are removed locally before the manifest comparison runs.
     if (doPull) try {
-      const tsResp = await fetch(
+      const tsResp = await peerSafeFetch(
         `${member.url}/api/sync/file-tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}`,
         opts(),
       );
@@ -1065,7 +1069,7 @@ async function syncFiles(
         .find(mFilter<FileTombstoneDoc>({ spaceId }))
         .toArray();
       if (ourTombstones.length > 0) {
-        await fetch(
+        await peerSafeFetch(
           `${member.url}/api/sync/file-tombstones?networkId=${encodeURIComponent(networkId)}`,
           {
             ...opts(),
@@ -1083,7 +1087,7 @@ async function syncFiles(
     // Only fetch the peer manifest if we need to pull or push (manifest comparison
     // drives both directions). When neither direction needs manifest, skip entirely.
     if (!doPull && !doPush) return { pulledFiles, pushedFiles, pulledPaths };
-    const resp = await fetch(`${member.url}/api/sync/manifest?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}`, opts());
+    const resp = await peerSafeFetch(`${member.url}/api/sync/manifest?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}`, opts());
     if (!resp.ok) { log.warn(`File manifest from ${member.label}: ${resp.status}`); return { pulledFiles, pushedFiles, pulledPaths }; }
     const { manifest } = await resp.json() as { manifest: { path: string; sha256: string; size: number; modifiedAt: string }[] };
 
@@ -1099,7 +1103,7 @@ async function syncFiles(
       if (local && local.sha256 === remote.sha256) continue; // already in sync
 
       try {
-        const dl = await fetch(
+        const dl = await peerSafeFetch(
           `${member.url}/api/files/${encodeURIComponent(remoteSpaceId)}?path=${encodeURIComponent(remote.path)}`,
           opts(),
         );
@@ -1170,7 +1174,7 @@ async function syncFiles(
       try {
         const absPath = path.join(spaceRoot, localPath);
         const bytes = await fs.readFile(absPath);
-        const pushResp = await fetch(
+        const pushResp = await peerSafeFetch(
           `${member.url}/api/files/${encodeURIComponent(remoteSpaceId)}?path=${encodeURIComponent(localPath)}`,
           {
             method: 'POST',
@@ -1253,7 +1257,7 @@ async function checkMerkleWithPeer(
     const { computeMerkleRoot } = await import('../brain/merkle.js');
     const [localResult, peerResp] = await Promise.all([
       computeMerkleRoot(spaceId),
-      fetch(
+      peerSafeFetch(
         `${member.url}/api/sync/merkle?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(net.id)}`,
         opts(),
       ),

--- a/server/src/sync/peer-fetch.ts
+++ b/server/src/sync/peer-fetch.ts
@@ -1,0 +1,40 @@
+/**
+ * SSRF-safe outbound fetch + URL validation for the sync engine.
+ *
+ * Sync connects to peer-supplied URLs. Peer URLs are validated at admission, but
+ * a peer can rewrite its own stored URL post-admission (gossip / self-update), so
+ * every outbound sync connection must be validated **at connection time** — DNS
+ * resolved, the socket pinned to the validated IP, and each redirect re-checked.
+ * `peerSafeFetch` is a drop-in for `fetch` that does exactly that (via
+ * `ssrfSafeFetch`), and `isPeerUrlAllowed` is the synchronous check used before
+ * persisting a peer-supplied URL.
+ *
+ * Policy: crown-jewel addresses (loopback, link-local/IMDS, unspecified) are
+ * always blocked. Other private ranges are blocked unless `allowPrivatePeers` is
+ * enabled (config key or the SYNC_ALLOW_PRIVATE_PEERS env var), for same-host /
+ * LAN deployments — including the test harness, whose peers are on the Docker
+ * bridge network.
+ */
+
+import { ssrfSafeFetch, isPeerUrlSafe } from '../util/ssrf.js';
+import { getConfig } from '../config/loader.js';
+
+/** Whether sync peers may use private/reserved (non-crown-jewel) addresses. */
+export function allowPrivatePeers(): boolean {
+  if (process.env['SYNC_ALLOW_PRIVATE_PEERS'] === 'true') return true;
+  try { return getConfig().allowPrivatePeers === true; } catch { return false; }
+}
+
+/** True if a peer-supplied URL may be stored/connected to under the current policy. */
+export function isPeerUrlAllowed(url: string): boolean {
+  return isPeerUrlSafe(url, allowPrivatePeers());
+}
+
+/**
+ * SSRF-safe drop-in for `fetch()` used by the sync engine. Resolves + pins + and
+ * re-validates redirects against the peer policy. Throws `SsrfBlockedError` when
+ * the target (or a redirect hop) resolves to a blocked address.
+ */
+export function peerSafeFetch(rawUrl: string, init: RequestInit = {}): Promise<Response> {
+  return ssrfSafeFetch(rawUrl, init, { allowPrivate: allowPrivatePeers() });
+}

--- a/server/src/util/ssrf.ts
+++ b/server/src/util/ssrf.ts
@@ -108,6 +108,24 @@ function isBlockedIpv4Int(n: number): boolean {
   return BLOCKED_IPV4_CIDRS.some(([base, mask]) => ((u & mask) >>> 0) === (base >>> 0));
 }
 
+/**
+ * "Crown-jewel" IPv4 ranges that are blocked even for peers allowed to use private
+ * addresses (`allowPrivatePeers`): loopback, link-local incl. cloud IMDS, the
+ * unspecified address, and broadcast. No legitimate peer ever lives on these, and
+ * they are the highest-value SSRF targets (169.254.169.254 → cloud credentials).
+ */
+const ALWAYS_BLOCKED_IPV4_CIDRS: ReadonlyArray<readonly [number, number]> = [
+  [0x00000000, 0xff000000], // 0.0.0.0/8      unspecified
+  [0x7f000000, 0xff000000], // 127.0.0.0/8    loopback
+  [0xa9fe0000, 0xffff0000], // 169.254.0.0/16 link-local incl. IMDS
+  [0xffffffff, 0xffffffff], // 255.255.255.255 broadcast
+];
+
+function isCrownJewelIpv4Int(n: number): boolean {
+  const u = n >>> 0;
+  return ALWAYS_BLOCKED_IPV4_CIDRS.some(([base, mask]) => ((u & mask) >>> 0) === (base >>> 0));
+}
+
 // ── IPv6 helpers ─────────────────────────────────────────────────────────────
 
 /**
@@ -166,6 +184,22 @@ function isBlockedIpv6Expanded(h: number[]): boolean {
   return false;
 }
 
+/** Crown-jewel IPv6: loopback ::1, unspecified ::, link-local fe80::/10, and any
+ *  embedded IPv4 that is itself a crown jewel. ULA (fc00::/7) is NOT a crown jewel
+ *  — it is a private range, allowable under `allowPrivatePeers`. */
+function isCrownJewelIpv6Expanded(h: number[]): boolean {
+  if (h.every(x => x === 0)) return true;                             // ::
+  if (h.slice(0, 7).every(x => x === 0) && h[7] === 1) return true;   // ::1 loopback
+  if ((h[0]! & 0xffc0) === 0xfe80) return true;                       // fe80::/10 link-local
+  if (h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0 && h[5] === 0xffff) {
+    return isCrownJewelIpv4Int((((h[6]! << 16) >>> 0) | h[7]!) >>> 0);
+  }
+  if (h.slice(0, 6).every(x => x === 0) && (h[6] !== 0 || h[7] !== 0)) {
+    return isCrownJewelIpv4Int((((h[6]! << 16) >>> 0) | h[7]!) >>> 0);
+  }
+  return false;
+}
+
 // ── Host classification ──────────────────────────────────────────────────────
 
 /**
@@ -173,18 +207,31 @@ function isBlockedIpv6Expanded(h: number[]): boolean {
  * blocked address. Returns false for plain hostnames — those must be resolved
  * via `assertUrlSafeResolved` before use.
  */
-export function isBlockedIp(host: string): boolean {
+function checkBlockedIp(host: string, ipv4: (n: number) => boolean, ipv6: (h: number[]) => boolean): boolean {
   let stripped = host.trim().toLowerCase();
   if (stripped.startsWith('[') && stripped.endsWith(']')) stripped = stripped.slice(1, -1);
   stripped = stripped.replace(/\.$/, ''); // tolerate a single trailing dot
   if (stripped.includes(':')) {
     const h = expandIpv6(stripped);
-    return h ? isBlockedIpv6Expanded(h) : false;
+    return h ? ipv6(h) : false;
   }
-  if (net.isIPv4(stripped)) return isBlockedIpv4Int(dottedIpv4ToInt(stripped)!);
+  if (net.isIPv4(stripped)) return ipv4(dottedIpv4ToInt(stripped)!);
   const canon = canonicalizeIpv4(stripped);
-  if (canon) return isBlockedIpv4Int(dottedIpv4ToInt(canon)!);
+  if (canon) return ipv4(dottedIpv4ToInt(canon)!);
   return false;
+}
+
+export function isBlockedIp(host: string): boolean {
+  return checkBlockedIp(host, isBlockedIpv4Int, isBlockedIpv6Expanded);
+}
+
+/**
+ * Block check for a peer target. Crown-jewel ranges (loopback, link-local/IMDS,
+ * unspecified) are always blocked; other private ranges (RFC-1918, CGNAT, ULA)
+ * are blocked unless `allowPrivate` is set (opt-in for same-host / LAN sync).
+ */
+export function isPeerBlockedIp(host: string, allowPrivate: boolean): boolean {
+  return allowPrivate ? checkBlockedIp(host, isCrownJewelIpv4Int, isCrownJewelIpv6Expanded) : isBlockedIp(host);
 }
 
 /** Normalise a URL hostname: lowercase, strip IPv6 brackets and a trailing dot. */
@@ -227,6 +274,22 @@ export function isSsrfSafeUrl(raw: string): boolean {
   return true;
 }
 
+/**
+ * Peer-aware synchronous validator (config-time, no DNS). Like `isSsrfSafeUrl`
+ * but honours `allowPrivate`. `localhost` and the cloud-metadata hostname are
+ * rejected regardless (they always resolve to crown-jewel addresses).
+ */
+export function isPeerUrlSafe(raw: string, allowPrivate: boolean): boolean {
+  let parsed: URL;
+  try { parsed = new URL(raw); } catch { return false; }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  if (parsed.username || parsed.password) return false;
+  const host = normaliseHost(parsed.hostname);
+  if (host === 'localhost' || host === 'metadata.google.internal') return false;
+  if (isPeerBlockedIp(host, allowPrivate)) return false;
+  return true;
+}
+
 /** Zod refinement message for SSRF-safe URL fields. */
 export const SSRF_SAFE_MESSAGE =
   'Peer URL must use http(s) and must not target private IPs, loopback, ' +
@@ -257,15 +320,16 @@ const defaultLookup: DnsLookup = async (hostname) => {
  */
 export async function assertUrlSafeResolved(
   raw: string,
-  opts: { lookup?: DnsLookup } = {},
+  opts: { lookup?: DnsLookup; allowPrivate?: boolean } = {},
 ): Promise<{ url: URL; addresses: string[] }> {
-  if (!isSsrfSafeUrl(raw)) {
+  const allowPrivate = opts.allowPrivate ?? false;
+  if (!isPeerUrlSafe(raw, allowPrivate)) {
     throw new SsrfBlockedError(`Blocked SSRF target (unsafe URL): ${raw}`);
   }
   const url = new URL(raw);
   const host = normaliseHost(url.hostname);
 
-  // IP literals were already validated by isSsrfSafeUrl — no DNS needed.
+  // IP literals were already validated above — no DNS needed.
   if (isIpLiteral(host)) return { url, addresses: [host] };
 
   const lookup = opts.lookup ?? defaultLookup;
@@ -274,7 +338,7 @@ export async function assertUrlSafeResolved(
     throw new SsrfBlockedError(`Blocked SSRF target (DNS returned no records): ${host}`);
   }
   for (const a of results) {
-    if (isBlockedIp(a.address)) {
+    if (isPeerBlockedIp(a.address, allowPrivate)) {
       throw new SsrfBlockedError(`Blocked SSRF target (${host} resolves to blocked address ${a.address})`);
     }
   }
@@ -320,14 +384,14 @@ export function pinnedAgent(ip: string): Agent {
 export async function ssrfSafeFetch(
   rawUrl: string,
   init: RequestInit = {},
-  opts: { maxRedirects?: number; lookup?: DnsLookup; fetchImpl?: typeof fetch } = {},
+  opts: { maxRedirects?: number; lookup?: DnsLookup; fetchImpl?: typeof fetch; allowPrivate?: boolean } = {},
 ): Promise<Response> {
   const maxRedirects = opts.maxRedirects ?? 3;
   const injected = opts.fetchImpl;
   let current = rawUrl;
 
   for (let hop = 0; hop <= maxRedirects; hop++) {
-    const { addresses } = await assertUrlSafeResolved(current, { lookup: opts.lookup });
+    const { addresses } = await assertUrlSafeResolved(current, { lookup: opts.lookup, allowPrivate: opts.allowPrivate });
 
     let resp: Response;
     let agent: Agent | undefined;

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -37,6 +37,7 @@ services:
       DATA_ROOT: /data
       MONGO_URI: mongodb://ythril-mongo-a:27017/?directConnection=true
       NODE_ENV: test
+      SYNC_ALLOW_PRIVATE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -87,6 +88,7 @@ services:
       DATA_ROOT: /data
       MONGO_URI: mongodb://ythril-mongo-b:27017/?directConnection=true
       NODE_ENV: test
+      SYNC_ALLOW_PRIVATE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -133,6 +135,7 @@ services:
       DATA_ROOT: /data
       MONGO_URI: mongodb://ythril-mongo-c:27017/?directConnection=true
       NODE_ENV: test
+      SYNC_ALLOW_PRIVATE_PEERS: "true"
     depends_on:
       ythril-mongo-c:
         condition: service_healthy
@@ -178,6 +181,7 @@ services:
       DATA_ROOT: /data
       MONGO_URI: mongodb://ythril-mongo-d:27017/?directConnection=true
       NODE_ENV: test
+      SYNC_ALLOW_PRIVATE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"

--- a/testing/red-team-tests/sync-peer-ssrf.test.js
+++ b/testing/red-team-tests/sync-peer-ssrf.test.js
@@ -1,0 +1,95 @@
+/**
+ * Red-team: post-admission peer-URL SSRF (S2.5).
+ *
+ * A peer's URL is SSRF-validated at admission, but the member self-update path
+ * (POST /api/sync/networks/:id/members) could previously overwrite a stored URL
+ * with no re-validation. A malicious/compromised member could move itself onto a
+ * crown-jewel address (cloud IMDS 169.254.169.254, loopback) and the sync engine
+ * would then connect there with peer auth headers attached.
+ *
+ * The fix re-validates the URL before persisting it. Crown-jewel addresses are
+ * rejected even though the test stack runs with SYNC_ALLOW_PRIVATE_PEERS=true
+ * (its peers live on the Docker bridge / RFC-1918); a legitimate private URL is
+ * still accepted.
+ *
+ * Run: node --test testing/red-team-tests/sync-peer-ssrf.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, del, delWithBody, getInstanceId, readContainerConfig } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let tokenA, instanceIdB, networkId, testSpaceId;
+
+function memberBUrl() {
+  const net = readContainerConfig('ythril-a').networks.find(n => n.id === networkId);
+  return net?.members.find(m => m.instanceId === instanceIdB)?.url;
+}
+
+async function selfUpdateB(url) {
+  return post(INSTANCES.a, tokenA, `/api/sync/networks/${networkId}/members`, {
+    instanceId: instanceIdB, label: 'Instance B', url, direction: 'both',
+  });
+}
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  instanceIdB = getInstanceId('ythril-b');
+
+  testSpaceId = `ssrf-peer-${RUN}`;
+  await post(INSTANCES.a, tokenA, '/api/spaces', { id: testSpaceId, label: 'SSRF Peer Test' });
+
+  const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+    label: `SSRF Peer ${RUN}`, type: 'closed', spaces: [testSpaceId], votingDeadlineHours: 1,
+  });
+  assert.equal(netR.status, 201, `create network: ${JSON.stringify(netR.body)}`);
+  networkId = netR.body.id;
+
+  const pt = await post(INSTANCES.a, tokenA, '/api/tokens', { name: `ssrf-peer-b-${RUN}` });
+  const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+    instanceId: instanceIdB, label: 'Instance B', url: 'http://ythril-b:3200', token: pt.body.plaintext, direction: 'both',
+  });
+  if (addB.status === 202) {
+    await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${addB.body.roundId}`, { vote: 'yes' });
+  }
+  assert.ok(memberBUrl(), 'B is a member on A after setup');
+});
+
+after(async () => {
+  if (networkId) {
+    await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('Post-admission peer-URL SSRF is refused', () => {
+  it('rejects a self-update to cloud IMDS (169.254.169.254)', async () => {
+    const before = memberBUrl();
+    await selfUpdateB('http://169.254.169.254:3200');
+    assert.equal(memberBUrl(), before, 'B URL must not become the IMDS address');
+  });
+
+  it('rejects a self-update to loopback (127.0.0.1)', async () => {
+    const before = memberBUrl();
+    await selfUpdateB('http://127.0.0.1:3200');
+    assert.equal(memberBUrl(), before, 'B URL must not become loopback');
+  });
+
+  it('rejects IMDS encoded as a decimal integer', async () => {
+    const before = memberBUrl();
+    await selfUpdateB('http://2852039166:3200'); // 169.254.169.254
+    assert.equal(memberBUrl(), before, 'B URL must not become the encoded IMDS address');
+  });
+
+  it('still accepts a legitimate private URL (allowPrivatePeers is on for the test stack)', async () => {
+    await selfUpdateB('http://ythril-b:3299');
+    assert.equal(memberBUrl(), 'http://ythril-b:3299', 'a valid private peer URL is accepted');
+  });
+});

--- a/testing/standalone/peer-ssrf-policy.test.js
+++ b/testing/standalone/peer-ssrf-policy.test.js
@@ -1,0 +1,65 @@
+/**
+ * Standalone unit tests: peer SSRF policy (S2.5).
+ *
+ * `isPeerUrlSafe(url, allowPrivate)` — the synchronous, literal (no-DNS) check
+ * used before a peer-supplied URL is stored or connected to.
+ *   - allowPrivate=false → public peers only (same block list as ssrfSafeFetch).
+ *   - allowPrivate=true  → private ranges (RFC-1918/CGNAT/ULA) allowed, but the
+ *     crown jewels (loopback, link-local/IMDS, unspecified) stay blocked.
+ *
+ * Pure in-process — no MongoDB. Run: node --test testing/standalone/peer-ssrf-policy.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isPeerUrlSafe } from '../../server/dist/util/ssrf.js';
+
+describe('Peer SSRF policy — strict (allowPrivate = false)', () => {
+  const cases = {
+    'http://8.8.8.8:3200': true,
+    'https://peer.example.com': true,
+    'http://10.0.0.5:3200': false,
+    'http://192.168.1.10:3200': false,
+    'http://172.16.0.1:3200': false,
+    'http://100.64.0.1:3200': false,          // CGNAT
+    'http://127.0.0.1:3200': false,
+    'http://169.254.169.254/latest/meta-data/': false,
+    'http://localhost:3200': false,
+    'http://metadata.google.internal/': false,
+    'http://[::1]:3200': false,
+    'http://[fe80::1]:3200': false,
+    'http://[fc00::1]:3200': false,           // ULA
+    'ftp://8.8.8.8': false,                    // scheme
+    'http://user:pass@8.8.8.8': false,         // embedded creds
+    'http://2852039166/': false,               // 169.254.169.254 as decimal
+  };
+  for (const [url, expected] of Object.entries(cases)) {
+    it(`${url} → ${expected}`, () => assert.equal(isPeerUrlSafe(url, false), expected));
+  }
+});
+
+describe('Peer SSRF policy — allowPrivate = true (crown jewels still blocked)', () => {
+  const cases = {
+    // Private ranges are now permitted (same-host / LAN sync).
+    'http://10.0.0.5:3200': true,
+    'http://192.168.1.10:3200': true,
+    'http://172.16.0.1:3200': true,            // Docker bridge
+    'http://100.64.0.1:3200': true,            // CGNAT
+    'http://[fc00::1]:3200': true,             // IPv6 ULA
+    'http://ythril-b:3200': true,              // hostname — literal check passes; DNS checked at connect
+    'http://8.8.8.8:3200': true,
+    // Crown jewels remain blocked regardless of allowPrivate.
+    'http://127.0.0.1:3200': false,
+    'http://169.254.169.254/': false,          // cloud IMDS
+    'http://2852039166/': false,               // IMDS as decimal
+    'http://0x7f000001/': false,               // 127.0.0.1 as hex
+    'http://localhost:3200': false,
+    'http://metadata.google.internal/': false,
+    'http://[::1]:3200': false,
+    'http://[fe80::1]:3200': false,            // link-local
+    'http://[::]:3200': false,                 // unspecified
+  };
+  for (const [url, expected] of Object.entries(cases)) {
+    it(`${url} → ${expected}`, () => assert.equal(isPeerUrlSafe(url, true), expected));
+  }
+});


### PR DESCRIPTION
## Summary

Closes the **HIGH** post-admission SSRF in multi-brain sync (backlog **S2.5**).

Peer URLs are SSRF-validated at admission, but a peer can rewrite its **own stored URL after admission** — via gossip (self-piggyback + peer-view) and the member self-update endpoint — with **no re-validation**, and the sync engine then connected with a **bare `fetch`** (no DNS pin). So an admitted-but-malicious member (admission is cheap: Club = single inviter, Pub/Sub = auto-accept) could point itself at `http://169.254.169.254/` (cloud IMDS), loopback, or an internal host, and the victim would `fetch` it **with peer auth headers attached** — SSRF against the host's internal network with credential theft from IMDS. It was a front-door lock on a building with no back wall.

## Fix

1. **Connection-time validation** — new `peerSafeFetch` (`server/src/sync/peer-fetch.ts`) routes all **15** outbound sync connections through `ssrfSafeFetch`: DNS-resolve → **pin the socket to the validated IP** → re-validate every redirect hop.
2. **Merge-time re-validation** — the three URL-merge paths (two gossip merges in `engine.ts`, the self-update in `api/sync.ts`) re-validate before persisting; a peer moving itself onto a blocked address is refused and logged.
3. **Two-tier peer policy** (`util/ssrf.ts`) — **crown-jewel addresses (loopback, link-local / IMDS, unspecified) are always blocked.** Other private ranges (RFC-1918 / CGNAT / IPv6 ULA) are blocked unless `allowPrivatePeers` is set.

### On `allowPrivatePeers`

The finding proposed a strict public-only guard, but that would break the **test harness and legitimate same-host / LAN deployments** — both address peers by private IP (the test peers live on the Docker bridge). So private ranges are permitted via an explicit opt-in (`allowPrivatePeers` config key or `SYNC_ALLOW_PRIVATE_PEERS` env), and **even then the crown jewels stay blocked** — the sharpest SSRF targets (IMDS/loopback) can never be reached regardless. `ssrfSafeFetch` / `assertUrlSafeResolved` gain an optional `allowPrivate` param defaulting to `false`, so the webhook path's strict behavior is unchanged.

## Testing

- `testing/standalone/peer-ssrf-policy.test.js` — **32 cases**: strict vs. `allowPrivate`, incl. decimal/hex IP encodings, IPv6 (`::1`, `fe80::`, ULA `fc00::`), `localhost`/metadata hostnames.
- `testing/red-team-tests/sync-peer-ssrf.test.js` — **4 cases**: a member self-update to IMDS / loopback / decimal-encoded IMDS is **rejected** (stored URL unchanged); a legitimate private URL is accepted.
- **Full sync suite green (173/174, 0 failures)** with the change — confirming `peerSafeFetch` + `allowPrivatePeers` did **not** regress sync (the test stack sets `SYNC_ALLOW_PRIVATE_PEERS=true`).

## Notes / follow-ups

- The gossip peer-view merge also lets a peer rewrite **other** members' URLs; re-validation now blocks pointing them at unsafe addresses, but restricting URL updates to a peer's *own* record (defense against redirecting a victim's sync traffic to a valid attacker-controlled URL) is a separate, lower-severity hardening left as a follow-up — it needs care not to break multi-hop topology propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)