### PR TITLE
chore(compose): bundle the conversion sidecar + forward MONGO_URI (C2, C4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,5 +43,9 @@ YTHRIL_PORT=3200
 # Prevent API-driven database migration when the DB is managed by your infrastructure:
 #   YTHRIL_MONGO_INFRA_MANAGED=true
 #
+# Document-conversion sidecar (PDF/DOCX/EPUB → Markdown). Defaults to the bundled
+# `unstructured` service; set this only to point at an external converter:
+#   CONVERSION_SIDECAR_URL=http://my-unstructured-host:8000
+#
 # Verbose logging:
 #   DEBUG=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docker-compose now matches what the docs promise (AUDIT C2 + C4).** Two `docker compose up`
+  gaps: (1) the `unstructured-api-full` document-conversion sidecar existed only in the Kubernetes
+  manifests, so on Compose `CONVERSION_SIDECAR_URL` pointed at nothing and every PDF/DOCX/EPUB upload
+  failed `sidecar_down` — despite the README calling it "bundled". It's now a service in
+  `docker-compose.yml`, wired via `CONVERSION_SIDECAR_URL`, on its own **internal** `ythril-convert`
+  network (no database access, no internet egress — it parses untrusted documents and its OCR models
+  are baked into the image). It is intentionally *not* a startup dependency of `ythril`, so the ~8–12 GB
+  image never blocks boot and conversion degrades gracefully until it's ready; `docs/dependencies.md`
+  documents the size and how to skip it on a small workstation. (2) `MONGO_URI` — the documented way to
+  point at an external MongoDB — was never forwarded into the `ythril` container's `environment`, so
+  the value silently never reached the server. It's now forwarded (empty default keeps the bundled
+  database), making the documented external-Mongo path actually work.
+
 - **The recurring "vote-signing relay" sync-test flake is fixed at its root — a test setup race,
   not a relay bug.** The test pins a third instance's signing key by writing `config.json` directly,
   then reloads. Under full-suite load that write races the server's own `saveConfig`: an in-flight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,14 @@
       # An explicit MONGO_URI (external cluster / managed Atlas) overrides both.
       MONGO_USERNAME: ${MONGO_USERNAME:-}
       MONGO_PASSWORD: ${MONGO_PASSWORD:-}
