### PR TITLE
fix(media): correct vision model name moondream2 → moondream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bundled image captioning never worked out of the box — the default vision model name was
+  invalid.** The default was `moondream2`, which is **not** a name in the Ollama registry (`moondream`
+  is), so the Compose auto-pull (`ollama pull moondream2 || echo WARN`) silently failed and every
+  caption request came back `HTTP 404 model 'moondream2' not found` → the image's `embeddingStatus`
+  flipped to `failed`. Corrected the name to `moondream` everywhere (the config default and provider
+  fallback, the Compose and Kubernetes pull commands, the Settings → Models placeholder, and the
+  docs), and — so existing installs self-heal without a manual config edit — the config loader now
+  **normalizes** a saved/env `moondream2` to `moondream` at load time. Covered by media-config unit
+  tests (default is `moondream`; a saved or env `moondream2` heals to `moondream`).
+  *Existing deployments: restart the `ollama` container (or run `docker exec ythril-ollama ollama pull
+  moondream`) so the model is actually present.*
+
 - **docker-compose now matches what the docs promise (AUDIT C2 + C4).** Two `docker compose up`
   gaps: (1) the `unstructured-api-full` document-conversion sidecar existed only in the Kubernetes
   manifests, so on Compose `CONVERSION_SIDECAR_URL` pointed at nothing and every PDF/DOCX/EPUB upload

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Uploaded PDF, DOCX, and EPUB files are automatically converted to text by the bu
 
 ### Image, Audio & Video Understanding
 
-Upload binary media and Ythril makes it searchable like everything else. Images are captioned with a vision model (default `moondream2` via Ollama), audio is silence-segmented and transcribed with Whisper, and video is decomposed into keyframes plus audio chunks. Every result lands in the **same** `nomic-embed-text-v1.5` vector space as memories, entities, and documents — so a single semantic query crosses text, speech, and pictures. Bundled out of the box on both Docker Compose and Kubernetes; toggle in **Settings → Models** if you'd rather plug in OpenAI, Azure, or your own endpoints.
+Upload binary media and Ythril makes it searchable like everything else. Images are captioned with a vision model (default `moondream` via Ollama), audio is silence-segmented and transcribed with Whisper, and video is decomposed into keyframes plus audio chunks. Every result lands in the **same** `nomic-embed-text-v1.5` vector space as memories, entities, and documents — so a single semantic query crosses text, speech, and pictures. Bundled out of the box on both Docker Compose and Kubernetes; toggle in **Settings → Models** if you'd rather plug in OpenAI, Azure, or your own endpoints.
 
 ### Face Recognition
 

