### PR TITLE
refactor(client): extract the Entities tab into a self-loading OnPush component (A17.9b-6e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Entities tab is now its own self-loading OnPush component (`entities-tab.component`), the second
+  record tab out of the shell.** Same pattern as memories: it owns the entity create form, inline edit,
+  delete, and its own entity-search / type-tag filter / pagination + loader; self-loads via a `spaceId`
+  effect; emits `mutated` so the shell refreshes tab-count stats; the shell's `loadCurrentTab`
+  early-returns for entities. Entity-specific behaviour preserved (and pinned by the relocated 6b case):
+  both create AND inline-edit strip empty optional properties via the entity schema (unlike memory,
+  which sends them raw), and entity search uses the `<app-entity-search>` bar (semantic default) with no
+  per-tab search-mode pill. Reuses the shared `brain-table.styles.ts`. The 6b `createEntity`
+  characterization case moved to `entities-tab.component.spec.ts` alongside new self-load / edit / delete
+  / search / pagination tests. `brain.component.ts` 2070 → 1762. Client suite: 190 → 197.
+
 - **The Memories tab is now its own self-loading OnPush component (`memories-tab.component`), the first
   record tab out of the shell.** It owns the memory create form, the inline edit, delete, and its own
   search / type-tag filter / pagination + list loader; it reads records and derived views from

--- a/client/src/app/pages/brain/brain.component.records.spec.ts
+++ b/client/src/app/pages/brain/brain.component.records.spec.ts
@@ -79,15 +79,6 @@ function make() {
 beforeEach(() => { for (const fn of [...Object.values(api), ...Object.values(filesApi)]) (fn as any).mockClear(); });
 
 describe('BrainComponent — create payloads', () => {
-  it('createEntity strips empty optional props via the schema (unlike memory)', () => {
-    const c = make();
-    c.store.spaceMeta.set({ typeSchemas: { entity: { Person: { propertySchemas: { note: { required: false } } } } } } as any);
-    c.entityForm = { name: ' Ann ', type: 'Person', tags: [], description: '', properties: { note: '' } };
-    c.createEntity();
-    // note is empty + optional → stripped → no properties key at all
-    expect(api.createEntity).toHaveBeenCalledWith('work', { name: 'Ann', type: 'Person' });
-  });
-
   it('createChrono resolves a __custom__ kind to the free-text customKind and ISO-encodes startsAt', () => {
     const c = make();
     c.chronoForm = { title: 'T', kind: '__custom__', customKind: ' launch ', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '' };

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -7,6 +7,7 @@ import { RecordDrawerComponent } from './record-drawer.component';
 import { QueryTabComponent } from './query-tab.component';
 import { RecordListState } from './record-list-state.service';
 import { MemoriesTabComponent } from './memories-tab.component';
+import { EntitiesTabComponent } from './entities-tab.component';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { toLocalDatetime, fmtApiError } from './brain-format';
 import { FormsModule } from '@angular/forms';
@@ -47,7 +48,7 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [BRAIN_CHIP_STYLES, `
     .space-tabs {
@@ -467,180 +468,7 @@ interface SpaceView {
         @if (activeTab() === 'memories') { <app-memories-tab [spaceId]="activeSpaceId()" (mutated)="loadStats(activeSpaceId())" /> }
 
         <!-- Entities -->
-        @if (activeTab() === 'entities') {
-
-          <div class="content-header">
-            <app-entity-search
-              mode="bar"
-              [spaceId]="activeSpaceId()"
-              placeholder="common.searchEntitiesPlaceholder"
-              defaultMode="semantic"
-              (queryChange)="onEntitySearchChange($event)"
-              (cleared)="onEntitySearchClear()"
-              (selected)="onEntitySearchPick($event)"
-            />
-            <button class="btn-primary btn btn-sm" (click)="openEntityForm()" [disabled]="showEntityForm()">{{ 'brain.entities.addButton' | transloco }}</button>
-          </div>
-          <div class="list-filter-row">
-            <app-record-filter-bar
-              [typeOptions]="store.entityTypeOptions()"
-              [tagSuggestions]="store.entityTagSuggestions()"
-              [value]="recordFilter()"
-              (filterChange)="onFilterChange($event)"
-            />
-          </div>
-
-          @if (showEntityForm()) {
-            <form class="create-form" (ngSubmit)="createEntity()">
-              <div class="field" style="flex:1; min-width:140px;">
-                <label>{{ 'brain.entities.table.name' | transloco }}</label>
-                <input type="text" [(ngModel)]="entityForm.name" name="name" required />
-              </div>
-              <div class="field" style="width:140px;">
-                <label>Type @if (store.entityTypeNames().length) { <span style="color:var(--error)">*</span> }</label>
-                @if (store.entityTypeNames().length) {
-                  <select [(ngModel)]="entityForm.type" name="type" required (ngModelChange)="onEntityTypeChange($event, 'create')">
-                    @for (t of store.entityTypeNames(); track t) {
-                      <option [value]="t">{{ t }}</option>
-                    }
-                  </select>
-                } @else {
-                  <input type="text" [(ngModel)]="entityForm.type" name="type" [placeholder]="'brain.entities.form.typePlaceholder' | transloco" />
-                }
-              </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'brain.entities.table.tags' | transloco }}</label>
-                <app-tag-input [(value)]="entityForm.tags" [suggestions]="store.entityTagSuggestions()" inputName="entFormTags" />
-              </div>
-              <div class="field" style="flex:1; min-width:200px;">
-                <label>{{ 'brain.entities.table.description' | transloco }}</label>
-                <textarea [(ngModel)]="entityForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:220px;">
-                <label>{{ 'brain.entities.table.properties' | transloco }}</label>
-                <app-properties-editor
-                  [schema]="store.entitySchema(entityForm.type)"
-                  [required]="store.requiredProps(store.entitySchema(entityForm.type))"
-                  [(value)]="entityForm.properties"
-                />
-              </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEntity() || !entityForm.name.trim() || (store.entityTypeNames().length ? !entityForm.type : false)">
-                @if (creatingEntity()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showEntityForm.set(false)">{{ 'common.cancel' | transloco }}</button>
-            </form>
-          }
-
-          @if (createEntityError()) {
-            <div class="alert alert-error" style="margin-bottom:12px;">{{ createEntityError() }}</div>
-          }
-
-          <div class="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>{{ 'brain.entities.table.name' | transloco }}</th><th>{{ 'brain.entities.table.type' | transloco }}</th><th>{{ 'brain.entities.table.description' | transloco }}</th><th>{{ 'brain.entities.table.tags' | transloco }}</th><th>{{ 'brain.entities.table.properties' | transloco }}</th><th>{{ 'brain.entities.table.created' | transloco }}</th><th></th>
-                </tr>
-              </thead>
-              <tbody>
-                @for (ent of store.entities(); track ent._id) {
-                  @if (recordList.editingId() === ent._id) {
-                    <tr>
-                      <td colspan="7">
-                        <div class="create-form" style="border:none; padding:8px 0;">
-                          <div class="field" style="flex:1; min-width:120px; margin-bottom:0;">
-                            <label>{{ 'brain.entities.table.name' | transloco }}</label>
-                            <input type="text" [(ngModel)]="editEntity.name" name="editEntName" />
-                          </div>
-                          <div class="field" style="width:120px; margin-bottom:0;">
-                            <label>Type @if (store.entityTypeNames().length) { <span style="color:var(--error)">*</span> }</label>
-                            @if (store.entityTypeNames().length) {
-                              <select [(ngModel)]="editEntity.type" name="editEntType" (ngModelChange)="onEntityTypeChange($event, 'inline')">
-                                @for (t of store.entityTypeNames(); track t) {
-                                  <option [value]="t">{{ t }}</option>
-                                }
-                              </select>
-                            } @else {
-                              <input type="text" [(ngModel)]="editEntity.type" name="editEntType" />
-                            }
-                          </div>
-                          <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
-                            <label>{{ 'brain.entities.table.description' | transloco }}</label>
-                            <textarea [(ngModel)]="editEntity.description" name="editEntDesc" rows="2" style="resize:vertical;"></textarea>
-                          </div>
-                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
-                            <label>{{ 'brain.entities.table.tags' | transloco }}</label>
-                            <app-tag-input [(value)]="editEntity.tags" [suggestions]="store.entityTagSuggestions()" inputName="entEditTags" />
-                          </div>
-                          <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
-                            <label>{{ 'brain.entities.table.properties' | transloco }}</label>
-                            <app-properties-editor
-                              [schema]="store.entitySchema(editEntity.type)"
-                              [required]="store.requiredProps(store.entitySchema(editEntity.type))"
-                              [(value)]="editEntity.properties"
-                            />
-                          </div>
-                          <div style="display:flex; gap:6px; align-items:flex-end;">
-                            <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditEntity(ent._id)">
-                              @if (recordList.editSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } Save
-                            </button>
-                            <button class="btn btn-sm btn-secondary" (click)="recordList.cancelEdit()">{{ 'common.cancel' | transloco }}</button>
-                          </div>
-                          @if (recordList.editError()) { <div style="font-size:12px; color:var(--error);">{{ recordList.editError() }}</div> }
-                        </div>
-                      </td>
-                    </tr>
-                  } @else {
-                    <tr>
-                      <td>{{ ent.name }}</td>
-                      <td>
-                        @if (ent.type) { <span class="badge badge-purple">{{ ent.type }}</span> }
-                      </td>
-                      <td class="desc-cell" style="max-width:200px;" [title]="ent.description ?? ''">
-                        {{ ent.description || '—' }}
-                      </td>
-                      <td style="font-size:11px;">
-                        @for (tag of (ent.tags ?? []); track tag) { <span class="tag">{{ tag }}</span> }
-                        @if (!(ent.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
-                      </td>
-                      <td><app-properties-view [properties]="ent.properties" [schema]="store.entitySchema(ent.type)" /></td>
-                      <td style="color:var(--text-muted)">{{ ent.createdAt | date:'dd.MM.yyyy' }}</td>
-                      <td style="white-space:nowrap;">
-                        <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('entity', ent)"><ph-icon name="eye" [size]="16"/></button>
-                        @if (recordList.confirmDeleteId() === ent._id) {
-                          <span class="inline-confirm">
-                            Delete?
-                            <button class="btn btn-sm btn-danger" (click)="deleteEntity(ent._id)">{{ 'common.yes' | transloco }}</button>
-                            <button class="btn btn-sm btn-secondary" (click)="cancelDelete()">{{ 'common.no' | transloco }}</button>
-                          </span>
-                        } @else {
-                          <button class="icon-btn danger" [attr.aria-label]="'brain.entities.deleteAriaLabel' | transloco" (click)="requestDelete(ent._id)"><ph-icon name="x" [size]="16"/></button>
-                        }
-                      </td>
-                    </tr>
-                  }
-                } @empty {
-                  <tr><td colspan="7">
-                    @if (recordList.loadError() !== null) {
-                      <app-error-state [message]="'brain.error.loadEntities' | transloco" [reason]="recordList.loadError() ?? ''" (retry)="retryCurrentTab()" />
-                    } @else {
-                    <div class="empty-state" style="padding:32px">
-                      <div class="empty-state-icon"><ph-icon name="tag" [size]="48"/></div>
-                      <h3>{{ 'brain.entities.empty.title' | transloco }}</h3>
-                    </div>
-                    }
-                  </td></tr>
-                }
-              </tbody>
-            </table>
-          </div>
-          <div class="pagination">
-            <button class="btn btn-sm btn-secondary" [disabled]="entitySkip() === 0" (click)="prevEntityPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-            <span class="pager-info">{{ store.entities().length ? (entitySkip() + 1) + '–' + (entitySkip() + store.entities().length) : '–' }}</span>
-            <button class="btn btn-sm btn-secondary" [disabled]="store.entities().length < pageSize" (click)="nextEntityPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
-          </div>
-        }
+        @if (activeTab() === 'entities') { <app-entities-tab [spaceId]="activeSpaceId()" (mutated)="loadStats(activeSpaceId())" /> }
 
         <!-- Edges -->
         @if (activeTab() === 'edges') {
@@ -1343,7 +1171,6 @@ export class BrainComponent implements OnInit {
     this.recordFilter.set(f);
     switch (this.activeTab()) {
       case 'memories': this.skip.set(0); break;
-      case 'entities': this.entitySkip.set(0); break;
       case 'edges': this.edgeSkip.set(0); break;
       case 'chrono': this.chronoSkip.set(0); break;
       default: break;
@@ -1355,9 +1182,6 @@ export class BrainComponent implements OnInit {
   skip = signal(0);
   filterEntity = signal('');
 
-  // Entities pagination + search
-  entitySkip = signal(0);
-  entitySearch = signal('');
   private _edgeSemTimer: ReturnType<typeof setTimeout> | null = null;
   private _chronoSemTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -1372,15 +1196,8 @@ export class BrainComponent implements OnInit {
   reindexing = signal(false);
   reindexResult = signal('');
 
-  editEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   editEdge = { from: '', to: '', fromName: undefined as string | undefined, toName: undefined as string | undefined, label: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '' };
-
-  // Create entity form
-  showEntityForm = signal(false);
-  creatingEntity = signal(false);
-  createEntityError = signal('');
-  entityForm = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
 
   // Create edge form
   showEdgeForm = signal(false);
@@ -1434,12 +1251,10 @@ export class BrainComponent implements OnInit {
     this.picker.spaceId.set(id);
     this.drawerState.spaceId.set(id);
     this.skip.set(0);
-    this.entitySkip.set(0);
     this.edgeSkip.set(0);
     this.chronoSkip.set(0);
     this.recordFilter.set({ type: '', tag: '' });
     this.filterEntity.set('');
-    this.entitySearch.set('');
     this.store.memorySearch.set('');
     this.store.edgeSearch.set('');
     this.store.chronoSearch.set('');
@@ -1456,7 +1271,6 @@ export class BrainComponent implements OnInit {
   setTab(tab: BrainTab): void {
     this.activeTab.set(tab);
     this.skip.set(0);
-    this.entitySkip.set(0);
     this.edgeSkip.set(0);
     this.chronoSkip.set(0);
     this.fileMetaSkip.set(0);
@@ -1473,9 +1287,6 @@ export class BrainComponent implements OnInit {
     this.loadCurrentTab(this.activeSpaceId());
   }
 
-  prevEntityPage(): void { this.entitySkip.update(s => Math.max(0, s - this.pageSize)); this.loadCurrentTab(this.activeSpaceId()); }
-  nextEntityPage(): void { this.entitySkip.update(s => s + this.pageSize); this.loadCurrentTab(this.activeSpaceId()); }
-
   prevEdgePage(): void { this.edgeSkip.update(s => Math.max(0, s - this.pageSize)); this.loadCurrentTab(this.activeSpaceId()); }
   nextEdgePage(): void { this.edgeSkip.update(s => s + this.pageSize); this.loadCurrentTab(this.activeSpaceId()); }
 
@@ -1488,38 +1299,6 @@ export class BrainComponent implements OnInit {
   onFileMetaSearch(q: string): void {
     this.store.fileMetaSearch.set(q);
     // client-side filter via filteredFileMetas computed() — no API call per keystroke
-  }
-
-  searchEntities(): void { this.entitySkip.set(0); this.loadCurrentTab(this.activeSpaceId()); }
-
-  // ── Entity search bar handlers (brain entities tab) ──────────────────────
-  onEntitySearchChange(q: string): void {
-    this.entitySearch.set(q);
-    this.entitySkip.set(0);
-    this.loadEntitiesSilent();
-  }
-  onEntitySearchClear(): void {
-    this.entitySearch.set('');
-    this.entitySkip.set(0);
-    this.loadEntitiesSilent();
-  }
-  onEntitySearchPick(ent: Entity): void {
-    this.entitySearch.set(ent.name);
-    this.entitySkip.set(0);
-    this.loadEntitiesSilent();
-  }
-
-  loadEntitiesSilent(): void {
-    const spaceId = this.activeSpaceId();
-    if (!spaceId) return;
-    const ef: { search?: string; type?: string; tag?: string } = {};
-    if (this.entitySearch()) ef.search = this.entitySearch();
-    if (this.recordFilter().type) ef.type = this.recordFilter().type;
-    if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-    this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
-      next: ({ entities }) => this.store.entities.set(entities),
-      error: () => {},
-    });
   }
 
   onEdgeSearch(q: string): void {
@@ -1630,21 +1409,11 @@ export class BrainComponent implements OnInit {
   private loadCurrentTab(spaceId: string): void {
     if (!spaceId) return;
     if (this.activeTab() === 'memories') return; // self-loading component
+    if (this.activeTab() === 'entities') return; // self-loading component
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
 
     switch (this.activeTab()) {
-      case 'entities': {
-        const ef: { search?: string; type?: string; tag?: string } = {};
-        if (this.entitySearch()) ef.search = this.entitySearch();
-        if (this.recordFilter().type) ef.type = this.recordFilter().type;
-        if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-        this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
-          next: ({ entities }) => { this.store.entities.set(entities); this.recordList.loading.set(false); },
-          error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
-        });
-        break;
-      }
       case 'edges': {
         const gf: { type?: string; tag?: string } = {};
         if (this.recordFilter().type) gf.type = this.recordFilter().type;
@@ -1723,18 +1492,6 @@ export class BrainComponent implements OnInit {
   requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
   cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
-  startEditEntity(ent: Entity): void {
-    this.recordList.editingId.set(ent._id);
-    this.recordList.editError.set('');
-    this.editEntity = {
-      name: ent.name,
-      type: ent.type ?? '',
-      tags: ent.tags ?? [],
-      description: ent.description ?? '',
-      properties: this.store.buildPropertiesObject('entity', ent.properties ?? {}, ent.type),
-    };
-  }
-
   startEditEdge(edge: Edge): void {
     this.recordList.editingId.set(edge._id);
     this.recordList.editError.set('');
@@ -1764,26 +1521,6 @@ export class BrainComponent implements OnInit {
       tags: entry.tags ?? [],
       entityIds: (entry.entityIds ?? []).join(', '),
     };
-  }
-
-  saveEditEntity(id: string): void {
-    this.recordList.editSaving.set(true);
-    this.recordList.editError.set('');
-    const entProps = this.store.stripEmptyOptionalProps(this.editEntity.properties, this.store.entitySchema(this.editEntity.type));
-    this.brainApi.updateEntity(this.activeSpaceId(), id, {
-      name: this.editEntity.name.trim(),
-      type: this.editEntity.type.trim(),
-      tags: this.editEntity.tags,
-      description: this.editEntity.description.trim(),
-      ...(Object.keys(entProps).length ? { properties: entProps } : {}),
-    }).subscribe({
-      next: (updated) => {
-        this.recordList.editSaving.set(false);
-        this.recordList.editingId.set('');
-        this.store.entities.update(list => list.map(e => e._id === id ? updated : e));
-      },
-      error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
-    });
   }
 
   saveEditEdge(id: string): void {
@@ -1897,28 +1634,6 @@ export class BrainComponent implements OnInit {
     this.setTab('files');
   }
 
-  createEntity(): void {
-    if (!this.entityForm.name.trim()) return;
-    this.creatingEntity.set(true);
-    this.createEntityError.set('');
-    const body: Parameters<BrainApi['createEntity']>[1] = { name: this.entityForm.name.trim() };
-    if (this.entityForm.type.trim()) body.type = this.entityForm.type.trim();
-    if (this.entityForm.tags.length) body.tags = this.entityForm.tags;
-    if (this.entityForm.description.trim()) body.description = this.entityForm.description.trim();
-    const props = this.store.stripEmptyOptionalProps(this.entityForm.properties, this.store.entitySchema(this.entityForm.type));
-    if (Object.keys(props).length) body.properties = props;
-    this.brainApi.createEntity(this.activeSpaceId(), body).subscribe({
-      next: () => {
-        this.creatingEntity.set(false);
-        this.showEntityForm.set(false);
-        this.entityForm = { name: '', type: '', tags: [], description: '', properties: {} as Record<string, string | number | boolean> };
-        this.loadStats(this.activeSpaceId());
-        this.loadCurrentTab(this.activeSpaceId());
-      },
-      error: (err) => { this.creatingEntity.set(false); this.createEntityError.set(fmtApiError(err, 'Failed to create entity')); },
-    });
-  }
-
   createEdge(): void {
     if (!this.edgeForm.from.trim() || !this.edgeForm.to.trim() || !this.edgeForm.label.trim()) return;
     this.creatingEdge.set(true);
@@ -1942,14 +1657,6 @@ export class BrainComponent implements OnInit {
         this.loadCurrentTab(this.activeSpaceId());
       },
       error: (err) => { this.creatingEdge.set(false); this.createEdgeError.set(fmtApiError(err, 'Failed to create edge')); },
-    });
-  }
-
-  deleteEntity(id: string): void {
-    this.recordList.confirmDeleteId.set('');
-    this.brainApi.deleteEntity(this.activeSpaceId(), id).subscribe({
-      next: () => { this.store.entities.update(list => list.filter(e => e._id !== id)); this.loadStats(this.activeSpaceId()); },
-      error: () => {},
     });
   }
 
@@ -2025,21 +1732,6 @@ export class BrainComponent implements OnInit {
   }
 
   // ── Form openers with schema prefill ────────────────────────────────────
-
-  openEntityForm(): void {
-    const firstType = Object.keys(this.store.spaceMeta()?.typeSchemas?.entity ?? {})[0] ?? '';
-    this.entityForm = { name: '', type: firstType, tags: [], description: '', properties: this.store.buildPropertiesObject('entity', {}, firstType) };
-    this.showEntityForm.set(true);
-  }
-
-  /** Called when the entity type dropdown changes. Rebuilds properties: keeps existing values, adds defaults for any new schema-required fields. */
-  onEntityTypeChange(type: string, target: 'create' | 'inline'): void {
-    if (target === 'create') {
-      this.entityForm.properties = this.store.buildPropertiesObject('entity', this.entityForm.properties, type);
-    } else {
-      this.editEntity.properties = this.store.buildPropertiesObject('entity', this.editEntity.properties, type);
-    }
-  }
 
   openEdgeForm(): void {
     const firstLabel = Object.keys(this.store.spaceMeta()?.typeSchemas?.edge ?? {})[0] ?? '';

--- a/client/src/app/pages/brain/entities-tab.component.spec.ts
+++ b/client/src/app/pages/brain/entities-tab.component.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * EntitiesTabComponent — entity create/edit/delete/load behaviour, relocated from
+ * brain.component.records.spec.ts (A17.9b-6b) when the tab became its own component (A17.9b-6e), plus
+ * the self-loading + `mutated` wiring the split introduced. Entity delta from memories: create AND
+ * inline-edit strip empty optional properties via the entity schema.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import type { Entity, SpaceMetaResponse } from '../../core/api.types';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainApi } from '../../core/brain-api.service';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+import { RecordListState } from './record-list-state.service';
+import { EntitiesTabComponent } from './entities-tab.component';
+
+const api = {
+  listEntities: vi.fn(() => of({ entities: [] as Entity[] })),
+  getEntitiesByIds: vi.fn(() => of({ entities: [] })),
+  createEntity: vi.fn(() => of({ _id: 'new' } as Entity)),
+  updateEntity: vi.fn((_s: string, id: string) => of({ _id: id, name: 'UPDATED' } as Entity)),
+  deleteEntity: vi.fn(() => of({})),
+};
+
+function make() {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [EntitiesTabComponent, getTranslocoModule()],
+    providers: [
+      RecordListState, BrainStore, EntityRefPicker, RecordDrawerState,
+      { provide: BrainApi, useValue: api },
+    ],
+  });
+  const fixture = TestBed.createComponent(EntitiesTabComponent);
+  fixture.componentRef.setInput('spaceId', 'work');
+  fixture.detectChanges(); // effect → load()
+  return fixture;
+}
+
+beforeEach(() => { for (const fn of Object.values(api)) (fn as any).mockClear(); });
+
+describe('EntitiesTabComponent', () => {
+  it('is compiled as OnPush', () => {
+    expect(EntitiesTabComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('self-loads on the spaceId input (page size + skip 0 + no filter)', () => {
+    make();
+    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, {});
+  });
+
+  it('renders the create form when opened', () => {
+    const fixture = make();
+    fixture.componentInstance.openEntityForm();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('form.create-form')).toBeTruthy();
+  });
+
+  it('createEntity strips empty optional props via the schema (unlike memory) and emits mutated', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const mutated = vi.fn();
+    c.mutated.subscribe(mutated);
+    c.store.spaceMeta.set({ typeSchemas: { entity: { Person: { propertySchemas: { note: { required: false } } } } } } as unknown as SpaceMetaResponse);
+    c.entityForm = { name: ' Ann ', type: 'Person', tags: [], description: '', properties: { note: '' } };
+    c.createEntity();
+    expect(api.createEntity).toHaveBeenCalledWith('work', { name: 'Ann', type: 'Person' });
+    expect(mutated).toHaveBeenCalled();
+  });
+
+  it('createEntity is a no-op when name is blank', () => {
+    const c = make().componentInstance;
+    c.entityForm = { name: '  ', type: '', tags: [], description: '', properties: {} };
+    c.createEntity();
+    expect(api.createEntity).not.toHaveBeenCalled();
+  });
+
+  it('saveEditEntity strips props, clears editingId, and patches the store list', () => {
+    const c = make().componentInstance;
+    c.store.spaceMeta.set({ typeSchemas: { entity: { Person: { propertySchemas: { note: { required: false } } } } } } as unknown as SpaceMetaResponse);
+    c.store.entities.set([{ _id: 'e1', name: 'old' } as Entity]);
+    c.recordList.editingId.set('e1');
+    c.editEntity = { name: ' Ann ', type: 'Person', tags: [], description: '', properties: { note: '' } };
+    c.saveEditEntity('e1');
+    expect(api.updateEntity).toHaveBeenCalledWith('work', 'e1', { name: 'Ann', type: 'Person', tags: [], description: '' });
+    expect(c.recordList.editingId()).toBe('');
+    expect(c.store.entities()[0].name).toBe('UPDATED');
+  });
+
+  it('deleteEntity removes from the store, clears confirmDeleteId, and emits mutated', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const mutated = vi.fn();
+    c.mutated.subscribe(mutated);
+    c.store.entities.set([{ _id: 'e1' } as Entity, { _id: 'e2' } as Entity]);
+    c.recordList.confirmDeleteId.set('e1');
+    c.deleteEntity('e1');
+    expect(c.store.entities().map(e => e._id)).toEqual(['e2']);
+    expect(c.recordList.confirmDeleteId()).toBe('');
+    expect(mutated).toHaveBeenCalled();
+  });
+
+  it('the search bar reloads silently with the search term; nextEntityPage advances skip', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    api.listEntities.mockClear();
+    c.onEntitySearchChange('ali');
+    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, { search: 'ali' });
+    c.nextEntityPage();
+    expect(c.entitySkip()).toBe(20);
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 20, { search: 'ali' });
+  });
+});

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -1,0 +1,382 @@
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { Entity } from '../../core/api.types';
+import { BrainApi } from '../../core/brain-api.service';
+import { httpErrorReason } from '../../core/http-error';
+import { TagInputComponent } from '../../shared/tag-input.component';
+import { PropertiesViewComponent } from '../../shared/properties-view.component';
+import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
+import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ErrorStateComponent } from '../../shared/error-state.component';
+import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+import { RecordListState } from './record-list-state.service';
+import { fmtApiError } from './brain-format';
+import { BRAIN_CHIP_STYLES } from './brain-form.styles';
+import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+
+/**
+ * The Entities record tab, extracted from BrainComponent (A17.9b-6e) following the memories pattern.
+ * Owns the entity create form, the (drawer-superseded) inline edit, delete, and the tab's own
+ * entity-search / type-tag filter / pagination + loader. Self-loads via an effect on the `spaceId`
+ * input; create/delete emit `mutated` so the shell refreshes tab-count stats.
+ *
+ * Entity delta from memories: both create AND inline-edit strip empty optional properties via the
+ * entity schema; entity search uses the <app-entity-search> bar (semantic default) with no per-tab
+ * search-mode pill.
+ */
+@Component({
+  selector: 'app-entities-tab',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
+  template: `
+
+          <div class="content-header">
+            <app-entity-search
+              mode="bar"
+              [spaceId]="spaceId()"
+              placeholder="common.searchEntitiesPlaceholder"
+              defaultMode="semantic"
+              (queryChange)="onEntitySearchChange($event)"
+              (cleared)="onEntitySearchClear()"
+              (selected)="onEntitySearchPick($event)"
+            />
+            <button class="btn-primary btn btn-sm" (click)="openEntityForm()" [disabled]="showEntityForm()">{{ 'brain.entities.addButton' | transloco }}</button>
+          </div>
+          <div class="list-filter-row">
+            <app-record-filter-bar
+              [typeOptions]="store.entityTypeOptions()"
+              [tagSuggestions]="store.entityTagSuggestions()"
+              [value]="recordFilter()"
+              (filterChange)="onFilterChange($event)"
+            />
+          </div>
+
+          @if (showEntityForm()) {
+            <form class="create-form" (ngSubmit)="createEntity()">
+              <div class="field" style="flex:1; min-width:140px;">
+                <label>{{ 'brain.entities.table.name' | transloco }}</label>
+                <input type="text" [(ngModel)]="entityForm.name" name="name" required />
+              </div>
+              <div class="field" style="width:140px;">
+                <label>Type @if (store.entityTypeNames().length) { <span style="color:var(--error)">*</span> }</label>
+                @if (store.entityTypeNames().length) {
+                  <select [(ngModel)]="entityForm.type" name="type" required (ngModelChange)="onEntityTypeChange($event, 'create')">
+                    @for (t of store.entityTypeNames(); track t) {
+                      <option [value]="t">{{ t }}</option>
+                    }
+                  </select>
+                } @else {
+                  <input type="text" [(ngModel)]="entityForm.type" name="type" [placeholder]="'brain.entities.form.typePlaceholder' | transloco" />
+                }
+              </div>
+              <div class="field" style="flex:1; min-width:180px;">
+                <label>{{ 'brain.entities.table.tags' | transloco }}</label>
+                <app-tag-input [(value)]="entityForm.tags" [suggestions]="store.entityTagSuggestions()" inputName="entFormTags" />
+              </div>
+              <div class="field" style="flex:1; min-width:200px;">
+                <label>{{ 'brain.entities.table.description' | transloco }}</label>
+                <textarea [(ngModel)]="entityForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
+              </div>
+              <div class="field" style="flex:1; min-width:220px;">
+                <label>{{ 'brain.entities.table.properties' | transloco }}</label>
+                <app-properties-editor
+                  [schema]="store.entitySchema(entityForm.type)"
+                  [required]="store.requiredProps(store.entitySchema(entityForm.type))"
+                  [(value)]="entityForm.properties"
+                />
+              </div>
+              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEntity() || !entityForm.name.trim() || (store.entityTypeNames().length ? !entityForm.type : false)">
+                @if (creatingEntity()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                {{ 'common.save' | transloco }}
+              </button>
+              <button class="btn-secondary btn btn-sm" type="button" (click)="showEntityForm.set(false)">{{ 'common.cancel' | transloco }}</button>
+            </form>
+          }
+
+          @if (createEntityError()) {
+            <div class="alert alert-error" style="margin-bottom:12px;">{{ createEntityError() }}</div>
+          }
+
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>{{ 'brain.entities.table.name' | transloco }}</th><th>{{ 'brain.entities.table.type' | transloco }}</th><th>{{ 'brain.entities.table.description' | transloco }}</th><th>{{ 'brain.entities.table.tags' | transloco }}</th><th>{{ 'brain.entities.table.properties' | transloco }}</th><th>{{ 'brain.entities.table.created' | transloco }}</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (ent of store.entities(); track ent._id) {
+                  @if (recordList.editingId() === ent._id) {
+                    <tr>
+                      <td colspan="7">
+                        <div class="create-form" style="border:none; padding:8px 0;">
+                          <div class="field" style="flex:1; min-width:120px; margin-bottom:0;">
+                            <label>{{ 'brain.entities.table.name' | transloco }}</label>
+                            <input type="text" [(ngModel)]="editEntity.name" name="editEntName" />
+                          </div>
+                          <div class="field" style="width:120px; margin-bottom:0;">
+                            <label>Type @if (store.entityTypeNames().length) { <span style="color:var(--error)">*</span> }</label>
+                            @if (store.entityTypeNames().length) {
+                              <select [(ngModel)]="editEntity.type" name="editEntType" (ngModelChange)="onEntityTypeChange($event, 'inline')">
+                                @for (t of store.entityTypeNames(); track t) {
+                                  <option [value]="t">{{ t }}</option>
+                                }
+                              </select>
+                            } @else {
+                              <input type="text" [(ngModel)]="editEntity.type" name="editEntType" />
+                            }
+                          </div>
+                          <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
+                            <label>{{ 'brain.entities.table.description' | transloco }}</label>
+                            <textarea [(ngModel)]="editEntity.description" name="editEntDesc" rows="2" style="resize:vertical;"></textarea>
+                          </div>
+                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
+                            <label>{{ 'brain.entities.table.tags' | transloco }}</label>
+                            <app-tag-input [(value)]="editEntity.tags" [suggestions]="store.entityTagSuggestions()" inputName="entEditTags" />
+                          </div>
+                          <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
+                            <label>{{ 'brain.entities.table.properties' | transloco }}</label>
+                            <app-properties-editor
+                              [schema]="store.entitySchema(editEntity.type)"
+                              [required]="store.requiredProps(store.entitySchema(editEntity.type))"
+                              [(value)]="editEntity.properties"
+                            />
+                          </div>
+                          <div style="display:flex; gap:6px; align-items:flex-end;">
+                            <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditEntity(ent._id)">
+                              @if (recordList.editSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } Save
+                            </button>
+                            <button class="btn btn-sm btn-secondary" (click)="recordList.cancelEdit()">{{ 'common.cancel' | transloco }}</button>
+                          </div>
+                          @if (recordList.editError()) { <div style="font-size:12px; color:var(--error);">{{ recordList.editError() }}</div> }
+                        </div>
+                      </td>
+                    </tr>
+                  } @else {
+                    <tr>
+                      <td>{{ ent.name }}</td>
+                      <td>
+                        @if (ent.type) { <span class="badge badge-purple">{{ ent.type }}</span> }
+                      </td>
+                      <td class="desc-cell" style="max-width:200px;" [title]="ent.description ?? ''">
+                        {{ ent.description || '—' }}
+                      </td>
+                      <td style="font-size:11px;">
+                        @for (tag of (ent.tags ?? []); track tag) { <span class="tag">{{ tag }}</span> }
+                        @if (!(ent.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
+                      </td>
+                      <td><app-properties-view [properties]="ent.properties" [schema]="store.entitySchema(ent.type)" /></td>
+                      <td style="color:var(--text-muted)">{{ ent.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td style="white-space:nowrap;">
+                        <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('entity', ent)"><ph-icon name="eye" [size]="16"/></button>
+                        @if (recordList.confirmDeleteId() === ent._id) {
+                          <span class="inline-confirm">
+                            Delete?
+                            <button class="btn btn-sm btn-danger" (click)="deleteEntity(ent._id)">{{ 'common.yes' | transloco }}</button>
+                            <button class="btn btn-sm btn-secondary" (click)="cancelDelete()">{{ 'common.no' | transloco }}</button>
+                          </span>
+                        } @else {
+                          <button class="icon-btn danger" [attr.aria-label]="'brain.entities.deleteAriaLabel' | transloco" (click)="requestDelete(ent._id)"><ph-icon name="x" [size]="16"/></button>
+                        }
+                      </td>
+                    </tr>
+                  }
+                } @empty {
+                  <tr><td colspan="7">
+                    @if (recordList.loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadEntities' | transloco" [reason]="recordList.loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
+                    <div class="empty-state" style="padding:32px">
+                      <div class="empty-state-icon"><ph-icon name="tag" [size]="48"/></div>
+                      <h3>{{ 'brain.entities.empty.title' | transloco }}</h3>
+                    </div>
+                    }
+                  </td></tr>
+                }
+              </tbody>
+            </table>
+          </div>
+          <div class="pagination">
+            <button class="btn btn-sm btn-secondary" [disabled]="entitySkip() === 0" (click)="prevEntityPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+            <span class="pager-info">{{ store.entities().length ? (entitySkip() + 1) + '–' + (entitySkip() + store.entities().length) : '–' }}</span>
+            <button class="btn btn-sm btn-secondary" [disabled]="store.entities().length < pageSize" (click)="nextEntityPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+          </div>
+  `,
+})
+export class EntitiesTabComponent {
+  readonly store = inject(BrainStore);
+  readonly picker = inject(EntityRefPicker);
+  readonly drawerState = inject(RecordDrawerState);
+  readonly recordList = inject(RecordListState);
+  private brainApi = inject(BrainApi);
+
+  readonly spaceId = input.required<string>();
+  /** Emitted after a create/delete so the shell can refresh the space's tab-count stats. */
+  readonly mutated = output<void>();
+
+  readonly pageSize = 20;
+
+  entitySkip = signal(0);
+  entitySearch = signal('');
+  recordFilter = signal<RecordFilter>({ type: '', tag: '' });
+
+  showEntityForm = signal(false);
+  creatingEntity = signal(false);
+  createEntityError = signal('');
+  entityForm = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
+  editEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
+
+  constructor() {
+    effect(() => {
+      const id = this.spaceId();
+      this.entitySkip.set(0);
+      this.entitySearch.set('');
+      this.recordFilter.set({ type: '', tag: '' });
+      if (id) this.load();
+    });
+  }
+
+  private load(): void {
+    const spaceId = this.spaceId();
+    if (!spaceId) return;
+    this.recordList.loading.set(true);
+    this.recordList.loadError.set(null);
+    const ef: { search?: string; type?: string; tag?: string } = {};
+    if (this.entitySearch()) ef.search = this.entitySearch();
+    if (this.recordFilter().type) ef.type = this.recordFilter().type;
+    if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
+    this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
+      next: ({ entities }) => { this.store.entities.set(entities); this.recordList.loading.set(false); },
+      error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
+    });
+  }
+
+  /** Reload without the loading overlay — used by the search bar (keeps focus/typing smooth). */
+  private loadEntitiesSilent(): void {
+    const spaceId = this.spaceId();
+    if (!spaceId) return;
+    const ef: { search?: string; type?: string; tag?: string } = {};
+    if (this.entitySearch()) ef.search = this.entitySearch();
+    if (this.recordFilter().type) ef.type = this.recordFilter().type;
+    if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
+    this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
+      next: ({ entities }) => this.store.entities.set(entities),
+      error: () => {},
+    });
+  }
+
+  retryCurrentTab(): void { this.load(); }
+
+  prevEntityPage(): void { this.entitySkip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
+  nextEntityPage(): void { this.entitySkip.update(s => s + this.pageSize); this.load(); }
+
+  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
+  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
+
+  onEntitySearchChange(q: string): void {
+    this.entitySearch.set(q);
+    this.entitySkip.set(0);
+    this.loadEntitiesSilent();
+  }
+  onEntitySearchClear(): void {
+    this.entitySearch.set('');
+    this.entitySkip.set(0);
+    this.loadEntitiesSilent();
+  }
+  onEntitySearchPick(ent: Entity): void {
+    this.entitySearch.set(ent.name);
+    this.entitySkip.set(0);
+    this.loadEntitiesSilent();
+  }
+
+  onFilterChange(f: RecordFilter): void {
+    this.recordFilter.set(f);
+    this.entitySkip.set(0);
+    this.load();
+  }
+
+  openEntityForm(): void {
+    const firstType = Object.keys(this.store.spaceMeta()?.typeSchemas?.entity ?? {})[0] ?? '';
+    this.entityForm = { name: '', type: firstType, tags: [], description: '', properties: this.store.buildPropertiesObject('entity', {}, firstType) };
+    this.showEntityForm.set(true);
+  }
+
+  /** Called when the entity type dropdown changes. Rebuilds properties: keeps existing values, adds defaults for any new schema-required fields. */
+  onEntityTypeChange(type: string, target: 'create' | 'inline'): void {
+    if (target === 'create') {
+      this.entityForm.properties = this.store.buildPropertiesObject('entity', this.entityForm.properties, type);
+    } else {
+      this.editEntity.properties = this.store.buildPropertiesObject('entity', this.editEntity.properties, type);
+    }
+  }
+
+  createEntity(): void {
+    if (!this.entityForm.name.trim()) return;
+    this.creatingEntity.set(true);
+    this.createEntityError.set('');
+    const body: Parameters<BrainApi['createEntity']>[1] = { name: this.entityForm.name.trim() };
+    if (this.entityForm.type.trim()) body.type = this.entityForm.type.trim();
+    if (this.entityForm.tags.length) body.tags = this.entityForm.tags;
+    if (this.entityForm.description.trim()) body.description = this.entityForm.description.trim();
+    const props = this.store.stripEmptyOptionalProps(this.entityForm.properties, this.store.entitySchema(this.entityForm.type));
+    if (Object.keys(props).length) body.properties = props;
+    this.brainApi.createEntity(this.spaceId(), body).subscribe({
+      next: () => {
+        this.creatingEntity.set(false);
+        this.showEntityForm.set(false);
+        this.entityForm = { name: '', type: '', tags: [], description: '', properties: {} as Record<string, string | number | boolean> };
+        this.mutated.emit();
+        this.load();
+      },
+      error: (err) => { this.creatingEntity.set(false); this.createEntityError.set(fmtApiError(err, 'Failed to create entity')); },
+    });
+  }
+
+  startEditEntity(ent: Entity): void {
+    this.recordList.editingId.set(ent._id);
+    this.recordList.editError.set('');
+    this.editEntity = {
+      name: ent.name,
+      type: ent.type ?? '',
+      tags: ent.tags ?? [],
+      description: ent.description ?? '',
+      properties: this.store.buildPropertiesObject('entity', ent.properties ?? {}, ent.type),
+    };
+  }
+
+  saveEditEntity(id: string): void {
+    this.recordList.editSaving.set(true);
+    this.recordList.editError.set('');
+    const entProps = this.store.stripEmptyOptionalProps(this.editEntity.properties, this.store.entitySchema(this.editEntity.type));
+    this.brainApi.updateEntity(this.spaceId(), id, {
+      name: this.editEntity.name.trim(),
+      type: this.editEntity.type.trim(),
+      tags: this.editEntity.tags,
+      description: this.editEntity.description.trim(),
+      ...(Object.keys(entProps).length ? { properties: entProps } : {}),
+    }).subscribe({
+      next: (updated) => {
+        this.recordList.editSaving.set(false);
+        this.recordList.editingId.set('');
+        this.store.entities.update(list => list.map(e => e._id === id ? updated : e));
+      },
+      error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
+    });
+  }
+
+  deleteEntity(id: string): void {
+    this.recordList.confirmDeleteId.set('');
+    this.brainApi.deleteEntity(this.spaceId(), id).subscribe({
+      next: () => { this.store.entities.update(list => list.filter(e => e._id !== id)); this.mutated.emit(); },
+      error: () => {},
+    });
+  }
+}


### PR DESCRIPTION
## What

The second record tab out of the shell — `entities-tab.component`, following the memories self-loading pattern (#250). It owns the entity create form, inline edit, delete, and its own entity-search / type-tag filter / pagination + loader; self-loads via a `spaceId` effect; emits `mutated` so the shell refreshes tab-count stats. The shell's `loadCurrentTab` early-returns for entities.

## Entity-specific behaviour preserved

- **Both create AND inline-edit strip empty optional properties** via the entity schema — unlike memory, which sends them raw (pinned by the relocated 6b characterization case).
- Entity search uses the `<app-entity-search>` bar (semantic default) with its own change/clear/pick handlers → a silent reload; no per-tab search-mode pill.
- Reuses the shared `brain-table.styles.ts` (no new CSS).

## Tests

The 6b `createEntity` characterization case moved to `entities-tab.component.spec.ts`, plus new tests: OnPush, self-load-on-`spaceId`, create-form render, create/save/delete (with `mutated` emission and the schema-strip), and the search-bar → silent-reload + pagination wiring.

## Verification

- `brain.component.ts` **2070 → 1762**.
- Full client suite: **190 → 197**, all passing.
- `tsc --noEmit --noUnusedLocals` clean on the brain files.
- Production AOT build warning-free apart from the pre-existing `qrcode` CommonJS bailout.
- CHANGELOG updated; internal refactor, no documented behaviour changed → no docs update.

Next: `9b-6f..h` extract edges/chrono/filemeta (edges/chrono have a semantic search-mode pill like memories; filemeta uses the files API + fm pickers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)