### PR TITLE
arch: unify the sync scheduler on node-cron (A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Sync scheduling now uses real cron (and honours cron expressions that were silently ignored).**
+  The per-network `syncSchedule` was parsed by a bespoke `*/N minutes|hours` / `every Nm|Nh` regex on
+  top of `setInterval`, so a **standard cron expression — the format the integration guide documents,
+  e.g. `*/5 * * * *`** — was not recognised and the network silently fell back to manual-sync only.
+  The scheduler now runs on `node-cron` (the same engine backups and the duplicate scanner already
+  use): a cron expression is used directly, and the two legacy shorthands are translated to cron for
+  backward compatibility (values cron can't express, e.g. `every 90m`, now warn instead of silently
+  scheduling). Covered by `testing/standalone/sync-cron.test.js`.
+
 ### Removed
 
 - **BREAKING: the legacy `/api/brain/:spaceId/memories` route shape is removed.** Space memory

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3057,6 +3057,8 @@ POST /api/networks
 
 **`requireSignedVotes`** (optional, default `false`): when `true`, governance vote casts must carry a valid Ed25519 signature from the voting member (strict mode). Leave it off until every member has synced at least once so their signing keys are published; then enable it (also settable via `PATCH`) to reject any unsigned or forged vote. See [Sync Protocol → Signed vote casts](sync-protocol.md).
 
+**`syncSchedule`** (optional): how often this network syncs automatically. Give a standard **cron expression** (e.g. `"*/5 * * * *"` = every 5 minutes, `"0 * * * *"` = hourly) — the same node-cron engine the backup scheduler uses. Two legacy shorthands are also accepted and translated to cron: `"*/N minutes"` / `"every Nm"` (1–59) and `"*/N hours"` / `"every Nh"` (1–23). Omit it (or set it empty) for manual-sync only. An unrecognised value is ignored with a startup warning, leaving the network on manual sync.
+
 **Response** `201`: the created network object.
 
 ---

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -26,6 +26,8 @@ import { peerSafeFetch, isPeerUrlAllowed } from './peer-fetch.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from '../api/sync.js';
 import { enqueueMediaJob } from '../files/media/job-queue.js';
 import { resolveInputFormat } from '../files/converters/pipeline.js';
+import { schedule as cronSchedule, type ScheduledTask } from 'node-cron';
+import { resolveSyncCron } from './schedule.js';
 import {
   syncCyclesTotal,
   syncItemsPulledTotal,
@@ -92,7 +94,7 @@ export function localToRemote(net: NetworkConfig, localId: string): string {
 
 // ── Cron scheduler ─────────────────────────────────────────────────────────
 
-const _scheduledTimers = new Map<string, ReturnType<typeof setInterval>>();
+const _scheduledTasks = new Map<string, ScheduledTask>();
 
 /** Start cron-based sync for all networks that have a syncSchedule.
  *  Call this from index.ts after spaces are initialised. */
@@ -104,50 +106,38 @@ export function startSyncScheduler(): void {
   log.debug(`Sync scheduler started (${cfg.networks.length} networks)`);
 }
 
-/** Stop all scheduled timers */
+/** Stop all scheduled tasks */
 export function stopSyncScheduler(): void {
-  for (const [id, timer] of _scheduledTimers) {
-    clearInterval(timer);
+  for (const [id, task] of _scheduledTasks) {
+    task.stop();
     log.debug(`Sync scheduler stopped for network ${id}`);
   }
-  _scheduledTimers.clear();
+  _scheduledTasks.clear();
 }
 
-/** Schedule (or reschedule) sync for a network */
+/** Schedule (or reschedule) sync for a network. `schedule` is a cron expression
+ *  (the documented format) or one of the legacy shorthands; see resolveSyncCron.
+ *  Uses node-cron — the same scheduler as backups and the duplicate scanner. */
 export function scheduleSyncForNetwork(networkId: string, schedule?: string): void {
-  const old = _scheduledTimers.get(networkId);
-  if (old) { clearInterval(old); _scheduledTimers.delete(networkId); }
+  const old = _scheduledTasks.get(networkId);
+  if (old) { old.stop(); _scheduledTasks.delete(networkId); }
 
   if (!schedule) return;
 
-  // Parse simple schedule: "*/N minutes" or "*/N hours"
-  // Full cron parsing out of scope — we parse the two most common patterns
-  const intervalMs = parseSyncSchedule(schedule);
-  if (!intervalMs) {
+  const cronExpr = resolveSyncCron(schedule);
+  if (!cronExpr) {
     log.warn(`Unrecognised sync schedule '${schedule}' for network ${networkId} — using manual sync only`);
     return;
   }
 
-  const timer = setInterval(() => {
+  const task = cronSchedule(cronExpr, () => {
     runSyncForNetwork(networkId).catch(err =>
       log.error(`Scheduled sync failed for network ${networkId}: ${err}`),
     );
-  }, intervalMs);
+  });
 
-  _scheduledTimers.set(networkId, timer);
-  log.info(`Sync scheduled for network ${networkId} every ${intervalMs / 1000}s`);
-}
-
-// Parse cron-style schedule patterns: "* /N minutes", "every Nm", "every Nh"
-// (space deliberately added above to avoid TS parsing as block comment end)
-function parseSyncSchedule(s: string): number | null {
-  const cronPattern = /\*\/(\d+)\s*(min(?:utes?)?|h(?:ours?)?)/i;
-  const m = cronPattern.exec(s) ?? /every\s+(\d+)\s*(m(?:in)?|h(?:r?)?)/i.exec(s);
-  if (!m) return null;
-  const n = parseInt(m[1]!, 10);
-  const unit = m[2]!.toLowerCase();
-  const isHours = unit.startsWith('h');
-  return n * (isHours ? 3_600_000 : 60_000);
+  _scheduledTasks.set(networkId, task);
+  log.info(`Sync scheduled for network ${networkId} (cron: "${cronExpr}")`);
 }
 
 // ── Per-network sync ────────────────────────────────────────────────────────

--- a/server/src/sync/schedule.ts
+++ b/server/src/sync/schedule.ts
@@ -1,0 +1,35 @@
+import { validate } from 'node-cron';
+
+/**
+ * Resolve a network's `syncSchedule` string to a cron expression that node-cron
+ * can run, or `null` when it isn't recognised (the caller then leaves the
+ * network on manual-sync only).
+ *
+ * Accepts:
+ *  - A **standard cron expression**, used as-is — the documented format the
+ *    integration guide shows (e.g. `"*​/5 * * * *"`). The previous bespoke parser
+ *    only understood the shorthands below and silently ignored real cron
+ *    expressions, leaving those networks on manual sync despite the docs.
+ *  - Two **legacy shorthands**, translated to cron for backward compatibility:
+ *      `"*​/N minutes"` | `"every Nm"` → `"*​/N * * * *"`  (1 ≤ N ≤ 59)
+ *      `"*​/N hours"`   | `"every Nh"` → `"0 *​/N * * *"`  (1 ≤ N ≤ 23)
+ *    Values outside cron's range (e.g. `"every 90m"`) return `null` — migrate
+ *    those to an explicit cron expression.
+ */
+export function resolveSyncCron(schedule: string): string | null {
+  const s = schedule.trim();
+  if (!s) return null;
+
+  // Already a valid cron expression — use it directly.
+  if (validate(s)) return s;
+
+  // Legacy shorthands (unchanged matching from the original parser).
+  const m = /\*\/(\d+)\s*(min(?:utes?)?|h(?:ours?)?)/i.exec(s)
+         ?? /every\s+(\d+)\s*(m(?:in)?|h(?:r?)?)/i.exec(s);
+  if (!m) return null;
+
+  const n = parseInt(m[1]!, 10);
+  const isHours = m[2]!.toLowerCase().startsWith('h');
+  if (isHours) return n >= 1 && n <= 23 ? `0 */${n} * * *` : null;
+  return n >= 1 && n <= 59 ? `*/${n} * * * *` : null;
+}

--- a/testing/standalone/sync-cron.test.js
+++ b/testing/standalone/sync-cron.test.js
@@ -1,0 +1,62 @@
+/**
+ * Unit tests: sync schedule → cron translation (sync/schedule.ts resolveSyncCron)
+ *
+ * The sync scheduler now runs on node-cron (same as backups). resolveSyncCron
+ * maps a network's `syncSchedule` string to a cron expression:
+ *  - a real cron expression passes through (the documented format — the old
+ *    bespoke parser silently ignored these, leaving networks on manual sync);
+ *  - two legacy shorthands are translated for backward compatibility;
+ *  - anything else returns null (caller falls back to manual sync).
+ *
+ * Pure in-process logic — no network, no config. Run with:
+ *   node --test testing/standalone/sync-cron.test.js
+ * (build the server first: npm run build:server)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveSyncCron } from '../../server/dist/sync/schedule.js';
+
+describe('resolveSyncCron — cron passthrough', () => {
+  it('keeps a standard 5-field cron expression as-is', () => {
+    assert.equal(resolveSyncCron('*/5 * * * *'), '*/5 * * * *');
+    assert.equal(resolveSyncCron('0 */2 * * *'), '0 */2 * * *');
+    assert.equal(resolveSyncCron('30 3 * * 1'), '30 3 * * 1');
+  });
+
+  it('keeps a 6-field (seconds) cron expression as-is', () => {
+    assert.equal(resolveSyncCron('0 */5 * * * *'), '0 */5 * * * *');
+  });
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(resolveSyncCron('  */10 * * * *  '), '*/10 * * * *');
+  });
+});
+
+describe('resolveSyncCron — legacy shorthand translation', () => {
+  it('translates "*/N minutes" and "every Nm"', () => {
+    assert.equal(resolveSyncCron('*/5 minutes'), '*/5 * * * *');
+    assert.equal(resolveSyncCron('*/15 minutes'), '*/15 * * * *');
+    assert.equal(resolveSyncCron('every 30m'), '*/30 * * * *');
+    assert.equal(resolveSyncCron('every 1min'), '*/1 * * * *');
+  });
+
+  it('translates "*/N hours" and "every Nh"', () => {
+    assert.equal(resolveSyncCron('*/2 hours'), '0 */2 * * *');
+    assert.equal(resolveSyncCron('every 3h'), '0 */3 * * *');
+  });
+});
+
+describe('resolveSyncCron — unrecognised / out-of-range → null', () => {
+  it('returns null for empty / gibberish', () => {
+    assert.equal(resolveSyncCron(''), null);
+    assert.equal(resolveSyncCron('   '), null);
+    assert.equal(resolveSyncCron('whenever'), null);
+  });
+
+  it('returns null for shorthand values cron cannot express', () => {
+    assert.equal(resolveSyncCron('every 90m'), null);   // minutes > 59
+    assert.equal(resolveSyncCron('*/25 hours'), null);   // hours > 23
+    assert.equal(resolveSyncCron('every 0m'), null);     // zero
+  });
+});


