### PR TITLE
docs: bring sync-protocol and network-types back in line with the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,19 +355,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Vote propagation now pulls before it pushes, so convergence no longer stalls behind an
-  unbounded push.** In each sync cycle `propagateVotesWithPeer` exchanged governance votes with a
-  peer by first pushing *every* cast of *every* locally-known round and only then pulling the peer's
-  rounds. Because a round is never removed from `pendingRounds` once it concludes, that push loop
-  grows without bound over a network's lifetime — and it `await`s each cast sequentially, so on a
-  busy or high-latency peer a cycle could spend all its time re-broadcasting dead history and never
-  reach the pull. Adopting the peer's casts is the convergence-critical half, so it now runs
-  **first** and persists immediately; the push runs after and additionally **skips any round that is
-  already concluded and past its deadline** (every peer concludes such a round independently once the
-  deadline passes, so re-pushing it forever is pure waste). No protocol or governance-semantics
-  change — only ordering and dead-round pruning from the push set. This also removes the load-sensitive
-  stall behind the intermittently-failing `vote-signing` relay test (its "triggers succeed but the
-  peer never delivers" timeout was this push starving the pull under full-suite load).
+- **Sync-protocol and network-types docs brought back in line with the code** after a full docs
+  audit cross-checked every claim. `docs/sync-protocol.md`: corrected the phase order (governance
+  gossip + vote propagation deliberately run *first*, ahead of the data phases) and documented the
+  previously missing presync warm-up (`POST /api/sync/warm`) and opt-in Merkle divergence check
+  (`GET /api/sync/merkle`); rewrote the file-sync section to match reality (file tombstones travel
+  both directions, files are pushed as well as pulled, and hash divergence produces a conflict
+  copy plus a `ConflictDoc` — never an overwrite); fixed the manual-trigger semantics (async fire-and-forget
+  returning `{ status: 'triggered' }`), the direction-enforcement 403 body, the file-download URL
+  shape (`?path=` query parameter), and the tombstone endpoint/pull descriptions (chrono is a
+  fourth synced type; tombstone push pages 500/request until drained); removed the nonexistent
+  `GET /api/sync/info` (identity comes from `GET /api/about` and the gossip `self` record);
+  documented the ingest safety caps (implausible-seq ceiling, fork depth/fan-out ≤ 10), the
+  50-page-per-type pull cap, watermark persistence via the coalesced config flush, gossip signing
+  fields, and the real auth model of the sync surface. `docs/network-types.md`: fixed the broken
+  tombstone-guard link, the invite-generate auth level (admin), the vote-deadline default (24 h,
+  configurable 1–72 h), and replaced the misleading offline-peer timing estimate with the accurate
+  bounded-timeout statement. Doc-only; no behavior change.
 
 - **Schema validation was a total no-op on MCP — the surface agents actually use.** `validateMemory()` keys
   the whole per-type schema lookup off `memory.type`, but the MCP `remember` and `bulk_write` tools never

--- a/docs/network-types.md
+++ b/docs/network-types.md
@@ -117,7 +117,7 @@ sequenceDiagram
     participant Net as Network (5 members)
 
     E->>Net: join request
-    Net-->>Net: voting round opens (48h deadline)
+    Net-->>Net: voting round opens (24h deadline by default, configurable 1–72h)
     Note over Net: A → yes<br/>B → yes<br/>C → yes<br/>D → abstains<br/>F → VETO
     Net-->>E: ✗ blocked by veto — not admitted
 ```
@@ -268,7 +268,7 @@ Subscribers may add their own content to the synced spaces. Publisher-pushed con
 1. **UUIDv4 identity** — every document `_id` is a UUIDv4 (122 bits of randomness). Two independent instances will never generate the same ID, so a publisher's tombstone structurally cannot target a subscriber-created document.
 2. **Author guard** — even if IDs hypothetically collided, `applyRemoteTombstone` compares `tombstone.instanceId` against `localDoc.author.instanceId` and skips the delete when they differ.
 
-See [Tombstone author guard](sync-protocol.md#tombstone-author-guard) and [Document ID collision safety](sync-protocol.md#document-id-collision-safety) in the sync protocol for details. The same protection applies to all directional network types (braintree, pubsub).
+See [Tombstone deletion authorisation](sync-protocol.md#tombstone-deletion-authorisation) and [Document ID collision safety](sync-protocol.md#document-id-collision-safety) in the sync protocol for details. The same protection applies to all directional network types (braintree, pubsub).
 
 **Key differences from Braintree:**
 
@@ -287,7 +287,7 @@ See [Tombstone author guard](sync-protocol.md#tombstone-author-guard) and [Docum
 
 A peer that is unreachable for a sync cycle is skipped, and the cycle continues for all other members. The `lastSyncAt` timestamp and the `lastSeqReceived` high-water mark are only advanced on a successful sync — so when the peer comes back online, it picks up exactly where it left off, regardless of how long it was gone. All accumulated changes since the last successful sync are exchanged on the next cycle.
 
-Each outbound connection attempt times out after **10 seconds** — a one-month-offline peer causes a 10 s delay per cycle, not the OS TCP timeout (~75 s).
+Every outbound call has its own bounded timeout (10 s for small requests, 60 s for batch transfers) rather than the OS TCP timeout (~75 s) — so an offline member simply makes the cycle take longer while it works through those timeouts; the cycle always completes and every other member still syncs.
 
 ### Consistently unreachable peers
 
@@ -419,7 +419,7 @@ sequenceDiagram
 
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| `POST` | `/api/invite/generate` | Bearer token | Start a session for a specific network |
+| `POST` | `/api/invite/generate` | Bearer token (admin) | Start a session for a specific network |
 | `POST` | `/api/invite/apply` | none (handshakeId is credential) | B submits its RSA public key; receives encrypted token |
 | `POST` | `/api/invite/finalize` | none (handshakeId is credential) | B delivers encrypted token for A; session completed |
 | `GET` | `/api/invite/status/:handshakeId` | none | Check if a session is still pending or completed |

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -8,16 +8,21 @@ This document describes how two brains exchange data in a sync cycle: the sequen
 
 Sync is **peer-to-peer over plain HTTPS**. Each brain calls its peers directly using the URL stored in the `member.url` config field — typically `https://brain.example.com`. There is no central broker.
 
-A sync cycle for a single member consists of four phases in order:
+A sync cycle for a single member consists of these phases in order:
 
 | Phase | Direction | Description |
 |-------|-----------|-------------|
+| **Warm-up** | us → peer | `POST /api/sync/warm` asks the peer to eagerly warm its embedding model, bcrypt token cache, and MongoDB collection handles before the real work starts; local collections are warmed in parallel. Best-effort. |
+| **Gossip** | us ↔ peer | Exchange member identity records (label, URL, children, signing keys) |
+| **Vote propagation** | us ↔ peer | Push local vote casts, pull the peer's rounds, conclude rounds |
 | **Pull** | peer → us | Fetch everything the peer has that we haven't seen yet |
 | **Push** | us → peer | Upload everything we have that the peer hasn't seen yet |
-| **File sync** | peer → us | Download files whose SHA-256 digest differs from ours |
-| **Gossip** | us ↔ peer | Exchange member identity records (label, URL, children) |
+| **File sync** | us ↔ peer | Exchange file tombstones, download files we lack, push files the peer lacks |
+| **Merkle check** | us ↔ peer | Opt-in (`network.merkle: true`): compare per-space Merkle roots after sync and log a `MERKLE_DIVERGENCE` warning on mismatch |
 
-Phases 1 and 2 are gated by [watermarks](#watermarks) so only new or changed documents travel over the wire. Phase 3 is manifest-based and equally incremental. Phase 4 propagates identity metadata across the member graph.
+Governance (gossip + vote propagation) runs **before** the data phases, deliberately: vote rounds are deadline-sensitive and their messages are small, so they must converge promptly and independently of the data plane. It used to run last, which meant any failure in the per-space data loop (a timed-out pull, a slow file transfer) skipped governance for the whole cycle — a saturated peer could starve vote propagation indefinitely.
+
+Pull and push are gated by [watermarks](#watermarks) so only new or changed documents travel over the wire. File sync is manifest-based and equally incremental.
 
 Which phases run for a given member depends on the `member.direction` field:
 
@@ -36,7 +41,7 @@ For non-directional networks (`closed`, `democratic`, `club`), pull and push alw
 Sync can be triggered two ways:
 
 - **Scheduled** — `syncSchedule` on the network config starts a node-cron task per network at startup. Accepts a standard cron expression (e.g. `"*/5 * * * *"`, `"0 * * * *"`); the legacy shorthands `"*/N minutes|hours"` and `"every Nm|Nh"` are also accepted and translated to cron.
-- **Manual** — `POST /api/notify/trigger { networkId }` runs the cycle immediately and returns `{ synced, errors }`.
+- **Manual** — `POST /api/notify/trigger { networkId }` starts the cycle asynchronously (fire-and-forget) and returns `{ status: 'triggered', networkId }` immediately — a full cycle can run for minutes, so the HTTP response never waits on it. Results surface in the per-network sync history and logs. (The admin UI's `POST /api/networks/:id/sync` behaves the same way, returning `{ ok: true }`.)
 
 ---
 
@@ -49,7 +54,7 @@ Two independent high-water marks prevent redundant data transfer:
 | `lastSeqReceived[spaceId]` | `Record<string,number>` | Highest seq we have ever pulled from this peer for this space |
 | `lastSeqPushed[spaceId]` | `Record<string,number>` | Highest seq we have confirmed pushed to this peer for this space |
 
-Both are stored per member in the config file and persisted immediately after a successful sync. If a sync fails mid-way, the watermark is not advanced — the next cycle retries from the last safe point, giving at-least-once delivery semantics.
+Both are stored per member in the config file. After a successful sync they are written through the coalesced asynchronous config flush (`saveConfigSoon`) rather than a blocking synchronous write — sync bookkeeping never stalls the event loop. If a sync fails mid-way, the watermark is not advanced — the next cycle retries from the last safe point, giving at-least-once delivery semantics (re-delivery is harmless: everything is re-derived from `seq`).
 
 ---
 
@@ -98,6 +103,8 @@ Without `?full=true` the list endpoints return `{_id, seq}` stubs, and the calle
 
 With `?full=true` the full document payload is embedded in the paginated list response. The pull phase is `ceil(N/200)` requests regardless of how many documents exist.
 
+Pagination is additionally capped at **50 pages per type per cycle** (~10,000 documents). A backlog larger than that is drained across successive cycles — the watermark advances each cycle, so nothing is lost, it just takes more than one cycle to catch up.
+
 **Impact at 100 ms WAN latency:**
 
 | Documents changed | Before | After |
@@ -125,7 +132,7 @@ All document `_id` values (`memories`, `entities`, `edges`, `chrono`) are **UUID
 
 ### `lastSeqReceived` update
 
-After all three document types are pulled, `lastSeqReceived[spaceId]` is advanced to the highest `seq` seen **among documents authored by the peer** (`doc.author.instanceId === member.instanceId`) and written to config. On the next cycle the watermark is passed as `sinceSeq` so the peer returns only documents newer than that point.
+After all four document types (memories, entities, edges, chrono) are pulled, `lastSeqReceived[spaceId]` is advanced to the highest `seq` seen **among documents authored by the peer** (`doc.author.instanceId === member.instanceId`) and written to config. On the next cycle the watermark is passed as `sinceSeq` so the peer returns only documents newer than that point.
 
 Docs that originate from a third instance but were relayed through the peer (e.g. during braintree or pubsub fanout) deliberately do not advance the watermark. Those relayed docs may carry a `seq` assigned by their true author's counter, which can be much higher than the peer's own counter. Allowing them to advance `lastSeqReceived` would cause the engine to skip the peer's locally-written documents on the next pull.
 
@@ -134,9 +141,11 @@ Docs that originate from a third instance but were relayed through the peer (e.g
 ## Push phase
 
 ```
-POST /api/sync/tombstones?spaceId=&networkId=                               (0 or 1 request)
+POST /api/sync/tombstones?spaceId=&networkId=                               (paged: 500/request, looped until drained)
 POST /api/sync/batch-upsert?spaceId=&networkId=                             (ceil(changed/200) requests)
 ```
+
+Tombstone push is deliberately **unbounded** (it loops in pages of 500 until every pending tombstone is delivered) so a peer that was offline for a long time never misses deletions.
 
 ### Incremental push via `lastSeqPushed`
 
@@ -159,7 +168,7 @@ Response: `{ status: 'ok', memories: {inserted,updated,forked,skipped,tombstoned
 
 ### `lastSeqPushed` update
 
-After a successful batch push, `lastSeqPushed[spaceId]` is advanced to the highest `seq` **among documents authored by this instance** (`doc.author.instanceId === cfg.instanceId`). This is evaluated per-batch so an interrupted push (network drop mid-way) advances the watermark only as far as the last acknowledged batch.
+After a successful batch push, `lastSeqPushed[spaceId]` is advanced to the highest `seq` **among documents authored by this instance** (`doc.author.instanceId === cfg.instanceId`). The maximum is tracked per acknowledged batch, but persistence happens once after all four collections have pushed — a network drop mid-push persists nothing for that cycle. That is safe, just conservative: the next cycle re-pushes from the old watermark and the upserts are idempotent.
 
 Relayed docs (received from a third peer and stored locally) are pushed to other members but do **not** advance `lastSeqPushed`. Their seq values belong to the originating instance's counter and could be arbitrarily higher than the local counter, which would incorrectly suppress future pushes of this instance's own work.
 
@@ -229,7 +238,7 @@ A leaf node has `direction='push'` toward its parent — meaning the engine push
 
 The direction field controls not only which phases the sync *engine* runs on the initiating side, but also which writes the *receiving server* accepts.
 
-When a peer POSTs data to any write endpoint (`/api/sync/memories`, `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/tombstones`, `/file-tombstones`), the server looks up the caller's member record in the network. If `member.direction === 'push'` — meaning "we push to them, they should not write to us" — the server responds `403 { error: 'Direction enforcement: inbound writes blocked for this member' }`.
+When a peer POSTs data to any write endpoint (`/api/sync/memories`, `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/tombstones`, `/file-tombstones`), the server looks up the member record for the caller's `peerInstanceId` (carried on server-issued peer tokens) in the network. If `member.direction === 'push'` — meaning "we push to them, they should not write to us" — the server responds `403 { error: 'Directional network: write not permitted from this peer' }`.
 
 This is the server-side complement to the engine's client-side skip logic. Together they guarantee:
 
@@ -244,23 +253,31 @@ Bidirectional network types (`closed`, `democratic`, `club`) always have `direct
 
 ## File sync
 
-After document sync, the engine performs a manifest-based file sync:
+After document sync, the engine performs a manifest-based file sync. It is bidirectional and tombstone-aware:
 
-1. `GET /api/sync/manifest?spaceId=&networkId=` retrieves the peer's list of `{ path, sha256, size, modifiedAt }`.
-2. Entries where the local SHA-256 differs (or the file is absent) are downloaded via `GET /api/files/:spaceId/:path`.
-3. The downloaded bytes are SHA-256 verified before writing to disk. A mismatch is logged and the file is discarded.
+1. **File tombstones, both directions** — the engine pulls the peer's file tombstones (`GET /api/sync/file-tombstones`) and applies them (subject to the same [deletion authorisation](#tombstone-deletion-authorisation) rules as document tombstones), then pushes its own pending file tombstones (`POST /api/sync/file-tombstones`).
+2. **Manifest** — `GET /api/sync/manifest?spaceId=&networkId=` retrieves the peer's list of `{ path, sha256, size, modifiedAt }`. Manifests are served from a per-space file-hash cache (`<spaceId>_file_hashes`), so the peer does not re-hash its whole tree per request.
+3. **Download** — files we lack entirely are downloaded via `GET /api/files/:spaceId?path=<relative path>` (the path travels as a query parameter). Downloaded bytes are SHA-256 verified before writing to disk; a mismatch is logged and the file discarded.
+4. **Divergence → conflict, never overwrite** — when a file exists on both sides with different hashes, the engine does **not** overwrite the local copy. It writes the peer's version as a conflict copy alongside and records a `ConflictDoc`, surfaced in **Settings → Conflicts** for the user to resolve.
+5. **Push** — files the peer lacks (or holds an older `modifiedAt` for) are uploaded to it.
 
-File sync uses the standard 10 s timeout per request. Large files that exceed this will be retried on the next cycle.
+Manifest requests and individual downloads use the 10 s timeout; the batch-style transfer operations use the 60 s batch timeout. Files that time out are retried on the next cycle.
+
+---
+
+## Merkle divergence check (opt-in)
+
+With `merkle: true` on the network config, the engine ends each per-space sync by comparing content roots with the peer: it computes the local Merkle root (embeddings excluded from hashing) and fetches the peer's via `GET /api/sync/merkle?spaceId=&networkId=`. Matching roots log `Merkle OK`; a mismatch logs a loud `MERKLE_DIVERGENCE` warning naming the space, peer, and both roots with leaf counts — the space contents differ *after* sync, indicating possible data loss, a concurrent write, or a sync bug. This is **detection only**: nothing is auto-repaired, and any failure in the check itself (peer error, missing field) degrades to a warning without affecting the sync result.
 
 ---
 
 ## Gossip phase
 
-After file sync, each engine cycle performs a lightweight member identity exchange with each peer:
+At the **start** of each cycle — before any data sync, see [Overview](#overview) for why — the engine performs a lightweight member identity exchange with each peer:
 
-1. **Self-announce** — `POST /api/sync/networks/:networkId/members` with `{ instanceId, label, children?, url? }`. The `url` field is included only when the `INSTANCE_URL` environment variable is set; if omitted, the peer keeps the URL it already has on record.
+1. **Self-announce** — `POST /api/sync/networks/:networkId/members` with `{ instanceId, label, children?, url?, signingPublicKey?, signingKeyRotation? }`. The `url` field is included only when the `INSTANCE_URL` environment variable is set; if omitted, the peer keeps the URL it already has on record. The signing fields distribute the instance's vote-signing public key (see [Signed vote casts](#signed-vote-casts)).
 
-2. **Self-record piggyback** — the receiving peer includes its own current identity in the `200` response as `{ status: 'ok', self: { instanceId, label, url? } }`. The caller updates its local member entry for that peer from this payload — no separate GET is needed.
+2. **Self-record piggyback** — the receiving peer includes its own current identity in the `200` response as `{ status: 'ok', self: { instanceId, label, url?, signingPublicKey?, signingKeyRotation? } }`. The caller updates its local member entry for that peer from this payload — no separate GET is needed.
 
 3. **Pull member view** — `GET /api/sync/networks/:networkId/members` fetches the peer's full member list. Any record whose `instanceId` is already known locally (but is not our own `instanceId`) has its `url`, `label`, and `children` merged in if they differ.
 
@@ -274,7 +291,7 @@ On the pulling side, records returned by `GET /members` that share our own `inst
 
 ## API reference
 
-All endpoints are under `/api/sync` and require a `Bearer` token that resolves to a network member (peer token, not a user PAT). Rate-limited per IP.
+All endpoints are under `/api/sync` and require a `Bearer` token. In normal operation that is a **peer token** — a PAT carrying `peerInstanceId`, issued to the peer during join — but the endpoints use the ordinary auth middleware, so admin and appropriately space-scoped user PATs are also accepted (token space-scope **and** network membership are enforced before any read or write; admin tokens additionally act as trusted local relays for tombstones). Rate-limited per IP.
 
 ### Read endpoints (called during pull)
 
@@ -288,10 +305,13 @@ All endpoints are under `/api/sync` and require a `Bearer` token that resolves t
 | `GET` | `/api/sync/edges/:id` | `spaceId`, `networkId` | Full `EdgeDoc` |
 | `GET` | `/api/sync/chrono` | same as memories | `{ items[], nextCursor }` |
 | `GET` | `/api/sync/chrono/:id` | `spaceId`, `networkId` | Full `ChronoEntry` |
-| `GET` | `/api/sync/tombstones` | `spaceId`, `networkId`, `sinceSeq` | `{ memories[], entities[], edges[] }` |
+| `GET` | `/api/sync/tombstones` | `spaceId`, `networkId`, `sinceSeq` | `{ memories[], entities[], edges[], chrono[] }` |
+| `GET` | `/api/sync/file-tombstones` | `spaceId`, `networkId` | `{ tombstones[] }` |
 | `GET` | `/api/sync/manifest` | `spaceId`, `networkId` | `{ manifest[{ path, sha256, size, modifiedAt }] }` |
-| `GET` | `/api/sync/info` | — | `{ instanceId, label, version }` |
+| `GET` | `/api/sync/merkle` | `spaceId`, `networkId` | `{ root, leafCount }` (only used when `network.merkle: true`) |
 | `GET` | `/api/sync/networks/:networkId/members` | `networkId` | `{ members[{ instanceId, label, url, direction, … }], updatedAt }` |
+
+There is no dedicated identity endpoint — a peer that needs the instance's identity calls the regular authenticated `GET /api/about` (`{ instanceId, instanceLabel, version, … }`), and identity also arrives on every cycle via the gossip `self` record.
 
 `?full=true` on the list endpoints returns complete documents instead of `{_id,seq}` stubs. Maximum `limit` is 500. Tombstone stubs (items with `deletedAt`) are always appended to list responses regardless of `full` mode.
 
@@ -299,17 +319,25 @@ All endpoints are under `/api/sync` and require a `Bearer` token that resolves t
 
 | Method | Path | Body | Returns |
 |--------|------|------|---------|
-| `POST` | `/api/sync/memories` | `MemoryDoc` | `200 { status:'ok' }` |
-| `POST` | `/api/sync/entities` | `EntityDoc` | `200 { status:'ok' }` |
-| `POST` | `/api/sync/edges` | `EdgeDoc` | `200 { status:'ok' }` |
+| `POST` | `/api/sync/memories` | `MemoryDoc` | `200 { status: 'inserted'\|'updated'\|'forked'\|'skipped'\|'tombstoned' }` |
+| `POST` | `/api/sync/entities` | `EntityDoc` | `200 { status:'ok' }` (or `'tombstoned'`) |
+| `POST` | `/api/sync/edges` | `EdgeDoc` | `200 { status:'ok' }` (or `'tombstoned'`) |
+| `POST` | `/api/sync/chrono` | `ChronoEntry` | `200 { status:'ok' }` (or `'tombstoned'`) |
 | `POST` | `/api/sync/batch-upsert` | `{ memories?, entities?, edges?, chrono? }` | `200 { status:'ok', memories:{…}, entities:{…}, edges:{…}, chrono:{…} }` |
 | `POST` | `/api/sync/tombstones` | `{ tombstones[] }` | `200 { applied: N }` |
+| `POST` | `/api/sync/file-tombstones` | `{ tombstones[] }` | `200 { applied: N }` |
+| `POST` | `/api/sync/warm` | `{ networkId, spaces[] }` | `200` once the embedding model, token cache, and collection handles are warm |
 
 All write endpoints enforce direction policy: if the caller's `member.direction === 'push'` in the network, the server returns `403`. See [Direction enforcement on inbound endpoints](#direction-enforcement-on-inbound-endpoints).
 
 `POST /batch-upsert` is the primary push path used by the engine. The individual `POST /memories`, `/entities`, `/edges` endpoints remain for backwards compatibility and direct API usage.
 
-All incoming documents are validated against Zod schemas before any database write. Invalid documents are rejected with `400` (single endpoints) or silently filtered out (batch-upsert). Key constraints: `tags` max 100 items, `entityIds` max 500, `seq` max 2^50, all string fields validated for type safety. Unknown fields are stripped.
+All incoming documents are validated against Zod schemas before any database write. Invalid documents are rejected with `400` (single endpoints) or silently filtered out (batch-upsert). Key constraints: `tags` max 100 items, `entityIds` max 500, all string fields validated for type safety. Unknown fields are stripped.
+
+Two additional ingest safety caps protect the local seq counter and fork chains from a malicious or corrupted peer:
+
+- **Implausible seq** — the schema bound on `seq` is 2^50, but ingest applies a stricter ceiling of `2^50 − 2^40` (`rejectImplausibleSeq`); a document above it is refused so a poisoned seq can never exhaust the counter's headroom.
+- **Fork limits** — fork chain depth and per-document fork fan-out are both capped at 10. Exceeding either returns `400` on the single endpoints and is silently skipped in `batch-upsert`.
 
 ### Gossip endpoints
 
@@ -346,9 +374,9 @@ With `requireSignedVotes: true` on the network, only signed-and-verified casts a
 
 ## Vote propagation phase
 
-After the gossip (member identity) exchange, the engine runs a vote propagation pass with each peer:
+Directly after the gossip (member identity) exchange — still ahead of the data phases — the engine runs a vote propagation pass with each peer:
 
-1. **Push casts** — for each open local vote round, each known vote cast is relayed to the peer via `POST /api/sync/networks/:networkId/votes/:roundId { vote, instanceId, sig, castAt }`, forwarding the voter's signature so the peer can verify and relay it onward. If the peer does not yet have the round (404), the push is silently skipped — the round will arrive on the peer's next pull cycle.
+1. **Push casts** — for each local vote round — including already-concluded ones, so that a round-concluding cast still reaches peers that have not concluded yet — each known vote cast is relayed to the peer via `POST /api/sync/networks/:networkId/votes/:roundId { vote, instanceId, sig, castAt }`, forwarding the voter's signature so the peer can verify and relay it onward. If the peer does not yet have the round (404), the push is silently skipped — the round will arrive on the peer's next pull cycle.
 
 2. **Pull rounds** — `GET /api/sync/networks/:networkId/votes` fetches the peer's open rounds. For each round:
    - **New round**: if the round does not exist locally, it is adopted into `pendingRounds` (with an empty `votes` array); votes are then merged in the same pass.


### PR DESCRIPTION
## Summary

Doc corrections from the 2026-07-15 full docs audit (every claim in `docs/sync-protocol.md` and `docs/network-types.md` was cross-checked against `server/src`). Doc-only; no behavior change.

**sync-protocol.md**
- **Phase order corrected**: governance gossip + vote propagation run *first*, ahead of the data phases (deliberate — deadline-sensitive, small messages, must not be starved by a slow data plane). Documented the previously missing presync warm-up (`POST /api/sync/warm`) and the opt-in Merkle divergence check (`GET /api/sync/merkle`, `network.merkle: true`, detection-only).
- **File sync section rewritten** — it documented about half of what runs: file tombstones travel both directions, files are pushed as well as pulled, hash divergence writes a conflict copy plus a `ConflictDoc` (never overwrites), manifests are served from the per-space file-hash cache, and the download URL uses a `?path=` query parameter.
- Manual trigger is async fire-and-forget returning `{ status: 'triggered' }`; direction-enforcement 403 body corrected; tombstones include chrono (four synced types, not three); tombstone push pages 500/request until drained; pull capped at 50 pages/type/cycle; watermark persistence goes through the coalesced config flush; `lastSeqPushed` persistence timing corrected.
- Removed the nonexistent `GET /api/sync/info` (identity: authenticated `GET /api/about` + the gossip `self` record); endpoint tables gain `file-tombstones` (GET/POST), `POST /chrono`, `POST /warm`, and the real per-status response shapes; documented the ingest safety caps (implausible-seq ceiling `2^50 − 2^40`, fork depth/fan-out ≤ 10); gossip body shapes now include the vote-signing key fields; the sync-surface auth model note now matches the code.

**network-types.md**
- Fixed the broken tombstone-guard cross-link, the invite-generate auth level (admin), the vote-deadline default (24 h, configurable 1–72 h), and replaced the misleading "10 s delay" offline-peer estimate with the accurate bounded-timeout statement (the cycle completes, just takes longer).

The braintree ancestor-voting description is **intentionally unchanged** — it documents the intended governance model; the code-side gap is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)