### PR TITLE
perf: OnPush on the file-manager page (P5, slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`OnPush` change detection on the file-manager page (P5, slice 3).** The file browser renders a
+  file listing, a recursive directory-tree sidebar, breadcrumbs, and a preview pane — previously all
+  re-checked on every unrelated tick/XHR/DOM event across the app. Every rendered value is
+  signal-backed (`entries`, `treeRoot`, `breadcrumbs`, `previewFile`/`previewHtml`, upload progress);
+  each tree expansion mutates a node in place but always follows with `treeRoot.set([...])`, and the
+  async preview/upload callbacks update via signal `.set()` — so `OnPush` re-checks exactly when
+  state changes. Verified with a spec that renders the listing and tree, opens the preview, and
+  replaces the `entries` signal, asserting each view refreshes.
+
+### Changed
+
 - **`OnPush` change detection on the audit-log page (P5, slice 2).** The audit-log viewer renders
   up to a 100-row table plus a live-streaming server log, and previously re-ran change detection over
   its whole subtree on every unrelated tick/XHR/DOM event. Every value it renders is already a signal

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * FileManagerComponent — verifies the OnPush conversion (P5, slice 3).
+ *
+ * All rendered state here is signal-backed: the file listing (`entries`), the directory tree
+ * (`treeRoot`), breadcrumbs, and the preview pane (`previewFile`/`previewKind`). The tree code
+ * mutates a node in place on expand but always follows with `treeRoot.set([...])`, and the async
+ * preview/upload callbacks use signal `.set()` — both of which mark an OnPush view dirty. These
+ * tests are the regression guard: after switching to OnPush, each signal-driven view must still
+ * refresh. The harness's negative control (change-detection-harness.spec.ts) separately proves the
+ * harness can see a stale OnPush view, so a passing assertion here means a real refresh occurred.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { ApiService, type FileEntry } from '../../core/api.service';
+import { AuthService } from '../../core/auth.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { FileManagerComponent } from './file-manager.component';
+
+function fileEntry(name: string, isDir = false): FileEntry {
+  return {
+    name,
+    isDirectory: isDir,
+    isFile: !isDir,
+    size: isDir ? 0 : 123,
+    modified: '2026-07-14T10:00:00.000Z',
+  } as FileEntry;
+}
+
+function makeApi(entries: FileEntry[]) {
+  return {
+    listSpaces: () => of({ spaces: [] }),
+    listFiles: () => of({ entries }),
+    getFileDownloadUrl: (spaceId: string, path: string) => `/api/files/${spaceId}${path}`,
+  } as unknown as ApiService;
+}
+
+describe('FileManagerComponent (OnPush)', () => {
+  const text = (f: { nativeElement: HTMLElement }) => f.nativeElement.textContent ?? '';
+
+  function create(entries: FileEntry[]) {
+    TestBed.configureTestingModule({
+      imports: [FileManagerComponent, getTranslocoModule()],
+      providers: [
+        { provide: ApiService, useValue: makeApi(entries) },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+      ],
+    });
+    const fixture = TestBed.createComponent(FileManagerComponent);
+    // Embedded path: skips space loading and drives straight to selectSpace → loadDir + loadTreeRoot.
+    fixture.componentRef.setInput('embeddedSpaceId', 'work');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(FileManagerComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders a row per file entry after load (signal-driven view updates under OnPush)', () => {
+    const fixture = create([fileEntry('readme.md'), fileEntry('notes.txt'), fileEntry('sub', true)]);
+    const names = Array.from(fixture.nativeElement.querySelectorAll('table tbody .file-name-btn')).map(
+      (b) => (b as HTMLElement).textContent?.trim(),
+    );
+    expect(names).toContain('readme.md');
+    expect(names).toContain('notes.txt');
+    expect(names).toContain('sub');
+  });
+
+  it('renders a tree node for each subdirectory (treeRoot signal)', () => {
+    const fixture = create([fileEntry('docs', true), fileEntry('src', true), fileEntry('readme.md')]);
+    const treeText = Array.from(fixture.nativeElement.querySelectorAll('.tree-node')).map(
+      (n) => (n as HTMLElement).textContent?.trim(),
+    );
+    // Only directories become tree nodes; the file must not.
+    expect(treeText.some((t) => t?.includes('docs'))).toBe(true);
+    expect(treeText.some((t) => t?.includes('src'))).toBe(true);
+    expect(treeText.some((t) => t?.includes('readme.md'))).toBe(false);
+  });
+
+  it('opens the preview overlay when the previewFile signal is set (OnPush re-checks the signal)', () => {
+    const fixture = create([fileEntry('photo.bin')]);
+    expect(fixture.nativeElement.querySelector('.preview-overlay')).toBeNull();
+
+    fixture.componentInstance.previewKind.set('unknown');
+    fixture.componentInstance.previewFile.set(fileEntry('photo.bin'));
+    fixture.detectChanges();
+
+    const overlay = fixture.nativeElement.querySelector('.preview-overlay');
+    expect(overlay).toBeTruthy();
+    expect(text(fixture)).toContain('photo.bin');
+  });
+
+  it('re-renders the listing when the entries signal is replaced (not just on first load)', () => {
+    const fixture = create([fileEntry('first.md')]);
+    const body = () => (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
+    expect(body()).toContain('first.md');
+    expect(body()).not.toContain('second.md');
+
+    fixture.componentInstance.entries.set([fileEntry('second.md')]);
+    fixture.detectChanges();
+
+    expect(body()).toContain('second.md');
+    expect(body()).not.toContain('first.md');
+  });
+});

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit, OnDestroy, HostListener, ElementRef, viewChild, Input, Output, EventEmitter } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal, OnInit, OnDestroy, HostListener, ElementRef, viewChild, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -72,6 +72,13 @@ function previewKind(name: string): PreviewKind {
 @Component({
   selector: 'app-file-manager',
   standalone: true,
+  // OnPush (P5): all rendered state is signal-backed (`entries`, `treeRoot`, `breadcrumbs`,
+  // `previewFile`/`previewHtml`, upload progress, …). Every tree expansion mutates a node in place
+  // but always follows with `treeRoot.set([...])` — a fresh reference that marks the view dirty —
+  // and the async preview/upload callbacks update via signal `.set()`, which notifies OnPush
+  // regardless of zone. Text fields (`newFolderName`, `renameValue`) are ngModel two-way bindings
+  // whose input events mark the view dirty. So OnPush re-checks exactly when state changes.
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe],
   styles: [`
     .toolbar {


### PR DESCRIPTION
Third slice of **P5**. Follows #189 (leaves) and #190 (audit-log), converting the busiest page so far.

## Why file-manager

It renders a **file-listing table, a recursive directory-tree sidebar, breadcrumbs, upload progress, and a preview pane** — and without `OnPush`, all of it re-checked on every unrelated tick/XHR/DOM event across the app.

## Why OnPush is safe here

Signal-first throughout — `entries`, `treeRoot`, `breadcrumbs`, `previewFile`/`previewKind`/`previewHtml`, and the upload signals are all set via `.set()`. The one spot that mutates a rendered object **in place** is tree expand/collapse (`node.expanded`/`node.children`/`node.loading`), and it *always* follows the mutation with `this.treeRoot.set([...this.treeRoot()])` — a fresh array reference that marks the view dirty. The async preview (fetch + highlight) and chunked-upload callbacks write signals, which notify `OnPush` regardless of zone. Text inputs are `ngModel` two-way bindings whose input events mark the view dirty.

## Proven, not assumed

Spec (5 tests): a row per file after load, a tree node per subdirectory (files excluded), the preview overlay opening when `previewFile` is set, and the listing refreshing when `entries` is *replaced*. Drives load via the embedded-space input path (no router query params needed).

Full client suite green (**21 tests**); production build unaffected.

Remaining: **brain**, then **graph** last (the riskiest — cytoscape handlers outside Angular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)