### PR TITLE
perf: stop sync bookkeeping writes from blocking the event loop (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Sync bookkeeping writes no longer block the event loop.** The sync engine persists tiny per-cycle
+  fields — pull/push watermarks, per-member failure counters, `lastSyncAt` — dozens to hundreds of times
+  per cycle, and each was a **synchronous whole-file rewrite** of `config.json` that stalled *all* request
+  handling for its duration (and the stall grows with config size, which OAuth-minted tokens can push up).
+  These four hot-path fields now write through a coalesced, asynchronous, serialized flush
+  (`saveConfigSoon`): a burst collapses to one off-loop write, and the change never blocks a response.
+  They are runtime state, not configuration, so a flush lost to a crash is harmless — watermarks re-derive
+  by seq on the next pull (idempotent, no data loss) and counters are cosmetic; a durable flush runs on
+  graceful shutdown regardless. Every other config write (tokens, spaces, networks, votes, gossip identity
+  merges, setup) stays durable and synchronous, and a generation guard ensures an in-flight async flush can
+  never clobber a fresher durable write. Covered by `testing/standalone/config-coalesced-write.test.js` and
+  the existing sync suites (watermark convergence across restarts).
 - **File sync no longer re-hashes every file on every round.** The file manifest read and SHA-256-hashed
   **every file** each time it was built, and it is built twice per sync round (once for the file diff,
   once for the Merkle root) per peer — so a space holding tens of GB re-read and re-hashed all of it on

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -156,8 +156,37 @@ export function getConfig(): Config {
   return _config;
 }
 
+// ── Config persistence ───────────────────────────────────────────────────────
+// Two write paths share config.json:
+//   • saveConfig()      — durable & synchronous. Used by every correctness- or
+//                         security-critical mutation (tokens, spaces, networks,
+//                         setup). Behaviour is unchanged: the change is on disk
+//                         before the call returns.
+//   • saveConfigSoon()  — coalesced & asynchronous. Used ONLY by the sync engine
+//                         hot path (P2), which persists tiny bookkeeping fields —
+//                         pull/push watermarks, per-member failure counters,
+//                         lastSyncAt — dozens to hundreds of times per cycle. Done
+//                         synchronously, each was a whole-file write that blocked
+//                         the event loop and stalled all request handling. These
+//                         fields are runtime state, not configuration: losing the
+//                         last few on a crash is harmless (watermarks re-derive by
+//                         seq on the next pull, counters are cosmetic), so they are
+//                         safe to flush lazily off the event loop.
+//
+// A monotonic generation counter lets the two paths coexist without a torn or
+// stale write: every in-memory mutation bumps `_writeGeneration`; the async
+// flush records the generation it commits, and a synchronous durable write that
+// lands a newer generation mid-flush causes the async flush to discard its
+// now-stale snapshot instead of clobbering the fresher on-disk copy.
+
+let _writeGeneration = 0;   // bumped on every in-memory config mutation via save*
+let _flushedGeneration = 0; // highest generation already durably on disk
+let _flushScheduled = false;
+let _flushChain: Promise<void> = Promise.resolve();
+
 export function saveConfig(config: Config): void {
   _config = config;
+  const gen = ++_writeGeneration;
   // Ensure parent directory exists
   fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
   // Atomic write: write to temp file then rename
@@ -166,6 +195,62 @@ export function saveConfig(config: Config): void {
   fs.renameSync(tmp, CONFIG_PATH);
   // Ensure permissions after write
   fs.chmodSync(CONFIG_PATH, 0o600);
+  if (gen > _flushedGeneration) _flushedGeneration = gen;
+}
+
+/**
+ * Persist config.json off the event loop, coalescing bursts. For the sync
+ * engine's high-frequency bookkeeping writes only — see the header above.
+ * Returns immediately; the write lands on a later tick.
+ */
+export function saveConfigSoon(config: Config): void {
+  _config = config;
+  _writeGeneration++;
+  if (_flushScheduled) return; // a flush is already queued — it will pick up the latest state
+  _flushScheduled = true;
+  setImmediate(() => {
+    _flushScheduled = false;
+    // Serialize writes so two flushes never race on the temp file.
+    _flushChain = _flushChain
+      .catch(() => { /* a prior flush failure must not break the chain */ })
+      .then(() => writeConfigAsync())
+      .catch(err => log.error(`Async config flush failed: ${err}`));
+  });
+}
+
+/** Atomically write the current in-memory config, unless a newer durable write
+ *  has already superseded the snapshot we captured. Uses a distinct temp file so
+ *  it never collides with saveConfig()'s synchronous write. */
+async function writeConfigAsync(): Promise<void> {
+  const gen = _writeGeneration;
+  const config = _config;
+  if (!config || gen <= _flushedGeneration) return; // nothing new to persist
+  const snapshot = JSON.stringify(config, null, 2);
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+  const tmp = CONFIG_PATH + '.async.tmp';
+  await fs.promises.writeFile(tmp, snapshot, { encoding: 'utf8', mode: 0o600 });
+  // A synchronous durable write may have landed a newer generation while we were
+  // writing — if so our snapshot is stale, so discard it rather than clobber disk.
+  if (_flushedGeneration >= gen) {
+    await fs.promises.unlink(tmp).catch(() => { /* already gone */ });
+    return;
+  }
+  await fs.promises.rename(tmp, CONFIG_PATH);
+  try { await fs.promises.chmod(CONFIG_PATH, 0o600); } catch { /* non-POSIX host — ignore */ }
+  if (gen > _flushedGeneration) _flushedGeneration = gen;
+}
+
+/**
+ * Flush any pending coalesced config write to disk and wait for it. Call on
+ * graceful shutdown so the last watermarks are persisted before exit.
+ */
+export async function flushConfig(): Promise<void> {
+  await _flushChain.catch(() => { /* logged at the flush site */ });
+  // A saveConfigSoon may have run after the last scheduled flush started — make a
+  // final durable pass if anything is still unwritten.
+  if (_config && _writeGeneration > _flushedGeneration) {
+    saveConfig(_config);
+  }
 }
 
 // ── Secrets ────────────────────────────────────────────────────────────────

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 ﻿import { createServer } from 'http';
 import os from 'os';
-import { configExists, loadConfig, loadSecrets, loadSchemaLibrary, getMongoUri } from './config/loader.js';
+import { configExists, loadConfig, loadSecrets, loadSchemaLibrary, getMongoUri, flushConfig } from './config/loader.js';
 import { connectMongo, closeMongo, checkVectorSearchAvailability } from './db/mongo.js';
 import { createApp } from './app.js';
 import { startConfiguredInstanceServices } from './bootstrap.js';
@@ -125,6 +125,8 @@ async function main(): Promise<void> {
     const { stopRetryWorker } = await import('./webhooks/dispatcher.js');
     stopRetryWorker();
     server.close(() => log.debug('HTTP server closed'));
+    // Persist any coalesced config writes (sync watermarks) before exit.
+    await flushConfig();
     await closeMongo();
     process.exit(0);
   };

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -15,7 +15,7 @@
  *   and pulls from its parent.
  */
 
-import { getConfig, saveConfig, getSecrets, getFaceRecognitionConfig } from '../config/loader.js';
+import { getConfig, saveConfig, saveConfigSoon, getSecrets, getFaceRecognitionConfig } from '../config/loader.js';
 import { col, asFilter, asDoc, asBulk } from '../db/mongo.js';
 import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
 import { recordSyncResult, type SyncCounts } from './history.js';
@@ -152,7 +152,9 @@ function _setFailureCount(networkId: string, instanceId: string, value: number |
   if (!member) return typeof value === 'number' ? value : 1;
   const newValue = value === 'increment' ? (member.consecutiveFailures ?? 0) + 1 : value;
   member.consecutiveFailures = newValue;
-  saveConfig(cfg);
+  // Hot-path bookkeeping: written for every member every cycle. Coalesced async
+  // write — a lost counter on crash is cosmetic (it re-derives on the next cycle).
+  saveConfigSoon(cfg);
   return newValue;
 }
 
@@ -505,7 +507,8 @@ async function runSyncForMember(
   const freshCfg = getConfig();
   const freshNet = freshCfg.networks.find(n => n.id === net.id);
   const m = freshNet?.members.find(m => m.instanceId === member.instanceId);
-  if (m) { m.lastSyncAt = new Date().toISOString(); saveConfig(freshCfg); }
+  // Hot-path bookkeeping: a cosmetic timestamp written every member every cycle.
+  if (m) { m.lastSyncAt = new Date().toISOString(); saveConfigSoon(freshCfg); }
 
   return { pulled, pushed };
 }
@@ -891,7 +894,10 @@ async function pullFromPeer(
     if (m) {
       m.lastSeqReceived ??= {};
       m.lastSeqReceived[spaceId] = highestSeq;
-      saveConfig(freshCfg);
+      // Hot-path watermark: written per space per member per cycle. Coalesced
+      // async write — if lost on crash the next pull simply re-pulls from the
+      // older watermark (idempotent by seq), never dropping data.
+      saveConfigSoon(freshCfg);
     }
   }
 
@@ -1002,7 +1008,10 @@ async function pushToPeer(
     if (m) {
       m.lastSeqPushed ??= {};
       m.lastSeqPushed[spaceId] = maxSeqPushed;
-      saveConfig(freshCfg);
+      // Hot-path watermark: written per space per member per cycle. Coalesced
+      // async write — if lost on crash the next push simply re-pushes from the
+      // older watermark (idempotent by seq), never dropping data.
+      saveConfigSoon(freshCfg);
     }
   }
 

--- a/testing/standalone/config-coalesced-write.test.js
+++ b/testing/standalone/config-coalesced-write.test.js
@@ -1,0 +1,102 @@
+/**
+ * Standalone unit tests: coalesced async config writer (P2)
+ *
+ * The sync engine persists tiny bookkeeping fields (watermarks, failure
+ * counters, lastSyncAt) many times per cycle. Those writes now go through
+ * saveConfigSoon() — an async, coalesced, event-loop-friendly path — instead of
+ * a blocking synchronous whole-file write. saveConfig() stays durable+sync for
+ * every other caller.
+ *
+ * These tests exercise the compiled loader directly against a temp config file
+ * (no server / Docker needed), verifying:
+ *  - saveConfigSoon() eventually lands on disk, and flushConfig() forces it.
+ *  - A burst of saveConfigSoon() calls coalesces to the LATEST state.
+ *  - A durable saveConfig() is never clobbered by a stale in-flight async flush.
+ *
+ * Run: node --test testing/standalone/config-coalesced-write.test.js
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-cfg-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+
+// CONFIG_PATH is read at module-load time — set it BEFORE importing the loader.
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let loader;
+
+function baseConfig() {
+  return { instanceId: 'test-instance', instanceLabel: 'test', spaces: [], tokens: [], networks: [] };
+}
+
+function readDisk() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+}
+
+const nextTick = () => new Promise(r => setImmediate(r));
+
+describe('Coalesced async config writer', () => {
+  before(async () => {
+    // Seed a valid config so loadConfig() succeeds, then import the compiled loader.
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(baseConfig(), null, 2), 'utf8');
+    loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    // Reset to a clean, durably-written baseline before each test.
+    loader.saveConfig(baseConfig());
+    await loader.flushConfig();
+  });
+
+  it('saveConfigSoon eventually persists to disk', async () => {
+    const cfg = { ...baseConfig(), instanceLabel: 'soon-1' };
+    loader.saveConfigSoon(cfg);
+    // Not necessarily on disk synchronously...
+    await loader.flushConfig();
+    assert.equal(readDisk().instanceLabel, 'soon-1');
+  });
+
+  it('coalesces a burst of writes to the latest state', async () => {
+    for (let i = 0; i < 50; i++) {
+      loader.saveConfigSoon({ ...baseConfig(), instanceLabel: `burst-${i}` });
+    }
+    await loader.flushConfig();
+    assert.equal(readDisk().instanceLabel, 'burst-49', 'last write in the burst must win');
+  });
+
+  it('flushConfig persists a write scheduled but not yet flushed', async () => {
+    loader.saveConfigSoon({ ...baseConfig(), instanceLabel: 'pending' });
+    await loader.flushConfig();
+    assert.equal(readDisk().instanceLabel, 'pending');
+  });
+
+  it('a durable saveConfig is not clobbered by an in-flight async flush', async () => {
+    // Schedule an async flush, then immediately land a newer durable write.
+    loader.saveConfigSoon({ ...baseConfig(), instanceLabel: 'stale-async' });
+    loader.saveConfig({ ...baseConfig(), instanceLabel: 'durable-wins' });
+    // Durable write is on disk right away.
+    assert.equal(readDisk().instanceLabel, 'durable-wins');
+    // Let the scheduled async flush run — it must detect it was superseded and
+    // NOT overwrite the fresher durable copy.
+    await nextTick();
+    await loader.flushConfig();
+    assert.equal(readDisk().instanceLabel, 'durable-wins', 'stale async flush must not clobber the durable write');
+  });
+
+  it('a later saveConfigSoon after a durable write still persists', async () => {
+    loader.saveConfig({ ...baseConfig(), instanceLabel: 'durable' });
+    loader.saveConfigSoon({ ...baseConfig(), instanceLabel: 'soon-after' });
+    await loader.flushConfig();
+    assert.equal(readDisk().instanceLabel, 'soon-after');
+  });
+});


### PR DESCRIPTION
## What

The sync engine persists tiny per-cycle bookkeeping fields — pull/push seq **watermarks**, per-member **failure counters**, and **`lastSyncAt`** — dozens to hundreds of times per cycle. Each was a **synchronous whole-file rewrite** of `config.json` that blocked the event loop (and all request handling) for its duration; the stall grows with config size, which OAuth-minted tokens can push up unboundedly.

This is **P2** from the performance backlog, done via the **tactical** path (coalesced async write). The structural option (relocating watermarks out of `config.json` into Mongo) was deliberately deferred — it needs a migration, and the tactical fix already removes the event-loop stall, which was the actual harm.

## How

- New `saveConfigSoon()` in the loader: a **coalesced, asynchronous, serialized** flush. A burst of calls collapses to one off-loop write.
- The **four hot-path** sync-engine writes switch to it. Everything else — tokens, spaces, networks, votes, gossip identity merges, setup (~60 call sites) — keeps `saveConfig()`'s **durable + synchronous** semantics unchanged.
- A monotonic **generation guard** lets the two paths coexist safely: an in-flight async flush that finds a newer durable write landed mid-flight **discards its stale snapshot** instead of clobbering disk, and the async writer uses a distinct temp file so it never collides with the synchronous writer.
- `flushConfig()` runs a final durable pass on **graceful shutdown**.

## Why it's safe to flush these lazily

They are runtime state, not configuration. A flush lost to a crash is harmless: watermarks re-derive by seq on the next pull (idempotent, no data loss) and counters are cosmetic. Consensus/security-relevant writes (votes, signing-key pins via gossip, membership) stay durable.

## Tests

- New `testing/standalone/config-coalesced-write.test.js`: persistence, burst coalescing, forced flush, and the durable-wins-over-stale-async race.
- Full core suite green locally — integration 822, sync 173, redteam 258, standalone 744, **0 failures**. The sync suites gate watermark convergence across restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)