### PR TITLE
chore: gitignore the local n8n/ auditor scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ docs/docker-build-protocol.md
 # publish it before the fixes ship.)
 todo/
 
+# Local-only automation scaffolding — n8n auditor workflow drafts + prompts.
+# Not part of the shipped product; kept out of the repo by design.
+n8n/
+
 # Debug artifacts
 _diag_body*.json
 


### PR DESCRIPTION
Adds `n8n/` to `.gitignore` — local-only draft workflow + prompts for the read-only Ythril repo-auditor agent, kept out of the repo the same way `todo/` is. One-line ignore change; no source or product impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)