### PR TITLE
refactor(client): SpacesStore owns the page data; O(1) per-row network lookup (A17.8b-2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -661,6 +661,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Gave the spaces page's server data a real owner (`SpacesStore`), and made the space list's
+  per-row network lookup O(1) (internal, no behavior change).** The space list, the networks, and
+  every mutation of them now live in a `SpacesStore` service, kept deliberately separate from
+  `SpaceSettingsState`: they are different kinds of state with different lifetimes — one is server
+  data shared by the list and every dialog, the other is ephemeral form state that dies when the
+  dialog closes. The old component owned both. The practical payoff is that the settings tabs can
+  mutate the list by *calling the store*, so the child components extracted next need **no
+  `@Output()` plumbing** and no component owns data that outlives it — and it is the same
+  signal-store shape the audit already prescribes for `brain.component` (A17.9), proven here on the
+  smaller page first, as the audit asks.
+  **Performance:** the list template called `networksForSpace(id)` — a full `networks().filter(...)`
+  — **twice per row** (once for `.length`, once for the `@for`), on every change-detection pass, each
+  call allocating a fresh array whose changing identity also defeated `@for` tracking. It is now a
+  `networksBySpace` computed index: built once per `networks()` change, O(1) per row, stable array
+  identity. Pinned by a test asserting reads return the *same* instance, since that is the property
+  `@for` depends on. `spaces.component.ts`: 1616 → 1578; client suite 109 → 121.
+  Recorded but deliberately **not** done here: `SpacesComponent` is the only major page not using
+  OnPush (`brain`, `file-manager`, `graph`, `audit-log` all do). It cannot simply be flipped —
+  `FileReader.onload` callbacks mutate plain fields (`schImportError`, `state.schTypeSchemas`) with
+  no signal write, so OnPush would leave the view stale. That is easy to fix per child component and
+  painful as a retrofit on a 1600-line parent, so it is tracked to land with the component extraction
+  (ARCHITECTURE-TODO A17.8, 8b-2b).
+
 - **Extracted the space-settings dialog state out of `SpacesComponent` into `SpaceSettingsState`
   (internal, no behavior change).** First half of A17.8: the settings state (`openSettings`,
   `buildMeta`, the type-schema helpers, the duplicate-rule helpers, and the four tabs' fields) now

--- a/client/src/app/pages/settings/spaces-store.service.spec.ts
+++ b/client/src/app/pages/settings/spaces-store.service.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * SpacesStore — the spaces page's server-data owner.
+ *
+ * Covers the behaviour moved out of SpacesComponent (A17.8b) plus the `networksBySpace` index that
+ * replaced the per-row `networks().filter(...)` scan. The index is the point of the class as much as
+ * the data is, so it is pinned here: correctness (right networks per space) AND the property that
+ * made it worth doing (a stable array identity across reads, which is what lets `@for` track rows
+ * instead of re-creating them every change-detection pass).
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { NetworksApi } from '../../core/networks-api.service';
+import { SpacesApi } from '../../core/spaces-api.service';
+import type { Network, Space } from '../../core/api.types';
+import { SpacesStore } from './spaces-store.service';
+
+const space = (id: string, over: Partial<Space> = {}): Space => ({ id, label: id, ...over } as Space);
+const net = (id: string, spaces: string[]): Network => ({ id, label: id.toUpperCase(), spaces } as Network);
+
+function make(opts: { spaces?: Space[]; networks?: Network[]; spacesFail?: boolean; networksFail?: boolean } = {}) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      SpacesStore,
+      { provide: SpacesApi, useValue: {
+        listSpaces: () => opts.spacesFail ? throwError(() => new Error('x')) : of({ spaces: opts.spaces ?? [] }),
+        reorderSpaces: (ids: string[]) => of({ spaces: (ids).map(i => space(i)) }),
+      } },
+      { provide: NetworksApi, useValue: {
+        listNetworks: () => opts.networksFail ? throwError(() => new Error('x')) : of({ networks: opts.networks ?? [] }),
+      } },
+    ],
+  });
+  return TestBed.inject(SpacesStore);
+}
+
+describe('SpacesStore — load', () => {
+  it('loads spaces and networks, and clears loading', () => {
+    const s = make({ spaces: [space('work')], networks: [net('n1', ['work'])] });
+    s.load();
+    expect(s.spaces().map(x => x.id)).toEqual(['work']);
+    expect(s.networks().map(x => x.id)).toEqual(['n1']);
+    expect(s.loading()).toBe(false);
+  });
+
+  it('a failing spaces call still clears loading', () => {
+    const s = make({ spacesFail: true });
+    s.load();
+    expect(s.loading()).toBe(false);
+    expect(s.spaces()).toEqual([]);
+  });
+
+  it('a failing networks call is non-fatal — spaces still load', () => {
+    const s = make({ spaces: [space('work')], networksFail: true });
+    s.load();
+    expect(s.spaces()).toHaveLength(1);
+    expect(s.networks()).toEqual([]);
+  });
+});
+
+describe('SpacesStore — networksBySpace index', () => {
+  // Replaces `networks().filter(n => n.spaces.includes(id))` called twice per row. Same answer,
+  // O(1) per row instead of a full scan, and — see the identity test — a stable array reference.
+  it('maps each space to the networks that contain it', () => {
+    const s = make({ networks: [net('a', ['work', 'home']), net('b', ['work'])] });
+    s.load();
+    expect(s.networksForSpace('work').map(n => n.id)).toEqual(['a', 'b']);
+    expect(s.networksForSpace('home').map(n => n.id)).toEqual(['a']);
+  });
+
+  it('a space in no network returns empty', () => {
+    const s = make({ networks: [net('a', ['other'])] });
+    s.load();
+    expect(s.networksForSpace('work')).toEqual([]);
+  });
+
+  it('returns the SAME array instance across reads — @for tracking depends on it', () => {
+    const s = make({ networks: [net('a', ['work'])] });
+    s.load();
+    expect(s.networksForSpace('work')).toBe(s.networksForSpace('work'));
+  });
+
+  it('recomputes when networks change', () => {
+    const s = make({ networks: [net('a', ['work'])] });
+    s.load();
+    expect(s.networksForSpace('work')).toHaveLength(1);
+    s.networks.set([net('a', ['work']), net('b', ['work'])]);
+    expect(s.networksForSpace('work').map(n => n.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('SpacesStore — mutations', () => {
+  it('applySpace merges a server-returned space into the list', () => {
+    const s = make();
+    s.spaces.set([space('work', { label: 'Old' }), space('home')]);
+    s.applySpace(space('work', { label: 'New' }));
+    expect(s.spaces().map(x => x.label)).toEqual(['New', 'home']);
+  });
+
+  it('applySpace leaves the list alone when the id is unknown', () => {
+    const s = make();
+    s.spaces.set([space('work')]);
+    s.applySpace(space('nope'));
+    expect(s.spaces().map(x => x.id)).toEqual(['work']);
+  });
+
+  it('reorder moves an item and persists the new order', () => {
+    const s = make();
+    s.spaces.set([space('a'), space('b'), space('c')]);
+    s.reorder(0, 2);
+    expect(s.spaces().map(x => x.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('reorder is a no-op when the index has not changed', () => {
+    const s = make();
+    const before = [space('a'), space('b')];
+    s.spaces.set(before);
+    s.reorder(1, 1);
+    expect(s.spaces()).toBe(before); // untouched, not even re-set
+  });
+
+  it('refreshNetworks refetches only the networks', () => {
+    const s = make({ networks: [net('a', ['work'])] });
+    s.refreshNetworks();
+    expect(s.networks().map(n => n.id)).toEqual(['a']);
+  });
+});

--- a/client/src/app/pages/settings/spaces-store.service.ts
+++ b/client/src/app/pages/settings/spaces-store.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { moveItemInArray } from '@angular/cdk/drag-drop';
+import { Network, Space } from '../../core/api.types';
+import { NetworksApi } from '../../core/networks-api.service';
+import { SpacesApi } from '../../core/spaces-api.service';
+
+/**
+ * Owns the spaces page's SERVER DATA — the space list, the networks, and every mutation of them.
+ *
+ * Split from SpaceSettingsState on purpose (A17.8b): the two are different kinds of state with
+ * different lifetimes. This is data fetched from the server and shared by the list and every dialog;
+ * SpaceSettingsState is ephemeral form state that dies when the dialog closes. Tangling them is what
+ * forced the old component to own both.
+ *
+ * Because it is a service, the dialogs and tabs mutate the list by calling it — no `@Output()`
+ * plumbing back to a parent, and no component owning data that outlives it. Provided by
+ * SpacesComponent (not root), so the lifetime matches the page.
+ *
+ * VIEW state (search text, sort mode) deliberately does NOT live here — that belongs to the
+ * component rendering the list, not to the data.
+ */
+@Injectable()
+export class SpacesStore {
+  private spacesApi   = inject(SpacesApi);
+  private networksApi = inject(NetworksApi);
+
+  readonly spaces   = signal<Space[]>([]);
+  readonly networks = signal<Network[]>([]);
+  readonly loading  = signal(true);
+
+  /**
+   * spaceId -> the networks that space belongs to.
+   *
+   * The list template needs this per row. It used to call `networks().filter(...)` inline — twice
+   * per row (once for `.length`, once for the `@for`) — so rendering N rows did 2N full scans of the
+   * network list on every change-detection pass, allocating a fresh array each time (which also
+   * defeats `@for` tracking, since the identity changed on every pass). This computes the index once
+   * per networks() change instead: O(1) lookup per row, and a stable array identity.
+   */
+  readonly networksBySpace = computed(() => {
+    const index = new Map<string, Network[]>();
+    for (const n of this.networks()) {
+      for (const spaceId of n.spaces) {
+        const list = index.get(spaceId);
+        if (list) list.push(n);
+        else index.set(spaceId, [n]);
+      }
+    }
+    return index;
+  });
+
+  /** Networks the given space belongs to. Empty array shared across misses — do not mutate it. */
+  private static readonly NO_NETWORKS: readonly Network[] = [];
+  networksForSpace(spaceId: string): Network[] {
+    return this.networksBySpace().get(spaceId) ?? (SpacesStore.NO_NETWORKS as Network[]);
+  }
+
+  load(): void {
+    this.loading.set(true);
+    this.spacesApi.listSpaces().subscribe({
+      next: ({ spaces }) => { this.spaces.set(spaces); this.loading.set(false); },
+      error: () => this.loading.set(false),
+    });
+    this.networksApi.listNetworks().subscribe({
+      next: ({ networks }) => this.networks.set(networks),
+      error: () => {},
+    });
+  }
+
+  refreshNetworks(): void {
+    this.networksApi.listNetworks().subscribe({
+      next: ({ networks }) => this.networks.set(networks),
+      error: () => {},
+    });
+  }
+
+  /** Merge a server-returned space back into the list (after a settings save). */
+  applySpace(space: Space): void {
+    this.spaces.update(list => list.map(s => s.id === space.id ? { ...s, ...space } : s));
+  }
+
+  /** Reorder optimistically, then persist; on failure fall back to a full reload. */
+  reorder(previousIndex: number, currentIndex: number): void {
+    if (previousIndex === currentIndex) return;
+    const list = [...this.spaces()];
+    moveItemInArray(list, previousIndex, currentIndex);
+    this.spaces.set(list);
+    this.spacesApi.reorderSpaces(list.map(s => s.id)).subscribe({
+      next: ({ spaces }) => { this.spaces.set(spaces); },
+      error: () => this.load(),
+    });
+  }
+
+  /**
+   * Poll until no space reports `indexStatus: 'building'`.
+   *
+   * A newly created space returns immediately with its Atlas vector indexes still building; recall
+   * stays empty until they are ready. Capped at ~2 min.
+   */
+  pollIndexStatus(attempt = 0): void {
+    if (attempt > 40) return; // ~2 min cap
+    setTimeout(() => {
+      this.spacesApi.listSpaces().subscribe({
+        next: ({ spaces }) => {
+          this.spaces.set(spaces);
+          if (spaces.some(s => s.indexStatus === 'building')) this.pollIndexStatus(attempt + 1);
+        },
+        error: () => {},
+      });
+    }, 3000);
+  }
+}

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -17,6 +17,7 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state.service';
+import { SpacesStore } from './spaces-store.service';
 
 @Component({
   selector: 'app-spaces',
@@ -24,7 +25,7 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
   imports: [CommonModule, FormsModule, TranslocoPipe, DragDropModule, PhIconComponent],
   // Provided here (not root) so each mount gets its own settings state, with a lifetime tied to
   // this component rather than the app.
-  providers: [SpaceSettingsState],
+  providers: [SpacesStore, SpaceSettingsState],
   styles: [`
     /* chip inputs */
     .chip-wrap {
@@ -147,7 +148,7 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
               </div>
               <div class="field" style="flex:1;margin-bottom:0;">
                 <label>{{ 'spaces.create.proxyFor' | transloco }}</label>
-                @if (spaces().length > 0) {
+                @if (store.spaces().length > 0) {
                   <div class="table-wrapper" style="max-height:180px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius-sm);">
                     <table style="margin:0;">
                       <thead><tr><th style="width:40px;"></th><th>{{ 'spaces.table.column.label' | transloco }}</th><th>{{ 'spaces.table.column.id' | transloco }}</th></tr></thead>
@@ -156,7 +157,7 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
                           <td style="text-align:center;"><input type="checkbox" [checked]="proxyForAll" (click)="$event.stopPropagation()" (change)="toggleProxyForAll()" /></td>
                           <td colspan="2" style="font-style:italic;color:var(--text-muted);">{{ 'spaces.create.proxyForAll' | transloco }}</td>
                         </tr>
-                        @for (s of spaces(); track s.id) {
+                        @for (s of store.spaces(); track s.id) {
                           <tr style="cursor:pointer;" [class.text-muted]="proxyForAll" (click)="!proxyForAll && toggleProxyFor(s.id)">
                             <td style="text-align:center;"><input type="checkbox" [checked]="proxyForAll || isProxyForSelected(s.id)" [disabled]="proxyForAll" (click)="$event.stopPropagation()" (change)="!proxyForAll && toggleProxyFor(s.id)" /></td>
                             <td>{{ s.label }}</td>
@@ -663,7 +664,7 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
                 </button>
               </div>
 
-              @let spaceNets = networksForSpace(state.settingsSpace()!.id);
+              @let spaceNets = store.networksForSpace(state.settingsSpace()!.id);
               @if (spaceNets.length > 0) {
                 <div class="dz-section">
                   <div class="dz-section-title">{{ 'spaces.dangerZone.leaveNetworksTitle' | transloco }}</div>
@@ -776,10 +777,10 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
             <button class="sort-btn" [class.active]="sortMode()==='usage-asc'" (click)="sortMode.set('usage-asc')" [attr.title]="'spaces.table.sort.usageAsc' | transloco">↑ GiB</button>
           </div>
           <button class="btn-primary btn btn-sm" (click)="showCreateDialog.set(true)">{{ 'spaces.table.createButton' | transloco }}</button>
-          <button class="btn-secondary btn btn-sm" (click)="load()">{{ 'spaces.table.refreshButton' | transloco }}</button>
+          <button class="btn-secondary btn btn-sm" (click)="store.load()">{{ 'spaces.table.refreshButton' | transloco }}</button>
         </div>
       </div>
-      @if (loading()) {
+      @if (store.loading()) {
         <div class="loading-overlay"><span class="spinner"></span></div>
       } @else {
         <div class="table-wrapper">
@@ -787,7 +788,7 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
             <thead>
               <tr><th style="width:32px;"></th><th>{{ 'spaces.table.column.label' | transloco }}</th><th>{{ 'spaces.table.column.id' | transloco }}</th><th>{{ 'spaces.table.column.storage' | transloco }}</th><th>{{ 'spaces.table.column.networks' | transloco }}</th><th>{{ 'spaces.table.column.proxy' | transloco }}</th><th></th></tr>
             </thead>
-            <tbody cdkDropList (cdkDropListDropped)="onSpaceDrop($event)">
+            <tbody cdkDropList (cdkDropListDropped)="store.reorder($event.previousIndex, $event.currentIndex)">
               @for (s of sortedSpaces(); track s.id) {
                 @let bar = storageInfo(s);
                 <tr cdkDrag cdkDragLockAxis="y" [cdkDragDisabled]="sortMode() !== 'custom'">
@@ -809,8 +810,9 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
                     }
                   </td>
                   <td>
-                    @if (networksForSpace(s.id).length) {
-                      @for (n of networksForSpace(s.id); track n.id) {
+                    @let nets = store.networksForSpace(s.id);
+                    @if (nets.length) {
+                      @for (n of nets; track n.id) {
                         <span class="badge badge-gray" style="margin-right:4px;">{{ n.label }}</span>
                       }
                     } @else { <span style="color:var(--text-muted)">—</span> }
@@ -845,15 +847,14 @@ export class SpacesComponent implements OnInit {
   private confirmDialog = inject(ConfirmDialogService);
   /** Settings-dialog state, shared with the tabs. Public: the template binds to it. */
   readonly state = inject(SpaceSettingsState);
+  /** Server data for the page (space list + networks). Public: the template binds to it. */
+  readonly store = inject(SpacesStore);
 
-  spaces   = signal<Space[]>([]);
-  networks = signal<Network[]>([]);
-  loading  = signal(true);
 
   spaceSearch = signal('');
   sortMode = signal<'custom' | 'az' | 'za' | 'usage-desc' | 'usage-asc'>('custom');
   sortedSpaces = computed(() => {
-    const list = this.spaces();
+    const list = this.store.spaces();
     const sorted = (() => {
       switch (this.sortMode()) {
         case 'az':         return [...list].sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
@@ -945,34 +946,10 @@ export class SpacesComponent implements OnInit {
   /** Tracks the kt/typeName target for per-type import. */
   private _typeImportTarget: { kt: KnowledgeType; name: string } | null = null;
 
-  ngOnInit(): void { this.load(); }
+  ngOnInit(): void { this.store.load(); }
 
-  load(): void {
-    this.loading.set(true);
-    this.spacesApi.listSpaces().subscribe({
-      next: ({ spaces }) => { this.spaces.set(spaces); this.loading.set(false); },
-      error: () => this.loading.set(false),
-    });
-    this.networksApi.listNetworks().subscribe({
-      next: ({ networks }) => this.networks.set(networks),
-      error: () => {},
-    });
-  }
 
-  onSpaceDrop(event: CdkDragDrop<Space[]>): void {
-    if (event.previousIndex === event.currentIndex) return;
-    const list = [...this.spaces()];
-    moveItemInArray(list, event.previousIndex, event.currentIndex);
-    this.spaces.set(list);
-    this.spacesApi.reorderSpaces(list.map(s => s.id)).subscribe({
-      next: ({ spaces }) => { this.spaces.set(spaces); },
-      error: () => this.load(),
-    });
-  }
 
-  networksForSpace(spaceId: string): Network[] {
-    return this.networks().filter(n => n.spaces.includes(spaceId));
-  }
 
   storageInfo(s: Space): { pct: number; label: string; cls: string } {
     const used = s.usageGiB ?? 0;
@@ -1022,21 +999,21 @@ export class SpacesComponent implements OnInit {
     ).subscribe({
       next: ({ space }) => {
         this.showCreateDialog.set(false);
-        this.spaces.update(list => [...list, space]);
+        this.store.spaces.update(list => [...list, space]);
         this.form = { label: '', id: '', maxGiB: null, purpose: SpacesComponent.DEFAULT_PURPOSE, validationMode: 'off', strictLinkage: false };
         this.proxyForSelected = [];
         this.proxyForAll = false;
         // Vector indexes finish building server-side (B1); poll so the "preparing
         // indexes" badge clears on its own when the space is ready.
-        if (space.indexStatus === 'building') this.pollIndexStatus();
+        if (space.indexStatus === 'building') this.store.pollIndexStatus();
       },
       error: (err) => {
         if (err instanceof TimeoutError) {
           // The server persists the space even if the response was slow — refetch so
           // it appears instead of silently vanishing, and show a soft note.
           this.createError.set(this.transloco.translate('spaces.error.createTimeout'));
-          this.load();
-          this.pollIndexStatus();
+          this.store.load();
+          this.store.pollIndexStatus();
         } else {
           this.createError.set(err.error?.error ?? this.transloco.translate('spaces.error.createFailed'));
         }
@@ -1044,21 +1021,6 @@ export class SpacesComponent implements OnInit {
     });
   }
 
-  /** Refetch the space list every few seconds while any space is still building its
-   *  vector indexes, so the "preparing indexes" badge clears without a manual reload.
-   *  Bounded so it always stops. */
-  private pollIndexStatus(attempt = 0): void {
-    if (attempt > 40) return; // ~2 min cap
-    setTimeout(() => {
-      this.spacesApi.listSpaces().subscribe({
-        next: ({ spaces }) => {
-          this.spaces.set(spaces);
-          if (spaces.some(s => s.indexStatus === 'building')) this.pollIndexStatus(attempt + 1);
-        },
-        error: () => {},
-      });
-    }, 3000);
-  }
 
   async saveDupeRules(): Promise<void> {
     const target = this.state.settingsSpace();
@@ -1095,7 +1057,7 @@ export class SpacesComponent implements OnInit {
         this.state.dupeSaved.set(true);
         // Reflect saved state back onto the space object.
         this.state.settingsSpace.set(space);
-        this.spaces.update(list => list.map(x => x.id === space.id ? space : x));
+        this.store.spaces.update(list => list.map(x => x.id === space.id ? space : x));
       },
       error: (e) => { this.state.dupeSaving.set(false); this.state.dupeError.set(e?.error?.error || this.transloco.translate('spaces.dupe.saveError')); },
     });
@@ -1113,7 +1075,7 @@ export class SpacesComponent implements OnInit {
     }).subscribe({
       next: ({ space }) => {
         this.state.settingsSaving.set(false);
-        this.spaces.update(list => list.map(s => s.id === space.id ? { ...s, ...space } : s));
+        this.store.applySpace(space);
         this.state.closeSettings();
       },
       error: (err) => { this.state.settingsSaving.set(false); this.state.settingsError.set(err.error?.error ?? this.transloco.translate('spaces.error.saveFailed')); },
@@ -1390,10 +1352,10 @@ export class SpacesComponent implements OnInit {
     this.spacesApi.renameSpace(target.id, newId).subscribe({
       next: ({ space }) => {
         this.state.dangerRenaming.set(false);
-        this.spaces.update(list => list.map(s => s.id === target.id ? space : s));
+        this.store.spaces.update(list => list.map(s => s.id === target.id ? space : s));
         this.state.settingsSpace.set(space);
         this.state.dangerRenameId = space.id;
-        this.networksApi.listNetworks().subscribe({ next: ({ networks }) => this.networks.set(networks), error: () => {} });
+        this.networksApi.listNetworks().subscribe({ next: ({ networks }) => this.store.networks.set(networks), error: () => {} });
       },
       error: (err) => { this.state.dangerRenaming.set(false); this.state.dangerRenameError.set(err.error?.error ?? this.transloco.translate('spaces.error.renameFailed')); },
     });
@@ -1446,7 +1408,7 @@ export class SpacesComponent implements OnInit {
     this.spacesApi.deleteSpace(target.id).subscribe({
       next: () => {
         this.state.dangerDeleting.set(false);
-        this.spaces.update(list => list.filter(s => s.id !== target.id));
+        this.store.spaces.update(list => list.filter(s => s.id !== target.id));
         this.state.closeSettings();
       },
       error: (err) => { this.state.dangerDeleting.set(false); this.state.dangerDeleteError.set(err.error?.error ?? this.transloco.translate('spaces.error.deleteFailed')); },
@@ -1462,7 +1424,7 @@ export class SpacesComponent implements OnInit {
     });
     if (!ok) return;
     this.networksApi.leaveNetwork(networkId).subscribe({
-      next: () => this.networksApi.listNetworks().subscribe({ next: ({ networks }) => this.networks.set(networks), error: () => {} }),
+      next: () => this.store.refreshNetworks(),
       error: () => this.toast.error(this.transloco.translate('spaces.error.leaveNetworkFailed')),
     });
   }


### PR DESCRIPTION
You asked for the more future-proof option — and neither of the two I offered was it. Outputs **(a)** paper over the real problem; lifting everything into one service **(b)** blurs it further.

## The actual problem: two kinds of state were tangled

| Owner | What | Lifetime |
|---|---|---|
| **`SpacesStore`** (new) | server data — spaces, networks, and their mutations | shared by the list *and* every dialog; outlives all of them |
| **`SpaceSettingsState`** (#238) | ephemeral form state | dies when the dialog closes |

The old component owned both, which is *why* the tabs seemed to need outputs.

**The payoff:** the settings tabs mutate the list by **calling the store**, so the child components extracted next need **no `@Output()` plumbing**, and no component owns data that outlives it. It's also the same signal-store shape **the audit already prescribes for `brain.component` (A17.9)** — proven here on the smaller page first, which is the order the audit explicitly asks for.

## Performance

The list template called `networksForSpace(id)` — a full `networks().filter(...)` — **twice per row** (once for `.length`, once for the `@for`), **on every change-detection pass**. Each call allocated a fresh array whose changing identity **also defeated `@for` tracking**, so rows were re-created every pass rather than tracked.

Now a `networksBySpace` computed index: built once per `networks()` change, **O(1) per row, stable identity**. Rendering N rows against M networks goes from `O(N·M·2)` per CD pass to `O(1)` per row.

A test asserts two reads return the **same instance** — because that identity is the property `@for` depends on. Assert the reason, not just the values.

## Recorded, not dropped: OnPush

`SpacesComponent` is the **only major page not using OnPush** (`brain`, `file-manager`, `graph`, `audit-log` all do). I did **not** flip it here, because it isn't safe as-is:

- `FileReader.onload` in `onImportSchemaFile`/`onImportTypeSchemaFile` mutates **plain fields** (`schImportError`, `state.schTypeSchemas`) with **no signal write in the same turn** → under OnPush the import result would silently not render.
- (`createSpace`'s reset of `form`/`proxyFor*` *is* safe — it writes `showCreateDialog`, a signal the template reads, in the same callback, which marks the view dirty.)

Converting those is easy per small child and painful as a retrofit on a 1600-line parent — so it lands **with** the component extraction, tracked as **A17.8 8b-2b** with the hazards named in `ARCHITECTURE-TODO`.

## Testing

- `spaces.component.ts`: 1616 → **1578**
- Client suite: **109 → 121**, all green (16 files); build clean
- The **36 characterization assertions from #237 still hold, unedited**, through a data-ownership change
- Docs checked — no doc references these internals

🤖 Generated with [Claude Code](https://claude.com/claude-code)