### PR TITLE
perf: OnPush on the pure-display leaf components (P5, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`OnPush` change detection on the pure-display leaf components (P5, first slice).** The client had
+  `OnPush` on **zero** of its components, so every timer tick, XHR completion and DOM event re-ran change
+  detection over the *entire* tree — including hundreds of `ph-icon`s and property views in large tables.
+  `ph-icon` and `app-properties-view` are now `OnPush`: both are pure and driven only by their inputs (plus,
+  for the view, one local signal), so they re-render exactly when they need to and are otherwise skipped.
+  These are the highest-instantiation leaves, squarely in the large-table hot path. Verified with specs that
+  render the component, change an input / toggle the signal, and assert the DOM updates — the conversion is
+  provable, not blind (the client test harness added earlier is what makes that possible). More components
+  follow, heaviest next.
+
 ### Added
 
 - **Client unit-test infrastructure (Vitest + jsdom).** The Angular client had **no test setup at all** —

--- a/client/src/app/shared/ph-icon.component.spec.ts
+++ b/client/src/app/shared/ph-icon.component.spec.ts
@@ -49,4 +49,22 @@ describe('PhIconComponent', () => {
     expect(svg).toBeTruthy();
     expect(svg.querySelector('path')).toBeNull();
   });
+
+  it('is OnPush and still re-renders on input change (the P5 contract)', () => {
+    // Guards the OnPush conversion specifically. An OnPush leaf must skip the whole-tree CD
+    // sweep BUT still update when its own @Input changes. If someone reverted OnPush this would
+    // still pass (default CD also updates), so it is not a full mutation test — but paired with
+    // the harness's negative control (which proves the harness CAN see a stale OnPush view),
+    // an input-driven update failing here would mean the conversion broke the component.
+    expect(PhIconComponent.ɵcmp?.onPush).toBe(true);
+
+    ref.setInput('name', 'trash');
+    ref.setInput('size', 12);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('svg').getAttribute('width')).toBe('12');
+
+    ref.setInput('size', 40);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('svg').getAttribute('width')).toBe('40');
+  });
 });

--- a/client/src/app/shared/ph-icon.component.ts
+++ b/client/src/app/shared/ph-icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, inject } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 /**
@@ -58,6 +58,11 @@ const ICONS: Record<string, string> = {
 @Component({
   selector: 'ph-icon',
   standalone: true,
+  // OnPush (P5): a pure leaf driven only by @Input — it has no async state, so it only ever
+  // needs to re-render when `name` or `size` change, which OnPush checks on input change. This
+  // is instantiated once per icon across every list row, toolbar and nav item, so keeping it
+  // out of the default whole-tree change-detection sweep is a real win in the hot path.
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<span class="ph-icon-wrap" [innerHTML]="svg" aria-hidden="true"></span>`,
   styles: [`
     :host { display: inline-flex; align-items: center; justify-content: center; line-height: 0; }

--- a/client/src/app/shared/properties-view.component.spec.ts
+++ b/client/src/app/shared/properties-view.component.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * PropertiesViewComponent — verifies the OnPush conversion (P5).
+ *
+ * The two things OnPush must preserve here: it still re-renders when the `properties` @Input
+ * changes, and when the local `mode` signal toggles (table ↔ json). Both are exercised below.
+ */
+import { ComponentRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTranslocoModule } from '../testing/transloco-testing';
+import { PropertiesViewComponent } from './properties-view.component';
+
+describe('PropertiesViewComponent (OnPush)', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<PropertiesViewComponent>>;
+  let ref: ComponentRef<PropertiesViewComponent>;
+  const text = () => (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [PropertiesViewComponent, getTranslocoModule()] });
+    fixture = TestBed.createComponent(PropertiesViewComponent);
+    ref = fixture.componentRef;
+  });
+
+  it('is compiled as OnPush', () => {
+    expect(PropertiesViewComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders an em-dash when there are no properties', () => {
+    ref.setInput('properties', {});
+    fixture.detectChanges();
+    expect(text()).toContain('—');
+  });
+
+  it('renders a table row per property', () => {
+    ref.setInput('properties', { status: 'open', owner: 'ada' });
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll('table.props-table tr');
+    expect(rows.length).toBe(2);
+    expect(text()).toContain('status');
+    expect(text()).toContain('open');
+  });
+
+  it('re-renders when the properties input reference changes (OnPush contract)', () => {
+    ref.setInput('properties', { a: '1' });
+    fixture.detectChanges();
+    expect(text()).toContain('a');
+    expect(text()).not.toContain('zzz');
+
+    ref.setInput('properties', { zzz: '9' });
+    fixture.detectChanges();
+    expect(text()).toContain('zzz');
+    expect(text()).not.toContain('"a"');
+  });
+
+  it('toggling the local mode signal switches to the JSON view', () => {
+    ref.setInput('properties', { k: 'v' });
+    fixture.detectChanges();
+    // table mode by default — no <pre>
+    expect(fixture.nativeElement.querySelector('pre.props-pre')).toBeNull();
+
+    // Flip the signal that a (click) handler sets; OnPush must still re-render on it.
+    fixture.componentInstance.mode.set('json');
+    fixture.detectChanges();
+    const pre = fixture.nativeElement.querySelector('pre.props-pre');
+    expect(pre).toBeTruthy();
+    expect(pre.textContent).toContain('"k": "v"');
+  });
+});

