### PR TITLE
refactor(brain): extract shared bulkWrite, fixing REST/MCP drift (A9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Extracted the bulk-write batch processor into one shared module (`brain/bulk.ts`), fixing a
+  REST/MCP drift.** The `POST /api/brain/spaces/:id/bulk` route and the MCP `bulk_write` tool were two
+  ~185-line copies of the same validate-and-dispatch loop (memories → entities → edges → chrono), and
+  they had **diverged**: the MCP copy skipped the 50 000-character `fact` cap and did not normalise
+  chrono `status` (unknown values were passed straight through instead of dropped). Both surfaces now
+  call the single `bulkWrite(spaceId, input)` — identical validation, the 500-item-per-type cap, and
+  the deterministic ordering that lets edges/chrono reference records created earlier in the same
+  batch — then each shapes its own response and emits the one `bulk.write` summary webhook with its
+  own actor/token attribution. Per-item webhooks stay suppressed (the shared writers are called
+  without a `WebhookActor`). Behavior-preserving for REST; the MCP path picks up the two corrected
+  behaviors. Covered by the existing REST (`brain.test.js`) and MCP (`mcp-tools.test.js`) bulk suites.
+  (ARCHITECTURE-TODO A9.)
+
 - **Centralized path normalisation into `util/paths.ts` (`toDocId` / `toSafeRelPath`).** The
   `p.replace(/\\/g, '/').replace(/^\/+/, '')` idiom was hand-rolled in ~13 places (3 named `normPath`
   defs + ~10 inline), and the copies had **diverged**: the media worker's variant also stripped `../`

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -10,6 +10,7 @@ import { listMemories, deleteMemory, countMemories, bulkDeleteMemories, remember
 import { listEntities, deleteEntity, upsertEntity, getEntityById, updateEntityById, bulkDeleteEntities, findEntitiesByName, findEntityBacklinks } from '../brain/entities.js';
 import { listEdges, deleteEdge, upsertEdge, getEdgeById, updateEdgeById, bulkDeleteEdges, traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE, resolveEdgeEntityNames } from '../brain/edges.js';
 import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from '../brain/embed-text.js';
+import { bulkWrite, bulkWriteTotal, type BulkInput } from '../brain/bulk.js';
 import { computeMergePlan, applyResolutions, executeMerge, validateResolution, type PropertyResolution } from '../brain/merge.js';
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../brain/delete-fields.js';
 /** Regex that matches a UUID v4 (case-insensitive). */
@@ -1748,21 +1749,6 @@ brainRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, 
 
 // ── Bulk write ────────────────────────────────────────────────────────────────
 
-const BULK_MAX_PER_TYPE = 500;
-
-interface BulkError {
-  type: 'memory' | 'entity' | 'edge' | 'chrono';
-  index: number;
-  reason: string;
-}
-
-interface BulkCounts {
-  memories: number;
-  entities: number;
-  edges: number;
-  chrono: number;
-}
-
 /**
  * POST /api/brain/spaces/:spaceId/bulk
  *
@@ -1784,182 +1770,10 @@ brainRouter.post('/spaces/:spaceId/bulk', globalRateLimit, requireSpaceAuth, den
   if (!wt.ok) { res.status(400).json({ error: wt.error }); return; }
   const targetSpace = wt.target;
 
-  // Schema validation context
-  const bulkMeta = getSpaceMeta(targetSpace);
-  const bulkValidation = bulkMeta?.validationMode ?? 'off';
-
-  const body = (req.body ?? {}) as Record<string, unknown>;
-  const rawMemories = Array.isArray(body['memories']) ? (body['memories'] as unknown[]).slice(0, BULK_MAX_PER_TYPE) : [];
-  const rawEntities = Array.isArray(body['entities']) ? (body['entities'] as unknown[]).slice(0, BULK_MAX_PER_TYPE) : [];
-  const rawEdges    = Array.isArray(body['edges'])    ? (body['edges']    as unknown[]).slice(0, BULK_MAX_PER_TYPE) : [];
-  const rawChrono   = Array.isArray(body['chrono'])   ? (body['chrono']   as unknown[]).slice(0, BULK_MAX_PER_TYPE) : [];
-
-  const inserted: BulkCounts = { memories: 0, entities: 0, edges: 0, chrono: 0 };
-  const updated:  BulkCounts = { memories: 0, entities: 0, edges: 0, chrono: 0 };
-  const errors: BulkError[] = [];
-
-  // ── memories ───────────────────────────────────────────────────────────────
-  for (let i = 0; i < rawMemories.length; i++) {
-    const item = rawMemories[i] as Record<string, unknown>;
-    const fact = typeof item['fact'] === 'string' ? item['fact'].trim() : '';
-    if (!fact) { errors.push({ type: 'memory', index: i, reason: 'missing required field: fact' }); continue; }
-    if (fact.length > 50_000) { errors.push({ type: 'memory', index: i, reason: '`fact` must not exceed 50 000 characters' }); continue; }
-    const tags: string[] = Array.isArray(item['tags']) ? (item['tags'] as unknown[]).filter((t): t is string => typeof t === 'string') : [];
-    const entityIds: string[] = Array.isArray(item['entityIds']) ? (item['entityIds'] as unknown[]).filter((t): t is string => typeof t === 'string') : [];
-    const description: string | undefined = typeof item['description'] === 'string' ? item['description'] : undefined;
-    const itemMemoryType: string | undefined = typeof item['type'] === 'string' ? item['type'] : undefined;
-    const properties: Record<string, string | number | boolean> | undefined =
-      item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties'])
-        ? (item['properties'] as Record<string, string | number | boolean>)
-        : undefined;
-    try {
-      // Schema validation per memory
-      if (bulkValidation !== 'off' && bulkMeta) {
-        const sv = validateMemory(bulkMeta, { type: itemMemoryType, properties });
-        if (sv.length > 0) {
-          if (bulkValidation === 'strict') { errors.push({ type: 'memory', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-          for (const v of sv) errors.push({ type: 'memory', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-        }
-      }
-      await remember(targetSpace, fact, entityIds, tags, description, properties, undefined, itemMemoryType);
-      inserted.memories++;
-    } catch (err) {
-      errors.push({ type: 'memory', index: i, reason: err instanceof Error ? err.message : String(err) });
-    }
+  const result = await bulkWrite(targetSpace, (req.body ?? {}) as BulkInput);
+  if (bulkWriteTotal(result) > 0) {
+    // Bulk suppresses per-item webhooks; emit ONE summary a workflow can inspect.
+    emitWebhookEvent({ event: 'bulk.write', spaceId: targetSpace, entry: { inserted: result.inserted, updated: result.updated, errorCount: result.errors.length }, ...webhookToken(req) });
   }
-
-  // ── entities ───────────────────────────────────────────────────────────────
-  for (let i = 0; i < rawEntities.length; i++) {
-    const item = rawEntities[i] as Record<string, unknown>;
-    const name = typeof item['name'] === 'string' ? item['name'].trim() : '';
-    if (!name) { errors.push({ type: 'entity', index: i, reason: 'missing required field: name' }); continue; }
-    const type = typeof item['type'] === 'string' ? item['type'].trim() : '';
-    if (!type) { errors.push({ type: 'entity', index: i, reason: 'missing required field: type' }); continue; }
-    const rawId = typeof item['id'] === 'string' ? item['id'].trim() : undefined;
-    if (rawId !== undefined && !UUID_V4_RE.test(rawId)) {
-      errors.push({ type: 'entity', index: i, reason: '`id` must be a valid UUID v4' }); continue;
-    }
-    const tags: string[] = Array.isArray(item['tags']) ? (item['tags'] as unknown[]).filter((t): t is string => typeof t === 'string') : [];
-    const description: string | undefined = typeof item['description'] === 'string' ? item['description'] : undefined;
-    const properties: Record<string, string | number | boolean> =
-      item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties'])
-        ? (item['properties'] as Record<string, string | number | boolean>)
-        : {};
-    try {
-      // Schema validation per entity
-      if (bulkValidation !== 'off' && bulkMeta) {
-        const sv = validateEntity(bulkMeta, { name, type, properties });
-        if (sv.length > 0) {
-          if (bulkValidation === 'strict') { errors.push({ type: 'entity', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-          for (const v of sv) errors.push({ type: 'entity', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-        }
-      }
-      // Check for existing entity by ID (if supplied) to determine inserted vs updated
-      const existing = rawId
-        ? await col<EntityDoc>(`${targetSpace}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId: targetSpace }))
-        : null;
-      const result = await upsertEntity(targetSpace, name, type, tags, properties, description, rawId);
-      if (existing) { updated.entities++; } else { inserted.entities++; }
-      if (result.warning) { errors.push({ type: 'entity', index: i, reason: result.warning }); }
-    } catch (err) {
-      errors.push({ type: 'entity', index: i, reason: err instanceof Error ? err.message : String(err) });
-    }
-  }
-
-  // ── edges ──────────────────────────────────────────────────────────────────
-  for (let i = 0; i < rawEdges.length; i++) {
-    const item = rawEdges[i] as Record<string, unknown>;
-    const from  = typeof item['from']  === 'string' ? item['from'].trim()  : '';
-    const to    = typeof item['to']    === 'string' ? item['to'].trim()    : '';
-    const label = typeof item['label'] === 'string' ? item['label'].trim() : '';
-    if (!from)  { errors.push({ type: 'edge', index: i, reason: 'missing required field: from' });  continue; }
-    if (isStrictLinkage(targetSpace) && !UUID_V4_RE.test(from)) { errors.push({ type: 'edge', index: i, reason: '`from` must be a valid UUID v4 (entity ID), not a name' }); continue; }
-    if (!to)    { errors.push({ type: 'edge', index: i, reason: 'missing required field: to' });    continue; }
-    if (isStrictLinkage(targetSpace) && !UUID_V4_RE.test(to)) { errors.push({ type: 'edge', index: i, reason: '`to` must be a valid UUID v4 (entity ID), not a name' }); continue; }
-    if (!label) { errors.push({ type: 'edge', index: i, reason: 'missing required field: label' }); continue; }
-    const weight:      number | undefined = typeof item['weight'] === 'number' ? item['weight'] : undefined;
-    const edgeType:    string | undefined = typeof item['type']   === 'string' ? item['type']   : undefined;
-    const description: string | undefined = typeof item['description'] === 'string' ? item['description'] : undefined;
-    const tags: string[] | undefined = Array.isArray(item['tags']) ? (item['tags'] as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-    const properties: Record<string, string | number | boolean> | undefined =
-      item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties'])
-        ? (item['properties'] as Record<string, string | number | boolean>)
-        : undefined;
-    try {
-      // Schema validation per edge
-      if (bulkValidation !== 'off' && bulkMeta) {
-        const sv = validateEdge(bulkMeta, { label, properties });
-        if (sv.length > 0) {
-          if (bulkValidation === 'strict') { errors.push({ type: 'edge', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-          for (const v of sv) errors.push({ type: 'edge', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-        }
-      }
-      const existing = await col<EdgeDoc>(`${targetSpace}_edges`).findOne(asFilter<EdgeDoc>({ spaceId: targetSpace, from, to, label }));
-      await upsertEdge(targetSpace, from, to, label, weight, edgeType, description, properties, tags);
-      if (existing) { updated.edges++; } else { inserted.edges++; }
-    } catch (err) {
-      errors.push({ type: 'edge', index: i, reason: err instanceof Error ? err.message : String(err) });
-    }
-  }
-
-  // ── chrono ─────────────────────────────────────────────────────────────────
-  const bulkAllowedChronoTypes = getAllowedChronoTypes(bulkMeta);
-  for (let i = 0; i < rawChrono.length; i++) {
-    const item = rawChrono[i] as Record<string, unknown>;
-    const title   = typeof item['title']   === 'string' ? item['title'].trim()   : '';
-    const type    = typeof item['type']    === 'string' ? item['type']           : '';
-    const startsAt = typeof item['startsAt'] === 'string' ? item['startsAt']     : '';
-    if (!title)   { errors.push({ type: 'chrono', index: i, reason: 'missing required field: title' });   continue; }
-    if (!bulkAllowedChronoTypes.has(type)) {
-      errors.push({ type: 'chrono', index: i, reason: `\`type\` must be one of: ${[...bulkAllowedChronoTypes].join(', ')}` });
-      continue;
-    }
-    if (!startsAt) { errors.push({ type: 'chrono', index: i, reason: 'missing required field: startsAt' }); continue; }
-    const endsAt:      string | undefined = typeof item['endsAt']      === 'string' ? item['endsAt']      : undefined;
-    const status:      ChronoStatus | undefined = typeof item['status'] === 'string' && CHRONO_STATUSES.has(item['status'] as ChronoStatus) ? item['status'] as ChronoStatus : undefined;
-    const confidence:  number | undefined = typeof item['confidence'] === 'number' ? item['confidence']   : undefined;
-    const description: string | undefined = typeof item['description'] === 'string' ? item['description'] : undefined;
-    const tags: string[] | undefined = Array.isArray(item['tags']) ? (item['tags'] as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-    const entityIds: string[] | undefined = Array.isArray(item['entityIds']) ? (item['entityIds'] as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-    const memoryIds: string[] | undefined = Array.isArray(item['memoryIds']) ? (item['memoryIds'] as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-    if (entityIds && isStrictLinkage(targetSpace)) {
-      const invalidEIds = entityIds.filter(id => !UUID_V4_RE.test(id));
-      if (invalidEIds.length > 0) { errors.push({ type: 'chrono', index: i, reason: '`entityIds` must contain valid UUID v4 values (entity IDs), not names' }); continue; }
-    }
-    if (memoryIds && isStrictLinkage(targetSpace)) {
-      const invalidMIds = memoryIds.filter(id => !UUID_V4_RE.test(id));
-      if (invalidMIds.length > 0) { errors.push({ type: 'chrono', index: i, reason: '`memoryIds` must contain valid UUID v4 values (memory IDs), not names' }); continue; }
-    }
-    const properties: Record<string, string | number | boolean> | undefined =
-      item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties'])
-        ? (item['properties'] as Record<string, string | number | boolean>)
-        : undefined;
-    try {
-      // Schema validation per chrono
-      if (bulkValidation !== 'off' && bulkMeta) {
-        const sv = validateChrono(bulkMeta, { type, properties });
-        if (sv.length > 0) {
-          if (bulkValidation === 'strict') { errors.push({ type: 'chrono', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-          for (const v of sv) errors.push({ type: 'chrono', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-        }
-      }
-      await createChrono(targetSpace, {
-        title, type: type as ChronoType, startsAt, endsAt, status, confidence,
-        description, tags, entityIds, memoryIds, properties,
-      });
-      inserted.chrono++;
-    } catch (err) {
-      errors.push({ type: 'chrono', index: i, reason: err instanceof Error ? err.message : String(err) });
-    }
-  }
-
-  // Bulk writes suppress per-item webhooks (they don't pass an actor into the shared functions,
-  // so a 10k-item import doesn't fire 10k events). Instead emit ONE summary a workflow can inspect.
-  const bulkTotal = inserted.memories + inserted.entities + inserted.edges + inserted.chrono
-    + updated.entities + updated.edges;
-  if (bulkTotal > 0) {
-    emitWebhookEvent({ event: 'bulk.write', spaceId: targetSpace, entry: { inserted, updated, errorCount: errors.length }, ...webhookToken(req) });
-  }
-
-  res.status(207).json({ inserted, updated, errors });
+  res.status(207).json(result);
 });

--- a/server/src/brain/bulk.ts
+++ b/server/src/brain/bulk.ts
@@ -1,0 +1,188 @@
+/**
+ * Shared bulk-write batch processor.
+ *
+ * The REST `POST /api/brain/spaces/:id/bulk` endpoint and the MCP `bulk_write` tool were two
+ * ~185-line parallel copies of the same validate-and-dispatch loop, and they had drifted (the
+ * MCP copy skipped the 50k-fact cap and did not normalise chrono `status`). This is the one
+ * source of truth: each surface coerces its input, calls `bulkWrite`, then shapes its own
+ * response and emits the single `bulk.write` summary webhook (with its own actor).
+ *
+ * Per-item webhooks are intentionally NOT emitted here — the shared writers are called without a
+ * WebhookActor, so a 10k-item import doesn't fire 10k events. The caller emits one summary.
+ */
+
+import { col, asFilter } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import {
+  resolveMetaRefs, getAllowedChronoTypes, validateMemory, validateEntity, validateEdge, validateChrono,
+} from '../spaces/schema-validation.js';
+import { isStrictLinkage } from '../spaces/proxy.js';
+import { remember } from './memory.js';
+import { upsertEntity } from './entities.js';
+import { upsertEdge } from './edges.js';
+import { createChrono } from './chrono.js';
+import type { EntityDoc, EdgeDoc, ChronoType, ChronoStatus } from '../config/types.js';
+
+/** Max items processed per collection in a single bulk call. */
+export const BULK_MAX_PER_TYPE = 500;
+
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CHRONO_STATUSES = new Set<ChronoStatus>(['upcoming', 'active', 'completed', 'overdue', 'cancelled']);
+const MAX_FACT_LENGTH = 50_000;
+
+interface Counts { memories: number; entities: number; edges: number; chrono: number }
+
+export interface BulkInput {
+  memories?: unknown;
+  entities?: unknown;
+  edges?: unknown;
+  chrono?: unknown;
+}
+
+export interface BulkResult {
+  inserted: Counts;
+  updated: Counts;
+  errors: { type: string; index: number; reason: string }[];
+}
+
+function strArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((t): t is string => typeof t === 'string') : [];
+}
+function optStrArray(v: unknown): string[] | undefined {
+  return Array.isArray(v) ? v.filter((t): t is string => typeof t === 'string') : undefined;
+}
+function optProps(v: unknown): Record<string, string | number | boolean> | undefined {
+  return v != null && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, string | number | boolean>) : undefined;
+}
+function slice(v: unknown): Record<string, unknown>[] {
+  return Array.isArray(v) ? (v.slice(0, BULK_MAX_PER_TYPE) as Record<string, unknown>[]) : [];
+}
+
+/**
+ * Process a batch of memories/entities/edges/chrono for one space. Deterministic order
+ * (memories → entities → edges → chrono) so edges/chrono can reference records created earlier
+ * in the same batch. Per-item failures are collected, never fatal. Returns counts + errors.
+ */
+export async function bulkWrite(spaceId: string, input: BulkInput): Promise<BulkResult> {
+  const metaRaw = getConfig().spaces.find(s => s.id === spaceId)?.meta;
+  const meta = metaRaw ? resolveMetaRefs(metaRaw) : undefined;
+  const mode = meta?.validationMode ?? 'off';
+  const strict = isStrictLinkage(spaceId);
+
+  const inserted: Counts = { memories: 0, entities: 0, edges: 0, chrono: 0 };
+  const updated: Counts = { memories: 0, entities: 0, edges: 0, chrono: 0 };
+  const errors: { type: string; index: number; reason: string }[] = [];
+
+  const schemaFails = (type: string, index: number, violations: { field: string; reason: string }[]): boolean => {
+    if (mode === 'off' || !meta || violations.length === 0) return false;
+    if (mode === 'strict') { errors.push({ type, index, reason: `schema_violation: ${violations.map(v => v.reason).join('; ')}` }); return true; }
+    for (const v of violations) errors.push({ type, index, reason: `schema_warning: ${v.field} — ${v.reason}` });
+    return false;
+  };
+
+  // ── memories ───────────────────────────────────────────────────────────────
+  const memories = slice(input.memories);
+  for (let i = 0; i < memories.length; i++) {
+    const item = memories[i]!;
+    const fact = typeof item['fact'] === 'string' ? item['fact'].trim() : '';
+    if (!fact) { errors.push({ type: 'memory', index: i, reason: 'missing required field: fact' }); continue; }
+    if (fact.length > MAX_FACT_LENGTH) { errors.push({ type: 'memory', index: i, reason: '`fact` must not exceed 50 000 characters' }); continue; }
+    const type = typeof item['type'] === 'string' && item['type'].trim() ? item['type'] : undefined;
+    const properties = optProps(item['properties']);
+    try {
+      if (schemaFails('memory', i, validateMemory(meta ?? {}, { type, properties }))) continue;
+      await remember(spaceId, fact, strArray(item['entityIds']), strArray(item['tags']),
+        typeof item['description'] === 'string' ? item['description'] : undefined, properties, undefined, type);
+      inserted.memories++;
+    } catch (err) { errors.push({ type: 'memory', index: i, reason: err instanceof Error ? err.message : String(err) }); }
+  }
+
+  // ── entities ───────────────────────────────────────────────────────────────
+  const entities = slice(input.entities);
+  for (let i = 0; i < entities.length; i++) {
+    const item = entities[i]!;
+    const name = typeof item['name'] === 'string' ? item['name'].trim() : '';
+    if (!name) { errors.push({ type: 'entity', index: i, reason: 'missing required field: name' }); continue; }
+    const type = typeof item['type'] === 'string' ? item['type'].trim() : '';
+    if (!type) { errors.push({ type: 'entity', index: i, reason: 'missing required field: type' }); continue; }
+    const rawId = typeof item['id'] === 'string' ? item['id'].trim() : undefined;
+    if (rawId !== undefined && !UUID_V4_RE.test(rawId)) { errors.push({ type: 'entity', index: i, reason: '`id` must be a valid UUID v4' }); continue; }
+    const properties = optProps(item['properties']) ?? {};
+    try {
+      if (schemaFails('entity', i, validateEntity(meta ?? {}, { name, type, properties }))) continue;
+      const existing = rawId
+        ? await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId }))
+        : null;
+      const result = await upsertEntity(spaceId, name, type, strArray(item['tags']), properties,
+        typeof item['description'] === 'string' ? item['description'] : undefined, rawId);
+      if (existing) updated.entities++; else inserted.entities++;
+      if (result.warning) errors.push({ type: 'entity', index: i, reason: result.warning });
+    } catch (err) { errors.push({ type: 'entity', index: i, reason: err instanceof Error ? err.message : String(err) }); }
+  }
+
+  // ── edges ──────────────────────────────────────────────────────────────────
+  const edges = slice(input.edges);
+  for (let i = 0; i < edges.length; i++) {
+    const item = edges[i]!;
+    const from = typeof item['from'] === 'string' ? item['from'].trim() : '';
+    const to = typeof item['to'] === 'string' ? item['to'].trim() : '';
+    const label = typeof item['label'] === 'string' ? item['label'].trim() : '';
+    if (!from) { errors.push({ type: 'edge', index: i, reason: 'missing required field: from' }); continue; }
+    if (strict && !UUID_V4_RE.test(from)) { errors.push({ type: 'edge', index: i, reason: '`from` must be a valid UUID v4 (entity ID), not a name' }); continue; }
+    if (!to) { errors.push({ type: 'edge', index: i, reason: 'missing required field: to' }); continue; }
+    if (strict && !UUID_V4_RE.test(to)) { errors.push({ type: 'edge', index: i, reason: '`to` must be a valid UUID v4 (entity ID), not a name' }); continue; }
+    if (!label) { errors.push({ type: 'edge', index: i, reason: 'missing required field: label' }); continue; }
+    const properties = optProps(item['properties']);
+    try {
+      if (schemaFails('edge', i, validateEdge(meta ?? {}, { label, properties }))) continue;
+      const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }));
+      await upsertEdge(spaceId, from, to, label,
+        typeof item['weight'] === 'number' ? item['weight'] : undefined,
+        typeof item['type'] === 'string' ? item['type'] : undefined,
+        typeof item['description'] === 'string' ? item['description'] : undefined,
+        properties, optStrArray(item['tags']));
+      if (existing) updated.edges++; else inserted.edges++;
+    } catch (err) { errors.push({ type: 'edge', index: i, reason: err instanceof Error ? err.message : String(err) }); }
+  }
+
+  // ── chrono ─────────────────────────────────────────────────────────────────
+  const allowedChronoTypes = getAllowedChronoTypes(meta);
+  const chrono = slice(input.chrono);
+  for (let i = 0; i < chrono.length; i++) {
+    const item = chrono[i]!;
+    const title = typeof item['title'] === 'string' ? item['title'].trim() : '';
+    const type = typeof item['type'] === 'string' ? item['type'] : '';
+    const startsAt = typeof item['startsAt'] === 'string' ? item['startsAt'] : '';
+    if (!title) { errors.push({ type: 'chrono', index: i, reason: 'missing required field: title' }); continue; }
+    if (!allowedChronoTypes.has(type)) { errors.push({ type: 'chrono', index: i, reason: `\`type\` must be one of: ${[...allowedChronoTypes].join(', ')}` }); continue; }
+    if (!startsAt) { errors.push({ type: 'chrono', index: i, reason: 'missing required field: startsAt' }); continue; }
+    const entityIds = optStrArray(item['entityIds']);
+    const memoryIds = optStrArray(item['memoryIds']);
+    if (strict && entityIds && entityIds.some(id => !UUID_V4_RE.test(id))) { errors.push({ type: 'chrono', index: i, reason: '`entityIds` must contain valid UUID v4 values (entity IDs), not names' }); continue; }
+    if (strict && memoryIds && memoryIds.some(id => !UUID_V4_RE.test(id))) { errors.push({ type: 'chrono', index: i, reason: '`memoryIds` must contain valid UUID v4 values (memory IDs), not names' }); continue; }
+    const properties = optProps(item['properties']);
+    // Normalise status to a known value (drop unknowns) — REST did this; MCP did not.
+    const status = typeof item['status'] === 'string' && CHRONO_STATUSES.has(item['status'] as ChronoStatus)
+      ? item['status'] as ChronoStatus : undefined;
+    try {
+      if (schemaFails('chrono', i, validateChrono(meta ?? {}, { type, properties }))) continue;
+      await createChrono(spaceId, {
+        title, type: type as ChronoType, startsAt,
+        endsAt: typeof item['endsAt'] === 'string' ? item['endsAt'] : undefined,
+        status, confidence: typeof item['confidence'] === 'number' ? item['confidence'] : undefined,
+        description: typeof item['description'] === 'string' ? item['description'] : undefined,
+        tags: optStrArray(item['tags']), entityIds, memoryIds, properties,
+      });
+      inserted.chrono++;
+    } catch (err) { errors.push({ type: 'chrono', index: i, reason: err instanceof Error ? err.message : String(err) }); }
+  }
+
+  return { inserted, updated, errors };
+}
+
+/** Total records actually written (used to decide whether to fire the bulk.write webhook). */
+export function bulkWriteTotal(r: BulkResult): number {
+  return r.inserted.memories + r.inserted.entities + r.inserted.edges + r.inserted.chrono
+    + r.updated.entities + r.updated.edges;
+}

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -1,4 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
+import { bulkWrite, bulkWriteTotal } from '../../brain/bulk.js';
 import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, type McpRecallTraverseItem } from './shared.js';
 import { createChrono } from '../../brain/chrono.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
