### PR TITLE
fix: embed record properties (with keys) so recall can use them (B4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Record properties are now fully embedded, so semantic recall can use them.** The text embedded for
+  a record mishandled `properties`: memory and entity embedded only the property **values** and dropped
+  the **keys**, while **edge and chrono embedded properties not at all**. So recall couldn't match on a
+  property name (a query about "role" had no "role" signal), and values lost their field context —
+  `{birthplace: "Paris"}` and `{currentCity: "Paris"}` embedded identically. All five builders (memory,
+  entity, edge, chrono, and the entity-merge copy) now fold `key value` pairs into the embedded text
+  via a single shared `propsEmbedText` helper, and chrono re-embeds when only its properties change.
+  Existing records keep their old (weaker) vectors until re-embedded — run
+  `POST /api/brain/spaces/:id/reindex` to rebuild them with property keys. Covered by
+  `testing/integration/embed-properties.test.js`.
 - **Recall no longer errors while a new space's vector indexes are still building.** Space creation now
   builds its `$vectorSearch` indexes asynchronously (see the space-creation fix above), and Atlas
   refuses queries against an index still in `INITIAL_SYNC` — so a recall during that brief window

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -3,6 +3,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
+import { propsEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
 
@@ -18,10 +19,13 @@ function chronoEmbedText(
   status: string,
   description?: string,
   tags: string[] = [],
+  properties?: Record<string, string | number | boolean>,
 ): string {
   const parts: string[] = [type, status, title];
   if (tags.length > 0) parts.push(tags.join(' '));
   if (description?.trim()) parts.push(description.trim());
+  const propsText = propsEmbedText(properties);
+  if (propsText) parts.push(propsText);
   return parts.join(' ');
 }
 
@@ -47,10 +51,10 @@ export async function createChrono(
   const status = fields.status ?? 'upcoming';
   const tags = fields.tags ?? [];
 
-  // Embed kind + status + title + description + tags (best-effort)
+  // Embed kind + status + title + description + tags + properties (best-effort)
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
   try {
-    const embedText = chronoEmbedText(fields.title, fields.type, status, fields.description, tags);
+    const embedText = chronoEmbedText(fields.title, fields.type, status, fields.description, tags, fields.properties);
     const embResult = await embed(embedText);
     embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
   } catch { /* embedding unavailable — chrono stored without vector */ }
@@ -102,15 +106,17 @@ export async function updateChrono(
     updates.description !== undefined ||
     updates.type !== undefined ||
     updates.status !== undefined ||
-    updates.tags !== undefined
+    updates.tags !== undefined ||
+    updates.properties !== undefined
   ) {
     const newTitle = updates.title ?? existing.title;
     const newKind = updates.type ?? existing.type;
     const newStatus = updates.status ?? existing.status;
     const newDesc = updates.description !== undefined ? updates.description : existing.description;
     const newTags = updates.tags ?? existing.tags;
+    const newProps = updates.properties !== undefined ? updates.properties : existing.properties;
     try {
-      const embedText = chronoEmbedText(newTitle, newKind, newStatus, newDesc, newTags);
+      const embedText = chronoEmbedText(newTitle, newKind, newStatus, newDesc, newTags, newProps);
       const embResult = await embed(embedText);
       $set['embedding'] = embResult.vector;
       $set['embeddingModel'] = embResult.model;

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -3,6 +3,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
+import { propsEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { getEntityById } from './entities.js';
@@ -50,12 +51,15 @@ function edgeEmbedText(
   tags: string[] = [],
   type?: string,
   description?: string,
+  properties?: Record<string, string | number | boolean>,
 ): string {
   const parts: string[] = [];
   if (tags.length > 0) parts.push(tags.join(' '));
   parts.push(from, label, to);
   if (type?.trim()) parts.push(type.trim());
   if (description?.trim()) parts.push(description.trim());
+  const propsText = propsEmbedText(properties);
+  if (propsText) parts.push(propsText);
   return parts.join(' ');
 }
 
@@ -85,12 +89,15 @@ export async function upsertEdge(
   const effectiveTags = tags !== undefined
     ? Array.from(new Set([...((existing as EdgeDoc | null)?.tags ?? []), ...tags]))
     : ((existing as EdgeDoc | null)?.tags ?? []);
+  const effectiveProps = properties !== undefined
+    ? { ...((existing as EdgeDoc | null)?.properties ?? {}), ...properties }
+    : (existing as EdgeDoc | null)?.properties;
 
   // Embed the edge text (best-effort) — resolve entity names so the vector captures semantics
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
   try {
     const [fromName, toName] = await resolveEdgeEntityNames(spaceId, from, to);
-    const embedText = edgeEmbedText(fromName, label, toName, effectiveTags, effectiveType, effectiveDesc);
+    const embedText = edgeEmbedText(fromName, label, toName, effectiveTags, effectiveType, effectiveDesc, effectiveProps);
     const embResult = await embed(embedText);
     embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
   } catch { /* embedding unavailable — edge stored without vector */ }
@@ -269,7 +276,7 @@ export async function updateEdgeById(
   // Re-embed whenever any content field changes — resolve entity names for semantic signal
   try {
     const [fromName, toName] = await resolveEdgeEntityNames(spaceId, existing.from, existing.to);
-    const embedText = edgeEmbedText(fromName, newLabel, toName, newTags, newType, newDesc);
+    const embedText = edgeEmbedText(fromName, newLabel, toName, newTags, newType, newDesc, newProps);
     const embResult = await embed(embedText);
     $set['embedding'] = embResult.vector;
     $set['embeddingModel'] = embResult.model;

--- a/server/src/brain/embed-text.ts
+++ b/server/src/brain/embed-text.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared helper for turning a knowledge record's `properties` into embeddable text.
+ *
+ * The per-type embed-text builders (memory, entity, edge, chrono, and the entity-merge
+ * copy) all need to fold `properties` into the string that gets embedded. Keeping the
+ * logic here means they cannot drift again — before this existed, memory/entity embedded
+ * only property VALUES (dropping the keys) while edge and chrono dropped properties
+ * entirely, so semantic recall couldn't match on a property name and values lost their
+ * field context (`{birthplace: "Paris"}` and `{currentCity: "Paris"}` embedded identically).
+ */
+export function propsEmbedText(
+  properties?: Record<string, string | number | boolean>,
+): string {
+  if (!properties) return '';
+  // Include BOTH the key and the value: the key ("role") makes the field name searchable,
+  // and pairing it with the value keeps each value tied to its field.
+  return Object.entries(properties)
+    .map(([k, v]) => `${k} ${String(v)}`)
+    .join(' ');
+}

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -3,6 +3,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
+import { propsEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './memory.js';
@@ -37,10 +38,8 @@ function entityEmbedText(
   const parts: string[] = [name, type];
   if (tags.length > 0) parts.push(tags.join(' '));
   if (description?.trim()) parts.push(description.trim());
-  const propEntries = Object.entries(properties);
-  if (propEntries.length > 0) {
-    parts.push(propEntries.map(([_k, v]) => String(v)).join(' '));
-  }
+  const propsText = propsEmbedText(properties);
+  if (propsText) parts.push(propsText);
   return parts.join(' ');
 }
 

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -5,6 +5,7 @@ import { parseLimit, parseSkip } from '../util/pagination.js';
 import { NotFoundError } from '../util/errors.js';
 import { hasReDoSRisk, MAX_PATTERN_LENGTH } from '../util/redos.js';
 import { embed } from './embedding.js';
+import { propsEmbedText } from './embed-text.js';
 import { getConfig, getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/spaces.js';
 import { applyDeleteFields } from './delete-fields.js';
@@ -89,12 +90,8 @@ function memoryEmbedText(
   if (entityNames.length > 0) parts.push(entityNames.join(' '));
   parts.push(fact);
   if (description?.trim()) parts.push(description.trim());
-  if (properties) {
-    const propEntries = Object.entries(properties);
-    if (propEntries.length > 0) {
-      parts.push(propEntries.map(([_k, v]) => String(v)).join(' '));
-    }
-  }
+  const propsText = propsEmbedText(properties);
+  if (propsText) parts.push(propsText);
   return parts.join(' ');
 }
 

--- a/server/src/brain/merge.ts
+++ b/server/src/brain/merge.ts
@@ -12,6 +12,7 @@
 import { col, getMongo, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
 import { embed } from './embedding.js';
+import { propsEmbedText } from './embed-text.js';
 import { getEntityById } from './entities.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
@@ -111,10 +112,8 @@ function entityEmbedText(
   const parts: string[] = [name, type];
   if (tags.length > 0) parts.push(tags.join(' '));
   if (description?.trim()) parts.push(description.trim());
-  const propEntries = Object.entries(properties);
-  if (propEntries.length > 0) {
-    parts.push(propEntries.map(([_k, v]) => String(v)).join(' '));
-  }
+  const propsText = propsEmbedText(properties);
+  if (propsText) parts.push(propsText);
   return parts.join(' ');
 }
 

--- a/testing/integration/embed-properties.test.js
+++ b/testing/integration/embed-properties.test.js
@@ -1,0 +1,103 @@
+/**
+ * Integration tests: property KEYS are embedded for semantic recall (B4).
+ *
+ * Previously the embedded text either dropped property keys (memory/entity) or omitted
+ * properties entirely (edge/chrono), so recall couldn't match on a property name and
+ * values lost their field context. All builders now fold `key value` pairs into the
+ * embedded text via the shared propsEmbedText helper.
+ *
+ * These tests assert the stored embedding text (`matchedText`, returned by recall)
+ * contains the property KEY for an entity, an edge, and a chrono entry — the edge and
+ * chrono cases embedded no property data at all before this fix.
+ *
+ * Run: node --test testing/integration/embed-properties.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `b4-embed-props-${RUN}`;
+
+let token;
+let embeddingAvailable = false;
+
+/** Poll recall until the doc with `id` appears, then return its result row. */
+async function recallMatch(id, query, types, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/recall`, { query, types, topK: 50 });
+    if (r.status === 200) {
+      const hit = r.body.results?.find(x => x._id === id);
+      if (hit) return hit;
+    }
+    await new Promise(res => setTimeout(res, 500));
+  }
+  return null;
+}
+
+describe('Property keys are embedded (B4)', () => {
+  before(async () => {
+    token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    const c = await post(INSTANCES.a, token, '/api/spaces', { id: SPACE, label: 'B4 Embed Props' });
+    assert.ok([201, 409].includes(c.status), `create space: ${JSON.stringify(c.body)}`);
+    // Probe whether embeddings are available in this stack.
+    const probe = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`,
+      { name: `__probe-${RUN}__`, type: 'probe', properties: { probe: 'yes' } });
+    embeddingAvailable = probe.status === 201;
+  });
+
+  after(async () => {
+    await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true }),
+    }).catch(() => {});
+  });
+
+  it('entity embedding text includes the property key', async (t) => {
+    if (!embeddingAvailable) return t.skip('Embedding not available');
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`,
+      { name: `EntPropKey-${RUN}`, type: 'concept', properties: { occupation: 'engineer' } });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    const hit = await recallMatch(r.body._id, `EntPropKey-${RUN}`, ['entity']);
+    assert.ok(hit, 'entity should be recallable once indexed');
+    assert.match(hit.matchedText ?? '', /occupation/,
+      `entity embed text must include the property key: ${hit.matchedText}`);
+  });
+
+  it('chrono embedding text includes the property key (previously omitted entirely)', async (t) => {
+    if (!embeddingAvailable) return t.skip('Embedding not available');
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/chrono`, {
+      title: `ChronoPropKey-${RUN}`, type: 'event', startsAt: new Date(RUN).toISOString(),
+      properties: { venue: 'stadium' },
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    const hit = await recallMatch(r.body._id, `ChronoPropKey-${RUN}`, ['chrono']);
+    assert.ok(hit, 'chrono should be recallable once indexed');
+    assert.match(hit.matchedText ?? '', /venue/,
+      `chrono embed text must include the property key: ${hit.matchedText}`);
+  });
+
+  it('edge embedding text includes the property key (previously omitted entirely)', async (t) => {
+    if (!embeddingAvailable) return t.skip('Embedding not available');
+    const from = `EdgeFrom-${RUN}`;
+    const to = `EdgeTo-${RUN}`;
+    await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`, { name: from, type: 'concept' });
+    await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`, { name: to, type: 'concept' });
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/edges`, {
+      from, to, label: `edgePropKey${RUN}`, properties: { medium: 'email' },
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    const hit = await recallMatch(r.body._id, `edgePropKey${RUN}`, ['edge']);
+    assert.ok(hit, 'edge should be recallable once indexed');
+    assert.match(hit.matchedText ?? '', /medium/,
+      `edge embed text must include the property key: ${hit.matchedText}`);
+  });
+});


### PR DESCRIPTION
## Bug (highest-priority backlog find)
The text embedded for a record mishandled `properties`, so semantic recall could barely use them:
- **memory & entity** embedded only property **values** and dropped the **keys** (`([_k, v]) => String(v)`);
- **edge & chrono** embedded properties **not at all** — their embed-text builders had no `properties` parameter.

So recall couldn't match on a property **name** (a query about "role" had no "role" signal), and values lost their field context — `{birthplace:"Paris"}` and `{currentCity:"Paris"}` embedded identically.

## Fix
Extract one shared **`propsEmbedText(properties)`** helper that folds `key value` pairs into the embedded text, and use it in **all five** builders (memory, entity, edge, chrono, and the entity-merge copy) so they can't drift again. `edgeEmbedText`/`chronoEmbedText` gain a `properties` parameter and are passed the effective properties from their create/update paths; chrono now also re-embeds when only its properties change.

The recall **query** side is unchanged (free text) — richer stored text just improves matching. Existing records keep their old (weaker) vectors until re-embedded: run `POST /api/brain/spaces/:id/reindex` to rebuild with property keys.

## Tests
`embed-properties.test.js` asserts the stored embedding text (`matchedText`, via recall) contains the property **key** for an entity, an edge, and a chrono entry — the edge/chrono cases embedded no property data at all before. Full `test:all:core` green (a lone vote-signing gossip-relay timeout under full-suite load is the known flaky test — unrelated, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)