### PR TITLE
refactor(client): extract the Memories tab into a self-loading OnPush component (A17.9b-6d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Memories tab is now its own self-loading OnPush component (`memories-tab.component`), the first
+  record tab out of the shell.** It owns the memory create form, the inline edit, delete, and its own
+  search / type-tag filter / pagination + list loader; it reads records and derived views from
+  `BrainStore`, shares the singleton load/edit/delete interaction with the shell via `RecordListState`,
+  uses `EntityRefPicker` for entity chips and `RecordDrawerState` to open the detail drawer. The shell
+  renders it behind `@if (activeTab() === 'memories')`, so it is created on activation and destroyed on
+  switch; an `effect` on its `spaceId` input loads on creation and reloads on a space switch while
+  mounted (replacing the shell's `loadCurrentTab` dispatch for this tab, which now early-returns for it).
+  Create/delete emit a `mutated` output so the shell refreshes the tab-count stats — the one legitimate
+  output, since tab counts are parent view-state. The brain-scoped record-table CSS (search header,
+  create form, filter chips, inline confirm, description cell) moved to a shared `brain-table.styles.ts`
+  the tab components import (the table/pagination/empty-state styles are global). The A17.9b-6b memories
+  characterization cases + the two memories-table rendering tests relocated to
+  `memories-tab.component.spec.ts`, plus new self-load and `mutated` assertions. `brain.component.ts`
+  2416 → 2070. Client suite: 188 → 190.
+
 - **The record tabs' shared interaction state moved into a `RecordListState` service — the keystone
   before the five record tabs become their own components.** `loading`, `loadError`, `editingId`,
   `editSaving`, `editError`, and `confirmDeleteId` are singleton by nature (only one record is loading,

--- a/client/src/app/pages/brain/brain-table.styles.ts
+++ b/client/src/app/pages/brain/brain-table.styles.ts
@@ -1,0 +1,113 @@
+/**
+ * Brain-scoped styles shared by the record tabs' list views (memories/entities/edges/chrono/filemeta)
+ * — the search/filter header, the create form, the filter chips, the inline delete confirm, and the
+ * clamped description cell. Extracted alongside the first tab component (A17.9b-6d); each tab component
+ * imports this so its Emulated-encapsulated view keeps the same look. The table/pagination/empty-state/
+ * tag styles are GLOBAL (styles.scss), so they are not duplicated here.
+ *
+ * The shell still carries its own copies inline while the remaining tabs live there; once all five tabs
+ * are components the shell's copies become dead and get removed in a final cleanup.
+ */
+export const BRAIN_RECORD_TABLE_STYLES = `
+    .content-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    .content-header input[type=search] {
+      flex: 1;
+      min-width: 180px;
+      max-width: 400px;
+      padding: 5px 10px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      background: var(--bg-surface);
+      color: var(--text-primary);
+    }
+    .content-header app-entity-search {
+      flex: 1;
+      min-width: 180px;
+      max-width: 520px;
+    }
+    .list-filter-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-bottom: 12px;
+    }
+    .filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 3px 8px;
+      border-radius: 10px;
+      background: var(--accent-dim);
+      border: 1px solid var(--accent);
+      color: var(--accent);
+      font-size: 11px;
+      font-weight: 500;
+    }
+    .filter-chip button {
+      background: none;
+      border: none;
+      color: var(--accent);
+      cursor: pointer;
+      font-size: 14px;
+      line-height: 1;
+      padding: 0 2px;
+    }
+    .tag-clickable, .entity-clickable {
+      cursor: pointer;
+      transition: opacity var(--transition);
+    }
+    .tag-clickable:hover, .entity-clickable:hover { opacity: 0.7; }
+    .create-form {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      background: var(--bg-surface);
+      margin-bottom: 12px;
+    }
+    .create-form .field { margin-bottom: 0; }
+    .create-form label { font-size: 11px; color: var(--text-muted); display: block; margin-bottom: 2px; }
+    .create-form input, .create-form textarea {
+      padding: 5px 8px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+    }
+    .create-form textarea { resize: vertical; }
+    .inline-confirm {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: var(--error);
+    }
+    .inline-confirm button { font-size: 11px; }
+    .desc-cell {
+      font-size: 12px;
+      color: var(--text-muted);
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .pill-group { display:flex; border:1px solid var(--border); border-radius:var(--radius-sm); overflow:hidden; flex-shrink:0; }
+    .pill-group button { padding:5px 10px; font-size:11px; background:transparent; border:none; border-right:1px solid var(--border); color:var(--text-secondary); cursor:pointer; white-space:nowrap; }
+    .pill-group button:last-child { border-right:none; }
+    .pill-group button.active { background:var(--accent-dim); color:var(--accent); }
+    .pill-group button:hover:not(.active) { background:var(--bg-surface); }
+`;

--- a/client/src/app/pages/brain/brain.component.records.spec.ts
+++ b/client/src/app/pages/brain/brain.component.records.spec.ts
@@ -79,27 +79,6 @@ function make() {
 beforeEach(() => { for (const fn of [...Object.values(api), ...Object.values(filesApi)]) (fn as any).mockClear(); });
 
 describe('BrainComponent — create payloads', () => {
-  it('createMemory sends fact + only the non-empty optional fields (properties raw, not stripped)', () => {
-    const c = make();
-    c.memoryForm = { fact: '  a fact  ', tags: ['t'], entityIds: 'e1, , e2', description: ' d ', properties: { k: 'v' } };
-    c.createMemory();
-    expect(api.createMemory).toHaveBeenCalledWith('work', {
-      fact: 'a fact', tags: ['t'], entityIds: ['e1', 'e2'], description: 'd', properties: { k: 'v' },
-    });
-  });
-
-  it('createMemory omits empty optionals and is a no-op when fact is blank', () => {
-    const c = make();
-    c.memoryForm = { fact: 'x', tags: [], entityIds: '', description: '', properties: {} };
-    c.createMemory();
-    expect(api.createMemory).toHaveBeenCalledWith('work', { fact: 'x' });
-
-    api.createMemory.mockClear();
-    c.memoryForm = { fact: '   ', tags: [], entityIds: '', description: '', properties: {} };
-    c.createMemory();
-    expect(api.createMemory).not.toHaveBeenCalled();
-  });
-
   it('createEntity strips empty optional props via the schema (unlike memory)', () => {
     const c = make();
     c.store.spaceMeta.set({ typeSchemas: { entity: { Person: { propertySchemas: { note: { required: false } } } } } } as any);
@@ -129,19 +108,6 @@ describe('BrainComponent — create payloads', () => {
 });
 
 describe('BrainComponent — inline edit', () => {
-  it('saveEditMemory sends the full shape, clears editingId, and patches the store list in place', () => {
-    const c = make();
-    c.store.memories.set([{ _id: 'm1', fact: 'old' } as Memory]);
-    c.recordList.editingId.set('m1');
-    c.editMemory = { fact: ' new ', tags: ['t'], entityIds: 'e1', description: ' d ', properties: {} };
-    c.saveEditMemory('m1');
-    expect(api.updateMemory).toHaveBeenCalledWith('work', 'm1', {
-      fact: 'new', tags: ['t'], entityIds: ['e1'], description: 'd',
-    });
-    expect(c.recordList.editingId()).toBe('');
-    expect(c.store.memories()[0].fact).toBe('UPDATED');
-  });
-
   it('saveEditChrono uses editChrono.kind directly as type (NO __custom__ resolution)', () => {
     const c = make();
     c.store.chrono.set([{ _id: 'c1' } as ChronoEntry]);
@@ -153,18 +119,6 @@ describe('BrainComponent — inline edit', () => {
 });
 
 describe('BrainComponent — delete', () => {
-  it('deleteMemory removes from the store, clears confirmDeleteId, and refreshes stats', () => {
-    const c = make();
-    c.store.memories.set([{ _id: 'm1' } as Memory, { _id: 'm2' } as Memory]);
-    c.recordList.confirmDeleteId.set('m1');
-    api.getSpaceStats.mockClear();
-    c.deleteMemory('m1');
-    expect(api.deleteMemory).toHaveBeenCalledWith('work', 'm1');
-    expect(c.store.memories().map(m => m._id)).toEqual(['m2']);
-    expect(c.recordList.confirmDeleteId()).toBe('');
-    expect(api.getSpaceStats).toHaveBeenCalled(); // stats refresh
-  });
-
   it('deleteEdge removes from the store but does NOT refresh stats (asymmetry with memory/entity)', () => {
     const c = make();
     c.store.edges.set([{ _id: 'x1' } as Edge]);
@@ -183,31 +137,5 @@ describe('BrainComponent — delete', () => {
     expect(filesApi.deleteFileMeta).toHaveBeenCalledWith('work', '/docs/a.md');
     expect(c.store.fileMetas()).toEqual([]);
     expect(c.recordList.confirmDeleteId()).toBe('');
-  });
-});
-
-describe('BrainComponent — load, filter, pagination (memories tab)', () => {
-  it('the memories load sends page size + skip + the active tag/type/entity filter', () => {
-    const c = make();
-    c.activeTab.set('memories');
-    c.recordFilter.set({ type: 'note', tag: 'urgent' });
-    c.filterEntity.set('e9');
-    api.listMemories.mockClear();
-    c.prevPage(); // skip is already 0 → Math.max(0, -pageSize) === 0, reloads
-    expect(api.listMemories).toHaveBeenCalledWith('work', c.pageSize, 0, { tag: 'urgent', entity: 'e9', type: 'note' });
-  });
-
-  it('nextPage advances skip by pageSize and reloads; prevPage clamps at 0', () => {
-    const c = make();
-    c.activeTab.set('memories');
-    c.nextPage();
-    expect(c.skip()).toBe(c.pageSize);
-    c.nextPage();
-    expect(c.skip()).toBe(2 * c.pageSize);
-    c.prevPage();
-    expect(c.skip()).toBe(c.pageSize);
-    // clamp: from 0 it never goes negative
-    c.prevPage(); c.prevPage();
-    expect(c.skip()).toBe(0);
   });
 });

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -17,7 +17,7 @@ import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
-import { type Memory, type Entity } from '../../core/api.types';
+import { type Entity } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { BrainApi } from '../../core/brain-api.service';
 import { FilesApi } from '../../core/files-api.service';
@@ -25,17 +25,6 @@ import { AuthService } from '../../core/auth.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { BrainComponent } from './brain.component';
 
-function memory(fact: string, id = fact): Memory {
-  return {
-    _id: id,
-    fact,
-    tags: [],
-    entityIds: [],
-    properties: {},
-    createdAt: '2026-07-14T10:00:00.000Z',
-    seq: 1,
-  } as unknown as Memory;
-}
 
 /** Read-only stub: brain's init cascade is listSpaces → getSpaceStats/getReindexStatus/getSpaceMeta. */
 function makeApi() {
@@ -72,34 +61,8 @@ describe('BrainComponent (OnPush)', () => {
     expect(BrainComponent.ɵcmp?.onPush).toBe(true);
   });
 
-  it('renders a row per memory on the memories tab (signal-driven view updates under OnPush)', () => {
-    const fixture = create();
-    const c = fixture.componentInstance;
-
-    c.activeTab.set('memories');
-    c.store.memories.set([memory('the sky is blue'), memory('water is wet')]);
-    fixture.detectChanges();
-
-    const body = (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
-    expect(body).toContain('the sky is blue');
-    expect(body).toContain('water is wet');
-  });
-
-  it('re-renders the list when the memories signal is replaced', () => {
-    const fixture = create();
-    const c = fixture.componentInstance;
-    const body = () => (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
-
-    c.activeTab.set('memories');
-    c.store.memories.set([memory('first fact')]);
-    fixture.detectChanges();
-    expect(body()).toContain('first fact');
-
-    c.store.memories.set([memory('second fact')]);
-    fixture.detectChanges();
-    expect(body()).toContain('second fact');
-    expect(body()).not.toContain('first fact');
-  });
+  // The memories table rendering (row-per-memory, signal re-render) moved to
+  // memories-tab.component.spec.ts when that tab became its own component (A17.9b-6d).
 
   // The detail-drawer rendering tests (open + plain-model, multiline description) moved to
   // record-drawer.component.spec.ts when the drawer became its own component (A17.9b-5).

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -6,10 +6,11 @@ import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordDrawerComponent } from './record-drawer.component';
 import { QueryTabComponent } from './query-tab.component';
 import { RecordListState } from './record-list-state.service';
+import { MemoriesTabComponent } from './memories-tab.component';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { toLocalDatetime, fmtApiError } from './brain-format';
 import { FormsModule } from '@angular/forms';
-import { Space, SpaceStats, Memory, Entity, Edge, ChronoEntry, ChronoType, ChronoStatus, FileMeta } from '../../core/api.types';
+import { Space, SpaceStats, Entity, Edge, ChronoEntry, ChronoType, ChronoStatus, FileMeta } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { BrainApi } from '../../core/brain-api.service';
 import { FilesApi } from '../../core/files-api.service';
@@ -46,7 +47,7 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordDrawerComponent, QueryTabComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [BRAIN_CHIP_STYLES, `
     .space-tabs {
@@ -463,222 +464,7 @@ interface SpaceView {
         }
 
         <!-- Memories -->
-        @if (activeTab() === 'memories') {
-
-          <div class="content-header">
-            <input type="search"
-              [placeholder]="'brain.memories.searchPlaceholder' | transloco"
-              [value]="store.memorySearch()"
-              (input)="onMemorySearch($any($event.target).value)"
-              [attr.aria-label]="'brain.memories.searchPlaceholder' | transloco" />
-            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-              <button [class.active]="store.memorySearchMode() === 'text'" (click)="setMemorySearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
-              <button [class.active]="store.memorySearchMode() === 'semantic'" (click)="setMemorySearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
-            </div>
-            <button class="btn-primary btn btn-sm" (click)="openMemoryForm()" [disabled]="showMemoryForm()">{{ 'brain.memories.addButton' | transloco }}</button>
-          </div>
-
-          <!-- Add memory form -->
-          @if (showMemoryForm()) {
-            <form class="create-form" (ngSubmit)="createMemory()">
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'common.form.fact' | transloco }}</label>
-                <textarea [(ngModel)]="memoryForm.fact" name="fact" rows="2" required style="width:100%;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'common.form.tags' | transloco }}</label>
-                <app-tag-input [(value)]="memoryForm.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memFormTags" />
-              </div>
-              <div class="field" style="flex:1; min-width:140px;">
-                <label>{{ 'common.form.entities' | transloco }}</label>
-                <div class="flyout-wrap">
-                  <div class="entity-multi">
-                    @for (chip of picker.entityChips(memoryForm.entityIds); track chip.id) {
-                      <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(memoryForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                    }
-                    <button type="button" class="chip-add" (click)="picker.openFlyout('create-memory-entityIds', memoryForm)">{{ 'common.addMore' | transloco }}</button>
-                  </div>
-                  @if (picker.flyoutField() === 'create-memory-entityIds') {
-                    <div class="flyout-panel">
-                      <app-entity-search
-                        mode="picker"
-                        [spaceId]="activeSpaceId()"
-                        placeholder="common.searchEntitiesPlaceholder"
-
-                        (selected)="picker.pickEntity($event, memoryForm)"
-                      />
-                      <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                        <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                      </div>
-                    </div>
-                  }
-                </div>
-              </div>
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'common.form.description' | transloco }}</label>
-                <textarea [(ngModel)]="memoryForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:220px;">
-                <label>{{ 'common.form.properties' | transloco }}</label>
-                <app-properties-editor [schema]="store.memorySchema()" [required]="store.requiredProps(store.memorySchema())" [(value)]="memoryForm.properties" />
-              </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingMemory() || !memoryForm.fact.trim()">
-                @if (creatingMemory()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showMemoryForm.set(false)">{{ 'common.cancel' | transloco }}</button>
-            </form>
-          }
-
-          @if (createMemoryError()) {
-            <div class="alert alert-error" style="margin-bottom:12px;">{{ createMemoryError() }}</div>
-          }
-
-          <!-- Shared type/tag filter (F6). Tag-clicks in the table feed this bar too. -->
-          <div class="list-filter-row">
-            <app-record-filter-bar
-              [typeOptions]="store.memoryTypeOptions()"
-              [tagSuggestions]="store.memoryTagSuggestions()"
-              [value]="recordFilter()"
-              (filterChange)="onFilterChange($event)"
-            />
-            @if (filterEntity(); as ent) {
-              <span class="filter-chip">{{ 'brain.filter.entityPrefix' | transloco }} {{ ent }} <button [attr.aria-label]="'brain.filter.clearEntityAriaLabel' | transloco" (click)="clearFilter('entity')"><ph-icon name="x" [size]="12"/></button></span>
-            }
-          </div>
-
-          <div class="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>{{ 'brain.memories.table.fact' | transloco }}</th><th>{{ 'brain.memories.table.description' | transloco }}</th><th>{{ 'brain.memories.table.tags' | transloco }}</th><th>{{ 'brain.memories.table.entities' | transloco }}</th><th>{{ 'brain.memories.table.properties' | transloco }}</th><th>{{ 'brain.memories.table.created' | transloco }}</th><th></th>
-                </tr>
-              </thead>
-              <tbody>
-                @for (mem of store.filteredMemories(); track mem._id) {
-                  @if (recordList.editingId() === mem._id) {
-                    <tr>
-                      <td colspan="7">
-                        <div class="create-form" style="border:none; padding:8px 0;">
-                          <div class="field" style="flex:2; min-width:200px; margin-bottom:0;">
-                            <label>{{ 'common.form.fact' | transloco }}</label>
-                            <textarea [(ngModel)]="editMemory.fact" name="editFact" rows="2" style="width:100%;"></textarea>
-                          </div>
-                          <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
-                            <label>{{ 'common.form.description' | transloco }}</label>
-                            <textarea [(ngModel)]="editMemory.description" name="editDesc" rows="2" style="resize:vertical;"></textarea>
-                          </div>
-                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
-                            <label>{{ 'common.form.tags' | transloco }}</label>
-                            <app-tag-input [(value)]="editMemory.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memEditTags" />
-                          </div>
-                          <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
-                            <label>{{ 'common.form.entities' | transloco }}</label>
-                            <div class="flyout-wrap">
-                              <div class="entity-multi">
-                                @for (chip of picker.entityChips(editMemory.entityIds); track chip.id) {
-                                  <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editMemory, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                                }
-                                <button type="button" class="chip-add" (click)="picker.openFlyout('edit-memory-entityIds', editMemory)">{{ 'common.addMore' | transloco }}</button>
-                              </div>
-                              @if (picker.flyoutField() === 'edit-memory-entityIds') {
-                                <div class="flyout-panel">
-                                  <app-entity-search
-                                    mode="picker"
-                                    [spaceId]="activeSpaceId()"
-                                    placeholder="common.searchEntitiesPlaceholder"
-
-                                    (selected)="picker.pickEntity($event, editMemory)"
-                                  />
-                                  <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                                    <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                                  </div>
-                                </div>
-                              }
-                            </div>
-                          </div>
-                          <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
-                            <label>{{ 'common.form.properties' | transloco }}</label>
-                            <app-properties-editor
-                              [schema]="store.memorySchema()"
-                              [required]="store.requiredProps(store.memorySchema())"
-                              [(value)]="editMemory.properties"
-                            />
-                          </div>
-                          <div style="display:flex; gap:6px; align-items:flex-end;">
-                            <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditMemory(mem._id)">
-                              @if (recordList.editSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } {{ 'common.save' | transloco }}
-                            </button>
-                            <button class="btn btn-sm btn-secondary" (click)="recordList.cancelEdit()">{{ 'common.cancel' | transloco }}</button>
-                          </div>
-                          @if (recordList.editError()) { <div style="font-size:12px; color:var(--error);">{{ recordList.editError() }}</div> }
-                        </div>
-                      </td>
-                    </tr>
-                  } @else {
-                    <tr>
-                      <td style="max-width:300px; white-space:pre-wrap; word-break:break-word;">{{ mem.fact }}</td>
-                      <td class="desc-cell" style="max-width:180px;" [title]="mem.description ?? ''">
-                        {{ mem.description || '—' }}
-                      </td>
-                      <td style="font-size:11px;">
-                        @for (tag of (mem.tags ?? []); track tag) { <span class="tag tag-clickable" (click)="applyFilter('tag', tag)">{{ tag }}</span> }
-                        @if (!(mem.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
-                      </td>
-                      <td style="font-size:11px;">
-                        @if (mem.entityIds?.length) {
-                          <div class="chip-list">
-                            @for (id of mem.entityIds!; track id) {
-                              <span class="chip" [title]="id">{{ picker.entityNameCache()[id] || id.slice(0,8) + '…' }}</span>
-                            }
-                          </div>
-                        } @else { <span style="color:var(--text-muted)">—</span> }
-                      </td>
-                      <td><app-properties-view [properties]="mem.properties" [schema]="store.memorySchema()" /></td>
-                      <td style="color:var(--text-muted)">{{ mem.createdAt | date:'dd.MM.yyyy' }}</td>
-                      <td style="white-space:nowrap;">
-                        <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('memory', mem)"><ph-icon name="eye" [size]="16"/></button>
-                        @if (recordList.confirmDeleteId() === mem._id) {
-                          <span class="inline-confirm">
-                            {{ 'common.deleteConfirm' | transloco }}
-                            <button class="btn btn-sm btn-danger" (click)="deleteMemory(mem._id)">{{ 'common.yes' | transloco }}</button>
-                            <button class="btn btn-sm btn-secondary" (click)="cancelDelete()">{{ 'common.no' | transloco }}</button>
-                          </span>
-                        } @else {
-                          <button class="icon-btn danger" [attr.title]="'brain.memories.deleteTitle' | transloco" [attr.aria-label]="'brain.memories.deleteAriaLabel' | transloco" (click)="requestDelete(mem._id)"><ph-icon name="x" [size]="16"/></button>
-                        }
-                      </td>
-                    </tr>
-                  }
-                } @empty {
-                  <tr><td colspan="7">
-                    @if (recordList.loadError() !== null) {
-                      <app-error-state [message]="'brain.error.loadMemories' | transloco" [reason]="recordList.loadError() ?? ''" (retry)="retryCurrentTab()" />
-                    } @else {
-                    <div class="empty-state" style="padding:32px">
-                      <div class="empty-state-icon"><ph-icon name="brain" [size]="48"/></div>
-                      @if (store.memorySearch() && store.memories().length) {
-                        <h3>{{ 'common.noMatches' | transloco }}</h3>
-                        <p>{{ 'brain.memories.empty.noMatchQuery' | transloco: { query: store.memorySearch() } }}</p>
-                      } @else {
-                        <h3>{{ 'brain.memories.empty.title' | transloco }}</h3>
-                        <p>{{ 'brain.memories.empty.body' | transloco }}</p>
-                      }
-                    </div>
-                    }
-                  </td></tr>
-                }
-              </tbody>
-            </table>
-          </div>
-          @if (store.memorySearchMode() !== 'semantic') {
-            <div class="pagination">
-              <button class="btn btn-sm btn-secondary" [disabled]="skip() === 0" (click)="prevPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-              <span class="pager-info">{{ store.filteredMemories().length ? (skip() + 1) + '–' + (skip() + store.filteredMemories().length) : '–' }}</span>
-              <button class="btn btn-sm btn-secondary" [disabled]="store.memories().length < pageSize" (click)="nextPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
-            </div>
-          }
-        }
+        @if (activeTab() === 'memories') { <app-memories-tab [spaceId]="activeSpaceId()" (mutated)="loadStats(activeSpaceId())" /> }
 
         <!-- Entities -->
         @if (activeTab() === 'entities') {
@@ -1572,7 +1358,6 @@ export class BrainComponent implements OnInit {
   // Entities pagination + search
   entitySkip = signal(0);
   entitySearch = signal('');
-  private _memSemTimer: ReturnType<typeof setTimeout> | null = null;
   private _edgeSemTimer: ReturnType<typeof setTimeout> | null = null;
   private _chronoSemTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -1587,16 +1372,9 @@ export class BrainComponent implements OnInit {
   reindexing = signal(false);
   reindexResult = signal('');
 
-  editMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   editEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   editEdge = { from: '', to: '', fromName: undefined as string | undefined, toName: undefined as string | undefined, label: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '' };
-
-  // Create memory form
-  showMemoryForm = signal(false);
-  creatingMemory = signal(false);
-  createMemoryError = signal('');
-  memoryForm = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
 
   // Create entity form
   showEntityForm = signal(false);
@@ -1695,9 +1473,6 @@ export class BrainComponent implements OnInit {
     this.loadCurrentTab(this.activeSpaceId());
   }
 
-  prevPage(): void { this.skip.update(s => Math.max(0, s - this.pageSize)); this.loadCurrentTab(this.activeSpaceId()); }
-  nextPage(): void { this.skip.update(s => s + this.pageSize); this.loadCurrentTab(this.activeSpaceId()); }
-
   prevEntityPage(): void { this.entitySkip.update(s => Math.max(0, s - this.pageSize)); this.loadCurrentTab(this.activeSpaceId()); }
   nextEntityPage(): void { this.entitySkip.update(s => s + this.pageSize); this.loadCurrentTab(this.activeSpaceId()); }
 
@@ -1744,43 +1519,6 @@ export class BrainComponent implements OnInit {
     this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
       next: ({ entities }) => this.store.entities.set(entities),
       error: () => {},
-    });
-  }
-
-  // ── Memory / Edge / Chrono search with mode toggle ─────────────────────────
-  onMemorySearch(q: string): void {
-    this.store.memorySearch.set(q);
-    if (this.store.memorySearchMode() === 'semantic') {
-      if (this._memSemTimer) clearTimeout(this._memSemTimer);
-      if (!q.trim()) { this.store.memories.set([]); return; }
-      this._memSemTimer = setTimeout(() => this.runSemanticMemorySearch(), 300);
-    }
-  }
-  setMemorySearchMode(m: 'text' | 'semantic'): void {
-    this.store.memorySearchMode.set(m);
-    const q = this.store.memorySearch().trim();
-    if (!q) return;
-    if (m === 'semantic') this.runSemanticMemorySearch();
-    else { this.skip.set(0); this.loadCurrentTab(this.activeSpaceId()); }
-  }
-  runSemanticMemorySearch(): void {
-    const q = this.store.memorySearch().trim();
-    const spaceId = this.activeSpaceId();
-    if (!q || !spaceId) { this.store.memories.set([]); return; }
-    this.brainApi.recallBrain(spaceId, { query: q, types: ['memory'], topK: 20 }).pipe(
-      catchError(() => of({ results: [], count: 0 })),
-    ).subscribe(res => {
-      this.store.memories.set(res.results.filter(r => r.type === 'memory').map(r => ({
-        _id: r['_id'] as string,
-        fact: (r['fact'] as string) ?? '',
-        tags: (r['tags'] as string[]) ?? [],
-        entityIds: (r['entityIds'] as string[]) ?? [],
-        description: r['description'] as string | undefined,
-        properties: (r['properties'] as Record<string, string | number | boolean>) ?? {},
-        createdAt: (r['createdAt'] as string) ?? '',
-        seq: (r['seq'] as number) ?? 0,
-        author: r['author'] as { instanceId: string } | undefined,
-      } as Memory)));
     });
   }
 
@@ -1891,26 +1629,11 @@ export class BrainComponent implements OnInit {
 
   private loadCurrentTab(spaceId: string): void {
     if (!spaceId) return;
+    if (this.activeTab() === 'memories') return; // self-loading component
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
 
     switch (this.activeTab()) {
-      case 'memories': {
-        const filters: { tag?: string; entity?: string; type?: string } = {};
-        if (this.recordFilter().tag) filters.tag = this.recordFilter().tag;
-        if (this.filterEntity()) filters.entity = this.filterEntity();
-        if (this.recordFilter().type) filters.type = this.recordFilter().type;
-        this.brainApi.listMemories(spaceId, this.pageSize, this.skip(), filters).subscribe({
-          next: ({ memories }) => {
-            this.store.memories.set(memories);
-            const ids = [...new Set(memories.flatMap(m => m.entityIds ?? []))];
-            if (ids.length) this.picker.resolveEntityNames(ids);
-            this.recordList.loading.set(false);
-          },
-          error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
-        });
-        break;
-      }
       case 'entities': {
         const ef: { search?: string; type?: string; tag?: string } = {};
         if (this.entitySearch()) ef.search = this.entitySearch();
@@ -2000,20 +1723,6 @@ export class BrainComponent implements OnInit {
   requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
   cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
-  // ── Inline edit methods ────────────────────────────────────────────────
-
-  startEditMemory(mem: Memory): void {
-    this.recordList.editingId.set(mem._id);
-    this.recordList.editError.set('');
-    this.editMemory = {
-      fact: mem.fact,
-      tags: mem.tags ?? [],
-      entityIds: (mem.entityIds ?? []).join(', '),
-      description: mem.description ?? '',
-      properties: this.store.buildPropertiesObject('memory', mem.properties ?? {}),
-    };
-  }
-
   startEditEntity(ent: Entity): void {
     this.recordList.editingId.set(ent._id);
     this.recordList.editError.set('');
@@ -2055,26 +1764,6 @@ export class BrainComponent implements OnInit {
       tags: entry.tags ?? [],
       entityIds: (entry.entityIds ?? []).join(', '),
     };
-  }
-
-  saveEditMemory(id: string): void {
-    this.recordList.editSaving.set(true);
-    this.recordList.editError.set('');
-    const memProps = this.editMemory.properties;
-    this.brainApi.updateMemory(this.activeSpaceId(), id, {
-      fact: this.editMemory.fact.trim(),
-      tags: this.editMemory.tags,
-      entityIds: this.editMemory.entityIds.split(',').map(s => s.trim()).filter(Boolean),
-      description: this.editMemory.description.trim(),
-      ...(Object.keys(memProps).length ? { properties: memProps } : {}),
-    }).subscribe({
-      next: (updated) => {
-        this.recordList.editSaving.set(false);
-        this.recordList.editingId.set('');
-        this.store.memories.update(list => list.map(m => m._id === id ? updated : m));
-      },
-      error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
-    });
   }
 
   saveEditEntity(id: string): void {
@@ -2136,14 +1825,6 @@ export class BrainComponent implements OnInit {
         this.store.chrono.update(list => list.map(c => c._id === id ? updated : c));
       },
       error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
-    });
-  }
-
-  deleteMemory(id: string): void {
-    this.recordList.confirmDeleteId.set('');
-    this.brainApi.deleteMemory(this.activeSpaceId(), id).subscribe({
-      next: () => { this.store.memories.update(list => list.filter(m => m._id !== id)); this.loadStats(this.activeSpaceId()); },
-      error: () => {},
     });
   }
 
@@ -2214,28 +1895,6 @@ export class BrainComponent implements OnInit {
     const dir = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) || '/' : '/';
     this.fileManagerNavPath.set(dir === '/' ? '' : dir);
     this.setTab('files');
-  }
-
-  createMemory(): void {
-    if (!this.memoryForm.fact.trim()) return;
-    this.creatingMemory.set(true);
-    this.createMemoryError.set('');
-    const entityIds = this.memoryForm.entityIds.split(',').map(s => s.trim()).filter(Boolean);
-    const body: Parameters<BrainApi['createMemory']>[1] = { fact: this.memoryForm.fact.trim() };
-    if (this.memoryForm.tags.length) body.tags = this.memoryForm.tags;
-    if (entityIds.length) body.entityIds = entityIds;
-    if (this.memoryForm.description.trim()) body.description = this.memoryForm.description.trim();
-    if (Object.keys(this.memoryForm.properties).length) body.properties = this.memoryForm.properties;
-    this.brainApi.createMemory(this.activeSpaceId(), body).subscribe({
-      next: () => {
-        this.creatingMemory.set(false);
-        this.showMemoryForm.set(false);
-        this.memoryForm = { fact: '', tags: [], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
-        this.loadStats(this.activeSpaceId());
-        this.loadCurrentTab(this.activeSpaceId());
-      },
-      error: (err) => { this.creatingMemory.set(false); this.createMemoryError.set(fmtApiError(err, 'Failed to create memory')); },
-    });
   }
 
   createEntity(): void {
@@ -2386,11 +2045,6 @@ export class BrainComponent implements OnInit {
     const firstLabel = Object.keys(this.store.spaceMeta()?.typeSchemas?.edge ?? {})[0] ?? '';
     this.edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: firstLabel, weight: null, tags: [], description: '', properties: this.store.buildPropertiesObject('edge', {}, firstLabel) };
     this.showEdgeForm.set(true);
-  }
-
-  openMemoryForm(): void {
-    this.memoryForm = { fact: '', tags: [], entityIds: '', description: '', properties: this.store.buildPropertiesObject('memory') };
-    this.showMemoryForm.set(true);
   }
 
   openChronoForm(): void {

--- a/client/src/app/pages/brain/memories-tab.component.spec.ts
+++ b/client/src/app/pages/brain/memories-tab.component.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * MemoriesTabComponent — the memories create/edit/delete/load behaviour, relocated here from
+ * brain.component.records.spec.ts (A17.9b-6b) when the tab became its own component (A17.9b-6d), plus
+ * the new self-loading + `mutated` output wiring the split introduced.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import type { Memory } from '../../core/api.types';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainApi } from '../../core/brain-api.service';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+import { RecordListState } from './record-list-state.service';
+import { MemoriesTabComponent } from './memories-tab.component';
+
+const api = {
+  listMemories: vi.fn(() => of({ memories: [] as Memory[] })),
+  getEntitiesByIds: vi.fn(() => of({ entities: [] })),
+  createMemory: vi.fn(() => of({ _id: 'new' } as Memory)),
+  updateMemory: vi.fn((_s: string, id: string) => of({ _id: id, fact: 'UPDATED' } as Memory)),
+  deleteMemory: vi.fn(() => of({})),
+  recallBrain: vi.fn(() => of({ results: [], count: 0 })),
+};
+
+function make() {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [MemoriesTabComponent, getTranslocoModule()],
+    providers: [
+      RecordListState, BrainStore, EntityRefPicker, RecordDrawerState,
+      { provide: BrainApi, useValue: api },
+    ],
+  });
+  const fixture = TestBed.createComponent(MemoriesTabComponent);
+  fixture.componentRef.setInput('spaceId', 'work');
+  fixture.detectChanges(); // effect → load()
+  return fixture;
+}
+
+const memory = (fact: string, id = fact): Memory =>
+  ({ _id: id, fact, tags: [], entityIds: [], properties: {}, createdAt: '2026-07-14T10:00:00.000Z', seq: 1 } as unknown as Memory);
+
+beforeEach(() => { for (const fn of Object.values(api)) (fn as any).mockClear(); });
+
+describe('MemoriesTabComponent', () => {
+  it('is compiled as OnPush', () => {
+    expect(MemoriesTabComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('self-loads on the spaceId input (sends page size + skip 0 + no filter)', () => {
+    make();
+    expect(api.listMemories).toHaveBeenCalledWith('work', 20, 0, {});
+  });
+
+  it('renders the create form when opened (plain ngModel model under OnPush)', () => {
+    const fixture = make();
+    fixture.componentInstance.openMemoryForm();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('form.create-form')).toBeTruthy();
+  });
+
+  it('renders a row per memory (signal-driven view updates under OnPush)', () => {
+    const fixture = make();
+    // set AFTER the initial self-load settles (the effect reruns only on spaceId change)
+    fixture.componentInstance.store.memories.set([memory('the sky is blue'), memory('water is wet')]);
+    fixture.detectChanges();
+    const body = (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
+    expect(body).toContain('the sky is blue');
+    expect(body).toContain('water is wet');
+  });
+
+  it('re-renders the list when the memories signal is replaced', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const body = () => (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';
+
+    c.store.memories.set([memory('first fact')]);
+    fixture.detectChanges();
+    expect(body()).toContain('first fact');
+
+    c.store.memories.set([memory('second fact')]);
+    fixture.detectChanges();
+    expect(body()).toContain('second fact');
+    expect(body()).not.toContain('first fact');
+  });
+
+  it('createMemory sends fact + only the non-empty optionals (properties raw) and emits mutated', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const mutated = vi.fn();
+    c.mutated.subscribe(mutated);
+    c.memoryForm = { fact: '  a fact  ', tags: ['t'], entityIds: 'e1, , e2', description: ' d ', properties: { k: 'v' } };
+    c.createMemory();
+    expect(api.createMemory).toHaveBeenCalledWith('work', {
+      fact: 'a fact', tags: ['t'], entityIds: ['e1', 'e2'], description: 'd', properties: { k: 'v' },
+    });
+    expect(mutated).toHaveBeenCalled();
+  });
+
+  it('createMemory is a no-op when fact is blank', () => {
+    const c = make().componentInstance;
+    c.memoryForm = { fact: '   ', tags: [], entityIds: '', description: '', properties: {} };
+    c.createMemory();
+    expect(api.createMemory).not.toHaveBeenCalled();
+  });
+
+  it('saveEditMemory sends the full shape, clears editingId, and patches the store list', () => {
+    const c = make().componentInstance;
+    c.store.memories.set([{ _id: 'm1', fact: 'old' } as Memory]);
+    c.recordList.editingId.set('m1');
+    c.editMemory = { fact: ' new ', tags: ['t'], entityIds: 'e1', description: ' d ', properties: {} };
+    c.saveEditMemory('m1');
+    expect(api.updateMemory).toHaveBeenCalledWith('work', 'm1', {
+      fact: 'new', tags: ['t'], entityIds: ['e1'], description: 'd',
+    });
+    expect(c.recordList.editingId()).toBe('');
+    expect(c.store.memories()[0].fact).toBe('UPDATED');
+  });
+
+  it('deleteMemory removes from the store, clears confirmDeleteId, and emits mutated', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const mutated = vi.fn();
+    c.mutated.subscribe(mutated);
+    c.store.memories.set([{ _id: 'm1' } as Memory, { _id: 'm2' } as Memory]);
+    c.recordList.confirmDeleteId.set('m1');
+    c.deleteMemory('m1');
+    expect(api.deleteMemory).toHaveBeenCalledWith('work', 'm1');
+    expect(c.store.memories().map(m => m._id)).toEqual(['m2']);
+    expect(c.recordList.confirmDeleteId()).toBe('');
+    expect(mutated).toHaveBeenCalled();
+  });
+
+  it('nextPage advances skip by pageSize and reloads; the load sends the active tag/type/entity filter', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    c.recordFilter.set({ type: 'note', tag: 'urgent' });
+    c.filterEntity.set('e9');
+    api.listMemories.mockClear();
+    c.nextPage();
+    expect(c.skip()).toBe(20);
+    expect(api.listMemories).toHaveBeenCalledWith('work', 20, 20, { tag: 'urgent', entity: 'e9', type: 'note' });
+    c.prevPage(); c.prevPage(); // clamp at 0
+    expect(c.skip()).toBe(0);
+  });
+});

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -1,0 +1,451 @@
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { catchError, of } from 'rxjs';
+import { Memory } from '../../core/api.types';
+import { BrainApi } from '../../core/brain-api.service';
+import { httpErrorReason } from '../../core/http-error';
+import { TagInputComponent } from '../../shared/tag-input.component';
+import { PropertiesViewComponent } from '../../shared/properties-view.component';
+import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
+import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ErrorStateComponent } from '../../shared/error-state.component';
+import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+import { RecordListState } from './record-list-state.service';
+import { fmtApiError } from './brain-format';
+import { BRAIN_CHIP_STYLES } from './brain-form.styles';
+import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+
+/**
+ * The Memories record tab, extracted from BrainComponent (A17.9b-6d) — the first of the five record
+ * tabs to become its own component. Owns the memory create form, the (drawer-superseded) inline edit,
+ * delete, and the tab's own search / filter / pagination + loader. Reads records and derived views
+ * from BrainStore; shares the singleton load/edit/delete interaction with the shell via
+ * RecordListState; uses EntityRefPicker for entity chips and RecordDrawerState to open the detail
+ * drawer.
+ *
+ * Self-loading: the shell renders this behind `@if (activeTab() === 'memories')`, so it is created on
+ * activation and destroyed on switch. An effect on the `spaceId` input loads on creation and reloads
+ * on a space switch while mounted. Create/delete emit `mutated` so the shell can refresh the tab-count
+ * stats (the one legitimate output — tab counts are parent view-state).
+ *
+ * OnPush: every async path writes a signal; the plain ngModel form models render because a sibling
+ * signal write (`showMemoryForm`/`recordList.editingId`) happens in the same turn.
+ */
+@Component({
+  selector: 'app-memories-tab',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
+  template: `
+
+          <div class="content-header">
+            <input type="search"
+              [placeholder]="'brain.memories.searchPlaceholder' | transloco"
+              [value]="store.memorySearch()"
+              (input)="onMemorySearch($any($event.target).value)"
+              [attr.aria-label]="'brain.memories.searchPlaceholder' | transloco" />
+            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
+              <button [class.active]="store.memorySearchMode() === 'text'" (click)="setMemorySearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
+              <button [class.active]="store.memorySearchMode() === 'semantic'" (click)="setMemorySearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
+            </div>
+            <button class="btn-primary btn btn-sm" (click)="openMemoryForm()" [disabled]="showMemoryForm()">{{ 'brain.memories.addButton' | transloco }}</button>
+          </div>
+
+          <!-- Add memory form -->
+          @if (showMemoryForm()) {
+            <form class="create-form" (ngSubmit)="createMemory()">
+              <div class="field" style="flex:2; min-width:200px;">
+                <label>{{ 'common.form.fact' | transloco }}</label>
+                <textarea [(ngModel)]="memoryForm.fact" name="fact" rows="2" required style="width:100%;"></textarea>
+              </div>
+              <div class="field" style="flex:1; min-width:180px;">
+                <label>{{ 'common.form.tags' | transloco }}</label>
+                <app-tag-input [(value)]="memoryForm.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memFormTags" />
+              </div>
+              <div class="field" style="flex:1; min-width:140px;">
+                <label>{{ 'common.form.entities' | transloco }}</label>
+                <div class="flyout-wrap">
+                  <div class="entity-multi">
+                    @for (chip of picker.entityChips(memoryForm.entityIds); track chip.id) {
+                      <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(memoryForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
+                    }
+                    <button type="button" class="chip-add" (click)="picker.openFlyout('create-memory-entityIds', memoryForm)">{{ 'common.addMore' | transloco }}</button>
+                  </div>
+                  @if (picker.flyoutField() === 'create-memory-entityIds') {
+                    <div class="flyout-panel">
+                      <app-entity-search
+                        mode="picker"
+                        [spaceId]="spaceId()"
+                        placeholder="common.searchEntitiesPlaceholder"
+
+                        (selected)="picker.pickEntity($event, memoryForm)"
+                      />
+                      <div style="display:flex; justify-content:flex-end; margin-top:8px;">
+                        <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+              <div class="field" style="flex:2; min-width:200px;">
+                <label>{{ 'common.form.description' | transloco }}</label>
+                <textarea [(ngModel)]="memoryForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
+              </div>
+              <div class="field" style="flex:1; min-width:220px;">
+                <label>{{ 'common.form.properties' | transloco }}</label>
+                <app-properties-editor [schema]="store.memorySchema()" [required]="store.requiredProps(store.memorySchema())" [(value)]="memoryForm.properties" />
+              </div>
+              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingMemory() || !memoryForm.fact.trim()">
+                @if (creatingMemory()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                {{ 'common.save' | transloco }}
+              </button>
+              <button class="btn-secondary btn btn-sm" type="button" (click)="showMemoryForm.set(false)">{{ 'common.cancel' | transloco }}</button>
+            </form>
+          }
+
+          @if (createMemoryError()) {
+            <div class="alert alert-error" style="margin-bottom:12px;">{{ createMemoryError() }}</div>
+          }
+
+          <!-- Shared type/tag filter (F6). Tag-clicks in the table feed this bar too. -->
+          <div class="list-filter-row">
+            <app-record-filter-bar
+              [typeOptions]="store.memoryTypeOptions()"
+              [tagSuggestions]="store.memoryTagSuggestions()"
+              [value]="recordFilter()"
+              (filterChange)="onFilterChange($event)"
+            />
+            @if (filterEntity(); as ent) {
+              <span class="filter-chip">{{ 'brain.filter.entityPrefix' | transloco }} {{ ent }} <button [attr.aria-label]="'brain.filter.clearEntityAriaLabel' | transloco" (click)="clearFilter('entity')"><ph-icon name="x" [size]="12"/></button></span>
+            }
+          </div>
+
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>{{ 'brain.memories.table.fact' | transloco }}</th><th>{{ 'brain.memories.table.description' | transloco }}</th><th>{{ 'brain.memories.table.tags' | transloco }}</th><th>{{ 'brain.memories.table.entities' | transloco }}</th><th>{{ 'brain.memories.table.properties' | transloco }}</th><th>{{ 'brain.memories.table.created' | transloco }}</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (mem of store.filteredMemories(); track mem._id) {
+                  @if (recordList.editingId() === mem._id) {
+                    <tr>
+                      <td colspan="7">
+                        <div class="create-form" style="border:none; padding:8px 0;">
+                          <div class="field" style="flex:2; min-width:200px; margin-bottom:0;">
+                            <label>{{ 'common.form.fact' | transloco }}</label>
+                            <textarea [(ngModel)]="editMemory.fact" name="editFact" rows="2" style="width:100%;"></textarea>
+                          </div>
+                          <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
+                            <label>{{ 'common.form.description' | transloco }}</label>
+                            <textarea [(ngModel)]="editMemory.description" name="editDesc" rows="2" style="resize:vertical;"></textarea>
+                          </div>
+                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
+                            <label>{{ 'common.form.tags' | transloco }}</label>
+                            <app-tag-input [(value)]="editMemory.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memEditTags" />
+                          </div>
+                          <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
+                            <label>{{ 'common.form.entities' | transloco }}</label>
+                            <div class="flyout-wrap">
+                              <div class="entity-multi">
+                                @for (chip of picker.entityChips(editMemory.entityIds); track chip.id) {
+                                  <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editMemory, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
+                                }
+                                <button type="button" class="chip-add" (click)="picker.openFlyout('edit-memory-entityIds', editMemory)">{{ 'common.addMore' | transloco }}</button>
+                              </div>
+                              @if (picker.flyoutField() === 'edit-memory-entityIds') {
+                                <div class="flyout-panel">
+                                  <app-entity-search
+                                    mode="picker"
+                                    [spaceId]="spaceId()"
+                                    placeholder="common.searchEntitiesPlaceholder"
+
+                                    (selected)="picker.pickEntity($event, editMemory)"
+                                  />
+                                  <div style="display:flex; justify-content:flex-end; margin-top:8px;">
+                                    <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
+                                  </div>
+                                </div>
+                              }
+                            </div>
+                          </div>
+                          <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
+                            <label>{{ 'common.form.properties' | transloco }}</label>
+                            <app-properties-editor
+                              [schema]="store.memorySchema()"
+                              [required]="store.requiredProps(store.memorySchema())"
+                              [(value)]="editMemory.properties"
+                            />
+                          </div>
+                          <div style="display:flex; gap:6px; align-items:flex-end;">
+                            <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditMemory(mem._id)">
+                              @if (recordList.editSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } {{ 'common.save' | transloco }}
+                            </button>
+                            <button class="btn btn-sm btn-secondary" (click)="recordList.cancelEdit()">{{ 'common.cancel' | transloco }}</button>
+                          </div>
+                          @if (recordList.editError()) { <div style="font-size:12px; color:var(--error);">{{ recordList.editError() }}</div> }
+                        </div>
+                      </td>
+                    </tr>
+                  } @else {
+                    <tr>
+                      <td style="max-width:300px; white-space:pre-wrap; word-break:break-word;">{{ mem.fact }}</td>
+                      <td class="desc-cell" style="max-width:180px;" [title]="mem.description ?? ''">
+                        {{ mem.description || '—' }}
+                      </td>
+                      <td style="font-size:11px;">
+                        @for (tag of (mem.tags ?? []); track tag) { <span class="tag tag-clickable" (click)="applyFilter('tag', tag)">{{ tag }}</span> }
+                        @if (!(mem.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
+                      </td>
+                      <td style="font-size:11px;">
+                        @if (mem.entityIds?.length) {
+                          <div class="chip-list">
+                            @for (id of mem.entityIds!; track id) {
+                              <span class="chip" [title]="id">{{ picker.entityNameCache()[id] || id.slice(0,8) + '…' }}</span>
+                            }
+                          </div>
+                        } @else { <span style="color:var(--text-muted)">—</span> }
+                      </td>
+                      <td><app-properties-view [properties]="mem.properties" [schema]="store.memorySchema()" /></td>
+                      <td style="color:var(--text-muted)">{{ mem.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td style="white-space:nowrap;">
+                        <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('memory', mem)"><ph-icon name="eye" [size]="16"/></button>
+                        @if (recordList.confirmDeleteId() === mem._id) {
+                          <span class="inline-confirm">
+                            {{ 'common.deleteConfirm' | transloco }}
+                            <button class="btn btn-sm btn-danger" (click)="deleteMemory(mem._id)">{{ 'common.yes' | transloco }}</button>
+                            <button class="btn btn-sm btn-secondary" (click)="cancelDelete()">{{ 'common.no' | transloco }}</button>
+                          </span>
+                        } @else {
+                          <button class="icon-btn danger" [attr.title]="'brain.memories.deleteTitle' | transloco" [attr.aria-label]="'brain.memories.deleteAriaLabel' | transloco" (click)="requestDelete(mem._id)"><ph-icon name="x" [size]="16"/></button>
+                        }
+                      </td>
+                    </tr>
+                  }
+                } @empty {
+                  <tr><td colspan="7">
+                    @if (recordList.loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadMemories' | transloco" [reason]="recordList.loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
+                    <div class="empty-state" style="padding:32px">
+                      <div class="empty-state-icon"><ph-icon name="brain" [size]="48"/></div>
+                      @if (store.memorySearch() && store.memories().length) {
+                        <h3>{{ 'common.noMatches' | transloco }}</h3>
+                        <p>{{ 'brain.memories.empty.noMatchQuery' | transloco: { query: store.memorySearch() } }}</p>
+                      } @else {
+                        <h3>{{ 'brain.memories.empty.title' | transloco }}</h3>
+                        <p>{{ 'brain.memories.empty.body' | transloco }}</p>
+                      }
+                    </div>
+                    }
+                  </td></tr>
+                }
+              </tbody>
+            </table>
+          </div>
+          @if (store.memorySearchMode() !== 'semantic') {
+            <div class="pagination">
+              <button class="btn btn-sm btn-secondary" [disabled]="skip() === 0" (click)="prevPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+              <span class="pager-info">{{ store.filteredMemories().length ? (skip() + 1) + '–' + (skip() + store.filteredMemories().length) : '–' }}</span>
+              <button class="btn btn-sm btn-secondary" [disabled]="store.memories().length < pageSize" (click)="nextPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+            </div>
+          }
+  `,
+})
+export class MemoriesTabComponent {
+  readonly store = inject(BrainStore);
+  readonly picker = inject(EntityRefPicker);
+  readonly drawerState = inject(RecordDrawerState);
+  readonly recordList = inject(RecordListState);
+  private brainApi = inject(BrainApi);
+
+  readonly spaceId = input.required<string>();
+  /** Emitted after a create/delete so the shell can refresh the space's tab-count stats. */
+  readonly mutated = output<void>();
+
+  readonly pageSize = 20;
+
+  skip = signal(0);
+  recordFilter = signal<RecordFilter>({ type: '', tag: '' });
+  filterEntity = signal('');
+
+  showMemoryForm = signal(false);
+  creatingMemory = signal(false);
+  createMemoryError = signal('');
+  memoryForm = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
+  editMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
+
+  private _memSemTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    // Self-load on creation (tab activation) and on a space switch while mounted.
+    effect(() => {
+      const id = this.spaceId();
+      this.skip.set(0);
+      this.recordFilter.set({ type: '', tag: '' });
+      this.filterEntity.set('');
+      if (id) this.load();
+    });
+  }
+
+  private load(): void {
+    const spaceId = this.spaceId();
+    if (!spaceId) return;
+    this.recordList.loading.set(true);
+    this.recordList.loadError.set(null);
+    const filters: { tag?: string; entity?: string; type?: string } = {};
+    if (this.recordFilter().tag) filters.tag = this.recordFilter().tag;
+    if (this.filterEntity()) filters.entity = this.filterEntity();
+    if (this.recordFilter().type) filters.type = this.recordFilter().type;
+    this.brainApi.listMemories(spaceId, this.pageSize, this.skip(), filters).subscribe({
+      next: ({ memories }) => {
+        this.store.memories.set(memories);
+        const ids = [...new Set(memories.flatMap(m => m.entityIds ?? []))];
+        if (ids.length) this.picker.resolveEntityNames(ids);
+        this.recordList.loading.set(false);
+      },
+      error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
+    });
+  }
+
+  retryCurrentTab(): void { this.load(); }
+
+  prevPage(): void { this.skip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
+  nextPage(): void { this.skip.update(s => s + this.pageSize); this.load(); }
+
+  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
+  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
+
+  onMemorySearch(q: string): void {
+    this.store.memorySearch.set(q);
+    if (this.store.memorySearchMode() === 'semantic') {
+      if (this._memSemTimer) clearTimeout(this._memSemTimer);
+      if (!q.trim()) { this.store.memories.set([]); return; }
+      this._memSemTimer = setTimeout(() => this.runSemanticMemorySearch(), 300);
+    }
+  }
+
+  setMemorySearchMode(m: 'text' | 'semantic'): void {
+    this.store.memorySearchMode.set(m);
+    const q = this.store.memorySearch().trim();
+    if (!q) return;
+    if (m === 'semantic') this.runSemanticMemorySearch();
+    else { this.skip.set(0); this.load(); }
+  }
+
+  runSemanticMemorySearch(): void {
+    const q = this.store.memorySearch().trim();
+    const spaceId = this.spaceId();
+    if (!q || !spaceId) { this.store.memories.set([]); return; }
+    this.brainApi.recallBrain(spaceId, { query: q, types: ['memory'], topK: 20 }).pipe(
+      catchError(() => of({ results: [], count: 0 })),
+    ).subscribe(res => {
+      this.store.memories.set(res.results.filter(r => r.type === 'memory').map(r => ({
+        _id: r['_id'] as string,
+        fact: (r['fact'] as string) ?? '',
+        tags: (r['tags'] as string[]) ?? [],
+        entityIds: (r['entityIds'] as string[]) ?? [],
+        description: r['description'] as string | undefined,
+        properties: (r['properties'] as Record<string, string | number | boolean>) ?? {},
+        createdAt: (r['createdAt'] as string) ?? '',
+        seq: (r['seq'] as number) ?? 0,
+        author: r['author'] as { instanceId: string } | undefined,
+      } as Memory)));
+    });
+  }
+
+  onFilterChange(f: RecordFilter): void {
+    this.recordFilter.set(f);
+    this.skip.set(0);
+    this.load();
+  }
+
+  applyFilter(type: 'tag' | 'entity', value: string): void {
+    if (type === 'tag') this.recordFilter.set({ ...this.recordFilter(), tag: value });
+    else this.filterEntity.set(value);
+    this.skip.set(0);
+    this.load();
+  }
+
+  clearFilter(which: 'tag' | 'entity' | 'all'): void {
+    if (which === 'tag' || which === 'all') this.recordFilter.set({ ...this.recordFilter(), tag: '' });
+    if (which === 'entity' || which === 'all') this.filterEntity.set('');
+    this.skip.set(0);
+    this.load();
+  }
+
+  openMemoryForm(): void {
+    this.memoryForm = { fact: '', tags: [], entityIds: '', description: '', properties: this.store.buildPropertiesObject('memory') };
+    this.showMemoryForm.set(true);
+  }
+
+  createMemory(): void {
+    if (!this.memoryForm.fact.trim()) return;
+    this.creatingMemory.set(true);
+    this.createMemoryError.set('');
+    const entityIds = this.memoryForm.entityIds.split(',').map(s => s.trim()).filter(Boolean);
+    const body: Parameters<BrainApi['createMemory']>[1] = { fact: this.memoryForm.fact.trim() };
+    if (this.memoryForm.tags.length) body.tags = this.memoryForm.tags;
+    if (entityIds.length) body.entityIds = entityIds;
+    if (this.memoryForm.description.trim()) body.description = this.memoryForm.description.trim();
+    if (Object.keys(this.memoryForm.properties).length) body.properties = this.memoryForm.properties;
+    this.brainApi.createMemory(this.spaceId(), body).subscribe({
+      next: () => {
+        this.creatingMemory.set(false);
+        this.showMemoryForm.set(false);
+        this.memoryForm = { fact: '', tags: [], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
+        this.mutated.emit();
+        this.load();
+      },
+      error: (err) => { this.creatingMemory.set(false); this.createMemoryError.set(fmtApiError(err, 'Failed to create memory')); },
+    });
+  }
+
+  startEditMemory(mem: Memory): void {
+    this.recordList.editingId.set(mem._id);
+    this.recordList.editError.set('');
+    this.editMemory = {
+      fact: mem.fact,
+      tags: mem.tags ?? [],
+      entityIds: (mem.entityIds ?? []).join(', '),
+      description: mem.description ?? '',
+      properties: this.store.buildPropertiesObject('memory', mem.properties ?? {}),
+    };
+  }
+
+  saveEditMemory(id: string): void {
+    this.recordList.editSaving.set(true);
+    this.recordList.editError.set('');
+    const memProps = this.editMemory.properties;
+    this.brainApi.updateMemory(this.spaceId(), id, {
+      fact: this.editMemory.fact.trim(),
+      tags: this.editMemory.tags,
+      entityIds: this.editMemory.entityIds.split(',').map(s => s.trim()).filter(Boolean),
+      description: this.editMemory.description.trim(),
+      ...(Object.keys(memProps).length ? { properties: memProps } : {}),
+    }).subscribe({
+      next: (updated) => {
+        this.recordList.editSaving.set(false);
+        this.recordList.editingId.set('');
+        this.store.memories.update(list => list.map(m => m._id === id ? updated : m));
+      },
+      error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
+    });
+  }
+
+  deleteMemory(id: string): void {
+    this.recordList.confirmDeleteId.set('');
+    this.brainApi.deleteMemory(this.spaceId(), id).subscribe({
+      next: () => { this.store.memories.update(list => list.filter(m => m._id !== id)); this.mutated.emit(); },
+      error: () => {},
+    });
+  }
+}


### PR DESCRIPTION
## What

The first record tab out of the shell — `memories-tab.component`, an OnPush component that owns the memory create form, inline edit, delete, and its own search / type-tag filter / pagination + list loader. Establishes the self-loading pattern the remaining four record tabs follow.

## Design

- **State it owns**: `memoryForm`/`editMemory`, the create/edit/delete flow, its own `skip`/`recordFilter`/`filterEntity`, and a local `load()`.
- **Shared collaborators it consumes**: `BrainStore` (records + derived views), `RecordListState` (the singleton `loading`/`editingId`/`editSaving`/`confirmDeleteId`), `EntityRefPicker` (entity chips), `RecordDrawerState` (open the drawer).
- **Self-loading**: the shell renders it behind `@if (activeTab() === 'memories')`, so it's created on activation and destroyed on switch. An `effect` on the `spaceId` input loads on creation and reloads on a space switch while mounted. The shell's `loadCurrentTab` now **early-returns** for memories (it no longer drives the tab's `loading`).
- **`mutated` output**: create/delete emit it so the shell refreshes the space's tab-count stats — the one legitimate output, since tab counts are parent view-state (no data outputs).
- **CSS**: the brain-scoped record-table rules (search header, create form, filter chips, inline confirm, description cell) moved to a shared `brain-table.styles.ts` the tab components import; table/pagination/empty-state/tag styles are global. The shell keeps its inline copies until the last record tab leaves, then a cleanup removes the dead CSS.

## Tests

The A17.9b-6b memories characterization cases (create/edit/delete/load) + the two memories-table rendering tests relocated to `memories-tab.component.spec.ts`, driving the component; **new** assertions cover the self-load-on-`spaceId` and the `mutated` emissions. The records spec keeps the entity/edge/chrono/filemeta cases (still on the shell).

## Verification

- `brain.component.ts` **2416 → 2070**.
- Full client suite: **188 → 190**, all passing.
- `tsc --noEmit --noUnusedLocals` clean on the brain files.
- Production AOT build warning-free apart from the pre-existing `qrcode` CommonJS bailout.
- CHANGELOG updated; internal refactor, no documented behaviour changed → no docs update.

Next: `9b-6e..h` extract entities/edges/chrono/filemeta, same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)