### PR TITLE
refactor(client): extract the Edges tab into a self-loading OnPush component (A17.9b-6f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Edges tab is now its own self-loading OnPush component (`edges-tab.component`), the third record
+  tab out of the shell.** Same pattern; edges have a text/semantic search-mode pill (via
+  `store.edgeSearch`/`edgeSearchMode`, like memories). Two edge-specific behaviours preserved and pinned:
+  create AND inline-edit strip empty optional properties via the edge schema, and **`deleteEdge` does
+  NOT refresh the space stats** (so it emits no `mutated`) — the asymmetry with memory/entity that the
+  A17.9b-6b tests pin. The edge from/to endpoint pickers (`pickEdgeFrom`/`pickEdgeTo`, on the shell since
+  the picker split) moved into the tab with `edgeForm`. The 6b `createEdge`/`deleteEdge` characterization
+  cases + the two edge-endpoint tests relocated to `edges-tab.component.spec.ts`. Removing the last of
+  memories/entities/edges also made `PropertiesViewComponent`/`PropertiesEditorComponent` unused in the
+  shell (chrono/filemeta have no schema-property editor) — dropped from its imports. `brain.component.ts`
+  1762 → 1402. Client suite: 197 → 200.
+
 - **The Entities tab is now its own self-loading OnPush component (`entities-tab.component`), the second
   record tab out of the shell.** Same pattern as memories: it owns the entity create form, inline edit,
   delete, and its own entity-search / type-tag filter / pagination + loader; self-loads via a `spaceId`

--- a/client/src/app/pages/brain/brain.component.records.spec.ts
+++ b/client/src/app/pages/brain/brain.component.records.spec.ts
@@ -90,12 +90,6 @@ describe('BrainComponent — create payloads', () => {
     expect('endsAt' in body).toBe(false);
   });
 
-  it('createEdge requires from+to+label and spreads weight only when set', () => {
-    const c = make();
-    c.edgeForm = { from: 'a', fromDisplay: '', to: 'b', toDisplay: '', label: 'knows', weight: null, tags: [], description: '', properties: {} };
-    c.createEdge();
-    expect(api.createEdge).toHaveBeenCalledWith('work', { from: 'a', to: 'b', label: 'knows' });
-  });
 });
 
 describe('BrainComponent — inline edit', () => {
@@ -110,16 +104,6 @@ describe('BrainComponent — inline edit', () => {
 });
 
 describe('BrainComponent — delete', () => {
-  it('deleteEdge removes from the store but does NOT refresh stats (asymmetry with memory/entity)', () => {
-    const c = make();
-    c.store.edges.set([{ _id: 'x1' } as Edge]);
-    api.getSpaceStats.mockClear();
-    c.deleteEdge('x1');
-    expect(api.deleteEdge).toHaveBeenCalledWith('work', 'x1');
-    expect(c.store.edges()).toEqual([]);
-    expect(api.getSpaceStats).not.toHaveBeenCalled();
-  });
-
   it('deleteFileMeta deletes by PATH via the files API and removes the metadata record', () => {
     const c = make();
     c.store.fileMetas.set([{ _id: 'f1', path: '/docs/a.md' } as FileMeta]);

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -17,7 +17,6 @@ import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
-import { type Entity } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { BrainApi } from '../../core/brain-api.service';
 import { FilesApi } from '../../core/files-api.service';
@@ -106,25 +105,5 @@ describe('BrainComponent (OnPush)', () => {
     expect(title).toContain('brain.spaceChip.network.vote');
   });
 
-  // ── Edge endpoint pickers (characterization) ───────────────────────────────
-  // These two branches did NOT move to EntityRefPicker (A17.9b-3): edge from/to set display fields
-  // on the shell-owned edgeForm and, unlike the entity-id chip fields, do NOT touch the name cache.
-  const ent = (id: string, name = id): Entity =>
-    ({ _id: id, name, tags: [], properties: {}, createdAt: '' } as unknown as Entity);
-
-  it('pickEdgeFrom sets edgeForm.from + fromDisplay without caching the name', () => {
-    const c = create().componentInstance;
-    c.pickEdgeFrom(ent('e1', 'Alice'));
-    expect(c.edgeForm.from).toBe('e1');
-    expect(c.edgeForm.fromDisplay).toBe('Alice');
-    expect(c.picker.entityNameCache()['e1']).toBeUndefined();
-  });
-
-  it('pickEdgeTo sets edgeForm.to + toDisplay without caching the name', () => {
-    const c = create().componentInstance;
-    c.pickEdgeTo(ent('e2', 'Bob'));
-    expect(c.edgeForm.to).toBe('e2');
-    expect(c.edgeForm.toDisplay).toBe('Bob');
-    expect(c.picker.entityNameCache()['e2']).toBeUndefined();
-  });
+  // The edge from/to endpoint pickers moved to edges-tab.component.spec.ts with the Edges tab (A17.9b-6f).
 });

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -8,18 +8,17 @@ import { QueryTabComponent } from './query-tab.component';
 import { RecordListState } from './record-list-state.service';
 import { MemoriesTabComponent } from './memories-tab.component';
 import { EntitiesTabComponent } from './entities-tab.component';
+import { EdgesTabComponent } from './edges-tab.component';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { toLocalDatetime, fmtApiError } from './brain-format';
 import { FormsModule } from '@angular/forms';
-import { Space, SpaceStats, Entity, Edge, ChronoEntry, ChronoType, ChronoStatus, FileMeta } from '../../core/api.types';
+import { Space, SpaceStats, ChronoEntry, ChronoType, ChronoStatus, FileMeta } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { BrainApi } from '../../core/brain-api.service';
 import { FilesApi } from '../../core/files-api.service';
 import { GraphComponent } from '../graph/graph.component';
 import { FileManagerComponent } from '../files/file-manager.component';
 import { EntitySearchComponent } from '../../shared/entity-search.component';
-import { PropertiesViewComponent } from '../../shared/properties-view.component';
-import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
@@ -48,7 +47,7 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, PropertiesViewComponent, PropertiesEditorComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, EntitySearchComponent, TagInputComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [BRAIN_CHIP_STYLES, `
     .space-tabs {
@@ -471,213 +470,7 @@ interface SpaceView {
         @if (activeTab() === 'entities') { <app-entities-tab [spaceId]="activeSpaceId()" (mutated)="loadStats(activeSpaceId())" /> }
 
         <!-- Edges -->
-        @if (activeTab() === 'edges') {
-
-          <div class="content-header">
-            <input type="search" [placeholder]="'brain.edges.searchPlaceholder' | transloco"
-              [value]="store.edgeSearch()"
-              (input)="onEdgeSearch($any($event.target).value)"
-              [attr.aria-label]="'brain.edges.searchPlaceholder' | transloco" />
-            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-              <button [class.active]="store.edgeSearchMode() === 'text'" (click)="setEdgeSearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
-              <button [class.active]="store.edgeSearchMode() === 'semantic'" (click)="setEdgeSearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
-            </div>
-            <button class="btn-primary btn btn-sm" (click)="openEdgeForm()" [disabled]="showEdgeForm()">{{ 'brain.edges.addButton' | transloco }}</button>
-          </div>
-          <div class="list-filter-row">
-            <app-record-filter-bar
-              [typeOptions]="store.edgeTypeOptions()"
-              [tagSuggestions]="store.edgeTagSuggestions()"
-              [value]="recordFilter()"
-              (filterChange)="onFilterChange($event)"
-            />
-          </div>
-
-          @if (showEdgeForm()) {
-            <form class="create-form" (ngSubmit)="createEdge()">
-              <div class="field" style="flex:1; min-width:120px;">
-                <label>{{ 'common.form.from' | transloco }}</label>
-                <app-entity-search
-                  mode="picker"
-                  [spaceId]="activeSpaceId()"
-                  placeholder="common.searchEntitiesPlaceholder"
-
-                  [value]="edgeForm.fromDisplay"
-                  (selected)="pickEdgeFrom($event)"
-                />
-              </div>
-              <div class="field" style="flex:1; min-width:120px;">
-                <label>{{ 'brain.edges.form.relation' | transloco }} <span style="color:var(--error)">*</span></label>
-                @if (store.edgeLabelNames().length) {
-                  <select [(ngModel)]="edgeForm.label" name="label" required>
-                    @for (l of store.edgeLabelNames(); track l) {
-                      <option [value]="l">{{ l }}</option>
-                    }
-                  </select>
-                } @else {
-                  <input type="text" [(ngModel)]="edgeForm.label" name="label" required />
-                }
-              </div>
-              <div class="field" style="flex:1; min-width:120px;">
-                <label>{{ 'common.form.to' | transloco }}</label>
-                <app-entity-search
-                  mode="picker"
-                  [spaceId]="activeSpaceId()"
-                  placeholder="common.searchEntitiesPlaceholder"
-
-                  [value]="edgeForm.toDisplay"
-                  (selected)="pickEdgeTo($event)"
-                />
-              </div>
-              <div class="field" style="width:80px;">
-                <label>{{ 'common.form.weight' | transloco }}</label>
-                <input type="number" [(ngModel)]="edgeForm.weight" name="weight" step="0.1" />
-              </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'brain.edges.table.tags' | transloco }}</label>
-                <app-tag-input [(value)]="edgeForm.tags" [suggestions]="store.edgeTagSuggestions()" inputName="edgeFormTags" />
-              </div>
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'brain.edges.table.description' | transloco }}</label>
-                <textarea [(ngModel)]="edgeForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:220px;">
-                <label>{{ 'brain.edges.table.properties' | transloco }}</label>
-                <app-properties-editor
-                  [schema]="store.edgeSchema(edgeForm.label)"
-                  [required]="store.requiredProps(store.edgeSchema(edgeForm.label))"
-                  [(value)]="edgeForm.properties"
-                />
-              </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEdge() || !edgeForm.from.trim() || !edgeForm.to.trim() || !edgeForm.label.trim()">
-                @if (creatingEdge()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showEdgeForm.set(false)">{{ 'common.cancel' | transloco }}</button>
-            </form>
-          }
-
-          @if (createEdgeError()) {
-            <div class="alert alert-error" style="margin-bottom:12px;">{{ createEdgeError() }}</div>
-          }
-          <div class="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>{{ 'brain.edges.table.from' | transloco }}</th><th>{{ 'brain.edges.table.relation' | transloco }}</th><th>{{ 'brain.edges.table.to' | transloco }}</th><th>{{ 'brain.edges.table.weight' | transloco }}</th><th>{{ 'brain.edges.table.tags' | transloco }}</th><th>{{ 'brain.edges.table.description' | transloco }}</th><th>{{ 'brain.edges.table.properties' | transloco }}</th><th>{{ 'brain.edges.table.created' | transloco }}</th><th></th>
-                </tr>
-              </thead>
-              <tbody>
-                @for (edge of store.filteredEdges(); track edge._id) {
-                  @if (recordList.editingId() === edge._id) {
-                    <tr>
-                      <td colspan="9">
-                        <div class="create-form" style="border:none; padding:8px 0;">
-                          <div class="field" style="min-width:200px; margin-bottom:0;">
-                            <label style="font-size:11px; color:var(--text-muted);">{{ 'brain.edges.form.editingLabel' | transloco }}</label>
-                            <div style="font-size:12px; padding:6px 8px; background:var(--bg-secondary); border-radius:4px; color:var(--text-muted);">
-                              {{ editEdge.fromName || editEdge.from }} → {{ editEdge.toName || editEdge.to }}
-                            </div>
-                          </div>
-                          <div class="field" style="flex:1; min-width:120px; margin-bottom:0;">
-                            <label>{{ 'brain.edges.form.relation' | transloco }}</label>
-                            @if (store.edgeLabelNames().length) {
-                              <select [(ngModel)]="editEdge.label" name="editEdgeLabel">
-                                @for (l of store.edgeLabelNames(); track l) {
-                                  <option [value]="l">{{ l }}</option>
-                                }
-                              </select>
-                            } @else {
-                              <input type="text" [(ngModel)]="editEdge.label" name="editEdgeLabel" />
-                            }
-                          </div>
-                          <div class="field" style="width:80px; margin-bottom:0;">
-                            <label>{{ 'common.form.weight' | transloco }}</label>
-                            <input type="number" [(ngModel)]="editEdge.weight" name="editEdgeWeight" step="0.1" />
-                          </div>
-                          <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
-                            <label>{{ 'brain.edges.table.description' | transloco }}</label>
-                            <textarea [(ngModel)]="editEdge.description" name="editEdgeDesc" rows="2" style="resize:vertical;"></textarea>
-                          </div>
-                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
-                            <label>{{ 'brain.edges.table.tags' | transloco }}</label>
-                            <app-tag-input [(value)]="editEdge.tags" [suggestions]="store.edgeTagSuggestions()" inputName="edgeEditTags" />
-                          </div>
-                          <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
-                            <label>{{ 'brain.edges.table.properties' | transloco }}</label>
-                            <app-properties-editor
-                              [schema]="store.edgeSchema(editEdge.label)"
-                              [required]="store.requiredProps(store.edgeSchema(editEdge.label))"
-                              [(value)]="editEdge.properties"
-                            />
-                          </div>
-                          <div style="display:flex; gap:6px; align-items:flex-end;">
-                            <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditEdge(edge._id)">
-                              @if (recordList.editSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } {{ 'common.save' | transloco }}
-                            </button>
-                            <button class="btn btn-sm btn-secondary" (click)="recordList.cancelEdit()">{{ 'common.cancel' | transloco }}</button>
-                          </div>
-                          @if (recordList.editError()) { <div style="font-size:12px; color:var(--error);">{{ recordList.editError() }}</div> }
-                        </div>
-                      </td>
-                    </tr>
-                  } @else {
-                    <tr style="vertical-align:top;">
-                      <td style="font-size:12px; white-space:nowrap;">{{ edge.fromName || edge.from }}</td>
-                      <td><span class="badge badge-blue">{{ edge.label }}</span></td>
-                      <td style="font-size:12px; white-space:nowrap;">{{ edge.toName || edge.to }}</td>
-                      <td style="color:var(--text-muted);">{{ edge.weight ?? '—' }}</td>
-                      <td style="font-size:11px;">
-                        @for (tag of (edge.tags ?? []); track tag) { <span class="tag">{{ tag }}</span> }
-                        @if (!(edge.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
-                      </td>
-                      <td style="font-size:12px; color:var(--text-muted); white-space:normal; word-break:break-word; min-width:140px; min-height:4.2em;">
-                        {{ edge.description || '—' }}
-                      </td>
-                      <td><app-properties-view [properties]="edge.properties" [schema]="store.edgeSchema(edge.label)" /></td>
-                      <td style="color:var(--text-muted); white-space:nowrap;">{{ edge.createdAt | date:'dd.MM.yyyy' }}</td>
-                      <td style="white-space:nowrap;">
-                        <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('edge', edge)"><ph-icon name="eye" [size]="16"/></button>
-                        @if (recordList.confirmDeleteId() === edge._id) {
-                          <span class="inline-confirm">
-                            {{ 'common.deleteConfirm' | transloco }}
-                            <button class="btn btn-sm btn-danger" (click)="deleteEdge(edge._id)">{{ 'common.yes' | transloco }}</button>
-                            <button class="btn btn-sm btn-secondary" (click)="cancelDelete()">{{ 'common.no' | transloco }}</button>
-                          </span>
-                        } @else {
-                          <button class="icon-btn danger" [attr.aria-label]="'brain.edges.deleteAriaLabel' | transloco" (click)="requestDelete(edge._id)"><ph-icon name="x" [size]="16"/></button>
-                        }
-                      </td>
-                    </tr>
-                  }
-                } @empty {
-                  <tr><td colspan="9">
-                    @if (recordList.loadError() !== null) {
-                      <app-error-state [message]="'brain.error.loadEdges' | transloco" [reason]="recordList.loadError() ?? ''" (retry)="retryCurrentTab()" />
-                    } @else {
-                    <div class="empty-state" style="padding:32px">
-                      <div class="empty-state-icon"><ph-icon name="graph" [size]="48"/></div>
-                      @if (store.edgeSearch() && store.edges().length) {
-                        <h3>{{ 'common.noMatches' | transloco }}</h3>
-                        <p>{{ 'brain.edges.empty.noMatchQuery' | transloco: { query: store.edgeSearch() } }}</p>
-                      } @else {
-                        <h3>{{ 'brain.edges.empty.title' | transloco }}</h3>
-                      }
-                    </div>
-                    }
-                  </td></tr>
-                }
-              </tbody>
-            </table>
-          </div>
-          @if (store.edgeSearchMode() !== 'semantic') {
-            <div class="pagination">
-              <button class="btn btn-sm btn-secondary" [disabled]="edgeSkip() === 0" (click)="prevEdgePage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-              <span class="pager-info">{{ store.filteredEdges().length ? (edgeSkip() + 1) + '–' + (edgeSkip() + store.filteredEdges().length) : '–' }}</span>
-              <button class="btn btn-sm btn-secondary" [disabled]="store.edges().length < pageSize" (click)="nextEdgePage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
-            </div>
-          }
-        }
+        @if (activeTab() === 'edges') { <app-edges-tab [spaceId]="activeSpaceId()" (mutated)="loadStats(activeSpaceId())" /> }
 
         <!-- Chrono -->
         @if (activeTab() === 'chrono') {
@@ -1171,7 +964,6 @@ export class BrainComponent implements OnInit {
     this.recordFilter.set(f);
     switch (this.activeTab()) {
       case 'memories': this.skip.set(0); break;
-      case 'edges': this.edgeSkip.set(0); break;
       case 'chrono': this.chronoSkip.set(0); break;
       default: break;
     }
@@ -1182,11 +974,7 @@ export class BrainComponent implements OnInit {
   skip = signal(0);
   filterEntity = signal('');
 
-  private _edgeSemTimer: ReturnType<typeof setTimeout> | null = null;
   private _chronoSemTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Edges pagination
-  edgeSkip = signal(0);
 
   // Chrono pagination
   chronoSkip = signal(0);
@@ -1196,14 +984,7 @@ export class BrainComponent implements OnInit {
   reindexing = signal(false);
   reindexResult = signal('');
 
-  editEdge = { from: '', to: '', fromName: undefined as string | undefined, toName: undefined as string | undefined, label: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '' };
-
-  // Create edge form
-  showEdgeForm = signal(false);
-  creatingEdge = signal(false);
-  createEdgeError = signal('');
-  edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
 
   // Create chrono form
   showChronoForm = signal(false);
@@ -1251,7 +1032,6 @@ export class BrainComponent implements OnInit {
     this.picker.spaceId.set(id);
     this.drawerState.spaceId.set(id);
     this.skip.set(0);
-    this.edgeSkip.set(0);
     this.chronoSkip.set(0);
     this.recordFilter.set({ type: '', tag: '' });
     this.filterEntity.set('');
@@ -1271,7 +1051,6 @@ export class BrainComponent implements OnInit {
   setTab(tab: BrainTab): void {
     this.activeTab.set(tab);
     this.skip.set(0);
-    this.edgeSkip.set(0);
     this.chronoSkip.set(0);
     this.fileMetaSkip.set(0);
     this.recordFilter.set({ type: '', tag: '' });
@@ -1287,9 +1066,6 @@ export class BrainComponent implements OnInit {
     this.loadCurrentTab(this.activeSpaceId());
   }
 
-  prevEdgePage(): void { this.edgeSkip.update(s => Math.max(0, s - this.pageSize)); this.loadCurrentTab(this.activeSpaceId()); }
-  nextEdgePage(): void { this.edgeSkip.update(s => s + this.pageSize); this.loadCurrentTab(this.activeSpaceId()); }
-
   prevChronoPage(): void { this.chronoSkip.update(s => Math.max(0, s - this.pageSize)); this.loadCurrentTab(this.activeSpaceId()); }
   nextChronoPage(): void { this.chronoSkip.update(s => s + this.pageSize); this.loadCurrentTab(this.activeSpaceId()); }
 
@@ -1299,44 +1075,6 @@ export class BrainComponent implements OnInit {
   onFileMetaSearch(q: string): void {
     this.store.fileMetaSearch.set(q);
     // client-side filter via filteredFileMetas computed() — no API call per keystroke
-  }
-
-  onEdgeSearch(q: string): void {
-    this.store.edgeSearch.set(q);
-    if (this.store.edgeSearchMode() === 'semantic') {
-      if (this._edgeSemTimer) clearTimeout(this._edgeSemTimer);
-      if (!q.trim()) { this.store.edges.set([]); return; }
-      this._edgeSemTimer = setTimeout(() => this.runSemanticEdgeSearch(), 300);
-    }
-  }
-  setEdgeSearchMode(m: 'text' | 'semantic'): void {
-    this.store.edgeSearchMode.set(m);
-    const q = this.store.edgeSearch().trim();
-    if (!q) return;
-    if (m === 'semantic') this.runSemanticEdgeSearch();
-    else { this.edgeSkip.set(0); this.loadCurrentTab(this.activeSpaceId()); }
-  }
-  runSemanticEdgeSearch(): void {
-    const q = this.store.edgeSearch().trim();
-    const spaceId = this.activeSpaceId();
-    if (!q || !spaceId) { this.store.edges.set([]); return; }
-    this.brainApi.recallBrain(spaceId, { query: q, types: ['edge'], topK: 20 }).pipe(
-      catchError(() => of({ results: [], count: 0 })),
-    ).subscribe(res => {
-      this.store.edges.set(res.results.filter(r => r.type === 'edge').map(r => ({
-        _id: r['_id'] as string,
-        from: (r['from'] as string) ?? '',
-        fromName: r['fromName'] as string | undefined,
-        to: (r['to'] as string) ?? '',
-        toName: r['toName'] as string | undefined,
-        label: (r['label'] as string) ?? '',
-        weight: r['weight'] as number | undefined,
-        tags: (r['tags'] as string[]) ?? [],
-        description: r['description'] as string | undefined,
-        properties: (r['properties'] as Record<string, string | number | boolean>) ?? {},
-        createdAt: (r['createdAt'] as string) ?? '',
-      } as Edge)));
-    });
   }
 
   onChronoSearch(q: string): void {
@@ -1410,20 +1148,11 @@ export class BrainComponent implements OnInit {
     if (!spaceId) return;
     if (this.activeTab() === 'memories') return; // self-loading component
     if (this.activeTab() === 'entities') return; // self-loading component
+    if (this.activeTab() === 'edges') return; // self-loading component
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
 
     switch (this.activeTab()) {
-      case 'edges': {
-        const gf: { type?: string; tag?: string } = {};
-        if (this.recordFilter().type) gf.type = this.recordFilter().type;
-        if (this.recordFilter().tag) gf.tag = this.recordFilter().tag;
-        this.brainApi.listEdges(spaceId, this.pageSize, this.edgeSkip(), gf).subscribe({
-          next: ({ edges }) => { this.store.edges.set(edges); this.recordList.loading.set(false); },
-          error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
-        });
-        break;
-      }
       case 'chrono': {
         const cf: { search?: string; type?: string; tag?: string } = {};
         if (this.store.chronoSearch()) cf.search = this.store.chronoSearch();
@@ -1492,22 +1221,6 @@ export class BrainComponent implements OnInit {
   requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
   cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
-  startEditEdge(edge: Edge): void {
-    this.recordList.editingId.set(edge._id);
-    this.recordList.editError.set('');
-    this.editEdge = {
-      from: edge.from,
-      to: edge.to,
-      fromName: edge.fromName,
-      toName: edge.toName,
-      label: edge.label,
-      weight: edge.weight ?? null,
-      tags: edge.tags ?? [],
-      description: edge.description ?? '',
-      properties: this.store.buildPropertiesObject('edge', edge.properties ?? {}, edge.label),
-    };
-  }
-
   startEditChrono(entry: ChronoEntry): void {
     this.recordList.editingId.set(entry._id);
     this.recordList.editError.set('');
@@ -1521,26 +1234,6 @@ export class BrainComponent implements OnInit {
       tags: entry.tags ?? [],
       entityIds: (entry.entityIds ?? []).join(', '),
     };
-  }
-
-  saveEditEdge(id: string): void {
-    this.recordList.editSaving.set(true);
-    this.recordList.editError.set('');
-    const edgeProps = this.store.stripEmptyOptionalProps(this.editEdge.properties, this.store.edgeSchema(this.editEdge.label));
-    this.brainApi.updateEdge(this.activeSpaceId(), id, {
-      label: this.editEdge.label.trim(),
-      tags: this.editEdge.tags,
-      description: this.editEdge.description.trim(),
-      ...(this.editEdge.weight != null ? { weight: this.editEdge.weight } : {}),
-      ...(Object.keys(edgeProps).length ? { properties: edgeProps } : {}),
-    }).subscribe({
-      next: (updated) => {
-        this.recordList.editSaving.set(false);
-        this.recordList.editingId.set('');
-        this.store.edges.update(list => list.map(e => e._id === id ? updated : e));
-      },
-      error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
-    });
   }
 
   saveEditChrono(id: string): void {
@@ -1634,40 +1327,6 @@ export class BrainComponent implements OnInit {
     this.setTab('files');
   }
 
-  createEdge(): void {
-    if (!this.edgeForm.from.trim() || !this.edgeForm.to.trim() || !this.edgeForm.label.trim()) return;
-    this.creatingEdge.set(true);
-    this.createEdgeError.set('');
-    const body: Parameters<BrainApi['createEdge']>[1] = {
-      from: this.edgeForm.from.trim(),
-      to: this.edgeForm.to.trim(),
-      label: this.edgeForm.label.trim(),
-    };
-    if (this.edgeForm.weight != null) body.weight = this.edgeForm.weight;
-    if (this.edgeForm.tags.length) body.tags = this.edgeForm.tags;
-    if (this.edgeForm.description.trim()) body.description = this.edgeForm.description.trim();
-    const edgeProps = this.store.stripEmptyOptionalProps(this.edgeForm.properties, this.store.edgeSchema(this.edgeForm.label));
-    if (Object.keys(edgeProps).length) body.properties = edgeProps;
-    this.brainApi.createEdge(this.activeSpaceId(), body).subscribe({
-      next: () => {
-        this.creatingEdge.set(false);
-        this.showEdgeForm.set(false);
-        this.edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: '', weight: null, tags: [], description: '', properties: {} as Record<string, string | number | boolean> };
-        this.loadStats(this.activeSpaceId());
-        this.loadCurrentTab(this.activeSpaceId());
-      },
-      error: (err) => { this.creatingEdge.set(false); this.createEdgeError.set(fmtApiError(err, 'Failed to create edge')); },
-    });
-  }
-
-  deleteEdge(id: string): void {
-    this.recordList.confirmDeleteId.set('');
-    this.brainApi.deleteEdge(this.activeSpaceId(), id).subscribe({
-      next: () => this.store.edges.update(list => list.filter(e => e._id !== id)),
-      error: () => {},
-    });
-  }
-
   createChrono(): void {
     if (!this.chronoForm.title.trim() || !this.chronoForm.startsAt) return;
     const resolvedKind = this.chronoForm.kind === '__custom__'
@@ -1733,30 +1392,11 @@ export class BrainComponent implements OnInit {
 
   // ── Form openers with schema prefill ────────────────────────────────────
 
-  openEdgeForm(): void {
-    const firstLabel = Object.keys(this.store.spaceMeta()?.typeSchemas?.edge ?? {})[0] ?? '';
-    this.edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: firstLabel, weight: null, tags: [], description: '', properties: this.store.buildPropertiesObject('edge', {}, firstLabel) };
-    this.showEdgeForm.set(true);
-  }
-
   openChronoForm(): void {
     this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '' };
     this.showChronoForm.set(true);
   }
 
-  // ── Edge endpoint pickers ───────────────────────────────────────────────
-  // Edge from/to set display fields on the shell-owned edgeForm and do NOT touch the entity-name
-  // cache — the two branches of the old pickEntity that stay here rather than move to the picker.
-
-  pickEdgeFrom(ent: Entity): void {
-    this.edgeForm.from = ent._id;
-    this.edgeForm.fromDisplay = ent.name;
-  }
-
-  pickEdgeTo(ent: Entity): void {
-    this.edgeForm.to = ent._id;
-    this.edgeForm.toDisplay = ent.name;
-  }
 
 }
 

--- a/client/src/app/pages/brain/edges-tab.component.spec.ts
+++ b/client/src/app/pages/brain/edges-tab.component.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * EdgesTabComponent — edge create/edit/delete/load behaviour, relocated from
+ * brain.component.records.spec.ts (A17.9b-6b) when the tab became its own component (A17.9b-6f), plus
+ * the self-loading wiring. Edge deltas: create/edit strip empty optional props; delete does NOT refresh
+ * stats, so it does NOT emit `mutated` (asymmetry with memory/entity).
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import type { Edge } from '../../core/api.types';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainApi } from '../../core/brain-api.service';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+import { RecordListState } from './record-list-state.service';
+import { EdgesTabComponent } from './edges-tab.component';
+
+const api = {
+  listEdges: vi.fn(() => of({ edges: [] as Edge[] })),
+  getEntitiesByIds: vi.fn(() => of({ entities: [] })),
+  createEdge: vi.fn(() => of({ _id: 'new' } as Edge)),
+  updateEdge: vi.fn((_s: string, id: string) => of({ _id: id, label: 'UPDATED' } as Edge)),
+  deleteEdge: vi.fn(() => of({})),
+  recallBrain: vi.fn(() => of({ results: [], count: 0 })),
+};
+
+function make() {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [EdgesTabComponent, getTranslocoModule()],
+    providers: [
+      RecordListState, BrainStore, EntityRefPicker, RecordDrawerState,
+      { provide: BrainApi, useValue: api },
+    ],
+  });
+  const fixture = TestBed.createComponent(EdgesTabComponent);
+  fixture.componentRef.setInput('spaceId', 'work');
+  fixture.detectChanges();
+  return fixture;
+}
+
+beforeEach(() => { for (const fn of Object.values(api)) (fn as any).mockClear(); });
+
+describe('EdgesTabComponent', () => {
+  it('is compiled as OnPush', () => {
+    expect(EdgesTabComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('self-loads on the spaceId input', () => {
+    make();
+    expect(api.listEdges).toHaveBeenCalledWith('work', 20, 0, {});
+  });
+
+  it('createEdge requires from+to+label, spreads weight only when set, and emits mutated', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const mutated = vi.fn();
+    c.mutated.subscribe(mutated);
+    c.edgeForm = { from: 'a', fromDisplay: '', to: 'b', toDisplay: '', label: 'knows', weight: null, tags: [], description: '', properties: {} };
+    c.createEdge();
+    expect(api.createEdge).toHaveBeenCalledWith('work', { from: 'a', to: 'b', label: 'knows' });
+    expect(mutated).toHaveBeenCalled();
+  });
+
+  it('createEdge is a no-op when from/to/label are incomplete', () => {
+    const c = make().componentInstance;
+    c.edgeForm = { from: 'a', fromDisplay: '', to: '', toDisplay: '', label: 'knows', weight: null, tags: [], description: '', properties: {} };
+    c.createEdge();
+    expect(api.createEdge).not.toHaveBeenCalled();
+  });
+
+  it('saveEditEdge sends label/tags/description (+weight when set), clears editingId, patches store', () => {
+    const c = make().componentInstance;
+    c.store.edges.set([{ _id: 'x1', label: 'old' } as Edge]);
+    c.recordList.editingId.set('x1');
+    c.editEdge = { from: 'a', to: 'b', fromName: undefined, toName: undefined, label: ' knows ', weight: 0.5, tags: ['t'], description: ' d ', properties: {} };
+    c.saveEditEdge('x1');
+    expect(api.updateEdge).toHaveBeenCalledWith('work', 'x1', { label: 'knows', tags: ['t'], description: 'd', weight: 0.5 });
+    expect(c.recordList.editingId()).toBe('');
+    expect(c.store.edges()[0].label).toBe('UPDATED');
+  });
+
+  it('deleteEdge removes from the store and clears confirmDeleteId but does NOT emit mutated (no stats refresh)', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const mutated = vi.fn();
+    c.mutated.subscribe(mutated);
+    c.store.edges.set([{ _id: 'x1' } as Edge, { _id: 'x2' } as Edge]);
+    c.recordList.confirmDeleteId.set('x1');
+    c.deleteEdge('x1');
+    expect(c.store.edges().map(e => e._id)).toEqual(['x2']);
+    expect(c.recordList.confirmDeleteId()).toBe('');
+    expect(mutated).not.toHaveBeenCalled(); // the asymmetry
+  });
+
+  it('pickEdgeFrom / pickEdgeTo set the endpoint id + display without touching the name cache', () => {
+    const c = make().componentInstance;
+    c.pickEdgeFrom({ _id: 'e1', name: 'Alice' } as any);
+    c.pickEdgeTo({ _id: 'e2', name: 'Bob' } as any);
+    expect(c.edgeForm.from).toBe('e1');
+    expect(c.edgeForm.fromDisplay).toBe('Alice');
+    expect(c.edgeForm.to).toBe('e2');
+    expect(c.edgeForm.toDisplay).toBe('Bob');
+    expect(c.picker.entityNameCache()['e1']).toBeUndefined();
+  });
+});

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -1,0 +1,435 @@
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { catchError, of } from 'rxjs';
+import { Edge, Entity } from '../../core/api.types';
+import { BrainApi } from '../../core/brain-api.service';
+import { httpErrorReason } from '../../core/http-error';
+import { TagInputComponent } from '../../shared/tag-input.component';
+import { PropertiesViewComponent } from '../../shared/properties-view.component';
+import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
+import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ErrorStateComponent } from '../../shared/error-state.component';
+import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+import { RecordListState } from './record-list-state.service';
+import { fmtApiError } from './brain-format';
+import { BRAIN_CHIP_STYLES } from './brain-form.styles';
+import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+
+/**
+ * The Edges record tab, extracted from BrainComponent (A17.9b-6f) following the memories pattern.
+ * Owns the edge create form, the (drawer-superseded) inline edit, delete, and the tab's own text/
+ * semantic search (via `store.edgeSearch`/`edgeSearchMode`, like memories) + type-tag filter +
+ * pagination + loader. Self-loads via a `spaceId` effect.
+ *
+ * Edge deltas: create AND inline-edit strip empty optional props (like entity); `deleteEdge` does NOT
+ * refresh the space stats (so it does NOT emit `mutated`) — the asymmetry pinned by the A17.9b-6b tests.
+ */
+@Component({
+  selector: 'app-edges-tab',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
+  template: `
+
+          <div class="content-header">
+            <input type="search" [placeholder]="'brain.edges.searchPlaceholder' | transloco"
+              [value]="store.edgeSearch()"
+              (input)="onEdgeSearch($any($event.target).value)"
+              [attr.aria-label]="'brain.edges.searchPlaceholder' | transloco" />
+            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
+              <button [class.active]="store.edgeSearchMode() === 'text'" (click)="setEdgeSearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
+              <button [class.active]="store.edgeSearchMode() === 'semantic'" (click)="setEdgeSearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
+            </div>
+            <button class="btn-primary btn btn-sm" (click)="openEdgeForm()" [disabled]="showEdgeForm()">{{ 'brain.edges.addButton' | transloco }}</button>
+          </div>
+          <div class="list-filter-row">
+            <app-record-filter-bar
+              [typeOptions]="store.edgeTypeOptions()"
+              [tagSuggestions]="store.edgeTagSuggestions()"
+              [value]="recordFilter()"
+              (filterChange)="onFilterChange($event)"
+            />
+          </div>
+
+          @if (showEdgeForm()) {
+            <form class="create-form" (ngSubmit)="createEdge()">
+              <div class="field" style="flex:1; min-width:120px;">
+                <label>{{ 'common.form.from' | transloco }}</label>
+                <app-entity-search
+                  mode="picker"
+                  [spaceId]="spaceId()"
+                  placeholder="common.searchEntitiesPlaceholder"
+
+                  [value]="edgeForm.fromDisplay"
+                  (selected)="pickEdgeFrom($event)"
+                />
+              </div>
+              <div class="field" style="flex:1; min-width:120px;">
+                <label>{{ 'brain.edges.form.relation' | transloco }} <span style="color:var(--error)">*</span></label>
+                @if (store.edgeLabelNames().length) {
+                  <select [(ngModel)]="edgeForm.label" name="label" required>
+                    @for (l of store.edgeLabelNames(); track l) {
+                      <option [value]="l">{{ l }}</option>
+                    }
+                  </select>
+                } @else {
+                  <input type="text" [(ngModel)]="edgeForm.label" name="label" required />
+                }
+              </div>
+              <div class="field" style="flex:1; min-width:120px;">
+                <label>{{ 'common.form.to' | transloco }}</label>
+                <app-entity-search
+                  mode="picker"
+                  [spaceId]="spaceId()"
+                  placeholder="common.searchEntitiesPlaceholder"
+
+                  [value]="edgeForm.toDisplay"
+                  (selected)="pickEdgeTo($event)"
+                />
+              </div>
+              <div class="field" style="width:80px;">
+                <label>{{ 'common.form.weight' | transloco }}</label>
+                <input type="number" [(ngModel)]="edgeForm.weight" name="weight" step="0.1" />
+              </div>
+              <div class="field" style="flex:1; min-width:180px;">
+                <label>{{ 'brain.edges.table.tags' | transloco }}</label>
+                <app-tag-input [(value)]="edgeForm.tags" [suggestions]="store.edgeTagSuggestions()" inputName="edgeFormTags" />
+              </div>
+              <div class="field" style="flex:2; min-width:200px;">
+                <label>{{ 'brain.edges.table.description' | transloco }}</label>
+                <textarea [(ngModel)]="edgeForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
+              </div>
+              <div class="field" style="flex:1; min-width:220px;">
+                <label>{{ 'brain.edges.table.properties' | transloco }}</label>
+                <app-properties-editor
+                  [schema]="store.edgeSchema(edgeForm.label)"
+                  [required]="store.requiredProps(store.edgeSchema(edgeForm.label))"
+                  [(value)]="edgeForm.properties"
+                />
+              </div>
+              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEdge() || !edgeForm.from.trim() || !edgeForm.to.trim() || !edgeForm.label.trim()">
+                @if (creatingEdge()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                {{ 'common.save' | transloco }}
+              </button>
+              <button class="btn-secondary btn btn-sm" type="button" (click)="showEdgeForm.set(false)">{{ 'common.cancel' | transloco }}</button>
+            </form>
+          }
+
+          @if (createEdgeError()) {
+            <div class="alert alert-error" style="margin-bottom:12px;">{{ createEdgeError() }}</div>
+          }
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>{{ 'brain.edges.table.from' | transloco }}</th><th>{{ 'brain.edges.table.relation' | transloco }}</th><th>{{ 'brain.edges.table.to' | transloco }}</th><th>{{ 'brain.edges.table.weight' | transloco }}</th><th>{{ 'brain.edges.table.tags' | transloco }}</th><th>{{ 'brain.edges.table.description' | transloco }}</th><th>{{ 'brain.edges.table.properties' | transloco }}</th><th>{{ 'brain.edges.table.created' | transloco }}</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (edge of store.filteredEdges(); track edge._id) {
+                  @if (recordList.editingId() === edge._id) {
+                    <tr>
+                      <td colspan="9">
+                        <div class="create-form" style="border:none; padding:8px 0;">
+                          <div class="field" style="min-width:200px; margin-bottom:0;">
+                            <label style="font-size:11px; color:var(--text-muted);">{{ 'brain.edges.form.editingLabel' | transloco }}</label>
+                            <div style="font-size:12px; padding:6px 8px; background:var(--bg-secondary); border-radius:4px; color:var(--text-muted);">
+                              {{ editEdge.fromName || editEdge.from }} → {{ editEdge.toName || editEdge.to }}
+                            </div>
+                          </div>
+                          <div class="field" style="flex:1; min-width:120px; margin-bottom:0;">
+                            <label>{{ 'brain.edges.form.relation' | transloco }}</label>
+                            @if (store.edgeLabelNames().length) {
+                              <select [(ngModel)]="editEdge.label" name="editEdgeLabel">
+                                @for (l of store.edgeLabelNames(); track l) {
+                                  <option [value]="l">{{ l }}</option>
+                                }
+                              </select>
+                            } @else {
+                              <input type="text" [(ngModel)]="editEdge.label" name="editEdgeLabel" />
+                            }
+                          </div>
+                          <div class="field" style="width:80px; margin-bottom:0;">
+                            <label>{{ 'common.form.weight' | transloco }}</label>
+                            <input type="number" [(ngModel)]="editEdge.weight" name="editEdgeWeight" step="0.1" />
+                          </div>
+                          <div class="field" style="flex:1; min-width:160px; margin-bottom:0;">
+                            <label>{{ 'brain.edges.table.description' | transloco }}</label>
+                            <textarea [(ngModel)]="editEdge.description" name="editEdgeDesc" rows="2" style="resize:vertical;"></textarea>
+                          </div>
+                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
+                            <label>{{ 'brain.edges.table.tags' | transloco }}</label>
+                            <app-tag-input [(value)]="editEdge.tags" [suggestions]="store.edgeTagSuggestions()" inputName="edgeEditTags" />
+                          </div>
+                          <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
+                            <label>{{ 'brain.edges.table.properties' | transloco }}</label>
+                            <app-properties-editor
+                              [schema]="store.edgeSchema(editEdge.label)"
+                              [required]="store.requiredProps(store.edgeSchema(editEdge.label))"
+                              [(value)]="editEdge.properties"
+                            />
+                          </div>
+                          <div style="display:flex; gap:6px; align-items:flex-end;">
+                            <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditEdge(edge._id)">
+                              @if (recordList.editSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } {{ 'common.save' | transloco }}
+                            </button>
+                            <button class="btn btn-sm btn-secondary" (click)="recordList.cancelEdit()">{{ 'common.cancel' | transloco }}</button>
+                          </div>
+                          @if (recordList.editError()) { <div style="font-size:12px; color:var(--error);">{{ recordList.editError() }}</div> }
+                        </div>
+                      </td>
+                    </tr>
+                  } @else {
+                    <tr style="vertical-align:top;">
+                      <td style="font-size:12px; white-space:nowrap;">{{ edge.fromName || edge.from }}</td>
+                      <td><span class="badge badge-blue">{{ edge.label }}</span></td>
+                      <td style="font-size:12px; white-space:nowrap;">{{ edge.toName || edge.to }}</td>
+                      <td style="color:var(--text-muted);">{{ edge.weight ?? '—' }}</td>
+                      <td style="font-size:11px;">
+                        @for (tag of (edge.tags ?? []); track tag) { <span class="tag">{{ tag }}</span> }
+                        @if (!(edge.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
+                      </td>
+                      <td style="font-size:12px; color:var(--text-muted); white-space:normal; word-break:break-word; min-width:140px; min-height:4.2em;">
+                        {{ edge.description || '—' }}
+                      </td>
+                      <td><app-properties-view [properties]="edge.properties" [schema]="store.edgeSchema(edge.label)" /></td>
+                      <td style="color:var(--text-muted); white-space:nowrap;">{{ edge.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td style="white-space:nowrap;">
+                        <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('edge', edge)"><ph-icon name="eye" [size]="16"/></button>
+                        @if (recordList.confirmDeleteId() === edge._id) {
+                          <span class="inline-confirm">
+                            {{ 'common.deleteConfirm' | transloco }}
+                            <button class="btn btn-sm btn-danger" (click)="deleteEdge(edge._id)">{{ 'common.yes' | transloco }}</button>
+                            <button class="btn btn-sm btn-secondary" (click)="cancelDelete()">{{ 'common.no' | transloco }}</button>
+                          </span>
+                        } @else {
+                          <button class="icon-btn danger" [attr.aria-label]="'brain.edges.deleteAriaLabel' | transloco" (click)="requestDelete(edge._id)"><ph-icon name="x" [size]="16"/></button>
+                        }
+                      </td>
+                    </tr>
+                  }
+                } @empty {
+                  <tr><td colspan="9">
+                    @if (recordList.loadError() !== null) {
+                      <app-error-state [message]="'brain.error.loadEdges' | transloco" [reason]="recordList.loadError() ?? ''" (retry)="retryCurrentTab()" />
+                    } @else {
+                    <div class="empty-state" style="padding:32px">
+                      <div class="empty-state-icon"><ph-icon name="graph" [size]="48"/></div>
+                      @if (store.edgeSearch() && store.edges().length) {
+                        <h3>{{ 'common.noMatches' | transloco }}</h3>
+                        <p>{{ 'brain.edges.empty.noMatchQuery' | transloco: { query: store.edgeSearch() } }}</p>
+                      } @else {
+                        <h3>{{ 'brain.edges.empty.title' | transloco }}</h3>
+                      }
+                    </div>
+                    }
+                  </td></tr>
+                }
+              </tbody>
+            </table>
+          </div>
+          @if (store.edgeSearchMode() !== 'semantic') {
+            <div class="pagination">
+              <button class="btn btn-sm btn-secondary" [disabled]="edgeSkip() === 0" (click)="prevEdgePage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+              <span class="pager-info">{{ store.filteredEdges().length ? (edgeSkip() + 1) + '–' + (edgeSkip() + store.filteredEdges().length) : '–' }}</span>
+              <button class="btn btn-sm btn-secondary" [disabled]="store.edges().length < pageSize" (click)="nextEdgePage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+            </div>
+          }
+  `,
+})
+export class EdgesTabComponent {
+  readonly store = inject(BrainStore);
+  readonly picker = inject(EntityRefPicker);
+  readonly drawerState = inject(RecordDrawerState);
+  readonly recordList = inject(RecordListState);
+  private brainApi = inject(BrainApi);
+
+  readonly spaceId = input.required<string>();
+  /** Emitted after a create so the shell can refresh the space's tab-count stats. (Delete does NOT — matches the shell's original edge behaviour.) */
+  readonly mutated = output<void>();
+
+  readonly pageSize = 20;
+
+  edgeSkip = signal(0);
+  recordFilter = signal<RecordFilter>({ type: '', tag: '' });
+
+  showEdgeForm = signal(false);
+  creatingEdge = signal(false);
+  createEdgeError = signal('');
+  edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
+  editEdge = { from: '', to: '', fromName: undefined as string | undefined, toName: undefined as string | undefined, label: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
+
+  private _edgeSemTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    effect(() => {
+      const id = this.spaceId();
+      this.edgeSkip.set(0);
+      this.recordFilter.set({ type: '', tag: '' });
+      if (id) this.load();
+    });
+  }
+
+  private load(): void {
+    const spaceId = this.spaceId();
+    if (!spaceId) return;
+    this.recordList.loading.set(true);
+    this.recordList.loadError.set(null);
+    const gf: { type?: string; tag?: string } = {};
+    if (this.recordFilter().type) gf.type = this.recordFilter().type;
+    if (this.recordFilter().tag) gf.tag = this.recordFilter().tag;
+    this.brainApi.listEdges(spaceId, this.pageSize, this.edgeSkip(), gf).subscribe({
+      next: ({ edges }) => { this.store.edges.set(edges); this.recordList.loading.set(false); },
+      error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
+    });
+  }
+
+  retryCurrentTab(): void { this.load(); }
+
+  prevEdgePage(): void { this.edgeSkip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
+  nextEdgePage(): void { this.edgeSkip.update(s => s + this.pageSize); this.load(); }
+
+  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
+  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
+
+  onEdgeSearch(q: string): void {
+    this.store.edgeSearch.set(q);
+    if (this.store.edgeSearchMode() === 'semantic') {
+      if (this._edgeSemTimer) clearTimeout(this._edgeSemTimer);
+      if (!q.trim()) { this.store.edges.set([]); return; }
+      this._edgeSemTimer = setTimeout(() => this.runSemanticEdgeSearch(), 300);
+    }
+  }
+
+  setEdgeSearchMode(m: 'text' | 'semantic'): void {
+    this.store.edgeSearchMode.set(m);
+    const q = this.store.edgeSearch().trim();
+    if (!q) return;
+    if (m === 'semantic') this.runSemanticEdgeSearch();
+    else { this.edgeSkip.set(0); this.load(); }
+  }
+
+  runSemanticEdgeSearch(): void {
+    const q = this.store.edgeSearch().trim();
+    const spaceId = this.spaceId();
+    if (!q || !spaceId) { this.store.edges.set([]); return; }
+    this.brainApi.recallBrain(spaceId, { query: q, types: ['edge'], topK: 20 }).pipe(
+      catchError(() => of({ results: [], count: 0 })),
+    ).subscribe(res => {
+      this.store.edges.set(res.results.filter(r => r.type === 'edge').map(r => ({
+        _id: r['_id'] as string,
+        from: (r['from'] as string) ?? '',
+        fromName: r['fromName'] as string | undefined,
+        to: (r['to'] as string) ?? '',
+        toName: r['toName'] as string | undefined,
+        label: (r['label'] as string) ?? '',
+        weight: r['weight'] as number | undefined,
+        tags: (r['tags'] as string[]) ?? [],
+        description: r['description'] as string | undefined,
+        properties: (r['properties'] as Record<string, string | number | boolean>) ?? {},
+        createdAt: (r['createdAt'] as string) ?? '',
+      } as Edge)));
+    });
+  }
+
+  onFilterChange(f: RecordFilter): void {
+    this.recordFilter.set(f);
+    this.edgeSkip.set(0);
+    this.load();
+  }
+
+  openEdgeForm(): void {
+    const firstLabel = Object.keys(this.store.spaceMeta()?.typeSchemas?.edge ?? {})[0] ?? '';
+    this.edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: firstLabel, weight: null, tags: [], description: '', properties: this.store.buildPropertiesObject('edge', {}, firstLabel) };
+    this.showEdgeForm.set(true);
+  }
+
+  createEdge(): void {
+    if (!this.edgeForm.from.trim() || !this.edgeForm.to.trim() || !this.edgeForm.label.trim()) return;
+    this.creatingEdge.set(true);
+    this.createEdgeError.set('');
+    const body: Parameters<BrainApi['createEdge']>[1] = {
+      from: this.edgeForm.from.trim(),
+      to: this.edgeForm.to.trim(),
+      label: this.edgeForm.label.trim(),
+    };
+    if (this.edgeForm.weight != null) body.weight = this.edgeForm.weight;
+    if (this.edgeForm.tags.length) body.tags = this.edgeForm.tags;
+    if (this.edgeForm.description.trim()) body.description = this.edgeForm.description.trim();
+    const edgeProps = this.store.stripEmptyOptionalProps(this.edgeForm.properties, this.store.edgeSchema(this.edgeForm.label));
+    if (Object.keys(edgeProps).length) body.properties = edgeProps;
+    this.brainApi.createEdge(this.spaceId(), body).subscribe({
+      next: () => {
+        this.creatingEdge.set(false);
+        this.showEdgeForm.set(false);
+        this.edgeForm = { from: '', fromDisplay: '', to: '', toDisplay: '', label: '', weight: null, tags: [], description: '', properties: {} as Record<string, string | number | boolean> };
+        this.mutated.emit();
+        this.load();
+      },
+      error: (err) => { this.creatingEdge.set(false); this.createEdgeError.set(fmtApiError(err, 'Failed to create edge')); },
+    });
+  }
+
+  startEditEdge(edge: Edge): void {
+    this.recordList.editingId.set(edge._id);
+    this.recordList.editError.set('');
+    this.editEdge = {
+      from: edge.from,
+      to: edge.to,
+      fromName: edge.fromName,
+      toName: edge.toName,
+      label: edge.label,
+      weight: edge.weight ?? null,
+      tags: edge.tags ?? [],
+      description: edge.description ?? '',
+      properties: this.store.buildPropertiesObject('edge', edge.properties ?? {}, edge.label),
+    };
+  }
+
+  saveEditEdge(id: string): void {
+    this.recordList.editSaving.set(true);
+    this.recordList.editError.set('');
+    const edgeProps = this.store.stripEmptyOptionalProps(this.editEdge.properties, this.store.edgeSchema(this.editEdge.label));
+    this.brainApi.updateEdge(this.spaceId(), id, {
+      label: this.editEdge.label.trim(),
+      tags: this.editEdge.tags,
+      description: this.editEdge.description.trim(),
+      ...(this.editEdge.weight != null ? { weight: this.editEdge.weight } : {}),
+      ...(Object.keys(edgeProps).length ? { properties: edgeProps } : {}),
+    }).subscribe({
+      next: (updated) => {
+        this.recordList.editSaving.set(false);
+        this.recordList.editingId.set('');
+        this.store.edges.update(list => list.map(e => e._id === id ? updated : e));
+      },
+      error: (err) => { this.recordList.editSaving.set(false); this.recordList.editError.set(fmtApiError(err, 'Failed to save')); },
+    });
+  }
+
+  deleteEdge(id: string): void {
+    this.recordList.confirmDeleteId.set('');
+    this.brainApi.deleteEdge(this.spaceId(), id).subscribe({
+      next: () => this.store.edges.update(list => list.filter(e => e._id !== id)),
+      error: () => {},
+    });
+  }
+
+  // Edge from/to endpoints set display fields on edgeForm and do NOT touch the entity-name cache
+  // (they're not chip fields) — the shell counterparts of the picker's target-based pickEntity.
+  pickEdgeFrom(ent: Entity): void {
+    this.edgeForm.from = ent._id;
+    this.edgeForm.fromDisplay = ent.name;
+  }
+
+  pickEdgeTo(ent: Entity): void {
+    this.edgeForm.to = ent._id;
+    this.edgeForm.toDisplay = ent.name;
+  }
+}


### PR DESCRIPTION
## What

The third record tab out of the shell — `edges-tab.component`, following the memories self-loading pattern. Edges have a text/semantic search-mode pill (via `store.edgeSearch`/`edgeSearchMode`, like memories).

## Edge-specific behaviour preserved (pinned by the relocated 6b cases)

- Create **and** inline-edit strip empty optional properties via the edge schema.
- **`deleteEdge` does NOT refresh the space stats** — so, unlike memory/entity, it emits no `mutated`. That asymmetry is now asserted in the edges spec (`expect(mutated).not.toHaveBeenCalled()`).
- The edge from/to endpoint pickers (`pickEdgeFrom`/`pickEdgeTo`, on the shell since the picker split in 9b-3) moved into the tab alongside `edgeForm`.

## Tests

The 6b `createEdge`/`deleteEdge` characterization cases and the two edge-endpoint tests relocated to `edges-tab.component.spec.ts`, plus OnPush + self-load.

## Also

Removing the last of memories/entities/edges made `PropertiesViewComponent`/`PropertiesEditorComponent` unused in the shell's template (chrono/filemeta have no schema-property editor) — AOT flagged them (NG8113), dropped from the imports.

## Verification

- `brain.component.ts` **1762 → 1402**.
- Full client suite: **197 → 200**, all passing.
- `tsc --noEmit --noUnusedLocals` clean; production AOT build warning-free apart from the pre-existing `qrcode` CommonJS bailout.
- CHANGELOG updated; no documented behaviour changed → no docs update.

Next: `9b-6g/h` (chrono, filemeta), then **A17.9d** (`RecordTabBase` — edges is now the third example that unblocks it) and **A17.9c** (unify the search bars), then the shell CSS/loader cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)