### PR TITLE
feat(client): multiline record descriptions (F7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multiline record descriptions (FEATURES F7).** Every description editor was a single-line
+  `<input>`, so a description with paragraphs or line breaks collapsed to one line while typing, and
+  the table cells rendered it `white-space: nowrap` (one line, ellipsis-truncated). Description fields
+  across the memory / entity / edge create forms, their inline-table editors, the detail-drawer
+  editors, and the file-meta editor are now `<textarea>`s (create/drawer `rows=3`, compact inline
+  `rows=2`, vertically resizable) — matching what the chrono editors already did. The four truncating
+  table cells (memories, entities, chrono, file-meta) now share a `.desc-cell` class that renders
+  `white-space: pre-wrap` and clamps to three lines, so newlines show instead of collapsing, while the
+  full text stays available on hover via each cell's `title`. Covered by brain-component tests
+  (multiline round-trip in the drawer textarea + the cell's pre-wrap) and verified end-to-end
+  (a memory with a three-line description keeps its newlines in the create form, the table cell, and
+  the drawer editor).
+
 - **Per-file upload progress with retry and cancel (UX U12).** The file manager showed a single
   aggregate progress bar for a multi-file upload, and if any file failed the whole batch stopped
   behind one generic "Upload failed" — you couldn't tell which file, retry just the failed one, or

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -119,4 +119,39 @@ describe('BrainComponent (OnPush)', () => {
     const textarea = drawer.querySelector('textarea') as HTMLTextAreaElement;
     expect(textarea.value).toBe('a load-bearing fact');
   });
+
+  it('edits the description in a multiline <textarea> (F7), preserving newlines', async () => {
+    // F7 swapped the single-line description <input> for a <textarea rows=3>. A record whose
+    // description spans several lines must round-trip those newlines into the editor.
+    const fixture = create();
+    const c = fixture.componentInstance;
+    const multiline = 'line one\nline two\nline three';
+
+    c.openDrawer('memory', {
+      _id: 'm1', fact: 'f', description: multiline, tags: [], entityIds: [], properties: {},
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const descField = fixture.nativeElement.querySelector(
+      '.drawer textarea[name="drwMemDesc"]',
+    ) as HTMLTextAreaElement | null;
+    // It must be a textarea (not the old input), and it must keep the newlines.
+    expect(descField, 'description should be a <textarea>').toBeTruthy();
+    expect(descField!.tagName).toBe('TEXTAREA');
+    expect(descField!.value).toBe(multiline);
+  });
+
+  it('clamps the memories description cell with the multiline-friendly .desc-cell class (F7)', () => {
+    const fixture = create();
+    const c = fixture.componentInstance;
+    c.activeTab.set('memories');
+    c.memories.set([{ ...memory('a fact'), description: 'x\ny' } as Memory]);
+    fixture.detectChanges();
+
+    const cell = fixture.nativeElement.querySelector('table tbody .desc-cell') as HTMLElement | null;
+    expect(cell, 'the description cell should use .desc-cell').toBeTruthy();
+    // pre-wrap (via the class) is what lets the newline render instead of collapsing.
+    expect(getComputedStyle(cell!).whiteSpace).toBe('pre-wrap');
+  });
 });

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -247,6 +247,20 @@ interface SpaceView {
       line-height: 1.4;
     }
 
+    /* Description table cells: clamp to a few lines but honour newlines (F7).
+       pre-wrap renders the multi-line text the textareas now allow; the box
+       clamp keeps rows compact, and each cell keeps its [title] for the full text. */
+    .desc-cell {
+      font-size: 12px;
+      color: var(--text-muted);
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
     .query-panel {
       display: flex;
       flex-direction: column;
@@ -596,7 +610,7 @@ interface SpaceView {
               </div>
               <div class="field" style="flex:2; min-width:200px;">
                 <label>{{ 'common.form.description' | transloco }}</label>
-                <input type="text" [(ngModel)]="memoryForm.description" name="description" />
+                <textarea [(ngModel)]="memoryForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
               </div>
               <div class="field" style="flex:1; min-width:220px;">
                 <label>{{ 'common.form.properties' | transloco }}</label>
@@ -646,7 +660,7 @@ interface SpaceView {
                           </div>
                           <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
                             <label>{{ 'common.form.description' | transloco }}</label>
-                            <input type="text" [(ngModel)]="editMemory.description" name="editDesc" />
+                            <textarea [(ngModel)]="editMemory.description" name="editDesc" rows="2" style="resize:vertical;"></textarea>
                           </div>
                           <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
                             <label>{{ 'common.form.tags' | transloco }}</label>
@@ -698,7 +712,7 @@ interface SpaceView {
                   } @else {
                     <tr>
                       <td style="max-width:300px; white-space:pre-wrap; word-break:break-word;">{{ mem.fact }}</td>
-                      <td style="font-size:12px; color:var(--text-muted); max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" [title]="mem.description ?? ''">
+                      <td class="desc-cell" style="max-width:180px;" [title]="mem.description ?? ''">
                         {{ mem.description || '—' }}
                       </td>
                       <td style="font-size:11px;">
@@ -800,7 +814,7 @@ interface SpaceView {
               </div>
               <div class="field" style="flex:1; min-width:200px;">
                 <label>{{ 'brain.entities.table.description' | transloco }}</label>
-                <input type="text" [(ngModel)]="entityForm.description" name="description" />
+                <textarea [(ngModel)]="entityForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
               </div>
               <div class="field" style="flex:1; min-width:220px;">
                 <label>{{ 'brain.entities.table.properties' | transloco }}</label>
@@ -853,7 +867,7 @@ interface SpaceView {
                           </div>
                           <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
                             <label>{{ 'brain.entities.table.description' | transloco }}</label>
-                            <input type="text" [(ngModel)]="editEntity.description" name="editEntDesc" />
+                            <textarea [(ngModel)]="editEntity.description" name="editEntDesc" rows="2" style="resize:vertical;"></textarea>
                           </div>
                           <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
                             <label>{{ 'brain.entities.table.tags' | transloco }}</label>
@@ -883,7 +897,7 @@ interface SpaceView {
                       <td>
                         @if (ent.type) { <span class="badge badge-purple">{{ ent.type }}</span> }
                       </td>
-                      <td style="font-size:12px; color:var(--text-muted); max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" [title]="ent.description ?? ''">
+                      <td class="desc-cell" style="max-width:200px;" [title]="ent.description ?? ''">
                         {{ ent.description || '—' }}
                       </td>
                       <td style="font-size:11px;">
@@ -989,7 +1003,7 @@ interface SpaceView {
               </div>
               <div class="field" style="flex:2; min-width:200px;">
                 <label>{{ 'brain.edges.table.description' | transloco }}</label>
-                <input type="text" [(ngModel)]="edgeForm.description" name="description" />
+                <textarea [(ngModel)]="edgeForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
               </div>
               <div class="field" style="flex:1; min-width:220px;">
                 <label>{{ 'brain.edges.table.properties' | transloco }}</label>
@@ -1047,7 +1061,7 @@ interface SpaceView {
                           </div>
                           <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
                             <label>{{ 'brain.edges.table.description' | transloco }}</label>
-                            <input type="text" [(ngModel)]="editEdge.description" name="editEdgeDesc" />
+                            <textarea [(ngModel)]="editEdge.description" name="editEdgeDesc" rows="2" style="resize:vertical;"></textarea>
                           </div>
                           <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
                             <label>{{ 'brain.edges.table.tags' | transloco }}</label>
@@ -1302,7 +1316,7 @@ interface SpaceView {
                   } @else {
                     <tr>
                       <td>{{ entry.title }}</td>
-                      <td style="font-size:12px; color:var(--text-muted); max-width:160px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" [title]="entry.description ?? ''">
+                      <td class="desc-cell" style="max-width:160px;" [title]="entry.description ?? ''">
                         {{ entry.description || '—' }}
                       </td>
                       <td><span class="badge badge-blue">{{ entry.type }}</span></td>
@@ -1399,7 +1413,7 @@ interface SpaceView {
                           <div class="edit-form-fields">
                             <div class="field" style="flex:2; min-width:180px; margin-bottom:0;">
                               <label>{{ 'brain.fileMeta.table.description' | transloco }}</label>
-                              <input type="text" [(ngModel)]="editFileMeta.description" name="fmEditDesc" />
+                              <textarea [(ngModel)]="editFileMeta.description" name="fmEditDesc" rows="2" style="resize:vertical;"></textarea>
                             </div>
                             <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                               <label>{{ 'brain.fileMeta.table.tags' | transloco }}</label>
@@ -1502,7 +1516,7 @@ interface SpaceView {
                             }
                           </div>
                         </td>
-                        <td class="text-muted" style="max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ fm.description || '–' }}</td>
+                        <td class="desc-cell" style="max-width:200px;" [title]="fm.description ?? ''">{{ fm.description || '–' }}</td>
                         <td>
                           <div class="chip-list">
                             @for (tag of fm.tags; track tag) {
@@ -1803,7 +1817,7 @@ interface SpaceView {
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.description' | transloco }}</div>
-                  <input type="text" [(ngModel)]="drawerEditMemory.description" name="drwMemDesc" />
+                  <textarea [(ngModel)]="drawerEditMemory.description" name="drwMemDesc" rows="3" style="resize:vertical;"></textarea>
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.tags' | transloco }}</div>
@@ -1873,7 +1887,7 @@ interface SpaceView {
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.description' | transloco }}</div>
-                  <input type="text" [(ngModel)]="drawerEditEntity.description" name="drwEntDesc" />
+                  <textarea [(ngModel)]="drawerEditEntity.description" name="drwEntDesc" rows="3" style="resize:vertical;"></textarea>
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.tags' | transloco }}</div>
@@ -1926,7 +1940,7 @@ interface SpaceView {
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.description' | transloco }}</div>
-                  <input type="text" [(ngModel)]="drawerEditEdge.description" name="drwEdgeDesc" />
+                  <textarea [(ngModel)]="drawerEditEdge.description" name="drwEdgeDesc" rows="3" style="resize:vertical;"></textarea>
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.tags' | transloco }}</div>

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -973,7 +973,7 @@ interface DetailRow {
                 </div>
                 <div class="bdrawer-field">
                   <div class="bdrawer-label">{{ 'common.form.description' | transloco }}</div>
-                  <input type="text" [(ngModel)]="drawerEditMemory.description" name="drwMemDesc" />
+                  <textarea [(ngModel)]="drawerEditMemory.description" name="drwMemDesc" rows="3" style="resize:vertical;"></textarea>
                 </div>
                 <div class="bdrawer-field">
                   <div class="bdrawer-label">{{ 'common.form.tags' | transloco }}</div>


### PR DESCRIPTION
## What & why

Every description editor was a single-line `<input>` (FEATURES **F7**). Type a description with paragraphs or line breaks and it collapsed to one line while editing; the table cells then rendered it `white-space: nowrap` — one line, ellipsis-truncated — so multi-line descriptions were effectively unusable.

## Changes

**Inputs → textareas** (`brain.component.ts`, `graph.component.ts`)
- Description fields on the memory / entity / edge **create forms**, their **inline-table editors**, the **detail-drawer** editors, and the **file-meta** editor are now `<textarea>`s. Create + drawer use `rows=3`, compact inline editors use `rows=2`, all `resize: vertical` — consistent with the chrono editors, which already used textareas. The graph node drawer's memory description gets the same swap.

**Truncating cells → clamped + pre-wrap** (`brain.component.ts`)
- The four cells that used `white-space: nowrap` (memories, entities, chrono, file-meta) now share a `.desc-cell` class: `white-space: pre-wrap` with a 3-line box clamp. Newlines render instead of collapsing; the full text stays available on hover via each cell's `title` (added one to the file-meta cell, which lacked it).

The edge description cell already wrapped (`white-space: normal`), so it was left as-is.

## Verification

- `ng build` clean; `vitest` — **62/62** (added two brain-component tests: the drawer description textarea round-trips a multi-line value with newlines intact, and the memories cell resolves to `.desc-cell` with `white-space: pre-wrap`).
- **Runtime (Playwright, isolated instance)** — created a memory with a three-line description: the create-form field is a `<textarea>`, the memories table cell keeps all three lines (pre-wrap), and opening the drawer shows a `<textarea>` holding the exact multi-line value. Zero unexpected console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
