### PR TITLE
security: read-only tokens could resolve/delete conflicts + derived guard coverage

### DIFF
--- a/server/src/api/conflicts.ts
+++ b/server/src/api/conflicts.ts
@@ -150,7 +150,7 @@ conflictsRouter.get('/link-violations', globalRateLimit, requireAuth, async (_re
 });
 
 // DELETE /api/conflicts/link-violations/:id — dismiss a single link violation
-conflictsRouter.delete('/link-violations/:id', globalRateLimit, requireAuth, async (req, res) => {
+conflictsRouter.delete('/link-violations/:id', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const spaces = accessibleSpaces(req.authToken?.spaces);
     for (const spaceId of spaces) {
@@ -169,7 +169,7 @@ conflictsRouter.delete('/link-violations/:id', globalRateLimit, requireAuth, asy
 });
 
 // DELETE /api/conflicts/link-violations — dismiss all link violations for accessible spaces
-conflictsRouter.delete('/link-violations', globalRateLimit, requireAuth, async (_req, res) => {
+conflictsRouter.delete('/link-violations', globalRateLimit, requireAuth, denyReadOnly, async (_req, res) => {
   try {
     const spaces = accessibleSpaces(_req.authToken?.spaces);
     let total = 0;
@@ -212,7 +212,7 @@ conflictsRouter.get('/:id', globalRateLimit, requireAuth, async (req, res) => {
 });
 
 // DELETE /api/conflicts/:id — dismiss (resolve) a conflict record
-conflictsRouter.delete('/:id', globalRateLimit, requireAuth, async (req, res) => {
+conflictsRouter.delete('/:id', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const spaces = accessibleSpaces(req.authToken?.spaces);
     for (const spaceId of spaces) {
@@ -231,7 +231,7 @@ conflictsRouter.delete('/:id', globalRateLimit, requireAuth, async (req, res) =>
 });
 
 // POST /api/conflicts/bulk-resolve — resolve multiple conflicts at once
-conflictsRouter.post('/bulk-resolve', globalRateLimit, requireAuth, async (req, res) => {
+conflictsRouter.post('/bulk-resolve', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const { ids, action, rename, targetSpaceId } = req.body ?? {};
     if (!Array.isArray(ids) || ids.length === 0) {
@@ -313,7 +313,7 @@ conflictsRouter.post('/seed', globalRateLimit, requireAdmin, denyReadOnly, async
 });
 
 // POST /api/conflicts/:id/resolve — resolve a single conflict with an action
-conflictsRouter.post('/:id/resolve', globalRateLimit, requireAuth, async (req, res) => {
+conflictsRouter.post('/:id/resolve', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const { action, rename, targetSpaceId } = req.body ?? {};
 

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -2220,6 +2220,27 @@ describe('Brain — read-only token blocked on REST write endpoints', () => {
     const r = await get(INSTANCES.a, readOnlyToken, '/api/brain/spaces/general/memories?limit=1');
     assert.equal(r.status, 200, `GET memories should be allowed, got ${r.status}`);
   });
+
+  // Regression: the conflict-resolution routes were missing `denyReadOnly`, so a read-only
+  // token could resolve a conflict (which REWRITES brain records) and delete conflicts. Found
+  // by route-guard-coverage.test.js — every other route in this block was written by hand and
+  // this whole surface was simply never covered.
+  it('POST /api/conflicts/:id/resolve is rejected for a read-only token', async () => {
+    const r = await post(INSTANCES.a, readOnlyToken, `/api/conflicts/does-not-exist-${RUN}/resolve`, {
+      action: 'keep-existing',
+    });
+    assert.equal(r.status, 403, `conflict resolve must reject a read-only token, got ${r.status}`);
+  });
+
+  it('POST /api/conflicts/bulk-resolve is rejected for a read-only token', async () => {
+    const r = await post(INSTANCES.a, readOnlyToken, '/api/conflicts/bulk-resolve', { action: 'keep-existing' });
+    assert.equal(r.status, 403, `bulk-resolve must reject a read-only token, got ${r.status}`);
+  });
+
+  it('DELETE /api/conflicts/:id is rejected for a read-only token', async () => {
+    const r = await del(INSTANCES.a, readOnlyToken, `/api/conflicts/does-not-exist-${RUN}`);
+    assert.equal(r.status, 403, `conflict delete must reject a read-only token, got ${r.status}`);
+  });
 });
 
 // ── Bulk write cap at 500 items per type ─────────────────────────────────────

--- a/testing/integration/space-wipe.test.js
+++ b/testing/integration/space-wipe.test.js
@@ -122,12 +122,67 @@ describe('Space wipe — full wipe', () => {
     assert.ok(r.body?.error?.toLowerCase().includes('types'), `Error should mention 'types': ${r.body?.error}`);
   });
 
-  it('wipe requires admin token — non-admin token is rejected', async () => {
-    // Create a non-admin token by checking that a space-scoped or read-only token is rejected.
-    // We use a random invalid token to simulate the 401 case.
-    const fakeToken = 'ythril_notavalidtoken';
-    const r = await post(INSTANCES.a, fakeToken, '/api/admin/spaces/general/wipe', {});
-    assert.ok(r.status === 401 || r.status === 403, `Expected 401 or 403, got ${r.status}`);
+  it('wipe requires admin — a VALID non-admin token is rejected (403)', async () => {
+    // Regression: this used to POST a random invalid token, which only exercises requireAuth's
+    // 401 — so it would still pass if the ADMIN gate were removed (a valid non-admin token
+    // would then wipe the space). Use a real, valid, non-admin token so the 403 proves the
+    // admin gate itself, not merely "unauthenticated is rejected".
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `wipe-nonadmin-${RUN_ID}`, admin: false });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    const nonAdmin = t.body.plaintext;
+    try {
+      const r = await post(INSTANCES.a, nonAdmin, '/api/admin/spaces/general/wipe', { confirm: true });
+      assert.equal(r.status, 403, `a valid non-admin token must be rejected by the admin gate, got ${r.status}`);
+    } finally {
+      await del(INSTANCES.a, adminToken, `/api/tokens/${t.body.token.id}`).catch(() => {});
+    }
+  });
+
+  it('a SPACE-SCOPED admin token cannot wipe / rename / delete an OUT-OF-SCOPE space (403)', async () => {
+    // Highest-blast-radius gap the vacuous-test audit found: requireAdminMfaScoped's
+    // enforceSpaceScope() call is the ONLY thing stopping a `{admin:true, spaces:[A]}` token
+    // from wiping/renaming/deleting space B. The guard logic was correct but UNTESTED — a
+    // regression that dropped the scope check would have let a scoped admin operate on ANY
+    // space, and nothing would have failed. This pins the behaviour.
+    const inScope = `scoped-in-${RUN_ID}`;
+    const outScope = `scoped-out-${RUN_ID}`;
+    for (const id of [inScope, outScope]) {
+      const c = await post(INSTANCES.a, adminToken, '/api/spaces', { id, label: id });
+      assert.equal(c.status, 201, JSON.stringify(c.body));
+      createdSpaceIds.push(id);
+    }
+
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', {
+      name: `scoped-admin-${RUN_ID}`, admin: true, spaces: [inScope],
+    });
+    assert.equal(t.status, 201, JSON.stringify(t.body));
+    const scopedAdmin = t.body.plaintext;
+
+    try {
+      // Positive control: the in-scope space IS operable (proves the token is a working admin,
+      // so the 403s below are the SCOPE check, not a broken token).
+      const okWipe = await post(INSTANCES.a, scopedAdmin, `/api/admin/spaces/${inScope}/wipe`, { confirm: true });
+      assert.equal(okWipe.status, 200, `in-scope wipe should succeed: ${okWipe.status} ${JSON.stringify(okWipe.body)}`);
+
+      // The actual assertions: every space-targeting admin op on the OUT-of-scope space is 403.
+      const wipe = await post(INSTANCES.a, scopedAdmin, `/api/admin/spaces/${outScope}/wipe`, { confirm: true });
+      assert.equal(wipe.status, 403, `out-of-scope WIPE must be 403, got ${wipe.status} — privilege escalation`);
+
+      const rename = await reqJson(INSTANCES.a, scopedAdmin, `/api/spaces/${outScope}/rename`, {
+        method: 'PATCH', body: JSON.stringify({ newId: `${outScope}-x` }),
+      });
+      assert.equal(rename.status, 403, `out-of-scope RENAME must be 403, got ${rename.status}`);
+
+      const schema = await reqJson(INSTANCES.a, scopedAdmin, `/api/spaces/${outScope}/schema`, {
+        method: 'PUT', body: JSON.stringify({ typeSchemas: {} }),
+      });
+      assert.equal(schema.status, 403, `out-of-scope SCHEMA write must be 403, got ${schema.status}`);
+
+      const delR = await delWithBody(INSTANCES.a, scopedAdmin, `/api/spaces/${outScope}`, { confirm: true });
+      assert.equal(delR.status, 403, `out-of-scope DELETE must be 403, got ${delR.status}`);
+    } finally {
+      await del(INSTANCES.a, adminToken, `/api/tokens/${t.body.token.id}`).catch(() => {});
+    }
   });
 });
 

--- a/testing/standalone/route-guard-coverage.test.js
+++ b/testing/standalone/route-guard-coverage.test.js
@@ -1,0 +1,201 @@
+/**
+ * Standalone tests: every mutating route must carry an authorisation guard.
+ *
+ * This is the security twin of audit-route-coverage.test.js, and it exists because of a
+ * question worth asking of any test: **what would still pass if the mechanism were removed?**
+ *
+ * Nothing in the suite would fail if `denyReadOnly` were dropped from a single route. The
+ * red-team tests prove a read-only token is rejected on *some* endpoints — not on *every*
+ * mutating endpoint — so a new route that forgot the guard would ship silently, and a
+ * read-only token could write through it. Same for `requireSpaceAuth`: a route without it is
+ * reachable by a token scoped to a different space.
+ *
+ * Per-route tests cannot close that: they enumerate what someone remembered to write. So this
+ * derives the route list from the ROUTER SOURCE and asserts the guard is present on each — add
+ * a mutating route without a guard and this fails, by name, until you either add the guard or
+ * declare the route exempt WITH A REASON.
+ *
+ * It checks the middleware chain is *wired*, not that each guard's logic is correct — the
+ * red-team suite covers the behaviour. The failure this catches is the one that actually
+ * happens in practice: a guard that was simply never attached.
+ *
+ * Run: node --test testing/standalone/route-guard-coverage.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const API_DIR = path.join(__dirname, '..', '..', 'server', 'src', 'api');
+const APP_TS = path.join(__dirname, '..', '..', 'server', 'src', 'app.ts');
+
+const MUTATING = new Set(['post', 'put', 'patch', 'delete']);
+
+/** Any of these means "an authenticated identity is required to reach this route". */
+const AUTH_GUARDS = [
+  'requireSpaceAuth',
+  'requireAuth',
+  'requireAdminMfaScoped',
+  'requireAdminMfa',
+  'requireAdmin',
+];
+
+/** Guards that block a READ-ONLY token from writing. Admin guards imply a non-read-only admin. */
+const WRITE_GUARDS = [
+  'denyReadOnly',
+  'requireAdminMfaScoped',
+  'requireAdminMfa',
+  'requireAdmin',
+];
+
+/**
+ * Routes that legitimately carry no auth guard. Every entry needs a REASON — an exemption
+ * without one is how a guard table rots (see the audit route table, which had drifted so far
+ * that file uploads and the entire governance surface were unlogged).
+ */
+const EXEMPT = new Map([
+  ['setupRouter', 'first-run setup — runs BEFORE any token exists; guarded by configExists()'],
+  ['syncRouter', 'peer-to-peer sync — authenticated as a PEER via peer tokens, not user tokens'],
+  ['inviteRouter', 'network invite handshake — authenticated by the invite key itself'],
+  ['oidcRouter', 'OIDC login/callback — this is how you GET a token'],
+  ['themeRouter', 'public unauthenticated theme endpoint (read-only, no user data)'],
+  ['notifyRouter', 'peer notifications + admin sync trigger — peer-authenticated'],
+  ['mcpRouter', 'MCP authorises at the tool dispatcher, not per-route'],
+  ['metricsRouter', 'Prometheus scrape — guarded by METRICS_TOKEN inside the router'],
+]);
+
+/**
+ * POSTs that are semantically READS (search/validate/dry-run). They must still require auth,
+ * but must NOT be blocked for a read-only token — searching is exactly what read-only is for.
+ */
+const READ_SHAPED_POSTS = [
+  '/spaces/:spaceId/query',
+  '/spaces/:spaceId/recall',
+  '/spaces/:spaceId/find-similar',
+  '/spaces/:spaceId/traverse',
+  '/recall',
+  '/:id/validate-schema',
+  '/export-space',
+  '/config/test',
+];
+
+/** @type {{router:string, method:string, routePath:string, chain:string, file:string}[]} */
+let routes = [];
+/** Guards applied to an ENTIRE router via `xRouter.use(...)` — they cover every route on it. */
+let routerLevelGuards = new Map();
+
+function mountedRouters() {
+  const src = fs.readFileSync(APP_TS, 'utf8');
+  const names = new Set();
+  const re = /app\.use\(\s*'[^']+'\s*,\s*([A-Za-z_]\w*)/g;
+  let m;
+  while ((m = re.exec(src)) !== null) names.add(m[1]);
+  return names;
+}
+
+describe('Route guards — every mutating route must be protected', () => {
+  before(() => {
+    const mounted = mountedRouters();
+
+    for (const file of fs.readdirSync(API_DIR).filter(f => f.endsWith('.ts'))) {
+      const src = fs.readFileSync(path.join(API_DIR, file), 'utf8');
+
+      // Router-level guards must count, or this reports false positives: webhooksRouter does
+      // `webhooksRouter.use(globalRateLimit, requireAdminMfa)` and then registers bare routes.
+      const useRe = /(\w+Router)\s*\.\s*use\s*\(([^)]*)\)/g;
+      let u;
+      while ((u = useRe.exec(src)) !== null) {
+        const prev = routerLevelGuards.get(u[1]) ?? '';
+        routerLevelGuards.set(u[1], prev + ',' + u[2]);
+      }
+
+      // Capture the middleware chain: everything between the path string and the handler.
+      // Handles both single-line and the multi-line registration style used in files.ts.
+      const re = /(\w+Router)\s*\.\s*(get|post|put|patch|delete)\s*\(\s*'([^']+)'\s*,([\s\S]{0,400}?)(?:async\s*\(|\(\s*req\b)/g;
+      let m;
+      while ((m = re.exec(src)) !== null) {
+        const [, router, method, routePath, chain] = m;
+        if (!mounted.has(router)) continue;
+        routes.push({ router, method, routePath, chain, file });
+      }
+    }
+  });
+
+  it('the parser found the routes (guard the guard — it must not pass vacuously)', () => {
+    // If the registration style changes and the regex stops matching, every assertion below
+    // would pass on an EMPTY list. That is the exact failure mode this whole test exists to
+    // prevent, so it must not be possible here either.
+    assert.ok(routes.length > 50, `expected to parse many routes, found ${routes.length}`);
+
+    const mutating = routes.filter(r => MUTATING.has(r.method));
+    assert.ok(mutating.length > 30, `expected many mutating routes, found ${mutating.length}`);
+
+    const sample = routes.find(r => r.router === 'brainRouter' && r.routePath === '/spaces/:spaceId/memories' && r.method === 'post');
+    assert.ok(sample, 'sanity: POST /spaces/:spaceId/memories should have been parsed');
+    assert.match(sample.chain, /requireSpaceAuth/, 'sanity: its chain should contain requireSpaceAuth');
+  });
+
+  /** A route is protected by its own chain OR by a guard its router applies to everything. */
+  function effectiveChain(r) {
+    return r.chain + (routerLevelGuards.get(r.router) ?? '');
+  }
+
+  it('every mutating route requires an authenticated identity', () => {
+    const unguarded = [];
+    for (const r of routes) {
+      if (!MUTATING.has(r.method)) continue;
+      if (EXEMPT.has(r.router)) continue;
+      if (!AUTH_GUARDS.some(g => effectiveChain(r).includes(g))) {
+        unguarded.push(`${r.method.toUpperCase()} ${r.routePath}  (${r.file}: ${r.router})`);
+      }
+    }
+    assert.deepEqual(
+      unguarded, [],
+      'These mutating routes have NO auth guard — they are reachable without a valid identity. ' +
+      'Add one, or add an EXEMPT entry WITH A REASON:\n  ' + unguarded.join('\n  '),
+    );
+  });
+
+  it('every mutating route blocks a READ-ONLY token', () => {
+    // The guard that is easiest to forget, and whose absence no existing test would catch:
+    // the red-team suite proves a read-only token is rejected on SOME endpoints, never on ALL.
+    const writable = [];
+    for (const r of routes) {
+      if (!MUTATING.has(r.method)) continue;
+      if (EXEMPT.has(r.router)) continue;
+      if (r.method === 'post' && READ_SHAPED_POSTS.includes(r.routePath)) continue;
+      if (!WRITE_GUARDS.some(g => effectiveChain(r).includes(g))) {
+        writable.push(`${r.method.toUpperCase()} ${r.routePath}  (${r.file}: ${r.router})`);
+      }
+    }
+    assert.deepEqual(
+      writable, [],
+      'These mutating routes do NOT block a read-only token — a read-only credential could ' +
+      'write through them. Add denyReadOnly (or an admin guard), or EXEMPT it with a reason:\n  ' +
+      writable.join('\n  '),
+    );
+  });
+
+  it('space-scoped routes enforce the space scope', () => {
+    // A `:spaceId` route without requireSpaceAuth is reachable by a token scoped to a
+    // DIFFERENT space — a cross-tenant read/write, not merely a missing login check.
+    const unscoped = [];
+    for (const r of routes) {
+      if (EXEMPT.has(r.router)) continue;
+      if (!/:spaceId\b/.test(r.routePath)) continue;
+      // Admin-scoped guards carry the space check themselves.
+      const chain = effectiveChain(r);
+      if (chain.includes('requireSpaceAuth') || chain.includes('requireAdminMfaScoped')) continue;
+      if (chain.includes('requireAdmin')) continue; // full admin — not space-scoped by design
+      unscoped.push(`${r.method.toUpperCase()} ${r.routePath}  (${r.file}: ${r.router})`);
+    }
+    assert.deepEqual(
+      unscoped, [],
+      'These :spaceId routes do not enforce the space scope — a token scoped to another space ' +
+      'could reach them:\n  ' + unscoped.join('\n  '),
+    );
+  });
+});


### PR DESCRIPTION
Applied the question you suggested — *"what would still pass if the mechanism were removed?"* — across the auth guards. It found a live bug and a highest-blast-radius coverage gap.

## 🔴 Live bug — conflict routes were missing `denyReadOnly`

The author knew the guard (it's on `POST /conflicts/seed`) but **forgot it on five mutating routes**:

- `POST /:id/resolve` — **rewrites brain records** (picks a winning version)
- `POST /bulk-resolve`
- `DELETE /:id`, `DELETE /link-violations`, `DELETE /link-violations/:id`

All carried only `requireAuth`, so a **read-only token could resolve conflicts (a write) and delete them.** Space scoping was intact (`findConflict` only searches the token's accessible spaces), so this is a read-only bypass, not cross-tenant. Fixed on all five.

**Why no test caught it:** the read-only red-team coverage proves a read-only token is rejected on *some* endpoints — never on *every* mutating one. A route that forgot the guard shipped silently.

## The durable fix — derived coverage

`testing/standalone/route-guard-coverage.test.js` parses the **router source** and asserts every mutating route:
1. requires an identity,
2. **blocks a read-only token**,
3. if it has `:spaceId`, enforces the space scope.

It honours router-level `.use()` guards, exempts read-shaped POSTs (search/validate) *with reasons*, and **guards itself** against the parser silently matching zero routes. Add a mutating route without a guard and it fails **by name**. This is what found the five conflict routes — a hand-enumerated test never would have.

## Two vacuous tests closed

- **`space-wipe` "non-admin token is rejected"** POSTed an *invalid* token — so it only tested `requireAuth`'s 401 and would pass even if the admin gate were removed. Now mints a **valid non-admin** token and asserts **403**.
- **Highest blast radius:** `requireAdminMfaScoped`'s space-scope check (`enforceSpaceScope`) was **entirely untested** — a `{admin:true, spaces:[A]}` token could in principle wipe/rename/delete space B and nothing would fail. **Verified empirically the guard is correct** (out-of-scope wipe/rename/schema/delete all 403; in-scope 200 as a positive control) and pinned it. Coverage gap, not a live hole.

## The method is now documented

Recorded in the security tracker as a repeatable procedure, with the ~12 remaining lower-severity vacuous-test findings logged as follow-up (e.g. `bulkWipeRateLimit` has no 429 test; MCP `projection` still uncovered end-to-end; several echo-only PUT/PATCH tests that never re-read).

Full core suite green: **integration 835, sync 173, redteam 258, standalone 779 — 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)