### PR TITLE
perf: go fully zoneless — drop the zone.js polyfill (P13)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: verify
+description: Runtime-verify a client or server change by booting an isolated Ythril instance (scratch config + scratch Mongo DB) and driving the Angular UI with Playwright. Use before committing nontrivial client/server changes.
+---
+
+# Verifying Ythril changes end-to-end
+
+The user's real instance runs in Docker on port 3210 with real data — never drive it.
+Boot an isolated copy instead; it takes ~30 s.
+
+## Isolated server (from source, scratch state)
+
+```powershell
+$env:PORT='3260'; $env:TRUST_PROXY='1'                 # TRUST_PROXY=1 or the dev proxy's xfwd header 500s every API call (rate limiter)
+$env:CONFIG_PATH='<scratch>\config\config.json'        # nonexistent file → server boots in first-run /setup mode
+$env:DATA_ROOT='<scratch>\data'
+$env:MONGO_URI='mongodb://127.0.0.1:27017/ythril_scratch'   # host mongod (8.2+, supports $vectorSearch); distinct DB name isolates it
+Set-Location server; npx tsx src/index.ts              # run in background, redirect output to a log
+```
+
+Wait for `http://localhost:3260/health` → 200. To reset to first-run: stop the server,
+delete the scratch config files, drop the scratch DB
+(`node -e "...MongoClient... db('ythril_scratch').dropDatabase()"` using the repo's mongodb package),
+restart. The server caches config in memory — a restart is required.
+
+## Client dev server
+
+`proxy.conf.json` targets 3210 — make a scratch copy pointing at 3260 (must be UTF-8 **without BOM**;
+PowerShell 5.1 `-Encoding utf8` writes a BOM and ng fails with `[1,1] InvalidSymbol`):
+
+```powershell
+Set-Location client; npx ng serve --port 4260 --proxy-config <scratch>\proxy.conf.json
+```
+
+## Driving the UI (Playwright, no install needed beyond npm)
+
+`npm i playwright` in a scratch dir; launch with `channel: 'msedge'` (installed on this machine — no browser download).
+
+Flow and selectors that work:
+- `/` unauthenticated → redirects to `/login`; click "Run first-time setup" → `/setup`.
+- Setup: `#label`, `#pw`, `#pw2`, submit → `.alert-success`, token in `.code-block span` (save it!), "Continue to sign in".
+- Login: `#token` + submit; bad token → "Invalid or expired token.".
+- Spaces/Tokens create flows are dialogs: "Create New Space" / "Create Token" buttons open them; submit with
+  `getByRole('button', {name: 'Create', exact: true})` — `has-text` is case-insensitive and matches the opener button too.
+- Brain tabs (Query, Graph, Files, Entities, Edges, Memories, Chrono, File Meta) carry count badges —
+  match with non-exact `getByText(tab).first()`.
+- Entity add-form's NAME field is the only visible input without a placeholder: `input:not([placeholder]):visible`.
+- Strong CD probes: language switch on `/settings/preferences` (`.lang-btn` "Deutsch" → nav shows "Abmelden"),
+  token create → success panel → list update, entity create → tab badge increments.
+
+Routes to sweep: `/brain`, `/files/conflicts`, `/schema-library`, `/settings/{tokens,spaces,storage,networks,preferences,audit-log,data,about,models,duplicates}`.
+
+## Gotchas
+
+- Setup auto-creates a "General" space.
+- Collect page console errors; filter for `NG0`/zone patterns after change-detection work.
+- One benign 500 ("Config not loaded") is logged during first-run before setup completes — pre-existing server behavior, not a client bug.
+- On plain host mongod the server logs "Could not list search indexes" warnings — harmless in scratch runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The client is fully zoneless (P13) — `zone.js` is gone.** The endgame of the P5 `OnPush` pass:
+  the app now bootstraps with `provideZonelessChangeDetection()` and the `zone.js` polyfill is removed
+  from the build (and from `dependencies`). Until now every timer, XHR, and DOM event anywhere in the
+  page scheduled a whole-tree change-detection sweep as a zone-driven safety net; change detection now
+  runs only when something Angular actually tracks changes — a signal write, an `ngModel`/event-handler
+  update, an `AsyncPipe` emission — which the P5 audit already established is how every page updates
+  state. The safety net was all cost and no catch. The polyfill's ~90 kB (raw) also drops out of the
+  initial bundle, which shrinks to 378.5 kB raw / 104.7 kB transfer with no polyfills chunk at all.
+  The Vitest environment flips with it (`test-setup.ts` provides the same zoneless providers to every
+  `TestBed`), so specs — including the change-detection harness whose negative control proves staleness
+  is still detectable — exercise the exact CD regime production runs. Verified beyond the suite with a
+  full Playwright click-through of every route on a fresh instance (first-run setup → login incl. the
+  invalid-token error path → space/token/entity creation → language switch re-rendering the whole
+  shell → all ten settings/workspace routes): no stale view, zero Angular console errors.
+
 - **Filtered semantic recall now pre-filters instead of scanning everything (P6), and per-space
   indexes shed their redundant `spaceId` key (P10) — one index migration for the major release.**
   Two changes that both rewrite live-space indexes, bundled into a single boot migration.

--- a/client/angular.json
+++ b/client/angular.json
@@ -26,7 +26,7 @@
             },
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               { "glob": "**/*", "input": "public" }

