### PR TITLE
ux: revert U8 (accent palette) and U9 (reduced-motion) per owner feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,9 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pronunciation and browser hyphenation stayed English for German and Polish users even though the UI
   was fully translated. The document language is now set on startup and updated on every language
   switch.
-- **Accent "dim" colors are back on-brand.** The active-nav highlight and dimmed accent chips were
-  driven by leftover purple/cyan tokens from an earlier palette. Both are now derived from `--accent`
-  via `color-mix()`, so they can't drift off-brand again.
 - **Close/remove buttons use a consistent icon everywhere.** Close and remove controls across the app
   rendered a mix of raw `✕` and `×` glyphs at different weights/baselines than the `ph-icon` used
   elsewhere. Every one — dialog close buttons, chip/tag remove buttons, and danger remove actions in
@@ -97,8 +94,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the migration. Covered by `testing/integration/auth.test.js`.
 ### Added
 
-- **`prefers-reduced-motion` support** — a global stylesheet rule collapses animations and transitions
-  when the OS "reduce motion" setting is on, for users with vestibular sensitivity.
 - **Per-route browser tab titles** — every page now sets a localized `<Page> · Ythril` title via a
   Transloco-aware `TitleStrategy`, so tabs, history entries, and bookmarks are distinguishable instead
   of all reading "Ythril".

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -13,13 +13,11 @@
 
   --accent:       #ceff80;
   --accent-hover: #a0ff80;
-  /* Derived from --accent so the dim variants can never drift off-brand again.
-     (Previously hardcoded to leftover purple/cyan from an earlier palette.) */
-  --accent-dim:   color-mix(in srgb, var(--accent) 15%, transparent);
+  --accent-dim:   rgba(124, 106, 247, 0.15);
   --accent-text:  #0d1117;
 
   --nav-active:     #a0ff80;
-  --nav-active-dim: color-mix(in srgb, var(--accent) 8%, transparent);
+  --nav-active-dim: rgba(0, 229, 255, 0.08);
 
   --success:      #3fb950;
   --warning:      #d29922;
@@ -685,17 +683,3 @@ hr, .divider {
 }
 .icon-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
 .icon-btn.danger:hover { color: var(--error); background: var(--error-dim); }
-
-/* ── Reduced motion ──────────────────────────────────────────────────────────
-   Honour the OS "reduce motion" setting: collapse animations and transitions
-   for users with vestibular sensitivity. Kept last so it overrides everything. */
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}


### PR DESCRIPTION
## Summary

Follow-up to #145. After reviewing the UX polish on a live instance, the owner flagged two of the five items as regressions in taste/behavior. This reverts those two; the other three (`U6` html-lang, `U10` page titles, `U11` consistent close/remove icon) are confirmed good and stay.

- **U8 — accent-dim palette reverted.** #145 re-pointed `--accent-dim` and `--nav-active-dim` at the lime `--accent` via `color-mix()`. The owner prefers the original purple/cyan dims — this also drives the **Brain active-space chip background** (`.space-chip.active`). Restored the original hardcoded token values. Purely aesthetic; not a bug.
- **U9 — `prefers-reduced-motion` rule removed.** The blanket `* { animation-duration: 0.01ms !important }` rule froze the **loading spinner mid-frame**, which looks worse than a smooth fast spin. Removed for now. A spinner-aware version (exempting `.spinner` so it keeps rotating while page transitions are reduced) could restore the accessibility benefit later without the wart.

## Scope
Only `client/src/styles.scss` (two token values restored, one media block removed) and the matching CHANGELOG entries. No behavior change to U6/U10/U11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
