### PR TITLE
security: harden Kubernetes deployment manifest (S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Kubernetes deployment is hardened and its probes/ports now actually work.** The stock
+  `kubernetes/manifests/ythril-deployment.yaml` had no `securityContext`, used the mutable
+  `:latest` image tag, set no resource limits on the main container, and targeted
+  `containerPort: 4100` with `/api/ready` probes — but the server listens on `3200` and the
+  readiness endpoint is `/ready`, so probes never passed and Service targeting hit a dead port.
+  The manifest now: enforces non-root (`runAsNonRoot`, uid/gid 1000) with
+  `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, all capabilities dropped, and
+  `seccompProfile: RuntimeDefault`; backs every writable path with a volume (`/data` and a new
+  `ythril-config` PVC for the previously-**unmounted** `/config`, plus an `emptyDir` for `/tmp`);
+  adds CPU/memory requests and limits to the main container; corrects the port to `3200` and the
+  probe path to `/ready`; and pins a concrete image version with inline guidance for digest
+  pinning. **Behavior change:** `/config` (tokens, spaces, networks, secrets) is now persisted on
+  its own PVC — previously this state was silently lost on every Pod restart. The `ythril-config`
+  PVC is created by the manifest; on clusters without a default StorageClass, provision it first.
 - **Sync connections are now SSRF-validated at connection time, and peer URL rewrites
   are re-validated.** Peer URLs were validated only at admission, but a peer can rewrite
   its own stored URL after admission (via gossip or the member self-update endpoint) with

--- a/kubernetes/manifests/ythril-deployment.yaml
+++ b/kubernetes/manifests/ythril-deployment.yaml
@@ -24,12 +24,43 @@ spec:
       labels:
         app: ythril
     spec:
+      # Pod-level hardening applied to every container. seccompProfile confines
+      # syscalls to the runtime default set; fsGroup makes the mounted volumes
+      # group-owned by gid 1000 so the non-root `node` user (uid/gid 1000, from
+      # the node:22-slim base) can write to them.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        fsGroup: 1000
       containers:
         # ── Main Ythril container ────────────────────────────────────────────
         - name: ythril
-          image: ghcr.io/ythril-network/ythril:latest
+          # Pin by immutable digest in production — a mutable tag (`:latest` or a
+          # version tag) lets a compromised registry silently swap the image on the
+          # next pull. Resolve the digest with:
+          #   docker buildx imagetools inspect ghcr.io/ythril-network/ythril:1.4.4
+          # then replace the tag below with @sha256:<digest>.
+          image: ghcr.io/ythril-network/ythril:1.4.4
+          # The image already sets `USER node`; these settings *enforce* non-root at
+          # the cluster level and lock the container down further. readOnlyRootFilesystem
+          # is safe here because every path the server writes is backed by a volume:
+          #   /data   — DATA_ROOT: file bytes, upload chunks, face/media models (PVC)
+          #   /config — CONFIG_PATH: config.json, secrets.json, schema library (PVC)
+          #   /tmp    — os.tmpdir() scratch for audio/video embedding (emptyDir)
+          # The embedding model is baked into the image at /app/model-cache (read-only)
+          # and is loaded, never written, at runtime — so it must NOT be shadowed by a
+          # writable mount.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
-            - containerPort: 4100
+            - containerPort: 3200
           env:
             - name: DATA_ROOT
               value: /data
@@ -37,19 +68,33 @@ spec:
             # Ythril reaches it on the loopback interface.
             - name: CONVERSION_SIDECAR_URL
               value: http://localhost:8000
+          # The conversion/embedding pipeline is CPU- and memory-hungry; without a
+          # limit an unbounded main container is a node-level DoS. Requests reserve
+          # headroom for the embedding model (~274 MB) plus the Node heap.
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "1Gi"
+            limits:
+              cpu: "2000m"
+              memory: "2Gi"
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: config
+              mountPath: /config
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
-              path: /api/ready
-              port: 4100
+              path: /ready
+              port: 3200
             initialDelaySeconds: 5
             periodSeconds: 10
           startupProbe:
             httpGet:
-              path: /api/ready
-              port: 4100
+              path: /ready
+              port: 3200
             failureThreshold: 30
             periodSeconds: 10
 
@@ -68,6 +113,14 @@ spec:
           # Pin to a specific tag and verify the LICENSE before upgrading.
           # Run `docker run --rm --entrypoint cat <image> /app/LICENSE` to confirm Apache-2.0.
           image: downloads.unstructured.io/unstructured-io/unstructured-api-full:0.0.75
+          # Lighter hardening than the main container: the OCR pipeline writes
+          # scratch files across its own filesystem, so readOnlyRootFilesystem is
+          # left off, but privilege escalation and added capabilities are still denied.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8000
           resources:
@@ -97,3 +150,28 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: ythril-data
+        - name: config
+          persistentVolumeClaim:
+            claimName: ythril-config
+        # os.tmpdir() scratch (audio/video embedding). Ephemeral by design — nothing
+        # here must survive a restart, so an emptyDir satisfies readOnlyRootFilesystem
+        # without provisioning storage.
+        - name: tmp
+          emptyDir: {}
+---
+# Persistent config store. /config holds config.json (tokens, spaces, networks),
+# secrets.json, and the schema library — all runtime-mutable state that must
+# survive Pod restarts. Previously /config was unmounted, so this state was lost
+# on every restart; readOnlyRootFilesystem also requires it to be a real volume.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ythril-config
+  labels:
+    app: ythril
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary

Hardens `kubernetes/manifests/ythril-deployment.yaml` (S3 from the security backlog). Manifest-only — no server code changes. While implementing I found the manifest was also **functionally broken** in two ways beyond the port the spec flagged.

### Security hardening
- **Pod:** `seccompProfile: RuntimeDefault`, `fsGroup: 1000` (so the non-root user can write the mounted PVCs).
- **Main container:** `runAsNonRoot` + `runAsUser/Group: 1000`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, all capabilities dropped. The image already set `USER node`; this enforces it at the cluster level.
- **Sidecar:** lighter context (`allowPrivilegeEscalation: false`, drop `ALL`) — the OCR pipeline writes scratch across its own FS, so `readOnlyRootFilesystem` is left off deliberately.
- **Image:** replaced the mutable `:latest` tag with a concrete version + inline instructions to pin by immutable `@sha256:` digest.
- **Resources:** added CPU/memory requests + limits to the main container (an unbounded embedding/conversion pipeline is a node-level DoS).

### Functional fixes (the manifest never reached Ready as written)
- **Port `4100` → `3200`** — nothing listens on 4100.
- **Probe path `/api/ready` → `/ready`** — `/api/ready` is a 404; the endpoint is `/ready`. So with the port *and* the path wrong, probes could never pass and the Service targeted a dead port.

### readOnlyRootFilesystem — writable paths backed by volumes
Traced every runtime write: `/data` (PVC, existing), `/config` (new `ythril-config` PVC — it was **previously unmounted**, so config.json/secrets/tokens were silently lost on every Pod restart), `/tmp` (emptyDir, for `os.tmpdir()` audio/video scratch). The embedding model baked at `/app/model-cache` is loaded read-only, so it is deliberately **not** shadowed by a writable mount.

**Behavior change:** `/config` now persists on its own PVC. The `ythril-config` PVC is defined in the manifest; on clusters with no default StorageClass, provision it first.

## Testing
No live cluster is reachable from the dev box, so a kind/minikube Ready check could not be run here (the spec's suggested test). Verified offline: the YAML parses as two documents, and assertions confirm every hardening field, both corrected ports, the `/ready` probe path, the three volume mounts, and the new PVC. CI or a reviewer with cluster access should confirm the Pod reaches Ready.

## Deferred
NetworkPolicy egress restriction (spec marked "consider") — higher-risk and needs per-cluster tuning against sync/embedding egress; left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