--- a/client/package.json
+++ b/client/package.json
@@ -26,8 +26,7 @@
     "highlight.js": "^11.11.1",
     "qrcode": "^1.5.4",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^2.6.3",

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, provideZoneChangeDetection, APP_INITIALIZER, inject } from '@angular/core';
+import { ApplicationConfig, provideZonelessChangeDetection, APP_INITIALIZER, inject } from '@angular/core';
 import { provideRouter, withComponentInputBinding, TitleStrategy } from '@angular/router';
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -20,7 +20,7 @@ export class TranslocoHttpLoader implements TranslocoLoader {
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideZonelessChangeDetection(),
     provideRouter(routes, withComponentInputBinding()),
     { provide: TitleStrategy, useClass: TranslocoTitleStrategy },
     provideHttpClient(withInterceptors([authInterceptor, mfaInterceptor])),

--- a/client/src/test-setup.ts
+++ b/client/src/test-setup.ts
@@ -1,16 +1,19 @@
 /**
  * Vitest setup — initialise the Angular test environment once per worker.
  *
- * The app runs with zone.js (not zoneless yet — that is the P5 endgame), so the tests load
- * zone.js + its testing patch and use the browser testing platform. When the app goes
- * zoneless, this file (and the `provideZonelessChangeDetection()` decision) is where that
- * flips.
+ * The app is zoneless (P13): `provideZonelessChangeDetection()` in app.config.ts, no zone.js
+ * polyfill. Tests must run under the SAME change-detection regime, or the OnPush/staleness
+ * assertions (see change-detection-harness.spec.ts) would be exercising a scheduler that
+ * production doesn't use. `ZonelessTestModule` injects the zoneless providers into every
+ * TestBed the same way app.config.ts does for the app.
  */
-import 'zone.js';
-import 'zone.js/testing';
+import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
+@NgModule({ providers: [provideZonelessChangeDetection()] })
+class ZonelessTestModule {}
+
 // Each spec file runs in its own isolated fork (see vitest.config.ts), so the platform is
 // created once per file — exactly what Angular's global TestBed expects.
-getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
+getTestBed().initTestEnvironment([BrowserTestingModule, ZonelessTestModule], platformBrowserTesting());

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,7 @@
         "highlight.js": "^11.11.1",
         "qrcode": "^1.5.4",
         "rxjs": "~7.8.0",
-        "tslib": "^2.3.0",
-        "zone.js": "~0.15.0"
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@analogjs/vite-plugin-angular": "^2.6.3",
@@ -18208,11 +18207,6 @@
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
-    },
-    "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w=="
     },
     "server": {
       "name": "@ythril/server",


### PR DESCRIPTION
## Summary

The endgame of the P5 `OnPush` pass, and the last item in the performance backlog: the client now bootstraps with `provideZonelessChangeDetection()` and the `zone.js` polyfill is removed from the build and from `dependencies`.

- **Why it matters:** until now every timer, XHR, and DOM event anywhere in the page scheduled a whole-tree change-detection sweep as a zone-driven safety net. P5 established that every page updates state through signals / template event handlers / `AsyncPipe` — so the net was all cost and no catch. Zoneless removes the implicit CD trigger for the *entire* app, not just the pages P5 annotated.
- **Bundle:** the polyfill's ~90 kB (raw) drops out of the initial bundle — now **378.5 kB raw / 104.7 kB transfer, with no polyfills chunk at all**.
- **Tests:** `test-setup.ts` now provides the same zoneless providers to every `TestBed`, so specs run under the exact CD regime production uses. The change-detection harness negative control still detects a stale `OnPush` view under zoneless. No `fakeAsync`/`tick`/`waitForAsync` existed anywhere in the suite, so nothing needed rewriting.
- Also persists the runtime-verification recipe as `.claude/skills/verify/SKILL.md` (isolated scratch instance + Playwright drive), so future sessions skip the cold start.

## Verification

- Full client suite: **29/29 specs pass** zoneless.
- Production build clean (both warnings pre-existing).
- **Playwright click-through of every route** on a fresh isolated instance (scratch config + scratch Mongo DB, real server from source): first-run setup (incl. password-mismatch hint on keystroke), login (incl. invalid-token error render), space creation dialog → table update, token creation → success panel → list update, brain entity creation → tab badge increments, brain tab sweep (Query/Graph/Files/Entities/Edges/Memories/Chrono/File Meta), language switch DE↔EN re-rendering the whole shell, and all ten settings/workspace routes. **21/21 steps passed, zero Angular console errors, no stale view anywhere.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)