### PR TITLE
fix: OIDC sign-in hangs when the whole SPA is embedded in a portal iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OIDC sign-in no longer hangs when the whole SPA is embedded in a portal iframe.** The callback
+  inferred "this is a silent-refresh frame" from simply being inside an iframe (`window.self !== window.top`)
+  and tried to `postMessage` the authorization code to `window.parent` targeted at Ythril's own origin. That
+  is correct for a genuine silent refresh (whose hidden iframe's parent *is* the SPA), but when the entire
+  Ythril SPA runs inside a host portal's iframe, the interactive redirect callback is also framed and its
+  parent is the *portal's* origin — so the browser refuses the cross-origin `postMessage` and the user is
+  stuck on "Completing sign-in…" forever. The silent-refresh flow now marks its request explicitly with a
+  `state` prefix (`silent.`), and the callback branches on that marker instead of on being framed — so an
+  embedded interactive sign-in completes normally while genuine silent refreshes are still recognised.
+  Client-only. Reported from a production embedded (iframe) deployment.
 - **Importing a schema no longer fails silently.** In **Settings → Spaces → Schema → Import JSON**, a
   valid-JSON file that contained none of the recognised `entity`/`edge`/`memory`/`chrono` keys — which
   includes Ythril's **own** per-type export shape `{knowledgeType, typeName, schema}` — fell straight

--- a/client/src/app/core/auth.service.ts
+++ b/client/src/app/core/auth.service.ts
@@ -9,6 +9,18 @@ const OIDC_CLIENT_ID_KEY = 'oidc_client_id';
 const OIDC_SCOPES_KEY = 'oidc_scopes';
 const OIDC_ID_TOKEN_KEY = 'oidc_id_token';
 
+/**
+ * Marker prepended to the OIDC `state` of a silent-refresh request. The callback
+ * component uses it to recognise a silent-refresh frame explicitly, rather than
+ * inferring "silent refresh" from merely being inside an iframe — which breaks
+ * when the ENTIRE SPA is embedded in a portal iframe (the interactive redirect
+ * callback is then also framed, but its parent is the portal's origin, so the
+ * silent-callback postMessage is refused and interactive sign-in hangs forever).
+ * `state` round-trips through the IdP unchanged, and `.` is not part of the
+ * base64url alphabet used for the random suffix, so the marker is unambiguous.
+ */
+export const OIDC_SILENT_STATE_PREFIX = 'silent.';
+
 /** Prefix that identifies a Ythril-issued Personal Access Token. */
 const PAT_TOKEN_PREFIX = 'ythril_';
 
@@ -268,7 +280,10 @@ export class AuthService {
       .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 
     const stateBytes = crypto.getRandomValues(new Uint8Array(16));
-    const state = btoa(String.fromCharCode(...stateBytes))
+    // Prefix the state so the callback recognises this as a silent-refresh frame
+    // explicitly (see OIDC_SILENT_STATE_PREFIX) instead of inferring it from being
+    // framed — the latter breaks when the whole SPA is embedded in a portal iframe.
+    const state = OIDC_SILENT_STATE_PREFIX + btoa(String.fromCharCode(...stateBytes))
       .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 
     // Fetch the discovery document to obtain the current endpoints

--- a/client/src/app/pages/oidc-callback/oidc-callback.component.ts
+++ b/client/src/app/pages/oidc-callback/oidc-callback.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AuthService } from '../../core/auth.service';
+import { AuthService, OIDC_SILENT_STATE_PREFIX } from '../../core/auth.service';
 import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -65,11 +65,14 @@ export class OidcCallbackComponent implements OnInit {
     const errorParam = params.get('error');
     const errorDescription = params.get('error_description');
 
-    // ── Silent refresh: running inside a hidden iframe ──────────────────────
-    // When the parent window performs a silent refresh it creates a hidden
-    // iframe that navigates here.  Post the result back via postMessage so the
-    // parent can exchange the code without any visible navigation.
-    if (window.self !== window.top) {
+    // ── Silent refresh: running inside the hidden refresh iframe ────────────
+    // AuthService.silentRefresh() creates a hidden iframe and marks its request
+    // with OIDC_SILENT_STATE_PREFIX on the `state`. Recognise the silent flow by
+    // that marker — NOT by merely being framed. Inferring it from framing broke
+    // when the whole SPA is embedded in a portal iframe: the interactive redirect
+    // callback is then also framed, but window.parent is the portal's origin, so
+    // this postMessage (targeted at location.origin) is refused and sign-in hangs.
+    if (state?.startsWith(OIDC_SILENT_STATE_PREFIX)) {
       window.parent.postMessage(
         { type: 'oidc_silent_callback', code, state, error: errorParam ?? null },
         location.origin,


### PR DESCRIPTION
## Reported by a production embedded (iframe) deployment

Priority bug from customer feedback: when the **entire** Ythril SPA is embedded as an iframe in a host portal, OIDC interactive sign-in hangs forever on *"Completing sign-in…"*.

## Cause

`oidc-callback.component.ts` inferred "this is a silent-refresh frame" from merely being framed:

```ts
if (window.self !== window.top) {
  window.parent.postMessage({ type: 'oidc_silent_callback', ... }, location.origin);
  return;
}
```

That's correct for a **genuine silent refresh** — its hidden iframe's parent *is* the SPA (same origin). But when the whole SPA runs inside a **portal** iframe, the *interactive* redirect callback is also framed, and `window.parent` is the **portal's** origin. The `postMessage` targeted at `location.origin` (Ythril's origin) is refused by the browser (`target origin … does not match recipient window origin …`), so the flow never completes. Genuine silent refresh still worked; only interactive redirect sign-in broke when embedded.

## Fix

Mark the silent-refresh flow **explicitly** instead of inferring it from framing (the customer's suggested approach):

- `AuthService.silentRefresh()` prefixes its OIDC `state` with `OIDC_SILENT_STATE_PREFIX` (`'silent.'`).
- The callback branches on `state?.startsWith(OIDC_SILENT_STATE_PREFIX)` → postMessage path; otherwise it completes via normal navigation, **even when framed**.

`state` round-trips through the IdP unchanged, and `.` is outside the base64url alphabet of the random suffix, so the marker is unambiguous. The interactive flow's own `state` validation (via `sessionStorage['oidc_state']`) is untouched, and the silent handler already compares the returned `state` to the prefixed local value.

## Testing

- Client typechecks clean (`tsc --noEmit`).
- The existing `oidc-silent-refresh` standalone test is a server-side contract test (SPA is served at `/oidc-callback`) and is unaffected.

## Note

CI on this branch will fail at the Docker image build until the separate HuggingFace-model-download issue is resolved (see #173) — it is unrelated to this change, which is client-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)