### PR TITLE
ux: spinner-aware prefers-reduced-motion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the migration. Covered by `testing/integration/auth.test.js`.
 ### Added
 
+- **`prefers-reduced-motion` support (spinner-aware)** — when the OS "reduce motion" setting is on, a
+  global rule collapses decorative animations and transitions for users with vestibular sensitivity.
+  The loading spinner is deliberately exempted so it keeps rotating — it is informative motion, and
+  freezing it mid-spin reads as broken rather than calmer.
 - **Per-route browser tab titles** — every page now sets a localized `<Page> · Ythril` title via a
   Transloco-aware `TitleStrategy`, so tabs, history entries, and bookmarks are distinguishable instead
   of all reading "Ythril".

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -683,3 +683,20 @@ hr, .divider {
 }
 .icon-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
 .icon-btn.danger:hover { color: var(--error); background: var(--error-dim); }
+
+/* ── Reduced motion ──────────────────────────────────────────────────────────
+   Honour the OS "reduce motion" setting: collapse decorative animations and
+   transitions for users with vestibular sensitivity. The loading spinner is
+   deliberately exempted — it is *informative* motion (it signals "working"),
+   and freezing it mid-rotation reads as broken rather than calmer. Kept last so
+   it overrides earlier rules. */
+@media (prefers-reduced-motion: reduce) {
+  *:not(.spinner),
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

Re-introduces `prefers-reduced-motion` support, fixing the wart that got the first attempt (#145) reverted (#146): the blanket `* { animation-duration: 0.01ms }` rule froze the loading spinner mid-rotation, which looked broken.

This version scopes the override with `*:not(.spinner)`, so:
- **Decorative** animations and transitions still collapse under `prefers-reduced-motion: reduce` (the accessibility win).
- **The loading spinner keeps rotating** — it's informative motion ("working…"), and a frozen spinner reads as broken, not calmer.

```scss
@media (prefers-reduced-motion: reduce) {
  *:not(.spinner), *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

The spinner (`.spinner`) rotates via `animation: spin` on the element itself (no pseudo-elements), so a single class exemption is sufficient and complete.

## Testing
`ng build` passes. To verify: DevTools → Rendering → **Emulate CSS `prefers-reduced-motion: reduce`** — page transitions become instant, but a loading spinner still spins smoothly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
