### PR TITLE
ci: cache the embedding model across builds so HF rate-limits stop breaking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,26 @@ jobs:
         run: npm run build:server
         # Required by testing/standalone/oidc.test.js which imports server/dist/
 
-      - name: Build test stack
-        run: docker compose -p ythril-test -f testing/docker-compose.test.yml build
-        # Single build (all services in one pass) is fine on CI — no VS Code to crash.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Expose GitHub Actions cache to Buildx
+        # Sets ACTIONS_CACHE_URL / ACTIONS_RUNTIME_TOKEN so `--cache-to type=gha` works.
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Build test image (shared GHA layer cache)
+        # Build the image ONCE with a persistent GitHub Actions layer cache and tag it
+        # ythril-test:latest — every compose service reuses that tag (see the compose
+        # file), so the stack is not rebuilt per instance. The cache means the embedding
+        # model (a cache-stable early layer in the Dockerfile) is restored across runs
+        # instead of re-downloaded from HuggingFace, whose anonymous per-IP rate limit
+        # was intermittently 403-ing shared CI runners at build time.
+        run: |
+          docker buildx build \
+            --cache-from type=gha,scope=ythril-test \
+            --cache-to type=gha,mode=max,scope=ythril-test \
+            --load -t ythril-test:latest \
+            -f Dockerfile .
 
       - name: Start test containers
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The embedding model is no longer re-downloaded from HuggingFace on every CI build.** The Dockerfile
+  fetched the ~274 MB `nomic-embed-text-v1.5` model in a layer that sat *after* the app-source copy, so any
+  source change invalidated it — and CI runners start with a cold build cache, so effectively every CI run
+  re-downloaded it anonymously. HuggingFace rate-limits anonymous downloads per-IP, and the shared CI
+  egress IP was intermittently getting `403 Forbidden`, failing the image build before any test ran. The
+  model download now runs as a **cache-stable early layer** (it depends only on the npm package, not our
+  source), CI builds the image **once** with a **persistent GitHub Actions layer cache** (`type=gha`) and
+  every compose instance reuses that tag, and the download has **retry/backoff** to ride through a
+  transient 403 on the rare build that must actually fetch. Build/CI only — no runtime change.
 - **File sync no longer re-hashes every file on every round.** The file manifest read and SHA-256-hashed
   **every file** each time it was built, and it is built twice per sync round (once for the file diff,
   once for the Merkle root) per peer — so a space holding tens of GB re-read and re-hashed all of it on

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,27 +59,45 @@ COPY server/package.json ./server/
 # Install production dependencies only
 RUN npm ci --workspace=server --omit=dev
 
+# Pre-download & cache the embedding model so first startup is instant and fully offline.
+# The model is then copied into the image layer so the container starts offline.
+#
+# This runs BEFORE the app-source COPYs below on purpose: it depends only on the
+# @huggingface/transformers npm package (installed above), NOT on our source. So
+# a normal source change does not invalidate this layer, which lets a layer cache
+# (CI's `--cache-from type=gha`) restore the already-downloaded model instead of
+# re-fetching ~274 MB from HuggingFace on every build. HF rate-limits anonymous
+# downloads per-IP (shared CI egress → intermittent 403), so the fewer fetches the
+# better; the retry/backoff below rides through a transient 403 on the rare build
+# that does have to download. `--mount=type=cache` additionally speeds local rebuilds.
+ENV MODEL_CACHE_DIR=/app/model-cache
+RUN --mount=type=cache,target=/tmp/hf-model-cache \
+    printf '%s\n' \
+    'import { pipeline, env } from "@huggingface/transformers";' \
+    'env.cacheDir = "/tmp/hf-model-cache";' \
+    'const load = () => pipeline("feature-extraction", "nomic-ai/nomic-embed-text-v1.5", { dtype: "fp32" });' \
+    'const attempts = 6;' \
+    'for (let i = 1; i <= attempts; i++) {' \
+    '  try { await load(); break; }' \
+    '  catch (err) {' \
+    '    if (i === attempts) throw err;' \
+    '    const delay = Math.min(60, 2 ** i);' \
+    '    console.warn(`model download attempt ${i}/${attempts} failed: ${err}; retrying in ${delay}s`);' \
+    '    await new Promise(r => setTimeout(r, delay * 1000));' \
+    '  }' \
+    '}' \
+    > /app/server/warm.mjs && \
+    node /app/server/warm.mjs && \
+    rm /app/server/warm.mjs && \
+    mkdir -p /app/model-cache && \
+    cp -a /tmp/hf-model-cache/. /app/model-cache/
+
 # Copy compiled output from builder
 COPY --from=builder /build/server/dist ./server/dist
 
 # Copy compiled Angular SPA from client-builder
 COPY --from=client-builder /build/client/dist/browser ./client/dist/browser
 
