### PR TITLE
docs(notice): attribute the runtime sidecar container images (A17.9 compliance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`NOTICE` now attributes the three runtime sidecar container images that were missing.** The file
+  already documented the `mongodb/mongodb-atlas-local` image as a "not bundled, pulled independently"
+  runtime dependency, but the other three sidecars referenced by `docker-compose.yml` / the Kubernetes
+  manifests were absent: `unstructured-io/unstructured-api` (Apache 2.0 — the OCR/document-conversion
+  sidecar), `ollama/ollama` (MIT — the vision/embedding model host), and `fedirz/faster-whisper-server`
+  (MIT — the speech-to-text sidecar). Each now has a section mirroring the mongodb one: role, license,
+  the not-bundled / network-isolated framing, and a note that models are pulled separately under their
+  own licenses (default `moondream` Apache 2.0; Whisper models Apache 2.0). All npm dependencies across
+  both workspaces were already attributed and were re-verified complete — the gap was only the images.
+  Licenses are grounded in `docs/dependencies.md`.
+
 - **The Chrono and File Meta tabs are now their own OnPush components, completing the record-tab split —
   and `BrainComponent` is now a thin nav shell (3701 → 637 lines across A17.9b).** With the last two
   tabs out, the shell's `loadCurrentTab` dispatcher is gone (every tab self-loads on its `spaceId`

--- a/NOTICE
+++ b/NOTICE
@@ -529,6 +529,73 @@ deployment without `mongot`.
 
 ---
 
+## Runtime Dependency: unstructured-io/unstructured-api (Docker image)
+
+Ythril's `docker-compose.yml` and `kubernetes/manifests/ythril-deployment.yaml` reference the
+`downloads.unstructured.io/unstructured-io/unstructured-api` container image published by
+Unstructured Technologies, Inc. This image is **not bundled with or distributed by Ythril** - it is
+pulled independently by Docker / Kubernetes at deployment time.
+
+Role: server-side PDF / DOCX / EPUB conversion (`hi_res` OCR + layout detection, table and
+embedded-image extraction).
+
+License: Apache License 2.0.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+The image tag is pinned deliberately: its bundled `LICENSE` is verified as Apache-2.0 (no
+commercial-use restriction) before every version bump - the procedure is documented in
+`docker-compose.yml` and the Kubernetes manifest. Ythril communicates with the sidecar only over an
+HTTP socket on an isolated internal network with no database access and no internet egress; no
+unstructured-api code is linked into or incorporated into the Ythril application binary or source tree.
+
+---
+
+## Runtime Dependency: ollama/ollama (Docker image)
+
+Ythril's `docker-compose.yml` and `kubernetes/manifests/ollama-deploy.yaml` reference the
+`ollama/ollama` container image published by the Ollama project. This image is **not bundled with or
+distributed by Ythril** - it is pulled independently at deployment time.
+
+Role: hosts the vision model that captions uploaded images for the media-embedding pipeline (default
+model `moondream`).
+
+License: MIT (the Ollama runtime). The full MIT text, with its copyright notice, ships in the image's
+bundled `LICENSE`; Ythril does not redistribute the image. Vision/LLM models are pulled separately at
+runtime under their own licenses - the default `moondream` is Apache 2.0.
+
+Ythril communicates with Ollama only over an HTTP socket on an isolated internal media network; no
+Ollama code is linked into or incorporated into the Ythril application.
+
+---
+
+## Runtime Dependency: fedirz/faster-whisper-server (Docker image)
+
+Ythril's `docker-compose.yml` and `kubernetes/manifests/whisper-deploy.yaml` reference the
+`fedirz/faster-whisper-server` container image. This image is **not bundled with or distributed by
+Ythril** - it is pulled independently at deployment time.
+
+Role: speech-to-text - transcribes uploaded / segmented audio via an OpenAI-compatible endpoint.
+
+License: MIT (the server). The full MIT text, with its copyright notice, ships in the image's bundled
+`LICENSE`; Ythril does not redistribute the image. Whisper models are pulled separately at runtime and
+are Apache 2.0 licensed.
+
+Ythril communicates with the sidecar only over an HTTP socket on an isolated internal media network; no
+faster-whisper-server code is linked into or incorporated into the Ythril application.
+
+---
+
 ## @phosphor-icons/core
 
 License: MIT


### PR DESCRIPTION
## What

`NOTICE` was missing attribution for three of the four runtime sidecar container images. It already documents `mongodb/mongodb-atlas-local` as a "not bundled, pulled independently" runtime dependency — this adds the same for the other three that `docker-compose.yml` and the Kubernetes manifests reference.

| Image | Role | License |
|---|---|---|
| `unstructured-io/unstructured-api` | OCR / PDF·DOCX·EPUB → Markdown | **Apache 2.0** |
| `ollama/ollama` | vision/embedding model host (default `moondream`) | **MIT** |
| `fedirz/faster-whisper-server` | speech-to-text | **MIT** |

(Spotted while reviewing the `unstructured-api` version pin — it wasn't in NOTICE, which prompted a full audit.)

## Approach

Each new section mirrors the existing mongodb one: role, license, the not-bundled / network-isolated framing, and a note that models are pulled separately under their own licenses (default `moondream` Apache 2.0; Whisper models Apache 2.0). The Apache-2.0 `unstructured-api` entry carries the standard Apache pointer block; the MIT images point to their bundled `LICENSE` for the full text, since Ythril does **not** redistribute the images (same reasoning the mongodb section uses).

## Verification

- **npm dependencies re-checked complete** — diffed NOTICE against all 19 server + 16 client runtime `dependencies`; every one is attributed. The gap was *only* the sidecar images.
- Licenses grounded in the project's own `docs/dependencies.md` (which already states them); the cited k8s manifest paths (`ollama-deploy.yaml`, `whisper-deploy.yaml`, `ythril-deployment.yaml`) all exist.
- NOTICE's UTF-8 BOM + CRLF encoding preserved.
- CHANGELOG updated.

Note: this is *attribution* only. The `unstructured-api` **version bump** is a separate track — it's gated on verifying the newer tag's bundled `LICENSE` is still Apache-2.0 (the repo's documented per-bump check), which is being run out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)