@@ -570,180 +571,16 @@ export const bulk_writeTool: ToolHandler = {
     if (!wt.ok) throw new Error(wt.error);
     const ts = wt.target;
 
-    // Schema validation context
-    const bwMetaRaw = getConfig().spaces.find(s => s.id === ts)?.meta;
-    const bwMeta = bwMetaRaw ? resolveMetaRefs(bwMetaRaw) : undefined;
-    const bwValidation = bwMeta?.validationMode ?? 'off';
-
-    const BULK_MAX = 500;
-    const rawMemories = Array.isArray(a['memories']) ? (a['memories'] as unknown[]).slice(0, BULK_MAX) : [];
-    const rawEntities = Array.isArray(a['entities']) ? (a['entities'] as unknown[]).slice(0, BULK_MAX) : [];
-    const rawEdges    = Array.isArray(a['edges'])    ? (a['edges']    as unknown[]).slice(0, BULK_MAX) : [];
-    const rawChrono   = Array.isArray(a['chrono'])   ? (a['chrono']   as unknown[]).slice(0, BULK_MAX) : [];
-
-    const inserted = { memories: 0, entities: 0, edges: 0, chrono: 0 };
-    const updated  = { memories: 0, entities: 0, edges: 0, chrono: 0 };
-    const errors: { type: string; index: number; reason: string }[] = [];
-
-    // memories
-    for (let i = 0; i < rawMemories.length; i++) {
-      const item = rawMemories[i] as Record<string, unknown>;
-      const fact = typeof item['fact'] === 'string' ? item['fact'].trim() : '';
-      if (!fact) { errors.push({ type: 'memory', index: i, reason: 'missing required field: fact' }); continue; }
-      const tags     = Array.isArray(item['tags'])      ? (item['tags']      as unknown[]).filter((t): t is string => typeof t === 'string') : [];
-      const entityIds = Array.isArray(item['entityIds']) ? (item['entityIds'] as unknown[]).filter((t): t is string => typeof t === 'string') : [];
-      const description = typeof item['description'] === 'string' ? item['description'] : undefined;
-      const props = (item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties']))
-        ? (item['properties'] as Record<string, string | number | boolean>) : undefined;
-      // Without `type`, validateMemory() cannot find a per-type schema and always returns
-      // zero violations — so strict mode was unenforceable on this path. See `remember`.
-      const memType = typeof item['type'] === 'string' && item['type'].trim() ? (item['type'] as string) : undefined;
-      try {
-        // Schema validation per memory
-        if (bwValidation !== 'off' && bwMeta) {
-          const sv = validateMemory(bwMeta, { type: memType, properties: props });
-          if (sv.length > 0) {
-            if (bwValidation === 'strict') { errors.push({ type: 'memory', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-            for (const v of sv) errors.push({ type: 'memory', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-          }
-        }
-        await remember(ts, fact, entityIds, tags, description, props, undefined, memType);
-        inserted.memories++;
-      } catch (err) {
-        errors.push({ type: 'memory', index: i, reason: err instanceof Error ? err.message : String(err) });
-      }
+    const result = await bulkWrite(ts, {
+      memories: a['memories'], entities: a['entities'], edges: a['edges'], chrono: a['chrono'],
+    });
+    if (bulkWriteTotal(result) > 0) {
+      // Bulk suppresses per-item webhooks; emit ONE summary a workflow can inspect.
+      emitWebhookEvent({ event: 'bulk.write', spaceId: ts, entry: { inserted: result.inserted, updated: result.updated, errorCount: result.errors.length }, ...(ctx.actor ?? {}) });
     }
-
-    // entities
-    for (let i = 0; i < rawEntities.length; i++) {
-      const item = rawEntities[i] as Record<string, unknown>;
-      const eName = typeof item['name'] === 'string' ? item['name'].trim() : '';
-      const eType = typeof item['type'] === 'string' ? item['type'].trim() : '';
-      if (!eName) { errors.push({ type: 'entity', index: i, reason: 'missing required field: name' }); continue; }
-      if (!eType) { errors.push({ type: 'entity', index: i, reason: 'missing required field: type' }); continue; }
-      const rawId = typeof item['id'] === 'string' ? item['id'].trim() : undefined;
-      if (rawId !== undefined && !UUID_V4_RE.test(rawId)) {
-        errors.push({ type: 'entity', index: i, reason: '`id` must be a valid UUID v4' }); continue;
-      }
-      const tags = Array.isArray(item['tags']) ? (item['tags'] as unknown[]).filter((t): t is string => typeof t === 'string') : [];
-      const description = typeof item['description'] === 'string' ? item['description'] : undefined;
-      const props = (item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties']))
-        ? (item['properties'] as Record<string, string | number | boolean>) : {};
-      try {
-        // Schema validation per entity
-        if (bwValidation !== 'off' && bwMeta) {
-          const sv = validateEntity(bwMeta, { name: eName, type: eType, properties: props });
-          if (sv.length > 0) {
-            if (bwValidation === 'strict') { errors.push({ type: 'entity', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-            for (const v of sv) errors.push({ type: 'entity', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-          }
-        }
-        // Check for existing entity by ID (if supplied) to determine inserted vs updated
-        const existing = rawId
-          ? await col<import('../../config/types.js').EntityDoc>(`${ts}_entities`).findOne(asFilter({ _id: rawId, spaceId: ts }))
-          : null;
-        const result = await upsertEntity(ts, eName, eType, tags, props, description, rawId);
-        if (existing) { updated.entities++; } else { inserted.entities++; }
-        if (result.warning) { errors.push({ type: 'entity', index: i, reason: result.warning }); }
-      } catch (err) {
-        errors.push({ type: 'entity', index: i, reason: err instanceof Error ? err.message : String(err) });
-      }
-    }
-
-    // edges
-    for (let i = 0; i < rawEdges.length; i++) {
-      const item = rawEdges[i] as Record<string, unknown>;
-      const from  = typeof item['from']  === 'string' ? item['from'].trim()  : '';
-      const to    = typeof item['to']    === 'string' ? item['to'].trim()    : '';
-      const label = typeof item['label'] === 'string' ? item['label'].trim() : '';
-      if (!from)  { errors.push({ type: 'edge', index: i, reason: 'missing required field: from' });  continue; }
-      if (isStrictLinkage(ts) && !UUID_V4_RE.test(from)) { errors.push({ type: 'edge', index: i, reason: '`from` must be a valid UUID v4 (entity ID), not a name' }); continue; }
-      if (!to)    { errors.push({ type: 'edge', index: i, reason: 'missing required field: to' });    continue; }
-      if (isStrictLinkage(ts) && !UUID_V4_RE.test(to)) { errors.push({ type: 'edge', index: i, reason: '`to` must be a valid UUID v4 (entity ID), not a name' }); continue; }
-      if (!label) { errors.push({ type: 'edge', index: i, reason: 'missing required field: label' }); continue; }
-      const weight      = typeof item['weight'] === 'number' ? item['weight'] : undefined;
-      const edgeType    = typeof item['type']   === 'string' ? item['type']   : undefined;
-      const description = typeof item['description'] === 'string' ? item['description'] : undefined;
-      const tags        = Array.isArray(item['tags']) ? (item['tags'] as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-      const props       = (item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties']))
-        ? (item['properties'] as Record<string, string | number | boolean>) : undefined;
-      try {
-        // Schema validation per edge — `properties` must be passed, or property schemas
-        // (required keys, types, enums) are never checked and strict mode is a no-op here.
-        // MCP upsert_edge and REST both pass it; only this bulk path omitted it.
-        if (bwValidation !== 'off' && bwMeta) {
-          const sv = validateEdge(bwMeta, { label, properties: props });
-          if (sv.length > 0) {
-            if (bwValidation === 'strict') { errors.push({ type: 'edge', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-            for (const v of sv) errors.push({ type: 'edge', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-          }
-        }
-        const existing = await col<import('../../config/types.js').EdgeDoc>(`${ts}_edges`).findOne(asFilter({ spaceId: ts, from, to, label }));
-        await upsertEdge(ts, from, to, label, weight, edgeType, description, props, tags);
-        if (existing) { updated.edges++; } else { inserted.edges++; }
-      } catch (err) {
-        errors.push({ type: 'edge', index: i, reason: err instanceof Error ? err.message : String(err) });
-      }
-    }
-
-    // chrono
-    const bwAllowedChronoTypes = getAllowedChronoTypes(bwMeta);
-    for (let i = 0; i < rawChrono.length; i++) {
-      const item = rawChrono[i] as Record<string, unknown>;
-      const title    = typeof item['title']    === 'string' ? item['title'].trim() : '';
-      const bwType   = typeof item['type']     === 'string' ? item['type']         : '';
-      const startsAt = typeof item['startsAt'] === 'string' ? item['startsAt']     : '';
-      if (!title)   { errors.push({ type: 'chrono', index: i, reason: 'missing required field: title' });   continue; }
-      if (!bwAllowedChronoTypes.has(bwType)) { errors.push({ type: 'chrono', index: i, reason: `\`type\` must be one of: ${[...bwAllowedChronoTypes].join(', ')}` }); continue; }
-      if (!startsAt) { errors.push({ type: 'chrono', index: i, reason: 'missing required field: startsAt' }); continue; }
-      const endsAt      = typeof item['endsAt']      === 'string' ? item['endsAt']      : undefined;
-      const status      = typeof item['status']      === 'string' ? item['status']      : undefined;
-      const confidence  = typeof item['confidence']  === 'number' ? item['confidence']  : undefined;
-      const description = typeof item['description'] === 'string' ? item['description'] : undefined;
-      const tags        = Array.isArray(item['tags'])       ? (item['tags']       as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-      const entityIds   = Array.isArray(item['entityIds'])  ? (item['entityIds']  as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-      const memoryIds   = Array.isArray(item['memoryIds'])  ? (item['memoryIds']  as unknown[]).filter((t): t is string => typeof t === 'string') : undefined;
-      if (entityIds && isStrictLinkage(ts)) {
-        const invalidEIds = entityIds.filter(id => !UUID_V4_RE.test(id));
-        if (invalidEIds.length > 0) { errors.push({ type: 'chrono', index: i, reason: '`entityIds` must contain valid UUID v4 values (entity IDs), not names' }); continue; }
-      }
-      if (memoryIds && isStrictLinkage(ts)) {
-        const invalidMIds = memoryIds.filter(id => !UUID_V4_RE.test(id));
-        if (invalidMIds.length > 0) { errors.push({ type: 'chrono', index: i, reason: '`memoryIds` must contain valid UUID v4 values (memory IDs), not names' }); continue; }
-      }
-      const props       = (item['properties'] != null && typeof item['properties'] === 'object' && !Array.isArray(item['properties']))
-        ? (item['properties'] as Record<string, string | number | boolean>) : undefined;
-      try {
-        // Schema validation per chrono
-        if (bwValidation !== 'off' && bwMeta) {
-          const sv = validateChrono(bwMeta, { type: bwType, properties: props });
-          if (sv.length > 0) {
-            if (bwValidation === 'strict') { errors.push({ type: 'chrono', index: i, reason: `schema_violation: ${sv.map(v => v.reason).join('; ')}` }); continue; }
-            for (const v of sv) errors.push({ type: 'chrono', index: i, reason: `schema_warning: ${v.field} — ${v.reason}` });
-          }
-        }
-        await createChrono(ts, {
-          title, type: bwType as import('../../config/types.js').ChronoType, startsAt, endsAt,
-          status: status as import('../../config/types.js').ChronoStatus | undefined,
-          confidence, description, tags, entityIds, memoryIds, properties: props,
-        });
-        inserted.chrono++;
-      } catch (err) {
-        errors.push({ type: 'chrono', index: i, reason: err instanceof Error ? err.message : String(err) });
-      }
-    }
-
-    // Per-item webhooks are suppressed for bulk (the shared functions get no actor); emit ONE
-    // summary event a workflow can inspect afterwards, matching the REST /bulk endpoint.
-    const bulkTotal = inserted.memories + inserted.entities + inserted.edges + inserted.chrono
-      + updated.entities + updated.edges;
-    if (bulkTotal > 0) {
-      emitWebhookEvent({ event: 'bulk.write', spaceId: ts, entry: { inserted, updated, errorCount: errors.length }, ...(ctx.actor ?? {}) });
-    }
-
-    const summary = `bulk_write complete — inserted: ${JSON.stringify(inserted)}, updated: ${JSON.stringify(updated)}, errors: ${errors.length}`;
+    const summary = `bulk_write complete — inserted: ${JSON.stringify(result.inserted)}, updated: ${JSON.stringify(result.updated)}, errors: ${result.errors.length}`;
     return {
-      content: [{ type: 'text' as const, text: summary + (errors.length > 0 ? '\n' + JSON.stringify(errors, null, 2) : '') }],
+      content: [{ type: 'text' as const, text: summary + (result.errors.length > 0 ? '\n' + JSON.stringify(result.errors, null, 2) : '') }],
       isError: false,
     };
   },


### PR DESCRIPTION
## What

Extracts the bulk-write batch processor into one shared module, `server/src/brain/bulk.ts`, and points both surfaces at it:

- `POST /api/brain/spaces/:id/bulk` (REST)
- `bulk_write` (MCP tool)

These were two ~185-line copies of the same validate-and-dispatch loop (memories → entities → edges → chrono), and they had **drifted**:

- the MCP copy **skipped the 50 000-character `fact` cap**, and
- the MCP copy **did not normalise chrono `status`** — unknown values were passed straight through instead of dropped.

## After

Both call `bulkWrite(spaceId, input)`: identical validation, the 500-item-per-type cap, and the deterministic ordering that lets edges/chrono reference records created earlier in the same batch. Each surface still shapes its own response and emits the one `bulk.write` summary webhook with its own actor/token attribution; per-item webhooks stay suppressed (shared writers called without a `WebhookActor`).

Behavior-preserving for REST; the MCP path picks up the two corrected behaviors.

## Testing

- `npm run build:server` — clean
- Standalone suite: **800 pass / 0 fail** (4 skipped), incl. the `bulk.write` webhook drift-guard
- `testing/integration/brain.test.js` — **183/183** (REST `/bulk`, incl. 500-cap)
- `testing/integration/mcp-tools.test.js` — **93/93** (MCP `bulk_write`: inserts, per-item error passthrough, empty/no arrays, invalid chrono type, read-only rejection)

(ARCHITECTURE-TODO A9.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)