### PR TITLE
arch: remove legacy /:spaceId brain memory routes, canonicalize on /spaces/:spaceId (A1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING: the legacy `/api/brain/:spaceId/memories` route shape is removed.** Space memory
+  endpoints used to be registered under two URL shapes — canonical `/api/brain/spaces/:spaceId/…` and
+  legacy `/api/brain/:spaceId/…` — with the handler bodies **copy-pasted** between them (and the
+  canonical shape was even missing `POST` create and `GET` by-id). Each endpoint is now registered
+  **once**, under the canonical `/spaces/:spaceId/…` path; the two-segment legacy shape now returns
+  `404`. This halves the memory-route surface that has to be auth-checked and tested and removes the
+  footgun where a guard added to one shape could be missed on the other. **Migration:** replace
+  `/api/brain/:spaceId/memories…` with `/api/brain/spaces/:spaceId/memories…`. The web client already
+  uses the canonical paths. (All other brain resources — entities, edges, chrono, stats — were already
+  canonical-only and are unaffected.)
+
 ### Security
 
 - **Kubernetes deployment is hardened and its probes/ports now actually work.** The stock

--- a/client/src/app/core/api.service.ts
+++ b/client/src/app/core/api.service.ts
@@ -683,7 +683,7 @@ export class ApiService {
   }
 
   createMemory(spaceId: string, body: { fact: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean> }): Observable<Memory> {
-    return this.http.post<Memory>(`/api/brain/${spaceId}/memories`, body);
+    return this.http.post<Memory>(`/api/brain/spaces/${spaceId}/memories`, body);
   }
 
   updateMemory(spaceId: string, id: string, body: Partial<{ fact: string; tags: string[]; entityIds: string[]; description: string; properties: Record<string, string | number | boolean>; deleteFields: string[] }>): Observable<Memory> {
@@ -757,7 +757,7 @@ export class ApiService {
   }
 
   getMemory(spaceId: string, id: string): Observable<Memory> {
-    return this.http.get<Memory>(`/api/brain/${spaceId}/memories/${id}`);
+    return this.http.get<Memory>(`/api/brain/spaces/${spaceId}/memories/${id}`);
   }
 
   getChrono(spaceId: string, id: string): Observable<ChronoEntry> {

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -523,7 +523,7 @@ Extended errors may include:
 | Global | 300 / min | All authenticated endpoints |
 | Sync | 2 000 / min | Sync API endpoints |
 | Notify | 60 / min | `POST /api/notify` |
-| Bulk wipe | 5 / min | `DELETE /api/brain/:spaceId/memories` |
+| Bulk wipe | 5 / min | `DELETE /api/brain/spaces/:spaceId/memories` |
 
 Rate limit headers are included in responses:
 
@@ -544,21 +544,20 @@ Base path: `/api/brain`
 
 > **Proxy spaces:** Read operations aggregate across all member spaces. Write operations require `?targetSpace=<member>` in the query string.
 
-### Route prefix variants
+### Route prefix
 
-Memory endpoints are available under two equivalent prefix forms:
+Every memory endpoint lives under the `/spaces/:spaceId/` prefix — the same prefix used by all other brain resource types (entities, edges, chrono, stats). For example:
 
-| Prefix | Example | Notes |
-|--------|---------|-------|
-| `/:spaceId/` | `GET /api/brain/general/memories` | Original form; supported for all memory operations |
-| `/spaces/:spaceId/` | `GET /api/brain/spaces/general/memories` | Preferred for new integrations; matches the prefix used by all other brain resource types (entities, edges, chrono, stats) |
+```
+GET /api/brain/spaces/general/memories
+```
 
-Both forms are fully supported and behave identically. The official web client uses `/spaces/:spaceId/` for list, delete, and bulk-wipe, and `/:spaceId/` for write.
+> **Breaking change (2.0):** the old two-segment shape `/api/brain/:spaceId/memories` (e.g. `/api/brain/general/memories`) has been **removed**. It previously duplicated these handlers under a second URL; it now returns `404`. Update any client still using it to the `/spaces/:spaceId/` prefix.
 
 ### Write a Memory
 
 ```
-POST /api/brain/:spaceId/memories
+POST /api/brain/spaces/:spaceId/memories
 ```
 
 ```json
@@ -598,7 +597,7 @@ POST /api/brain/:spaceId/memories
 ### Get a Memory by ID
 
 ```
-GET /api/brain/:spaceId/memories/:id
+GET /api/brain/spaces/:spaceId/memories/:id
 ```
 
 **Response** `200`: Full `MemoryDoc` (same shape as write response).
@@ -608,7 +607,7 @@ GET /api/brain/:spaceId/memories/:id
 ### List Memories
 
 ```
-GET /api/brain/:spaceId/memories?limit=100&skip=0
+GET /api/brain/spaces/:spaceId/memories?limit=100&skip=0
 ```
 
 Optional filters:
@@ -639,7 +638,7 @@ Default limit: 100, max: 500. Use `skip` for offset pagination.
 ### Delete a Memory
 
 ```
-DELETE /api/brain/:spaceId/memories/:id
+DELETE /api/brain/spaces/:spaceId/memories/:id
 ```
 
 **Response** `204` (no body).
@@ -649,7 +648,7 @@ DELETE /api/brain/:spaceId/memories/:id
 ### Wipe All Memories
 
 ```
-DELETE /api/brain/:spaceId/memories
+DELETE /api/brain/spaces/:spaceId/memories
 Content-Type: application/json
 
 { "confirm": true }
@@ -1467,7 +1466,7 @@ All `PATCH` update endpoints — entities, edges, and memories — accept an opt
 ```
 PATCH /api/brain/spaces/:spaceId/entities/:id
 PATCH /api/brain/spaces/:spaceId/edges/:id
-PATCH /api/brain/:spaceId/memories/:id
+PATCH /api/brain/spaces/:spaceId/memories/:id
 PATCH /api/brain/spaces/:spaceId/memories/:id
 ```
 
@@ -5674,7 +5673,7 @@ Configured in `config.json` under `storage`:
 All list endpoints accept `limit` and `skip`:
 
 ```
-GET /api/brain/general/memories?limit=100&skip=200
+GET /api/brain/spaces/general/memories?limit=100&skip=200
 ```
 
 ### Cursor Pagination (Sync API)

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -52,8 +52,6 @@ function getSpaceMeta(spaceId: string): SpaceMeta | undefined {
   return resolveMetaRefs(meta);
 }
 
-
-
 /**
  * Apply schema validation to a write operation.
  * Returns { blocked: true, violations } when strict mode rejects the write.
@@ -77,8 +75,8 @@ function applyValidation(
 // ── Short-form memory CRUD  (/:spaceId/memories) ──────────────────────────
 // These are the primary REST endpoints used by API clients and integration tests.
 
-// POST /api/brain/:spaceId/memories — create a memory
-brainRouter.post('/:spaceId/memories', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
+// POST /api/brain/spaces/:spaceId/memories — create a memory
+brainRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
   if (!cfg.spaces.some(s => s.id === spaceId)) {
@@ -207,24 +205,8 @@ function buildMemoryFilter(query: Record<string, unknown>): Record<string, unkno
   return filter;
 }
 
-// GET /api/brain/:spaceId/memories — list memories
-brainRouter.get('/:spaceId/memories', globalRateLimit, requireSpaceAuth, async (req, res) => {
-  const spaceId = req.params['spaceId'] as string;
-  const cfg = getConfig();
-  if (!cfg.spaces.some(s => s.id === spaceId)) {
-    res.status(404).json({ error: `Space '${spaceId}' not found` });
-    return;
-  }
-  const limit = parseLimit(req.query['limit'], 100, 500);
-  const skip = parseSkip(req.query['skip']);
-  const filter = buildMemoryFilter(req.query as Record<string, unknown>);
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid => listMemories(mid, filter, limit, skip)))).flat();
-  res.json({ memories: capPage(all, limit), limit, skip });
-});
-
-// GET /api/brain/:spaceId/memories/:id — get single memory
-brainRouter.get('/:spaceId/memories/:id', globalRateLimit, requireSpaceAuth, async (req, res) => {
+// GET /api/brain/spaces/:spaceId/memories/:id — get single memory
+brainRouter.get('/spaces/:spaceId/memories/:id', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
   const cfg = getConfig();
@@ -238,112 +220,6 @@ brainRouter.get('/:spaceId/memories/:id', globalRateLimit, requireSpaceAuth, asy
     if (doc) { res.json(doc); return; }
   }
   res.status(404).json({ error: 'Memory not found' });
-});
-
-// DELETE /api/brain/:spaceId/memories/:id — delete memory
-brainRouter.delete('/:spaceId/memories/:id', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
-  const spaceId = req.params['spaceId'] as string;
-  const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    if (await deleteMemory(mid, id)) {
-      emitWebhookEvent({ event: 'memory.deleted', spaceId: mid, entry: { _id: id }, ...webhookToken(req) });
-      res.status(204).end();
-      return;
-    }
-  }
-  res.status(404).json({ error: 'Memory not found' });
-});
-
-// PATCH /api/brain/:spaceId/memories/:id — partial update a memory
-brainRouter.patch('/:spaceId/memories/:id', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
-  const spaceId = req.params['spaceId'] as string;
-  const id = req.params['id'] as string;
-  const cfg = getConfig();
-  if (!cfg.spaces.some(s => s.id === spaceId)) {
-    res.status(404).json({ error: `Space '${spaceId}' not found` });
-    return;
-  }
-  const wt = resolveWriteTarget(spaceId, req.query['targetSpace'] as string | undefined);
-  if (!wt.ok) { res.status(400).json({ error: wt.error }); return; }
-  const { fact, tags, entityIds, description, properties, deleteFields } = req.body ?? {};
-  // Validate deleteFields
-  const dfResult = validateDeleteFields(deleteFields);
-  if (!dfResult.ok) { res.status(400).json({ error: dfResult.error }); return; }
-  const dfPaths: string[] | undefined = Array.isArray(deleteFields) && deleteFields.length > 0 ? deleteFields : undefined;
-  const updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean> } = {};
-  if (fact !== undefined) {
-    if (typeof fact !== 'string' || !fact.trim()) { res.status(400).json({ error: '`fact` must be a non-empty string' }); return; }
-    updates.fact = fact;
-  }
-  if (tags !== undefined) {
-    if (!Array.isArray(tags) || tags.some((t: unknown) => typeof t !== 'string')) { res.status(400).json({ error: '`tags` must be an array of strings' }); return; }
-    updates.tags = tags;
-  }
-  if (entityIds !== undefined) {
-    if (!Array.isArray(entityIds) || entityIds.some((t: unknown) => typeof t !== 'string')) { res.status(400).json({ error: '`entityIds` must be an array of strings' }); return; }
-    if (isStrictLinkage(wt.target)) {
-      const invalidIds = entityIds.filter((id: string) => !UUID_V4_RE.test(id));
-      if (invalidIds.length > 0) { res.status(400).json({ error: '`entityIds` must contain valid UUID v4 values (entity IDs), not names', invalid: invalidIds }); return; }
-    }
-    updates.entityIds = entityIds;
-  }
-  if (description !== undefined) {
-    if (typeof description !== 'string') { res.status(400).json({ error: '`description` must be a string' }); return; }
-    updates.description = description;
-  }
-  if (properties !== undefined) {
-    if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) { res.status(400).json({ error: '`properties` must be a plain object' }); return; }
-    updates.properties = properties as Record<string, string | number | boolean>;
-  }
-  if (Object.keys(updates).length === 0 && !dfPaths) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
-  const memberIds = resolveMemberSpaces(wt.target);
-  for (const mid of memberIds) {
-    // Schema validation after deleteFields + merge for memories
-    if (dfPaths) {
-      const existing = await listMemories(mid, { _id: id }, 1, 0);
-      if (existing.length === 0) continue;
-      const mem = existing[0]!;
-      const resultProps = updates.properties ?? (mem.properties != null ? { ...mem.properties } : {});
-      const sim: Record<string, unknown> = { properties: resultProps };
-      applyDeleteFieldsPaths(sim, dfPaths);
-      const simProps = (sim['properties'] ?? {}) as Record<string, unknown>;
-      const meta = getSpaceMeta(mid);
-      const violations = validateMemory(meta ?? {}, { properties: simProps });
-      const validation = applyValidation(meta, violations);
-      if (validation.blocked) {
-        res.status(422).json({ error: 'schema_violation', message: 'deleteFields + merge result violates required properties', violations: validation.warnings });
-        return;
-      }
-    }
-    const updated = await updateMemory(mid, id, updates, dfPaths);
-    if (updated) {
-      emitWebhookEvent({ event: 'memory.updated', spaceId: mid, entry: { ...updated, embedding: undefined }, ...webhookToken(req) });
-      res.json(updated);
-      return;
-    }
-  }
-  res.status(404).json({ error: 'Memory not found' });
-});
-
-// DELETE /api/brain/:spaceId/memories — bulk wipe all memories
-brainRouter.delete('/:spaceId/memories', bulkWipeRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
-  const spaceId = req.params['spaceId'] as string;
-  const cfg = getConfig();
-  if (!cfg.spaces.some(s => s.id === spaceId)) {
-    res.status(404).json({ error: `Space '${spaceId}' not found` });
-    return;
-  }
-  if (isProxySpace(spaceId)) {
-    res.status(400).json({ error: 'Bulk wipe not supported on proxy spaces — target member spaces individually' });
-    return;
-  }
-  if (req.body?.confirm !== true) {
-    res.status(400).json({ error: '`confirm: true` required in request body' });
-    return;
-  }
-  const deleted = await bulkDeleteMemories(spaceId);
-  res.json({ deleted });
 });
 
 // GET /api/brain/spaces/:spaceId/stats

--- a/testing/_init/seed-brain.js
+++ b/testing/_init/seed-brain.js
@@ -141,7 +141,7 @@ const MEMORIES = [
 async function seedMemories() {
   let count = 0;
   for (const { space, fact, tags } of MEMORIES) {
-    await api('POST', `/api/brain/${space}/memories`, { fact, tags });
+    await api('POST', `/api/brain/spaces/${space}/memories`, { fact, tags });
     count++;
   }
   console.log(`  Created ${count} memories`);

--- a/testing/integration/audit.test.js
+++ b/testing/integration/audit.test.js
@@ -48,7 +48,7 @@ describe('Audit Log', () => {
 
   it('Audit log returns entries after a write operation', async () => {
     // Perform a memory create
-    const memR = await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    const memR = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: 'Audit test fact ' + Date.now(),
       tags: ['audit-test'],
     });

--- a/testing/integration/auth.test.js
+++ b/testing/integration/auth.test.js
@@ -121,11 +121,11 @@ describe('Token lifecycle', () => {
     const scopedToken = create.body.plaintext;
 
     // Should be rejected on general space
-    const wrongSpace = await get(INSTANCES.a, scopedToken, '/api/brain/general/memories');
+    const wrongSpace = await get(INSTANCES.a, scopedToken, '/api/brain/spaces/general/memories');
     assert.equal(wrongSpace.status, 403, 'Scoped token should be rejected on wrong space');
 
     // Should work on the scoped space
-    const rightSpace = await get(INSTANCES.a, scopedToken, `/api/brain/${spaceId}/memories`);
+    const rightSpace = await get(INSTANCES.a, scopedToken, `/api/brain/spaces/${spaceId}/memories`);
     assert.equal(rightSpace.status, 200, 'Scoped token should work on its own space');
 
     // Clean up

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -34,7 +34,7 @@ describe('Brain â€” memories', () => {
   });
 
   it('Write a memory returns 201 with _id and seq', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: 'The sky is blue',
       tags: ['science', 'color'],
     });
@@ -45,49 +45,49 @@ describe('Brain â€” memories', () => {
   });
 
   it('List memories returns written memory', async () => {
-    const write = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const write = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: 'Unique fact for list test',
       tags: ['list-test'],
     });
     const memId = write.body._id ?? write.body.id;
 
-    const r = await get(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(r.status, 200, `Written memory should be retrievable by ID: ${JSON.stringify(r.body)}`);
   });
 
   it('Delete a memory returns 204 and it is gone', async () => {
-    const write = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const write = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: 'Memory to delete',
       tags: ['delete-test'],
     });
     const memId = write.body._id ?? write.body.id;
 
-    const delR = await del(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`);
+    const delR = await del(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(delR.status, 204, `Delete: ${JSON.stringify(delR.body)}`);
 
     // Confirm deletion via direct ID lookup — 404 is the authoritative signal;
     // scanning a paginated list would give a false pass once >100 memories exist.
-    const lookup = await get(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`);
+    const lookup = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(lookup.status, 404, 'Deleted memory must return 404 on direct lookup');
   });
 
   it('Wipe all memories requires confirm:true in body', async () => {
     // No body → 400
-    const noBody = await del(INSTANCES.a, token(), '/api/brain/general/memories');
+    const noBody = await del(INSTANCES.a, token(), '/api/brain/spaces/general/memories');
     assert.equal(noBody.status, 400, `No body should 400, got ${noBody.status}`);
 
     // confirm:false → 400
-    const noConfirm = await delWithBody(INSTANCES.a, token(), '/api/brain/general/memories', { confirm: false });
+    const noConfirm = await delWithBody(INSTANCES.a, token(), '/api/brain/spaces/general/memories', { confirm: false });
     assert.equal(noConfirm.status, 400, `confirm:false should 400, got ${noConfirm.status}`);
   });
 
   it('Delete non-existent memory returns 404', async () => {
-    const r = await del(INSTANCES.a, token(), '/api/brain/general/memories/nonexistent-id');
+    const r = await del(INSTANCES.a, token(), '/api/brain/spaces/general/memories/nonexistent-id');
     assert.equal(r.status, 404);
   });
 
   it('Access memory in non-existent space returns 404', async () => {
-    const r = await get(INSTANCES.a, token(), '/api/brain/nonexistent-space/memories');
+    const r = await get(INSTANCES.a, token(), '/api/brain/spaces/nonexistent-space/memories');
     assert.equal(r.status, 404, `Got ${r.status}`);
   });
 });
@@ -104,7 +104,7 @@ describe('Brain â€” stats', () => {
 
 describe('Brain â€” conflicts protection', () => {
   it('Writing to a wrongly spelled spaceId returns error', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/GENERAL/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/GENERAL/memories', {
       fact: 'Case sensitivity test',
     });
     // Space IDs are lowercase â€” GENERAL should 404
@@ -387,7 +387,7 @@ describe('Brain — memory list filtering', () => {
   });
 
   it('Filter by tag returns only matching memories', async () => {
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/general/memories?tag=physics&limit=500');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories?tag=physics&limit=500');
     assert.equal(r.status, 200, JSON.stringify(r.body));
     const ids = r.body.memories.map(m => m._id);
     assert.ok(ids.includes(`filt-${RUN}-1`), 'Alpha (physics) should match');
@@ -397,14 +397,14 @@ describe('Brain — memory list filtering', () => {
   });
 
   it('Tag filter is case-insensitive', async () => {
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/general/memories?tag=PHYSICS&limit=500');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories?tag=PHYSICS&limit=500');
     assert.equal(r.status, 200);
     const ids = r.body.memories.map(m => m._id);
     assert.ok(ids.includes(`filt-${RUN}-1`), 'Should match physics despite uppercase query');
   });
 
   it('Filter by entity returns only linked memories', async () => {
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/general/memories?entity=ent-y&limit=500');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories?entity=ent-y&limit=500');
     assert.equal(r.status, 200, JSON.stringify(r.body));
     const ids = r.body.memories.map(m => m._id);
     assert.ok(ids.includes(`filt-${RUN}-2`), 'Beta (ent-y) should match');
@@ -415,7 +415,7 @@ describe('Brain — memory list filtering', () => {
 
   it('Combine tag + entity returns intersection', async () => {
     // tag=physics AND entity=ent-x → items 1 and 3
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/general/memories?tag=physics&entity=ent-x&limit=500');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories?tag=physics&entity=ent-x&limit=500');
     assert.equal(r.status, 200, JSON.stringify(r.body));
     const ids = r.body.memories.map(m => m._id);
     assert.ok(ids.includes(`filt-${RUN}-1`), 'Alpha (physics + ent-x) should match');
@@ -424,7 +424,7 @@ describe('Brain — memory list filtering', () => {
   });
 
   it('No filter returns all (at least our 5)', async () => {
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/general/memories?limit=500');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories?limit=500');
     assert.equal(r.status, 200);
     const ids = r.body.memories.map(m => m._id);
     for (let i = 1; i <= 5; i++) {
@@ -433,7 +433,7 @@ describe('Brain — memory list filtering', () => {
   });
 
   it('Filter with no matches returns empty array', async () => {
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/general/memories?tag=nonexistent-tag-xyz&limit=500');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories?tag=nonexistent-tag-xyz&limit=500');
     assert.equal(r.status, 200);
     assert.equal(r.body.memories.length, 0, 'Should return empty array for non-matching filter');
   });
@@ -458,15 +458,15 @@ describe('Brain â€” memory list limit/skip pagination', () => {
   });
 
   it('limit=3 returns at most 3 memories', async () => {
-    const r = await get(INSTANCES.a, token(), '/api/brain/general/memories?limit=3');
+    const r = await get(INSTANCES.a, token(), '/api/brain/spaces/general/memories?limit=3');
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.ok(Array.isArray(r.body.memories), 'memories must be array');
     assert.ok(r.body.memories.length <= 3, `Expected â‰¤3 items, got ${r.body.memories.length}`);
   });
 
   it('skip pagination returns disjoint results', async () => {
-    const page1 = await get(INSTANCES.a, token(), '/api/brain/general/memories?limit=3&skip=0');
-    const page2 = await get(INSTANCES.a, token(), '/api/brain/general/memories?limit=3&skip=3');
+    const page1 = await get(INSTANCES.a, token(), '/api/brain/spaces/general/memories?limit=3&skip=0');
+    const page2 = await get(INSTANCES.a, token(), '/api/brain/spaces/general/memories?limit=3&skip=3');
     assert.equal(page1.status, 200);
     assert.equal(page2.status, 200);
     const p1Ids = new Set(page1.body.memories.map(m => m._id));
@@ -476,7 +476,7 @@ describe('Brain â€” memory list limit/skip pagination', () => {
   });
 
   it('limit cap â€” limit > 500 is capped at 500', async () => {
-    const r = await get(INSTANCES.a, token(), '/api/brain/general/memories?limit=9999');
+    const r = await get(INSTANCES.a, token(), '/api/brain/spaces/general/memories?limit=9999');
     assert.equal(r.status, 200);
     assert.ok(r.body.limit <= 500, `Expected limit â‰¤500 in response, got ${r.body.limit}`);
   });
@@ -598,19 +598,19 @@ describe('Brain — POST /api/brain/spaces/:spaceId/reindex', () => {
 
 describe('Brain â€” memory fact validation', () => {
   it('Returns 400 if fact is missing', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', { tags: ['nofact'] });
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', { tags: ['nofact'] });
     assert.equal(r.status, 400);
   });
 
   it('Returns 400 if fact exceeds 50 000 characters', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: 'x'.repeat(50_001),
     });
     assert.equal(r.status, 400);
   });
 
   it('Returns 400 if tags contains non-string', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: 'valid fact',
       tags: [1, 2, 3],
     });
@@ -618,7 +618,7 @@ describe('Brain â€” memory fact validation', () => {
   });
 
   it('Returns 201 at exactly 50 000 character fact', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: 'a'.repeat(50_000),
     });
     assert.equal(r.status, 201, `Boundary-value fact should be accepted: ${JSON.stringify(r.body)}`);
@@ -652,38 +652,38 @@ describe('Brain — bulk memory wipe', () => {
     }
 
     // Create one more memory via brain API to capture the current seq counter
-    const marker = await post(INSTANCES.a, tokenA, `/api/brain/${WIPE_SPACE}/memories`, {
+    const marker = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories`, {
       fact: 'Seq marker for wipe test', tags: ['wipe-marker'],
     });
     assert.equal(marker.status, 201);
     seqBefore = marker.body.seq;
 
     // Verify they exist
-    const list = await get(INSTANCES.a, tokenA, `/api/brain/${WIPE_SPACE}/memories?limit=500`);
+    const list = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories?limit=500`);
     for (const id of seededIds) {
       assert.ok(list.body.memories.some(m => m._id === id), `Seeded ${id} should exist`);
     }
   });
 
   it('DELETE without body returns 400', async () => {
-    const r = await del(INSTANCES.a, tokenA, `/api/brain/${WIPE_SPACE}/memories`);
+    const r = await del(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories`);
     assert.equal(r.status, 400, `expected 400, got ${r.status}: ${JSON.stringify(r.body)}`);
   });
 
   it('DELETE with confirm:false returns 400', async () => {
-    const r = await delWithBody(INSTANCES.a, tokenA, `/api/brain/${WIPE_SPACE}/memories`, { confirm: false });
+    const r = await delWithBody(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories`, { confirm: false });
     assert.equal(r.status, 400, `expected 400, got ${r.status}: ${JSON.stringify(r.body)}`);
   });
 
   it('DELETE with confirm:true returns {deleted: N}', async () => {
-    const r = await delWithBody(INSTANCES.a, tokenA, `/api/brain/${WIPE_SPACE}/memories`, { confirm: true });
+    const r = await delWithBody(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories`, { confirm: true });
     assert.equal(r.status, 200, `expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
     assert.ok(typeof r.body.deleted === 'number', 'deleted must be a number');
     assert.ok(r.body.deleted >= 10, `Should have deleted at least 10, got ${r.body.deleted}`);
   });
 
   it('Memories are gone after wipe', async () => {
-    const list = await get(INSTANCES.a, tokenA, `/api/brain/${WIPE_SPACE}/memories?limit=500`);
+    const list = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories?limit=500`);
     assert.equal(list.status, 200);
     for (const id of seededIds) {
       const found = list.body.memories.some(m => m._id === id);
@@ -735,7 +735,7 @@ describe('Brain — bulk memory wipe', () => {
   });
 
   it('Wipe on unknown space returns 404', async () => {
-    const r = await delWithBody(INSTANCES.a, tokenA, '/api/brain/no-such-space/memories', { confirm: true });
+    const r = await delWithBody(INSTANCES.a, tokenA, '/api/brain/spaces/no-such-space/memories', { confirm: true });
     assert.equal(r.status, 404, `expected 404, got ${r.status}`);
   });
 });
@@ -979,7 +979,7 @@ describe('Brain — memory description and properties fields', () => {
   const RUN = Date.now();
 
   it('POST /memories with description and properties stores both fields', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `DescPropFact-${RUN}`,
       tags: ['desc-prop-test'],
       description: 'Context for this fact',
@@ -991,7 +991,7 @@ describe('Brain — memory description and properties fields', () => {
   });
 
   it('description and properties are retrievable by ID', async () => {
-    const write = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const write = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `DescPropRetrieve-${RUN}`,
       description: 'Retrievable description',
       properties: { key: 'val' },
@@ -999,14 +999,14 @@ describe('Brain — memory description and properties fields', () => {
     assert.equal(write.status, 201);
     const memId = write.body._id;
 
-    const r = await get(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(r.status, 200);
     assert.equal(r.body.description, 'Retrievable description');
     assert.deepStrictEqual(r.body.properties, { key: 'val' });
   });
 
   it('memory without description/properties works (optional fields)', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `NoDescProp-${RUN}`,
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
@@ -1016,7 +1016,7 @@ describe('Brain — memory description and properties fields', () => {
 
   it('non-string description is ignored (coerced away)', async () => {
     // Server strips non-string description — must not crash
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `BadDesc-${RUN}`,
       description: 12345,
     });
@@ -1024,7 +1024,7 @@ describe('Brain — memory description and properties fields', () => {
   });
 
   it('non-object properties is ignored (coerced away)', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `BadProps-${RUN}`,
       properties: 'not-an-object',
     });
@@ -1532,7 +1532,7 @@ describe('Brain — POST /spaces/:spaceId/query', () => {
   before(async () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     // Seed a memory with a distinctive tag and fact for query tests
-    const r = await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: `QueryTest-${RUN} authentication service bootstrap`,
       tags: [`qtest-${RUN}`, 'auth'],
     });
@@ -1683,7 +1683,7 @@ describe('Brain — PATCH memory updates description and properties', () => {
   let memId;
 
   before(async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `PatchMemFact-${RUN}`,
       tags: ['patch-test'],
       description: 'Initial description',
@@ -1694,32 +1694,32 @@ describe('Brain — PATCH memory updates description and properties', () => {
   });
 
   it('PATCH memory updates description field', async () => {
-    const r = await patch(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`, {
+    const r = await patch(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`, {
       description: 'Updated description',
     });
     assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
     assert.equal(r.body.description, 'Updated description', 'description must be updated');
 
-    const get2 = await get(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`);
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(get2.status, 200);
     assert.equal(get2.body.description, 'Updated description', 'description persisted to DB');
   });
 
   it('PATCH memory updates properties field', async () => {
-    const r = await patch(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`, {
+    const r = await patch(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`, {
       properties: { source: 'patched', extra: 'yes' },
     });
     assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
     assert.equal(r.body.properties?.source, 'patched', 'source property updated');
 
-    const get2 = await get(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`);
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(get2.status, 200);
     assert.equal(get2.body.properties?.source, 'patched', 'properties persisted to DB');
     assert.equal(get2.body.properties?.extra, 'yes', 'new property persisted');
   });
 
   it('PATCH memory updates fact field', async () => {
-    const r = await patch(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`, {
+    const r = await patch(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`, {
       fact: `PatchMemFact-updated-${RUN}`,
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
@@ -1727,19 +1727,19 @@ describe('Brain — PATCH memory updates description and properties', () => {
   });
 
   it('PATCH memory with no fields returns 400', async () => {
-    const r = await patch(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`, {});
+    const r = await patch(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`, {});
     assert.equal(r.status, 400, `Expected 400 for empty body`);
   });
 
   it('PATCH memory with unknown ID returns 404', async () => {
-    const r = await patch(INSTANCES.a, token(), `/api/brain/general/memories/nonexistent-id-${RUN}`, {
+    const r = await patch(INSTANCES.a, token(), `/api/brain/spaces/general/memories/nonexistent-id-${RUN}`, {
       description: 'should not matter',
     });
     assert.equal(r.status, 404, `Expected 404 for unknown ID`);
   });
 
   after(async () => {
-    if (memId) await del(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`).catch(() => {});
+    if (memId) await del(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`).catch(() => {});
   });
 });
 
@@ -1750,7 +1750,7 @@ describe('Brain — PATCH memory long-form path persists description and propert
   let memId;
 
   before(async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `PatchMemLong-${RUN}`,
       description: 'Initial',
       properties: { v: 1 },
@@ -1770,7 +1770,7 @@ describe('Brain — PATCH memory long-form path persists description and propert
   });
 
   after(async () => {
-    if (memId) await del(INSTANCES.a, token(), `/api/brain/general/memories/${memId}`).catch(() => {});
+    if (memId) await del(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`).catch(() => {});
   });
 });
 
@@ -2102,7 +2102,7 @@ describe('Brain — read-only token blocked on REST write endpoints', () => {
     readOnlyTokenId = tokenRes.body.id;
 
     // Seed test objects using the admin token for later PATCH/DELETE tests
-    const memR = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const memR = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `ROTest-mem-${RUN}`,
     });
     testMemId = memR.body._id;
@@ -2130,7 +2130,7 @@ describe('Brain — read-only token blocked on REST write endpoints', () => {
 
   after(async () => {
     if (readOnlyTokenId) await del(INSTANCES.a, token(), `/api/tokens/${readOnlyTokenId}`).catch(() => {});
-    if (testMemId) await del(INSTANCES.a, token(), `/api/brain/general/memories/${testMemId}`).catch(() => {});
+    if (testMemId) await del(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${testMemId}`).catch(() => {});
     if (testEntId) await del(INSTANCES.a, token(), `/api/brain/spaces/general/entities/${testEntId}`).catch(() => {});
     if (helperEntId2) await del(INSTANCES.a, token(), `/api/brain/spaces/general/entities/${helperEntId2}`).catch(() => {});
     if (testEdgeId) await del(INSTANCES.a, token(), `/api/brain/spaces/general/edges/${testEdgeId}`).catch(() => {});
@@ -2138,14 +2138,14 @@ describe('Brain — read-only token blocked on REST write endpoints', () => {
   });
 
   it('POST /memories blocked with read-only token (403)', async () => {
-    const r = await post(INSTANCES.a, readOnlyToken, '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, readOnlyToken, '/api/brain/spaces/general/memories', {
       fact: 'Should be blocked',
     });
     assert.equal(r.status, 403, `Expected 403, got ${r.status}`);
   });
 
   it('PATCH /memories/:id blocked with read-only token (403)', async () => {
-    const r = await patch(INSTANCES.a, readOnlyToken, `/api/brain/general/memories/${testMemId}`, {
+    const r = await patch(INSTANCES.a, readOnlyToken, `/api/brain/spaces/general/memories/${testMemId}`, {
       fact: 'Should be blocked',
     });
     assert.equal(r.status, 403, `Expected 403, got ${r.status}`);
@@ -2217,7 +2217,7 @@ describe('Brain — read-only token blocked on REST write endpoints', () => {
   });
 
   it('GET /memories allowed with read-only token', async () => {
-    const r = await get(INSTANCES.a, readOnlyToken, '/api/brain/general/memories?limit=1');
+    const r = await get(INSTANCES.a, readOnlyToken, '/api/brain/spaces/general/memories?limit=1');
     assert.equal(r.status, 200, `GET memories should be allowed, got ${r.status}`);
   });
 });
@@ -2292,11 +2292,11 @@ describe('Brain — find-similar', () => {
 
   it('POST /find-similar returns results for a valid memory', async () => {
     // Write two similar memories
-    const w1 = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const w1 = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `FindSimilar test: authentication and authorization ${RUN}`,
       tags: ['find-similar-test'],
     });
-    const w2 = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const w2 = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `FindSimilar test: auth and authz security ${RUN}`,
       tags: ['find-similar-test'],
     });
@@ -2322,7 +2322,7 @@ describe('Brain — find-similar', () => {
   });
 
   it('POST /find-similar respects targetTypes filter', async () => {
-    const w = await post(INSTANCES.a, token(), '/api/brain/general/memories', {
+    const w = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `FindSimilar targetTypes test ${RUN}`,
     });
     const sourceId = w.body._id ?? w.body.id;
@@ -2346,5 +2346,30 @@ describe('Brain — find-similar', () => {
       entryType: 'memory',
     });
     assert.equal(r.status, 404, `Got ${r.status}`);
+  });
+});
+
+// ── A1: legacy /:spaceId route shape removed (breaking change for 2.0) ──────
+describe('Brain — legacy route shape removed (A1)', () => {
+  let tk;
+  before(() => {
+    tk = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  });
+
+  it('legacy GET /:spaceId/memories is gone (404, not a redirect)', async () => {
+    const r = await get(INSTANCES.a, tk, '/api/brain/general/memories');
+    assert.equal(r.status, 404, 'the legacy /:spaceId shape must be removed (404)');
+  });
+
+  it('legacy POST /:spaceId/memories is gone (404)', async () => {
+    const r = await post(INSTANCES.a, tk, '/api/brain/general/memories', { fact: 'legacy gone' });
+    assert.equal(r.status, 404);
+  });
+
+  it('canonical /spaces/:spaceId/memories create + get-by-id still work', async () => {
+    const w = await post(INSTANCES.a, tk, '/api/brain/spaces/general/memories', { fact: 'a1 canonical ok' });
+    assert.equal(w.status, 201, `canonical create must work: ${JSON.stringify(w.body)}`);
+    const g = await get(INSTANCES.a, tk, `/api/brain/spaces/general/memories/${w.body._id}`);
+    assert.equal(g.status, 200, 'canonical get-by-id must work');
   });
 });

--- a/testing/integration/db-migration.test.js
+++ b/testing/integration/db-migration.test.js
@@ -322,7 +322,7 @@ describe('Backup + Restore — round-trip', () => {
   it('backup → delete data → restore → data is back', async () => {
     // 1. Seed a uniquely-named memory
     const memName = `restore-test-memory-${RUN_ID}`;
-    const createR = await post(BASE, adminToken, '/api/brain/general/memories',
+    const createR = await post(BASE, adminToken, '/api/brain/spaces/general/memories',
       { fact: memName, tags: ['restore-test'] });
     assert.equal(createR.status, 201, `seed memory: ${JSON.stringify(createR.body)}`);
     const memId = createR.body._id ?? createR.body.id;
@@ -334,11 +334,11 @@ describe('Backup + Restore — round-trip', () => {
     const backupId = backupR.body.backup.id;
 
     // 3. Delete the seeded memory
-    const delR = await del(BASE, adminToken, `/api/brain/general/memories/${memId}`);
+    const delR = await del(BASE, adminToken, `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(delR.status, 204, `delete memory: ${JSON.stringify(delR.body)}`);
 
     // 4. Verify memory is gone
-    const goneR = await reqJson(BASE, adminToken, `/api/brain/general/memories/${memId}`);
+    const goneR = await reqJson(BASE, adminToken, `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(goneR.status, 404, 'memory should be gone after delete');
 
     // 5. Restore from the backup (auto-manages maintenance)
@@ -347,13 +347,13 @@ describe('Backup + Restore — round-trip', () => {
     assert.equal(restoreR.body.ok, true, JSON.stringify(restoreR.body));
 
     // 6. Verify memory is back
-    const backR = await reqJson(BASE, adminToken, `/api/brain/general/memories/${memId}`);
+    const backR = await reqJson(BASE, adminToken, `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(backR.status, 200, `memory should be back after restore: ${JSON.stringify(backR.body)}`);
     const restoredFact = backR.body.fact ?? backR.body.content;
     assert.equal(restoredFact, memName, `memory content mismatch: ${JSON.stringify(backR.body)}`);
 
     // 7. Clean up — delete the test memory again
-    await del(BASE, adminToken, `/api/brain/general/memories/${memId}`).catch(() => {});
+    await del(BASE, adminToken, `/api/brain/spaces/general/memories/${memId}`).catch(() => {});
   });
 
   it('restore with unknown backupId returns 404', async () => {

--- a/testing/integration/entity-merge.test.js
+++ b/testing/integration/entity-merge.test.js
@@ -48,7 +48,7 @@ async function createEdge(from, to, label, props = {}) {
 }
 
 async function createMemory(fact, entityIds, tags = []) {
-  const r = await post(A, token(), `/api/brain/${SPACE}/memories`, { fact, entityIds, tags });
+  const r = await post(A, token(), `/api/brain/spaces/${SPACE}/memories`, { fact, entityIds, tags });
   assert.equal(r.status, 201, `Memory create failed: ${JSON.stringify(r.body)}`);
   return r.body;
 }
@@ -107,7 +107,7 @@ describe('Entity Merge — integration', () => {
 
     await merge(survivor._id, absorbed._id);
 
-    const m = await get(A, token(), `/api/brain/${SPACE}/memories/${mem._id}`);
+    const m = await get(A, token(), `/api/brain/spaces/${SPACE}/memories/${mem._id}`);
     assert.equal(m.status, 200);
     assert.ok(m.body.entityIds.includes(survivor._id), 'Memory entityIds should contain survivor');
     assert.ok(!m.body.entityIds.includes(absorbed._id), 'Memory entityIds should NOT contain absorbed');

--- a/testing/integration/mcp-tools.test.js
+++ b/testing/integration/mcp-tools.test.js
@@ -673,7 +673,7 @@ describe('MCP recall_global — space-scoped token must only see its own spaces'
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
 
     // Write a secret fact into the 'general' space using the full-access token
-    await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: secretFact,
       tags: ['scope-leak-test'],
     });
@@ -764,7 +764,7 @@ describe('MCP brain tools � update_memory / delete_memory / get_stats', () => 
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     session = await openMcpSession(tokenA);
     // Create a memory via REST API so we have an ID to update/delete
-    const res = await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    const res = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: factText,
       tags: ['mcp-update-test'],
     });

--- a/testing/integration/pagination-and-trust-proxy.test.js
+++ b/testing/integration/pagination-and-trust-proxy.test.js
@@ -42,7 +42,7 @@ before(async () => {
   const r = await post(INSTANCES.a, token(), '/api/spaces', { id: SPACE, label: `PgTrust ${RUN}` });
   assert.equal(r.status, 201, `create space: ${JSON.stringify(r.body)}`);
   for (let i = 0; i < 3; i++) {
-    await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, { fact: `pagination memory ${i} ${RUN}` });
+    await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, { fact: `pagination memory ${i} ${RUN}` });
   }
 });
 
@@ -52,38 +52,38 @@ after(async () => {
 
 describe('Pagination clamp (S4)', () => {
   it('non-numeric ?limit=abc is coerced to the default, not NaN/unbounded', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=abc`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories?limit=abc`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.ok(Array.isArray(r.body.memories));
     assert.equal(r.body.memories.length, 3, 'returns all 3 (default applied)');
   });
 
   it('?limit=1 returns exactly one', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=1`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories?limit=1`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.memories.length, 1);
   });
 
   it('negative ?limit=-5 is clamped to >= 1', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=-5`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories?limit=-5`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.memories.length, 1, 'clamped to minimum 1');
   });
 
   it('huge ?limit=1e9 does not error and stays bounded', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?limit=1e9`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories?limit=1e9`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.memories.length, 3);
   });
 
   it('non-numeric ?skip=abc is treated as 0', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?skip=abc&limit=100`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories?skip=abc&limit=100`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.memories.length, 3, 'skip=abc → 0, all returned');
   });
 
   it('?skip=2 skips two', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/${SPACE}/memories?skip=2&limit=100`);
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories?skip=2&limit=100`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.memories.length, 1);
   });
@@ -92,7 +92,7 @@ describe('Pagination clamp (S4)', () => {
 describe('Trust proxy default (S1)', () => {
   it('a spoofed X-Forwarded-For does not become the audited client IP', async () => {
     // An audited write carrying a spoofed forwarded-for header.
-    const w = await raw('POST', `/api/brain/${SPACE}/memories`, {
+    const w = await raw('POST', `/api/brain/spaces/${SPACE}/memories`, {
       body: { fact: `trust-proxy probe ${RUN}` },
       headers: { 'X-Forwarded-For': SPOOFED_IP },
     });

--- a/testing/integration/proxy-spaces.test.js
+++ b/testing/integration/proxy-spaces.test.js
@@ -202,7 +202,7 @@ describe('Proxy spaces', () => {
     let memIdA, memIdB;
 
     it('Write to proxy without targetSpace returns 400', async () => {
-      const r = await post(BASE, tokenA, `/api/brain/${PROXY}/memories`, {
+      const r = await post(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories`, {
         fact: 'Should fail',
       });
       assert.equal(r.status, 400);
@@ -210,7 +210,7 @@ describe('Proxy spaces', () => {
     });
 
     it('Write to proxy with invalid targetSpace returns 400', async () => {
-      const r = await post(BASE, tokenA, `/api/brain/${PROXY}/memories?targetSpace=non-member`, {
+      const r = await post(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories?targetSpace=non-member`, {
         fact: 'Should fail',
       });
       assert.equal(r.status, 400);
@@ -218,7 +218,7 @@ describe('Proxy spaces', () => {
     });
 
     it('Write memory to alpha via proxy', async () => {
-      const r = await post(BASE, tokenA, `/api/brain/${PROXY}/memories?targetSpace=${SPACE_A}`, {
+      const r = await post(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories?targetSpace=${SPACE_A}`, {
         fact: 'Alpha fact from proxy',
         tags: ['alpha'],
       });
@@ -228,7 +228,7 @@ describe('Proxy spaces', () => {
     });
 
     it('Write memory to beta via proxy', async () => {
-      const r = await post(BASE, tokenA, `/api/brain/${PROXY}/memories?targetSpace=${SPACE_B}`, {
+      const r = await post(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories?targetSpace=${SPACE_B}`, {
         fact: 'Beta fact from proxy',
         tags: ['beta'],
       });
@@ -238,7 +238,7 @@ describe('Proxy spaces', () => {
     });
 
     it('List memories via proxy aggregates both spaces', async () => {
-      const r = await get(BASE, tokenA, `/api/brain/${PROXY}/memories?limit=100`);
+      const r = await get(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories?limit=100`);
       assert.equal(r.status, 200);
       const facts = r.body.memories.map(m => m.fact);
       assert.ok(facts.includes('Alpha fact from proxy'), 'Should include alpha memory');
@@ -247,7 +247,7 @@ describe('Proxy spaces', () => {
 
     it('Get memory by ID via proxy finds it across members', async () => {
       // memIdA is in alpha, try to get via proxy
-      const r = await get(BASE, tokenA, `/api/brain/${PROXY}/memories/${memIdA}`);
+      const r = await get(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories/${memIdA}`);
       assert.equal(r.status, 200);
       assert.equal(r.body.fact, 'Alpha fact from proxy');
     });
@@ -265,11 +265,11 @@ describe('Proxy spaces', () => {
     });
 
     it('Delete memory via proxy works (alpha memory)', async () => {
-      const r = await del(BASE, tokenA, `/api/brain/${PROXY}/memories/${memIdA}`);
+      const r = await del(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories/${memIdA}`);
       assert.equal(r.status, 204);
 
       // Confirm it's gone
-      const r2 = await get(BASE, tokenA, `/api/brain/${PROXY}/memories/${memIdA}`);
+      const r2 = await get(BASE, tokenA, `/api/brain/spaces/${PROXY}/memories/${memIdA}`);
       assert.equal(r2.status, 404);
     });
 
@@ -417,7 +417,7 @@ describe('Proxy spaces', () => {
 
   describe('Regular spaces unaffected by proxy code', () => {
     it('Write memory to alpha directly (no targetSpace needed)', async () => {
-      const r = await post(BASE, tokenA, `/api/brain/${SPACE_A}/memories`, {
+      const r = await post(BASE, tokenA, `/api/brain/spaces/${SPACE_A}/memories`, {
         fact: 'Direct alpha fact',
       });
       assert.equal(r.status, 201, JSON.stringify(r.body));
@@ -437,11 +437,11 @@ describe('Proxy spaces', () => {
     let session;
     before(async () => {
       // Seed data: one memory in each member space for recall testing
-      await post(BASE, tokenA, `/api/brain/${SPACE_A}/memories`, {
+      await post(BASE, tokenA, `/api/brain/spaces/${SPACE_A}/memories`, {
         fact: 'Alpha MCP recall test fact about quantum physics',
         tags: ['mcp-test'],
       });
-      await post(BASE, tokenA, `/api/brain/${SPACE_B}/memories`, {
+      await post(BASE, tokenA, `/api/brain/spaces/${SPACE_B}/memories`, {
         fact: 'Beta MCP recall test fact about machine learning',
         tags: ['mcp-test'],
       });

--- a/testing/integration/recall-filter.test.js
+++ b/testing/integration/recall-filter.test.js
@@ -383,7 +383,7 @@ describe('Recall filter — numeric gt/gte/lt/lte on properties', () => {
 
   before(async (t) => {
     if (!embeddingAvailable) return t.skip('Embedding not available');
-    const high = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const high = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} high-count`,
       description: desc,
       properties: { count: 50, label: 'high' },
@@ -392,7 +392,7 @@ describe('Recall filter — numeric gt/gte/lt/lte on properties', () => {
     assert.equal(high.status, 201, `Create high-count memory failed: ${JSON.stringify(high.body)}`);
     highId = high.body._id;
 
-    const low = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const low = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} low-count`,
       description: desc,
       properties: { count: 5, label: 'low' },
@@ -455,7 +455,7 @@ describe('Recall filter — tags in (any-of)', () => {
 
   before(async (t) => {
     if (!embeddingAvailable) return t.skip('Embedding not available');
-    const sec = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const sec = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} security-tagged`,
       description: desc,
       tags: ['security', 'auth'],
@@ -463,7 +463,7 @@ describe('Recall filter — tags in (any-of)', () => {
     assert.equal(sec.status, 201, `Create security memory failed: ${JSON.stringify(sec.body)}`);
     securityId = sec.body._id;
 
-    const infra = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const infra = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} infra-tagged`,
       description: desc,
       tags: ['infra'],
@@ -471,7 +471,7 @@ describe('Recall filter — tags in (any-of)', () => {
     assert.equal(infra.status, 201, `Create infra memory failed: ${JSON.stringify(infra.body)}`);
     infraId = infra.body._id;
 
-    const unrel = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const unrel = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} unrelated-tagged`,
       description: desc,
       tags: ['unrelated-tag-xyzzy'],
@@ -505,7 +505,7 @@ describe('Recall filter — exists operator', () => {
 
   before(async (t) => {
     if (!embeddingAvailable) return t.skip('Embedding not available');
-    const withProp = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const withProp = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} with-domain-prop`,
       description: desc,
       properties: { domain: 'infra' },
@@ -514,7 +514,7 @@ describe('Recall filter — exists operator', () => {
     assert.equal(withProp.status, 201, `Create with-prop memory failed: ${JSON.stringify(withProp.body)}`);
     withPropId = withProp.body._id;
 
-    const withoutProp = await post(INSTANCES.a, token(), `/api/brain/${SPACE}/memories`, {
+    const withoutProp = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/memories`, {
       fact: `${desc} without-domain-prop`,
       description: desc,
       tags: ['exists-test'],

--- a/testing/integration/schema-validation.test.js
+++ b/testing/integration/schema-validation.test.js
@@ -150,7 +150,7 @@ describe('Schema validation — strict mode', () => {
   });
 
   it('rejects memory with missing required property', async () => {
-    const r = await post(INSTANCES.a, token(), `/api/brain/${TEST_SPACE}/memories`, {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${TEST_SPACE}/memories`, {
       fact: `Schema strict test ${RUN}`,
       type: 'note',
     });
@@ -160,7 +160,7 @@ describe('Schema validation — strict mode', () => {
   });
 
   it('accepts valid memory', async () => {
-    const r = await post(INSTANCES.a, token(), `/api/brain/${TEST_SPACE}/memories`, {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${TEST_SPACE}/memories`, {
       fact: `Schema strict test ${RUN} valid`,
       type: 'note',
       properties: { source: 'test-suite' },

--- a/testing/integration/space-deletion.test.js
+++ b/testing/integration/space-deletion.test.js
@@ -43,7 +43,7 @@ describe('Space deletion — full cleanup', () => {
     assert.equal(createR.status, 201, `Create: ${JSON.stringify(createR.body)}`);
 
     // 2. Write a memory
-    const memR = await post(INSTANCES.a, token, `/api/brain/${spaceId}/memories`, {
+    const memR = await post(INSTANCES.a, token, `/api/brain/spaces/${spaceId}/memories`, {
       fact: 'Memory that should be deleted',
       tags: ['deletion-test'],
     });

--- a/testing/integration/space-export.test.js
+++ b/testing/integration/space-export.test.js
@@ -69,7 +69,7 @@ describe('Space export — basic export', () => {
     createdSpaceIds.push(spaceId);
 
     // Seed one of each type
-    const memR = await post(INSTANCES.a, adminToken, `/api/brain/${spaceId}/memories`, { fact: 'Export memory fact', tags: ['export-tag'] });
+    const memR = await post(INSTANCES.a, adminToken, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Export memory fact', tags: ['export-tag'] });
     assert.equal(memR.status, 201);
 
     const entR = await post(INSTANCES.a, adminToken, `/api/brain/spaces/${spaceId}/entities`, { name: 'ExportEnt', type: 'concept' });
@@ -288,7 +288,7 @@ describe('Space export/import — round-trip (export → wipe → import)', () =
     roundTripSpaceIds.push(spaceId);
 
     // Seed diverse data
-    const memR = await post(INSTANCES.a, tok, `/api/brain/${spaceId}/memories`, { fact: 'Round-trip memory', tags: ['rt-tag'] });
+    const memR = await post(INSTANCES.a, tok, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Round-trip memory', tags: ['rt-tag'] });
     assert.equal(memR.status, 201);
     const memId = memR.body._id;
 
@@ -345,7 +345,7 @@ describe('Space export/import — round-trip (export → wipe → import)', () =
     assert.ok(postImportStats.body.chrono >= 1, 'Chrono should be restored');
 
     // Verify the specific memory is restored with the same ID
-    const memCheck = await reqJson(INSTANCES.a, tok, `/api/brain/${spaceId}/memories/${memId}`);
+    const memCheck = await reqJson(INSTANCES.a, tok, `/api/brain/spaces/${spaceId}/memories/${memId}`);
     assert.equal(memCheck.status, 200, `Memory ${memId} should be retrievable after import`);
     assert.equal(memCheck.body.fact, 'Round-trip memory');
     assert.deepEqual(memCheck.body.tags, ['rt-tag']);

--- a/testing/integration/space-rename.test.js
+++ b/testing/integration/space-rename.test.js
@@ -58,7 +58,7 @@ describe('Space rename', () => {
     await post(INSTANCES.a, tokenA, '/api/spaces', { id: oldId, label: 'Data Rename' });
 
     // Write a memory
-    const writeR = await post(INSTANCES.a, tokenA, `/api/brain/${oldId}/memories`, {
+    const writeR = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/memories`, {
       fact: 'Rename survival test fact',
       tags: ['rename-test'],
     });
@@ -71,11 +71,11 @@ describe('Space rename', () => {
     createdSpaceIds.push(newId);
 
     // Old ID should 404
-    const oldR = await get(INSTANCES.a, tokenA, `/api/brain/${oldId}/memories`);
+    const oldR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/memories`);
     assert.ok(oldR.status === 403 || oldR.status === 404, `Old space should be gone, got ${oldR.status}`);
 
     // New ID should have the memory
-    const newR = await get(INSTANCES.a, tokenA, `/api/brain/${newId}/memories`);
+    const newR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${newId}/memories`);
     assert.equal(newR.status, 200);
     const found = newR.body.memories?.some(m => m._id === memId);
     assert.ok(found, 'Memory should exist under the renamed space');

--- a/testing/integration/space-wipe.test.js
+++ b/testing/integration/space-wipe.test.js
@@ -45,7 +45,7 @@ describe('Space wipe — full wipe', () => {
     createdSpaceIds.push(spaceId);
 
     // Seed data in every collection
-    const memR = await post(INSTANCES.a, adminToken, `/api/brain/${spaceId}/memories`, { fact: 'Memory to wipe', tags: ['wipe-test'] });
+    const memR = await post(INSTANCES.a, adminToken, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Memory to wipe', tags: ['wipe-test'] });
     assert.equal(memR.status, 201, `Memory: ${JSON.stringify(memR.body)}`);
 
     const entR = await post(INSTANCES.a, adminToken, `/api/brain/spaces/${spaceId}/entities`, { name: 'WipeEnt', type: 'concept' });
@@ -152,7 +152,7 @@ describe('Space wipe — partial wipe (by type)', () => {
     partialWipeSpaceIds.push(spaceId);
 
     // Seed one of each type
-    await post(INSTANCES.a, adminTok, `/api/brain/${spaceId}/memories`, { fact: 'Mem to wipe', tags: [] });
+    await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Mem to wipe', tags: [] });
     await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/entities`, { name: 'SurvivingEnt', type: 'concept' });
     await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/chrono`, { title: 'Surviving chrono', type: 'event', startsAt: new Date().toISOString() });
 
@@ -182,7 +182,7 @@ describe('Space wipe — partial wipe (by type)', () => {
     assert.equal(createR.status, 201);
     partialWipeSpaceIds.push(spaceId);
 
-    await post(INSTANCES.a, adminTok, `/api/brain/${spaceId}/memories`, { fact: 'Surviving memory', tags: [] });
+    await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Surviving memory', tags: [] });
     await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/entities`, { name: 'EntToWipe', type: 'concept' });
 
     // Wipe entities only
@@ -211,7 +211,7 @@ describe('Space wipe — partial wipe (by type)', () => {
     assert.ok(fileR.status === 200 || fileR.status === 201 || fileR.status === 202, `Upload: ${fileR.status}`);
 
     // Seed a memory so we can check it survives
-    await post(INSTANCES.a, adminTok, `/api/brain/${spaceId}/memories`, { fact: 'Surviving memory', tags: [] });
+    await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Surviving memory', tags: [] });
 
     const preStats = await get(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/stats`);
     assert.ok(preStats.body.files >= 1, 'Should have at least 1 file');
@@ -238,7 +238,7 @@ describe('Space wipe — partial wipe (by type)', () => {
     assert.equal(createR.status, 201);
     partialWipeSpaceIds.push(spaceId);
 
-    await post(INSTANCES.a, adminTok, `/api/brain/${spaceId}/memories`, { fact: 'Memory to wipe', tags: [] });
+    await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/memories`, { fact: 'Memory to wipe', tags: [] });
     await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/entities`, { name: 'EntToWipe', type: 'concept' });
     await post(INSTANCES.a, adminTok, `/api/brain/spaces/${spaceId}/chrono`, { title: 'Surviving chrono', type: 'event', startsAt: new Date().toISOString() });
 

--- a/testing/integration/spaces.test.js
+++ b/testing/integration/spaces.test.js
@@ -86,7 +86,7 @@ describe('Space management', () => {
     // Use the explicit-test-space created in this run
     const isolationSpace = `explicit-test-space-${RUN_ID}`;
     // Write a memory to the explicit-test-space (it was created above and pushed to createdSpaceIds)
-    const writeR = await post(INSTANCES.a, tokenA, `/api/brain/${isolationSpace}/memories`, {
+    const writeR = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${isolationSpace}/memories`, {
       fact: 'Isolated space fact',
       tags: ['isolation-test'],
     });
@@ -94,13 +94,13 @@ describe('Space management', () => {
     const memId = writeR.body._id ?? writeR.body.id;
 
     // Should NOT appear in general space
-    const generalR = await get(INSTANCES.a, tokenA, '/api/brain/general/memories');
+    const generalR = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories');
     assert.equal(generalR.status, 200);
     const found = generalR.body.memories?.some(m => m._id === memId);
     assert.ok(!found, `Memory from ${isolationSpace} must not appear in general space`);
 
     // Should appear in the isolation space
-    const ownSpaceR = await get(INSTANCES.a, tokenA, `/api/brain/${isolationSpace}/memories`);
+    const ownSpaceR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${isolationSpace}/memories`);
     assert.equal(ownSpaceR.status, 200);
     const ownFound = ownSpaceR.body.memories?.some(m => m._id === memId);
     assert.ok(ownFound, 'Memory should be visible in its own space');

--- a/testing/red-team-tests/auth-bypass.test.js
+++ b/testing/red-team-tests/auth-bypass.test.js
@@ -115,7 +115,7 @@ describe('Protected routes without auth return 401 not 500', () => {
     ['GET', '/api/spaces'],
     ['GET', '/api/networks'],
     ['GET', '/api/files/general'],
-    ['GET', '/api/brain/general/memories'],
+    ['GET', '/api/brain/spaces/general/memories'],
   ];
   for (const [method, route] of ROUTES) {
     it(`${method} ${route} without auth → 401`, async () => {

--- a/testing/red-team-tests/auth-escalation.test.js
+++ b/testing/red-team-tests/auth-escalation.test.js
@@ -135,28 +135,36 @@ describe('H2 — MFA cannot be rotated/disabled with just an admin PAT once enab
   // documented break-glass way: remove `totpSecret` from secrets.json on disk and
   // restart, which reloads the (now MFA-off) config from disk. Code-free and
   // reliable — no TOTP generation needed.
-  function disableMfaViaRestart() {
+  async function disableMfaViaRestart() {
     execSync(`docker exec ythril-a node -e "const fs=require('fs');const p='/config/secrets.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));delete s.totpSecret;fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600})"`);
     execSync('docker restart ythril-a', { stdio: 'ignore' });
-    const sleep1s = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
-    for (let i = 0; i < 45; i++) {
+    // Wait for the API to actually serve again — poll the readiness endpoint
+    // (not just docker's health status), retrying through the stale keep-alive
+    // sockets still pointing at the dead process. Throw loudly on timeout so we
+    // never run assertions against a half-restarted server. The old 45s docker-
+    // health loop returned SILENTLY on timeout, so a slow restart left `before`
+    // hitting a dead server and the MFA request hung to its timeout — the flake.
+    const deadline = Date.now() + 90_000;
+    while (Date.now() < deadline) {
       try {
-        if (execSync('docker inspect -f "{{.State.Health.Status}}" ythril-a').toString().trim() === 'healthy') return;
-      } catch { /* container mid-restart */ }
-      sleep1s();
+        const r = await fetch(`${INSTANCES.a}/ready`);
+        if (r.ok) return;
+      } catch { /* container mid-restart / stale socket */ }
+      await new Promise(res => setTimeout(res, 500));
     }
