### PR TITLE
refactor(proxy): centralise member fan-out into two shared helpers (A16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Centralised the proxy member-space fan-out into two shared helpers
+  (`findFirstAcrossMembers` / `collectAcrossMembers`).** A proxy space reads and writes across its
+  member spaces, and two idioms were hand-rolled ~40 times across the REST brain routes and MCP
+  tools: "try each member in order, stop at the first hit" (get/update/delete by id) and "query
+  every member and flatten" (list/search). Both now live once in `spaces/proxy.ts`, so proxy
+  semantics (member ordering, the resolve step, the first-hit `accept` rule) can't drift between
+  surfaces. 22 clean call sites were converted (`api/brain.ts` and the MCP memory/entity/edge
+  tools); the remaining member loops are intentionally left as-is because they aren't the two clean
+  idioms — schema-validation loops with early error returns, directory-listing aggregation with
+  per-member `try/catch` tolerance and name de-duplication, and graph traversal that already takes a
+  pre-resolved member array. Pure refactor, no behavior change; covered by the existing
+  `proxy-spaces` integration suite (which exercises proxy read/list/update/delete end-to-end).
+  (ARCHITECTURE-TODO A16.)
+
 - **Unified file-processing dispatch into one shared helper (`files/dispatch.ts`), and MCP
   `write_file` now converts documents asynchronously like REST.** The "resolve format → media job |
   document conversion" sequence was inlined in three places — the REST single-request upload, the

--- a/server/src/api/brain.ts
+++ b/server/src/api/brain.ts
@@ -26,7 +26,7 @@ import { needsReindex, clearReindexFlag } from '../spaces/spaces.js';
 import { log } from '../util/log.js';
 import { parseLimit, parseSkip, capPage } from '../util/pagination.js';
 import { checkQuota, QuotaError } from '../quota/quota.js';
-import { resolveMemberSpaces, resolveWriteTarget, findSpace, isProxySpace, isStrictLinkage } from '../spaces/proxy.js';
+import { resolveMemberSpaces, resolveWriteTarget, findSpace, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../spaces/proxy.js';
 import { validateEntity, validateEdge, validateMemory, validateChrono, resolveMetaRefs, getAllowedChronoTypes, type SchemaViolation } from '../spaces/schema-validation.js';
 import type { MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc, ChronoType, ChronoStatus, SpaceMeta } from '../config/types.js';
 import { reindexInProgress } from '../metrics/registry.js';
@@ -178,11 +178,9 @@ brainRouter.get('/spaces/:spaceId/memories/:id', globalRateLimit, requireSpaceAu
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    const doc = await col<MemoryDoc>(`${mid}_memories`).findOne(asFilter<MemoryDoc>({ _id: id })) as MemoryDoc | null;
-    if (doc) { res.json(doc); return; }
-  }
+  const doc = await findFirstAcrossMembers(spaceId,
+    mid => col<MemoryDoc>(`${mid}_memories`).findOne(asFilter<MemoryDoc>({ _id: id })));
+  if (doc) { res.json(doc); return; }
   res.status(404).json({ error: 'Memory not found' });
 });
 
@@ -222,8 +220,7 @@ brainRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth, 
   const limit = parseLimit(req.query['limit'], 100, 500);
   const skip = parseSkip(req.query['skip']);
   const filter = buildMemoryFilter(req.query as Record<string, unknown>);
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid => listMemories(mid, filter, limit, skip)))).flat();
+  const all = await collectAcrossMembers(spaceId, mid => listMemories(mid, filter, limit, skip));
   res.json({ memories: capPage(all, limit), limit, skip });
 });
 
@@ -231,13 +228,8 @@ brainRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAuth, 
 brainRouter.delete('/spaces/:spaceId/memories/:id', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    if (await deleteMemory(mid, id, webhookToken(req))) {
-      res.status(204).end();
-      return;
-    }
-  }
+  const deleted = await findFirstAcrossMembers(spaceId, mid => deleteMemory(mid, id, webhookToken(req)));
+  if (deleted) { res.status(204).end(); return; }
   res.status(404).json({ error: 'Memory not found' });
 });
 