+      # External MongoDB (managed Atlas / self-hosted cluster): set MONGO_URI in .env to
+      # point Ythril at an external database instead of the bundled ythril-mongo (C4).
+      # Empty (the default) keeps the bundled database. When you set this, also consider
+      # YTHRIL_MONGO_INFRA_MANAGED=true (below) to disable API-driven migration.
+      MONGO_URI: ${MONGO_URI:-}
+      # Document-conversion sidecar (PDF / DOCX / EPUB → Markdown). Defaults to the bundled
+      # `unstructured` service defined below; override to use an external converter (C2).
+      CONVERSION_SIDECAR_URL: ${CONVERSION_SIDECAR_URL:-http://unstructured:8000}
       YTHRIL_LOCAL_AGENT_ENABLED: ${YTHRIL_LOCAL_AGENT_ENABLED:-}
       YTHRIL_LOCAL_AGENT_URL: ${YTHRIL_LOCAL_AGENT_URL:-http://localhost:38123}
       YTHRIL_LOCAL_AGENT_TOKEN: ${YTHRIL_LOCAL_AGENT_TOKEN:-}
@@ -41,6 +49,7 @@
     networks:
       - ythril-db        # database access
       - ythril-media     # outbound internet + media sidecars
+      - ythril-convert   # document-conversion sidecar (isolated: no DB, no internet)
 
   ythril-mongo:
     # mongodb/mongodb-atlas-local includes mongot — required for $vectorSearch
@@ -138,6 +147,40 @@
     networks:
       - ythril-media     # deliberately NOT on ythril-db
 
+  # ── Document-conversion sidecar (PDF / DOCX / EPUB → Markdown) ─────────────
+  # Bundles the `unstructured-api-full` server (C2). Without it, `docker compose up`
+  # leaves CONVERSION_SIDECAR_URL pointing at nothing and PDF/DOCX/EPUB uploads fail
+  # `sidecar_down` — Ythril itself still runs, so it is intentionally NOT a startup
+  # dependency of the ythril service (conversion degrades gracefully until it is up).
+  #
+  # HEAVY IMAGE: unstructured-api-full bundles OCR model weights (Tesseract/PaddleOCR)
+  # and is ~8–12 GB; first boot is slow (hence the long start_period). See
+  # docs/dependencies.md. To skip it on a resource-constrained workstation, stop it
+  # (`docker compose stop unstructured`) or scale it to zero
+  # (`docker compose up --scale unstructured=0`); in-process text/HTML conversion and
+  # all other features keep working — only PDF/DOCX/EPUB conversion is unavailable.
+  #
+  # Isolation: it parses UNTRUSTED user-supplied documents, so it sits on its own
+  # internal `ythril-convert` network — no database access and no internet egress
+  # (its models are baked into the image). This mirrors the Kubernetes deployment,
+  # where the sidecar runs pod-local behind NetworkPolicy egress rules.
+  unstructured:
+    # Pin the tag and verify the bundled LICENSE (Apache-2.0) before upgrading:
+    #   docker run --rm --entrypoint cat <image> /app/LICENSE
+    image: downloads.unstructured.io/unstructured-io/unstructured-api-full:0.0.75
+    container_name: ythril-unstructured
+    restart: unless-stopped
+    healthcheck:
+      # The image is a Python/uvicorn service; probe /healthcheck with the bundled
+      # interpreter rather than assuming curl/wget is present.
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8000/healthcheck',timeout=3).read() or sys.exit(1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 120s
+    networks:
+      - ythril-convert   # isolated: no DB, no internet
+
 volumes:
   ythril-data:
   ythril-mongo-data:
@@ -169,3 +212,9 @@ networks:
     # NOT internal: ythril reaches external embedding/LLM endpoints through this network,
     # and ollama/whisper download their models from the internet.
     internal: false
+  ythril-convert:
+    driver: bridge
+    # The document-conversion sidecar parses untrusted PDF/DOCX/EPUB and needs neither
+    # the database nor the internet (its OCR models are baked into the image), so this
+    # network is internal — a parser exploit there can reach nothing but ythril.
+    internal: true

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -206,12 +206,20 @@ Legal principle that runtime infrastructure must be listed with its licensing im
 | `fedirz/faster-whisper-server` | Speech-to-text — transcribes uploaded/segmented audio via an OpenAI-compatible endpoint. | MIT (the server). Whisper models are pulled separately and are Apache 2.0. |
 | `unstructured-io/unstructured-api-full` | Server-side PDF / DOCX / EPUB conversion (`hi_res` OCR + layout detection, table and embedded-image extraction). | Apache 2.0. |
 
-**Where they are referenced.** `ollama` and `whisper` are services in
-[`docker-compose.yml`](../docker-compose.yml) (media-embedding stack) and have matching
-Kubernetes manifests (`kubernetes/manifests/{ollama,whisper}-deploy.yaml`). The
-`unstructured-api-full` sidecar is defined in the Kubernetes deployment
-(`kubernetes/manifests/ythril-deployment.yaml`) and is being added to Compose as the
-bundled document-conversion sidecar.
+**Where they are referenced.** `ollama`, `whisper`, and `unstructured` are all services in
+[`docker-compose.yml`](../docker-compose.yml) and have matching Kubernetes manifests
+(`kubernetes/manifests/{ollama,whisper}-deploy.yaml`; the `unstructured-api-full` sidecar is
+in `kubernetes/manifests/ythril-deployment.yaml`, pod-local). `ollama`/`whisper` form the
+media-embedding stack; `unstructured` is the bundled document-conversion sidecar.
+
+> **Image size — `unstructured-api-full` is heavy (~8–12 GB).** It bundles OCR model weights
+> (Tesseract / PaddleOCR), so the first `docker compose up` pulls a large image and the sidecar
+> is slow to become ready (a long `start_period`). It is intentionally **not** a startup
+> dependency of the `ythril` service — Ythril runs without it and PDF/DOCX/EPUB conversion
+> simply reports `sidecar_down` until the sidecar is up. On a resource-constrained workstation,
+> skip it with `docker compose stop unstructured` (or `--scale unstructured=0`); in-process
+> text/HTML conversion and every other feature keep working. It runs on an isolated, internal
+> `ythril-convert` network with no database access and no internet egress.
 
 **Licensing impact — none on Ythril's PolyForm obligations.** All three are permissively
 licensed (MIT / Apache 2.0), carry no copyleft, and run as independent network services


### PR DESCRIPTION
## What & why

Two `docker compose up` gaps where the stack didn't match the docs (AUDIT **C2 + C4**).

### C2 — bundle the document-conversion sidecar
The `unstructured-api-full` sidecar (PDF/DOCX/EPUB → Markdown) existed **only** in the Kubernetes manifests. On Compose, `CONVERSION_SIDECAR_URL` defaulted to `http://localhost:8000` — nothing — so every PDF/DOCX/EPUB upload failed `sidecar_down`, even though the README calls it "bundled".

- Added an `unstructured` service (pinned `…:0.0.75`, same tag as K8s) and wired `CONVERSION_SIDECAR_URL: http://unstructured:8000` on the `ythril` service.
- Put it on its **own internal `ythril-convert` network** — **no database access and no internet egress**. It parses untrusted user documents and its OCR models are baked into the image, so it needs neither; this mirrors the pod-local + NetworkPolicy isolation the K8s deployment already enforces, and fits the file's existing "keep untrusted parsers off the DB network" model (stricter, even, than ollama/whisper, which need egress).
- **Not a startup dependency** of `ythril`: the ~8–12 GB image never blocks boot, and conversion degrades gracefully (`sidecar_down`) until the sidecar is ready. `docs/dependencies.md` documents the size + how to skip it (`docker compose stop unstructured`); `.env.example` notes the external-converter override.

### C4 — forward `MONGO_URI`
`MONGO_URI` (the documented external-MongoDB path) was never in the `ythril` service's `environment:` block, so the value silently never reached the server. Now forwarded — empty default keeps the bundled `ythril-mongo`.

## Verification

`docker compose config` validates cleanly for **both** the base file and the full merge with `docker-compose.override.yml` (what users actually run). The resolved config shows `CONVERSION_SIDECAR_URL=http://unstructured:8000`, `MONGO_URI` passthrough, and the new internal `ythril-convert` network. Docs/infra only — no application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