-# Pre-download & cache the embedding model so first startup is instant and fully offline.
-# --mount=type=cache keeps downloaded files on the build host between rebuilds so that
-# invalidating an earlier layer (e.g. npm ci) doesn't re-download ~274 MB every time.
-# The model is then copied into the image layer so the container starts offline.
-ENV MODEL_CACHE_DIR=/app/model-cache
-RUN --mount=type=cache,target=/tmp/hf-model-cache \
-    printf '%s\n' \
-    'import { pipeline, env } from "@huggingface/transformers";' \
-    'env.cacheDir = "/tmp/hf-model-cache";' \
-    'await pipeline("feature-extraction", "nomic-ai/nomic-embed-text-v1.5", { dtype: "fp32" });' \
-    > /app/server/warm.mjs && \
-    node /app/server/warm.mjs && \
-    rm /app/server/warm.mjs && \
-    mkdir -p /app/model-cache && \
-    cp -a /tmp/hf-model-cache/. /app/model-cache/
 ENV NODE_ENV=production
 ENV PORT=3200
 ENV CONFIG_PATH=/config/config.json

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -26,6 +26,7 @@ services:
   # ──────────────────────────────────────────
   ythril-a:
     build: ..
+    image: ythril-test:latest  # fixed tag so CI pre-builds once (shared layer cache) and every instance reuses it
     container_name: ythril-a
     ports:
       - "3200:3200"
@@ -77,6 +78,7 @@ services:
   # ──────────────────────────────────────────
   ythril-b:
     build: ..
+    image: ythril-test:latest  # fixed tag so CI pre-builds once (shared layer cache) and every instance reuses it
     container_name: ythril-b
     ports:
       - "3201:3200"
@@ -124,6 +126,7 @@ services:
   # ──────────────────────────────────────────
   ythril-c:
     build: ..
+    image: ythril-test:latest  # fixed tag so CI pre-builds once (shared layer cache) and every instance reuses it
     container_name: ythril-c
     ports:
       - "3202:3200"
@@ -170,6 +173,7 @@ services:
   # ──────────────────────────────────────────
   ythril-d:
     build: ..
+    image: ythril-test:latest  # fixed tag so CI pre-builds once (shared layer cache) and every instance reuses it
     container_name: ythril-d
     ports:
       - "3203:3200"


### PR DESCRIPTION
## Problem

Every CI run rebuilds the test image, and the Dockerfile downloaded the ~274 MB `nomic-embed-text-v1.5` model in a layer sitting **after** the app-source `COPY`. So any source change invalidated it, and since CI runners start with a **cold build cache**, effectively every run re-downloaded the model **anonymously**. HuggingFace rate-limits anonymous downloads per-IP, and the shared GitHub-runner egress IP was intermittently returning **`403 Forbidden`** — failing the image build *before any test ran*. This blocked several PRs (#170 merge, #171, #172) and left `main` red for a non-code reason.

## Fix — remove the dependency on a live anonymous fetch

1. **Cache-stable early layer.** Move the model download ahead of the source `COPY`s. It depends only on the `@huggingface/transformers` npm package (already installed), not our source — so a normal code change no longer invalidates it.
2. **Build once with a persistent GHA layer cache.** CI now runs a single `docker buildx build --cache-from/--cache-to type=gha` and tags `ythril-test:latest`; every compose instance reuses that tag instead of rebuilding. Adds `docker/setup-buildx-action` + `crazy-max/ghaction-github-runtime` (to expose the GHA cache to Buildx).
3. **Retry/backoff** (6 attempts, exponential to 60 s) on the download, so the rare build that must actually fetch rides through a transient 403.

Together: the model layer is restored from the GHA cache across runs instead of re-fetched, and source-only PRs never hit HuggingFace at all.

## Validation

- Reordered image builds locally; model present at `/app/model-cache` (523 MB).
- `docker compose config` and `ci.yml` both parse.
- **Note:** the *first* CI run on this branch still has a cold GHA cache, so it must fetch the model once to populate it (the retry helps if HF is still throttling). Every run after restores from cache.

Once this lands, re-running #171 (P2) and #172 (vote-signing fix) should get past the build step and actually exercise the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)