### PR TITLE
perf: OnPush on the brain page (P5, slice 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`OnPush` change detection on the brain page (P5, slice 4).** Brain is the heaviest page in the
+  app — 49 signals, five record tabs, a detail drawer and an embedded graph — and previously re-checked
+  all of it on every unrelated tick/XHR/DOM event. It is safe under `OnPush` because every async path
+  (list/create/save subscribes, the 300 ms search debounces) writes signals, which notify `OnPush`
+  regardless of zone, and nothing mutates a signal's value in place. The page also renders plain,
+  non-signal form models (`memoryForm`, `drawerEdit*`) through `ngModel`; those re-check only because
+  each write is paired with a signal write in the same turn, or happens in a template event handler.
+  That coupling is load-bearing and invisible in the source, so a spec now pins it — the drawer title
+  binds the plain field, and dropping the sibling signal write fails CI instead of silently rendering
+  a stale form.
+
 - **`OnPush` change detection on the file-manager page (P5, slice 3).** The file browser renders a
   file listing, a recursive directory-tree sidebar, breadcrumbs, and a preview pane — previously all
   re-checked on every unrelated tick/XHR/DOM event across the app. Every rendered value is

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * BrainComponent — verifies the OnPush conversion (P5, slice 4).
+ *
+ * Brain is the heaviest page in the app (49 signals, five record tabs, a detail drawer). It is
+ * OnPush-safe because every async path writes signals, which notify OnPush regardless of zone.
+ *
+ * The subtle part — and the reason the drawer test below exists — is that brain also renders plain,
+ * NON-signal form models (`memoryForm`, `drawerEditMemory`, …) through ngModel. A plain-field write
+ * does not mark an OnPush view dirty on its own; these render only because every write is
+ * accompanied by a signal write in the same turn (`openDrawer` sets the `drawerRecord` signal; the
+ * create callbacks set `creatingX`/`showXForm`) or happens inside a template event handler. That
+ * coupling is load-bearing and invisible in the source, so it is pinned here: the drawer title binds
+ * the plain `drawerEditMemory.fact`, and if the sibling signal write were ever dropped, the title
+ * would render empty and this test would fail rather than the bug shipping silently.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { ApiService, type Memory } from '../../core/api.service';
+import { AuthService } from '../../core/auth.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainComponent } from './brain.component';
+
+function memory(fact: string, id = fact): Memory {
+  return {
+    _id: id,
+    fact,
+    tags: [],
+    entityIds: [],
+    properties: {},
+    createdAt: '2026-07-14T10:00:00.000Z',
+    seq: 1,
+  } as unknown as Memory;
+}
+
+/** Read-only stub: brain's init cascade is listSpaces → getSpaceStats/getReindexStatus/getSpaceMeta. */
+function makeApi() {
+  return {
+    listSpaces: () => of({ spaces: [{ id: 'work', label: 'Work' }] }),
+    getSpaceStats: () => of({ memories: 0, entities: 0, edges: 0, chrono: 0, files: 0 }),
+    getReindexStatus: () => of({ needsReindex: false }),
+    getSpaceMeta: () => of({ tagSuggestions: [], typeSchemas: {} }),
+    listMemories: () => of({ memories: [] }),
+    getEntitiesByIds: () => of({ entities: [] }),
+  } as unknown as ApiService;
+}
+
+describe('BrainComponent (OnPush)', () => {
+  function create() {
+    TestBed.configureTestingModule({
+      imports: [BrainComponent, getTranslocoModule()],
+      providers: [
+        { provide: ApiService, useValue: makeApi() },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+      ],
+    });
+    const fixture = TestBed.createComponent(BrainComponent);
+    fixture.detectChanges(); // ngOnInit → listSpaces resolves synchronously via of()
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(BrainComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders a row per memory on the memories tab (signal-driven view updates under OnPush)', () => {
+    const fixture = create();
+    const c = fixture.componentInstance;
+
+    c.activeTab.set('memories');
+    c.memories.set([memory('the sky is blue'), memory('water is wet')]);
+    fixture.detectChanges();
+
+    const body = (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
+    expect(body).toContain('the sky is blue');
+    expect(body).toContain('water is wet');
+  });
+
+  it('re-renders the list when the memories signal is replaced', () => {
+    const fixture = create();
+    const c = fixture.componentInstance;
+    const body = () => (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
+
+    c.activeTab.set('memories');
+    c.memories.set([memory('first fact')]);
+    fixture.detectChanges();
+    expect(body()).toContain('first fact');
+
+    c.memories.set([memory('second fact')]);
+    fixture.detectChanges();
+    expect(body()).toContain('second fact');
+    expect(body()).not.toContain('first fact');
+  });
+
+  it('opens the detail drawer AND renders its plain (non-signal) form model', async () => {
+    // The load-bearing case. `openDrawer` writes the `drawerRecord` SIGNAL (which marks the OnPush
+    // view dirty) and the plain `drawerEditMemory` field in the same turn. The drawer title binds
+    // that plain field — so this asserts the plain-field write is actually picked up by the CD pass
+    // the signal write scheduled. Drop the sibling signal write and this goes blank.
+    const fixture = create();
+    const c = fixture.componentInstance;
+    expect(fixture.nativeElement.querySelector('.drawer')).toBeNull();
+
+    c.openDrawer('memory', { _id: 'm1', fact: 'a load-bearing fact', tags: [], entityIds: [], properties: {} });
+    fixture.detectChanges();
+
+    const drawer = fixture.nativeElement.querySelector('.drawer');
+    expect(drawer, 'the drawer should be open').toBeTruthy();
+    const title = fixture.nativeElement.querySelector('.drawer-title') as HTMLElement;
+    expect(title.textContent).toContain('a load-bearing fact');
+
+    // And the ngModel-bound textarea reflects the same plain field. ngModel writes its DOM value in
+    // a microtask, so let that settle before reading it.
+    await fixture.whenStable();
+    const textarea = drawer.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('a load-bearing fact');
+  });
+});

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, inject, signal, computed, OnInit } from '@angular/core';
+﻿import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ApiService, Space, SpaceStats, Memory, Entity, Edge, ChronoEntry, ChronoType, ChronoStatus, QueryCollection, QueryResult, RecallResult, RecallKnowledgeType, SpaceMetaResponse, KnowledgeType, PropertySchema, FileMeta } from '../../core/api.service';
@@ -22,6 +22,16 @@ interface SpaceView {
 @Component({
   selector: 'app-brain',
   standalone: true,
+  // OnPush (P5): the heaviest page in the app — 49 signals, five record tabs, a detail drawer and
+  // an embedded graph. Safe because every async path (list/create/save subscribes, the 300 ms search
+  // debounces) writes signals, which notify OnPush regardless of zone; nothing mutates a signal's
+  // value in place. NOTE the plain (non-signal) form models — `memoryForm`, `drawerEdit*`, … — are
+  // rendered via ngModel and are re-checked only because each write is accompanied by a signal write
+  // in the same turn (e.g. `openDrawer` sets `drawerRecord`; the create callbacks set
+  // `creatingX`/`showXForm`) or happens in a template event handler, both of which mark the view
+  // dirty. That coupling is load-bearing: the drawer spec below pins it, so dropping the sibling
+  // signal write would fail CI rather than silently render a stale form.
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, TranslocoPipe],
   styles: [`
     .space-tabs {


### PR DESCRIPTION
Fourth slice of **P5**, and the heaviest page in the app: **49 signals, five record tabs, a detail drawer and an embedded graph** — all previously re-checked on every unrelated tick/XHR/DOM event across the app.

## Audited safe, not assumed safe

- Every async path writes **signals** (list/create/save subscribes, the 300 ms search debounces), and signal writes notify `OnPush` regardless of zone.
- **Nothing mutates a signal's value in place** — grepping for `().push(` / `.splice(` on signal values returns zero hits.
- The plain non-signal fields that get rendered (`collectionTabs`, `chronoKinds`, …) are immutable option arrays.

## The subtle part, and why there's a test for it

Brain renders plain, **non-signal** form models (`memoryForm`, `entityForm`, `drawerEdit*`) through `ngModel`. **A plain-field write does not mark an OnPush view dirty on its own.** They render only because every write is accompanied by a signal write in the same turn (`openDrawer` sets the `drawerRecord` signal; the create callbacks set `creatingX`/`showXForm`), or happens inside a template event handler.

That coupling is **load-bearing and invisible in the source** — so the spec pins it. The drawer title binds the plain `drawerEditMemory.fact`; if the sibling signal write were ever dropped, the title renders empty and **CI fails**, rather than the bug shipping as a silently stale form. That's the failure mode `OnPush` is notorious for, and it's now guarded.

## Tests

4 tests: `OnPush` is set, memories render per row, the list refreshes when the `memories` signal is *replaced*, and the drawer opens rendering **both** its signal-driven and plain-field-driven content (title + `ngModel` textarea).

Full client suite green (**25 tests**); production build unaffected.

**Graph is the last one** — the riskiest (cytoscape handlers fire outside Angular), deliberately left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)