### PR TITLE
fix(compose): whisper healthcheck uses python3, not python

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,9 +103,10 @@
     volumes:
       - ythril-whisper-cache:/root/.cache
     healthcheck:
-      # faster-whisper-server is python-based; use the bundled python rather
-      # than relying on curl/wget being present in the slim base image.
-      test: ["CMD", "python", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/health',timeout=3).read() or sys.exit(1)"]
+      # faster-whisper-server is python-based; use the bundled interpreter rather
+      # than relying on curl/wget being present in the slim base image. The image
+      # exposes `python3` (not a bare `python`), so probe with that.
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/health',timeout=3).read() or sys.exit(1)"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

The Whisper (`faster-whisper-server:latest-cpu`) sidecar was marked **unhealthy** by Docker even though the server ran fine. Its healthcheck invoked `python`, but the current image ships **`python3`** on PATH with no bare `python` alias, so the probe command errored on every run.

```diff
-      test: ["CMD", "python",  "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/health',timeout=3).read() or sys.exit(1)"]
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/health',timeout=3).read() or sys.exit(1)"]
```

The probe logic (a `urllib` GET of `/health`) was already correct — only the interpreter name was wrong. This affects **anyone** running the default media stack on this image, not just a local setup.

## Verification
- `docker exec ythril-whisper sh -c 'command -v python3'` → `/usr/bin/python3` (and `python` is absent).
- `docker exec ythril-whisper python3 -c "...urlopen('http://localhost:8000/health')"` → exit `0`.
- After editing and `docker compose up -d whisper`, the container reached **healthy** within ~10s (was perpetually unhealthy before).

Compose-only change; no image or app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
