### PR TITLE
fix(client): scope base tsconfig include to src (fixes editor rootDir error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Client base `tsconfig.json` no longer reports a spurious `rootDir` error in the editor.** The
+  base config sets `rootDir: ./src` but had no `include`, so TypeScript fell back to its default
+  `**/*` pattern and pulled in `vitest.config.ts` at the client root — a file outside `rootDir` —
+  raising `TS6059` whenever an editor (or a direct `tsc -p tsconfig.json`) loaded the base project.
+  It was latent until the Vitest client-test infra added that root-level config file. Scoped the
+  base's `include` to `src/**/*.ts` so it agrees with `rootDir`. Editor-only; `ng build`
+  (`tsconfig.app.json`) and the Vitest suite (`tsconfig.spec.json`) set their own `include` and were
+  never affected.
+
 - **Sync-protocol and network-types docs brought back in line with the code** after a full docs
   audit cross-checked every claim. `docs/sync-protocol.md`: corrected the phase order (governance
   gossip + vote propagation deliberately run *first*, ahead of the data phases) and documented the

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -25,5 +25,6 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

The client base `tsconfig.json` sets `rootDir: ./src` but had **no `include`**, so TypeScript fell back to its default `**/*` pattern and pulled in `client/vitest.config.ts` — a file at the client root, **outside `rootDir`** — raising **`TS6059`** whenever an editor (or a direct `tsc -p tsconfig.json`) loads the base project as a program.

It was latent until the Vitest client-test infrastructure added `vitest.config.ts` at the client root; before that, there were no root-level `.ts` files for `**/*` to catch, so `rootDir` was never violated.

**Fix:** scope the base's `include` to `src/**/*.ts` so it agrees with `rootDir`.

```diff
   "angularCompilerOptions": { … }
-  }
+  },
+  "include": ["src/**/*.ts"]
 }
```

## Why it's safe

- **Editor-only issue.** `ng build` uses `tsconfig.app.json` and Vitest uses `tsconfig.spec.json`; both set their own `files`/`include` (which override the base per `extends` semantics), so neither was ever affected and neither changes here.
- `include: ["src/**/*.ts"]` is a **strict subset** of the previous default `**/*`, so the base project gains no new files — it only drops the out-of-`rootDir` `vitest.config.ts`.

## Verification

- `tsc --noEmit -p tsconfig.json`: **TS6059 gone** (was the reported error).
- `tsc --noEmit -p tsconfig.app.json`: clean (unchanged).
- `tsc --noEmit -p tsconfig.spec.json`: unchanged.

(Under bare `tsc` the base and spec configs both surface the same pre-existing `TS2339` `.ɵcmp` errors from the change-detection test harness — those only type-check under the Vitest Angular transform and are unrelated to this change; CI runs `vitest run`, not `tsc`, on specs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)