@@ -479,8 +471,7 @@ brainRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAuth, 
   if (typeof req.query['name'] === 'string') filter['name'] = req.query['name'];
   if (typeof req.query['type'] === 'string') filter['type'] = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid => listEntities(mid, filter, limit, skip)))).flat();
+  const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, filter, limit, skip));
   res.json({ entities: capPage(all, limit), limit, skip });
 });
 
@@ -499,8 +490,7 @@ brainRouter.get('/spaces/:spaceId/entities/by-ids', globalRateLimit, requireSpac
   }
   const ids = [...new Set(raw.split(',').map(s => s.trim()).filter(Boolean))].slice(0, 100);
   if (!ids.length) { res.json({ entities: [] }); return; }
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid => listEntities(mid, { _id: { $in: ids } }, 100)))).flat();
+  const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, { _id: { $in: ids } }, 100));
   res.json({ entities: all });
 });
 
@@ -517,10 +507,9 @@ brainRouter.get('/spaces/:spaceId/entities/by-name', globalRateLimit, requireSpa
     res.status(400).json({ error: '`name` query parameter required' });
     return;
   }
-  const memberIds = resolveMemberSpaces(spaceId);
   // Case-insensitive substring search — escape user input to prevent ReDoS
   const escaped = escapeRegex(name.trim());
-  const all = (await Promise.all(memberIds.map(mid => listEntities(mid, { name: { $regex: escaped, $options: 'i' } }, 20)))).flat();
+  const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, { name: { $regex: escaped, $options: 'i' } }, 20));
   res.json({ entities: all });
 });
 
@@ -528,11 +517,8 @@ brainRouter.get('/spaces/:spaceId/entities/by-name', globalRateLimit, requireSpa
 brainRouter.get('/spaces/:spaceId/entities/:id', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    const doc = await getEntityById(mid, id);
-    if (doc) { res.json(doc); return; }
-  }
+  const doc = await findFirstAcrossMembers(spaceId, mid => getEntityById(mid, id));
+  if (doc) { res.json(doc); return; }
   res.status(404).json({ error: 'Entity not found' });
 });
 
@@ -761,18 +747,16 @@ brainRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
   if (typeof req.query['label'] === 'string') filter.label = req.query['label'];
   if (typeof req.query['type'] === 'string') filter.type = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter.tag = req.query['tag'];
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid => listEdges(mid, filter, limit, skip)))).flat();
+  const all = await collectAcrossMembers(spaceId, mid => listEdges(mid, filter, limit, skip));
   // Batch-resolve entity names for from/to so the client can display names instead of raw UUIDs
   const allEntityIds = [...new Set(all.flatMap(e => [e.from, e.to]))];
   const nameMap = new Map<string, string>();
   if (allEntityIds.length) {
-    await Promise.all(memberIds.map(async (mid) => {
-      const docs = await col<{ _id: string; name: string }>(`${mid}_entities`)
+    const nameDocs = await collectAcrossMembers(spaceId, mid =>
+      col<{ _id: string; name: string }>(`${mid}_entities`)
         .find(asFilter<{ _id: string; name: string }>({ _id: { $in: allEntityIds } }), { projection: { _id: 1, name: 1 } })
-        .toArray();
-      for (const d of docs) nameMap.set(String(d._id), d.name);
-    }));
+        .toArray());
+    for (const d of nameDocs) nameMap.set(String(d._id), d.name);
   }
   const enriched = all.map(e => ({ ...e, fromName: nameMap.get(e.from), toName: nameMap.get(e.to) }));
   res.json({ edges: capPage(enriched, limit), limit, skip });
