### PR TITLE
security: allow authenticating the bundled MongoDB (S7, part 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# Ythril — Docker Compose environment.
+#
+#   cp .env.example .env      then edit the values below.
+#
+# .env is gitignored. Never commit real credentials.
+
+# ── Database credentials (bundled MongoDB) ───────────────────────────────────
+#
+# SET THESE ON A NEW INSTALL.
+#
+# The bundled database is unauthenticated unless you set these. That matters more than it
+# looks: Ythril's tokens, admin gating, space scoping and audit log are enforced at the API
+# layer ONLY — not at the database. Anything that can open a TCP connection to port 27017
+# can read and rewrite EVERY space, invisibly to the audit log.
+#
+# Generate a strong password, e.g.:
+#
+#   openssl rand -base64 24
+#
+MONGO_USERNAME=ythril
+MONGO_PASSWORD=CHANGE_ME
+
+# IMPORTANT — EXISTING INSTALLS: leave these EMPTY.
+#
+# MongoDB cannot have authentication switched on in place. The Atlas Local image runs a
+# single-node replica set (required for $vectorSearch) and only provisions the internal
+# keyfile that auth needs on a FIRST init. Adding credentials to a database that already
+# has data does NOT enable auth — mongod fails to start with
+# "Unable to acquire security key[s]".
+#
+# Migrating an existing database is a deliberate dump/restore. See docs/dependencies.md.
+
+# ── Port ─────────────────────────────────────────────────────────────────────
+# Host port the UI/API is published on (container always listens on 3200).
+YTHRIL_PORT=3200
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+# Point at an EXTERNAL database (managed Atlas, your own cluster). When set, this wins over
+# MONGO_USERNAME/MONGO_PASSWORD above, and you should remove the bundled ythril-mongo
+# service from docker-compose.yml.
+#   MONGO_URI=mongodb+srv://user:pass@cluster.example.mongodb.net/ythril
+#
+# Prevent API-driven database migration when the DB is managed by your infrastructure:
+#   YTHRIL_MONGO_INFRA_MANAGED=true
+#
+# Verbose logging:
+#   DEBUG=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The bundled MongoDB can now be authenticated, and new installs should be.** The bundled database
+  accepted any connection, and Ythril's security model (tokens, admin gating, space scoping, read-only
+  tokens, the audit log) is enforced at the **API layer only** — so anything able to reach port 27017 could
+  read and rewrite every space, invisibly to the audit log. Set `MONGO_USERNAME` / `MONGO_PASSWORD` (see the
+  new `.env.example`) and Ythril connects with credentials, percent-encoded so a password containing `@`,
+  `:` or `/` cannot corrupt the URI. An explicit `MONGO_URI` (managed Atlas, your own cluster) still wins
+  and is untouched. The test stack now runs **authenticated**, so every CI run proves Ythril works against
+  a credentialed database.
+  **Existing installs are unaffected and must not just add credentials:** MongoDB cannot have auth switched
+  on in place — the Atlas Local image runs a single-node replica set (needed for `$vectorSearch`) and only
+  provisions the required internal keyfile on a **first** init, so adding credentials to a database that
+  already holds data makes mongod fail to start (`Unable to acquire security key[s]`). Leaving the variables
+  empty preserves today's behaviour exactly; migrating is a deliberate dump/restore, documented in
+  `docs/dependencies.md`.
+  Also fixes a **vacuous test**: `mongoUriRedacted` asserted the URI contained no `@`, which passed only
+  because the test database had no credentials — the redaction path never ran. It now asserts the password
+  is absent and that a `user:pass` pair cannot survive redaction.
+
 ### Added
 
 - **Cross-origin embedding is now possible — explicitly opt-in, and never by default.** Portal-style

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@
       CONFIG_PATH: /config/config.json
       DATA_ROOT: /data
       NODE_ENV: production
