### PR TITLE
fix: notify limiter ignored the test kill-switch — the real vote-signing flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The notify limiter now honours the test kill-switch — the real cause of the “flaky” signed-vote relay test.**
+  `POST /api/notify/trigger` is how the test harness drives a sync cycle, and it is guarded by
+  `notifyRateLimit` (60/min per IP). Every request from the harness shares one source IP, so the sync suites
+  collectively blew past 60/min and started getting `429`s — which the tests' trigger call swallowed, so the
+  sync cycle silently never ran and load-sensitive assertions timed out looking like flakes. `notifyRateLimit`
+  was the **only** limiter with no `skip:` clause (`authRateLimit`, `globalRateLimit`, `syncRateLimit` and
+  `bulkWipeRateLimit` all have one); it now honours `SKIP_SYNC_RATE_LIMIT` like the rest of the sync plane.
+  **No production impact:** the kill-switch is inert unless `NODE_ENV !== 'production'`, scheduled sync calls
+  the engine in-process (it never touches this limiter at all), and instance C deliberately omits the env so
+  the genuine 429 behaviour stays covered. Pinned by `testing/standalone/notify-rate-limit.test.js`, which
+  asserts both halves: A must not throttle, C still must.
+
 - **OIDC sign-in no longer hangs when the whole SPA is embedded in a portal iframe.** The callback
   inferred "this is a silent-refresh frame" from simply being inside an iframe (`window.self !== window.top`)
   and tried to `postMessage` the authorization code to `window.parent` targeted at Ythril's own origin. That

