### PR TITLE
test: surface sync-trigger failures instead of swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sync tests can no longer turn a persistent, actionable error into an unexplained timeout.** The sync
+  suites re-trigger a sync on every poll (deliberate — a single up-front trigger races a slow gossip
+  cycle), but they did it as `triggerSync(...).catch(() => {})`, which treats a transient blip and a
+  permanent misconfiguration identically. That trap is *why* the notify rate-limit bug survived three wrong
+  fixes: every trigger was coming back `429`, the `.catch()` ate it, no sync cycle ever ran, and all anyone
+  saw was `waitFor timed out after 90000ms`. `waitFor` now takes a `diagnose` argument appended to its
+  timeout message, and `makeTriggerProbe` still tolerates a failed poll but **remembers the last failure**
+  and reports it — so the message becomes "every sync trigger to A was failing (…); last error:
+  triggerSync failed: 429 …" instead of a bare stall. Test-harness only. Pinned by
+  `testing/standalone/waitfor-diagnostics.test.js`.
+
 - **The notify limiter now honours the test kill-switch — the real cause of the “flaky” signed-vote relay test.**
   `POST /api/notify/trigger` is how the test harness drives a sync cycle, and it is guarded by
   `notifyRateLimit` (60/min per IP). Every request from the harness shares one source IP, so the sync suites

