### PR TITLE
feat(client): distinct error states for failed list loads (U3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Failed loads now render a distinct error state instead of a "no data" empty state (UX U3).**
+  Every list view swallowed load failures (`error: () => loading.set(false)`) and fell through to its
+  empty state — so a 500, a dropped connection, or an expired backend rendered as a friendly
+  *"No memories yet…"*. Told in the app's own reassuring voice that their data doesn't exist, a user
+  won't retry and may conclude the brain was wiped; the *well-designed* empty states made the lie more
+  convincing. A shared `ErrorStateComponent` (warning icon, "Couldn't load …", the failure reason, and
+  a **Retry** button, `role="alert"`) is now checked **before** the empty state at all eight list call
+  sites: the Brain tabs (memories, entities, edges, chrono, file-meta), the file manager, the schema
+  library, and the graph traversal. Each keeps a per-view error signal set to the server's reason (via
+  a shared `httpErrorReason` helper) and cleared on a successful load; Retry re-runs that view's fetch.
+  Covered by `error-state.component.spec.ts` and verified end-to-end (a forced 500 shows the error
+  state + reason + Retry, not the empty state, and Retry recovers).
+
 ### Fixed
 
 - **The recurring "vote-signing relay" sync-test flake is fixed at its root — a test setup race,

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1030,5 +1030,15 @@
   "tokens.confirm.rotateTitle": "Secret rotieren",
   "tokens.rotateButton": "Rotieren",
   "tokens.confirm.revokeTitle": "Token widerrufen",
-  "nav.menu": "Menü"
+  "nav.menu": "Menü",
+  "common.retry": "Erneut versuchen",
+  "common.loadFailed": "Inhalt konnte nicht geladen werden.",
+  "brain.error.loadMemories": "Erinnerungen konnten nicht geladen werden.",
+  "brain.error.loadEntities": "Entitäten konnten nicht geladen werden.",
+  "brain.error.loadEdges": "Kanten konnten nicht geladen werden.",
+  "brain.error.loadChrono": "Zeitleisteneinträge konnten nicht geladen werden.",
+  "brain.error.loadFileMeta": "Dateidatensätze konnten nicht geladen werden.",
+  "files.error.loadFiles": "Dateien konnten nicht geladen werden.",
+  "schemaLib.error.load": "Schema-Bibliothek konnte nicht geladen werden.",
+  "graph.error.load": "Graph konnte nicht geladen werden."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1029,5 +1029,15 @@
   "tokens.confirm.rotateTitle": "Rotate secret",
   "tokens.rotateButton": "Rotate",
   "tokens.confirm.revokeTitle": "Revoke token",
-  "nav.menu": "Menu"
+  "nav.menu": "Menu",
+  "common.retry": "Retry",
+  "common.loadFailed": "Couldn't load this content.",
+  "brain.error.loadMemories": "Couldn't load memories.",
+  "brain.error.loadEntities": "Couldn't load entities.",
+  "brain.error.loadEdges": "Couldn't load edges.",
+  "brain.error.loadChrono": "Couldn't load timeline entries.",
+  "brain.error.loadFileMeta": "Couldn't load file records.",
+  "files.error.loadFiles": "Couldn't load files.",
+  "schemaLib.error.load": "Couldn't load the schema library.",
+  "graph.error.load": "Couldn't load the graph."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1030,5 +1030,15 @@
   "tokens.confirm.rotateTitle": "Zmień sekret",
   "tokens.rotateButton": "Zmień",
   "tokens.confirm.revokeTitle": "Unieważnij token",
-  "nav.menu": "Menu"
+  "nav.menu": "Menu",
+  "common.retry": "Ponów",
+  "common.loadFailed": "Nie udało się załadować treści.",
+  "brain.error.loadMemories": "Nie udało się załadować wspomnień.",
+  "brain.error.loadEntities": "Nie udało się załadować encji.",
+  "brain.error.loadEdges": "Nie udało się załadować krawędzi.",
+  "brain.error.loadChrono": "Nie udało się załadować wpisów osi czasu.",
+  "brain.error.loadFileMeta": "Nie udało się załadować rekordów plików.",
+  "files.error.loadFiles": "Nie udało się załadować plików.",
+  "schemaLib.error.load": "Nie udało się załadować biblioteki schematów.",
+  "graph.error.load": "Nie udało się załadować grafu."
 }

