### PR TITLE
fix(files,webhooks): file/media robustness + centralized webhook emission

### DIFF
--- a/.github/workflows/image-pin-check.yml
+++ b/.github/workflows/image-pin-check.yml
@@ -1,0 +1,115 @@
+name: Image Pin Check
+
+# Verifies that every externally-hosted image/model Ythril pins is still pullable
+# with anonymous credentials — WITHOUT downloading them (manifest HEAD only).
+#
+# Why this exists: upstreams have twice broken a pinned reference out from under us
+# with no code change on our side —
+#   - #218/#220: `unstructured-api-full` was made PRIVATE on quay.io (401 on pull).
+#   - #219:      the Ollama vision model `moondream2` was renamed to `moondream` (404).
+# Both surfaced only when a developer ran `docker compose up`. This job catches the
+# next one on a schedule (and at PR time when a pin changes) instead.
+#
+# It needs no secrets: every check uses anonymous registry auth, exactly like a fresh
+# `docker pull` on a clean machine would.
+
+on:
+  schedule:
+    # Weekly, Monday 07:00 UTC. A failed scheduled run emails the repo's watchers and
+    # shows red in the Actions tab — that is the notification.
+    - cron: '0 7 * * 1'
+  workflow_dispatch: {}
+  pull_request:
+    # Also verify at PR time whenever a pinned reference could change, so a bad new
+    # pin fails the PR instead of a teammate's first `docker compose up`.
+    paths:
+      - 'docker-compose.yml'
+      - 'testing/docker-compose.test.yml'
+      - 'kubernetes/manifests/**'
+      - '.github/workflows/image-pin-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Verify pinned images are pullable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        # `docker buildx imagetools inspect` resolves a remote manifest via the registry's
+        # normal anonymous token flow and never pulls layers — the faithful, registry-agnostic
+        # equivalent of "can `docker pull` see this?" for Docker Hub, quay, and the
+        # downloads.unstructured.io mirror alike.
+        uses: docker/setup-buildx-action@v3
+
+      - name: Check container image manifests
+        run: |
+          set -uo pipefail
+
+          # Collect every `image:` reference from the files that pin external images,
+          # strip any trailing `# comment`, and dedupe. Parsing the real deploy files
+          # (rather than a hand-maintained list here) means this check cannot drift from
+          # what we actually ship.
+          mapfile -t ALL_REFS < <(
+            grep -rhoE '^\s*image:[[:space:]]*[^[:space:]#]+' \
+              docker-compose.yml testing/docker-compose.test.yml kubernetes/manifests/ \
+              | sed -E 's/^\s*image:[[:space:]]*//' \
+              | sort -u
+          )
+
+          # First-party images are built in-repo / published by our own release pipeline —
+          # not an upstream that can disappear — so they are out of scope for this check.
+          FIRST_PARTY='^(ghcr\.io/ythril-network/ythril|ythril-local|ythril-test)'
+
+          fail=0
+          echo "## Image pin check" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reference | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+
+          for ref in "${ALL_REFS[@]}"; do
+            if printf '%s' "$ref" | grep -qE "$FIRST_PARTY"; then
+              echo "skip (first-party): $ref"
+              continue
+            fi
+            if docker buildx imagetools inspect "$ref" > /dev/null 2>&1; then
+              echo "OK    $ref"
+              echo "| \`$ref\` | ✅ pullable |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "FAIL  $ref  — manifest not resolvable with anonymous credentials"
+              echo "| \`$ref\` | ❌ **not pullable** |" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            fi
+          done
+
+          # Ollama vision model. Not an `image:` line — the sidecar pulls it at runtime from
+          # the Ollama registry — but it is a pinned upstream reference with the same failure
+          # mode (#219). Default model name lives in server/src/files/media/providers.ts.
+          OLLAMA_MODEL='moondream'
+          code=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+            "https://registry.ollama.ai/v2/library/${OLLAMA_MODEL}/manifests/latest")
+          if [ "$code" = "200" ]; then
+            echo "OK    ollama model: ${OLLAMA_MODEL} (HTTP ${code})"
+            echo "| ollama model \`${OLLAMA_MODEL}\` | ✅ pullable |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "FAIL  ollama model: ${OLLAMA_MODEL} — HTTP ${code} from registry.ollama.ai"
+            echo "| ollama model \`${OLLAMA_MODEL}\` | ❌ **HTTP ${code}** |" >> "$GITHUB_STEP_SUMMARY"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "::error::One or more pinned upstream references are no longer pullable anonymously."
+            echo "An upstream likely privatised, removed, or renamed a tag (see the FAIL rows above)."
+            echo "Fix: find the current replacement image/tag, update the pin in the compose and"
+            echo "kubernetes manifests, and verify the new tag's LICENSE before merging."
+            exit 1
+          fi
+          echo ""
+          echo "All pinned upstream references are pullable."

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD024": { "siblings_only": true }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Webhooks now fire for agent-driven (MCP) brain mutations, emitted from one place.** Previously
+  only the REST API emitted `memory.*`/`entity.*`/`edge.*`/`chrono.*` events; the equivalent MCP
+  tools (`remember`, `upsert_entity`, `upsert_edge`, `create_chrono`, `update_*`, `delete_*`,
+  `merge_entities`) emitted nothing, so subscribers silently missed everything agents did — the bulk
+  of writes in an MCP-first deployment. Emission is now **centralised inside the shared brain
+  functions** (`remember`/`updateMemory`/`deleteMemory`, `upsertEntity`/`updateEntityById`/
+  `deleteEntity`, `upsertEdge`/`updateEdgeById`/`deleteEdge`, `createChrono`/`updateChrono`/
+  `deleteChrono`, `executeMerge`), which emit when handed a `WebhookActor` — so REST and MCP both
+  emit (with token attribution threaded through the MCP tool context, fixing the missing
+  `tokenId`/`tokenLabel` on MCP file webhooks too) while internal callers (sync, import) stay silent.
+  The manual per-route emits were removed, so each event has a single source of truth. A latent bug
+  is fixed in passing: a by-id entity update emitted `entity.created` (the route keyed off a dup
+  warning) — it now correctly emits `entity.updated`. **Bulk writes** (`POST /bulk`, MCP `bulk_write`)
+  intentionally do **not** fire per-item events (no 10k-webhook firehose); they emit one new
+  **`bulk.write`** summary event (`{ inserted, updated, errorCount }`) a workflow can inspect.
+  *(Note: the single-memory REST create still inlines its own emit — a duplication tracked for the
+  modularity pass.)*
+
+- **Optional soft-delete for file metadata (`softDeleteFileMeta`) + a metadata-delete guard.**
+  A new top-level config flag (default `false`, preserving today's hard-delete behavior) changes
+  what happens to a file's metadata record when the file is deleted: instead of removing the record,
+  it is flagged `deletedAt = <now>` and retained. Flagged records stay listed and searchable but show
+  a **"deleted" badge** in the Brain → File Meta view; re-uploading the same path clears the flag.
+  Independently of the setting, the metadata-delete endpoint (`DELETE /api/brain/spaces/:id/files`)
+  now **refuses (409) to remove a record whose file still exists on disk** — deleting metadata for a
+  live file would silently orphan it; delete the file itself instead. Only a flagged or orphaned
+  record (file already gone) can be purged. Derived records (conversion chunks / `_converted` /
+  `_extracted`) are always hard-removed regardless of the setting. Applies across the file, folder,
+  MCP, and media-worker delete paths.
+
+- **CI guard against upstream image/tag breakage (`Image Pin Check` workflow).** Twice now an
+  upstream has broken a pinned reference with no change on our side — `unstructured-api-full` went
+  private on quay.io (this release) and the Ollama model `moondream2` was renamed to `moondream`
+  (#219) — each surfacing only when a developer ran `docker compose up`. A new scheduled workflow
+  (`.github/workflows/image-pin-check.yml`) now HEAD-checks every externally-hosted pin **without
+  pulling**: it parses the `image:` references straight out of `docker-compose.yml`, the test compose,
+  and `kubernetes/manifests/` (so it can't drift from what we ship), verifies each is still resolvable
+  with anonymous credentials via `docker buildx imagetools inspect`, and separately checks the Ollama
+  `moondream` model manifest. Runs weekly, on `workflow_dispatch`, and on any PR that touches a file
+  which pins an image — so a bad pin fails the PR instead of a teammate's first boot. Needs no secrets.
+
 - **Type & tag filtering across the Brain views (FEATURES F5 + F6).** Filtering was uneven and
   mostly absent: list tabs could only be narrowed by clicking an existing tag, and the semantic
   Search tab's only "filter by schema" affordance was a raw JSON textarea. Now a shared
@@ -92,63 +133,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a shared `httpErrorReason` helper) and cleared on a successful load; Retry re-runs that view's fetch.
   Covered by `error-state.component.spec.ts` and verified end-to-end (a forced 500 shows the error
   state + reason + Retry, not the empty state, and Retry recovers).
-
-### Fixed
-
-- **Image/PDF previews and file downloads were broken (blank pane / failed download).** They loaded
-  the file via a browser-native `<img src>` / `<iframe src>` / `<a href download>`, none of which can
-  send the `Authorization` header — and the client papered over that by appending `?…&token=` to the
-  URL, a fallback that was **scoped to the two SSE endpoints only** in the auth-surface hardening
-  (query-token scope, #134). So every image/PDF preview and every download hit the file endpoint with
-  no valid auth → **401 → blank preview / failed download** (text previews survived because they
-  already used `fetch` with the header). Previews and downloads now `fetch` the file **with the token
-  in the header** and hand the view a same-origin `blob:` object URL (revoked on close), so the token
-  never rides in the URL (keeping #134's intent) and a failed preview shows a reason instead of a blank
-  pane. Covered by a regression test (download sends `Authorization`, never `token=` in the URL) and
-  verified end-to-end (an uploaded PNG previews from a `blob:` URL with a 200 authenticated GET).
-
-- **Bundled image captioning never worked out of the box — the default vision model name was
-  invalid.** The default was `moondream2`, which is **not** a name in the Ollama registry (`moondream`
-  is), so the Compose auto-pull (`ollama pull moondream2 || echo WARN`) silently failed and every
-  caption request came back `HTTP 404 model 'moondream2' not found` → the image's `embeddingStatus`
-  flipped to `failed`. Corrected the name to `moondream` everywhere (the config default and provider
-  fallback, the Compose and Kubernetes pull commands, the Settings → Models placeholder, and the
-  docs), and — so existing installs self-heal without a manual config edit — the config loader now
-  **normalizes** a saved/env `moondream2` to `moondream` at load time. Covered by media-config unit
-  tests (default is `moondream`; a saved or env `moondream2` heals to `moondream`).
-  *Existing deployments: restart the `ollama` container (or run `docker exec ythril-ollama ollama pull
-  moondream`) so the model is actually present.*
-
-- **docker-compose now matches what the docs promise (AUDIT C2 + C4).** Two `docker compose up`
-  gaps: (1) the `unstructured-api-full` document-conversion sidecar existed only in the Kubernetes
-  manifests, so on Compose `CONVERSION_SIDECAR_URL` pointed at nothing and every PDF/DOCX/EPUB upload
-  failed `sidecar_down` — despite the README calling it "bundled". It's now a service in
-  `docker-compose.yml`, wired via `CONVERSION_SIDECAR_URL`, on its own **internal** `ythril-convert`
-  network (no database access, no internet egress — it parses untrusted documents and its OCR models
-  are baked into the image). It is intentionally *not* a startup dependency of `ythril`, so the ~8–12 GB
-  image never blocks boot and conversion degrades gracefully until it's ready; `docs/dependencies.md`
-  documents the size and how to skip it on a small workstation. (2) `MONGO_URI` — the documented way to
-  point at an external MongoDB — was never forwarded into the `ythril` container's `environment`, so
-  the value silently never reached the server. It's now forwarded (empty default keeps the bundled
-  database), making the documented external-Mongo path actually work.
-
-- **The recurring "vote-signing relay" sync-test flake is fixed at its root — a test setup race,
-  not a relay bug.** The test pins a third instance's signing key by writing `config.json` directly,
-  then reloads. Under full-suite load that write races the server's own `saveConfig`: an in-flight
-  sync cycle (left over from a prior test's fire-and-forget trigger) captured the config *before* the
-  patch and writes its stale copy back, silently dropping the pinned key — after which the relaying
-  instance rejects the third instance's cast on **every** cycle, so the relay can never converge and
-  the assertion times out. Widening the wait (as two prior PRs did) cannot fix an un-pinned key. The
-  fix makes the out-of-band injection *stick*: a `patchAndConfirm` helper re-applies the patch until
-  it is confirmed stable across consecutive live reads (idempotently, so a re-apply never duplicates
-  the member/round), and the assertion now polls the guaranteed eventual convergence with a
-  self-diagnosing message (it reports whether the key is pinned and whether the round arrived) — the
-  wait was *reduced* 90s→60s, not widened. The production relay itself was already timing-independent:
-  every cycle re-pulls the peer's full open-round set and re-merges missing casts, so a delayed or
-  dropped message is re-derived from source of truth on the next cycle. Verified across three
-  back-to-back full-suite runs under load. Test-only change.
-
-### Added
 
 - **Mobile navigation drawer restores the app on phones (UX U2).** Below 768px the sidebar was
   simply `display: none` with no replacement — no hamburger, no drawer, no top-nav fallback — so on a
@@ -283,6 +267,361 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rolls out to existing networks without a flag day. New tests: `testing/standalone/vote-signing.test.js`
   (20 unit cases) and `testing/sync/vote-signing.test.js` (signed cast + key distribution + safe relay
   of a third-party signed cast, tampered cast rejected).
+
+### Fixed
+
+- **Moving a file/folder resurrected the pre-move copy on sync peers (both HTTP and MCP).** A move
+  removes the file from its old path on disk, but neither the `PATCH /api/files` route nor the MCP
+  `move_file` tool wrote a tombstone for it — and sync has no rename detection, so a peer's manifest
+  still advertised the old path and pushed it straight back (leaving the file at *both* paths). Both
+  movers now tombstone the old path(s) — the source file, or every child file for a directory move —
+  before renaming. Covered by a new move-propagation sync test.
+
+- **MCP file tools had divergent side effects from the equivalent HTTP routes.** `write_file`,
+  `delete_file`, and `move_file` did not emit the `file.created` / `file.deleted` / `file.updated`
+  webhooks their HTTP counterparts do (so webhook subscribers missed all agent-driven file changes);
+  `delete_file` skipped `invalidateUsageCache` (stale quota after a delete); `move_file` only re-rooted
+  the single source record, not the child records under a moved **directory** (`renameFileMetaByPrefix`),
+  orphaning their metadata; `write_file` did not project the incoming size into its storage-quota check
+  (so an over-limit agent write wasn't rejected up-front) and did not clear stale conversion artifacts
+  when overwriting a document (leaving duplicate chunk records). All now match the HTTP API. (Brain MCP
+  tools — `remember`, `upsert_entity`, etc. — still emit no webhooks; tracked as a separate follow-up.)
+
+- **Deleting a folder (or a file via MCP) did not propagate to sync peers (files resurrected).**
+  Single-file delete over the HTTP API wrote a `FileTombstoneDoc` so peers remove the file too, but
+  recursive folder delete wrote none, and the MCP `delete_file` tool wrote none either — so on the
+  next sync a peer's manifest still advertised the files and pushed them straight back. Tombstone
+  creation is now a shared helper (`writeFileTombstones`) used by all three paths: folder delete
+  enumerates every removed file (the folder tree plus its `_converted`/`_extracted` sidecars) before
+  deletion and writes a tombstone for each, and MCP `delete_file` writes one for the deleted file.
+
+- **Deleting a file or folder orphaned its embedding metadata and left a media job retrying
+  forever.** Deleting a file (or a folder containing one) removed the file from disk but never
+  cancelled its queued media/text embedding job, so the worker kept reclaiming the job and failing
+  it with `ENOENT: no such file` — endlessly, because the stalled-job sweep re-queued it. It also
+  left orphaned filemeta records behind: folder deletion only cleaned records under `<folder>/`, but
+  document-conversion sidecars live under the separate `_converted/<path>` and `_extracted/<path>`
+  prefixes, so those DB records and their on-disk files survived (and `deleteConversionArtifacts`
+  never removed the sidecar files from disk even on single-file delete). Now (1) file, folder, and
+  MCP deletes cancel the associated media jobs (`cancelMediaJob` / `cancelMediaJobsByPrefix`);
+  (2) folder delete also clears conversion artifacts for the whole subtree, records **and** disk
+  (`deleteConversionArtifactsByPrefix`), and `deleteConversionArtifacts` now removes the
+  `_converted/`/`_extracted/` files too; and (3) the media worker treats a missing source file
+  (`ENOENT`) as **terminal, not retryable** — it reconciles to disk truth by dropping the job and any
+  orphaned metadata/artifacts instead of looping. Regression test covers folder delete leaving zero
+  records (including hidden chunks) under the deleted path.
+
+- **`docker compose up` failed to pull the document-conversion sidecar (`401 UNAUTHORIZED`).** The
+  bundled `unstructured` service (C2, #218) pinned `unstructured-io/unstructured-api-full:0.0.75`, but
+  Unstructured made the `-full` repository private on quay.io — an anonymous pull of the whole repo now
+  returns `401 UNAUTHORIZED` (registries return 401, not 404, for inaccessible manifests), so the tag
+  no longer resolves. Switched the sidecar (both `docker-compose.yml` and the pod-local
+  `kubernetes/manifests/ythril-deployment.yaml`) to the still-public `unstructured-io/unstructured-api:0.0.75`
+  — the same upstream release minus the `-full` extras (extra Tesseract language packs + LibreOffice),
+  which Ythril's `hi_res` OCR + embedded-image extraction path does not use. It is also the image
+  upstream's own README points self-hosters at, is ~4.5 GB compressed (vs the heavier `-full`), and stays
+  Apache-2.0. No server or config change was needed; the sidecar API (`/general/v0/general`) is identical.
+
+- **Image/PDF previews and file downloads were broken (blank pane / failed download).** They loaded
+  the file via a browser-native `<img src>` / `<iframe src>` / `<a href download>`, none of which can
+  send the `Authorization` header — and the client papered over that by appending `?…&token=` to the
+  URL, a fallback that was **scoped to the two SSE endpoints only** in the auth-surface hardening
+  (query-token scope, #134). So every image/PDF preview and every download hit the file endpoint with
+  no valid auth → **401 → blank preview / failed download** (text previews survived because they
+  already used `fetch` with the header). Previews and downloads now `fetch` the file **with the token
+  in the header** and hand the view a same-origin `blob:` object URL (revoked on close), so the token
+  never rides in the URL (keeping #134's intent) and a failed preview shows a reason instead of a blank
+  pane. Covered by a regression test (download sends `Authorization`, never `token=` in the URL) and
+  verified end-to-end (an uploaded PNG previews from a `blob:` URL with a 200 authenticated GET).
+
+- **Bundled image captioning never worked out of the box — the default vision model name was
+  invalid.** The default was `moondream2`, which is **not** a name in the Ollama registry (`moondream`
+  is), so the Compose auto-pull (`ollama pull moondream2 || echo WARN`) silently failed and every
+  caption request came back `HTTP 404 model 'moondream2' not found` → the image's `embeddingStatus`
+  flipped to `failed`. Corrected the name to `moondream` everywhere (the config default and provider
+  fallback, the Compose and Kubernetes pull commands, the Settings → Models placeholder, and the
+  docs), and — so existing installs self-heal without a manual config edit — the config loader now
+  **normalizes** a saved/env `moondream2` to `moondream` at load time. Covered by media-config unit
+  tests (default is `moondream`; a saved or env `moondream2` heals to `moondream`).
+  *Existing deployments: restart the `ollama` container (or run `docker exec ythril-ollama ollama pull
+  moondream`) so the model is actually present.*
+
+- **docker-compose now matches what the docs promise (AUDIT C2 + C4).** Two `docker compose up`
+  gaps: (1) the `unstructured-api-full` document-conversion sidecar existed only in the Kubernetes
+  manifests, so on Compose `CONVERSION_SIDECAR_URL` pointed at nothing and every PDF/DOCX/EPUB upload
+  failed `sidecar_down` — despite the README calling it "bundled". It's now a service in
+  `docker-compose.yml`, wired via `CONVERSION_SIDECAR_URL`, on its own **internal** `ythril-convert`
+  network (no database access, no internet egress — it parses untrusted documents and its OCR models
+  are baked into the image). It is intentionally *not* a startup dependency of `ythril`, so the ~8–12 GB
+  image never blocks boot and conversion degrades gracefully until it's ready; `docs/dependencies.md`
+  documents the size and how to skip it on a small workstation. (2) `MONGO_URI` — the documented way to
+  point at an external MongoDB — was never forwarded into the `ythril` container's `environment`, so
+  the value silently never reached the server. It's now forwarded (empty default keeps the bundled
+  database), making the documented external-Mongo path actually work.
+
+- **The recurring "vote-signing relay" sync-test flake is fixed at its root — a test setup race,
+  not a relay bug.** The test pins a third instance's signing key by writing `config.json` directly,
+  then reloads. Under full-suite load that write races the server's own `saveConfig`: an in-flight
+  sync cycle (left over from a prior test's fire-and-forget trigger) captured the config *before* the
+  patch and writes its stale copy back, silently dropping the pinned key — after which the relaying
+  instance rejects the third instance's cast on **every** cycle, so the relay can never converge and
+  the assertion times out. Widening the wait (as two prior PRs did) cannot fix an un-pinned key. The
+  fix makes the out-of-band injection *stick*: a `patchAndConfirm` helper re-applies the patch until
+  it is confirmed stable across consecutive live reads (idempotently, so a re-apply never duplicates
+  the member/round), and the assertion now polls the guaranteed eventual convergence with a
+  self-diagnosing message (it reports whether the key is pinned and whether the round arrived) — the
+  wait was *reduced* 90s→60s, not widened. The production relay itself was already timing-independent:
+  every cycle re-pulls the peer's full open-round set and re-merges missing casts, so a delayed or
+  dropped message is re-derived from source of truth on the next cycle. Verified across three
+  back-to-back full-suite runs under load. Test-only change.
+
+- **Client base `tsconfig.json` no longer reports a spurious `rootDir` error in the editor.** The
+  base config sets `rootDir: ./src` but had no `include`, so TypeScript fell back to its default
+  `**/*` pattern and pulled in `vitest.config.ts` at the client root — a file outside `rootDir` —
+  raising `TS6059` whenever an editor (or a direct `tsc -p tsconfig.json`) loaded the base project.
+  It was latent until the Vitest client-test infra added that root-level config file. Scoped the
+  base's `include` to `src/**/*.ts` so it agrees with `rootDir`. Editor-only; `ng build`
+  (`tsconfig.app.json`) and the Vitest suite (`tsconfig.spec.json`) set their own `include` and were
+  never affected.
+
+- **User guide, integration guide, usecase examples, workstation guide, and the top-level docs
+  brought back in line with the code** — the rest of the same full docs audit. Highlights:
+  two dangerous user-guide MFA errors fixed (disabling MFA **requires** a current TOTP code; the
+  TOTP secret is server-generated, not browser-only), the Webhooks section rewritten as an API
+  how-to (no management UI exists yet), the About page corrected (no live log — that's the Audit
+  Log), and the guide re-synced with the current UI (Brain has eight tabs; Graph/Files are tabs
+  not routes; MFA lives under Preferences; corrected admin nav, labels, and destructive-op
+  locations). Integration guide: `GET /api/about` is not public, the OIDC spaces-claim is
+  fail-closed, `files` added to the MCP `query` enum, entities list max is 500, recall filter keys
+  include `status`/`label` with native `$vectorSearch` pre-filtering, draft-7 rate-limit headers,
+  plus newly documented `indexStatus`, bulk wipes, the `help` tool, and several endpoints.
+  Usecase examples: `recall_global` → `recall`, no `"expired"` chrono status, and a caveat that
+  `remember()` does not auto-create entities. Workstation guide: the port-override that never frees
+  3200 removed (use `YTHRIL_PORT`), `MONGO_URI` must be in the compose environment to reach the
+  container, and the connector binds `0.0.0.0` (bearer-protected). README/NOTICE/contribution-guide/
+  dependencies: `recall_global` → `recall`, `list_spaces`/`help` added (31 tools), webhook event
+  counts (16/19), embedding features, NOTICE dependency list (drop zone.js, add undici), and the
+  local-dev DB/proxy setup. Doc-only; no behavior change.
+
+- **Sync-protocol and network-types docs brought back in line with the code** after a full docs
+  audit cross-checked every claim. `docs/sync-protocol.md`: corrected the phase order (governance
+  gossip + vote propagation deliberately run *first*, ahead of the data phases) and documented the
+  previously missing presync warm-up (`POST /api/sync/warm`) and opt-in Merkle divergence check
+  (`GET /api/sync/merkle`); rewrote the file-sync section to match reality (file tombstones travel
+  both directions, files are pushed as well as pulled, and hash divergence produces a conflict
+  copy plus a `ConflictDoc` — never an overwrite); fixed the manual-trigger semantics (async fire-and-forget
+  returning `{ status: 'triggered' }`), the direction-enforcement 403 body, the file-download URL
+  shape (`?path=` query parameter), and the tombstone endpoint/pull descriptions (chrono is a
+  fourth synced type; tombstone push pages 500/request until drained); removed the nonexistent
+  `GET /api/sync/info` (identity comes from `GET /api/about` and the gossip `self` record);
+  documented the ingest safety caps (implausible-seq ceiling, fork depth/fan-out ≤ 10), the
+  50-page-per-type pull cap, watermark persistence via the coalesced config flush, gossip signing
+  fields, and the real auth model of the sync surface. `docs/network-types.md`: fixed the broken
+  tombstone-guard link, the invite-generate auth level (admin), the vote-deadline default (24 h,
+  configurable 1–72 h), and replaced the misleading offline-peer timing estimate with the accurate
+  bounded-timeout statement. Doc-only; no behavior change.
+
+- **Schema validation was a total no-op on MCP — the surface agents actually use.** `validateMemory()` keys
+  the whole per-type schema lookup off `memory.type`, but the MCP `remember` and `bulk_write` tools never
+  exposed `type` and passed `undefined` to the engine. With no type there is no schema, so validation always
+  returned **zero violations** and the `validationMode: 'strict'` gate **could never fire**. A space that
+  enforces required memory properties enforced them over REST and **silently ignored them over MCP**. Both
+  tools now accept `type`, forward it to the validator and persist it. (The existing schema-validation suite
+  set up exactly this scenario and asserted a 400 — but **only through REST**: the one surface that could
+  fail was never tested. Same shape as the space-rename bug.)
+
+- **MCP `bulk_write` never validated edge `properties`.** It called `validateEdge(meta, { label })`, omitting
+  `properties`, so required/typed edge properties were never checked and strict mode was unenforceable on
+  that path — while MCP `upsert_edge` and REST both got it right.
+
+- **Chrono `recurrence` was unreachable from MCP and unvalidated over REST.** The engine has supported it all
+  along, but no MCP tool declared it, so agents could not create or modify recurring entries. Meanwhile REST
+  destructured it straight out of the request body and persisted it **with no shape check at all** — unlike
+  every sibling field — so an arbitrary object could be stored and later read as a recurrence rule. Both
+  surfaces now share one validator (`freq` enum, positive integer `interval`, ISO `until`).
+
+- **Completed the space-rename data-integrity fix — three more instances of the same bug.** The audit that
+  followed the rename fix found the same "stale `spaceId`" flaw in places the first pass missed:
+  - **Deleted files could resurrect.** `{spaceId}_file_tombstones` carries a `spaceId` field and its readers
+    filter on it, but the collection was **missing from the repair's hardcoded list**, so after a rename every
+    pre-rename deletion became invisible to sync — and peers that still held the file pushed it straight back.
+    The repair now **discovers a space's collections by prefix** instead of walking a fixed list, so this and
+    any future per-space collection are covered automatically. (It only rewrites a `spaceId` that is present
+    but wrong, never inventing one — `{spaceId}_file_hashes` legitimately has no such field.)
+  - **A rename silently stopped a space syncing.** The seq counter lives in the *global* `ythril_counters`
+    collection keyed by `_id: <spaceId>`, so the prefix-based collection rename missed it and `nextSeq()`
+    restarted at **1** — while the rename deliberately carries the OLD, high sync watermarks over to the new
+    id. Every subsequent write got a seq *below* the watermark and was **never pushed to peers**: the space
+    kept working locally while quietly never syncing again. The counter (and the dupe-scan cursor) now move
+    with the rename.
+  - **Cross-space import wrote invisible data.** The export embeds the source space's id in every document,
+    and import wrote them verbatim — so importing space A's export into space B produced documents that were
+    counted but invisible to every list. Imported documents are now re-tagged to the target space.
+  - `traverseFromSeeds` filtered entities but not edges by `spaceId`, so a stale value returned an edge whose
+    neighbour entity silently vanished — half a graph, no error. The redundant filter is gone; the collection
+    name is the only real scope.
+
+  Tests now cover **chrono** and the **seq counter** across a rename, and **cross-space import** — the gaps
+  that let all of this through. (The original rename test asserted only memories, the one read path that does
+  not filter on `spaceId`, and the import tests asserted only counts and memory-by-id — likewise immune.)
+
+- **Renaming a space no longer makes its entities and edges vanish from the UI.** `moveSpaceData`
+  renamed the collections (`{old}_entities` → `{new}_entities`) but never rewrote the `spaceId` field
+  *inside* the documents, so every one still pointed at the OLD space id. `listEntities`, `listEdges`,
+  entity lookup-by-name, the edge-dedup lookup and the cascade deletes all filter on that field — so a
+  renamed space looked **catastrophic but was actually intact**: the entry counts still showed the data
+  (counts read the collection) while every list came back **empty**. Worse, because lookup-by-name
+  stopped matching, `remember` would start creating **duplicate entities** instead of linking to the
+  existing one. Memories were unaffected (`listMemories` does not filter on `spaceId`) — which is
+  exactly why the existing rename test, which only checked memories, never caught this. The rename now
+  rewrites the field, and **existing affected databases self-heal on boot** (`repairStaleSpaceIds`,
+  run from `initSpace`): documents living in `{spaceId}_*` belong to `spaceId` by definition, so the
+  repair is safe and idempotent. Sync had the same flaw — a `spaceMap`-aliased pull wrote peer documents
+  into the local collection while keeping the *remote* space id — and now re-tags them to the local
+  space. Regression test added covering entities, edges and lookup-by-name across a rename.
+
+- **The test stack no longer races four concurrent builds onto one image tag.** Giving every instance the
+  shared `ythril-test:latest` tag (so CI can pre-build once against a layer cache) made `docker compose
+  build` build the *same* tag from four services simultaneously, which races on the image export and could
+  corrupt it locally (`failed to extract layer … EOF`). Only `ythril-a` builds the image now; b/c/d simply
+  reference the tag. CI is unaffected — it pre-builds the tag itself.
+
+- **Rebuilding the test stack no longer leaks Docker disk without bound.** Every `--build` orphaned the
+  previous multi-GB image (each bakes a ~520 MB embedding model, node_modules and ffmpeg) and grew the
+  BuildKit cache forever — on one workstation this reached **35 GB of build cache plus 20 GB of orphaned
+  images**, filled the drive and took Docker Desktop down. `test:up:rebuild` now runs `test:prune` (drop
+  dangling images, cap the cache at 5 GB), and a new `npm run docker:reclaim` handles an already-ballooned
+  install: it prunes, then `fstrim`s inside the VM, then prints the exact elevated `diskpart` steps to
+  **compact** `docker_data.vhdx` — necessary because pruning frees space *inside* the VM while the
+  dynamically-expanding disk only ever grows on the host. It locates the disk even when relocated to
+  another drive (`CustomWslDistroDir`).
+
+- **Sync tests can no longer turn a persistent, actionable error into an unexplained timeout.** The sync
+  suites re-trigger a sync on every poll (deliberate — a single up-front trigger races a slow gossip
+  cycle), but they did it as `triggerSync(...).catch(() => {})`, which treats a transient blip and a
+  permanent misconfiguration identically. That trap is *why* the notify rate-limit bug survived three wrong
+  fixes: every trigger was coming back `429`, the `.catch()` ate it, no sync cycle ever ran, and all anyone
+  saw was `waitFor timed out after 90000ms`. `waitFor` now takes a `diagnose` argument appended to its
+  timeout message, and `makeTriggerProbe` still tolerates a failed poll but **remembers the last failure**
+  and reports it — so the message becomes "every sync trigger to A was failing (…); last error:
+  triggerSync failed: 429 …" instead of a bare stall. Test-harness only. Pinned by
+  `testing/standalone/waitfor-diagnostics.test.js`.
+
+- **The notify limiter now honours the test kill-switch — the real cause of the “flaky” signed-vote relay test.**
+  `POST /api/notify/trigger` is how the test harness drives a sync cycle, and it is guarded by
+  `notifyRateLimit` (60/min per IP). Every request from the harness shares one source IP, so the sync suites
+  collectively blew past 60/min and started getting `429`s — which the tests' trigger call swallowed, so the
+  sync cycle silently never ran and load-sensitive assertions timed out looking like flakes. `notifyRateLimit`
+  was the **only** limiter with no `skip:` clause (`authRateLimit`, `globalRateLimit`, `syncRateLimit` and
+  `bulkWipeRateLimit` all have one); it now honours `SKIP_SYNC_RATE_LIMIT` like the rest of the sync plane.
+  **No production impact:** the kill-switch is inert unless `NODE_ENV !== 'production'`, scheduled sync calls
+  the engine in-process (it never touches this limiter at all), and instance C deliberately omits the env so
+  the genuine 429 behaviour stays covered. Pinned by `testing/standalone/notify-rate-limit.test.js`, which
+  asserts both halves: A must not throttle, C still must.
+
+- **OIDC sign-in no longer hangs when the whole SPA is embedded in a portal iframe.** The callback
+  inferred "this is a silent-refresh frame" from simply being inside an iframe (`window.self !== window.top`)
+  and tried to `postMessage` the authorization code to `window.parent` targeted at Ythril's own origin. That
+  is correct for a genuine silent refresh (whose hidden iframe's parent *is* the SPA), but when the entire
+  Ythril SPA runs inside a host portal's iframe, the interactive redirect callback is also framed and its
+  parent is the *portal's* origin — so the browser refuses the cross-origin `postMessage` and the user is
+  stuck on "Completing sign-in…" forever. The silent-refresh flow now marks its request explicitly with a
+  `state` prefix (`silent.`), and the callback branches on that marker instead of on being framed — so an
+  embedded interactive sign-in completes normally while genuine silent refreshes are still recognised.
+  Client-only. Reported from a production embedded (iframe) deployment.
+
+- **Governance votes and member gossip now converge even when data sync is slow or failing.** In each
+  sync cycle, gossip (member list, signing-key pinning) and vote propagation ran **after** the per-space
+  data and file sync for a peer — and that data loop is not isolated, so any timed-out pull, unreachable
+  member, or slow file transfer threw out of the member's sync and **skipped governance entirely for that
+  cycle**. On a lightly loaded system the data plane is fast so this never showed, but under heavy load a
+  saturated peer could starve time-sensitive vote propagation (rounds have deadlines) for many cycles in
+  a row — the root cause behind the intermittently-timing-out signed-vote relay test. Governance now runs
+  **first**, ahead of the data loop, so it converges promptly and independently of data-plane health. The
+  two calls remain internally best-effort and are additionally wrapped so a later data-plane failure can
+  never mask governance progress. Covered by the existing sync/vote suites.
+
+- **Importing a schema no longer fails silently.** In **Settings → Spaces → Schema → Import JSON**, a
+  valid-JSON file that contained none of the recognised `entity`/`edge`/`memory`/`chrono` keys — which
+  includes Ythril's **own** per-type export shape `{knowledgeType, typeName, schema}` — fell straight
+  through the import loop and then *cleared the error field*, so it looked like it worked while doing
+  nothing. Import now: (1) also accepts the `{knowledgeType, typeName, schema}` export shape; (2) shows a
+  specific error listing the expected keys and what the file actually contained when nothing is
+  recognised; and (3) confirms success with a note that the imported types are **staged — press Save to
+  apply**. Client-only.
+
+- **Record properties are now fully embedded, so semantic recall can use them.** The text embedded for
+  a record mishandled `properties`: memory and entity embedded only the property **values** and dropped
+  the **keys**, while **edge and chrono embedded properties not at all**. So recall couldn't match on a
+  property name (a query about "role" had no "role" signal), and values lost their field context —
+  `{birthplace: "Paris"}` and `{currentCity: "Paris"}` embedded identically. All five builders (memory,
+  entity, edge, chrono, and the entity-merge copy) now fold `key value` pairs into the embedded text
+  via a single shared `propsEmbedText` helper, and chrono re-embeds when only its properties change.
+  Existing records keep their old (weaker) vectors until re-embedded — run
+  `POST /api/brain/spaces/:id/reindex` to rebuild them with property keys. Covered by
+  `testing/integration/embed-properties.test.js`.
+
+- **Recall no longer errors while a new space's vector indexes are still building.** Space creation now
+  builds its `$vectorSearch` indexes asynchronously (see the space-creation fix above), and Atlas
+  refuses queries against an index still in `INITIAL_SYNC` — so a recall during that brief window
+  failed the whole request with a `400` ("cannot query vector index … while in state INITIAL_SYNC")
+  instead of returning results from the collections that were ready. Recall now treats a
+  not-yet-queryable index like a missing one — no results from that collection — so it degrades to a
+  partial/empty result during the build window instead of erroring. Covered by
+  `testing/integration/space-creation-async.test.js`.
+
+- **Creating a space no longer times out or "appears only after a reload".** `createSpace` awaited the
+  build of a space's 5+ Atlas `$vectorSearch` indexes, each polling for READY up to 60 s (worst case
+  minutes) — so the `201` landed far past the client's 30 s timeout, on a dead subscription, and the
+  space seemed to vanish until the page was refreshed. Creation now returns in seconds: collections and
+  regular indexes are created synchronously (the space always has a backing DB), the vector-index READY
+  wait is **deferred**, and the space is returned with `indexStatus: 'building'` and finalized to
+  `ready`/`failed` by a background task. The space is writable immediately; only semantic recall waits
+  for READY. The UI shows a "Preparing indexes…" badge until it clears. `GET /api/spaces` surfaces
+  `indexStatus`. Covered by `testing/integration/space-creation-async.test.js`.
+
+- **Document embedding failures are reported instead of faked as success.** When a text/document
+  upload's chunks failed to embed, an empty `catch` swallowed the error and the job still reported
+  `embeddingStatus: 'complete'` — so a file that was permanently invisible to `$vectorSearch` looked
+  fully indexed, with no failure signal and never engaging the existing retry/backoff machinery. A
+  total failure now routes into that retry path (ending `failed` if it can't recover); a partial
+  failure is recorded as `embeddingStatus: 'partial'` (new state) and is retriable. A **Retry** button
+  and a "Partly embedded" badge were added to the file list, wiring the previously-unused
+  `retry_embedding` endpoint. Covered by `testing/standalone/embedding-failure-reporting.test.js`.
+
+- **Space rename/delete are now crash-safe.** A rename or delete spans `config.json`, MongoDB
+  collections, and the filesystem and cannot be atomic — a crash mid-operation (after renaming some
+  collections, or after moving files but before the config write) could leave them permanently
+  inconsistent with no recovery. A `pendingSpaceOp` write-ahead marker is now persisted before any
+  physical change and cleared only on commit; the physical steps are idempotent, and an interrupted
+  operation is completed on the next boot (and on `reload-config`). Covered by
+  `testing/standalone/space-op-recovery.test.js`.
+
+- **The governance vote "No" button now works (and casts a veto).** The Networks UI offered **Yes/No**
+  buttons, but the server accepts only `yes`/`veto` (`VoteValue`), so clicking **No** returned `400`
+  and there was no way to cast a blocking vote from the UI at all. The negative button now casts a
+  `veto` — the blocking vote the model and docs already describe ("a single no blocks it") — and is
+  relabelled **Veto** to match. Client-only fix.
+
+- **`<html lang>` now tracks the active UI language.** It was hardcoded to `en`, so screen-reader
+  pronunciation and browser hyphenation stayed English for German and Polish users even though the UI
+  was fully translated. The document language is now set on startup and updated on every language
+  switch.
+
+- **Close/remove buttons use a consistent icon everywhere.** Close and remove controls across the app
+  rendered a mix of raw `✕` and `×` glyphs at different weights/baselines than the `ph-icon` used
+  elsewhere. Every one — dialog close buttons, chip/tag remove buttons, and danger remove actions in
+  networks, spaces, schema-library, tokens, and the shared property/tag editors — now uses the `x`
+  icon, and dialog close buttons that were missing an `aria-label` gained one.
+
+- **Legacy tokens are no longer silently invalidated on upgrade** — a startup/reload migration
+  *deleted* any PAT created before the `prefix` field existed, on the assumption it "cannot be
+  verified." In fact a prefix-less token can still be bcrypt-verified; the prefix is only a lookup
+  optimization. The deletion meant that after an innocuous restart/upgrade, every client sharing such
+  a token — web UI, monitors, MCP connectors — dropped to `401` at once, with nothing but a single log
+  line to explain it. Legacy tokens are now **verified via a fallback scan and self-heal**: the prefix
+  is backfilled on first use so subsequent lookups take the fast path, and no token is ever deleted by
+  the migration. Covered by `testing/integration/auth.test.js`.
 
 ### Changed
 
@@ -550,256 +889,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/api/brain/:spaceId/memories…` with `/api/brain/spaces/:spaceId/memories…`. The web client already
   uses the canonical paths. (All other brain resources — entities, edges, chrono, stats — were already
   canonical-only and are unaffected.)
-
-### Fixed
-
-- **Client base `tsconfig.json` no longer reports a spurious `rootDir` error in the editor.** The
-  base config sets `rootDir: ./src` but had no `include`, so TypeScript fell back to its default
-  `**/*` pattern and pulled in `vitest.config.ts` at the client root — a file outside `rootDir` —
-  raising `TS6059` whenever an editor (or a direct `tsc -p tsconfig.json`) loaded the base project.
-  It was latent until the Vitest client-test infra added that root-level config file. Scoped the
-  base's `include` to `src/**/*.ts` so it agrees with `rootDir`. Editor-only; `ng build`
-  (`tsconfig.app.json`) and the Vitest suite (`tsconfig.spec.json`) set their own `include` and were
-  never affected.
-
-- **User guide, integration guide, usecase examples, workstation guide, and the top-level docs
-  brought back in line with the code** — the rest of the same full docs audit. Highlights:
-  two dangerous user-guide MFA errors fixed (disabling MFA **requires** a current TOTP code; the
-  TOTP secret is server-generated, not browser-only), the Webhooks section rewritten as an API
-  how-to (no management UI exists yet), the About page corrected (no live log — that's the Audit
-  Log), and the guide re-synced with the current UI (Brain has eight tabs; Graph/Files are tabs
-  not routes; MFA lives under Preferences; corrected admin nav, labels, and destructive-op
-  locations). Integration guide: `GET /api/about` is not public, the OIDC spaces-claim is
-  fail-closed, `files` added to the MCP `query` enum, entities list max is 500, recall filter keys
-  include `status`/`label` with native `$vectorSearch` pre-filtering, draft-7 rate-limit headers,
-  plus newly documented `indexStatus`, bulk wipes, the `help` tool, and several endpoints.
-  Usecase examples: `recall_global` → `recall`, no `"expired"` chrono status, and a caveat that
-  `remember()` does not auto-create entities. Workstation guide: the port-override that never frees
-  3200 removed (use `YTHRIL_PORT`), `MONGO_URI` must be in the compose environment to reach the
-  container, and the connector binds `0.0.0.0` (bearer-protected). README/NOTICE/contribution-guide/
-  dependencies: `recall_global` → `recall`, `list_spaces`/`help` added (31 tools), webhook event
-  counts (16/19), embedding features, NOTICE dependency list (drop zone.js, add undici), and the
-  local-dev DB/proxy setup. Doc-only; no behavior change.
-
-- **Sync-protocol and network-types docs brought back in line with the code** after a full docs
-  audit cross-checked every claim. `docs/sync-protocol.md`: corrected the phase order (governance
-  gossip + vote propagation deliberately run *first*, ahead of the data phases) and documented the
-  previously missing presync warm-up (`POST /api/sync/warm`) and opt-in Merkle divergence check
-  (`GET /api/sync/merkle`); rewrote the file-sync section to match reality (file tombstones travel
-  both directions, files are pushed as well as pulled, and hash divergence produces a conflict
-  copy plus a `ConflictDoc` — never an overwrite); fixed the manual-trigger semantics (async fire-and-forget
-  returning `{ status: 'triggered' }`), the direction-enforcement 403 body, the file-download URL
-  shape (`?path=` query parameter), and the tombstone endpoint/pull descriptions (chrono is a
-  fourth synced type; tombstone push pages 500/request until drained); removed the nonexistent
-  `GET /api/sync/info` (identity comes from `GET /api/about` and the gossip `self` record);
-  documented the ingest safety caps (implausible-seq ceiling, fork depth/fan-out ≤ 10), the
-  50-page-per-type pull cap, watermark persistence via the coalesced config flush, gossip signing
-  fields, and the real auth model of the sync surface. `docs/network-types.md`: fixed the broken
-  tombstone-guard link, the invite-generate auth level (admin), the vote-deadline default (24 h,
-  configurable 1–72 h), and replaced the misleading offline-peer timing estimate with the accurate
-  bounded-timeout statement. Doc-only; no behavior change.
-
-- **Schema validation was a total no-op on MCP — the surface agents actually use.** `validateMemory()` keys
-  the whole per-type schema lookup off `memory.type`, but the MCP `remember` and `bulk_write` tools never
-  exposed `type` and passed `undefined` to the engine. With no type there is no schema, so validation always
-  returned **zero violations** and the `validationMode: 'strict'` gate **could never fire**. A space that
-  enforces required memory properties enforced them over REST and **silently ignored them over MCP**. Both
-  tools now accept `type`, forward it to the validator and persist it. (The existing schema-validation suite
-  set up exactly this scenario and asserted a 400 — but **only through REST**: the one surface that could
-  fail was never tested. Same shape as the space-rename bug.)
-
-- **MCP `bulk_write` never validated edge `properties`.** It called `validateEdge(meta, { label })`, omitting
-  `properties`, so required/typed edge properties were never checked and strict mode was unenforceable on
-  that path — while MCP `upsert_edge` and REST both got it right.
-
-- **Chrono `recurrence` was unreachable from MCP and unvalidated over REST.** The engine has supported it all
-  along, but no MCP tool declared it, so agents could not create or modify recurring entries. Meanwhile REST
-  destructured it straight out of the request body and persisted it **with no shape check at all** — unlike
-  every sibling field — so an arbitrary object could be stored and later read as a recurrence rule. Both
-  surfaces now share one validator (`freq` enum, positive integer `interval`, ISO `until`).
-
-- **Completed the space-rename data-integrity fix — three more instances of the same bug.** The audit that
-  followed the rename fix found the same "stale `spaceId`" flaw in places the first pass missed:
-  - **Deleted files could resurrect.** `{spaceId}_file_tombstones` carries a `spaceId` field and its readers
-    filter on it, but the collection was **missing from the repair's hardcoded list**, so after a rename every
-    pre-rename deletion became invisible to sync — and peers that still held the file pushed it straight back.
-    The repair now **discovers a space's collections by prefix** instead of walking a fixed list, so this and
-    any future per-space collection are covered automatically. (It only rewrites a `spaceId` that is present
-    but wrong, never inventing one — `{spaceId}_file_hashes` legitimately has no such field.)
-  - **A rename silently stopped a space syncing.** The seq counter lives in the *global* `ythril_counters`
-    collection keyed by `_id: <spaceId>`, so the prefix-based collection rename missed it and `nextSeq()`
-    restarted at **1** — while the rename deliberately carries the OLD, high sync watermarks over to the new
-    id. Every subsequent write got a seq *below* the watermark and was **never pushed to peers**: the space
-    kept working locally while quietly never syncing again. The counter (and the dupe-scan cursor) now move
-    with the rename.
-  - **Cross-space import wrote invisible data.** The export embeds the source space's id in every document,
-    and import wrote them verbatim — so importing space A's export into space B produced documents that were
-    counted but invisible to every list. Imported documents are now re-tagged to the target space.
-  - `traverseFromSeeds` filtered entities but not edges by `spaceId`, so a stale value returned an edge whose
-    neighbour entity silently vanished — half a graph, no error. The redundant filter is gone; the collection
-    name is the only real scope.
-
-  Tests now cover **chrono** and the **seq counter** across a rename, and **cross-space import** — the gaps
-  that let all of this through. (The original rename test asserted only memories, the one read path that does
-  not filter on `spaceId`, and the import tests asserted only counts and memory-by-id — likewise immune.)
-
-- **Renaming a space no longer makes its entities and edges vanish from the UI.** `moveSpaceData`
-  renamed the collections (`{old}_entities` → `{new}_entities`) but never rewrote the `spaceId` field
-  *inside* the documents, so every one still pointed at the OLD space id. `listEntities`, `listEdges`,
-  entity lookup-by-name, the edge-dedup lookup and the cascade deletes all filter on that field — so a
-  renamed space looked **catastrophic but was actually intact**: the entry counts still showed the data
-  (counts read the collection) while every list came back **empty**. Worse, because lookup-by-name
-  stopped matching, `remember` would start creating **duplicate entities** instead of linking to the
-  existing one. Memories were unaffected (`listMemories` does not filter on `spaceId`) — which is
-  exactly why the existing rename test, which only checked memories, never caught this. The rename now
-  rewrites the field, and **existing affected databases self-heal on boot** (`repairStaleSpaceIds`,
-  run from `initSpace`): documents living in `{spaceId}_*` belong to `spaceId` by definition, so the
-  repair is safe and idempotent. Sync had the same flaw — a `spaceMap`-aliased pull wrote peer documents
-  into the local collection while keeping the *remote* space id — and now re-tags them to the local
-  space. Regression test added covering entities, edges and lookup-by-name across a rename.
-
-- **The test stack no longer races four concurrent builds onto one image tag.** Giving every instance the
-  shared `ythril-test:latest` tag (so CI can pre-build once against a layer cache) made `docker compose
-  build` build the *same* tag from four services simultaneously, which races on the image export and could
-  corrupt it locally (`failed to extract layer … EOF`). Only `ythril-a` builds the image now; b/c/d simply
-  reference the tag. CI is unaffected — it pre-builds the tag itself.
-
-- **Rebuilding the test stack no longer leaks Docker disk without bound.** Every `--build` orphaned the
-  previous multi-GB image (each bakes a ~520 MB embedding model, node_modules and ffmpeg) and grew the
-  BuildKit cache forever — on one workstation this reached **35 GB of build cache plus 20 GB of orphaned
-  images**, filled the drive and took Docker Desktop down. `test:up:rebuild` now runs `test:prune` (drop
-  dangling images, cap the cache at 5 GB), and a new `npm run docker:reclaim` handles an already-ballooned
-  install: it prunes, then `fstrim`s inside the VM, then prints the exact elevated `diskpart` steps to
-  **compact** `docker_data.vhdx` — necessary because pruning frees space *inside* the VM while the
-  dynamically-expanding disk only ever grows on the host. It locates the disk even when relocated to
-  another drive (`CustomWslDistroDir`).
-
-- **Sync tests can no longer turn a persistent, actionable error into an unexplained timeout.** The sync
-  suites re-trigger a sync on every poll (deliberate — a single up-front trigger races a slow gossip
-  cycle), but they did it as `triggerSync(...).catch(() => {})`, which treats a transient blip and a
-  permanent misconfiguration identically. That trap is *why* the notify rate-limit bug survived three wrong
-  fixes: every trigger was coming back `429`, the `.catch()` ate it, no sync cycle ever ran, and all anyone
-  saw was `waitFor timed out after 90000ms`. `waitFor` now takes a `diagnose` argument appended to its
-  timeout message, and `makeTriggerProbe` still tolerates a failed poll but **remembers the last failure**
-  and reports it — so the message becomes "every sync trigger to A was failing (…); last error:
-  triggerSync failed: 429 …" instead of a bare stall. Test-harness only. Pinned by
-  `testing/standalone/waitfor-diagnostics.test.js`.
-
-- **The notify limiter now honours the test kill-switch — the real cause of the “flaky” signed-vote relay test.**
-  `POST /api/notify/trigger` is how the test harness drives a sync cycle, and it is guarded by
-  `notifyRateLimit` (60/min per IP). Every request from the harness shares one source IP, so the sync suites
-  collectively blew past 60/min and started getting `429`s — which the tests' trigger call swallowed, so the
-  sync cycle silently never ran and load-sensitive assertions timed out looking like flakes. `notifyRateLimit`
-  was the **only** limiter with no `skip:` clause (`authRateLimit`, `globalRateLimit`, `syncRateLimit` and
-  `bulkWipeRateLimit` all have one); it now honours `SKIP_SYNC_RATE_LIMIT` like the rest of the sync plane.
-  **No production impact:** the kill-switch is inert unless `NODE_ENV !== 'production'`, scheduled sync calls
-  the engine in-process (it never touches this limiter at all), and instance C deliberately omits the env so
-  the genuine 429 behaviour stays covered. Pinned by `testing/standalone/notify-rate-limit.test.js`, which
-  asserts both halves: A must not throttle, C still must.
-
-- **OIDC sign-in no longer hangs when the whole SPA is embedded in a portal iframe.** The callback
-  inferred "this is a silent-refresh frame" from simply being inside an iframe (`window.self !== window.top`)
-  and tried to `postMessage` the authorization code to `window.parent` targeted at Ythril's own origin. That
-  is correct for a genuine silent refresh (whose hidden iframe's parent *is* the SPA), but when the entire
-  Ythril SPA runs inside a host portal's iframe, the interactive redirect callback is also framed and its
-  parent is the *portal's* origin — so the browser refuses the cross-origin `postMessage` and the user is
-  stuck on "Completing sign-in…" forever. The silent-refresh flow now marks its request explicitly with a
-  `state` prefix (`silent.`), and the callback branches on that marker instead of on being framed — so an
-  embedded interactive sign-in completes normally while genuine silent refreshes are still recognised.
-  Client-only. Reported from a production embedded (iframe) deployment.
-
-- **Governance votes and member gossip now converge even when data sync is slow or failing.** In each
-  sync cycle, gossip (member list, signing-key pinning) and vote propagation ran **after** the per-space
-  data and file sync for a peer — and that data loop is not isolated, so any timed-out pull, unreachable
-  member, or slow file transfer threw out of the member's sync and **skipped governance entirely for that
-  cycle**. On a lightly loaded system the data plane is fast so this never showed, but under heavy load a
-  saturated peer could starve time-sensitive vote propagation (rounds have deadlines) for many cycles in
-  a row — the root cause behind the intermittently-timing-out signed-vote relay test. Governance now runs
-  **first**, ahead of the data loop, so it converges promptly and independently of data-plane health. The
-  two calls remain internally best-effort and are additionally wrapped so a later data-plane failure can
-  never mask governance progress. Covered by the existing sync/vote suites.
-
-- **Importing a schema no longer fails silently.** In **Settings → Spaces → Schema → Import JSON**, a
-  valid-JSON file that contained none of the recognised `entity`/`edge`/`memory`/`chrono` keys — which
-  includes Ythril's **own** per-type export shape `{knowledgeType, typeName, schema}` — fell straight
-  through the import loop and then *cleared the error field*, so it looked like it worked while doing
-  nothing. Import now: (1) also accepts the `{knowledgeType, typeName, schema}` export shape; (2) shows a
-  specific error listing the expected keys and what the file actually contained when nothing is
-  recognised; and (3) confirms success with a note that the imported types are **staged — press Save to
-  apply**. Client-only.
-
-- **Record properties are now fully embedded, so semantic recall can use them.** The text embedded for
-  a record mishandled `properties`: memory and entity embedded only the property **values** and dropped
-  the **keys**, while **edge and chrono embedded properties not at all**. So recall couldn't match on a
-  property name (a query about "role" had no "role" signal), and values lost their field context —
-  `{birthplace: "Paris"}` and `{currentCity: "Paris"}` embedded identically. All five builders (memory,
-  entity, edge, chrono, and the entity-merge copy) now fold `key value` pairs into the embedded text
-  via a single shared `propsEmbedText` helper, and chrono re-embeds when only its properties change.
-  Existing records keep their old (weaker) vectors until re-embedded — run
-  `POST /api/brain/spaces/:id/reindex` to rebuild them with property keys. Covered by
-  `testing/integration/embed-properties.test.js`.
-
-- **Recall no longer errors while a new space's vector indexes are still building.** Space creation now
-  builds its `$vectorSearch` indexes asynchronously (see the space-creation fix above), and Atlas
-  refuses queries against an index still in `INITIAL_SYNC` — so a recall during that brief window
-  failed the whole request with a `400` ("cannot query vector index … while in state INITIAL_SYNC")
-  instead of returning results from the collections that were ready. Recall now treats a
-  not-yet-queryable index like a missing one — no results from that collection — so it degrades to a
-  partial/empty result during the build window instead of erroring. Covered by
-  `testing/integration/space-creation-async.test.js`.
-
-- **Creating a space no longer times out or "appears only after a reload".** `createSpace` awaited the
-  build of a space's 5+ Atlas `$vectorSearch` indexes, each polling for READY up to 60 s (worst case
-  minutes) — so the `201` landed far past the client's 30 s timeout, on a dead subscription, and the
-  space seemed to vanish until the page was refreshed. Creation now returns in seconds: collections and
-  regular indexes are created synchronously (the space always has a backing DB), the vector-index READY
-  wait is **deferred**, and the space is returned with `indexStatus: 'building'` and finalized to
-  `ready`/`failed` by a background task. The space is writable immediately; only semantic recall waits
-  for READY. The UI shows a "Preparing indexes…" badge until it clears. `GET /api/spaces` surfaces
-  `indexStatus`. Covered by `testing/integration/space-creation-async.test.js`.
-
-- **Document embedding failures are reported instead of faked as success.** When a text/document
-  upload's chunks failed to embed, an empty `catch` swallowed the error and the job still reported
-  `embeddingStatus: 'complete'` — so a file that was permanently invisible to `$vectorSearch` looked
-  fully indexed, with no failure signal and never engaging the existing retry/backoff machinery. A
-  total failure now routes into that retry path (ending `failed` if it can't recover); a partial
-  failure is recorded as `embeddingStatus: 'partial'` (new state) and is retriable. A **Retry** button
-  and a "Partly embedded" badge were added to the file list, wiring the previously-unused
-  `retry_embedding` endpoint. Covered by `testing/standalone/embedding-failure-reporting.test.js`.
-
-- **Space rename/delete are now crash-safe.** A rename or delete spans `config.json`, MongoDB
-  collections, and the filesystem and cannot be atomic — a crash mid-operation (after renaming some
-  collections, or after moving files but before the config write) could leave them permanently
-  inconsistent with no recovery. A `pendingSpaceOp` write-ahead marker is now persisted before any
-  physical change and cleared only on commit; the physical steps are idempotent, and an interrupted
-  operation is completed on the next boot (and on `reload-config`). Covered by
-  `testing/standalone/space-op-recovery.test.js`.
-
-- **The governance vote "No" button now works (and casts a veto).** The Networks UI offered **Yes/No**
-  buttons, but the server accepts only `yes`/`veto` (`VoteValue`), so clicking **No** returned `400`
-  and there was no way to cast a blocking vote from the UI at all. The negative button now casts a
-  `veto` — the blocking vote the model and docs already describe ("a single no blocks it") — and is
-  relabelled **Veto** to match. Client-only fix.
-
-- **`<html lang>` now tracks the active UI language.** It was hardcoded to `en`, so screen-reader
-  pronunciation and browser hyphenation stayed English for German and Polish users even though the UI
-  was fully translated. The document language is now set on startup and updated on every language
-  switch.
-
-- **Close/remove buttons use a consistent icon everywhere.** Close and remove controls across the app
-  rendered a mix of raw `✕` and `×` glyphs at different weights/baselines than the `ph-icon` used
-  elsewhere. Every one — dialog close buttons, chip/tag remove buttons, and danger remove actions in
-  networks, spaces, schema-library, tokens, and the shared property/tag editors — now uses the `x`
-  icon, and dialog close buttons that were missing an `aria-label` gained one.
-
-- **Legacy tokens are no longer silently invalidated on upgrade** — a startup/reload migration
-  *deleted* any PAT created before the `prefix` field existed, on the assumption it "cannot be
-  verified." In fact a prefix-less token can still be bcrypt-verified; the prefix is only a lookup
-  optimization. The deletion meant that after an innocuous restart/upgrade, every client sharing such
-  a token — web UI, monitors, MCP connectors — dropped to `401` at once, with nothing but a single log
-  line to explain it. Legacy tokens are now **verified via a fallback scan and self-heal**: the prefix
-  is backfilled on first use so subsequent lookups take the fast path, and no token is ever deleted by
-  the migration. Covered by `testing/integration/auth.test.js`.
 
 ### Security
 
@@ -1424,6 +1513,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `whisper:8000`) which resolve in both Docker Compose bridge DNS and the K8s
   `ythril` namespace.
 
+- **`PUT /api/spaces/:id/schema`** — New endpoint for *full* typeSchemas replacement
+  (PUT semantics).  Before overwriting, the previous schema is written to a timestamped
+  JSON backup file (`_schema-backup-<timestamp>.json`) inside the space's file store so it
+  can be recovered or re-imported.  Use this endpoint when an intentional full replacement is
+  required instead of an incremental update.  Returns the updated space on success.
+
+---
+
 ### Fixed
 
 - **`PATCH /api/spaces/:id` now uses true merge semantics for `meta`** — Previously,
@@ -1434,16 +1531,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   merged per-knowledge-type and per-type-name, so types absent from the request body are
   preserved.  This also means existing meta fields are no longer lost when only `typeSchemas`
   is patched.
-
-### Added
-
-- **`PUT /api/spaces/:id/schema`** — New endpoint for *full* typeSchemas replacement
-  (PUT semantics).  Before overwriting, the previous schema is written to a timestamped
-  JSON backup file (`_schema-backup-<timestamp>.json`) inside the space's file store so it
-  can be recovered or re-imported.  Use this endpoint when an intentional full replacement is
-  required instead of an incremental update.  Returns the updated space on success.
-
----
 
 ## [1.2.0] — 2026-04-24
 
@@ -1479,7 +1566,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.gitignore`** — added `config/schema-catalogs.json` and `testing/sync/configs/*/schema-catalogs.json` (and test-instance `schema-library.json`) to prevent accidental commits of runtime data files.
 
 ---
-
 
 ## [1.1.0] — 2026-04-22
 
@@ -1527,7 +1613,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `config/schema-library.json` added to `.gitignore` — the instance-level library file is runtime data and must not be committed alongside `config.json` and `secrets.json`.
 
-
 ## [1.0.0] — 2026-04-20
 
 ### ⚠ Breaking Changes
@@ -1541,17 +1626,20 @@ Two breaking API changes are present in this release. Clients, tests, and script
 The `kind` field on chrono entries has been renamed to `type` to be consistent with all other knowledge types in the API (`memory.type`, `entity.type`, `edge.type`).
 
 **Affected endpoints:**
+
 - `POST /api/brain/spaces/:spaceId/chrono` — request body
 - `POST /api/brain/spaces/:spaceId/bulk` — `chrono[]` items in the bulk body
 - `GET /api/brain/spaces/:spaceId/chrono` — response documents
 - MCP tools: `create_chrono`, `bulk_write` (chrono items), `list_chrono` (filter param and response)
 
 **Migration — before:**
+
 ```json
 { "title": "Sprint review", "kind": "event", "startsAt": "2026-05-01T10:00:00Z" }
 ```
 
 **Migration — after:**
+
 ```json
 { "title": "Sprint review", "type": "event", "startsAt": "2026-05-01T10:00:00Z" }
 ```
@@ -1567,12 +1655,14 @@ The TypeScript type alias `ChronoKind` remains exported as a deprecated alias fo
 The flat schema fields on `SpaceMeta` (`entityTypes`, `edgeLabels`, `namingPatterns`, `requiredProperties`, `propertySchemas`) have been replaced by a single nested `typeSchemas` object. The old flat fields are no longer accepted — `PATCH /api/spaces/:id` uses a strict Zod schema and will return 400 `unrecognized_key` for any old field names.
 
 **Affected endpoints:**
+
 - `PATCH /api/spaces/:id` — `meta` field in request body
 - `GET /api/spaces/:id/meta` — response shape (no `entityTypes` array in response)
 - `POST /api/spaces/:id/validate-schema` — schema in `meta` payload
 - MCP tools: `update_space` (meta argument), `get_space_meta` (response)
 
 **Migration — before (flat format):**
+
 ```json
 {
   "validationMode": "strict",
@@ -1595,6 +1685,7 @@ The flat schema fields on `SpaceMeta` (`entityTypes`, `edgeLabels`, `namingPatte
 ```
 
 **Migration — after (`typeSchemas` format):**
+
 ```json
 {
   "validationMode": "strict",
@@ -1639,6 +1730,7 @@ The flat schema fields on `SpaceMeta` (`entityTypes`, `edgeLabels`, `namingPatte
 ```
 
 Key differences:
+
 - `entityTypes` and `edgeLabels` are gone — allowed types/labels are now inferred from the keys of `typeSchemas.entity` and `typeSchemas.edge`
 - `namingPatterns` (global map) → `typeSchemas.entity.<typeName>.namingPattern` (per-type inline string)
 - `requiredProperties` (list per knowledge-type) → `required: true` flag inline on each `propertySchemas` entry
@@ -1991,6 +2083,7 @@ Initial public release.
 ### Added
 
 #### Core
+
 - Space-isolated knowledge management: memories, entities, edges, tombstones.
 - Semantic search via OpenAI-compatible embedding endpoint (`/v1/embeddings`).
 - Proxy spaces — virtual read-aggregation across multiple real spaces.
@@ -1999,6 +2092,7 @@ Initial public release.
 - Storage quota enforcement (soft/hard limits for files and brain data).
 
 #### Authentication & Security
+
 - PAT token auth (`ythril_*`) with bcrypt-hashed storage, space-scoped allowlists.
 - Optional MFA (TOTP) for admin mutations.
 - RSA-4096-OAEP zero-knowledge invite handshake.
@@ -2010,6 +2104,7 @@ Initial public release.
 - Global rate-limiting middleware (configurable per-endpoint).
 
 #### Brain Networks & Sync
+
 - Network types: Closed, Democratic, Club, Braintree (hierarchical push-only).
 - Watermark-based incremental sync: pull → push → file manifest (SHA-256) → gossip.
 - Voting system for membership changes (unanimous, majority, supermajority, ancestor-path).
@@ -2018,17 +2113,20 @@ Initial public release.
 - Sync history tracking with per-run stats and error reporting.
 
 #### Client (Angular 21)
+
 - Web UI: brain explorer, file manager, space manager, token manager, network manager.
 - Conflict resolution page with bulk actions.
 - MFA enrollment flow with QR code display.
 - Accessible forms with aria-labels and HTML5 validation.
 
 #### Infrastructure
+
 - Single `docker-compose.yml` deployment with MongoDB Atlas Local.
 - Docker healthcheck on `/health` endpoint.
 - Hot-reloadable configuration with permissions enforcement.
 - First-run setup wizard (admin password, instance label, embedding config).
 
 #### Documentation
+
 - User guide, integration guide (full REST & MCP API reference), contribution guide.
 - Network types specification, sync protocol specification, dependency inventory.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Track events, deadlines, plans, predictions, and milestones with the **chrono** 
 
 Full file manager with **chunked upload** (5 MB pieces, progress tracking, automatic retry), directory tree, inline preview (text, code, images, PDF), and file-level metadata (description, tags, properties). All file operations are available as MCP tools and via the REST API.
 
-Uploaded PDF, DOCX, and EPUB files are automatically converted to text by the bundled `unstructured-api-full` sidecar using full OCR and layout detection (`hi_res` strategy). Tables are extracted as structured HTML; embedded images are extracted as independent subfiles and queued for the full media pipeline (captioning + face recognition). Plain-text and HTML files are converted in-process. All converted content is chunked and embedded so it is immediately searchable via `recall`.
+Uploaded PDF, DOCX, and EPUB files are automatically converted to text by the bundled `unstructured-api` sidecar using full OCR and layout detection (`hi_res` strategy). Tables are extracted as structured HTML; embedded images are extracted as independent subfiles and queued for the full media pipeline (captioning + face recognition). Plain-text and HTML files are converted in-process. All converted content is chunked and embedded so it is immediately searchable via `recall`.
 
 ### Image, Audio & Video Understanding
 

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -339,6 +339,7 @@
   "brain.fileMeta.embedding": "Einbettung…",
   "brain.fileMeta.embeddingFailed": "Einbettung fehlgeschlagen",
   "brain.fileMeta.embeddingPartial": "Teilweise eingebettet",
+  "brain.fileMeta.deleted": "Gelöscht",
   "brain.fileMeta.retryEmbedding": "Wiederholen",
   "brain.fileMeta.picker.searchMemories": "Erinnerungen suchen…",
   "brain.fileMeta.picker.searchChrono": "Chrono suchen…",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -338,6 +338,7 @@
   "brain.fileMeta.embedding": "Embedding…",
   "brain.fileMeta.embeddingFailed": "Embedding failed",
   "brain.fileMeta.embeddingPartial": "Partly embedded",
+  "brain.fileMeta.deleted": "Deleted",
   "brain.fileMeta.retryEmbedding": "Retry",
   "brain.fileMeta.picker.searchMemories": "Search memories…",
   "brain.fileMeta.picker.searchChrono": "Search chrono…",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -339,6 +339,7 @@
   "brain.fileMeta.embedding": "Osadzanie…",
   "brain.fileMeta.embeddingFailed": "Osadzanie nie powiodło się",
   "brain.fileMeta.embeddingPartial": "Częściowo osadzone",
+  "brain.fileMeta.deleted": "Usunięto",
   "brain.fileMeta.retryEmbedding": "Ponów",
   "brain.fileMeta.picker.searchMemories": "Szukaj wspomnień…",
   "brain.fileMeta.picker.searchChrono": "Szukaj chrono…",

--- a/client/src/app/core/api.service.ts
+++ b/client/src/app/core/api.service.ts
@@ -286,6 +286,9 @@ export interface FileMeta {
   /** Error message when embeddingStatus is "failed". */
   mediaJobError?: string;
   chunkCount?: number;
+  /** Set when the file was deleted but its metadata was retained (softDeleteFileMeta):
+   *  ISO8601 deletion timestamp. Such records show a "deleted" badge and can be purged. */
+  deletedAt?: string;
 }
 
 export interface UploadProgress {

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -1556,6 +1556,9 @@ interface SpaceView {
                         <td>
                           <div style="display:flex; align-items:center; gap:6px; flex-wrap:wrap;">
                             <button class="link-btn" [attr.title]="'brain.fileMeta.openInFilesTabTitle' | transloco" (click)="openFileInManager(fm.path)">{{ fm.path }}</button>
+                            @if (fm.deletedAt) {
+                              <span class="badge badge-red" style="font-size:10px;" [title]="'Deleted ' + (fm.deletedAt | date:'dd.MM.yyyy HH:mm')">{{ 'brain.fileMeta.deleted' | transloco }}</span>
+                            }
                             @if (fm.embeddingStatus === 'pending' || fm.embeddingStatus === 'processing') {
                               <span class="badge badge-blue" style="font-size:10px;" title="Embedding in progress…"><span class="spinner" style="width:8px;height:8px;border-width:1.5px;display:inline-block;vertical-align:middle;margin-right:3px;"></span>{{ 'brain.fileMeta.embedding' | transloco }}</span>
                             } @else if (fm.embeddingStatus === 'failed') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,13 +148,13 @@
       - ythril-media     # deliberately NOT on ythril-db
 
   # ── Document-conversion sidecar (PDF / DOCX / EPUB → Markdown) ─────────────
-  # Bundles the `unstructured-api-full` server (C2). Without it, `docker compose up`
+  # Bundles the `unstructured-api` server (C2). Without it, `docker compose up`
   # leaves CONVERSION_SIDECAR_URL pointing at nothing and PDF/DOCX/EPUB uploads fail
   # `sidecar_down` — Ythril itself still runs, so it is intentionally NOT a startup
   # dependency of the ythril service (conversion degrades gracefully until it is up).
   #
-  # HEAVY IMAGE: unstructured-api-full bundles OCR model weights (Tesseract/PaddleOCR)
-  # and is ~8–12 GB; first boot is slow (hence the long start_period). See
+  # HEAVY IMAGE: unstructured-api bundles OCR model weights (Tesseract) and is
+  # ~4.5 GB compressed (~6–8 GB on disk); first boot is slow (hence the long start_period). See
   # docs/dependencies.md. To skip it on a resource-constrained workstation, stop it
   # (`docker compose stop unstructured`) or scale it to zero
   # (`docker compose up --scale unstructured=0`); in-process text/HTML conversion and
@@ -167,7 +167,11 @@
   unstructured:
     # Pin the tag and verify the bundled LICENSE (Apache-2.0) before upgrading:
     #   docker run --rm --entrypoint cat <image> /app/LICENSE
-    image: downloads.unstructured.io/unstructured-io/unstructured-api-full:0.0.75
+    # NOTE: the `-full` variant was made private on quay.io (401 UNAUTHORIZED on pull).
+    # The public `unstructured-api` image is the same release minus extra Tesseract
+    # language packs / LibreOffice, and fully supports the hi_res OCR + image-extraction
+    # path Ythril uses. Upstream's README points self-hosters at this image too.
+    image: downloads.unstructured.io/unstructured-io/unstructured-api:0.0.75
     container_name: ythril-unstructured
     restart: unless-stopped
     healthcheck:

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -204,16 +204,23 @@ Legal principle that runtime infrastructure must be listed with its licensing im
 |---|---|---|
 | `ollama/ollama` | Vision model host — captions uploaded images (default `moondream`) for the media pipeline. | MIT (the Ollama runtime). Models are pulled separately; the default `moondream` is Apache 2.0. |
 | `fedirz/faster-whisper-server` | Speech-to-text — transcribes uploaded/segmented audio via an OpenAI-compatible endpoint. | MIT (the server). Whisper models are pulled separately and are Apache 2.0. |
-| `unstructured-io/unstructured-api-full` | Server-side PDF / DOCX / EPUB conversion (`hi_res` OCR + layout detection, table and embedded-image extraction). | Apache 2.0. |
+| `unstructured-io/unstructured-api` | Server-side PDF / DOCX / EPUB conversion (`hi_res` OCR + layout detection, table and embedded-image extraction). | Apache 2.0. |
 
 **Where they are referenced.** `ollama`, `whisper`, and `unstructured` are all services in
 [`docker-compose.yml`](../docker-compose.yml) and have matching Kubernetes manifests
-(`kubernetes/manifests/{ollama,whisper}-deploy.yaml`; the `unstructured-api-full` sidecar is
+(`kubernetes/manifests/{ollama,whisper}-deploy.yaml`; the `unstructured-api` sidecar is
 in `kubernetes/manifests/ythril-deployment.yaml`, pod-local). `ollama`/`whisper` form the
 media-embedding stack; `unstructured` is the bundled document-conversion sidecar.
 
-> **Image size — `unstructured-api-full` is heavy (~8–12 GB).** It bundles OCR model weights
-> (Tesseract / PaddleOCR), so the first `docker compose up` pulls a large image and the sidecar
+> **Why not `unstructured-api-full`?** The `-full` variant (extra Tesseract language packs +
+> LibreOffice) was made private on quay.io and now returns `401 UNAUTHORIZED` on an anonymous
+> pull. The public `unstructured-api` image is built from the same release, supports the exact
+> `hi_res` OCR + embedded-image extraction path Ythril calls, and is what upstream's own README
+> points self-hosters at. Ythril's PDF/DOCX/EPUB + English-OCR path needs nothing the `-full`
+> extras add.
+>
+> **Image size — `unstructured-api` is heavy (~4.5 GB compressed).** It bundles OCR model
+> weights (Tesseract), so the first `docker compose up` pulls a large image and the sidecar
 > is slow to become ready (a long `start_period`). It is intentionally **not** a startup
 > dependency of the `ythril` service — Ythril runs without it and PDF/DOCX/EPUB conversion
 > simply reports `sidecar_down` until the sidecar is up. On a resource-constrained workstation,
@@ -224,6 +231,6 @@ media-embedding stack; `unstructured` is the bundled document-conversion sidecar
 **Licensing impact — none on Ythril's PolyForm obligations.** All three are permissively
 licensed (MIT / Apache 2.0), carry no copyleft, and run as independent network services
 rather than linked code — the same TCP-socket relationship analysed for MongoDB above.
-`unstructured-api-full` in particular ships under Apache 2.0, but because its tag can change,
+`unstructured-api` in particular ships under Apache 2.0, but because its tag can change,
 verify the image's bundled `LICENSE` on every version bump (the procedure is documented in
 the header of `kubernetes/manifests/ythril-deployment.yaml`).

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1694,7 +1694,23 @@ DELETE /api/files/:spaceId?path=reports/q1.pdf
 
 To delete a directory, include `{ "confirm": true }` in the request body.
 
-Deleting a file that was converted automatically cascades: all chunk records and the `_converted/<id>.md` file are removed from the file store.
+Deleting a file cascades: its metadata record, any queued embedding job, and all conversion
+artifacts — chunk records plus the on-disk `_converted/<id>.md` and `_extracted/<id>/` sidecars —
+are removed from the file store. Deleting a **directory** does the same for every file beneath it,
+including the `_converted/<path>` and `_extracted/<path>` subtrees, and writes a sync **tombstone**
+per removed file so peers delete their copies too (otherwise the next sync would push them back).
+
+**Soft-delete (`softDeleteFileMeta`).** With this top-level config flag set to `true` (default
+`false`), deleting a file **retains** its metadata record and flags it `deletedAt = <timestamp>`
+instead of removing it. Flagged records stay listed and searchable but are shown as "deleted" in the
+UI; re-uploading the same path clears the flag. Derived records (conversion chunks / `_converted` /
+`_extracted`) are always hard-removed regardless of the setting.
+
+**Metadata-only delete + guard.** `DELETE /api/brain/spaces/:spaceId/files?path=…` removes a metadata
+record *without* touching disk — but only when doing so is safe. If the file **still exists on disk**
+and the record is not flagged deleted, the request is refused with **`409`** (deleting the metadata
+would silently orphan a live file — delete the file itself instead). A flagged or already-orphaned
+record (its file gone) can be purged this way.
 
 ---
 
@@ -5013,8 +5029,13 @@ Webhooks allow external systems to receive real-time HTTP POST notifications whe
 | `file.created` | A file is written (new or overwrite) |
 | `file.updated` | A file is moved/renamed |
 | `file.deleted` | A file is deleted |
+| `bulk.write` | A bulk write completed (`POST /bulk` or MCP `bulk_write`). Per-item events are **not** fired for bulk; this one summary carries `entry` = `{ inserted, updated, errorCount }` for a workflow to inspect. |
 | `duplicate.detected` | The duplicate scanner found a near-duplicate pair under a `notify` rule (see [Duplicate Scanner](#duplicate-scanner--action-rules)). Payload `entry` = `{ type, score, a: {record}, b: {record} }` |
 | `test.ping` | Synthetic test event sent via the test endpoint |
+
+> Events fire for **both** REST API and MCP (agent) writes — emission lives in the shared
+> brain/file functions, so an agent creating a memory or entity delivers the same events a REST
+> client would. Internal writes (sync replication, space import) do not emit.
 
 ### Create Subscription
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -551,7 +551,7 @@ These are set in `config.json` under `mediaEmbedding.faceRecognition` — they a
 
 ### Document Processing (OCR & Image Extraction)
 
-When you upload a PDF, DOCX, or EPUB, Ythril converts it to text using the `unstructured-api-full` sidecar, which includes Tesseract OCR. The conversion strategy controls the trade-off between speed and quality.
+When you upload a PDF, DOCX, or EPUB, Ythril converts it to text using the `unstructured-api` sidecar, which includes Tesseract OCR. The conversion strategy controls the trade-off between speed and quality.
 
 These settings live in `config.json` under `mediaEmbedding.documentProcessing`:
 

--- a/kubernetes/manifests/ythril-deployment.yaml
+++ b/kubernetes/manifests/ythril-deployment.yaml
@@ -1,10 +1,10 @@
 # ── Ythril Deployment ────────────────────────────────────────────────────────
-# This manifest deploys Ythril with the unstructured-api-full sidecar for
+# This manifest deploys Ythril with the unstructured-api sidecar for
 # server-side PDF / DOCX / EPUB conversion.
 #
-# BEFORE DEPLOYING: Verify the unstructured-api-full image tag's LICENSE file:
+# BEFORE DEPLOYING: Verify the unstructured-api image tag's LICENSE file:
 #   docker run --rm --entrypoint cat \
-#     downloads.unstructured.io/unstructured-io/unstructured-api-full:<TAG> \
+#     downloads.unstructured.io/unstructured-io/unstructured-api:<TAG> \
 #     /app/LICENSE
 # Confirm it is Apache-2.0 with no commercial-use restrictions.
 # Repeat on every version bump.
@@ -104,15 +104,16 @@ spec:
         # strategy=auto: fast text-layer extraction for digital PDFs;
         # hi_res OCR (Tesseract/PaddleOCR) for scanned/image-only PDFs.
         #
-        # Image: downloads.unstructured.io/unstructured-io/unstructured-api-full
+        # Image: downloads.unstructured.io/unstructured-io/unstructured-api
         # License: Apache-2.0 (verify before pinning any new tag — see note above)
-        # The full image bundles OCR model weights (Tesseract/PaddleOCR) and is
-        # 8–12 GB. Pre-pull on nodes before first deployment to avoid cold-start
-        # delays on Pod restarts.
+        # NOTE: the `-full` variant was made private on quay.io (401 on pull); the public
+        # `unstructured-api` image is the same release minus extra Tesseract language packs
+        # and still bundles OCR model weights (Tesseract) — ~4.5 GB compressed. Pre-pull on
+        # nodes before first deployment to avoid cold-start delays on Pod restarts.
         - name: unstructured
           # Pin to a specific tag and verify the LICENSE before upgrading.
           # Run `docker run --rm --entrypoint cat <image> /app/LICENSE` to confirm Apache-2.0.
-          image: downloads.unstructured.io/unstructured-io/unstructured-api-full:0.0.75
+          image: downloads.unstructured.io/unstructured-io/unstructured-api:0.0.75
           # Lighter hardening than the main container: the OCR pipeline writes
           # scratch files across its own filesystem, so readOnlyRootFilesystem is
           # left off, but privilege escalation and added capabilities are still denied.

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -14,6 +14,7 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 import { createChrono, updateChrono, getChronoById, listChrono, deleteChrono, bulkDeleteChrono, parseRecurrence, ChronoFilter } from '../brain/chrono.js';
 import { embed } from '../brain/embedding.js';
 import { updateFileMeta, deleteFileMeta } from '../files/file-meta.js';
+import { fileExists } from '../files/files.js';
 import { getConfig } from '../config/loader.js';
 import { col, asFilter, asDoc } from '../db/mongo.js';
 import { nextSeq } from '../util/seq.js';
@@ -271,8 +272,7 @@ brainRouter.delete('/spaces/:spaceId/memories/:id', globalRateLimit, requireSpac
   const id = req.params['id'] as string;
   const memberIds = resolveMemberSpaces(spaceId);
   for (const mid of memberIds) {
-    if (await deleteMemory(mid, id)) {
-      emitWebhookEvent({ event: 'memory.deleted', spaceId: mid, entry: { _id: id }, ...webhookToken(req) });
+    if (await deleteMemory(mid, id, webhookToken(req))) {
       res.status(204).end();
       return;
     }
@@ -341,9 +341,8 @@ brainRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSpace
         return;
       }
     }
-    const updated = await updateMemory(mid, id, updates, dfPaths);
+    const updated = await updateMemory(mid, id, updates, dfPaths, webhookToken(req));
     if (updated) {
-      emitWebhookEvent({ event: 'memory.updated', spaceId: mid, entry: { ...updated, embedding: undefined }, ...webhookToken(req) });
       res.json(updated);
       return;
     }
@@ -423,8 +422,7 @@ brainRouter.post('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAuth,
   }
 
   try {
-    const { entity, warning } = await upsertEntity(wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId);
-    emitWebhookEvent({ event: warning ? 'entity.updated' : 'entity.created', spaceId: wt.target, entry: { ...entity, embedding: undefined }, ...webhookToken(req) });
+    const { entity, warning } = await upsertEntity(wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId, undefined, webhookToken(req));
     const result: Record<string, unknown> = { ...entity };
     if (warning) result['warning'] = warning;
     if (validation.warnings.length > 0) result['warnings'] = validation.warnings;
@@ -499,8 +497,8 @@ brainRouter.post('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, de
   const edge = await upsertEdge(
     wt.target, from.trim(), to.trim(), label.trim(), weight, type?.trim(),
     typeof description === 'string' ? description : undefined, safeProps, safeTags,
+    webhookToken(req),
   );
-  emitWebhookEvent({ event: 'edge.created', spaceId: wt.target, entry: { ...edge, embedding: undefined }, ...webhookToken(req) });
   const result: Record<string, unknown> = { ...edge };
   if (validation.warnings.length > 0) result['warnings'] = validation.warnings;
   res.status(201).json(result);
@@ -593,8 +591,7 @@ brainRouter.delete('/spaces/:spaceId/entities/:id', globalRateLimit, requireSpac
         return;
       }
     }
-    if (await deleteEntity(mid, id)) {
-      emitWebhookEvent({ event: 'entity.deleted', spaceId: mid, entry: { _id: id }, ...webhookToken(req) });
+    if (await deleteEntity(mid, id, webhookToken(req))) {
       res.status(204).end();
       return;
     }
@@ -668,9 +665,8 @@ brainRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSpace
         return;
       }
     }
-    const updated = await updateEntityById(mid, id, updates, dfPaths);
+    const updated = await updateEntityById(mid, id, updates, dfPaths, webhookToken(req));
     if (updated) {
-      emitWebhookEvent({ event: 'entity.updated', spaceId: mid, entry: { ...updated, embedding: undefined }, ...webhookToken(req) });
       res.json(updated);
       return;
     }
@@ -758,16 +754,8 @@ brainRouter.post('/spaces/:spaceId/entities/:survivorId/merge/:absorbedId', glob
     plan.absorbedOnlyProperties,
   );
 
-  const mergeResult = await executeMerge(spaceId, survivor, absorbed, mergedProperties);
+  const mergeResult = await executeMerge(spaceId, survivor, absorbed, mergedProperties, webhookToken(req));
   const mergedEntity = mergeResult.entity;
-
-  // Emit webhook events
-  emitWebhookEvent({ event: 'entity.merged', spaceId, entry: { survivor: { ...mergedEntity, embedding: undefined }, absorbedId: absorbed._id }, ...webhookToken(req) });
-  emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...mergedEntity, embedding: undefined }, ...webhookToken(req) });
-  emitWebhookEvent({ event: 'entity.deleted', spaceId, entry: { _id: absorbed._id }, ...webhookToken(req) });
-  for (const dupId of mergeResult.deletedDuplicateEdgeIds) {
-    emitWebhookEvent({ event: 'edge.deleted', spaceId, entry: { _id: dupId }, ...webhookToken(req) });
-  }
 
   res.json({
     merged: { ...mergedEntity, embedding: undefined },
@@ -847,8 +835,7 @@ brainRouter.delete('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAu
   const id = req.params['id'] as string;
   const memberIds = resolveMemberSpaces(spaceId);
   for (const mid of memberIds) {
-    if (await deleteEdge(mid, id)) {
-      emitWebhookEvent({ event: 'edge.deleted', spaceId: mid, entry: { _id: id }, ...webhookToken(req) });
+    if (await deleteEdge(mid, id, webhookToken(req))) {
       res.status(204).end();
       return;
     }
@@ -918,9 +905,8 @@ brainRouter.patch('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAut
         return;
       }
     }
-    const updated = await updateEdgeById(mid, id, updates, dfPaths);
+    const updated = await updateEdgeById(mid, id, updates, dfPaths, webhookToken(req));
     if (updated) {
-      emitWebhookEvent({ event: 'edge.updated', spaceId: mid, entry: { ...updated, embedding: undefined }, ...webhookToken(req) });
       res.json(updated);
       return;
     }
@@ -1069,8 +1055,7 @@ brainRouter.post('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, d
   const entry = await createChrono(wt.target, {
     title: title.trim(), type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
-  });
-  emitWebhookEvent({ event: 'chrono.created', spaceId: wt.target, entry: { ...entry, embedding: undefined }, ...webhookToken(req) });
+  }, webhookToken(req));
   const result: Record<string, unknown> = { ...entry };
   if (validation.warnings.length > 0) result['warnings'] = validation.warnings;
   res.status(201).json(result);
@@ -1126,9 +1111,8 @@ brainRouter.post('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceAut
   const updated = await updateChrono(wt.target, id, {
     title, type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
-  });
+  }, webhookToken(req));
   if (!updated) { res.status(404).json({ error: 'Chrono entry not found' }); return; }
-  emitWebhookEvent({ event: 'chrono.updated', spaceId: wt.target, entry: { ...updated, embedding: undefined }, ...webhookToken(req) });
   res.json(updated);
 });
 
@@ -1184,9 +1168,8 @@ brainRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceAu
     const updated = await updateChrono(mid, id, {
       title, type, startsAt, endsAt, status, confidence,
       tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
-    });
+    }, webhookToken(req));
     if (updated) {
-      emitWebhookEvent({ event: 'chrono.updated', spaceId: mid, entry: { ...updated, embedding: undefined }, ...webhookToken(req) });
       res.json(updated);
       return;
     }
@@ -1251,8 +1234,7 @@ brainRouter.delete('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceA
   const id = req.params['id'] as string;
   const memberIds = resolveMemberSpaces(spaceId);
   for (const mid of memberIds) {
-    if (await deleteChrono(mid, id)) {
-      emitWebhookEvent({ event: 'chrono.deleted', spaceId: mid, entry: { _id: id }, ...webhookToken(req) });
+    if (await deleteChrono(mid, id, webhookToken(req))) {
       res.status(204).end();
       return;
     }
@@ -1323,6 +1305,19 @@ brainRouter.delete('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   const wt = resolveWriteTarget(spaceId, req.query['targetSpace'] as string | undefined);
   if (!wt.ok) { res.status(400).json({ error: wt.error }); return; }
   const memberIds = resolveMemberSpaces(wt.target);
+  const norm = path.replace(/\\/g, '/').replace(/^\/+/, '');
+  // Guard: a metadata record may only be removed if its file is gone (orphan) or the
+  // record is flagged deleted. Deleting the metadata of a file that still exists would
+  // silently orphan a live file — refuse and tell the caller to delete the file itself.
+  for (const mid of memberIds) {
+    const rec = await col<FileMetaDoc>(`${mid}_files`).findOne(asFilter<FileMetaDoc>({ _id: norm })) as FileMetaDoc | null;
+    if (rec && !rec.deletedAt && await fileExists(mid, norm)) {
+      res.status(409).json({
+        error: 'Cannot delete metadata while the file still exists. Delete the file itself (which also removes its metadata), or enable softDeleteFileMeta and delete the file first.',
+      });
+      return;
+    }
+  }
   for (const mid of memberIds) {
     await deleteFileMeta(mid, path);
   }
@@ -2031,6 +2026,14 @@ brainRouter.post('/spaces/:spaceId/bulk', globalRateLimit, requireSpaceAuth, den
     } catch (err) {
       errors.push({ type: 'chrono', index: i, reason: err instanceof Error ? err.message : String(err) });
     }
+  }
+
+  // Bulk writes suppress per-item webhooks (they don't pass an actor into the shared functions,
+  // so a 10k-item import doesn't fire 10k events). Instead emit ONE summary a workflow can inspect.
+  const bulkTotal = inserted.memories + inserted.entities + inserted.edges + inserted.chrono
+    + updated.entities + updated.edges;
+  if (bulkTotal > 0) {
+    emitWebhookEvent({ event: 'bulk.write', spaceId: targetSpace, entry: { inserted, updated, errorCount: errors.length }, ...webhookToken(req) });
   }
 
   res.status(207).json({ inserted, updated, errors });

--- a/server/src/api/duplicates.ts
+++ b/server/src/api/duplicates.ts
@@ -16,7 +16,6 @@ import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { scanSpace } from '../brain/dupe-scanner.js';
 import { computeMergePlan, applyResolutions, executeMerge } from '../brain/merge.js';
-import { emitWebhookEvent } from '../webhooks/dispatcher.js';
 import type { DupeCandidateDoc } from '../config/types.js';
 
 /** Find a candidate across the caller's accessible spaces. */
@@ -130,9 +129,7 @@ duplicatesRouter.post('/:id/merge', globalRateLimit, requireAuth, denyReadOnly, 
     if (!plan.fullyResolved) { res.status(409).json({ error: 'Property value conflict — resolve manually', plan: plan.plan }); return; }
 
     const mergedProps = applyResolutions(plan.survivor.properties ?? {}, plan.absorbed.properties ?? {}, plan.plan.propertyConflicts, plan.plan.absorbedOnlyProperties);
-    const result = await executeMerge(spaceId, plan.survivor, plan.absorbed, mergedProps);
-    emitWebhookEvent({ event: 'entity.merged', spaceId, entry: { survivor: { ...result.entity, embedding: undefined }, absorbedId: plan.absorbed._id } });
-    emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...result.entity, embedding: undefined } });
+    const result = await executeMerge(spaceId, plan.survivor, plan.absorbed, mergedProps, { tokenId: req.authToken?.id, tokenLabel: req.authToken?.name });
 
     await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).updateOne(
       asFilter<DupeCandidateDoc>({ _id: doc._id }),

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -32,6 +32,7 @@ import {
   deleteFile,
   createDir,
   moveFile,
+  listFilesRecursive,
 } from '../files/files.js';
 import {
   parseContentRange,
@@ -42,14 +43,14 @@ import {
 import { checkQuota, QuotaError, invalidateUsageCache } from '../quota/quota.js';
 import { resolveSafePath, assertNoSymlinkEscape, spaceRoot } from '../files/sandbox.js';
 import { col, asFilter, asDoc } from '../db/mongo.js';
-import type { FileTombstoneDoc, FileMetaDoc } from '../config/types.js';
-import { upsertFileMeta, deleteFileMeta, deleteFileMetaByPrefix, renameFileMeta, renameFileMetaByPrefix } from '../files/file-meta.js';
-import { v4 as uuidv4 } from 'uuid';
+import type { FileMetaDoc } from '../config/types.js';
+import { upsertFileMeta, deleteFileMeta, deleteFileMetaByPrefix, renameFileMeta, renameFileMetaByPrefix, markFileMetaDeleted, markFileMetaDeletedByPrefix } from '../files/file-meta.js';
+import { writeFileTombstones } from '../files/tombstones.js';
 import { resolveMemberSpaces, resolveWriteTarget } from '../spaces/proxy.js';
 import { emitWebhookEvent } from '../webhooks/dispatcher.js';
-import { resolveInputFormat, deleteConversionArtifacts, isMediaFormat } from '../files/converters/pipeline.js';
+import { resolveInputFormat, deleteConversionArtifacts, deleteConversionArtifactsByPrefix, isMediaFormat } from '../files/converters/pipeline.js';
 import type { InputFormat } from '../files/converters/pipeline.js';
-import { enqueueMediaJob, enqueueTextJob } from '../files/media/job-queue.js';
+import { enqueueMediaJob, enqueueTextJob, cancelMediaJob, cancelMediaJobsByPrefix } from '../files/media/job-queue.js';
 import { getMediaEmbeddingConfig } from '../config/loader.js';
 
 export const filesRouter = Router();
@@ -625,12 +626,42 @@ filesRouter.delete('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly,
       return;
     }
     try {
+      // Enumerate every file about to be removed — the folder tree AND its conversion
+      // sidecars — BEFORE deleting, so we can write a sync tombstone for each. Without
+      // tombstones a peer would re-push the files on the next sync (resurrection).
+      const removedPaths = (await Promise.all([
+        listFilesRecursive(targetSpace, filePath),
+        listFilesRecursive(targetSpace, `_converted/${filePath}`),
+        listFilesRecursive(targetSpace, `_extracted/${filePath}`),
+      ])).flat();
+
       await fs.rm(absPath, { recursive: true, force: false });
       log.info(`Deleted directory ${absPath} (space: ${targetSpace})`);
       invalidateUsageCache(); // freed disk — reflect it in the next quota check
-      await deleteFileMetaByPrefix(targetSpace, filePath).catch(err => {
-        log.warn(`deleteFileMetaByPrefix error for space ${targetSpace}, path ${filePath}: ${err}`);
+
+      // Metadata: soft-flag the user-visible file records (retain for audit) or hard-delete
+      // them, per the softDeleteFileMeta setting. Derived chunk records are always removed.
+      if (getConfig().softDeleteFileMeta === true) {
+        await markFileMetaDeletedByPrefix(targetSpace, filePath).catch(err => {
+          log.warn(`markFileMetaDeletedByPrefix error for space ${targetSpace}, path ${filePath}: ${err}`);
+        });
+      } else {
+        await deleteFileMetaByPrefix(targetSpace, filePath).catch(err => {
+          log.warn(`deleteFileMetaByPrefix error for space ${targetSpace}, path ${filePath}: ${err}`);
+        });
+      }
+      // Cancel any queued media/text jobs for files under this folder, or they would
+      // outlive their sources and retry forever against paths that no longer exist.
+      await cancelMediaJobsByPrefix(targetSpace, filePath).catch(err => {
+        log.warn(`cancelMediaJobsByPrefix error for space ${targetSpace}, path ${filePath}: ${err}`);
       });
+      // Remove conversion sidecar records + on-disk files (`_converted/<path>`,
+      // `_extracted/<path>`), which live outside the folder prefix and would otherwise orphan.
+      await deleteConversionArtifactsByPrefix(targetSpace, filePath).catch(err => {
+        log.warn(`deleteConversionArtifactsByPrefix error for space ${targetSpace}, path ${filePath}: ${err}`);
+      });
+      // Propagate the deletion to sync peers.
+      await writeFileTombstones(targetSpace, removedPaths);
       res.status(204).end();
     } catch (err) {
       log.warn(`rm dir error for space ${targetSpace}, path ${filePath}: ${err}`);
@@ -642,15 +673,21 @@ filesRouter.delete('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly,
   try {
     await deleteFile(targetSpace, filePath);
     invalidateUsageCache(); // freed disk — reflect it in the next quota check
-    const tombstone: FileTombstoneDoc = {
-      _id: uuidv4(),
-      spaceId: targetSpace,
-      path: filePath.replace(/\\/g, '/'),
-      deletedAt: new Date().toISOString(),
-    };
-    await col<FileTombstoneDoc>(`${targetSpace}_file_tombstones`).insertOne(asDoc<FileTombstoneDoc>(tombstone));
-    await deleteFileMeta(targetSpace, filePath).catch(err => {
-      log.warn(`deleteFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
+    // Propagate the deletion to sync peers.
+    await writeFileTombstones(targetSpace, [filePath]);
+    // Metadata: soft-flag (retain for audit) or hard-delete, per softDeleteFileMeta.
+    if (getConfig().softDeleteFileMeta === true) {
+      await markFileMetaDeleted(targetSpace, filePath).catch(err => {
+        log.warn(`markFileMetaDeleted error for space ${targetSpace}, path ${filePath}: ${err}`);
+      });
+    } else {
+      await deleteFileMeta(targetSpace, filePath).catch(err => {
+        log.warn(`deleteFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
+      });
+    }
+    // Cancel any queued media/text job so it cannot outlive the file and retry forever.
+    await cancelMediaJob(targetSpace, filePath).catch(err => {
+      log.warn(`cancelMediaJob error for space ${targetSpace}, path ${filePath}: ${err}`);
     });
     await deleteConversionArtifacts(targetSpace, filePath).catch(err => {
       log.warn(`deleteConversionArtifacts error for space ${targetSpace}, path ${filePath}: ${err}`);
@@ -691,6 +728,13 @@ filesRouter.patch('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly, 
   }
 
   try {
+    // Collect the OLD paths before the move so we can tombstone them: sync has no rename
+    // detection, so without a tombstone the peer's manifest still advertises the source path
+    // and re-downloads it (the moved-away file resurrects). For a directory move these are the
+    // child files; for a single file it is the source path itself.
+    const movedChildren = await listFilesRecursive(targetSpace, srcPath);
+    const oldPaths = movedChildren.length > 0 ? movedChildren : [srcPath];
+
     await moveFile(targetSpace, srcPath, destination);
     await Promise.all([
       renameFileMeta(targetSpace, srcPath, destination),
@@ -698,6 +742,7 @@ filesRouter.patch('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly, 
     ]).catch(err => {
       log.warn(`renameFileMeta error for space ${targetSpace}, ${srcPath} → ${destination}: ${err}`);
     });
+    await writeFileTombstones(targetSpace, oldPaths);
     emitWebhookEvent({ event: 'file.updated', spaceId: targetSpace, entry: { path: destination, previousPath: srcPath }, ...webhookToken(req) });
     res.json({ from: srcPath, to: destination });
   } catch (err) {

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -5,6 +5,7 @@ import { parseLimit, parseSkip } from '../util/pagination.js';
 import { embed } from './embedding.js';
 import { propsEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
+import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
 
 function authorRef() {
@@ -95,6 +96,7 @@ export async function createChrono(
     properties?: Record<string, string | number | boolean>;
     recurrence?: ChronoEntry['recurrence'];
   },
+  actor?: WebhookActor,
 ): Promise<ChronoEntry> {
   const seq = await nextSeq(spaceId);
   const now = new Date().toISOString();
@@ -132,6 +134,7 @@ export async function createChrono(
   if (fields.recurrence !== undefined) doc.recurrence = fields.recurrence;
 
   await col<ChronoEntry>(`${spaceId}_chrono`).insertOne(asDoc<ChronoEntry>(doc));
+  if (actor) emitWebhookEvent({ event: 'chrono.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   return doc;
 }
 
@@ -139,6 +142,7 @@ export async function updateChrono(
   spaceId: string,
   id: string,
   updates: Partial<Pick<ChronoEntry, 'title' | 'description' | 'type' | 'startsAt' | 'endsAt' | 'status' | 'confidence' | 'tags' | 'entityIds' | 'memoryIds' | 'properties' | 'recurrence'>>,
+  actor?: WebhookActor,
 ): Promise<ChronoEntry | null> {
   const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as ChronoEntry | null;
   if (!existing) return null;
@@ -178,7 +182,9 @@ export async function updateChrono(
     asFilter<ChronoEntry>({ _id: id }),
     asUpdate<ChronoEntry>({ $set }),
   );
-  return { ...existing, ...($set as Partial<ChronoEntry>) } as ChronoEntry;
+  const updatedChrono = { ...existing, ...($set as Partial<ChronoEntry>) } as ChronoEntry;
+  if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...updatedChrono, embedding: undefined }, ...actor });
+  return updatedChrono;
 }
 
 export async function getChronoById(spaceId: string, id: string): Promise<ChronoEntry | null> {
@@ -256,6 +262,7 @@ export async function listChrono(
 export async function deleteChrono(
   spaceId: string,
   chronoId: string,
+  actor?: WebhookActor,
 ): Promise<boolean> {
   const existing = await col<ChronoEntry>(`${spaceId}_chrono`)
     .findOne(asFilter<ChronoEntry>({ _id: chronoId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
@@ -280,6 +287,7 @@ export async function deleteChrono(
     asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
+  if (actor) emitWebhookEvent({ event: 'chrono.deleted', spaceId, entry: { _id: chronoId }, ...actor });
   return true;
 }
 

--- a/server/src/brain/dupe-scanner.ts
+++ b/server/src/brain/dupe-scanner.ts
@@ -123,9 +123,7 @@ async function tryAutoMerge(spaceId: string, seed: RecallResult, match: RecallRe
     const { plan, fullyResolved, survivor, absorbed } = result;
     if (!fullyResolved) return false;   // a property value conflict — not lossless, leave for review
     const mergedProps = applyResolutions(survivor.properties ?? {}, absorbed.properties ?? {}, plan.propertyConflicts, plan.absorbedOnlyProperties);
-    const res = await executeMerge(spaceId, survivor, absorbed, mergedProps);
-    emitWebhookEvent({ event: 'entity.merged', spaceId, entry: { survivor: { ...res.entity, embedding: undefined }, absorbedId: absorbed._id, auto: true } });
-    emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...res.entity, embedding: undefined } });
+    await executeMerge(spaceId, survivor, absorbed, mergedProps, { tokenLabel: 'dupe-scanner' });
     log.info(`Auto-merged entity ${absorbed._id} → ${survivor._id} in '${spaceId}' (score ${(match.score ?? 0).toFixed(3)})`);
     return true;
   } catch (err) {

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -7,6 +7,7 @@ import { propsEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { getEntityById } from './entities.js';
+import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EdgeDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
 
 export interface TraverseNode {
@@ -77,6 +78,7 @@ export async function upsertEdge(
   description?: string,
   properties?: Record<string, string | number | boolean>,
   tags?: string[],
+  actor?: WebhookActor,
 ): Promise<EdgeDoc> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
   const existing = await collection.findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }));
@@ -117,7 +119,7 @@ export async function upsertEdge(
       asFilter<EdgeDoc>({ _id: (existing as EdgeDoc)._id }),
       asUpdate<EdgeDoc>({ $set }),
     );
-    return {
+    const updatedEdge: EdgeDoc = {
       ...(existing as EdgeDoc),
       seq,
       updatedAt: now,
@@ -128,6 +130,8 @@ export async function upsertEdge(
       ...(properties !== undefined ? { properties: { ...((existing as EdgeDoc).properties ?? {}), ...properties } } : {}),
       ...embeddingFields,
     };
+    if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...updatedEdge, embedding: undefined }, ...actor });
+    return updatedEdge;
   }
 
   const doc: EdgeDoc = {
@@ -148,6 +152,7 @@ export async function upsertEdge(
     ...embeddingFields,
   };
   await collection.insertOne(asDoc<EdgeDoc>(doc));
+  if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   return doc;
 }
 
@@ -174,7 +179,7 @@ export async function listEdges(
 }
 
 /** Delete an edge by ID and write tombstone */
-export async function deleteEdge(spaceId: string, edgeId: string): Promise<boolean> {
+export async function deleteEdge(spaceId: string, edgeId: string, actor?: WebhookActor): Promise<boolean> {
   const existing = await col<EdgeDoc>(`${spaceId}_edges`)
     .findOne(asFilter<EdgeDoc>({ _id: edgeId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
   const seq = await nextSeq(spaceId);
@@ -198,6 +203,7 @@ export async function deleteEdge(spaceId: string, edgeId: string): Promise<boole
     asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
+  if (actor) emitWebhookEvent({ event: 'edge.deleted', spaceId, entry: { _id: edgeId }, ...actor });
   return true;
 }
 
@@ -212,6 +218,7 @@ export async function updateEdgeById(
   id: string,
   updates: { label?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; weight?: number; type?: string },
   deleteFieldsPaths?: string[],
+  actor?: WebhookActor,
 ): Promise<EdgeDoc | null> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
   const existing = await collection.findOne(asFilter<EdgeDoc>({ _id: id, spaceId })) as EdgeDoc | null;
@@ -308,6 +315,7 @@ export async function updateEdgeById(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
+  if (actor) emitWebhookEvent({ event: 'edge.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }
 

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -7,6 +7,7 @@ import { propsEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './memory.js';
+import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc } from '../config/types.js';
 
 /** A backlink entry describing an item that references a given entity. */
@@ -63,6 +64,7 @@ export async function upsertEntity(
   description?: string,
   id?: string,
   opts?: DupeCheckOpts,
+  actor?: WebhookActor,
 ): Promise<UpsertResult> {
   const collection = col<EntityDoc>(`${spaceId}_entities`);
 
@@ -95,6 +97,7 @@ export async function upsertEntity(
       asUpdate<EntityDoc>({ $set }),
     );
     const entity: EntityDoc = { ...existing, name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields, ...(description !== undefined ? { description } : {}) };
+    if (actor) emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...entity, embedding: undefined }, ...actor });
     return { entity };
   }
 
@@ -135,6 +138,7 @@ export async function upsertEntity(
   if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {
     import('./dupe-scanner.js').then(m => m.evaluateRecordForDuplicates(spaceId, 'entity', doc._id)).catch(() => { /* best-effort */ });
   }
+  if (actor) emitWebhookEvent({ event: 'entity.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   return { entity: doc, warning, similar };
 }
 
@@ -160,6 +164,7 @@ export async function updateEntityById(
   id: string,
   updates: { name?: string; type?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> },
   deleteFieldsPaths?: string[],
+  actor?: WebhookActor,
 ): Promise<EntityDoc | null> {
   const collection = col<EntityDoc>(`${spaceId}_entities`);
   const existing = await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null;
@@ -243,6 +248,7 @@ export async function updateEntityById(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
+  if (actor) emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }
 
@@ -264,6 +270,7 @@ export async function listEntities(
 export async function deleteEntity(
   spaceId: string,
   entityId: string,
+  actor?: WebhookActor,
 ): Promise<boolean> {
   const existing = await col<EntityDoc>(`${spaceId}_entities`)
     .findOne(asFilter<EntityDoc>({ _id: entityId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
@@ -288,6 +295,7 @@ export async function deleteEntity(
     asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
+  if (actor) emitWebhookEvent({ event: 'entity.deleted', spaceId, entry: { _id: entityId }, ...actor });
   return true;
 }
 

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -9,6 +9,7 @@ import { propsEmbedText } from './embed-text.js';
 import { getConfig, getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex, vectorFilterFieldsFor } from '../spaces/spaces.js';
 import { applyDeleteFields } from './delete-fields.js';
+import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { MemoryDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
 
 // ── Prefiltered recall ────────────────────────────────────────────────────
@@ -164,6 +165,7 @@ export async function remember(
   entityNames?: string[],
   type?: string,
   opts?: DupeCheckOpts,
+  actor?: WebhookActor,
 ): Promise<MemoryDoc & { similar?: SimilarMatch[] }> {
   const names = entityNames ?? await resolveEntityNames(spaceId, entityIds);
   const embedText = memoryEmbedText(fact, tags, names, description, properties);
@@ -202,6 +204,7 @@ export async function remember(
   if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {
     import('./dupe-scanner.js').then(m => m.evaluateRecordForDuplicates(spaceId, 'memory', doc._id)).catch(() => { /* best-effort */ });
   }
+  if (actor) emitWebhookEvent({ event: 'memory.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   return similar ? { ...doc, similar } : doc;
 }
 
@@ -714,6 +717,7 @@ export async function updateMemory(
   memoryId: string,
   updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; type?: string },
   deleteFieldsPaths?: string[],
+  actor?: WebhookActor,
 ): Promise<MemoryDoc | null> {
   const existing = await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: memoryId, spaceId })) as MemoryDoc | null;
   if (!existing) return null;
@@ -791,6 +795,7 @@ export async function updateMemory(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
+  if (actor) emitWebhookEvent({ event: 'memory.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }
 
@@ -798,6 +803,7 @@ export async function updateMemory(
 export async function deleteMemory(
   spaceId: string,
   memoryId: string,
+  actor?: WebhookActor,
 ): Promise<boolean> {
   const existing = await col<MemoryDoc>(`${spaceId}_memories`)
     .findOne(asFilter<MemoryDoc>({ _id: memoryId, spaceId }), { projection: { seq: 1 } }) as { seq?: number } | null;
@@ -822,6 +828,7 @@ export async function deleteMemory(
     asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
+  if (actor) emitWebhookEvent({ event: 'memory.deleted', spaceId, entry: { _id: memoryId }, ...actor });
   return true;
 }
 

--- a/server/src/brain/merge.ts
+++ b/server/src/brain/merge.ts
@@ -16,6 +16,7 @@ import { propsEmbedText } from './embed-text.js';
 import { getEntityById } from './entities.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
+import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc, SpaceMeta, PropertySchema } from '../config/types.js';
 
 // ── Public types ───────────────────────────────────────────────────────────
@@ -344,6 +345,7 @@ export async function executeMerge(
   survivor: EntityDoc,
   absorbed: EntityDoc,
   mergedProperties: Record<string, string | number | boolean>,
+  actor?: WebhookActor,
 ): Promise<{ entity: EntityDoc; deletedDuplicateEdgeIds: string[] }> {
   const session = getMongo().startSession();
   const deletedDuplicateEdgeIds: string[] = [];
@@ -481,6 +483,18 @@ export async function executeMerge(
     });
   } finally {
     await session.endSession();
+  }
+
+  // Centralised webhook emission: a merge is an update to the survivor, deletion of the
+  // absorbed entity, and deletion of any duplicate edges collapsed in the process. All four
+  // fire here so every caller (REST, duplicates, dupe-scanner, MCP) is consistent.
+  if (actor) {
+    emitWebhookEvent({ event: 'entity.merged', spaceId, entry: { survivor: { ...survivor, embedding: undefined }, absorbedId: absorbed._id }, ...actor });
+    emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...survivor, embedding: undefined }, ...actor });
+    emitWebhookEvent({ event: 'entity.deleted', spaceId, entry: { _id: absorbed._id }, ...actor });
+    for (const dupId of deletedDuplicateEdgeIds) {
+      emitWebhookEvent({ event: 'edge.deleted', spaceId, entry: { _id: dupId }, ...actor });
+    }
   }
 
   return {

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -668,6 +668,17 @@ export interface Config {
   storage?: StorageConfig;
   /** Optional media embedding pipeline (image / audio / video). Off by default. */
   mediaEmbedding?: MediaEmbeddingConfig;
+  /**
+   * When true, deleting a file flags its metadata record as deleted
+   * (`deletedAt = <now>`) instead of removing it, keeping an audit trail. Flagged
+   * records stay listed and searchable but are marked "deleted" in the UI, and only
+   * a flagged/orphaned record (one whose file no longer exists) may be purged — a
+   * metadata record whose file is still present cannot be deleted directly.
+   * Default false (delete the metadata record immediately, the historical behavior).
+   * Derived records (conversion chunks / `_converted` / `_extracted`) are always
+   * hard-removed regardless of this setting.
+   */
+  softDeleteFileMeta?: boolean;
   maxUploadBodyBytes?: number;
   /** Max total size (bytes) a chunked upload may declare via Content-Range.
    *  Default 10 GiB. The storage quota (if configured) applies on top. */
@@ -928,6 +939,10 @@ export interface FileMetaDoc {
   updatedAt: string;    // ISO8601 — last write timestamp
   sizeBytes: number;    // file size in bytes at last write
   author: AuthorRef;    // writer: instanceId + instanceLabel
+  /** Set when the file was deleted while `softDeleteFileMeta` is enabled: ISO8601
+   *  timestamp of the deletion. The record is retained (still listed/searchable, shown
+   *  as "deleted" in the UI) until purged. Absent for live files. */
+  deletedAt?: string;
   embedding?: number[];
   embeddingModel?: string;
   // ── Conversion pipeline fields ────────────────────────────────────────────

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -9,6 +9,7 @@
  */
 
 import path from 'path';
+import fs from 'fs/promises';
 import { UnstructuredConverter } from './unstructured.js';
 import type { ExtractedImage } from './unstructured.js';
 import { HtmlConverter } from './html.js';
@@ -19,6 +20,7 @@ import { paragraphChunk } from './paragraph-chunker.js';
 import type { Chunk } from './types.js';
 import { ConversionUnavailableError } from './types.js';
 import { writeFile, writeFileBytes } from '../files.js';
+import { resolveSafePathChecked } from '../sandbox.js';
 import { col, asFilter, asDoc } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig } from '../../config/loader.js';
@@ -402,17 +404,68 @@ export async function storeConversionResults(
   return { chunkCount: chunks.length, convertedFileId, embedFailures };
 }
 
-/** Delete all chunk records and the _converted/ file for a given original file. */
+/** Escape a string for safe use inside a RegExp. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Best-effort recursive delete of a space-relative path. Never throws (missing = success). */
+async function rmArtifactPath(spaceId: string, relPath: string): Promise<void> {
+  try {
+    const abs = await resolveSafePathChecked(spaceId, relPath);
+    await fs.rm(abs, { recursive: true, force: true });
+  } catch (err) {
+    log.warn(`Failed to remove conversion artifact path ${spaceId}/${relPath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Delete every conversion artifact belonging to a single original file:
+ * its chunk / `_converted/` / `_extracted/` filemeta records AND the mirrored
+ * on-disk sidecar files (`_converted/<id>.md`, `_extracted/<id>/`).
+ */
 export async function deleteConversionArtifacts(
   spaceId: string,
   originalFilePath: string,
 ): Promise<void> {
   const originalId = normPath(originalFilePath);
 
-  // Delete all filemeta records with parentFileId = originalId
+  // DB: all filemeta records with parentFileId = originalId (chunks, converted, extracted).
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
     asFilter<FileMetaDoc>({ parentFileId: originalId }),
   );
 
+  // Disk: the sidecar files those records described. deleteMany above does not touch disk,
+  // so without this the `_converted/`/`_extracted/` trees would be orphaned on the filesystem.
+  await rmArtifactPath(spaceId, `_converted/${originalId}.md`);
+  await rmArtifactPath(spaceId, `_extracted/${originalId}`);
+
   log.info(`Deleted conversion artifacts for ${spaceId}/${originalId}`);
+}
+
+/**
+ * Delete conversion artifacts for EVERY original file under `dirPath/` — used
+ * when a directory is deleted recursively. The sidecar records/files live under
+ * the separate `_converted/<path>` and `_extracted/<path>` top-level prefixes,
+ * so a `<dirPath>/`-only cleanup (deleteFileMetaByPrefix + fs.rm) leaves them
+ * orphaned; this removes them by parent-path prefix and clears the sidecar trees.
+ */
+export async function deleteConversionArtifactsByPrefix(
+  spaceId: string,
+  dirPath: string,
+): Promise<void> {
+  const dir = normPath(dirPath).replace(/\/?$/, '');
+  if (!dir) return; // guard: empty path would match everything
+  const escaped = escapeRegex(dir + '/');
+
+  // DB: every child record whose parent lived under the folder.
+  await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
+    asFilter<FileMetaDoc>({ parentFileId: { $regex: `^${escaped}` } }),
+  );
+
+  // Disk: the mirrored sidecar subtrees.
+  await rmArtifactPath(spaceId, `_converted/${dir}`);
+  await rmArtifactPath(spaceId, `_extracted/${dir}`);
+
+  log.info(`Deleted conversion artifacts under ${spaceId}/${dir}/`);
 }

--- a/server/src/files/converters/unstructured.ts
+++ b/server/src/files/converters/unstructured.ts
@@ -1,6 +1,6 @@
 /**
  * UnstructuredConverter — converts PDF, DOCX, EPUB to Markdown via the
- * unstructured-api-full sidecar (localhost:8000).
+ * unstructured-api sidecar (localhost:8000).
  *
  * Default strategy: hi_res (full OCR + layout detection, image extraction).
  * Configurable via mediaEmbedding.documentProcessing.strategy in config.json.

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -94,9 +94,10 @@ export async function upsertFileMeta(
     if (opts.description !== undefined) $set['description'] = opts.description;
     if (opts.tags !== undefined) $set['tags'] = opts.tags;
     if (opts.properties !== undefined) $set['properties'] = opts.properties;
+    // A write to a soft-deleted path means the file is live again — clear the flag.
     await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
       asFilter<FileMetaDoc>({ _id: normalised }),
-      asUpdate<FileMetaDoc>({ $set }),
+      asUpdate<FileMetaDoc>({ $set, $unset: { deletedAt: '' } }),
     );
   } else {
     const doc: FileMetaDoc = {
@@ -247,6 +248,47 @@ export async function deleteFileMetaByPrefix(
   const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
     asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }),
+  );
+}
+
+/**
+ * Soft-delete: flag a single file's metadata record as deleted (`deletedAt = now`)
+ * instead of removing it. No-op if the record does not exist. Used when
+ * `softDeleteFileMeta` is enabled so a deleted file leaves an auditable record.
+ */
+export async function markFileMetaDeleted(
+  spaceId: string,
+  filePath: string,
+): Promise<void> {
+  const normalised = normPath(filePath);
+  await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
+    asFilter<FileMetaDoc>({ _id: normalised }),
+    asUpdate<FileMetaDoc>({ $set: { deletedAt: new Date().toISOString() } }),
+  );
+}
+
+/**
+ * Soft-delete a whole directory subtree: flag every top-level file record under
+ * `dirPath/` as deleted, and hard-remove the derived chunk records (which carry no
+ * independent audit value). The `_converted`/`_extracted` sidecars are cleaned
+ * separately by deleteConversionArtifactsByPrefix.
+ */
+export async function markFileMetaDeletedByPrefix(
+  spaceId: string,
+  dirPath: string,
+): Promise<void> {
+  const norm = normPath(dirPath).replace(/\/?$/, '');
+  if (!norm) return; // guard: empty path would match everything
+  const escaped = (norm + '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const coll = col<FileMetaDoc>(`${spaceId}_files`);
+  // Flag the user-visible file records.
+  await coll.updateMany(
+    asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` }, parentFileId: { $exists: false } }),
+    asUpdate<FileMetaDoc>({ $set: { deletedAt: new Date().toISOString() } }),
+  );
+  // Remove derived chunk records outright.
+  await coll.deleteMany(
+    asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` }, parentFileId: { $exists: true } }),
   );
 }
 

--- a/server/src/files/files.ts
+++ b/server/src/files/files.ts
@@ -79,6 +79,17 @@ export async function deleteFile(spaceId: string, filePath: string): Promise<voi
   await fs.unlink(abs);
 }
 
+/** True if a regular file exists at the given space-relative path. */
+export async function fileExists(spaceId: string, filePath: string): Promise<boolean> {
+  try {
+    const abs = await resolveSafePathChecked(spaceId, filePath);
+    const st = await fs.stat(abs);
+    return st.isFile();
+  } catch {
+    return false;
+  }
+}
+
 /** Create a directory (including parents) */
 export async function createDir(spaceId: string, dirPath: string): Promise<void> {
   const abs = await resolveSafePathChecked(spaceId, dirPath);
@@ -118,6 +129,41 @@ export async function getDirSizeBytes(dir: string): Promise<number> {
     }
   }
   return total;
+}
+
+/**
+ * Recursively list every file under a space-relative directory, returning
+ * space-relative forward-slash paths (e.g. `notes/2024/jan.md`). Returns [] if the
+ * directory does not exist. Used to enumerate a subtree before deleting it so a sync
+ * tombstone can be written for each removed file.
+ */
+export async function listFilesRecursive(spaceId: string, dirPath: string): Promise<string[]> {
+  const root = spaceRoot(spaceId);
+  let absDir: string;
+  try {
+    absDir = await resolveSafePathChecked(spaceId, dirPath);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return; // missing or unreadable — nothing to list
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        out.push(path.relative(root, full).replace(/\\/g, '/'));
+      }
+    }
+  }
+  await walk(absDir);
+  return out;
 }
 
 export interface QuotaCheckResult {

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -441,6 +441,33 @@ export async function resetStalledJobs(
   }
 }
 
+// ── Cancel (on file / directory deletion) ──────────────────────────────────
+
+/**
+ * Delete the media job for a single file, if one exists. Called when the file
+ * is deleted so a queued job cannot outlive its source and retry forever
+ * against a path that no longer exists.
+ */
+export async function cancelMediaJob(spaceId: string, filePath: string): Promise<void> {
+  const id = normPath(filePath);
+  await jobCollection(spaceId).deleteOne(asFilter<MediaJobDoc>({ _id: id }));
+}
+
+/**
+ * Delete every media job for files under `dirPath/` — including the jobs for
+ * document-conversion sidecars (`_converted/<dir>/`, `_extracted/<dir>/`), whose
+ * job ids do not share the folder prefix. Called on recursive directory delete.
+ */
+export async function cancelMediaJobsByPrefix(spaceId: string, dirPath: string): Promise<void> {
+  const dir = normPath(dirPath).replace(/\/?$/, '');
+  if (!dir) return; // guard: empty path would match everything
+  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const prefixes = [`${dir}/`, `_converted/${dir}/`, `_extracted/${dir}/`];
+  await jobCollection(spaceId).deleteMany(
+    asFilter<MediaJobDoc>({ $or: prefixes.map(p => ({ _id: { $regex: `^${esc(p)}` } })) }),
+  );
+}
+
 // ── retry_embedding helper ─────────────────────────────────────────────────
 
 /**

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -36,13 +36,13 @@ import type { MediaJobDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { createMediaProviders } from './providers.js';
 import type { MediaProviderBundle } from './providers.js';
-import { claimNextJob, completeJob, failJob, resetStalledJobs, currentWorkEpoch, waitForWork, wakeWorkers } from './job-queue.js';
+import { claimNextJob, completeJob, failJob, resetStalledJobs, cancelMediaJob, currentWorkEpoch, waitForWork, wakeWorkers } from './job-queue.js';
 import { embedImage } from './image-embedder.js';
 import { embedAudio } from './audio-embedder.js';
 import { embedVideo } from './video-embedder.js';
 import { col, asFilter } from '../../db/mongo.js';
 import type { FileMetaDoc } from '../../config/types.js';
-import { updateFileMeta } from '../file-meta.js';
+import { updateFileMeta, markFileMetaDeleted } from '../file-meta.js';
 import {
   runConversionPipeline,
   storeConversionResults,
@@ -280,6 +280,15 @@ async function processJob(
     try {
       fileBytes = await fs.readFile(absolutePath);
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // The source file is gone — it was deleted after this job was queued. Retrying can
+        // never succeed, so this is TERMINAL, not a failure: reconcile to disk truth by
+        // dropping the job and any orphaned metadata/artifacts, and stop (no retry, no
+        // "exhausted retries" churn — that infinite loop is exactly what this avoids).
+        await reconcileDeletedSource(spaceId, fileId);
+        log.info(`Media worker: source file ${spaceId}/${fileId} no longer exists — removed job and orphaned metadata (no retry)`);
+        return;
+      }
       throw new Error(`Could not read file for embedding: ${err instanceof Error ? err.message : String(err)}`);
     }
 
@@ -382,6 +391,32 @@ async function processJob(
     );
   } finally {
     endTimer();
+  }
+}
+
+/**
+ * Reconcile a media job whose source file has been deleted: remove the job, its
+ * orphaned file-meta record, and any conversion artifacts (chunks / converted /
+ * extracted). Disk is the source of truth for the file store, so a job pointing at
+ * a file that no longer exists is stale and must be cleaned up, not retried.
+ * Best-effort throughout — each step swallows its own error.
+ */
+async function reconcileDeletedSource(spaceId: string, fileId: string): Promise<void> {
+  await cancelMediaJob(spaceId, fileId).catch(err =>
+    log.warn(`reconcileDeletedSource: cancelMediaJob ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
+  );
+  await deleteConversionArtifacts(spaceId, fileId).catch(err =>
+    log.warn(`reconcileDeletedSource: deleteConversionArtifacts ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
+  );
+  // Honour softDeleteFileMeta: flag the orphaned record for audit, or hard-remove it.
+  if (getConfig().softDeleteFileMeta === true) {
+    await markFileMetaDeleted(spaceId, fileId).catch(err =>
+      log.warn(`reconcileDeletedSource: flag file meta ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
+    );
+  } else {
+    await col<FileMetaDoc>(`${spaceId}_files`).deleteOne(asFilter<FileMetaDoc>({ _id: fileId })).catch(err =>
+      log.warn(`reconcileDeletedSource: delete file meta ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
+    );
   }
 }
 

--- a/server/src/files/tombstones.ts
+++ b/server/src/files/tombstones.ts
@@ -1,0 +1,31 @@
+/**
+ * File sync tombstones.
+ *
+ * A `FileTombstoneDoc` in the per-space `<spaceId>_file_tombstones` collection
+ * records that a file was deleted locally. The sync engine pushes these to peers,
+ * which then unlink the file and drop its metadata — without them, a peer's manifest
+ * still advertises the file and pushes it straight back (resurrection). Every code
+ * path that deletes a file (API, folder delete, MCP) must write one.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { col, asDoc } from '../db/mongo.js';
+import type { FileTombstoneDoc } from '../config/types.js';
+import { log } from '../util/log.js';
+
+/**
+ * Insert a sync tombstone for each of `paths` so peers remove the files too.
+ * Paths are normalised (forward slashes, no leading slash) and deduped.
+ * Best-effort — logs on failure rather than throwing, so a delete still returns success.
+ */
+export async function writeFileTombstones(spaceId: string, paths: string[]): Promise<void> {
+  const unique = [...new Set(paths.map(p => p.replace(/\\/g, '/').replace(/^\/+/, '')))].filter(Boolean);
+  if (unique.length === 0) return;
+  const now = new Date().toISOString();
+  const docs: FileTombstoneDoc[] = unique.map(p => ({ _id: uuidv4(), spaceId, path: p, deletedAt: now }));
+  try {
+    await col<FileTombstoneDoc>(`${spaceId}_file_tombstones`).insertMany(docs.map(d => asDoc<FileTombstoneDoc>(d)));
+  } catch (err) {
+    log.warn(`writeFileTombstones error for space ${spaceId} (${unique.length} paths): ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -48,7 +48,7 @@ function sessionTag(sessionId: string): string {
  *
  *  Tool schemas, authorization gates and handlers all come from the registry in
  *  ./tools — there is one source of truth per tool. */
-function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdmin?: boolean): Server {
+function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdmin?: boolean, tokenId?: string, tokenLabel?: string): Server {
   const cfg = getConfig();
   const accessibleSpaces = cfg.spaces.filter(s => !tokenSpaces || tokenSpaces.includes(s.id));
   const accessibleSpaceIds = accessibleSpaces.map(s => s.id);
@@ -156,6 +156,7 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
         tokenSpaces,
         isAdmin,
         readOnly,
+        actor: { tokenId, tokenLabel },
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -201,7 +202,7 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
     log.debug(`MCP global session ${sessionTag(transport.sessionId)} closed`);
   });
 
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin);
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name);
   log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
 });
@@ -232,7 +233,7 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
 // This transport requires no persistent connection and works through standard HTTP proxies.
 mcpRouter.post('/', globalRateLimit, async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin);
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name);
   // Register cleanup before handling the request so it fires regardless of outcome.
   res.on('close', () => {
     transport.close();

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -106,7 +106,7 @@ export const create_chronoTool: ToolHandler = {
       memoryIds: chronoMemoryIds,
       properties: chronoProps,
       ...(rec.value ? { recurrence: rec.value } : {}),
-    });
+    }, ctx.actor);
     let text = `Chrono entry '${entry.title}' (${entry.type}) created (ID ${entry._id}, seq ${entry.seq}).`
       + (remQuota.softBreached ? `\n⚠️ Storage warning: ${remQuota.warning}` : '');
     if (chronoMeta?.validationMode === 'warn') {
@@ -196,7 +196,7 @@ export const update_chronoTool: ToolHandler = {
       updates['recurrence'] = rec.value;
     }
 
-    const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2]);
+    const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2], ctx.actor);
     if (!entry) throw new Error(`Chrono entry '${id}' not found`);
     return { content: [{ type: 'text' as const, text: `Chrono entry '${entry.title}' updated (seq ${entry.seq}).` }] };
   },

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -61,7 +61,7 @@ export const upsert_edgeTool: ToolHandler = {
       return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(edgeSchemaViolations, null, 2)}` }], isError: true };
     }
 
-    const edge = await upsertEdge(wt.target, from, to, label, weight, edgeType, description, edgeProps, edgeTags);
+    const edge = await upsertEdge(wt.target, from, to, label, weight, edgeType, description, edgeProps, edgeTags, ctx.actor);
     let edgeMsg = `Edge '${label}' (${from} → ${to}) upserted (ID ${edge._id}).`;
     if (edgeMeta?.validationMode === 'warn') {
       for (const v of edgeSchemaViolations) edgeMsg += `\n⚠️ Schema: ${v.field} — ${v.reason}`;
@@ -120,7 +120,7 @@ export const update_edgeTool: ToolHandler = {
     const memberIds = resolveMemberSpaces(wt.target);
     let updatedEdge = null;
     for (const mid of memberIds) {
-      updatedEdge = await updateEdgeById(mid, id, updates, dfPaths);
+      updatedEdge = await updateEdgeById(mid, id, updates, dfPaths, ctx.actor);
       if (updatedEdge) break;
     }
     if (!updatedEdge) throw new Error(`Edge '${id}' not found`);

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -61,7 +61,7 @@ export const upsert_entityTool: ToolHandler = {
     const entDupeCheck = a['checkDuplicates'] !== false;
     const entDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
     const { entity, warning, similar } = await upsertEntity(wt.target, eName, eType, tags, props, description, rawId,
-      { checkDuplicates: entDupeCheck, dupeThreshold: entDupeThreshold });
+      { checkDuplicates: entDupeCheck, dupeThreshold: entDupeThreshold }, ctx.actor);
     let msg = `Entity '${entity.name}' (${entity.type}) upserted (ID ${entity._id}).${warning ? `\n⚠️ ${warning}` : ''}`;
     if (similar && similar.length > 0) {
       msg += `\n⚠️ Possible duplicate — ${similar.length} existing entit${similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. Pass checkDuplicates:false to skip, or provide the existing id to update it instead.`;
@@ -122,7 +122,7 @@ export const update_entityTool: ToolHandler = {
     const memberIds = resolveMemberSpaces(wt.target);
     let updatedEnt = null;
     for (const mid of memberIds) {
-      updatedEnt = await updateEntityById(mid, id, updates, dfPaths);
+      updatedEnt = await updateEntityById(mid, id, updates, dfPaths, ctx.actor);
       if (updatedEnt) break;
     }
     if (!updatedEnt) throw new Error(`Entity '${id}' not found`);
@@ -231,7 +231,7 @@ export const merge_entitiesTool: ToolHandler = {
       plan.absorbedOnlyProperties,
     );
 
-    const mergeResult = await executeMerge(wt.target, survivor, absorbed, mergedProperties);
+    const mergeResult = await executeMerge(wt.target, survivor, absorbed, mergedProperties, ctx.actor);
     const mergedEntity = mergeResult.entity;
 
     const lines: string[] = [

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -1,14 +1,16 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { recall } from '../../brain/memory.js';
-import { getMediaEmbeddingConfig } from '../../config/loader.js';
+import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
-import { type InputFormat, isMediaFormat, resolveInputFormat, runConversionPipeline, storeConversionResults } from '../../files/converters/pipeline.js';
+import { type InputFormat, isMediaFormat, resolveInputFormat, runConversionPipeline, storeConversionResults, deleteConversionArtifacts } from '../../files/converters/pipeline.js';
 import { ConversionUnavailableError } from '../../files/converters/types.js';
-import { deleteFileMeta, renameFileMeta, upsertFileMeta } from '../../files/file-meta.js';
-import { createDir, deleteFile, listDir, moveFile, readFile, writeFile } from '../../files/files.js';
-import { enqueueMediaJob } from '../../files/media/job-queue.js';
-import { QuotaError, checkQuota } from '../../quota/quota.js';
+import { deleteFileMeta, markFileMetaDeleted, renameFileMeta, renameFileMetaByPrefix, upsertFileMeta } from '../../files/file-meta.js';
+import { createDir, deleteFile, listDir, listFilesRecursive, moveFile, readFile, writeFile } from '../../files/files.js';
+import { enqueueMediaJob, cancelMediaJob } from '../../files/media/job-queue.js';
+import { writeFileTombstones } from '../../files/tombstones.js';
+import { QuotaError, checkQuota, invalidateUsageCache } from '../../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
+import { emitWebhookEvent } from '../../webhooks/dispatcher.js';
 import { log } from '../../util/log.js';
 
 export const read_fileTool: ToolHandler = {
@@ -71,10 +73,11 @@ export const write_fileTool: ToolHandler = {
     if (!filePath.trim()) throw new Error('path must not be empty');
     const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
     if (!wt.ok) throw new Error(wt.error);
-    // Quota check — throws QuotaError (caught below) on hard limit
-    const wfQuota = await checkQuota('files');
-    const { sha256 } = await writeFile(wt.target, filePath, content);
+    // Quota check — project the incoming size so a write that would exceed the hard limit is
+    // rejected up-front (parity with the REST upload), throwing QuotaError (caught below).
     const sizeBytes = Buffer.byteLength(content, 'utf8');
+    const wfQuota = await checkQuota('files', sizeBytes);
+    const { sha256 } = await writeFile(wt.target, filePath, content);
     const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> } = {};
     if (typeof a['description'] === 'string') metaOpts.description = a['description'];
     if (Array.isArray(a['tags'])) metaOpts.tags = a['tags'] as string[];
@@ -114,6 +117,9 @@ export const write_fileTool: ToolHandler = {
       }
     } else if (resolvedFmt !== 'text') {
       try {
+        // Clear any prior conversion artifacts first so overwriting a document does not leave
+        // stale/duplicate chunk records behind (parity with the REST upload path).
+        await deleteConversionArtifacts(wt.target, filePath).catch(() => {});
         const { chunks, convertedMarkdown, extractedImages } = await runConversionPipeline(fileBytes, filePath, resolvedFmt);
         if (chunks.length > 0 || extractedImages.length > 0) {
           const { chunkCount, convertedFileId } = await storeConversionResults(wt.target, filePath, chunks, convertedMarkdown, extractedImages);
@@ -134,6 +140,7 @@ export const write_fileTool: ToolHandler = {
         }
       }
     }
+    emitWebhookEvent({ event: 'file.created', spaceId: wt.target, entry: { path: filePath, sha256 }, ...(ctx.actor ?? {}) });
     const wfText = `Written (sha256: ${sha256}).`
       + (wfQuota.softBreached ? `\n⚠️ Storage warning: ${wfQuota.warning}` : '');
     return {
@@ -202,7 +209,20 @@ export const delete_fileTool: ToolHandler = {
     const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
     if (!wt.ok) throw new Error(wt.error);
     await deleteFile(wt.target, filePath);
-    await deleteFileMeta(wt.target, filePath);
+    // Propagate the deletion to sync peers (else the peer's manifest re-pushes the file).
+    await writeFileTombstones(wt.target, [filePath]);
+    // Soft-flag (retain for audit) or hard-delete the metadata, per softDeleteFileMeta.
+    if (getConfig().softDeleteFileMeta === true) {
+      await markFileMetaDeleted(wt.target, filePath);
+    } else {
+      await deleteFileMeta(wt.target, filePath);
+    }
+    // Cancel any queued embedding job and remove conversion artifacts so nothing
+    // outlives the file (a stale job would retry forever against the missing path).
+    await cancelMediaJob(wt.target, filePath).catch(() => {});
+    await deleteConversionArtifacts(wt.target, filePath).catch(() => {});
+    invalidateUsageCache(); // freed disk — reflect it in the next quota check
+    emitWebhookEvent({ event: 'file.deleted', spaceId: wt.target, entry: { path: filePath }, ...(ctx.actor ?? {}) });
     return { content: [{ type: 'text' as const, text: `Deleted '${filePath}'.` }] };
   },
 };
@@ -255,8 +275,23 @@ export const move_fileTool: ToolHandler = {
     if (!dst.trim()) throw new Error('dst must not be empty');
     const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
     if (!wt.ok) throw new Error(wt.error);
+    // Tombstone the OLD path(s) before moving (sync has no rename detection, so the source
+    // would otherwise resurrect from a peer's manifest). Children for a dir move, else src.
+    const movedChildren = await listFilesRecursive(wt.target, src);
+    const oldPaths = movedChildren.length > 0 ? movedChildren : [src];
+
     await moveFile(wt.target, src, dst);
-    await renameFileMeta(wt.target, src, dst);
+    // Re-root metadata: the file record at `src` AND, for a directory move, every child
+    // record under `src/` (renameFileMetaByPrefix). The HTTP PATCH route does both; MCP
+    // previously did only the single-file rename, orphaning child records on a dir move.
+    await Promise.all([
+      renameFileMeta(wt.target, src, dst),
+      renameFileMetaByPrefix(wt.target, src, dst),
+    ]).catch(err => {
+      log.warn(`move_file renameFileMeta error for ${wt.target}, ${src} → ${dst}: ${err instanceof Error ? err.message : String(err)}`);
+    });
+    await writeFileTombstones(wt.target, oldPaths);
+    emitWebhookEvent({ event: 'file.updated', spaceId: wt.target, entry: { path: dst, previousPath: src }, ...(ctx.actor ?? {}) });
     return { content: [{ type: 'text' as const, text: `Moved '${src}' → '${dst}'.` }] };
   },
 };

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -8,6 +8,7 @@ import { type FilterExpression, type RecallKnowledgeType, type RecallResult, del
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { QuotaError, checkQuota } from '../../quota/quota.js';
+import { emitWebhookEvent } from '../../webhooks/dispatcher.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
 import { getAllowedChronoTypes, resolveMetaRefs, validateChrono, validateEdge, validateEntity, validateMemory } from '../../spaces/schema-validation.js';
 
@@ -98,7 +99,7 @@ export const rememberTool: ToolHandler = {
     const remDupeCheck = a['checkDuplicates'] !== false;
     const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
     const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames, memType,
-      { checkDuplicates: remDupeCheck, dupeThreshold: remDupeThreshold });
+      { checkDuplicates: remDupeCheck, dupeThreshold: remDupeThreshold }, ctx.actor);
     const warnings: string[] = [];
     if (mem.similar && mem.similar.length > 0) {
       warnings.push(`⚠️ Possible duplicate — ${mem.similar.length} existing memor${mem.similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${mem.similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.`);
@@ -175,7 +176,7 @@ export const update_memoryTool: ToolHandler = {
     // Search member spaces sequentially — consistent with REST endpoint behaviour.
     let updated = null;
     for (const mid of memberIds) {
-      updated = await updateMemory(mid, id, updates, dfPaths);
+      updated = await updateMemory(mid, id, updates, dfPaths, ctx.actor);
       if (updated) break;
     }
     if (!updated) throw new Error(`Memory '${id}' not found`);
@@ -210,7 +211,7 @@ export const delete_memoryTool: ToolHandler = {
     const memberIds = resolveMemberSpaces(wt.target);
     let deleted = false;
     for (const mid of memberIds) {
-      if (await deleteMemory(mid, id)) { deleted = true; break; }
+      if (await deleteMemory(mid, id, ctx.actor)) { deleted = true; break; }
     }
     if (!deleted) throw new Error(`Memory '${id}' not found`);
     return {
@@ -730,6 +731,14 @@ export const bulk_writeTool: ToolHandler = {
       } catch (err) {
         errors.push({ type: 'chrono', index: i, reason: err instanceof Error ? err.message : String(err) });
       }
+    }
+
+    // Per-item webhooks are suppressed for bulk (the shared functions get no actor); emit ONE
+    // summary event a workflow can inspect afterwards, matching the REST /bulk endpoint.
+    const bulkTotal = inserted.memories + inserted.entities + inserted.edges + inserted.chrono
+      + updated.entities + updated.edges;
+    if (bulkTotal > 0) {
+      emitWebhookEvent({ event: 'bulk.write', spaceId: ts, entry: { inserted, updated, errorCount: errors.length }, ...(ctx.actor ?? {}) });
     }
 
     const summary = `bulk_write complete — inserted: ${JSON.stringify(inserted)}, updated: ${JSON.stringify(updated)}, errors: ${errors.length}`;

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -1,4 +1,5 @@
 import type { Config, SpaceConfig } from '../../config/types.js';
+import type { WebhookActor } from '../../webhooks/dispatcher.js';
 
 /**
  * The space schemas injected into each tool's `inputSchema`. The `space` enum is
@@ -28,6 +29,9 @@ export interface ToolContext {
   isAdmin?: boolean;
   /** True when the calling token is read-only (mutating tools are gated out). */
   readOnly?: boolean;
+  /** Identity of the calling token, for webhook attribution. Passed to shared brain/file
+   *  mutation functions so agent-driven writes emit attributed webhooks like REST writes. */
+  actor?: WebhookActor;
 }
 
 export type ToolResult = {

--- a/server/src/webhooks/dispatcher.ts
+++ b/server/src/webhooks/dispatcher.ts
@@ -118,6 +118,18 @@ async function enqueueRetry(
 
 // ── Public emit API ─────────────────────────────────────────────────────────
 
+/**
+ * Identifies the token that caused a mutation, for webhook attribution. Threaded from the
+ * request/MCP surface down into the shared brain functions, which own webhook emission: a
+ * shared mutating function emits when (and only when) it is given an actor — so user-facing
+ * surfaces (REST, MCP) pass one and emit, while internal callers (sync, import, bulk) pass
+ * none and stay silent. Centralises both the emit call AND its attribution in one place.
+ */
+export interface WebhookActor {
+  tokenId?: string;
+  tokenLabel?: string;
+}
+
 export interface EmitWebhookEventOptions {
   event: WebhookEventType;
   spaceId: string;

--- a/server/src/webhooks/types.ts
+++ b/server/src/webhooks/types.ts
@@ -13,6 +13,7 @@ export type WebhookEventType =
   | 'edge.created'   | 'edge.updated'   | 'edge.deleted'
   | 'chrono.created'  | 'chrono.updated'  | 'chrono.deleted'
   | 'file.created'    | 'file.updated'    | 'file.deleted'
+  | 'bulk.write'
   | 'link_violation.created'
   | 'duplicate.detected'
   | 'test.ping';
@@ -23,6 +24,7 @@ export const ALL_WEBHOOK_EVENTS: ReadonlySet<string> = new Set<WebhookEventType>
   'edge.created',   'edge.updated',   'edge.deleted',
   'chrono.created',  'chrono.updated',  'chrono.deleted',
   'file.created',    'file.updated',    'file.deleted',
+  'bulk.write',
   'link_violation.created',
   'duplicate.detected',
   'test.ping',

--- a/testing/integration/files.test.js
+++ b/testing/integration/files.test.js
@@ -418,7 +418,9 @@ describe('File metadata (MongoDB)', () => {
     assert.equal(q.body.files[0].path, filePath, 'Returned path must be the normalised (no-slash) form');
   });
 
-  it('DELETE /api/brain/.../files removes metadata without deleting the file on disk', async () => {
+  it('DELETE /api/brain/.../files refuses (409) to remove metadata while the file exists on disk', async () => {
+    // Contract: a metadata record may not be deleted while its file is present — doing so
+    // would silently orphan a live file. Delete the file itself instead (or soft-delete first).
     const filePath = `meta-braindelete-${RUN}.txt`;
     await uploadFile(tokenA, 'general', filePath, 'keep me on disk');
 
@@ -430,15 +432,14 @@ describe('File metadata (MongoDB)', () => {
       method: 'DELETE',
       headers: { 'Authorization': `Bearer ${tokenA}` },
     });
-    assert.equal(dr.status, 204, `Expected 204, got ${dr.status}: ${await dr.text()}`);
+    assert.equal(dr.status, 409, `Expected 409 while file present, got ${dr.status}: ${await dr.text()}`);
 
+    // Both the metadata and the file must still be there.
     const q2 = await listFileMeta(tokenA, 'general', `?path=${encodeURIComponent(filePath)}`);
-    assert.equal(q2.body.files.length, 0, 'Metadata must be gone after brain DELETE');
-
-    // File itself must still be downloadable
+    assert.equal(q2.body.files.length, 1, 'Metadata must remain after a refused delete');
     const dlUrl = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
     const dlr = await fetch(dlUrl, { headers: { 'Authorization': `Bearer ${tokenA}` } });
-    assert.equal(dlr.status, 200, 'File on disk must still exist after metadata-only delete');
+    assert.equal(dlr.status, 200, 'File on disk must still exist');
   });
 
   it('Brain stats endpoint includes files count', async () => {
@@ -657,6 +658,44 @@ describe('File metadata (MongoDB) — directory operations', () => {
     const after = await listFileMeta();
     const remaining = after.body.files.filter(f => f.path.startsWith(`${dir}/`));
     assert.equal(remaining.length, 0, `Metadata must be removed for all files under ${dir}`);
+  });
+
+  it('Deleting a directory leaves no orphaned metadata or chunks (regression: folder-delete orphans)', async () => {
+    const dir = `orphan-cleanup-${RUN}`;
+    // A raw image both creates a top-level file-meta record AND (with media embedding on)
+    // enqueues a media job — the exact shape that used to orphan on folder delete: a leftover
+    // metafile plus a job retrying forever against the now-missing file. A text file adds
+    // hidden chunk records that must also be cleaned.
+    const jpg = Buffer.from('ffd8ffe0006a706567', 'hex');
+    await uploadRaw(tokenA, 'general', `${dir}/pic.jpg`, jpg, 'image/jpeg');
+    await upload(`${dir}/note.txt`, 'some text body');
+
+    // Sanity: records (including hidden chunk/subfile records) exist under the folder.
+    const before = await listFileMeta('?includeChunks=true&limit=200');
+    assert.ok(
+      before.body.files.some(f => f.path.startsWith(`${dir}/`)),
+      `Expected records under ${dir} before delete`,
+    );
+
+    // Delete the folder.
+    const delUrl = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(dir)}`;
+    const dr = await fetch(delUrl, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${tokenA}` },
+      body: JSON.stringify({ confirm: true }),
+    });
+    assert.equal(dr.status, 204, 'Directory delete should return 204');
+
+    // No record of ANY kind (file, chunk, or conversion artifact) may remain under the folder —
+    // whether its own path or its parent's path is under the deleted directory.
+    const after = await listFileMeta('?includeChunks=true&limit=200');
+    const remaining = after.body.files.filter(f =>
+      f.path.startsWith(`${dir}/`) || (f.parentFileId && f.parentFileId.startsWith(`${dir}/`)),
+    );
+    assert.equal(
+      remaining.length, 0,
+      `No orphaned records may remain under ${dir}; found ${JSON.stringify(remaining.map(f => f.path))}`,
+    );
   });
 
   it('Moving a directory updates metadata paths for all files inside it', async () => {

--- a/testing/integration/webhooks.test.js
+++ b/testing/integration/webhooks.test.js
@@ -159,6 +159,23 @@ describe('Webhook dispatch — real match + sign + deliver + log', () => {
     assert.ok(!leaked, 'a webhook filtered to entity.created must not receive memory.created');
   });
 
+  it('a REST entity create fires entity.created via the centralized upsertEntity emit', async () => {
+    // hookOther is subscribed to entity.created in spaceX. Creating an entity must deliver —
+    // proving emission now lives in the shared upsertEntity function (not the route).
+    const created = await post(INSTANCES.a, token, `/api/brain/spaces/${spaceX}/entities`, {
+      name: `wh-ent-${RUN}`, type: 'concept',
+    });
+    assert.equal(created.status, 201, `create entity: ${JSON.stringify(created.body)}`);
+
+    let delivery;
+    await waitFor(async () => {
+      const r = await get(INSTANCES.a, token, `/api/admin/webhooks/${hookOther}/deliveries`);
+      delivery = r.body.deliveries?.find(d => d.event === 'entity.created');
+      return Boolean(delivery);
+    }, 20_000, 500, 'no entity.created delivery — centralized upsertEntity emission did not run');
+    assert.equal(delivery.spaceId, spaceX, 'entity.created delivery records the originating space');
+  });
+
   it('the test-delivery endpoint records a test.ping attempt', async () => {
     const t = await post(INSTANCES.a, token, `/api/admin/webhooks/${hookMatch}/test`, {});
     assert.equal(t.status, 200, `test endpoint: ${JSON.stringify(t.body)}`);

--- a/testing/red-team-tests/auth-escalation.test.js
+++ b/testing/red-team-tests/auth-escalation.test.js
@@ -137,14 +137,21 @@ describe('H2 — MFA cannot be rotated/disabled with just an admin PAT once enab
   // reliable — no TOTP generation needed.
   async function disableMfaViaRestart() {
     execSync(`docker exec ythril-a node -e "const fs=require('fs');const p='/config/secrets.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));delete s.totpSecret;fs.writeFileSync(p,JSON.stringify(s,null,2),{mode:0o600})"`);
-    execSync('docker restart ythril-a', { stdio: 'ignore' });
+    // `-t 3`: force-kill after a 3s graceful window instead of docker's default 10s. Under
+    // full-suite load the instance is mid-sync with its peers, and a slow graceful stop plus a
+    // busy daemon was pushing the whole restart past the readiness deadline below.
+    execSync('docker restart -t 3 ythril-a', { stdio: 'ignore' });
     // Wait for the API to actually serve again — poll the readiness endpoint
     // (not just docker's health status), retrying through the stale keep-alive
     // sockets still pointing at the dead process. Throw loudly on timeout so we
     // never run assertions against a half-restarted server. The old 45s docker-
     // health loop returned SILENTLY on timeout, so a slow restart left `before`
     // hitting a dead server and the MFA request hung to its timeout — the flake.
-    const deadline = Date.now() + 90_000;
+    // 240s (not 90s): when this test runs late in the full suite, peer instances b/c/d are
+    // still syncing against A, so a fresh A is flooded on boot and readiness lags — in
+    // isolation this restart is ~2s, but under that background load it has been observed to
+    // take ~175s, so the deadline needs comfortable headroom above that.
+    const deadline = Date.now() + 240_000;
     while (Date.now() < deadline) {
       try {
         const r = await fetch(`${INSTANCES.a}/ready`);

--- a/testing/standalone/webhooks.test.js
+++ b/testing/standalone/webhooks.test.js
@@ -34,6 +34,7 @@ describe('Webhook event types (real ALL_WEBHOOK_EVENTS from the compiled build)'
       'edge.created', 'edge.updated', 'edge.deleted',
       'chrono.created', 'chrono.updated', 'chrono.deleted',
       'file.created', 'file.updated', 'file.deleted',
+      'bulk.write',
       'link_violation.created',
       'duplicate.detected',
       'test.ping',

--- a/testing/sync/file-sync.test.js
+++ b/testing/sync/file-sync.test.js
@@ -170,6 +170,69 @@ describe('File sync — cross-instance', () => {
     assert.equal(check.status, 404, 'Deleted file must not exist on B after sync');
   });
 
+  it('folder deleted on A propagates deletion to B (folder tombstones)', async () => {
+    const dir = `sync-test-${RUN}-deldir`;
+    const f1 = `${dir}/one.txt`;
+    const f2 = `${dir}/nested/two.txt`;
+
+    // Upload two files under the folder and sync both to B.
+    await uploadFile(INSTANCES.a, tokenA, 'general', f1, `a-${RUN}`);
+    await uploadFile(INSTANCES.a, tokenA, 'general', f2, `b-${RUN}`);
+    await triggerAndWait(networkId, tokenA, async () => {
+      const r1 = await downloadFile(INSTANCES.b, tokenB, 'general', f1);
+      const r2 = await downloadFile(INSTANCES.b, tokenB, 'general', f2);
+      return r1.status === 200 && r2.status === 200;
+    });
+
+    // Delete the whole folder on A (requires confirm). Without per-file tombstones,
+    // B's manifest would push these files straight back on the next sync.
+    const delR = await reqJson(INSTANCES.a, tokenA, `/api/files/general?path=${encodeURIComponent(dir)}`, {
+      method: 'DELETE',
+      body: JSON.stringify({ confirm: true }),
+    });
+    assert.equal(delR.status, 204, `Folder delete on A: ${JSON.stringify(delR.body)}`);
+
+    // After sync, BOTH files must be gone on B and must NOT resurrect.
+    await triggerAndWait(networkId, tokenA, async () => {
+      const r1 = await downloadFile(INSTANCES.b, tokenB, 'general', f1);
+      const r2 = await downloadFile(INSTANCES.b, tokenB, 'general', f2);
+      return r1.status === 404 && r2.status === 404;
+    });
+    const c1 = await downloadFile(INSTANCES.b, tokenB, 'general', f1);
+    const c2 = await downloadFile(INSTANCES.b, tokenB, 'general', f2);
+    assert.equal(c1.status, 404, 'Deleted folder file one.txt must not exist on B after sync');
+    assert.equal(c2.status, 404, 'Deleted folder file nested/two.txt must not exist on B after sync');
+  });
+
+  it('file moved on A propagates as a move to B (old path tombstoned, no resurrection)', async () => {
+    const src = `sync-test-${RUN}-movesrc.txt`;
+    const dst = `sync-test-${RUN}-movedst.txt`;
+    const content = `move-me-${RUN}`;
+
+    await uploadFile(INSTANCES.a, tokenA, 'general', src, content);
+    await triggerAndWait(networkId, tokenA, async () =>
+      (await downloadFile(INSTANCES.b, tokenB, 'general', src)).status === 200);
+
+    // Move on A. Without an old-path tombstone, B's manifest would re-push `src` back.
+    const mvR = await reqJson(INSTANCES.a, tokenA, `/api/files/general?path=${encodeURIComponent(src)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ destination: dst }),
+    });
+    assert.equal(mvR.status, 200, `Move on A: ${JSON.stringify(mvR.body)}`);
+
+    // After sync: B has the file at dst, and src is gone and stays gone.
+    await triggerAndWait(networkId, tokenA, async () => {
+      const rd = await downloadFile(INSTANCES.b, tokenB, 'general', dst);
+      const rs = await downloadFile(INSTANCES.b, tokenB, 'general', src);
+      return rd.status === 200 && rs.status === 404;
+    });
+    const cd = await downloadFile(INSTANCES.b, tokenB, 'general', dst);
+    const cs = await downloadFile(INSTANCES.b, tokenB, 'general', src);
+    assert.equal(cd.status, 200, 'Moved file must exist at destination on B');
+    assert.equal(cd.body, content, 'Destination content must match');
+    assert.equal(cs.status, 404, 'Old path must NOT resurrect on B after sync');
+  });
+
   it('hash mismatch creates conflict copy on receiving side — local file preserved', async () => {
     const filePath = `sync-test-${RUN}-conflict.txt`;
     const contentA = `version-A-${RUN}`;


### PR DESCRIPTION
## Summary

A batch of file/media-subsystem robustness fixes plus a webhook-emission refactor, developed together this session. Each piece is covered by tests and has a `CHANGELOG` entry.

### Fixes

- **`docker compose up` failed (`401 UNAUTHORIZED`) pulling the conversion sidecar.** Unstructured made `unstructured-api-full` private on quay.io; switched the `unstructured` service (compose + K8s manifest) to the still-public `unstructured-api` (same release, minus extras Ythril doesn't use).
- **Deleting a file/folder orphaned embedding metadata and left a media job retrying forever.** File/folder/MCP deletes now cancel the media job; folder delete clears conversion artifacts (records **and** on-disk `_converted`/`_extracted`); the media worker treats a missing source file (`ENOENT`) as terminal and reconciles instead of looping.
- **Deletes/moves resurrected files on sync peers.** Folder delete, MCP `delete_file`, and both movers now write per-file sync tombstones (sync has no rename detection, so a move without an old-path tombstone re-pushed the source).
- **MCP file tools diverged from the HTTP routes.** `write_file`/`delete_file`/`move_file` now emit the same webhooks, `move_file` re-roots child metadata on directory moves, `delete_file` invalidates the usage cache, and `write_file` projects the quota size + clears stale conversion artifacts on overwrite.

### Features

- **Optional soft-delete for file metadata (`softDeleteFileMeta`, default off).** Deleting a file flags its record `deletedAt` instead of removing it (audit trail); flagged records stay listed/searchable with a "deleted" badge and can be purged. A metadata-delete now refuses (409) while the file still exists.
- **Webhooks fire for agent (MCP) writes, emitted from one place.** Emission is centralised inside the shared brain functions (`remember`/`upsertEntity`/`upsertEdge`/`createChrono`/…/`executeMerge`), gated on a `WebhookActor` threaded from REST and MCP — so both surfaces emit (with token attribution) while sync/import stay silent. Manual per-route emits removed (single source of truth). Bulk writes emit one new **`bulk.write`** summary instead of a per-item firehose. Fixes a latent bug: a by-id entity update now emits `entity.updated` (was `entity.created`).

### CI / tooling

- **`Image Pin Check` workflow** — scheduled + on-PR guard that HEAD-checks every pinned upstream image/model is still pullable, so an upstream privatising/renaming a tag fails CI instead of a developer's `docker compose up`.
- **`.markdownlint.json`** + a CHANGELOG consolidation (duplicate `### Added`/`### Fixed` headings merged per version; content-preserving) so the changelog lints clean.
- **Hardened the flaky `H2` MFA red-team test** — force-quick container restart + realistic readiness headroom, so its `docker restart` no longer times out late in the full suite under background sync load.

## Deferred (tracked for the follow-up modularity pass)

- The single-memory REST create still inlines its own logic/emit instead of calling `remember()` — a duplication to unify in the modularity audit, which will also fully centralise memory emission.

## Testing

- Full `test:all:core` green in a clean (test-stack-only) environment.
- New/updated tests: folder-delete & move sync-propagation (tombstones), folder-delete orphan cleanup + metadata-delete guard (files), centralized `entity.created` webhook delivery, `bulk.write` in the event drift-guard.
- Verified at runtime: MCP `delete_file` writes a tombstone; MCP `upsert_entity` fires an attributed `entity.created` webhook.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
