### PR TITLE
fix: report document embedding failures instead of faking success (B3)

### DIFF
--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -312,6 +312,8 @@
   "brain.fileMeta.openInFilesTabTitle": "Im Dateien-Tab \u00f6ffnen",
   "brain.fileMeta.embedding": "Einbettung\u2026",
   "brain.fileMeta.embeddingFailed": "Einbettung fehlgeschlagen",
+  "brain.fileMeta.embeddingPartial": "Teilweise eingebettet",
+  "brain.fileMeta.retryEmbedding": "Wiederholen",
   "brain.fileMeta.picker.searchMemories": "Erinnerungen suchen\u2026",
   "brain.fileMeta.picker.searchChrono": "Chrono suchen\u2026",
   "graph.toolbar.depth": "Tiefe",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -311,6 +311,8 @@
   "brain.fileMeta.openInFilesTabTitle": "Open in Files tab",
   "brain.fileMeta.embedding": "Embedding…",
   "brain.fileMeta.embeddingFailed": "Embedding failed",
+  "brain.fileMeta.embeddingPartial": "Partly embedded",
+  "brain.fileMeta.retryEmbedding": "Retry",
   "brain.fileMeta.picker.searchMemories": "Search memories\u2026",
   "brain.fileMeta.picker.searchChrono": "Search chrono\u2026",
   "graph.toolbar.depth": "Depth",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -312,6 +312,8 @@
   "brain.fileMeta.openInFilesTabTitle": "Otw\u00f3rz w karcie Pliki",
   "brain.fileMeta.embedding": "Osadzanie\u2026",
   "brain.fileMeta.embeddingFailed": "Osadzanie nie powiod\u0142o si\u0119",
+  "brain.fileMeta.embeddingPartial": "Cz\u0119\u015bciowo osadzone",
+  "brain.fileMeta.retryEmbedding": "Pon\u00f3w",
   "brain.fileMeta.picker.searchMemories": "Szukaj wspomnie\u0144\u2026",
   "brain.fileMeta.picker.searchChrono": "Szukaj chrono\u2026",
   "graph.toolbar.depth": "G\u0142\u0119boko\u015b\u0107",

