### PR TITLE
fix(security): enforce join governance on invite-key and RSA-handshake paths (S9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -631,6 +631,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Both non-admin join paths bypassed join governance entirely (S9).** The documented model admits a
+  new member only after the required vote passes — braintree: a yes from **every ancestor on the path
+  from the inviting node to the root**; closed: all members; democratic: a majority. Neither non-admin
+  join path implemented this: `POST /api/networks/:id/join` with an invite key **direct-joined**
+  braintree networks (no vote round at all), and the RSA-handshake finalize (`POST /api/invite/finalize`)
+  added the member directly **for every network type** — so a leaf-level invite admitted a member into a
+  braintree, closed, or democratic network with no ancestor or member ever consulted. Ancestor voting
+  existed only on the admin member-add path. Both paths now open the same join vote round the admin path
+  uses: the member record (and its credentials) is **held on the round** (`pendingMember`) and only
+  enters the member list when the vote concludes yes; the braintree required-voter set is recomputed
+  from local topology at conclusion (never trusted from the wire), and the joiner always becomes a child
+  of the instance it joined through — topology fields from the request body are ignored. The inviting
+  instance's own yes is cast implicitly (its admin generated the invite/key), so the common flows are
+  unchanged: club/pubsub still direct-join (documented), and a braintree **root** invite or the first
+  member of a closed network still joins immediately. While a round is open the joiner's provisioned
+  peer PAT is **refused on `/api/sync/*`** (previously an unknown-peer fallback would have honoured its
+  space scope), and a vetoed or expired join round now **revokes the provisioned credentials**
+  (peer PAT and outbound token) instead of leaving them live forever. Re-presenting the consumed invite key with the
+  same `instanceId` polls the round: `202` while open, `200 joined` once admitted, `403` if denied —
+  this also repairs the closed/democratic invite-key flow, which previously **lost the member record
+  entirely** (the round held no `pendingMember`, so a passed vote admitted nobody and the consumed key
+  made re-joining impossible). Covered end-to-end (two live instances, gossip, veto, credential
+  revocation, sync-hold) by `testing/sync/join-governance.test.js`.
+
 - **Dozens of mutating endpoints produced no audit entry at all.** The audit middleware keeps a
   hand-maintained route table — a second, shadow copy of the router's paths — and nothing kept the two in
   sync. It had drifted badly: the file-upload rule pointed at `/api/files/:space/upload`, **a route that has

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -770,6 +770,7 @@
   "networks.dialog.join.error.aliasInvalid": "Alias \"{{ alias }}\" ist ung\u00fcltig \u2014 nur Kleinbuchstaben, Zahlen und Bindestriche sind erlaubt.",
   "networks.dialog.join.error.aliasExists": "Alias \"{{ alias }}\" existiert bereits lokal \u2014 w\u00e4hlen Sie einen anderen Namen.",
   "networks.dialog.join.success.joined": "Netzwerk \"{{ networkLabel }}\" erfolgreich beigetreten.",
+  "networks.dialog.join.success.votePending": "Beitrittsanfrage an \"{{ networkLabel }}\" gesendet 2014 die Aufnahme erfordert die Zustimmung der Mitglieder. Die Synchronisierung startet automatisch, sobald die Abstimmung angenommen wurde.",
   "networks.dialog.join.success.createdSpaces": "Neue Spaces erstellt: {{ spaces }}.",
   "networks.dialog.join.success.existingSpaces": "\u26a0\ufe0f Vorhandene Spaces in Sync zusammengef\u00fchrt: {{ spaces }} \u2014 Daten aus dem Remote-Brain werden in diese Spaces synchronisiert.",
   "networks.dialog.join.success.aliases": "Aliase: {{ aliases }}.",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -765,6 +765,7 @@
   "networks.dialog.join.error.aliasInvalid": "Alias \"{{ alias }}\" is invalid \u2014 use lowercase letters, numbers, and hyphens only.",
   "networks.dialog.join.error.aliasExists": "Alias \"{{ alias }}\" already exists as a local space \u2014 choose a different name.",
   "networks.dialog.join.success.joined": "Joined network \"{{ networkLabel }}\" successfully.",
+  "networks.dialog.join.success.votePending": "Join request sent to \"{{ networkLabel }}\" 2014 admission requires member approval. Sync starts automatically once the vote passes.",
   "networks.dialog.join.success.createdSpaces": "Created new spaces: {{ spaces }}.",
   "networks.dialog.join.success.existingSpaces": "\u26a0\ufe0f Existing spaces merged into sync: {{ spaces }} \u2014 data from the remote brain will be synced into these spaces.",
   "networks.dialog.join.success.aliases": "Aliases: {{ aliases }}.",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -766,6 +766,7 @@
   "networks.dialog.join.error.aliasInvalid": "Alias \"{{ alias }}\" jest nieprawid\u0142owy \u2014 u\u017cyj tylko ma\u0142ych liter, cyfr i my\u015blnik\u00f3w.",
   "networks.dialog.join.error.aliasExists": "Alias \"{{ alias }}\" ju\u017c istnieje lokalnie \u2014 wybierz inn\u0105 nazw\u0119.",
   "networks.dialog.join.success.joined": "Pomy\u015blnie do\u0142\u0105czono do sieci \"{{ networkLabel }}\".",
+  "networks.dialog.join.success.votePending": "Wysłano prośbę o dołączenie do sieci \"{{ networkLabel }}\" — przyjęcie wymaga zatwierdzenia przez członków. Synchronizacja rozpocznie się automatycznie po pozytywnym głosowaniu.",
   "networks.dialog.join.success.createdSpaces": "Utworzono nowe przestrzenie: {{ spaces }}.",
   "networks.dialog.join.success.existingSpaces": "\u26a0\ufe0f Istniej\u0105ce przestrzenie zosta\u0142y w\u0142\u0105czone do synchronizacji: {{ spaces }} \u2014 dane ze zdalnego braina b\u0119d\u0105 synchronizowane do tych przestrzeni.",
   "networks.dialog.join.success.aliases": "Aliasy: {{ aliases }}.",

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -1100,7 +1100,12 @@ export class NetworksComponent implements OnInit {
     }).subscribe({
       next: (result) => {
         this.joining.set(false);
-        let msg = this.transloco.translate('networks.dialog.join.success.joined', { networkLabel: result.networkLabel });
+        // Vote-governed networks hold the join in a vote round on the inviter's
+        // side; sync begins once the members/ancestors approve.
+        const successKey = result.status === 'vote_pending'
+          ? 'networks.dialog.join.success.votePending'
+          : 'networks.dialog.join.success.joined';
+        let msg = this.transloco.translate(successKey, { networkLabel: result.networkLabel });
         if (result.createdSpaces?.length) {
           msg += ` ${this.transloco.translate('networks.dialog.join.success.createdSpaces', { spaces: result.createdSpaces.join(', ') })}`;
         }

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3187,6 +3187,20 @@ POST /api/networks/:id/join
 }
 ```
 
+**Response** — depends on the network's governance:
+
+- `club` / `pubsub`: `200` `{ "status": "joined", "members": [...], "networkId": "..." }` — direct join, no vote.
+- `closed` / `democratic` / `braintree`: `202` `{ "status": "vote_pending", "roundId": "..." }` — the member
+  is **held in the vote round** (no sync possible) until the required voters approve (closed: all members;
+  democratic: majority; braintree: every ancestor from the inviting node to the root). Exception: a join on a
+  braintree **root** concludes immediately (the root is the only required voter) and returns `200 joined`.
+- In a braintree the joiner always becomes a **child of the instance it joins through**; `parentInstanceId`
+  and `direction` from the request body are ignored for braintree joins.
+
+The invite key is consumed when the round opens (pubsub keys stay reusable). **Re-presenting the same key
+with the same `instanceId` polls the outcome**: `202` while the vote is open, `200 joined` with the member
+list once admitted, `403` if the round was vetoed or expired.
+
 ---
 
 ### Cast a Vote
@@ -3591,6 +3605,14 @@ POST /api/invite/finalize
 ```json
 { "status": "joined", "instanceId": "joiner-uuid", "networkId": "net-uuid" }
 ```
+
+On vote-governed networks (`closed`, `democratic`, `braintree`) the join is **held in a vote round**
+instead of taking effect immediately — the response is then
+`{ "status": "vote_pending", "roundId": "...", ... }`. The inviting instance's own yes vote is cast
+implicitly (its admin generated the invite), so the common cases — first member of a closed network,
+leaf under a braintree **root** — still conclude immediately and return `"joined"`. While the round is
+open the joiner's provisioned peer token is refused on `/api/sync/*`; sync starts automatically once
+the vote passes. If the round is vetoed or expires, the provisioned credentials are revoked.
 
 ---
 

--- a/server/src/api/invite.ts
+++ b/server/src/api/invite.ts
@@ -47,9 +47,12 @@ import { requireAdmin } from '../auth/middleware.js';
 import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, saveSecrets } from '../config/loader.js';
 import { createToken } from '../auth/tokens.js';
+import { concludeRoundIfReady } from './sync.js';
+import { buildBraintreeAncestors } from '../util/braintree.js';
+import { makeSignedOwnCast } from '../util/signing.js';
 import { log } from '../util/log.js';
 import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../util/ssrf.js';
-import type { NetworkMember } from '../config/types.js';
+import type { NetworkMember, VoteRound } from '../config/types.js';
 
 export const inviteRouter = Router();
 
@@ -379,7 +382,8 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
   secrets.peerTokens[instanceId] = peerToken;
   saveSecrets(secrets);
 
-  let responseStatus: 'joined' | 'reparented';
+  let responseStatus: 'joined' | 'reparented' | 'vote_pending';
+  let pendingRoundId: string | undefined;
 
   if (session.reparentInstanceId) {
     // ── Reparent path ───────────────────────────────────────────────────────
@@ -437,10 +441,51 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
       lastSyncAt: undefined,
       lastSeqReceived: {},
       children: net.type === 'braintree' ? [] : undefined,
+      // The handshake was initiated by THIS instance's invite — the joiner
+      // becomes a child of this node in a braintree.
+      parentInstanceId: net.type === 'braintree' ? cfg.instanceId : undefined,
     };
-    net.members.push(newMember);
-    log.info(`Invite handshake complete: ${instanceLabel} (${instanceId}) joined network ${session.networkId}`);
-    responseStatus = 'joined';
+
+    if (net.type === 'club' || net.type === 'pubsub') {
+      // Direct join — documented behavior for these types.
+      net.members.push(newMember);
+      log.info(`Invite handshake complete: ${instanceLabel} (${instanceId}) joined network ${session.networkId}`);
+      responseStatus = 'joined';
+    } else {
+      // ── Vote-governed types (closed / democratic / braintree) — S9 ────────
+      // Hold the member in a join round instead of admitting directly. This
+      // instance's own yes vote is implicit (its admin generated the invite);
+      // braintree additionally requires every ancestor from this node up to
+      // the root to vote yes, closed requires all members, democratic a
+      // majority. `concludeRoundIfReady` recomputes the braintree ancestor set
+      // from local topology, so the requirement cannot be shrunk from the wire.
+      const round: VoteRound = {
+        roundId: uuidv4(),
+        type: 'join',
+        subjectInstanceId: instanceId,
+        subjectLabel: instanceLabel,
+        subjectUrl: instanceUrl,
+        deadline: new Date(Date.now() + net.votingDeadlineHours * 3_600_000).toISOString(),
+        openedAt: new Date().toISOString(),
+        votes: [],
+        pendingMember: newMember,
+        ...(net.type === 'braintree'
+          ? { requiredVoters: buildBraintreeAncestors(net, cfg.instanceId, cfg.instanceId) }
+          : {}),
+      };
+      net.pendingRounds.push(round);
+      round.votes.push(makeSignedOwnCast(net.id, round, cfg.instanceId, 'yes'));
+      if (concludeRoundIfReady(net, round)) {
+        // Sole-voter case (braintree root / no other members): admit immediately.
+        net.members.push(newMember);
+        log.info(`Invite handshake complete: ${instanceLabel} (${instanceId}) joined network ${session.networkId}`);
+        responseStatus = 'joined';
+      } else {
+        log.info(`Invite handshake held: join round ${round.roundId} opened for ${instanceLabel} (${instanceId}) in network ${session.networkId}`);
+        responseStatus = 'vote_pending';
+        pendingRoundId = round.roundId;
+      }
+    }
   }
 
   saveConfig(cfg);
@@ -448,7 +493,13 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
   // Discard the session — private key is no longer needed
   _sessions.delete(sessionKey);
 
-  res.json({ status: responseStatus, instanceId, networkId: session.networkId, temporary: session.reparentInstanceId != null });
+  res.json({
+    status: responseStatus,
+    instanceId,
+    networkId: session.networkId,
+    temporary: session.reparentInstanceId != null,
+    ...(pendingRoundId ? { roundId: pendingRoundId } : {}),
+  });
 });
 
 // ── GET /api/invite/status/:handshakeId ───────────────────────────────────────

--- a/server/src/api/networks.ts
+++ b/server/src/api/networks.ts
@@ -18,23 +18,11 @@ import { createSpace } from '../spaces/spaces.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from './sync.js';
 import { getSyncHistory } from '../sync/history.js';
 import { buildBraintreeAncestors } from '../util/braintree.js';
-import { signOwnVoteCast, getSigningPublicKey, forceSetMemberSigningKey } from '../util/signing.js';
+import { makeSignedOwnCast, forceSetMemberSigningKey } from '../util/signing.js';
 import { log } from '../util/log.js';
-import type { NetworkConfig, NetworkMember, VoteRound, VoteCast } from '../config/types.js';
+import type { NetworkConfig, NetworkMember, VoteRound } from '../config/types.js';
 
 export const networksRouter = Router();
-
-/** Build this instance's own vote cast, signed when a signing key is available. */
-function makeSignedOwnCast(networkId: string, round: VoteRound, instanceId: string, vote: 'yes' | 'veto'): VoteCast {
-  const sig = signOwnVoteCast({
-    networkId,
-    roundId: round.roundId,
-    subjectInstanceId: round.subjectInstanceId,
-    instanceId,
-    vote,
-  });
-  return { instanceId, vote, castAt: new Date().toISOString(), ...(sig ? { sig } : {}) };
-}
 
 const BCRYPT_ROUNDS = 12;
 
@@ -966,6 +954,13 @@ const JoinNetworkBody = z.object({
   skipTlsVerify: z.boolean().optional(),
 });
 
+/** Member list a joiner receives once admitted (credential fields stripped). */
+function safeMemberList(net: NetworkConfig, excludeInstanceId: string) {
+  return net.members
+    .filter(m => m.instanceId !== excludeInstanceId)
+    .map(({ tokenHash: _th, skipTlsVerify: _sv, ...m }) => m);
+}
+
 networksRouter.post('/:id/join', globalRateLimit, requireAdmin, async (req, res) => {
   try {
     const parsed = JoinNetworkBody.safeParse(req.body);
@@ -975,13 +970,50 @@ networksRouter.post('/:id/join', globalRateLimit, requireAdmin, async (req, res)
     const net = cfg.networks.find(n => n.id === req.params['id']);
     if (!net) { res.status(404).json({ error: 'Network not found' }); return; }
 
-    if (!net.inviteKeyHash) {
-      res.status(400).json({ error: 'No active invite key — generate one first via POST /invite' });
-      return;
-    }
+    const keyValid = net.inviteKeyHash
+      ? await bcrypt.compare(parsed.data.inviteKey, net.inviteKeyHash)
+      : false;
 
-    const keyValid = await bcrypt.compare(parsed.data.inviteKey, net.inviteKeyHash);
     if (!keyValid) {
+      // Vote-governed joins consume the network's invite key when the round opens
+      // and preserve the validated hash on the round record. Re-presenting the
+      // same key lets the joiner poll the outcome of its own round.
+      for (let i = net.pendingRounds.length - 1; i >= 0; i--) {
+        const round = net.pendingRounds[i]!;
+        if (round.type !== 'join' || !round.inviteKeyHash) continue;
+        if (round.subjectInstanceId !== parsed.data.instanceId) continue;
+        if (!await bcrypt.compare(parsed.data.inviteKey, round.inviteKeyHash)) continue;
+
+        if (!round.concluded) {
+          res.status(202).json({ status: 'vote_pending', roundId: round.roundId });
+          return;
+        }
+        if (!round.passed) {
+          res.status(403).json({ error: 'Join was denied by network governance (vetoed or expired)' });
+          return;
+        }
+        // Passed: the member is normally added when the round concludes; re-add
+        // from the round's pendingMember if that side-effect was lost (crash
+        // between conclusion and persistence). Re-fetch config after the async
+        // bcrypt compares to avoid clobbering concurrent writes.
+        const freshCfg = getConfig();
+        const freshNet = freshCfg.networks.find(n => n.id === req.params['id']);
+        if (!freshNet) { res.status(404).json({ error: 'Network not found' }); return; }
+        if (!freshNet.members.some(m => m.instanceId === parsed.data.instanceId)) {
+          if (!round.pendingMember) {
+            res.status(410).json({ error: 'Join round passed but the member record was not retained — generate a new invite' });
+            return;
+          }
+          freshNet.members.push(round.pendingMember);
+          saveConfig(freshCfg);
+        }
+        res.status(200).json({ status: 'joined', members: safeMemberList(freshNet, parsed.data.instanceId), networkId: freshNet.id });
+        return;
+      }
+      if (!net.inviteKeyHash) {
+        res.status(400).json({ error: 'No active invite key — generate one first via POST /invite' });
+        return;
+      }
       res.status(403).json({ error: 'Invalid invite key' });
       return;
     }
@@ -1013,18 +1045,67 @@ networksRouter.post('/:id/join', globalRateLimit, requireAdmin, async (req, res)
         deadline: new Date(Date.now() + freshNet.votingDeadlineHours * 3_600_000).toISOString(),
         openedAt: new Date().toISOString(),
         votes: [],
+        pendingMember: member,             // held here until the vote passes
         inviteKeyHash: net.inviteKeyHash,  // preserve the original validated hash in the round record
       };
       freshNet.pendingRounds.push(round);
       // Revoke invite key after use to prevent replay
       freshNet.inviteKeyHash = undefined;
+      // Save the plaintext peer token so the sync engine can use it once the vote passes
+      const secrets = getSecrets();
+      secrets.peerTokens[instanceId] = token;
+      saveSecrets(secrets);
       saveConfig(freshCfg);
       log.info(`Join via invite key opened vote round ${round.roundId} for ${label}`);
       res.status(202).json({ status: 'vote_pending', roundId: round.roundId });
       return;
     }
 
-    // Club / Braintree / Pubsub — direct join via invite key
+    if (freshNet.type === 'braintree') {
+      // Braintree is vote-governed (S9): the joiner is admitted only after every
+      // ancestor on the path from this (inviting) node to the root votes yes —
+      // same round shape as the admin member-add path. The joiner always becomes
+      // a child of the inviting node; topology fields from the wire are ignored.
+      member.parentInstanceId = freshCfg.instanceId;
+      member.direction = 'push';   // we push to our children
+      const requiredVoters = buildBraintreeAncestors(freshNet, freshCfg.instanceId, freshCfg.instanceId);
+      const round: VoteRound = {
+        roundId: uuidv4(),
+        type: 'join',
+        subjectInstanceId: instanceId,
+        subjectLabel: label,
+        subjectUrl: url,
+        deadline: new Date(Date.now() + freshNet.votingDeadlineHours * 3_600_000).toISOString(),
+        openedAt: new Date().toISOString(),
+        votes: [],
+        pendingMember: member,
+        requiredVoters,
+        inviteKeyHash: net.inviteKeyHash,  // preserve the validated hash so the joiner can poll
+      };
+      freshNet.pendingRounds.push(round);
+      // The inviting node's approval is implicit — it generated the invite key.
+      round.votes.push(makeSignedOwnCast(freshNet.id, round, freshCfg.instanceId, 'yes'));
+      // Consume the key (single-use) and store the peer token for post-admission sync.
+      freshNet.inviteKeyHash = undefined;
+      const secrets = getSecrets();
+      secrets.peerTokens[instanceId] = token;
+      saveSecrets(secrets);
+      const immediatePassed = concludeRoundIfReady(freshNet, round);
+      if (immediatePassed) {
+        // Root case: the ancestor path is only [self] → admit immediately
+        freshNet.members.push(member);
+        saveConfig(freshCfg);
+        log.info(`Braintree join via invite key immediate (root): added ${label} (${instanceId}) to network ${freshNet.id}`);
+        res.status(200).json({ status: 'joined', members: safeMemberList(freshNet, instanceId), networkId: freshNet.id });
+        return;
+      }
+      saveConfig(freshCfg);
+      log.info(`Join via invite key opened braintree ancestor round ${round.roundId} for ${label} (${instanceId}) in network ${freshNet.id}`);
+      res.status(202).json({ status: 'vote_pending', roundId: round.roundId });
+      return;
+    }
+
+    // Club / Pubsub — direct join via invite key (documented behavior)
     // Pubsub subscribers are always push-only (publisher pushes to them).
     if (freshNet.type === 'pubsub') member.direction = 'push';
     freshNet.members.push(member);
@@ -1035,10 +1116,7 @@ networksRouter.post('/:id/join', globalRateLimit, requireAdmin, async (req, res)
     log.info(`Member ${label} joined network ${freshNet.id} via invite key`);
 
     // Return peer the member list and network metadata (enough to start syncing)
-    const safeMemberList = freshNet.members
-      .filter(m => m.instanceId !== instanceId)
-      .map(({ tokenHash: _th, skipTlsVerify: _sv, ...m }) => m);
-    res.status(200).json({ status: 'joined', members: safeMemberList, networkId: freshNet.id });
+    res.status(200).json({ status: 'joined', members: safeMemberList(freshNet, instanceId), networkId: freshNet.id });
   } catch (err) {
     log.error(`POST /api/networks/:id/join: ${err}`);
     res.status(500).json({ error: 'Internal error' });

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -361,6 +361,14 @@ function spaceAllowed(
         : memberNets;
       return usable.some(n => n.spaces.includes(spaceId));
     }
+    // A peer whose join is still being voted on (or was denied) holds a
+    // provisioned PAT but no membership — it must NOT fall through to plain
+    // space scoping, or the vote hold would be meaningless (S9). A passed
+    // round implies membership, which is handled above.
+    const heldByJoinRound = cfg.networks.some(n =>
+      n.pendingRounds?.some(r =>
+        r.type === 'join' && r.subjectInstanceId === peerId && !r.passed));
+    if (heldByJoinRound) return false;
     // Unknown peer (manual token / asymmetric network): fall through to the
     // legacy space-existence check below — the token's own scope still applies.
   }
@@ -1438,17 +1446,20 @@ syncRouter.post('/networks/:networkId/votes/:roundId', syncRateLimit, requireAut
       sendMemberRemovedNotify(round.subjectUrl, round.subjectInstanceId, net.id);
     }
 
-    // If a braintree join round just passed via this vote relay, add the pending member
-    // only if this instance is the direct parent in the tree.
-    if (round.concluded && round.type === 'join' && round.pendingMember &&
-        net.type === 'braintree') {
+    // If a join round just passed via this vote relay, add the pending member.
+    if (round.concluded && round.type === 'join' && round.pendingMember) {
       const alreadyAdded = net.members.some(m => m.instanceId === round.subjectInstanceId);
-      const isDirectParent = !round.pendingMember.parentInstanceId ||
-        round.pendingMember.parentInstanceId === cfg.instanceId;
+      // Braintree: only the direct parent in the tree admits (ancestor-voters
+      // must not add the joiner to their own lists). Other vote-governed types:
+      // only the instance that holds the joiner's credentials admits — gossip-
+      // adopted round copies have pendingMember.tokenHash stripped.
+      const mayAdmit = net.type === 'braintree'
+        ? (!round.pendingMember.parentInstanceId || round.pendingMember.parentInstanceId === cfg.instanceId)
+        : Boolean(round.pendingMember.tokenHash);
       const vetoed = round.votes.some(v => v.vote === 'veto');
-      if (!alreadyAdded && isDirectParent && !vetoed) {
+      if (!alreadyAdded && mayAdmit && !vetoed) {
         net.members.push(round.pendingMember);
-        log.info(`Braintree join ${round.roundId} passed via vote relay â€” added ${round.subjectLabel} to network ${net.id}`);
+        log.info(`Join round ${round.roundId} passed via vote relay — added ${round.subjectLabel} to network ${net.id}`);
       }
     }
 
@@ -1498,6 +1509,17 @@ function concludeRoundIfReady(
   if (vetoCount > 0 || pastDeadline) {
     round.concluded = true;
     round.passed = false;
+    // A failed JOIN leaves the candidate's provisioned credentials (peer PAT
+    // issued at invite/apply time, outbound token in secrets) with no membership
+    // to justify them — revoke unless something else still references the
+    // instance. Deferred a tick so the caller's saveConfig runs first.
+    if (round.type === 'join' && round.subjectInstanceId) {
+      const rejectedId = round.subjectInstanceId;
+      setImmediate(() => {
+        revokePeerCredentialsIfOrphaned(rejectedId)
+          .catch(err => log.error(`peer credential revocation for rejected joiner ${rejectedId}: ${err}`));
+      });
+    }
     return false;
   }
 

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -787,18 +787,21 @@ async function propagateVotesWithPeer(
           if (justPassed && round.type === 'remove') {
             sendMemberRemovedNotify(round.subjectUrl, round.subjectInstanceId, net.id);
           }
-          // For braintree join rounds, add the pending member only if this instance
-          // is the direct parent (i.e. the node that opened the round).
-          // Ancestor-voters must NOT add the joining node to their own member list.
-          if (justPassed && round.type === 'join' && round.pendingMember &&
-              freshNet.type === 'braintree') {
+          // For join rounds, add the held pending member on conclusion.
+          // Braintree: only the direct parent (the node that opened the round)
+          // admits — ancestor-voters must NOT add the joining node to their own
+          // member list. Other vote-governed types: only the instance holding
+          // the joiner's credentials admits (gossip-adopted round copies have
+          // pendingMember.tokenHash stripped).
+          if (justPassed && round.type === 'join' && round.pendingMember) {
             const alreadyAdded = freshNet.members.some(m => m.instanceId === round.subjectInstanceId);
-            const isDirectParent = !round.pendingMember.parentInstanceId ||
-              round.pendingMember.parentInstanceId === fresh.instanceId;
+            const mayAdmit = freshNet.type === 'braintree'
+              ? (!round.pendingMember.parentInstanceId || round.pendingMember.parentInstanceId === fresh.instanceId)
+              : Boolean(round.pendingMember.tokenHash);
             const vetoed = round.votes.some(v => v.vote === 'veto');
-            if (!alreadyAdded && isDirectParent && !vetoed) {
+            if (!alreadyAdded && mayAdmit && !vetoed) {
               freshNet.members.push(round.pendingMember);
-              log.info(`Braintree join ${round.roundId} concluded via gossip — added ${round.subjectLabel} to network ${net.id}`);
+              log.info(`Join round ${round.roundId} concluded via gossip — added ${round.subjectLabel} to network ${net.id}`);
             }
           }
         }

--- a/server/src/util/signing.ts
+++ b/server/src/util/signing.ts
@@ -152,6 +152,18 @@ export function signOwnVoteCast(params: {
   return signMessage(kp.privateKeyPem, voteCastMessage(params));
 }
 
+/** Build this instance's own vote cast, signed when a signing key is available. */
+export function makeSignedOwnCast(networkId: string, round: VoteRound, instanceId: string, vote: 'yes' | 'veto'): VoteCast {
+  const sig = signOwnVoteCast({
+    networkId,
+    roundId: round.roundId,
+    subjectInstanceId: round.subjectInstanceId,
+    instanceId,
+    vote,
+  });
+  return { instanceId, vote, castAt: new Date().toISOString(), ...(sig ? { sig } : {}) };
+}
+
 // ── Key rotation ─────────────────────────────────────────────────────────────
 
 /** A signed proof that a new signing key supersedes a previous one. */

--- a/testing/sync/join-governance.test.js
+++ b/testing/sync/join-governance.test.js
@@ -1,0 +1,647 @@
+/**
+ * Integration tests: join-path governance (SECURITY S9)
+ *
+ * The documented governance model admits a new member only after the required
+ * vote passes (braintree: every ancestor from the inviting node to the root;
+ * closed: all members; democratic: majority). These tests verify that BOTH
+ * non-admin join paths honour that model:
+ *
+ *   1. POST /api/networks/:id/join  (invite key)
+ *      - braintree root    → immediate join (single-ancestor auto-pass)
+ *      - braintree child   → 202 vote_pending, held until ancestors vote yes
+ *      - ancestor veto     → never admitted, poll returns 403
+ *      - club              → direct join unchanged (documented behavior)
+ *      - re-presenting the consumed key polls the round outcome
+ *
+ *   2. POST /api/invite/finalize  (RSA handshake)
+ *      - braintree root    → status 'joined' (back-compat)
+ *      - braintree child   → status 'vote_pending', held; pending peer PAT is
+ *                            refused on /api/sync/* until the vote passes
+ *      - closed w/ members → status 'vote_pending', held
+ *      - democratic w/ 2 members → status 'vote_pending', held
+ *
+ * Topology used for the "child" scenarios: A (root) → B (intermediate).
+ * The joining leaf is simulated by this test process (no third container
+ * needed — the join endpoints are driven directly).
+ *
+ * Run:  node --test testing/sync/join-governance.test.js
+ * Pre-requisite: docker compose -f docker-compose.test.yml up && node testing/sync/setup.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'url';
+import {
+  INSTANCES, post, get, del, delWithBody, waitFor, triggerSync,
+  getInstanceId, readContainerConfig, readContainerSecrets, dockerExec,
+} from './helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, 'configs');
+
+// ── module-level state ──────────────────────────────────────────────────────
+
+let tokenA, tokenB;
+let instanceIdA, instanceIdB;
+let peerTokenForA; // token B issued → A uses to authenticate inbound calls TO B
+let peerTokenForB; // token A issued → B uses to authenticate inbound calls TO A
+let testSpaceId;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function injectPeerToken(container, instanceId, token) {
+  const script = [
+    `const fs=require('fs');`,
+    `const p='/config/secrets.json';`,
+    `const s=JSON.parse(fs.readFileSync(p,'utf8'));`,
+    `s.peerTokens=s.peerTokens||{};`,
+    `s.peerTokens['${instanceId}']='${token}';`,
+    `fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600});`,
+    `process.stdout.write('ok');`,
+  ].join('');
+  dockerExec(`docker exec ${container} node -e "${script}"`);
+}
+
+/** A (root) → B (child) braintree network, registered on both instances. */
+async function setupBraintreeAB(label) {
+  const netR = await post(INSTANCES.a, tokenA, '/api/networks', {
+    label: `${label} ${Date.now()}`,
+    type: 'braintree',
+    spaces: [testSpaceId],
+    votingDeadlineHours: 1,
+  });
+  assert.equal(netR.status, 201, `Create net on A: ${JSON.stringify(netR.body)}`);
+  const networkId = netR.body.id;
+
+  injectPeerToken('ythril-a', instanceIdB, peerTokenForA);
+  await post(INSTANCES.a, tokenA, '/api/admin/reload-config', {});
+  const addBR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+    instanceId: instanceIdB,
+    label: 'Instance B',
+    url: 'http://ythril-b:3200',
+    token: peerTokenForA,
+    direction: 'push',
+    parentInstanceId: instanceIdA,
+  });
+  assert.equal(addBR.status, 201, `Add B to A: ${JSON.stringify(addBR.body)}`);
+
+  injectPeerToken('ythril-b', instanceIdA, peerTokenForB);
+  await post(INSTANCES.b, tokenB, '/api/admin/reload-config', {});
+  const regBR = await post(INSTANCES.b, tokenB, '/api/networks', {
+    id: networkId,
+    label,
+    type: 'braintree',
+    spaces: [testSpaceId],
+    votingDeadlineHours: 1,
+    myParentInstanceId: instanceIdA,
+  });
+  assert.ok(regBR.status === 201 || regBR.status === 409, `Register net on B: ${JSON.stringify(regBR.body)}`);
+  return networkId;
+}
+
+/** waitFor() that re-triggers a sync run on A each poll so a lost gossip cycle
+ *  cannot stall the test (a single up-front trigger races slow cycles). */
+async function waitForWithSyncFromA(networkId, condition, timeout, diagnose) {
+  let lastTriggerError = null;
+  await waitFor(async () => {
+    if (await condition()) return true;
+    try {
+      await triggerSync(INSTANCES.a, tokenA, networkId);
+      lastTriggerError = null;
+    } catch (err) {
+      lastTriggerError = err;
+    }
+    return condition();
+  }, timeout, 1_000, () => `${diagnose}${lastTriggerError ? ` (last sync trigger failed: ${lastTriggerError.message})` : ''}`);
+}
+
+/** Let A discover B's open round via gossip and cast a vote on it. */
+async function castVoteFromA(networkId, roundId, vote) {
+  await triggerSync(INSTANCES.a, tokenA, networkId);
+  await waitForWithSyncFromA(networkId, async () => {
+    const cfgA = readContainerConfig('ythril-a');
+    const netA = cfgA.networks?.find(n => n.id === networkId);
+    return netA?.pendingRounds?.some(r => r.roundId === roundId);
+  }, 30_000, `round ${roundId} never appeared on A via gossip`);
+
+  const voteR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${roundId}`, { vote });
+  assert.equal(voteR.status, 200, `A vote ${vote}: ${JSON.stringify(voteR.body)}`);
+
+  // Propagate A's cast back to B
+  await triggerSync(INSTANCES.a, tokenA, networkId);
+}
+
+/** Drive the RSA invite handshake against `baseUrl` acting as a fake joiner. */
+async function rsaHandshakeJoin(baseUrl, adminToken, networkId, joinerInstanceId, joinerLabel) {
+  const gen = await post(baseUrl, adminToken, '/api/invite/generate', { networkId });
+  assert.equal(gen.status, 201, `invite/generate: ${JSON.stringify(gen.body)}`);
+
+  const { privateKey: joinerPriv, publicKey: joinerPub } = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 4096,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  const applyR = await post(baseUrl, '', '/api/invite/apply', {
+    handshakeId: gen.body.handshakeId,
+    networkId,
+    instanceId: joinerInstanceId,
+    instanceLabel: joinerLabel,
+    instanceUrl: 'https://joiner.ythril-test.example.com',
+    rsaPublicKeyPem: joinerPub,
+  });
+  assert.equal(applyR.status, 200, `invite/apply: ${JSON.stringify(applyR.body)}`);
+
+  // Decrypt the PAT the inviter issued for the joiner (used later to probe /api/sync/*)
+  const joinerPat = crypto.privateDecrypt(
+    { key: joinerPriv, padding: crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepHash: 'sha256' },
+    Buffer.from(applyR.body.encryptedTokenForB, 'base64'),
+  ).toString('utf8');
+  assert.ok(joinerPat.startsWith('ythril_'), 'decrypted PAT should be valid');
+
+  // Synthetic return token — finalize only validates the prefix and stores it
+  const tokenForInviter = `ythril_${crypto.randomBytes(32).toString('base64url')}`;
+  const encryptedTokenForA = crypto.publicEncrypt(
+    { key: applyR.body.rsaPublicKeyPem, padding: crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepHash: 'sha256' },
+    Buffer.from(tokenForInviter, 'utf8'),
+  ).toString('base64');
+
+  const finalR = await post(baseUrl, '', '/api/invite/finalize', {
+    handshakeId: gen.body.handshakeId,
+    encryptedTokenForA,
+  });
+  assert.equal(finalR.status, 200, `invite/finalize: ${JSON.stringify(finalR.body)}`);
+  return { finalize: finalR.body, joinerPat };
+}
+
+// ── outer setup ─────────────────────────────────────────────────────────────
+
+describe('Join-path governance (S9) — invite key and RSA handshake respect voting', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    tokenB = fs.readFileSync(path.join(CONFIGS, 'b', 'token.txt'), 'utf8').trim();
+
+    instanceIdA = getInstanceId('ythril-a');
+    instanceIdB = getInstanceId('ythril-b');
+
+    testSpaceId = `s9-join-${Date.now()}`;
+    const spA = await post(INSTANCES.a, tokenA, '/api/spaces', { id: testSpaceId, label: 'S9 Join Space' });
+    assert.equal(spA.status, 201, `Create space on A: ${JSON.stringify(spA.body)}`);
+    const spB = await post(INSTANCES.b, tokenB, '/api/spaces', { id: testSpaceId, label: 'S9 Join Space' });
+    assert.equal(spB.status, 201, `Create space on B: ${JSON.stringify(spB.body)}`);
+
+    const ptForA = await post(INSTANCES.b, tokenB, '/api/tokens', { name: `s9-peer-a-${Date.now()}` });
+    assert.equal(ptForA.status, 201);
+    peerTokenForA = ptForA.body.plaintext;
+
+    const ptForB = await post(INSTANCES.a, tokenA, '/api/tokens', { name: `s9-peer-b-${Date.now()}` });
+    assert.equal(ptForB.status, 201);
+    peerTokenForB = ptForB.body.plaintext;
+  });
+
+  after(async () => {
+    await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+    await delWithBody(INSTANCES.b, tokenB, `/api/spaces/${testSpaceId}`, { confirm: true }).catch(() => {});
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 1a. Invite-key join on braintree ROOT — single ancestor, immediate join
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Invite-key join — braintree root admits immediately', () => {
+    let networkId;
+
+    before(async () => {
+      const r = await post(INSTANCES.a, tokenA, '/api/networks', {
+        label: `S9 BT Root ${Date.now()}`,
+        type: 'braintree',
+        spaces: [testSpaceId],
+        votingDeadlineHours: 1,
+      });
+      assert.equal(r.status, 201);
+      networkId = r.body.id;
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it('join via invite key on the root returns 200 joined (ancestor path = [root])', async () => {
+      const inv = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/invite`, {});
+      assert.ok(inv.body.inviteKey, 'invite key expected');
+
+      const joinR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/join`, {
+        inviteKey: inv.body.inviteKey,
+        instanceId: `s9-root-leaf-${Date.now()}`,
+        label: 'Root Leaf',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(joinR.status, 200, `Expected 200 immediate join, got ${joinR.status}: ${JSON.stringify(joinR.body)}`);
+      assert.equal(joinR.body.status, 'joined');
+
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      const openRounds = net?.pendingRounds?.filter(r => !r.concluded) ?? [];
+      assert.equal(openRounds.length, 0, 'no open rounds should remain after a root join');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 1b. Invite-key join on braintree CHILD — held until ancestor votes yes
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Invite-key join — braintree child holds the member for the ancestor vote', () => {
+    let networkId;
+    let inviteKey;
+    let roundId;
+    const leafId = `s9-leaf-${Date.now()}`;
+
+    before(async () => {
+      networkId = await setupBraintreeAB('S9 BT Child Join');
+      const inv = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/invite`, {});
+      assert.ok(inv.body.inviteKey, 'invite key expected');
+      inviteKey = inv.body.inviteKey;
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+      await del(INSTANCES.b, tokenB, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it('join on the child returns 202 vote_pending and the member is NOT admitted', async () => {
+      const joinR = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/join`, {
+        inviteKey,
+        instanceId: leafId,
+        label: 'Held Leaf',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(joinR.status, 202, `Expected 202 vote_pending, got ${joinR.status}: ${JSON.stringify(joinR.body)}`);
+      assert.equal(joinR.body.status, 'vote_pending');
+      assert.ok(joinR.body.roundId, 'roundId expected');
+      roundId = joinR.body.roundId;
+
+      const cfgB = readContainerConfig('ythril-b');
+      const netB = cfgB.networks.find(n => n.id === networkId);
+      assert.ok(!netB.members.some(m => m.instanceId === leafId), 'leaf must NOT be a member while the vote is open');
+
+      const round = netB.pendingRounds.find(r => r.roundId === roundId);
+      assert.ok(round, 'round must exist on B');
+      assert.ok(round.requiredVoters?.includes(instanceIdB), 'requiredVoters must include B (inviting node)');
+      assert.ok(round.requiredVoters?.includes(instanceIdA), 'requiredVoters must include A (root)');
+      assert.ok(round.votes.some(v => v.instanceId === instanceIdB && v.vote === 'yes'),
+        "B's implicit yes vote (invite key = inviter intent) must be cast");
+      assert.ok(round.pendingMember, 'the member record must be held on the round');
+      assert.equal(round.pendingMember.parentInstanceId, instanceIdB, 'joiner must be held as a child of the inviting node');
+    });
+
+    it('re-presenting the consumed invite key polls the pending round (202 again)', async () => {
+      const pollR = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/join`, {
+        inviteKey,
+        instanceId: leafId,
+        label: 'Held Leaf',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(pollR.status, 202, `Expected 202 poll, got ${pollR.status}: ${JSON.stringify(pollR.body)}`);
+      assert.equal(pollR.body.roundId, roundId, 'poll must return the SAME round, not open a new one');
+    });
+
+    it("after A's yes vote propagates, the leaf is admitted on B", async () => {
+      await castVoteFromA(networkId, roundId, 'yes');
+
+      await waitForWithSyncFromA(networkId, async () => {
+        const cfgB = readContainerConfig('ythril-b');
+        const netB = cfgB.networks?.find(n => n.id === networkId);
+        return netB?.members?.some(m => m.instanceId === leafId);
+      }, 30_000, 'leaf never admitted on B after ancestor yes vote');
+
+      const cfgB = readContainerConfig('ythril-b');
+      const netB = cfgB.networks.find(n => n.id === networkId);
+      const member = netB.members.find(m => m.instanceId === leafId);
+      assert.equal(member.parentInstanceId, instanceIdB, 'admitted leaf must be a child of B');
+    });
+
+    it('polling with the key after admission returns 200 joined + member list', async () => {
+      const pollR = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/join`, {
+        inviteKey,
+        instanceId: leafId,
+        label: 'Held Leaf',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(pollR.status, 200, `Expected 200 joined, got ${pollR.status}: ${JSON.stringify(pollR.body)}`);
+      assert.equal(pollR.body.status, 'joined');
+      assert.ok(Array.isArray(pollR.body.members), 'member list expected');
+      assert.ok(!pollR.body.members.some(m => m.tokenHash), 'member list must not leak tokenHash');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 1c. Invite-key join on braintree CHILD — ancestor veto never admits
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Invite-key join — ancestor veto never admits, credentials are revoked', () => {
+    let networkId;
+    let inviteKey;
+    let roundId;
+    const leafId = `s9-veto-leaf-${Date.now()}`;
+
+    before(async () => {
+      networkId = await setupBraintreeAB('S9 BT Veto Join');
+      const inv = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/invite`, {});
+      inviteKey = inv.body.inviteKey;
+
+      const joinR = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/join`, {
+        inviteKey,
+        instanceId: leafId,
+        label: 'Vetoed Leaf',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(joinR.status, 202, `Expected 202, got ${joinR.status}: ${JSON.stringify(joinR.body)}`);
+      roundId = joinR.body.roundId;
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+      await del(INSTANCES.b, tokenB, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it("A's veto concludes the round as failed on B and the leaf is never admitted", async () => {
+      await castVoteFromA(networkId, roundId, 'veto');
+
+      await waitForWithSyncFromA(networkId, async () => {
+        const cfgB = readContainerConfig('ythril-b');
+        const netB = cfgB.networks?.find(n => n.id === networkId);
+        const r = netB?.pendingRounds?.find(r => r.roundId === roundId);
+        return r?.concluded === true && r?.passed === false;
+      }, 30_000, 'veto never concluded the round on B');
+
+      const cfgB = readContainerConfig('ythril-b');
+      const netB = cfgB.networks.find(n => n.id === networkId);
+      assert.ok(!netB.members.some(m => m.instanceId === leafId), 'vetoed leaf must never be admitted');
+    });
+
+    it("the vetoed joiner's provisioned outbound token is revoked", async () => {
+      await waitFor(async () => {
+        const secretsB = readContainerSecrets('ythril-b');
+        return !secretsB.peerTokens?.[leafId];
+      }, 15_000, 500, `secrets.peerTokens still holds an entry for rejected joiner ${leafId}`);
+    });
+
+    it('polling with the key after the veto returns 403', async () => {
+      const pollR = await post(INSTANCES.b, tokenB, `/api/networks/${networkId}/join`, {
+        inviteKey,
+        instanceId: leafId,
+        label: 'Vetoed Leaf',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(pollR.status, 403, `Expected 403 denied, got ${pollR.status}: ${JSON.stringify(pollR.body)}`);
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 1d. Invite-key join on club — direct join unchanged
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Invite-key join — club still direct-joins (documented behavior)', () => {
+    let networkId;
+
+    before(async () => {
+      const r = await post(INSTANCES.a, tokenA, '/api/networks', {
+        label: `S9 Club ${Date.now()}`,
+        type: 'club',
+        spaces: [testSpaceId],
+        votingDeadlineHours: 1,
+      });
+      assert.equal(r.status, 201);
+      networkId = r.body.id;
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it('club join via invite key returns 200 joined with no vote round', async () => {
+      const inv = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/invite`, {});
+      const joinR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/join`, {
+        inviteKey: inv.body.inviteKey,
+        instanceId: `s9-club-${Date.now()}`,
+        label: 'Club Member',
+        url: 'http://ythril-c:3200',
+        token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+      });
+      assert.equal(joinR.status, 200, `Expected 200 direct join, got ${joinR.status}: ${JSON.stringify(joinR.body)}`);
+      assert.equal(joinR.body.status, 'joined');
+
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      assert.equal((net.pendingRounds ?? []).length, 0, 'club join must not open a vote round');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 2a. RSA finalize on braintree ROOT — back-compat immediate join
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('RSA finalize — braintree root still joins immediately', () => {
+    let networkId;
+
+    before(async () => {
+      const r = await post(INSTANCES.a, tokenA, '/api/networks', {
+        label: `S9 RSA BT Root ${Date.now()}`,
+        type: 'braintree',
+        spaces: [testSpaceId],
+        votingDeadlineHours: 1,
+      });
+      assert.equal(r.status, 201);
+      networkId = r.body.id;
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it("finalize on the root returns status 'joined' and the member is admitted", async () => {
+      const joinerId = crypto.randomUUID();
+      const { finalize } = await rsaHandshakeJoin(INSTANCES.a, tokenA, networkId, joinerId, 'RSA Root Leaf');
+      assert.equal(finalize.status, 'joined', `Expected joined, got: ${JSON.stringify(finalize)}`);
+
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      const member = net.members.find(m => m.instanceId === joinerId);
+      assert.ok(member, 'member must be admitted immediately (root = sole required voter)');
+      assert.equal(member.parentInstanceId, instanceIdA, 'joiner must be a child of the root');
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 2b. RSA finalize on braintree CHILD — held; pending PAT refused on sync API
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('RSA finalize — braintree child holds the member and its credentials', () => {
+    let networkId;
+    let roundId;
+    let joinerPat;
+    const joinerId = crypto.randomUUID();
+
+    before(async () => {
+      networkId = await setupBraintreeAB('S9 RSA BT Child');
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+      await del(INSTANCES.b, tokenB, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it("finalize on the child returns status 'vote_pending' and does NOT admit", async () => {
+      const result = await rsaHandshakeJoin(INSTANCES.b, tokenB, networkId, joinerId, 'RSA Held Leaf');
+      joinerPat = result.joinerPat;
+      assert.equal(result.finalize.status, 'vote_pending', `Expected vote_pending, got: ${JSON.stringify(result.finalize)}`);
+      assert.ok(result.finalize.roundId, 'roundId expected in finalize response');
+      roundId = result.finalize.roundId;
+
+      const cfgB = readContainerConfig('ythril-b');
+      const netB = cfgB.networks.find(n => n.id === networkId);
+      assert.ok(!netB.members.some(m => m.instanceId === joinerId), 'joiner must NOT be a member while the vote is open');
+      const round = netB.pendingRounds.find(r => r.roundId === roundId);
+      assert.ok(round?.pendingMember, 'member record must be held on the round');
+      assert.ok(round.requiredVoters?.includes(instanceIdA), 'root must be a required voter');
+    });
+
+    it('the pending joiner PAT is refused on /api/sync/* (no sync possible)', async () => {
+      const probe = await get(INSTANCES.b, joinerPat,
+        `/api/sync/memories?spaceId=${testSpaceId}&networkId=${networkId}`);
+      assert.equal(probe.status, 403, `Expected 403 for pending joiner, got ${probe.status}: ${JSON.stringify(probe.body)}`);
+    });
+
+    it("after the root's yes vote, the joiner is admitted and its PAT works", async () => {
+      await castVoteFromA(networkId, roundId, 'yes');
+
+      await waitForWithSyncFromA(networkId, async () => {
+        const cfgB = readContainerConfig('ythril-b');
+        const netB = cfgB.networks?.find(n => n.id === networkId);
+        return netB?.members?.some(m => m.instanceId === joinerId);
+      }, 30_000, 'joiner never admitted on B after ancestor yes vote');
+
+      const cfgB = readContainerConfig('ythril-b');
+      const netB = cfgB.networks.find(n => n.id === networkId);
+      const member = netB.members.find(m => m.instanceId === joinerId);
+      assert.equal(member.parentInstanceId, instanceIdB, 'admitted joiner must be a child of B');
+
+      const probe = await get(INSTANCES.b, joinerPat,
+        `/api/sync/memories?spaceId=${testSpaceId}&networkId=${networkId}`);
+      assert.equal(probe.status, 200, `Admitted joiner PAT must work, got ${probe.status}: ${JSON.stringify(probe.body)}`);
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 2c. RSA finalize on a closed network with an existing member — held
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('RSA finalize — closed network with existing members holds the join', () => {
+    let networkId;
+
+    before(async () => {
+      const r = await post(INSTANCES.a, tokenA, '/api/networks', {
+        label: `S9 RSA Closed ${Date.now()}`,
+        type: 'closed',
+        spaces: [testSpaceId],
+        votingDeadlineHours: 1,
+      });
+      assert.equal(r.status, 201);
+      networkId = r.body.id;
+
+      // Admit B as the first member (closed admin-add opens a round; A's local
+      // yes concludes it — no other members exist yet).
+      const addBR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+        instanceId: instanceIdB,
+        label: 'Instance B',
+        url: 'http://ythril-b:3200',
+        token: peerTokenForA,
+      });
+      assert.equal(addBR.status, 202, `Add B: ${JSON.stringify(addBR.body)}`);
+      const voteR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${addBR.body.roundId}`, { vote: 'yes' });
+      assert.equal(voteR.status, 200);
+      assert.equal(voteR.body.concluded, true, 'sole-proposer closed round should conclude on own yes');
+
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      assert.ok(net.members.some(m => m.instanceId === instanceIdB), 'B must be a member before the RSA join test');
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it("finalize returns status 'vote_pending' — all existing members must vote", async () => {
+      const joinerId = crypto.randomUUID();
+      const { finalize } = await rsaHandshakeJoin(INSTANCES.a, tokenA, networkId, joinerId, 'RSA Closed Joiner');
+      assert.equal(finalize.status, 'vote_pending', `Expected vote_pending, got: ${JSON.stringify(finalize)}`);
+
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      assert.ok(!net.members.some(m => m.instanceId === joinerId), 'joiner must NOT be admitted before B votes');
+      const round = net.pendingRounds.find(r => r.roundId === finalize.roundId);
+      assert.ok(round && !round.concluded, 'round must be open');
+      assert.ok(round.votes.some(v => v.instanceId === instanceIdA && v.vote === 'yes'),
+        "A's implicit yes (it generated the invite) must be cast");
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 2d. RSA finalize on a democratic network with two members — held
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('RSA finalize — democratic network with two members holds the join', () => {
+    let networkId;
+
+    before(async () => {
+      const r = await post(INSTANCES.a, tokenA, '/api/networks', {
+        label: `S9 RSA Democratic ${Date.now()}`,
+        type: 'democratic',
+        spaces: [testSpaceId],
+        votingDeadlineHours: 1,
+      });
+      assert.equal(r.status, 201);
+      networkId = r.body.id;
+
+      // Seed two dummy members (each add opens a round; A's yes concludes it
+      // while it is still the only voter).
+      for (const n of [1, 2]) {
+        const addR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {
+          instanceId: `s9-dem-seed-${n}-${Date.now()}`,
+          label: `Seed ${n}`,
+          url: 'http://ythril-c:3200',
+          token: `ythril_${crypto.randomBytes(24).toString('base64url')}`,
+        });
+        assert.equal(addR.status, 202, `Seed add ${n}: ${JSON.stringify(addR.body)}`);
+        const voteR = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/votes/${addR.body.roundId}`, { vote: 'yes' });
+        assert.equal(voteR.status, 200, `Seed vote ${n}: ${JSON.stringify(voteR.body)}`);
+      }
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      assert.equal(net.members.length, 2, 'two seed members expected');
+    });
+
+    after(async () => {
+      await del(INSTANCES.a, tokenA, `/api/networks/${networkId}`).catch(() => {});
+    });
+
+    it("finalize returns status 'vote_pending' — a majority is required", async () => {
+      const joinerId = crypto.randomUUID();
+      const { finalize } = await rsaHandshakeJoin(INSTANCES.a, tokenA, networkId, joinerId, 'RSA Democratic Joiner');
+      assert.equal(finalize.status, 'vote_pending', `Expected vote_pending, got: ${JSON.stringify(finalize)}`);
+
+      const cfg = readContainerConfig('ythril-a');
+      const net = cfg.networks.find(n => n.id === networkId);
+      assert.ok(!net.members.some(m => m.instanceId === joinerId), 'joiner must NOT be admitted on a 1-of-2 vote');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **S9** (2026-07-15 docs audit): both non-admin join paths bypassed join governance. The documented model — braintree: yes from **every ancestor on the path from the inviting node to the root**; closed: all members; democratic: majority — was only enforced on the admin member-add path:

- `POST /api/networks/:id/join` (invite key) **direct-joined** braintree networks — no vote round at all.
- `POST /api/invite/finalize` (RSA handshake) added the member directly **for every network type**, bypassing closed/democratic governance too.

Owner decision: *the code is the bug — networks must work as documented.*

## What changed

**Both join paths now open the same join vote round the admin-add path uses** (`server/src/api/networks.ts`, `server/src/api/invite.ts`):

- The member record (and its credentials) is **held on the round** (`pendingMember`) and only enters the member list when the vote concludes yes.
- Braintree `requiredVoters` are recomputed **from local topology at conclusion** (existing `concludeRoundIfReady` guarantee) — never trusted from the wire. The joiner always becomes a **child of the instance it joined through**; `parentInstanceId`/`direction` from the request body are ignored for braintree.
- The inviting instance's own yes is cast implicitly (its admin generated the invite/key), so the common flows are byte-compatible: **club/pubsub still direct-join** (documented), and a **braintree root invite / first member of a closed network still joins immediately** (existing RSA-handshake integration test passes unchanged).

**Credentials are actually held, not just the member row** (`server/src/api/sync.ts`):

- A peer whose join is pending (or denied) is **refused on `/api/sync/*`** — previously the unknown-peer fallback in `spaceAllowed` would have honoured its space-scoped PAT while the vote was still open.
- A vetoed/expired join round now **revokes the provisioned credentials** (peer PAT + outbound token) via `revokePeerCredentialsIfOrphaned`, instead of leaving them live forever.

**Round conclusion admits the held member on the right instance only** (`sync.ts` vote relay, `sync/engine.ts` gossip): braintree — only the direct parent; closed/democratic — only the instance holding the joiner's credentials (gossip-adopted round copies have `tokenHash` stripped).

**Invite-key polling**: the key is consumed when the round opens (unchanged), and its hash is preserved on the round — re-presenting the same key with the same `instanceId` polls the outcome: `202` while open, `200 joined` + member list once admitted, `403` if vetoed/expired. This also repairs the **closed/democratic invite-key flow, which was broken end-to-end**: the round held no `pendingMember` (a passed vote admitted nobody) and the consumed key made re-joining impossible.

**Client** (`networks.component.ts` + en/de/pl locales): the join dialog now shows a "join request sent, awaiting member approval" message when the handshake returns `vote_pending` instead of falsely claiming "joined".

**Docs** (`docs/integration-guide.md`): response semantics for both endpoints. `docs/network-types.md` needed no changes — it already documented this behavior; the code was the bug.

## Tests

New `testing/sync/join-governance.test.js` (15 cases, two live instances, real gossip):

- invite-key join: braintree root → immediate `200`; braintree child → `202`, **not admitted**, requiredVoters `[B, A]`, admitted only after A's gossiped yes; ancestor **veto** → never admitted, provisioned outbound token **revoked**, poll → `403`; club → direct join unchanged.
- RSA finalize: braintree root → `joined` (back-compat); braintree child → `vote_pending`, pending PAT **403 on `/api/sync/*`**, admitted + PAT works after root's yes; closed with an existing member → held; democratic with two members → held.

Suites run against the rebuilt stack (one at a time): `test:sync`, `test:integration`, `test:redteam`, `test:standalone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