@@ -782,11 +766,8 @@ brainRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
 brainRouter.get('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    const doc = await getEdgeById(mid, id);
-    if (doc) { res.json(doc); return; }
-  }
+  const doc = await findFirstAcrossMembers(spaceId, mid => getEdgeById(mid, id));
+  if (doc) { res.json(doc); return; }
   res.status(404).json({ error: 'Edge not found' });
 });
 
@@ -794,13 +775,8 @@ brainRouter.get('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAuth,
 brainRouter.delete('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    if (await deleteEdge(mid, id, webhookToken(req))) {
-      res.status(204).end();
-      return;
-    }
-  }
+  const deleted = await findFirstAcrossMembers(spaceId, mid => deleteEdge(mid, id, webhookToken(req)));
+  if (deleted) { res.status(204).end(); return; }
   res.status(404).json({ error: 'Edge not found' });
 });
 
@@ -1124,17 +1100,11 @@ brainRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceAu
       ? (properties as Record<string, string | number | boolean>)
       : undefined;
 
-  const memberIds = resolveMemberSpaces(wt.target);
-  for (const mid of memberIds) {
-    const updated = await updateChrono(mid, id, {
-      title, type, startsAt, endsAt, status, confidence,
-      tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
-    }, webhookToken(req));
-    if (updated) {
-      res.json(updated);
-      return;
-    }
-  }
+  const updated = await findFirstAcrossMembers(wt.target, mid => updateChrono(mid, id, {
+    title, type, startsAt, endsAt, status, confidence,
+    tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
+  }, webhookToken(req)));
+  if (updated) { res.json(updated); return; }
   res.status(404).json({ error: 'Chrono entry not found' });
 });
 
@@ -1142,11 +1112,8 @@ brainRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceAu
 brainRouter.get('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    const doc = await getChronoById(mid, id);
-    if (doc) { res.json(doc); return; }
-  }
+  const doc = await findFirstAcrossMembers(spaceId, mid => getChronoById(mid, id));
+  if (doc) { res.json(doc); return; }
   res.status(404).json({ error: 'Chrono entry not found' });
 });
 
@@ -1184,8 +1151,7 @@ brainRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, as
   if (typeof req.query['before'] === 'string') filter.before = req.query['before'];
   if (typeof req.query['search'] === 'string') filter.search = req.query['search'];
 
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid => listChrono(mid, filter, limit, skip)))).flat();
+  const all = await collectAcrossMembers(spaceId, mid => listChrono(mid, filter, limit, skip));
   res.json({ chrono: capPage(all, limit), limit, skip });
 });
 
@@ -1193,13 +1159,8 @@ brainRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, as
 brainRouter.delete('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
-  for (const mid of memberIds) {
-    if (await deleteChrono(mid, id, webhookToken(req))) {
-      res.status(204).end();
-      return;
-    }
-  }
+  const deleted = await findFirstAcrossMembers(spaceId, mid => deleteChrono(mid, id, webhookToken(req)));
+  if (deleted) { res.status(204).end(); return; }
   res.status(404).json({ error: 'Chrono entry not found' });
 });
 
@@ -1240,15 +1201,14 @@ brainRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, asy
   if (!includeChunks) filter['parentFileId'] = { $exists: false };
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
   if (typeof req.query['path'] === 'string') filter['path'] = toDocId(req.query['path']);
-  const memberIds = resolveMemberSpaces(spaceId);
-  const all = (await Promise.all(memberIds.map(mid =>
+  const all = await collectAcrossMembers(spaceId, mid =>
     col(`${mid}_files`)
       .find(asFilter(filter))
       .sort({ updatedAt: -1 })
       .skip(skip)
       .limit(limit)
       .toArray(),
-  ))).flat();
+  );
   res.json({ files: capPage(all, limit), limit, skip });
 });
 
@@ -1308,11 +1268,9 @@ brainRouter.patch('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, d
     res.status(400).json({ error: '`properties` must be a plain object' }); return;
   }
 
