### PR TITLE
refactor: dedupe authorRef (9→1) and escapeRegex (8→1) onto shared modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Deduplicated two copy-pasted helpers onto shared modules (internal, no behavior change).**
+  `authorRef()` — the `{ instanceId, instanceLabel }` write stamp — was defined identically in nine
+  files across the brain and file subsystems; it now lives once in `config/author.ts`. The RegExp
+  literal-escape (`s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`) was hand-rolled in eight places (two
+  named, six inline); it is now `escapeRegex()` in the existing `util/redos.ts` regex-safety module.
+  Both are byte-identical extractions — the value is one source of truth so the identity/escape logic
+  can't drift. (ARCHITECTURE-TODO A12 + A14.)
+
 - **Concluded vote rounds are now pruned, so `pendingRounds` no longer grows for the life of a
   network (P14).** `concludeRoundIfReady` marks a round `concluded` but never removed it, so every
   governance vote a network ever held accumulated forever in `config.json` — bloating the file, the

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { escapeRegex } from '../util/redos.js';
 import type express from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { requireSpaceAuth, denyReadOnly } from '../auth/middleware.js';
@@ -160,7 +161,7 @@ function buildMemoryFilter(query: Record<string, unknown>): Record<string, unkno
   const tag = typeof query['tag'] === 'string' ? query['tag'] : undefined;
   const entity = typeof query['entity'] === 'string' ? query['entity'] : undefined;
   const type = typeof query['type'] === 'string' ? query['type'] : undefined;
