### PR TITLE
refactor(client): unify the record-tab search bars into RecordSearchBar (A17.9c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The record tabs' search bars are unified in one `RecordSearchBar` component, resolving the
+  four-different-shapes inconsistency.** memories/edges/chrono had byte-identical inline markup (a search
+  input + an A–Z/Semantic pill wired to the store's `*SearchMode` signal) and file-meta a plain input;
+  they now all render `<app-record-search-bar>`, a dumb presentational component that takes `value`/
+  `mode`/`placeholder` in and emits `valueChange`/`modeChange` — omit `mode` to hide the pill (file-meta's
+  client-side filter). `:host { display: contents }` keeps the input and pill as direct flex children of
+  the header, so the layout is byte-for-byte unchanged; an optional `ariaLabel` preserves file-meta's
+  distinct label. Two boundaries are deliberate: the **entities** tab keeps `<app-entity-search>` (its
+  bar does entity autocomplete, a richer interaction), and the semantic-search LOGIC stays in each tab
+  (its recall-result mapping is per-collection). Behaviour unchanged — all tests green (215; +7 for the
+  new component's spec).
+
 - **The five record-tab components now share a `RecordTabBase`, removing ~140 lines of duplicated
   boilerplate.** After all five landed, each carried a byte-identical copy of the same machinery — the
   `store`/`picker`/`recordList` injects, the `spaceId` input, `pageSize`, the paging cursor, the

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -13,6 +13,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
+import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError, toLocalDatetime } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -32,19 +33,15 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
           <div class="content-header">
-            <input type="search" [placeholder]="'brain.chrono.searchPlaceholder' | transloco"
-              [value]="store.chronoSearch()"
-              (input)="onChronoSearch($any($event.target).value)"
-              [attr.aria-label]="'brain.chrono.searchPlaceholder' | transloco" />
-            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-              <button [class.active]="store.chronoSearchMode() === 'text'" (click)="setChronoSearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
-              <button [class.active]="store.chronoSearchMode() === 'semantic'" (click)="setChronoSearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
-            </div>
+            <app-record-search-bar
+              [value]="store.chronoSearch()" (valueChange)="onChronoSearch($event)"
+              [mode]="store.chronoSearchMode()" (modeChange)="setChronoSearchMode($event)"
+              placeholder="brain.chrono.searchPlaceholder" />
             <button class="btn-primary btn btn-sm" (click)="openChronoForm()" [disabled]="showChronoForm()">{{ 'brain.chrono.addButton' | transloco }}</button>
           </div>
           <div class="list-filter-row">

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -15,6 +15,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
+import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -32,19 +33,15 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-edges-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
           <div class="content-header">
-            <input type="search" [placeholder]="'brain.edges.searchPlaceholder' | transloco"
-              [value]="store.edgeSearch()"
-              (input)="onEdgeSearch($any($event.target).value)"
-              [attr.aria-label]="'brain.edges.searchPlaceholder' | transloco" />
-            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-              <button [class.active]="store.edgeSearchMode() === 'text'" (click)="setEdgeSearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
-              <button [class.active]="store.edgeSearchMode() === 'semantic'" (click)="setEdgeSearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
-            </div>
+            <app-record-search-bar
+              [value]="store.edgeSearch()" (valueChange)="onEdgeSearch($event)"
+              [mode]="store.edgeSearchMode()" (modeChange)="setEdgeSearchMode($event)"
+              placeholder="brain.edges.searchPlaceholder" />
             <button class="btn-primary btn btn-sm" (click)="openEdgeForm()" [disabled]="showEdgeForm()">{{ 'brain.edges.addButton' | transloco }}</button>
           </div>
           <div class="list-filter-row">

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -11,6 +11,7 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordTabBase } from './record-tab-base';
+import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -29,11 +30,11 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-filemeta-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
           <div class="content-header">
-            <input type="search" [value]="store.fileMetaSearch()" (input)="onFileMetaSearch($any($event.target).value)" [placeholder]="'brain.fileMeta.filterPlaceholder' | transloco" [attr.aria-label]="'brain.fileMeta.filterAriaLabel' | transloco" />
+            <app-record-search-bar [value]="store.fileMetaSearch()" (valueChange)="onFileMetaSearch($event)" placeholder="brain.fileMeta.filterPlaceholder" ariaLabel="brain.fileMeta.filterAriaLabel" />
           </div>
           @if (recordList.loading()) {
             <div class="empty-state"><span class="spinner"></span></div>

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -15,6 +15,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
+import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -39,20 +40,15 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-memories-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
           <div class="content-header">
-            <input type="search"
-              [placeholder]="'brain.memories.searchPlaceholder' | transloco"
-              [value]="store.memorySearch()"
-              (input)="onMemorySearch($any($event.target).value)"
-              [attr.aria-label]="'brain.memories.searchPlaceholder' | transloco" />
-            <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-              <button [class.active]="store.memorySearchMode() === 'text'" (click)="setMemorySearchMode('text')">{{ 'common.sortAZ' | transloco }}</button>
-              <button [class.active]="store.memorySearchMode() === 'semantic'" (click)="setMemorySearchMode('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
-            </div>
+            <app-record-search-bar
+              [value]="store.memorySearch()" (valueChange)="onMemorySearch($event)"
+              [mode]="store.memorySearchMode()" (modeChange)="setMemorySearchMode($event)"
+              placeholder="brain.memories.searchPlaceholder" />
             <button class="btn-primary btn btn-sm" (click)="openMemoryForm()" [disabled]="showMemoryForm()">{{ 'brain.memories.addButton' | transloco }}</button>
           </div>
 

--- a/client/src/app/pages/brain/record-search-bar.component.spec.ts
+++ b/client/src/app/pages/brain/record-search-bar.component.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * RecordSearchBarComponent — the dumb search bar the record tabs share (A17.9c). Verifies the
+ * value/mode inputs, the valueChange/modeChange outputs, and that the pill is shown only when a mode
+ * is provided (file-meta omits it).
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { RecordSearchBarComponent } from './record-search-bar.component';
+
+function create(inputs: { value: string; placeholder: string; mode?: 'text' | 'semantic' | null; ariaLabel?: string }) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [RecordSearchBarComponent, getTranslocoModule()] });
+  const fixture = TestBed.createComponent(RecordSearchBarComponent);
+  fixture.componentRef.setInput('value', inputs.value);
+  fixture.componentRef.setInput('placeholder', inputs.placeholder);
+  if ('mode' in inputs) fixture.componentRef.setInput('mode', inputs.mode);
+  if (inputs.ariaLabel) fixture.componentRef.setInput('ariaLabel', inputs.ariaLabel);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('RecordSearchBarComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(RecordSearchBarComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders the search input with the bound value', () => {
+    const fixture = create({ value: 'hello', placeholder: 'ph' });
+    const input = fixture.nativeElement.querySelector('input[type=search]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('hello');
+  });
+
+  it('emits valueChange with the typed string on input', () => {
+    const fixture = create({ value: '', placeholder: 'ph' });
+    const emitted: string[] = [];
+    fixture.componentInstance.valueChange.subscribe(v => emitted.push(v));
+    const input = fixture.nativeElement.querySelector('input[type=search]') as HTMLInputElement;
+    input.value = 'abc';
+    input.dispatchEvent(new Event('input'));
+    expect(emitted).toEqual(['abc']);
+  });
+
+  it('hides the mode pill when no mode is given (file-meta case)', () => {
+    const fixture = create({ value: '', placeholder: 'ph' });
+    expect(fixture.nativeElement.querySelector('.pill-group')).toBeNull();
+  });
+
+  it('shows the pill and marks the active mode when a mode is given', () => {
+    const fixture = create({ value: '', placeholder: 'ph', mode: 'semantic' });
+    const pill = fixture.nativeElement.querySelector('.pill-group');
+    expect(pill).toBeTruthy();
+    const buttons = pill.querySelectorAll('button');
+    expect(buttons[0].classList.contains('active')).toBe(false); // text
+    expect(buttons[1].classList.contains('active')).toBe(true);  // semantic
+  });
+
+  it('emits modeChange when a pill button is clicked', () => {
+    const fixture = create({ value: '', placeholder: 'ph', mode: 'text' });
+    const emitted: string[] = [];
+    fixture.componentInstance.modeChange.subscribe(m => emitted.push(m));
+    const buttons = fixture.nativeElement.querySelectorAll('.pill-group button');
+    (buttons[1] as HTMLButtonElement).click(); // semantic
+    expect(emitted).toEqual(['semantic']);
+  });
+
+  it('uses a distinct aria-label when provided, else the placeholder', () => {
+    const withAria = create({ value: '', placeholder: 'ph', ariaLabel: 'distinctAria' });
+    // transloco test harness echoes the key, so aria-label reflects the ariaLabel key
+    expect((withAria.nativeElement.querySelector('input') as HTMLInputElement).getAttribute('aria-label')).toBe('distinctAria');
+
+    const withoutAria = create({ value: '', placeholder: 'ph' });
+    expect((withoutAria.nativeElement.querySelector('input') as HTMLInputElement).getAttribute('aria-label')).toBe('ph');
+  });
+});