+      # Credentials for the BUNDLED database (see the ythril-mongo service below and
+      # .env.example). When set, Ythril connects with authentication; when empty it falls
+      # back to the historical unauthenticated URI, so existing installs keep working.
+      # An explicit MONGO_URI (external cluster / managed Atlas) overrides both.
+      MONGO_USERNAME: ${MONGO_USERNAME:-}
+      MONGO_PASSWORD: ${MONGO_PASSWORD:-}
       YTHRIL_LOCAL_AGENT_ENABLED: ${YTHRIL_LOCAL_AGENT_ENABLED:-}
       YTHRIL_LOCAL_AGENT_URL: ${YTHRIL_LOCAL_AGENT_URL:-http://localhost:38123}
       YTHRIL_LOCAL_AGENT_TOKEN: ${YTHRIL_LOCAL_AGENT_TOKEN:-}
@@ -47,12 +53,29 @@
     restart: unless-stopped
     logging:
       driver: "none"
+    environment:
+      # SECURITY: authenticate the bundled database. Unauthenticated, anything that can reach
+      # port 27017 can read and rewrite EVERY space — Ythril's tokens, space scoping and audit
+      # log are enforced at the API layer only, not at the database (S7).
+      #
+      # Set MONGO_USERNAME / MONGO_PASSWORD in .env (see .env.example). New installs should
+      # always set them. They are OPTIONAL, and empty means "no auth", because MongoDB cannot
+      # have auth switched on in place: the Atlas Local image runs a single-node replica set
+      # (needed for $vectorSearch) and only provisions the required internal keyfile on a
+      # FIRST init. Adding credentials to an existing database therefore does NOT enable auth
+      # — it makes mongod fail to start ("Unable to acquire security key[s]"). Migrating an
+      # existing database is a deliberate, documented dump/restore (see docs/dependencies.md).
+      MONGODB_INITDB_ROOT_USERNAME: ${MONGO_USERNAME:-}
+      MONGODB_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-}
     volumes:
       - ythril-mongo-data:/data/db
       - ythril-mongo-configdb:/data/configdb
     healthcheck:
