### PR TITLE
perf(sync): prune concluded, expired vote rounds (P14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Concluded vote rounds are now pruned, so `pendingRounds` no longer grows for the life of a
+  network (P14).** `concludeRoundIfReady` marks a round `concluded` but never removed it, so every
+  governance vote a network ever held accumulated forever in `config.json` — bloating the file, the
+  `GET /votes` scan, and gossip payloads, and (before #200) the per-cycle vote push. The sync engine
+  now drops rounds that are concluded **and** past their deadline, once per cycle: after the deadline
+  every peer concludes such a round independently, so it can influence nothing and needs no further
+  propagation. Within-deadline concluded rounds and open rounds are always kept (a concluding cast may
+  still need to reach peers; open rounds are live governance). Completes the scaling fix started in
+  #200. Covered by `testing/standalone/vote-round-prune.test.js` (retention rule) and
+  `testing/sync/vote-round-prune-sync.test.js` (pruned end-to-end during a real sync cycle).
+
 - **The client is fully zoneless (P13) — `zone.js` is gone.** The endgame of the P5 `OnPush` pass:
   the app now bootstraps with `provideZonelessChangeDetection()` and the `zone.js` polyfill is removed
   from the build (and from `dependencies`). Until now every timer, XHR, and DOM event anywhere in the

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -158,6 +158,33 @@ function _setFailureCount(networkId: string, instanceId: string, value: number |
   return newValue;
 }
 
+// ── Vote-round retention ────────────────────────────────────────────────────
+
+/** A round is prunable once it is concluded AND past its deadline. After the deadline
+ *  every peer concludes the round independently (the deadline path in
+ *  `concludeRoundIfReady`), so such a round can no longer influence any decision and
+ *  never needs re-serving or re-propagating. A malformed/unparseable deadline yields
+ *  `NaN`, and `NaN < now` is false, so we keep the round rather than prune on doubt. */
+export function isRoundPrunable(
+  round: { concluded?: boolean; deadline: string },
+  now: number = Date.now(),
+): boolean {
+  return Boolean(round.concluded) && new Date(round.deadline).getTime() < now;
+}
+
+/** Drop concluded-and-expired rounds from a network's `pendingRounds` in place.
+ *  `concludeRoundIfReady` marks a round `concluded` but never removes it, so without
+ *  this `pendingRounds` grows for the life of the network — bloating `config.json`, the
+ *  `GET /votes` scan, and gossip payloads. Returns the number of rounds removed. */
+export function pruneExpiredRounds(net: NetworkConfig, now: number = Date.now()): number {
+  const rounds = net.pendingRounds;
+  if (!rounds || rounds.length === 0) return 0;
+  const kept = rounds.filter(r => !isRoundPrunable(r, now));
+  const removed = rounds.length - kept.length;
+  if (removed > 0) net.pendingRounds = kept;
+  return removed;
+}
+
 // ── Per-network sync dedup lock ─────────────────────────────────────────────
 // Prevents concurrent sync cycles for the same network from competing for
 // bcrypt cache, MongoDB connections, and peer HTTP sockets.  When a trigger
@@ -315,6 +342,23 @@ async function _runSyncForNetworkImpl(networkId: string): Promise<{ synced: numb
           changed = true;
         }
         if (changed) saveConfig(freshCfg);
+      }
+    }
+  }
+
+  // ── Prune expired vote rounds ───────────────────────────────────────────
+  // Concluded rounds are never removed by the governance code (concludeRoundIfReady
+  // only flips `concluded`), so pendingRounds would otherwise grow for the life of the
+  // network. Once a round is concluded AND past its deadline it can influence nothing
+  // and needs no further propagation, so drop it here, once per cycle.
+  {
+    const freshCfg = getConfig();
+    const freshNet = freshCfg.networks.find(n => n.id === networkId);
+    if (freshNet) {
+      const removed = pruneExpiredRounds(freshNet);
+      if (removed > 0) {
+        log.info(`Pruned ${removed} concluded+expired vote round(s) from network '${freshNet.label}'`);
+        saveConfig(freshCfg);
       }
     }
   }
