### PR TITLE
refactor(spaces): lift vector-index management into spaces/vector-index.ts (A17.7 step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Lifted vector-index management out of `spaces/spaces.ts` into `spaces/vector-index.ts`
+  (internal, no behavior change).** The new module owns building/diffing each collection's Atlas
+  `$vectorSearch` index (`ensureVectorSearchIndex`), polling it to READY (`pollVectorIndexReady`,
+  `waitForSpaceIndexesReady`, `finalizeSpaceIndexReady`, which is what flips a space's
+  `indexStatus` to `ready`/`failed`), and deriving the filter fields that let a recall use native ANN
+  pre-filtering instead of an exhaustive ENN scan (`vectorFilterFieldsFor`). The dependency is
+  one-way — `spaces.ts` calls in, `vector-index.ts` never reaches back — and `brain/recall.ts` now
+  imports `vectorFilterFieldsFor` from it directly. `spaces.ts` drops 1204 → 959 lines. Three pieces
+  of **pre-existing dead code** were removed in passing, all confirmed dead in the original: an
+  `asUpdate` import, and an unused `const embCfg = getEmbeddingConfig()` in `initSpace` (the file had
+  two such declarations; only the one inside the vector-index code was ever read — the repo build has
+  `noUnusedLocals` off, so it never surfaced). The space-lifecycle and rename splits the audit also
+  calls for are **not** in this change — that block does heavy live-`Config` mutation and is tracked
+  as the remaining half of A17.7. (ARCHITECTURE-TODO A17.7, step 1 of 2.)
+
 - **Split the 1713-line `api/sync.ts` (24 routes) into per-concern sub-routers, and moved network
   governance out of the route layer (internal, no behavior change).** Now `api/sync/`: `docs.ts`
   (13 — the four record families plus batch-upsert), `tombstones.ts` (4 — record and file

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -9,7 +9,8 @@ import { col, isVectorSearchAvailable, asFilter } from '../db/mongo.js';
 import { NotFoundError } from '../util/errors.js';
 import { embed } from './embedding.js';
 import { getEmbeddingConfig } from '../config/loader.js';
-import { needsReindex, vectorFilterFieldsFor } from '../spaces/spaces.js';
+import { needsReindex } from '../spaces/spaces.js';
+import { vectorFilterFieldsFor } from '../spaces/vector-index.js';
 import { FilterExpression, buildMongoFilter, toNativeVectorFilter } from './filter.js';
 
 export type RecallKnowledgeType = 'memory' | 'entity' | 'edge' | 'chrono' | 'file';

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -3,13 +3,13 @@ import { escapeRegex } from '../util/redos.js';
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs/promises';
 import path from 'path';
-import { getDb, col, asDoc, asFilter, asUpdate } from '../db/mongo.js';
-import { getConfig, saveConfig, getEmbeddingConfig, getDataRoot, getFaceRecognitionConfig } from '../config/loader.js';
+import { getDb, col, asDoc, asFilter } from '../db/mongo.js';
+import { getConfig, saveConfig, getEmbeddingConfig, getDataRoot } from '../config/loader.js';
 import { ensureSpaceFilesDir, writeFile as writeSpaceFile } from '../files/files.js';
-import { resolveMetaRefs } from './schema-validation.js';
 import { invalidateUsageCache } from '../quota/quota.js';
 import { log } from '../util/log.js';
 import type { Config, SpaceConfig, SpaceMeta, MemoryDoc, KnowledgeType, DupeActionRule, PendingSpaceOp } from '../config/types.js';
+import { VECTOR_INDEXED_COLLECTIONS, buildSpaceVectorIndexes, finalizeSpaceIndexReady } from './vector-index.js';
 
 const SCHEMA_KTS: KnowledgeType[] = ['entity', 'edge', 'memory', 'chrono'];
 
@@ -42,10 +42,6 @@ export async function syncSchemaFiles(spaceId: string, meta: SpaceMeta | undefin
 }
 
 const SPACE_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'tombstones', 'conflicts', 'files', 'dupe_candidates'] as const;
-
-// Collections that have vector search indexes for semantic recall
-const VECTOR_INDEXED_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
-type VectorIndexedCollection = typeof VECTOR_INDEXED_COLLECTIONS[number];
 
 // ── Embedding model mismatch tracking ──────────────────────────────────────
 const _reindexNeeded = new Set<string>();
@@ -170,7 +166,6 @@ export async function initSpace(
 ): Promise<void> {
   const waitForVectorReady = opts.waitForVectorReady ?? true;
   const db = getDb();
-  const embCfg = getEmbeddingConfig();
 
   // Ensure collections exist (MongoDB creates them lazily on first insert,
   // but we create them explicitly to enable index creation)
@@ -258,246 +253,6 @@ export async function initSpace(
   } else {
     _reindexNeeded.delete(spaceId);
   }
-}
-
-/**
- * The fixed (non-`properties`) fields declared as `$vectorSearch` filter fields per collection, so
- * that a recall filtering on them uses native ANN pre-filtering instead of the exhaustive ENN scan
- * (P6). Only fields that (a) exist on the document type and (b) are reachable through the recall
- * filter API (`ALLOWED_FILTER_KEY_PREFIXES` in brain/memory.ts: tags/type/name/status/label) are
- * listed. `properties.<key>` paths are added dynamically from the space's schema — see
- * `deriveVectorFilterFields`.
- */
-const FIXED_VECTOR_FILTER_FIELDS: Record<VectorIndexedCollection, string[]> = {
-  memories: ['tags', 'type'],
-  entities: ['tags', 'type', 'name'],
-  edges: ['tags', 'type', 'label'],
-  chrono: ['tags', 'type', 'status'],
-  files: ['tags'],
-};
-
-/** Map a per-space collection suffix to the KnowledgeType whose schema governs its `properties`. */
-const COLLECTION_KNOWLEDGE_TYPE: Partial<Record<VectorIndexedCollection, KnowledgeType>> = {
-  memories: 'memory',
-  entities: 'entity',
-  edges: 'edge',
-  chrono: 'chrono',
-  // files carry no per-type schema (file is not a KnowledgeType), so no `properties.*` filter paths
-};
-
-/**
- * The full set of `$vectorSearch` filter-field paths for a collection: the fixed fields above, plus
- * one `properties.<key>` path for every property key declared in the space's schema for the
- * matching knowledge type (union across sub-types). Declaring the schema property paths is what lets
- * a `properties.*` filter take the fast ANN path on a schema-defined space — dynamic property keys
- * that no schema declares still fall back to ENN, which is correct, just slower.
- */
-function deriveVectorFilterFields(spaceId: string, collectionSuffix: VectorIndexedCollection): string[] {
-  const fields = [...(FIXED_VECTOR_FILTER_FIELDS[collectionSuffix] ?? [])];
-  const kt = COLLECTION_KNOWLEDGE_TYPE[collectionSuffix];
-  if (!kt) return fields;
-
-  const rawMeta = getConfig().spaces.find(s => s.id === spaceId)?.meta;
-  if (!rawMeta?.typeSchemas) return fields;
-  const meta = resolveMetaRefs(rawMeta);
-  const ktMap = meta.typeSchemas?.[kt];
-  if (!ktMap) return fields;
-
-  const propKeys = new Set<string>();
-  for (const typeSchema of Object.values(ktMap)) {
-    for (const key of Object.keys(typeSchema.propertySchemas ?? {})) {
-      // Guard against a schema key that would break the dot-path or duplicate a fixed field.
-      if (key && !key.includes('.') && !key.includes('$')) propKeys.add(`properties.${key}`);
-    }
-  }
-  return [...fields, ...propKeys];
-}
-
-/** The exported list of filter fields a recall query may safely push into `$vectorSearch.filter`
- *  for a given collection. Mirrors what `ensureVectorSearchIndex` declares, so recall routing and
- *  index definition never drift. */
-export function vectorFilterFieldsFor(spaceId: string, collectionSuffix: string): string[] {
-  if (!(VECTOR_INDEXED_COLLECTIONS as readonly string[]).includes(collectionSuffix)) return [];
-  return deriveVectorFilterFields(spaceId, collectionSuffix as VectorIndexedCollection);
-}
-
-interface SearchIndexField { type?: string; path?: string; numDimensions?: number }
-
-/**
- * Create or validate the $vectorSearch index for a space collection.
- *
- * The index declares the vector field plus a set of `type:"filter"` fields (P6) so recall can
- * pre-filter natively on the ANN path. When an index already exists, its live definition is compared
- * against the desired one (dimensions AND the filter-field set); a difference triggers an in-place
- * `updateSearchIndex` (falling back to drop+recreate), so a schema change that adds/removes a
- * filterable property re-shapes the index without manual intervention.
- *
- * When `waitForReady` (default), polls for READY status up to 60 seconds; pass false to return
- * immediately and let Atlas finish the build in the background (B1 — the caller confirms READY
- * asynchronously via pollVectorIndexReady).
- */
-async function ensureVectorSearchIndex(
-  spaceId: string,
-  collectionSuffix: VectorIndexedCollection,
-  numDimensions: number,
-  similarity: string,
-  vectorPath: string = 'embedding',
-  indexSuffix: string = 'embedding',
-  waitForReady: boolean = true,
-  filterFields: string[] = [],
-): Promise<void> {
-  const db = getDb();
-  const coll = db.collection(`${spaceId}_${collectionSuffix}`);
-  const indexName = `${spaceId}_${collectionSuffix}_${indexSuffix}`;
-
-  const definition = {
-    fields: [
-      { type: 'vector', path: vectorPath, numDimensions, similarity },
-      ...filterFields.map(path => ({ type: 'filter', path })),
-    ],
-  };
-
-  // List existing search indexes
-  let indexes: Array<{ name: string; status?: string; latestDefinition?: { fields?: SearchIndexField[] } }> = [];
-  try {
-    indexes = await coll.listSearchIndexes().toArray() as typeof indexes;
-  } catch {
-    // If listSearchIndexes fails (e.g. not Atlas Local), skip vector search index creation
-    log.warn(
-      `Could not list search indexes for ${spaceId}_memories. ` +
-        `Vector search may be unavailable. Use mongodb/mongodb-atlas-local for $vectorSearch support.`,
-    );
-    return;
-  }
-
-  const existing = indexes.find(i => i.name === indexName);
-
-  if (existing) {
-    const existingFields = existing.latestDefinition?.fields ?? [];
-    const existingDims = existingFields.find(f => f.type === 'vector')?.numDimensions
-      ?? existingFields[0]?.numDimensions; // tolerate older single-field definitions
-    const existingFilters = new Set(existingFields.filter(f => f.type === 'filter').map(f => f.path));
-    const desiredFilters = new Set(filterFields);
-    const dimsMatch = existingDims === numDimensions;
-    const filtersMatch = existingFilters.size === desiredFilters.size
-      && [...desiredFilters].every(p => existingFilters.has(p));
-    if (dimsMatch && filtersMatch) {
-      log.debug(`Vector search index ${indexName} already up to date`);
-      return;
-    }
-
-    // Definition changed (dimensions or filter fields). Prefer an in-place update — Atlas keeps
-    // serving the old definition until the rebuilt one is READY, so recall never goes dark.
-    log.warn(
-      `Updating vector search index ${indexName} (dims ${existingDims}→${numDimensions}, ` +
-      `filter fields ${existingFilters.size}→${desiredFilters.size})`,
-    );
-    try {
-      await coll.updateSearchIndex(indexName, definition);
-      if (waitForReady) {
-        const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName);
-        if (!ready) log.warn(`Vector search index ${indexName} did not reach READY within 60s after update`);
-      }
-      return;
-    } catch (err) {
-      // updateSearchIndex may be unsupported (older Atlas Local) or reject a dims change — fall
-      // back to drop + recreate. This one path DOES leave a brief INITIAL_SYNC gap during which
-      // recall on this collection returns empty (handled by the recall error-swallow), which is
-      // acceptable for the rare dims change.
-      log.warn(`updateSearchIndex failed for ${indexName} (${err}); dropping and recreating`);
-      try {
-        await coll.dropSearchIndex(indexName);
-        await new Promise(r => setTimeout(r, 2000));
-      } catch (dropErr) {
-        log.warn(`Failed to drop vector search index ${indexName}: ${dropErr}`);
-      }
-    }
-  }
-
-  log.debug(`Creating vector search index ${indexName} (${numDimensions}d, ${similarity}, path: ${vectorPath}, ${filterFields.length} filter field(s))`);
-  try {
-    await coll.createSearchIndex(asDoc({
-      name: indexName,
-      type: 'vectorSearch',
-      definition,
-    }));
-  } catch (err) {
-    log.warn(`Failed to create vector search index ${indexName}: ${err}. Semantic recall will be unavailable.`);
-    return;
-  }
-
-  // Poll for READY status (unless the caller will confirm asynchronously — B1).
-  if (waitForReady) {
-    const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName);
-    if (!ready) log.warn(`Vector search index ${indexName} did not reach READY state within 60 seconds`);
-  }
-}
-
-/** Poll a single vector-search index for READY status, up to ~60 seconds.
- *  Returns true once READY, false if it never became READY in the window. */
-async function pollVectorIndexReady(
-  spaceId: string,
-  collectionSuffix: VectorIndexedCollection,
-  indexName: string,
-): Promise<boolean> {
-  const coll = getDb().collection(`${spaceId}_${collectionSuffix}`);
-  for (let attempt = 0; attempt < 60; attempt++) {
-    await new Promise(r => setTimeout(r, 1000));
-    try {
-      const current = await coll.listSearchIndexes(indexName).toArray() as Array<{ status?: string }>;
-      if (current[0]?.status === 'READY') {
-        log.debug(`Vector search index ${indexName} is READY`);
-        return true;
-      }
-    } catch { /* ignore intermittent errors during polling */ }
-  }
-  return false;
-}
-
-/** Create every $vectorSearch index a space needs (per-type embedding indexes plus
- *  the optional face index). `waitForReady` is threaded to each — false creates them
- *  and returns without polling (B1). */
-async function buildSpaceVectorIndexes(spaceId: string, waitForReady: boolean): Promise<void> {
-  const embCfg = getEmbeddingConfig();
-  for (const suffix of VECTOR_INDEXED_COLLECTIONS) {
-    const filterFields = deriveVectorFilterFields(spaceId, suffix);
-    await ensureVectorSearchIndex(spaceId, suffix, embCfg.dimensions, embCfg.similarity, 'embedding', 'embedding', waitForReady, filterFields);
-  }
-  const faceCfg = getFaceRecognitionConfig();
-  if (faceCfg.enabled) {
-    await ensureVectorSearchIndex(spaceId, 'files', 128, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady);
-  }
-}
-
-/** Poll all of a space's vector-search indexes until READY. Returns true only if every
- *  expected index reached READY within the window. */
-async function waitForSpaceIndexesReady(spaceId: string): Promise<boolean> {
-  let allReady = true;
-  for (const suffix of VECTOR_INDEXED_COLLECTIONS) {
-    if (!(await pollVectorIndexReady(spaceId, suffix, `${spaceId}_${suffix}_embedding`))) allReady = false;
-  }
-  if (getFaceRecognitionConfig().enabled) {
-    if (!(await pollVectorIndexReady(spaceId, 'files', `${spaceId}_files_faceEmbedding`))) allReady = false;
-  }
-  return allReady;
-}
-
-/** Background step kicked off by createSpace: wait for the deferred vector-index
- *  builds to reach READY, then flip the space's indexStatus to 'ready' (or 'failed').
- *  A crash before this completes is recovered on the next boot by initAllSpaces. */
-async function finalizeSpaceIndexReady(spaceId: string): Promise<void> {
-  let ok = false;
-  try {
-    ok = await waitForSpaceIndexesReady(spaceId);
-  } catch (err) {
-    log.warn(`Space '${spaceId}': error awaiting vector index readiness: ${err instanceof Error ? err.message : String(err)}`);
-  }
-  const cfg = getConfig();
-  const space = cfg.spaces.find(s => s.id === spaceId);
-  if (!space) return; // space was deleted while its indexes built
-  space.indexStatus = ok ? 'ready' : 'failed';
-  saveConfig(cfg);
-  log.info(`Space '${spaceId}': vector indexes ${ok ? 'ready' : 'did not reach READY (marked failed)'}`);
 }
 
 /** Initialise all spaces defined in config */

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -1,0 +1,257 @@
+/**
+ * Atlas $vectorSearch index management for a space's collections.
+ *
+ * Lifted out of spaces/spaces.ts (A17.7): building/diffing each collection's vector index, polling
+ * it to READY, and deriving the filter fields that let a recall use native ANN pre-filtering instead
+ * of an exhaustive ENN scan. Cohesive and self-contained — it does not reach back into space
+ * lifecycle; spaces.ts calls in, not the other way round.
+ */
+import { getDb, asDoc } from '../db/mongo.js';
+import { getConfig, saveConfig, getEmbeddingConfig, getFaceRecognitionConfig } from '../config/loader.js';
+import { resolveMetaRefs } from './schema-validation.js';
+import { log } from '../util/log.js';
+import type { KnowledgeType } from '../config/types.js';
+
+// Collections that have vector search indexes for semantic recall
+export const VECTOR_INDEXED_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
+export type VectorIndexedCollection = typeof VECTOR_INDEXED_COLLECTIONS[number];
+
+/**
+ * The fixed (non-`properties`) fields declared as `$vectorSearch` filter fields per collection, so
+ * that a recall filtering on them uses native ANN pre-filtering instead of the exhaustive ENN scan
+ * (P6). Only fields that (a) exist on the document type and (b) are reachable through the recall
+ * filter API (`ALLOWED_FILTER_KEY_PREFIXES` in brain/memory.ts: tags/type/name/status/label) are
+ * listed. `properties.<key>` paths are added dynamically from the space's schema — see
+ * `deriveVectorFilterFields`.
+ */
+const FIXED_VECTOR_FILTER_FIELDS: Record<VectorIndexedCollection, string[]> = {
+  memories: ['tags', 'type'],
+  entities: ['tags', 'type', 'name'],
+  edges: ['tags', 'type', 'label'],
+  chrono: ['tags', 'type', 'status'],
+  files: ['tags'],
+};
+
+/** Map a per-space collection suffix to the KnowledgeType whose schema governs its `properties`. */
+const COLLECTION_KNOWLEDGE_TYPE: Partial<Record<VectorIndexedCollection, KnowledgeType>> = {
+  memories: 'memory',
+  entities: 'entity',
+  edges: 'edge',
+  chrono: 'chrono',
+  // files carry no per-type schema (file is not a KnowledgeType), so no `properties.*` filter paths
+};
+
+/**
+ * The full set of `$vectorSearch` filter-field paths for a collection: the fixed fields above, plus
+ * one `properties.<key>` path for every property key declared in the space's schema for the
+ * matching knowledge type (union across sub-types). Declaring the schema property paths is what lets
+ * a `properties.*` filter take the fast ANN path on a schema-defined space — dynamic property keys
+ * that no schema declares still fall back to ENN, which is correct, just slower.
+ */
+export function deriveVectorFilterFields(spaceId: string, collectionSuffix: VectorIndexedCollection): string[] {
+  const fields = [...(FIXED_VECTOR_FILTER_FIELDS[collectionSuffix] ?? [])];
+  const kt = COLLECTION_KNOWLEDGE_TYPE[collectionSuffix];
+  if (!kt) return fields;
+
+  const rawMeta = getConfig().spaces.find(s => s.id === spaceId)?.meta;
+  if (!rawMeta?.typeSchemas) return fields;
+  const meta = resolveMetaRefs(rawMeta);
+  const ktMap = meta.typeSchemas?.[kt];
+  if (!ktMap) return fields;
+
+  const propKeys = new Set<string>();
+  for (const typeSchema of Object.values(ktMap)) {
+    for (const key of Object.keys(typeSchema.propertySchemas ?? {})) {
+      // Guard against a schema key that would break the dot-path or duplicate a fixed field.
+      if (key && !key.includes('.') && !key.includes('$')) propKeys.add(`properties.${key}`);
+    }
+  }
+  return [...fields, ...propKeys];
+}
+
+/** The exported list of filter fields a recall query may safely push into `$vectorSearch.filter`
+ *  for a given collection. Mirrors what `ensureVectorSearchIndex` declares, so recall routing and
+ *  index definition never drift. */
+export function vectorFilterFieldsFor(spaceId: string, collectionSuffix: string): string[] {
+  if (!(VECTOR_INDEXED_COLLECTIONS as readonly string[]).includes(collectionSuffix)) return [];
+  return deriveVectorFilterFields(spaceId, collectionSuffix as VectorIndexedCollection);
+}
+
+interface SearchIndexField { type?: string; path?: string; numDimensions?: number }
+
+/**
+ * Create or validate the $vectorSearch index for a space collection.
+ *
+ * The index declares the vector field plus a set of `type:"filter"` fields (P6) so recall can
+ * pre-filter natively on the ANN path. When an index already exists, its live definition is compared
+ * against the desired one (dimensions AND the filter-field set); a difference triggers an in-place
+ * `updateSearchIndex` (falling back to drop+recreate), so a schema change that adds/removes a
+ * filterable property re-shapes the index without manual intervention.
+ *
+ * When `waitForReady` (default), polls for READY status up to 60 seconds; pass false to return
+ * immediately and let Atlas finish the build in the background (B1 — the caller confirms READY
+ * asynchronously via pollVectorIndexReady).
+ */
+export async function ensureVectorSearchIndex(
+  spaceId: string,
+  collectionSuffix: VectorIndexedCollection,
+  numDimensions: number,
+  similarity: string,
+  vectorPath: string = 'embedding',
+  indexSuffix: string = 'embedding',
+  waitForReady: boolean = true,
+  filterFields: string[] = [],
+): Promise<void> {
+  const db = getDb();
+  const coll = db.collection(`${spaceId}_${collectionSuffix}`);
+  const indexName = `${spaceId}_${collectionSuffix}_${indexSuffix}`;
+
+  const definition = {
+    fields: [
+      { type: 'vector', path: vectorPath, numDimensions, similarity },
+      ...filterFields.map(path => ({ type: 'filter', path })),
+    ],
+  };
+
+  // List existing search indexes
+  let indexes: Array<{ name: string; status?: string; latestDefinition?: { fields?: SearchIndexField[] } }> = [];
+  try {
+    indexes = await coll.listSearchIndexes().toArray() as typeof indexes;
+  } catch {
+    // If listSearchIndexes fails (e.g. not Atlas Local), skip vector search index creation
+    log.warn(
+      `Could not list search indexes for ${spaceId}_memories. ` +
+        `Vector search may be unavailable. Use mongodb/mongodb-atlas-local for $vectorSearch support.`,
+    );
+    return;
+  }
+
+  const existing = indexes.find(i => i.name === indexName);
+
+  if (existing) {
+    const existingFields = existing.latestDefinition?.fields ?? [];
+    const existingDims = existingFields.find(f => f.type === 'vector')?.numDimensions
+      ?? existingFields[0]?.numDimensions; // tolerate older single-field definitions
+    const existingFilters = new Set(existingFields.filter(f => f.type === 'filter').map(f => f.path));
+    const desiredFilters = new Set(filterFields);
+    const dimsMatch = existingDims === numDimensions;
+    const filtersMatch = existingFilters.size === desiredFilters.size
+      && [...desiredFilters].every(p => existingFilters.has(p));
+    if (dimsMatch && filtersMatch) {
+      log.debug(`Vector search index ${indexName} already up to date`);
+      return;
+    }
+
+    // Definition changed (dimensions or filter fields). Prefer an in-place update — Atlas keeps
+    // serving the old definition until the rebuilt one is READY, so recall never goes dark.
+    log.warn(
+      `Updating vector search index ${indexName} (dims ${existingDims}→${numDimensions}, ` +
+      `filter fields ${existingFilters.size}→${desiredFilters.size})`,
+    );
+    try {
+      await coll.updateSearchIndex(indexName, definition);
+      if (waitForReady) {
+        const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName);
+        if (!ready) log.warn(`Vector search index ${indexName} did not reach READY within 60s after update`);
+      }
+      return;
+    } catch (err) {
+      // updateSearchIndex may be unsupported (older Atlas Local) or reject a dims change — fall
+      // back to drop + recreate. This one path DOES leave a brief INITIAL_SYNC gap during which
+      // recall on this collection returns empty (handled by the recall error-swallow), which is
+      // acceptable for the rare dims change.
+      log.warn(`updateSearchIndex failed for ${indexName} (${err}); dropping and recreating`);
+      try {
+        await coll.dropSearchIndex(indexName);
+        await new Promise(r => setTimeout(r, 2000));
+      } catch (dropErr) {
+        log.warn(`Failed to drop vector search index ${indexName}: ${dropErr}`);
+      }
+    }
+  }
+
+  log.debug(`Creating vector search index ${indexName} (${numDimensions}d, ${similarity}, path: ${vectorPath}, ${filterFields.length} filter field(s))`);
+  try {
+    await coll.createSearchIndex(asDoc({
+      name: indexName,
+      type: 'vectorSearch',
+      definition,
+    }));
+  } catch (err) {
+    log.warn(`Failed to create vector search index ${indexName}: ${err}. Semantic recall will be unavailable.`);
+    return;
+  }
+
+  // Poll for READY status (unless the caller will confirm asynchronously — B1).
+  if (waitForReady) {
+    const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName);
+    if (!ready) log.warn(`Vector search index ${indexName} did not reach READY state within 60 seconds`);
+  }
+}
+
+/** Poll a single vector-search index for READY status, up to ~60 seconds.
+ *  Returns true once READY, false if it never became READY in the window. */
+export async function pollVectorIndexReady(
+  spaceId: string,
+  collectionSuffix: VectorIndexedCollection,
+  indexName: string,
+): Promise<boolean> {
+  const coll = getDb().collection(`${spaceId}_${collectionSuffix}`);
+  for (let attempt = 0; attempt < 60; attempt++) {
+    await new Promise(r => setTimeout(r, 1000));
+    try {
+      const current = await coll.listSearchIndexes(indexName).toArray() as Array<{ status?: string }>;
+      if (current[0]?.status === 'READY') {
+        log.debug(`Vector search index ${indexName} is READY`);
+        return true;
+      }
+    } catch { /* ignore intermittent errors during polling */ }
+  }
+  return false;
+}
+
+/** Create every $vectorSearch index a space needs (per-type embedding indexes plus
+ *  the optional face index). `waitForReady` is threaded to each — false creates them
+ *  and returns without polling (B1). */
+export async function buildSpaceVectorIndexes(spaceId: string, waitForReady: boolean): Promise<void> {
+  const embCfg = getEmbeddingConfig();
+  for (const suffix of VECTOR_INDEXED_COLLECTIONS) {
+    const filterFields = deriveVectorFilterFields(spaceId, suffix);
+    await ensureVectorSearchIndex(spaceId, suffix, embCfg.dimensions, embCfg.similarity, 'embedding', 'embedding', waitForReady, filterFields);
+  }
+  const faceCfg = getFaceRecognitionConfig();
+  if (faceCfg.enabled) {
+    await ensureVectorSearchIndex(spaceId, 'files', 128, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady);
+  }
+}
+
+/** Poll all of a space's vector-search indexes until READY. Returns true only if every
+ *  expected index reached READY within the window. */
+export async function waitForSpaceIndexesReady(spaceId: string): Promise<boolean> {
+  let allReady = true;
+  for (const suffix of VECTOR_INDEXED_COLLECTIONS) {
+    if (!(await pollVectorIndexReady(spaceId, suffix, `${spaceId}_${suffix}_embedding`))) allReady = false;
+  }
+  if (getFaceRecognitionConfig().enabled) {
+    if (!(await pollVectorIndexReady(spaceId, 'files', `${spaceId}_files_faceEmbedding`))) allReady = false;
+  }
+  return allReady;
+}
+
+/** Background step kicked off by createSpace: wait for the deferred vector-index
+ *  builds to reach READY, then flip the space's indexStatus to 'ready' (or 'failed').
+ *  A crash before this completes is recovered on the next boot by initAllSpaces. */
+export async function finalizeSpaceIndexReady(spaceId: string): Promise<void> {
+  let ok = false;
+  try {
+    ok = await waitForSpaceIndexesReady(spaceId);
+  } catch (err) {
+    log.warn(`Space '${spaceId}': error awaiting vector index readiness: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const cfg = getConfig();
+  const space = cfg.spaces.find(s => s.id === spaceId);
+  if (!space) return; // space was deleted while its indexes built
+  space.indexStatus = ok ? 'ready' : 'failed';
+  saveConfig(cfg);
+  log.info(`Space '${spaceId}': vector indexes ${ok ? 'ready' : 'did not reach READY (marked failed)'}`);
+}


### PR DESCRIPTION
## Scope — deliberately half of A17.7

The audit sequences this file for a reason: *"Lift the cohesive vector-index block first; then `lifecycle.ts` + `rename.ts`. Heavy live-`Config` mutation → risky."* This PR is **step 1** only.

`spaces/vector-index.ts` now owns:

| Function | Role |
|---|---|
| `ensureVectorSearchIndex` | build/diff each collection's Atlas `$vectorSearch` index |
| `pollVectorIndexReady`, `waitForSpaceIndexesReady`, `finalizeSpaceIndexReady` | poll to READY; finalize is what flips a space's `indexStatus` to `ready`/`failed` |
| `vectorFilterFieldsFor`, `deriveVectorFilterFields` | the filter fields that let a recall use native ANN pre-filtering instead of an exhaustive ENN scan |

**`spaces.ts`: 1204 → 959 lines.**

## Why this is safe

- **Dependency is one-way**: `spaces.ts` calls in; `vector-index.ts` never reaches back. I checked before moving — the only `createSpace` reference inside the block turned out to be a comment, so there's no cycle.
- Only `vectorFilterFieldsFor` was used outside the file (`brain/recall.ts`), which now imports it from the new module.
- The **completeness assertion** (added after the A17.5 SSRF near-miss) confirms every non-import source line survived the move.

## Pre-existing dead code removed

Three items, each confirmed dead **in the original** before I touched it:
- an `asUpdate` import (import-only in the original)
- an unused `const embCfg = getEmbeddingConfig()` in `initSpace` — the file declared `embCfg` **twice**, and only the one inside the vector-index code was ever read

The repo build has `noUnusedLocals` off, so none of this ever surfaced; I only see it because I run `tsc --noUnusedLocals` as an extra gate on these splits.

## Not in this PR

The lifecycle (`initSpace`/`createSpace`/`removeSpace`/`wipeSpace`/`reconcilePendingSpaceOp`) and rename (`slugify`/`moveSpaceData`/`renameSpace`) splits. That half mutates live `Config` and coordinates with `PendingSpaceOp` crash recovery — it earns its own PR rather than riding along here. Tracked as **A17.7 step 2** in the audit doc, with the sync + red-team suites named as the gate.

## Testing

- build clean; `tsc --noUnusedLocals` — no dead code in `spaces/` or `vector-index.ts`
- standalone **801/0** (805), sync **191/0**, red-team **272/272**
- brain **183/183**, mcp-tools **94/94**, proxy-spaces **44/44**, space-export **14/14**, schema-validation **29/29**, schema-library **85/85**, conflict-resolution **15/15**, file-conversion **8/8**
- **Docs checked** — no doc references these internals, and the documented `indexStatus` contract (`building` → `ready`/`failed`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)