--- a/client/src/app/shared/properties-view.component.ts
+++ b/client/src/app/shared/properties-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PropertySchema } from '../core/api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -6,6 +6,10 @@ import { TranslocoPipe } from '@jsverse/transloco';
 @Component({
   selector: 'app-properties-view',
   standalone: true,
+  // OnPush (P5): display-only. Re-renders when its @Input (`properties`/`schema`) reference
+  // changes or its local `mode` signal toggles — both of which OnPush checks. Rendered once per
+  // row in entity/memory tables, so it is squarely in the large-table CD hot path.
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, TranslocoPipe],
   styles: [`
     .props-none { color: var(--text-muted); font-size: 12px; }

--- a/client/src/app/testing/transloco-testing.ts
+++ b/client/src/app/testing/transloco-testing.ts
@@ -1,0 +1,19 @@
+import { TranslocoTestingModule, TranslocoTestingOptions } from '@jsverse/transloco';
+
+/**
+ * Transloco module for component specs.
+ *
+ * Any component whose template uses the `transloco` pipe needs a TranslocoService in its test
+ * injector. This provides one with an empty `en` translation and the missing-key handler set to
+ * echo the key back — so a spec can assert on stable key strings without maintaining a copy of
+ * the real translation files. Pass `translation` to override a specific key when a test needs
+ * the rendered text.
+ */
+export function getTranslocoModule(options: TranslocoTestingOptions = {}) {
+  return TranslocoTestingModule.forRoot({
+    langs: { en: options.translation?.['en'] ?? {} },
+    translocoConfig: { availableLangs: ['en'], defaultLang: 'en' },
+    preloadLangs: true,
+    ...options,
+  });
+}


### PR DESCRIPTION
First slice of **P5** (the client has `OnPush` on *zero* of its components, so every tick/XHR/DOM event re-runs change detection over the whole tree).

## Why leaves first, not graph

The backlog says "heaviest first (graph…)", but graph is the **riskiest** place to establish a *verifiable* pattern: 2000+ lines, 15 subscriptions, and **9 cytoscape handlers that fire outside Angular**. `ph-icon` and `app-properties-view` are the opposite — pure, input-driven, no async — **and** the highest-instantiation components (one per row / toolbar / nav icon), so they sit right in the large-table CD hot path. Right risk/reward to go first.

## What changed

- **`ph-icon`** → `OnPush`. `@Input name/size` + `ngOnChanges`, nothing else; OnPush re-checks on input change, which is all it ever needs.
- **`app-properties-view`** → `OnPush`. `@Input properties/schema` + one local `mode` signal; re-checks on input-ref change and on the signal toggle — both covered.

## Proven, not assumed

Each conversion has a spec that **renders the component, changes an input / toggles the signal, and asserts the DOM updates**. This is only possible because of the client test harness (#188) — without it, an `OnPush` regression (a silently-stale view) would be invisible to CI. Added a small `transloco-testing` helper so components using the `transloco` pipe can be tested.

Full client suite green (**11 tests**); production build unaffected (`OnPush` is a metadata flag; specs are excluded from the build). Heaviest components next, one small PR each — building up to graph once the pattern is mature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)