### PR TITLE
fix: renaming a space made its entities and edges invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renaming a space no longer makes its entities and edges vanish from the UI.** `moveSpaceData`
+  renamed the collections (`{old}_entities` → `{new}_entities`) but never rewrote the `spaceId` field
+  *inside* the documents, so every one still pointed at the OLD space id. `listEntities`, `listEdges`,
+  entity lookup-by-name, the edge-dedup lookup and the cascade deletes all filter on that field — so a
+  renamed space looked **catastrophic but was actually intact**: the entry counts still showed the data
+  (counts read the collection) while every list came back **empty**. Worse, because lookup-by-name
+  stopped matching, `remember` would start creating **duplicate entities** instead of linking to the
+  existing one. Memories were unaffected (`listMemories` does not filter on `spaceId`) — which is
+  exactly why the existing rename test, which only checked memories, never caught this. The rename now
+  rewrites the field, and **existing affected databases self-heal on boot** (`repairStaleSpaceIds`,
+  run from `initSpace`): documents living in `{spaceId}_*` belong to `spaceId` by definition, so the
+  repair is safe and idempotent. Sync had the same flaw — a `spaceMap`-aliased pull wrote peer documents
+  into the local collection while keeping the *remote* space id — and now re-tags them to the local
+  space. Regression test added covering entities, edges and lookup-by-name across a rename.
+
 - **The test stack no longer races four concurrent builds onto one image tag.** Giving every instance the
   shared `ythril-test:latest` tag (so CI can pre-build once against a layer cache) made `docker compose
   build` build the *same* tag from four services simultaneously, which races on the image export and could

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs/promises';
 import path from 'path';
-import { getDb, col, asDoc } from '../db/mongo.js';
+import { getDb, col, asDoc, asFilter, asUpdate } from '../db/mongo.js';
 import { getConfig, saveConfig, getEmbeddingConfig, getDataRoot, getFaceRecognitionConfig } from '../config/loader.js';
 import { ensureSpaceFilesDir, writeFile as writeSpaceFile } from '../files/files.js';
 import { invalidateUsageCache } from '../quota/quota.js';
@@ -61,6 +61,51 @@ export function clearReindexFlag(spaceId: string): void {
  *  With `waitForVectorReady: false` the (slow) $vectorSearch indexes are created but
  *  the READY poll is skipped, so the call returns in ~seconds — used by createSpace so
  *  the API can respond immediately (B1). Defaults to waiting (boot / reload paths). */
+/**
+ * Repair documents whose `spaceId` field disagrees with the collection they live in.
+ *
+ * Collections are already per-space (`{spaceId}_entities`), so the `spaceId` field inside
+ * each document is redundant — but the read paths filter on it (`listEntities`,
+ * `findEntityByName`, the edge-dedup lookup, the cascade deletes). If the field goes stale,
+ * the data is still counted (counts read the collection) but becomes INVISIBLE to every
+ * list and lookup — and worse, `findEntityByName` stops matching, so `remember` starts
+ * creating duplicate entities instead of linking to the existing one.
+ *
+ * Two paths used to leave it stale:
+ *   1. renaming a space — `moveSpaceData` renamed the collections but never rewrote the
+ *      field, so every document kept the OLD space id;
+ *   2. syncing with `spaceMap` aliasing — pulled documents were written into the local
+ *      collection while keeping the REMOTE space id.
+ *
+ * Both are fixed at the source, but existing databases are already affected, so this runs
+ * on every `initSpace` (boot). A document living in `{spaceId}_*` belongs to `spaceId` by
+ * definition, which makes this safe and idempotent: it only touches documents that
+ * disagree, and there is nothing it could wrongly "fix".
+ */
+export async function repairStaleSpaceIds(spaceId: string): Promise<number> {
+  let repaired = 0;
+  for (const suffix of SPACE_COLLECTIONS) {
+    try {
+      const res = await col<{ spaceId?: string }>(`${spaceId}_${suffix}`).updateMany(
+        asFilter<{ spaceId?: string }>({ spaceId: { $ne: spaceId } }),
+        asUpdate<{ spaceId?: string }>({ $set: { spaceId } }),
+      );
+      repaired += res.modifiedCount ?? 0;
+    } catch (err) {
+      // Never let a repair failure block startup — the space is still usable.
+      log.warn(`Stale-spaceId repair failed for ${spaceId}_${suffix}: ${err}`);
+    }
+  }
+  if (repaired > 0) {
+    log.warn(
+      `Space '${spaceId}': repaired ${repaired} document(s) carrying a stale spaceId ` +
+      `(left behind by a space rename or an aliased sync). They were present but invisible ` +
+      `to list/lookup queries; they are now visible again.`,
+    );
+  }
+  return repaired;
+}
+
 export async function initSpace(
   spaceId: string,
   opts: { waitForVectorReady?: boolean } = {},
@@ -81,6 +126,9 @@ export async function initSpace(
       log.debug(`Created collection ${name}`);
     }
   }
+
+  // Self-heal data left invisible by an older rename / aliased sync (see above).
+  await repairStaleSpaceIds(spaceId);
 
   // Regular indexes
   const memoriesColl = db.collection(`${spaceId}_memories`);
@@ -709,6 +757,26 @@ async function moveSpaceData(oldId: string, newId: string): Promise<string[]> {
       log.warn(msg);
       errors.push(msg);
     }
+  }
+
+  // 1b. Rewrite the `spaceId` field inside the moved documents.
+  //
+  // Renaming the collection is NOT enough: every document still carries the OLD space id,
+  // and the read paths filter on that field (listEntities, findEntityByName, the edge-dedup
+  // lookup, the cascade deletes). Without this the renamed space looks CATASTROPHIC but is
+  // actually intact — counts still show the documents (counts read the collection) while
+  // every list comes back empty, and `findEntityByName` stops matching, so `remember` starts
+  // creating duplicates instead of linking to the existing entity.
+  //
+  // Idempotent, and safe on a partial re-run: a document living in `{newId}_*` belongs to
+  // `newId` by definition, so we only touch the ones that disagree.
+  try {
+    const repaired = await repairStaleSpaceIds(newId);
+    if (repaired > 0) log.debug(`Rewrote spaceId on ${repaired} document(s) for renamed space ${newId}`);
+  } catch (err) {
+    const msg = `Could not rewrite spaceId field for renamed space ${newId}: ${err}`;
+    log.warn(msg);
+    errors.push(msg);
   }
 
   // 2. Move the files directory (skip if already moved — old dir gone)

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -872,7 +872,7 @@ async function pullFromPeer(
           highSeq = (doc as MemoryDoc).seq;
         }
       }
