### PR TITLE
perf: cache file-manifest hashes so sync stops re-hashing every file (P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **File sync no longer re-hashes every file on every round.** The file manifest read and SHA-256-hashed
+  **every file** each time it was built, and it is built twice per sync round (once for the file diff,
+  once for the Merkle root) per peer — so a space holding tens of GB re-read and re-hashed all of it on
+  every cycle, pure CPU and disk for a result that is almost always identical to last time. Hashes are
+  now cached per space (a local `<spaceId>_file_hashes` collection keyed by path with the size+mtime they
+  were hashed at); an unchanged file reuses its stored hash and only new or modified files are re-read. A
+  `force` option re-reads everything for reconciliation. The cache is never synced and is dropped with the
+  space. Covered by the existing file-sync suites (write / overwrite / delete / `since`).
 - **Sync pull applies each page in a bounded number of round trips instead of 2×N.** Pulling docs from
   a peer ran a `findOne` + conditional `replaceOne` **per document** — so a 50k-memory backfill was
   ~100k sequential MongoDB round trips even though the data already arrived in 200-doc pages, and on a

--- a/server/src/files/manifest.ts
+++ b/server/src/files/manifest.ts
@@ -2,18 +2,35 @@
  * File manifest builder for sync.
  * Produces { path, sha256, size, modifiedAt } entries for all files in a space,
  * optionally filtered to only files modified since a given timestamp.
+ *
+ * SHA-256 hashes are cached per space (P4). A manifest is rebuilt on every sync
+ * round (twice — once for the file diff, once for the Merkle root), and hashing
+ * re-reads the entire file, so re-hashing an unchanged multi-GB space every cycle
+ * dominated file sync. The cache (collection `<spaceId>_file_hashes`, keyed by path
+ * with the (size, mtime) it was hashed at) lets an unchanged file reuse its stored
+ * hash; only new or modified files (size or mtime changed) are re-read. The cache is
+ * a LOCAL derived index — it is never synced, and it is dropped with the space.
  */
 
 import fs from 'fs/promises';
 import path from 'path';
 import { createHash } from 'crypto';
 import { getDataRoot } from '../config/loader.js';
+import { col, asFilter, asBulk } from '../db/mongo.js';
 
 export interface ManifestEntry {
   path: string;        // relative to space files root, e.g. "notes/2024.md"
   sha256: string;
   size: number;
   modifiedAt: string;  // ISO 8601
+}
+
+/** Cached hash for one file, invalidated when size or mtime changes. */
+interface HashCacheDoc {
+  _id: string;      // path relative to the space files root
+  size: number;
+  mtimeMs: number;
+  sha256: string;
 }
 
 function spaceFilesRoot(spaceId: string): string {
@@ -26,38 +43,83 @@ async function hashFile(absPath: string): Promise<string> {
   return createHash('sha256').update(Buffer.from(data)).digest('hex');
 }
 
-/** Recursively walk a directory, yielding all file paths */
-async function walk(dir: string, base: string, since: Date | undefined, results: ManifestEntry[]): Promise<void> {
-  let names: string[];
-  try {
-    names = await fs.readdir(dir);
-  } catch {
-    return; // directory doesn't exist — no files
+/**
+ * Build a full or incremental file manifest for a space.
+ *
+ * @param since  when set, only files modified at/after this time are included.
+ * @param opts.force  bypass the hash cache and re-read every file (reconciliation
+ *   safety valve for the rare out-of-band edit that preserves size AND mtime).
+ */
+export async function buildFileManifest(
+  spaceId: string,
+  since?: Date,
+  opts: { force?: boolean } = {},
+): Promise<ManifestEntry[]> {
+  const root = spaceFilesRoot(spaceId);
+  const cacheColl = col<HashCacheDoc>(`${spaceId}_file_hashes`);
+
+  // Load the existing hash cache once (empty on a forced rebuild).
+  const cache = new Map<string, HashCacheDoc>();
+  if (!opts.force) {
+    const docs = await cacheColl.find(asFilter<HashCacheDoc>({})).toArray() as HashCacheDoc[];
+    for (const d of docs) cache.set(d._id, d);
   }
 
-  for (const name of names) {
-    const abs = path.join(dir, name);
-    const stat = await fs.stat(abs).catch(() => null);
-    if (!stat) continue;
-    if (stat.isDirectory()) {
-      await walk(abs, base, since, results);
-    } else if (stat.isFile()) {
-      if (since && stat.mtimeMs < since.getTime()) continue;
-      const sha256 = await hashFile(abs);
-      results.push({
-        path: path.relative(base, abs).replace(/\\/g, '/'),
-        sha256,
-        size: stat.size,
-        modifiedAt: stat.mtime.toISOString(),
-      });
+  const results: ManifestEntry[] = [];
+  const seen = new Set<string>();
+  const updates: HashCacheDoc[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    let names: string[];
+    try {
+      names = await fs.readdir(dir);
+    } catch {
+      return; // directory doesn't exist — no files
+    }
+    for (const name of names) {
+      const abs = path.join(dir, name);
+      const stat = await fs.stat(abs).catch(() => null);
+      if (!stat) continue;
+      if (stat.isDirectory()) {
+        await walk(abs);
+      } else if (stat.isFile()) {
+        if (since && stat.mtimeMs < since.getTime()) continue;
+        const relPath = path.relative(root, abs).replace(/\\/g, '/');
+        seen.add(relPath);
+        const cached = cache.get(relPath);
+        let sha256: string;
+        if (cached && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) {
+          sha256 = cached.sha256; // unchanged — reuse the cached hash
+        } else {
+          sha256 = await hashFile(abs);
+          updates.push({ _id: relPath, size: stat.size, mtimeMs: stat.mtimeMs, sha256 });
+        }
+        results.push({
+          path: relPath,
+          sha256,
+          size: stat.size,
+          modifiedAt: stat.mtime.toISOString(),
+        });
+      }
     }
   }
-}
 
-/** Build a full or incremental file manifest for a space */
-export async function buildFileManifest(spaceId: string, since?: Date): Promise<ManifestEntry[]> {
-  const root = spaceFilesRoot(spaceId);
-  const results: ManifestEntry[] = [];
-  await walk(root, root, since, results);
+  await walk(root);
+
+  // Persist newly-computed / changed hashes so the next round reuses them.
+  if (updates.length > 0) {
+    await cacheColl.bulkWrite(asBulk<HashCacheDoc>(
+      updates.map(u => ({ replaceOne: { filter: { _id: u._id }, replacement: u, upsert: true } })),
+    ));
+  }
+  // Prune cache entries for files that no longer exist (only on a full walk, where
+  // `seen` is complete). Bounded by the number of deletions since the last build.
+  if (!since && !opts.force) {
+    const stale = [...cache.keys()].filter(p => !seen.has(p));
+    if (stale.length > 0) {
+      await cacheColl.deleteMany(asFilter<HashCacheDoc>({ _id: { $in: stale } }));
+    }
+  }
+
   return results;
 }


### PR DESCRIPTION
## Problem
`buildFileManifest` read and SHA-256-hashed **every file** each time it ran — and it runs **twice per sync round per peer** (once for the file diff in `syncFiles`, once for the Merkle root). So a space holding tens of GB re-read and re-hashed **all of it on every cycle**: pure CPU and disk for a result almost always identical to last time. This is the file-sync half of the "sync performance" story (P3 was the pull N+1).

## Fix
Cache the hashes per space — a **local** `<spaceId>_file_hashes` collection keyed by path with the `(size, mtime)` the hash was computed at. `buildFileManifest` loads the cache once, **reuses a stored hash when a file's size AND mtime are unchanged**, re-reads only new/modified files, persists newly-computed hashes in one `bulkWrite`, and prunes entries for deleted files. A `force` option re-reads everything for reconciliation.

The cache is a local derived index: **not in the synced collection set**, it follows a space rename (`<spaceId>_*`), and it's dropped with the space.

## Tests
The existing file-sync suites are the gate and pass unchanged — notably **"file overwritten propagates updated sha256"** (an mtime/size change busts the cache → re-hash → new hash syncs), plus write / delete / `?since=`. Full `test:all:core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)