### PR TITLE
fix: complete the stale-spaceId fix — file tombstones, seq counter, cross-space import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Completed the space-rename data-integrity fix — three more instances of the same bug.** The audit that
+  followed the rename fix found the same "stale `spaceId`" flaw in places the first pass missed:
+  - **Deleted files could resurrect.** `{spaceId}_file_tombstones` carries a `spaceId` field and its readers
+    filter on it, but the collection was **missing from the repair's hardcoded list**, so after a rename every
+    pre-rename deletion became invisible to sync — and peers that still held the file pushed it straight back.
+    The repair now **discovers a space's collections by prefix** instead of walking a fixed list, so this and
+    any future per-space collection are covered automatically. (It only rewrites a `spaceId` that is present
+    but wrong, never inventing one — `{spaceId}_file_hashes` legitimately has no such field.)
+  - **A rename silently stopped a space syncing.** The seq counter lives in the *global* `ythril_counters`
+    collection keyed by `_id: <spaceId>`, so the prefix-based collection rename missed it and `nextSeq()`
+    restarted at **1** — while the rename deliberately carries the OLD, high sync watermarks over to the new
+    id. Every subsequent write got a seq *below* the watermark and was **never pushed to peers**: the space
+    kept working locally while quietly never syncing again. The counter (and the dupe-scan cursor) now move
+    with the rename.
+  - **Cross-space import wrote invisible data.** The export embeds the source space's id in every document,
+    and import wrote them verbatim — so importing space A's export into space B produced documents that were
+    counted but invisible to every list. Imported documents are now re-tagged to the target space.
+  - `traverseFromSeeds` filtered entities but not edges by `spaceId`, so a stale value returned an edge whose
+    neighbour entity silently vanished — half a graph, no error. The redundant filter is gone; the collection
+    name is the only real scope.
+
+  Tests now cover **chrono** and the **seq counter** across a rename, and **cross-space import** — the gaps
+  that let all of this through. (The original rename test asserted only memories, the one read path that does
+  not filter on `spaceId`, and the import tests asserted only counts and memory-by-id — likewise immune.)
+
 - **Renaming a space no longer makes its entities and edges vanish from the UI.** `moveSpaceData`
   renamed the collections (`{old}_entities` → `{new}_entities`) but never rewrote the `spaceId` field
   *inside* the documents, so every one still pointed at the OLD space id. `listEntities`, `listEdges`,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -366,9 +366,19 @@ export function createApp() {
         // Extract and coerce the _id to a plain string to prevent any operator injection.
         const docId = String((doc as Record<string, unknown>)['_id']);
         try {
+          // Re-tag the document to the TARGET space.
+          //
+          // The export embeds the source space's id in every document, and the read paths
+          // filter on that field (listEntities, listEdges, listChrono, entity lookup-by-name,
+          // the edge-dedup lookup). Importing space A's export into space B while keeping
+          // `spaceId: "A"` writes documents that are counted but INVISIBLE to every list —
+          // the import looks like it worked, and the data appears to be missing. The
+          // collection name is the only real scope, so a document we write into
+          // `{spaceId}_*` belongs to `spaceId` by definition.
+          const retagged = { ...(doc as Record<string, unknown>), spaceId };
           const r = await col(collName).replaceOne(
             asFilter({ _id: docId }),
-            asDoc(doc as Record<string, unknown>),
+            asDoc(retagged),
             { upsert: true },
           );
           if (r.upsertedCount > 0) {

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -504,8 +504,16 @@ export async function traverseFromSeeds(
 
     if (newNeighborIds.length === 0) break;
 
+    // NOTE: no `spaceId` filter here — deliberately, and it must stay that way.
+    //
+    // The edge query above (same loop) does not filter on the spaceId field either, and the
+    // collection name `{spaceId}_entities` is already the only real scope. When the two
+    // disagreed, a document with a stale spaceId produced the worst possible outcome: the
+    // EDGE was found but its neighbour ENTITY was silently dropped, so a traversal returned
+    // half a graph with no error. Filtering on a redundant, denormalised field is what made
+    // a space rename hide data in the first place.
     const entities = await col<EntityDoc>(`${spaceId}_entities`)
-      .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId }))
+      .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds } }))
       .project({ embedding: 0 })
       .toArray() as EntityDoc[];
     const entityMap = new Map<string, EntityDoc>();

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -83,24 +83,53 @@ export function clearReindexFlag(spaceId: string): void {
  * disagree, and there is nothing it could wrongly "fix".
  */
 export async function repairStaleSpaceIds(spaceId: string): Promise<number> {
+  const db = getDb();
+  const prefix = `${spaceId}_`;
+
+  // Discover the space's collections rather than iterating a hardcoded list.
+  //
+  // The original repair walked SPACE_COLLECTIONS, which covers only the 8 collections
+  // initSpace creates — and so it MISSED `{spaceId}_file_tombstones`, whose readers DO
+  // filter on the spaceId field (api/sync.ts, sync/engine.ts). After a rename, every
+  // pre-rename file deletion became invisible to sync, and peers that still held the file
+  // pushed it straight back: deleted files resurrected. Scanning by prefix fixes that and
+  // means any per-space collection added in future is covered automatically — the hardcoded
+  // list was itself the bug.
+  let collections: string[];
+  try {
+    collections = (await db.listCollections().toArray())
+      .map(c => c.name)
+      .filter(n => n.startsWith(prefix));
+  } catch (err) {
+    log.warn(`Stale-spaceId repair: could not list collections for '${spaceId}': ${err}`);
+    return 0;
+  }
+
   let repaired = 0;
-  for (const suffix of SPACE_COLLECTIONS) {
+  for (const name of collections) {
     try {
-      const res = await col<{ spaceId?: string }>(`${spaceId}_${suffix}`).updateMany(
-        asFilter<{ spaceId?: string }>({ spaceId: { $ne: spaceId } }),
-        asUpdate<{ spaceId?: string }>({ $set: { spaceId } }),
+      // `$exists: true` is load-bearing: only rewrite a spaceId that is present but WRONG.
+      // Some per-space collections legitimately carry no spaceId field at all — notably
+      // `{spaceId}_file_hashes` (the manifest hash cache, keyed by path, one document per
+      // file). A bare `$ne` also matches missing fields, so without this guard the repair
+      // would ADD a spaceId to every cached file hash on every boot: pointless writes,
+      // potentially hundreds of thousands of them on a file-heavy space.
+      const res = await db.collection(name).updateMany(
+        { spaceId: { $exists: true, $ne: spaceId } },
+        { $set: { spaceId } },
       );
       repaired += res.modifiedCount ?? 0;
     } catch (err) {
       // Never let a repair failure block startup — the space is still usable.
-      log.warn(`Stale-spaceId repair failed for ${spaceId}_${suffix}: ${err}`);
+      log.warn(`Stale-spaceId repair failed for ${name}: ${err}`);
     }
   }
+
   if (repaired > 0) {
     log.warn(
       `Space '${spaceId}': repaired ${repaired} document(s) carrying a stale spaceId ` +
-      `(left behind by a space rename or an aliased sync). They were present but invisible ` +
-      `to list/lookup queries; they are now visible again.`,
+      `(left behind by a space rename, a cross-space import, or an aliased sync). They were ` +
+      `present but invisible to list/lookup queries; they are now visible again.`,
     );
   }
   return repaired;
@@ -777,6 +806,57 @@ async function moveSpaceData(oldId: string, newId: string): Promise<string[]> {
     const msg = `Could not rewrite spaceId field for renamed space ${newId}: ${err}`;
     log.warn(msg);
     errors.push(msg);
+  }
+
+  // 1c. Migrate the GLOBAL collections that are keyed by space id.
+  //
+  // These are not under the `{oldId}_` prefix, so the collection rename above misses them
+  // entirely — and for the seq counter that is dangerous, not cosmetic:
+  //
+  //   `ythril_counters` stores the space's monotonic seq as `_id: <spaceId>`. Losing it
+  //   means nextSeq() restarts at 1 — while applySpaceRenameToConfig deliberately carries
+  //   the OLD, high `lastSeqPushed` / `lastSeqReceived` watermarks over to the new id. Every
+  //   subsequent local write would then get a seq BELOW the watermark, and sync would skip
+  //   it forever: the space keeps working locally while silently never pushing to peers.
+  //
+  // `_id` is immutable in MongoDB, so these are copy-then-delete. Take the MAX of old and
+  // any pre-existing counter so a re-run can never move the sequence backwards.
+  try {
+    const counters = col<{ _id: string; seq: number }>('ythril_counters');
+    const oldCounter = await counters.findOne(asFilter<{ _id: string; seq: number }>({ _id: oldId }));
+    if (oldCounter) {
+      const newCounter = await counters.findOne(asFilter<{ _id: string; seq: number }>({ _id: newId }));
+      const seq = Math.max(oldCounter.seq ?? 0, newCounter?.seq ?? 0);
+      await counters.replaceOne(
+        asFilter<{ _id: string; seq: number }>({ _id: newId }),
+        asDoc({ _id: newId, seq }),
+        { upsert: true },
+      );
+      await counters.deleteOne(asFilter<{ _id: string; seq: number }>({ _id: oldId }));
+      log.debug(`Migrated seq counter ${oldId} → ${newId} (seq=${seq})`);
+    }
+  } catch (err) {
+    const msg = `Could not migrate the seq counter ${oldId} → ${newId}: ${err}`;
+    log.warn(msg);
+    errors.push(msg);
+  }
+
+  // The duplicate-scanner cursor is keyed `${spaceId}:${type}`. Losing it is harmless
+  // (the space simply re-scans from the start) but it leaves orphaned rows behind, so
+  // move it across rather than stranding it.
+  try {
+    const scanState = col<{ _id: string }>('ythril_dupe_scan_state');
+    const stale = await scanState
+      .find(asFilter<{ _id: string }>({ _id: { $regex: `^${oldId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:` } }))
+      .toArray() as Array<Record<string, unknown> & { _id: string }>;
+    for (const doc of stale) {
+      const moved = { ...doc, _id: `${newId}:${doc._id.slice(oldId.length + 1)}` };
+      await scanState.replaceOne(asFilter<{ _id: string }>({ _id: moved._id }), asDoc(moved), { upsert: true });
+      await scanState.deleteOne(asFilter<{ _id: string }>({ _id: doc._id }));
+    }
+  } catch (err) {
+    // Non-fatal: worst case the renamed space re-scans for duplicates from scratch.
+    log.warn(`Could not migrate the dupe-scan cursor ${oldId} → ${newId}: ${err}`);
   }
 
   // 2. Move the files directory (skip if already moved — old dir gone)

--- a/testing/integration/space-export.test.js
+++ b/testing/integration/space-export.test.js
@@ -350,4 +350,59 @@ describe('Space export/import — round-trip (export → wipe → import)', () =
     assert.equal(memCheck.body.fact, 'Round-trip memory');
     assert.deepEqual(memCheck.body.tags, ['rt-tag']);
   });
+
+  it('CROSS-SPACE import — entities/edges/chrono are LISTED in the target space', async () => {
+    // The export embeds the SOURCE space's id in every document, and listEntities/listEdges/
+    // listChrono filter on that field. Importing space A's export into space B while keeping
+    // `spaceId: "A"` wrote documents that were counted but INVISIBLE to every list — the
+    // import reported success and the data looked lost.
+    //
+    // The whole import suite missed this because it only ever round-trips into the SAME space
+    // (so spaceId stays consistent) and only ever asserts via /stats (counts) and
+    // GET /memories/:id — the three read paths that do NOT filter on spaceId. Exactly the
+    // trap that hid the space-rename bug.
+    const srcId = `xspace-src-${RUN_ID}`;
+    const dstId = `xspace-dst-${RUN_ID}`;
+    for (const id of [srcId, dstId]) {
+      const c = await post(INSTANCES.a, tok, '/api/spaces', { id, label: `Cross ${id}` });
+      assert.equal(c.status, 201, JSON.stringify(c.body));
+      roundTripSpaceIds.push(id);
+    }
+
+    const e1 = await post(INSTANCES.a, tok, `/api/brain/spaces/${srcId}/entities`, { name: 'Ada', type: 'person' });
+    const e2 = await post(INSTANCES.a, tok, `/api/brain/spaces/${srcId}/entities`, { name: 'Grace', type: 'person' });
+    assert.equal(e1.status, 201, JSON.stringify(e1.body));
+    assert.equal(e2.status, 201, JSON.stringify(e2.body));
+    const ed = await post(INSTANCES.a, tok, `/api/brain/spaces/${srcId}/edges`, {
+      from: e1.body._id, to: e2.body._id, label: 'knows',
+    });
+    assert.equal(ed.status, 201, JSON.stringify(ed.body));
+    const ch = await post(INSTANCES.a, tok, `/api/brain/spaces/${srcId}/chrono`, {
+      title: 'Cross import milestone', type: 'milestone', startsAt: new Date().toISOString(),
+    });
+    assert.equal(ch.status, 201, JSON.stringify(ch.body));
+
+    const exp = await get(INSTANCES.a, tok, `/api/admin/spaces/${srcId}/export`);
+    assert.equal(exp.status, 200, JSON.stringify(exp.body));
+
+    // Import SOURCE's export into a DIFFERENT space.
+    const imp = await post(INSTANCES.a, tok, `/api/admin/spaces/${dstId}/import`, exp.body);
+    assert.ok([200, 201].includes(imp.status), JSON.stringify(imp.body));
+
+    const ents = await get(INSTANCES.a, tok, `/api/brain/spaces/${dstId}/entities`);
+    assert.equal(ents.status, 200);
+    assert.equal(
+      ents.body.entities?.length, 2,
+      'imported entities must be LISTED in the TARGET space — they were being written with the ' +
+      'source space id, which made them invisible to every list while still being counted',
+    );
+
+    const edges = await get(INSTANCES.a, tok, `/api/brain/spaces/${dstId}/edges`);
+    assert.equal(edges.status, 200);
+    assert.equal(edges.body.edges?.length, 1, 'imported edges must be LISTED in the target space');
+
+    const chrono = await get(INSTANCES.a, tok, `/api/brain/spaces/${dstId}/chrono`);
+    assert.equal(chrono.status, 200);
+    assert.equal(chrono.body.chrono?.length, 1, 'imported chrono entries must be LISTED in the target space');
+  });
 });

--- a/testing/integration/space-rename.test.js
+++ b/testing/integration/space-rename.test.js
@@ -128,6 +128,64 @@ describe('Space rename', () => {
     );
   });
 
