### PR TITLE
fix(security): make the sync data-write surface peer-only and harden direction enforcement (S10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -631,6 +631,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The sync data-write surface is now peer-only, and direction enforcement can no longer be
+  side-stepped (S10).** The direction guard on the seven `/api/sync/*` write endpoints (`memories`,
+  `entities`, `edges`, `chrono`, `batch-upsert`, `tombstones`, `file-tombstones`) had two holes. First,
+  it only ever bound tokens carrying `peerInstanceId` — **any space-scoped user PAT could write through
+  the sync surface** regardless of the network's direction topology. That matters because sync writes,
+  unlike the REST API (which assigns `seq`/`_id`/`author` server-side), carry raw stream metadata: a
+  downstream operator in a braintree or pub/sub network holding any leaked upstream user PAT could push
+  content upstream, defeating the documented one-way flow and forging sync state the REST API never
+  permits. Second, the guard keyed on the **caller-supplied `networkId` query parameter** — a push-only
+  peer could simply omit it (or name a non-directional network sharing the space) and write anyway.
+  Both are closed: data writes now require a **peer token or an admin token** (403 otherwise, with the
+  error pointing user PATs at the regular REST API), and for identified peers the direction check is
+  derived from this instance's **own membership records covering the target space** — allowed only when
+  at least one relationship carrying that space permits inbound flow — never from wire input. Reads and
+  the governance relays (votes/member gossip, which have their own forgery protections) are unchanged,
+  as are asymmetric topologies where the writer is not listed as a member (braintree parents, single-side
+  configs): their handshake-issued tokens already carry `peerInstanceId`. **Migration for
+  manually-configured networks:** a hand-provisioned peer token must now be minted with
+  `POST /api/tokens { peerInstanceId: "<peer-uuid>" }` (documented in the integration guide); an
+  existing plain PAT used by a peer for data pushes will start receiving 403s on upgrade.
+
 - **Both non-admin join paths bypassed join governance entirely (S9).** The documented model admits a
   new member only after the required vote passes — braintree: a yes from **every ancestor on the path
   from the inviting node to the root**; closed: all members; democratic: a majority. Neither non-admin

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2997,6 +2997,7 @@ POST /api/tokens
 | `readOnly` | Block all writes. Ignored when `schemaLibrary` is `true` (always read-only). |
 | `spaces` | Array of space IDs to scope this token. Omit for all-spaces access. Must be empty or omitted when `schemaLibrary` is `true`. |
 | `expiresAt` | ISO 8601 expiry timestamp. Omit for non-expiring. |
+| `peerInstanceId` | Bind this token to a network peer (UUID). Required for tokens a peer will present on the `/api/sync/*` **data-write** endpoints in manually-configured networks — the invite handshake sets it automatically. Peer identity is server-issued and cannot be self-declared by the caller. |
 | `schemaLibrary` | `true` to issue a **library access token**. See below. |
 
 **Response** `201`:

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -238,7 +238,9 @@ A leaf node has `direction='push'` toward its parent — meaning the engine push
 
 The direction field controls not only which phases the sync *engine* runs on the initiating side, but also which writes the *receiving server* accepts.
 
-When a peer POSTs data to any write endpoint (`/api/sync/memories`, `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/tombstones`, `/file-tombstones`), the server looks up the member record for the caller's `peerInstanceId` (carried on server-issued peer tokens) in the network. If `member.direction === 'push'` — meaning "we push to them, they should not write to us" — the server responds `403 { error: 'Directional network: write not permitted from this peer' }`.
+**The data-write surface is peer-only.** A POST to any write endpoint (`/api/sync/memories`, `/entities`, `/edges`, `/chrono`, `/batch-upsert`, `/tombstones`, `/file-tombstones`) must be presented with a **peer token** (a PAT carrying `peerInstanceId` — issued by the invite handshake, or minted explicitly via `POST /api/tokens { peerInstanceId }` for manually-configured topologies) or an **admin token** (the local operator, who could write through the regular REST API anyway). A space-scoped user PAT is refused with `403 { error: 'Sync writes require a peer token (peerInstanceId) or an admin token — use the regular REST API for user writes' }`. Unlike the REST API, which assigns `seq`/`_id`/`author` server-side, sync writes carry raw stream metadata — accepting user PATs here would let anyone holding one forge sync state, e.g. a downstream operator pushing content upstream in a directional network.
+
+For an identified peer, the server then derives the direction check from **its own membership records covering the target space** — never from the caller-supplied `networkId` query parameter. The write is allowed only when at least one of the caller's network relationships carrying that space permits inbound flow (`direction` pull/both, or a non-directional network type). If every relationship covering the space is `push` — "we push to them, they should not write to us" — the server responds `403 { error: 'Directional network: write not permitted from this peer' }`. A peer that is a member of no local network carrying the space (asymmetric/single-side topologies, a braintree child receiving from its unlisted parent) is governed by token space scope and the pending-join hold instead.
 
 This is the server-side complement to the engine's client-side skip logic. Together they guarantee:
 
@@ -247,7 +249,7 @@ This is the server-side complement to the engine's client-side skip logic. Toget
 | Braintree parent → child | Parent pushes, child does not push back | Child rejects POST from parent's subtree peers |
 | Pub/Sub publisher → subscriber | Publisher pushes, subscriber does not push | Publisher rejects POST from subscribers |
 
-Bidirectional network types (`closed`, `democratic`, `club`) always have `direction='both'` on all members, so the guard never fires.
+Bidirectional network types (`closed`, `democratic`, `club`) always have `direction='both'` on all members, so the directional guard never fires — but the peer-only write gate still applies.
 
 ---
 
@@ -291,7 +293,7 @@ On the pulling side, records returned by `GET /members` that share our own `inst
 
 ## API reference
 
-All endpoints are under `/api/sync` and require a `Bearer` token. In normal operation that is a **peer token** — a PAT carrying `peerInstanceId`, issued to the peer during join — but the endpoints use the ordinary auth middleware, so admin and appropriately space-scoped user PATs are also accepted (token space-scope **and** network membership are enforced before any read or write; admin tokens additionally act as trusted local relays for tombstones). Rate-limited per IP.
+All endpoints are under `/api/sync` and require a `Bearer` token. In normal operation that is a **peer token** — a PAT carrying `peerInstanceId`, issued to the peer during join. Read endpoints and the governance relays additionally accept admin and appropriately space-scoped user PATs (token space-scope **and** network membership are enforced before any read or write; admin tokens additionally act as trusted local relays for tombstones). The seven **data-write endpoints accept only peer or admin tokens** — see [Direction enforcement on inbound endpoints](#direction-enforcement-on-inbound-endpoints). Rate-limited per IP.
 
 ### Read endpoints (called during pull)
 

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -384,6 +384,27 @@ function spaceAllowed(
 }
 
 /**
+ * S10: the sync data-write surface is for peers. A write must be presented by
+ * a server-issued peer token (`peerInstanceId`, set by the invite handshake or
+ * minted explicitly via POST /api/tokens) or by an admin token — the local
+ * operator, who could write through the regular REST API anyway. Space-scoped
+ * user PATs are refused: unlike the REST API (which assigns seq/_id/author
+ * server-side), sync writes carry raw sync metadata, so accepting them would
+ * let any user-PAT holder forge stream state — e.g. a downstream operator in
+ * a directional network pushing content upstream with a leaked upstream PAT,
+ * defeating the documented one-way flow.
+ *
+ * Returns true if the write must be REJECTED (403).
+ */
+function isNonPeerSyncWrite(authToken: Record<string, unknown> | undefined): boolean {
+  if (authToken?.['admin'] === true) return false;
+  return !callerPeerId(authToken);
+}
+
+const NON_PEER_WRITE_MESSAGE =
+  'Sync writes require a peer token (peerInstanceId) or an admin token — use the regular REST API for user writes';
+
+/**
  * For directional networks (braintree, pubsub), reject inbound writes from
  * members whose direction is 'push'. Direction is stored from THIS instance's
  * perspective:
@@ -391,32 +412,33 @@ function spaceAllowed(
  *   direction='pull'  → we pull FROM them → they may push to us (data source)
  *   direction='both'  → bidirectional → accept
  *
- * Enforcement is against an IDENTIFIED member: the peer token carries a
- * server-issued `peerInstanceId` (set by the invite handshake) that is matched
- * against the member list. This covers the real case — a push-only subscriber
- * or child trying to write back to its publisher/parent, where that peer IS a
- * member with direction='push' on this side, so it is blocked.
+ * Enforcement is against an IDENTIFIED member and derived from THIS instance's
+ * own membership records covering the TARGET SPACE — never from the caller-
+ * supplied `networkId` query param, which a push-only peer could previously
+ * simply omit (or point at a non-directional network sharing the space) to
+ * slip past the guard. The write is space-level, so it is allowed only when
+ * at least one of the caller's network relationships carrying that space
+ * permits inbound flow (direction pull/both, or a non-directional type).
  *
- * A token with NO `peerInstanceId` is intentionally NOT blocked here: in a
- * braintree tree the receiver does not list its parent as a member at all, and
- * manually-provisioned peer tokens legitimately omit `peerInstanceId`, so a
- * blanket refusal would break those topologies. `peerInstanceId` is issued
- * server-side and cannot be self-declared, so an attacker cannot forge a
- * matching identity to bypass the check either.
+ * A token with NO `peerInstanceId` never reaches this check on the write
+ * endpoints (isNonPeerSyncWrite gates first); a peer that is a member of no
+ * local network carrying the space is governed by token space scope and the
+ * pending-join hold in spaceAllowed (braintree receivers legitimately do not
+ * list their parent as a member).
  *
  * Returns true if the write should be REJECTED (403).
  */
-function isDirectionalWriteBlocked(networkId: string | undefined, authToken: Record<string, unknown> | undefined): boolean {
+function isDirectionalWriteBlocked(spaceId: string, authToken: Record<string, unknown> | undefined): boolean {
   const peerInstanceId = callerPeerId(authToken);
-  if (!networkId || !peerInstanceId) return false;
-  const cfg = getConfig();
-  const net = cfg.networks.find(n => n.id === networkId);
-  if (!net) return false;
-  if (net.type !== 'braintree' && net.type !== 'pubsub') return false;
-  const member = net.members.find(m => m.instanceId === peerInstanceId);
-  if (!member) return false;
-  // direction='push' means WE push to THEM — they should not be writing to us
-  return member.direction === 'push';
+  if (!peerInstanceId) return false;
+  const nets = peerMemberNetworks(peerInstanceId).filter(n => n.spaces.includes(spaceId));
+  if (nets.length === 0) return false;
+  return !nets.some(n => {
+    if (n.type !== 'braintree' && n.type !== 'pubsub') return true;
+    const member = n.members.find(m => m.instanceId === peerInstanceId);
+    // direction='push' means WE push to THEM — they should not be writing to us
+    return member ? member.direction !== 'push' : false;
+  });
 }
 
 // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -499,7 +521,8 @@ syncRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async (re
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingMemoryDoc.safeParse(req.body);
     if (!parsed.success) {
@@ -637,7 +660,8 @@ syncRouter.post('/entities', syncRateLimit, requireAuth, denyReadOnly, async (re
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingEntityDoc.safeParse(req.body);
     if (!parsed.success) {
@@ -736,7 +760,8 @@ syncRouter.post('/edges', syncRateLimit, requireAuth, denyReadOnly, async (req, 
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingEdgeDoc.safeParse(req.body);
     if (!parsed.success) {
@@ -836,7 +861,8 @@ syncRouter.post('/chrono', syncRateLimit, requireAuth, denyReadOnly, async (req,
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const parsed = IncomingChronoDoc.safeParse(req.body);
     if (!parsed.success) {
@@ -896,7 +922,8 @@ syncRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, async
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const body = req.body as { memories?: unknown[]; entities?: unknown[]; edges?: unknown[]; chrono?: unknown[] };
     const memoriesRaw = (Array.isArray(body?.memories) ? body.memories.slice(0, 500) : [])
@@ -1076,7 +1103,8 @@ syncRouter.post('/tombstones', syncRateLimit, requireAuth, denyReadOnly, async (
     const { spaceId, networkId } = req.query as Record<string, string>;
     if (!spaceId) { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const body = req.body as { tombstones?: TombstoneDoc[] };
     const tombstones = body?.tombstones ?? [];
@@ -1175,7 +1203,8 @@ syncRouter.post('/file-tombstones', syncRateLimit, requireAuth, denyReadOnly, as
     if (!spaceId || typeof spaceId !== 'string') { res.status(400).json({ error: 'spaceId required' }); return; }
     if (!Array.isArray(tombstones)) { res.status(400).json({ error: 'tombstones must be array' }); return; }
     if (!spaceAllowed(spaceId, networkId, req.authToken?.spaces, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Forbidden' }); return; }
-    if (isDirectionalWriteBlocked(networkId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
+    if (isNonPeerSyncWrite(req.authToken as Record<string, unknown>)) { res.status(403).json({ error: NON_PEER_WRITE_MESSAGE }); return; }
+    if (isDirectionalWriteBlocked(spaceId, req.authToken as Record<string, unknown>)) { res.status(403).json({ error: 'Directional network: write not permitted from this peer' }); return; }
 
     const spaceFiles = path.resolve(getDataRoot(), 'files', spaceId);
     let applied = 0;

--- a/testing/red-team-tests/direction-enforcement.test.js
+++ b/testing/red-team-tests/direction-enforcement.test.js
@@ -209,4 +209,131 @@ describe('Directional network: push-only peer cannot write to sync endpoints', (
     );
     assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
   });
+
+  // ── networkId is wire input — omitting or misdirecting it must not bypass ──
+  // (S10: pre-fix, the guard keyed on the caller-supplied networkId query
+  //  param, so a push-only peer could write by simply leaving it out.)
+
+  it('Subscriber cannot bypass the guard by OMITTING networkId → 403', async () => {
+    const r = await post(INSTANCES.a, subscriberToken,
+      `/api/sync/memories?spaceId=general`,
+      { _id: crypto.randomUUID(), fact: 'injected without networkId', seq: 1 },
+    );
+    assert.equal(r.status, 403, `Expected 403, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.ok(r.body.error?.includes('write not permitted'), `Error should be the direction guard: ${r.body.error}`);
+  });
+
+  it('Subscriber cannot bypass the guard by naming a BOGUS networkId → 403', async () => {
+    const r = await post(INSTANCES.a, subscriberToken,
+      `/api/sync/memories?spaceId=general&networkId=${crypto.randomUUID()}`,
+      { _id: crypto.randomUUID(), fact: 'injected via bogus networkId', seq: 1 },
+    );
+    assert.equal(r.status, 403, `Expected 403, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// S10: the sync data-write surface is peer-only — a space-scoped user PAT
+// must not be able to write through /api/sync/* at all (it could otherwise
+// forge raw seq/_id/author stream metadata and push content upstream in a
+// directional network). Reads stay open; admin remains a local override.
+// ══════════════════════════════════════════════════════════════════════════
+
+describe('S10: non-peer user PATs are refused on sync data writes', () => {
+  let userPat;          // space-scoped, non-admin, no peerInstanceId
+  let closedNetworkId;
+  let closedPeerToken;  // peer-bound token with direction='both' (positive control)
+
+  before(async () => {
+    adminToken = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+
+    const t = await post(INSTANCES.a, adminToken, '/api/tokens', {
+      name: `s10-user-pat-${Date.now()}`,
+      spaces: ['general'],
+    });
+    assert.equal(t.status, 201);
+    userPat = t.body.plaintext;
+
+    // Closed network + handshake-joined peer → direction 'both' (may write)
+    const n = await post(INSTANCES.a, adminToken, '/api/networks', {
+      label: `S10 Closed ${Date.now()}`,
+      type: 'closed',
+      spaces: ['general'],
+    });
+    assert.equal(n.status, 201);
+    closedNetworkId = n.body.id;
+    const peer = await doHandshake(adminToken, closedNetworkId, 'S10 Closed Peer');
+    closedPeerToken = peer.token;
+  });
+
+  after(async () => {
+    if (closedNetworkId) {
+      await del(INSTANCES.a, adminToken, `/api/networks/${closedNetworkId}`).catch(() => {});
+    }
+  });
+
+  const WRITE_CASES = [
+    ['memories', { fact: 'user-pat injected', seq: 1 }],
+    ['entities', { name: 'user-pat entity', type: 'person', seq: 1 }],
+    ['edges', { from: 'a', to: 'b', label: 'user-pat edge', seq: 1 }],
+    ['chrono', { type: 'memory', targetId: 'x', seq: 1 }],
+  ];
+
+  for (const [endpoint, doc] of WRITE_CASES) {
+    it(`user PAT cannot POST /api/sync/${endpoint} → 403 (peer-token required)`, async () => {
+      const r = await post(INSTANCES.a, userPat,
+        `/api/sync/${endpoint}?spaceId=general&networkId=${closedNetworkId}`,
+        { _id: crypto.randomUUID(), ...doc },
+      );
+      assert.equal(r.status, 403, `Expected 403, got ${r.status}: ${JSON.stringify(r.body)}`);
+      assert.ok(r.body.error?.includes('peer token'), `Error should demand a peer token: ${r.body.error}`);
+    });
+  }
+
+  it('user PAT cannot POST /api/sync/batch-upsert → 403', async () => {
+    const r = await post(INSTANCES.a, userPat,
+      `/api/sync/batch-upsert?spaceId=general`,
+      { memories: [{ _id: crypto.randomUUID(), fact: 'user-pat batch', seq: 1 }] },
+    );
+    assert.equal(r.status, 403, `Expected 403, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('user PAT cannot POST /api/sync/tombstones → 403', async () => {
+    const r = await post(INSTANCES.a, userPat,
+      `/api/sync/tombstones?spaceId=general`,
+      { tombstones: [{ _id: crypto.randomUUID(), type: 'memory', instanceId: 'attacker', deletedAt: new Date().toISOString() }] },
+    );
+    assert.equal(r.status, 403, `Expected 403, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('user PAT cannot POST /api/sync/file-tombstones → 403', async () => {
+    const r = await post(INSTANCES.a, userPat,
+      `/api/sync/file-tombstones`,
+      { spaceId: 'general', tombstones: [{ _id: crypto.randomUUID(), path: 'attack.txt', deletedAt: new Date().toISOString() }] },
+    );
+    assert.equal(r.status, 403, `Expected 403, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  // ── What must still work ──────────────────────────────────────────────────
+
+  it('user PAT can still READ /api/sync/memories → 200', async () => {
+    const r = await get(INSTANCES.a, userPat, `/api/sync/memories?spaceId=general`);
+    assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('admin token can still write (local operator override) → 200', async () => {
+    const r = await post(INSTANCES.a, adminToken,
+      `/api/sync/batch-upsert?spaceId=general`,
+      { memories: [{ _id: crypto.randomUUID(), fact: `s10 admin positive control ${Date.now()}`, seq: 1 }] },
+    );
+    assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it("peer with direction 'both' (closed network) can still write → 200", async () => {
+    const r = await post(INSTANCES.a, closedPeerToken,
+      `/api/sync/batch-upsert?spaceId=general&networkId=${closedNetworkId}`,
+      { memories: [{ _id: crypto.randomUUID(), fact: `s10 peer positive control ${Date.now()}`, seq: 1 }] },
+    );
+    assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
 });

--- a/testing/red-team-tests/sync-scope-bypass.test.js
+++ b/testing/red-team-tests/sync-scope-bypass.test.js
@@ -140,13 +140,18 @@ describe('Space-scoped token cannot access sync endpoints of other spaces', () =
     assert.equal(r.status, 200, `Scoped token should access its own space, got ${r.status}: ${JSON.stringify(r.body)}`);
   });
 
-  it('Scoped token CAN batch-upsert into its own space → 200', async () => {
+  it('Scoped token cannot batch-upsert even into its own space → 403 (S10: sync writes are peer-only)', async () => {
+    // The sync data-write surface requires a peer token (peerInstanceId) or an
+    // admin token: sync writes carry raw seq/_id/author stream metadata, which
+    // a space-scoped user PAT must not be able to forge. User writes go through
+    // the regular REST API instead.
     const r = await post(
       INSTANCES.a,
       scopedToken,
       '/api/sync/batch-upsert?spaceId=general',
       { memories: [{ _id: 'rt-scope-allowed-001', fact: 'allowed write', seq: 1 }] },
     );
-    assert.equal(r.status, 200, `Scoped token should write to its own space, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.equal(r.status, 403, `Non-peer PAT must not write via /api/sync, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.ok(r.body.error?.includes('peer token'), `Error should demand a peer token: ${r.body.error}`);
   });
 });

--- a/testing/sync/braintree.test.js
+++ b/testing/sync/braintree.test.js
@@ -11,7 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import {
-  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, waitFor,
+  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, waitFor, getInstanceId,
 } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -45,9 +45,14 @@ describe('Braintree topology (A -> B -> C)', () => {
     assert.equal(r.status, 201, `Create network: ${JSON.stringify(r.body)}`);
     networkId = r.body.id;
 
-    // Create peer tokens
-    const bPeer = await postRetry429(INSTANCES.b, tokenB, '/api/tokens', { name: 'bt-peer-a' });
-    const cPeer = await postRetry429(INSTANCES.c, tokenC, '/api/tokens', { name: 'bt-peer-b' });
+    // Create peer tokens — peer-bound to the instance that PRESENTS them
+    // (sync data writes require a peer or admin token — S10).
+    const bPeer = await postRetry429(INSTANCES.b, tokenB, '/api/tokens', {
+      name: 'bt-peer-a', peerInstanceId: getInstanceId('ythril-a'),
+    });
+    const cPeer = await postRetry429(INSTANCES.c, tokenC, '/api/tokens', {
+      name: 'bt-peer-b', peerInstanceId: getInstanceId('ythril-b'),
+    });
     assert.equal(bPeer.status, 201);
     assert.equal(cPeer.status, 201);
 

--- a/testing/sync/entity-edge-sync.test.js
+++ b/testing/sync/entity-edge-sync.test.js
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'url';
 import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { INSTANCES, post, get, del, reqJson, waitFor, triggerSync } from './helpers.js';
+import { INSTANCES, post, get, del, reqJson, waitFor, triggerSync, getInstanceId } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -46,7 +46,12 @@ describe('Entity/edge sync — cross-instance (A→B)', () => {
     assert.equal(netR.status, 201, `Create network: ${JSON.stringify(netR.body)}`);
     networkId = netR.body.id;
 
-    const ptB = await post(INSTANCES.b, tokenB, '/api/tokens', { name: `entity-sync-peer-${RUN}` });
+    // Peer-bound: this token is presented BY instance A when pushing to B
+    // (sync data writes require a peer or admin token — S10).
+    const ptB = await post(INSTANCES.b, tokenB, '/api/tokens', {
+      name: `entity-sync-peer-${RUN}`,
+      peerInstanceId: getInstanceId('ythril-a'),
+    });
     assert.equal(ptB.status, 201);
 
     const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {

--- a/testing/sync/file-sync.test.js
+++ b/testing/sync/file-sync.test.js
@@ -19,7 +19,7 @@ import assert from 'node:assert/strict';
 import { fileURLToPath } from 'url';
 import fs from 'node:fs';
 import path from 'node:path';
-import { INSTANCES, post, get, del, reqJson, waitFor } from './helpers.js';
+import { INSTANCES, post, get, del, reqJson, waitFor, getInstanceId } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, 'configs');
@@ -79,7 +79,12 @@ describe('File sync — cross-instance', () => {
     assert.equal(netR.status, 201, `Create network: ${JSON.stringify(netR.body)}`);
     networkId = netR.body.id;
 
-    const ptB = await post(INSTANCES.b, tokenB, '/api/tokens', { name: `filesync-peer-${RUN}` });
+    // Peer-bound: this token is presented BY instance A when pushing to B
+    // (sync data writes require a peer or admin token — S10).
+    const ptB = await post(INSTANCES.b, tokenB, '/api/tokens', {
+      name: `filesync-peer-${RUN}`,
+      peerInstanceId: getInstanceId('ythril-a'),
+    });
     assert.equal(ptB.status, 201);
 
     const addB = await post(INSTANCES.a, tokenA, `/api/networks/${networkId}/members`, {

--- a/testing/sync/merkle.test.js
+++ b/testing/sync/merkle.test.js
@@ -182,13 +182,18 @@ describe('Merkle root', () => {
       assert.equal(n.status, 201, `Create network: ${JSON.stringify(n.body)}`);
       networkId = n.body.id;
 
-      // Issue peer tokens for cross-instance auth
-      const ptA = await post(INSTANCES.b, tokenB, '/api/tokens', { name: `merkle-peer-a-${Date.now()}` });
+      // Issue peer tokens for cross-instance auth — peer-bound to the instance
+      // that PRESENTS them (sync data writes require a peer or admin token — S10).
+      const ptA = await post(INSTANCES.b, tokenB, '/api/tokens', {
+        name: `merkle-peer-a-${Date.now()}`, peerInstanceId: instanceIdA,
+      });
       assert.equal(ptA.status, 201);
       peerTokenForA = ptA.body.plaintext;
       peerTokenForAId = ptA.body.token.id;
 
-      const ptB = await post(INSTANCES.a, tokenA, '/api/tokens', { name: `merkle-peer-b-${Date.now()}` });
+      const ptB = await post(INSTANCES.a, tokenA, '/api/tokens', {
+        name: `merkle-peer-b-${Date.now()}`, peerInstanceId: instanceIdB,
+      });
       assert.equal(ptB.status, 201);
       peerTokenForB = ptB.body.plaintext;
       peerTokenForBId = ptB.body.token.id;


### PR DESCRIPTION
## Summary

Fixes **S10** (2026-07-15 docs audit, PR 2 in the ordered plan): direction enforcement on the `/api/sync/*` write surface only bound tokens carrying `peerInstanceId`, and even for those it keyed on wire input. Investigated per the tracker; implemented **option (b)** ("the sync surface is for peers"), which the audit already leaned toward.

Two holes closed on the seven data-write endpoints (`memories`, `entities`, `edges`, `chrono`, `batch-upsert`, `tombstones`, `file-tombstones`):

1. **Any space-scoped user PAT could write through the sync surface.** Sync writes — unlike the REST API, which assigns `seq`/`_id`/`author` server-side — carry raw stream metadata. A downstream operator in a braintree/pubsub network holding any leaked upstream user PAT could push content upstream (defeating the documented one-way flow) and forge sync state the REST API never permits.
2. **The direction guard keyed on the caller-supplied `networkId` query param.** A push-only peer could simply omit it, or name a non-directional network sharing the space, and write anyway.

## What changed

`server/src/api/sync.ts`:

- **Peer-only write gate**: the seven data-write endpoints now require a **peer token** (`peerInstanceId` — issued by the invite handshake, or minted via `POST /api/tokens { peerInstanceId }` for manual topologies) or an **admin token** (local-operator override; admin could write via REST anyway). User PATs get `403` with an error pointing them at the regular REST API.
- **Membership-derived direction check**: for identified peers, direction is now derived from this instance's own membership records covering the **target space** — the write is allowed only if at least one of the caller's relationships carrying that space permits inbound flow (`pull`/`both`, or a non-directional type). `networkId` from the wire no longer participates.

**Unchanged**: all GET endpoints; the governance relays (`/api/sync/networks/*` votes/member gossip — they have their own forgery protections and are legitimately used by admin/local relays); asymmetric topologies where the writer is not listed as a member (braintree parents, single-side configs) — their handshake-issued tokens already carry `peerInstanceId`; `/api/files/*` content pushes.

**Migration note (breaking for manually-configured networks)**: a hand-provisioned peer token used for data pushes must be re-minted with `peerInstanceId` (field documented in the integration guide's token table). Handshake-created networks are unaffected — those tokens were always peer-bound.

## Tests

- `red-team-tests/direction-enforcement.test.js` — new cases: push-only subscriber can no longer bypass the guard by **omitting** `networkId` or naming a **bogus** one; a space-scoped **user PAT gets 403 on all seven write endpoints** (the tracker's red-team test) while reads stay 200; positive controls prove an **admin token** and a **direction-`both` handshake peer** still write successfully.
- `red-team-tests/sync-scope-bypass.test.js` — the "scoped token CAN batch-upsert into its own space" assertion flipped to expect 403 (that behavior *was* the S10 hole).
- Four sync tests (`entity-edge-sync`, `braintree`, `merkle`, `file-sync`) minted plain PATs for engine-driven cross-instance pushes; they now mint them **peer-bound to the presenting instance**, matching what production handshakes produce. (Surveyed the entire test tree: all other sync-write usage is via admin tokens, already peer-bound tokens, or networks that push no data.)

Docs: `sync-protocol.md` (direction-enforcement section + API reference), `integration-guide.md` (token `peerInstanceId` field). CHANGELOG under [Unreleased] Security with the migration note.

Suites run against the rebuilt stack (one at a time): `test:redteam`, `test:sync`, `test:integration`, `test:standalone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
