### PR TITLE
chore: small correctness & consistency fixes (C8, U13, A21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Brain space/tab record counts now refresh right after an upload, not only after a delete.** The
+  embedded file manager already told the Brain page to reload its counts when a file was deleted, but
+  an upload completing emitted nothing, so the Files / File Meta counters stayed stale until you left
+  the space and came back. The file manager's output was generalized (`fileDeleted` → `filesChanged`,
+  fired on both delete and upload completion) and the Brain host refreshes stats on it.
+
 - **`mcp-tools` integration suite: embedding-availability gate is no longer racy during ollama
   warm-up.** Each embedding-dependent `describe` block probed availability once (a single `remember`)
   and cached the result, so a mid-warm-up model could pass the probe and then flake a later `recall`
@@ -711,6 +717,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the migration. Covered by `testing/integration/auth.test.js`.
 
 ### Changed
+
+- **The `SpacesComponent` page shell is now OnPush.** The A17.8 spaces-component split left the shell
+  on default change-detection while all its extracted children were OnPush; now that the shell is fully
+  signal-driven, it's flipped to `OnPush` for consistency and to skip re-checking it on unrelated ticks.
+  Added to the change-detection spec so a future non-signal mutation trips the assertion.
 
 - **`docs/` is now markdownlint-clean and gated in CI so it can't rot again.** The docs had never
   passed `markdownlint-cli2` (~318 violations). Fixed all of them — added a language to every fenced

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -227,7 +227,7 @@ interface SpaceView {
 
         <!-- Files tab -->
         @if (activeTab() === 'files') {
-          <app-file-manager [embeddedSpaceId]="activeSpaceId()" [navigatePath]="fileManagerNavPath()" (viewFileMeta)="openFileMetaEntry($event)" (fileDeleted)="loadStats(activeSpaceId())" />
+          <app-file-manager [embeddedSpaceId]="activeSpaceId()" [navigatePath]="fileManagerNavPath()" (viewFileMeta)="openFileMetaEntry($event)" (filesChanged)="loadStats(activeSpaceId())" />
         }
 
         <!-- Memories -->

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -620,7 +620,8 @@ export class FileManagerComponent implements OnInit, OnDestroy {
 
   /** Emits the file path when user clicks "View Brain Metadata" in the preview pane. */
   @Output() viewFileMeta = new EventEmitter<string>();
-  @Output() fileDeleted = new EventEmitter<void>();
+  /** Fires whenever the file set in this space changes (delete or upload complete) so the host can refresh counts. */
+  @Output() filesChanged = new EventEmitter<void>();
 
   /** Navigate to the given directory when changed from parent (used by Brain filemeta→Files link). */
   @Input() set navigatePath(p: string) {
@@ -817,8 +818,9 @@ export class FileManagerComponent implements OnInit, OnDestroy {
           this.uploadSubs.delete(item.id);
           this.patchUpload(item.id, { status: 'done', percent: 100 });
           this.processing = false;
-          // Show the freshly uploaded file straight away.
+          // Show the freshly uploaded file straight away, and let the host refresh its record counts.
           this.loadDir(this.currentPath());
+          this.filesChanged.emit();
           this.processQueue();
         },
       });
@@ -916,7 +918,7 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     if (!ok) return;
     const path = this.join(this.currentPath(), entry.name);
     this.filesApi.deleteFile(this.activeSpaceId(), path).subscribe({
-      next: () => { this.loadDir(this.currentPath()); this.fileDeleted.emit(); },
+      next: () => { this.loadDir(this.currentPath()); this.filesChanged.emit(); },
       error: () => this.toast.error(this.transloco.translate('files.error.deleteFailed')),
     });
   }

--- a/client/src/app/pages/settings/space-components.onpush.spec.ts
+++ b/client/src/app/pages/settings/space-components.onpush.spec.ts
@@ -10,16 +10,23 @@
  *
  * This asserts the property directly, because losing OnPush is invisible — nothing fails, the app
  * just quietly re-checks everything on every tick again.
+ *
+ * A21: the 262-line `SpacesComponent` page shell itself is now OnPush too. Once the FileReader
+ * offenders moved into the schema tab, the shell became fully signal-driven (all state is
+ * signals/computed; `saveSettings` writes only signals), so the flip is safe — and it is included
+ * below so a future edit that reintroduces non-signal mutation trips this assertion.
  */
 import { describe, it, expect } from 'vitest';
