### PR TITLE
fix(test): make mcp-tools embedding gate reflect readiness at use time (A19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-tools` integration suite: embedding-availability gate is no longer racy during ollama
+  warm-up.** Each embedding-dependent `describe` block probed availability once (a single `remember`)
+  and cached the result, so a mid-warm-up model could pass the probe and then flake a later `recall`
+  while it was still loading. A shared `waitForEmbeddingReady` helper now gates on a real
+  remember→recall round-trip that must return a non-zero count, retried with backoff across warm-up,
+  and returns `false` immediately when the endpoint is unreachable — so CI (which runs no embedding
+  server) still skips deterministically with no added cost, while a cold local stack waits for the
+  model instead of failing. Unifies all six probe sites (one previously inlined the degraded-mode
+  recall-count check; the others were plain one-shot probes). Test harness only. Warm stack: 94/94.
+
 - **Reindexing degraded embeddings — dropped edge/chrono properties and embedded raw entity IDs
   for edges.** The `POST /reindex` job re-derived each record's embedding text with its own inline
   copies of the per-type builders, and those copies had drifted badly from the real writers: memory

--- a/testing/integration/mcp-tools.test.js
+++ b/testing/integration/mcp-tools.test.js
@@ -184,6 +184,46 @@ async function ensureReindexed(baseUrl, token) {
   }
 }
 
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Probe embedding readiness at USE time, not once. Readiness is defined by a full round-trip:
+ * a uniquely-remembered fact must be *recallable with a non-zero count*. That is stricter than
+ * "the endpoint answered" on purpose — memory storage succeeds in a degraded mode with no
+ * embedding server, but recall then returns empty without vectors, and a mid-warm-up model can
+ * answer one call and then fail the next. This retries across ollama warm-up, which is the flake
+ * it replaces: the old one-shot probe passed the instant the endpoint answered, then a later
+ * recall failed while the model was still loading (observed once on a cold stack).
+ *
+ * Returns false fast when the endpoint is unreachable — the server says "Could not reach embedding
+ * endpoint …" (server/src/brain/embedding.ts), which the CI test stack always hits (no embedding
+ * service), so CI keeps skipping deterministically with no retry cost. Transient warm-up states
+ * (HTTP 5xx while the model loads, empty vector, recall count 0) are retried with backoff.
+ */
+async function waitForEmbeddingReady(session, space = 'general', { attempts = 8, delayMs = 2000 } = {}) {
+  const unreachable = (text) => text.includes('could not reach') || text.includes('unreachable');
+  for (let i = 0; i < attempts; i++) {
+    const fact = `__embedding-probe-${Date.now()}-${i}__`;
+    const remembered = await session.callTool('remember', { space, fact, tags: [] });
+    const remText = (remembered?.content?.[0]?.text ?? '').toLowerCase();
+    if (remembered?.isError && unreachable(remText)) return false; // endpoint down → deterministic skip
+    if (!remembered?.isError) {
+      // remember succeeded; the real readiness signal is a recall that returns actual results.
+      const recalled = await session.callTool('recall', { space, query: fact, topK: 1 });
+      if (!recalled?.isError) {
+        let count = 0;
+        try { count = JSON.parse(recalled?.content?.[0]?.text ?? '{}').count ?? 0; }
+        catch { count = (recalled?.content?.[0]?.text ?? '').length > 0 ? 1 : 0; }
+        if (count > 0) return true;
+      } else if (unreachable((recalled?.content?.[0]?.text ?? '').toLowerCase())) {
+        return false;
+      }
+    }
+    if (i < attempts - 1) await sleep(delayMs); // transient warm-up (loading / empty) → retry
+  }
+  return false;
+}
+
 // ── Brain tool tests ──────────────────────────────────────────────────────
 
 describe('MCP brain tools — remember / recall / query', () => {
@@ -195,11 +235,9 @@ describe('MCP brain tools — remember / recall / query', () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     await ensureReindexed(INSTANCES.a, tokenA);
     session = await openMcpSession(tokenA);
-    // Probe: attempt one remember to find out if embedding is configured.
-    // If it returns isError with an embedding-unreachable message, skip embedding tests.
-    const probe = await session.callTool('remember', { space: 'general', fact: `__embedding-probe-${Date.now()}__`, tags: [] });
-    const probeText = probe?.content?.[0]?.text ?? '';
-    embeddingAvailable = !probe?.isError || !probeText.toLowerCase().includes('embedding');
+    // Gate embedding-dependent tests on a real remember→recall round-trip, retried across
+    // ollama warm-up so a mid-warm-up probe can't pass and then flake a later recall.
+    embeddingAvailable = await waitForEmbeddingReady(session);
   });
   after(() => session?.close());
 
@@ -774,10 +812,8 @@ describe('MCP recall_global — full-access token, multi-space isolation', () =>
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     await ensureReindexed(INSTANCES.a, tokenA);
     session = await openMcpSession(tokenA);
-    // Probe embedding availability before attempting to remember a seed fact.
-    const probe = await session.callTool('remember', { space: 'general', fact: `__rg-probe-${Date.now()}__`, tags: [] });
-    const probeText = probe?.content?.[0]?.text ?? '';
-    embeddingAvailable = !probe?.isError || !probeText.toLowerCase().includes('embedding');
+    // Gate on a real remember→recall round-trip (retried across warm-up) before seeding the fact.
+    embeddingAvailable = await waitForEmbeddingReady(session);
     if (embeddingAvailable) {
       await session.callTool('remember', { space: 'general', fact: spaceAFact, tags: ['global-recall-test'] });
     }
@@ -1135,10 +1171,7 @@ describe('MCP recall � types filter restricts result set', () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     await ensureReindexed(INSTANCES.a, tokenA);
     session = await openMcpSession(tokenA);
-    // Probe embedding availability
-    const probe = await session.callTool('remember', { space: 'general', fact: `__types-probe-${Date.now()}__`, tags: [] });
-    const probeText = probe?.content?.[0]?.text ?? '';
-    embeddingAvailable = !probe?.isError || !probeText.toLowerCase().includes('embedding');
+    embeddingAvailable = await waitForEmbeddingReady(session);
     if (embeddingAvailable) {
       // Seed an entity so entity-type results exist
       await session.callTool('upsert_entity', { space: 'general', name: entityName, type: 'concept', tags: ['types-filter-test'] });
@@ -1193,9 +1226,7 @@ describe('MCP brain tools � remember with description and properties', () => {
   before(async () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     session = await openMcpSession(tokenA);
-    const probe = await session.callTool('remember', { space: 'general', fact: `__rich-fields-probe-${Date.now()}__`, tags: [] });
-    const probeText = probe?.content?.[0]?.text ?? '';
-    embeddingAvailable = !probe?.isError || !probeText.toLowerCase().includes('embedding');
+    embeddingAvailable = await waitForEmbeddingReady(session);
   });
   after(() => session?.close());
 
@@ -1477,24 +1508,9 @@ describe('MCP brain tools � recall and recall_global with minPerType', () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     await ensureReindexed(INSTANCES.a, tokenA);
     session = await openMcpSession(tokenA);
-    const probeFact = `__minpertype-probe-${Date.now()}__`;
-    const probe = await session.callTool('remember', { space: 'general', fact: probeFact, tags: [] });
-    const probeText = probe?.content?.[0]?.text ?? '';
-    const storeSucceeded = !probe?.isError || !probeText.toLowerCase().includes('embedding');
-    if (storeSucceeded) {
-      // Verify recall actually returns results — memory storage succeeds in degraded
-      // mode (no embedding server) but recall returns empty without vectors.
-      const recallProbe = await session.callTool('recall', { space: 'general', query: probeFact, topK: 1 });
-      if (!recallProbe?.isError) {
-        try {
-          const rp = JSON.parse(recallProbe?.content?.[0]?.text ?? '{}');
-          embeddingAvailable = (rp.count ?? 0) > 0;
-        } catch {
-          // Non-JSON response means the tool returned formatted text — assume available
-          embeddingAvailable = (recallProbe?.content?.[0]?.text ?? '').length > 0;
-        }
-      }
-    }
+    // waitForEmbeddingReady already validates recall returns a non-zero count (the degraded-mode
+    // guard this block used to inline), now retried across warm-up.
+    embeddingAvailable = await waitForEmbeddingReady(session);
     if (embeddingAvailable) {
       await session.callTool('upsert_entity', { space: 'general', name: entityName, type: 'concept', tags: ['minpertype-test'] });
     }
@@ -1559,9 +1575,7 @@ describe('MCP brain tools � recall and recall_global with minScore', () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
     await ensureReindexed(INSTANCES.a, tokenA);
     session = await openMcpSession(tokenA);
-    const probe = await session.callTool('remember', { space: 'general', fact: `__minscore-probe-${Date.now()}__`, tags: [] });
-    const probeText = probe?.content?.[0]?.text ?? '';
-    embeddingAvailable = !probe?.isError || !probeText.toLowerCase().includes('embedding');
+    embeddingAvailable = await waitForEmbeddingReady(session);
     if (embeddingAvailable) {
       await session.callTool('remember', { space: 'general', fact: factForScore, tags: ['minscore-test'] });
     }


### PR DESCRIPTION
## What

Fixes the racy embedding-availability gate in `testing/integration/mcp-tools.test.js` (audit item **A19**). Each embedding-dependent `describe` block probed availability **once** (a single `remember`) and cached the result; a mid-warm-up ollama could pass that probe and then flake a later `recall` while the model was still loading.

## Fix

A shared `waitForEmbeddingReady(session)` helper replaces every one-shot probe. Readiness is now defined by a **real remember→recall round-trip that returns a non-zero count**, retried with backoff across warm-up:

- **Down** (CI — no embedding server): the server returns `"Could not reach embedding endpoint …"`, so the helper returns `false` on the first attempt — **no retry cost, CI keeps skipping deterministically**.
- **Warm**: `remember` + `recall` succeed with results → `true` on attempt 0.
- **Mid-warm-up** (the flake): transient errors / empty recalls are retried (≤ ~16s bounded) until the model actually serves — no more spurious failure.

This satisfies both remedies the tracker suggested: the probe asserts the model *actually returns results*, and transient failures are *retried before giving up*.

## Consolidation

Unifies **all six** probe sites across the file. One of them (the `minPerType` block) had already grown a stricter inline check — remember → recall → `count > 0` to guard against a degraded mode where storage succeeds without vectors — and the helper now adopts that stricter signal for every site, so the degraded-mode guard is applied uniformly rather than in just one block.

## Verification

- Ran `node --test testing/integration/mcp-tools.test.js` against a live warm stack: **94 pass, 0 fail, 0 skipped** — the helper correctly detected embedding-ready and all embedding tests ran green (no regression to the warm path).
- Down-path (immediate `false` on "could not reach") is straightforward and syntax-verified; CI has no embedding server so it exercises that path and continues to skip.
- Test harness only — no production code touched.

Closes **A19**. Remaining audit backlog: **A18** (docs markdownlint), which closes the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)