--- a/testing/standalone/waitfor-diagnostics.test.js
+++ b/testing/standalone/waitfor-diagnostics.test.js
@@ -1,0 +1,75 @@
+/**
+ * Standalone tests: waitFor diagnostics + trigger probe.
+ *
+ * A bare "waitFor timed out after 90000ms" is worse than useless — it makes a
+ * persistent, actionable error look like a random flake. That is precisely how the
+ * notify rate-limit bug survived three wrong fixes: every sync trigger was coming back
+ * 429, the tests swallowed it with `.catch(() => {})`, and all anyone ever saw was a
+ * timeout.
+ *
+ * These tests pin the guard so that failure mode cannot silently return:
+ *  - waitFor appends its `diagnose` output to the timeout message
+ *  - makeTriggerProbe tolerates failures (one bad poll must not fail a test) but
+ *    REMEMBERS the last one and reports it
+ *
+ * Run: node --test testing/standalone/waitfor-diagnostics.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { INSTANCES, waitFor, makeTriggerProbe } from '../sync/helpers.js';
+
+describe('waitFor — timeout diagnostics', () => {
+  it('appends the diagnose string to the timeout message', async () => {
+    await assert.rejects(
+      () => waitFor(async () => false, 300, 100, 'because the widget never arrived'),
+      (err) => {
+        assert.match(err.message, /timed out after 300ms/);
+        assert.match(err.message, /because the widget never arrived/);
+        return true;
+      },
+    );
+  });
+
+  it('accepts a diagnose function evaluated at timeout', async () => {
+    let polls = 0;
+    await assert.rejects(
+      () => waitFor(async () => { polls++; return false; }, 300, 100, () => `polled ${polls} times`),
+      (err) => {
+        assert.match(err.message, /polled \d+ times/);
+        return true;
+      },
+    );
+  });
+
+  it('still resolves normally when the condition passes (no diagnosis emitted)', async () => {
+    const ok = await waitFor(async () => true, 1000, 50, 'should never be seen');
+    assert.equal(ok, true);
+  });
+});
+
+describe('makeTriggerProbe — surfaces a persistently-failing trigger', () => {
+  it('records the failure and reports it instead of a bare timeout', async () => {
+    // A deliberately invalid token: every trigger is rejected (401). Before this guard
+    // the rejection was swallowed and the test died with an unexplained timeout.
+    const probe = makeTriggerProbe(INSTANCES.a, 'ythril_totally-invalid-token', 'nonexistent-net', 'A');
+
+    await assert.rejects(
+      () => waitFor(async () => { await probe(); return false; }, 600, 150, probe.diagnose),
+      (err) => {
+        assert.match(err.message, /every sync trigger to A was failing/);
+        assert.match(err.message, /triggerSync failed: 401/, `expected the real cause, got: ${err.message}`);
+        return true;
+      },
+    );
+
+    assert.ok(probe.failCount > 0, 'probe must have recorded failures');
+    assert.ok(probe.lastError, 'probe must retain the last error');
+  });
+
+  it('a probe whose triggers all succeed says so — pointing at the peer, not the trigger', async () => {
+    const probe = makeTriggerProbe(INSTANCES.a, 'ythril_totally-invalid-token', 'nonexistent-net', 'A');
+    // Never invoked, so nothing failed: the diagnosis must not blame the trigger.
+    assert.match(probe.diagnose(), /all succeeded/);
+  });
+});

--- a/testing/sync/closed-network.test.js
+++ b/testing/sync/closed-network.test.js
@@ -12,7 +12,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { dockerExec,
   INSTANCES,
-  post, get, del, delWithBody, triggerSync, waitFor,
+  post, get, del, delWithBody, triggerSync, waitFor, makeTriggerProbe,
 } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -139,16 +139,17 @@ describe('Closed Network (A <-> B)', () => {
 
     // Trigger sync on A (A pulls from B — B doesn't have this network configured).
     // Re-trigger every 3 seconds in case the first async fire was queued behind other work.
+    // The probe records failures so a persistently-rejected trigger is reported as itself
+    // rather than as a bare timeout (see makeTriggerProbe).
     await triggerSync(INSTANCES.a, tokenA, networkId);
-    const retrigger = setInterval(() => {
-      triggerSync(INSTANCES.a, tokenA, networkId).catch(() => {});
-    }, 3_000);
+    const triggerA = makeTriggerProbe(INSTANCES.a, tokenA, networkId, 'A');
+    const retrigger = setInterval(() => { void triggerA(); }, 3_000);
 
     try {
       await waitFor(async () => {
         const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
         return r.status === 200;
-      }, 20_000);
+      }, 20_000, 500, triggerA.diagnose);
     } finally {
       clearInterval(retrigger);
     }

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -145,20 +145,62 @@ export async function get(baseUrl, token, path) {
   return reqJson(baseUrl, token, path);
 }
 
-/** Poll until condition() returns true or timeout (ms) */
-export async function waitFor(condition, timeout = 15_000, interval = 500) {
+/**
+ * Poll until condition() returns true or timeout (ms).
+ *
+ * `diagnose` (string or fn) is appended to the timeout message. Use it to explain WHY
+ * the wait failed — a bare "timed out after 90000ms" is nearly useless, and actively
+ * dangerous: a persistent, actionable error can masquerade as a mysterious flake. That
+ * is exactly how the notify rate-limit bug hid for weeks — every sync trigger was being
+ * rejected with 429, the tests swallowed it, and all we ever saw was a timeout.
+ */
+export async function waitFor(condition, timeout = 15_000, interval = 500, diagnose) {
   const start = Date.now();
   while (Date.now() - start < timeout) {
     if (await condition()) return true;
     await new Promise(r => setTimeout(r, interval));
   }
-  throw new Error(`waitFor timed out after ${timeout}ms`);
+  const detail = typeof diagnose === 'function' ? diagnose() : diagnose;
+  throw new Error(`waitFor timed out after ${timeout}ms${detail ? ` — ${detail}` : ''}`);
 }
 
-/** Trigger a sync run on an instance for a given networkId */
+/** Trigger a sync run on an instance for a given networkId. Throws on any non-200. */
 export async function triggerSync(baseUrl, token, networkId) {
   const r = await post(baseUrl, token, '/api/notify/trigger', { networkId });
   if (r.status !== 200) throw new Error(`triggerSync failed: ${r.status} ${JSON.stringify(r.body)}`);
+}
+
+/**
+ * Build a sync trigger for use INSIDE a waitFor poll.
+ *
+ * Re-triggering each poll is deliberate (a single up-front trigger races a slow gossip
+ * cycle), but a naked `triggerSync(...).catch(() => {})` is a trap: it tolerates a
+ * transient blip and a permanent misconfiguration identically, and the latter then
+ * shows up only as an unexplained timeout.
+ *
+ * This tolerates failures so one bad poll doesn't fail the test, but REMEMBERS the last
+ * one. Pass `probe.diagnose` to waitFor so a persistent failure is reported as itself
+ * (e.g. "429 Too Many Requests") instead of a silent stall.
+ */
+export function makeTriggerProbe(baseUrl, token, networkId, label = baseUrl) {
+  const probe = async () => {
+    try {
+      await triggerSync(baseUrl, token, networkId);
+      probe.lastError = null;
+      probe.okCount++;
+    } catch (err) {
+      probe.lastError = err;
+      probe.failCount++;
+    }
+  };
+  probe.lastError = null;
+  probe.okCount = 0;
+  probe.failCount = 0;
+  probe.diagnose = () =>
+    probe.lastError
+      ? `every sync trigger to ${label} was failing (${probe.failCount} failed / ${probe.okCount} ok); last error: ${probe.lastError.message}`
+      : `sync triggers to ${label} all succeeded (${probe.okCount}) — the peer simply never delivered the expected state`;
+  return probe;
 }
 
 /** Create a memory on an instance's general space */

--- a/testing/sync/vote-signing.test.js
+++ b/testing/sync/vote-signing.test.js
@@ -19,7 +19,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { dockerExec, INSTANCES, post, del, delWithBody, triggerSync, waitFor } from './helpers.js';
+import { dockerExec, INSTANCES, post, del, delWithBody, waitFor, makeTriggerProbe } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -127,22 +127,27 @@ describe('Signed governance votes and safe relay', () => {
     // Propagate to B and confirm the signature survived unchanged. Re-trigger the
     // sync on each poll so a slow gossip cycle on a loaded CI runner still converges
     // (a single up-front trigger raced the injection and made this test flaky).
+    // The probe records trigger failures so a persistent one is reported as itself
+    // rather than as a bare timeout — see makeTriggerProbe.
+    const triggerB = makeTriggerProbe(INSTANCES.b, tokenB, networkId, 'B');
     await waitFor(async () => {
-      await triggerSync(INSTANCES.b, tokenB, networkId).catch(() => {});
+      await triggerB();
       const rb = readConfig('ythril-b').networks.find(n => n.id === networkId)?.pendingRounds.find(r => r.roundId === roundId);
       const bCast = rb?.votes?.find(v => v.instanceId === instanceIdA);
       return bCast?.sig === aCast.sig;
-    }, 90_000, 2_000);
+    }, 90_000, 2_000, triggerB.diagnose);
   });
 
   it('peers pin each other\'s signing public keys via gossip', async () => {
+    const triggerA = makeTriggerProbe(INSTANCES.a, tokenA, networkId, 'A');
+    const triggerB = makeTriggerProbe(INSTANCES.b, tokenB, networkId, 'B');
     await waitFor(async () => {
-      await triggerSync(INSTANCES.a, tokenA, networkId).catch(() => {});
-      await triggerSync(INSTANCES.b, tokenB, networkId).catch(() => {});
+      await triggerA();
+      await triggerB();
       const aSeesB = readConfig('ythril-a').networks.find(n => n.id === networkId)?.members.find(m => m.instanceId === instanceIdB)?.signingPublicKey;
       const bSeesA = readConfig('ythril-b').networks.find(n => n.id === networkId)?.members.find(m => m.instanceId === instanceIdA)?.signingPublicKey;
       return !!aSeesB && !!bSeesA;
-    }, 90_000, 2_000);
+    }, 90_000, 2_000, () => `${triggerA.diagnose()} | ${triggerB.diagnose()}`);
   });
 
   it('a VALID signed cast from a third instance is accepted when relayed by B; a tampered one is rejected', async () => {
@@ -169,18 +174,21 @@ describe('Signed governance votes and safe relay', () => {
     patch('ythril-b', networkId, `n.pendingRounds=n.pendingRounds||[];n.pendingRounds.push(${JSON.stringify(mkRound(validRid, 'yes', validSig))});n.pendingRounds.push(${JSON.stringify(mkRound(tamperRid, 'veto', tamperSig))});`);
     await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
 
-    // A pulls from B (relay). Re-trigger each poll so the relay converges even when
-    // a loaded CI runner's gossip cycle lags. runSyncForNetwork coalesces concurrent
-    // triggers (one in-flight cycle + one queued rerun), so a re-trigger only guarantees
-    // ONE more full cycle — and under full-suite load a cycle can take tens of seconds.
-    // The window must fit a few of those cycles, hence 90s (it still exits as soon as the
-    // relay lands — usually within seconds when the stack isn't saturated).
+    // A pulls from B (relay). Re-trigger each poll so the relay converges even when a
+    // loaded CI runner's gossip cycle lags; the window is generous because it exits as
+    // soon as the relay lands (usually seconds).
+    //
+    // This is the assertion that used to "flake". It never was flaky: under full-suite
+    // load the harness exhausted the notify limiter (60/min per IP, shared by every
+    // instance), every trigger came back 429, the old `.catch(() => {})` ate it, and so
+    // NO sync cycle ran at all. The probe below reports that class of failure as itself.
+    const triggerA = makeTriggerProbe(INSTANCES.a, tokenA, networkId, 'A');
     await waitFor(async () => {
-      await triggerSync(INSTANCES.a, tokenA, networkId).catch(() => {});
+      await triggerA();
       const nets = readConfig('ythril-a').networks.find(n => n.id === networkId);
       const ok = nets?.pendingRounds?.find(r => r.roundId === validRid);
       return ok?.votes?.some(v => v.instanceId === instanceIdC && v.vote === 'yes');
-    }, 90_000, 2_000);
+    }, 90_000, 2_000, triggerA.diagnose);
 
     const netA = readConfig('ythril-a').networks.find(n => n.id === networkId);
     const validRound = netA.pendingRounds.find(r => r.roundId === validRid);


### PR DESCRIPTION
Follow-up to #176. That bug survived **three** wrong fixes for one reason: **the tests hid it.**

## The trap

The sync suites re-trigger a sync on every poll — deliberate, since a single up-front trigger races a slow gossip cycle — but they did it as:

```js
await triggerSync(INSTANCES.a, tokenA, networkId).catch(() => {});
```

That treats a **transient blip** and a **permanent misconfiguration** identically. So when the harness exhausted the notify limiter and every trigger came back `429`, the `.catch()` ate it, **no sync cycle ever ran**, and the only evidence was:

```
waitFor timed out after 90000ms
```

A clear, actionable error was laundered into a mystery flake — and a bare timeout invites you to "fix" the *timing* (which is exactly what #165 and #168 did, and #168 made it worse by polling harder).

## The guard

Test-harness only:

- **`waitFor(…, diagnose)`** — optional string/fn appended to the timeout message.
- **`makeTriggerProbe()`** replaces the naked catch. It still tolerates a failed poll (one blip must not fail a test) but **remembers the last failure** and reports it:
  - persistent failure → `every sync trigger to A was failing (45 failed / 0 ok); last error: triggerSync failed: 429 …`
  - healthy triggers → `sync triggers to A all succeeded (45) — the peer simply never delivered the expected state` → correctly points at the **peer**, not the trigger.
- Applied to the three vote-signing waits and the closed-network retrigger loop — **every site that swallowed a trigger error**.

## Tests

New `testing/standalone/waitfor-diagnostics.test.js` pins the guard, including a probe with an invalid token asserting the timeout message carries the **real cause** (`triggerSync failed: 401`) instead of a bare stall.

Sync **173 pass / 0 fail**, standalone **751 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)