### PR TITLE
fix(brain): route REST memory-create through remember() — fixes property-embedding drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Memories created over the REST API embedded properties without their keys (semantic-recall
+  regression).** `POST /api/brain/spaces/:id/memories` re-implemented the create logic inline instead
+  of calling the shared `remember()`, and the copy had drifted: it folded properties **values-only**
+  (`"pilot"`) instead of `key value` (`"occupation pilot"`) via the shared `propsEmbedText` helper —
+  the exact regression the helper was extracted to prevent — so a memory created via REST embedded
+  differently from the identical one created via MCP, and recall couldn't match on a property name.
+  The inline copy also never set `matchedText` and never fired the insert-time duplicate-rule check.
+  The route now routes through `remember()`, so REST and MCP produce identical records; ~55 lines of
+  duplication removed. Covered by a new memory case in the property-key embedding test.
+
 - **Moving a file/folder resurrected the pre-move copy on sync peers (both HTTP and MCP).** A move
   removes the file from its old path on disk, but neither the `PATCH /api/files` route nor the MCP
   `move_file` tool wrote a tombstone for it — and sync has no rename detection, so a peer's manifest

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -138,58 +138,15 @@ brainRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth,
     return;
   }
 
-  // Resolve entity names for richer embedding
-  let entityNames: string[] = [];
-  if (safeEntityIds.length > 0) {
-    try {
-      const entityDocs = await col<EntityDoc>(`${targetSpace}_entities`)
-        .find(asFilter<EntityDoc>({ _id: { $in: safeEntityIds } }), { projection: { name: 1 } })
-        .toArray() as Array<{ name: string }>;
-      entityNames = entityDocs.map(e => e.name);
-    } catch { /* ignore — entity names are best-effort */ }
-  }
-
-  // Assemble embedding text from all content fields
-  const embedParts: string[] = [];
-  if (safeTags.length > 0) embedParts.push(safeTags.join(' '));
-  if (entityNames.length > 0) embedParts.push(entityNames.join(' '));
-  embedParts.push(fact);
-  if (safeDesc?.trim()) embedParts.push(safeDesc.trim());
-  if (safeProps) {
-    const propEntries = Object.entries(safeProps);
-    if (propEntries.length > 0) embedParts.push(propEntries.map(([_k, v]) => String(v)).join(' '));
-  }
-
-  // Attempt embedding; fall back to empty vector if server not configured/reachable
-  let embedding: number[] = [];
-  let embeddingModel = 'none';
-  try {
-    const result = await embed(embedParts.join(' '));
-    embedding = result.vector;
-    embeddingModel = result.model;
-  } catch (err) {
-    log.warn(`Embedding unavailable, storing without vector: ${err}`);
-  }
-  const seq = await nextSeq(targetSpace);
-  const now = new Date().toISOString();
-  const doc: MemoryDoc = {
-    _id: uuidv4(),
-    spaceId: targetSpace,
-    fact,
-    embedding,
-    tags: safeTags,
-    entityIds: safeEntityIds,
-    author: { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel },
-    createdAt: now,
-    updatedAt: now,
-    seq,
-    embeddingModel,
-  };
-  if (safeDesc !== undefined) doc.description = safeDesc;
-  if (safeProps !== undefined) doc.properties = safeProps;
-  if (safeMemoryType !== undefined) doc.type = safeMemoryType;
-  await col<MemoryDoc>(`${targetSpace}_memories`).insertOne(asDoc<MemoryDoc>(doc));
-  emitWebhookEvent({ event: 'memory.created', spaceId: targetSpace, entry: { ...doc, embedding: undefined }, ...webhookToken(req) });
+  // Persist through the shared remember() so REST and MCP produce identical records: the same
+  // embed-text derivation (properties folded as `key value` via propsEmbedText, entity names
+  // resolved consistently), the `matchedText` source string, the author, insert-time duplicate-
+  // rule evaluation, and the memory.created webhook. Previously inlined here, which had drifted
+  // into three bugs: values-only property embedding, no `matchedText`, and no dupe-rule firing.
+  const doc = await remember(
+    targetSpace, fact, safeEntityIds, safeTags, safeDesc, safeProps,
+    undefined, safeMemoryType, undefined, webhookToken(req),
+  );
   const body: Record<string, unknown> = { ...doc };
   if (quotaResult?.softBreached) body['storageWarning'] = true;
   if (validation.warnings.length > 0) body['warnings'] = validation.warnings;