--- a/client/src/app/pages/settings/models.component.ts
+++ b/client/src/app/pages/settings/models.component.ts
@@ -94,7 +94,7 @@ interface MediaCfg {
           </label>
           <input type="text" [(ngModel)]="form.vision!.model"
             [disabled]="isLocked('vision.model')"
-            placeholder="moondream2" />
+            placeholder="moondream" />
         </div>
         <div class="field">
           <label>API Key (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@
         ollama serve &
         SERVE_PID=$$!
         until ollama list >/dev/null 2>&1; do sleep 1; done
-        ollama pull moondream2 || echo "WARN: moondream2 pull failed; will retry on first request"
+        ollama pull moondream || echo "WARN: moondream pull failed; will retry on first request"
         wait $$SERVE_PID
     environment:
       OLLAMA_KEEP_ALIVE: "24h"

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -202,7 +202,7 @@ Legal principle that runtime infrastructure must be listed with its licensing im
 
 | Image | Role | License |
 |---|---|---|
-| `ollama/ollama` | Vision model host — captions uploaded images (default `moondream2`) for the media pipeline. | MIT (the Ollama runtime). Models are pulled separately; the default `moondream2` is Apache 2.0. |
+| `ollama/ollama` | Vision model host — captions uploaded images (default `moondream`) for the media pipeline. | MIT (the Ollama runtime). Models are pulled separately; the default `moondream` is Apache 2.0. |
 | `fedirz/faster-whisper-server` | Speech-to-text — transcribes uploaded/segmented audio via an OpenAI-compatible endpoint. | MIT (the server). Whisper models are pulled separately and are Apache 2.0. |
 | `unstructured-io/unstructured-api-full` | Server-side PDF / DOCX / EPUB conversion (`hi_res` OCR + layout detection, table and embedded-image extraction). | Apache 2.0. |
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1846,7 +1846,7 @@ All media ultimately produces text that passes through the same `nomic-embed-tex
 Use **Settings → Models** in the web UI, or `PATCH /api/admin/media-config`, or set `MEDIA_EMBEDDING_ENABLED=false` in Ythril's environment to turn the pipeline off.
 
 Required services (bundled by default; override only when you point at external providers):
-- **Ollama** (image captioning): `OLLAMA_URL=http://ollama:11434` — deploy any vision-capable model (default: `moondream2`).
+- **Ollama** (image captioning): `OLLAMA_URL=http://ollama:11434` — deploy any vision-capable model (default: `moondream`).
 - **faster-whisper-server** (audio/video STT): `WHISPER_URL=http://whisper:8000` — set model via `WHISPER_MODEL` (default: `base`).
 
 Kubernetes manifests are provided in `kubernetes/manifests/ollama-deploy.yaml` and `kubernetes/manifests/whisper-deploy.yaml`. Dual `NetworkPolicy` + `CiliumNetworkPolicy` resources are in `media-netpol.yaml` and `media-cilium-netpol.yaml`.
@@ -1921,7 +1921,7 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `visionProvider` | `VISION_PROVIDER` | `local` | `local` (Ollama) or `external` (OpenAI-compatible) |
 | `sttProvider` | `STT_PROVIDER` | `local` | `local` (Whisper) or `external` (OpenAI-compatible) |
 | `vision.baseUrl` | `OLLAMA_URL` | `http://ollama:11434` | Vision service endpoint (short name resolves in both Docker Compose and the K8s `ythril` namespace) |
-| `vision.model` | `VISION_MODEL` | `moondream2` | Vision model name |
+| `vision.model` | `VISION_MODEL` | `moondream` | Vision model name |
 | `vision.apiKey` | `VISION_API_KEY` | — | API key for external vision provider (stored in `secrets.json`, never in `config.json`) |
 | `stt.baseUrl` | `WHISPER_URL` | `http://whisper:8000` | STT service endpoint |
 | `stt.model` | `WHISPER_MODEL` | `base` | Whisper model size/name |

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -503,13 +503,13 @@ Click **Leave network** at the bottom of the network card. Your local data in th
 
 **Settings → Models** (admin only, MFA-protected) controls how Ythril turns image, audio, video, and document uploads into searchable content.
 
-By default, Ythril ships with a bundled vision service (Ollama running `moondream2`) and a bundled speech-to-text service (faster-whisper-server). When you upload a picture, Ythril writes a short caption of what's in it; when you upload audio or video, it transcribes the words. The result is added to the same search index as your memories, so you can find an attachment by what's *inside* it, not just its filename.
+By default, Ythril ships with a bundled vision service (Ollama running `moondream`) and a bundled speech-to-text service (faster-whisper-server). When you upload a picture, Ythril writes a short caption of what's in it; when you upload audio or video, it transcribes the words. The result is added to the same search index as your memories, so you can find an attachment by what's *inside* it, not just its filename.
 
 ### When to change this
 
 - **Disable it.** Untick **Enable media embedding** if you don't upload media or your machine is tight on memory. Existing files keep their captions; new uploads are stored as-is.
 - **Use an external provider.** Switch **Vision provider** or **STT provider** to *External* if you'd rather call OpenAI, Azure, or any other OpenAI-compatible service. Fill in the **Base URL**, **Model**, and **API key** for that provider. API keys are stored in the encrypted secrets file, never alongside the rest of the configuration.
-- **Use a different local model.** Keep the provider on *Local* but change the **Model** field — for example, switch the vision model from `moondream2` to `llava` if you've pulled it into Ollama.
+- **Use a different local model.** Keep the provider on *Local* but change the **Model** field — for example, switch the vision model from `moondream` to `llava` if you've pulled it into Ollama.
 
 ### Locked fields
 

--- a/docs/workstation-mode-guide.md
+++ b/docs/workstation-mode-guide.md
@@ -20,7 +20,7 @@ Recommended host minimums:
 
 - CPU: 2 cores
 - RAM: 6 GB (4 GB for Ythril + Mongo, ~2 GB for the bundled media-embedding stack)
-- Disk: at least 12 GB free (includes ~2 GB for the `moondream2` vision model and the Whisper `base` model)
+- Disk: at least 12 GB free (includes ~2 GB for the `moondream` vision model and the Whisper `base` model)
 
 > **Slimmer install:** Ythril ships with bundled image and audio/video understanding
 > services so attachments become searchable automatically. If your machine is tight

--- a/kubernetes/manifests/ollama-deploy.yaml
+++ b/kubernetes/manifests/ollama-deploy.yaml
@@ -3,11 +3,12 @@
 # Provides the Ollama API (POST /api/chat with image payload) used by
 # OllamaVisionProvider in server/src/files/media/providers.ts.
 #
-# Default model: moondream2 (Apache 2.0 — no commercial-use restrictions).
+# Default model: moondream (moondream2, Apache 2.0 — no commercial-use restrictions).
+# NOTE: the Ollama registry name is `moondream`, NOT `moondream2` (the latter 404s).
 # Pull the model into the PVC before enabling media embedding:
-#   kubectl exec -n ythril deploy/ollama -- ollama pull moondream2
+#   kubectl exec -n ythril deploy/ollama -- ollama pull moondream
 #
-# LICENCE NOTE: Ollama itself is MIT. moondream2 is Apache 2.0.
+# LICENCE NOTE: Ollama itself is MIT. moondream is Apache 2.0.
 # Before switching to a different model, verify its licence.
 #
 # RESOURCE NOTE: GPU is optional — CPU inference works but is slower.

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -432,6 +432,13 @@ const MEDIA_EMBEDDING_DEFAULTS: Required<Omit<MediaEmbeddingConfig, 'vision' | '
  * Populates `lockedByInfra` with any key whose effective value came from an
  * env var — the Settings UI uses this list to render those fields as read-only.
  */
+/** Correct the invalid Ollama model name `moondream2` (which 404s on pull) to the
+ *  real registry name `moondream`. Applied to the resolved vision model from any
+ *  source so installs that saved the bad name keep working after the fix. */
+function normalizeVisionModel(model: string): string {
+  return model === 'moondream2' ? 'moondream' : model;
+}
+
 export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   const cfg = getConfig();
   const base = cfg.mediaEmbedding ?? {};
@@ -472,10 +479,13 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
       //  - Docker Compose: bridge-network DNS to the `ollama` service
       //  - K8s: ClusterFirst DNS within the `ythril` namespace
       ?? 'http://ollama:11434',
-    model: visionModelEnv
-      ?? base.vision?.model
-      ?? base.visionModel
-      ?? 'moondream2',
+    // `moondream` is the correct Ollama registry name; `moondream2` does not exist
+    // there (a pull 404s), which silently broke bundled image captioning. Normalise
+    // the invalid legacy name from ANY source (env / saved config) so existing installs
+    // self-heal without a config-file migration.
+    model: normalizeVisionModel(
+      visionModelEnv ?? base.vision?.model ?? base.visionModel ?? 'moondream',
+    ),
     apiKey: visionApiKeyEnv ?? mediaSecrets.visionApiKey ?? base.vision?.apiKey,
     label: base.vision?.label ?? 'Vision provider (Ollama-compatible)',
   };

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -237,7 +237,7 @@ export interface MediaProviderConfig {
   /** Base URL of the provider (e.g. `http://ollama.ythril.svc.cluster.local:11434`
    *  or `https://api.openai.com/v1`). The provider client appends the route. */
   baseUrl?: string;
-  /** Model tag passed to the provider (e.g. `moondream2`, `gpt-4o-mini`,
+  /** Model tag passed to the provider (e.g. `moondream`, `gpt-4o-mini`,
    *  `whisper-1`, `base`). */
   model?: string;
   /** Optional API key for endpoints that require Authorization.

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -93,7 +93,7 @@ export class OllamaVisionProvider implements VisionProvider {
 
   async caption(imageBytes: Buffer, _mimeType: string): Promise<string> {
     const base = (this.cfg.baseUrl ?? 'http://ollama.ythril.svc.cluster.local:11434').replace(/\/$/, '');
-    const model = this.cfg.model ?? 'moondream2';
+    const model = this.cfg.model ?? 'moondream';  // `moondream2` is not a valid Ollama registry name
     const url = `${base}/api/chat`;
     const b64 = imageBytes.toString('base64');
 

--- a/testing/standalone/media-config.test.js
+++ b/testing/standalone/media-config.test.js
@@ -159,6 +159,27 @@ describe('getMediaEmbeddingConfig', () => {
       assert.equal(cfg.vision?.model, 'llava:13b');
     });
 
+    it('defaults the vision model to `moondream` (the real Ollama registry name)', () => {
+      writeConfig();
+      const cfg = getMediaEmbeddingConfig();
+      assert.equal(cfg.vision?.model, 'moondream');
+    });
+
+    it('heals the invalid legacy vision model `moondream2` → `moondream` from saved config', () => {
+      // `moondream2` is not a real Ollama model (a pull 404s); an install that saved it
+      // must self-heal so image captioning works without a manual config edit.
+      writeConfig({ mediaEmbedding: { vision: { model: 'moondream2' } } });
+      const cfg = getMediaEmbeddingConfig();
+      assert.equal(cfg.vision?.model, 'moondream');
+    });
+
+    it('heals `moondream2` from the VISION_MODEL env var too', () => {
+      process.env['VISION_MODEL'] = 'moondream2';
+      writeConfig();
+      const cfg = getMediaEmbeddingConfig();
+      assert.equal(cfg.vision?.model, 'moondream');
+    });
+
     it('WHISPER_URL overrides default STT URL', () => {
       process.env['WHISPER_URL'] = 'http://custom-whisper:8000';
       writeConfig();


### PR DESCRIPTION
## What & why

**Bundled image captioning has never worked out of the box.** The default vision model was `moondream2` — which is **not** a name in the Ollama registry (`moondream` is). So on a stock deployment:

1. the Compose auto-pull `ollama pull moondream2 || echo "WARN…"` **silently failed** (model not found), leaving ollama running without the model;
2. every caption request then returned `HTTP 404 model 'moondream2' not found`, and the image's `embeddingStatus` flipped to **`failed`** — it never became searchable.

Reported from a real upload (a plain PNG):
```
Media worker: job …/2023-12-03_21-34-05_3203.png failed:
  Ollama vision HTTP 404: {"error":"model 'moondream2' not found"}
```

Verified against the registry — `…/library/moondream/manifests/latest` → **200**, `…/moondream2/…` → **404**.

## Fix

- Corrected the name to **`moondream`** everywhere: the config default (`loader.ts`) and provider fallback (`providers.ts`), the **Compose** and **Kubernetes** pull commands, the Settings → Models placeholder, the config type comment, and the docs (README, userguide, integration/dependencies/workstation guides).
- **Self-heal for existing installs:** the config loader now **normalizes** a saved-config or `VISION_MODEL`-env value of `moondream2` to `moondream` at load time, so an install that persisted the bad name starts working without a manual edit. (`moondream2` is provably invalid, so this can't override a legitimate choice.)

## Verification

- `media-config` standalone tests extended (**26 pass**): the default resolves to `moondream`, and a `moondream2` coming from **saved config** or the **`VISION_MODEL` env var** heals to `moondream`. Server + client build clean.
- The two historical `moondream2` mentions in past CHANGELOG entries are left as-is (accurate record of what those releases shipped).

## Existing deployments

The model still has to be *present* in ollama. After updating: **restart the `ollama` container** (its entrypoint re-pulls) or run:
```
docker exec ythril-ollama ollama pull moondream
```

---

*Separately noticed during this report and tracked as a follow-up (not in this PR): the Brain space **counters don't refresh live** after an upload — they update when you navigate away and back to the space.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
