### PR TITLE
perf: stream space export instead of buffering the whole space (P7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Space export streams instead of buffering the whole space into memory (P7).** The export endpoint —
+  the one you reach for to back a space up — loaded all five collections into memory with `.toArray()` in
+  parallel and then `res.json()`'d the result, so the entire space sat on the heap **twice** (the documents
+  plus their serialised JSON) at once. A large space OOM'd the backup, exactly when losing data hurts most.
+  The response is now written incrementally over each collection's cursor, one document at a time, with
+  backpressure so the socket buffer cannot grow unbounded either. The output is **byte-for-byte identical**
+  — same object, same keys, same order — so import and every existing consumer are untouched. Covered by a
+  new scale test (250 documents with characters that must be JSON-escaped, asserting the streamed response
+  parses and round-trips exactly).
+
+### Changed
+
 - **Bulk deletes no longer make one database round trip per document (P9).** Wiping a collection writes a
   tombstone per deleted document, and the seq for each was fetched with its own `nextSeq()` call — so
   clearing 100k memories cost **100k sequential round trips before the delete even started**. All four bulk

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -287,33 +287,64 @@ export function createApp() {
       return;
     }
 
-    try {
-      // Fetch all documents in parallel, stripping the embedding vector to keep the
-      // payload manageable. embeddingModel is retained so the import consumer knows
-      // what model was in use before the wipe.
-      const projection = { embedding: 0 };
-      const [memories, entities, edges, chrono, files] = await Promise.all([
-        col(`${spaceId}_memories`).find({}, { projection }).toArray(),
-        col(`${spaceId}_entities`).find({}, { projection }).toArray(),
-        col(`${spaceId}_edges`).find({}, { projection }).toArray(),
-        col(`${spaceId}_chrono`).find({}, { projection }).toArray(),
-        col(`${spaceId}_files`).find({}, { projection }).toArray(),
-      ]);
+    // Stream the export instead of buffering it (P7).
+    //
+    // This used to `.toArray()` all five collections in parallel and then `res.json()` the
+    // result — so the whole space sat on the heap TWICE (the documents, plus their serialised
+    // JSON string) at once. A 100k-memory space OOM'd the backup endpoint, exactly when losing
+    // data hurts most. We now walk each collection's cursor and write documents out one at a
+    // time, respecting backpressure so the response buffer cannot grow unbounded either.
+    //
+    // The OUTPUT SHAPE is byte-for-byte identical to before — same object, same keys, same
+    // order — so the import side and every existing consumer are untouched. (NDJSON would be
+    // cleaner but would break the import contract; not worth it for the memory win.)
+    const projection = { embedding: 0 };
 
-      res.json({
-        exportedAt: new Date().toISOString(),
-        spaceId,
-        spaceName: space.label,
-        version: _serverVersion,
-        memories,
-        entities,
-        edges,
-        chrono,
-        files,
-      });
+    // Backpressure-aware write: pause the cursor walk when the socket buffer is full.
+    const write = (chunk: string): Promise<void> =>
+      res.write(chunk) ? Promise.resolve() : new Promise<void>(resolve => res.once('drain', resolve));
+
+    /** Stream one collection as a JSON array value: `[doc, doc, …]`. */
+    const streamArray = async (collName: string): Promise<void> => {
+      await write('[');
+      const cursor = col(collName).find({}, { projection });
+      let first = true;
+      for await (const doc of cursor) {
+        await write((first ? '' : ',') + JSON.stringify(doc));
+        first = false;
+      }
+      await write(']');
+    };
+
+    try {
+      res.status(200);
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      // Envelope fields first — JSON.stringify each value so escaping is correct.
+      await write(
+        '{' +
+        `"exportedAt":${JSON.stringify(new Date().toISOString())},` +
+        `"spaceId":${JSON.stringify(spaceId)},` +
+        `"spaceName":${JSON.stringify(space.label)},` +
+        `"version":${JSON.stringify(_serverVersion)},`,
+      );
+      await write('"memories":'); await streamArray(`${spaceId}_memories`);
+      await write(',"entities":'); await streamArray(`${spaceId}_entities`);
+      await write(',"edges":'); await streamArray(`${spaceId}_edges`);
+      await write(',"chrono":'); await streamArray(`${spaceId}_chrono`);
+      await write(',"files":'); await streamArray(`${spaceId}_files`);
+      await write('}');
+      res.end();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      res.status(500).json({ error: msg });
+      if (!res.headersSent) {
+        res.status(500).json({ error: msg });
+      } else {
+        // We have already sent `200` and a partial body, so we cannot change the status.
+        // Destroy the socket so the client sees a TRUNCATED/aborted response rather than a
+        // syntactically-valid JSON that is silently missing documents.
+        log.error(`Space export for '${spaceId}' failed mid-stream: ${msg}`);
+        res.destroy(err instanceof Error ? err : new Error(msg));
+      }
     }
   });
 

