### PR TITLE
fix: recall tolerates a still-building vector index (B1 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Recall no longer errors while a new space's vector indexes are still building.** Space creation now
+  builds its `$vectorSearch` indexes asynchronously (see the space-creation fix above), and Atlas
+  refuses queries against an index still in `INITIAL_SYNC` — so a recall during that brief window
+  failed the whole request with a `400` ("cannot query vector index … while in state INITIAL_SYNC")
+  instead of returning results from the collections that were ready. Recall now treats a
+  not-yet-queryable index like a missing one — no results from that collection — so it degrades to a
+  partial/empty result during the build window instead of erroring. Covered by
+  `testing/integration/space-creation-async.test.js`.
 - **Creating a space no longer times out or "appears only after a reload".** `createSpace` awaited the
   build of a space's 5+ Atlas `$vectorSearch` indexes, each polling for READY up to 60 s (worst case
   minutes) — so the `201` landed far past the client's 30 s timeout, on a dead subscription, and the

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -467,9 +467,13 @@ async function recallByType(
     return docs.map(d => mapToRecallResult(d, knowledgeType));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // Only swallow "index not found" errors (e.g. new space with no data yet).
-    // All other errors are rethrown so they surface to the caller.
-    if (/index.*not.*found|no.*such.*index|search.*index/i.test(msg)) {
+    // Treat a missing OR not-yet-queryable vector index as "no results from this
+    // collection" rather than failing the whole recall. A newly created space builds
+    // its vector indexes asynchronously (createSpace / B1), and Atlas refuses queries
+    // against an index that is still building — e.g. "cannot query vector index … while
+    // in state INITIAL_SYNC". That is a transient empty state, not an error to surface.
+    // All other errors are rethrown so real failures still reach the caller.
+    if (/index.*not.*found|no.*such.*index|search.*index|cannot query.*vector index|while in state (INITIAL_SYNC|PENDING|BUILDING|STARTING)/i.test(msg)) {
       return [];
     }
     throw err;

--- a/testing/integration/space-creation-async.test.js
+++ b/testing/integration/space-creation-async.test.js
@@ -69,6 +69,21 @@ describe('Space creation is asynchronous (B1)', () => {
     assert.equal(mem.status, 201, `space must accept writes while building: ${JSON.stringify(mem.body)}`);
   });
 
+  it('recall on a just-created space (indexes still building) returns 200, not an error', async () => {
+    // Atlas refuses queries against a vector index still in INITIAL_SYNC; recall must
+    // treat a building index as "no results yet" (200), not surface a 400 — otherwise
+    // recall is broken for the whole window B1 opened.
+    const id = `b1-recall-building-${RUN_ID}`;
+    const r = await post(INSTANCES.a, tokenA, '/api/spaces', { id, label: 'B1 Recall Building' });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    created.push(id);
+
+    const rec = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${id}/recall`,
+      { query: 'anything', topK: 5 });
+    assert.equal(rec.status, 200,
+      `recall on a still-building space must return 200, got ${rec.status}: ${JSON.stringify(rec.body)}`);
+  });
+
   it('converges to indexStatus=ready once the vector indexes finish', async () => {
     const id = `b1-ready-${RUN_ID}`;
     const r = await post(INSTANCES.a, tokenA, '/api/spaces', { id, label: 'B1 Ready Converge' });


### PR DESCRIPTION
## Regression
Space creation now builds its `$vectorSearch` indexes **asynchronously** (B1, #162), so for a brief window a new space's index is in state `INITIAL_SYNC`. Atlas refuses queries against such an index, and `recallByType` only swallowed *"index not found"* errors — every other error was rethrown. So a recall during the build window failed the **whole request** with a `400`:

```
cannot query vector index … while in state INITIAL_SYNC
```

instead of returning results from the collections that were ready. (This surfaced as an intermittent `recall-filter` CI failure once B1 landed.)

## Fix
Treat a **not-yet-queryable** index the same as a missing one — return no results from that collection rather than failing the recall. During the build window recall degrades to a partial/empty result; once the index is `READY` it behaves exactly as before. Narrowly scoped: only the build-state / index-missing messages are swallowed; all other aggregate errors still surface to the caller.

## Tests
`space-creation-async.test.js` now asserts a recall on a just-created space returns `200`, not an error. Full `test:all:core` green. This also removes the intermittent `recall-filter` CI flake the async index build exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)