### PR TITLE
chore(deps): bump unstructured-api sidecar 0.0.75 → 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Bumped the `unstructured-api` document-conversion sidecar `0.0.75` → `0.1.2`** in
+  `docker-compose.yml` and `kubernetes/manifests/ythril-deployment.yaml`. The pin's license gate holds:
+  the 0.1.2 release is Apache-2.0 (verified against the upstream repo). The converter's contract points
+  are unchanged — it still POSTs to `/general/v0/general` and the health probes hit `/healthcheck`, both
+  long-stable unstructured-api endpoints. Per the repo's own per-bump discipline, the image's bundled
+  `/app/LICENSE` and a PDF/DOCX/EPUB conversion round-trip should be confirmed against 0.1.2 in the
+  Docker test stack before release.
+
 - **The five record-tab components now share a `RecordTabBase`, removing ~140 lines of duplicated
   boilerplate.** After all five landed, each carried a byte-identical copy of the same machinery — the
   `store`/`picker`/`recordList` injects, the `spaceId` input, `pageSize`, the paging cursor, the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@
     # The public `unstructured-api` image is the same release minus extra Tesseract
     # language packs / LibreOffice, and fully supports the hi_res OCR + image-extraction
     # path Ythril uses. Upstream's README points self-hosters at this image too.
-    image: downloads.unstructured.io/unstructured-io/unstructured-api:0.0.75
+    image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2
     container_name: ythril-unstructured
     restart: unless-stopped
     healthcheck:

--- a/kubernetes/manifests/ythril-deployment.yaml
+++ b/kubernetes/manifests/ythril-deployment.yaml
@@ -113,7 +113,7 @@ spec:
         - name: unstructured
           # Pin to a specific tag and verify the LICENSE before upgrading.
           # Run `docker run --rm --entrypoint cat <image> /app/LICENSE` to confirm Apache-2.0.
-          image: downloads.unstructured.io/unstructured-io/unstructured-api:0.0.75
+          image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2
           # Lighter hardening than the main container: the OCR pipeline writes
           # scratch files across its own filesystem, so readOnlyRootFilesystem is
           # left off, but privilege escalation and added capabilities are still denied.


### PR DESCRIPTION
## What

Bumps the `unstructured-api` document-conversion sidecar image tag from **0.0.75 → 0.1.2** in `docker-compose.yml` and `kubernetes/manifests/ythril-deployment.yaml`. (`docs/dependencies.md` references the image + its Apache-2.0 license but doesn't pin a version, so it needs no change.)

## Why it was pinned / the license gate

The tag is pinned deliberately as an **Apache-2.0 license safeguard** (unstructured image tags can carry commercial-use restrictions). The gate holds for 0.1.2: the release is **Apache-2.0**, verified against the upstream `Unstructured-IO/unstructured-api` repo.

## Verify before release (per the repo's own per-bump discipline)

Two items I could not clear from a dev box — flagged, not skipped:

1. **Image `/app/LICENSE`** — the repo's documented process checks the *image's* bundled LICENSE, not just the git repo (the image can bundle other components). One-liner:
   ```
   docker run --rm --entrypoint cat downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2 /app/LICENSE | head -30
   ```
   Confirm Apache-2.0, no commercial-use restriction.
2. **API round-trip** — the converter POSTs to `/general/v0/general` and the health probes hit `/healthcheck` (both long-stable unstructured-api endpoints, so very likely unchanged), but a **PDF/DOCX/EPUB conversion round-trip against 0.1.2 in the Docker test stack** should confirm the sidecar boots and the element schema the converter parses is unchanged.

## Notes

- No application code changes — image tag only.
- If the `/app/LICENSE` check surfaces an added restriction on 0.1.2, that *is* the reason to stay pinned; close this and I'll record it in the pin comment so it isn't re-questioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)