### PR TITLE
ux: polish pass — html lang, accent tokens, reduced-motion, page titles, close icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`<html lang>` now tracks the active UI language.** It was hardcoded to `en`, so screen-reader
+  pronunciation and browser hyphenation stayed English for German and Polish users even though the UI
+  was fully translated. The document language is now set on startup and updated on every language
+  switch.
+- **Accent "dim" colors are back on-brand.** The active-nav highlight and dimmed accent chips were
+  driven by leftover purple/cyan tokens from an earlier palette. Both are now derived from `--accent`
+  via `color-mix()`, so they can't drift off-brand again.
+- **Close/remove buttons use a consistent icon everywhere.** Close and remove controls across the app
+  rendered a mix of raw `✕` and `×` glyphs at different weights/baselines than the `ph-icon` used
+  elsewhere. Every one — dialog close buttons, chip/tag remove buttons, and danger remove actions in
+  networks, spaces, schema-library, tokens, and the shared property/tag editors — now uses the `x`
+  icon, and dialog close buttons that were missing an `aria-label` gained one.
 - **Legacy tokens are no longer silently invalidated on upgrade** — a startup/reload migration
   *deleted* any PAT created before the `prefix` field existed, on the assumption it "cannot be
   verified." In fact a prefix-less token can still be bcrypt-verified; the prefix is only a lookup
@@ -71,6 +83,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the migration. Covered by `testing/integration/auth.test.js`.
 ### Added
 
+- **`prefers-reduced-motion` support** — a global stylesheet rule collapses animations and transitions
+  when the OS "reduce motion" setting is on, for users with vestibular sensitivity.
+- **Per-route browser tab titles** — every page now sets a localized `<Page> · Ythril` title via a
+  Transloco-aware `TitleStrategy`, so tabs, history entries, and bookmarks are distinguishable instead
+  of all reading "Ythril".
 - **Governance signing-key rotation** — an instance can now rotate its Ed25519 vote-signing keypair
   via `POST /api/admin/rotate-signing-key` (unrestricted admin; +TOTP when MFA is enabled). Rotation
   produces a **continuity proof** signed by the old key over the new one; peers that had pinned the

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -974,5 +974,7 @@
   "duplicates.merge": "Zusammenf\u00fchren",
   "duplicates.dismiss": "Verwerfen",
   "duplicates.confirmMerge": "Diese beiden Entit\u00e4ten zusammenf\u00fchren? Der \u00e4ltere Datensatz wird behalten und der andere absorbiert. Dies kann nicht r\u00fcckg\u00e4ngig gemacht werden.",
-  "duplicates.mergeError": "Zusammenf\u00fchren fehlgeschlagen."
+  "duplicates.mergeError": "Zusammenf\u00fchren fehlgeschlagen.",
+  "titles.models": "Modelle",
+  "titles.setup": "Einrichtung"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -973,5 +973,7 @@
   "duplicates.scanForbidden": "You do not have permission to run a scan (admin only).",
   "duplicates.dismissError": "Could not dismiss this candidate.",
   "spaces.dupe.onInsert": "Evaluate rules in real time (on insert)",
-  "spaces.dupe.onInsertHint": "When on, rules also run the moment a record is inserted, not only during the scheduled scan. Applies to all inserts including bulk; leave off for scan-time only."
+  "spaces.dupe.onInsertHint": "When on, rules also run the moment a record is inserted, not only during the scheduled scan. Applies to all inserts including bulk; leave off for scan-time only.",
+  "titles.models": "Models",
+  "titles.setup": "Setup"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -974,5 +974,7 @@
   "duplicates.merge": "Scal",
   "duplicates.dismiss": "Odrzu\u0107",
   "duplicates.confirmMerge": "Scali\u0107 te dwie encje? Starszy rekord zostanie zachowany, a drugi wch\u0142oni\u0119ty. Tej operacji nie mo\u017cna cofn\u0105\u0107.",