-  if (tag) filter['tags'] = { $regex: `^${tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' };
+  if (tag) filter['tags'] = { $regex: `^${escapeRegex(tag)}$`, $options: 'i' };
   if (entity) filter['entityIds'] = entity;
   if (type) filter['type'] = type;
   return filter;
@@ -516,7 +517,7 @@ brainRouter.get('/spaces/:spaceId/entities/by-name', globalRateLimit, requireSpa
   }
   const memberIds = resolveMemberSpaces(spaceId);
   // Case-insensitive substring search — escape user input to prevent ReDoS
-  const escaped = name.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = escapeRegex(name.trim());
   const all = (await Promise.all(memberIds.map(mid => listEntities(mid, { name: { $regex: escaped, $options: 'i' } }, 20)))).flat();
   res.json({ entities: all });
 });

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
@@ -8,10 +9,6 @@ import { getConfig } from '../config/loader.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
 
-function authorRef() {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 const RECURRENCE_FREQ = ['daily', 'weekly', 'monthly', 'yearly'] as const;
 

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
@@ -30,10 +31,6 @@ export interface TraverseResult {
   truncated: boolean;
 }
 
-function authorRef() {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 /** Resolve entity IDs to names for embedding. Falls back to the raw ID if the entity is not found. */
 export async function resolveEdgeEntityNames(spaceId: string, fromId: string, toId: string): Promise<[string, string]> {

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
@@ -23,10 +24,6 @@ export interface UpsertResult {
   similar?: SimilarMatch[];
 }
 
-function authorRef() {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 /** Derive the text to embed for an entity (name + type + tags + description + properties). */
 

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { authorRef } from '../config/author.js';
 import { col, isVectorSearchAvailable, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
@@ -122,10 +123,6 @@ export function toNativeVectorFilter(
   return clauses.length === 1 ? clauses[0] : { $and: clauses };
 }
 
-function authorRef() {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 /** Derive the text to embed for a memory (tags + entity names + fact + description + properties). */
 /** Resolve entity IDs to their names from the database. */

--- a/server/src/config/author.ts
+++ b/server/src/config/author.ts
@@ -1,0 +1,12 @@
+import { getConfig } from './loader.js';
+import type { AuthorRef } from './types.js';
+
+/**
+ * The `{ instanceId, instanceLabel }` stamp recording which instance wrote a record.
+ * Single source of truth — every knowledge/file writer stamps its docs with this so the
+ * identity shape can never drift across the brain and file subsystems.
+ */
+export function authorRef(): AuthorRef {
+  const cfg = getConfig();
+  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
+}

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -9,6 +9,8 @@
  */
 
 import path from 'path';
+import { escapeRegex } from '../../util/redos.js';
+import { authorRef } from '../../config/author.js';
 import fs from 'fs/promises';
 import { UnstructuredConverter } from './unstructured.js';
 import type { ExtractedImage } from './unstructured.js';
@@ -40,10 +42,6 @@ export function isMediaFormat(fmt: ResolvedFormat): fmt is 'image' | 'audio' | '
   return MEDIA_FORMATS.has(fmt);
 }
 
-function authorRef(): AuthorRef {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 const EXT_MAP: Record<string, ResolvedFormat> = {
   '.pdf': 'pdf',
@@ -402,11 +400,6 @@ export async function storeConversionResults(
   }
 
   return { chunkCount: chunks.length, convertedFileId, embedFailures };
-}
-
-/** Escape a string for safe use inside a RegExp. */
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /** Best-effort recursive delete of a space-relative path. Never throws (missing = success). */

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -13,16 +13,14 @@
  */
 
 import path from 'node:path';
+import { escapeRegex } from '../util/redos.js';
+import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { embed } from '../brain/embedding.js';
 import { fileEmbedText } from '../brain/embed-text.js';
 import { getConfig } from '../config/loader.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../config/types.js';
 
-function authorRef(): AuthorRef {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 /** Normalise a path to forward-slash convention and strip leading slashes (used as _id). */
 function normPath(p: string): string {
@@ -228,7 +226,7 @@ export async function deleteFileMetaByPrefix(
   const prefix = norm + '/';
   // Escape regex special characters in the prefix so a path like "my.dir/"
   // doesn't accidentally match "myXdir/" etc.
-  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = escapeRegex(prefix);
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
     asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }),
   );
@@ -262,7 +260,7 @@ export async function markFileMetaDeletedByPrefix(
 ): Promise<void> {
   const norm = normPath(dirPath).replace(/\/?$/, '');
   if (!norm) return; // guard: empty path would match everything
-  const escaped = (norm + '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = escapeRegex(norm + '/');
   const coll = col<FileMetaDoc>(`${spaceId}_files`);
   // Flag the user-visible file records.
   await coll.updateMany(
@@ -327,7 +325,7 @@ export async function renameFileMetaByPrefix(
   const dstPrefix = normDst + '/';
   if (srcPrefix === dstPrefix) return;
 
-  const escaped = srcPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = escapeRegex(srcPrefix);
   const docs = await col<FileMetaDoc>(`${spaceId}_files`)
     .find(asFilter<FileMetaDoc>({ _id: { $regex: `^${escaped}` } }))
     .toArray() as FileMetaDoc[];

--- a/server/src/files/media/audio-embedder.ts
+++ b/server/src/files/media/audio-embedder.ts
@@ -12,6 +12,7 @@
  */
 
 import { spawn } from 'child_process';
+import { authorRef } from '../../config/author.js';
 import { randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
@@ -23,10 +24,6 @@ import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
 import type { SttProvider, SttSegment } from './providers.js';
 import { log } from '../../util/log.js';
 
-function authorRef(): AuthorRef {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 // ── ffmpeg helpers ────────────────────────────────────────────────────────
 

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -29,6 +29,7 @@
  */
 
 import path from 'path';
+import { authorRef } from '../../config/author.js';
 import sharp from 'sharp';
 import { col, asDoc, asFilter } from '../../db/mongo.js';
 import { getConfig, getDataRoot, getFaceRecognitionConfig } from '../../config/loader.js';
@@ -181,10 +182,6 @@ async function gallerySearch(
 
 // ── Public API ─────────────────────────────────────────────────────────────
 
-function authorRef(): AuthorRef {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 /**
  * Detect all faces in an image and persist one face-chunk record per face.

--- a/server/src/files/media/image-embedder.ts
+++ b/server/src/files/media/image-embedder.ts
@@ -7,16 +7,13 @@
  */
 
 import { col, asDoc, asFilter } from '../../db/mongo.js';
+import { authorRef } from '../../config/author.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
 import { log } from '../../util/log.js';
 import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
 import type { VisionProvider } from './providers.js';
 
-function authorRef(): AuthorRef {
-  const cfg = getConfig();
-  return { instanceId: cfg.instanceId, instanceLabel: cfg.instanceLabel };
-}
 
 /**
  * Generate caption + embedding for an image and store one chunk record.

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -6,6 +6,7 @@
  */
 
 import { col, asFilter, asDoc, asUpdate } from '../../db/mongo.js';
+import { escapeRegex } from '../../util/redos.js';
 import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 
@@ -461,10 +462,9 @@ export async function cancelMediaJob(spaceId: string, filePath: string): Promise
 export async function cancelMediaJobsByPrefix(spaceId: string, dirPath: string): Promise<void> {
   const dir = normPath(dirPath).replace(/\/?$/, '');
   if (!dir) return; // guard: empty path would match everything
-  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const prefixes = [`${dir}/`, `_converted/${dir}/`, `_extracted/${dir}/`];
   await jobCollection(spaceId).deleteMany(
-    asFilter<MediaJobDoc>({ $or: prefixes.map(p => ({ _id: { $regex: `^${esc(p)}` } })) }),
+    asFilter<MediaJobDoc>({ $or: prefixes.map(p => ({ _id: { $regex: `^${escapeRegex(p)}` } })) }),
   );
 }
 

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -1,4 +1,5 @@
 import type { Collection } from 'mongodb';
+import { escapeRegex } from '../util/redos.js';
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs/promises';
 import path from 'path';
@@ -992,7 +993,7 @@ async function moveSpaceData(oldId: string, newId: string): Promise<string[]> {
   try {
     const scanState = col<{ _id: string }>('ythril_dupe_scan_state');
     const stale = await scanState
-      .find(asFilter<{ _id: string }>({ _id: { $regex: `^${oldId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:` } }))
+      .find(asFilter<{ _id: string }>({ _id: { $regex: `^${escapeRegex(oldId)}:` } }))
       .toArray() as Array<Record<string, unknown> & { _id: string }>;
     for (const doc of stale) {
       const moved = { ...doc, _id: `${newId}:${doc._id.slice(oldId.length + 1)}` };

--- a/server/src/util/redos.ts
+++ b/server/src/util/redos.ts
@@ -8,6 +8,15 @@
 export const MAX_PATTERN_LENGTH = 500;
 
 /**
+ * Escape a string for safe literal use inside a RegExp (e.g. building a `^prefix`
+ * anchor for a Mongo `$regex`). Single source of truth — every call site that
+ * hand-rolled `s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')` should use this.
+ */
+export function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Rejects patterns with nested quantifiers like (a+)+, (a*)*b, (a|a)+, etc.
  * This is a conservative heuristic — it may block some safe patterns, which
  * is the correct fail-safe direction for user-supplied regexes.


### PR DESCRIPTION
## Summary

Two low-risk, high-copy-count helper extractions from the modularity audit (ARCHITECTURE-TODO **A12 + A14**). Both are **byte-identical** extractions — behavior-preserving, one source of truth so the logic can't drift.

- **`authorRef()`** — the `{ instanceId, instanceLabel }` write stamp — was defined identically in **9 files** across `brain/` and `files/`. Now `config/author.ts`.
- **RegExp literal-escape** (`s.replace(/[.*+?^${}()|[\]\]/g, '\$&')`) — hand-rolled in **8 places** (2 named, 6 inline). Now `escapeRegex()` in the existing `util/redos.ts` regex-safety module (its natural home).

No copies remain (`grep` confirms only the shared definitions).

## Testing

- `tsc` clean (every call site resolves to the shared function).
- 53/53 in the files + embed-properties suites — exercises `escapeRegex` via folder-delete-by-prefix (`deleteFileMetaByPrefix`) and `authorRef` via both file and brain writes.

Next in the audit: A13 (`normPath` → `toDocId`/`toSafeRelPath`, which also closes a traversal-strip divergence in the media worker), then A9/A10/A16, then the monolith splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)