--- a/testing/integration/space-export.test.js
+++ b/testing/integration/space-export.test.js
@@ -405,4 +405,47 @@ describe('Space export/import — round-trip (export → wipe → import)', () =
     assert.equal(chrono.status, 200);
     assert.equal(chrono.body.chrono?.length, 1, 'imported chrono entries must be LISTED in the target space');
   });
+
+  it('export streams MANY documents as valid JSON and round-trips them exactly', async () => {
+    // The export is streamed (P7): the envelope and each collection's array are written to the
+    // socket incrementally, with the inter-document commas placed by hand. That comma logic is
+    // invisible with 1-2 documents and is exactly where a streaming bug hides — a missing comma
+    // (invalid JSON) or a trailing one only shows up across many docs and cursor batch
+    // boundaries. So seed a few hundred and assert the response parses AND every document
+    // survives a round trip. The old buffered `res.json()` could not have this bug; the
+    // streamed version can, so it must be tested at scale.
+    const N = 250;
+    const srcId = `stream-src-${RUN_ID}`;
+    const dstId = `stream-dst-${RUN_ID}`;
+    for (const id of [srcId, dstId]) {
+      const c = await post(INSTANCES.a, tok, '/api/spaces', { id, label: `Stream ${id}` });
+      assert.equal(c.status, 201, JSON.stringify(c.body));
+      roundTripSpaceIds.push(id);
+    }
+
+    // Bulk-write so seeding N is fast. Include characters that MUST be JSON-escaped, so the
+    // streamed output is exercised on escaping too, not just plain ASCII.
+    const memories = Array.from({ length: N }, (_, i) => ({
+      fact: `stream doc ${i} — "quoted", \\backslash\\, newline\n, tab\t, unicode ☃`,
+      tags: [`t${i % 5}`],
+    }));
+    const bulk = await post(INSTANCES.a, tok, `/api/brain/spaces/${srcId}/bulk`, { memories });
+    assert.ok([200, 201, 207].includes(bulk.status), JSON.stringify(bulk.body)); // /bulk returns 207 Multi-Status
+    assert.equal(bulk.body.errors?.length ?? 0, 0, `bulk seed must have no errors: ${JSON.stringify(bulk.body.errors)}`);
+
+    // Export must be syntactically valid JSON with all N memories present.
+    const exp = await get(INSTANCES.a, tok, `/api/admin/spaces/${srcId}/export`);
+    assert.equal(exp.status, 200);
+    assert.ok(Array.isArray(exp.body.memories), 'memories must be an array');
+    assert.equal(exp.body.memories.length, N, `all ${N} memories must be exported, got ${exp.body.memories.length}`);
+    // The tricky-character doc must survive escaping intact.
+    const doc0 = exp.body.memories.find(m => m.fact.startsWith('stream doc 0 '));
+    assert.ok(doc0 && doc0.fact.includes('☃') && doc0.fact.includes('"quoted"'), 'special characters must round-trip through the stream');
+
+    // And the whole thing must import back cleanly.
+    const imp = await post(INSTANCES.a, tok, `/api/admin/spaces/${dstId}/import`, exp.body);
+    assert.ok([200, 201].includes(imp.status), JSON.stringify(imp.body));
+    const stats = await get(INSTANCES.a, tok, `/api/brain/spaces/${dstId}/stats`);
+    assert.equal(stats.body.memories, N, `all ${N} memories must import into the target space`);
+  });
 });


### PR DESCRIPTION
## The problem

The export endpoint — the one you reach for to **back a space up** — did `.toArray()` on all five collections in parallel and then `res.json()`'d the result. So the entire space was resident on the heap **twice** at the peak: every document, *plus* the serialised JSON string of all of them. A 100k-memory space OOM'd the backup — the worst possible moment to fall over.

## The fix

The response is written incrementally: envelope fields, then each collection walked as a cursor with `for await`, each document written as it's read. Writes **respect backpressure** (await `'drain'` when the socket buffer is full), so the buffered form of the same OOM can't reappear — only one document plus the socket's high-water mark are ever in memory.

**Output shape is byte-for-byte identical** — same object, same keys, same order — so the import side and every consumer are untouched. (NDJSON would be cleaner and make import streamable too, but it breaks the import contract and every consumer; not worth it for the memory win alone.)

## Error handling

Once the `200` + partial body are on the wire, the status can't change — so a mid-stream failure **destroys the socket**. The client sees a truncated/aborted response rather than syntactically-valid JSON silently missing documents. Pre-flight checks (space exists) still return a clean 404/500 because they run before anything is written.

## Tests

New scale case: seeds **250 memories with characters that must be JSON-escaped** (quotes, backslashes, newlines, tabs, unicode ☃) and asserts the streamed response is valid JSON with all 250 present and round-trips through import exactly.

The hand-placed inter-document commas are invisible with 1–2 docs and are exactly where a streaming bug hides — the old buffered `res.json()` *couldn't* have that bug, so the streamed version must be tested at scale. (That test also caught a bug in *itself* — I'd asserted `/bulk` returns 200/201; it returns 207 Multi-Status.)

Full core suite green: **integration 834, sync 173, redteam 258, standalone 779 — 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)