-  "duplicates.mergeError": "Scalanie nie powiod\u0142o si\u0119."
+  "duplicates.mergeError": "Scalanie nie powiod\u0142o si\u0119.",
+  "titles.models": "Modele",
+  "titles.setup": "Konfiguracja"
 }

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideZoneChangeDetection, APP_INITIALIZER, inject } from '@angular/core';
-import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { provideRouter, withComponentInputBinding, TitleStrategy } from '@angular/router';
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideTransloco, Translation, TranslocoLoader, TranslocoService } from '@jsverse/transloco';
@@ -8,6 +8,7 @@ import { routes } from './app.routes';
 import { authInterceptor } from './core/auth.interceptor';
 import { mfaInterceptor } from './core/mfa.interceptor';
 import { ThemeService } from './core/theme.service';
+import { TranslocoTitleStrategy } from './core/title-strategy';
 
 @Injectable({ providedIn: 'root' })
 export class TranslocoHttpLoader implements TranslocoLoader {
@@ -21,6 +22,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes, withComponentInputBinding()),
+    { provide: TitleStrategy, useClass: TranslocoTitleStrategy },
     provideHttpClient(withInterceptors([authInterceptor, mfaInterceptor])),
     provideAnimationsAsync(),
     {
@@ -36,6 +38,13 @@ export const appConfig: ApplicationConfig = {
         if (saved && ['en', 'de', 'pl'].includes(saved)) {
           transloco.setActiveLang(saved);
         }
+        // Keep <html lang> in sync so screen-reader pronunciation and browser
+        // hyphenation match the active UI language — on startup and on every
+        // switch (langChanges$ fires whenever setActiveLang is called).
+        document.documentElement.lang = transloco.getActiveLang();
+        transloco.langChanges$.subscribe(lang => {
+          document.documentElement.lang = lang;
+        });
       },
       deps: [TranslocoService],
       multi: true,

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -7,12 +7,14 @@ export const routes: Routes = [
   // Public routes
   {
     path: 'setup',
+    title: 'titles.setup',
     canActivate: [setupGuard],
     loadComponent: () =>
       import('./pages/setup/setup.component').then(m => m.SetupComponent),
   },
   {
     path: 'login',
+    title: 'login.signIn',
     loadComponent: () =>
       import('./pages/login/login.component').then(m => m.LoginComponent),
   },
@@ -35,16 +37,19 @@ export const routes: Routes = [
       { path: '', redirectTo: 'brain', pathMatch: 'full' },
       {
         path: 'brain',
+        title: 'nav.brain',
         loadComponent: () =>
           import('./pages/brain/brain.component').then(m => m.BrainComponent),
       },
       {
         path: 'files/conflicts',
+        title: 'nav.conflicts',
         loadComponent: () =>
           import('./pages/files/conflicts.component').then(m => m.ConflictsComponent),
       },
       {
         path: 'schema-library',
+        title: 'nav.schemaLibrary',
         loadComponent: () =>
           import('./pages/schema-library/schema-library.component').then(m => m.SchemaLibraryComponent),
       },
@@ -56,51 +61,61 @@ export const routes: Routes = [
           { path: '', redirectTo: 'tokens', pathMatch: 'full' },
           {
             path: 'preferences',
+            title: 'nav.settings',
             loadComponent: () =>
               import('./pages/settings/preferences.component').then(m => m.PreferencesComponent),
           },
           {
             path: 'tokens',
+            title: 'nav.tokens',
             loadComponent: () =>
               import('./pages/settings/tokens.component').then(m => m.TokensComponent),
           },
           {
             path: 'spaces',
+            title: 'nav.spaces',
             loadComponent: () =>
               import('./pages/settings/spaces.component').then(m => m.SpacesComponent),
           },
           {
             path: 'storage',
+            title: 'nav.metrics',
             loadComponent: () =>
               import('./pages/settings/storage.component').then(m => m.StorageComponent),
           },
           {
             path: 'networks',
+            title: 'nav.networks',
             loadComponent: () =>
               import('./pages/settings/networks.component').then(m => m.NetworksComponent),
           },
           {
             path: 'audit-log',
+            title: 'nav.logs',
             loadComponent: () =>
               import('./pages/settings/audit-log.component').then(m => m.AuditLogComponent),
           },
           {
             path: 'data',
+            title: 'nav.data',
             loadComponent: () =>
               import('./pages/settings/data.component').then(m => m.DataComponent),
           },
           {
             path: 'about',
+            title: 'nav.about',
             loadComponent: () =>
               import('./pages/settings/about.component').then(m => m.AboutComponent),
           },
           {
             path: 'models',
+            title: 'titles.models',
             loadComponent: () =>
               import('./pages/settings/models.component').then(m => m.ModelsComponent),
           },
           {
             path: 'duplicates',
+            title: 'nav.duplicates',
             loadComponent: () =>
               import('./pages/settings/duplicates.component').then(m => m.DuplicatesComponent),
           },

--- a/client/src/app/core/title-strategy.ts
+++ b/client/src/app/core/title-strategy.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { TranslocoService } from '@jsverse/transloco';
+import { Subscription } from 'rxjs';
+
+/**
+ * Sets the browser tab title from each route's `title` (treated as a Transloco
+ * key), formatted as `<Page> · Ythril`. Uses `selectTranslate` so the title is
+ * correct even before the active language file has finished loading, and
+ * re-emits when the language changes. Routes without a `title` fall back to the
+ * bare app name.
+ */
+@Injectable({ providedIn: 'root' })
+export class TranslocoTitleStrategy extends TitleStrategy {
+  private readonly title = inject(Title);
+  private readonly transloco = inject(TranslocoService);
+  private sub?: Subscription;
+
+  override updateTitle(snapshot: RouterStateSnapshot): void {
+    this.sub?.unsubscribe();
+    const key = this.buildTitle(snapshot);
+    if (!key) {
+      this.title.setTitle('Ythril');
+      return;
+    }
+    this.sub = this.transloco.selectTranslate(key).subscribe(page => {
+      this.title.setTitle(`${page} · Ythril`);
+    });
+  }
+}

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -547,7 +547,7 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
             <div class="sch-sub">{{ 'spaces.schema.tagSuggestions' | transloco }} <span style="font-size:10px;font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);">{{ 'spaces.schema.tagSuggestionsHint' | transloco }}</span></div>
             <div class="chip-wrap" (click)="tagChipInput?.focus()">
               @for (tag of form.schemaState.tagSuggestions; track tag) {
-                <span class="chip">{{ tag }} <button class="chip-rm" type="button" (mousedown)="removeTag(tag)">×</button></span>
+                <span class="chip">{{ tag }} <button class="chip-rm" type="button" (mousedown)="removeTag(tag)"><ph-icon name="x" [size]="12"/></button></span>
               }
               <input #tagChipInput class="chip-field" [(ngModel)]="form.schemaState._newTagInput"
                      [placeholder]="form.schemaState.tagSuggestions.length ? '' : ('spaces.schema.addTagPlaceholder' | transloco)"

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -4,10 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { ApiService, InviteBundle, Network, Space, SyncHistoryRecord, VoteRound } from '../../core/api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
 @Component({
   selector: 'app-networks',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent],
   styles: [`
     .network-card {
       background: var(--bg-surface);
@@ -295,7 +296,7 @@ import { TranslocoService } from '@jsverse/transloco';
                     (click)="removeMember(net, m.instanceId, m.label)"
                     [attr.title]="'networks.network.members.removeTitle' | transloco"
                     [attr.aria-label]="'networks.network.members.removeAriaLabel' | transloco"
-                  >×</button>
+                  ><ph-icon name="x" [size]="14"/></button>
                 </div>
               }
 
@@ -329,7 +330,7 @@ import { TranslocoService } from '@jsverse/transloco';
         <div class="dialog" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <div class="card-title">{{ 'networks.dialog.create.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
           </div>
 
           @if (createError()) { <div class="alert alert-error">{{ createError() }}</div> }
@@ -407,7 +408,7 @@ import { TranslocoService } from '@jsverse/transloco';
         <div class="dialog" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <div class="card-title">{{ 'networks.dialog.join.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showJoinDialog.set(false)">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showJoinDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
           </div>
 
           @if (joinError()) { <div class="alert alert-error">{{ joinError() }}</div> }
@@ -481,7 +482,7 @@ import { TranslocoService } from '@jsverse/transloco';
         <div class="dialog" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <div class="card-title">{{ 'networks.wizard.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showEnableNetworksWizard.set(false)">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showEnableNetworksWizard.set(false)"><ph-icon name="x" [size]="14"/></button>
           </div>
 
           @if (enableWizardError()) { <div class="alert alert-error">{{ enableWizardError() }}</div> }

--- a/client/src/app/pages/settings/schema-library.component.ts
+++ b/client/src/app/pages/settings/schema-library.component.ts
@@ -244,7 +244,7 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
             <div class="card-title">
               {{ editingEntry() ? ('schemaLib.dialog.editTitle' | transloco) : ('schemaLib.dialog.createTitle' | transloco) }}
             </div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="closeDialog()">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="closeDialog()"><ph-icon name="x" [size]="14"/></button>
           </div>
 
           @if (dialogError()) {
@@ -310,7 +310,7 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
         <div class="dialog" style="max-width:400px;" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <div class="card-title">{{ 'schemaLib.delete.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="deletingEntry.set(null)">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="deletingEntry.set(null)"><ph-icon name="x" [size]="14"/></button>
           </div>
           <p style="font-size:13px; color:var(--text-secondary); margin:0 0 16px;">
             {{ 'schemaLib.delete.confirm' | transloco }} <strong>{{ deletingEntry()?.name }}</strong>?

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -123,7 +123,7 @@ interface TypeSchemaState {
         <div class="dialog" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <div class="card-title">{{ 'spaces.create.title' | transloco }}</div>
-            <button class="icon-btn" (click)="showCreateDialog.set(false)">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
           </div>
           @if (createError()) { <div class="alert alert-error">{{ createError() }}</div> }
           <form (ngSubmit)="createSpace()" style="display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap;">
@@ -202,7 +202,7 @@ interface TypeSchemaState {
               <div style="font-weight:600;font-size:16px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ settingsSpace()!.label }}</div>
               <div style="font-size:12px;color:var(--text-muted);font-family:var(--font-mono);">{{ settingsSpace()!.id }}</div>
             </div>
-            <button class="icon-btn" (click)="closeSettings()">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="closeSettings()"><ph-icon name="x" [size]="14"/></button>
           </div>
           <div class="sp-tabs">
             <button class="sp-tab" [class.active]="settingsTab()==='settings'" (click)="settingsTab.set('settings')">{{ 'spaces.popup.tab.settings' | transloco }}</button>
@@ -304,7 +304,7 @@ interface TypeSchemaState {
                   <div class="sch-sub" style="margin-top:28px;">{{ 'spaces.schema.globalTagSuggestions' | transloco }} <span style="font-size:10px;font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);">{{ 'spaces.schema.globalTagSuggestionsHint' | transloco }}</span></div>
                   <div class="chip-wrap">
                     @for (t of schTagSuggestions; track t) {
-                      <span class="chip">{{ t }}<button type="button" class="chip-rm" (click)="schTagSuggestions=schTagSuggestions.filter(x=>x!==t)">×</button></span>
+                      <span class="chip">{{ t }}<button type="button" class="chip-rm" (click)="schTagSuggestions=schTagSuggestions.filter(x=>x!==t)"><ph-icon name="x" [size]="12"/></button></span>
                     }
                     <input type="text" class="chip-field" [(ngModel)]="schNewTagInput"
                       [placeholder]="schTagSuggestions.length ? '' : ('spaces.schema.addTagSuggestionPlaceholder' | transloco)"
@@ -355,7 +355,7 @@ interface TypeSchemaState {
                               }
                               <button class="btn btn-ghost btn-sm" type="button" (click)="toggleTypeExpand(kt,name)"
                                 style="font-size:10px;padding:2px 8px;min-width:28px;">{{ isTypeExpanded(kt,name) ? '▲' : '▼' }}</button>
-                              <button class="icon-btn danger" type="button" (click)="removeType(kt,name)" [attr.title]="'common.remove' | transloco">✕</button>
+                              <button class="icon-btn danger" type="button" (click)="removeType(kt,name)" [attr.title]="'common.remove' | transloco"><ph-icon name="x" [size]="14"/></button>
                             </div>
                           </td>
                         </tr>
@@ -385,7 +385,7 @@ interface TypeSchemaState {
                                     <label>{{ 'spaces.schema.tagSuggestions' | transloco }} <span style="font-size:10px;font-weight:400;color:var(--text-muted);">{{ 'spaces.schema.tagSuggestionsHint' | transloco }}</span></label>
                                     <div class="chip-wrap">
                                       @for (tag of typeState(kt,name).tagSuggestions; track tag) {
-                                        <span class="chip">{{ tag }}<button type="button" class="chip-rm" (click)="typeState(kt,name).tagSuggestions=typeState(kt,name).tagSuggestions.filter(x=>x!==tag)">×</button></span>
+                                        <span class="chip">{{ tag }}<button type="button" class="chip-rm" (click)="typeState(kt,name).tagSuggestions=typeState(kt,name).tagSuggestions.filter(x=>x!==tag)"><ph-icon name="x" [size]="12"/></button></span>
                                       }
                                       <input type="text" class="chip-field" [(ngModel)]="typeState(kt,name)._newTagInput"
                                         [placeholder]="typeState(kt,name).tagSuggestions.length ? '' : ('spaces.schema.addTagPlaceholder' | transloco)"
@@ -429,7 +429,7 @@ interface TypeSchemaState {
                                           </td>
                                           <td (click)="$event.stopPropagation()">
                                             <div style="display:flex;gap:4px;justify-content:flex-end;">
-                                              <button class="icon-btn danger" type="button" (click)="removeProp(kt,name,p.key)" [attr.title]="'common.remove' | transloco">✕</button>
+                                              <button class="icon-btn danger" type="button" (click)="removeProp(kt,name,p.key)" [attr.title]="'common.remove' | transloco"><ph-icon name="x" [size]="14"/></button>
                                             </div>
                                           </td>
                                         </tr>
@@ -485,7 +485,7 @@ interface TypeSchemaState {
                                                       <label>{{ 'spaces.schema.propDetail.enumValues' | transloco }} <span style="font-size:11px;font-weight:normal;color:var(--text-muted);">{{ 'spaces.schema.propDetail.enumHint' | transloco }}</span></label>
                                                       <div class="chip-wrap">
                                                         @for (ev of (p.s.enum??[]); track ev) {
-                                                          <span class="chip">{{ ev }}<button type="button" class="chip-rm" (click)="removeEnumVal(kt,name,p.key,ev)">×</button></span>
+                                                          <span class="chip">{{ ev }}<button type="button" class="chip-rm" (click)="removeEnumVal(kt,name,p.key,ev)"><ph-icon name="x" [size]="12"/></button></span>
                                                         }
                                                         <input type="text" class="chip-field" [(ngModel)]="p._enumInput"
                                                           [placeholder]="'spaces.schema.propDetail.enumPlaceholder' | transloco" (keydown)="onEnumKey($event,kt,name,p.key)" />
@@ -730,7 +730,7 @@ interface TypeSchemaState {
         <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:560px;max-width:96vw;max-height:80vh;overflow-y:auto;" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;">
             <strong>{{ 'spaces.schema.libPicker.title' | transloco }}</strong>
-            <button class="icon-btn" type="button" (click)="closeLibPicker()">✕</button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="closeLibPicker()"><ph-icon name="x" [size]="14"/></button>
           </div>
           @if (libPickerLoading()) {
             <div class="empty-state"><span class="spinner"></span></div>

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -4,11 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { ApiService, Space, TokenRecord } from '../../core/api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
 
 @Component({
   selector: 'app-tokens',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent],
   styles: [`
     .new-token-banner {
       background: var(--success-dim);
@@ -273,7 +274,7 @@ import { TranslocoService } from '@jsverse/transloco';
         <div class="dialog" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <div class="card-title">{{ 'tokens.create.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)">✕</button>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
           </div>
 
           @if (createError()) {
@@ -422,7 +423,7 @@ import { TranslocoService } from '@jsverse/transloco';
                   </td>
                   <td style="white-space:nowrap; display:flex; gap:6px; align-items:center;">
                     <button class="icon-btn" [attr.title]="'tokens.action.rotateTitle' | transloco" [attr.aria-label]="'tokens.action.rotateAriaLabel' | transloco" (click)="regenerate(t)" style="font-size:14px;">↺</button>
-                    <button class="icon-btn danger" [attr.title]="'tokens.action.revokeTitle' | transloco" [attr.aria-label]="'tokens.action.revokeAriaLabel' | transloco" (click)="revoke(t)">✕</button>
+                    <button class="icon-btn danger" [attr.title]="'tokens.action.revokeTitle' | transloco" [attr.aria-label]="'tokens.action.revokeAriaLabel' | transloco" (click)="revoke(t)"><ph-icon name="x" [size]="14"/></button>
                   </td>
                 </tr>
               } @empty {

--- a/client/src/app/shared/prop-schema-table.component.ts
+++ b/client/src/app/shared/prop-schema-table.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { PropertySchema } from '../core/api.service';
+import { PhIconComponent } from './ph-icon.component';
 
 export interface PropSchemaRow {
   key: string;
@@ -12,7 +13,7 @@ export interface PropSchemaRow {
 @Component({
   selector: 'app-prop-schema-table',
   standalone: true,
-  imports: [FormsModule, TranslocoPipe],
+  imports: [FormsModule, TranslocoPipe, PhIconComponent],
   styles: [`
     .prop-table { width:100%; border-collapse:collapse; font-size:13px; }
     .prop-table th { text-align:left; font-size:11px; font-weight:600; color:var(--text-muted); padding:5px 8px; border-bottom:1px solid var(--border); }
@@ -66,7 +67,7 @@ export interface PropSchemaRow {
               </td>
               <td>
                 <div style="display:flex;gap:4px;justify-content:flex-end;">
-                  <button class="icon-btn danger" type="button" (click)="removeRow(p.key); $event.stopPropagation()" [attr.title]="'common.remove' | transloco">✕</button>
+                  <button class="icon-btn danger" type="button" (click)="removeRow(p.key); $event.stopPropagation()" [attr.title]="'common.remove' | transloco"><ph-icon name="x" [size]="14"/></button>
                 </div>
               </td>
             </tr>
@@ -122,7 +123,7 @@ export interface PropSchemaRow {
                           <label>{{ 'spaces.schema.propDetail.enumValues' | transloco }} <span style="font-size:11px;font-weight:normal;color:var(--text-muted);">{{ 'spaces.schema.propDetail.enumHint' | transloco }}</span></label>
                           <div class="chip-wrap">
                             @for (ev of (p.s.enum ?? []); track ev) {
-                              <span class="chip">{{ ev }}<button type="button" class="chip-rm" (click)="removeEnumVal(p, ev)">×</button></span>
+                              <span class="chip">{{ ev }}<button type="button" class="chip-rm" (click)="removeEnumVal(p, ev)"><ph-icon name="x" [size]="12"/></button></span>
                             }
                             <input type="text" class="chip-field" [(ngModel)]="p._enumInput"
                               [placeholder]="'spaces.schema.propDetail.enumPlaceholder' | transloco"

--- a/client/src/app/shared/properties-editor.component.ts
+++ b/client/src/app/shared/properties-editor.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PropertySchema } from '../core/api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from './ph-icon.component';
 
 interface PropRow {
   key: string;
@@ -12,7 +13,7 @@ interface PropRow {
 @Component({
   selector: 'app-properties-editor',
   standalone: true,
-  imports: [FormsModule, TranslocoPipe],
+  imports: [FormsModule, TranslocoPipe, PhIconComponent],
   template: `
     <div class="prop-editor">
       @for (row of rows; track $index; let i = $index) {
@@ -43,7 +44,7 @@ interface PropRow {
               [placeholder]="'propertiesEditor.valuePlaceholder' | transloco" [name]="'propVal' + i" (ngModelChange)="emit()" />
           }
           @if (row.removable) {
-            <button type="button" class="prop-remove" [attr.title]="'propertiesEditor.removeTitle' | transloco" (click)="removeRow(i)">×</button>
+            <button type="button" class="prop-remove" [attr.title]="'propertiesEditor.removeTitle' | transloco" (click)="removeRow(i)"><ph-icon name="x" [size]="14"/></button>
           } @else {
             <span class="prop-req">{{ 'propertiesEditor.requiredBadge' | transloco }}</span>
           }

--- a/client/src/app/shared/tag-input.component.ts
+++ b/client/src/app/shared/tag-input.component.ts
@@ -1,17 +1,18 @@
 import { Component, Input, Output, EventEmitter, signal, computed, ElementRef, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from './ph-icon.component';
 
 @Component({
   selector: 'app-tag-input',
   standalone: true,
-  imports: [FormsModule, TranslocoPipe],
+  imports: [FormsModule, TranslocoPipe, PhIconComponent],
   template: `
     <div class="tag-input-wrap" (click)="focusInput()">
       @for (tag of value; track tag) {
         <span class="tag-pill">
           {{ tag }}
-          <button type="button" class="tag-remove" (click)="remove(tag); $event.stopPropagation()" [attr.aria-label]="'tagInput.removeAriaLabel' | transloco">×</button>
+          <button type="button" class="tag-remove" (click)="remove(tag); $event.stopPropagation()" [attr.aria-label]="'tagInput.removeAriaLabel' | transloco"><ph-icon name="x" [size]="12"/></button>
         </span>
       }
       <div class="tag-input-inner" style="position:relative; flex:1; min-width:80px;">

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -13,11 +13,13 @@
 
   --accent:       #ceff80;
   --accent-hover: #a0ff80;
-  --accent-dim:   rgba(124, 106, 247, 0.15);
+  /* Derived from --accent so the dim variants can never drift off-brand again.
+     (Previously hardcoded to leftover purple/cyan from an earlier palette.) */
+  --accent-dim:   color-mix(in srgb, var(--accent) 15%, transparent);
   --accent-text:  #0d1117;
 
   --nav-active:     #a0ff80;
-  --nav-active-dim: rgba(0, 229, 255, 0.08);
+  --nav-active-dim: color-mix(in srgb, var(--accent) 8%, transparent);
 
   --success:      #3fb950;
   --warning:      #d29922;
@@ -683,3 +685,17 @@ hr, .divider {
 }
 .icon-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
 .icon-btn.danger:hover { color: var(--error); background: var(--error-dim); }
+
+/* ── Reduced motion ──────────────────────────────────────────────────────────
+   Honour the OS "reduce motion" setting: collapse animations and transitions
+   for users with vestibular sensitivity. Kept last so it overrides everything. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

A low-risk UX/accessibility polish pass bundling five items from `UX-TODO.md` (**U6, U8, U9, U10, U11**). Client-only; the Angular build passes.

| Item | Change |
|---|---|
| **U6** | `<html lang>` now tracks the active UI language — set on startup and on every switch (was hardcoded `en`). Fixes screen-reader pronunciation & browser hyphenation for German/Polish users. |
| **U8** | `--accent-dim` and `--nav-active-dim` are now derived from `--accent` via `color-mix()` (were leftover purple/cyan). The active-nav highlight and accent chips are back on-brand and can't drift again. |
| **U9** | Global `prefers-reduced-motion` rule collapses animations/transitions for vestibular-sensitive users. |
| **U10** | Per-route localized `<Page> · Ythril` browser titles via a Transloco-aware `TitleStrategy`. Tabs/history/bookmarks are now distinguishable. |
| **U11** | **Every** raw `✕`/`×` glyph — dialog close buttons, chip/tag remove buttons, and danger remove actions — replaced with `<ph-icon name="x">` across pages and shared components, with `aria-label`s added where missing. |

## Notes
- **U10 titles reuse existing `nav.*` keys** where a page already has a sidebar label, so terminology stays consistent with the nav. Only two new i18n keys were added — `titles.models`, `titles.setup` — across `en`/`de`/`pl`. The `TitleStrategy` uses `selectTranslate`, so the title is correct even before the active language file has loaded and re-emits on language change.
- **U11 is a complete sweep**: `networks`, `spaces`, `schema-library`, `tokens`, plus the shared `prop-schema-table`, `properties-editor`, and `tag-input` components. Icons inherit `currentColor`, so the existing hover/danger color styles still apply; sizes are 14px for icon-buttons and 12px for chips to match the glyphs they replace. Zero raw `✕`/`×` glyphs remain in the client. (Also spotted a hardcoded `"Models"` string in the shell nav — a separate U7 i18n item — and left it untouched.)

## Testing
`ng build` completes cleanly (the one `NG8102` warning is pre-existing, in a file/line this PR doesn't touch). These are presentational/behavioral UI changes with no automated client tests in the repo; verified via the successful build and by tracing the logic. Worth an eyeball on: the sidebar active-nav highlight color (U8), the tab title on a couple of routes (U10), and the remove/close buttons rendering at the right size (U11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