-      # Wait for the replica set to elect a primary (not just mongod accepting connections)
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
+      # Wait for the replica set to elect a primary (not just mongod accepting connections).
+      # mongosh does NOT pick the root credentials up from the environment, so pass them
+      # explicitly — otherwise the healthcheck fails permanently once auth is enabled.
+      # Falls back to an unauthenticated probe when no credentials are configured.
+      test: ["CMD", "sh", "-c", "if [ -n \"$$MONGODB_INITDB_ROOT_USERNAME\" ]; then mongosh --quiet -u \"$$MONGODB_INITDB_ROOT_USERNAME\" -p \"$$MONGODB_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval 'db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)'; else mongosh --quiet --eval 'db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)'; fi"]
       interval: 10s
       timeout: 10s
       retries: 18

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -52,6 +52,61 @@ bridge network (`ythril-db`). Ythril connects to it over TCP at `mongodb://ythri
 > If you add a service that needs the database, put it on `ythril-db` deliberately — and
 > understand that you are granting it unauthenticated access to the entire brain.
 
+### Authenticating the bundled database
+
+**New installs: just set credentials.** Copy `.env.example` to `.env` and set:
+
+```bash
+MONGO_USERNAME=ythril
+MONGO_PASSWORD=$(openssl rand -base64 24)
+```
+
+Compose passes them to the database as the root user and to Ythril, which builds an
+authenticated connection URI. Nothing else is required.
+
+**Existing installs: leave them empty, and migrate deliberately.**
+
+MongoDB **cannot have authentication switched on in place**. The Atlas Local image runs a
+single-node replica set (required for `$vectorSearch`), and auth on a replica set needs an
+internal keyfile that the image only provisions on a **first** init. Adding credentials to a
+database that already holds data does **not** enable auth — mongod fails to start with
+`Unable to acquire security key[s]`, and hand-placing a keyfile breaks the replica set
+(`node is not in primary or recovering state`).
+
+So migrating means recreating the database and restoring into it. **Back up first.**
+
+```bash
+# 1. Dump the application database ONLY. Never dump/restore `admin` — it holds the auth
+#    users, and restoring it over a fresh instance clobbers the account you just created.
+docker exec ythril-mongo mongodump --db=ythril --out=/tmp/dump
+docker cp ythril-mongo:/tmp/dump ./mongo-dump
+
+# 2. Also copy the data directory itself, so the old state is recoverable.
+cp -r local-data/mongo local-data/mongo.backup
+
+# 3. Set MONGO_USERNAME / MONGO_PASSWORD in .env, then recreate the database from empty
+#    (this is the only path on which the image can enable auth).
+docker compose down
+docker volume rm ythril_ythril-mongo-data ythril_ythril-mongo-configdb   # or clear the bind mount
+docker compose up -d ythril-mongo
+
+# 4. Restore, authenticating with the new credentials.
+docker cp ./mongo-dump ythril-mongo:/tmp/dump
+docker exec ythril-mongo mongorestore \
+  -u "$MONGO_USERNAME" -p "$MONGO_PASSWORD" --authenticationDatabase admin \
+  --db=ythril /tmp/dump/ythril
+
+# 5. Start Ythril. It rebuilds the $vectorSearch indexes on boot.
+docker compose up -d
+```
+
+Verify before deleting the backup: the entry counts in **Settings → Spaces** should match
+what you had, and semantic recall should return results once the vector indexes finish
+building.
+
+**Already using managed Atlas or your own cluster?** Nothing to do — set `MONGO_URI` and it
+wins over everything above; those deployments are already authenticated.
+
 ```
 [ythril container] --TCP:27017--> [ythril-mongo container]
                                    ├── mongod (SSPL)

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -373,8 +373,29 @@ export function getEmbeddingConfig() {
 
 export function getMongoUri(): string {
   const cfg = _config;
-  // env var wins — infra-managed deployments must be able to override config.json
-  return process.env['MONGO_URI'] ?? cfg?.mongo?.uri ?? 'mongodb://ythril-mongo:27017/ythril?directConnection=true';
+  // An explicit URI always wins — infra-managed deployments (managed Atlas, an existing
+  // cluster) must be able to override, and they carry their own credentials.
+  const explicit = process.env['MONGO_URI'] ?? cfg?.mongo?.uri;
+  if (explicit) return explicit;
+
+  // Otherwise we are talking to the BUNDLED `ythril-mongo` container. If the operator
+  // supplied credentials for it, authenticate — the bundled database is unauthenticated
+  // by default, which means anything that can reach port 27017 can read and rewrite every
+  // space, bypassing tokens, space scoping and the audit log entirely (see S7).
+  //
+  // Credentials are optional so that EXISTING installs keep working: MongoDB cannot have
+  // auth switched on in place (the Atlas Local image only provisions the replica-set
+  // keyfile on a first init), so an existing database must be migrated deliberately.
+  const user = process.env['MONGO_USERNAME'];
+  const pass = process.env['MONGO_PASSWORD'];
+  if (user && pass) {
+    // Percent-encode: a password may legitimately contain `@`, `:`, `/` etc., which would
+    // otherwise be parsed as URI delimiters and produce a confusing connection failure.
+    const creds = `${encodeURIComponent(user)}:${encodeURIComponent(pass)}`;
+    return `mongodb://${creds}@ythril-mongo:27017/ythril?directConnection=true&authSource=admin`;
+  }
+
+  return 'mongodb://ythril-mongo:27017/ythril?directConnection=true';
 }
 
 export function getDataRoot(): string {

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -40,7 +40,7 @@ services:
     environment:
       CONFIG_PATH: /config/config.json
       DATA_ROOT: /data
-      MONGO_URI: mongodb://ythril-mongo-a:27017/?directConnection=true
+      MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-a:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
@@ -68,8 +68,13 @@ services:
     volumes:
       - ythril-mongo-a-data:/data/db
       - ythril-mongo-a-configdb:/data/configdb
+    environment:
+      # Authenticate the test databases too — this is what proves, on every CI run, that
+      # Ythril actually works against an authenticated MongoDB (see S7 / .env.example).
+      MONGODB_INITDB_ROOT_USERNAME: ythril
+      MONGODB_INITDB_ROOT_PASSWORD: ythril-test-pw
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
+      test: ["CMD", "mongosh", "--quiet", "-u", "ythril", "-p", "ythril-test-pw", "--authenticationDatabase", "admin", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
       interval: 10s
       timeout: 10s
       retries: 18
@@ -91,7 +96,7 @@ services:
     environment:
       CONFIG_PATH: /config/config.json
       DATA_ROOT: /data
-      MONGO_URI: mongodb://ythril-mongo-b:27017/?directConnection=true
+      MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-b:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
@@ -115,8 +120,13 @@ services:
     volumes:
       - ythril-mongo-b-data:/data/db
       - ythril-mongo-b-configdb:/data/configdb
+    environment:
+      # Authenticate the test databases too — this is what proves, on every CI run, that
+      # Ythril actually works against an authenticated MongoDB (see S7 / .env.example).
+      MONGODB_INITDB_ROOT_USERNAME: ythril
+      MONGODB_INITDB_ROOT_PASSWORD: ythril-test-pw
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
+      test: ["CMD", "mongosh", "--quiet", "-u", "ythril", "-p", "ythril-test-pw", "--authenticationDatabase", "admin", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
       interval: 10s
       timeout: 10s
       retries: 18
@@ -138,7 +148,7 @@ services:
     environment:
       CONFIG_PATH: /config/config.json
       DATA_ROOT: /data
-      MONGO_URI: mongodb://ythril-mongo-c:27017/?directConnection=true
+      MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-c:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
     depends_on:
@@ -159,8 +169,13 @@ services:
     volumes:
       - ythril-mongo-c-data:/data/db
       - ythril-mongo-c-configdb:/data/configdb
+    environment:
+      # Authenticate the test databases too — this is what proves, on every CI run, that
+      # Ythril actually works against an authenticated MongoDB (see S7 / .env.example).
+      MONGODB_INITDB_ROOT_USERNAME: ythril
+      MONGODB_INITDB_ROOT_PASSWORD: ythril-test-pw
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
+      test: ["CMD", "mongosh", "--quiet", "-u", "ythril", "-p", "ythril-test-pw", "--authenticationDatabase", "admin", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
       interval: 10s
       timeout: 10s
       retries: 18
@@ -184,7 +199,7 @@ services:
     environment:
       CONFIG_PATH: /config/config.json
       DATA_ROOT: /data
-      MONGO_URI: mongodb://ythril-mongo-d:27017/?directConnection=true
+      MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-d:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
@@ -210,8 +225,13 @@ services:
     volumes:
       - ythril-mongo-d-data:/data/db
       - ythril-mongo-d-configdb:/data/configdb
+    environment:
+      # Authenticate the test databases too — this is what proves, on every CI run, that
+      # Ythril actually works against an authenticated MongoDB (see S7 / .env.example).
+      MONGODB_INITDB_ROOT_USERNAME: ythril
+      MONGODB_INITDB_ROOT_PASSWORD: ythril-test-pw
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
+      test: ["CMD", "mongosh", "--quiet", "-u", "ythril", "-p", "ythril-test-pw", "--authenticationDatabase", "admin", "--eval", "db.adminCommand({replSetGetStatus:1}).myState===1 ? 1 : quit(1)"]
       interval: 10s
       timeout: 10s
       retries: 18

--- a/testing/integration/db-migration.test.js
+++ b/testing/integration/db-migration.test.js
@@ -67,13 +67,32 @@ describe('Data Config — GET /api/admin/data/config', () => {
     assert.ok(['env', 'config', 'default'].includes(r.body.source), `unexpected source: ${r.body.source}`);
   });
 
-  it('returns mongoUriRedacted (no credentials in string)', async () => {
+  it('returns mongoUriRedacted with the credentials stripped', async () => {
     const r = await adminGet('/api/admin/data/config');
     assert.equal(r.status, 200, JSON.stringify(r.body));
-    assert.ok(typeof r.body.mongoUriRedacted === 'string', 'mongoUriRedacted must be a string');
-    assert.ok(r.body.mongoUriRedacted.startsWith('mongodb'), 'URI must start with mongodb');
-    // Must not contain credentials (anything between // and @)
-    assert.ok(!r.body.mongoUriRedacted.includes('@'), 'redacted URI must not contain @');
+    const redacted = r.body.mongoUriRedacted;
+    assert.ok(typeof redacted === 'string', 'mongoUriRedacted must be a string');
+    assert.ok(redacted.startsWith('mongodb'), 'URI must start with mongodb');
+
+    // Assert on the SECRET, not on the '@' delimiter.
+    //
+    // This test used to assert `!redacted.includes('@')`, which passed only because the
+    // test database had no credentials at all — so the redaction path never actually ran.
+    // `redactUri` rewrites `//user:pass@host` to `//[credentials]@host`, deliberately KEEPING
+    // the '@' so the result is still a recognisable URI. The old assertion therefore tested
+    // the fixture, not the redaction, and would have missed a leak of the real password.
+    // The test stack now authenticates, so this exercises the real thing.
+    assert.doesNotMatch(
+      redacted, /ythril-test-pw/,
+      `the password must never be returned; got: ${redacted}`,
+    );
+    assert.doesNotMatch(
+      redacted, /\/\/[^/@]*:[^/@]*@/,
+      `no user:pass pair may survive redaction; got: ${redacted}`,
+    );
+    if (redacted.includes('@')) {
+      assert.match(redacted, /\/\/\[credentials\]@/, `credentials must be masked; got: ${redacted}`);
+    }
   });
 
   it('returns 403 for non-admin token', async () => {

--- a/testing/standalone/mongo-auth-uri.test.js
+++ b/testing/standalone/mongo-auth-uri.test.js
@@ -1,0 +1,85 @@
+/**
+ * Standalone tests: MongoDB connection URI + credentials (S7, part 2).
+ *
+ * The bundled database is unauthenticated unless the operator supplies credentials. That
+ * matters because Ythril's security model (tokens, admin gating, space scoping, the audit
+ * log) is enforced at the API layer ONLY — anything that can reach port 27017 can read and
+ * rewrite every space, invisibly.
+ *
+ * These tests pin getMongoUri()'s precedence and its credential handling:
+ *   - an explicit MONGO_URI always wins (managed Atlas / an existing cluster brings its own
+ *     credentials, and must never be silently rewritten)
+ *   - MONGO_USERNAME/MONGO_PASSWORD authenticate the BUNDLED database
+ *   - credentials are percent-encoded (a password may contain `@`, `:`, `/` — which would
+ *     otherwise be parsed as URI delimiters and produce a baffling connection failure)
+ *   - with no credentials we fall back to the historical unauthenticated URI, so EXISTING
+ *     installs keep working (MongoDB cannot have auth switched on in place)
+ *
+ * Run: node --test testing/standalone/mongo-auth-uri.test.js
+ */
+
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+let getMongoUri;
+const saved = {};
+const KEYS = ['MONGO_URI', 'MONGO_USERNAME', 'MONGO_PASSWORD'];
+
+describe('getMongoUri — bundled-database credentials', () => {
+  before(async () => {
+    for (const k of KEYS) saved[k] = process.env[k];
+    ({ getMongoUri } = await import('../../server/dist/config/loader.js'));
+  });
+
+  beforeEach(() => {
+    for (const k of KEYS) delete process.env[k];
+  });
+
+  after(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('falls back to the unauthenticated URI when no credentials are set (existing installs)', () => {
+    const uri = getMongoUri();
+    assert.equal(uri, 'mongodb://ythril-mongo:27017/ythril?directConnection=true');
+    assert.doesNotMatch(uri, /@/, 'must not invent credentials');
+  });
+
+  it('authenticates against the bundled database when credentials are supplied', () => {
+    process.env['MONGO_USERNAME'] = 'ythril';
+    process.env['MONGO_PASSWORD'] = 'sup3rs3cret';
+    const uri = getMongoUri();
+    assert.match(uri, /^mongodb:\/\/ythril:sup3rs3cret@ythril-mongo:27017\/ythril\?/);
+    assert.match(uri, /authSource=admin/, 'the root user lives in the admin database');
+  });
+
+  it('percent-encodes credentials so URI delimiters in a password cannot break the connection', () => {
+    process.env['MONGO_USERNAME'] = 'user@name';
+    process.env['MONGO_PASSWORD'] = 'p@ss:w/rd';
+    const uri = getMongoUri();
+    assert.match(uri, /user%40name:p%40ss%3Aw%2Frd@ythril-mongo/);
+    // The host must still parse as the host — i.e. the LAST '@' separates credentials.
+    assert.equal(new URL(uri.replace(/^mongodb:/, 'http:')).hostname, 'ythril-mongo');
+  });
+
+  it('an explicit MONGO_URI always wins — it carries its own credentials', () => {
+    process.env['MONGO_URI'] = 'mongodb+srv://u:p@cluster.example.mongodb.net/ythril';
+    process.env['MONGO_USERNAME'] = 'ythril';
+    process.env['MONGO_PASSWORD'] = 'ignored';
+    assert.equal(getMongoUri(), 'mongodb+srv://u:p@cluster.example.mongodb.net/ythril');
+  });
+
+  it('a half-configured credential pair is ignored rather than producing a broken URI', () => {
+    // `mongodb://user:@host` (or `:pass@`) is the kind of thing that fails at connect time
+    // with an opaque error. Requiring BOTH keeps the failure mode obvious instead.
+    process.env['MONGO_USERNAME'] = 'ythril';
+    assert.doesNotMatch(getMongoUri(), /@/, 'username without password must not build a URI');
+
+    delete process.env['MONGO_USERNAME'];
+    process.env['MONGO_PASSWORD'] = 'lonely';
+    assert.doesNotMatch(getMongoUri(), /@/, 'password without username must not build a URI');
+  });
+});


### PR DESCRIPTION
The bundled database accepted **any** connection. Ythril's security model — PATs, admin gating, space scoping, read-only tokens, the audit log — is enforced at the **API layer only**, so anything that could reach port 27017 could read and rewrite every space, invisibly to the audit log. #178 removed the reachable attack path (the media sidecars); this closes the trust-by-default underneath it.

## New installs

Set `MONGO_USERNAME` / `MONGO_PASSWORD` (see the new `.env.example`). Ythril builds an authenticated URI, **percent-encoded** so a password containing `@`, `:` or `/` can't corrupt it into an opaque connection failure. An explicit `MONGO_URI` (managed Atlas / your own cluster) still wins, untouched.

## Existing installs are deliberately unaffected — and must NOT just add credentials

**MongoDB cannot have auth switched on in place.** Atlas Local runs a single-node replica set (required for `$vectorSearch`), and auth on a replica set needs an internal keyfile the image only provisions on a **first** init. Adding credentials to a database that already holds data does **not** enable auth — mongod fails to start (`Unable to acquire security key[s]`), and hand-placing a keyfile breaks the replica set (`node is not in primary or recovering state`).

All of that was verified **on throwaway volumes, never on real data.**

So the variables are **optional**, and empty means "no auth" (verified: an empty env value does not enable auth), preserving today's behaviour byte for byte. Migration is a deliberate dump/restore, documented in `docs/dependencies.md` — including the trap that **dumping `admin` clobbers the auth users on restore**.

## The test stack now runs authenticated

It's torn down with `down -v` and recreated from empty volumes every run, so it always takes the first-init path. **Every CI run now proves Ythril actually works against a credentialed database.**

## That immediately caught a vacuous test

`mongoUriRedacted` asserted the URI contained no `@`. But `redactUri` rewrites `//user:pass@host` → `//[credentials]@host` — deliberately **keeping** the `@`. The old assertion only ever passed because **the test database had no credentials**: it tested the fixture, not the redaction, and would not have caught a leak of the real password.

It now asserts the password is absent and that no `user:pass` pair survives redaction. (Same class as #179 — a test that looked like coverage but exercised the one case that couldn't fail.)

## Tests

New `testing/standalone/mongo-auth-uri.test.js` pins precedence, credential building, percent-encoding, and that a half-configured pair is ignored rather than producing a broken URI.

Full core suite green **against an authenticated database**: **integration 823, sync 173, redteam 258, standalone 769 — 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)