### PR TITLE
refactor(client): shared RecordTabBase to dedup the record-tab boilerplate (A17.9d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The five record-tab components now share a `RecordTabBase`, removing ~140 lines of duplicated
+  boilerplate.** After all five landed, each carried a byte-identical copy of the same machinery — the
+  `store`/`picker`/`recordList` injects, the `spaceId` input, `pageSize`, the paging cursor, the
+  self-load `effect`, `prevPage`/`nextPage`, `retryCurrentTab`, and `requestDelete`/`cancelDelete`.
+  Those move to an abstract `@Directive()` base each tab extends; the skip signal and pagination methods
+  are normalized to one name (`skip`/`prevPage`/`nextPage`) across all tabs. **Deliberately minimal:**
+  everything that VARIES stays in the subclass — the `brainApi`/`filesApi`/`drawerState` a tab may not
+  need, the `mutated`/`openInManager` outputs, the per-tab filter/search state, and every
+  create/edit/delete/search body. That boundary is the point: a base that absorbed those would erase the
+  per-tab asymmetries the A17.9b-6b tests pin (memory sends properties raw while entity/edge strip;
+  delete refreshes stats for some tabs but not others; chrono has no `mutated`; file-meta has no filter
+  bar). A `resetOnSpaceChange()` template-method hook lets each tab clear its own filter/search on a
+  space switch. Behaviour is identical — all 208 tests green, unchanged, now exercising the inherited
+  methods. Net: −113 lines across the six files.
+
 - **The Chrono and File Meta tabs are now their own OnPush components, completing the record-tab split —
   and `BrainComponent` is now a thin nav shell (3701 → 637 lines across A17.9b).** With the last two
   tabs out, the shell's `loadCurrentTab` dispatcher is gone (every tab self-loads on its `spaceId`

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -11,10 +11,8 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
-import { BrainStore } from './brain-store.service';
-import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordDrawerState } from './record-drawer-state.service';
-import { RecordListState } from './record-list-state.service';
+import { RecordTabBase } from './record-tab-base';
 import { fmtApiError, toLocalDatetime } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -271,25 +269,17 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
           </div>
           @if (store.chronoSearchMode() !== 'semantic') {
             <div class="pagination">
-              <button class="btn btn-sm btn-secondary" [disabled]="chronoSkip() === 0" (click)="prevChronoPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-              <span class="pager-info">{{ store.chrono().length ? (chronoSkip() + 1) + '–' + (chronoSkip() + store.chrono().length) : '–' }}</span>
-              <button class="btn btn-sm btn-secondary" [disabled]="store.chrono().length < pageSize" (click)="nextChronoPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+              <button class="btn btn-sm btn-secondary" [disabled]="skip() === 0" (click)="prevPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+              <span class="pager-info">{{ store.chrono().length ? (skip() + 1) + '–' + (skip() + store.chrono().length) : '–' }}</span>
+              <button class="btn btn-sm btn-secondary" [disabled]="store.chrono().length < pageSize" (click)="nextPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
             </div>
           }
   `,
 })
-export class ChronoTabComponent {
-  readonly store = inject(BrainStore);
-  readonly picker = inject(EntityRefPicker);
+export class ChronoTabComponent extends RecordTabBase {
   readonly drawerState = inject(RecordDrawerState);
-  readonly recordList = inject(RecordListState);
   private brainApi = inject(BrainApi);
 
-  readonly spaceId = input.required<string>();
-
-  readonly pageSize = 20;
-
-  chronoSkip = signal(0);
   recordFilter = signal<RecordFilter>({ type: '', tag: '' });
 
   showChronoForm = signal(false);
@@ -300,16 +290,11 @@ export class ChronoTabComponent {
 
   private _chronoSemTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor() {
-    effect(() => {
-      const id = this.spaceId();
-      this.chronoSkip.set(0);
-      this.recordFilter.set({ type: '', tag: '' });
-      if (id) this.load();
-    });
+  protected override resetOnSpaceChange(): void {
+    this.recordFilter.set({ type: '', tag: '' });
   }
 
-  private load(): void {
+  protected override load(): void {
     const spaceId = this.spaceId();
     if (!spaceId) return;
     this.recordList.loading.set(true);
@@ -318,7 +303,7 @@ export class ChronoTabComponent {
     if (this.store.chronoSearch()) cf.search = this.store.chronoSearch();
     if (this.recordFilter().type) cf.type = this.recordFilter().type;
     if (this.recordFilter().tag) cf.tag = this.recordFilter().tag;
-    this.brainApi.listChrono(spaceId, this.pageSize, this.chronoSkip(), cf).subscribe({
+    this.brainApi.listChrono(spaceId, this.pageSize, this.skip(), cf).subscribe({
       next: ({ chrono }) => {
         this.store.chrono.set(chrono);
         const ids = [...new Set(chrono.flatMap(e => e.entityIds ?? []))];
@@ -328,14 +313,6 @@ export class ChronoTabComponent {
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
   }
-
-  retryCurrentTab(): void { this.load(); }
-
-  prevChronoPage(): void { this.chronoSkip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
-  nextChronoPage(): void { this.chronoSkip.update(s => s + this.pageSize); this.load(); }
-
-  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
-  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
   onChronoSearch(q: string): void {
     this.store.chronoSearch.set(q);
@@ -385,7 +362,7 @@ export class ChronoTabComponent {
 
   onFilterChange(f: RecordFilter): void {
     this.recordFilter.set(f);
-    this.chronoSkip.set(0);
+    this.skip.set(0);
     this.load();
   }
 

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -13,10 +13,8 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
-import { BrainStore } from './brain-store.service';
-import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordDrawerState } from './record-drawer-state.service';
-import { RecordListState } from './record-list-state.service';
+import { RecordTabBase } from './record-tab-base';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -237,27 +235,20 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
           </div>
           @if (store.edgeSearchMode() !== 'semantic') {
             <div class="pagination">
-              <button class="btn btn-sm btn-secondary" [disabled]="edgeSkip() === 0" (click)="prevEdgePage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-              <span class="pager-info">{{ store.filteredEdges().length ? (edgeSkip() + 1) + '–' + (edgeSkip() + store.filteredEdges().length) : '–' }}</span>
-              <button class="btn btn-sm btn-secondary" [disabled]="store.edges().length < pageSize" (click)="nextEdgePage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+              <button class="btn btn-sm btn-secondary" [disabled]="skip() === 0" (click)="prevPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+              <span class="pager-info">{{ store.filteredEdges().length ? (skip() + 1) + '–' + (skip() + store.filteredEdges().length) : '–' }}</span>
+              <button class="btn btn-sm btn-secondary" [disabled]="store.edges().length < pageSize" (click)="nextPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
             </div>
           }
   `,
 })