--- a/client/src/app/core/http-error.ts
+++ b/client/src/app/core/http-error.ts
@@ -1,0 +1,18 @@
+/**
+ * Extract a short, human-readable reason from an HttpErrorResponse (or any
+ * thrown error) for display in an error state or toast. Prefers the server's
+ * own `{ error: string }` body, then the HTTP status text, then the JS message.
+ * Returns '' when nothing useful is available (the UI then shows a generic line).
+ */
+export function httpErrorReason(err: unknown): string {
+  const e = err as { error?: { error?: unknown }; statusText?: string; status?: number; message?: string } | null;
+  if (!e) return '';
+  const serverMsg = e.error?.error;
+  if (typeof serverMsg === 'string' && serverMsg.trim()) return serverMsg;
+  if (typeof e.statusText === 'string' && e.statusText && e.statusText !== 'OK') {
+    return e.status ? `${e.status} ${e.statusText}` : e.statusText;
+  }
+  if (typeof e.status === 'number' && e.status > 0) return `HTTP ${e.status}`;
+  if (typeof e.message === 'string' && e.message.trim()) return e.message;
+  return '';
+}

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -9,9 +9,11 @@ import { PropertiesViewComponent } from '../../shared/properties-view.component'
 import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ErrorStateComponent } from '../../shared/error-state.component';
 import { catchError, of } from 'rxjs';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { ToastService } from '../../core/toast.service';
+import { httpErrorReason } from '../../core/http-error';
 
 type BrainTab = 'query' | 'graph' | 'files' | 'entities' | 'edges' | 'memories' | 'chrono' | 'filemeta';
 