--- a/client/src/app/core/api.service.ts
+++ b/client/src/app/core/api.service.ts
@@ -269,8 +269,9 @@ export interface FileMeta {
   updatedAt: string;
   /** Async embedding lifecycle status (text documents and media files).
    *  "pending" → queued; "processing" → being embedded; "complete" → done;
+   *  "partial" → stored but some chunks failed to embed (retry-eligible);
    *  "failed" → all retries exhausted; "skipped" / "disabled" → media-only states. */
-  embeddingStatus?: 'pending' | 'processing' | 'complete' | 'failed' | 'skipped' | 'disabled';
+  embeddingStatus?: 'pending' | 'processing' | 'complete' | 'partial' | 'failed' | 'skipped' | 'disabled';
   /** Error message when embeddingStatus is "failed". */
   mediaJobError?: string;
   chunkCount?: number;
@@ -920,6 +921,12 @@ export class ApiService {
   updateFileMeta(spaceId: string, path: string, body: Partial<{ description: string; tags: string[]; entityIds: string[]; chronoIds: string[]; memoryIds: string[]; properties: Record<string, string | number | boolean> }>): Observable<FileMeta> {
     const params = new HttpParams().set('path', path);
     return this.http.patch<FileMeta>(`/api/brain/spaces/${spaceId}/files`, body, { params });
+  }
+
+  /** Re-queue embedding for a file whose embedding failed or is only partial. */
+  retryEmbedding(spaceId: string, path: string): Observable<{ queued: boolean }> {
+    const params = new HttpParams().set('path', path);
+    return this.http.post<{ queued: boolean }>(`/api/files/${spaceId}/retry_embedding`, {}, { params });
   }
 
   deleteFileMeta(spaceId: string, path: string): Observable<void> {

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -1463,6 +1463,11 @@ interface SpaceView {
                               <span class="badge badge-blue" style="font-size:10px;" title="Embedding in progress…"><span class="spinner" style="width:8px;height:8px;border-width:1.5px;display:inline-block;vertical-align:middle;margin-right:3px;"></span>{{ 'brain.fileMeta.embedding' | transloco }}</span>
                             } @else if (fm.embeddingStatus === 'failed') {
                               <span class="badge badge-red" style="font-size:10px;" [title]="fm.mediaJobError || 'Embedding failed'">{{ 'brain.fileMeta.embeddingFailed' | transloco }}</span>
+                            } @else if (fm.embeddingStatus === 'partial') {
+                              <span class="badge badge-yellow" style="font-size:10px;" title="Some chunks could not be embedded — retry to complete">{{ 'brain.fileMeta.embeddingPartial' | transloco }}</span>
+                            }
+                            @if (fm.embeddingStatus === 'failed' || fm.embeddingStatus === 'partial') {
+                              <button class="link-btn" style="font-size:10px;" [disabled]="retryingEmbedding().has(fm.path)" (click)="retryFileEmbedding(fm)">{{ 'brain.fileMeta.retryEmbedding' | transloco }}</button>
                             }
                           </div>
                         </td>
@@ -1983,6 +1988,8 @@ export class BrainComponent implements OnInit {
   fileMetas = signal<FileMeta[]>([]);
   fileMetaSkip = signal(0);
   fileMetaSearch = signal('');
+  /** Paths whose embedding retry is currently in flight (disables the Retry button). */
+  retryingEmbedding = signal<Set<string>>(new Set());
   fileManagerNavPath = signal('');
 
   editFileMeta = { description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[], chronoIds: [] as string[] };
@@ -2484,6 +2491,19 @@ export class BrainComponent implements OnInit {
         });
         break;
     }
+  }
+
+  /** Re-queue embedding for a file whose embedding failed or is only partial,
+   *  then refresh the file-meta list so the badge updates. */
+  retryFileEmbedding(fm: FileMeta): void {
+    const spaceId = this.activeSpaceId();
+    if (!spaceId || this.retryingEmbedding().has(fm.path)) return;
+    this.retryingEmbedding.update(s => new Set(s).add(fm.path));
+    const done = () => {
+      this.retryingEmbedding.update(s => { const n = new Set(s); n.delete(fm.path); return n; });
+      this.loadCurrentTab(spaceId);
+    };
+    this.api.retryEmbedding(spaceId, fm.path).subscribe({ next: done, error: done });
   }
 
   applyFilter(type: 'tag' | 'entity', value: string): void {

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -922,12 +922,14 @@ export interface FileMetaDoc {
   /** Async embedding lifecycle for binary media:
    *   "pending"    → enqueued, not yet processed
    *   "processing" → claimed by a worker
-   *   "complete"   → all chunk records produced
+   *   "complete"   → all chunk records produced AND embedded
+   *   "partial"    → chunks produced but some failed to embed; searchable but incomplete.
+   *                  Re-runnable via POST /api/files/:spaceId/retry_embedding.
    *   "failed"     → exhausted retries; mediaJobError carries the reason
    *   "skipped"    → file too large (> maxFileSizeBytes) — original kept, no embedding
    *   "disabled"   → mediaEmbedding.enabled=false at upload time
    */
-  embeddingStatus?: 'pending' | 'processing' | 'complete' | 'failed' | 'skipped' | 'disabled';
+  embeddingStatus?: 'pending' | 'processing' | 'complete' | 'partial' | 'failed' | 'skipped' | 'disabled';
   /** For audio/video chunk records: start offset within the parent media file. */
   chunkOffsetMs?: number;
   /** For audio/video chunk records: duration covered by this chunk. */

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -251,9 +251,10 @@ export async function storeConversionResults(
   chunks: Chunk[],
   convertedMarkdown: string | null,
   extractedImages: ExtractedImage[] = [],
-): Promise<{ chunkCount: number; convertedFileId: string | null }> {
+): Promise<{ chunkCount: number; convertedFileId: string | null; embedFailures: number }> {
   const originalId = normPath(originalFilePath);
   const now = new Date().toISOString();
+  let embedFailures = 0;
 
   // 1. Write the full converted Markdown to disk (binary formats only)
   let convertedFileId: string | null = null;
@@ -340,8 +341,12 @@ export async function storeConversionResults(
         embeddingModel: embResult.model,
         matchedText: embedText,
       };
-    } catch {
-      // best-effort — chunk stored without vector if embedding unavailable
+    } catch (err) {
+      // The chunk is still stored (its text is preserved) but without a vector, so it
+      // is invisible to $vectorSearch. Count and log it so the caller can report the
+      // job as failed/partial instead of silently "complete" (B3).
+      embedFailures++;
+      log.warn(`Chunk embed failed for ${spaceId}/${chunkId}: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     const chunkDoc: FileMetaDoc = {
@@ -363,7 +368,7 @@ export async function storeConversionResults(
     await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(chunkDoc));
   }
 
-  return { chunkCount: chunks.length, convertedFileId };
+  return { chunkCount: chunks.length, convertedFileId, embedFailures };
 }
 
 /** Delete all chunk records and the _converted/ file for a given original file. */

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -209,7 +209,15 @@ export async function claimNextJob(
 
 // ── Complete / fail ────────────────────────────────────────────────────────
 
-export async function completeJob(spaceId: string, fileId: string): Promise<void> {
+/** Mark a job done. The job itself is always `complete` (no more retries), but the
+ *  FILE's embeddingStatus reflects whether every chunk actually embedded: pass
+ *  'partial' when some chunks stored without a vector so the file stays distinguishable
+ *  and retry-eligible instead of masquerading as fully embedded (B3). */
+export async function completeJob(
+  spaceId: string,
+  fileId: string,
+  fileEmbeddingStatus: 'complete' | 'partial' = 'complete',
+): Promise<void> {
   const now = new Date().toISOString();
   await jobCollection(spaceId).updateOne(
     asFilter<MediaJobDoc>({ _id: fileId }),
@@ -217,7 +225,7 @@ export async function completeJob(spaceId: string, fileId: string): Promise<void
   );
   await fileCollection(spaceId).updateOne(
     asFilter<FileMetaDoc>({ _id: fileId }),
-    { $set: { embeddingStatus: 'complete', updatedAt: now } },
+    { $set: { embeddingStatus: fileEmbeddingStatus, updatedAt: now } },
   );
 }
 

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -273,6 +273,10 @@ async function processJob(
 
     // Run the appropriate embedder
     let derivedDescription: string | undefined;
+    // Final file embeddingStatus for a job that completes without retrying. Text
+    // conversion may embed some chunks and fail others; a partial result is recorded
+    // as 'partial' (not 'complete') so it stays visible and retry-eligible (B3).
+    let fileEmbeddingStatus: 'complete' | 'partial' = 'complete';
     switch (mediaType) {
       case 'image':
         derivedDescription = await embedImage(spaceId, fileId, fileBytes, mimeType, providers.vision);
@@ -292,7 +296,7 @@ async function processJob(
           fileBytes, filePath, resolvedFmt,
         );
         if (chunks.length > 0 || extractedImages.length > 0) {
-          const { chunkCount, convertedFileId } = await storeConversionResults(
+          const { chunkCount, convertedFileId, embedFailures } = await storeConversionResults(
             spaceId, filePath, chunks, convertedMarkdown, extractedImages,
           );
           const metaUpdate: Record<string, unknown> = { chunkCount };
@@ -301,6 +305,18 @@ async function processJob(
             asFilter<FileMetaDoc>({ _id: fileId }),
             { $set: metaUpdate },
           ).catch(() => {});
+
+          // Embedding outcome drives the job result (B3): a total failure throws so
+          // the existing failJob → backoff → retry path handles a transient embedder
+          // outage; a partial failure is recorded but not retried (the embedded chunks
+          // are useful and a retry re-embeds everything).
+          if (chunkCount > 0 && embedFailures === chunkCount) {
+            throw new Error(`All ${chunkCount} chunk(s) failed to embed`);
+          }
+          if (embedFailures > 0) {
+            fileEmbeddingStatus = 'partial';
+            log.warn(`Media worker: ${spaceId}/${fileId} embedded with ${embedFailures}/${chunkCount} chunk failure(s) — marked partial`);
+          }
         }
         break;
       }
@@ -322,9 +338,9 @@ async function processJob(
       }
     }
 
-    await completeJob(spaceId, fileId);
+    await completeJob(spaceId, fileId, fileEmbeddingStatus);
     mediaJobsCompletedTotal.labels({ space: spaceId, media_type: mediaType }).inc();
-    log.info(`Media worker: completed ${mediaType} job ${spaceId}/${fileId}`);
+    log.info(`Media worker: completed ${mediaType} job ${spaceId}/${fileId} (${fileEmbeddingStatus})`);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn(`Media worker: job ${spaceId}/${fileId} failed: ${message}`);

--- a/testing/standalone/embedding-failure-reporting.test.js
+++ b/testing/standalone/embedding-failure-reporting.test.js
@@ -1,0 +1,149 @@
+/**
+ * B3: embedding failures must not be reported as success.
+ *
+ * A text/document upload is chunked and each chunk embedded by the media worker.
+ * Previously an embed failure was swallowed by an empty catch and the job still
+ * reported embeddingStatus='complete' — so a file whose chunks never embedded was
+ * silently invisible to $vectorSearch, with no failure signal and no retry.
+ *
+ * This drives the real path: break the embedding provider (point it at a dead
+ * endpoint via config + reload), upload a document, and assert the file is NEVER
+ * marked 'complete'. Then restore the provider, hit the existing retry endpoint,
+ * and assert it embeds to 'complete' — proving failures are visible and recoverable.
+ *
+ * NOTE: patches config.json (embedding.baseUrl) on instance A — do not run in
+ * parallel with reload-config.test.js / quota.test.js. The `after` hook restores
+ * the original embedding config no matter what.
+ *
+ * Run: node --test testing/standalone/embedding-failure-reporting.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CANDIDATE_CONFIGS = [
+  path.join(__dirname, '..', 'sync', 'configs', 'a', 'config.json'),
+  path.join(__dirname, '..', '..', 'config', 'config.json'),
+];
+const CONFIG_FILE = CANDIDATE_CONFIGS.find(p => fs.existsSync(p)) ?? null;
+const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+const USE_DOCKER_EXEC = process.platform !== 'win32' && CONFIG_FILE?.includes(path.join('sync', 'configs'));
+const CONTAINER_A = 'ythril-a';
+const RUN_ID = Date.now();
+const SPACE_ID = `b3-embed-fail-${RUN_ID}`;
+const DOC_PATH = `b3-doc-${RUN_ID}.md`;
+
+// A document with two sections long enough to produce chunk records.
+const DOC = '# B3 Document\n\nIntroduction paragraph with enough words to matter.\n\n' +
+  '## Section One\n\nThis first section has enough content to exceed the minimum chunk ' +
+  'body length so that a chunk record is created and an embedding is attempted.\n\n' +
+  '## Section Two\n\nThe second section likewise carries enough text to pass the minimum ' +
+  'body length threshold and produce a second embeddable chunk record.';
+
+let token;
+let originalEmbedding;
+
+function readConfig() {
+  if (USE_DOCKER_EXEC) {
+    return JSON.parse(execSync(`docker exec ${CONTAINER_A} cat /config/config.json`).toString('utf8'));
+  }
+  return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+}
+
+function writeConfig(cfg) {
+  if (USE_DOCKER_EXEC) {
+    execSync(
+      `docker exec -i ${CONTAINER_A} sh -c 'cat > /config/config.json && chmod 600 /config/config.json'`,
+      { input: JSON.stringify(cfg, null, 2) },
+    );
+    return;
+  }
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2), 'utf8');
+}
+
+async function setEmbeddingAndReload(embedding) {
+  const cfg = readConfig();
+  if (embedding === undefined) delete cfg.embedding;
+  else cfg.embedding = embedding;
+  writeConfig(cfg);
+  // Let the Docker Desktop bind-mount propagate before the reload (see reload-config.test.js).
+  await new Promise(r => setTimeout(r, 600));
+  const reload = await post(INSTANCES.a, token, '/api/admin/reload-config', {});
+  assert.equal(reload.status, 200, `reload-config failed: ${JSON.stringify(reload.body)}`);
+}
+
+/** Read the ORIGINAL document's embeddingStatus (chunk records carry `#chunk` ids). */
+async function docStatus() {
+  const r = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE_ID}/files?limit=200`);
+  if (r.status !== 200) return undefined;
+  const meta = r.body.files?.find(f => f._id === DOC_PATH || f.path === DOC_PATH);
+  return meta?.embeddingStatus;
+}
+
+async function waitForStatus(predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = await docStatus();
+    if (predicate(last)) return last;
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  return last;
+}
+
+describe('B3: embedding failure is reported, not silently completed', () => {
+  before(async () => {
+    if (!CONFIG_FILE) throw new Error('No config.json found for test or dev stack');
+    token = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+    originalEmbedding = readConfig().embedding; // may be undefined (local pipeline)
+    const created = await post(INSTANCES.a, token, '/api/spaces', { id: SPACE_ID, label: 'B3 Embed Fail' });
+    assert.ok([201, 409].includes(created.status), `create space: ${JSON.stringify(created.body)}`);
+  });
+
+  after(async () => {
+    // ALWAYS restore embeddings so a failure here doesn't break the rest of the suite.
+    await setEmbeddingAndReload(originalEmbedding).catch(() => {});
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${SPACE_ID}`, { confirm: true }).catch(() => {});
+  });
+
+  it('a document whose chunks all fail to embed is never marked complete', async () => {
+    // Break the embedding provider: point it at a closed port → embed() throws fast.
+    await setEmbeddingAndReload({ ...(originalEmbedding ?? {}), baseUrl: 'http://127.0.0.1:1' });
+
+    const up = await post(INSTANCES.a, token, `/api/files/${SPACE_ID}?path=${encodeURIComponent(DOC_PATH)}`,
+      { content: DOC, encoding: 'utf8' });
+    assert.equal(up.status, 202, `upload should be async (202): ${JSON.stringify(up.body)}`);
+    assert.equal(up.body.embeddingStatus, 'pending');
+
+    // The worker will claim it ('processing'), fail every chunk embed, and route into
+    // the retry path — so it must reach 'processing' and NEVER flip to 'complete'.
+    // Allow > the idle-backoff poll cap (default 30s) for the worker to pick the job up.
+    const reached = await waitForStatus(s => s === 'processing' || s === 'failed', 45_000);
+    assert.ok(
+      reached === 'processing' || reached === 'failed',
+      `worker should have engaged the failing job, last status: ${reached}`,
+    );
+    // Give it more room and assert it still never claims success.
+    const settled = await waitForStatus(s => s === 'complete', 8_000);
+    assert.notEqual(settled, 'complete',
+      'a file whose every chunk failed to embed must NOT be reported complete (B3 regression)');
+  });
+
+  it('the retry endpoint re-embeds once the provider is healthy', async () => {
+    // Restore the working provider and re-trigger the existing retry endpoint.
+    await setEmbeddingAndReload(originalEmbedding);
+    const retry = await post(INSTANCES.a, token,
+      `/api/files/${SPACE_ID}/retry_embedding?path=${encodeURIComponent(DOC_PATH)}`, {});
+    assert.equal(retry.status, 202, `retry should queue (202): ${JSON.stringify(retry.body)}`);
+
+    // Allow > the idle-backoff poll cap for the worker to re-claim the reset job.
+    const status = await waitForStatus(s => s === 'complete', 50_000);
+    assert.equal(status, 'complete', `file should embed to complete after retry, got: ${status}`);
+  });
+});


