### PR TITLE
test(client): characterization tests for BrainComponent's derived state (A17.9a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Characterization tests for `BrainComponent`'s derived list state (18 tests), landed before the
+  A17.9 split.** The flagship 3701-line component has only 9 tests, and they cover rendering (OnPush,
+  the record drawer, the network indicator) — none touch the pure derived state, which is exactly
+  what the split relocates when the eight tab-views become child components. These pin the four
+  `filtered*` computeds, the `*TagSuggestions` union (space schema suggestions ∪ tags present on
+  loaded records, deduped), and `*TypeOptions` (schema names ∪ values present, deduped and sorted).
+  Two behaviours worth naming, because both are the kind a split quietly "tidies away": searching in
+  **semantic mode bypasses the client-side filter entirely** (the server already ranked those
+  results), and **files have no such bypass** — there is no `fileMetaSearchMode` at all, so file
+  search always filters. That asymmetry is now asserted rather than folded into one shape by
+  accident. Verified green against the unmodified component *and* verified to fail when the semantic
+  bypass is deliberately removed — a characterization test that cannot fail is worthless. Client
+  suite: 127 → 145.
+
 - **Characterization tests for the settings `SpacesComponent` (36 tests), landed before it is split.**
   The 1893-line component had **no test coverage at all**, and the client suite as a whole (71 tests)
   is far thinner than the server's — the AOT build proves a component compiles, not that it still