-  const memberIds = resolveMemberSpaces(wt.target);
-  for (const mid of memberIds) {
-    const updated = await updateFileMeta(mid, path, { description, tags, entityIds, chronoIds, memoryIds, properties });
-    if (updated) { res.json(updated); return; }
-  }
+  const updated = await findFirstAcrossMembers(wt.target,
+    mid => updateFileMeta(mid, path, { description, tags, entityIds, chronoIds, memoryIds, properties }));
+  if (updated) { res.json(updated); return; }
   res.status(404).json({ error: 'File metadata record not found' });
 });
 
@@ -1342,19 +1300,16 @@ brainRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, as
   const safeMaxTimeMS = typeof maxTimeMS === 'number' ? maxTimeMS : 5000;
 
   try {
-    const memberIds = resolveMemberSpaces(spaceId);
-    const docs = (await Promise.all(
-      memberIds.map(mid =>
-        queryBrain(
-          mid,
-          collection as typeof validCollections[number],
-          safeFilter,
-          safeProjection,
-          safeLimit,
-          safeMaxTimeMS,
-        ),
+    const docs = await collectAcrossMembers(spaceId, mid =>
+      queryBrain(
+        mid,
+        collection as typeof validCollections[number],
+        safeFilter,
+        safeProjection,
+        safeLimit,
+        safeMaxTimeMS,
       ),
-    )).flat();
+    );
     res.json({ results: docs, collection, count: docs.length });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -3,7 +3,7 @@ import { UUID_V4_RE } from './shared.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { traverseGraph, updateEdgeById, upsertEdge } from '../../brain/edges.js';
 import { getConfig } from '../../config/loader.js';
-import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
+import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateEdge } from '../../spaces/schema-validation.js';
 
 export const upsert_edgeTool: ToolHandler = {
@@ -117,12 +117,7 @@ export const update_edgeTool: ToolHandler = {
     if (typeof a['weight'] === 'number') updates.weight = a['weight'] as number;
     if (typeof a['type'] === 'string') updates.type = (a['type'] as string).trim();
     if (Object.keys(updates).length === 0 && !dfPaths) throw new Error('At least one of label, description, tags, properties, weight, type, or deleteFields must be provided');
-    const memberIds = resolveMemberSpaces(wt.target);
-    let updatedEdge = null;
-    for (const mid of memberIds) {
-      updatedEdge = await updateEdgeById(mid, id, updates, dfPaths, ctx.actor);
-      if (updatedEdge) break;
-    }
+    const updatedEdge = await findFirstAcrossMembers(wt.target, mid => updateEdgeById(mid, id, updates, dfPaths, ctx.actor));
     if (!updatedEdge) throw new Error(`Edge '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Edge '${updatedEdge.label}' updated (ID ${updatedEdge._id}, seq ${updatedEdge.seq}).` }],

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -4,7 +4,7 @@ import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { findEntitiesByName, updateEntityById, upsertEntity } from '../../brain/entities.js';
 import { type PropertyResolution, applyResolutions, computeMergePlan, executeMerge, validateResolution } from '../../brain/merge.js';
 import { getConfig } from '../../config/loader.js';
-import { isProxySpace, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
+import { isProxySpace, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateEntity } from '../../spaces/schema-validation.js';
 
 export const upsert_entityTool: ToolHandler = {
@@ -119,12 +119,7 @@ export const update_entityTool: ToolHandler = {
       updates.properties = a['properties'] as Record<string, string | number | boolean>;
     }
     if (Object.keys(updates).length === 0 && !dfPaths) throw new Error('At least one of name, type, description, tags, properties, or deleteFields must be provided');
-    const memberIds = resolveMemberSpaces(wt.target);
-    let updatedEnt = null;
-    for (const mid of memberIds) {
-      updatedEnt = await updateEntityById(mid, id, updates, dfPaths, ctx.actor);
-      if (updatedEnt) break;
-    }
+    const updatedEnt = await findFirstAcrossMembers(wt.target, mid => updateEntityById(mid, id, updates, dfPaths, ctx.actor));
     if (!updatedEnt) throw new Error(`Entity '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Entity '${updatedEnt.name}' (${updatedEnt.type}) updated (ID ${updatedEnt._id}, seq ${updatedEnt.seq}).` }],
@@ -268,8 +263,7 @@ export const find_entities_by_nameTool: ToolHandler = {
     const { args: a, callSpace, name } = ctx;
     const searchName = String(a['name'] ?? '').trim();
     if (!searchName) throw new Error('name must not be empty');
-    const memberIds = resolveMemberSpaces(callSpace);
-    const all = (await Promise.all(memberIds.map(mid => findEntitiesByName(mid, searchName)))).flat();
+    const all = await collectAcrossMembers(callSpace, mid => findEntitiesByName(mid, searchName));
     if (all.length === 0) {
       return { content: [{ type: 'text' as const, text: `No entities found with name '${searchName}'.` }] };
     }

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -10,7 +10,7 @@ import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { QuotaError, checkQuota } from '../../quota/quota.js';
 import { emitWebhookEvent } from '../../webhooks/dispatcher.js';
-import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
+import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { getAllowedChronoTypes, resolveMetaRefs, validateChrono, validateEdge, validateEntity, validateMemory } from '../../spaces/schema-validation.js';
 
 export const rememberTool: ToolHandler = {
@@ -173,13 +173,8 @@ export const update_memoryTool: ToolHandler = {
 
     if (Object.keys(updates).length === 0 && !dfPaths) throw new Error('At least one of fact, tags, entityIds, description, properties, or deleteFields must be provided');
 
-    const memberIds = resolveMemberSpaces(wt.target);
     // Search member spaces sequentially — consistent with REST endpoint behaviour.
-    let updated = null;
-    for (const mid of memberIds) {
-      updated = await updateMemory(mid, id, updates, dfPaths, ctx.actor);
-      if (updated) break;
-    }
+    const updated = await findFirstAcrossMembers(wt.target, mid => updateMemory(mid, id, updates, dfPaths, ctx.actor));
     if (!updated) throw new Error(`Memory '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Memory updated (ID ${updated._id}, seq ${updated.seq}).` }],
@@ -209,11 +204,7 @@ export const delete_memoryTool: ToolHandler = {
     const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
     if (!wt.ok) throw new Error(wt.error);
 
-    const memberIds = resolveMemberSpaces(wt.target);
-    let deleted = false;
-    for (const mid of memberIds) {
-      if (await deleteMemory(mid, id, ctx.actor)) { deleted = true; break; }
-    }
+    const deleted = await findFirstAcrossMembers(wt.target, mid => deleteMemory(mid, id, ctx.actor));
     if (!deleted) throw new Error(`Memory '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Memory deleted (ID ${id}).` }],
@@ -459,8 +450,7 @@ export const queryTool: ToolHandler = {
         ? (a['projection'] as Record<string, unknown>)
         : undefined;
 
-    const memberIds = resolveMemberSpaces(callSpace);
-    const docs = (await Promise.all(memberIds.map(mid =>
+    const docs = await collectAcrossMembers(callSpace, mid =>
       queryBrain(
         mid,
         collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files',
@@ -468,8 +458,7 @@ export const queryTool: ToolHandler = {
         projection,
         limit,
         maxTimeMS,
-      ),
-    ))).flat();
+      ));
     return {
       content: [
         {

--- a/server/src/spaces/proxy.ts
+++ b/server/src/spaces/proxy.ts
@@ -83,3 +83,41 @@ export function resolveWriteTarget(
 export function isStrictLinkage(spaceId: string): boolean {
   return findSpace(spaceId)?.meta?.strictLinkage === true;
 }
+
+// ── Member fan-out ─────────────────────────────────────────────────────────
+// A proxy space reads/writes across its member spaces. Two shapes recur across the REST brain
+// routes and MCP tools: "try each member in order, stop at the first hit" (get/update/delete by id)
+// and "query every member and flatten" (list/search). These two helpers centralise both so proxy
+// semantics (member ordering, the resolve step) stay uniform instead of being re-derived ~40 times.
+
+/**
+ * Run `fn` against each member space **in order** and return the first accepted result — the
+ * proxy read/update-by-id pattern (the record lives in exactly one member). `accept` decides what
+ * counts as a hit; it defaults to "non-null", which also treats a truthy boolean (e.g. a
+ * `deleteX() → boolean`) as a hit. Members after the first hit are not visited. Returns the
+ * accepted result, or `undefined` if no member produced one.
+ */
+export async function findFirstAcrossMembers<T>(
+  spaceId: string,
+  fn: (memberId: string) => Promise<T>,
+  accept: (result: T) => boolean = (r): boolean => r != null && r !== false,
+): Promise<T | undefined> {
+  for (const member of resolveMemberSpaces(spaceId)) {
+    const result = await fn(member);
+    if (accept(result)) return result;
+  }
+  return undefined;
+}
+
+/**
+ * Run `fn` against every member space **concurrently** and flatten the per-member arrays into one
+ * — the proxy list/search pattern. Preserves member order in the flattened output (Promise.all
+ * keeps input order). The caller still applies any paging/cap to the combined result.
+ */
+export async function collectAcrossMembers<T>(
+  spaceId: string,
+  fn: (memberId: string) => Promise<T[]>,
+): Promise<T[]> {
+  const perMember = await Promise.all(resolveMemberSpaces(spaceId).map(fn));
+  return perMember.flat();
+}


### PR DESCRIPTION
## What

A proxy space reads and writes across its member spaces. Two idioms were hand-rolled ~40 times across the REST brain routes and MCP tools:

- **"try each member in order, stop at the first hit"** — get/update/delete by id (the record lives in exactly one member)
- **"query every member and flatten"** — list/search

Both now live once in `spaces/proxy.ts`:

```ts
findFirstAcrossMembers<T>(spaceId, fn, accept?): Promise<T | undefined>   // sequential, first accepted result
collectAcrossMembers<T>(spaceId, fn): Promise<T[]>                        // concurrent, flattened
```

So proxy semantics — member ordering, the resolve step, and the first-hit `accept` rule (default: non-null, and a `false` boolean counts as a miss so a `deleteX() → boolean` fan-out works) — can't drift between surfaces.

## Scope

**22 clean call sites converted** in `api/brain.ts` (7 flatten + 9 first-hit incl. the edge name-resolution fan-out) and the MCP `memory`/`entity`/`edge` tools (6).

Loops **left as-is** on purpose — they aren't the two clean idioms:
- schema-validation loops with early `409`/error returns inside the loop (entity/edge/memory updates, entity-delete backlink check)
- directory-listing aggregation with per-member `try/catch` tolerance + name de-duplication (`api/files.ts`, MCP `list_dir`/`read_file`)
- graph traversal (`brain/edges.ts`, `traverse`) that already takes a **pre-resolved** member array, not a `spaceId`
- global recall/search that fans out over `accessibleSpaceIds`, not a single space's members

## Testing

Pure refactor, no behavior change.

- `npm run build:server` — clean (no dead imports/orphaned locals)
- `proxy-spaces` **44/44** — the end-to-end guard: exercises proxy read/list/update/delete across members
- `brain` **183/183**, `mcp-tools` **94/94**, `schema-validation` **29/29**, `schema-library` **85/85**, `conflict-resolution` **15/15**, `space-export` **14/14**, `file-conversion` **8/8**
- Standalone: **800 pass / 0 fail** (4 skipped)

(ARCHITECTURE-TODO A16.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)