@@ -793,9 +837,7 @@ async function propagateVotesWithPeer(
     const cfg = getConfig();
     const localNet = cfg.networks.find(n => n.id === net.id);
     const now = Date.now();
-    const roundsToPush = (localNet?.pendingRounds ?? []).filter(
-      r => !(r.concluded && new Date(r.deadline).getTime() < now),
-    );
+    const roundsToPush = (localNet?.pendingRounds ?? []).filter(r => !isRoundPrunable(r, now));
     for (const round of roundsToPush) {
       for (const cast of round.votes) {
         await peerSafeFetch(`${base}/votes/${encodeURIComponent(round.roundId)}`, {

--- a/testing/standalone/vote-round-prune.test.js
+++ b/testing/standalone/vote-round-prune.test.js
@@ -1,0 +1,86 @@
+/**
+ * Standalone tests: vote-round retention (P14)
+ *
+ * `concludeRoundIfReady` marks a round `concluded` but never removes it from
+ * `pendingRounds`, so without pruning the array grows for the life of the network.
+ * `pruneExpiredRounds` drops rounds that are concluded AND past their deadline — those
+ * can no longer influence any decision (every peer concludes them independently once the
+ * deadline passes) and need no further propagation. These tests pin the retention rule:
+ * open rounds and within-deadline concluded rounds are always kept; only concluded +
+ * expired rounds are removed; a malformed deadline is kept (never prune on doubt).
+ *
+ * Run: node --test testing/standalone/vote-round-prune.test.js  (requires server build)
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let isRoundPrunable, pruneExpiredRounds;
+
+const NOW = 1_000_000_000_000; // fixed reference instant for deterministic tests
+const past = new Date(NOW - 60_000).toISOString();   // 1 min ago
+const future = new Date(NOW + 3_600_000).toISOString(); // 1 h ahead
+
+const round = (over) => Object.assign(
+  { roundId: 'r', type: 'remove', subjectInstanceId: 's', deadline: future, concluded: false, votes: [] },
+  over,
+);
+
+describe('vote-round retention — isRoundPrunable', () => {
+  before(async () => {
+    ({ isRoundPrunable, pruneExpiredRounds } = await import('../../server/dist/sync/engine.js'));
+  });
+
+  it('concluded AND past deadline → prunable', () => {
+    assert.equal(isRoundPrunable(round({ concluded: true, deadline: past }), NOW), true);
+  });
+
+  it('concluded but within deadline → kept (a concluding cast may still need to propagate)', () => {
+    assert.equal(isRoundPrunable(round({ concluded: true, deadline: future }), NOW), false);
+  });
+
+  it('open (not concluded) and past deadline → kept (still live governance)', () => {
+    assert.equal(isRoundPrunable(round({ concluded: false, deadline: past }), NOW), false);
+  });
+
+  it('open and within deadline → kept', () => {
+    assert.equal(isRoundPrunable(round({ concluded: false, deadline: future }), NOW), false);
+  });
+
+  it('malformed deadline → kept (never prune on doubt)', () => {
+    assert.equal(isRoundPrunable(round({ concluded: true, deadline: 'not-a-date' }), NOW), false);
+  });
+});
+
+describe('vote-round retention — pruneExpiredRounds', () => {
+  before(async () => {
+    ({ isRoundPrunable, pruneExpiredRounds } = await import('../../server/dist/sync/engine.js'));
+  });
+
+  it('removes only concluded+expired rounds and returns the count', () => {
+    const net = { pendingRounds: [
+      round({ roundId: 'keep-open-future', concluded: false, deadline: future }),
+      round({ roundId: 'keep-open-past', concluded: false, deadline: past }),
+      round({ roundId: 'keep-concluded-future', concluded: true, deadline: future }),
+      round({ roundId: 'drop-concluded-past-1', concluded: true, deadline: past }),
+      round({ roundId: 'drop-concluded-past-2', concluded: true, deadline: past }),
+    ] };
+    const removed = pruneExpiredRounds(net, NOW);
+    assert.equal(removed, 2);
+    const ids = net.pendingRounds.map(r => r.roundId).sort();
+    assert.deepEqual(ids, ['keep-concluded-future', 'keep-open-future', 'keep-open-past']);
+  });
+
+  it('is a no-op (returns 0, array identity unchanged) when nothing is expired', () => {
+    const rounds = [round({ concluded: true, deadline: future }), round({ concluded: false, deadline: past })];
+    const net = { pendingRounds: rounds };
+    const removed = pruneExpiredRounds(net, NOW);
+    assert.equal(removed, 0);
+    assert.equal(net.pendingRounds, rounds, 'array is not reassigned when nothing changes');
+  });
+
+  it('handles an empty / missing pendingRounds safely', () => {
+    assert.equal(pruneExpiredRounds({ pendingRounds: [] }, NOW), 0);
+    assert.equal(pruneExpiredRounds({}, NOW), 0);
+  });
+});

--- a/testing/sync/vote-round-prune-sync.test.js
+++ b/testing/sync/vote-round-prune-sync.test.js
@@ -1,0 +1,105 @@
+/**
+ * Integration test: expired vote rounds are pruned during a sync cycle (P14).
+ *
+ * `concludeRoundIfReady` marks rounds `concluded` but never removes them from
+ * `pendingRounds`, so the array would grow for the life of the network. The sync engine
+ * now prunes rounds that are concluded AND past their deadline, once per cycle. This test
+ * proves the wiring end-to-end against a running instance: inject three rounds directly
+ * into A's config — one concluded+expired (must be pruned), one concluded-but-future and
+ * one open+expired (both must survive) — run a sync cycle, and assert the outcome.
+ *
+ * The prune runs post-member-loop and unconditionally, so a reachable peer is not
+ * required; the injected peer only exists so the network has a member to iterate.
+ *
+ * Run:  node --test testing/sync/vote-round-prune-sync.test.js
+ * Pre-requisite: docker compose -f docker-compose.test.yml up && node testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { dockerExec, INSTANCES, post, del, delWithBody, waitFor, makeTriggerProbe } from './helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, 'configs');
+
+let tokenA, instanceIdA, networkId, testSpaceId;
+
+function readConfig(c) {
+  return JSON.parse(dockerExec(`docker exec ${c} node -e "const fs=require('fs');process.stdout.write(fs.readFileSync('/config/config.json','utf8'))"`).toString());
+}
+function patch(c, netId, fnBody) {
+  const b64 = Buffer.from(fnBody, 'utf8').toString('base64');
+  const s = `const fs=require('fs');const p='/config/config.json';const cfg=JSON.parse(fs.readFileSync(p,'utf8'));const n=cfg.networks.find(x=>x.id==='${netId}');const patch=new Function('n','cfg',Buffer.from('${b64}','base64').toString('utf8'));patch(n,cfg);fs.writeFileSync(p,JSON.stringify(cfg,null,2),{mode:0o600});process.stdout.write('ok');`;
+  dockerExec(`docker exec ${c} node -e "${s}"`);
+}
+
+function roundIds(c, netId) {
+  const net = readConfig(c).networks.find(n => n.id === netId);
+  return new Set((net?.pendingRounds ?? []).map(r => r.roundId));
+}
+
+describe('Expired vote rounds are pruned during sync', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    instanceIdA = dockerExec(`docker exec ythril-a node -e "const fs=require('fs');process.stdout.write(JSON.parse(fs.readFileSync('/config/config.json','utf8')).instanceId)"`).toString().trim();
+
+    testSpaceId = `prune-${Date.now()}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: testSpaceId, label: 'Prune Test Space' });
+
+    const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+      label: `Prune ${Date.now()}`, type: 'closed', spaces: [testSpaceId], votingDeadlineHours: 1,
+    });
+    assert.equal(netR.status, 201, JSON.stringify(netR.body));
+    networkId = netR.body.id;
+
+    // Give the network a member so the cycle has something to iterate. It is virtual and
+    // unreachable — irrelevant to the prune, which runs after the member loop regardless.
+    patch('ythril-a', networkId, `n.members.push({instanceId:'virt-prune-${Date.now()}',label:'Virtual',url:'http://virtual-prune.internal:3200',tokenHash:'x',direction:'both'});`);
+    await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+  });
+
+  after(async () => {
+    if (networkId) {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+      await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+    }
+  });
+
+  it('prunes concluded+expired rounds and keeps concluded-future and open-expired rounds', async () => {
+    const pastDeadline = new Date(Date.now() - 60_000).toISOString();       // 1 min ago
+    const futureDeadline = new Date(Date.now() + 3_600_000).toISOString();  // 1 h ahead
+    const mk = (roundId, concluded, deadline) => ({
+      roundId, type: 'remove', subjectInstanceId: 'ghost', subjectLabel: 'Ghost',
+      subjectUrl: 'http://ghost.internal:3200', deadline,
+      openedAt: new Date().toISOString(), concluded, votes: [],
+    });
+
+    // Inject three rounds directly into A's pendingRounds and reload.
+    patch('ythril-a', networkId,
+      `n.pendingRounds=n.pendingRounds||[];` +
+      `n.pendingRounds.push(${JSON.stringify(mk('drop-concluded-expired', true, pastDeadline))});` +
+      `n.pendingRounds.push(${JSON.stringify(mk('keep-concluded-future', true, futureDeadline))});` +
+      `n.pendingRounds.push(${JSON.stringify(mk('keep-open-expired', false, pastDeadline))});`);
+    await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+
+    const before = roundIds('ythril-a', networkId);
+    assert.ok(before.has('drop-concluded-expired'), 'setup: expired round is present before sync');
+    assert.ok(before.has('keep-concluded-future'));
+    assert.ok(before.has('keep-open-expired'));
+
+    // Trigger sync cycles on A until the expired round is pruned from its on-disk config.
+    const triggerA = makeTriggerProbe(INSTANCES.a, tokenA, networkId, 'A');
+    await waitFor(async () => {
+      await triggerA();
+      return !roundIds('ythril-a', networkId).has('drop-concluded-expired');
+    }, 60_000, 2_000, triggerA.diagnose);
+
+    const after = roundIds('ythril-a', networkId);
+    assert.ok(!after.has('drop-concluded-expired'), 'concluded+expired round must be pruned');
+    assert.ok(after.has('keep-concluded-future'), 'concluded-but-within-deadline round must survive (may still need to propagate)');
+    assert.ok(after.has('keep-open-expired'), 'open round must survive even when past deadline (still live governance)');
+  });
+});


### PR DESCRIPTION
## Summary

Completes the vote-round scaling fix started in #200. `concludeRoundIfReady` marks a round `concluded` but **never removed it** from `pendingRounds`, so every governance vote a network ever held accumulated in `config.json` for the life of the network — bloating the file, the `GET /votes` scan, gossip payloads, and (before #200) the per-cycle vote push.

The engine now **prunes rounds that are concluded AND past their deadline**, once per sync cycle (`pruneExpiredRounds` / `isRoundPrunable` in `sync/engine.ts`). After the deadline every peer concludes such a round independently, so it can influence nothing and needs no further propagation.

- **Always kept:** open rounds (live governance) and concluded-but-within-deadline rounds (a concluding cast may still need to reach peers that haven't concluded yet).
- **Safe on doubt:** a malformed/unparseable deadline is kept, never pruned.
- The push-skip filter added in #200 now reuses the same `isRoundPrunable` predicate, so the "what counts as dead" rule lives in one place.

`pendingRounds` is now bounded by open + within-deadline rounds instead of all-of-history.

## Verification

Three levels, all green:

- **Unit — `testing/standalone/vote-round-prune.test.js` (8/8):** the retention rule — concluded+expired → pruned; concluded+future, open+expired, open+future → kept; malformed deadline → kept; `pruneExpiredRounds` removes only the right rounds, returns the count, and is a no-op (no array reallocation) when nothing is expired.
- **Integration — `testing/sync/vote-round-prune-sync.test.js`:** against the running 4-instance stack, injects a concluded+expired round plus concluded-future and open-expired controls, runs a real sync cycle, and asserts the expired one is pruned from on-disk config while both controls survive.
- **Regression — full sync suite, serial (`npm run test:sync`, as CI runs it): 174 passed, 0 failed, 1 skipped** (175 total, including the new integration test). No governance-semantics regression.

Closes P14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)