--- a/server/src/rate-limit/middleware.ts
+++ b/server/src/rate-limit/middleware.ts
@@ -51,6 +51,14 @@ export const notifyRateLimit = rateLimit({
     log.warn(`notifyRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
     res.status(options.statusCode).json(options.message);
   },
+  // This limiter guards POST /api/notify/trigger, which is how the test harness
+  // drives sync — and every request from the harness shares one source IP, so the
+  // suites collectively blew through 60/min and got 429s. Those 429s were swallowed
+  // by the tests' trigger `.catch()`, so no sync cycle ran and load-sensitive sync
+  // assertions timed out looking like flakes. It was the ONLY limiter missing a
+  // kill-switch; it now honours the same one as the rest of the sync plane.
+  // Instance C omits the env so rate-limit tests still exercise the real 429.
+  skip: () => skipRateLimit('SKIP_SYNC_RATE_LIMIT'),
 });
 
 /** 300 requests/minute per IP — general API and MCP endpoints */

--- a/testing/standalone/notify-rate-limit.test.js
+++ b/testing/standalone/notify-rate-limit.test.js
@@ -1,0 +1,68 @@
+/**
+ * Standalone tests: the notify limiter honours the test kill-switch.
+ *
+ * `POST /api/notify/trigger` is how the harness drives a sync cycle. It is guarded
+ * by `notifyRateLimit` (60/min per IP) — and every request from the harness shares a
+ * single source IP, so the sync suites collectively exhausted the window and started
+ * getting 429s. The tests' trigger call swallows errors, so a 429 meant the sync cycle
+ * silently never ran, and load-sensitive sync assertions timed out looking like flakes
+ * (this is what made the signed-vote relay test intermittently fail in CI).
+ *
+ * notifyRateLimit was the ONLY limiter with no `skip:` clause. These tests pin both
+ * halves of the fix:
+ *   - instance A (SKIP_SYNC_RATE_LIMIT=true) must serve well past 60 triggers/min
+ *   - instance C (no kill-switch) must still enforce the real 429
+ *
+ * Run: node --test testing/standalone/notify-rate-limit.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+
+const tokenFor = (inst) => fs.readFileSync(path.join(CONFIGS, inst, 'token.txt'), 'utf8').trim();
+
+/** Fire n sequential triggers, returning the set of status codes seen. */
+async function hammerTrigger(baseUrl, token, n) {
+  const codes = [];
+  for (let i = 0; i < n; i++) {
+    const res = await fetch(`${baseUrl}/api/notify/trigger`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      // A networkId that does not exist: the endpoint is fire-and-forget, so this
+      // exercises the rate limiter without kicking off real sync work.
+      body: JSON.stringify({ networkId: 'rate-limit-probe-nonexistent' }),
+    });
+    codes.push(res.status);
+  }
+  return codes;
+}
+
+describe('notify rate limit — kill-switch', () => {
+  it('instance A (SKIP_SYNC_RATE_LIMIT set) serves far more than 60 triggers/min', async () => {
+    // 90 > the 60/min ceiling. Before the fix this produced 30x 429 on A, which is
+    // precisely how the harness lost its sync triggers under load.
+    const codes = await hammerTrigger(INSTANCES.a, tokenFor('a'), 90);
+    const tooMany = codes.filter(c => c === 429).length;
+    assert.equal(
+      tooMany, 0,
+      `notify triggers on A must not be rate-limited when the kill-switch is set (got ${tooMany}x 429)`,
+    );
+    assert.ok(codes.every(c => c === 200), `expected all 200s, saw: ${[...new Set(codes)].join(',')}`);
+  });
+
+  it('instance C (no kill-switch) still enforces the real 60/min limit', async () => {
+    // C deliberately omits the SKIP_* envs so the genuine 429 behaviour stays covered.
+    const codes = await hammerTrigger(INSTANCES.c, tokenFor('c'), 75);
+    assert.ok(
+      codes.includes(429),
+      'C must still rate-limit notify — the kill-switch must not weaken real deployments',
+    );
+  });
+});


### PR DESCRIPTION
## The actual root cause, after three wrong ones

The signed-vote relay test has flaked in CI across **three** previous attempts (#165 timing, #168 90s window, #172 governance-first). None of them were the cause. This is.

`POST /api/notify/trigger` is how the test harness drives a sync cycle, and it's guarded by `notifyRateLimit` (**60/min per IP**). Every request from the harness shares **one source IP**, so the sync suites collectively exceeded 60/min and started getting `429`s. The tests' trigger call swallows errors (`.catch(() => {})`), so a 429 meant **the sync cycle silently never ran** — and the assertion just sat there until its 90s window elapsed, looking exactly like a flake.

That explains every symptom:
- **load-dependent** — slower CI ⇒ tests run longer ⇒ more polls ⇒ quota exhausted
- **always passed in isolation** — one test alone stays under 60/min
- **widening the window made it *worse*** — more polling burned more quota

**Proven before fixing:** 70 rapid triggers against instance A — which *already* sets `SKIP_AUTH_RATE_LIMIT`, `SKIP_GLOBAL_RATE_LIMIT` **and** `SKIP_SYNC_RATE_LIMIT` — returned **60× 200 then 10× 429**.

## The fix

`notifyRateLimit` was the **only** limiter with no `skip:` clause — `authRateLimit`, `globalRateLimit`, `syncRateLimit` and `bulkWipeRateLimit` all have one. It now honours `SKIP_SYNC_RATE_LIMIT` like the rest of the sync plane. One line.

## Why this does not weaken production

- `skipRateLimit()` is **inert unless `NODE_ENV !== 'production'`** — a leaked env var can never disable throttling on a live deployment.
- **Scheduled sync never touches this limiter**: the cron task calls `runSyncForNetwork()` *in-process* (`engine.ts:133`), not over HTTP.
- The real callers of `/api/notify` are **lifecycle events** — member add/remove, space create/delete — a handful at a time, nowhere near 60/min.
- **Instance C deliberately omits the env**, so the genuine 429 behaviour stays enforced *and tested*.

The 30–45 sustained HTTP triggers/min from a single IP that tripped this is a **test-harness artifact**, not a production access pattern.

## Tests

New `testing/standalone/notify-rate-limit.test.js` pins **both halves** so this can't silently regress into a mystery timeout again:
- instance A (kill-switch set) must serve **90 triggers with zero 429s**
- instance C (no kill-switch) must **still 429**

Full core suite green: **integration 822, standalone 746, redteam 258, sync 173 — 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)