### PR TITLE
docs: apply 2026-07-15 audit corrections (userguide, integration, examples, workstation, meta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **User guide, integration guide, usecase examples, workstation guide, and the top-level docs
+  brought back in line with the code** — the rest of the same full docs audit. Highlights:
+  two dangerous user-guide MFA errors fixed (disabling MFA **requires** a current TOTP code; the
+  TOTP secret is server-generated, not browser-only), the Webhooks section rewritten as an API
+  how-to (no management UI exists yet), the About page corrected (no live log — that's the Audit
+  Log), and the guide re-synced with the current UI (Brain has eight tabs; Graph/Files are tabs
+  not routes; MFA lives under Preferences; corrected admin nav, labels, and destructive-op
+  locations). Integration guide: `GET /api/about` is not public, the OIDC spaces-claim is
+  fail-closed, `files` added to the MCP `query` enum, entities list max is 500, recall filter keys
+  include `status`/`label` with native `$vectorSearch` pre-filtering, draft-7 rate-limit headers,
+  plus newly documented `indexStatus`, bulk wipes, the `help` tool, and several endpoints.
+  Usecase examples: `recall_global` → `recall`, no `"expired"` chrono status, and a caveat that
+  `remember()` does not auto-create entities. Workstation guide: the port-override that never frees
+  3200 removed (use `YTHRIL_PORT`), `MONGO_URI` must be in the compose environment to reach the
+  container, and the connector binds `0.0.0.0` (bearer-protected). README/NOTICE/contribution-guide/
+  dependencies: `recall_global` → `recall`, `list_spaces`/`help` added (31 tools), webhook event
+  counts (16/19), embedding features, NOTICE dependency list (drop zone.js, add undici), and the
+  local-dev DB/proxy setup. Doc-only; no behavior change.
+
 - **Sync-protocol and network-types docs brought back in line with the code** after a full docs
   audit cross-checked every claim. `docs/sync-protocol.md`: corrected the phase order (governance
   gossip + vote propagation deliberately run *first*, ahead of the data phases) and documented the

--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,7 @@ copyright notices are reproduced below as required by each license.
 
 ---
 
-## @angular/animations, @angular/cdk, @angular/common, @angular/compiler, @angular/core, @angular/forms, @angular/platform-browser, @angular/platform-browser-dynamic, @angular/router, zone.js
+## @angular/animations, @angular/cdk, @angular/common, @angular/compiler, @angular/core, @angular/forms, @angular/platform-browser, @angular/platform-browser-dynamic, @angular/router
 
 License: MIT
 Copyright (c) 2010-2026 Google LLC. https://angular.dev/license
@@ -167,6 +167,31 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+---
+
+## undici
+
+License: MIT
+Copyright (c) Matteo Collina and Undici contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ---
 
@@ -476,7 +501,7 @@ The image packages two components:
 ### Relationship to Ythril's PolyForm license
 
 Ythril communicates with `mongod`/`mongot` exclusively over a TCP network socket
-on the private `ythril-internal` Docker bridge network. No MongoDB or `mongot`
+on the private `ythril-db` Docker bridge network. No MongoDB or `mongot`
 code is linked into, compiled with, or incorporated into the Ythril application
 binary or source tree.
 
@@ -497,7 +522,7 @@ separately and independently of Ythril's PolyForm license. Ythril's source
 obligations are unaffected.
 
 The dependency on the proprietary `mongot` binary means that the semantic recall
-feature (`query`, `recall`, `recall_global` MCP tools) cannot currently be
+feature (`query`, `recall` MCP tools) cannot currently be
 provided by a fully open-source stack. This is acknowledged as a known constraint.
 A future version of Ythril may introduce an optional vector-search backend allowing
 deployment without `mongot`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Self-hosted brain server for AI assistants.** Persistent memory, knowledge graphs, semantic search, file storage, and multi-brain sync — all behind a standard MCP interface, fully under your control.
 
-Ythril gives every MCP-compatible client (Claude, Cursor, Windsurf, VS Code Copilot, or anything that speaks the [Model Context Protocol](https://modelcontextprotocol.io)) a persistent, structured knowledge backend. Data is organised into **spaces** — isolated containers with their own memories, entities, edges, timelines, files, and schemas. Each space exposes its own MCP endpoint with 30 tools, a full REST API, and a web UI. Spaces can be synced across multiple brains through policy-driven networks with fine-grained governance. Run it with `docker compose up -d` and complete setup in minutes (first pull/build can take longer on a clean machine).
+Ythril gives every MCP-compatible client (Claude, Cursor, Windsurf, VS Code Copilot, or anything that speaks the [Model Context Protocol](https://modelcontextprotocol.io)) a persistent, structured knowledge backend. Data is organised into **spaces** — isolated containers with their own memories, entities, edges, timelines, files, and schemas. Each space exposes its own MCP endpoint with 31 tools, a full REST API, and a web UI. Spaces can be synced across multiple brains through policy-driven networks with fine-grained governance. Run it with `docker compose up -d` and complete setup in minutes (first pull/build can take longer on a clean machine).
 
 ---
 
@@ -64,9 +64,9 @@ Append-only, immutable access log of every authenticated API operation. The audi
 
 ### Webhooks
 
-Subscribe external systems to real-time HTTP POST notifications when write events occur. Supports 16 domain event types across memories, entities, edges, chrono, and files (including `entity.merged`) — 19 in total once the operational events `link_violation.created`, `duplicate.detected`, and `test.ping` are counted. Payloads are signed with HMAC-SHA256, delivered with at-least-once guarantees (6 retries with exponential backoff), and SSRF-protected — targets are DNS-resolved and validated at delivery time and every redirect hop is re-validated, so a webhook cannot be pointed (or redirected/rebound) at a private/reserved IP. Manage subscriptions through the REST API or the **Settings → Webhooks** UI.
+Subscribe external systems to real-time HTTP POST notifications when write events occur. Supports 16 domain event types across memories, entities, edges, chrono, and files (including `entity.merged`) — 19 in total once the operational events `link_violation.created`, `duplicate.detected`, and `test.ping` are counted. Payloads are signed with HMAC-SHA256, delivered with at-least-once guarantees (6 retries with exponential backoff), and SSRF-protected — targets are DNS-resolved and validated at delivery time and every redirect hop is re-validated, so a webhook cannot be pointed (or redirected/rebound) at a private/reserved IP. Manage subscriptions through the REST API (`/api/admin/webhooks`).
 
-### 30 MCP Tools
+### 31 MCP Tools
 
 Every capability is exposed as an MCP tool that any LLM client can call:
 
@@ -76,7 +76,8 @@ Every capability is exposed as an MCP tool that any LLM client can call:
 | Knowledge graph | `upsert_entity`, `update_entity`, `merge_entities`, `find_entities_by_name`, `upsert_edge`, `update_edge`, `traverse`, `query` |
 | Timeline | `create_chrono`, `update_chrono`, `list_chrono` |
 | Files | `read_file`, `write_file`, `list_dir`, `delete_file`, `create_dir`, `move_file` |
-| Batch & admin | `list_spaces`, `bulk_write`, `get_stats`, `get_space_meta`, `update_space`, `wipe_space` |
+| Discovery | `help`, `list_spaces`, `get_stats`, `get_space_meta` |
+| Batch & admin | `bulk_write`, `update_space`, `wipe_space` |
 | Sync | `list_peers`, `sync_now` |
 
 Read-only tokens automatically hide all mutating tools and block them if called directly.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ythril gives every MCP-compatible client (Claude, Cursor, Windsurf, VS Code Copi
 
 ### Semantic Recall
 
-Store facts and context as **memories** with automatic vector embeddings. The `recall` and `recall_global` MCP tools perform semantic search across all knowledge types — memories, entities, edges, chrono entries, and files — using MongoDB Atlas `$vectorSearch`. Results are ranked by similarity and include a type discriminator, so an LLM can search the entire brain with a single natural-language query.
+Store facts and context as **memories** with automatic vector embeddings. The `recall` MCP tool performs semantic search across all knowledge types — memories, entities, edges, chrono entries, and files — using MongoDB Atlas `$vectorSearch`. Results are ranked by similarity and include a type discriminator, so an LLM can search the entire brain with a single natural-language query. Omit the `space` parameter and `recall` searches across every space the token can access.
 
 ### Knowledge Graph
 
@@ -64,7 +64,7 @@ Append-only, immutable access log of every authenticated API operation. The audi
 
 ### Webhooks
 
-Subscribe external systems to real-time HTTP POST notifications when write events occur. Supports 15 event types across memories, entities, edges, chrono, and files. Payloads are signed with HMAC-SHA256, delivered with at-least-once guarantees (6 retries with exponential backoff), and SSRF-protected — targets are DNS-resolved and validated at delivery time and every redirect hop is re-validated, so a webhook cannot be pointed (or redirected/rebound) at a private/reserved IP. Manage subscriptions through the REST API or the **Settings → Webhooks** UI.
+Subscribe external systems to real-time HTTP POST notifications when write events occur. Supports 16 domain event types across memories, entities, edges, chrono, and files (including `entity.merged`) — 19 in total once the operational events `link_violation.created`, `duplicate.detected`, and `test.ping` are counted. Payloads are signed with HMAC-SHA256, delivered with at-least-once guarantees (6 retries with exponential backoff), and SSRF-protected — targets are DNS-resolved and validated at delivery time and every redirect hop is re-validated, so a webhook cannot be pointed (or redirected/rebound) at a private/reserved IP. Manage subscriptions through the REST API or the **Settings → Webhooks** UI.
 
 ### 30 MCP Tools
 
@@ -72,11 +72,11 @@ Every capability is exposed as an MCP tool that any LLM client can call:
 
 | Category | Tools |
 |----------|-------|
-| Memory | `remember`, `recall`, `recall_global`, `update_memory`, `delete_memory`, `find_similar` |
+| Memory | `remember`, `recall`, `update_memory`, `delete_memory`, `find_similar` |
 | Knowledge graph | `upsert_entity`, `update_entity`, `merge_entities`, `find_entities_by_name`, `upsert_edge`, `update_edge`, `traverse`, `query` |
 | Timeline | `create_chrono`, `update_chrono`, `list_chrono` |
 | Files | `read_file`, `write_file`, `list_dir`, `delete_file`, `create_dir`, `move_file` |
-| Batch & admin | `bulk_write`, `get_stats`, `get_space_meta`, `update_space`, `wipe_space` |
+| Batch & admin | `list_spaces`, `bulk_write`, `get_stats`, `get_space_meta`, `update_space`, `wipe_space` |
 | Sync | `list_peers`, `sync_now` |
 
 Read-only tokens automatically hide all mutating tools and block them if called directly.
@@ -110,6 +110,7 @@ Membership changes are decided by **cryptographically signed votes**: each brain
 - **Storage quotas** (soft/hard limits) for files and brain data
 - **Global rate limiting** (configurable per-endpoint)
 - **Content-Security-Policy**, security headers, `0600` config file enforcement
+- **Opt-in cross-origin embedding** — off by default (`frame-ancestors 'self'`). Listing trusted origins under `embed.allowedOrigins` in config adds them to the CSP `frame-ancestors` directive and lets them push `ythril:theme` postMessages; loading the app with `?embedded=1` hides the host chrome for iframe/portal deployments
 
 ---
 

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -43,10 +43,13 @@ ythril/
 ├── client/          Angular 21 SPA (workspace: @ythril/client)
 ├── server/          Express 5 + TypeScript API (workspace: @ythril/server)
 ├── testing/
+│   ├── _init/       Test bootstrap (config reset, sync-token provisioning)
 │   ├── integration/ API scenario tests
 │   ├── red-team-tests/ Security attack simulations
 │   ├── standalone/  Unit-level tests (no Docker)
 │   └── sync/        Multi-instance sync tests (4 containers)
+├── kubernetes/      K8s manifests (Ythril + ollama/whisper/unstructured sidecars, NetworkPolicies)
+├── scripts/         Build, setup, and maintenance scripts
 ├── config/          Runtime config (bind-mounted into container)
 ├── docs/            Project documentation
 ├── docker-compose.yml          Production compose
@@ -77,19 +80,22 @@ npm run dev
 cd client && npm start
 ```
 
-The Angular dev server proxies `/api`, `/mcp`, `/setup`, `/health`, and `/ready` to `localhost:3200` via `proxy.conf.json`.
-
-For development you still need a MongoDB instance. The easiest way is running just the database from the compose file:
+The Angular dev server proxies `/api`, `/mcp`, `/setup`, `/health`, and `/ready` to `localhost:3210` via `proxy.conf.json`. Note the port: `proxy.conf.json` targets **3210**, but `npm run dev` starts the API on its default port **3200**. Run the server on 3210 so the proxy can reach it:
 
 ```bash
-docker compose up -d ythril-mongo
+PORT=3210 TRUST_PROXY=1 npm run dev
 ```
 
-Then set the env var before starting the dev server:
+`TRUST_PROXY=1` is required when the server runs bare behind `ng serve`: the dev proxy adds an `X-Forwarded-For` header (`xfwd: true`), and with trust proxy off `express-rate-limit` rejects **every** API call with a 500 (`ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`).
+
+For development you still need a MongoDB instance, and you must provide your own — the bundled `ythril-mongo` from `docker-compose.yml` publishes **no host ports** and sits on an `internal: true` network (a deliberate security hardening), so it is intentionally unreachable from the host. Point `MONGO_URI` at a developer-provided MongoDB instead:
 
 ```bash
-MONGO_URI=mongodb://localhost:27017/?directConnection=true npm run dev
+# Option A — a local mongod listening on 127.0.0.1:27017
+MONGO_URI=mongodb://127.0.0.1:27017/?directConnection=true PORT=3210 TRUST_PROXY=1 npm run dev
 ```
+
+Or, to reuse the bundled container, expose its port with a dev-only `docker-compose.override.yml` that publishes `27017` and drops the `internal` flag — never commit that override, and keep it out of any deployed environment.
 
 ---
 
@@ -129,7 +135,15 @@ The Dockerfile is a three-stage build:
 
 ## Testing
 
-All tests use Node.js built-in `node --test` — no extra test framework.
+Server-side and integration tests use Node.js' built-in `node --test` runner — no extra framework. The **client** has its own unit suite built on **Vitest + jsdom**.
+
+### Client unit tests (no Docker required)
+
+```bash
+npm run test:client          # → vitest run
+```
+
+Runs the Angular component/service specs under `client/` in a jsdom environment. This suite runs in CI as the dedicated **"Client unit tests"** step (`.github/workflows/ci.yml`).
 
 ### Standalone tests (no Docker required)
 
@@ -369,6 +383,7 @@ Ythril ships under the PolyForm Small Business License 1.0.0. Every contribution
 - **TypeScript** — strict mode, ES2022 target, NodeNext modules.
 - **Server** — Express 5, Zod for validation, no ORMs (raw MongoDB driver).
 - **Client** — Angular 21, standalone components, signals over observables where possible.
+- **Client is fully zoneless** — zone.js has been removed. There is no zone-driven change-detection safety net, and heavy pages run with `OnPush`, so all async state must flow through **signals**, the **`AsyncPipe`**, or explicit change detection (`ChangeDetectorRef`/`markForCheck`). Mutating a field imperatively after an `await` will not repaint the view.
 - No mocking in tests — all tests run against real Docker containers.
 - Validate at system boundaries; trust internal code.
 - No temp fixes, no lazy implementations. State-of-the-art from day one.
@@ -394,6 +409,7 @@ Use conventional-commit-style prefixes:
 ## Pull Request Checklist
 
 - [ ] All existing tests pass (`npm run test:all`)
+- [ ] Client unit tests pass (`npm run test:client`)
 - [ ] If debugging failures, use `npm run test:all:keep` and clean up afterwards
 - [ ] New features have corresponding tests
 - [ ] Red-team tests still pass after security-adjacent changes

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -7,8 +7,11 @@ status of each, and why Ythril's PolyForm Small Business License obligations are
 
 ## Node.js packages
 
-All Node.js dependencies are listed in `package.json` and reproduced in [NOTICE](../NOTICE).
-They are MIT, Apache 2.0, or ISC licensed. No copyleft restrictions apply.
+Ythril is an npm-workspaces monorepo: the **root** `package.json` declares no runtime
+dependencies of its own — they live in [`server/package.json`](../server/package.json)
+and [`client/package.json`](../client/package.json). The attribution-requiring packages
+across both workspaces are reproduced in [NOTICE](../NOTICE). They are MIT, Apache 2.0,
+0BSD, BSD-3-Clause, or ISC licensed. No copyleft restrictions apply.
 
 ---
 
@@ -28,7 +31,8 @@ The image bundles two processes:
 
 `mongot` is the reason this specific image is used instead of plain Community Edition.
 Ythril issues `$vectorSearch` aggregation queries against MongoDB to power semantic
-recall (`query`, `recall`, `recall_global` MCP tools). That stage requires `mongot`
+recall (`query` and `recall` MCP tools; calling `recall` with its `space` parameter
+omitted searches across every space the token can access). That stage requires `mongot`
 to be running and connected to `mongod`. There is currently no fully open-source
 drop-in replacement that provides equivalent vector search on top of MongoDB.
 
@@ -184,3 +188,34 @@ this the only fully SSPL-only (no proprietary) deployment option with full
 
 See [integration-guide.md](integration-guide.md#mongodb-flexibility) for
 connection configuration.
+
+---
+
+## Media & document runtime images (Docker / Kubernetes sidecars)
+
+Ythril's media-embedding and document-conversion pipelines run as **separate
+container images**, pulled independently at deployment time exactly like the
+MongoDB image above. None of them are bundled into or distributed by Ythril, and
+none are linked into the application — Ythril talks to each over HTTP on a private
+network. They are documented here per the [contribution guide's](contribution-guide.md)
+Legal principle that runtime infrastructure must be listed with its licensing impact.
+
+| Image | Role | License |
+|---|---|---|
+| `ollama/ollama` | Vision model host — captions uploaded images (default `moondream2`) for the media pipeline. | MIT (the Ollama runtime). Models are pulled separately; the default `moondream2` is Apache 2.0. |
+| `fedirz/faster-whisper-server` | Speech-to-text — transcribes uploaded/segmented audio via an OpenAI-compatible endpoint. | MIT (the server). Whisper models are pulled separately and are Apache 2.0. |
+| `unstructured-io/unstructured-api-full` | Server-side PDF / DOCX / EPUB conversion (`hi_res` OCR + layout detection, table and embedded-image extraction). | Apache 2.0. |
+
+**Where they are referenced.** `ollama` and `whisper` are services in
+[`docker-compose.yml`](../docker-compose.yml) (media-embedding stack) and have matching
+Kubernetes manifests (`kubernetes/manifests/{ollama,whisper}-deploy.yaml`). The
+`unstructured-api-full` sidecar is defined in the Kubernetes deployment
+(`kubernetes/manifests/ythril-deployment.yaml`) and is being added to Compose as the
+bundled document-conversion sidecar.
+
+**Licensing impact — none on Ythril's PolyForm obligations.** All three are permissively
+licensed (MIT / Apache 2.0), carry no copyleft, and run as independent network services
+rather than linked code — the same TCP-socket relationship analysed for MongoDB above.
+`unstructured-api-full` in particular ships under Apache 2.0, but because its tag can change,
+verify the image's bundled `LICENSE` on every version bump (the procedure is documented in
+the header of `kubernetes/manifests/ythril-deployment.yaml`).

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -32,12 +32,15 @@ If you are here for web UI usage, read [User Guide](userguide.md). If you are co
 17. [Admin API](#admin-api) — config reload, export/import, space wipe
 18. [Data Management API](#data-management-api) — maintenance mode, backup, restore, migration, backup config
 19. [Audit Log API](#audit-log-api) — token and access audit trail
-20. [Webhooks API](#webhooks-api) — event subscriptions for space write events
-21. [About API](#about-api) — instance info and logs
-22. [Theme API](#theme-api) — external CSS theming
-23. [MCP (Model Context Protocol)](#mcp-model-context-protocol) — AI tool integration
-24. [Storage Quotas](#storage-quotas)
-25. [Pagination](#pagination)
+20. [Duplicate Scanner & Action Rules](#duplicate-scanner--action-rules) — dedupe scan and automated action rules
+21. [Webhooks API](#webhooks-api) — event subscriptions for space write events
+22. [About API](#about-api) — instance info and logs
+23. [Theme API](#theme-api) — external CSS theming
+24. [Embedded (chrome-less) Mode](#embedded-chrome-less-mode) — iframe-embeddable UI
+25. [MCP (Model Context Protocol)](#mcp-model-context-protocol) — AI tool integration
+26. [Storage Quotas](#storage-quotas)
+27. [Pagination](#pagination)
+28. [OIDC (OpenID Connect) Authentication](#oidc-openid-connect-authentication) — browser SSO via an external IdP
 
 ---
 
@@ -453,7 +456,7 @@ docker compose start
 
 ## Authentication
 
-Every API request requires a Bearer token, except a handful of public routes: `/health`, `/ready`, `/api/theme`, `/api/setup/status`, `/setup`, `/api/invite/apply`, `/api/auth/oidc-info`, and `GET /api/about`:
+Every API request requires a Bearer token, except a handful of public routes: `/health`, `/ready`, `/api/theme`, `/api/setup/status`, `/setup`, `/api/invite/apply`, and `/api/auth/oidc-info`:
 
 ```
 Authorization: Bearer ythril_<base62-encoded-token>
@@ -522,15 +525,14 @@ Extended errors may include:
 | Auth | 10 / min | Token creation, setup, invite/apply |
 | Global | 300 / min | All authenticated endpoints |
 | Sync | 2 000 / min | Sync API endpoints |
-| Notify | 60 / min | `POST /api/notify` |
-| Bulk wipe | 5 / min | `DELETE /api/brain/spaces/:spaceId/memories` |
+| Notify | 60 / min | `GET /api/notify`, `POST /api/notify`, `POST /api/notify/trigger` |
+| Bulk wipe | 5 / min | `DELETE /api/brain/spaces/:spaceId/{memories,entities,edges,chrono}` |
 
-Rate limit headers are included in responses:
+Rate limit headers follow the IETF draft-7 format: a single combined `RateLimit` header plus a `RateLimit-Policy` header (the legacy draft-6 `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` headers are not emitted):
 
 ```
-RateLimit-Limit: 300
-RateLimit-Remaining: 297
-RateLimit-Reset: 1711381200
+RateLimit: limit=300, remaining=297, reset=42
+RateLimit-Policy: 300;w=60
 Retry-After: 42
 ```
 
@@ -656,6 +658,7 @@ Content-Type: application/json
 
 **Response** `200` `{ deleted: <count> }`. Rate-limited to 5 requests/minute.
 
+Entities, edges, and chrono entries have the same bulk-wipe endpoint shape — `DELETE /api/brain/spaces/:spaceId/entities`, `.../edges`, and `.../chrono`, each requiring `{ "confirm": true }`, returning `{ deleted: <count> }`, and sharing the same 5/minute bulk-wipe limit. Bulk wipe is rejected on proxy spaces (`400`) — target member spaces individually.
 
 ---
 
@@ -795,7 +798,7 @@ Multiple operators on the same key are AND-ed (range queries):
 { "properties.score": { "gte": 50, "lt": 100 } }
 ```
 
-**Allowed filter key prefixes:** `properties.`, `tags`, `type`, `name`. Any other key returns `400`. This prevents filter-key injection attacks.
+**Allowed filter key prefixes:** `properties.`, `tags`, `type`, `name`, `status`, `label`. Any other key returns `400`. This prevents filter-key injection attacks.
 
 **Examples:**
 
@@ -813,7 +816,7 @@ Multiple operators on the same key are AND-ed (range queries):
 { "filter": { "properties.domain": { "exists": true } } }
 ```
 
-> **Performance note:** When a `filter` is provided, Ythril switches to ENN (exact nearest-neighbour) search — MongoDB exhaustively scores all documents in the space, applies the filter, then returns the top-K results. This is semantically correct for any collection size: ANN + post-filter would silently discard matching documents that fell below the ANN candidate threshold. For very large spaces (>50k records per type), consider adding a standard MongoDB index on heavily-filtered fields (e.g. `properties.status`) to speed up the post-match stage.
+> **Performance note:** A filter that references only declared index fields — `tags`, `type`, `name`, `status`, `label`, and any schema-declared `properties.<key>` — using the operators `eq`, `in`, `gt`, `gte`, `lt`, or `lte` is pushed into a native `$vectorSearch` `filter` and runs as `exact:true` search restricted to the matching subset, so cost is proportional to the number of matching records rather than the whole collection. Only undeclared dynamic `properties.*` keys, `exists`, and `ne` fall back to the exhaustive ENN path, which scores every document in the space before applying the filter. To keep a heavily-filtered property on the fast path, declare it in the space schema rather than adding a standalone MongoDB index.
 
 **What is vector-indexed:**
 
@@ -949,6 +952,26 @@ Returns all entities with the exact name, regardless of type. Multiple entities 
 
 ---
 
+### Get Entities by IDs
+
+```
+GET /api/brain/spaces/:spaceId/entities/by-ids?ids=id1,id2,id3
+```
+
+Batch-fetch entities by ID. `ids` is a comma-separated list (required — `400` if missing), deduplicated and capped at **100** IDs per call. Returns `{ "entities": [ ... ] }`; unknown IDs are simply absent from the result.
+
+---
+
+### Get an Entity by ID
+
+```
+GET /api/brain/spaces/:spaceId/entities/:id
+```
+
+Returns the single entity, or `404` if no entity with that ID exists in the space. Edges and chrono entries have the same single-doc shape — `GET /api/brain/spaces/:spaceId/edges/:id` and `GET /api/brain/spaces/:spaceId/chrono/:id`.
+
+---
+
 ### List Entities
 
 ```
@@ -965,7 +988,7 @@ GET /api/brain/spaces/:spaceId/entities?limit=50&skip=0
 }
 ```
 
-Default limit: 50, max: 200.
+Default limit: 50, max: 500.
 
 ---
 
@@ -2077,7 +2100,13 @@ POST /api/spaces
 | `folders` | no | Pre-create these directories on disk at space creation time. |
 | `maxGiB` | no | Maximum storage quota for the space (positive number in GiB). |
 
-**Response** `201`: the created space object.
+**Response** `201`: the created space object, wrapped in a `space` field:
+
+```json
+{ "space": { "id": "research", "label": "Research Notes", "indexStatus": "building" } }
+```
+
+> **Async vector-index build:** creating a real space returns immediately with `indexStatus: "building"`. The space is writable straight away, but semantic `recall` returns no results until the Atlas vector indexes finish building and `indexStatus` flips to `"ready"` (this can take up to a few minutes; a failed build reports `"failed"`). Poll the space via `GET /api/spaces` if you need to gate recall on readiness. Proxy spaces and spaces created before this behaviour have no `indexStatus` and should be treated as ready.
 
 ---
 
@@ -2102,6 +2131,7 @@ POST /api/spaces
 - All `proxyFor` members must be existing real spaces (not proxies — nesting is not allowed).
 - Proxy spaces are virtual: no DB collections or file directories are created.
 - The calling token must have access to **all** member spaces.
+- The single-element wildcard `"proxyFor": ["*"]` creates an **all-spaces** proxy: it aggregates over every real space the caller can access (resolved dynamically), skipping per-member validation. The wildcard cannot be mixed with explicit member IDs.
 
 **Read operations** (GET memories, entities, edges, files, recall, query) aggregate results across all member spaces transparently.
 
@@ -2662,6 +2692,37 @@ Authorization: Bearer <token>
 > **Safe deletion:** Before deleting an entry, call `GET /api/schema-library/:name/usages` to find all spaces that reference it. For each usage, `PUT /api/spaces/:spaceId/meta/typeSchemas/:kt/:typeName` with the inline schema (copied from the library entry) to replace the `$ref` with a standalone definition. Once all references are replaced, the `DELETE` can proceed without breaking any space's validation.
 >
 > The admin UI performs this sequence automatically — it shows a warning with the affected spaces and an **Unlink & Delete** button that handles the replacement before deleting.
+
+#### Schema groups
+
+Library entries can carry a `schemaGroup` tag, letting a related set of type schemas be exported from and applied to spaces as a unit.
+
+```
+GET /api/schema-library/groups
+Authorization: Bearer <token>
+```
+
+**Response** `200 { "groups": [ { "name", "count" } ] }` — every distinct `schemaGroup` with the number of entries in it, sorted by name.
+
+```
+POST /api/schema-library/export-space
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{ "spaceId": "research", "groupName": "research-schemas", "namePrefix": "research" }
+```
+
+Creates or updates one library entry per **inline** type schema in the space's `meta.typeSchemas`, tagging them all with `groupName` (`$ref` entries are skipped — they are already library-backed). Entry names are derived as `<namePrefix|groupName>-<knowledgeType>-<typeName>`. **Response** `200 { "created", "updated", "entries": [ ... ] }`. Requires an admin token (and MFA when enabled).
+
+```
+POST /api/schema-library/groups/:group/apply
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{ "spaceId": "research-2" }
+```
+
+Injects a `$ref` into the target space's `typeSchemas` for every library entry in `:group`, wiring the space to the shared definitions. **Response** `200` with the applied entries; `404` if the group has no entries or the space does not exist. Requires an admin token (and MFA when enabled).
 
 #### Using `$ref` in space typeSchemas
 
@@ -3253,7 +3314,7 @@ What to do:
 Notes:
 
 - This validation is enforced for `Join via Invite Key`, `Join Remote`, and invite `apply` payloads.
-- There is no runtime toggle to allow private or loopback peer URLs in these endpoints.
+- There is no runtime toggle to allow private or loopback peer URLs in these endpoints. `SYNC_ALLOW_PRIVATE_PEERS` (and the `allowPrivatePeers` config key) relaxes only the sync-time/gossip URL check used when connecting to and storing already-known peers; the join / member-add URL validation shown here always uses the strict SSRF check regardless of that setting.
 
 ---
 
@@ -3765,11 +3826,11 @@ POST /api/mfa/setup
 ```json
 {
   "secret": "JBSWY3DPEHPK3PXP",
-  "otpauth": "otpauth://totp/ythril:admin?secret=JBSWY3DPEHPK3PXP&issuer=ythril"
+  "otpauth": "otpauth://totp/Ythril:My%20Brain?secret=JBSWY3DPEHPK3PXP&issuer=Ythril"
 }
 ```
 
-Scan the `otpauth` URI as a QR code in any TOTP app.
+Scan the `otpauth` URI as a QR code in any TOTP app. The issuer is always `Ythril`, and the account label is the instance label (`instanceLabel`, falling back to `brain`).
 
 > When MFA is **already enabled**, `POST /api/mfa/setup` (rotating the secret) and `DELETE /api/mfa`
 > (disabling) require a current TOTP code in the `X-TOTP-Code` header — a stolen admin PAT alone
@@ -5306,7 +5367,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`recall`, `query`, `get_stats`, `get_space_meta`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -5387,6 +5448,7 @@ Content-Type: application/json
 
 | Tool | Description |
 |---|---|
+| `list_spaces` | List accessible space IDs with descriptions and entry counts (memories, entities, edges, chrono) |
 | `remember` | Store a memory with optional tags and entity links |
 | `update_memory` | Update an existing memory's fact, tags, entity links, or delete specific fields via `deleteFields` |
 | `delete_memory` | Delete a memory by ID |
@@ -5548,6 +5610,8 @@ For cross-space recall (omit `space`), `spaceId` on each result identifies which
 | `types` | `string[]` | — | Optional knowledge-type filter — restrict results to one or more of `memory`, `entity`, `edge`, `chrono`, `file`. Omit to search all types. |
 | `minPerType` | `object` | — | Optional minimum result count per type. Guarantees at least that many results of each specified type if available (e.g. `{"entity": 2, "edge": 1}`). Uses two-phase search: guaranteed slots filled first, remaining slots filled by score. Omit to use pure score ranking. |
 | `minScore` | `number` | — | Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded. Applies before `topK` — so `topK=10, minScore=0.7` returns at most 10 results, all with score ≥ 0.7. |
+| `filter` | `object` | — | Property equality/comparison filter applied to the vector-search results. Same shape and allowed key prefixes as the [recall filter](#prefiltered-recall-filter-parameter) (`properties.`, `tags`, `type`, `name`, `status`, `label`) with `eq`/`ne`/`in`/`exists`/`gt`/`gte`/`lt`/`lte` operators. Records not matching **all** conditions are excluded. |
+| `traverse` | `number` | — | Graph-expansion depth (integer `0`–`5`, default `0`). When `> 0`, each semantic match is expanded along knowledge-graph edges up to this many hops; connected entities are returned alongside the seeds, annotated with `source` (`recall`/`traverse`), `hops`, and `path`. |
 
 When `space` is omitted, `recall` searches across all accessible spaces — the same as the former `recall_global` behaviour.
 
@@ -5659,12 +5723,13 @@ Works with any valid token (including read-only). For proxy spaces, returns aggr
 | `entities` | Named entities in the knowledge graph |
 | `edges` | Directed relationship edges between entities |
 | `chrono` | Chronological entries (events, deadlines, plans, predictions, milestones) |
+| `files` | File metadata records (path, tags, description, embedding status) |
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `collection` | `string` | ✅ | One of the four values above |
+| `collection` | `string` | ✅ | One of the five values above |
 | `filter` | `object` | ✅ | MongoDB filter document |
 | `projection` | `object` | — | Fields to include (`1`) or exclude (`0`) |
 | `limit` | `number` | — | Max documents (default `20`, max `100`) |
@@ -5828,9 +5893,13 @@ Used by the web client login flow to decide whether OIDC is enabled and which is
   "enabled": true,
   "issuerUrl": "https://keycloak.example.com/realms/my-realm",
   "clientId": "ythril",
-  "scopes": ["openid", "profile", "email"]
+  "scopes": ["openid", "profile", "email"],
+  "enforceForBrowser": false,
+  "postLogoutRedirectUri": "https://brain.example.com/login"
 }
 ```
+
+`enforceForBrowser` is always present (boolean). `postLogoutRedirectUri` is included only when it is configured on the `oidc` block.
 
 ### Login Flow (Browser)
 
@@ -5950,7 +6019,7 @@ After saving any IdP configuration, run `POST /api/admin/reload-config` to apply
 - **No server-side token revocation for OIDC.**  JWTs are validated statelessly (signature + `exp`).  Once issued by the IdP, a token is valid until it expires.  To revoke access, disable or remove the user at the IdP and set short token lifetimes (5–15 minutes recommended).
 - **Silent token refresh.**  The SPA automatically schedules a background token refresh 60 seconds before the access token expires.  A hidden iframe is created with `prompt=none`; if the IdP session is still valid the user stays logged in with no interruption.  If the IdP session has also expired (or the IdP does not support `prompt=none`) the next API call returns 401 and the browser is redirected to the login page.  Configure your IdP's access token lifetime to balance UX vs security (5–15 minutes is a reasonable default).  This mechanism requires `Content-Security-Policy: frame-ancestors 'self'` (included in the default `frame-ancestors 'self'; object-src 'none'; base-uri 'self'` policy set by the server).
 - **`admin` and `readOnly` cannot both match.**  If both claim rules match the same JWT, `admin: true` takes precedence and `readOnly` is ignored.  Design your IdP roles to be mutually exclusive.
-- **Spaces claim controls visibility.**  When a `spaces` claim is present in the JWT, the OIDC session can only see and modify those spaces.  If the claim is missing or not an array, the session has access to all spaces (same as a PAT with no `spaces` allowlist).  Users who cannot see expected spaces should check with their administrator that the IdP is emitting the correct claim values.
+- **Spaces claim controls visibility (fail-closed).**  When a `spaces` mapping is configured, the OIDC session can only see and modify the spaces named in that claim.  If the mapping is configured but the claim is missing or is not a string array, the allow-list is **empty (deny all)** — not "all spaces".  Users who cannot see expected spaces should check with their administrator that the IdP is emitting the correct claim values.
 - **Config validation.**  When `oidc.enabled` is `true`, `issuerUrl` and `clientId` are required.  The server validates the OIDC config block at startup and on `reload-config` — a malformed block will prevent the server from starting.
 - **Config reload required.**  Any change to the `oidc` block requires `POST /api/admin/reload-config` or a container restart to take effect.  The OIDC discovery document and JWKS key set are cached in memory and flushed on reload.
 - **Enforcing OIDC for browser sessions.**  Set `enforceForBrowser: true` to prevent users who have a cached PAT in their browser from bypassing the IdP.  When this flag is set the SPA clears any PAT-based localStorage session on startup and forces a fresh OIDC login.  Programmatic callers (API, MCP) that supply an `Authorization: ****** header are not affected.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5367,7 +5367,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -5448,6 +5448,7 @@ Content-Type: application/json
 
 | Tool | Description |
 |---|---|
+| `help` | Self-documenting system guide — the knowledge model, how to choose between `query` / `recall` / filtered recall, schema authoring, and the tools available to the calling token. Read-only, no `space` needed; scoped to the token so it never lists tools the token can't call |
 | `list_spaces` | List accessible space IDs with descriptions and entry counts (memories, entities, edges, chrono) |
 | `remember` | Store a memory with optional tags and entity links |
 | `update_memory` | Update an existing memory's fact, tags, entity links, or delete specific fields via `deleteFields` |

--- a/docs/usecase-examples.md
+++ b/docs/usecase-examples.md
@@ -2,6 +2,11 @@
 
 Practical scenarios showing how Ythril spaces and networks solve real knowledge management challenges.
 
+> **How entity linking works in these examples:**
+>
+> - **`remember(entities: [...])` links to *existing* entities only** — it does not create them. Names that don't resolve to an existing entity are skipped with a warning ("Unresolved entity names — create them first"). Call `upsert_entity` for each new entity *before* (or alongside) the `remember` that references it, otherwise the memory is stored unlinked.
+> - **Passing entity *names* to `upsert_edge` and to chrono `entityIds` works only when `strictLinkage` is off** (the default). Spaces with `strictLinkage` enabled reject names and require entity **IDs** (UUIDs).
+
 ---
 
 ## 1. Personal Multi-Device Sync
@@ -264,7 +269,7 @@ graph LR
 
 **Wow factor:**
 - The LLM builds a knowledge graph *about you* over time — entities for your projects, edges for relationships, chrono entries for deadlines — and any future conversation can traverse it.
-- `recall_global` lets the LLM search across *all* your spaces at once: "What do I know about Kubernetes across my work KB, personal notes, and homelab docs?"
+- `recall` with the `space` parameter omitted searches across *all* your accessible spaces at once: "What do I know about Kubernetes across my work KB, personal notes, and homelab docs?"
 - `create_chrono(type: "prediction", confidence: 0.7)` → the LLM can track its own predictions and score itself over time.
 
 ---
@@ -324,7 +329,7 @@ graph TD
 **Consumers:** Department heads receive deadline-aware knowledge that their LLM can query.
 
 **Wow factor:**
-- `list_chrono({status: "overdue"})` — instant visibility into missed obligations across the org. No spreadsheet hunting.
+- `list_chrono({status: "overdue"})` — lists every obligation **explicitly marked** `overdue`. (Status lives on the entry; a passed `startsAt` does not auto-flag it — mark deadlines overdue as you triage them.)
 - `create_chrono({type: "deadline", title: "DORA ICT risk assessment due", startsAt: "2026-06-30", entityIds: ["DORA", "ICT-risk"]})` → departments' LLMs can ask "What compliance deadlines do we have this quarter?" and get structured answers, not just documents.
 - Braintree pushes mean the legal team publishes once and all departments receive. Departments **cannot** alter the authoritative deadline — temporal integrity by architecture.
 - `query(chrono, {type: "prediction", confidence: {$gte: 0.5}})` → the legal team can even log risk predictions ("60% chance of regulatory change in Q3") and track them.
@@ -356,7 +361,7 @@ graph LR
 **Wow factor:**
 - One Ythril instance, N customers, full isolation via spaces + space-scoped tokens. No separate databases, no tenant ID middleware hell.
 - Customer gives their MCP client a space-scoped token → the LLM can `remember`, `recall`, `write_file` only within their silo. Zero chance of cross-tenant leakage — it's token-enforced at the API layer, not application-logic.
-- Support agent connects with a proxy space → `recall_global("connection timeout")` → finds matching incidents across ALL customers, ranked by relevance. "This looks like the same issue Customer B had last week."
+- Support agent connects with a proxy space → `recall("connection timeout")` with `space` omitted → finds matching incidents across ALL customers, ranked by relevance. "This looks like the same issue Customer B had last week."
 - Read-only tokens for customer-facing dashboards — they can query their knowledge but not accidentally corrupt it.
 
 ---
@@ -603,7 +608,7 @@ graph TD
 
 **Wow factor:**
 - Partner asks: `recall("cloud migration cost overrun")` on the proxy → gets results from internal templates AND both client engagements, ranked by relevance, with `spaceId` showing which client each result came from.
-- Consultant on-site with Client Alpha has two spaces syncing to their laptop: `internal-kb` (club) and `client-alpha` (closed). Their LLM uses `recall_global` to search both. They get the firm's methodology templates alongside Alpha-specific context in one query.
+- Consultant on-site with Client Alpha has two spaces syncing to their laptop: `internal-kb` (club) and `client-alpha` (closed). Their LLM uses `recall` with `space` omitted to search both. They get the firm's methodology templates alongside Alpha-specific context in one query.
 - Client Alpha's external instance syncs only `client-alpha` — they never see `internal-kb` or `client-beta`. Token-scoped, network-scoped, zero crossover.
 - `query(entities, {type: "deliverable", properties.status: "overdue"})` on the proxy → overdue deliverables across all clients. `list_chrono({status: "upcoming", type: "deadline"})` → upcoming deadlines across all engagements.
 - New client onboarded? Create space, create closed network, add to `proxyFor` on `partner-view`. The proxy starts including it immediately — no data migration, no restructuring.
@@ -701,7 +706,7 @@ graph LR
 - `recall("semiconductor exposure")` on the proxy → pulls trade history from `trading`, any related notes from `savings` (maybe a semiconductor ETF in your 401k), all ranked by relevance with `spaceId` attribution.
 - `query(entities, {type: "stock"})` on the proxy → every position across all accounts. `query(edges, {label: "thesis_for"})` → your investment thesis graph. "Why did I buy AMD again?" — instant recall.
 - `create_chrono({type: "event", title: "NVDA earnings Q1 2026", startsAt: "2026-05-28", entityIds: ["NVDA"]})` → `list_chrono({status: "upcoming"})` → your LLM reminds you of catalysts tied to positions you actually hold.
-- `create_chrono({type: "prediction", title: "AMD will outperform NVDA in inference workloads by Q4", confidence: 0.6, entityIds: ["AMD", "NVDA"]})` → track your own predictions. `query(chrono, {type: "prediction", status: "expired"})` → "How good were my calls?"
+- `create_chrono({type: "prediction", title: "AMD will outperform NVDA in inference workloads by Q4", confidence: 0.6, entityIds: ["AMD", "NVDA"]})` → track your own predictions. `query(chrono, {type: "prediction", status: "completed"})` → "How good were my calls?"
 - Everything stays on your hardware. Your brokerage data, trade theses, and spending patterns never touch a third-party API. Closed network sync to your laptop = offline access.
 
 ---
@@ -829,7 +834,7 @@ graph LR
 - Parent A: `remember("Boiler annual service due in October. Last serviced by PlumbCo, invoice #8812.", entities: ["boiler", "PlumbCo"], tags: ["maintenance"])` → syncs to everyone. Next year, any family member's LLM: `recall("boiler service")` → full history.
 - `create_chrono({type: "deadline", title: "Kid soccer tournament registration closes", startsAt: "2026-04-15", entityIds: ["soccer"]})` → `list_chrono({status: "upcoming"})` → the household LLM surfaces it to whoever asks.
 - `upsert_entity("family-van", "vehicle", ["maintenance"], {mileage: 82000, nextService: "85000km"})` → `query(entities, {type: "vehicle"})` → "When is the van due for service?" Structured, not buried in a note.
-- Parent A's `private-a` space is **not in any network** — it never leaves the phone. Medical notes, financial planning, personal journal — truly private. The LLM on that phone can still `recall_global` across both `household` and `private-a` locally.
+- Parent A's `private-a` space is **not in any network** — it never leaves the phone. Medical notes, financial planning, personal journal — truly private. The LLM on that phone can still `recall` with `space` omitted across both `household` and `private-a` locally.
 - Kid's tablet has a space-scoped token for `household` (read/write) and `kids-school` (read/write). No access to parent private spaces — not by policy, by architecture.
 - Democratic governance on `household` means the kid's tablet has equal vote weight. Conflict? Fork-on-conflict preserves both versions — no silent data loss.
 
@@ -966,14 +971,14 @@ graph TD
 
 1. **Discover duplicates** — agent uses `find_similar` to find high-similarity entities:
    ```json
-   { "entryId": "<docker-entity-1-uuid>", "entryType": "entity", "minScore": 0.85 }
+   { "space": "<space-id>", "entryId": "<docker-entity-1-uuid>", "entryType": "entity", "minScore": 0.85 }
    ```
 
 2. **Inspect the merge plan** — call `merge_entities` with an empty resolution map:
    ```json
-   { "survivorId": "<docker-entity-1-uuid>", "absorbedId": "<docker-entity-2-uuid>", "resolutions": [] }
+   { "space": "<space-id>", "survivorId": "<docker-entity-1-uuid>", "absorbedId": "<docker-entity-2-uuid>", "resolutions": [] }
    ```
-   The endpoint returns `409` with a `MergePlan` showing:
+   The MCP `merge_entities` tool returns the plan as a **text response flagged `isError: true`** (so the agent reads it and retries with resolutions); the REST endpoint returns the equivalent `409` with a `MergePlan` body. Either surface shows:
    - Property conflicts (e.g. `score: 80 vs 95`, `active: true vs false`)
    - Absorbed-only properties (auto-added, no resolution needed)
    - Duplicate edge warnings (edges that become identical after relinking)
@@ -981,6 +986,7 @@ graph TD
 3. **Resolve conflicts** — agent fills in resolutions (numeric via function, text via LLM judgment):
    ```json
    {
+     "space": "<space-id>",
      "survivorId": "<docker-entity-1-uuid>",
      "absorbedId": "<docker-entity-2-uuid>",
      "resolutions": [

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -12,19 +12,20 @@ For setting up a workstation quickly see [workstation-mode-guide.md](workstation
 1. [Logging in](#logging-in)
 2. [Navigation](#navigation)
 3. [Spaces — what they are](#spaces--what-they-are)
-4. [Brain](#brain)
+4. [Brain](#brain) — tabs: [Query](#query), [Graph](#graph), [Files](#files), Entities, Edges, Memories, Chrono, [File Meta](#file-meta)
    - [Memories](#memories)
    - [Entities](#entities)
    - [Edges](#edges)
    - [Chrono](#chrono)
    - [Query](#query)
+   - [File Meta](#file-meta)
 5. [Graph](#graph)
 6. [Files](#files)
 7. [Conflict resolution](#conflict-resolution)
 8. [Schema Library](#schema-library)
 9. [Settings — Spaces](#settings--spaces)
 10. [Settings — Tokens](#settings--tokens)
-11. [Settings — MFA](#settings--mfa)
+11. [Multi-factor authentication (MFA)](#multi-factor-authentication-mfa)
 12. [Settings — Networks](#settings--networks)
 13. [Settings — Models](#settings--models)
     - [Face Recognition](#face-recognition)
@@ -32,21 +33,24 @@ For setting up a workstation quickly see [workstation-mode-guide.md](workstation
 14. [Settings — Storage](#settings--storage)
 15. [Settings — Data](#settings--data)
 16. [Settings — Audit Log](#settings--audit-log)
-17. [Settings — Webhooks](#settings--webhooks)
-18. [Settings — About](#settings--about)
-19. [Connecting an AI assistant (MCP)](#connecting-an-ai-assistant-mcp)
+17. [Settings — Duplicates](#settings--duplicates)
+18. [Settings — Webhooks](#settings--webhooks)
+19. [Settings — About](#settings--about)
+20. [Connecting an AI assistant (MCP)](#connecting-an-ai-assistant-mcp)
 
 ---
 
 ## Logging in
 
-Open your instance URL in a browser (e.g. `http://localhost:3200`). Enter your access token — the one you received during setup — and click **Log in**.
+Open your instance URL in a browser (e.g. `http://localhost:3200`). Enter your access token — the one you received during setup — and click **Sign in**.
 
 If your organisation uses single sign-on (SSO), you will be redirected to your identity provider automatically. After authenticating there you land back in Ythril already logged in.
 
 To sign in with a token when SSO is active, go to `/login?local`.
 
-Clicking **Log out** in the sidebar footer clears the session.
+**First run:** on a brand-new instance the login page shows a **Run first-time setup** link (`/setup`) that walks you through creating the admin account and your first access token.
+
+Clicking **Sign out** in the topbar clears the session. (In embedded mode — see below — the topbar and its Sign out button are hidden.)
 
 ---
 
@@ -55,17 +59,16 @@ Clicking **Log out** in the sidebar footer clears the session.
 The left sidebar is the main navigation. It is divided into two sections:
 
 **Workspace**
-- **Brain** — store and search everything you know
-- **Graph** — visualise how entities connect
-- **Files** — manage uploaded documents and files
+- **Brain** — store, browse, and search everything you know. Graph and Files are *tabs inside Brain*, not separate pages — there are no `/graph` or `/files` routes (those URLs just redirect to Brain).
 - **Schema Library** — reusable data definitions shared across spaces
+- **Conflicts** — appears only when file conflicts are waiting to be resolved, with a red count badge showing how many.
 
 **Admin** (admin tokens only)
-- **Settings** → Tokens, Spaces, Networks, Storage, Audit Log, Webhooks, About, Preferences
+- **Settings** → Tokens, Spaces, Storage, Networks, Preferences, Audit Log, Data, Models, Duplicates, About
 
-A space selector at the top of the sidebar (or inside each page) lets you switch between spaces. Everything you see is scoped to the selected space.
+There is no global space selector in the sidebar. Space switching happens per page — the Brain page shows a row of space chips, and the Graph tab has its own space picker in the toolbar. Everything you see is scoped to the space you pick there.
 
-A red badge appears next to **Files** when there are file conflicts waiting to be resolved.
+**Embedded mode:** loading the app with `?embedded=1` on the URL hides the topbar (logo and **Sign out**) so Ythril can sit cleanly inside a host portal's own chrome. Navigation is unaffected — it lives in the sidebar. Trusted host origins that may iframe Ythril and push theme tokens are listed in `embed.allowedOrigins` in the config; empty or absent means same-origin only.
 
 ---
 
@@ -79,11 +82,11 @@ The `general` space is created automatically on first run. Admins can create add
 
 ## Brain
 
-The Brain is where all your knowledge lives. It has five tabs: **Memories**, **Entities**, **Edges**, **Chrono**, and **Query**.
+The Brain is where all your knowledge lives. It has eight tabs: **Query**, **Graph**, **Files**, **Entities**, **Edges**, **Memories**, **Chrono**, and **File Meta**.
 
-Five stat pills at the top of the page show the current counts for each collection in the selected space.
+At the top of the page a row of **space chips** lets you switch space; each chip shows the space's total record count. The tab buttons themselves carry small count badges for the collection they open.
 
-If the search index needs rebuilding (for example after upgrading the embedding model), an **⚠ Needs reindex** banner appears. Click **Reindex now** to rebuild it.
+If the search index needs rebuilding (for example after the embedding model changes), a banner appears reading *"Embeddings are stale — the embedding model has changed and this space needs reindexing."* Click **Reindex now** to rebuild it.
 
 ### Memories
 
@@ -101,13 +104,13 @@ Memories are the core knowledge unit — plain-language statements you want to r
 
 Click **Save**. The memory is indexed immediately and available for search.
 
-**Searching:** Type a natural-language question or phrase in the search bar and press Enter. Ythril uses semantic (meaning-based) search to find the most relevant memories.
+**Searching:** Type in the search bar and press Enter. A toggle beside it switches between **text** matching (plain substring/sort) and **Semantic** (meaning-based) search. Semantic mode returns a ranked set and is not paginated.
 
 **Filtering:** Click any tag or entity badge on a memory row to filter the list. Active filters appear as chips above the table. Click **×** on a chip to remove it, or **Clear all** to reset.
 
 **Deleting:** Each row has a **✕** button. A small inline confirmation appears — click **Yes** to confirm, **No** to cancel.
 
-**Wiping everything:** Click **Wipe all** in the toolbar. You will be asked to type the space ID to confirm. This removes all memories in the space.
+**Wiping everything:** There is no "Wipe all" button on the Brain toolbar. To clear a space's data, go to **Settings → Spaces → (space) → Danger tab** and use **Wipe all data**. You will be asked to type the space ID to confirm.
 
 ---
 
@@ -140,6 +143,8 @@ Edges connect two entities and describe the relationship between them (e.g. *ser
 
 Each edge has a **from** entity, a **to** entity, a **label** (the relationship name), and optional **type**, **weight**, **tags**, **description**, and **properties**.
 
+**Searching:** The search bar has a **text / Semantic** toggle, same as Memories — text matches the label/description, Semantic ranks edges by meaning.
+
 **Creating an edge:** Click **+ Add edge**. Use the entity pickers to select the source and target, choose or type a label, and click **Save**.
 
 When a **label** is selected and the space has a schema defined for that label, the properties section is pre-populated with all fields from that label's schema — the same required/optional behaviour as entities applies.
@@ -154,6 +159,8 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 
 **Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, and linked entities.
 
+**Searching:** The search bar has a **text / Semantic** toggle — text matches title/description, Semantic ranks entries by meaning.
+
 **Filtering:** The filter bar above the table lets you narrow by tag text and status. Filters apply immediately.
 
 **Deleting:** Inline ✕ confirmation per row.
@@ -162,9 +169,24 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 
 ### Query
 
-The Query panel lets you run structured searches across any collection in the current space.
+The Query tab has two modes, switched with the buttons at the top: **Semantic Search** and **Advanced Query**.
 
-Select a collection (`memories`, `entities`, `edges`, `chrono`, or `files`), enter a filter as JSON, and click **Run**. Results appear in a table below.
+#### Semantic Search
+
+Type a natural-language query and press Enter (or click **Search**) to find the most relevant records by meaning across the space. Two options sit next to the query box:
+
+- **topK** — how many results to return (1–100).
+- **minScore** — drop results below this similarity score (0–1).
+
+Click **Show advanced** for more control:
+
+- **Types** — restrict the search to specific record types (memory, entity, edge, chrono). For each ticked type you can also set a per-type **minimum** number of results to guarantee.
+- **Tags** — a tag filter applied to results.
+- **Filter** — a JSON object of extra field constraints, validated before the search runs. The recall filter accepts fields such as `status` and `label`, which are applied as native `$vectorSearch` pre-filters (they narrow the candidate set inside the vector index rather than filtering afterwards).
+
+#### Advanced Query
+
+Runs a structured MongoDB-style query against one collection. Select a collection (`memories`, `entities`, `edges`, `chrono`, or `files`), optionally set a **limit** and **max time (ms)**, enter a filter as JSON, and click **Run**. Results appear below.
 
 Example — find all entities of type `service`:
 ```json
@@ -178,13 +200,23 @@ Example — find memories tagged `infra`:
 
 ---
 
+### File Meta
+
+The **File Meta** tab lists the metadata records Ythril keeps for uploaded files — the searchable side of a file (its caption/extracted text, tags, and links) as distinct from the raw bytes you manage on the Files tab.
+
+Each row can be opened inline to edit its links: you can attach **entities**, **memories**, and **chrono** entries to a file so it surfaces alongside related knowledge. Opening a file from the Files tab's metadata action jumps you straight to its File Meta entry.
+
+---
+
 ## Graph
+
+> Graph is a **tab inside Brain**, not a separate page. Open Brain and click the **Graph** tab.
 
 The Graph view lets you explore how entities relate to each other visually.
 
 **Getting started:**
-1. Click **Graph** in the sidebar.
-2. Select a space from the toolbar.
+1. Open the **Graph** tab in Brain.
+2. Select a space from the tab's toolbar.
 3. Type an entity name in the search bar and click the result to load its graph.
 
 **Toolbar controls:**
@@ -209,6 +241,8 @@ The detail panel below the canvas shows all memories and chrono entries linked t
 ---
 
 ## Files
+
+> Files is a **tab inside Brain**, not a separate page. Open Brain and click the **Files** tab.
 
 The file manager lets you upload, download, organise, and preview files within each space.
 
@@ -244,9 +278,9 @@ Press **Escape** or click the backdrop to close. Use arrow keys to move to the p
 
 ## Conflict resolution
 
-When two connected brains modify the same file before syncing, a conflict is created. The sidebar shows a red badge on Files when conflicts are waiting.
+When two connected brains modify the same file before syncing, a conflict is created. A dedicated **Conflicts** item then appears in the sidebar's Workspace section, carrying a red count badge of how many are waiting.
 
-Open **Files → Conflicts** to see them. For each conflict choose what to do:
+Open **Conflicts** from the sidebar to see them. For each conflict choose what to do:
 
 | Option | Result |
 |--------|--------|
@@ -313,8 +347,10 @@ Click **+ Create space**. Fill in:
 
 - **Display Name** — the human-readable label shown everywhere in the UI.
 - **ID** — optional. Short lowercase identifier (auto-generated from the name if left blank).
-- **Max Storage (GiB)** — optional quota limit. Leave blank for unlimited.
+- **Max GiB** — optional storage quota. Leave blank for unlimited.
 - **Purpose** — optional description of what this space is for. Visible to AI assistants.
+- **Proxy for** — optionally mark this as a proxy space standing in for one or more other spaces (tick individual spaces or "all").
+- **Validation mode** — the schema-validation posture for the new space: `off`, `warn`, or `strict`.
 
 ### Space settings
 
@@ -336,9 +372,11 @@ Click the gear icon on any space row to open its settings panel. Changes save an
 
 **Danger tab:** Rename the space ID, wipe all data, or delete the space entirely.
 
+Each space row carries only a gear/configure (⚙) button — there is no pencil icon. Renaming, wiping, and deleting all live inside the space's settings panel, on the **Danger** tab.
+
 ### Renaming a space
 
-Click the pencil icon on a space row to rename its ID. All data, files, token scopes, and network sync mappings are updated automatically.
+Open the space's settings panel and go to the **Danger** tab to rename its ID. All data, files, token scopes, and network sync mappings are updated automatically.
 
 ### Deleting a space
 
@@ -346,7 +384,7 @@ In the space's settings panel, open the **Danger** tab and click **Delete space*
 
 ### Wiping a space
 
-In the **Danger** tab, click **Wipe space**. A confirmation dialog shows how many items are in each collection before you proceed. The space itself (its settings, label, schema) is kept — only the data inside it is removed.
+In the **Danger** tab, click **Wipe all data**. A confirmation dialog shows how many items are in each collection and asks you to type the space ID before you proceed. The space itself (its settings, label, schema) is kept — only the data inside it is removed.
 
 ---
 
@@ -367,7 +405,9 @@ Tokens can also be **space-scoped** — restricted to a specific list of spaces.
 
 ### Creating a token
 
-Click **+ New token**. Enter a name, choose a permission level, optionally set an expiry date, and optionally restrict it to specific spaces. To create a library access token (for sharing your schema library with other instances), enable **Library Access** — space selection and write access are then disabled automatically. Click **Create** — the token value is shown **once**. Copy it immediately.
+Click **Create Token**. Enter a name, choose a permission level, optionally set an expiry date, and optionally restrict it to specific spaces. Click **Create** — the token value is shown **once**. Copy it immediately.
+
+This dialog has no "Library Access" toggle. Library Access tokens (for sharing your schema library with other instances) are created separately, from the **Schema Library** page's own **Create token** dialog — see [Schema Library](#schema-library).
 
 ### Rotating a token
 
@@ -377,21 +417,21 @@ Click the ↺ icon on any token row. A new secret is generated; the old one stop
 
 Click the ✕ icon and confirm. The token is deleted and can never be used again.
 
-Your current session token is marked **(you)** in the list.
+Your current session token is marked **(current session)** in the list.
 
 ---
 
-## Settings — MFA
+## Multi-factor authentication (MFA)
 
-MFA adds a one-time code requirement for admin actions (creating tokens, managing spaces). Normal data operations are not affected.
+MFA adds a one-time code requirement for admin actions (creating tokens, managing spaces). Normal data operations are not affected. There is no separate "MFA" page — the MFA panel lives inside **Settings → Preferences**.
 
 ### Enrolling
 
-1. Open **Settings → MFA** and click **Enable MFA**.
+1. Open **Settings → Preferences** and click **Enable MFA**.
 2. Scan the QR code with an authenticator app (Google Authenticator, Authy, 1Password, Bitwarden, etc.).
 3. Enter the 6-digit code shown in the app and click **Confirm**.
 
-The TOTP secret is generated in your browser and never sent to any server other than to store the encrypted key for verification.
+The TOTP secret is generated **on the server** and returned to your browser so it can be shown as the QR code / setup key. Your authenticator and the server then share that secret to verify future codes.
 
 ### Day-to-day use
 
@@ -399,7 +439,9 @@ When you perform an admin action, the UI prompts for a 6-digit code. After enter
 
 ### Disabling
 
-Click **Disable MFA**. No code is needed — this is intentional, so you can recover if you lose your authenticator.
+Click **Disable MFA**. This **requires a current 6-digit code** — you cannot turn MFA off without your authenticator, which is deliberate: a stolen admin token must not be able to silently remove the second factor.
+
+**Lost your authenticator?** Because disabling needs a code, recovery is an operator action on the host: remove the `totpSecret` entry from `secrets.json` in the instance's config directory and restart. MFA is then disabled and you can re-enrol.
 
 ---
 
@@ -448,6 +490,8 @@ Expand a network card and click **Sync History** to see a log of every sync cycl
 ### Voting
 
 When a vote is open (e.g. a member wants to leave), expand the network card and scroll to **Open votes**. Click **✓ Yes** or **✗ No** to cast your vote.
+
+**Signed votes:** a network can set `requireSignedVotes` so every vote cast must carry a valid Ed25519 signature from the voting member (verified against its pinned signing key). Enable it once all members have published a signing key; if a member rotates its signing key, the new key is accepted with a rotation proof that references the previous one.
 
 ### Leaving a network
 
@@ -552,7 +596,7 @@ Toggle the **Maintenance mode** button to enable or disable it. A banner appears
 
 ### Backups
 
-Click **Run backup now** to trigger an immediate point-in-time dump of the entire MongoDB database. The backup is stored inside the instance's data directory (`<data-root>/backups/<timestamp>/`). Each backup contains a `manifest.json` with metadata and one NDJSON file per collection.
+Click **Back Up Now** to trigger an immediate point-in-time dump of the entire MongoDB database. The backup is stored inside the instance's data directory (`<data-root>/backups/<timestamp>/`). Each backup contains a `manifest.json` with metadata and one NDJSON file per collection.
 
 The **Backups** table lists all available backups with their timestamp and the collections they contain.
 
@@ -560,7 +604,7 @@ The **Backups** table lists all available backups with their timestamp and the c
 
 > **This feature must be explicitly enabled by your infrastructure administrator** (`YTHRIL_DB_MIGRATION_ENABLED=true`). It is disabled by default.
 
-Configure automatic backups and an optional offsite destination from **Settings → Database** using the **Backup Destination** and **Scheduled Backups** cards. Settings are saved to `backup.json` (alongside `config.json`, typically `/config/backup.json`). You can also create or edit this file directly — see `config/backup.example.json` in the repository for the full schema.
+Configure automatic backups and an optional offsite destination from **Settings → Data** using the **Backup Destination** and **Scheduled Backups** cards. Settings are saved to `backup.json` (alongside `config.json`, typically `/config/backup.json`). You can also create or edit this file directly — see `config/backup.example.json` in the repository for the full schema.
 
 **Example `backup.json`:**
 
@@ -673,7 +717,7 @@ Restore is irreversible — all data written after the backup timestamp will be 
 
 > **This feature must be explicitly enabled by your infrastructure administrator** (`YTHRIL_DB_MIGRATION_ENABLED=true`). It is disabled by default on all instances.
 
-> **Not available when `MONGO_URI` is set.** If the connection is managed via environment variable, the **Migrate Database** card shows an informational message instead of the migration form. To change the database in that case, update `MONGO_URI` in your deployment configuration and restart.
+> **Infrastructure-managed connections are locked.** When `MONGO_URI` comes from the environment, the UI shows an informational note that the connection is externally managed. The *hard* server-side block on changing database settings, however, is the separate `YTHRIL_MONGO_INFRA_MANAGED=true` environment variable: with it set, the **Migrate Database** card is disabled entirely. To change the database in a managed deployment, update your deployment configuration (the `MONGO_URI` your orchestrator injects) and restart.
 
 Database migration moves the entire database to a different MongoDB server — for example, from the bundled container to Atlas, or between clusters.
 
@@ -697,32 +741,48 @@ Migration is a one-way operation. Keep your old database available until you hav
 
 **Exporting:** Download the current filtered view as JSON or CSV.
 
+**Live server log:** the Audit Log page also carries the instance's **live server log**, streamed in real time over Server-Sent Events (SSE). It loads the recent lines and then appends new ones as they happen, colour-coded by level.
+
+---
+
+## Settings — Duplicates
+
+**Settings → Duplicates** (admin only) surfaces near-duplicate records found by the background semantic-duplicate scanner.
+
+A status filter (**open / dismissed / all**) and a **Scan now** button sit at the top. The table lists each duplicate pair — space, record type, a summary of record A and record B, the similarity score, status, and when it was detected. For an entity pair you can **Merge** the two records; any pair can be **Dismiss**ed (the ✕ button).
+
+**Per-space rules:** how the scanner reacts is configured per space in the instance config (`dupeRules`). Each rule can `flag` a pair for review, `automerge` it, or `notify` — the notify action emits a `duplicate.detected` webhook (optionally to a rule-specific URL). The scanner is opt-in and off by default.
+
 ---
 
 ## Settings — Webhooks
 
-**Settings → Webhooks** (admin only) lets you send HTTP notifications to external systems whenever data changes.
+Webhooks send signed HTTP notifications to external systems when events occur. **There is no Settings → Webhooks page yet** — a management UI is planned, but today webhooks are configured through the admin API at `/api/admin/webhooks` (admin token + MFA required). All endpoints must be HTTPS and are SSRF-checked.
 
-### Creating a webhook
+### Listing and creating
 
-Click **+ New Webhook**. Enter:
-- **URL** — the HTTPS endpoint to notify.
-- **Secret** — used to sign payloads so your endpoint can verify they came from Ythril.
-- Optionally restrict to specific spaces and event types.
-
-### Event types
-
-Webhooks fire on any write event: `memory.created`, `entity.updated`, `file.deleted`, etc. — across all five data types (memory, entity, edge, chrono, file).
+- **List:** `GET /api/admin/webhooks`
+- **Create:** `POST /api/admin/webhooks` with a JSON body of:
+  - **`url`** — the HTTPS endpoint to notify.
+  - **`secret`** — at least 8 characters; used to HMAC-sign each payload so your endpoint can verify it came from Ythril.
+  - **`spaces`** — optional array of space IDs to restrict to (omit/empty = all spaces).
+  - **`events`** — optional array of event types to restrict to (omit/empty = all events).
+- **Delete:** `DELETE /api/admin/webhooks/:id`
+- **Update:** `PATCH /api/admin/webhooks/:id`
 
 ### Testing
 
-Click **Test** on a webhook card to send a test ping and verify the endpoint is reachable.
+`POST /api/admin/webhooks/:id/test` delivers a `test.ping` event to that webhook so you can confirm the endpoint is reachable. Recent delivery attempts are available at `GET /api/admin/webhooks/:id/deliveries`.
+
+### Event types
+
+Beyond the per-collection write events (`memory.created`, `entity.updated`, `file.deleted`, … across memory, entity, edge, chrono, and file), the following are also emitted: `entity.merged`, `link_violation.created`, `duplicate.detected`, and `test.ping`.
 
 ---
 
 ## Settings — About
 
-The About page shows instance information: label, version, uptime, database version, disk usage, and the last 200 lines of the server log (auto-refreshed every 15 seconds).
+The About page loads once (no auto-refresh) and shows instance information: instance label, instance ID, version, uptime, MongoDB version, and a disk-usage bar. It does **not** show the server log — the live server log lives on the [Audit Log](#settings--audit-log) page.
 
 ---
 
@@ -749,7 +809,11 @@ Add the following to your MCP client's config file:
 
 Replace `localhost:3200` with your instance URL and `ythril_yourTokenHere` with a valid token.
 
-One connection entry is all you need — every space the token can access is available. The AI will see instructions listing the available spaces when it connects.
+One connection entry is all you need — every space the token can access is available. On connect, the AI receives instructions naming the spaces it can reach and is told to call **`list_spaces`** (and `get_space_meta`) to learn the schema, purpose, and record counts of each — so it can orient itself before reading or writing.
+
+### Browser connectors (OAuth)
+
+Static-token clients like Claude Desktop, Cursor, and VS Code just send the `Authorization: Bearer ythril_…` header shown above. Browser-based connectors that use the claude.ai-style OAuth flow instead — connect Ythril's `/mcp` URL and you'll be sent through an OAuth **consent** screen where you paste a valid Ythril token to approve. On approval Ythril mints a fresh PAT with the same privileges as the approving token; it appears under **Settings → Tokens** named **`MCP connector: <client>`**. This flow requires the instance to know its own public HTTPS URL (`publicUrl` / `PUBLIC_BASE_URL`).
 
 ### What the AI can do
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -809,7 +809,7 @@ Add the following to your MCP client's config file:
 
 Replace `localhost:3200` with your instance URL and `ythril_yourTokenHere` with a valid token.
 
-One connection entry is all you need — every space the token can access is available. On connect, the AI receives instructions naming the spaces it can reach and is told to call **`list_spaces`** (and `get_space_meta`) to learn the schema, purpose, and record counts of each — so it can orient itself before reading or writing.
+One connection entry is all you need — every space the token can access is available. On connect, the AI receives instructions naming the spaces it can reach and is told to call **`list_spaces`** (and `get_space_meta`) to learn the schema, purpose, and record counts of each — so it can orient itself before reading or writing. It can also call the **`help`** tool for a guided overview of the whole system (the knowledge model, when to use `query` vs. `recall`, and the tools available to its token).
 
 ### Browser connectors (OAuth)
 

--- a/docs/workstation-mode-guide.md
+++ b/docs/workstation-mode-guide.md
@@ -293,7 +293,7 @@ Why: pulls latest images and recreates containers while keeping volumes (data).
 
 1. Port 3200 already in use
 - Symptom: compose fails to bind `0.0.0.0:3200`.
-- Fix: stop the conflicting process or create `docker-compose.override.yml` with `"3201:3200"` and use `http://localhost:3201`.
+- Fix: stop the conflicting process, or set `YTHRIL_PORT` in `.env` to a free host port (e.g. `YTHRIL_PORT=3201`) and use `http://localhost:3201`. Do **not** add a second `ports:` entry via `docker-compose.override.yml` — Compose concatenates `ports` lists, so the base `3200` mapping still binds and startup fails.
 
 2. UI opens but setup/auth fails
 - Check logs:

--- a/docs/workstation-mode-guide.md
+++ b/docs/workstation-mode-guide.md
@@ -70,19 +70,18 @@ The media containers (`ollama`, `whisper`) start by default; disable them with `
 
 Option A: keep defaults (port 3200 + bundled MongoDB)
 
-Option B: port `3200` is occupied (use `3201` instead)
+Option B: port `3200` is occupied (use a different host port)
 
-Create an override file:
+Set `YTHRIL_PORT` in `.env` (Compose auto-loads it, and the base `ports` mapping is `"${YTHRIL_PORT:-3200}:3200"`):
 
-```yaml
-# docker-compose.override.yml
-services:
-  ythril:
-    ports:
-      - "3201:3200"
+```bash
+# .env
+YTHRIL_PORT=3201
 ```
 
 You will open `http://localhost:3201` instead of `http://localhost:3200`.
+
+Note: a `docker-compose.override.yml` with a second `ports:` entry does **not** work here — Compose concatenates `ports` lists across files, so the base `3200` mapping still binds and startup fails. Change the host port with `YTHRIL_PORT`.
 
 How to check what is using 3200 on Windows:
 
@@ -110,19 +109,23 @@ Authentication note:
 - For an external MongoDB, use a real authenticated connection string from your database setup.
 - If your username or password contains special characters (`@`, `:`, `/`, `?`, `#`), URL-encode them.
 
-1. Set `MONGO_URI` to your existing database.
+1. Add `MONGO_URI` to the `environment:` block of a `docker-compose.override.yml` for the `ythril` service, so it actually reaches the container. Setting it only as a host shell variable (`$env:MONGO_URI`) does **not** work — Compose does not forward it into the container, and the server reads `MONGO_URI` only from `process.env`.
 2. Start only `ythril` and skip dependencies.
 
-PowerShell example:
+Example override:
 
-```powershell
-$env:MONGO_URI = "mongodb://ythril_user:YOUR_PASSWORD@my-mongo-host:27017/ythril?authSource=admin&directConnection=true"
+```yaml
+# docker-compose.override.yml
+services:
+  ythril:
+    environment:
+      MONGO_URI: "mongodb://ythril_user:YOUR_PASSWORD@my-mongo-host:27017/ythril?authSource=admin&directConnection=true"
 ```
 
-Atlas example:
+Atlas connection string (use in place of the URI above):
 
-```powershell
-$env:MONGO_URI = "mongodb+srv://ythril_user:YOUR_PASSWORD@cluster0.example.mongodb.net/ythril?retryWrites=true&w=majority"
+```text
+mongodb+srv://ythril_user:YOUR_PASSWORD@cluster0.example.mongodb.net/ythril?retryWrites=true&w=majority
 ```
 
 Why `--no-deps`: the default compose file has `ythril` depending on `ythril-mongo`. When you use external MongoDB, you intentionally bypass that local dependency.
@@ -133,10 +136,10 @@ Start command (run exactly one):
 # A) Default (port 3200 + bundled MongoDB)
 docker compose up -d
 
-# B) Alternate port (after creating docker-compose.override.yml)
+# B) Alternate port (after setting YTHRIL_PORT in .env)
 docker compose up -d
 
-# C) Existing MongoDB (after setting MONGO_URI)
+# C) Existing MongoDB (after adding MONGO_URI to docker-compose.override.yml)
 docker compose up -d --no-deps ythril
 ```
 
@@ -258,7 +261,7 @@ Example MCP config:
 Persistent data locations:
 
 - Host bind mount: `./config` (config and secrets)
-- Docker volumes: `ythril-data`, `ythril-mongo-data`, `ythril-mongo-configdb`
+- Docker volumes: `ythril-data`, `ythril-mongo-data`, `ythril-mongo-configdb`, `ythril-ollama-models`, `ythril-whisper-cache` (the last two hold the vision and speech model caches, ~2 GB)
 
 Common operations:
 
@@ -374,6 +377,20 @@ The Ythril container cannot spawn processes on your Windows host, so the local c
 
 ```powershell
 npm run local-connector:start
+```
+
+Note: `local-connector:start` runs the compiled output under `server/dist/`, which is gitignored and is **not** produced by `docker compose build` (that builds the image, not your host `dist/`). Build it on the host first:
+
+```powershell
+npm install
+npm run build:server
+npm run local-connector:start
+```
+
+Or run straight from source (no build step, via tsx):
+
+```powershell
+npm run local-connector:dev --workspace=server
 ```
 
 Keep this terminal open (or set it up as a startup item) — the connector must be running before you use the wizard.
@@ -499,7 +516,7 @@ Do not use the one-time Cloudflare login callback URL as your service URL.
 With this setup, internet traffic reaches only what the tunnel hostname maps to.
 
 - Good: hostname mapped to Ythril only.
-- Good: local helper remains on `127.0.0.1`.
+- Good: the local connector is guarded by a bearer token, not by its bind address. It binds `0.0.0.0` by default (deliberately, so the Docker container can reach it via host-gateway), so do not rely on the bind for isolation. Operators who want to tighten the bind can set `YTHRIL_CONNECTOR_BIND_HOST`.
 - Avoid: adding extra ingress rules for unrelated local ports.
 
 ### Validation checklist


### PR DESCRIPTION
## Summary

Fixes every **doc-side** finding from the full 2026-07-15 docs audit — the remaining sections after the sync-protocol/network-types corrections already merged (#199). Every change was cross-checked against source (five parallel passes, then reconciled after #198's `help` tool landed). **Doc-only; no behavior change.** Code-side findings from the same audit are tracked separately.

### Highlights

**userguide.md** — two *dangerous* MFA errors fixed: disabling MFA **requires a current TOTP code** (the guide said no code needed), and the TOTP secret is **server-generated** (not "generated in your browser, never sent"). Webhooks section rewritten as an API how-to (no management UI exists yet). About page corrected (no live log/auto-refresh — that's the Audit Log). Absorbed the UI restructure the guide had missed: Brain has **eight** tabs; Graph/Files are Brain tabs, not routes; MFA lives under Preferences; corrected admin nav, labels, and the wipe/delete/rename locations (Settings → Spaces → Danger). Added coverage for semantic-search advanced options, per-tab search, File Meta, Duplicates, embedded mode, MCP OAuth, signed votes, first-run setup, and the `help` tool.

**integration-guide.md** — `GET /api/about` is not public; OIDC spaces-claim is fail-closed; `files` added to the MCP `query` enum; entities list max is 500; recall filter keys include `status`/`label` with native `$vectorSearch` pre-filtering; draft-7 rate-limit headers; newly documented `indexStatus`, bulk wipes, `recall` filter/traverse, `list_spaces`/`find_similar`/`help`, three TOC sections, and several endpoints.

**usecase-examples.md** — `recall_global` → `recall` (space omitted); no `"expired"` chrono status; one authoritative caveat that `remember()` does not auto-create entities and that name-based linking needs `strictLinkage` off; `space` added to merge examples.

**workstation-mode-guide.md** — dropped the port-override that never frees 3200 (use `YTHRIL_PORT`, fixed in two spots); `MONGO_URI` must be in the compose `environment` to reach the container; the connector binds `0.0.0.0` (bearer-protected), not 127.0.0.1; build `server/dist` before `local-connector:start`; listed the model-cache volumes.

**README / NOTICE / contribution-guide / dependencies** — `recall_global` → `recall`, `list_spaces` + `help` added (**31 tools**), webhook event counts (16/19), opt-in embedding features; NOTICE drops zone.js, adds undici, fixes the network name; contribution-guide fixes the local-dev DB flow + dev proxy (`PORT=3210` + `TRUST_PROXY=1`) + the Vitest client suite + zoneless code style; dependencies documents the three runtime images. (`docs/docker-build-protocol.md` is gitignored, so its single-builder fixes are local-only and not in this diff.)

### Owner decisions folded in
- **Webhooks UI** → downgraded doc to API how-to; building the UI is filed as a follow-up.
- **Conversion sidecar** → will be bundled in compose (follow-up); README's claim kept.
- **Destructive-op confirm** → keeping the guide's "type the space ID" text; adding it to the code is a filed follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)