### PR TITLE
perf: OnPush on the graph page (P5, final slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`OnPush` change detection on the graph page (P5, final slice).** The graph view — a cytoscape
+  canvas whose event handlers fire outside Angular — was the highest-value and highest-risk `OnPush`
+  target, and completes the P5 pass over the app's heavy pages. Audited safe: the four handlers that
+  touch Angular state (node/edge/background tap, double-tap re-root) write only signals, which notify
+  `OnPush` regardless of zone; the rest only toggle cytoscape CSS classes on the canvas. Nothing
+  mutates a signal's value in place, and the plain node/edge/colour fields are canvas-only (never in
+  the template). Verified with a spec that drives the tap-written signals and asserts the side panels
+  open/close, plus the drawer's plain-field/signal coupling — cytoscape is mocked because it needs a
+  real canvas jsdom lacks, but the behaviour under test is entirely Angular's signal→CD path.
+
 - **`OnPush` change detection on the brain page (P5, slice 4).** Brain is the heaviest page in the
   app — 49 signals, five record tabs, a detail drawer and an embedded graph — and previously re-checked
   all of it on every unrelated tick/XHR/DOM event. It is safe under `OnPush` because every async path

--- a/client/src/app/pages/graph/graph.component.spec.ts
+++ b/client/src/app/pages/graph/graph.component.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * GraphComponent — verifies the OnPush conversion (P5, final slice).
+ *
+ * Graph is the highest-value and highest-risk P5 target: a cytoscape canvas whose event handlers
+ * fire OUTSIDE Angular. The conversion is safe because the handlers that touch Angular state write
+ * signals (`selectedNode`/`selectedEdge`/…), and signal writes notify OnPush regardless of zone. The
+ * tests below drive those signals directly — simulating what a node/edge tap does — and assert the
+ * side panels render, which is the property that would break if a handler wrote a plain field
+ * instead. The drawer test additionally pins the plain-field/signal coupling (same shape as brain).
+ *
+ * cytoscape is mocked: it renders to a real canvas, which jsdom does not provide. The mock is a
+ * chainable no-op so `ngAfterViewInit → initCytoscape()` runs without a DOM canvas; the OnPush
+ * behaviour under test lives entirely in Angular's signal → change-detection path, not in cytoscape.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+
+vi.mock('cytoscape', () => {
+  const chain: any = new Proxy(() => chain, { get: () => () => chain });
+  return { default: () => chain };
+});
+
+import { ApiService } from '../../core/api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { GraphComponent } from './graph.component';
+
+function makeApi() {
+  return {
+    getMe: () => of({ readOnly: false }),
+    listSpaces: () => of({ spaces: [] }),
+  } as unknown as ApiService;
+}
+
+describe('GraphComponent (OnPush)', () => {
+  function create() {
+    TestBed.configureTestingModule({
+      imports: [GraphComponent, getTranslocoModule()],
+      providers: [
+        { provide: ApiService, useValue: makeApi() },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } },
+      ],
+    });
+    const fixture = TestBed.createComponent(GraphComponent);
+    fixture.componentRef.setInput('embeddedSpaceId', 'work'); // embedded path: skip listSpaces
+    fixture.detectChanges(); // ngOnInit + ngAfterViewInit (cytoscape mocked)
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(GraphComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders the node side panel when selectedNode is set (the signal a cytoscape tap writes)', () => {
+    const fixture = create();
+    const c = fixture.componentInstance;
+    expect(fixture.nativeElement.querySelector('.side-panel')).toBeNull();
+
+    // This is exactly what the `cy.on('tap','node')` handler does — write the signal.
+    c.selectedNode.set({ _id: 'n1', name: 'Ada Lovelace', type: 'person', depth: 1 } as any);
+    fixture.detectChanges();
+
+    const panel = fixture.nativeElement.querySelector('.side-panel');
+    expect(panel, 'the side panel should open on selectedNode').toBeTruthy();
+    expect(panel.querySelector('h3').textContent).toContain('Ada Lovelace');
+  });
+
+  it('closes the side panel when selectedNode is cleared (background-tap path)', () => {
+    const fixture = create();
+    const c = fixture.componentInstance;
+    c.selectedNode.set({ _id: 'n1', name: 'Node', type: 'x', depth: 1 } as any);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.side-panel')).toBeTruthy();
+
+    c.selectedNode.set(null); // what the background-tap handler does
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.side-panel')).toBeNull();
+  });
+
+  it('opens the brain drawer and renders its plain (non-signal) form model', () => {
+    // Same load-bearing coupling as brain: openBrainDrawer writes the drawerRecord SIGNAL (guards the
+    // drawer @if) and the plain drawerEditMemory field in the same turn. The title binds the plain
+    // field, so if the sibling signal write were dropped this would render empty rather than ship stale.
+    const fixture = create();
+    const c = fixture.componentInstance;
+    expect(fixture.nativeElement.querySelector('.drawer')).toBeNull();
+
+    c.openBrainDrawer('memory', { _id: 'm1', fact: 'a graph-drawer fact', tags: [], entityIds: [], properties: {} });
+    fixture.detectChanges();
+
+    const drawer = fixture.nativeElement.querySelector('.bdrawer-modal');
+    expect(drawer, 'the drawer should be open').toBeTruthy();
+    expect((fixture.nativeElement.querySelector('.bdrawer-title') as HTMLElement).textContent)
+      .toContain('a graph-drawer fact');
+  });
+});

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -1,4 +1,5 @@
 ﻿import {
+  ChangeDetectionStrategy,
   Component,
   OnInit,
   AfterViewInit,
@@ -52,6 +53,16 @@ interface DetailRow {
 @Component({
   selector: 'app-graph-view',
   standalone: true,
+  // OnPush (P5, final slice): the highest-value target — a cytoscape canvas whose 9 event handlers
+  // fire OUTSIDE Angular. Audited safe: the four handlers that touch Angular state
+  // (node/edge/background tap, dbltap re-root) write only signals (`selectedNode`/`selectedEdge`/…),
+  // and signal writes notify OnPush regardless of zone; the other five only toggle cytoscape CSS
+  // classes on the canvas, never Angular state. Nothing mutates a signal's value in place, and the
+  // plain `graphNodes`/`graphEdges`/color fields are canvas-only (never in the template). The one
+  // pair of template-bound plain fields — `drawerEditMemory`/`drawerEditChrono` — is written in
+  // `openBrainDrawer` alongside the `drawerRecord` signal that guards the drawer's `@if`, the same
+  // load-bearing coupling pinned by the brain spec.
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, TagInputComponent, PropertiesEditorComponent, PhIconComponent, TranslocoPipe],
   host: { '[class.embedded]': 'isEmbedded()' },
   styles: [`


### PR DESCRIPTION
**Final slice of P5** — completes the `OnPush` pass over the app's heavy pages (leaves #189, audit-log #190, file-manager #191, brain #194, graph here).

The graph view was deliberately saved for last: **highest value** (a cytoscape canvas is the single biggest CD cost) but **highest risk**, because cytoscape's event handlers fire **outside Angular** — being inside a zone guarantees nothing about a handler's state change being seen.

## Audited, not assumed

Of the **9 cytoscape handlers**, only four touch Angular state — node tap, edge tap, background tap, double-tap re-root — and **every one writes signals** (`selectedNode`/`selectedEdge`/…), which notify `OnPush` regardless of zone. The other five only add/remove cytoscape CSS classes on the canvas. A full sweep confirms:
- nothing mutates a signal's value in place;
- the plain `graphNodes`/`graphEdges`/colour fields are **canvas-only** (never in the template);
- the only template-bound plain fields are `drawerEditMemory`/`drawerEditChrono`, written in `openBrainDrawer` alongside the `drawerRecord` signal that guards the drawer — the same load-bearing coupling pinned in brain (#194).

## Tests

4 tests: `OnPush` is set; the node side panel **opens** when `selectedNode` is set (exactly what the tap handler does) and **closes** when cleared (background-tap path); the brain drawer opens rendering its plain-field-driven title. cytoscape is mocked (it renders to a real canvas jsdom lacks) — the behaviour under test is entirely Angular's signal→CD path, not cytoscape's.

Full client suite green (**29 tests**); production build unaffected.

## P5 is now done

The four heaviest pages + the highest-instantiation leaves are all `OnPush`, each with a verifying spec. These are the components that dominated the whole-tree CD sweep on every 60 s conflict poll; they now opt out when idle. The ~30 remaining lighter components (dialogs, settings sub-panels) aren't in any hot path — cheap but low-value. **The real next prize is fully zoneless** (`provideZonelessChangeDetection`); with the heavy pages `OnPush` and the codebase signal-heavy, that's now a much smaller step. Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)