### PR TITLE
fix: run governance gossip/votes before data sync so load can't starve them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Governance votes and member gossip now converge even when data sync is slow or failing.** In each
+  sync cycle, gossip (member list, signing-key pinning) and vote propagation ran **after** the per-space
+  data and file sync for a peer — and that data loop is not isolated, so any timed-out pull, unreachable
+  member, or slow file transfer threw out of the member's sync and **skipped governance entirely for that
+  cycle**. On a lightly loaded system the data plane is fast so this never showed, but under heavy load a
+  saturated peer could starve time-sensitive vote propagation (rounds have deadlines) for many cycles in
+  a row — the root cause behind the intermittently-timing-out signed-vote relay test. Governance now runs
+  **first**, ahead of the data loop, so it converges promptly and independently of data-plane health. The
+  two calls remain internally best-effort and are additionally wrapped so a later data-plane failure can
+  never mask governance progress. Covered by the existing sync/vote suites.
 - **Importing a schema no longer fails silently.** In **Settings → Spaces → Schema → Import JSON**, a
   valid-JSON file that contained none of the recognised `entity`/`edge`/`memory`/`chrono` keys — which
   includes Ythril's **own** per-type export shape `{knowledgeType, typeName, schema}` — fell straight

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -422,6 +422,28 @@ async function runSyncForMember(
     await Promise.all([peerWarm, localWarm]);
   }
 
+  // ── Governance gossip + vote propagation (BEFORE data sync) ───────────────
+  // 1. Push our own self-record to this peer so it stays current on our URL/label.
+  // 2. Pull the peer's view of the member list; update our local records.
+  // 3. Push our open vote casts to the peer.
+  // 4. Pull the peer's open rounds and votes; merge any new rounds or casts.
+  //
+  // This runs FIRST — ahead of the per-space data/file loop — on purpose.
+  // Governance is deadline-sensitive (vote rounds expire) and its messages are
+  // small, so it must converge promptly and independently of the data plane.
+  // Previously it ran last, which meant any failure in the per-space loop (a
+  // timed-out pull, an unreachable member, a slow file transfer) threw out of
+  // this function and skipped governance for the whole cycle — so under load a
+  // saturated peer could starve vote propagation indefinitely. Both calls are
+  // internally best-effort (they catch their own errors); the extra guard here
+  // keeps a data-plane failure below from ever masking governance progress.
+  try {
+    await gossipWithPeer(net, member, headers, fetchOpts);
+    await propagateVotesWithPeer(net, member, headers, fetchOpts);
+  } catch (err) {
+    log.warn(`Governance gossip with ${member.label} (${member.instanceId}): ${err}`);
+  }
+
   // Pre-build reverse spaceMap (local → remote) for O(1) lookup per space
   // instead of the O(n) linear scan inside localToRemote().
   const reverseSpaceMap = new Map(
@@ -492,14 +514,6 @@ async function runSyncForMember(
       await checkMerkleWithPeer(net, member, spaceId, remoteSpaceId, fetchOpts);
     }
   }
-
-  // ── Gossip: member list exchange + vote propagation ──────────────────────
-  // 1. Push our own self-record to this peer so it stays current on our URL/label.
-  // 2. Pull the peer's view of the member list; update our local records.
-  // 3. Push our open vote casts to the peer.
-  // 4. Pull the peer's open rounds and votes; merge any new rounds or casts.
-  await gossipWithPeer(net, member, headers, fetchOpts);
-  await propagateVotesWithPeer(net, member, headers, fetchOpts);
 
   // Update lastSyncAt
   const freshCfg = getConfig();


### PR DESCRIPTION
## Root cause of the recurring vote-signing relay flake

The signed-vote relay test (`testing/sync/vote-signing.test.js` → *\"a VALID signed cast from a third instance is accepted when relayed by B\"*) has flaked intermittently in CI across several hardening attempts (#165 timing, #168 → 90s window). Widening the timeout never fixed it because **the propagation was being *skipped*, not merely delayed**.

In `runSyncForMember`, per peer, the order was:

1. warm-up
2. **per-space data + file sync loop** (pull / push / files, for every space)
3. gossip (member list, signing-key pinning)
4. vote propagation

The data loop (step 2) is **not isolated** — a timed-out pull (10s control / 60s batch `AbortSignal.timeout`), an unreachable member, or a slow file transfer throws out of `runSyncForMember`, caught by the network-level member loop. That means **governance (steps 3–4) is skipped for the entire cycle** whenever any data-plane request to that peer fails.

On a lightly loaded system the data plane is fast, so this never shows — the test passes in **~3s in isolation** (verified, 3×). Under full-suite CI saturation a peer exceeds the fetch timeouts, the data loop throws, and governance is skipped cycle after cycle — starving the deadline-sensitive vote relay until the 90s window elapses.

## Fix

Run **gossip + vote propagation first**, ahead of the per-space data/file loop. Governance is deadline-sensitive (vote rounds expire) and its messages are small, so it should converge promptly and independently of data-plane health. Both calls are already internally best-effort; they're additionally wrapped so a data-plane failure below can never mask governance progress.

This shrinks the failure surface from *\"governance skipped if **any** of ~6 per-space data requests fails\"* to *\"skipped only if the 1–2 small governance requests themselves fail\"* — and is the correct design regardless of the test: bulk data sync should never block deadline-bound governance.

## Testing

- Full sync suite green locally — **173 pass, 0 fail, 1 skip** (baseline), including all vote/governance tests.
- The flake is **load-induced and does not reproduce locally** (isolation run is ~3s), so CI is the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)