### PR TITLE
test(security): assert real effects in five vacuous test groups (S8 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -631,6 +631,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Test hardening: five test groups that would pass with their mechanism removed now assert the
+  real effect (S8, part 1).** Applying the "what would still pass if the mechanism were removed?"
+  method: **(1)** the three untested rate limiters get real 429 burst tests on instance C —
+  `bulkWipeRateLimit` (5/min, the tightest destructive limiter, previously swappable for
+  `globalRateLimit` with no test going red), `globalRateLimit` (300/min) and `syncRateLimit`
+  (2000/min) — each with a positive control proving the first request reaches the route.
+  **(2)** the `retry_embedding` "requires write access" test used the ADMIN token and asserted
+  success, testing nothing; it now uses a read-only token and asserts 403, and a new effect test
+  proves the retry actually resets `embeddingStatus` to pending and the requeued job re-runs to a
+  terminal state. **(3)** `notify/trigger` and `sync_available` asserted only the echoed
+  status/204 — satisfied by a handler that does nothing, which is exactly how the notify
+  rate-limit bug once hid; both now poll the network's sync-history for the record a real cycle
+  appends. **(4)** MCP `update_memory` and the remaining echo-only `PATCH /memories` cases
+  (fact, long-form) re-read the document and deep-equal the persisted value. **(5)** the
+  echo-only PUT/PATCH tests for media-config and edge/memory/chrono type-schemas, and the chrono
+  update paths, all re-read through GET to confirm persistence. Test-only change; no runtime code
+  touched.
+
 - **The sync data-write surface is now peer-only, and direction enforcement can no longer be
   side-stepped (S10).** The direction guard on the seven `/api/sync/*` write endpoints (`memories`,
   `entities`, `edges`, `chrono`, `batch-upsert`, `tombstones`, `file-tombstones`) had two holes. First,

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -1203,6 +1203,11 @@ describe('Brain — chrono properties field', () => {
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.deepStrictEqual(r.body.properties, { phase: 'beta', priority: 2, critical: false });
+
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/chrono/${chronoId}`);
+    assert.equal(get2.status, 200);
+    assert.deepStrictEqual(get2.body.properties, { phase: 'beta', priority: 2, critical: false },
+      'updated properties persisted to DB');
   });
 
   after(async () => {
@@ -1724,6 +1729,10 @@ describe('Brain — PATCH memory updates description and properties', () => {
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.fact, `PatchMemFact-updated-${RUN}`);
+
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
+    assert.equal(get2.status, 200);
+    assert.equal(get2.body.fact, `PatchMemFact-updated-${RUN}`, 'fact persisted to DB');
   });
 
   it('PATCH memory with no fields returns 400', async () => {
@@ -1767,6 +1776,11 @@ describe('Brain — PATCH memory long-form path persists description and propert
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.description, 'Long-form updated');
     assert.equal(r.body.properties?.v, 2);
+
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/memories/${memId}`);
+    assert.equal(get2.status, 200);
+    assert.equal(get2.body.description, 'Long-form updated', 'description persisted to DB');
+    assert.deepEqual(get2.body.properties, { v: 2 }, 'properties persisted to DB');
   });
 
   after(async () => {
@@ -1923,6 +1937,10 @@ describe('Brain — PATCH chrono by ID', () => {
     });
     assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
     assert.equal(r.body.description, 'Updated chrono description', 'description updated');
+
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/chrono/${chronoId}`);
+    assert.equal(get2.status, 200);
+    assert.equal(get2.body.description, 'Updated chrono description', 'description persisted to DB');
   });
 
   it('PATCH chrono updates properties by ID', async () => {
@@ -1931,6 +1949,10 @@ describe('Brain — PATCH chrono by ID', () => {
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.properties?.phase, 'beta', 'property updated');
+
+    const get2 = await get(INSTANCES.a, token(), `/api/brain/spaces/general/chrono/${chronoId}`);
+    assert.equal(get2.status, 200);
+    assert.equal(get2.body.properties?.phase, 'beta', 'updated property persisted to DB');
   });
 
   it('PATCH chrono with unknown ID returns 404', async () => {

--- a/testing/integration/files.test.js
+++ b/testing/integration/files.test.js
@@ -774,20 +774,86 @@ describe('Media embedding — retry_embedding endpoint', () => {
     assert.equal(r.status, 401, `Expected 401 without auth, got ${r.status}`);
   });
 
-  it('retry_embedding requires write access (read-only token blocked)', async () => {
-    // Skip this test in environments where we can't create read-only tokens
-    // In full CI, read-only tokens can be obtained from the token management API
-    // For now: just verify the endpoint exists and responds
+  it('retry_embedding requires write access (read-only token → 403)', async () => {
+    const tokRes = await fetch(`${INSTANCES.a}/api/tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${tokenA}` },
+      body: JSON.stringify({ name: `retry-readonly-${RUN}`, readOnly: true }),
+    });
+    assert.equal(tokRes.status, 201, 'read-only token creation failed');
+    const readOnlyToken = (await tokRes.json()).plaintext;
+
     const url = `${INSTANCES.a}/api/files/general/retry_embedding?path=test.png`;
     const r = await fetch(url, {
       method: 'POST',
-      headers: { 'Authorization': `Bearer ${tokenA}` },
+      headers: { 'Authorization': `Bearer ${readOnlyToken}` },
     });
-    // 404 (no job) or 409 (already processing) are both valid — just not 404 from auth
-    assert.ok(
-      [404, 409, 202].includes(r.status),
-      `Expected 404/409/202, got ${r.status}`,
-    );
+    assert.equal(r.status, 403, `Read-only token must be blocked with 403, got ${r.status}`);
+  });
+
+  it('retry_embedding actually resets embeddingStatus to pending and the job re-runs', async () => {
+    // Dedicated space so the file listing is small and unpolluted.
+    const spaceId = `s8-retry-${RUN}`;
+    const createSpace = await fetch(`${INSTANCES.a}/api/spaces`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${tokenA}` },
+      body: JSON.stringify({ id: spaceId, label: 'S8 Retry Effect' }),
+    });
+    assert.equal(createSpace.status, 201);
+
+    const filePath = `retry-effect-${RUN}.txt`;
+    const docStatus = async () => {
+      const r = await fetch(`${INSTANCES.a}/api/brain/spaces/${spaceId}/files?limit=200`, {
+        headers: { 'Authorization': `Bearer ${tokenA}` },
+      });
+      const body = await r.json().catch(() => ({}));
+      const meta = body.files?.find(f => (f.path ?? f._id ?? '').includes(filePath));
+      return meta?.embeddingStatus;
+    };
+    const waitForStatus = async (predicate, timeoutMs) => {
+      const start = Date.now();
+      let last;
+      while (Date.now() - start < timeoutMs) {
+        last = await docStatus();
+        if (predicate(last)) return last;
+        await new Promise(res => setTimeout(res, 1000));
+      }
+      return last;
+    };
+
+    try {
+      await uploadFile(tokenA, spaceId, filePath,
+        'Retry effect document with enough words to be chunked and embedded by the media worker.');
+
+      // Let the initial job settle so the retry starts from a terminal state.
+      const settled = await waitForStatus(s => s === 'complete' || s === 'failed', 60_000);
+      assert.ok(settled === 'complete' || settled === 'failed',
+        `initial embedding never settled (last status: ${settled})`);
+
+      const retry = await fetch(
+        `${INSTANCES.a}/api/files/${spaceId}/retry_embedding?path=${encodeURIComponent(filePath)}`,
+        { method: 'POST', headers: { 'Authorization': `Bearer ${tokenA}` } },
+      );
+      assert.equal(retry.status, 202, `retry should queue, got ${retry.status}`);
+
+      // The 202 alone is satisfied by a handler that queues nothing. The retry
+      // EFFECT is the status reset — observable as pending (or already claimed
+      // as processing) immediately after...
+      const flipped = await docStatus();
+      assert.ok(['pending', 'processing'].includes(flipped),
+        `embeddingStatus must flip to pending/processing after retry, got: ${flipped}`);
+
+      // ...and the requeued job must actually run back to a terminal state.
+      const final = await waitForStatus(s => s === 'complete' || s === 'failed', 60_000);
+      assert.ok(final === 'complete' || final === 'failed',
+        `retried job never re-ran to a terminal state (last status: ${final})`);
+    } finally {
+      await fetch(`${INSTANCES.a}/api/spaces/${spaceId}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${tokenA}` },
+        body: JSON.stringify({ confirm: true }),
+      }).catch(() => {});
+    }
   });
 });
 

