### PR TITLE
security: MCP auth-lifecycle hardening (SSE session identity binding, OAuth token expiry/rotation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rate-limit kill-switches (`SKIP_*_RATE_LIMIT`) are ignored in production.** These test-only
   env vars are now honoured outside `NODE_ENV=production` only, so a leaked flag can't silently
   disable rate limiting on a live deployment. A loud warning is logged at startup if one is set.
+- **MCP SSE sessions are now bound to the identity that opened them.** An MCP `GET /mcp` SSE
+  session was authorized once, at open time, and `POST /mcp/messages?sessionId=…` then dispatched
+  into it keyed by `sessionId` **alone** — never re-checking whose token drove the call. Because the
+  `sessionId` travels as a query parameter (it lands in reverse-proxy access logs, browser history,
+  and referrers) it is not a secret; any holder of a valid token — even a read-only, single-space
+  one — who learned another session's id could POST tool calls that executed with that session's
+  privileges. Each session is now pinned to the opening token's **id and scope signature**; a
+  `POST` whose token id differs, or whose scopes have since changed, is rejected with `403`. This
+  also fixes privilege staleness (a mid-session scope downgrade now forces reconnect). Raw session
+  ids are no longer logged — only a short non-reversible tag. Covered by
+  `testing/red-team-tests/mcp-security.test.js`.
+- **MCP OAuth connector tokens now expire and rotate instead of accumulating.** Every browser-connector
+  consent minted a **permanent** PAT with no cap, so a connector that re-authorized on each reconnect
+  grew `config.json` without bound and left a trail of orphaned, long-lived credentials (and every
+  `saveConfig` rewrites the whole file). OAuth-minted tokens now carry a default **90-day expiry**
+  (`MCP_OAUTH_TOKEN_TTL_DAYS`, `0` = never), a fresh consent **rotates** the single token held for that
+  client rather than appending, and the total connector-token count is capped (oldest evicted). The
+  token exchange advertises `expires_in` so clients can anticipate re-consent. **Behavior change:**
+  connectors will need to re-authorize when their token expires. Covered by
+  `testing/integration/mcp-oauth.test.js`.
 
 ### Fixed
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -192,6 +192,7 @@ DEBUG=1 docker compose up
 | `METRICS_TOKEN` | (unset) | When set, `GET /metrics` requires this exact value as a Bearer token — the recommended path for Prometheus scrape configs. If unset, the endpoint falls back to requiring a valid admin PAT. |
 | `TRUST_PROXY` | `false` | Express `trust proxy` setting (overrides the `trustProxy` config key). Default `false` — `req.ip` comes from the socket. **Set this when running behind a reverse proxy**, to the exact number of proxy hops (e.g. `1`), *not* `true` (which trusts the whole `X-Forwarded-For` chain and is client-spoofable). Also accepts `loopback` or a comma-separated CIDR/IP list. Rate limiting and the audit log key on `req.ip`, so a wrong value here is a security setting. |
 | `SYNC_ALLOW_PRIVATE_PEERS` | `false` | Allow sync **peer URLs** to resolve to private/reserved addresses (RFC-1918, CGNAT, IPv6 ULA) — for same-host or LAN networks (overrides the `allowPrivatePeers` config key). Default `false`: sync connects only to public peers, and any peer that tries to move its URL onto a private address is refused. Even when `true`, crown-jewel addresses (loopback, link-local / cloud IMDS `169.254.169.254`, unspecified) stay blocked. |
+| `MCP_OAUTH_TOKEN_TTL_DAYS` | `90` | Lifetime (in days) of PATs minted by the MCP OAuth browser-connector flow. Tokens expire after this many days, so an abandoned connector leaves no permanent credential behind; the connector re-consents when its token lapses. Each connector holds **one** token that a fresh consent rotates (never accumulates), and the total connector-token count is capped. Set to `0` to disable expiry (tokens never expire) if you need long-lived connector credentials. |
 
 ### Data Persistence
 
@@ -5311,6 +5312,8 @@ Discovery + grant endpoints (mounted at the application root):
 | `POST /token` | Token endpoint — exchanges an auth code (+ PKCE) for an access token |
 
 **The consent step.** The user is shown a page asking them to paste a Ythril access token to approve the connection. The connector is then issued a **new** PAT with **the same permissions** (admin / space scope / read-only) as the token that approved it. That connector token is named `MCP connector: <client>` and can be revoked independently under **Settings → Tokens** (or `DELETE /api/tokens/:id`). Only someone who already holds a valid Ythril token can approve a connection — there is no way to gain access without one.
+
+Connector tokens **expire** after `MCP_OAUTH_TOKEN_TTL_DAYS` (default 90 days) so an abandoned connector never leaves a permanent credential behind — the exchange advertises `expires_in`, and the connector re-runs consent when its token lapses. Re-consenting **rotates** the single token held for that client rather than appending a new one, so `config.json` does not grow with every reconnect, and the total connector-token count is capped. Set `MCP_OAUTH_TOKEN_TTL_DAYS=0` to opt out of expiry.
 
 Access tokens are non-expiring PATs, so no refresh-token flow is used.
 

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -184,6 +184,68 @@ export async function createToken(opts: {
   return { record, plaintext };
 }
 
+/**
+ * Mint a PAT for an MCP OAuth connector (S5). Unlike {@link createToken} this
+ * bounds token growth in a single config write:
+ *  - carries an `expiresAt` so abandoned connector tokens self-expire;
+ *  - rotates — any prior token for the same `clientId` is revoked, so a
+ *    connector that re-consents on every reconnect never accumulates tokens;
+ *  - caps the total number of connector tokens, evicting the oldest beyond
+ *    `maxTokens` as a belt-and-braces bound across all clients.
+ */
+export async function createOAuthToken(opts: {
+  clientId: string;
+  name: string;
+  spaces?: string[];
+  admin?: boolean;
+  readOnly?: boolean;
+  ttlMs: number | null; // null = never expires
+  maxTokens: number;
+}): Promise<{ record: TokenRecord; plaintext: string }> {
+  const plaintext = generateToken();
+  const hash = await hashToken(plaintext);
+  const record: TokenRecord = {
+    id: uuidv4(),
+    name: opts.name,
+    hash,
+    prefix: tokenPrefix(plaintext),
+    createdAt: new Date().toISOString(),
+    lastUsed: null,
+    expiresAt: opts.ttlMs === null ? null : new Date(Date.now() + opts.ttlMs).toISOString(),
+    spaces: opts.spaces,
+    admin: opts.admin ?? false,
+    readOnly: opts.readOnly ?? false,
+    oauthClientId: opts.clientId,
+  };
+  const config = getConfig();
+  const removedIds: string[] = [];
+  // Rotate: drop any prior token for this client.
+  config.tokens = config.tokens.filter(t => {
+    if (t.oauthClientId === opts.clientId) { removedIds.push(t.id); return false; }
+    return true;
+  });
+  config.tokens.push(record);
+  // Cap: keep only the newest `maxTokens` connector tokens overall.
+  const oauthTokens = config.tokens.filter(t => t.oauthClientId);
+  if (oauthTokens.length > opts.maxTokens) {
+    const byAge = [...oauthTokens].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    const evict = new Set(byAge.slice(0, oauthTokens.length - opts.maxTokens).map(t => t.id));
+    config.tokens = config.tokens.filter(t => {
+      if (evict.has(t.id)) { removedIds.push(t.id); return false; }
+      return true;
+    });
+  }
+  saveConfig(config);
+  // Evict any cached entries for revoked tokens so bcrypt compare is never skipped.
+  if (removedIds.length) {
+    const gone = new Set(removedIds);
+    for (const [key, val] of _tokenCache) {
+      if (gone.has(val.tokenId)) _tokenCache.delete(key);
+    }
+  }
+  return { record, plaintext };
+}
+
 /** List all token records (hashes excluded) */
 export function listTokens(): Omit<TokenRecord, 'hash'>[] {
   return getConfig().tokens.map(({ hash: _h, ...rest }) => rest);

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -11,6 +11,7 @@ export interface TokenRecord {
   readOnly?: boolean;   // true = read-only access; all mutations blocked
   peerInstanceId?: string; // set on tokens created for network peers — links this PAT to the peer that uses it inbound
   schemaLibrary?: boolean; // true = only valid on GET /api/schema-library/public*; no space access
+  oauthClientId?: string;  // set on PATs minted by the MCP OAuth flow — links this token to the connector client that created it (for rotation, capping, and UI attribution)
 }
 
 // ── Space meta / schema types ──────────────────────────────────────────────

--- a/server/src/mcp/oauth.ts
+++ b/server/src/mcp/oauth.ts
@@ -38,7 +38,7 @@ import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/serv
 import type { OAuthClientInformationFull, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { getConfig, saveConfig } from '../config/loader.js';
-import { createToken, findMatchingToken } from '../auth/tokens.js';
+import { createOAuthToken, findMatchingToken } from '../auth/tokens.js';
 import { authRateLimit } from '../rate-limit/middleware.js';
 import { log } from '../util/log.js';
 
@@ -78,6 +78,17 @@ export function mcpResourceMetadataUrl(): string {
 // Cap the number of stored DCR clients so a client that re-registers on every
 // connect cannot grow config.json without bound. Oldest entries are evicted.
 const MAX_OAUTH_CLIENTS = 50;
+
+// Connector-token lifecycle (S5). OAuth-minted PATs expire by default so
+// abandoned connectors don't leave permanent credentials behind, and the total
+// count is capped as a backstop. Both are overridable via env; a TTL of 0 opts
+// out of expiry (tokens never expire) for operators who need long-lived ones.
+const OAUTH_TOKEN_TTL_DAYS = (() => {
+  const raw = Number(process.env['MCP_OAUTH_TOKEN_TTL_DAYS']);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 90;
+})();
+const OAUTH_TOKEN_TTL_MS: number | null = OAUTH_TOKEN_TTL_DAYS === 0 ? null : OAUTH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+const MAX_OAUTH_TOKENS = 50;
 
 const clientsStore: OAuthRegisteredClientsStore = {
   getClient(clientId: string): OAuthClientInformationFull | undefined {
@@ -170,19 +181,25 @@ const provider: OAuthServerProvider = {
       throw new InvalidGrantError('redirect_uri does not match the authorization request');
     }
 
-    const { plaintext } = await createToken({
+    const { plaintext } = await createOAuthToken({
+      clientId: client.client_id,
       name: `MCP connector: ${sanitizeName(client.client_name) ?? client.client_id}`,
       admin: entry.identity.admin,
       spaces: entry.identity.spaces,
       readOnly: entry.identity.readOnly,
+      ttlMs: OAUTH_TOKEN_TTL_MS,
+      maxTokens: MAX_OAUTH_TOKENS,
     });
-    log.info(`Issued MCP OAuth access token for client ${client.client_id} (admin=${entry.identity.admin}, readOnly=${entry.identity.readOnly})`);
+    log.info(`Issued MCP OAuth access token for client ${client.client_id} (admin=${entry.identity.admin}, readOnly=${entry.identity.readOnly}, ttlDays=${OAUTH_TOKEN_TTL_DAYS || 'never'})`);
 
-    // No expires_in and no refresh_token: the PAT does not expire, so the
-    // client treats the access token as long-lived and never attempts refresh.
+    // We rotate one PAT per client and issue no refresh token. When the PAT
+    // expires the client re-runs the authorization flow (re-consent) rather than
+    // refreshing. Advertise expires_in when the token is time-limited so clients
+    // can anticipate re-authorization.
     return {
       access_token: plaintext,
       token_type: 'Bearer',
+      ...(OAUTH_TOKEN_TTL_MS !== null ? { expires_in: Math.floor(OAUTH_TOKEN_TTL_MS / 1000) } : {}),
       ...(entry.scopes.length ? { scope: entry.scopes.join(' ') } : {}),
     };
   },

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -9,6 +9,7 @@ import {
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, getMediaEmbeddingConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
+import { createHash } from 'node:crypto';
 import { checkQuota, QuotaError } from '../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage } from '../spaces/proxy.js';
 import { updateSpace, wipeSpace, WIPE_COLLECTION_TYPES, type WipeCollectionType } from '../spaces/spaces.js';
@@ -44,6 +45,34 @@ import type { InputFormat } from '../files/converters/pipeline.js';
 
 // Session map: sessionId → transport
 const transports = new Map<string, SSEServerTransport>();
+
+// Identity binding for SSE sessions (S2). Each open SSE session is pinned to the
+// id of the token that opened it and a signature of that token's authorization
+// scopes. `POST /mcp/messages?sessionId=…` must present the *same* token id, and
+// that token's *current* scopes must still match — otherwise the request is
+// rejected. Without this, any valid token that learns another session's id (it
+// travels as a query parameter, so it lands in proxy logs and browser history)
+// could drive tool calls with the opening session's privileges.
+interface SessionBinding {
+  tokenId: string;
+  scopeSig: string;
+}
+const sessionBindings = new Map<string, SessionBinding>();
+
+/** Stable signature of a token's authorization scopes, order-independent. */
+function scopeSignature(t: { admin?: boolean; readOnly?: boolean; spaces?: string[] } | undefined): string {
+  return JSON.stringify([
+    Boolean(t?.admin),
+    Boolean(t?.readOnly),
+    [...(t?.spaces ?? [])].sort(),
+  ]);
+}
+
+/** Short, non-reversible tag for correlating an SSE session in logs without
+ *  emitting the raw sessionId (which is a bearer-equivalent routing secret). */
+function sessionTag(sessionId: string): string {
+  return createHash('sha256').update(sessionId).digest('hex').slice(0, 12);
+}
 
 /** Format a RecallResult as a single human-readable summary line. */
 function formatRecallSummary(r: RecallResult): string {
@@ -2141,16 +2170,21 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
   const postEndpoint = '/mcp/messages';
   const transport = new SSEServerTransport(postEndpoint, res);
   transports.set(transport.sessionId, transport);
+  sessionBindings.set(transport.sessionId, {
+    tokenId: req.authToken?.id ?? '',
+    scopeSig: scopeSignature(req.authToken),
+  });
   mcpConnectionsActive.inc();
 
   res.on('close', () => {
     transports.delete(transport.sessionId);
+    sessionBindings.delete(transport.sessionId);
     mcpConnectionsActive.dec();
-    log.debug(`MCP global session ${transport.sessionId} closed`);
+    log.debug(`MCP global session ${sessionTag(transport.sessionId)} closed`);
   });
 
   const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin);
-  log.debug(`MCP global session ${transport.sessionId} opened`);
+  log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
 });
 
@@ -2160,6 +2194,16 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
   const transport = transports.get(sessionId);
   if (!transport) {
     res.status(404).json({ error: 'Unknown MCP session. Open an SSE connection first.' });
+    return;
+  }
+  // S2: the POST must be driven by the *same* token that opened the SSE session,
+  // and that token's scopes must not have changed since. requireMcpAuth has
+  // already re-validated the bearer (a revoked/expired token never reaches here),
+  // so this closes cross-token hijacking and mid-session privilege staleness.
+  const binding = sessionBindings.get(sessionId);
+  if (!binding || binding.tokenId !== (req.authToken?.id ?? '') || binding.scopeSig !== scopeSignature(req.authToken)) {
+    log.warn(`MCP session ${sessionTag(sessionId)} rejected: token does not match the identity that opened it`);
+    res.status(403).json({ error: 'This MCP session is bound to a different identity. Open your own SSE connection.' });
     return;
   }
   await transport.handlePostMessage(req, res, req.body);

--- a/testing/integration/mcp-oauth.test.js
+++ b/testing/integration/mcp-oauth.test.js
@@ -243,3 +243,43 @@ describe('MCP OAuth: token exchange', () => {
     assert.equal(replay.body.error, 'invalid_grant');
   });
 });
+
+describe('MCP OAuth: connector-token lifecycle (S5)', () => {
+  before(() => {
+    adminToken = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  });
+
+  // Full authorize → consent → exchange for a given client.
+  async function fullExchange(clientId) {
+    const { verifier, challenge } = pkce();
+    const consent = await submitConsent({ clientId, redirectUri: REDIRECT, challenge, token: adminToken });
+    const code = new URL(consent.headers.get('location')).searchParams.get('code');
+    return exchangeCode({ clientId, code, verifier, redirectUri: REDIRECT });
+  }
+
+  it('minted token carries an expiry (expires_in advertised, expiresAt persisted)', async () => {
+    const { clientId } = await registerClient(REDIRECT);
+    const { status, body } = await fullExchange(clientId);
+    assert.equal(status, 200, `exchange failed: ${JSON.stringify(body)}`);
+    assert.equal(typeof body.expires_in, 'number', 'a time-limited token must advertise expires_in');
+    assert.ok(body.expires_in > 0, 'expires_in must be positive');
+
+    const list = await get(BASE, adminToken, '/api/tokens');
+    const tok = list.body.tokens.find(t => t.oauthClientId === clientId);
+    assert.ok(tok, 'connector token must be listed with its oauthClientId');
+    assert.ok(tok.expiresAt, 'connector token must carry expiresAt (no permanent PATs)');
+    assert.ok(new Date(tok.expiresAt).getTime() > Date.now(), 'expiresAt must be in the future');
+  });
+
+  it('repeat consent for the same client rotates rather than accumulates tokens', async () => {
+    const { clientId } = await registerClient(REDIRECT);
+    await fullExchange(clientId);
+    await fullExchange(clientId);
+    await fullExchange(clientId);
+    const list = await get(BASE, adminToken, '/api/tokens');
+    const forClient = list.body.tokens.filter(t => t.oauthClientId === clientId);
+    assert.equal(forClient.length, 1,
+      `VULNERABILITY: re-consent must keep exactly one token per client (rotation); found ${forClient.length}. ` +
+      `config.tokens grows without bound otherwise.`);
+  });
+});

--- a/testing/red-team-tests/mcp-security.test.js
+++ b/testing/red-team-tests/mcp-security.test.js
@@ -159,6 +159,103 @@ function openMcpSession(instance, bearerToken, spaceId = 'general', timeoutMs = 
   });
 }
 
+/**
+ * Open a raw MCP SSE session and expose its sessionId so a test can drive
+ * `/mcp/messages` with an arbitrary bearer (not necessarily the opener's).
+ * Returns { status, sessionId, close }.
+ */
+function openRawSession(instance, bearerToken, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host, port, path: '/mcp', method: 'GET',
+        headers: { ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}), Accept: 'text/event-stream' } },
+      (res) => {
+        if (res.statusCode !== 200) { res.resume(); resolve({ status: res.statusCode, sessionId: null, close: () => {} }); return; }
+        let buffer = '';
+        let sessionId = null;
+        res.setEncoding('utf8');
+        res.on('data', chunk => {
+          buffer += chunk;
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() ?? '';
+          for (const part of parts) {
+            if (!part.trim()) continue;
+            let eventType = 'message', data = '';
+            for (const line of part.split('\n')) {
+              if (line.startsWith('event:')) eventType = line.slice(6).trim();
+              else if (line.startsWith('data:')) data = line.slice(5).trim();
+            }
+            if (eventType === 'endpoint') {
+              const m = data.match(/sessionId=([^&\s]+)/);
+              if (m) sessionId = m[1];
+            }
+          }
+        });
+        const deadline = Date.now() + timeoutMs;
+        const poll = setInterval(() => {
+          if (sessionId) { clearInterval(poll); resolve({ status: 200, sessionId, close: () => req.destroy() }); }
+          else if (Date.now() > deadline) { clearInterval(poll); req.destroy(); resolve({ status: 200, sessionId: null, close: () => {} }); }
+        }, 50);
+      },
+    );
+    req.on('error', () => resolve({ status: 0, sessionId: null, close: () => {} }));
+    req.end();
+  });
+}
+
+/** POST a tool call to an existing session id with a chosen bearer; resolves the HTTP status. */
+function rawPostToSession(instance, sessionId, bearerToken, toolName, toolArgs) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+  const payload = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: toolName, arguments: toolArgs } });
+  return new Promise((resolve, reject) => {
+    const pr = http.request(
+      { host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload),
+          ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}) } },
+      pres => { let txt = ''; pres.setEncoding('utf8'); pres.on('data', c => { txt += c; }); pres.on('end', () => resolve({ status: pres.statusCode, body: txt })); },
+    );
+    pr.on('error', reject);
+    pr.write(payload);
+    pr.end();
+  });
+}
+
+// ── S2: SSE session is bound to the opening identity ───────────────────────
+
+describe('MCP security — SSE session identity binding (S2)', () => {
+  let readOnlyToken;
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    // Mint a second, distinct token (different id) valid on instance A.
+    const r = await post(INSTANCES.a, tokenA, '/api/tokens', { name: `s2-readonly-${Date.now()}`, readOnly: true });
+    readOnlyToken = r?.body?.plaintext;
+  });
+
+  it('POST /mcp/messages with a DIFFERENT token than opened the session returns 403', async () => {
+    assert.ok(readOnlyToken && readOnlyToken.startsWith('ythril_'), 'second token must be minted');
+    const sess = await openRawSession(INSTANCES.a, tokenA);
+    try {
+      assert.equal(sess.status, 200);
+      assert.ok(sess.sessionId, 'SSE session must open and yield a sessionId');
+
+      // Attacker holds a valid (read-only) token and learns the admin session id.
+      const hijack = await rawPostToSession(INSTANCES.a, sess.sessionId, readOnlyToken, 'remember', { fact: 'S2-hijack-attempt', space: 'general' });
+      assert.equal(hijack.status, 403,
+        `VULNERABILITY: a different token drove the session (got ${hijack.status}). ` +
+        `The SSE session must be bound to the id of the token that opened it.`);
+
+      // Control: the opening token itself is still accepted (202/200).
+      const legit = await rawPostToSession(INSTANCES.a, sess.sessionId, tokenA, 'recall', { query: 'anything' });
+      assert.ok([200, 202].includes(legit.status), `opening token must still drive its own session (got ${legit.status})`);
+    } finally { sess.close(); }
+  });
+});
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('MCP security — authentication', () => {


### PR DESCRIPTION
## Summary

Two independent MCP auth-lifecycle hardening items from the security backlog, batched because they share the MCP-connector surface.

### S2 — MCP SSE sessions are now bound to the identity that opened them
An MCP `GET /mcp` SSE session was authorized once, at open time; `POST /mcp/messages?sessionId=…` then dispatched into it keyed by `sessionId` **alone**, never re-checking whose token drove the call. Because the `sessionId` travels as a query parameter (it lands in reverse-proxy access logs, browser history, and referrers) it is not a secret — so any holder of a valid token, even a read-only single-space one, who learned another session's id could POST tool calls that executed with that session's privileges.

- Each session is pinned to the opening token's **id + scope signature**.
- A `POST` whose token id differs, or whose scopes have since changed, is rejected `403`.
- Fixes privilege staleness as a side effect: a mid-session scope downgrade now forces reconnect.
- Raw session ids are no longer logged — only a short non-reversible tag.

### S5 — MCP OAuth connector tokens now expire and rotate
Every browser-connector consent minted a **permanent** PAT with no cap, so a connector re-authorizing on each reconnect grew `config.json` without bound and left orphaned long-lived credentials.

- OAuth-minted tokens carry a default **90-day expiry** (`MCP_OAUTH_TOKEN_TTL_DAYS`, `0` = never).
- A fresh consent **rotates** the single token held for that client rather than appending.
- Total connector-token count is capped (oldest evicted), in one `saveConfig`.
- The token exchange advertises `expires_in`.

**Behavior change:** connectors will need to re-authorize when their token expires (90d default).

## Tests
- `testing/red-team-tests/mcp-security.test.js` — new S2 case: open an SSE session with an admin token, capture its `sessionId`, POST a mutating tool call with a *different* (read-only) token → asserts `403`; control POST with the opening token still succeeds.
- `testing/integration/mcp-oauth.test.js` — new S5 cases: minted token advertises `expires_in` and persists `expiresAt`; three repeat consents for one client leave exactly **one** token (rotation, not accumulation).

Verified on the Docker test stack: red-team **254/254**, integration **812 pass / 4 skipped / 0 fail**. Server `tsc --noEmit` clean (including after rebase onto the merged #142). S2/S5 touch a disjoint subsystem from #142 (MCP auth vs. sync SSRF); CI re-runs the full suite on the merged code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