+  it('Data survives rename — chrono entries are still LISTED under the new ID', async () => {
+    // `listChrono` filters on the spaceId FIELD (brain/chrono.ts), exactly like entities and
+    // edges — so a rename hid chrono entries too. Nothing covered it: the rename suite only
+    // ever created memories, which are the ONE read path that does not filter on spaceId.
+    const oldId = `chrono-rename-${RUN_ID}`;
+    const newId = `chrono-renamed-${RUN_ID}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: oldId, label: 'Chrono Rename' });
+
+    const cR = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/chrono`, {
+      title: 'Launch', type: 'milestone', startsAt: new Date().toISOString(),
+    });
+    assert.equal(cR.status, 201, JSON.stringify(cR.body));
+
+    const renameR = await patch(INSTANCES.a, tokenA, `/api/spaces/${oldId}/rename`, { newId });
+    assert.equal(renameR.status, 200, JSON.stringify(renameR.body));
+    createdSpaceIds.push(newId);
+
+    const listR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${newId}/chrono`);
+    assert.equal(listR.status, 200);
+    assert.equal(
+      listR.body.chrono?.length, 1,
+      'chrono entries must still be LISTED after a rename (listChrono filters on the spaceId field)',
+    );
+  });
+
+  it('Rename carries the seq counter forward — new writes still sync to peers', async () => {
+    // The seq counter lives in the GLOBAL `ythril_counters` collection keyed by `_id: spaceId`,
+    // so the prefix-based collection rename missed it and nextSeq() restarted at 1 — while the
+    // rename deliberately carries the OLD, high sync watermarks over to the new id. Every new
+    // write then got a seq BELOW the watermark and was never pushed: the space kept working
+    // locally while silently never syncing again.
+    const oldId = `seq-rename-${RUN_ID}`;
+    const newId = `seq-renamed-${RUN_ID}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: oldId, label: 'Seq Rename' });
+
+    // Burn some sequence numbers so the counter is unambiguously > 1.
+    for (let i = 0; i < 3; i++) {
+      const w = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/memories`, { fact: `seq burn ${i}` });
+      assert.equal(w.status, 201, JSON.stringify(w.body));
+    }
+    const beforeR = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${oldId}/memories`);
+    const seqBefore = Math.max(...beforeR.body.memories.map(m => m.seq));
+    assert.ok(seqBefore >= 3, `expected a burned-in seq, got ${seqBefore}`);
+
+    const renameR = await patch(INSTANCES.a, tokenA, `/api/spaces/${oldId}/rename`, { newId });
+    assert.equal(renameR.status, 200, JSON.stringify(renameR.body));
+    createdSpaceIds.push(newId);
+
+    // The next write must continue the sequence, NOT restart at 1.
+    const afterW = await post(INSTANCES.a, tokenA, `/api/brain/spaces/${newId}/memories`, { fact: 'after rename' });
+    assert.equal(afterW.status, 201, JSON.stringify(afterW.body));
+    assert.ok(
+      afterW.body.seq > seqBefore,
+      `seq must keep climbing across a rename (was ${seqBefore}, got ${afterW.body.seq}) — a reset to 1 ` +
+      'silently strands every later write below the sync watermark',
+    );
+  });
+
   it('Files survive rename — accessible under new path', async () => {
     const oldId = `file-rename-${RUN_ID}`;
     const newId = `file-renamed-${RUN_ID}`;


### PR DESCRIPTION
Follow-up audit after #179 found **three more instances of the same bug** — two of which cause *data loss*, not just invisibility.

## 1. Deleted files could resurrect 🔴

`{spaceId}_file_tombstones` carries a `spaceId` field and its readers filter on it ([sync.ts:1141](server/src/api/sync.ts#L1141), [engine.ts:1084](server/src/sync/engine.ts#L1084)) — but the collection was **missing from the repair's hardcoded `SPACE_COLLECTIONS` list**. After a rename, every pre-rename file deletion became invisible to sync, so **peers that still held the file pushed it straight back**.

The repair now **discovers a space's collections by prefix** instead of walking a fixed list — *the hardcoded list was itself the bug*. Any per-space collection added in future is covered automatically.

It rewrites only a `spaceId` that is **present but wrong** (`$exists: true`), never inventing one: `{spaceId}_file_hashes` (the P4 manifest cache) legitimately has no `spaceId`, and a bare `$ne` also matches missing fields — which would have added the field to **every cached file hash on every boot**.

## 2. A rename silently stopped a space syncing 🔴

The seq counter lives in the **global** `ythril_counters` collection keyed by `_id: <spaceId>`, so the prefix-based collection rename never moved it and `nextSeq()` restarted at **1** — while `applySpaceRenameToConfig` deliberately carries the OLD, high `lastSeqPushed`/`lastSeqReceived` watermarks across.

Every later write then got a seq **below the watermark and was never pushed**. The space kept working locally while quietly never syncing again. The counter (and the dupe-scan cursor) now move with the rename; the counter takes `max(old, existing)` so a re-run can never rewind it.

## 3. Cross-space import wrote invisible data 🔴

The export embeds the source space's id in every document, and import wrote them **verbatim** — so importing space A's export into space B produced documents that were counted but invisible to every list. Imported documents are now **re-tagged to the target space**.

## 4. `traverseFromSeeds` filtered entities but not edges

The worst possible split: a stale `spaceId` returned the **edge** while silently dropping its neighbour **entity** — half a graph, no error. The redundant filter is removed; the collection name is the only real scope.

## The test gaps that let all of this through

This is the same pattern every time — **a test that looks like coverage but exercises the one case that cannot fail**:

- the rename test asserted **only memories** — the single read path that does *not* filter on `spaceId`
- the import tests asserted **only counts and memory-by-id** — likewise immune

Now covered: **chrono** and the **seq counter** across a rename, and **cross-space import**.

Full core suite green: **integration 826, sync 173, redteam 258, standalone 769 — 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)