--- a/client/src/app/pages/brain/brain.component.filters.spec.ts
+++ b/client/src/app/pages/brain/brain.component.filters.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * BrainComponent — CHARACTERIZATION tests for the derived list state.
+ *
+ * Written against the unmodified 3701-line component BEFORE the A17.9 split, and landed as their own
+ * PR. A characterization test only means anything if it was green against the ORIGINAL code; written
+ * during a refactor it just proves the new code agrees with itself.
+ *
+ * The existing brain.component.spec.ts covers rendering (OnPush, the drawer, the network indicator).
+ * It does not touch the pure derived state below — which is precisely what A17.9 relocates when the
+ * eight tab-views become child components over a shared BrainState. So this pins:
+ *
+ *   - the four `filtered*` computeds, including the semantic-mode BYPASS (searching in semantic mode
+ *     returns the list untouched) and the fact that files have NO such bypass — an asymmetry that is
+ *     easy to "tidy away" during a split
+ *   - which fields each search actually looks at (they differ per collection)
+ *   - the `*TagSuggestions` union of schema suggestions + tags present on loaded records
+ *   - `*TypeOptions`: schema names UNION values present, deduped and SORTED
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect } from 'vitest';
+import { of } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import type { ChronoEntry, Edge, Entity, FileMeta, Memory, SpaceMetaResponse } from '../../core/api.types';
+import { SpacesApi } from '../../core/spaces-api.service';
+import { BrainApi } from '../../core/brain-api.service';
+import { FilesApi } from '../../core/files-api.service';
+import { AuthService } from '../../core/auth.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainComponent } from './brain.component';
+
+const mem = (fact: string, over: Partial<Memory> = {}): Memory =>
+  ({ _id: fact, fact, tags: [], createdAt: '', seq: 1, ...over } as Memory);
+const ent = (name: string, over: Partial<Entity> = {}): Entity =>
+  ({ _id: name, name, tags: [], createdAt: '', ...over } as Entity);
+const edge = (label: string, over: Partial<Edge> = {}): Edge =>
+  ({ _id: label, from: 'a', to: 'b', label, tags: [], createdAt: '', ...over } as Edge);
+const chrono = (title: string, over: Partial<ChronoEntry> = {}): ChronoEntry =>
+  ({ _id: title, title, type: 'event', tags: [], entityIds: [], memoryIds: [], startsAt: '', status: 'upcoming', ...over } as ChronoEntry);
+const fileMeta = (path: string, over: Partial<FileMeta> = {}): FileMeta =>
+  ({ _id: path, path, tags: [], sizeBytes: 0, spaceId: 'work', createdAt: '', updatedAt: '', ...over } as FileMeta);
+
+function makeApi() {
+  return {
+    listSpaces: () => of({ spaces: [{ id: 'work', label: 'Work' }] }),
+    getSpaceStats: () => of({ memories: 0, entities: 0, edges: 0, chrono: 0, files: 0 }),
+    getReindexStatus: () => of({ needsReindex: false }),
+    getSpaceMeta: () => of({ tagSuggestions: [], typeSchemas: {} }),
+    listMemories: () => of({ memories: [] }),
+    getEntitiesByIds: () => of({ entities: [] }),
+    listFileMeta: () => of({ files: [] }),
+  } as any;
+}
+
+function create() {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [BrainComponent, getTranslocoModule()],
+    providers: [
+      { provide: SpacesApi, useValue: makeApi() },
+      { provide: BrainApi, useValue: makeApi() },
+      { provide: FilesApi, useValue: makeApi() },
+      { provide: AuthService, useValue: { token: () => '' } },
+      { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+    ],
+  });
+  const fixture = TestBed.createComponent(BrainComponent);
+  fixture.detectChanges();
+  return fixture.componentInstance;
+}
+
+describe('BrainComponent — filteredMemories', () => {
+  it('no query returns everything', () => {
+    const c = create();
+    c.memories.set([mem('a'), mem('b')]);
+    expect(c.filteredMemories()).toHaveLength(2);
+  });
+
+  it('filters on fact, case-insensitively', () => {
+    const c = create();
+    c.memories.set([mem('the sky is blue'), mem('water is wet')]);
+    c.memorySearch.set('SKY');
+    expect(c.filteredMemories().map(m => m.fact)).toEqual(['the sky is blue']);
+  });
+
+  it('a whitespace-only query is not a filter', () => {
+    const c = create();
+    c.memories.set([mem('a'), mem('b')]);
+    c.memorySearch.set('   ');
+    expect(c.filteredMemories()).toHaveLength(2);
+  });
+
+  it('SEMANTIC mode bypasses the text filter entirely — the server already ranked these', () => {
+    const c = create();
+    c.memories.set([mem('the sky is blue'), mem('water is wet')]);
+    c.memorySearch.set('sky');
+    c.memorySearchMode.set('semantic');
+    expect(c.filteredMemories()).toHaveLength(2);
+  });
+});
+
+describe('BrainComponent — filteredChrono', () => {
+  it('searches title, description, type AND tags', () => {
+    const c = create();
+    c.chrono.set([
+      chrono('launch', { description: 'ship it' }),
+      chrono('review', { type: 'deadline' } as Partial<ChronoEntry>),
+      chrono('retro', { tags: ['team'] }),
+      chrono('unrelated'),
+    ]);
+    const found = (q: string) => { c.chronoSearch.set(q); return c.filteredChrono().map(e => e.title); };
+    expect(found('launch')).toEqual(['launch']);   // title
+    expect(found('ship')).toEqual(['launch']);     // description
+    expect(found('deadline')).toEqual(['review']); // type
+    expect(found('team')).toEqual(['retro']);      // tag
+  });
+
+  it('SEMANTIC mode bypasses the text filter', () => {
+    const c = create();
+    c.chrono.set([chrono('launch'), chrono('review')]);
+    c.chronoSearch.set('launch');
+    c.chronoSearchMode.set('semantic');
+    expect(c.filteredChrono()).toHaveLength(2);
+  });
+});
+
+describe('BrainComponent — filteredEdges', () => {
+  it('searches label, fromName and toName', () => {
+    const c = create();
+    c.edges.set([
+      edge('owns', { fromName: 'alice', toName: 'car' }),
+      edge('knows', { fromName: 'bob', toName: 'carol' }),
+    ]);
+    const found = (q: string) => { c.edgeSearch.set(q); return c.filteredEdges().map(e => e.label); };
+    expect(found('owns')).toEqual(['owns']);    // label
+    expect(found('alice')).toEqual(['owns']);   // fromName
+    expect(found('carol')).toEqual(['knows']);  // toName
+  });
+
+  it('an edge with no fromName/toName does not throw', () => {
+    const c = create();
+    c.edges.set([edge('owns')]);
+    c.edgeSearch.set('zzz');
+    expect(c.filteredEdges()).toEqual([]);
+  });
+
+  it('SEMANTIC mode bypasses the text filter', () => {
+    const c = create();
+    c.edges.set([edge('owns'), edge('knows')]);
+    c.edgeSearch.set('owns');
+    c.edgeSearchMode.set('semantic');
+    expect(c.filteredEdges()).toHaveLength(2);
+  });
+});
+
+describe('BrainComponent — filteredFileMetas', () => {
+  it('searches path, description and tags', () => {
+    const c = create();
+    c.fileMetas.set([
+      fileMeta('docs/readme.md', { description: 'intro' }),
+      fileMeta('src/main.ts', { tags: ['code'] }),
+    ]);
+    const found = (q: string) => { c.fileMetaSearch.set(q); return c.filteredFileMetas().map(f => f.path); };
+    expect(found('readme')).toEqual(['docs/readme.md']); // path
+    expect(found('intro')).toEqual(['docs/readme.md']);  // description
+    expect(found('code')).toEqual(['src/main.ts']);      // tag
+  });
+
+  it('files have NO semantic bypass — unlike memories/chrono/edges, the filter always applies', () => {
+    // Deliberate asymmetry in the original: there is no fileMetaSearchMode at all. Pinned so a split
+    // does not "tidy" the four filters into one shape and silently change file search.
+    const c = create();
+    c.fileMetas.set([fileMeta('a.md'), fileMeta('b.md')]);
+    c.fileMetaSearch.set('a.md');
+    expect(c.filteredFileMetas().map(f => f.path)).toEqual(['a.md']);
+    expect('fileMetaSearchMode' in c).toBe(false);
+  });
+});
+
+describe('BrainComponent — tag suggestions', () => {
+  const meta = (tagSuggestions: string[]) => ({ tagSuggestions, typeSchemas: {} } as unknown as SpaceMetaResponse);
+
+  it('unions the space schema suggestions with tags present on loaded records, deduped', () => {
+    const c = create();
+    c.spaceMeta.set(meta(['schema-tag', 'shared']));
+    c.memories.set([mem('a', { tags: ['shared', 'from-record'] })]);
+    expect(c.memoryTagSuggestions()).toEqual(['schema-tag', 'shared', 'from-record']);
+  });
+
+  it('works with no schema suggestions at all', () => {
+    const c = create();
+    c.spaceMeta.set(null);
+    c.entities.set([ent('x', { tags: ['only-record'] })]);
+    expect(c.entityTagSuggestions()).toEqual(['only-record']);
+  });
+
+  it('each collection draws from its OWN records', () => {
+    const c = create();
+    c.spaceMeta.set(meta([]));
+    c.edges.set([edge('e', { tags: ['edge-tag'] })]);
+    c.chrono.set([chrono('c', { tags: ['chrono-tag'] })]);
+    expect(c.edgeTagSuggestions()).toEqual(['edge-tag']);
+    expect(c.chronoTagSuggestions()).toEqual(['chrono-tag']);
+  });
+});
+
+describe('BrainComponent — type options for the filter bar', () => {
+  it('unions schema type names with the types actually present, deduped and sorted', () => {
+    const c = create();
+    c.spaceMeta.set({ typeSchemas: { memory: { note: {}, decision: {} } } } as unknown as SpaceMetaResponse);
+    c.memories.set([mem('a', { type: 'observation' }), mem('b', { type: 'note' })]);
+    expect(c.memoryTypeOptions()).toEqual(['decision', 'note', 'observation']);
+  });
+
+  it('records with no type contribute nothing', () => {
+    const c = create();
+    c.spaceMeta.set({ typeSchemas: { memory: { note: {} } } } as unknown as SpaceMetaResponse);
+    c.memories.set([mem('a')]);
+    expect(c.memoryTypeOptions()).toEqual(['note']);
+  });
+
+  it('edge types are not schema-backed — options come only from the loaded list', () => {
+    const c = create();
+    c.spaceMeta.set({ typeSchemas: { edge: { knows: {} } } } as unknown as SpaceMetaResponse);
+    c.edges.set([edge('x', { type: 'runtime-type' })]);
+    expect(c.edgeTypeOptions()).toEqual(['runtime-type']);
+  });
+
+  it('with no schema and no records the options are empty', () => {
+    const c = create();
+    c.spaceMeta.set(null);
+    expect(c.memoryTypeOptions()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Net first, as its own PR. **`brain.component.ts` is untouched here.**

## The gap

The flagship monolith is **3701 lines with 9 tests**, and all 9 are rendering-focused (OnPush, the record drawer, the network indicator). **None touch the pure derived state** — which is exactly what A17.9 relocates when the eight tab-views become child components over a shared `BrainState`.

## What's pinned

- the four `filtered*` computeds, and **which fields each search actually reads** — they differ per collection: memories=`fact`; chrono=`title`/`description`/`type`/`tags`; edges=`label`/`fromName`/`toName`; files=`path`/`description`/`tags`
- `*TagSuggestions` — the union of space schema suggestions + tags present on loaded records, deduped, per collection
- `*TypeOptions` — schema names ∪ values present, deduped and **sorted**; edge types aren't schema-backed so they come only from the loaded list

## The two that matter

Both are exactly what a split quietly tidies away:

1. **Semantic mode bypasses the client-side filter entirely** — the server already ranked those results, so re-filtering them client-side would drop hits.
2. **Files have no such bypass.** There is no `fileMetaSearchMode` at all — file search always filters.

Four filters that *look* like they should share one shape, and one deliberately doesn't. That was folklore; now it's asserted.

## Verified both directions

A test that can't fail is worthless:

- ✅ **18/18 green against the unmodified component**
- ✅ **red on exactly the semantic-bypass test** — and nothing else — when that bypass is deliberately removed from `filteredMemories`:
  ```
  × BrainComponent — filteredMemories > SEMANTIC mode bypasses the text filter entirely
  ```
  Restored → green again.

## Testing

- Client suite: **127 → 145**, all green (19 files); build clean
- Docs checked — tests only, no behavior change

Next: A17.9b — the split itself, using the `BrainStore`/state pattern the audit prescribed and the spaces page just proved (1893 → 262, no data outputs, children OnPush from birth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)