### PR TITLE
fix: governance "No" vote button casts a veto (was sending an invalid value)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The governance vote "No" button now works (and casts a veto).** The Networks UI offered **Yes/No**
+  buttons, but the server accepts only `yes`/`veto` (`VoteValue`), so clicking **No** returned `400`
+  and there was no way to cast a blocking vote from the UI at all. The negative button now casts a
+  `veto` — the blocking vote the model and docs already describe ("a single no blocks it") — and is
+  relabelled **Veto** to match. Client-only fix.
 - **`<html lang>` now tracks the active UI language.** It was hardcoded to `en`, so screen-reader
   pronunciation and browser hyphenation stayed English for German and Polish users even though the UI
   was fully translated. The document language is now set on startup and updated on every language

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -475,7 +475,7 @@
   "networks.network.members.removeAriaLabel": "Mitglied entfernen",
   "networks.network.votes.title": "Offene Abstimmungen",
   "networks.network.votes.yes": "\u2713 Ja",
-  "networks.network.votes.no": "\u2717 Nein",
+  "networks.network.votes.veto": "\u2717 Veto",
   "networks.network.leaveButton": "Netzwerk verlassen",
   "networks.dialog.create.title": "Netzwerk erstellen",
   "networks.dialog.create.label": "Netzwerkbezeichnung",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -474,7 +474,7 @@
   "networks.network.members.removeAriaLabel": "Remove member",
   "networks.network.votes.title": "Open votes",
   "networks.network.votes.yes": "\u2713 Yes",
-  "networks.network.votes.no": "\u2717 No",
+  "networks.network.votes.veto": "\u2717 Veto",
   "networks.network.leaveButton": "Leave network",
   "networks.dialog.create.title": "Create network",
   "networks.dialog.create.label": "Network label",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -475,7 +475,7 @@
   "networks.network.members.removeAriaLabel": "Usu\u0144 cz\u0142onka",
   "networks.network.votes.title": "Otwarte g\u0142osowanie",
   "networks.network.votes.yes": "\u2713 Tak",
-  "networks.network.votes.no": "\u2717 Nie",
+  "networks.network.votes.veto": "\u2717 Weto",
   "networks.network.leaveButton": "Opu\u015b\u0107 sie\u0107",
   "networks.dialog.create.title": "Utw\u00f3rz sie\u0107",
   "networks.dialog.create.label": "Etykieta sieciowa",

--- a/client/src/app/core/api.service.ts
+++ b/client/src/app/core/api.service.ts
@@ -317,7 +317,7 @@ export interface VoteRound {
   openedAt: string;
   deadline: string;
   status: 'open' | 'passed' | 'failed';
-  votes: { instanceId: string; vote: 'yes' | 'no'; }[];
+  votes: { instanceId: string; vote: 'yes' | 'veto'; }[];
 }
 
 export interface ConflictRecord {
@@ -1026,7 +1026,7 @@ export class ApiService {
     return this.http.post<{ ok: boolean }>(`/api/networks/${networkId}/sync`, {});
   }
 
-  castVote(networkId: string, roundId: string, vote: 'yes' | 'no'): Observable<void> {
+  castVote(networkId: string, roundId: string, vote: 'yes' | 'veto'): Observable<void> {
     return this.http.post<void>(`/api/networks/${networkId}/votes/${roundId}`, { vote });
   }
 

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -308,7 +308,7 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
                     <div class="vote-row">
                       <span style="flex:1;">{{ round.type }}: {{ round.subject }}</span>
                       <button class="btn-primary btn btn-sm" (click)="castVote(net.id, round.id, 'yes')">{{ 'networks.network.votes.yes' | transloco }}</button>
-                      <button class="btn-danger btn btn-sm" (click)="castVote(net.id, round.id, 'no')">{{ 'networks.network.votes.no' | transloco }}</button>
+                      <button class="btn-danger btn btn-sm" (click)="castVote(net.id, round.id, 'veto')">{{ 'networks.network.votes.veto' | transloco }}</button>
                     </div>
                   }
                 </div>
@@ -1210,7 +1210,7 @@ export class NetworksComponent implements OnInit {
     return this.votesByNetwork[networkId] ?? [];
   }
 
-  castVote(networkId: string, roundId: string, vote: 'yes' | 'no'): void {
+  castVote(networkId: string, roundId: string, vote: 'yes' | 'veto'): void {
     this.api.castVote(networkId, roundId, vote).subscribe({
       next: () => this.loadVotes(networkId),
       error: (err) => alert(err.error?.error ?? this.transloco.translate('networks.error.castVoteFailed')),

--- a/docs/network-types.md
+++ b/docs/network-types.md
@@ -109,7 +109,7 @@ graph LR
     style D fill:#2a3a1a,color:#eee,stroke:#66aa44
 ```
 
-**5-member network, join vote (3 yes, 1 no, 1 veto):**
+**5-member network, join vote (3 yes, 1 abstain, 1 veto):**
 
 ```mermaid
 sequenceDiagram
@@ -118,7 +118,7 @@ sequenceDiagram
 
     E->>Net: join request
     Net-->>Net: voting round opens (48h deadline)
-    Note over Net: A → yes<br/>B → yes<br/>C → yes<br/>D → no<br/>F → VETO
+    Note over Net: A → yes<br/>B → yes<br/>C → yes<br/>D → abstains<br/>F → VETO
     Net-->>E: ✗ blocked by veto — not admitted
 ```
 


### PR DESCRIPTION
## Summary

Fixes a broken governance control: the Networks UI's **"No"** vote button sent an invalid value and returned `400`, and there was **no way to cast a blocking vote from the UI at all**.

## The bug
- The server's vote model is `VoteValue = 'yes' | 'veto'` (`server/src/config/types.ts:411`), enforced by `z.enum(['yes','veto'])` (`api/networks.ts:77`).
- The client offered **Yes / No** buttons and cast `{ vote: 'no' }` (`api.service.ts`, `networks.component.ts`) — not a valid value, so **clicking "No" 400'd**.
- There was **no Veto button anywhere** in the client, so members could not block a join/removal/deletion through the UI even though the model (and docs) rely on veto as *the* blocking action.

## The fix
The negative button now casts a **`veto`** — the blocking vote the model and docs already describe (`network-types.md`: *"A single no blocks it"*; democratic: *"any single member can cast an explicit veto to block"*). It's relabelled **Veto** so the UI matches the server's yes/veto model honestly, rather than saying "No" while hard-blocking a majority.

- `api.service.ts` + `networks.component.ts`: cast `'veto'`; types tightened to `'yes' | 'veto'`.
- i18n (en/de/pl): `votes.no` → `votes.veto`, labelled **✗ Veto** / **✗ Weto**.
- `docs/network-types.md`: the *"3 yes, 1 no, 1 veto"* example implied a distinct **non-blocking "no"** that does not exist in the model — that member now **abstains**, which is what the yes/veto model actually supports (and it still illustrates the point: a single veto blocks despite a majority).

## Why not add `'no'` to the server instead?
Considered and rejected. A non-blocking "no" is functionally identical to not voting (conclusion counts `yes` vs voters; a `no` neither counts toward passing nor blocks), so it would add a third value with no effect on any outcome — while **still** leaving users unable to veto, since the UI has no veto control. Making the existing negative button do the one thing the model needs (block) is the coherent fix.

## Testing
Client `ng build` passes. Server unchanged — it already accepts and tests `veto` (exercised by the governance/veto sync suites, e.g. *"Veto on space_deletion round dismisses deletion"*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
