### PR TITLE
arch: rename the MongoDB cast helpers m* -> as* (A7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The MongoDB cast helpers are renamed `mFilter`/`mDoc`/`mUpdate`/`mBulk` → `asFilter`/`asDoc`/
+  `asUpdate`/`asBulk` (internal, no behavior change).** The `m`-prefixed names read like "sanitise for
+  Mongo", but the bodies are pure `as unknown as` casts that bridge our document interfaces to
+  MongoDB's strict generics — they validate nothing. That is a dangerous thing to misread on the
+  sync-ingest path, where a lot of peer-supplied data flows through them. The `as*` names say plainly
+  that these are type casts, and the module now states where the real validation lives (the Zod
+  `Incoming*Doc` schemas in `api/sync.ts`).
 - **MCP tools are now a registry instead of a 1,200-line `switch` (internal, no behavior change).**
   Every tool used to be spread across **four** places that had to be kept in sync by hand: a schema in a
   big `allTools` array, a `case` in one giant `switch`, and membership in three separate `Set`s

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -15,7 +15,7 @@ import { createChrono, updateChrono, getChronoById, listChrono, deleteChrono, bu
 import { embed } from '../brain/embedding.js';
 import { updateFileMeta, deleteFileMeta } from '../files/file-meta.js';
 import { getConfig } from '../config/loader.js';
-import { col, mFilter, mDoc } from '../db/mongo.js';
+import { col, asFilter, asDoc } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { needsReindex, clearReindexFlag } from '../spaces/spaces.js';
 import { log } from '../util/log.js';
@@ -142,7 +142,7 @@ brainRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth,
   if (safeEntityIds.length > 0) {
     try {
       const entityDocs = await col<EntityDoc>(`${targetSpace}_entities`)
-        .find(mFilter<EntityDoc>({ _id: { $in: safeEntityIds } }), { projection: { name: 1 } })
+        .find(asFilter<EntityDoc>({ _id: { $in: safeEntityIds } }), { projection: { name: 1 } })
         .toArray() as Array<{ name: string }>;
       entityNames = entityDocs.map(e => e.name);
     } catch { /* ignore — entity names are best-effort */ }
@@ -187,7 +187,7 @@ brainRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth,
   if (safeDesc !== undefined) doc.description = safeDesc;
   if (safeProps !== undefined) doc.properties = safeProps;
   if (safeMemoryType !== undefined) doc.type = safeMemoryType;
-  await col<MemoryDoc>(`${targetSpace}_memories`).insertOne(mDoc<MemoryDoc>(doc));
+  await col<MemoryDoc>(`${targetSpace}_memories`).insertOne(asDoc<MemoryDoc>(doc));
   emitWebhookEvent({ event: 'memory.created', spaceId: targetSpace, entry: { ...doc, embedding: undefined }, ...webhookToken(req) });
   const body: Record<string, unknown> = { ...doc };
   if (quotaResult?.softBreached) body['storageWarning'] = true;
@@ -216,7 +216,7 @@ brainRouter.get('/spaces/:spaceId/memories/:id', globalRateLimit, requireSpaceAu
   }
   const memberIds = resolveMemberSpaces(spaceId);
   for (const mid of memberIds) {
-    const doc = await col<MemoryDoc>(`${mid}_memories`).findOne(mFilter<MemoryDoc>({ _id: id })) as MemoryDoc | null;
+    const doc = await col<MemoryDoc>(`${mid}_memories`).findOne(asFilter<MemoryDoc>({ _id: id })) as MemoryDoc | null;
     if (doc) { res.json(doc); return; }
   }
   res.status(404).json({ error: 'Memory not found' });
@@ -816,7 +816,7 @@ brainRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
   if (allEntityIds.length) {
     await Promise.all(memberIds.map(async (mid) => {
       const docs = await col<{ _id: string; name: string }>(`${mid}_entities`)
-        .find(mFilter<{ _id: string; name: string }>({ _id: { $in: allEntityIds } }), { projection: { _id: 1, name: 1 } })
+        .find(asFilter<{ _id: string; name: string }>({ _id: { $in: allEntityIds } }), { projection: { _id: 1, name: 1 } })
         .toArray();
       for (const d of docs) nameMap.set(String(d._id), d.name);
     }));
@@ -1278,7 +1278,7 @@ brainRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, asy
   const memberIds = resolveMemberSpaces(spaceId);
   const all = (await Promise.all(memberIds.map(mid =>
     col(`${mid}_files`)
-      .find(mFilter(filter))
+      .find(asFilter(filter))
       .sort({ updatedAt: -1 })
       .skip(skip)
       .limit(limit)
@@ -1581,7 +1581,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
           while (true) {
             const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
             const batch: MemoryDoc[] = await col<MemoryDoc>(`${mid}_memories`)
-              .find(mFilter<MemoryDoc>(q), { projection: { _id: 1, fact: 1, tags: 1, entityIds: 1, description: 1, properties: 1 } })
+              .find(asFilter<MemoryDoc>(q), { projection: { _id: 1, fact: 1, tags: 1, entityIds: 1, description: 1, properties: 1 } })
               .sort({ _id: 1 })
               .limit(BATCH)
               .toArray() as MemoryDoc[];
@@ -1591,7 +1591,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
                 const entityIds: string[] = Array.isArray(doc.entityIds) ? doc.entityIds : [];
                 const entityDocs = entityIds.length > 0
                   ? await col<EntityDoc>(`${mid}_entities`)
-                      .find(mFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
+                      .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
                       .toArray() as Array<{ name: string }>
                   : [];
                 const entityNames = entityDocs.map(e => e.name);
@@ -1625,7 +1625,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
           while (true) {
             const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
             const batch: EntityDoc[] = await col<EntityDoc>(`${mid}_entities`)
-              .find(mFilter<EntityDoc>(q), { projection: { _id: 1, name: 1, type: 1, tags: 1, description: 1, properties: 1 } })
+              .find(asFilter<EntityDoc>(q), { projection: { _id: 1, name: 1, type: 1, tags: 1, description: 1, properties: 1 } })
               .sort({ _id: 1 })
               .limit(BATCH)
               .toArray() as EntityDoc[];
@@ -1659,7 +1659,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
           while (true) {
             const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
             const batch: EdgeDoc[] = await col<EdgeDoc>(`${mid}_edges`)
-              .find(mFilter<EdgeDoc>(q), { projection: { _id: 1, from: 1, label: 1, to: 1, type: 1, tags: 1, description: 1 } })
+              .find(asFilter<EdgeDoc>(q), { projection: { _id: 1, from: 1, label: 1, to: 1, type: 1, tags: 1, description: 1 } })
               .sort({ _id: 1 })
               .limit(BATCH)
               .toArray() as EdgeDoc[];
@@ -1691,7 +1691,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
           while (true) {
             const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
             const batch: ChronoEntry[] = await col<ChronoEntry>(`${mid}_chrono`)
-              .find(mFilter<ChronoEntry>(q), { projection: { _id: 1, title: 1, type: 1, status: 1, description: 1, tags: 1 } })
+              .find(asFilter<ChronoEntry>(q), { projection: { _id: 1, title: 1, type: 1, status: 1, description: 1, tags: 1 } })
               .sort({ _id: 1 })
               .limit(BATCH)
               .toArray() as ChronoEntry[];
@@ -1724,7 +1724,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
               ? { _id: { $gt: cursor }, parentFileId: { $exists: false } }
               : { parentFileId: { $exists: false } };
             const batch: FileMetaDoc[] = await col<FileMetaDoc>(`${mid}_files`)
-              .find(mFilter<FileMetaDoc>(q), { projection: { _id: 1, path: 1, tags: 1, description: 1, properties: 1, entityIds: 1 } })
+              .find(asFilter<FileMetaDoc>(q), { projection: { _id: 1, path: 1, tags: 1, description: 1, properties: 1, entityIds: 1 } })
               .sort({ _id: 1 })
               .limit(BATCH)
               .toArray() as FileMetaDoc[];
@@ -1735,7 +1735,7 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
                 const entityIds: string[] = Array.isArray(doc.entityIds) ? doc.entityIds : [];
                 const entityDocs = entityIds.length > 0
                   ? await col<EntityDoc>(`${mid}_entities`)
-                      .find(mFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
+                      .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
                       .toArray() as Array<{ name: string }>
                   : [];
                 const entityNames = entityDocs.map(e => e.name);
@@ -1882,7 +1882,7 @@ brainRouter.post('/spaces/:spaceId/bulk', globalRateLimit, requireSpaceAuth, den
       }
       // Check for existing entity by ID (if supplied) to determine inserted vs updated
       const existing = rawId
-        ? await col<EntityDoc>(`${targetSpace}_entities`).findOne(mFilter<EntityDoc>({ _id: rawId, spaceId: targetSpace }))
+        ? await col<EntityDoc>(`${targetSpace}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId: targetSpace }))
         : null;
       const result = await upsertEntity(targetSpace, name, type, tags, properties, description, rawId);
       if (existing) { updated.entities++; } else { inserted.entities++; }
@@ -1920,7 +1920,7 @@ brainRouter.post('/spaces/:spaceId/bulk', globalRateLimit, requireSpaceAuth, den
           for (const v of sv) errors.push({ type: 'edge', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
         }
       }
-      const existing = await col<EdgeDoc>(`${targetSpace}_edges`).findOne(mFilter<EdgeDoc>({ spaceId: targetSpace, from, to, label }));
+      const existing = await col<EdgeDoc>(`${targetSpace}_edges`).findOne(asFilter<EdgeDoc>({ spaceId: targetSpace, from, to, label }));
       await upsertEdge(targetSpace, from, to, label, weight, edgeType, description, properties, tags);
       if (existing) { updated.edges++; } else { inserted.edges++; }
     } catch (err) {

--- a/server/src/api/conflicts.ts
+++ b/server/src/api/conflicts.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { requireAuth, requireAdmin, denyReadOnly } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
-import { col, mFilter, mDoc } from '../db/mongo.js';
+import { col, asFilter, asDoc } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { resolveSafePath, spaceRoot } from '../files/sandbox.js';
@@ -29,7 +29,7 @@ async function findConflict(
 ): Promise<{ doc: ConflictDoc; spaceId: string } | null> {
   for (const spaceId of spaces) {
     const doc = await col<ConflictDoc>(`${spaceId}_conflicts`)
-      .findOne(mFilter<ConflictDoc>({ _id: conflictId })) as ConflictDoc | null;
+      .findOne(asFilter<ConflictDoc>({ _id: conflictId })) as ConflictDoc | null;
     if (doc) return { doc, spaceId };
   }
   return null;
@@ -90,7 +90,7 @@ async function executeResolve(
 
   // Remove the conflict record
   await col<ConflictDoc>(`${spaceId}_conflicts`)
-    .deleteOne(mFilter<ConflictDoc>({ _id: doc._id }));
+    .deleteOne(asFilter<ConflictDoc>({ _id: doc._id }));
 }
 
 // GET /api/conflicts — list unresolved conflicts for all accessible spaces
@@ -155,7 +155,7 @@ conflictsRouter.delete('/link-violations/:id', globalRateLimit, requireAuth, asy
     const spaces = accessibleSpaces(req.authToken?.spaces);
     for (const spaceId of spaces) {
       const result = await col<LinkViolationDoc>(`${spaceId}_link_violations`)
-        .deleteOne(mFilter<LinkViolationDoc>({ _id: req.params['id'] }));
+        .deleteOne(asFilter<LinkViolationDoc>({ _id: req.params['id'] }));
       if (result.deletedCount > 0) {
         res.status(204).end();
         return;
@@ -190,7 +190,7 @@ conflictsRouter.get('/:id', globalRateLimit, requireAuth, async (req, res) => {
     const spaces = accessibleSpaces(req.authToken?.spaces);
     for (const spaceId of spaces) {
       const doc = await col<ConflictDoc>(`${spaceId}_conflicts`)
-        .findOne(mFilter<ConflictDoc>({ _id: req.params['id'] })) as ConflictDoc | null;
+        .findOne(asFilter<ConflictDoc>({ _id: req.params['id'] })) as ConflictDoc | null;
       if (doc) {
         res.json({
           id: doc._id,
@@ -217,7 +217,7 @@ conflictsRouter.delete('/:id', globalRateLimit, requireAuth, async (req, res) =>
     const spaces = accessibleSpaces(req.authToken?.spaces);
     for (const spaceId of spaces) {
       const result = await col<ConflictDoc>(`${spaceId}_conflicts`)
-        .deleteOne(mFilter<ConflictDoc>({ _id: req.params['id'] }));
+        .deleteOne(asFilter<ConflictDoc>({ _id: req.params['id'] }));
       if (result.deletedCount > 0) {
         res.status(204).end();
         return;
@@ -304,7 +304,7 @@ conflictsRouter.post('/seed', globalRateLimit, requireAdmin, denyReadOnly, async
       peerInstanceLabel: peerInstanceLabel || 'Unknown',
       detectedAt: detectedAt || new Date().toISOString(),
     };
-    await col<ConflictDoc>(`${spaceId}_conflicts`).insertOne(mDoc<ConflictDoc>(doc));
+    await col<ConflictDoc>(`${spaceId}_conflicts`).insertOne(asDoc<ConflictDoc>(doc));
     res.status(201).json({ id: _id });
   } catch (err) {
     log.error(`POST /api/conflicts/seed: ${err}`);

--- a/server/src/api/duplicates.ts
+++ b/server/src/api/duplicates.ts
@@ -11,7 +11,7 @@
 import { Router } from 'express';
 import { requireAuth, requireAdminMfa, denyReadOnly } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
-import { col, mFilter, mUpdate } from '../db/mongo.js';
+import { col, asFilter, asUpdate } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { scanSpace } from '../brain/dupe-scanner.js';
@@ -25,7 +25,7 @@ async function findCandidate(id: string, tokenSpaces?: string[]): Promise<{ doc:
   const all = cfg.spaces.map(s => s.id);
   const spaces = !tokenSpaces || tokenSpaces.length === 0 ? all : all.filter(s => tokenSpaces.includes(s));
   for (const spaceId of spaces) {
-    const doc = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).findOne(mFilter<DupeCandidateDoc>({ _id: id })) as DupeCandidateDoc | null;
+    const doc = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).findOne(asFilter<DupeCandidateDoc>({ _id: id })) as DupeCandidateDoc | null;
     if (doc) return { doc, spaceId };
   }
   return null;
@@ -73,7 +73,7 @@ duplicatesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
       // spaceId pins the leading index field; status matches the {spaceId,status,score,detectedAt} index.
       const q = status === 'all' ? { spaceId } : { spaceId, status };
       const docs = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`)
-        .find(mFilter<DupeCandidateDoc>(q))
+        .find(asFilter<DupeCandidateDoc>(q))
         .sort({ score: -1, detectedAt: -1 })
         .limit(500)
         .toArray() as DupeCandidateDoc[];
@@ -95,8 +95,8 @@ duplicatesRouter.post('/:id/dismiss', globalRateLimit, requireAuth, denyReadOnly
     const spaces = accessibleSpaces(req.authToken?.spaces);
     for (const spaceId of spaces) {
       const r = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).updateOne(
-        mFilter<DupeCandidateDoc>({ _id: id }),
-        mUpdate<DupeCandidateDoc>({ $set: { status: 'dismissed', updatedAt: new Date().toISOString() } }),
+        asFilter<DupeCandidateDoc>({ _id: id }),
+        asUpdate<DupeCandidateDoc>({ $set: { status: 'dismissed', updatedAt: new Date().toISOString() } }),
       );
       if (r.matchedCount > 0) { res.json({ status: 'dismissed' }); return; }
     }
@@ -133,8 +133,8 @@ duplicatesRouter.post('/:id/merge', globalRateLimit, requireAuth, denyReadOnly, 
     emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...result.entity, embedding: undefined } });
 
     await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).updateOne(
-      mFilter<DupeCandidateDoc>({ _id: doc._id }),
-      mUpdate<DupeCandidateDoc>({ $set: { status: 'resolved', resolution: 'merged', updatedAt: new Date().toISOString() } }),
+      asFilter<DupeCandidateDoc>({ _id: doc._id }),
+      asUpdate<DupeCandidateDoc>({ $set: { status: 'resolved', resolution: 'merged', updatedAt: new Date().toISOString() } }),
     );
     res.json({ status: 'merged', survivorId: result.entity._id });
   } catch (err) {

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -41,7 +41,7 @@ import {
 } from '../files/chunks.js';
 import { checkQuota, QuotaError } from '../quota/quota.js';
 import { resolveSafePath, assertNoSymlinkEscape, spaceRoot } from '../files/sandbox.js';
-import { col, mFilter, mDoc } from '../db/mongo.js';
+import { col, asFilter, asDoc } from '../db/mongo.js';
 import type { FileTombstoneDoc, FileMetaDoc } from '../config/types.js';
 import { upsertFileMeta, deleteFileMeta, deleteFileMetaByPrefix, renameFileMeta, renameFileMetaByPrefix } from '../files/file-meta.js';
 import { v4 as uuidv4 } from 'uuid';
@@ -333,7 +333,7 @@ filesRouter.post(
             const mediaCfg = getMediaEmbeddingConfig();
             if (mediaCfg.enabled && range.total <= (mediaCfg.maxFileSizeBytes ?? 524_288_000)) {
               await col<FileMetaDoc>(`${targetSpace}_files`).updateOne(
-                mFilter<FileMetaDoc>({ _id: filePath.replace(/\\/g, '/').replace(/^\/+/, '') }),
+                asFilter<FileMetaDoc>({ _id: filePath.replace(/\\/g, '/').replace(/^\/+/, '') }),
                 { $set: { mediaType: resolvedFmt, embeddingStatus: 'pending' } },
               );
               await enqueueMediaJob(targetSpace, filePath, chunkedMimeType, resolvedFmt).catch(err => {
@@ -438,20 +438,20 @@ filesRouter.post(
         if (!mediaCfg.enabled) {
           embeddingStatusForResponse = 'disabled';
           await col<FileMetaDoc>(`${targetSpace}_files`).updateOne(
-            mFilter<FileMetaDoc>({ _id: normId }),
+            asFilter<FileMetaDoc>({ _id: normId }),
             { $set: { mediaType: resolvedFormat, embeddingStatus: 'disabled' } },
           );
         } else if (incomingBytes > (mediaCfg.maxFileSizeBytes ?? 524_288_000)) {
           embeddingStatusForResponse = 'skipped';
           await col<FileMetaDoc>(`${targetSpace}_files`).updateOne(
-            mFilter<FileMetaDoc>({ _id: normId }),
+            asFilter<FileMetaDoc>({ _id: normId }),
             { $set: { mediaType: resolvedFormat, embeddingStatus: 'skipped' } },
           );
           log.info(`Media file ${targetSpace}/${filePath} skipped: ${incomingBytes} bytes exceeds maxFileSizeBytes (${mediaCfg.maxFileSizeBytes})`);
         } else {
           embeddingStatusForResponse = 'pending';
           await col<FileMetaDoc>(`${targetSpace}_files`).updateOne(
-            mFilter<FileMetaDoc>({ _id: normId }),
+            asFilter<FileMetaDoc>({ _id: normId }),
             { $set: { mediaType: resolvedFormat, embeddingStatus: 'pending' } },
           );
           await enqueueMediaJob(targetSpace, filePath, mimeType, resolvedFormat).catch(err => {
@@ -589,7 +589,7 @@ filesRouter.delete('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly,
       // If there is none, the path was never known — return 404.
       const normalisedPath = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
       const orphan = await col<FileMetaDoc>(`${targetSpace}_files`).findOne(
-        mFilter<FileMetaDoc>({ _id: normalisedPath }),
+        asFilter<FileMetaDoc>({ _id: normalisedPath }),
       );
       if (orphan) {
         await deleteFileMeta(targetSpace, filePath).catch(err => {
@@ -639,7 +639,7 @@ filesRouter.delete('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly,
       path: filePath.replace(/\\/g, '/'),
       deletedAt: new Date().toISOString(),
     };
-    await col<FileTombstoneDoc>(`${targetSpace}_file_tombstones`).insertOne(mDoc<FileTombstoneDoc>(tombstone));
+    await col<FileTombstoneDoc>(`${targetSpace}_file_tombstones`).insertOne(asDoc<FileTombstoneDoc>(tombstone));
     await deleteFileMeta(targetSpace, filePath).catch(err => {
       log.warn(`deleteFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
     });

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -11,7 +11,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
-import { col, mFilter, mDoc, mUpdate } from '../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { warmEmbeddingModel } from '../brain/embedding.js';
 import { syncRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, getSecrets, getDataRoot, loadConfig, saveConfig } from '../config/loader.js';
@@ -86,7 +86,7 @@ async function recordLinkViolation(
       peerInstanceId,
       detectedAt: new Date().toISOString(),
     };
-    await col<LinkViolationDoc>(`${spaceId}_link_violations`).insertOne(mDoc<LinkViolationDoc>(doc));
+    await col<LinkViolationDoc>(`${spaceId}_link_violations`).insertOne(asDoc<LinkViolationDoc>(doc));
     emitWebhookEvent({ event: 'link_violation.created', spaceId, entry: doc as unknown as Record<string, unknown> });
   } catch (err) {
     log.error(`Failed to record link violation for ${docType} ${docId}: ${err}`);
@@ -110,7 +110,7 @@ async function checkEdgeLinkViolations(
       await recordLinkViolation(spaceId, edge._id, 'edge', field,
         `${field} '${val}' is not a valid UUID v4`, peerInstanceId);
     } else {
-      const exists = await col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: val }));
+      const exists = await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: val }));
       if (!exists) {
         await recordLinkViolation(spaceId, edge._id, 'edge', field,
           `${field} references non-existent entity '${val}'`, peerInstanceId);
@@ -136,7 +136,7 @@ async function checkEntityIdLinkViolations(
       await recordLinkViolation(spaceId, docId, docType, 'entityIds',
         `entityIds contains non-UUID value '${eid}'`, peerInstanceId);
     } else {
-      const exists = await col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: eid }));
+      const exists = await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: eid }));
       if (!exists) {
         await recordLinkViolation(spaceId, docId, docType, 'entityIds',
           `entityIds references non-existent entity '${eid}'`, peerInstanceId);
@@ -280,7 +280,7 @@ async function forkChainDepth(spaceId: string, docId: string | undefined): Promi
   while (currentId && depth <= MAX_FORK_DEPTH) {
     if (visited.has(currentId)) break; // cycle guard
     visited.add(currentId);
-    const doc = await coll.findOne(mFilter<MemoryDoc>({ _id: currentId })) as MemoryDoc | null;
+    const doc = await coll.findOne(asFilter<MemoryDoc>({ _id: currentId })) as MemoryDoc | null;
     if (!doc?.forkOf) break;
     depth++;
     currentId = doc.forkOf;
@@ -431,8 +431,8 @@ syncRouter.get('/memories', syncRateLimit, requireAuth, async (req, res) => {
     const returnFull = fullParam === 'true';
 
     const rawDocs = returnFull
-      ? await col<MemoryDoc>(`${spaceId}_memories`).find(mFilter<MemoryDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as MemoryDoc[]
-      : await col<MemoryDoc>(`${spaceId}_memories`).find(mFilter<MemoryDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
+      ? await col<MemoryDoc>(`${spaceId}_memories`).find(asFilter<MemoryDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as MemoryDoc[]
+      : await col<MemoryDoc>(`${spaceId}_memories`).find(asFilter<MemoryDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
 
     const hasMore = rawDocs.length > pageSize;
     const items: typeof rawDocs = hasMore ? rawDocs.slice(0, pageSize) : rawDocs;
@@ -472,7 +472,7 @@ syncRouter.get('/memories/:id', syncRateLimit, requireAuth, async (req, res) => 
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
-    const doc = await col<MemoryDoc>(`${spaceId}_memories`).findOne(mFilter<MemoryDoc>({ _id: req.params['id'] }));
+    const doc = await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
     res.json(doc);
   } catch (err) {
@@ -503,22 +503,22 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
 
     // Check for tombstone â€” if a tombstone with >= seq exists, skip
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-      .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'memory' })) as TombstoneDoc | null;
+      .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'memory' })) as TombstoneDoc | null;
     if (tombstone && tombstone.seq >= incoming.seq) {
       res.status(200).json({ status: 'tombstoned' });
       return;
     }
     // Clean up stale tombstone superseded by the incoming document
     if (tombstone) {
-      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
     }
 
     const existing = await col<MemoryDoc>(`${spaceId}_memories`)
-      .findOne(mFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
+      .findOne(asFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
 
     if (!existing) {
       // No local copy â€” insert directly
-      await col<MemoryDoc>(`${spaceId}_memories`).insertOne(mDoc<MemoryDoc>(incoming));
+      await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(incoming));
       const peerInst = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string ?? 'unknown';
       checkEntityIdLinkViolations(spaceId, incoming._id, 'memory', incoming.entityIds, peerInst).catch(() => {});
       res.status(200).json({ status: 'inserted' });
@@ -527,7 +527,7 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
 
     if (incoming.seq > existing.seq) {
       // Remote is newer â€” overwrite
-      await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(mFilter<MemoryDoc>({ _id: incoming._id }), mDoc<MemoryDoc>(incoming));
+      await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(asFilter<MemoryDoc>({ _id: incoming._id }), asDoc<MemoryDoc>(incoming));
       const peerInst = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string ?? 'unknown';
       checkEntityIdLinkViolations(spaceId, incoming._id, 'memory', incoming.entityIds, peerInst).catch(() => {});
       res.status(200).json({ status: 'updated' });
@@ -543,7 +543,7 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
       }
       // Also cap fan-out: count how many forks already point to this document.
       const siblingCount = await col<MemoryDoc>(`${spaceId}_memories`)
-        .countDocuments(mFilter<MemoryDoc>({ forkOf: incoming._id }), { limit: MAX_FORK_DEPTH + 1 });
+        .countDocuments(asFilter<MemoryDoc>({ forkOf: incoming._id }), { limit: MAX_FORK_DEPTH + 1 });
       if (siblingCount >= MAX_FORK_DEPTH) {
         res.status(400).json({ error: `Fork depth limit (${MAX_FORK_DEPTH}) exceeded for _id '${incoming._id}'` });
         return;
@@ -557,7 +557,7 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };
-      await col<MemoryDoc>(`${spaceId}_memories`).insertOne(mDoc<MemoryDoc>(fork));
+      await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(fork));
       res.status(200).json({ status: 'forked', forkId: fork._id });
       return;
     }
@@ -584,8 +584,8 @@ syncRouter.get('/entities', syncRateLimit, requireAuth, async (req, res) => {
     const returnFull = fullParam === 'true';
 
     const rawDocs = returnFull
-      ? await col<EntityDoc>(`${spaceId}_entities`).find(mFilter<EntityDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as EntityDoc[]
-      : await col<EntityDoc>(`${spaceId}_entities`).find(mFilter<EntityDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
+      ? await col<EntityDoc>(`${spaceId}_entities`).find(asFilter<EntityDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as EntityDoc[]
+      : await col<EntityDoc>(`${spaceId}_entities`).find(asFilter<EntityDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
 
     const hasMore = rawDocs.length > pageSize;
     const items: typeof rawDocs = hasMore ? rawDocs.slice(0, pageSize) : rawDocs;
@@ -616,7 +616,7 @@ syncRouter.get('/entities/:id', syncRateLimit, requireAuth, async (req, res) => 
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
-    const doc = await col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: req.params['id'] }));
+    const doc = await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
     res.json(doc);
   } catch (err) {
@@ -640,25 +640,25 @@ syncRouter.post('/entities', syncRateLimit, requireAuth, denyReadOnly, async (re
     if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
 
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-      .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'entity' })) as TombstoneDoc | null;
+      .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'entity' })) as TombstoneDoc | null;
     if (tombstone && tombstone.seq >= incoming.seq) {
       res.status(200).json({ status: 'tombstoned' });
       return;
     }
     if (tombstone) {
-      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
     }
 
     await col<EntityDoc>(`${spaceId}_entities`).updateOne(
-      mFilter<EntityDoc>({ _id: incoming._id }),
-      mUpdate<EntityDoc>({ $setOnInsert: incoming }),
+      asFilter<EntityDoc>({ _id: incoming._id }),
+      asUpdate<EntityDoc>({ $setOnInsert: incoming }),
       { upsert: true },
     );
 
     // Merge tags on conflict
-    const existing = await col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc;
+    const existing = await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc;
     if (existing && incoming.seq > existing.seq) {
-      await col<EntityDoc>(`${spaceId}_entities`).replaceOne(mFilter<EntityDoc>({ _id: incoming._id }), mDoc<EntityDoc>(incoming));
+      await col<EntityDoc>(`${spaceId}_entities`).replaceOne(asFilter<EntityDoc>({ _id: incoming._id }), asDoc<EntityDoc>(incoming));
     }
 
     res.status(200).json({ status: 'ok' });
@@ -683,8 +683,8 @@ syncRouter.get('/edges', syncRateLimit, requireAuth, async (req, res) => {
     const returnFull = fullParam === 'true';
 
     const rawDocs = returnFull
-      ? await col<EdgeDoc>(`${spaceId}_edges`).find(mFilter<EdgeDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as EdgeDoc[]
-      : await col<EdgeDoc>(`${spaceId}_edges`).find(mFilter<EdgeDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
+      ? await col<EdgeDoc>(`${spaceId}_edges`).find(asFilter<EdgeDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as EdgeDoc[]
+      : await col<EdgeDoc>(`${spaceId}_edges`).find(asFilter<EdgeDoc>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
 
     const hasMore = rawDocs.length > pageSize;
     const items: typeof rawDocs = hasMore ? rawDocs.slice(0, pageSize) : rawDocs;
@@ -715,7 +715,7 @@ syncRouter.get('/edges/:id', syncRateLimit, requireAuth, async (req, res) => {
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
-    const doc = await col<EdgeDoc>(`${spaceId}_edges`).findOne(mFilter<EdgeDoc>({ _id: req.params['id'] }));
+    const doc = await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
     res.json(doc);
   } catch (err) {
@@ -739,20 +739,20 @@ syncRouter.post('/edges', syncRateLimit, requireAuth, denyReadOnly, async (req, 
     if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
 
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-      .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'edge' })) as TombstoneDoc | null;
+      .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'edge' })) as TombstoneDoc | null;
     if (tombstone && tombstone.seq >= incoming.seq) {
       res.status(200).json({ status: 'tombstoned' });
       return;
     }
     if (tombstone) {
-      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
     }
 
-    const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(mFilter<EdgeDoc>({ _id: incoming._id })) as EdgeDoc | null;
+    const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ _id: incoming._id })) as EdgeDoc | null;
     if (!existing || incoming.seq > existing.seq) {
       await col<EdgeDoc>(`${spaceId}_edges`).replaceOne(
-        mFilter<EdgeDoc>({ _id: incoming._id }),
-        mDoc<EdgeDoc>(incoming),
+        asFilter<EdgeDoc>({ _id: incoming._id }),
+        asDoc<EdgeDoc>(incoming),
         { upsert: true },
       );
     }
@@ -783,8 +783,8 @@ syncRouter.get('/chrono', syncRateLimit, requireAuth, async (req, res) => {
     const returnFull = fullParam === 'true';
 
     const rawDocs = returnFull
-      ? await col<ChronoEntry>(`${spaceId}_chrono`).find(mFilter<ChronoEntry>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as ChronoEntry[]
-      : await col<ChronoEntry>(`${spaceId}_chrono`).find(mFilter<ChronoEntry>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
+      ? await col<ChronoEntry>(`${spaceId}_chrono`).find(asFilter<ChronoEntry>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).toArray() as ChronoEntry[]
+      : await col<ChronoEntry>(`${spaceId}_chrono`).find(asFilter<ChronoEntry>({ seq: { $gt: sinceVal } })).sort({ seq: 1 }).limit(pageSize + 1).project({ _id: 1, seq: 1 }).toArray() as { _id: string; seq: number }[];
 
     const hasMore = rawDocs.length > pageSize;
     const items: typeof rawDocs = hasMore ? rawDocs.slice(0, pageSize) : rawDocs;
@@ -815,7 +815,7 @@ syncRouter.get('/chrono/:id', syncRateLimit, requireAuth, async (req, res) => {
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
 
-    const doc = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(mFilter<ChronoEntry>({ _id: req.params['id'] }));
+    const doc = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: req.params['id'] }));
     if (!doc) { res.status(404).json({ error: 'Not found' }); return; }
     res.json(doc);
   } catch (err) {
@@ -844,20 +844,20 @@ syncRouter.post('/chrono', syncRateLimit, requireAuth, denyReadOnly, async (req,
     }
 
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-      .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'chrono' })) as TombstoneDoc | null;
+      .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'chrono' })) as TombstoneDoc | null;
     if (tombstone && tombstone.seq >= incoming.seq) {
       res.status(200).json({ status: 'tombstoned' });
       return;
     }
     if (tombstone) {
-      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
     }
 
-    const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(mFilter<ChronoEntry>({ _id: incoming._id })) as ChronoEntry | null;
+    const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: incoming._id })) as ChronoEntry | null;
     if (!existing || incoming.seq > existing.seq) {
       await col<ChronoEntry>(`${spaceId}_chrono`).replaceOne(
-        mFilter<ChronoEntry>({ _id: incoming._id }),
-        mDoc<ChronoEntry>(incoming),
+        asFilter<ChronoEntry>({ _id: incoming._id }),
+        asDoc<ChronoEntry>(incoming),
         { upsert: true },
       );
     }
@@ -923,17 +923,17 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
     const memStats = { inserted: 0, updated: 0, forked: 0, skipped: 0, tombstoned: 0 };
     for (const incoming of memories) {
       const tomb = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-        .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'memory' })) as TombstoneDoc | null;
+        .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'memory' })) as TombstoneDoc | null;
       if (tomb && tomb.seq >= incoming.seq) { memStats.tombstoned++; continue; }
-      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
 
       const existing = await col<MemoryDoc>(`${spaceId}_memories`)
-        .findOne(mFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
+        .findOne(asFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
       if (!existing) {
-        await col<MemoryDoc>(`${spaceId}_memories`).insertOne(mDoc<MemoryDoc>(incoming));
+        await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(incoming));
         memStats.inserted++;
       } else if (incoming.seq > existing.seq) {
-        await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(mFilter<MemoryDoc>({ _id: incoming._id }), mDoc<MemoryDoc>(incoming));
+        await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(asFilter<MemoryDoc>({ _id: incoming._id }), asDoc<MemoryDoc>(incoming));
         memStats.updated++;
       } else if (incoming.seq === existing.seq && incoming.fact !== existing.fact) {
         // Cap fork chains to prevent unbounded growth
@@ -945,7 +945,7 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
           ...incoming, _id: uuidv4(), forkOf: incoming._id, seq: forkSeq,
           createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
         };
-        await col<MemoryDoc>(`${spaceId}_memories`).insertOne(mDoc<MemoryDoc>(fork));
+        await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(fork));
         memStats.forked++;
       } else {
         memStats.skipped++;
@@ -956,15 +956,15 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
     const entStats = { upserted: 0, skipped: 0, tombstoned: 0 };
     for (const incoming of entities) {
       const tomb = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-        .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'entity' })) as TombstoneDoc | null;
+        .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'entity' })) as TombstoneDoc | null;
       if (tomb && tomb.seq >= incoming.seq) { entStats.tombstoned++; continue; }
-      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
 
       const existing = await col<EntityDoc>(`${spaceId}_entities`)
-        .findOne(mFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc | null;
+        .findOne(asFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc | null;
       if (!existing || incoming.seq > existing.seq) {
         await col<EntityDoc>(`${spaceId}_entities`).replaceOne(
-          mFilter<EntityDoc>({ _id: incoming._id }), mDoc<EntityDoc>(incoming), { upsert: true },
+          asFilter<EntityDoc>({ _id: incoming._id }), asDoc<EntityDoc>(incoming), { upsert: true },
         );
         entStats.upserted++;
       } else {
@@ -976,15 +976,15 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
     const edgeStats = { upserted: 0, skipped: 0, tombstoned: 0 };
     for (const incoming of edges) {
       const tomb = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-        .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'edge' })) as TombstoneDoc | null;
+        .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'edge' })) as TombstoneDoc | null;
       if (tomb && tomb.seq >= incoming.seq) { edgeStats.tombstoned++; continue; }
-      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
 
       const existing = await col<EdgeDoc>(`${spaceId}_edges`)
-        .findOne(mFilter<EdgeDoc>({ _id: incoming._id })) as EdgeDoc | null;
+        .findOne(asFilter<EdgeDoc>({ _id: incoming._id })) as EdgeDoc | null;
       if (!existing || incoming.seq > existing.seq) {
         await col<EdgeDoc>(`${spaceId}_edges`).replaceOne(
-          mFilter<EdgeDoc>({ _id: incoming._id }), mDoc<EdgeDoc>(incoming), { upsert: true },
+          asFilter<EdgeDoc>({ _id: incoming._id }), asDoc<EdgeDoc>(incoming), { upsert: true },
         );
         edgeStats.upserted++;
       } else {
@@ -996,15 +996,15 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
     const chronoStats = { upserted: 0, skipped: 0, tombstoned: 0 };
     for (const incoming of chrono) {
       const tomb = await col<TombstoneDoc>(`${spaceId}_tombstones`)
-        .findOne(mFilter<TombstoneDoc>({ _id: incoming._id, type: 'chrono' })) as TombstoneDoc | null;
+        .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'chrono' })) as TombstoneDoc | null;
       if (tomb && tomb.seq >= incoming.seq) { chronoStats.tombstoned++; continue; }
-      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(mFilter<TombstoneDoc>({ _id: incoming._id }));
+      if (tomb) await col<TombstoneDoc>(`${spaceId}_tombstones`).deleteOne(asFilter<TombstoneDoc>({ _id: incoming._id }));
 
       const existing = await col<ChronoEntry>(`${spaceId}_chrono`)
-        .findOne(mFilter<ChronoEntry>({ _id: incoming._id })) as ChronoEntry | null;
+        .findOne(asFilter<ChronoEntry>({ _id: incoming._id })) as ChronoEntry | null;
       if (!existing || incoming.seq > existing.seq) {
         await col<ChronoEntry>(`${spaceId}_chrono`).replaceOne(
-          mFilter<ChronoEntry>({ _id: incoming._id }), mDoc<ChronoEntry>(incoming), { upsert: true },
+          asFilter<ChronoEntry>({ _id: incoming._id }), asDoc<ChronoEntry>(incoming), { upsert: true },
         );
         chronoStats.upserted++;
       } else {
@@ -1142,7 +1142,7 @@ syncRouter.get('/file-tombstones', syncRateLimit, requireAuth, async (req, res) 
       ? { spaceId, deletedAt: { $gt: since } }
       : { spaceId };
     const tombstones = await col<FileTombstoneDoc>(`${spaceId}_file_tombstones`)
-      .find(mFilter<FileTombstoneDoc>(filter))
+      .find(asFilter<FileTombstoneDoc>(filter))
       .sort({ deletedAt: 1 })
       .limit(5000)
       .toArray();
@@ -1192,8 +1192,8 @@ syncRouter.post('/file-tombstones', syncRateLimit, requireAuth, denyReadOnly, as
         deletedAt: typeof ts.deletedAt === 'string' ? ts.deletedAt : new Date().toISOString(),
       };
       await col<FileTombstoneDoc>(`${spaceId}_file_tombstones`).updateOne(
-        mFilter<FileTombstoneDoc>({ _id: doc._id }),
-        mUpdate<FileTombstoneDoc>({ $setOnInsert: doc }),
+        asFilter<FileTombstoneDoc>({ _id: doc._id }),
+        asUpdate<FileTombstoneDoc>({ $setOnInsert: doc }),
         { upsert: true },
       );
       applied++;
@@ -1643,10 +1643,10 @@ syncRouter.post('/warm', syncRateLimit, requireAuth, async (req, res) => {
         log.warn(`Warm: embedding model failed: ${err}`),
       ),
       ...body.spaces.flatMap(sid => [
-        col(`${sid}_memories`).findOne(mFilter({}), { projection: { _id: 1 } }).catch(() => {}),
-        col(`${sid}_entities`).findOne(mFilter({}), { projection: { _id: 1 } }).catch(() => {}),
-        col(`${sid}_edges`).findOne(mFilter({}), { projection: { _id: 1 } }).catch(() => {}),
-        col(`${sid}_chrono`).findOne(mFilter({}), { projection: { _id: 1 } }).catch(() => {}),
+        col(`${sid}_memories`).findOne(asFilter({}), { projection: { _id: 1 } }).catch(() => {}),
+        col(`${sid}_entities`).findOne(asFilter({}), { projection: { _id: 1 } }).catch(() => {}),
+        col(`${sid}_edges`).findOne(asFilter({}), { projection: { _id: 1 } }).catch(() => {}),
+        col(`${sid}_chrono`).findOne(asFilter({}), { projection: { _id: 1 } }).catch(() => {}),
       ]),
     ]);
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -35,7 +35,7 @@ import { requireAuth, requireAdminMfa, requireAdminMfaScoped } from './auth/midd
 import { clearTokenCache } from './auth/tokens.js';
 import { clearOidcCache } from './auth/oidc.js';
 import { initSpace, ensureGeneralSpace, wipeSpace, WIPE_COLLECTION_TYPES, type WipeCollectionType } from './spaces/spaces.js';
-import { col, mFilter, mDoc } from './db/mongo.js';
+import { col, asFilter, asDoc } from './db/mongo.js';
 import { log } from './util/log.js';
 import { getReadiness } from './ready.js';
 import {
@@ -361,8 +361,8 @@ export function createApp() {
         const docId = String((doc as Record<string, unknown>)['_id']);
         try {
           const r = await col(collName).replaceOne(
-            mFilter({ _id: docId }),
-            mDoc(doc as Record<string, unknown>),
+            asFilter({ _id: docId }),
+            asDoc(doc as Record<string, unknown>),
             { upsert: true },
           );
           if (r.upsertedCount > 0) {

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { col, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
@@ -77,7 +77,7 @@ export async function createChrono(
   if (fields.properties !== undefined) doc.properties = fields.properties;
   if (fields.recurrence !== undefined) doc.recurrence = fields.recurrence;
 
-  await col<ChronoEntry>(`${spaceId}_chrono`).insertOne(mDoc<ChronoEntry>(doc));
+  await col<ChronoEntry>(`${spaceId}_chrono`).insertOne(asDoc<ChronoEntry>(doc));
   return doc;
 }
 
@@ -86,7 +86,7 @@ export async function updateChrono(
   id: string,
   updates: Partial<Pick<ChronoEntry, 'title' | 'description' | 'type' | 'startsAt' | 'endsAt' | 'status' | 'confidence' | 'tags' | 'entityIds' | 'memoryIds' | 'properties' | 'recurrence'>>,
 ): Promise<ChronoEntry | null> {
-  const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(mFilter<ChronoEntry>({ _id: id, spaceId })) as ChronoEntry | null;
+  const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as ChronoEntry | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -119,14 +119,14 @@ export async function updateChrono(
   }
 
   await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(
-    mFilter<ChronoEntry>({ _id: id }),
-    mUpdate<ChronoEntry>({ $set }),
+    asFilter<ChronoEntry>({ _id: id }),
+    asUpdate<ChronoEntry>({ $set }),
   );
   return { ...existing, ...($set as Partial<ChronoEntry>) } as ChronoEntry;
 }
 
 export async function getChronoById(spaceId: string, id: string): Promise<ChronoEntry | null> {
-  return col<ChronoEntry>(`${spaceId}_chrono`).findOne(mFilter<ChronoEntry>({ _id: id, spaceId })) as Promise<ChronoEntry | null>;
+  return col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as Promise<ChronoEntry | null>;
 }
 
 export interface ChronoFilter {
@@ -190,7 +190,7 @@ export async function listChrono(
   }
 
   return col<ChronoEntry>(`${spaceId}_chrono`)
-    .find(mFilter<ChronoEntry>(query))
+    .find(asFilter<ChronoEntry>(query))
     .sort({ createdAt: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
@@ -202,7 +202,7 @@ export async function deleteChrono(
   chronoId: string,
 ): Promise<boolean> {
   const existing = await col<ChronoEntry>(`${spaceId}_chrono`)
-    .findOne(mFilter<ChronoEntry>({ _id: chronoId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
+    .findOne(asFilter<ChronoEntry>({ _id: chronoId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
   const seq = await nextSeq(spaceId);
   const result = await col<ChronoEntry>(`${spaceId}_chrono`).deleteOne({
     _id: chronoId,
@@ -220,8 +220,8 @@ export async function deleteChrono(
     ...(existing?.seq !== undefined ? { originalSeq: existing.seq } : {}),
   };
   await col<TombstoneDoc>(`${spaceId}_tombstones`).replaceOne(
-    mFilter<TombstoneDoc>({ _id: chronoId }),
-    mDoc<TombstoneDoc>(tombstone),
+    asFilter<TombstoneDoc>({ _id: chronoId }),
+    asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
   return true;
@@ -253,7 +253,7 @@ export async function bulkDeleteChrono(spaceId: string): Promise<number> {
   const ops = tombstones.map(t => ({
     replaceOne: { filter: { _id: t._id }, replacement: t, upsert: true },
   }));
-  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(mBulk<TombstoneDoc>(ops));
+  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(asBulk<TombstoneDoc>(ops));
   await coll.deleteMany({});
   return ids.length;
 }

--- a/server/src/brain/dupe-scanner.ts
+++ b/server/src/brain/dupe-scanner.ts
@@ -23,7 +23,7 @@
  */
 
 import { schedule, validate, type ScheduledTask } from 'node-cron';
-import { col, mFilter, mUpdate, isVectorSearchAvailable } from '../db/mongo.js';
+import { col, asFilter, asUpdate, isVectorSearchAvailable } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/spaces.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
@@ -63,14 +63,14 @@ function pairKey(type: DupeScanType, aId: string, bId: string): string {
 // ── Cursor state ─────────────────────────────────────────────────────────────
 
 async function getCursor(spaceId: string, type: DupeScanType): Promise<number> {
-  const doc = await col<DupeScanStateDoc>(SCAN_STATE).findOne(mFilter<DupeScanStateDoc>({ _id: `${spaceId}:${type}` }));
+  const doc = await col<DupeScanStateDoc>(SCAN_STATE).findOne(asFilter<DupeScanStateDoc>({ _id: `${spaceId}:${type}` }));
   return doc?.cursorSeq ?? 0;
 }
 
 async function setCursor(spaceId: string, type: DupeScanType, cursorSeq: number): Promise<void> {
   await col<DupeScanStateDoc>(SCAN_STATE).updateOne(
-    mFilter<DupeScanStateDoc>({ _id: `${spaceId}:${type}` }),
-    mUpdate<DupeScanStateDoc>({ $set: { spaceId, type, cursorSeq, updatedAt: new Date().toISOString() } }),
+    asFilter<DupeScanStateDoc>({ _id: `${spaceId}:${type}` }),
+    asUpdate<DupeScanStateDoc>({ $set: { spaceId, type, cursorSeq, updatedAt: new Date().toISOString() } }),
     { upsert: true },
   );
 }
@@ -95,8 +95,8 @@ async function upsertCandidate(
   const _id = pairKey(type, a._id, b._id);
   const now = new Date().toISOString();
   await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).updateOne(
-    mFilter<DupeCandidateDoc>({ _id }),
-    mUpdate<DupeCandidateDoc>({
+    asFilter<DupeCandidateDoc>({ _id }),
+    asUpdate<DupeCandidateDoc>({
       $setOnInsert: { spaceId, type, aId: a._id, bId: b._id, detectedAt: now },
       $set: {
         aSummary: summariseRecall(a), bSummary: summariseRecall(b),
@@ -164,7 +164,7 @@ async function handlePair(spaceId: string, type: DupeScanType, seed: RecallResul
   const bSeq = b.seq ?? 0;
   const _id = pairKey(type, a._id, b._id);
 
-  const existing = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).findOne(mFilter<DupeCandidateDoc>({ _id }));
+  const existing = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).findOne(asFilter<DupeCandidateDoc>({ _id }));
   if (existing) {
     if (existing.status === 'resolved' && existing.resolution === 'merged') return; // absorbed record gone
     if (existing.aSeq === aSeq && existing.bSeq === bSeq) return;                    // unchanged since last seen
@@ -269,7 +269,7 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
       const batch = await col<{ _id: string; seq?: number }>(coll)
         // spaceId pins the leading field of the {spaceId,seq} index so this is an
         // indexed range scan + sorted output, not a collection scan + blocking sort.
-        .find(mFilter<{ _id: string; seq?: number }>({ spaceId, seq: { $gt: cursor } }), { projection: { _id: 1, seq: 1 } })
+        .find(asFilter<{ _id: string; seq?: number }>({ spaceId, seq: { $gt: cursor } }), { projection: { _id: 1, seq: 1 } })
         .sort({ seq: 1 })
         .limit(take)
         .toArray();

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { col, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
@@ -75,7 +75,7 @@ export async function upsertEdge(
   tags?: string[],
 ): Promise<EdgeDoc> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
-  const existing = await collection.findOne(mFilter<EdgeDoc>({ spaceId, from, to, label }));
+  const existing = await collection.findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }));
 
   const seq = await nextSeq(spaceId);
   const now = new Date().toISOString();
@@ -107,8 +107,8 @@ export async function upsertEdge(
       $set['properties'] = mergedProps;
     }
     await collection.updateOne(
-      mFilter<EdgeDoc>({ _id: (existing as EdgeDoc)._id }),
-      mUpdate<EdgeDoc>({ $set }),
+      asFilter<EdgeDoc>({ _id: (existing as EdgeDoc)._id }),
+      asUpdate<EdgeDoc>({ $set }),
     );
     return {
       ...(existing as EdgeDoc),
@@ -140,7 +140,7 @@ export async function upsertEdge(
     seq,
     ...embeddingFields,
   };
-  await collection.insertOne(mDoc<EdgeDoc>(doc));
+  await collection.insertOne(asDoc<EdgeDoc>(doc));
   return doc;
 }
 
@@ -156,7 +156,7 @@ export async function listEdges(
   if (filter.to) q['to'] = filter.to;
   if (filter.label) q['label'] = filter.label;
   return col<EdgeDoc>(`${spaceId}_edges`)
-    .find(mFilter<EdgeDoc>(q))
+    .find(asFilter<EdgeDoc>(q))
     .sort({ seq: -1, createdAt: -1, _id: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
@@ -166,7 +166,7 @@ export async function listEdges(
 /** Delete an edge by ID and write tombstone */
 export async function deleteEdge(spaceId: string, edgeId: string): Promise<boolean> {
   const existing = await col<EdgeDoc>(`${spaceId}_edges`)
-    .findOne(mFilter<EdgeDoc>({ _id: edgeId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
+    .findOne(asFilter<EdgeDoc>({ _id: edgeId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
   const seq = await nextSeq(spaceId);
   const result = await col<EdgeDoc>(`${spaceId}_edges`).deleteOne({
     _id: edgeId,
@@ -184,8 +184,8 @@ export async function deleteEdge(spaceId: string, edgeId: string): Promise<boole
     ...(existing?.seq !== undefined ? { originalSeq: existing.seq } : {}),
   };
   await col<TombstoneDoc>(`${spaceId}_tombstones`).replaceOne(
-    mFilter<TombstoneDoc>({ _id: edgeId }),
-    mDoc<TombstoneDoc>(tombstone),
+    asFilter<TombstoneDoc>({ _id: edgeId }),
+    asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
   return true;
@@ -193,7 +193,7 @@ export async function deleteEdge(spaceId: string, edgeId: string): Promise<boole
 
 /** Find an edge by exact ID */
 export async function getEdgeById(spaceId: string, id: string): Promise<EdgeDoc | null> {
-  return col<EdgeDoc>(`${spaceId}_edges`).findOne(mFilter<EdgeDoc>({ _id: id, spaceId })) as Promise<EdgeDoc | null>;
+  return col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ _id: id, spaceId })) as Promise<EdgeDoc | null>;
 }
 
 /** Update an existing edge by ID. Partial update — only supplied fields are changed. Re-embeds when any content field changes. */
@@ -204,7 +204,7 @@ export async function updateEdgeById(
   deleteFieldsPaths?: string[],
 ): Promise<EdgeDoc | null> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
-  const existing = await collection.findOne(mFilter<EdgeDoc>({ _id: id, spaceId })) as EdgeDoc | null;
+  const existing = await collection.findOne(asFilter<EdgeDoc>({ _id: id, spaceId })) as EdgeDoc | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -278,7 +278,7 @@ export async function updateEdgeById(
 
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
-  await collection.updateOne(mFilter<EdgeDoc>({ _id: id }), mUpdate<EdgeDoc>(updateOp));
+  await collection.updateOne(asFilter<EdgeDoc>({ _id: id }), asUpdate<EdgeDoc>(updateOp));
 
   const result = {
     ...existing,
@@ -326,7 +326,7 @@ export async function bulkDeleteEdges(spaceId: string): Promise<number> {
   const ops = tombstones.map(t => ({
     replaceOne: { filter: { _id: t._id }, replacement: t, upsert: true },
   }));
-  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(mBulk<TombstoneDoc>(ops));
+  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(asBulk<TombstoneDoc>(ops));
   await coll.deleteMany({});
   return ids.length;
 }
@@ -373,7 +373,7 @@ export async function traverseGraph(
       } else {
         q = { spaceId: mid, $or: [{ from: { $in: frontier } }, { to: { $in: frontier } }], ...labelFilter };
       }
-      const edges = await col<EdgeDoc>(`${mid}_edges`).find(mFilter<EdgeDoc>(q)).toArray() as EdgeDoc[];
+      const edges = await col<EdgeDoc>(`${mid}_edges`).find(asFilter<EdgeDoc>(q)).toArray() as EdgeDoc[];
       adjacentEdges.push(...edges);
     }
 
@@ -403,7 +403,7 @@ export async function traverseGraph(
     const entityMap = new Map<string, EntityDoc>();
     for (const mid of memberIds) {
       const entities = await col<EntityDoc>(`${mid}_entities`)
-        .find(mFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId: mid }))
+        .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId: mid }))
         .toArray() as EntityDoc[];
       for (const e of entities) entityMap.set(e._id, e);
     }
@@ -480,7 +480,7 @@ export async function traverseFromSeeds(
 
   while (frontier.length > 0 && depth < maxDepth) {
     const edges = await col<EdgeDoc>(`${spaceId}_edges`)
-      .find(mFilter<EdgeDoc>({ $or: [{ from: { $in: frontier } }, { to: { $in: frontier } }] }))
+      .find(asFilter<EdgeDoc>({ $or: [{ from: { $in: frontier } }, { to: { $in: frontier } }] }))
       .toArray() as EdgeDoc[];
 
     const newNeighborIds: string[] = [];
@@ -498,7 +498,7 @@ export async function traverseFromSeeds(
     if (newNeighborIds.length === 0) break;
 
     const entities = await col<EntityDoc>(`${spaceId}_entities`)
-      .find(mFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId }))
+      .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId }))
       .project({ embedding: 0 })
       .toArray() as EntityDoc[];
     const entityMap = new Map<string, EntityDoc>();

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { col, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
@@ -69,7 +69,7 @@ export async function upsertEntity(
 
   // When an id is provided, attempt to find the existing record by primary key.
   const existing: EntityDoc | null = id
-    ? (await collection.findOne(mFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null)
+    ? (await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null)
     : null;
 
   const seq = await nextSeq(spaceId);
@@ -92,8 +92,8 @@ export async function upsertEntity(
     const $set: Record<string, unknown> = { name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields };
     if (description !== undefined) $set['description'] = description;
     await collection.updateOne(
-      mFilter<EntityDoc>({ _id: existing._id }),
-      mUpdate<EntityDoc>({ $set }),
+      asFilter<EntityDoc>({ _id: existing._id }),
+      asUpdate<EntityDoc>({ $set }),
     );
     const entity: EntityDoc = { ...existing, name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields, ...(description !== undefined ? { description } : {}) };
     return { entity };
@@ -102,7 +102,7 @@ export async function upsertEntity(
   // Warn when inserting without an explicit id and duplicates already exist
   let warning: string | undefined;
   if (!id) {
-    const existingCount = await collection.countDocuments(mFilter<EntityDoc>({ spaceId, name, type }));
+    const existingCount = await collection.countDocuments(asFilter<EntityDoc>({ spaceId, name, type }));
     if (existingCount > 0) {
       warning = `${existingCount} existing entit${existingCount === 1 ? 'y' : 'ies'} with name '${name}' and type '${type}' already exist in this space. A new entity was created because no id was supplied. To update an existing entity, provide its id.`;
     }
@@ -130,7 +130,7 @@ export async function upsertEntity(
     ...embeddingFields,
   };
   if (description !== undefined) doc.description = description;
-  await collection.insertOne(mDoc<EntityDoc>(doc));
+  await collection.insertOne(asDoc<EntityDoc>(doc));
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
   if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {
@@ -146,13 +146,13 @@ export async function upsertEntity(
  */
 export async function findEntitiesByName(spaceId: string, name: string): Promise<EntityDoc[]> {
   return col<EntityDoc>(`${spaceId}_entities`)
-    .find(mFilter<EntityDoc>({ spaceId, name }))
+    .find(asFilter<EntityDoc>({ spaceId, name }))
     .toArray() as Promise<EntityDoc[]>;
 }
 
 /** Find an entity by exact ID */
 export async function getEntityById(spaceId: string, id: string): Promise<EntityDoc | null> {
-  return col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: id, spaceId })) as Promise<EntityDoc | null>;
+  return col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as Promise<EntityDoc | null>;
 }
 
 /** Update an existing entity by ID. Partial update — only supplied fields are changed. Re-embeds when any content field changes. */
@@ -163,7 +163,7 @@ export async function updateEntityById(
   deleteFieldsPaths?: string[],
 ): Promise<EntityDoc | null> {
   const collection = col<EntityDoc>(`${spaceId}_entities`);
-  const existing = await collection.findOne(mFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null;
+  const existing = await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -225,7 +225,7 @@ export async function updateEntityById(
 
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
-  await collection.updateOne(mFilter<EntityDoc>({ _id: id }), mUpdate<EntityDoc>(updateOp));
+  await collection.updateOne(asFilter<EntityDoc>({ _id: id }), asUpdate<EntityDoc>(updateOp));
 
   const result = {
     ...existing,
@@ -255,7 +255,7 @@ export async function listEntities(
   skip = 0,
 ): Promise<EntityDoc[]> {
   return col<EntityDoc>(`${spaceId}_entities`)
-    .find(mFilter<EntityDoc>({ ...filter, spaceId }))
+    .find(asFilter<EntityDoc>({ ...filter, spaceId }))
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
     .toArray() as Promise<EntityDoc[]>;
@@ -267,7 +267,7 @@ export async function deleteEntity(
   entityId: string,
 ): Promise<boolean> {
   const existing = await col<EntityDoc>(`${spaceId}_entities`)
-    .findOne(mFilter<EntityDoc>({ _id: entityId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
+    .findOne(asFilter<EntityDoc>({ _id: entityId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
   const seq = await nextSeq(spaceId);
   const result = await col<EntityDoc>(`${spaceId}_entities`).deleteOne({
     _id: entityId,
@@ -285,8 +285,8 @@ export async function deleteEntity(
     ...(existing?.seq !== undefined ? { originalSeq: existing.seq } : {}),
   };
   await col<TombstoneDoc>(`${spaceId}_tombstones`).replaceOne(
-    mFilter<TombstoneDoc>({ _id: entityId }),
-    mDoc<TombstoneDoc>(tombstone),
+    asFilter<TombstoneDoc>({ _id: entityId }),
+    asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
   return true;
@@ -318,7 +318,7 @@ export async function bulkDeleteEntities(spaceId: string): Promise<number> {
   const ops = tombstones.map(t => ({
     replaceOne: { filter: { _id: t._id }, replacement: t, upsert: true },
   }));
-  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(mBulk<TombstoneDoc>(ops));
+  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(asBulk<TombstoneDoc>(ops));
   await coll.deleteMany({});
   return ids.length;
 }
@@ -333,19 +333,19 @@ export async function findEntityBacklinks(spaceId: string, entityId: string): Pr
 
   // Edges referencing this entity as from or to
   const edges = await col<EdgeDoc>(`${spaceId}_edges`)
-    .find(mFilter<EdgeDoc>({ spaceId, $or: [{ from: entityId }, { to: entityId }] }), { projection: { _id: 1 } })
+    .find(asFilter<EdgeDoc>({ spaceId, $or: [{ from: entityId }, { to: entityId }] }), { projection: { _id: 1 } })
     .toArray() as Array<{ _id: string }>;
   for (const e of edges) backlinks.push({ type: 'edge', _id: e._id });
 
   // Memories referencing this entity in entityIds
   const memories = await col<MemoryDoc>(`${spaceId}_memories`)
-    .find(mFilter<MemoryDoc>({ spaceId, entityIds: entityId }), { projection: { _id: 1 } })
+    .find(asFilter<MemoryDoc>({ spaceId, entityIds: entityId }), { projection: { _id: 1 } })
     .toArray() as Array<{ _id: string }>;
   for (const m of memories) backlinks.push({ type: 'memory', _id: m._id });
 
   // Chrono entries referencing this entity in entityIds
   const chronos = await col<ChronoEntry>(`${spaceId}_chrono`)
-    .find(mFilter<ChronoEntry>({ spaceId, entityIds: entityId }), { projection: { _id: 1 } })
+    .find(asFilter<ChronoEntry>({ spaceId, entityIds: entityId }), { projection: { _id: 1 } })
     .toArray() as Array<{ _id: string }>;
   for (const c of chronos) backlinks.push({ type: 'chrono', _id: c._id });
 

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { col, isVectorSearchAvailable, mFilter, mDoc, mUpdate, mBulk } from '../db/mongo.js';
+import { col, isVectorSearchAvailable, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { NotFoundError } from '../util/errors.js';
@@ -102,7 +102,7 @@ function memoryEmbedText(
 async function resolveEntityNames(spaceId: string, entityIds: string[]): Promise<string[]> {
   if (entityIds.length === 0) return [];
   const docs = await col<EntityDoc>(`${spaceId}_entities`)
-    .find(mFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
+    .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
     .toArray() as Array<{ name: string }>;
   return docs.map(d => d.name);
 }
@@ -150,7 +150,7 @@ export async function remember(
   if (type !== undefined) doc.type = type;
   if (description !== undefined) doc.description = description;
   if (properties !== undefined) doc.properties = properties;
-  await col<MemoryDoc>(`${spaceId}_memories`).insertOne(mDoc<MemoryDoc>(doc));
+  await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(doc));
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
   if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {
@@ -519,7 +519,7 @@ async function enrichFileChunksWithParent(spaceId: string, results: RecallResult
 
   // Batch-fetch parent file docs — projection only (no embedding field)
   const parents = (await col(`${spaceId}_files`)
-    .find(mFilter({ _id: { $in: parentIds } }), { projection: { path: 1, description: 1, tags: 1 } })
+    .find(asFilter({ _id: { $in: parentIds } }), { projection: { path: 1, description: 1, tags: 1 } })
     .toArray()) as unknown as Array<{ _id: string; path?: string; description?: string; tags?: string[] }>;
 
   const parentMap = new Map(parents.map(p => [p._id, p]));
@@ -570,7 +570,7 @@ async function getEntryEmbedding(
   const collSuffix = KNOWLEDGE_COLLECTION[entryType];
   const collName = `${spaceId}_${collSuffix}`;
   const doc = await col(collName).findOne(
-    mFilter({ _id: entryId, spaceId }),
+    asFilter({ _id: entryId, spaceId }),
     { projection: { embedding: 1, _id: 1, spaceId: 1, name: 1, fact: 1, label: 1, title: 1, path: 1, type: 1, description: 1 } },
   ) as Record<string, unknown> | null;
   if (!doc) return null;
@@ -655,7 +655,7 @@ export async function updateMemory(
   updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; type?: string },
   deleteFieldsPaths?: string[],
 ): Promise<MemoryDoc | null> {
-  const existing = await col<MemoryDoc>(`${spaceId}_memories`).findOne(mFilter<MemoryDoc>({ _id: memoryId, spaceId })) as MemoryDoc | null;
+  const existing = await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: memoryId, spaceId })) as MemoryDoc | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -720,8 +720,8 @@ export async function updateMemory(
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
   await col<MemoryDoc>(`${spaceId}_memories`).updateOne(
-    mFilter<MemoryDoc>({ _id: memoryId }),
-    mUpdate<MemoryDoc>(updateOp),
+    asFilter<MemoryDoc>({ _id: memoryId }),
+    asUpdate<MemoryDoc>(updateOp),
   );
 
   const result = { ...existing, ...($set as Partial<MemoryDoc>) } as MemoryDoc;
@@ -740,7 +740,7 @@ export async function deleteMemory(
   memoryId: string,
 ): Promise<boolean> {
   const existing = await col<MemoryDoc>(`${spaceId}_memories`)
-    .findOne(mFilter<MemoryDoc>({ _id: memoryId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
+    .findOne(asFilter<MemoryDoc>({ _id: memoryId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
   const seq = await nextSeq(spaceId);
   const result = await col<MemoryDoc>(`${spaceId}_memories`).deleteOne({
     _id: memoryId,
@@ -758,8 +758,8 @@ export async function deleteMemory(
     ...(existing?.seq !== undefined ? { originalSeq: existing.seq } : {}),
   };
   await col<TombstoneDoc>(`${spaceId}_tombstones`).replaceOne(
-    mFilter<TombstoneDoc>({ _id: memoryId }),
-    mDoc<TombstoneDoc>(tombstone),
+    asFilter<TombstoneDoc>({ _id: memoryId }),
+    asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
   return true;
@@ -773,7 +773,7 @@ export async function listMemories(
   skip = 0,
 ) {
   return col<MemoryDoc>(`${spaceId}_memories`)
-    .find(mFilter<MemoryDoc>(filter))
+    .find(asFilter<MemoryDoc>(filter))
     .project({ embedding: 0 })
     .sort({ createdAt: -1 })
     .skip(parseSkip(skip))
@@ -817,7 +817,7 @@ export async function bulkDeleteMemories(spaceId: string): Promise<number> {
   const ops = tombstones.map(t => ({
     replaceOne: { filter: { _id: t._id }, replacement: t, upsert: true },
   }));
-  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(mBulk<TombstoneDoc>(ops));
+  await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(asBulk<TombstoneDoc>(ops));
   await coll.deleteMany({});
   return ids.length;
 }

--- a/server/src/brain/merge.ts
+++ b/server/src/brain/merge.ts
@@ -9,7 +9,7 @@
  * IDs in the same space.  Candidate discovery is the caller's responsibility.
  */
 
-import { col, getMongo, mFilter, mDoc, mUpdate } from '../db/mongo.js';
+import { col, getMongo, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { embed } from './embedding.js';
 import { getEntityById } from './entities.js';
@@ -206,12 +206,12 @@ async function detectDuplicateEdges(
 
   // All edges currently referencing the absorbed entity
   const absorbedEdges = await edgeColl
-    .find(mFilter<EdgeDoc>({ spaceId, $or: [{ from: absorbedId }, { to: absorbedId }] }))
+    .find(asFilter<EdgeDoc>({ spaceId, $or: [{ from: absorbedId }, { to: absorbedId }] }))
     .toArray() as EdgeDoc[];
 
   // All edges currently referencing the survivor entity
   const survivorEdges = await edgeColl
-    .find(mFilter<EdgeDoc>({ spaceId, $or: [{ from: survivorId }, { to: survivorId }] }))
+    .find(asFilter<EdgeDoc>({ spaceId, $or: [{ from: survivorId }, { to: survivorId }] }))
     .toArray() as EdgeDoc[];
 
   const warnings: DuplicateEdgeWarning[] = [];
@@ -364,12 +364,12 @@ export async function executeMerge(
 
       // Collect all absorbed edges (from=absorbed OR to=absorbed).
       const absorbedEdges = await edgeColl
-        .find(mFilter<EdgeDoc>({ spaceId, $or: [{ from: absorbed._id }, { to: absorbed._id }] }), { session })
+        .find(asFilter<EdgeDoc>({ spaceId, $or: [{ from: absorbed._id }, { to: absorbed._id }] }), { session })
         .toArray() as EdgeDoc[];
 
       // Build a set of existing survivor edge keys for collision detection.
       const survivorEdges = await edgeColl
-        .find(mFilter<EdgeDoc>({ spaceId, $or: [{ from: survivor._id }, { to: survivor._id }] }), { session })
+        .find(asFilter<EdgeDoc>({ spaceId, $or: [{ from: survivor._id }, { to: survivor._id }] }), { session })
         .toArray() as EdgeDoc[];
       const survivorKeys = new Set(survivorEdges.map(e => `${e.from}|${e.to}|${e.label}`));
 
@@ -382,11 +382,11 @@ export async function executeMerge(
         const postKey = `${newFrom}|${newTo}|${edge.label}`;
         if (survivorKeys.has(postKey)) {
           // This absorbed edge would collide — delete it as a duplicate.
-          await edgeColl.deleteOne(mFilter<EdgeDoc>({ _id: edge._id }), { session });
+          await edgeColl.deleteOne(asFilter<EdgeDoc>({ _id: edge._id }), { session });
           const tombSeq = await nextSeq(spaceId);
           await col<TombstoneDoc>(`${spaceId}_tombstones`).replaceOne(
-            mFilter<TombstoneDoc>({ _id: edge._id }),
-            mDoc<TombstoneDoc>({ _id: edge._id, type: 'edge', spaceId, deletedAt: now, instanceId: getConfig().instanceId, seq: tombSeq }),
+            asFilter<TombstoneDoc>({ _id: edge._id }),
+            asDoc<TombstoneDoc>({ _id: edge._id, type: 'edge', spaceId, deletedAt: now, instanceId: getConfig().instanceId, seq: tombSeq }),
             { upsert: true, session },
           );
           deletedDuplicateEdgeIds.push(edge._id);
@@ -406,8 +406,8 @@ export async function executeMerge(
         const edgeSeq = await nextSeq(spaceId);
         (updates as Record<string, unknown>)['seq'] = edgeSeq;
         await edgeColl.updateOne(
-          mFilter<EdgeDoc>({ _id: edge._id }),
-          mUpdate<EdgeDoc>({ $set: updates }),
+          asFilter<EdgeDoc>({ _id: edge._id }),
+          asUpdate<EdgeDoc>({ $set: updates }),
           { session },
         );
       }
@@ -415,15 +415,15 @@ export async function executeMerge(
       // ── 2. Relink memories ─────────────────────────────────────────────
       const memoryColl = col<MemoryDoc>(`${spaceId}_memories`);
       const affectedMemories = await memoryColl
-        .find(mFilter<MemoryDoc>({ spaceId, entityIds: absorbed._id }), { session })
+        .find(asFilter<MemoryDoc>({ spaceId, entityIds: absorbed._id }), { session })
         .toArray() as MemoryDoc[];
       for (const mem of affectedMemories) {
         const newEntityIds = mem.entityIds.map(id => id === absorbed._id ? survivor._id : id);
         const dedupedIds = [...new Set(newEntityIds)];
         const memSeq = await nextSeq(spaceId);
         await memoryColl.updateOne(
-          mFilter<MemoryDoc>({ _id: mem._id }),
-          mUpdate<MemoryDoc>({ $set: { entityIds: dedupedIds, updatedAt: now, seq: memSeq } }),
+          asFilter<MemoryDoc>({ _id: mem._id }),
+          asUpdate<MemoryDoc>({ $set: { entityIds: dedupedIds, updatedAt: now, seq: memSeq } }),
           { session },
         );
       }
@@ -431,15 +431,15 @@ export async function executeMerge(
       // ── 3. Relink chrono entries ───────────────────────────────────────
       const chronoColl = col<ChronoEntry>(`${spaceId}_chrono`);
       const affectedChronos = await chronoColl
-        .find(mFilter<ChronoEntry>({ spaceId, entityIds: absorbed._id }), { session })
+        .find(asFilter<ChronoEntry>({ spaceId, entityIds: absorbed._id }), { session })
         .toArray() as ChronoEntry[];
       for (const ch of affectedChronos) {
         const newEntityIds = ch.entityIds.map(id => id === absorbed._id ? survivor._id : id);
         const dedupedIds = [...new Set(newEntityIds)];
         const chSeq = await nextSeq(spaceId);
         await chronoColl.updateOne(
-          mFilter<ChronoEntry>({ _id: ch._id }),
-          mUpdate<ChronoEntry>({ $set: { entityIds: dedupedIds, updatedAt: now, seq: chSeq } }),
+          asFilter<ChronoEntry>({ _id: ch._id }),
+          asUpdate<ChronoEntry>({ $set: { entityIds: dedupedIds, updatedAt: now, seq: chSeq } }),
           { session },
         );
       }
@@ -457,17 +457,17 @@ export async function executeMerge(
       } catch { /* embedding unavailable — keep existing embedding */ }
 
       await entityColl.updateOne(
-        mFilter<EntityDoc>({ _id: survivor._id }),
-        mUpdate<EntityDoc>({ $set: { properties: mergedProperties, tags: mergedTags, updatedAt: now, seq, ...embeddingFields } }),
+        asFilter<EntityDoc>({ _id: survivor._id }),
+        asUpdate<EntityDoc>({ $set: { properties: mergedProperties, tags: mergedTags, updatedAt: now, seq, ...embeddingFields } }),
         { session },
       );
 
       // ── 5. Delete absorbed entity + write tombstone ────────────────────
       const absorbedSeq = await nextSeq(spaceId);
-      await entityColl.deleteOne(mFilter<EntityDoc>({ _id: absorbed._id, spaceId }), { session });
+      await entityColl.deleteOne(asFilter<EntityDoc>({ _id: absorbed._id, spaceId }), { session });
       await col<TombstoneDoc>(`${spaceId}_tombstones`).replaceOne(
-        mFilter<TombstoneDoc>({ _id: absorbed._id }),
-        mDoc<TombstoneDoc>({ _id: absorbed._id, type: 'entity', spaceId, deletedAt: now, instanceId: getConfig().instanceId, seq: absorbedSeq }),
+        asFilter<TombstoneDoc>({ _id: absorbed._id }),
+        asDoc<TombstoneDoc>({ _id: absorbed._id, type: 'entity', spaceId, deletedAt: now, instanceId: getConfig().instanceId, seq: absorbedSeq }),
         { upsert: true, session },
       );
 

--- a/server/src/brain/merkle.ts
+++ b/server/src/brain/merkle.ts
@@ -25,7 +25,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { col, mFilter } from '../db/mongo.js';
+import { col, asFilter } from '../db/mongo.js';
 import { buildFileManifest } from '../files/manifest.js';
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -123,7 +123,7 @@ export async function computeMerkleRoot(spaceId: string): Promise<MerkleResult> 
   for (const collType of ['memories', 'entities', 'edges', 'chrono'] as const) {
     const collName = `${spaceId}_${collType}`;
     const cursor = col<Record<string, unknown>>(collName)
-      .find(mFilter({}))
+      .find(asFilter({}))
       .project({ embedding: 0, embeddingModel: 0, matchedText: 0 });
 
     for await (const doc of cursor) {

--- a/server/src/brain/tombstones.ts
+++ b/server/src/brain/tombstones.ts
@@ -1,4 +1,4 @@
-import { col, mFilter, mDoc, mUpdate } from '../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { log } from '../util/log.js';
 import type { TombstoneDoc } from '../config/types.js';
 
@@ -21,7 +21,7 @@ export async function listTombstones(
   const filter: Record<string, unknown> = { seq: { $gt: sinceSeq } };
   if (type) filter['type'] = type;
   return col<TombstoneDoc>(`${spaceId}_tombstones`)
-    .find(mFilter<TombstoneDoc>(filter))
+    .find(asFilter<TombstoneDoc>(filter))
     .sort({ seq: 1 })
     .limit(limit)
     .toArray() as Promise<TombstoneDoc[]>;
@@ -33,14 +33,14 @@ export async function applyRemoteTombstone(tombstone: TombstoneDoc, auth: Tombst
 
   // Idempotent upsert — only insert if not present or remote seq is higher
   await col<TombstoneDoc>(`${spaceId}_tombstones`).updateOne(
-    mFilter<TombstoneDoc>({ _id }),
-    mUpdate<TombstoneDoc>({ $setOnInsert: tombstone }),
+    asFilter<TombstoneDoc>({ _id }),
+    asUpdate<TombstoneDoc>({ $setOnInsert: tombstone }),
     { upsert: true },
   );
 
   // If the doc already exists locally with a strictly higher seq, the remote tombstone is stale — skip
   // Note: equal seq means we just inserted it above (or it already existed at same seq), so still apply.
-  const existing = await col<TombstoneDoc>(`${spaceId}_tombstones`).findOne(mFilter<TombstoneDoc>({ _id }));
+  const existing = await col<TombstoneDoc>(`${spaceId}_tombstones`).findOne(asFilter<TombstoneDoc>({ _id }));
   if (existing && (existing as TombstoneDoc).seq > seq) return;
 
   // Delete the underlying document — but only if it was authored by the same
@@ -55,7 +55,7 @@ export async function applyRemoteTombstone(tombstone: TombstoneDoc, auth: Tombst
   };
   const targetColl = collMap[type];
   if (targetColl) {
-    const localDoc = await col(targetColl).findOne(mFilter({ _id })) as { author?: { instanceId?: string } } | null;
+    const localDoc = await col(targetColl).findOne(asFilter({ _id })) as { author?: { instanceId?: string } } | null;
     if (localDoc?.author?.instanceId) {
       const issuer = tombstone.instanceId;
       // The tombstone may only delete a document authored by its own issuer.
@@ -81,6 +81,6 @@ export async function applyRemoteTombstone(tombstone: TombstoneDoc, auth: Tombst
       }
     }
     // Documents without author metadata (legacy) carry nothing to protect — delete as before.
-    await col(targetColl).deleteOne(mFilter({ _id }));
+    await col(targetColl).deleteOne(asFilter({ _id }));
   }
 }

--- a/server/src/db/mongo.ts
+++ b/server/src/db/mongo.ts
@@ -117,36 +117,50 @@ export function col<T extends object>(name: string): Collection<T> {
   return getDb().collection<T>(name);
 }
 
+// ── Typing bridges (NOT validators) ─────────────────────────────────────────
+//
+// The helpers below are pure `as unknown as` casts that bridge our plain document
+// interfaces to MongoDB's strict generics (which expect an index signature). They
+// perform NO sanitisation and NO validation: an object that is hostile going in is
+// still hostile coming out.
+//
+// This matters because a lot of peer-supplied sync data passes through them. Real
+// validation of ingested documents happens at the call sites, via the Zod
+// `Incoming*Doc` schemas in `api/sync.ts` — not here.
+//
+// They are named `as*` precisely so they read as casts. The previous `m`-prefixed
+// names read like "sanitise for Mongo", which is exactly the wrong assumption to
+// invite for code on the sync-ingest path.
+
 /**
- * Cast a plain object to MongoDB's `Filter<T>` without `as never`.
- * Used at call sites where MongoDB's strict Filter generic typing conflicts with
- * TypeScript document interfaces that don't carry an index signature.
+ * Cast a plain object to MongoDB's `Filter<T>`. A typing bridge, not a sanitiser.
  * The cast is semantically correct: the object IS intended as a filter for T.
  */
-export function mFilter<T extends object>(f: Record<string, unknown>): Filter<T> {
+export function asFilter<T extends object>(f: Record<string, unknown>): Filter<T> {
   return f as unknown as Filter<T>;
 }
 
 /**
- * Cast a document value to `OptionalUnlessRequiredId<T>` for insertOne / replaceOne
- * without `as never`. Semantically correct: d is the document being inserted.
+ * Cast a document value to `OptionalUnlessRequiredId<T>` for insertOne / replaceOne.
+ * A typing bridge, not a sanitiser: d is the document being inserted.
  */
-export function mDoc<T extends object>(d: T | Record<string, unknown>): OptionalUnlessRequiredId<T> {
+export function asDoc<T extends object>(d: T | Record<string, unknown>): OptionalUnlessRequiredId<T> {
   return d as unknown as OptionalUnlessRequiredId<T>;
 }
 
 /**
- * Cast a plain update-operator object to MongoDB's `UpdateFilter<T>` without `as never`.
- * Semantically correct: u is an update descriptor (`{ $set: {...} }` etc.) for T.
+ * Cast a plain update-operator object to MongoDB's `UpdateFilter<T>`.
+ * A typing bridge, not a sanitiser: u is an update descriptor (`{ $set: {...} }`) for T.
  */
-export function mUpdate<T extends object>(u: Record<string, unknown>): UpdateFilter<T> {
+export function asUpdate<T extends object>(u: Record<string, unknown>): UpdateFilter<T> {
   return u as unknown as UpdateFilter<T>;
 }
 
 /**
- * Cast a bulk-write operations array to `AnyBulkWriteOperation<T>[]` without `as never`.
+ * Cast a bulk-write operations array to `AnyBulkWriteOperation<T>[]`.
+ * A typing bridge, not a sanitiser.
  */
-export function mBulk<T extends object>(ops: unknown[]): AnyBulkWriteOperation<T>[] {
+export function asBulk<T extends object>(ops: unknown[]): AnyBulkWriteOperation<T>[] {
   return ops as unknown as AnyBulkWriteOperation<T>[];
 }
 

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -19,7 +19,7 @@ import { paragraphChunk } from './paragraph-chunker.js';
 import type { Chunk } from './types.js';
 import { ConversionUnavailableError } from './types.js';
 import { writeFile, writeFileBytes } from '../files.js';
-import { col, mFilter, mDoc } from '../../db/mongo.js';
+import { col, asFilter, asDoc } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig } from '../../config/loader.js';
 import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
@@ -275,7 +275,7 @@ export async function storeConversionResults(
       author: authorRef(),
       parentFileId: originalId,
     };
-    await col<FileMetaDoc>(`${spaceId}_files`).insertOne(mDoc<FileMetaDoc>(convertedDoc));
+    await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(convertedDoc));
   }
 
   // 2. Write extracted image subfiles and enqueue for media pipeline.
@@ -312,7 +312,7 @@ export async function storeConversionResults(
           author: authorRef(),
           parentFileId: originalId,
         };
-        await col<FileMetaDoc>(`${spaceId}_files`).insertOne(mDoc<FileMetaDoc>(imgDoc));
+        await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(imgDoc));
 
         // Enqueue for media pipeline (caption + face recognition)
         const mimeType = `image/${img.ext === 'jpg' ? 'jpeg' : img.ext}`;
@@ -360,7 +360,7 @@ export async function storeConversionResults(
       ...embeddingFields,
     };
 
-    await col<FileMetaDoc>(`${spaceId}_files`).insertOne(mDoc<FileMetaDoc>(chunkDoc));
+    await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(chunkDoc));
   }
 
   return { chunkCount: chunks.length, convertedFileId };
@@ -375,7 +375,7 @@ export async function deleteConversionArtifacts(
 
   // Delete all filemeta records with parentFileId = originalId
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
-    mFilter<FileMetaDoc>({ parentFileId: originalId }),
+    asFilter<FileMetaDoc>({ parentFileId: originalId }),
   );
 
   log.info(`Deleted conversion artifacts for ${spaceId}/${originalId}`);

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -13,7 +13,7 @@
  */
 
 import path from 'node:path';
-import { col, mFilter, mDoc, mUpdate } from '../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { embed } from '../brain/embedding.js';
 import { getConfig } from '../config/loader.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../config/types.js';
@@ -52,7 +52,7 @@ async function resolveEntityNames(spaceId: string, entityIds: string[]): Promise
   if (entityIds.length === 0) return [];
   try {
     const docs = await col<EntityDoc>(`${spaceId}_entities`)
-      .find(mFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
+      .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
       .toArray() as Array<{ name: string }>;
     return docs.map(d => d.name);
   } catch { return []; }
@@ -73,7 +73,7 @@ export async function upsertFileMeta(
   const now = new Date().toISOString();
 
   const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
-    mFilter<FileMetaDoc>({ _id: normalised }),
+    asFilter<FileMetaDoc>({ _id: normalised }),
   );
 
   // Embed path + entity names + tags + description + property values — best-effort, never blocks write
@@ -95,8 +95,8 @@ export async function upsertFileMeta(
     if (opts.tags !== undefined) $set['tags'] = opts.tags;
     if (opts.properties !== undefined) $set['properties'] = opts.properties;
     await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
-      mFilter<FileMetaDoc>({ _id: normalised }),
-      mUpdate<FileMetaDoc>({ $set }),
+      asFilter<FileMetaDoc>({ _id: normalised }),
+      asUpdate<FileMetaDoc>({ $set }),
     );
   } else {
     const doc: FileMetaDoc = {
@@ -112,7 +112,7 @@ export async function upsertFileMeta(
       author: authorRef(),
       ...embeddingFields,
     };
-    await col<FileMetaDoc>(`${spaceId}_files`).insertOne(mDoc<FileMetaDoc>(doc));
+    await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(doc));
   }
 }
 
@@ -135,7 +135,7 @@ export async function updateFileMeta(
   },
 ): Promise<FileMetaDoc | null> {
   const normalised = normPath(filePath);
-  const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(mFilter<FileMetaDoc>({ _id: normalised })) as FileMetaDoc | null;
+  const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(asFilter<FileMetaDoc>({ _id: normalised })) as FileMetaDoc | null;
   if (!existing) return null;
 
   const now = new Date().toISOString();
@@ -161,8 +161,8 @@ export async function updateFileMeta(
   if (opts.properties !== undefined) $set['properties'] = opts.properties;
 
   await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
-    mFilter<FileMetaDoc>({ _id: normalised }),
-    mUpdate<FileMetaDoc>({ $set }),
+    asFilter<FileMetaDoc>({ _id: normalised }),
+    asUpdate<FileMetaDoc>({ $set }),
   );
 
   // Face recognition side-effects when entity links change.
@@ -186,7 +186,7 @@ export async function updateFileMeta(
       const faceCfg = getFaceRecognitionConfig();
       if (faceCfg.enabled) {
         const faceChunkCount = await col<FileMetaDoc>(`${spaceId}_files`).countDocuments(
-          mFilter<FileMetaDoc>({ parentFileId: normalised, faceEmbedding: { $exists: true } }),
+          asFilter<FileMetaDoc>({ parentFileId: normalised, faceEmbedding: { $exists: true } }),
         );
 
         if (faceChunkCount === 0 && faceCfg.reprocessSyncedImages) {
@@ -203,7 +203,7 @@ export async function updateFileMeta(
         } else if (faceChunkCount === 1) {
           // Case B: face chunks exist — propagate label if exactly 1 person entity.
           const entities = await col<EntityDoc>(`${spaceId}_entities`)
-            .find(mFilter<EntityDoc>({ _id: { $in: opts.entityIds } }), { projection: { _id: 1, type: 1 } })
+            .find(asFilter<EntityDoc>({ _id: { $in: opts.entityIds } }), { projection: { _id: 1, type: 1 } })
             .toArray() as Array<{ _id: string; type: string }>;
           const personEntities = entities.filter(e =>
             faceCfg.personEntityTypes.some(t => t.toLowerCase() === e.type.toLowerCase()),
@@ -217,7 +217,7 @@ export async function updateFileMeta(
     } catch { /* non-fatal — face side-effects must never block file meta write */ }
   }
 
-  return col<FileMetaDoc>(`${spaceId}_files`).findOne(mFilter<FileMetaDoc>({ _id: normalised })) as Promise<FileMetaDoc | null>;
+  return col<FileMetaDoc>(`${spaceId}_files`).findOne(asFilter<FileMetaDoc>({ _id: normalised })) as Promise<FileMetaDoc | null>;
 }
 
 /** Remove the metadata record when a file is deleted. */
@@ -227,7 +227,7 @@ export async function deleteFileMeta(
 ): Promise<void> {
   const normalised = normPath(filePath);
   await col<FileMetaDoc>(`${spaceId}_files`).deleteOne(
-    mFilter<FileMetaDoc>({ _id: normalised }),
+    asFilter<FileMetaDoc>({ _id: normalised }),
   );
 }
 
@@ -246,7 +246,7 @@ export async function deleteFileMetaByPrefix(
   // doesn't accidentally match "myXdir/" etc.
   const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
-    mFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }),
+    asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }),
   );
 }
 
@@ -265,14 +265,14 @@ export async function renameFileMeta(
   if (normSrc === normDst) return;
 
   const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
-    mFilter<FileMetaDoc>({ _id: normSrc }),
+    asFilter<FileMetaDoc>({ _id: normSrc }),
   );
   if (!existing) return;
 
   const now = new Date().toISOString();
   // MongoDB does not allow updating _id; delete + re-insert with new path.
-  await col<FileMetaDoc>(`${spaceId}_files`).deleteOne(mFilter<FileMetaDoc>({ _id: normSrc }));
-  await col<FileMetaDoc>(`${spaceId}_files`).insertOne(mDoc<FileMetaDoc>({
+  await col<FileMetaDoc>(`${spaceId}_files`).deleteOne(asFilter<FileMetaDoc>({ _id: normSrc }));
+  await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>({
     ...existing,
     _id: normDst,
     path: normDst,
@@ -304,7 +304,7 @@ export async function renameFileMetaByPrefix(
 
   const escaped = srcPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const docs = await col<FileMetaDoc>(`${spaceId}_files`)
-    .find(mFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }))
+    .find(asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }))
     .toArray() as FileMetaDoc[];
 
   if (docs.length === 0) return;
@@ -313,7 +313,7 @@ export async function renameFileMetaByPrefix(
   // Delete existing records and re-insert with updated paths.
   const oldIds = docs.map(d => d._id);
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
-    mFilter<FileMetaDoc>({ _id: { $in: oldIds } }),
+    asFilter<FileMetaDoc>({ _id: { $in: oldIds } }),
   );
   const updated = docs.map(d => ({
     ...d,
@@ -321,5 +321,5 @@ export async function renameFileMetaByPrefix(
     path: dstPrefix + d.path.slice(srcPrefix.length),
     updatedAt: now,
   }));
-  await col<FileMetaDoc>(`${spaceId}_files`).insertMany(updated.map(d => mDoc<FileMetaDoc>(d)));
+  await col<FileMetaDoc>(`${spaceId}_files`).insertMany(updated.map(d => asDoc<FileMetaDoc>(d)));
 }

--- a/server/src/files/media/audio-embedder.ts
+++ b/server/src/files/media/audio-embedder.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { col, mDoc, mFilter } from '../../db/mongo.js';
+import { col, asDoc, asFilter } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig } from '../../config/loader.js';
 import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
@@ -267,8 +267,8 @@ export async function embedAudio(
         };
 
         await col<FileMetaDoc>(`${spaceId}_files`).replaceOne(
-          mFilter<FileMetaDoc>({ _id: chunkId }),
-          mDoc<FileMetaDoc>(chunkDoc),
+          asFilter<FileMetaDoc>({ _id: chunkId }),
+          asDoc<FileMetaDoc>(chunkDoc),
           { upsert: true },
         );
 

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -30,7 +30,7 @@
 
 import path from 'path';
 import sharp from 'sharp';
-import { col, mDoc, mFilter } from '../../db/mongo.js';
+import { col, asDoc, asFilter } from '../../db/mongo.js';
 import { getConfig, getDataRoot, getFaceRecognitionConfig } from '../../config/loader.js';
 import { updateFileMeta } from '../file-meta.js';
 import { log } from '../../util/log.js';
@@ -303,8 +303,8 @@ export async function embedFaces(
     };
 
     await col<FileMetaDoc>(`${spaceId}_files`).replaceOne(
-      mFilter<FileMetaDoc>({ _id: chunkId }),
-      mDoc<FileMetaDoc>(chunkDoc as FileMetaDoc),
+      asFilter<FileMetaDoc>({ _id: chunkId }),
+      asDoc<FileMetaDoc>(chunkDoc as FileMetaDoc),
       { upsert: true },
     );
   }
@@ -313,7 +313,7 @@ export async function embedFaces(
   if (autoLabelEntityId) {
     try {
       const parent = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
-        mFilter<FileMetaDoc>({ _id: fileId }),
+        asFilter<FileMetaDoc>({ _id: fileId }),
         { projection: { entityIds: 1 } },
       ) as FileMetaDoc | null;
 
@@ -349,7 +349,7 @@ export async function propagateFaceLabel(
   try {
     const now = new Date().toISOString();
     await col<FileMetaDoc>(`${spaceId}_files`).updateMany(
-      mFilter<FileMetaDoc>({ parentFileId: fileId, faceEmbedding: { $exists: true } }),
+      asFilter<FileMetaDoc>({ parentFileId: fileId, faceEmbedding: { $exists: true } }),
       { $set: { faceEntityId: entityId, updatedAt: now } },
     );
   } catch (err) {

--- a/server/src/files/media/image-embedder.ts
+++ b/server/src/files/media/image-embedder.ts
@@ -6,7 +6,7 @@
  * on the {spaceId}_files collection with `derivedText` = caption.
  */
 
-import { col, mDoc, mFilter } from '../../db/mongo.js';
+import { col, asDoc, asFilter } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
 import { log } from '../../util/log.js';
@@ -60,8 +60,8 @@ export async function embedImage(
 
   // Upsert: a retry may re-run this after a partial failure
   await col<FileMetaDoc>(`${spaceId}_files`).replaceOne(
-    mFilter<FileMetaDoc>({ _id: chunkId }),
-    mDoc<FileMetaDoc>(chunkDoc),
+    asFilter<FileMetaDoc>({ _id: chunkId }),
+    asDoc<FileMetaDoc>(chunkDoc),
     { upsert: true },
   );
 

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -5,7 +5,7 @@
  * collection.  The worker claims jobs atomically via findOneAndUpdate.
  */
 
-import { col, mFilter, mDoc, mUpdate } from '../../db/mongo.js';
+import { col, asFilter, asDoc, asUpdate } from '../../db/mongo.js';
 import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 
@@ -57,7 +57,7 @@ export async function enqueueMediaJob(
   const now = new Date().toISOString();
 
   const existing = await jobCollection(spaceId).findOne(
-    mFilter<MediaJobDoc>({ _id: id }),
+    asFilter<MediaJobDoc>({ _id: id }),
   ) as MediaJobDoc | null;
 
   if (existing && (existing.status === 'pending' || existing.status === 'processing')) {
@@ -68,8 +68,8 @@ export async function enqueueMediaJob(
   if (existing) {
     // Terminal state (complete/failed) — reset so re-upload triggers re-processing
     await jobCollection(spaceId).updateOne(
-      mFilter<MediaJobDoc>({ _id: id }),
-      mUpdate<MediaJobDoc>({
+      asFilter<MediaJobDoc>({ _id: id }),
+      asUpdate<MediaJobDoc>({
         $set: {
           status: 'pending',
           attempts: 0,
@@ -98,7 +98,7 @@ export async function enqueueMediaJob(
       createdAt: now,
       updatedAt: now,
     };
-    await jobCollection(spaceId).insertOne(mDoc<MediaJobDoc>(doc));
+    await jobCollection(spaceId).insertOne(asDoc<MediaJobDoc>(doc));
   }
 }
 
@@ -121,14 +121,14 @@ export async function enqueueTextJob(
   const now = new Date().toISOString();
 
   const existing = await jobCollection(spaceId).findOne(
-    mFilter<MediaJobDoc>({ _id: id }),
+    asFilter<MediaJobDoc>({ _id: id }),
   ) as MediaJobDoc | null;
 
   if (existing) {
     // Always reset — new upload supersedes any previous or in-progress job
     await jobCollection(spaceId).updateOne(
-      mFilter<MediaJobDoc>({ _id: id }),
-      mUpdate<MediaJobDoc>({
+      asFilter<MediaJobDoc>({ _id: id }),
+      asUpdate<MediaJobDoc>({
         $set: {
           status: 'pending',
           attempts: 0,
@@ -159,13 +159,13 @@ export async function enqueueTextJob(
       createdAt: now,
       updatedAt: now,
     };
-    await jobCollection(spaceId).insertOne(mDoc<MediaJobDoc>(doc));
+    await jobCollection(spaceId).insertOne(asDoc<MediaJobDoc>(doc));
   }
 
   // Reflect pending status on the file meta record immediately so the UI
   // can show an "embedding" indicator without waiting for the worker.
   await fileCollection(spaceId).updateOne(
-    mFilter<FileMetaDoc>({ _id: id }),
+    asFilter<FileMetaDoc>({ _id: id }),
     { $set: { embeddingStatus: 'pending', updatedAt: now } },
   ).catch(err => {
     log.debug(`enqueueTextJob: could not set embeddingStatus on file meta ${spaceId}/${id}: ${err instanceof Error ? err.message : String(err)}`);
@@ -187,7 +187,7 @@ export async function claimNextJob(
   const now = new Date().toISOString();
   for (const spaceId of spaceIds) {
     const claimed = await jobCollection(spaceId).findOneAndUpdate(
-      mFilter<MediaJobDoc>({
+      asFilter<MediaJobDoc>({
         status: 'pending',
         // Either no backoff set, or backoff has elapsed.
         $or: [
@@ -196,7 +196,7 @@ export async function claimNextJob(
           { claimableAfter: { $lte: now } as unknown as string },
         ],
       }),
-      mUpdate<MediaJobDoc>({
+      asUpdate<MediaJobDoc>({
         $set: { status: 'processing', claimedAt: now, claimableAfter: null, updatedAt: now },
         $inc: { attempts: 1 },
       }),
@@ -212,11 +212,11 @@ export async function claimNextJob(
 export async function completeJob(spaceId: string, fileId: string): Promise<void> {
   const now = new Date().toISOString();
   await jobCollection(spaceId).updateOne(
-    mFilter<MediaJobDoc>({ _id: fileId }),
-    mUpdate<MediaJobDoc>({ $set: { status: 'complete', claimedAt: null, updatedAt: now } }),
+    asFilter<MediaJobDoc>({ _id: fileId }),
+    asUpdate<MediaJobDoc>({ $set: { status: 'complete', claimedAt: null, updatedAt: now } }),
   );
   await fileCollection(spaceId).updateOne(
-    mFilter<FileMetaDoc>({ _id: fileId }),
+    asFilter<FileMetaDoc>({ _id: fileId }),
     { $set: { embeddingStatus: 'complete', updatedAt: now } },
   );
 }
@@ -238,8 +238,8 @@ export async function failJob(
     // the claim). Schedule the *next* claim for `attempts + 1` slots out.
     const claimableAfter = nextClaimableAfter(attempts + 1);
     await jobCollection(spaceId).updateOne(
-      mFilter<MediaJobDoc>({ _id: fileId }),
-      mUpdate<MediaJobDoc>({
+      asFilter<MediaJobDoc>({ _id: fileId }),
+      asUpdate<MediaJobDoc>({
         $set: {
           status: 'pending',
           claimedAt: null,
@@ -253,8 +253,8 @@ export async function failJob(
   } else {
     // Exhausted retries
     await jobCollection(spaceId).updateOne(
-      mFilter<MediaJobDoc>({ _id: fileId }),
-      mUpdate<MediaJobDoc>({
+      asFilter<MediaJobDoc>({ _id: fileId }),
+      asUpdate<MediaJobDoc>({
         $set: {
           status: 'failed',
           claimedAt: null,
@@ -264,7 +264,7 @@ export async function failJob(
       }),
     );
     await fileCollection(spaceId).updateOne(
-      mFilter<FileMetaDoc>({ _id: fileId }),
+      asFilter<FileMetaDoc>({ _id: fileId }),
       { $set: { embeddingStatus: 'failed', mediaJobError: safeError || undefined, updatedAt: now } },
     );
     log.warn(`Media job ${spaceId}/${fileId} exhausted retries: ${errorMessage}`);
@@ -295,7 +295,7 @@ export async function resetStalledJobs(
     for (let i = 0; i < maxPerSpace; i++) {
       const now = new Date().toISOString();
       const claimed = await jobCollection(spaceId).findOneAndUpdate(
-        mFilter<MediaJobDoc>({
+        asFilter<MediaJobDoc>({
           status: 'processing',
           claimedAt: { $lt: cutoff } as unknown as string,
         }),
@@ -330,7 +330,7 @@ export async function retryJob(
   fileId: string,
 ): Promise<'ok' | 'not_found' | 'processing'> {
   const existing = await jobCollection(spaceId).findOne(
-    mFilter<MediaJobDoc>({ _id: fileId }),
+    asFilter<MediaJobDoc>({ _id: fileId }),
   ) as MediaJobDoc | null;
 
   if (!existing) return 'not_found';
@@ -338,8 +338,8 @@ export async function retryJob(
 
   const now = new Date().toISOString();
   await jobCollection(spaceId).updateOne(
-    mFilter<MediaJobDoc>({ _id: fileId }),
-    mUpdate<MediaJobDoc>({
+    asFilter<MediaJobDoc>({ _id: fileId }),
+    asUpdate<MediaJobDoc>({
       $set: {
         status: 'pending',
         attempts: 0,
@@ -351,7 +351,7 @@ export async function retryJob(
     }),
   );
   await fileCollection(spaceId).updateOne(
-    mFilter<FileMetaDoc>({ _id: fileId }),
+    asFilter<FileMetaDoc>({ _id: fileId }),
     { $set: { embeddingStatus: 'pending', mediaJobError: undefined, updatedAt: now } },
   );
   return 'ok';

--- a/server/src/files/media/video-embedder.ts
+++ b/server/src/files/media/video-embedder.ts
@@ -13,7 +13,7 @@ import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { col, mFilter, mUpdate } from '../../db/mongo.js';
+import { col, asFilter, asUpdate } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import type { VisionProvider, SttProvider } from './providers.js';
@@ -181,8 +181,8 @@ export async function embedVideo(
       try {
         const embResult = await embed(combined);
         await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
-          mFilter<FileMetaDoc>({ _id: chunk.chunkId }),
-          mUpdate<FileMetaDoc>({
+          asFilter<FileMetaDoc>({ _id: chunk.chunkId }),
+          asUpdate<FileMetaDoc>({
             $set: {
               content: combined,
               matchedText: combined,

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -32,7 +32,7 @@ import { claimNextJob, completeJob, failJob, resetStalledJobs } from './job-queu
 import { embedImage } from './image-embedder.js';
 import { embedAudio } from './audio-embedder.js';
 import { embedVideo } from './video-embedder.js';
-import { col, mFilter } from '../../db/mongo.js';
+import { col, asFilter } from '../../db/mongo.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { updateFileMeta } from '../file-meta.js';
 import {
@@ -176,7 +176,7 @@ async function processJob(
     // Mark file as "processing" in file meta
     const now = new Date().toISOString();
     await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
-      mFilter<FileMetaDoc>({ _id: fileId }),
+      asFilter<FileMetaDoc>({ _id: fileId }),
       { $set: { embeddingStatus: 'processing', updatedAt: now } },
     ).catch(() => {}); // non-fatal — job tracking is the source of truth
 
@@ -207,7 +207,7 @@ async function processJob(
           const metaUpdate: Record<string, unknown> = { chunkCount };
           if (convertedFileId) metaUpdate['convertedFileId'] = convertedFileId;
           await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
-            mFilter<FileMetaDoc>({ _id: fileId }),
+            asFilter<FileMetaDoc>({ _id: fileId }),
             { $set: metaUpdate },
           ).catch(() => {});
         }
@@ -221,7 +221,7 @@ async function processJob(
     // This also re-embeds the parent file meta so the caption is searchable on the file itself.
     if (derivedDescription) {
       const parentMeta = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
-        mFilter<FileMetaDoc>({ _id: fileId }),
+        asFilter<FileMetaDoc>({ _id: fileId }),
         { projection: { description: 1 } },
       );
       if (!parentMeta?.description?.trim()) {
@@ -242,7 +242,7 @@ async function processJob(
     const permanent = err instanceof ConversionUnavailableError && err.reason === 'too_large';
     if (permanent) {
       await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
-        mFilter<FileMetaDoc>({ _id: fileId }),
+        asFilter<FileMetaDoc>({ _id: fileId }),
         { $set: { embeddingStatus: 'skipped' } },
       ).catch(() => {});
     }

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -1,7 +1,7 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { recall } from '../../brain/memory.js';
 import { getMediaEmbeddingConfig } from '../../config/loader.js';
-import { col, mFilter } from '../../db/mongo.js';
+import { col, asFilter } from '../../db/mongo.js';
 import { type InputFormat, isMediaFormat, resolveInputFormat, runConversionPipeline, storeConversionResults } from '../../files/converters/pipeline.js';
 import { ConversionUnavailableError } from '../../files/converters/types.js';
 import { deleteFileMeta, renameFileMeta, upsertFileMeta } from '../../files/file-meta.js';
@@ -94,18 +94,18 @@ export const write_fileTool: ToolHandler = {
       const mediaCfg = getMediaEmbeddingConfig();
       if (!mediaCfg.enabled) {
         await col<import('../../config/types.js').FileMetaDoc>(`${wt.target}_files`).updateOne(
-          mFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
+          asFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
           { $set: { mediaType: resolvedFmt, embeddingStatus: 'disabled' } },
         );
       } else if (sizeBytes > (mediaCfg.maxFileSizeBytes ?? 524_288_000)) {
         await col<import('../../config/types.js').FileMetaDoc>(`${wt.target}_files`).updateOne(
-          mFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
+          asFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
           { $set: { mediaType: resolvedFmt, embeddingStatus: 'skipped' } },
         );
       } else {
         const mimeType = 'application/octet-stream';
         await col<import('../../config/types.js').FileMetaDoc>(`${wt.target}_files`).updateOne(
-          mFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
+          asFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
           { $set: { mediaType: resolvedFmt, embeddingStatus: 'pending' } },
         );
         await enqueueMediaJob(wt.target, filePath, mimeType, resolvedFmt).catch(err => {
@@ -120,7 +120,7 @@ export const write_fileTool: ToolHandler = {
           const metaUpdate: Record<string, unknown> = { chunkCount };
           if (convertedFileId) metaUpdate['convertedFileId'] = convertedFileId;
           await col<import('../../config/types.js').FileMetaDoc>(`${wt.target}_files`).updateOne(
-            mFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
+            asFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
             { $set: metaUpdate },
           );
         }
@@ -128,7 +128,7 @@ export const write_fileTool: ToolHandler = {
         if (err instanceof ConversionUnavailableError) {
           log.warn(`write_file conversion failed for ${wt.target}/${filePath}: ${err.message}`);
           await col<import('../../config/types.js').FileMetaDoc>(`${wt.target}_files`).updateOne(
-            mFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
+            asFilter<import('../../config/types.js').FileMetaDoc>({ _id: normId }),
             { $set: { conversionError: err.message } },
           );
         }

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -6,7 +6,7 @@ import { MAX_RECALL_TRAVERSE, traverseRecallSeeds, upsertEdge } from '../../brai
 import { findEntitiesByName, upsertEntity } from '../../brain/entities.js';
 import { type FilterExpression, type RecallKnowledgeType, type RecallResult, deleteMemory, findSimilar, queryBrain, recall, recallGlobal, remember, updateMemory, validateFilterExpression } from '../../brain/memory.js';
 import { getConfig } from '../../config/loader.js';
-import { col, mFilter } from '../../db/mongo.js';
+import { col, asFilter } from '../../db/mongo.js';
 import { QuotaError, checkQuota } from '../../quota/quota.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
 import { getAllowedChronoTypes, resolveMetaRefs, validateChrono, validateEdge, validateEntity, validateMemory } from '../../spaces/schema-validation.js';
@@ -629,7 +629,7 @@ export const bulk_writeTool: ToolHandler = {
         }
         // Check for existing entity by ID (if supplied) to determine inserted vs updated
         const existing = rawId
-          ? await col<import('../../config/types.js').EntityDoc>(`${ts}_entities`).findOne(mFilter({ _id: rawId, spaceId: ts }))
+          ? await col<import('../../config/types.js').EntityDoc>(`${ts}_entities`).findOne(asFilter({ _id: rawId, spaceId: ts }))
           : null;
         const result = await upsertEntity(ts, eName, eType, tags, props, description, rawId);
         if (existing) { updated.entities++; } else { inserted.entities++; }
@@ -665,7 +665,7 @@ export const bulk_writeTool: ToolHandler = {
             for (const v of sv) errors.push({ type: 'edge', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
           }
         }
-        const existing = await col<import('../../config/types.js').EdgeDoc>(`${ts}_edges`).findOne(mFilter({ spaceId: ts, from, to, label }));
+        const existing = await col<import('../../config/types.js').EdgeDoc>(`${ts}_edges`).findOne(asFilter({ spaceId: ts, from, to, label }));
         await upsertEdge(ts, from, to, label, weight, edgeType, description, props, tags);
         if (existing) { updated.edges++; } else { inserted.edges++; }
       } catch (err) {

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs/promises';
 import path from 'path';
-import { getDb, col, mDoc } from '../db/mongo.js';
+import { getDb, col, asDoc } from '../db/mongo.js';
 import { getConfig, saveConfig, getEmbeddingConfig, getDataRoot, getFaceRecognitionConfig } from '../config/loader.js';
 import { ensureSpaceFilesDir, writeFile as writeSpaceFile } from '../files/files.js';
 import { log } from '../util/log.js';
@@ -192,7 +192,7 @@ async function ensureVectorSearchIndex(
 
   log.debug(`Creating vector search index ${indexName} (${numDimensions}d, ${similarity}, path: ${vectorPath})`);
   try {
-    await coll.createSearchIndex(mDoc({
+    await coll.createSearchIndex(asDoc({
       name: indexName,
       type: 'vectorSearch',
       definition: {

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -16,7 +16,7 @@
  */
 
 import { getConfig, saveConfig, getSecrets, getFaceRecognitionConfig } from '../config/loader.js';
-import { col, mFilter, mDoc } from '../db/mongo.js';
+import { col, asFilter, asDoc } from '../db/mongo.js';
 import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
 import { recordSyncResult, type SyncCounts } from './history.js';
 import { buildFileManifest } from '../files/manifest.js';
@@ -405,16 +405,16 @@ async function runSyncForMember(
     const localWarm = Promise.all(
       net.spaces.flatMap(sid => [
         col<MemoryDoc>(`${sid}_memories`)
-          .findOne(mFilter({}), { projection: { _id: 1 } })
+          .findOne(asFilter({}), { projection: { _id: 1 } })
           .catch(() => {}),
         col<EntityDoc>(`${sid}_entities`)
-          .findOne(mFilter({}), { projection: { _id: 1 } })
+          .findOne(asFilter({}), { projection: { _id: 1 } })
           .catch(() => {}),
         col<EdgeDoc>(`${sid}_edges`)
-          .findOne(mFilter({}), { projection: { _id: 1 } })
+          .findOne(asFilter({}), { projection: { _id: 1 } })
           .catch(() => {}),
         col<ChronoEntry>(`${sid}_chrono`)
-          .findOne(mFilter({}), { projection: { _id: 1 } })
+          .findOne(asFilter({}), { projection: { _id: 1 } })
           .catch(() => {}),
       ]),
     );
@@ -957,7 +957,7 @@ async function pushToPeer(
     let seqCursor = lastSeqPushed;
     while (true) {
       const batch = await col<T>(collName)
-        .find(mFilter<T>({ seq: { $gt: seqCursor }, ...ownedFilter }))
+        .find(asFilter<T>({ seq: { $gt: seqCursor }, ...ownedFilter }))
         .sort({ seq: 1 })
         .limit(PUSH_BATCH_SIZE)
         .toArray() as T[];
@@ -1056,7 +1056,7 @@ async function syncFiles(
     // Files we deleted locally must be propagated to the peer so they disappear there too.
     if (doPush) try {
       const ourTombstones = await col<FileTombstoneDoc>(`${spaceId}_file_tombstones`)
-        .find(mFilter<FileTombstoneDoc>({ spaceId }))
+        .find(asFilter<FileTombstoneDoc>({ spaceId }))
         .toArray();
       if (ourTombstones.length > 0) {
         await peerSafeFetch(
@@ -1136,7 +1136,7 @@ async function syncFiles(
             peerInstanceLabel: member.label,
             detectedAt: new Date().toISOString(),
           };
-          await col<ConflictDoc>(`${spaceId}_conflicts`).insertOne(mDoc<ConflictDoc>(conflictDoc));
+          await col<ConflictDoc>(`${spaceId}_conflicts`).insertOne(asDoc<ConflictDoc>(conflictDoc));
 
           log.warn(
             `FILE_CONFLICT: '${remote.path}' from peer '${member.label}' differs from local copy. ` +
@@ -1196,30 +1196,30 @@ async function syncFiles(
 // ── Local upsert helpers ────────────────────────────────────────────────────
 
 async function upsertMemory(spaceId: string, incoming: MemoryDoc): Promise<void> {
-  const existing = await col<MemoryDoc>(`${spaceId}_memories`).findOne(mFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
+  const existing = await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
   if (!existing || incoming.seq > existing.seq) {
-    await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(mFilter<MemoryDoc>({ _id: incoming._id }), mDoc<MemoryDoc>(incoming), { upsert: true });
+    await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(asFilter<MemoryDoc>({ _id: incoming._id }), asDoc<MemoryDoc>(incoming), { upsert: true });
   }
 }
 
 async function upsertEntity(spaceId: string, incoming: EntityDoc): Promise<void> {
-  const existing = await col<EntityDoc>(`${spaceId}_entities`).findOne(mFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc | null;
+  const existing = await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc | null;
   if (!existing || incoming.seq > existing.seq) {
-    await col<EntityDoc>(`${spaceId}_entities`).replaceOne(mFilter<EntityDoc>({ _id: incoming._id }), mDoc<EntityDoc>(incoming), { upsert: true });
+    await col<EntityDoc>(`${spaceId}_entities`).replaceOne(asFilter<EntityDoc>({ _id: incoming._id }), asDoc<EntityDoc>(incoming), { upsert: true });
   }
 }
 
 async function upsertEdge(spaceId: string, incoming: EdgeDoc): Promise<void> {
-  const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(mFilter<EdgeDoc>({ _id: incoming._id })) as EdgeDoc | null;
+  const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ _id: incoming._id })) as EdgeDoc | null;
   if (!existing || incoming.seq > existing.seq) {
-    await col<EdgeDoc>(`${spaceId}_edges`).replaceOne(mFilter<EdgeDoc>({ _id: incoming._id }), mDoc<EdgeDoc>(incoming), { upsert: true });
+    await col<EdgeDoc>(`${spaceId}_edges`).replaceOne(asFilter<EdgeDoc>({ _id: incoming._id }), asDoc<EdgeDoc>(incoming), { upsert: true });
   }
 }
 
 async function upsertChrono(spaceId: string, incoming: ChronoEntry): Promise<void> {
-  const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(mFilter<ChronoEntry>({ _id: incoming._id })) as ChronoEntry | null;
+  const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: incoming._id })) as ChronoEntry | null;
   if (!existing || incoming.seq > existing.seq) {
-    await col<ChronoEntry>(`${spaceId}_chrono`).replaceOne(mFilter<ChronoEntry>({ _id: incoming._id }), mDoc<ChronoEntry>(incoming), { upsert: true });
+    await col<ChronoEntry>(`${spaceId}_chrono`).replaceOne(asFilter<ChronoEntry>({ _id: incoming._id }), asDoc<ChronoEntry>(incoming), { upsert: true });
   }
 }
 

--- a/server/src/sync/history.ts
+++ b/server/src/sync/history.ts
@@ -1,4 +1,4 @@
-import { col, mFilter, mDoc } from '../db/mongo.js';
+import { col, asFilter, asDoc } from '../db/mongo.js';
 import { v4 as uuidv4 } from 'uuid';
 
 export interface SyncCounts {
@@ -26,11 +26,11 @@ const MAX_PER_NETWORK = 100;
 export async function recordSyncResult(record: Omit<SyncHistoryRecord, '_id'>): Promise<void> {
   const doc: SyncHistoryRecord = { _id: uuidv4(), ...record };
   const coll = col<SyncHistoryRecord>(COLLECTION);
-  await coll.insertOne(mDoc<SyncHistoryRecord>(doc));
+  await coll.insertOne(asDoc<SyncHistoryRecord>(doc));
 
   // Prune: keep only the most recent MAX_PER_NETWORK per network
   const boundary = await coll
-    .find(mFilter<SyncHistoryRecord>({ networkId: record.networkId }))
+    .find(asFilter<SyncHistoryRecord>({ networkId: record.networkId }))
     .sort({ completedAt: -1 })
     .skip(MAX_PER_NETWORK)
     .limit(1)
@@ -38,7 +38,7 @@ export async function recordSyncResult(record: Omit<SyncHistoryRecord, '_id'>): 
     .toArray();
 
   if (boundary.length > 0) {
-    await coll.deleteMany(mFilter<SyncHistoryRecord>({
+    await coll.deleteMany(asFilter<SyncHistoryRecord>({
       networkId: record.networkId,
       completedAt: { $lte: (boundary[0] as unknown as { completedAt: string }).completedAt },
     }));
@@ -47,7 +47,7 @@ export async function recordSyncResult(record: Omit<SyncHistoryRecord, '_id'>): 
 
 export async function getSyncHistory(networkId: string, limit: number = 20): Promise<SyncHistoryRecord[]> {
   return col<SyncHistoryRecord>(COLLECTION)
-    .find(mFilter<SyncHistoryRecord>({ networkId }))
+    .find(asFilter<SyncHistoryRecord>({ networkId }))
     .sort({ completedAt: -1 })
     .limit(Math.min(limit, 100))
     .toArray() as Promise<SyncHistoryRecord[]>;

--- a/server/src/util/seq.ts
+++ b/server/src/util/seq.ts
@@ -1,4 +1,4 @@
-import { col, mFilter, mUpdate } from '../db/mongo.js';
+import { col, asFilter, asUpdate } from '../db/mongo.js';
 import { getConfig, saveConfig } from '../config/loader.js';
 import { log } from './log.js';
 import type { SpaceCounterDoc } from '../config/types.js';
@@ -21,7 +21,7 @@ export async function nextSeq(spaceId: string): Promise<number> {
 /** Read the current counter for a space (0 when it does not exist yet). */
 export async function currentSeq(spaceId: string): Promise<number> {
   const doc = await col<SpaceCounterDoc>('ythril_counters')
-    .findOne(mFilter<SpaceCounterDoc>({ _id: spaceId })) as SpaceCounterDoc | null;
+    .findOne(asFilter<SpaceCounterDoc>({ _id: spaceId })) as SpaceCounterDoc | null;
   return doc?.seq ?? 0;
 }
 
@@ -80,8 +80,8 @@ export async function bumpSeq(spaceId: string, minSeq: number): Promise<void> {
     minSeq = MAX_INGEST_SEQ;
   }
   await col<SpaceCounterDoc>('ythril_counters').updateOne(
-    mFilter<SpaceCounterDoc>({ _id: spaceId }),
-    mUpdate<SpaceCounterDoc>({ $max: { seq: minSeq } }),
+    asFilter<SpaceCounterDoc>({ _id: spaceId }),
+    asUpdate<SpaceCounterDoc>({ $max: { seq: minSeq } }),
     { upsert: true },
   );
 }


### PR DESCRIPTION
## Summary

Architectural item **A7**: rename the MongoDB cast helpers so they stop lying about what they do.

`mFilter` / `mDoc` / `mUpdate` / `mBulk` read like *"sanitise for Mongo"* — but the bodies are pure `as unknown as` casts that bridge our plain document interfaces to MongoDB's strict generics:

```ts
export function mFilter<T extends object>(f: Record<string, unknown>): Filter<T> {
  return f as unknown as Filter<T>;   // validates nothing
}
```

They perform **no** sanitisation and **no** validation. That's a dangerous thing to misread given how much **peer-supplied sync data** flows through them — a reader could easily assume ingest is being cleaned here when it isn't.

## What changed
- Renamed to **`asFilter` / `asDoc` / `asUpdate` / `asBulk`** — names that read as casts. **358 call sites across 29 files**, mechanical and compiler-checked.
- `db/mongo.ts` now says it outright: these are **typing bridges, NOT validators**, and points at where the real validation actually lives — the Zod **`Incoming*Doc`** schemas in `api/sync.ts`.

## No behavior change
Pure rename. Nothing outside `server/src` referenced these (checked client, tests, scripts, docs).

## Testing
`tsc --noEmit` clean (the real gate for a rename — it proves the rename is complete and consistent). Runtime confirmed anyway since these sit on every DB path: **integration 815 pass / 4 skipped / 0 fail**, **red-team 258/258**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