--- a/testing/integration/mcp-tools.test.js
+++ b/testing/integration/mcp-tools.test.js
@@ -808,6 +808,13 @@ describe('MCP brain tools � update_memory / delete_memory / get_stats', () => 
     assert.ok(!result?.isError, `update_memory returned isError: ${JSON.stringify(result)}`);
     const text = result?.content?.[0]?.text ?? '';
     assert.ok(text.includes('updated') || text.includes(storedMemoryId), `Expected updated confirmation: ${text}`);
+
+    // Effect: re-read via REST and deep-equal the persisted value — the
+    // confirmation text alone is satisfied by a handler that persists nothing.
+    const reread = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${storedMemoryId}`);
+    assert.equal(reread.status, 200, JSON.stringify(reread.body));
+    assert.deepEqual(reread.body.tags, ['mcp-updated-tag'], 'updated tags must be persisted');
+    assert.equal(reread.body.fact, factText, 'untouched fields must survive the update');
   });
 
   it('update_memory on non-existent id returns isError', async () => {

--- a/testing/integration/media-config.test.js
+++ b/testing/integration/media-config.test.js
@@ -77,5 +77,11 @@ describe('Media config hot-reload (A6)', () => {
       'The media worker never picked up the media-config change (providerReloadPending stayed true). ' +
       'Provider config is being cached at worker start again — it would now need a restart to take effect (A6 regression).',
     );
+
+    // Re-read the persisted value: the PATCH echo alone is satisfied by a
+    // handler that persists nothing (the worker flag only proves a reload ran).
+    const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    assert.equal(reread.status, 200);
+    assert.equal(reread.body?.vision?.model, probeModel, 'patched vision.model must round-trip through GET');
   });
 });

--- a/testing/integration/notify.test.js
+++ b/testing/integration/notify.test.js
@@ -16,7 +16,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del } from '../sync/helpers.js';
+import { INSTANCES, post, get, del, waitFor } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
@@ -70,13 +70,27 @@ describe('Notify channel', () => {
     assert.equal(r.status, 204, JSON.stringify(r.body));
   });
 
-  it('sync_available event returns 204', async () => {
+  it('sync_available event returns 204 AND actually starts a sync cycle', async () => {
+    // Baseline: how many sync-history records exist before the event.
+    const before = await get(INSTANCES.a, token, `/api/networks/${networkId}/sync-history?limit=100`);
+    assert.equal(before.status, 200, JSON.stringify(before.body));
+    const baseline = before.body.history?.length ?? 0;
+
     const r = await post(INSTANCES.a, token, '/api/notify', {
       networkId,
       instanceId: MEMBER_ID,
       event: 'sync_available',
     });
     assert.equal(r.status, 204, JSON.stringify(r.body));
+
+    // A 204 from a handler that does nothing would pass the assertion above —
+    // the real effect is a sync cycle, which unconditionally appends a
+    // sync-history record when it completes (even when the peer is
+    // unreachable, as here — the record then has status failed/partial).
+    await waitFor(async () => {
+      const after = await get(INSTANCES.a, token, `/api/networks/${networkId}/sync-history?limit=100`);
+      return (after.body.history?.length ?? 0) > baseline;
+    }, 30_000, 500, 'sync_available never produced a sync-history record — the event did not start a sync cycle');
   });
 
   it('vote_pending event returns 204', async () => {
@@ -254,11 +268,29 @@ describe('Notify channel', () => {
 
   // â”€â”€ POST /api/notify/trigger â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-  it('POST /api/notify/trigger with valid networkId returns 200', async () => {
+  it('POST /api/notify/trigger returns 200 AND a sync cycle actually runs', async () => {
+    // Baseline sync-history count — the echoed {status:'triggered'} alone is
+    // satisfied by a handler that does nothing (exactly how the notify
+    // rate-limit bug hid); the observable effect is a new history record.
+    const before = await get(INSTANCES.a, token, `/api/networks/${networkId}/sync-history?limit=100`);
+    assert.equal(before.status, 200, JSON.stringify(before.body));
+    const baseline = before.body.history?.length ?? 0;
+
     const r = await post(INSTANCES.a, token, '/api/notify/trigger', { networkId });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.status, 'triggered', JSON.stringify(r.body));
     assert.equal(r.body.networkId, networkId, 'Response must echo the networkId');
+
+    await waitFor(async () => {
+      const after = await get(INSTANCES.a, token, `/api/networks/${networkId}/sync-history?limit=100`);
+      return (after.body.history?.length ?? 0) > baseline;
+    }, 30_000, 500, 'trigger never produced a sync-history record — no sync cycle ran');
+
+    // The completed record must be a real cycle result, not a placeholder.
+    const after = await get(INSTANCES.a, token, `/api/networks/${networkId}/sync-history?limit=100`);
+    const rec = after.body.history[0];
+    assert.ok(rec.completedAt, 'history record must carry completedAt');
+    assert.ok(['success', 'partial', 'failed'].includes(rec.status), `unexpected history status: ${rec.status}`);
   });
 
   it('POST /api/notify/trigger without networkId returns 400', async () => {

--- a/testing/integration/type-schema-crud.test.js
+++ b/testing/integration/type-schema-crud.test.js
@@ -196,6 +196,12 @@ describe('PUT /api/spaces/:id/meta/typeSchemas/:kt/:typeName — upsert', () => 
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.typeName, 'depends_on');
+
+    // Re-read: the echoed typeName alone is satisfied by a handler that persists nothing.
+    const getR = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/edge/depends_on`);
+    assert.equal(getR.status, 200, 'edge type must be persisted');
+    assert.deepEqual(getR.body.schema.propertySchemas?.confidence, { type: 'number', minimum: 0, maximum: 1 },
+      'edge type schema persisted');
   });
 
   it('adds a memory type', async () => {
@@ -204,6 +210,11 @@ describe('PUT /api/spaces/:id/meta/typeSchemas/:kt/:typeName — upsert', () => 
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.typeName, 'note');
+
+    const getR = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/memory/note`);
+    assert.equal(getR.status, 200, 'memory type must be persisted');
+    assert.deepEqual(getR.body.schema.propertySchemas?.source, { type: 'string', required: true },
+      'memory type schema persisted');
   });
 
   it('adds a chrono type', async () => {
@@ -212,12 +223,21 @@ describe('PUT /api/spaces/:id/meta/typeSchemas/:kt/:typeName — upsert', () => 
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.typeName, 'deadline');
+
+    const getR = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/chrono/deadline`);
+    assert.equal(getR.status, 200, 'chrono type must be persisted');
+    assert.deepEqual(getR.body.schema.propertySchemas?.priority, { type: 'string', enum: ['low', 'medium', 'high'] },
+      'chrono type schema persisted');
   });
 
   it('accepts an empty schema body (bare type with no configuration)', async () => {
     const r = await put(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/entity/bare_type`, {});
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.deepEqual(r.body.schema, {});
+
+    const getR = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/entity/bare_type`);
+    assert.equal(getR.status, 200, 'bare type must be persisted');
+    assert.deepEqual(getR.body.schema, {}, 'bare type persists as an empty schema');
   });
 
   it('returns 400 for an invalid knowledgeType', async () => {

--- a/testing/standalone/rate-limit.test.js
+++ b/testing/standalone/rate-limit.test.js
@@ -1,10 +1,14 @@
 /**
  * Integration tests: Rate-limit enforcement
  *
- * Covers:
- *  - authRateLimit (10 req/min): POST /api/tokens bursts 11 times → 11th gets 429
+ * Covers (each limiter keeps its own per-IP counter, so the bursts don't
+ * cross-contaminate):
+ *  - authRateLimit (10/min): POST /api/tokens bursts 11 times → at least one 429
  *  - RateLimit-* headers present in responses
  *  - POST /api/invite/apply (authRateLimit, unauth) rate-limited after threshold
+ *  - bulkWipeRateLimit (5/min): the destructive bulk-delete limiter actually 429s
+ *  - globalRateLimit (300/min): general API limiter actually 429s
+ *  - syncRateLimit (2000/min): sync-surface limiter actually 429s
  *
  * IMPORTANT: These tests consume from the rate-limit window for the test
  * runner's IP. Run with:
@@ -13,7 +17,8 @@
  * Do NOT include in parallel test runs — windows are shared per IP.
  *
  * Note: Rate-limit windows are per-minute. Tests use instance C (port 3202)
- * so they don't affect tests on A and B.
+ * so they don't affect tests on A and B — and any test hitting instance C
+ * within a minute of this file must expect residual 429s.
  */
 
 import { describe, it, before } from 'node:test';
@@ -86,5 +91,118 @@ describe('authRateLimit on POST /api/invite/apply (unauthenticated)', () => {
     assert.ok(got429,
       `Expected at least one 429 (rate limit) in ${JSON.stringify(statuses)}. ` +
       `If all are 400, the rate limiter may not be active on /api/invite/apply.`);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S8.1 — the remaining limiters had NO 429 test: swap any of them for a
+// different limiter (or remove them) and nothing failed. Each burst asserts
+// a real 429 plus a positive control that the first request reached the
+// route (i.e. the 429 comes from the limiter under test, not from an earlier
+// guard or a polluted window).
+//
+// The limiter fires BEFORE auth/validation and counts failed requests, so
+// the bursts below deliberately use requests that cannot mutate anything.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Fire `count` requests in bounded-concurrency batches; returns all statuses. */
+async function burstStatuses(count, makeRequest, concurrency = 100) {
+  const statuses = [];
+  for (let i = 0; i < count; i += concurrency) {
+    const batch = await Promise.all(
+      Array.from({ length: Math.min(concurrency, count - i) }, (_, j) =>
+        makeRequest(i + j).then(r => r.status)),
+    );
+    statuses.push(...batch);
+  }
+  return statuses;
+}
+
+/**
+ * Wait until a limiter's fixed per-minute window is fresh, then return the
+ * status of the confirming (non-429) request.
+ *
+ * These limiters share the runner's IP with any prior run within the same
+ * minute — so a re-run inside 60s would find the window already saturated and
+ * defeat the "first request is not 429" positive control. express-rate-limit's
+ * default store is a FIXED window (extra requests don't extend it), so polling
+ * rides out the original window's expiry. Returns quickly (one request) when
+ * the window is already clean, which is the normal single-pass case.
+ */
+async function waitForFreshWindow(makeRequest, timeoutMs = 70_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const s = (await makeRequest()).status;
+    if (s !== 429) return s;
+    if (Date.now() >= deadline) {
+      throw new Error(`rate-limit window never cleared within ${timeoutMs}ms — cannot run a clean burst`);
+    }
+    await new Promise(r => setTimeout(r, 3000));
+  }
+}
+
+describe('bulkWipeRateLimit on bulk DELETE (5/min)', () => {
+  before(() => {
+    tokenC = fs.readFileSync(TOKEN_FILE_C, 'utf8').trim();
+  });
+
+  it('reaches the route once, then 429s within the limit (5/min)', async () => {
+    // Non-existent space + missing confirm body: the request is counted by the
+    // limiter but can never delete anything.
+    const bulkDelete = () => fetch(`${INSTANCES.c}/api/brain/spaces/rl-bulkwipe-probe/memories`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${tokenC}` },
+      body: JSON.stringify({}),
+    });
+
+    // Positive control on a guaranteed-fresh window (consumes slot 1 of 5).
+    const first = await waitForFreshWindow(bulkDelete);
+    assert.notEqual(first, 429, `First bulk delete must reach the route, got ${first}`);
+
+    // Slots 2..7 → the limit (5) is crossed, so a 429 must appear. A swap to
+    // globalRateLimit (300/min) would yield NO 429 here — that is the mechanism
+    // this catches.
+    const rest = [];
+    for (let i = 0; i < 6; i++) rest.push((await bulkDelete()).status);
+    assert.ok(rest.includes(429),
+      `Expected a 429 within the limit (5/min), got first=${first} rest=${JSON.stringify(rest)}. ` +
+      `If none, bulkWipeRateLimit is not enforced on the bulk-delete routes.`);
+  });
+});
+
+describe('globalRateLimit (300/min)', () => {
+  before(() => {
+    tokenC = fs.readFileSync(TOKEN_FILE_C, 'utf8').trim();
+  });
+
+  it('Burst past 300 GET /api/networks → first succeeds, at least one 429', async () => {
+    const req = () => fetch(`${INSTANCES.c}/api/networks`, { headers: { 'Authorization': `Bearer ${tokenC}` } });
+    const first = await waitForFreshWindow(req);
+    assert.equal(first, 200, `First request must succeed (positive control), got ${first}`);
+
+    const statuses = await burstStatuses(305, req);
+    const count429 = statuses.filter(s => s === 429).length;
+    assert.ok(count429 >= 1,
+      `Expected at least one 429 after 300 requests (globalRateLimit), got statuses: ` +
+      `${JSON.stringify([...new Set(statuses)])} (429 count: ${count429})`);
+  });
+});
+
+describe('syncRateLimit (2000/min)', () => {
+  before(() => {
+    tokenC = fs.readFileSync(TOKEN_FILE_C, 'utf8').trim();
+  });
+
+  it('Burst past 2000 GET /api/sync/memories → first reaches the route, at least one 429', async () => {
+    // No spaceId → fast 400 from the handler; the limiter counts it anyway.
+    const req = () => fetch(`${INSTANCES.c}/api/sync/memories`, { headers: { 'Authorization': `Bearer ${tokenC}` } });
+    const first = await waitForFreshWindow(req);
+    assert.equal(first, 400, `First request must reach the handler (positive control), got ${first}`);
+
+    const statuses = await burstStatuses(2005, req, 200);
+    const count429 = statuses.filter(s => s === 429).length;
+    assert.ok(count429 >= 1,
+      `Expected at least one 429 after 2000 requests (syncRateLimit), got statuses: ` +
+      `${JSON.stringify([...new Set(statuses)])} (429 count: ${count429})`);
   });
 });


### PR DESCRIPTION
## Summary

**PR 3 from the ordered plan — S8 part 1 (test hardening: effect & persistence assertions).** Five groups of tests would have kept passing with their mechanism removed — the "what would still pass if the mechanism were removed?" audit shape. All now assert the real effect. Test-only; no runtime code touched.

## Changes

**S8.1 — the three untested rate limiters get real 429 burst tests** (`testing/standalone/rate-limit.test.js`, on instance C, the only instance with rate limiting active):
- `bulkWipeRateLimit` (5/min) — the tightest destructive limiter could previously be swapped for `globalRateLimit` (or removed) with no test going red. 7 sequential bulk-deletes against a non-existent space (counted by the limiter, can never delete anything) → 429 by the 6th.
- `globalRateLimit` (300/min) — 305-request burst against `GET /api/networks` → ≥1 429, first request 200 as positive control.
- `syncRateLimit` (2000/min) — 2005-request burst against `GET /api/sync/memories` (no `spaceId` → cheap 400) → ≥1 429, first request 400 as positive control that the route (not an earlier guard) was reached.
- Each limiter keeps its own counter, so the bursts don't cross-contaminate; header comment documents the residual-window caveat for anything hitting instance C within a minute.

**S8.5 — `retry_embedding`** (`testing/integration/files.test.js`): the "requires write access" test used the **admin** token and asserted success — it tested nothing. Now: a real read-only token gets **403**, and a new effect test (dedicated space) uploads a doc, waits for the initial job to settle, retries, asserts `embeddingStatus` **flips to pending/processing**, and that the requeued job re-runs to a terminal state.

**S8.6 — `notify/trigger` and `sync_available`** (`testing/integration/notify.test.js`): both asserted only the echoed `{status:'triggered'}` / `204` — satisfied by a handler that does nothing, which is exactly how the notify rate-limit bug once hid. Both now baseline the network's sync-history count and poll for the record a completed cycle unconditionally appends (works even with the test's unreachable fake peer — the record is then `failed`/`partial`).

**S8.3 — `update_memory` / `PATCH /memories` re-reads**: MCP `update_memory` (tags) now re-reads via REST and deep-equals the persisted tags plus asserts untouched fields survive; the two remaining echo-only PATCH cases (`fact`, long-form description+properties) in `brain.test.js` re-read via GET.

**S8.12 — echo-only PUT/PATCH tests re-read persistence**: media-config PATCH round-trips `vision.model` through GET (the worker-reload flag alone doesn't prove the value persisted); type-schema PUT for **edge/memory/chrono** (+ empty-schema case) now GET the type back and deep-equal the schema, matching what the entity cases already did; both chrono update paths (legacy POST and PATCH by ID) re-read the document.

## Verification

All affected files run green against the live stack, plus the full `test:standalone` and `test:integration` suites (sync/red-team untouched by this PR). The new burst tests complete in ~2s combined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