--- a/client/src/app/pages/brain/record-search-bar.component.ts
+++ b/client/src/app/pages/brain/record-search-bar.component.ts
@@ -1,0 +1,69 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+
+/**
+ * The record tabs' search bar — a text input plus an optional A–Z / Semantic mode pill.
+ *
+ * Unifies four near-identical inline bars (A17.9c): memories/edges/chrono had byte-identical markup
+ * (input + pill) and file-meta a plain input (no pill). It is a DUMB presentational component — the
+ * parent owns the state (in `BrainStore`) and passes `value`/`mode` in, receiving `valueChange`/
+ * `modeChange` out. Omit `mode` (leave it null) to hide the pill — that is how file-meta reuses it for
+ * its client-side filter.
+ *
+ * NOT here: the entities tab's search, which uses `<app-entity-search>` (entity autocomplete — a richer
+ * interaction, intentionally separate), and the semantic-search LOGIC (`onXSearch`/`runSemanticXSearch`),
+ * which stays in the tabs because its recall-result mapping is per-collection.
+ *
+ * `:host { display: contents }` so the input and pill remain direct flex children of the parent's
+ * `.content-header`, preserving the original layout exactly.
+ */
+@Component({
+  selector: 'app-record-search-bar',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslocoPipe, PhIconComponent],
+  styles: [`
+    :host { display: contents; }
+    input[type=search] {
+      flex: 1;
+      min-width: 180px;
+      max-width: 400px;
+      padding: 5px 10px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      background: var(--bg-surface);
+      color: var(--text-primary);
+    }
+    .pill-group { display: flex; border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; flex-shrink: 0; }
+    .pill-group button { padding: 5px 10px; font-size: 11px; background: transparent; border: none; border-right: 1px solid var(--border); color: var(--text-secondary); cursor: pointer; white-space: nowrap; }
+    .pill-group button:last-child { border-right: none; }
+    .pill-group button.active { background: var(--accent-dim); color: var(--accent); }
+    .pill-group button:hover:not(.active) { background: var(--bg-surface); }
+  `],
+  template: `
+    <input type="search"
+      [value]="value()"
+      (input)="valueChange.emit($any($event.target).value)"
+      [placeholder]="placeholder() | transloco"
+      [attr.aria-label]="(ariaLabel() ?? placeholder()) | transloco" />
+    @if (mode(); as m) {
+      <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
+        <button [class.active]="m === 'text'" (click)="modeChange.emit('text')">{{ 'common.sortAZ' | transloco }}</button>
+        <button [class.active]="m === 'semantic'" (click)="modeChange.emit('semantic')"><ph-icon name="star-four" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:3px;"/> {{ 'common.semantic' | transloco }}</button>
+      </div>
+    }
+  `,
+})
+export class RecordSearchBarComponent {
+  readonly value = input.required<string>();
+  readonly placeholder = input.required<string>();
+  /** Optional distinct aria-label i18n key; falls back to `placeholder` when unset. */
+  readonly ariaLabel = input<string | null>(null);
+  /** null/absent hides the pill (e.g. file-meta's client-side filter). */
+  readonly mode = input<'text' | 'semantic' | null>(null);
+
+  readonly valueChange = output<string>();
+  readonly modeChange = output<'text' | 'semantic'>();
+}