+    throw new Error('instance A did not come back after MFA-disable restart');
   }
 
   before(async () => {
-    disableMfaViaRestart();                       // ensure a clean (MFA-off) start
+    await disableMfaViaRestart();                 // ensure a clean (MFA-off) start
     const setup = await post(INSTANCES.a, adminToken, '/api/mfa/setup', {});  // first-time enrol needs no code
     assert.equal(setup.status, 201, `enable MFA: ${JSON.stringify(setup.body)}`);
     const status = await get(INSTANCES.a, adminToken, '/api/mfa/status');
     assert.equal(status.body.enabled, true, 'MFA should be enabled after setup');
   });
 
-  after(() => {
-    disableMfaViaRestart();
+  after(async () => {
+    await disableMfaViaRestart();
   });
 
   it('POST /api/mfa/setup (rotate) with only an admin PAT is rejected once MFA is enabled', async () => {

--- a/testing/red-team-tests/auth-surface-hardening.test.js
+++ b/testing/red-team-tests/auth-surface-hardening.test.js
@@ -62,7 +62,7 @@ describe('M2 — ?token= is accepted only on the SSE endpoints', () => {
     '/api/spaces',
     '/api/tokens',
     '/api/networks',
-    '/api/brain/general/memories',
+    '/api/brain/spaces/general/memories',
     '/api/files/general?path=.',
     '/api/about',
   ];

--- a/testing/red-team-tests/mcp-security.test.js
+++ b/testing/red-team-tests/mcp-security.test.js
@@ -322,7 +322,7 @@ describe('MCP security — recall_global scope isolation', () => {
 
     // Write a secret memory into instance B's space using tokenB
     const secretFact = `SECRET-SCOPELEAK-${Date.now()}`;
-    await post(INSTANCES.b, tokenB, '/api/brain/general/memories', { fact: secretFact });
+    await post(INSTANCES.b, tokenB, '/api/brain/spaces/general/memories', { fact: secretFact });
 
     // Now open an MCP session on instance A with tokenA (scope: instance A only)
     const { status, callTool, close } = await openMcpSession(INSTANCES.a, tokenA);

--- a/testing/red-team-tests/mongodb-injection.test.js
+++ b/testing/red-team-tests/mongodb-injection.test.js
@@ -26,7 +26,7 @@ let token;
 
 /** POST to brain memories with arbitrary body */
 async function postMemory(body) {
-  const r = await fetch(`${INSTANCES.a}/api/brain/general/memories`, {
+  const r = await fetch(`${INSTANCES.a}/api/brain/spaces/general/memories`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
     body: JSON.stringify(body),

--- a/testing/red-team-tests/oversized-payload.test.js
+++ b/testing/red-team-tests/oversized-payload.test.js
@@ -48,7 +48,7 @@ describe('JSON body size limits (application/json endpoints)', () => {
 
   it('Brain fact string exceeding 50 000 chars → 400', async () => {
     const hugeFact = 'X'.repeat(50_001);
-    const r = await fetch(`${INSTANCES.a}/api/brain/general/memories`, {
+    const r = await fetch(`${INSTANCES.a}/api/brain/spaces/general/memories`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
       body: JSON.stringify({ fact: hugeFact }),
@@ -60,7 +60,7 @@ describe('JSON body size limits (application/json endpoints)', () => {
 
   it('Brain fact string of 1MB → 400 (fact length limit is 50k)', async () => {
     const hugeFact = 'X'.repeat(1024 * 1024); // 1 MB string
-    const r = await fetch(`${INSTANCES.a}/api/brain/general/memories`, {
+    const r = await fetch(`${INSTANCES.a}/api/brain/spaces/general/memories`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
       body: JSON.stringify({ fact: hugeFact }),

--- a/testing/red-team-tests/seq-injection.test.js
+++ b/testing/red-team-tests/seq-injection.test.js
@@ -102,7 +102,7 @@ describe('seq injection — MAX_SAFE_INTEGER poisons the high-water mark', () =>
     // This validates that even if a poisoned doc slips through, the nextSeq()
     // function does not start returning MAX_SAFE + 1 (which would overflow).
     // After a fix, the poison doc is rejected, so nextSeq should still be healthy.
-    const r = await post(INSTANCES.a, token, '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token, '/api/brain/spaces/general/memories', {
       fact: `seq health check ${Date.now()}`,
     });
     assert.equal(r.status, 201, `Write after poison attempt: ${JSON.stringify(r.body)}`);

--- a/testing/red-team-tests/space-boundary.test.js
+++ b/testing/red-team-tests/space-boundary.test.js
@@ -80,7 +80,7 @@ describe('Space-scoped token enforcement', () => {
 
   it('Scoped token cannot access brain in a different space → 403', async () => {
     // Uses OUT_OF_SCOPE_SPACE (created in before()) so a 404 cannot mask enforcement.
-    const r = await fetch(`${INSTANCES.a}/api/brain/${OUT_OF_SCOPE_SPACE}/memories`, {
+    const r = await fetch(`${INSTANCES.a}/api/brain/spaces/${OUT_OF_SCOPE_SPACE}/memories`, {
       headers: { 'Authorization': `Bearer ${generalOnlyToken}` },
     });
     assert.equal(r.status, 403,

--- a/testing/standalone/quota.test.js
+++ b/testing/standalone/quota.test.js
@@ -88,7 +88,7 @@ async function uploadFile(t, filePath, content = 'hello quota test') {
 }
 
 async function writeMemory(t, fact = 'quota test memory') {
-  return post(INSTANCES.a, t, '/api/brain/general/memories', { fact });
+  return post(INSTANCES.a, t, '/api/brain/spaces/general/memories', { fact });
 }
 
 // ── Test suite ────────────────────────────────────────────────────────────────

--- a/testing/standalone/reload-config.test.js
+++ b/testing/standalone/reload-config.test.js
@@ -155,7 +155,7 @@ describe('POST /api/admin/reload-config — quota changes take effect', () => {
         await new Promise(resolve => setTimeout(resolve, 600));
         const reloadR = await post(INSTANCES.a, token, '/api/admin/reload-config', {});
         if (reloadR.status !== 200) { await new Promise(resolve => setTimeout(resolve, 400)); continue; }
-        const probe = await post(INSTANCES.a, token, '/api/brain/general/memories', {
+        const probe = await post(INSTANCES.a, token, '/api/brain/spaces/general/memories', {
           fact: `__quota-cleanup-probe-${Date.now()}__`,
         });
         if (probe.status === 201) break;
@@ -173,7 +173,7 @@ describe('POST /api/admin/reload-config — quota changes take effect', () => {
       },
     });
 
-    const r = await post(INSTANCES.a, token, '/api/brain/general/memories', {
+    const r = await post(INSTANCES.a, token, '/api/brain/spaces/general/memories', {
       fact: `reload-config quota enforcement test ${Date.now()}`,
     });
     assert.equal(r.status, 507,
@@ -195,7 +195,7 @@ describe('POST /api/admin/reload-config — quota changes take effect', () => {
     let status = 507;
     let body = {};
     for (let attempt = 0; attempt < 20 && status !== 201; attempt++) {
-      const r = await post(INSTANCES.a, token, '/api/brain/general/memories', {
+      const r = await post(INSTANCES.a, token, '/api/brain/spaces/general/memories', {
         fact: `reload-config restore enforcement test ${Date.now()}`,
       });
       status = r.status;
@@ -229,7 +229,7 @@ describe('POST /api/admin/reload-config — space config changes take effect', (
     originalConfig = baseConfig;
     // Ensure the server is also free of quota enforcement before proceeding.
     for (let attempt = 0; attempt < 20; attempt++) {
-      const probe = await post(INSTANCES.a, token, '/api/brain/general/memories', {
+      const probe = await post(INSTANCES.a, token, '/api/brain/spaces/general/memories', {
         fact: `__space-suite-quota-guard-${Date.now()}__`,
       });
       if (probe.status === 201) break;
@@ -274,7 +274,7 @@ describe('POST /api/admin/reload-config — space config changes take effect', (
     }
     assert.ok(spaceVisible, `Space '${NEW_SPACE_ID}' should appear in /api/spaces after reload`);
 
-    const r = await post(INSTANCES.a, token, `/api/brain/${NEW_SPACE_ID}/memories`, {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${NEW_SPACE_ID}/memories`, {
       fact: `testing new space after reload ${RUN}`,
     });
     assert.equal(r.status, 201,
@@ -309,7 +309,7 @@ describe('POST /api/admin/reload-config — space config changes take effect', (
     }
     assert.ok(spaceGone, `Space '${NEW_SPACE_ID}' should be gone from /api/spaces after reload`);
 
-    const r = await post(INSTANCES.a, token, `/api/brain/${NEW_SPACE_ID}/memories`, {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${NEW_SPACE_ID}/memories`, {
       fact: 'should be rejected',
     });
     assert.equal(r.status, 404,

--- a/testing/sync/braintree.test.js
+++ b/testing/sync/braintree.test.js
@@ -98,7 +98,7 @@ describe('Braintree topology (A -> B -> C)', () => {
   });
 
   it('Root A: write propagates down to B and then to C', async () => {
-    const write = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+    const write = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Root fact from A',
       tags: ['braintree-test'],
     });
@@ -108,7 +108,7 @@ describe('Braintree topology (A -> B -> C)', () => {
     // A pushes to B
     await triggerSync(INSTANCES.a, tokenA, networkId);
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${memId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
     console.log(`  Root fact appeared on B ✓`);
@@ -116,14 +116,14 @@ describe('Braintree topology (A -> B -> C)', () => {
     // B pushes to C
     await triggerSync(INSTANCES.b, tokenB, networkId);
     await waitFor(async () => {
-      const r = await get(INSTANCES.c, tokenC, `/api/brain/${testSpaceId}/memories/${memId}`);
+      const r = await get(INSTANCES.c, tokenC, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
     console.log(`  Root fact appeared on C ✓`);
   });
 
   it('Leaf C: write does NOT propagate up to B (push-only)', async () => {
-    const write = await post(INSTANCES.c, tokenC, `/api/brain/${testSpaceId}/memories`, {
+    const write = await post(INSTANCES.c, tokenC, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Leaf-only fact from C',
       tags: ['braintree-leaf'],
     });
@@ -136,13 +136,13 @@ describe('Braintree topology (A -> B -> C)', () => {
 
     // Wait a short time and verify this specific memory is NOT on B
     await new Promise(r => setTimeout(r, 3000));
-    const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${leafMemId}`);
+    const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${leafMemId}`);
     assert.equal(r.status, 404, 'Leaf fact should NOT have propagated to B');
     console.log(`  Leaf fact correctly absent from B ✓`);
   });
 
   it('Node B: write does NOT propagate up to A', async () => {
-    const write = await post(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories`, {
+    const write = await post(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Node-only fact from B',
       tags: ['braintree-node'],
     });
@@ -153,7 +153,7 @@ describe('Braintree topology (A -> B -> C)', () => {
     await triggerSync(INSTANCES.a, tokenA, networkId);
 
     await new Promise(r => setTimeout(r, 3000));
-    const r = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${nodeMemId}`);
+    const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${nodeMemId}`);
     assert.equal(r.status, 404, 'Node fact should NOT have propagated to A');
     console.log(`  Node fact correctly absent from A ✓`);
   });

--- a/testing/sync/closed-network.test.js
+++ b/testing/sync/closed-network.test.js
@@ -113,7 +113,7 @@ describe('Closed Network (A <-> B)', () => {
 
   it('A can write a memory and sync pushes it to B', async () => {
     // Write a memory on A
-    const write = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, { fact: 'The quick brown fox', tags: ['test'] });
+    const write = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, { fact: 'The quick brown fox', tags: ['test'] });
     assert.equal(write.status, 201, `Write: ${JSON.stringify(write.body)}`);
     const memId = write.body._id ?? write.body.id;
     console.log(`  Wrote memory ${memId} on A`);
@@ -124,7 +124,7 @@ describe('Closed Network (A <-> B)', () => {
 
     // Wait for B to have the memory (lookup by direct ID to avoid pagination)
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${memId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
 
@@ -132,7 +132,7 @@ describe('Closed Network (A <-> B)', () => {
   });
 
   it('B can write a memory and it syncs back to A', async () => {
-    const write = await post(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories`, { fact: 'Jumped over the lazy dog', tags: ['test'] });
+    const write = await post(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories`, { fact: 'Jumped over the lazy dog', tags: ['test'] });
     assert.equal(write.status, 201);
     const memId = write.body._id ?? write.body.id;
     console.log(`  Wrote memory ${memId} on B`);
@@ -146,7 +146,7 @@ describe('Closed Network (A <-> B)', () => {
 
     try {
       await waitFor(async () => {
-        const r = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${memId}`);
+        const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
         return r.status === 200;
       }, 20_000);
     } finally {
@@ -158,19 +158,19 @@ describe('Closed Network (A <-> B)', () => {
 
   it('Deletion tombstone propagates from A to B', async () => {
     // Write and sync a memory
-    const write = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, { fact: 'Memory to be deleted', tags: ['delete-test'] });
+    const write = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, { fact: 'Memory to be deleted', tags: ['delete-test'] });
     assert.equal(write.status, 201);
     const memId = write.body._id ?? write.body.id;
 
     await triggerSync(INSTANCES.a, tokenA, networkId);
     // Wait for B to have the memory (direct ID lookup)
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${memId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
 
     // Delete on A
-    const del_ = await del(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${memId}`);
+    const del_ = await del(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
     assert.equal(del_.status, 204, `Delete: ${JSON.stringify(del_.body)}`);
     console.log(`  Deleted memory ${memId} on A`);
 
@@ -179,7 +179,7 @@ describe('Closed Network (A <-> B)', () => {
 
     // Wait for tombstone to arrive on B (memory disappears — direct ID lookup returns 404)
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${memId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 404;
     });
 

--- a/testing/sync/conflict.test.js
+++ b/testing/sync/conflict.test.js
@@ -39,7 +39,7 @@ describe('Conflict detection (concurrent writes)', () => {
 
   it('Concurrent writes with same seq fork rather than overwrite', async () => {
     // Write a memory on A
-    const writeA = await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    const writeA = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: 'Original fact — version A',
       tags: ['conflict-test'],
     });
@@ -81,7 +81,7 @@ describe('Conflict detection (concurrent writes)', () => {
       console.log(`  Fork created: forkId=${syncPush.body.forkId} ✓`);
       if (syncPush.body.forkId) injectedMemIds.push(syncPush.body.forkId);
       // Verify the fork exists by direct ID lookup (avoids pagination limits)
-      const forkResp = await get(INSTANCES.a, tokenA, `/api/brain/general/memories/${syncPush.body.forkId}`);
+      const forkResp = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${syncPush.body.forkId}`);
       assert.equal(forkResp.status, 200, `Fork memory not found: ${JSON.stringify(forkResp.body)}`);
       const fork = forkResp.body;
       assert.equal(fork.forkOf, memId);
@@ -94,7 +94,7 @@ describe('Conflict detection (concurrent writes)', () => {
 
   it('Higher seq incoming doc overwrites local doc', async () => {
     // Write a memory on A
-    const writeA = await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    const writeA = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: 'To be overwritten',
       tags: ['overwrite-test'],
     });
@@ -124,14 +124,14 @@ describe('Conflict detection (concurrent writes)', () => {
     console.log(`  Higher-seq overwrite: status=${resp.body.status} ✓`);
 
     // Verify the local doc was updated
-    const mem = await get(INSTANCES.a, tokenA, `/api/brain/general/memories/${memId}`);
+    const mem = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(mem.body.fact, 'Updated fact with higher seq');
     console.log(`  Local doc updated to new version ✓`);
   });
 
   it('Tombstone prevents resurrection of deleted document', async () => {
     // Write and then delete a memory on A
-    const writeA = await post(INSTANCES.a, tokenA, '/api/brain/general/memories', {
+    const writeA = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', {
       fact: 'To be deleted then resurrected',
       tags: ['tomb-test'],
     });
@@ -140,7 +140,7 @@ describe('Conflict detection (concurrent writes)', () => {
     const seqA = writeA.body.seq;
 
     // Delete it
-    const deleteR = await fetch(`${INSTANCES.a}/api/brain/general/memories/${memId}`, {
+    const deleteR = await fetch(`${INSTANCES.a}/api/brain/spaces/general/memories/${memId}`, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${tokenA}` },
     });
@@ -168,14 +168,14 @@ describe('Conflict detection (concurrent writes)', () => {
     console.log(`  Resurrection correctly blocked by tombstone ✓`);
 
     // Verify the doc is still absent
-    const check = await get(INSTANCES.a, tokenA, `/api/brain/general/memories/${memId}`);
+    const check = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${memId}`);
     assert.equal(check.status, 404);
     console.log(`  Memory correctly absent after resurrection attempt ✓`);
   });
 
   after(async () => {
     for (const id of injectedMemIds) {
-      await del(INSTANCES.a, tokenA, `/api/brain/general/memories/${id}`).catch(() => {});
+      await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${id}`).catch(() => {});
     }
     if (networkId) {
       await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});

--- a/testing/sync/entity-edge-sync.test.js
+++ b/testing/sync/entity-edge-sync.test.js
@@ -174,7 +174,7 @@ describe('Entity/edge sync — cross-instance (A→B)', () => {
   it('GET /api/sync/memories cursor pagination works', async () => {
     // Write 3 memories to ensure we have data, then page with limit=2
     for (let i = 0; i < 3; i++) {
-      await post(INSTANCES.a, tokenA, '/api/brain/general/memories', { fact: `cursor-test-${RUN}-${i}`, tags: ['cursor'] });
+      await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', { fact: `cursor-test-${RUN}-${i}`, tags: ['cursor'] });
     }
 
     const page1 = await reqJson(INSTANCES.a, tokenA, '/api/sync/memories?spaceId=general&limit=2');

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -163,7 +163,7 @@ export async function triggerSync(baseUrl, token, networkId) {
 
 /** Create a memory on an instance's general space */
 export async function createMemory(baseUrl, token, fact, tags = []) {
-  return post(baseUrl, token, '/api/brain/general/memories', { fact, tags });
+  return post(baseUrl, token, '/api/brain/spaces/general/memories', { fact, tags });
 }
 
 /**
@@ -176,7 +176,7 @@ export async function listMemories(baseUrl, token) {
   let skip = 0;
   const pageSize = 500;
   while (true) {
-    const r = await get(baseUrl, token, `/api/brain/general/memories?limit=${pageSize}&skip=${skip}`);
+    const r = await get(baseUrl, token, `/api/brain/spaces/general/memories?limit=${pageSize}&skip=${skip}`);
     if (r.status !== 200) return r; // surface errors to callers as-is
     const page = r.body.memories ?? [];
     all.push(...page);

--- a/testing/sync/merkle.test.js
+++ b/testing/sync/merkle.test.js
@@ -60,7 +60,7 @@ async function getMerkle(instance, token, spaceId, networkId) {
 
 /** Write a memory document to the brain API (simulates a write). */
 async function writeMemory(instance, token, spaceId, text) {
-  return post(instance, token, `/api/brain/${spaceId}/memories`, {
+  return post(instance, token, `/api/brain/spaces/${spaceId}/memories`, {
     fact: text,
   });
 }

--- a/testing/sync/pubsub-topology.test.js
+++ b/testing/sync/pubsub-topology.test.js
@@ -111,7 +111,7 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
   });
 
   it('Publisher A: write propagates down to Subscriber B', async () => {
-    const write = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+    const write = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Published fact from A',
       tags: ['pubsub-test'],
     });
@@ -121,14 +121,14 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     // A pushes to B
     await triggerSync(INSTANCES.a, tokenA, networkId);
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${memId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
     console.log(`  Published fact appeared on B ✓`);
   });
 
   it('Subscriber B: write does NOT propagate to Publisher A', async () => {
-    const write = await post(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories`, {
+    const write = await post(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Subscriber-only fact from B',
       tags: ['pubsub-sub-local'],
     });
@@ -143,14 +143,14 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
 
     // Wait and verify the subscriber-local fact is NOT on A
     await new Promise(r => setTimeout(r, 3_000));
-    const r = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${subMemId}`);
+    const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${subMemId}`);
     assert.equal(r.status, 404, 'Subscriber fact should NOT appear on publisher');
     console.log(`  Subscriber fact correctly absent from A ✓`);
   });
 
   it('Subscriber-local content survives publisher tombstone', async () => {
     // B creates a local memory
-    const subWrite = await post(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories`, {
+    const subWrite = await post(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Subscriber local fact for tombstone test',
       tags: ['pubsub-survivor'],
     });
@@ -158,7 +158,7 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     const subMemId = subWrite.body._id ?? subWrite.body.id;
 
     // A creates and then deletes a memory — tombstone should propagate to B
-    const pubWrite = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+    const pubWrite = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'Publisher fact to be deleted',
       tags: ['pubsub-delete-test'],
     });
@@ -168,12 +168,12 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     // Push publisher memory to B first
     await triggerSync(INSTANCES.a, tokenA, networkId);
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${pubMemId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${pubMemId}`);
       return r.status === 200;
     });
 
     // Now delete on A
-    const delR = await del(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${pubMemId}`);
+    const delR = await del(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${pubMemId}`);
     assert.equal(delR.status, 204, `Delete on A: expected 204, got ${delR.status}`);
 
     // Push tombstone to B
@@ -181,13 +181,13 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
 
     // Wait for tombstone to propagate
     await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${pubMemId}`);
+      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${pubMemId}`);
       return r.status === 404;
     });
     console.log(`  Publisher's deleted fact removed from B ✓`);
 
     // Verify subscriber's own memory still exists
-    const subCheck = await get(INSTANCES.b, tokenB, `/api/brain/${testSpaceId}/memories/${subMemId}`);
+    const subCheck = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${subMemId}`);
     assert.equal(subCheck.status, 200, 'Subscriber local fact must survive publisher tombstone');
     console.log(`  Subscriber local fact survived publisher tombstone ✓`);
   });

--- a/testing/sync/tombstone-forgery.test.js
+++ b/testing/sync/tombstone-forgery.test.js
@@ -67,7 +67,7 @@ describe('Forged tombstone cross-instance deletion is refused', () => {
 
   it('B cannot delete A-authored content by forging a tombstone as A', async () => {
     // A authors a memory (author.instanceId = A).
-    const w = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+    const w = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'A-authored memory that B must not be able to delete', tags: ['victim'],
     });
     assert.equal(w.status, 201, JSON.stringify(w.body));
@@ -85,12 +85,12 @@ describe('Forged tombstone cross-instance deletion is refused', () => {
     assert.equal(forged.status, 200, JSON.stringify(forged.body));
 
     // The victim memory must still exist.
-    const check = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${victimId}`);
+    const check = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${victimId}`);
     assert.equal(check.status, 200, 'VULNERABILITY: forged tombstone deleted A-authored content');
   });
 
   it('a trusted (admin) tombstone for the same author still deletes — endpoint is not simply broken', async () => {
-    const w = await post(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories`, {
+    const w = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories`, {
       fact: 'A-authored memory deleted via a trusted admin tombstone', tags: ['control'],
     });
     assert.equal(w.status, 201, JSON.stringify(w.body));
@@ -105,7 +105,7 @@ describe('Forged tombstone cross-instance deletion is refused', () => {
     });
     assert.equal(t.status, 200, JSON.stringify(t.body));
 
-    const check = await get(INSTANCES.a, tokenA, `/api/brain/${testSpaceId}/memories/${id}`);
+    const check = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${id}`);
     assert.equal(check.status, 404, 'trusted admin tombstone should have deleted the memory');
   });
 });


### PR DESCRIPTION
## Summary

Architectural item **A1**: collapse the duplicated space-route surface in `brain.ts` onto the canonical `/spaces/:spaceId/…` shape. Space memory endpoints were registered under **two** URL shapes — canonical `/api/brain/spaces/:spaceId/…` and legacy `/api/brain/:spaceId/…` — with the handler bodies **copy-pasted** between them. That doubled the surface to auth-check and test, and is a latent footgun: a guard added to one shape can be missed on the other (exactly the class the security audit kept hitting). The canonical shape was also **incomplete** — it had list/patch/delete/bulk but was missing `POST` create and `GET` by-id, which existed *only* under the legacy shape.

## Breaking change (for 2.0)
The legacy two-segment shape `/api/brain/:spaceId/memories` is **removed** — it now returns `404`. Rather than shipping deprecation 308-redirects (the cautious choice for a minor release), we take the clean break now since the next tag is a major version. Each memory endpoint is registered **once**, under `/spaces/:spaceId/…`.

## What changed
- **`server/src/api/brain.ts`**: re-pathed the two legacy-only handlers (create, get-by-id) to canonical — which also **fixes the incomplete canonical CRUD** — and deleted the four duplicated legacy handler bodies (list, delete-`:id`, patch-`:id`, bulk-wipe). All brain resources are now canonical-only.
- **`client/src/app/core/api.service.ts`**: the two legacy calls (create, get-by-id) already use canonical paths.
- **Tests**: migrated **all 170 legacy memory calls across 33 files** (+ `sync/helpers.js`, `_init/seed-brain.js`) to canonical; `brain.test.js` asserts the legacy shape now `404`s and canonical create/get-by-id work.
- **`docs/integration-guide.md`** + **`CHANGELOG.md`**: documented as a breaking removal with a migration note.

## Also fixed: a flaky MFA test (unrelated to the route change)
While validating, `auth-escalation.test.js`'s `disableMfaViaRestart()` intermittently hung for 56s and failed. Root cause: it only polled Docker's health status, capped at 45s, and **returned silently on timeout** — so a slow container restart left `before()` hitting a dead server and the MFA request hung to its timeout. It now polls the API readiness endpoint and **throws loudly** on timeout (H2 went from a 56s hang to ~3s). This is the robust pattern already used by the sibling `auth-surface-hardening.test.js`.

## Scope note
`files.ts` is deliberately untouched — contrary to the original audit note it has **no** dual shape (it's single-shape, nothing to de-duplicate), and canonicalizing it would mean 308-redirecting large file uploads.

## Testing
On a **fresh** Docker test stack: **sync 173 pass / 1 skip / 0 fail**, **integration 815 pass / 4 skip / 0 fail**, **red-team 258 pass / 0 fail**. Server `tsc --noEmit` and client `ng build` both clean. (An earlier vote-forgery failure was cross-suite state contamination from running suites on a non-reset stack — it passes cleanly on a fresh stack; no code issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
