### PR TITLE
security: governance rounds must not conclude on an empty voter set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Governance rounds no longer conclude on an empty voter set.** `concludeRoundIfReady` treated
+  "no remote voters" (the only member left is the round's subject) as vacuously "everyone voted yes",
+  so a `closed`/braintree round with **zero votes** passed. Combined with gossip round adoption, a
+  malicious peer in a small network could serve a **forged `remove` / `space_deletion` / `meta_change`
+  round** and the victim would conclude it — ejecting a member or deleting a space **without any
+  legitimate vote**. (The per-cast forgery guard correctly rejected the forged votes, but the round
+  needed none to pass.) An empty voter set now concludes only when **this instance itself voted yes**,
+  i.e. a locally-proposed action — a gossip-adopted round carries no local vote and never concludes.
+  Legitimate solo actions (self-initiated remove / space deletion, which cast our own yes) are
+  unaffected. Regression-guarded by `testing/sync/vote-forgery.test.js` and `governance.test.js`.
 - **Kubernetes deployment is hardened and its probes/ports now actually work.** The stock
   `kubernetes/manifests/ythril-deployment.yaml` had no `securityContext`, used the mutable
   `:latest` image tag, set no resource limits on the main container, and targeted

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -1504,9 +1504,25 @@ function concludeRoundIfReady(
   // For unanimous-requirement types (closed, braintree): every remote voter must have voted yes
   // individually. A self/proposer yes vote counts as evidence of intent but does NOT short-circuit
   // the requirement for all listed members to vote.
+  //
+  // SECURITY: when there are no remote voters (the only member left is the round's
+  // subject), conclude ONLY if THIS instance itself voted yes — i.e. a local
+  // operator proposed the action. A self-initiated remove / space_deletion casts
+  // our own yes when the round opens, so legitimate solo actions still pass. An
+  // empty voter set was previously treated as vacuously "all voted yes", so a round
+  // ADOPTED via gossip (which never carries our vote) concluded on an empty
+  // quorum — letting a malicious peer in a small network force a
+  // remove / space_deletion / meta_change through with no legitimate vote. Forged
+  // casts are dropped by acceptVoteCast, so an adopted forged round holds no local
+  // yes and correctly never concludes here.
+  const localInstanceId = getConfig().instanceId;
+  const localVotedYes = round.votes.some(
+    c => c.instanceId === localInstanceId && c.vote === 'yes',
+  );
   const allRemoteVotedYes =
-    voters.length === 0 ||
-    voters.every(v => round.votes.some(c => c.instanceId === v.instanceId && c.vote === 'yes'));
+    voters.length === 0
+      ? localVotedYes
+      : voters.every(v => round.votes.some(c => c.instanceId === v.instanceId && c.vote === 'yes'));
 
   const yesCount = round.votes.filter(v => v.vote === 'yes').length;
 


### PR DESCRIPTION
## Summary

Fixes a **governance vulnerability** surfaced while validating A4: `concludeRoundIfReady` concluded a `closed`/braintree vote round on an **empty voter set with zero votes**, letting a malicious peer force membership/space changes through gossip with no legitimate quorum.

## The bug
For `closed` (and the braintree fallback), `allRemoteVotedYes` was:

```js
const allRemoteVotedYes =
  voters.length === 0 ||                       // ← vacuously true with NO votes
  voters.every(v => round.votes.some(c => c.instanceId === v.instanceId && c.vote === 'yes'));
```

`voters = members.filter(!= subject)`. Networks store **peers only** (self isn't in `members`), so in a two-member network `A.members = [B]`, and a `remove-B` round computes `voters = []` → `voters.length === 0` → **passed with zero votes**.

Gossip round adoption (`engine.ts`) then does the damage: when A pulls from a malicious B, B serves a **forged** `remove` / `space_deletion` / `meta_change` round. The per-cast forgery guard (`acceptVoteCast`) *correctly rejects* the forged votes — but the round needs none to pass, so A adopts it (`changed = true`), re-evaluates, and concludes it, **ejecting the member / deleting the space with no legitimate vote.** Confirmed in `ythril-a` logs:

```
Vote gossip: rejecting cast ... unsigned vote relayed on behalf of another instance   ← guard works
Vote gossip: adopted round forged-... (remove)
Starting sync cycle for network 'Vote Forgery' (0 members)                            ← B ejected
```

## The fix
An empty voter set now concludes **only when this instance itself voted yes** — evidence of a locally-proposed action:

```js
const localVotedYes = round.votes.some(c => c.instanceId === getConfig().instanceId && c.vote === 'yes');
const allRemoteVotedYes = voters.length === 0 ? localVotedYes : voters.every(/* … */);
```

Self-initiated rounds cast our own yes when they open (`remove` casts it when we're a required voter; `space_deletion` opens with `votes: [{self, yes}]`), so **legitimate solo actions still conclude**. A gossip-adopted round never carries our vote, so a forged one **no longer concludes**.

> I first tried "a non-subject member voted yes", which broke `space_deletion` — those rounds set `subjectInstanceId = self`, so the proposer *is* the subject. "This instance voted yes" is the correct discriminator; caught by `governance.test.js` before it went anywhere.

## Why the test looked "flaky"
`vote-forgery.test.js` passed non-deterministically: on a fresh stack A often didn't pull the forged round in time (passing for the wrong reason); when sync delivered it, the bug ejected B. **The test was right; the code was wrong.** It now passes deterministically and guards the fix.

## Testing
Fresh Docker stack: **sync 173 / 0 fail** (incl. `vote-forgery` + `governance`), **integration 815 / 0**, **red-team 258 / 0**. Server `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
