### PR TITLE
fix: schema import no longer fails silently (B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Importing a schema no longer fails silently.** In **Settings → Spaces → Schema → Import JSON**, a
+  valid-JSON file that contained none of the recognised `entity`/`edge`/`memory`/`chrono` keys — which
+  includes Ythril's **own** per-type export shape `{knowledgeType, typeName, schema}` — fell straight
+  through the import loop and then *cleared the error field*, so it looked like it worked while doing
+  nothing. Import now: (1) also accepts the `{knowledgeType, typeName, schema}` export shape; (2) shows a
+  specific error listing the expected keys and what the file actually contained when nothing is
+  recognised; and (3) confirms success with a note that the imported types are **staged — press Save to
+  apply**. Client-only.
 - **Record properties are now fully embedded, so semantic recall can use them.** The text embedded for
   a record mishandled `properties`: memory and entity embedded only the property **values** and dropped
   the **keys**, while **edge and chrono embedded properties not at all**. So recall couldn't match on a

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -718,6 +718,8 @@
   "spaces.schema.removePropertyTitle": "Eigenschaft entfernen",
   "spaces.schema.import.invalidFile": "Ung\u00fcltige Schemadatei \u2014 ein typeSchemas-Objekt wird erwartet.",
   "spaces.schema.import.parseFailed": "JSON-Datei konnte nicht geparst werden.",
+  "spaces.schema.import.noTypesFound": "Keine Schematypen in der Datei gefunden. Erwartet wurden die Schl\u00fcssel entity/edge/memory/chrono, ein typeSchemas-Wrapper oder ein {knowledgeType, typeName, schema}-Export \u2014 gefunden: {{keys}}.",
+  "spaces.schema.import.staged": "{{count}} Typschema(s) importiert. Zum Anwenden auf Speichern klicken.",
   "spaces.stats.memories": "Erinnerungen",
   "spaces.stats.entities": "Entit\u00e4ten",
   "spaces.stats.edges": "Kanten",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -713,6 +713,8 @@
   "spaces.schema.removePropertyTitle": "Remove property",
   "spaces.schema.import.invalidFile": "Invalid schema file \u2014 expected a typeSchemas object.",
   "spaces.schema.import.parseFailed": "Could not parse JSON file.",
+  "spaces.schema.import.noTypesFound": "No schema types found in the file. Expected keys entity/edge/memory/chrono, a typeSchemas wrapper, or a {knowledgeType, typeName, schema} export \u2014 got: {{keys}}.",
+  "spaces.schema.import.staged": "Imported {{count}} type schema(s). Press Save to apply them.",
   "spaces.stats.memories": "Memories",
   "spaces.stats.entities": "Entities",
   "spaces.stats.edges": "Edges",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -714,6 +714,8 @@
   "spaces.schema.removePropertyTitle": "Usu\u0144 w\u0142a\u015bciwo\u015b\u0107",
   "spaces.schema.import.invalidFile": "Nieprawid\u0142owy plik schematu \u2014 oczekiwano obiektu typeSchemas.",
   "spaces.schema.import.parseFailed": "Nie uda\u0142o si\u0119 odczyta\u0107 pliku JSON.",
+  "spaces.schema.import.noTypesFound": "Nie znaleziono typ\u00f3w schematu w pliku. Oczekiwano kluczy entity/edge/memory/chrono, obiektu typeSchemas lub eksportu {knowledgeType, typeName, schema} \u2014 znaleziono: {{keys}}.",
+  "spaces.schema.import.staged": "Zaimportowano {{count}} schemat(\u00f3w) typ\u00f3w. Naci\u015bnij Zapisz, aby je zastosowa\u0107.",
   "spaces.stats.memories": "Wspomnienia",
   "spaces.stats.entities": "Podmioty",
   "spaces.stats.edges": "Kraw\u0119dzie",

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -264,19 +264,19 @@ interface TypeSchemaState {
               </div>
               <!-- collection tabs -->
               <div class="sch-coll-tabs">
-                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='entity'" (click)="schemaCollTab.set('entity');schImportError=''">
+                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='entity'" (click)="schemaCollTab.set('entity');schImportError='';schImportInfo=''">
                   {{ 'spaces.schema.tab.entities' | transloco }}
                   @if (typeCount('entity')) { <span class="sch-cnt-badge">{{ typeCount('entity') }}</span> }
                 </button>
-                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='edge'" (click)="schemaCollTab.set('edge');schImportError=''">
+                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='edge'" (click)="schemaCollTab.set('edge');schImportError='';schImportInfo=''">
                   {{ 'spaces.schema.tab.edges' | transloco }}
                   @if (typeCount('edge')) { <span class="sch-cnt-badge">{{ typeCount('edge') }}</span> }
                 </button>
-                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='memory'" (click)="schemaCollTab.set('memory');schImportError=''">
+                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='memory'" (click)="schemaCollTab.set('memory');schImportError='';schImportInfo=''">
                   {{ 'spaces.schema.tab.memories' | transloco }}
                   @if (typeCount('memory')) { <span class="sch-cnt-badge">{{ typeCount('memory') }}</span> }
                 </button>
-                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='chrono'" (click)="schemaCollTab.set('chrono');schImportError=''">
+                <button class="sch-coll-tab" [class.active]="schemaCollTab()==='chrono'" (click)="schemaCollTab.set('chrono');schImportError='';schImportInfo=''">
                   {{ 'spaces.schema.tab.chrono' | transloco }}
                   @if (typeCount('chrono')) { <span class="sch-cnt-badge">{{ typeCount('chrono') }}</span> }
                 </button>
@@ -546,6 +546,9 @@ interface TypeSchemaState {
                 </div>
                 @if (schImportError) {
                   <div style="font-size:12px;color:var(--error);margin-top:4px;">{{ schImportError }}</div>
+                }
+                @if (schImportInfo) {
+                  <div style="font-size:12px;color:var(--success);margin-top:4px;">{{ schImportInfo }}</div>
                 }
               </ng-template>
             }
@@ -955,6 +958,8 @@ export class SpacesComponent implements OnInit {
   schExpandedType:   { kt: KnowledgeType; name: string } | null = null;
   schExpandedProp:   { kt: KnowledgeType; typeName: string; propKey: string } | null = null;
   schImportError     = '';
+  /** Success/info note after a schema import stages types (cleared on the next action). */
+  schImportInfo      = '';
   /** Pending import conflict: holds the parsed state waiting for user resolution. */
   importConflict = signal<{ kt: KnowledgeType; name: string; state: TypeSchemaState; allowAddAs: boolean } | null>(null);
   importConflictAddAsName = signal('');
@@ -1298,48 +1303,83 @@ export class SpacesComponent implements OnInit {
     this.schImportInputRef?.nativeElement.click();
   }
 
+  /** Map one raw type-schema object (as exported / stored) into editor state. */
+  private mapImportedTypeSchema(ts2: Record<string, unknown>): TypeSchemaState {
+    return {
+      namingPattern:   typeof ts2['namingPattern'] === 'string' ? ts2['namingPattern'] : '',
+      tagSuggestions:  Array.isArray(ts2['tagSuggestions']) ? [...ts2['tagSuggestions'] as string[]] : [],
+      propertySchemas: (() => {
+        const ps = ts2['propertySchemas'];
+        if (!ps || typeof ps !== 'object' || Array.isArray(ps)) return [];
+        // Spread preserves every field, including `$ref` (library references).
+        return Object.entries(ps as Record<string, unknown>).map(([k, v]) => ({
+          key: k,
+          s:   { ...(v as PropertySchema) },
+          _enumInput: '',
+        }));
+      })(),
+      _newPropInput: '',
+      _newTagInput:  '',
+    };
+  }
+
   onImportSchemaFile(event: Event): void {
     const file = (event.target as HTMLInputElement).files?.[0];
     if (!file) return;
+    this.schImportError = '';
+    this.schImportInfo = '';
     const reader = new FileReader();
     reader.onload = () => {
       try {
         const raw = JSON.parse(reader.result as string);
-        // Accept either { typeSchemas: {...} } wrapper or bare typeSchemas object
+        // Accept either { typeSchemas: {...} } wrapper or a bare typeSchemas object.
         const ts: unknown = raw?.typeSchemas ?? raw;
         if (!ts || typeof ts !== 'object' || Array.isArray(ts)) {
           this.schImportError = this.transloco.translate('spaces.schema.import.invalidFile');
           return;
         }
+        const tsObj = ts as Record<string, unknown>;
         const KINDS: KnowledgeType[] = ['entity', 'edge', 'memory', 'chrono'];
         const merged = { ...this.schTypeSchemas };
-        for (const kt of KINDS) {
-          const ktRaw = (ts as Record<string, unknown>)[kt];
-          if (!ktRaw || typeof ktRaw !== 'object' || Array.isArray(ktRaw)) continue;
-          const ktMap = ktRaw as Record<string, unknown>;
-          const existing = { ...(merged[kt] ?? {}) };
-          for (const [typeName, tsRaw] of Object.entries(ktMap)) {
-            const ts2 = tsRaw as Record<string, unknown>;
-            existing[typeName] = {
-              namingPattern:   typeof ts2['namingPattern'] === 'string' ? ts2['namingPattern'] : '',
-              tagSuggestions:  Array.isArray(ts2['tagSuggestions']) ? [...ts2['tagSuggestions'] as string[]] : [],
-              propertySchemas: (() => {
-                const ps = ts2['propertySchemas'];
-                if (!ps || typeof ps !== 'object' || Array.isArray(ps)) return [];
-                return Object.entries(ps as Record<string, unknown>).map(([k, v]) => ({
-                  key: k,
-                  s:   { ...(v as PropertySchema) },
-                  _enumInput: '',
-                }));
-              })(),
-              _newPropInput: '',
-              _newTagInput:  '',
-            };
+        let imported = 0;
+
+        if (typeof tsObj['knowledgeType'] === 'string'
+            && typeof tsObj['typeName'] === 'string'
+            && tsObj['schema'] && typeof tsObj['schema'] === 'object' && !Array.isArray(tsObj['schema'])) {
+          // Shape 1: Ythril's own per-type export — { knowledgeType, typeName, schema }.
+          const kt = tsObj['knowledgeType'] as KnowledgeType;
+          if (KINDS.includes(kt)) {
+            const existing = { ...(merged[kt] ?? {}) };
+            existing[tsObj['typeName'] as string] = this.mapImportedTypeSchema(tsObj['schema'] as Record<string, unknown>);
+            merged[kt] = existing;
+            imported++;
           }
-          merged[kt] = existing;
+        } else {
+          // Shape 2: { entity: { <typeName>: <schema>, ... }, edge: {...}, ... }.
+          for (const kt of KINDS) {
+            const ktRaw = tsObj[kt];
+            if (!ktRaw || typeof ktRaw !== 'object' || Array.isArray(ktRaw)) continue;
+            const existing = { ...(merged[kt] ?? {}) };
+            for (const [typeName, tsRaw] of Object.entries(ktRaw as Record<string, unknown>)) {
+              existing[typeName] = this.mapImportedTypeSchema(tsRaw as Record<string, unknown>);
+              imported++;
+            }
+            merged[kt] = existing;
+          }
         }
+
+        if (imported === 0) {
+          // Valid JSON, but nothing recognisable — tell the user instead of silently
+          // clearing the error and appearing to succeed (B2).
+          const foundKeys = Object.keys(tsObj).slice(0, 12).join(', ') || '(none)';
+          this.schImportError = this.transloco.translate('spaces.schema.import.noTypesFound', { keys: foundKeys });
+          return;
+        }
+
         this.schTypeSchemas = merged;
         this.schImportError = '';
+        // Import only STAGES the schemas — they aren't persisted until Save is pressed.
+        this.schImportInfo = this.transloco.translate('spaces.schema.import.staged', { count: imported });
       } catch {
         this.schImportError = this.transloco.translate('spaces.schema.import.parseFailed');
       } finally {


### PR DESCRIPTION
## Bug
In **Settings → Spaces → Schema → Import JSON**, a valid-JSON file that contained none of the recognised `entity`/`edge`/`memory`/`chrono` keys fell through the import loop and then **cleared the error field** — so it looked like it worked while doing nothing. This is trivially hit: Ythril's **own** per-type export emits `{knowledgeType, typeName, schema}`, which the importer didn't recognise, so **re-importing an export was a silent no-op**.

## Fix
`onImportSchemaFile` now:
- also accepts the **`{knowledgeType, typeName, schema}`** single-type export shape (in addition to the `{ typeSchemas: {...} }` wrapper and the bare `{ entity: {...}, ... }` object);
- **counts** imported types and, when nothing is recognised, shows a **specific error** listing the expected keys and what the file actually contained — instead of silently clearing the error;
- confirms success with a note that imported types are **staged — press Save to apply** (import only stages editor state).

The per-type property mapping is extracted into a shared helper (preserving `$ref` library references via the object spread). i18n for en/de/pl.

Client-only; the Angular production build compiles it (which is what CI's image build runs). The schema-library page's separate bulk file-import — the other silent path in the original report — no longer exists, so this covers the remaining import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)