@@ -33,7 +35,7 @@ interface SpaceView {
   // dirty. That coupling is load-bearing: the drawer spec below pins it, so dropping the sibling
   // signal write would fail CI rather than silently render a stale form.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe],
   styles: [`
     .space-tabs {
       display: flex;
@@ -730,6 +732,9 @@ interface SpaceView {
                   }
                 } @empty {
                   <tr><td colspan="7">
+                    @if (loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadMemories' | transloco" [reason]="loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
                     <div class="empty-state" style="padding:32px">
                       <div class="empty-state-icon"><ph-icon name="brain" [size]="48"/></div>
                       @if (memorySearch() && memories().length) {
@@ -740,6 +745,7 @@ interface SpaceView {
                         <p>{{ 'brain.memories.empty.body' | transloco }}</p>
                       }
                     </div>
+                    }
                   </td></tr>
                 }
               </tbody>
@@ -902,10 +908,14 @@ interface SpaceView {
                   }
                 } @empty {
                   <tr><td colspan="7">
+                    @if (loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadEntities' | transloco" [reason]="loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
                     <div class="empty-state" style="padding:32px">
                       <div class="empty-state-icon"><ph-icon name="tag" [size]="48"/></div>
                       <h3>{{ 'brain.entities.empty.title' | transloco }}</h3>
                     </div>
+                    }
                   </td></tr>
                 }
               </tbody>
@@ -1092,6 +1102,9 @@ interface SpaceView {
                   }
                 } @empty {
                   <tr><td colspan="9">
+                    @if (loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadEdges' | transloco" [reason]="loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
                     <div class="empty-state" style="padding:32px">
                       <div class="empty-state-icon"><ph-icon name="graph" [size]="48"/></div>
                       @if (edgeSearch() && edges().length) {
@@ -1101,6 +1114,7 @@ interface SpaceView {
                         <h3>{{ 'brain.edges.empty.title' | transloco }}</h3>
                       }
                     </div>
+                    }
                   </td></tr>
                 }
               </tbody>
@@ -1323,6 +1337,9 @@ interface SpaceView {
                   }
                 } @empty {
                   <tr><td colspan="9">
+                    @if (loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadChrono' | transloco" [reason]="loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
                     <div class="empty-state" style="padding:32px">
                       <div class="empty-state-icon"><ph-icon name="timer" [size]="48"/></div>
                       @if (chronoSearch()) {
@@ -1332,6 +1349,7 @@ interface SpaceView {
                         <h3>{{ 'brain.chrono.empty.title' | transloco }}</h3>
                       }
                     </div>
+                    }
                   </td></tr>
                 }
               </tbody>
@@ -1353,6 +1371,8 @@ interface SpaceView {
           </div>
           @if (loading()) {
             <div class="empty-state"><span class="spinner"></span></div>
+          } @else if (loadError() !== null) {
+            <app-error-state [message]="'brain.error.loadFileMeta' | transloco" [reason]="loadError() ?? ''" (retry)="retryCurrentTab()" />
           } @else if (!fileMetas().length) {
             <div class="empty-state">{{ 'brain.fileMeta.empty' | transloco }}</div>
           } @else {
@@ -2055,6 +2075,10 @@ export class BrainComponent implements OnInit {
   activeSpaceId = signal('');
   activeTab = signal<BrainTab>('query');
   loading = signal(false);
+  /** Set to the failure reason when the current tab's list load fails; null when
+   *  the load succeeded (or hasn't run). Rendered as a distinct error state
+   *  BEFORE the empty state so a failed load never reads as "no data" (U3). */
+  loadError = signal<string | null>(null);
   loadingSpaces = signal(true);
 
   memories = signal<Memory[]>([]);
@@ -2507,9 +2531,16 @@ export class BrainComponent implements OnInit {
     });
   }
 
+  /** Re-run the current tab's load — bound to the error state's Retry button. */
+  retryCurrentTab(): void {
+    const spaceId = this.activeSpaceId();
+    if (spaceId) this.loadCurrentTab(spaceId);
+  }
+
   private loadCurrentTab(spaceId: string): void {
     if (!spaceId) return;
     this.loading.set(true);
+    this.loadError.set(null);
 
     switch (this.activeTab()) {
       case 'memories': {
@@ -2523,20 +2554,20 @@ export class BrainComponent implements OnInit {
             if (ids.length) this.resolveEntityNames(ids);
             this.loading.set(false);
           },
-          error: () => this.loading.set(false),
+          error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
         });
         break;
       }
       case 'entities':
         this.api.listEntities(spaceId, this.pageSize, this.entitySkip(), this.entitySearch() || undefined).subscribe({
           next: ({ entities }) => { this.entities.set(entities); this.loading.set(false); },
-          error: () => this.loading.set(false),
+          error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
         });
         break;
       case 'edges':
         this.api.listEdges(spaceId, this.pageSize, this.edgeSkip()).subscribe({
           next: ({ edges }) => { this.edges.set(edges); this.loading.set(false); },
-          error: () => this.loading.set(false),
+          error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
         });
         break;
       case 'chrono': {
@@ -2549,7 +2580,7 @@ export class BrainComponent implements OnInit {
             if (ids.length) this.resolveEntityNames(ids);
             this.loading.set(false);
           },
-          error: () => this.loading.set(false),
+          error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
         });
         break;
       }
@@ -2568,7 +2599,7 @@ export class BrainComponent implements OnInit {
       case 'filemeta':
         this.api.listFileMeta(spaceId, this.pageSize, this.fileMetaSkip(), this.fileMetaSearch() || undefined).subscribe({
           next: ({ files }) => { this.fileMetas.set(files); this.loading.set(false); },
-          error: () => this.loading.set(false),
+          error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
         });
         break;
     }

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -9,6 +9,8 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+import { ErrorStateComponent } from '../../shared/error-state.component';
+import { httpErrorReason } from '../../core/http-error';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 import typescript from 'highlight.js/lib/languages/typescript';
@@ -81,7 +83,7 @@ function previewKind(name: string): PreviewKind {
   // regardless of zone. Text fields (`newFolderName`, `renameValue`) are ngModel two-way bindings
   // whose input events mark the view dirty. So OnPush re-checks exactly when state changes.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent],
   styles: [`
     .toolbar {
       display: flex;
@@ -398,11 +400,15 @@ function previewKind(name: string): PreviewKind {
                   </tr>
                 } @empty {
                   <tr><td colspan="5">
+                    @if (loadError() !== null) {
+                      <app-error-state [message]="'files.error.loadFiles' | transloco" [reason]="loadError() ?? ''" (retry)="reloadDir()" />
+                    } @else {
                     <div class="empty-state" style="padding:32px">
                       <div class="empty-state-icon"><ph-icon name="folder-open" [size]="48"/></div>
                       <h3>{{ 'files.emptyFolder.title' | transloco }}</h3>
                       <p>{{ 'files.emptyFolder.body' | transloco }}</p>
                     </div>
+                    }
                   </td></tr>
                 }
               </tbody>
@@ -504,6 +510,8 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   currentPath = signal('/');
   entries = signal<FileEntry[]>([]);
   loading = signal(false);
+  /** Failure reason for the directory listing; null when it loaded (U3). */
+  loadError = signal<string | null>(null);
   loadingSpaces = signal(true);
   uploading = signal(false);
   uploadError = signal('');
@@ -581,14 +589,19 @@ export class FileManagerComponent implements OnInit, OnDestroy {
 
   private loadDir(path: string): void {
     this.loading.set(true);
+    this.loadError.set(null);
     this.api.listFiles(this.activeSpaceId(), path).subscribe({
       next: ({ entries }) => {
         this.entries.set(entries);
         this.loading.set(false);
       },
-      error: () => this.loading.set(false),
+      // A failed listing must not fall through to the "empty folder" state (U3).
+      error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
     });
   }
+
+  /** Re-load the current directory — bound to the error state's Retry button. */
+  reloadDir(): void { this.loadDir(this.currentPath()); }
 
   @HostListener('dragover', ['$event'])
   onDragOver(event: DragEvent): void {

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -18,6 +18,8 @@ import { Subscription, forkJoin, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import cytoscape from 'cytoscape';
 import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ErrorStateComponent } from '../../shared/error-state.component';
+import { httpErrorReason } from '../../core/http-error';
 import {
   ApiService,
   Space,
@@ -63,7 +65,7 @@ interface DetailRow {
   // `openBrainDrawer` alongside the `drawerRecord` signal that guards the drawer's `@if`, the same
   // load-bearing coupling pinned by the brain spec.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, TagInputComponent, PropertiesEditorComponent, PhIconComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, TagInputComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe],
   host: { '[class.embedded]': 'isEmbedded()' },
   styles: [`
     :host {
@@ -689,7 +691,11 @@ interface DetailRow {
           <div class="loading-overlay"><div class="loading-spinner"></div></div>
         }
 
-        @if (!rootEntity() && !loading()) {
+        @if (loadError() !== null && !loading()) {
+          <div class="canvas-empty">
+            <app-error-state [message]="'graph.error.load' | transloco" [reason]="loadError() ?? ''" (retry)="retryTraverse()" />
+          </div>
+        } @else if (!rootEntity() && !loading()) {
           <div class="canvas-empty">
             <div class="empty-icon"><ph-icon name="circle-dashed" [size]="52"/></div>
             <h3>{{ 'graph.empty.title' | transloco }}</h3>
@@ -1172,6 +1178,11 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly chronoStatusOptions: ChronoStatus[] = ['upcoming', 'active', 'completed', 'overdue', 'cancelled'];
 
   loading = signal(false);
+  /** Failure reason for the last traversal; null when it succeeded (U3). A
+   *  failed traversal must not render as an empty graph (which reads as "no
+   *  connections"). */
+  loadError = signal<string | null>(null);
+  private lastTraverse: { startId: string; maxDepth: number; direction: 'outbound' | 'inbound' | 'both' } | null = null;
 
   // â”€â”€ Computed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   allDetails = computed<DetailRow[]>(() => {
@@ -1632,9 +1643,11 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     const incremental = sameRoot && maxDepth > this.cacheMaxDepth && !this.cacheTruncated;
 
     this.loading.set(true);
-    this.api.traverseGraph(spaceId, { startId, direction, maxDepth, limit: 200 }).pipe(
-      catchError(() => of({ nodes: [], edges: [], truncated: false } as TraverseResult)),
-    ).subscribe(result => {
+    this.loadError.set(null);
+    this.lastTraverse = { startId, maxDepth, direction };
+    this.api.traverseGraph(spaceId, { startId, direction, maxDepth, limit: 200 }).subscribe({
+      error: (e) => { this.loading.set(false); this.loadError.set(httpErrorReason(e)); },
+      next: (result) => {
       this.loading.set(false);
 
       if (incremental) {
@@ -1655,7 +1668,16 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
 
       this.truncated.set(result.truncated);
       this.applyDepthFilter(startId, maxDepth);
+      },
     });
+  }
+
+  /** Re-run the last traversal — bound to the error state's Retry button. */
+  retryTraverse(): void {
+    if (this.lastTraverse) {
+      const { startId, maxDepth, direction } = this.lastTraverse;
+      this.traverse(startId, maxDepth, direction);
+    }
   }
 
   // Filter the full cache down to the requested depth and re-render

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -20,6 +20,8 @@ import { TranslocoService } from '@jsverse/transloco';
 import { ToastService } from '../../core/toast.service';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { PropSchemaTableComponent } from '../../shared/prop-schema-table.component';
+import { ErrorStateComponent } from '../../shared/error-state.component';
+import { httpErrorReason } from '../../core/http-error';
 
 // ── Local form state ────────────────────────────────────────────────────────
 
@@ -94,7 +96,7 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
 @Component({
   selector: 'app-schema-library',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, PropSchemaTableComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, PropSchemaTableComponent, ErrorStateComponent],
   styles: [`
     /* chip inputs — same as spaces.component.ts */
     .chip-wrap {
@@ -219,6 +221,8 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     @if (pageTab() === 'library') {
       @if (loading()) {
         <div class="empty-state"><span class="spinner"></span></div>
+      } @else if (loadError() !== null) {
+        <app-error-state [message]="'schemaLib.error.load' | transloco" [reason]="loadError() ?? ''" (retry)="load()" />
       } @else if (!entries().length) {
         <div class="empty-state">
           <div class="empty-state-icon"><ph-icon name="bookmarks" [size]="48"/></div>
@@ -614,6 +618,8 @@ export class SchemaLibraryComponent implements OnInit {
   private toast = inject(ToastService);
 
   entries         = signal<SchemaLibraryEntry[]>([]);
+  /** Failure reason for the library list load; null when it loaded (U3). */
+  loadError       = signal<string | null>(null);
   usageCounts     = signal<Record<string, number>>({});
   loading         = signal(true);
   saving          = signal(false);
@@ -740,6 +746,7 @@ export class SchemaLibraryComponent implements OnInit {
 
   load(): void {
     this.loading.set(true);
+    this.loadError.set(null);
     this.api.listSchemaLibrary().pipe(
       finalize(() => this.loading.set(false)),
     ).subscribe({
@@ -758,7 +765,8 @@ export class SchemaLibraryComponent implements OnInit {
           error: () => {}, // usage counts are non-critical
         });
       },
-      error: () => this.entries.set([]),
+      // Distinguish a failed load from a genuinely empty library (U3).
+      error: (e) => { this.entries.set([]); this.loadError.set(httpErrorReason(e)); },
     });
   }
 

--- a/client/src/app/shared/error-state.component.spec.ts
+++ b/client/src/app/shared/error-state.component.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Component } from '@angular/core';
+import { getTranslocoModule } from '../testing/transloco-testing';
+import { ErrorStateComponent } from './error-state.component';
+
+// Host to exercise inputs/outputs the way real call sites do.
+@Component({
+  standalone: true,
+  imports: [ErrorStateComponent],
+  template: `<app-error-state [message]="msg" [reason]="reason" (retry)="onRetry()" />`,
+})
+class HostComponent {
+  msg = 'Couldn\'t load memories';
+  reason = '';
+  retried = 0;
+  onRetry() { this.retried++; }
+}
+
+describe('ErrorStateComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  function mount(over: Partial<HostComponent> = {}) {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ imports: [HostComponent, getTranslocoModule()] });
+    const fixture = TestBed.createComponent(HostComponent);
+    Object.assign(fixture.componentInstance, over);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders the message headline', () => {
+    const el = mount().nativeElement as HTMLElement;
+    expect(el.querySelector('.error-title')?.textContent).toContain("Couldn't load memories");
+  });
+
+  it('renders the reason when provided, and omits it when empty', () => {
+    const withReason = mount({ reason: '500 Internal Server Error' }).nativeElement as HTMLElement;
+    expect(withReason.querySelector('.error-reason')?.textContent).toContain('500 Internal Server Error');
+
+    const withoutReason = mount({ reason: '' }).nativeElement as HTMLElement;
+    expect(withoutReason.querySelector('.error-reason')).toBeNull();
+  });
+
+  it('always shows a Retry button and emits retry on click', () => {
+    const fixture = mount();
+    const el = fixture.nativeElement as HTMLElement;
+    const btn = el.querySelector('.retry-btn') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    btn.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.retried).toBe(1);
+  });
+
+  it('exposes role=alert so it is announced', () => {
+    const el = mount().nativeElement as HTMLElement;
+    expect(el.querySelector('[role="alert"]')).toBeTruthy();
+  });
+});

--- a/client/src/app/shared/error-state.component.ts
+++ b/client/src/app/shared/error-state.component.ts
@@ -1,0 +1,65 @@
+/**
+ * Error-state — the counterpart to the empty state, for when a list *failed to
+ * load* rather than legitimately having no rows (UX U3).
+ *
+ * A failed request must never fall through to a friendly "No memories yet…"
+ * empty state: that tells the user, in the app's own reassuring voice, that
+ * their data does not exist — so they won't retry and may conclude the brain
+ * was wiped. This renders a visually distinct state (warning icon, "Couldn't
+ * load …", the failure reason, and a Retry button) that call sites show
+ * *before* the empty state whenever their error signal is set.
+ *
+ * Usage:
+ *   @if (loadError()) {
+ *     <app-error-state [message]="'brain.error.loadMemories' | transloco"
+ *                      [reason]="loadError()" (retry)="reload()" />
+ *   } @else if (rows().length === 0) { ...empty state... }
+ */
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from './ph-icon.component';
+
+@Component({
+  selector: 'app-error-state',
+  standalone: true,
+  imports: [CommonModule, TranslocoPipe, PhIconComponent],
+  styles: [`
+    .error-state {
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      text-align: center;
+      padding: 40px 24px;
+      color: var(--text-secondary);
+    }
+    .error-icon { color: var(--error); margin-bottom: 12px; opacity: 0.85; }
+    .error-title { font-size: 15px; font-weight: 600; color: var(--text-primary); margin: 0 0 4px; }
+    .error-reason {
+      font-size: 12px; color: var(--text-muted); margin: 0 0 16px;
+      max-width: 420px; word-break: break-word;
+      font-family: var(--font-mono, monospace);
+    }
+    .retry-btn { display: inline-flex; align-items: center; gap: 6px; }
+  `],
+  template: `
+    <div class="error-state" role="alert">
+      <div class="error-icon"><ph-icon name="warning" [size]="icon()"/></div>
+      <p class="error-title">{{ message() || ('common.loadFailed' | transloco) }}</p>
+      @if (reason()) {
+        <p class="error-reason">{{ reason() }}</p>
+      }
+      <button type="button" class="btn btn-secondary btn-sm retry-btn" (click)="retry.emit()">
+        <ph-icon name="arrows-clockwise" [size]="14"/>{{ 'common.retry' | transloco }}
+      </button>
+    </div>
+  `,
+})
+export class ErrorStateComponent {
+  /** Headline, e.g. "Couldn't load memories". Falls back to a generic message. */
+  message = input<string>('');
+  /** Optional failure detail (HTTP status text / server error message). */
+  reason = input<string>('');
+  /** Icon size (defaults to 48 to match the empty-state icons). */
+  icon = input<number>(48);
+  /** Emitted when the user clicks Retry — the call site re-runs its load. */
+  retry = output<void>();
+}


### PR DESCRIPTION
## Summary

**PR 7 from the ordered plan — UX U3.** Every list view swallowed its load failures with `error: () => this.loading.set(false)` and fell through to the *empty state* — so a 500, a dropped connection, or an expired backend rendered as a friendly **"No memories yet…"**. Told in the app's own reassuring voice that their data doesn't exist, a user won't retry and may reasonably conclude the brain was wiped. The well-designed empty states made the lie more convincing.

## What changed

A shared **`ErrorStateComponent`** (warning icon, "Couldn't load …", the failure reason in monospace, a **Retry** button, `role="alert"`) is now checked **before** the empty state at all eight list call sites:

- Brain tabs — memories, entities, edges, chrono, file-meta
- File manager (directory listing)
- Schema library (entries)
- Graph (traversal — a failed traversal no longer renders as an empty graph)

Each view keeps a per-view `loadError` signal, set to the server's message via a shared **`httpErrorReason`** helper (prefers the `{ error }` body, then status text, then the JS message) and cleared at the start of every load. Retry re-runs that view's fetch. New `common.retry`/`common.loadFailed` plus per-view `*.error.load*` keys in en/de/pl.

## Tests

- `error-state.component.spec.ts` — renders the message, shows/omits the reason, always offers Retry and emits on click, exposes `role="alert"`. Full client suite: **53 pass**.
- Type-check + production build clean.
- **Runtime-verified**: with the memories API forced to 500 via request interception, the Memories tab renders the error state ("Couldn't load memories." + "Simulated backend failure" + Retry) and **not** the empty state; clicking Retry (now succeeding) recovers to the genuine empty state — zero console errors.

The spec notes a broader responsive/table pass is out of scope; this restores the *distinction* between "no data" and "load failed", which was the actively-misleading part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)