### PR TITLE
perf: OnPush on the audit-log page (P5, slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`OnPush` change detection on the audit-log page (P5, slice 2).** The audit-log viewer renders
+  up to a 100-row table plus a live-streaming server log, and previously re-ran change detection over
+  its whole subtree on every unrelated tick/XHR/DOM event. Every value it renders is already a signal
+  updated immutably (`entries`, `total`, `selectedEntry`, and the SSE log via `.update([...])`), and
+  its filter fields are `ngModel` two-way bindings whose input events mark the view dirty — so `OnPush`
+  is safe and re-checks exactly when state changes. Verified with a spec that loads rows, opens the
+  detail panel, and replaces the `entries` signal, asserting the table refreshes each time — the
+  conversion is proven, not blind.
+
+### Changed
+
 - **`OnPush` change detection on the pure-display leaf components (P5, first slice).** The client had
   `OnPush` on **zero** of its components, so every timer tick, XHR completion and DOM event re-ran change
   detection over the *entire* tree — including hundreds of `ph-icon`s and property views in large tables.

--- a/client/src/app/pages/settings/audit-log.component.spec.ts
+++ b/client/src/app/pages/settings/audit-log.component.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * AuditLogComponent — verifies the OnPush conversion (P5, slice 2).
+ *
+ * Every rendered value on this page is a signal. The point of these tests is the OnPush
+ * regression guard: after switching the component to OnPush, the signal-driven views must still
+ * update — the row table when `entries` is set, the detail panel when `selectedEntry` is set, the
+ * empty state when there are no rows. If the conversion had broken change detection, one of these
+ * would render stale and the assertion would catch it. (The harness's negative control in
+ * change-detection-harness.spec.ts separately proves this harness *can* see a stale OnPush view,
+ * so a passing assertion here means the view genuinely refreshed, not that staleness is invisible.)
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of } from 'rxjs';
+import { ApiService, type AuditLogEntry } from '../../core/api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { AuditLogComponent } from './audit-log.component';
+
+function entry(over: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    _id: 'id-' + (over.operation ?? 'x'),
+    timestamp: '2026-07-14T10:00:00.000Z',
+    operation: 'memory.create',
+    status: 200,
+    ip: '10.0.0.1',
+    durationMs: 12,
+    ...over,
+  } as AuditLogEntry;
+}
+
+/** Minimal ApiService stub: the component only calls these three, all Observable-returning. */
+function makeApi(entries: AuditLogEntry[]) {
+  return {
+    listSpaces: () => of({ spaces: [] }),
+    getAuditLog: () => of({ entries, total: entries.length, hasMore: false, retentionDays: 90 }),
+    getAboutLogs: () => of({ lines: [] }),
+  } as unknown as ApiService;
+}
+
+describe('AuditLogComponent (OnPush)', () => {
+  const text = (f: { nativeElement: HTMLElement }) => f.nativeElement.textContent ?? '';
+
+  function create(entries: AuditLogEntry[]) {
+    TestBed.configureTestingModule({
+      imports: [AuditLogComponent, getTranslocoModule()],
+      providers: [{ provide: ApiService, useValue: makeApi(entries) }],
+    });
+    const fixture = TestBed.createComponent(AuditLogComponent);
+    fixture.detectChanges(); // ngOnInit → load() resolves synchronously via of()
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(AuditLogComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders a table row per audit entry after load (signal-driven view updates under OnPush)', () => {
+    const fixture = create([entry({ operation: 'memory.create' }), entry({ operation: 'entity.delete' })]);
+    const rows = fixture.nativeElement.querySelectorAll('table.audit-table tbody tr');
+    expect(rows.length).toBe(2);
+    expect(text(fixture)).toContain('memory.create');
+    expect(text(fixture)).toContain('entity.delete');
+  });
+
+  it('shows the empty state when there are no entries', () => {
+    const fixture = create([]);
+    expect(fixture.nativeElement.querySelector('table.audit-table')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.empty')).toBeTruthy();
+  });
+
+  it('opens the detail panel when selectedEntry is set (OnPush re-checks the signal)', () => {
+    const fixture = create([entry({ operation: 'space.wipe' })]);
+    expect(fixture.nativeElement.querySelector('.detail-panel')).toBeNull();
+
+    fixture.componentInstance.showDetail(entry({ operation: 'space.wipe' }));
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector('.detail-panel');
+    expect(panel).toBeTruthy();
+    expect(panel.textContent).toContain('space.wipe');
+  });
+
+  it('re-renders rows when the entries signal is replaced (not just on first load)', () => {
+    // Scope to the table body — the filter dropdown lists every operation name, so the
+    // full-page text always contains them regardless of what rows are shown.
+    const body = (f: { nativeElement: HTMLElement }) =>
+      (f.nativeElement.querySelector('table.audit-table tbody') as HTMLElement)?.textContent ?? '';
+
+    const fixture = create([entry({ operation: 'memory.create' })]);
+    expect(body(fixture)).toContain('memory.create');
+    expect(body(fixture)).not.toContain('token.delete');
+
+    fixture.componentInstance.entries.set([entry({ operation: 'token.delete' })]);
+    fixture.detectChanges();
+
+    expect(body(fixture)).toContain('token.delete');
+    expect(body(fixture)).not.toContain('memory.create');
+  });
+});

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit, OnDestroy, effect } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal, OnInit, OnDestroy, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService, type AuditLogEntry, type AuditLogParams, type Space } from '../../core/api.service';
@@ -7,6 +7,12 @@ import { TranslocoPipe } from '@jsverse/transloco';
 @Component({
   selector: 'app-audit-log',
   standalone: true,
+  // OnPush (P5): every rendered value is a signal set immutably (`entries`, `total`,
+  // `selectedEntry`, `serverLogLines` via `.update([...])`, etc.), and the filter fields are
+  // ngModel two-way bindings whose input events mark the view dirty. So OnPush re-checks exactly
+  // when state changes and skips the whole-tree sweep otherwise — this page renders up to a
+  // 100-row table plus a live-streaming server log, both in the CD hot path.
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, TranslocoPipe],
   styles: [`
     .audit-toolbar {


### PR DESCRIPTION
Second slice of **P5**. Follows #189 (the pure-display leaves), moving up to the first *page*.

## Why audit-log is next

It renders up to a **100-row table plus a live-streaming server log**, so it sits squarely in the change-detection hot path — and without `OnPush` it re-ran CD over its whole subtree on every unrelated tick/XHR/DOM event across the app. It's also the *safest* page to convert because it was already written signal-first.

## Why OnPush is safe here

Every rendered value is a signal, updated **immutably**:
- `entries` / `total` / `hasMore` / `selectedEntry` / `retentionDays` via `.set()`
- the SSE server-log via `.update(lines => [...lines, data])` — a new array, never an in-place `push`

The filter fields are `ngModel` two-way bindings, whose input events mark the view dirty. So `OnPush` re-checks exactly when state changes and skips the whole-tree sweep otherwise, with **no behavioural change**.

## Proven, not assumed

Spec (5 tests) exercises the signal-driven views under `OnPush`: rows render per entry after load, the empty state shows with no rows, the detail panel opens when `selectedEntry` is set, and the table refreshes when the `entries` signal is *replaced* (not just first load). Row-content assertions are scoped to the table body — the operation filter dropdown enumerates every operation name, so full-page text would always match.

Full client suite green (**16 tests**); production build unaffected.

Heaviest components (files, brain, graph) still to come, one small PR each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)