### PR TITLE
refactor: centralize path normalisation into util/paths.ts (toDocId / toSafeRelPath)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Centralized path normalisation into `util/paths.ts` (`toDocId` / `toSafeRelPath`).** The
+  `p.replace(/\\/g, '/').replace(/^\/+/, '')` idiom was hand-rolled in ~13 places (3 named `normPath`
+  defs + ~10 inline), and the copies had **diverged**: the media worker's variant also stripped `../`
+  for path-traversal defense while every other copy did not. Split into two clearly-named helpers —
+  `toDocId` (Mongo `_id`/path keys, keeps `..`) and `toSafeRelPath` (values joined to a filesystem
+  root, strips `..`) — and pointed each call site at the right one. Behavior-preserving for the id/key
+  sites; the sync tombstone-application paths (`api/sync.ts`, `sync/engine.ts`), which join a peer-
+  supplied path to the space files root, now strip `..` as **defense-in-depth** alongside their
+  existing boundary check (a no-op for legitimate paths). Locked by a unit test. (ARCHITECTURE-TODO A13.)
+
 - **Deduplicated two copy-pasted helpers onto shared modules (internal, no behavior change).**
   `authorRef()` — the `{ instanceId, instanceLabel }` write stamp — was defined identically in nine
   files across the brain and file subsystems; it now lives once in `config/author.ts`. The RegExp

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { toDocId } from '../util/paths.js';
 import { escapeRegex } from '../util/redos.js';
 import type express from 'express';
 import { v4 as uuidv4 } from 'uuid';
