### PR TITLE
fix(sync): pull vote rounds before pushing, skip dead rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vote propagation now pulls before it pushes, so convergence no longer stalls behind an
+  unbounded push.** In each sync cycle `propagateVotesWithPeer` exchanged governance votes with a
+  peer by first pushing *every* cast of *every* locally-known round and only then pulling the peer's
+  rounds. Because a round is never removed from `pendingRounds` once it concludes, that push loop
+  grows without bound over a network's lifetime — and it `await`s each cast sequentially, so on a
+  busy or high-latency peer a cycle could spend all its time re-broadcasting dead history and never
+  reach the pull. Adopting the peer's casts is the convergence-critical half, so it now runs
+  **first** and persists immediately; the push runs after and additionally **skips any round that is
+  already concluded and past its deadline** (every peer concludes such a round independently once the
+  deadline passes, so re-pushing it forever is pure waste). No protocol or governance-semantics
+  change — only ordering and dead-round pruning from the push set. This also removes the load-sensitive
+  stall behind the intermittently-failing `vote-signing` relay test (its "triggers succeed but the
+  peer never delivers" timeout was this push starving the pull under full-suite load).
+
 - **Schema validation was a total no-op on MCP — the surface agents actually use.** `validateMemory()` keys
   the whole per-type schema lookup off `memory.type`, but the MCP `remember` and `bulk_write` tools never
   exposed `type` and passed `undefined` to the engine. With no type there is no schema, so validation always

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -663,30 +663,13 @@ async function propagateVotesWithPeer(
 ): Promise<void> {
   const base = `${member.url}/api/sync/networks/${encodeURIComponent(net.id)}`;
 
-  // 1. Push our open votes to the peer (non-fatal 404 if peer doesn't have the round yet)
-  try {
-    const cfg = getConfig();
-    const localNet = cfg.networks.find(n => n.id === net.id);
-    // Include all rounds — not just open ones — so that a vote that immediately concludes a
-    // round on this instance (e.g. a final yes or a veto) still propagates to peers that
-    // haven't yet received the concluding cast.
-    const roundsToPush = localNet?.pendingRounds ?? [];
-    for (const round of roundsToPush) {
-      for (const cast of round.votes) {
-        await peerSafeFetch(`${base}/votes/${encodeURIComponent(round.roundId)}`, {
-          ...opts(),
-          method: 'POST',
-          // Forward the signature (and castAt) so the peer can verify and, when
-          // valid, relay this cast onward — signed casts are relay-safe.
-          body: JSON.stringify({ vote: cast.vote, instanceId: cast.instanceId, sig: cast.sig, castAt: cast.castAt }),
-        }).catch(err => log.warn(`Vote push (${round.roundId}) to ${member.label}: ${err}`));
-      }
-    }
-  } catch (err) {
-    log.warn(`Vote push to ${member.label}: ${err}`);
-  }
-
-  // 2. Pull peer's open rounds; create new ones locally and merge vote casts
+  // Pull the peer's rounds FIRST, then push ours (the push block below explains why the
+  // order matters). Adopting and persisting the peer's vote casts is the convergence-
+  // critical step, so it must not be gated behind our push. The early `return`s in this
+  // block bail out only when the peer is unreachable / misbehaving or our network is gone
+  // — exactly the cases where the push below would be pointless anyway.
+  //
+  // Pull peer's open rounds; create new ones locally and merge vote casts
   try {
     const resp = await peerSafeFetch(`${base}/votes`, opts());
     if (!resp.ok) {
@@ -791,6 +774,41 @@ async function propagateVotesWithPeer(
     }
   } catch (err) {
     log.warn(`Vote pull from ${member.label}: ${err}`);
+  }
+
+  // Push our votes to the peer (non-fatal 404 if the peer doesn't have the round yet).
+  //
+  // This runs AFTER the pull on purpose. It re-sends every cast of every locally-known
+  // round, and a round is never removed from `pendingRounds` once it concludes, so on an
+  // instance with a long governance history this loop grows without bound. Running it
+  // before the pull would let a peer spend an entire sync cycle pushing dead history and
+  // never reach the pull — stalling vote propagation under load. Pulling first makes
+  // convergence independent of how much history we have to broadcast.
+  //
+  // We still push open rounds and recently-concluded ones (a concluding cast must reach
+  // peers that haven't concluded yet), but skip any round already concluded AND past its
+  // deadline: every peer concludes such a round independently once the deadline passes, so
+  // re-pushing it every cycle forever is pure waste.
+  try {
+    const cfg = getConfig();
+    const localNet = cfg.networks.find(n => n.id === net.id);
+    const now = Date.now();
+    const roundsToPush = (localNet?.pendingRounds ?? []).filter(
+      r => !(r.concluded && new Date(r.deadline).getTime() < now),
+    );
+    for (const round of roundsToPush) {
+      for (const cast of round.votes) {
+        await peerSafeFetch(`${base}/votes/${encodeURIComponent(round.roundId)}`, {
+          ...opts(),
+          method: 'POST',
+          // Forward the signature (and castAt) so the peer can verify and, when
+          // valid, relay this cast onward — signed casts are relay-safe.
+          body: JSON.stringify({ vote: cast.vote, instanceId: cast.instanceId, sig: cast.sig, castAt: cast.castAt }),
+        }).catch(err => log.warn(`Vote push (${round.roundId}) to ${member.label}: ${err}`));
+      }
+    }
+  } catch (err) {
+    log.warn(`Vote push to ${member.label}: ${err}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the root cause behind the intermittently-failing `vote-signing` relay test (the one that just failed CI on an unrelated PR), which is also a real production scaling bug in vote propagation.

**The bug** — in each sync cycle, `propagateVotesWithPeer`:
1. `concludeRoundIfReady` marks rounds `concluded` but **never removes them** from `pendingRounds` — rounds accumulate for the life of the network.
2. The function **pushes every cast of every round (including all the dead concluded ones) to the peer, sequentially with `await`, and only *then* pulls** the peer's rounds. The pull is the convergence-critical half. On a busy or high-latency peer — or, in CI, when rounds have piled up across the whole sync suite hammering the same 4 instances — that unbounded push can consume the entire cycle and never reach the pull. That is the `vote-signing` flake's exact signature: "sync triggers succeed but the peer never delivers the expected state," a 90s timeout.

**The fix** — pull the peer's rounds **first** (and persist immediately with `saveConfig`), then push. Convergence no longer sits behind our history broadcast. The push additionally **skips any round already concluded *and* past its deadline** — every peer concludes such a round independently once the deadline passes, so re-pushing it every cycle forever is pure waste. Open rounds and recently-concluded rounds are still pushed, so a concluding cast still propagates to peers that haven't concluded yet.

No protocol or governance-semantics change — only ordering and dead-round pruning from the push set. The pull's early-return paths (peer unreachable / malformed response / network gone) now also skip the push, which is correct: those are exactly the cases where the push would be pointless.

## Verification

Ran against the real 4-instance Docker test stack (rebuilt with this change):

- **Full sync suite (`npm run test:sync`, what failed in CI): 173 passed, 0 failed, 1 skipped.** The entire governance surface — vote propagation, signing, relay, forgery, key rotation, braintree/democratic/closed governance, leave/removal — is green, confirming the reorder preserves vote-propagation semantics.
- The previously-flaky subtest ("a VALID signed cast from a third instance is accepted when relayed by B; a tampered one is rejected") converges in **~1.6–2.8s** instead of hitting the 90s wall.

Partially addresses the P14 scaling item (unbounded per-cycle push); fully pruning concluded rounds out of `pendingRounds` remains tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)