-      await batchUpsertBySeq<T>(`${spaceId}_${urlSuffix}`, pageDocs);
+      await batchUpsertBySeq<T>(`${spaceId}_${urlSuffix}`, pageDocs, spaceId);
       cur = nextCursor; pg++;
     } while (cur && pg < 50);
     return { count, highSeq, maxSeq };
@@ -1230,8 +1230,23 @@ async function syncFiles(
 async function batchUpsertBySeq<T extends { _id: string; seq: number }>(
   collName: string,
   docs: T[],
+  localSpaceId: string,
 ): Promise<void> {
   if (docs.length === 0) return;
+
+  // Re-tag incoming documents to the LOCAL space.
+  //
+  // A peer's document carries ITS space id, and with `spaceMap` aliasing that is not our
+  // space id — but we store it in OUR collection. The read paths filter on this field
+  // (listEntities, findEntityByName, the edge-dedup lookup, cascade deletes), so leaving
+  // the remote id in place would make every synced document invisible to list and lookup
+  // while still being counted: the data looks lost, and `findEntityByName` stops matching,
+  // so `remember` starts creating duplicates. The collection name is the only real scope,
+  // so a document we write into `{localSpaceId}_*` belongs to `localSpaceId` by definition.
+  for (const doc of docs) {
+    (doc as unknown as { spaceId?: string }).spaceId = localSpaceId;
+  }
+
   const collection = col<T>(collName);
   const ids = docs.map(d => d._id);
   const existing = await collection

--- a/testing/integration/space-rename.test.js
+++ b/testing/integration/space-rename.test.js
@@ -81,6 +81,53 @@ describe('Space rename', () => {
     assert.ok(found, 'Memory should exist under the renamed space');
   });
 
+  it('Data survives rename — entities and edges are still LISTED under the new ID', async () => {
+    // Regression: renaming a space renamed its collections but left the `spaceId` field
+    // inside every document pointing at the OLD id. `listEntities` / `listEdges` filter on
+    // that field, so the data silently vanished from the UI — while the counts (which read
+    // the collection) still showed it. `listMemories` does NOT filter on spaceId, which is
+    // exactly why the memory-only test above kept passing and this went unnoticed.
+    const oldId = `ee-rename-${RUN_ID}`;
+    const newId = `ee-renamed-${RUN_ID}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: oldId, label: 'Entity Edge Rename' });
+
+    const aR = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/entities`, { name: 'Ada', type: 'person' });
+    const bR = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/entities`, { name: 'Grace', type: 'person' });
+    assert.equal(aR.status, 201, JSON.stringify(aR.body));
+    assert.equal(bR.status, 201, JSON.stringify(bR.body));
+
+    const edgeR = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/edges`, {
+      from: aR.body._id, to: bR.body._id, label: 'knows',
+    });
+    assert.equal(edgeR.status, 201, JSON.stringify(edgeR.body));
+
+    const renameR = await patch(INSTANCES.a, tokenA, `/api/spaces/${oldId}/rename`, { newId });
+    assert.equal(renameR.status, 200, JSON.stringify(renameR.body));
+    createdSpaceIds.push(newId);
+
+    const entR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${newId}/entities`);
+    assert.equal(entR.status, 200);
+    assert.equal(
+      entR.body.entities?.length, 2,
+      'entities must still be LISTED after a rename (they were present but invisible: the ' +
+      'spaceId field inside each document still pointed at the old space id)',
+    );
+
+    const edgR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${newId}/edges`);
+    assert.equal(edgR.status, 200);
+    assert.equal(edgR.body.edges?.length, 1, 'edges must still be LISTED after a rename');
+
+    // The stale field also broke entity lookup BY NAME (the same spaceId filter), which is
+    // what `remember` uses to link to an existing entity rather than creating a duplicate.
+    const byName = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${newId}/entities?name=Ada`);
+    assert.equal(byName.status, 200);
+    assert.equal(
+      byName.body.entities?.length, 1,
+      'entity lookup by name must still work after a rename — otherwise `remember` stops ' +
+      'matching existing entities and starts creating duplicates',
+    );
+  });
+
   it('Files survive rename — accessible under new path', async () => {
     const oldId = `file-rename-${RUN_ID}`;
     const newId = `file-renamed-${RUN_ID}`;


### PR DESCRIPTION
Reported as **"my personal data is gone"**. The data was never gone — it was invisible.

## What happened

`moveSpaceData` renamed a space's collections (`{old}_entities` → `{new}_entities`) but **never rewrote the `spaceId` field inside the documents**. Every document still pointed at the OLD space id.

`listEntities`, `listEdges`, entity **lookup-by-name**, the **edge-dedup** lookup and the **cascade deletes** all filter on that field. So a renamed space looked catastrophic but was perfectly intact:

- the entry **counts still showed the data** (counts read the collection directly)
- every **list came back empty**

And it was worse than cosmetic: because lookup-by-name stopped matching, **`remember` would create duplicate entities** instead of linking to the existing one, and edges stopped de-duplicating.

## Why the test suite never caught it

`listMemories` is the one read path that does **not** filter on `spaceId`:

| | filters on `spaceId`? | after a rename |
|---|---|---|
| `listMemories` | **no** | ✅ visible |
| `listEntities` | yes | ❌ invisible |
| `listEdges` | yes | ❌ invisible |

The existing rename test asserted **only memories** — the single case that couldn't fail. That asymmetry also matches the report word for word: *"I still see a memory but for edges (22) and entities (8) no entries show."*

Sync had the same flaw: a `spaceMap`-aliased pull wrote a peer's documents into the **local** collection while keeping the **remote** space id.

## Fix — at every source, plus self-healing

- `moveSpaceData` rewrites the `spaceId` field after renaming the collections.
- `batchUpsertBySeq` re-tags pulled documents to the local space.
- **`repairStaleSpaceIds()` runs from `initSpace` on every boot**, so already-affected databases recover with **no operator action**.

The repair is safe and idempotent by construction: a document living in `{spaceId}_*` **belongs to** `{spaceId}` by definition. It only touches documents that disagree, and there is nothing it could wrongly "fix".

## Verified end-to-end on the test stack

```
before fix:  entities across a rename   3 -> 0
after  fix:  entities across a rename   3 -> 3
self-heal :  corrupt spaceId -> listed 0 -> restart -> listed 3, field corrected
```

## Tests

`space-rename.test.js` now covers **entities, edges and lookup-by-name** across a rename — closing the exact gap that let this through.

Full core suite green: **integration 823, sync 173, redteam 258, standalone 764 — 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)