--- a/testing/integration/embed-properties.test.js
+++ b/testing/integration/embed-properties.test.js
@@ -7,8 +7,10 @@
  * embedded text via the shared propsEmbedText helper.
  *
  * These tests assert the stored embedding text (`matchedText`, returned by recall)
- * contains the property KEY for an entity, an edge, and a chrono entry — the edge and
- * chrono cases embedded no property data at all before this fix.
+ * contains the property KEY for a memory, an entity, an edge, and a chrono entry — the edge
+ * and chrono cases embedded no property data at all before the original fix, and the REST
+ * memory-create path had *regressed* to values-only (it inlined its own embed-text derivation
+ * instead of calling the shared `remember()` — fixed by routing it through the shared function).
  *
  * Run: node --test testing/integration/embed-properties.test.js
  */
@@ -59,6 +61,21 @@ describe('Property keys are embedded (B4)', () => {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({ confirm: true }),
     }).catch(() => {});
+  });
+
+  it('memory embedding text includes the property key (REST create, via shared remember())', async (t) => {
+    if (!embeddingAvailable) return t.skip('Embedding not available');
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`,
+      { fact: `MemPropKey-${RUN}`, properties: { occupation: 'pilot' } });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    // remember() stores matchedText on the doc, so the create response now exposes it directly —
+    // before the fix the REST create set no matchedText and embedded values only ("pilot").
+    assert.match(r.body.matchedText ?? '', /occupation pilot/,
+      `memory create must fold "key value" into matchedText: ${r.body.matchedText}`);
+    const hit = await recallMatch(r.body._id, `MemPropKey-${RUN}`, ['memory']);
+    assert.ok(hit, 'memory should be recallable once indexed');
+    assert.match(hit.matchedText ?? '', /occupation/,
+      `memory embed text must include the property key: ${hit.matchedText}`);
   });
 
   it('entity embedding text includes the property key', async (t) => {


### PR DESCRIPTION
## Summary

First item from the modularity audit (ARCHITECTURE-TODO **A8**), and it turned out to be a **live correctness bug**, not just duplication.

`POST /api/brain/spaces/:id/memories` re-implemented memory creation inline (~55 lines) instead of calling the shared `remember()`. The copy had drifted behind the shared function into three defects — all on the REST path only:

1. **Properties embedded values-only** (`"pilot"`) instead of `key value` (`"occupation pilot"`) via the shared `propsEmbedText` helper — the exact regression that helper was extracted to prevent (`brain/embed-text.ts`). So a memory created over REST embedded *differently* from the identical one created via MCP, and semantic recall could not match on a property name.
2. **`matchedText`** (the pre-embedding source string surfaced by recall) was never stored on REST-created memories.
3. The **insert-time duplicate-rule check** (`dupeRulesOnInsert`) never fired for REST creates.

## Fix

Route the handler through `remember()`, keeping the REST-specific validation / quota / schema checks and response shape. REST and MCP now produce identical records; ~55 lines of duplicated embed/insert/emit logic removed. This also completes the memory-webhook centralization deferred in #221.

Entity/edge/chrono creates already call their shared functions — this brings memory in line.

## Testing

- `embed-properties.test.js` guards exactly this (`matchedText` must contain the property **key**) but only covered entity/edge/chrono — it **missed memory**, the path that regressed. Added a memory case asserting both the create-response `matchedText` and recall fold `occupation pilot`.
- Full run green: 187/187 in the embed-properties + brain suites, including the existing "create + get-by-id still work" contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)