+import { SpacesComponent } from './spaces.component';
 import { SpaceCreateDialogComponent } from './space-create-dialog.component';
 import { SpaceSettingsTabComponent } from './space-settings-tab.component';
 import { SpaceSchemaTabComponent } from './space-schema-tab.component';
 import { SpaceDuplicatesTabComponent } from './space-duplicates-tab.component';
 import { SpaceDangerTabComponent } from './space-danger-tab.component';
 
-describe('spaces page — extracted components are OnPush', () => {
+describe('spaces page — the shell and extracted components are OnPush', () => {
   const CASES: [string, { ɵcmp?: { onPush?: boolean } }][] = [
+    ['SpacesComponent', SpacesComponent],
     ['SpaceCreateDialogComponent', SpaceCreateDialogComponent],
     ['SpaceSettingsTabComponent', SpaceSettingsTabComponent],
     ['SpaceSchemaTabComponent', SpaceSchemaTabComponent],

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, inject, signal, computed, OnInit, ElementRef, ViewChild } from '@angular/core';
+﻿import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { finalize, timeout, TimeoutError } from 'rxjs';
@@ -34,6 +34,7 @@ import { SpaceCreateDialogComponent } from './space-create-dialog.component';
   // Provided here (not root) so each mount gets its own settings state, with a lifetime tied to
   // this component rather than the app.
   providers: [SpacesStore, SpaceSettingsState],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [SPACE_DIALOG_STYLES],
   template: `
     <!-- CREATE DIALOG -->

--- a/server/src/db/backup-config.ts
+++ b/server/src/db/backup-config.ts
@@ -2,12 +2,15 @@
  * Backup configuration loader.
  *
  * Reads backup.json from the same directory as config.json (typically
- * /config/backup.json).  This file is NEVER written by the API — it is
- * managed exclusively by the infrastructure admin via the filesystem.
+ * /config/backup.json).  It can also be written by the API via
+ * `PUT /api/admin/data/backup-config`, but only behind `requireAdminMfa` AND
+ * the `YTHRIL_DB_MIGRATION_ENABLED` feature flag (off by default); otherwise
+ * it is managed by the infrastructure admin on the filesystem.
  *
- * Design rationale: keeping backup config out of config.json (which IS
- * API-writable) prevents a compromised admin token from redirecting backups
- * to an attacker-controlled path.
+ * Design rationale: keeping backup config out of config.json (which is freely
+ * API-writable) means redirecting backups to an attacker-controlled path takes
+ * MFA plus an explicitly-enabled feature flag, not just an admin token — and
+ * `offsite.destPath` is additionally required to be absolute.
  *
  * Example backup.json — see config/backup.example.json for the full schema.
  *


### PR DESCRIPTION
Three independent, low-risk items from the reconciled backlog, bundled because each is individually too small for its own PR.

## U13 — Brain counts refresh after an upload (UX, bug fix)

The embedded file manager told the Brain page to reload its record counts on **delete** (`(fileDeleted)="loadStats(...)"`), but an **upload completing** emitted nothing — so the Files / File Meta counters stayed stale until you left the space and came back.

Generalized the output: `fileDeleted` → **`filesChanged`**, emitted on both delete and upload completion (one "the file set changed" signal), and the Brain host refreshes stats on it. Single emit site, single consumer — clean rename, no parallel output.

## A21 — `SpacesComponent` shell → OnPush (consistency/perf)

The A17.8 spaces-component split left OnPush children but the 262-line shell on **default** change-detection. The shell is now fully signal-driven (all state is signals/computed; `saveSettings` writes only signals; the old `FileReader.onload` offenders moved into the schema tab during the split), so the flip is safe. Added `SpacesComponent` to `space-components.onpush.spec.ts` so a future non-signal mutation trips the assertion.

## C8 — fix stale comment in `backup-config.ts` (hygiene)

The header comment claimed `backup.json` "is NEVER written by the API." It **is** — `PUT /api/admin/data/backup-config` writes it, behind `requireAdminMfa` **and** the `YTHRIL_DB_MIGRATION_ENABLED` feature flag. Corrected the comment and updated the security rationale (the protection is MFA + feature flag + absolute-path check, not immutability).

## Verification

- Client suite: **217 passed** (incl. the new OnPush case for the shell).
- Server build + client AOT build: clean, no warnings.
- Docs: userguide describes *what* the space-chip count is, not its refresh timing — U13 just makes reality match expectation, so no doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)