### PR DESCRIPTION
## Summary

Architectural item **A4**: unify the sync scheduler on `node-cron`. The per-network `syncSchedule` was parsed by a **bespoke `*/N minutes|hours` / `every Nm|Nh` regex** on top of `setInterval`, separate from the `node-cron` scheduler that backups and the duplicate scanner already use.

## The bug this also fixes
The integration guide documents `syncSchedule` as a **standard cron expression** (`"*/5 * * * *"`), but the bespoke parser only understood the shorthands — so a user following the docs got their schedule **silently ignored**, with the network falling back to manual-sync only. That mismatch is now fixed: real cron expressions work.

## What changed
- **`server/src/sync/schedule.ts`** (new, lightweight — only imports node-cron's `validate`): `resolveSyncCron(schedule)` maps a `syncSchedule` string to a cron expression:
  - a valid **cron expression passes through** (the documented format);
  - the two **legacy shorthands** are translated to cron for backward compatibility (`*/N minutes` / `every Nm` → `*/N * * * *`; `*/N hours` / `every Nh` → `0 */N * * *`);
  - anything else returns `null` → the caller warns and leaves the network on manual sync.
- **`server/src/sync/engine.ts`**: the scheduler now uses `node-cron`'s `schedule()` / `ScheduledTask` instead of `setInterval`, mirroring `backup-scheduler.ts` and `dupe-scanner.ts`.
- **`testing/standalone/sync-cron.test.js`** (new): unit tests for cron passthrough (5- and 6-field), shorthand translation, whitespace trimming, and unrecognised/out-of-range → `null`.
- **`docs/integration-guide.md`**: documents the accepted `syncSchedule` formats.

## Behavior note
Values cron cannot express (e.g. `every 90m`, minutes > 59) now **warn** instead of silently scheduling — migrate those to an explicit cron expression. Everything cron *can* express (all realistic schedules) is unchanged or newly working.

## Testing
On a fresh Docker test stack: **sync suite 173 pass / 1 skip / 0 fail**, **standalone 733 pass / 0 fail** (including the new cron unit tests). Server `tsc --noEmit` clean. The scheduler's run path is exercised by the existing sync suites (which trigger sync); the translation is covered by the new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