-export class EdgesTabComponent {
-  readonly store = inject(BrainStore);
-  readonly picker = inject(EntityRefPicker);
+export class EdgesTabComponent extends RecordTabBase {
   readonly drawerState = inject(RecordDrawerState);
-  readonly recordList = inject(RecordListState);
   private brainApi = inject(BrainApi);
 
-  readonly spaceId = input.required<string>();
   /** Emitted after a create so the shell can refresh the space's tab-count stats. (Delete does NOT — matches the shell's original edge behaviour.) */
   readonly mutated = output<void>();
 
-  readonly pageSize = 20;
-
-  edgeSkip = signal(0);
   recordFilter = signal<RecordFilter>({ type: '', tag: '' });
 
   showEdgeForm = signal(false);
@@ -268,16 +259,11 @@ export class EdgesTabComponent {
 
   private _edgeSemTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor() {
-    effect(() => {
-      const id = this.spaceId();
-      this.edgeSkip.set(0);
-      this.recordFilter.set({ type: '', tag: '' });
-      if (id) this.load();
-    });
+  protected override resetOnSpaceChange(): void {
+    this.recordFilter.set({ type: '', tag: '' });
   }
 
-  private load(): void {
+  protected override load(): void {
     const spaceId = this.spaceId();
     if (!spaceId) return;
     this.recordList.loading.set(true);
@@ -285,19 +271,11 @@ export class EdgesTabComponent {
     const gf: { type?: string; tag?: string } = {};
     if (this.recordFilter().type) gf.type = this.recordFilter().type;
     if (this.recordFilter().tag) gf.tag = this.recordFilter().tag;
-    this.brainApi.listEdges(spaceId, this.pageSize, this.edgeSkip(), gf).subscribe({
+    this.brainApi.listEdges(spaceId, this.pageSize, this.skip(), gf).subscribe({
       next: ({ edges }) => { this.store.edges.set(edges); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
   }
-
-  retryCurrentTab(): void { this.load(); }
-
-  prevEdgePage(): void { this.edgeSkip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
-  nextEdgePage(): void { this.edgeSkip.update(s => s + this.pageSize); this.load(); }
-
-  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
-  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
   onEdgeSearch(q: string): void {
     this.store.edgeSearch.set(q);
@@ -313,7 +291,7 @@ export class EdgesTabComponent {
     const q = this.store.edgeSearch().trim();
     if (!q) return;
     if (m === 'semantic') this.runSemanticEdgeSearch();
-    else { this.edgeSkip.set(0); this.load(); }
+    else { this.skip.set(0); this.load(); }
   }
 
   runSemanticEdgeSearch(): void {
@@ -341,7 +319,7 @@ export class EdgesTabComponent {
 
   onFilterChange(f: RecordFilter): void {
     this.recordFilter.set(f);
-    this.edgeSkip.set(0);
+    this.skip.set(0);
     this.load();
   }
 

--- a/client/src/app/pages/brain/entities-tab.component.spec.ts
+++ b/client/src/app/pages/brain/entities-tab.component.spec.ts
@@ -102,14 +102,14 @@ describe('EntitiesTabComponent', () => {
     expect(mutated).toHaveBeenCalled();
   });
 
-  it('the search bar reloads silently with the search term; nextEntityPage advances skip', () => {
+  it('the search bar reloads silently with the search term; nextPage advances skip', () => {
     const fixture = make();
     const c = fixture.componentInstance;
     api.listEntities.mockClear();
     c.onEntitySearchChange('ali');
     expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, { search: 'ali' });
-    c.nextEntityPage();
-    expect(c.entitySkip()).toBe(20);
+    c.nextPage();
+    expect(c.skip()).toBe(20);
     expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 20, { search: 'ali' });
   });
 });

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -12,10 +12,8 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
-import { BrainStore } from './brain-store.service';
-import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordDrawerState } from './record-drawer-state.service';
-import { RecordListState } from './record-list-state.service';
+import { RecordTabBase } from './record-tab-base';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -205,26 +203,19 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             </table>
           </div>
           <div class="pagination">
-            <button class="btn btn-sm btn-secondary" [disabled]="entitySkip() === 0" (click)="prevEntityPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-            <span class="pager-info">{{ store.entities().length ? (entitySkip() + 1) + '–' + (entitySkip() + store.entities().length) : '–' }}</span>
-            <button class="btn btn-sm btn-secondary" [disabled]="store.entities().length < pageSize" (click)="nextEntityPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+            <button class="btn btn-sm btn-secondary" [disabled]="skip() === 0" (click)="prevPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+            <span class="pager-info">{{ store.entities().length ? (skip() + 1) + '–' + (skip() + store.entities().length) : '–' }}</span>
+            <button class="btn btn-sm btn-secondary" [disabled]="store.entities().length < pageSize" (click)="nextPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
           </div>
   `,
 })
-export class EntitiesTabComponent {
-  readonly store = inject(BrainStore);
-  readonly picker = inject(EntityRefPicker);
+export class EntitiesTabComponent extends RecordTabBase {
   readonly drawerState = inject(RecordDrawerState);
-  readonly recordList = inject(RecordListState);
   private brainApi = inject(BrainApi);
 
-  readonly spaceId = input.required<string>();
   /** Emitted after a create/delete so the shell can refresh the space's tab-count stats. */
   readonly mutated = output<void>();
 
-  readonly pageSize = 20;
-
-  entitySkip = signal(0);
   entitySearch = signal('');
   recordFilter = signal<RecordFilter>({ type: '', tag: '' });
 
@@ -234,17 +225,12 @@ export class EntitiesTabComponent {
   entityForm = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   editEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
 
-  constructor() {
-    effect(() => {
-      const id = this.spaceId();
-      this.entitySkip.set(0);
-      this.entitySearch.set('');
-      this.recordFilter.set({ type: '', tag: '' });
-      if (id) this.load();
-    });
+  protected override resetOnSpaceChange(): void {
+    this.entitySearch.set('');
+    this.recordFilter.set({ type: '', tag: '' });
   }
 
-  private load(): void {
+  protected override load(): void {
     const spaceId = this.spaceId();
     if (!spaceId) return;
     this.recordList.loading.set(true);
@@ -253,7 +239,7 @@ export class EntitiesTabComponent {
     if (this.entitySearch()) ef.search = this.entitySearch();
     if (this.recordFilter().type) ef.type = this.recordFilter().type;
     if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-    this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
+    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef).subscribe({
       next: ({ entities }) => { this.store.entities.set(entities); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
@@ -267,39 +253,31 @@ export class EntitiesTabComponent {
     if (this.entitySearch()) ef.search = this.entitySearch();
     if (this.recordFilter().type) ef.type = this.recordFilter().type;
     if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-    this.brainApi.listEntities(spaceId, this.pageSize, this.entitySkip(), ef).subscribe({
+    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef).subscribe({
       next: ({ entities }) => this.store.entities.set(entities),
       error: () => {},
     });
   }
 
-  retryCurrentTab(): void { this.load(); }
-
-  prevEntityPage(): void { this.entitySkip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
-  nextEntityPage(): void { this.entitySkip.update(s => s + this.pageSize); this.load(); }
-
-  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
-  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
-
   onEntitySearchChange(q: string): void {
     this.entitySearch.set(q);
-    this.entitySkip.set(0);
+    this.skip.set(0);
     this.loadEntitiesSilent();
   }
   onEntitySearchClear(): void {
     this.entitySearch.set('');
-    this.entitySkip.set(0);
+    this.skip.set(0);
     this.loadEntitiesSilent();
   }
   onEntitySearchPick(ent: Entity): void {
     this.entitySearch.set(ent.name);
-    this.entitySkip.set(0);
+    this.skip.set(0);
     this.loadEntitiesSilent();
   }
 
   onFilterChange(f: RecordFilter): void {
     this.recordFilter.set(f);
-    this.entitySkip.set(0);
+    this.skip.set(0);
     this.load();
   }
 

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
@@ -10,9 +10,7 @@ import { TagInputComponent } from '../../shared/tag-input.component';
 import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
-import { BrainStore } from './brain-store.service';
-import { EntityRefPicker } from './entity-ref-picker.service';
-import { RecordListState } from './record-list-state.service';
+import { RecordTabBase } from './record-tab-base';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -222,59 +220,38 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
               </table>
             </div>
             <div class="pagination">
-              <button class="btn btn-sm btn-secondary" [disabled]="fileMetaSkip() === 0" (click)="prevFileMetaPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
-              <span class="pager-info">{{ store.fileMetas().length ? (fileMetaSkip() + 1) + '–' + (fileMetaSkip() + store.fileMetas().length) : '–' }}</span>
-              <button class="btn btn-sm btn-secondary" [disabled]="store.fileMetas().length < pageSize" (click)="nextFileMetaPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
+              <button class="btn btn-sm btn-secondary" [disabled]="skip() === 0" (click)="prevPage()"><ph-icon name="arrow-left" [size]="14" style="display:inline-flex;vertical-align:middle;"/> {{ 'common.prev' | transloco }}</button>
+              <span class="pager-info">{{ store.fileMetas().length ? (skip() + 1) + '–' + (skip() + store.fileMetas().length) : '–' }}</span>
+              <button class="btn btn-sm btn-secondary" [disabled]="store.fileMetas().length < pageSize" (click)="nextPage()">{{ 'common.next' | transloco }} <ph-icon name="arrow-right" [size]="14" style="display:inline-flex;vertical-align:middle;"/></button>
             </div>
           }
   `,
 })
-export class FilemetaTabComponent {
-  readonly store = inject(BrainStore);
-  readonly picker = inject(EntityRefPicker);
-  readonly recordList = inject(RecordListState);
+export class FilemetaTabComponent extends RecordTabBase {
   private filesApi = inject(FilesApi);
   private toast = inject(ToastService);
   private transloco = inject(TranslocoService);
 
-  readonly spaceId = input.required<string>();
   /** Emitted after a delete so the shell can refresh the space's tab-count stats. */
   readonly mutated = output<void>();
   /** Emitted to open a file's directory in the Files tab (shell navigation). */
   readonly openInManager = output<string>();
 
-  readonly pageSize = 20;
-
-  fileMetaSkip = signal(0);
   retryingEmbedding = signal<Set<string>>(new Set());
   editFileMeta = { description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[], chronoIds: [] as string[] };
 
-  constructor() {
-    effect(() => {
-      const id = this.spaceId();
-      this.fileMetaSkip.set(0);
-      if (id) this.load();
-    });
-  }
+  // No resetOnSpaceChange override: file-meta has no filter bar, so the base's skip reset is enough.
 
-  private load(): void {
+  protected override load(): void {
     const spaceId = this.spaceId();
     if (!spaceId) return;
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
-    this.filesApi.listFileMeta(spaceId, this.pageSize, this.fileMetaSkip(), this.store.fileMetaSearch() || undefined).subscribe({
+    this.filesApi.listFileMeta(spaceId, this.pageSize, this.skip(), this.store.fileMetaSearch() || undefined).subscribe({
       next: ({ files }) => { this.store.fileMetas.set(files); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
   }
-
-  retryCurrentTab(): void { this.load(); }
-
-  prevFileMetaPage(): void { this.fileMetaSkip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
-  nextFileMetaPage(): void { this.fileMetaSkip.update(s => s + this.pageSize); this.load(); }
-
-  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
-  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
   onFileMetaSearch(q: string): void {
     this.store.fileMetaSearch.set(q);

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -13,10 +13,8 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
-import { BrainStore } from './brain-store.service';
-import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordDrawerState } from './record-drawer-state.service';
-import { RecordListState } from './record-list-state.service';
+import { RecordTabBase } from './record-tab-base';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -260,20 +258,13 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
           }
   `,
 })
-export class MemoriesTabComponent {
-  readonly store = inject(BrainStore);
-  readonly picker = inject(EntityRefPicker);
+export class MemoriesTabComponent extends RecordTabBase {
   readonly drawerState = inject(RecordDrawerState);
-  readonly recordList = inject(RecordListState);
   private brainApi = inject(BrainApi);
 
-  readonly spaceId = input.required<string>();
   /** Emitted after a create/delete so the shell can refresh the space's tab-count stats. */
   readonly mutated = output<void>();
 
-  readonly pageSize = 20;
-
-  skip = signal(0);
   recordFilter = signal<RecordFilter>({ type: '', tag: '' });
   filterEntity = signal('');
 
@@ -285,18 +276,12 @@ export class MemoriesTabComponent {
 
   private _memSemTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor() {
-    // Self-load on creation (tab activation) and on a space switch while mounted.
-    effect(() => {
-      const id = this.spaceId();
-      this.skip.set(0);
-      this.recordFilter.set({ type: '', tag: '' });
-      this.filterEntity.set('');
-      if (id) this.load();
-    });
+  protected override resetOnSpaceChange(): void {
+    this.recordFilter.set({ type: '', tag: '' });
+    this.filterEntity.set('');
   }
 
-  private load(): void {
+  protected override load(): void {
     const spaceId = this.spaceId();
     if (!spaceId) return;
     this.recordList.loading.set(true);
@@ -315,14 +300,6 @@ export class MemoriesTabComponent {
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
   }
-
-  retryCurrentTab(): void { this.load(); }
-
-  prevPage(): void { this.skip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
-  nextPage(): void { this.skip.update(s => s + this.pageSize); this.load(); }
-
-  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
-  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
 
   onMemorySearch(q: string): void {
     this.store.memorySearch.set(q);

--- a/client/src/app/pages/brain/record-tab-base.ts
+++ b/client/src/app/pages/brain/record-tab-base.ts
@@ -1,0 +1,57 @@
+import { Directive, effect, inject, input, signal } from '@angular/core';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordListState } from './record-list-state.service';
+
+/**
+ * Shared machinery for the five record-tab components (memories/entities/edges/chrono/filemeta),
+ * extracted after all five landed (A17.9d). Holds ONLY what is provably universal across all of them
+ * — the collaborators every tab injects, the `spaceId` input, page size, the paging cursor, the
+ * self-load effect, and the delete-confirm toggle.
+ *
+ * Deliberately minimal: everything that VARIES stays in the subclass — the `brainApi`/`filesApi` and
+ * `drawerState` a tab may or may not need, the `mutated`/`openInManager` outputs, the `recordFilter`/
+ * search state, and every create/edit/delete/search body. That is the point: a "CRUD base" that
+ * absorbed those would erase the per-tab asymmetries the A17.9b-6b characterization tests pin (memory
+ * sends properties raw while entity/edge strip; delete refreshes stats for some tabs but not others;
+ * memory/chrono resolve chip names on load, entity does not). The base cannot force a wrong shape.
+ *
+ * `@Directive()` (not a plain abstract class) is the Angular-blessed carrier for shared component
+ * logic with `input()`/`inject()`/`effect()`; concrete tabs extend it and add their own `@Component`.
+ */
+@Directive()
+export abstract class RecordTabBase {
+  readonly store = inject(BrainStore);
+  readonly picker = inject(EntityRefPicker);
+  readonly recordList = inject(RecordListState);
+
+  readonly spaceId = input.required<string>();
+  readonly pageSize = 20;
+
+  skip = signal(0);
+
+  constructor() {
+    // Self-load on creation (tab activation via the shell's gated @if) and on a space switch while
+    // mounted. The `if (id)` guard keeps it to a single real load until the input settles.
+    effect(() => {
+      const id = this.spaceId();
+      this.skip.set(0);
+      this.resetOnSpaceChange();
+      if (id) this.load();
+    });
+  }
+
+  /** Load the tab's list for the active space. Sets `recordList.loading`/`loadError` + `store.<coll>`. */
+  protected abstract load(): void;
+
+  /** Override to clear per-tab filter/search state on a space switch (default: nothing beyond skip). */
+  protected resetOnSpaceChange(): void {}
+
+  retryCurrentTab(): void { this.load(); }
+
+  prevPage(): void { this.skip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
+  nextPage(): void { this.skip.update(s => s + this.pageSize); this.load(); }
+
+  requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
+  cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
+}


### PR DESCRIPTION
## What

The five record-tab components each carried a **byte-identical** copy of the same machinery. This moves it to an abstract `@Directive()` `RecordTabBase` each tab extends — removing ~140 lines of duplication.

Into the base (the provably-universal bits): the `store`/`picker`/`recordList` injects, the `spaceId` input, `pageSize`, the paging cursor, the self-load `effect`, `prevPage`/`nextPage`, `retryCurrentTab`, and `requestDelete`/`cancelDelete`. `skip` and the pagination methods are normalized to one name across all tabs.

## Why it's audit-safe (the boundary is the point)

Deliberately **minimal** — everything that varies stays in the subclass: the `brainApi`/`filesApi`/`drawerState` a tab may not need, the `mutated`/`openInManager` outputs, the per-tab filter/search state, and every create/edit/delete/search body. The classic failure of a "CRUD base" is swallowing the per-tab asymmetries the 6b characterization tests pin — memory sends properties **raw** while entity/edge strip; delete refreshes stats for some tabs but **not** others; chrono has **no** `mutated`; file-meta has **no** filter bar. The base cannot force a wrong shape on any of those. A `resetOnSpaceChange()` template-method hook lets each tab clear its own filter/search on a space switch.

Two decisions from the plan's audit-vet, confirmed in practice:
- `requestDelete`/`cancelDelete` went on the **base**, not `RecordListState` — same home concept, but zero template churn (templates keep calling them unqualified).
- Used an abstract **`@Directive`** (not a plain class) so Angular recognizes the inherited `input()`/`effect()` — the fallback the plan flagged for exactly this; the AOT build confirms it works.

## Verification

- **Behaviour identical** — all **208** tests green, *unchanged*, now exercising the inherited methods (the point of relying on the existing self-load/pagination specs). Only fix needed was renaming the entities spec's `entitySkip`/`nextEntityPage` to the normalized `skip`/`nextPage`.
- Net **−113 lines** across the six files (base is 57; ~140 removed).
- `tsc --noEmit --noUnusedLocals` clean; production AOT build warning-free apart from the pre-existing `qrcode` CommonJS bailout.
- CHANGELOG updated; no documented behaviour changed → no docs update.

Next: **A17.9c** (unify the four search bars into a `RecordSearchBar`) + the shell dead-CSS sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)