### PR DESCRIPTION
## Bug
A text/document upload is chunked and each chunk embedded by the media worker. `storeConversionResults` swallowed per-chunk embed failures in an **empty catch**, so a file whose chunks never embedded still fell through to `completeJob` and was marked `embeddingStatus='complete'` — **permanently invisible to `$vectorSearch`, with no failure signal**, and never engaging the retry/backoff/dead-letter infrastructure that already wraps this path.

## Fix — server
- `storeConversionResults` counts and logs each chunk embed failure and returns `embedFailures`.
- The worker drives the job result from it:
  - **Total** failure (every chunk) → throws, so the existing `failJob → backoff → retry → 'failed'` path handles a transient embedder outage.
  - **Partial** failure → marks the file `embeddingStatus='partial'` (new state) and completes without retrying (the embedded chunks are useful; a retry re-embeds all).
- `completeJob` takes the final file `embeddingStatus`.

## Fix — client (the retry UX the tracker called for)
- `FileMeta` gains `'partial'`; new `ApiService.retryEmbedding()` wires the existing (until now **unused**) `POST /api/files/:spaceId/retry_embedding` endpoint.
- The brain file list shows a **"Partly embedded"** badge and a **Retry** button for `failed`/`partial` files (disabled while a retry is in flight). i18n keys added for en/de/pl.

## Test
`testing/standalone/embedding-failure-reporting.test.js` breaks the embedding provider (dead endpoint via config + reload), uploads a document, and asserts it is **never** marked `complete`; then restores the provider, calls the retry endpoint, and asserts it embeds to `complete` — proving failures are both visible and recoverable.

Full `test:all:core` green (0 failures; standalone 739→741). Angular production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)