### PR TITLE
arch: consolidate auth middleware onto a shared core (A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Auth middleware consolidated onto a shared core (internal, no behavior change).** The six
+  `require*` middlewares (`requireAuth`/`requireMcpAuth`, `requireSpaceAuth`, `requireAdmin`,
+  `requireAdminMfa`, `requireAdminMfaScoped`) each repeated the same bearer-extract → resolve →
+  attach-`req.authToken` preamble, and the space-scope and MFA checks were copy-pasted between pairs of
+  them — the kind of duplication where a guard added to one path silently misses another. They now
+  share `resolveAuthOrFail` + `enforceAdmin`/`enforceMfa`/`enforceSpaceScope`/`attachToken` helpers.
+  Exported names, signatures, status codes, error bodies, metrics, and the MCP `WWW-Authenticate`
+  challenge are all preserved exactly; verified against the auth red-team suites (`auth-bypass`,
+  `auth-escalation`, `auth-surface-hardening`, `space-boundary`, `mcp-security`).
+
 ### Removed
 
 - **BREAKING: the legacy `/api/brain/:spaceId/memories` route shape is removed.** Space memory

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -94,6 +94,109 @@ function extractBearer(req: Request): string | null {
   return null;
 }
 
+// ── Shared auth core ─────────────────────────────────────────────────────────
+// The require* middlewares below share the same extract → resolve → attach
+// preamble, plus a couple of common predicates (admin, MFA, space scope). These
+// helpers hold each in one place so a change — a new metric, an audit hook, an
+// OIDC tweak — is made once instead of mirrored by hand across ~6 functions.
+
+/** Attach the resolved record to the request and refresh a PAT's lastUsed. */
+function attachToken(
+  req: Request,
+  record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
+  bearer: string,
+): void {
+  req.authToken = record;
+  // Update lastUsed asynchronously for PAT tokens — do not block the request.
+  if (isPat(bearer) && 'id' in record) touchToken(record.id);
+}
+
+/**
+ * Extract and resolve the bearer, writing the shared 401 responses. Returns the
+ * resolved record (and the raw bearer) on success, or null once a response has
+ * been sent — callers must `return` immediately on null.
+ *
+ * `onChallenge` runs just before a 401 (to attach a `WWW-Authenticate` header).
+ * `recordInvalidMetric` preserves the historical behaviour where only the
+ * non-admin paths increment `authAttemptsTotal{result="invalid"}`.
+ */
+async function resolveAuthOrFail(
+  req: Request,
+  res: Response,
+  opts: { onChallenge?: (res: Response) => void; recordInvalidMetric?: boolean } = {},
+): Promise<{ record: Omit<TokenRecord, 'hash'> | OidcTokenRecord; bearer: string } | null> {
+  const bearer = extractBearer(req);
+  if (!bearer) {
+    if (opts.onChallenge) opts.onChallenge(res);
+    res.status(401).json({ error: 'Missing Authorization header' });
+    return null;
+  }
+  const record = await resolveBearer(bearer);
+  if (!record) {
+    if (opts.recordInvalidMetric) authAttemptsTotal.inc({ result: 'invalid' });
+    logAuthFailure(req);
+    if (opts.onChallenge) opts.onChallenge(res);
+    res.status(401).json({ error: 'Invalid or expired token' });
+    return null;
+  }
+  return { record, bearer };
+}
+
+/** Enforce `admin: true`; writes 403 and returns false when the token is not admin. */
+function enforceAdmin(res: Response, record: Omit<TokenRecord, 'hash'> | OidcTokenRecord): boolean {
+  if (!record.admin) {
+    res.status(403).json({ error: 'Admin token required' });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Enforce a current TOTP code for PAT sessions when MFA is enabled. Writes the
+ * MFA_REQUIRED / MFA_INVALID 403 and returns false on failure. OIDC sessions are
+ * exempt (the IdP handles its own step-up auth).
+ */
+function enforceMfa(req: Request, res: Response, bearer: string): boolean {
+  if (isPat(bearer) && isMfaEnabled()) {
+    const code = (req.headers['x-totp-code'] as string | undefined ?? '').trim();
+    if (!code) {
+      res.status(403).json({ error: 'MFA_REQUIRED' });
+      return false;
+    }
+    if (!verifyMfaCode(code)) {
+      res.status(403).json({ error: 'MFA_INVALID' });
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Enforce the token's `spaces` allowlist against a space id (proxy-aware).
+ * Writes 403 and returns false when the token lacks access. Unrestricted tokens
+ * (no `spaces` allowlist) always pass.
+ */
+function enforceSpaceScope(
+  res: Response,
+  record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
+  spaceId: string | undefined,
+): boolean {
+  if (record.spaces && spaceId) {
+    // For proxy spaces, the token must have access to all member spaces.
+    // If the space doesn't exist in config, resolveMemberSpaces returns [].
+    // Fall back to [spaceId] so the scope check still rejects tokens that
+    // don't list this space — returning 403 instead of leaking a 404.
+    const memberIds = resolveMemberSpaces(spaceId);
+    const targets = memberIds.length > 0 ? memberIds : [spaceId];
+    const missing = targets.filter(sid => !record.spaces!.includes(sid));
+    if (missing.length > 0) {
+      res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Middleware that requires a valid Bearer PAT token.
  * Sets req.authToken on success.
@@ -134,21 +237,9 @@ async function performAuth(
   next: NextFunction,
   onChallenge?: (res: Response) => void,
 ): Promise<void> {
-  const bearer = extractBearer(req);
-  if (!bearer) {
-    if (onChallenge) onChallenge(res);
-    res.status(401).json({ error: 'Missing Authorization header' });
-    return;
-  }
-
-  const record = await resolveBearer(bearer);
-  if (!record) {
-    authAttemptsTotal.inc({ result: 'invalid' });
-    logAuthFailure(req);
-    if (onChallenge) onChallenge(res);
-    res.status(401).json({ error: 'Invalid or expired token' });
-    return;
-  }
+  const auth = await resolveAuthOrFail(req, res, { onChallenge, recordInvalidMetric: true });
+  if (!auth) return;
+  const { record, bearer } = auth;
 
   // schemaLibrary tokens have no space/admin access — reject them on all other routes
   if ('schemaLibrary' in record && record.schemaLibrary) {
@@ -157,11 +248,7 @@ async function performAuth(
   }
 
   authAttemptsTotal.inc({ result: 'success' });
-  req.authToken = record;
-
-  // Update lastUsed asynchronously for PAT tokens — do not block request
-  if (isPat(bearer) && 'id' in record) touchToken(record.id);
-
+  attachToken(req, record, bearer);
   next();
 }
 
@@ -195,8 +282,7 @@ export async function acceptSchemaLibraryToken(
   }
 
   authAttemptsTotal.inc({ result: 'success' });
-  req.authToken = record;
-  if (isPat(bearer) && 'id' in record) touchToken(record.id);
+  attachToken(req, record, bearer);
   next();
 }
 
@@ -209,39 +295,16 @@ export async function requireSpaceAuth(
   res: Response,
   next: NextFunction,
 ): Promise<void> {
-  const bearer = extractBearer(req);
-  if (!bearer) {
-    res.status(401).json({ error: 'Missing Authorization header' });
-    return;
-  }
-
-  const record = await resolveBearer(bearer);
-  if (!record) {
-    authAttemptsTotal.inc({ result: 'invalid' });
-    logAuthFailure(req);
-    res.status(401).json({ error: 'Invalid or expired token' });
-    return;
-  }
+  const auth = await resolveAuthOrFail(req, res, { recordInvalidMetric: true });
+  if (!auth) return;
+  const { record, bearer } = auth;
 
   const spaceId = req.params['spaceId'] as string | undefined;
-  if (record.spaces && spaceId) {
-    // For proxy spaces, the token must have access to all member spaces.
-    // If the space doesn't exist in config, resolveMemberSpaces returns [].
-    // Fall back to [spaceId] so the scope check still rejects tokens that
-    // don't list this space — returning 403 instead of leaking a 404.
-    const memberIds = resolveMemberSpaces(spaceId);
-    const targets = memberIds.length > 0 ? memberIds : [spaceId];
-    const missing = targets.filter(sid => !record.spaces!.includes(sid));
-    if (missing.length > 0) {
-      res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });
-      return;
-    }
-  }
+  if (!enforceSpaceScope(res, record, spaceId)) return;
 
   authAttemptsTotal.inc({ result: 'success' });
-  req.authToken = record;
+  attachToken(req, record, bearer);
   req.resolvedSpaceId = spaceId;
-  if (isPat(bearer) && 'id' in record) touchToken(record.id);
   next();
 }
 
@@ -255,52 +318,19 @@ export async function requireSpaceAuth(
  */
 export function requireAdminMfaScoped(paramName: string) {
   return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
-    const bearer = extractBearer(req);
-    if (!bearer) {
-      res.status(401).json({ error: 'Missing Authorization header' });
-      return;
-    }
+    const auth = await resolveAuthOrFail(req, res, {});
+    if (!auth) return;
+    const { record, bearer } = auth;
 
-    const record = await resolveBearer(bearer);
-    if (!record) {
-      logAuthFailure(req);
-      res.status(401).json({ error: 'Invalid or expired token' });
-      return;
-    }
-
-    if (!record.admin) {
-      res.status(403).json({ error: 'Admin token required' });
-      return;
-    }
-
-    // MFA check — same as requireAdminMfa
-    if (isPat(bearer) && isMfaEnabled()) {
-      const code = (req.headers['x-totp-code'] as string | undefined ?? '').trim();
-      if (!code) {
-        res.status(403).json({ error: 'MFA_REQUIRED' });
-        return;
-      }
-      if (!verifyMfaCode(code)) {
-        res.status(403).json({ error: 'MFA_INVALID' });
-        return;
-      }
-    }
+    if (!enforceAdmin(res, record)) return;
+    if (!enforceMfa(req, res, bearer)) return;
 
     // Space-scope enforcement for space-restricted admin tokens.
     // Tokens without a spaces allowlist (unrestricted admin) are always allowed.
     const spaceId = req.params[paramName] as string | undefined;
-    if (record.spaces && spaceId) {
-      const memberIds = resolveMemberSpaces(spaceId);
-      const targets = memberIds.length > 0 ? memberIds : [spaceId];
-      const missing = targets.filter(sid => !record.spaces!.includes(sid));
-      if (missing.length > 0) {
-        res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });
-        return;
-      }
-    }
+    if (!enforceSpaceScope(res, record, spaceId)) return;
 
-    req.authToken = record;
-    if (isPat(bearer) && 'id' in record) touchToken(record.id);
+    attachToken(req, record, bearer);
     next();
   };
 }
@@ -313,26 +343,13 @@ export function requireAdminMfaScoped(paramName: string) {
  *  admin flag is derived from the configured claimMapping.admin rule.
  */
 export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const bearer = extractBearer(req);
-  if (!bearer) {
-    res.status(401).json({ error: 'Missing Authorization header' });
-    return;
-  }
+  const auth = await resolveAuthOrFail(req, res, {});
+  if (!auth) return;
+  const { record, bearer } = auth;
 
-  const record = await resolveBearer(bearer);
-  if (!record) {
-    logAuthFailure(req);
-    res.status(401).json({ error: 'Invalid or expired token' });
-    return;
-  }
+  if (!enforceAdmin(res, record)) return;
 
-  if (!record.admin) {
-    res.status(403).json({ error: 'Admin token required' });
-    return;
-  }
-
-  req.authToken = record;
-  if (isPat(bearer) && 'id' in record) touchToken(record.id);
+  attachToken(req, record, bearer);
   next();
 }
 
@@ -351,38 +368,13 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
  *   403 { error: 'MFA_INVALID'  } — MFA enabled, code wrong / expired
  */
 export async function requireAdminMfa(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const bearer = extractBearer(req);
-  if (!bearer) {
-    res.status(401).json({ error: 'Missing Authorization header' });
-    return;
-  }
+  const auth = await resolveAuthOrFail(req, res, {});
+  if (!auth) return;
+  const { record, bearer } = auth;
 
-  const record = await resolveBearer(bearer);
-  if (!record) {
-    logAuthFailure(req);
-    res.status(401).json({ error: 'Invalid or expired token' });
-    return;
-  }
+  if (!enforceAdmin(res, record)) return;
+  if (!enforceMfa(req, res, bearer)) return;
 
-  if (!record.admin) {
-    res.status(403).json({ error: 'Admin token required' });
-    return;
-  }
-
-  // MFA is only enforced for PAT sessions; OIDC sessions use IdP step-up auth.
-  if (isPat(bearer) && isMfaEnabled()) {
-    const code = (req.headers['x-totp-code'] as string | undefined ?? '').trim();
-    if (!code) {
-      res.status(403).json({ error: 'MFA_REQUIRED' });
-      return;
-    }
-    if (!verifyMfaCode(code)) {
-      res.status(403).json({ error: 'MFA_INVALID' });
-      return;
-    }
-  }
-
-  req.authToken = record;
-  if (isPat(bearer) && 'id' in record) touchToken(record.id);
+  attachToken(req, record, bearer);
   next();
 }


### PR DESCRIPTION
## Summary

Architectural item **A2**: consolidate the shared auth-middleware core. The six `require*` middlewares in `server/src/auth/middleware.ts` each repeated the same **bearer-extract → resolve → attach-`req.authToken`** preamble, and the **space-scope** and **MFA** checks were copy-pasted between pairs of them. That's the exact duplication class the security audit kept hitting: a guard added to one path can be silently missed on another.

## What changed
Extract the shared pieces into helpers and rebuild each middleware on top of them:

- **`resolveAuthOrFail(req, res, opts)`** — the extract + resolve + shared 401 responses; returns the resolved record (and raw bearer), or `null` after a response has been written.
- **`enforceAdmin` / `enforceMfa` / `enforceSpaceScope`** — the reusable predicates (each writes its 403 and returns a boolean).
- **`attachToken`** — set `req.authToken` + refresh a PAT's `lastUsed`.

`requireAuth`/`requireMcpAuth` (via `performAuth`), `requireSpaceAuth`, `requireAdmin`, `requireAdminMfa`, and `requireAdminMfaScoped` are now thin compositions of these.

## Behavior is byte-identical
This is a pure refactor — no exported name/signature changes, no route registration changes. Every divergence between the middlewares is preserved deliberately:

- **Metrics**: `authAttemptsTotal{invalid|success}` is still incremented only by the non-admin paths (`performAuth`, `acceptSchemaLibraryToken`, `requireSpaceAuth`); the admin middlewares still record **nothing** — a pre-existing quirk kept intact rather than "fixed", to avoid changing observable `/metrics` output.
- **Success metric timing**: still counted *after* each path's own checks pass (so a space-denied `403` is not counted as success).
- **MCP challenge**: the `WWW-Authenticate: Bearer resource_metadata="…"` header is still emitted only by `requireMcpAuth`.
- **schemaLibrary reject** (only `performAuth`), **`req.resolvedSpaceId`** (only `requireSpaceAuth`), and `logAuthFailure` ordering are all unchanged.
- `acceptSchemaLibraryToken` keeps its unique "no header → public access" path; it only adopts `attachToken`.

## Testing
On the Docker test stack (merged with A1): the auth red-team suites — `auth-bypass`, `auth-escalation`, `auth-surface-hardening`, `space-boundary`, `mcp-security` — plus integration `auth` all pass **in isolation** (the gate the audit specified for this file). Full **integration 815 pass / 4 skip / 0 fail** and **red-team 258 / 0 fail**. Server `tsc --noEmit` clean.

Branch is merged up to date with `main` (includes A1 #149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