@@ -1237,7 +1238,7 @@ brainRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, asy
   const filter: Record<string, unknown> = {};
   if (!includeChunks) filter['parentFileId'] = { $exists: false };
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
-  if (typeof req.query['path'] === 'string') filter['path'] = req.query['path'].replace(/\\/g, '/').replace(/^\/+/, '');
+  if (typeof req.query['path'] === 'string') filter['path'] = toDocId(req.query['path']);
   const memberIds = resolveMemberSpaces(spaceId);
   const all = (await Promise.all(memberIds.map(mid =>
     col(`${mid}_files`)
@@ -1264,7 +1265,7 @@ brainRouter.delete('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   const wt = resolveWriteTarget(spaceId, req.query['targetSpace'] as string | undefined);
   if (!wt.ok) { res.status(400).json({ error: wt.error }); return; }
   const memberIds = resolveMemberSpaces(wt.target);
-  const norm = path.replace(/\\/g, '/').replace(/^\/+/, '');
+  const norm = toDocId(path);
   // Guard: a metadata record may only be removed if its file is gone (orphan) or the
   // record is flagged deleted. Deleting the metadata of a file that still exists would
   // silently orphan a live file — refuse and tell the caller to delete the file itself.

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -18,6 +18,7 @@
  */
 
 import express, { Router } from 'express';
+import { toDocId } from '../util/paths.js';
 import type { Request, Response, NextFunction } from 'express';
 import fs from 'fs/promises';
 import path from 'path';
@@ -341,7 +342,7 @@ filesRouter.post(
             const mediaCfg = getMediaEmbeddingConfig();
             if (mediaCfg.enabled && range.total <= (mediaCfg.maxFileSizeBytes ?? 524_288_000)) {
               await col<FileMetaDoc>(`${targetSpace}_files`).updateOne(
-                asFilter<FileMetaDoc>({ _id: filePath.replace(/\\/g, '/').replace(/^\/+/, '') }),
+                asFilter<FileMetaDoc>({ _id: toDocId(filePath) }),
                 { $set: { mediaType: resolvedFmt, embeddingStatus: 'pending' } },
               );
               await enqueueMediaJob(targetSpace, filePath, chunkedMimeType, resolvedFmt).catch(err => {
@@ -435,7 +436,7 @@ filesRouter.post(
       // Run conversion pipeline for convertible formats, or enqueue media/text jobs
       const inputFormat = typeof req.body?.inputFormat === 'string' ? req.body.inputFormat as InputFormat : 'auto';
       const resolvedFormat = resolveInputFormat(filePath, req.headers['content-type'], inputFormat);
-      const normId = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
+      const normId = toDocId(filePath);
       const mimeType = (req.headers['content-type'] ?? 'application/octet-stream').split(';')[0]!.trim();
 
       let embeddingStatusForResponse: 'disabled' | 'skipped' | 'pending' | undefined;
@@ -528,7 +529,7 @@ filesRouter.post(
 
     let normId: string;
     try {
-      normId = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
+      normId = toDocId(filePath);
       // Validate the path doesn't escape the space root
       resolveSafePath(targetSpace, filePath);
     } catch (err) {
@@ -595,7 +596,7 @@ filesRouter.delete('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOnly,
       // Check for an orphaned meta record (file deleted externally, meta still exists).
       // If there is one, clean it up and return 204 so the UI can remove it.
       // If there is none, the path was never known — return 404.
-      const normalisedPath = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
+      const normalisedPath = toDocId(filePath);
       const orphan = await col<FileMetaDoc>(`${targetSpace}_files`).findOne(
         asFilter<FileMetaDoc>({ _id: normalisedPath }),
       );

--- a/server/src/api/sync.ts
+++ b/server/src/api/sync.ts
@@ -9,6 +9,7 @@
  */
 
 import { Router } from 'express';
+import { toSafeRelPath } from '../util/paths.js';
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
@@ -1214,7 +1215,7 @@ syncRouter.post('/file-tombstones', syncRateLimit, requireAuth, denyReadOnly, as
       if (!ts._id || !ts.path || typeof ts.path !== 'string') continue;
 
       // Path-traversal guard â€” must stay within the space's files directory.
-      const rel = ts.path.replace(/\\/g, '/').replace(/^\/+/, '');
+      const rel = toSafeRelPath(ts.path);
       const abs = path.join(spaceFiles, rel);
       if (!abs.startsWith(spaceFiles + path.sep) && abs !== spaceFiles) continue;
 

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -9,6 +9,7 @@
  */
 
 import path from 'path';
+import { toDocId } from '../../util/paths.js';
 import { escapeRegex } from '../../util/redos.js';
 import { authorRef } from '../../config/author.js';
 import fs from 'fs/promises';
@@ -226,10 +227,6 @@ export async function runConversionPipeline(
   return { chunks, convertedMarkdown, extractedImages: [] };
 }
 
-/** Normalise a path to forward-slash convention and strip leading slashes. */
-function normPath(p: string): string {
-  return p.replace(/\\/g, '/').replace(/^\/+/, '');
-}
 
 /**
  * Store a converted file's chunk records in the {spaceId}_files collection.
@@ -252,7 +249,7 @@ export async function storeConversionResults(
   convertedMarkdown: string | null,
   extractedImages: ExtractedImage[] = [],
 ): Promise<{ chunkCount: number; convertedFileId: string | null; embedFailures: number }> {
-  const originalId = normPath(originalFilePath);
+  const originalId = toDocId(originalFilePath);
   const now = new Date().toISOString();
   let embedFailures = 0;
 
@@ -261,7 +258,7 @@ export async function storeConversionResults(
   if (convertedMarkdown !== null) {
     const convertedPath = `_converted/${originalId}.md`;
     await writeFile(spaceId, convertedPath, convertedMarkdown);
-    convertedFileId = normPath(convertedPath);
+    convertedFileId = toDocId(convertedPath);
 
     // Insert a minimal filemeta record for the converted file so it's discoverable
     const convertedSizeBytes = Buffer.byteLength(convertedMarkdown, 'utf8');
@@ -292,7 +289,7 @@ export async function storeConversionResults(
   if (extractedImages.length > 0) {
     for (const img of extractedImages) {
       const imgPath = `_extracted/${originalId}/image-${img.index}.${img.ext}`;
-      const imgId = normPath(imgPath);
+      const imgId = toDocId(imgPath);
       try {
         const imgBytes = Buffer.from(img.base64, 'base64');
         if (extractedBytesTotal + imgBytes.length > MAX_EXTRACTED_IMAGE_BYTES) {
@@ -421,7 +418,7 @@ export async function deleteConversionArtifacts(
   spaceId: string,
   originalFilePath: string,
 ): Promise<void> {
-  const originalId = normPath(originalFilePath);
+  const originalId = toDocId(originalFilePath);
 
   // DB: all filemeta records with parentFileId = originalId (chunks, converted, extracted).
   await col<FileMetaDoc>(`${spaceId}_files`).deleteMany(
@@ -447,7 +444,7 @@ export async function deleteConversionArtifactsByPrefix(
   spaceId: string,
   dirPath: string,
 ): Promise<void> {
-  const dir = normPath(dirPath).replace(/\/?$/, '');
+  const dir = toDocId(dirPath).replace(/\/?$/, '');
   if (!dir) return; // guard: empty path would match everything
   const escaped = escapeRegex(dir + '/');
 

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -13,6 +13,7 @@
  */
 
 import path from 'node:path';
+import { toDocId } from '../util/paths.js';
 import { escapeRegex } from '../util/redos.js';
 import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
@@ -22,10 +23,6 @@ import { getConfig } from '../config/loader.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../config/types.js';
 
 
-/** Normalise a path to forward-slash convention and strip leading slashes (used as _id). */
-function normPath(p: string): string {
-  return p.replace(/\\/g, '/').replace(/^\/+/, '');
-}
 
 
 /** Resolve entity names from a list of entity IDs in this space. Best-effort — returns [] on error. */
@@ -50,7 +47,7 @@ export async function upsertFileMeta(
   sizeBytes: number,
   opts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> } = {},
 ): Promise<void> {
-  const normalised = normPath(filePath);
+  const normalised = toDocId(filePath);
   const now = new Date().toISOString();
 
   const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
@@ -116,7 +113,7 @@ export async function updateFileMeta(
     properties?: Record<string, string | number | boolean>;
   },
 ): Promise<FileMetaDoc | null> {
-  const normalised = normPath(filePath);
+  const normalised = toDocId(filePath);
   const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(asFilter<FileMetaDoc>({ _id: normalised })) as FileMetaDoc | null;
   if (!existing) return null;
 
@@ -207,7 +204,7 @@ export async function deleteFileMeta(
   spaceId: string,
   filePath: string,
 ): Promise<void> {
-  const normalised = normPath(filePath);
+  const normalised = toDocId(filePath);
   await col<FileMetaDoc>(`${spaceId}_files`).deleteOne(
     asFilter<FileMetaDoc>({ _id: normalised }),
   );
@@ -221,7 +218,7 @@ export async function deleteFileMetaByPrefix(
   spaceId: string,
   dirPath: string,
 ): Promise<void> {
-  const norm = normPath(dirPath).replace(/\/?$/, '');
+  const norm = toDocId(dirPath).replace(/\/?$/, '');
   if (!norm) return; // guard: empty path would match everything
   const prefix = norm + '/';
   // Escape regex special characters in the prefix so a path like "my.dir/"
@@ -241,7 +238,7 @@ export async function markFileMetaDeleted(
   spaceId: string,
   filePath: string,
 ): Promise<void> {
-  const normalised = normPath(filePath);
+  const normalised = toDocId(filePath);
   await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
     asFilter<FileMetaDoc>({ _id: normalised }),
     asUpdate<FileMetaDoc>({ $set: { deletedAt: new Date().toISOString() } }),
@@ -258,7 +255,7 @@ export async function markFileMetaDeletedByPrefix(
   spaceId: string,
   dirPath: string,
 ): Promise<void> {
-  const norm = normPath(dirPath).replace(/\/?$/, '');
+  const norm = toDocId(dirPath).replace(/\/?$/, '');
   if (!norm) return; // guard: empty path would match everything
   const escaped = escapeRegex(norm + '/');
   const coll = col<FileMetaDoc>(`${spaceId}_files`);
@@ -283,8 +280,8 @@ export async function renameFileMeta(
   srcPath: string,
   dstPath: string,
 ): Promise<void> {
-  const normSrc = normPath(srcPath);
-  const normDst = normPath(dstPath);
+  const normSrc = toDocId(srcPath);
+  const normDst = toDocId(dstPath);
   if (normSrc === normDst) return;
 
   const existing = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
@@ -318,8 +315,8 @@ export async function renameFileMetaByPrefix(
   srcDir: string,
   dstDir: string,
 ): Promise<void> {
-  const normSrc = normPath(srcDir).replace(/\/?$/, '');
-  const normDst = normPath(dstDir).replace(/\/?$/, '');
+  const normSrc = toDocId(srcDir).replace(/\/?$/, '');
+  const normDst = toDocId(dstDir).replace(/\/?$/, '');
   if (!normSrc || !normDst) return; // guard: empty path would match everything
   const srcPrefix = normSrc + '/';
   const dstPrefix = normDst + '/';

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -6,6 +6,7 @@
  */
 
 import { col, asFilter, asDoc, asUpdate } from '../../db/mongo.js';
+import { toDocId } from '../../util/paths.js';
 import { escapeRegex } from '../../util/redos.js';
 import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
@@ -27,10 +28,6 @@ function nextClaimableAfter(nextAttempt: number): string {
   return new Date(Date.now() + delay).toISOString();
 }
 
-/** Normalise a path to forward-slash convention and strip leading slashes. */
-export function normPath(p: string): string {
-  return p.replace(/\\/g, '/').replace(/^\/+/, '');
-}
 
 function jobCollection(spaceId: string) {
   return col<MediaJobDoc>(`${spaceId}_media_jobs`);
@@ -54,7 +51,7 @@ export async function enqueueMediaJob(
   mimeType: string,
   mediaType: 'image' | 'audio' | 'video',
 ): Promise<void> {
-  const id = normPath(filePath);
+  const id = toDocId(filePath);
   const now = new Date().toISOString();
 
   const existing = await jobCollection(spaceId).findOne(
@@ -121,7 +118,7 @@ export async function enqueueTextJob(
   resolvedFormat: string,
   mimeType = 'text/plain',
 ): Promise<void> {
-  const id = normPath(filePath);
+  const id = toDocId(filePath);
   const now = new Date().toISOString();
 
   const existing = await jobCollection(spaceId).findOne(
@@ -450,7 +447,7 @@ export async function resetStalledJobs(
  * against a path that no longer exists.
  */
 export async function cancelMediaJob(spaceId: string, filePath: string): Promise<void> {
-  const id = normPath(filePath);
+  const id = toDocId(filePath);
   await jobCollection(spaceId).deleteOne(asFilter<MediaJobDoc>({ _id: id }));
 }
 
@@ -460,7 +457,7 @@ export async function cancelMediaJob(spaceId: string, filePath: string): Promise
  * job ids do not share the folder prefix. Called on recursive directory delete.
  */
 export async function cancelMediaJobsByPrefix(spaceId: string, dirPath: string): Promise<void> {
-  const dir = normPath(dirPath).replace(/\/?$/, '');
+  const dir = toDocId(dirPath).replace(/\/?$/, '');
   if (!dir) return; // guard: empty path would match everything
   const prefixes = [`${dir}/`, `_converted/${dir}/`, `_extracted/${dir}/`];
   await jobCollection(spaceId).deleteMany(

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -31,6 +31,7 @@
  */
 
 import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
+import { toSafeRelPath } from '../../util/paths.js';
 import { isProxySpace } from '../../spaces/proxy.js';
 import type { MediaJobDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
@@ -436,7 +437,7 @@ function getLocalSpaceIds(): string[] {
 function resolveFilePath(spaceId: string, filePath: string): string {
   const base = spaceRoot(spaceId);
   // Prevent path traversal: only forward-slash paths, no `..` segments
-  const safe = filePath.replace(/\\/g, '/').replace(/\.\.\//g, '').replace(/^\/+/, '');
+  const safe = toSafeRelPath(filePath);
   return path.join(base, safe);
 }
 

--- a/server/src/files/tombstones.ts
+++ b/server/src/files/tombstones.ts
@@ -9,6 +9,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { toDocId } from '../util/paths.js';
 import { col, asDoc } from '../db/mongo.js';
 import type { FileTombstoneDoc } from '../config/types.js';
 import { log } from '../util/log.js';
@@ -19,7 +20,7 @@ import { log } from '../util/log.js';
  * Best-effort — logs on failure rather than throwing, so a delete still returns success.
  */
 export async function writeFileTombstones(spaceId: string, paths: string[]): Promise<void> {
-  const unique = [...new Set(paths.map(p => p.replace(/\\/g, '/').replace(/^\/+/, '')))].filter(Boolean);
+  const unique = [...new Set(paths.map(toDocId))].filter(Boolean);
   if (unique.length === 0) return;
   const now = new Date().toISOString();
   const docs: FileTombstoneDoc[] = unique.map(p => ({ _id: uuidv4(), spaceId, path: p, deletedAt: now }));

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -1,4 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
+import { toDocId } from '../../util/paths.js';
 import { recall } from '../../brain/memory.js';
 import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
@@ -89,7 +90,7 @@ export const write_fileTool: ToolHandler = {
     const ifFmt = typeof a['inputFormat'] === 'string' ? a['inputFormat'] as InputFormat : 'auto';
     const fileBytes = Buffer.from(content, 'utf8');
     const resolvedFmt = resolveInputFormat(filePath, undefined, ifFmt);
-    const normId = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
+    const normId = toDocId(filePath);
 
     if (isMediaFormat(resolvedFmt)) {
       // MCP write_file is text-only; media content via MCP is not expected,

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -16,6 +16,7 @@
  */
 
 import { getConfig, saveConfig, saveConfigSoon, getSecrets, getFaceRecognitionConfig } from '../config/loader.js';
+import { toSafeRelPath } from '../util/paths.js';
 import { col, asFilter, asDoc, asBulk } from '../db/mongo.js';
 import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
 import { recordSyncResult, type SyncCounts } from './history.js';
@@ -1131,7 +1132,7 @@ async function syncFiles(
         for (const ts of tombstones) {
           try {
             // Normalise to prevent path traversal (sandbox-safe relative path).
-            const rel = ts.path.replace(/\\/g, '/').replace(/^\/+/, '');
+            const rel = toSafeRelPath(ts.path);
             const abs = path.join(spaceFiles, rel);
             if (!abs.startsWith(spaceFiles + path.sep) && abs !== spaceFiles) continue;
             await fs.unlink(abs).catch(() => { /* already gone — ignore */ });

--- a/server/src/util/paths.ts
+++ b/server/src/util/paths.ts
@@ -1,0 +1,23 @@
+/**
+ * Path normalisation — single source of truth. Two clearly-named variants because the
+ * two use cases have different safety requirements, and hand-rolled copies had drifted
+ * (the media worker stripped `..` for traversal defense while every other copy did not).
+ */
+
+/**
+ * Normalise a path for use as a Mongo document `_id` / `path` field: forward slashes,
+ * no leading slash(es). Does NOT strip `..` — the result is a key, never a filesystem path.
+ */
+export function toDocId(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+/**
+ * Normalise a peer/user-supplied path that will be joined to a filesystem root: forward
+ * slashes, `..` segments stripped, no leading slash. Use this (not `toDocId`) whenever the
+ * result feeds `path.join(root, …)` — it is defense-in-depth alongside the caller's boundary
+ * check, not a replacement for it.
+ */
+export function toSafeRelPath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/\.\.\//g, '').replace(/^\/+/, '');
+}

--- a/testing/standalone/paths-util.test.js
+++ b/testing/standalone/paths-util.test.js
@@ -1,0 +1,33 @@
+/**
+ * Unit tests for the shared path normalisers (compiled build).
+ *
+ * `toDocId` normalises to a Mongo _id/path key; `toSafeRelPath` additionally strips `..`
+ * for values that get joined to a filesystem root. Before centralisation these were
+ * hand-rolled in ~13 places, and the media worker's copy stripped `..` while the others
+ * did not — this pins the two contracts so that divergence can't recur.
+ *
+ * Run: node --test testing/standalone/paths-util.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { toDocId, toSafeRelPath } from '../../server/dist/util/paths.js';
+
+describe('path normalisers', () => {
+  it('toDocId: backslashes → slashes, strips leading slashes, keeps `..`', () => {
+    assert.equal(toDocId('foo\\bar.txt'), 'foo/bar.txt');
+    assert.equal(toDocId('/foo/bar'), 'foo/bar');
+    assert.equal(toDocId('///a/b'), 'a/b');
+    // toDocId is for keys, not filesystem paths — it must NOT alter `..` (that's the id).
+    assert.equal(toDocId('a/../b'), 'a/../b');
+  });
+
+  it('toSafeRelPath: same normalisation PLUS strips `../` traversal segments', () => {
+    assert.equal(toSafeRelPath('foo\\bar.txt'), 'foo/bar.txt');
+    assert.equal(toSafeRelPath('/foo/bar'), 'foo/bar');
+    assert.equal(toSafeRelPath('../../etc/passwd'), 'etc/passwd');
+    assert.equal(toSafeRelPath('a/../../b'), 'a/b');
+    // A legitimate file path (no `..`) is unchanged — the strip is a no-op for real paths.
+    assert.equal(toSafeRelPath('notes/2024/jan.md'), 'notes/2024/jan.md');
+  });
+});


### PR DESCRIPTION
## Summary

ARCHITECTURE-TODO **A13** — the last of the helper-dedup batch, and the one with a real safety angle.

The `p.replace(/\/g, '/').replace(/^\/+/, '')` normalisation was hand-rolled in **~13 places** (3 named `normPath` defs + ~10 inline). The copies had **diverged**: the media worker's variant *also* stripped `../` for path-traversal defense while every other copy did not — so "which normaliser strips `..`?" depended on which file you were in.

Split into two clearly-named helpers in `util/paths.ts`, and pointed each call site at the correct one:

- **`toDocId(p)`** — for Mongo `_id` / `path` **keys**. Keeps `..` (it's part of the id).
- **`toSafeRelPath(p)`** — for values that get **joined to a filesystem root**. Strips `..`.

## Safety note

Behavior-preserving for all the id/key sites (`toDocId` is byte-identical to the old `normPath`). The two **sync tombstone-application** paths (`api/sync.ts`, `sync/engine.ts`) — which join a **peer-supplied** path to the space files root before `fs.unlink` — now use `toSafeRelPath`, stripping `..` as **defense-in-depth** alongside their existing `abs.startsWith(spaceFilesRoot)` boundary check. It's a no-op for legitimate tombstone paths (which never contain `..`). The single-purpose leading-slash strip inside `sandbox.ts`'s own resolver is intentionally left as-is.

## Testing

- `tsc` clean; new `paths-util.test.js` pins both contracts (toDocId keeps `..`, toSafeRelPath strips it).
- 63/63 in the paths + files + file-sync suites — `toDocId` exercised across file ops, `toSafeRelPath` exercised by tombstone deletion propagation (still converges).

Next: A9 (shared `bulkWrite`), A10 (file-processing dispatch), A16 (member fan-out), then the monolith splits (A17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)