### PR DESCRIPTION
## What

Resolves the four-different-shapes search inconsistency (the one raised in review). `memories`/`edges`/`chrono` had **byte-identical** inline search markup — a text input + an A–Z/Semantic pill wired to the store's `*SearchMode` signal — and `filemeta` a plain input. They now all render **`<app-record-search-bar>`**, a dumb presentational component:

- inputs: `value`, `placeholder`, optional `mode` (`'text'|'semantic'|null` — omit to hide the pill, which is how file-meta reuses it), optional `ariaLabel`.
- outputs: `valueChange`, `modeChange`.
- `:host { display: contents }` keeps the input and pill as **direct flex children** of the header, so the layout is byte-for-byte unchanged.

## Deliberate boundaries (documented so they aren't read as oversights)

- **Entities stays on `<app-entity-search>`** — its bar does entity *autocomplete*, a richer interaction than plain text/semantic search; folding it in would drop that or bloat the shared bar.
- **The semantic-search *logic* stays per-tab** (`onXSearch` debounce + `runSemanticXSearch`) because its recall-result → typed-record mapping differs per collection. That's a separate candidate (A17.9e); this PR unifies the *bar* (the visible half of the inconsistency).

## Verification

- Behaviour unchanged — full client suite **215** (208 + 7 for the new component's spec: value/mode inputs, valueChange/modeChange outputs, pill shown only with a mode, distinct-aria fallback).
- `tsc --noEmit --noUnusedLocals` clean; production AOT build warning-free apart from the pre-existing `qrcode` bailout.
- CHANGELOG updated. Docs: the userguide's text/Semantic toggle behaviour is unchanged (same toggle, same "semantic is not paginated" rule) → no docs edit; the earlier "9c is a docs-trigger" note resolves with no change.

Next: the shell dead-CSS sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)