### PR TITLE
feat(client): accessible modals on the Schema Library page (U5, pt 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -726,6 +726,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Schema Library page's modal overlays are now accessible dialogs (U5, part 2).** The remaining
+  hand-rolled, inline-styled overlays on the Schema Library page — add-catalog, browse-catalog, create
+  library-access-token, the token one-time reveal, export-space, apply-group-to-space, the create/edit
+  entry dialog, and the delete dialog — now carry the same `[appModal]` treatment (role, aria-modal,
+  focus trap, Escape-to-close), and their close buttons that were missing an `aria-label` got one. With
+  part 1, every hand-rolled overlay in the app is now an accessible modal.
+
 - **The settings-area modal overlays are now accessible dialogs (U5, part 1).** The hand-rolled
   overlays for creating a space, creating a token, the network create/join/enable-wizard, and the
   schema-library create/edit + delete dialogs were plain `div`s with no `role`, `aria-modal`, focus

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -24,6 +24,7 @@ import { ToastService } from '../../core/toast.service';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { PropSchemaTableComponent } from '../../shared/prop-schema-table.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
+import { ModalDirective } from '../../shared/modal.directive';
 import { httpErrorReason } from '../../core/http-error';
 
 // ── Local form state ────────────────────────────────────────────────────────
@@ -99,7 +100,7 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
 @Component({
   selector: 'app-schema-library',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, PropSchemaTableComponent, ErrorStateComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, PropSchemaTableComponent, ErrorStateComponent, ModalDirective],
   styles: [`
     /* chip inputs — same as spaces.component.ts */
     .chip-wrap {
@@ -312,10 +313,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Add Catalog dialog -->
     @if (showAddCatalog()) {
       <div style="position:fixed;inset:0;background:var(--bg-scrim);display:flex;align-items:center;justify-content:center;z-index:200;" (click)="showAddCatalog.set(false)">
-        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:480px;" (click)="$event.stopPropagation()">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:480px;" [appModal]="'schemaLib.catalog.addTitle' | transloco" (dismiss)="showAddCatalog.set(false)" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.catalog.addTitle' | transloco }}</h3>
-            <button class="icon-btn" type="button" (click)="showAddCatalog.set(false)"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="showAddCatalog.set(false)"><ph-icon name="x" [size]="18"/></button>
           </div>
           <div class="field" style="margin-bottom:14px;">
             <label>{{ 'schemaLib.catalog.nameLabel' | transloco }}</label>
@@ -347,10 +348,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Catalog browse dialog -->
     @if (browsing(); as b) {
       <div style="position:fixed;inset:0;background:var(--bg-scrim);display:flex;align-items:center;justify-content:center;z-index:200;" (click)="browsing.set(null)">
-        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:96vw;max-width:780px;max-height:85vh;display:flex;flex-direction:column;" (click)="$event.stopPropagation()">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:96vw;max-width:780px;max-height:85vh;display:flex;flex-direction:column;" [appModal]="'schemaLib.catalog.browseTitle' | transloco" (dismiss)="browsing.set(null)" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;flex-shrink:0;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.catalog.browseTitle' | transloco }}: <span style="font-family:var(--font-mono);">{{ b.catalogName }}</span></h3>
-            <button class="icon-btn" type="button" (click)="browsing.set(null)"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="browsing.set(null)"><ph-icon name="x" [size]="18"/></button>
           </div>
           @if (b.loading) {
             <div style="flex:1;display:flex;align-items:center;justify-content:center;"><span class="spinner"></span></div>
@@ -381,10 +382,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Create library access token dialog -->
     @if (showCreateLibToken()) {
       <div style="position:fixed;inset:0;background:var(--bg-scrim);display:flex;align-items:center;justify-content:center;z-index:200;" (click)="closeCreateLibToken()">
-        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:420px;" (click)="$event.stopPropagation()">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:420px;" [appModal]="'schemaLib.share.tokenDialogTitle' | transloco" (dismiss)="closeCreateLibToken()" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.share.tokenDialogTitle' | transloco }}</h3>
-            <button class="icon-btn" type="button" (click)="closeCreateLibToken()"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="closeCreateLibToken()"><ph-icon name="x" [size]="18"/></button>
           </div>
           <p style="font-size:13px;color:var(--text-secondary);margin:0 0 16px;">{{ 'schemaLib.share.tokenDialogHint' | transloco }}</p>
           <div class="field" style="margin-bottom:14px;">
@@ -405,7 +406,7 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Library access token one-time reveal -->
     @if (libTokenRevealed()) {
       <div style="position:fixed;inset:0;background:var(--bg-scrim);display:flex;align-items:center;justify-content:center;z-index:210;">
-        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:480px;">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:480px;" [appModal]="'schemaLib.share.tokenCreatedTitle' | transloco" (dismiss)="libTokenRevealed.set(null)">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.share.tokenCreatedTitle' | transloco }}</h3>
           </div>
@@ -424,10 +425,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Export space schema dialog -->
     @if (exportSpaceDialog()) {
       <div style="position:fixed;inset:0;background:var(--bg-scrim);display:flex;align-items:center;justify-content:center;z-index:200;" (click)="exportSpaceDialog.set(null)">
-        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:500px;" (click)="$event.stopPropagation()">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:500px;" [appModal]="'schemaLib.exportSpace.dialogTitle' | transloco" (dismiss)="exportSpaceDialog.set(null)" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.exportSpace.dialogTitle' | transloco }}</h3>
-            <button class="icon-btn" type="button" (click)="exportSpaceDialog.set(null)"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="exportSpaceDialog.set(null)"><ph-icon name="x" [size]="18"/></button>
           </div>
           <p style="font-size:13px;color:var(--text-secondary);margin:0 0 16px;">{{ 'schemaLib.exportSpace.dialogHint' | transloco }}</p>
           <div class="field" style="margin-bottom:14px;">
@@ -465,10 +466,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Apply group to space dialog -->
     @if (applyGroupDialog()) {
       <div style="position:fixed;inset:0;background:var(--bg-scrim);display:flex;align-items:center;justify-content:center;z-index:200;" (click)="applyGroupDialog.set(null)">
-        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:500px;" (click)="$event.stopPropagation()">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;width:92vw;max-width:500px;" [appModal]="'schemaLib.applyGroup.dialogTitle' | transloco" (dismiss)="applyGroupDialog.set(null)" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.applyGroup.dialogTitle' | transloco }}</h3>
-            <button class="icon-btn" type="button" (click)="applyGroupDialog.set(null)"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="applyGroupDialog.set(null)"><ph-icon name="x" [size]="18"/></button>
           </div>
           <p style="font-size:13px;color:var(--text-secondary);margin:0 0 16px;">{{ 'schemaLib.applyGroup.dialogHint' | transloco }}</p>
           <div class="field" style="margin-bottom:14px;">
@@ -505,10 +506,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
 
     @if (showDialog()) {
       <div class="dialog-backdrop" (click)="closeDialog()">
-        <div class="dialog" (click)="$event.stopPropagation()">
+        <div class="dialog" [appModal]="editingName() ? ('schemaLib.dialog.editTitle' | transloco) : ('schemaLib.dialog.createTitle' | transloco)" (dismiss)="closeDialog()" (click)="$event.stopPropagation()">
           <div class="dialog-header">
             <h3>{{ editingName() ? ('schemaLib.dialog.editTitle' | transloco) : ('schemaLib.dialog.createTitle' | transloco) }}</h3>
-            <button class="icon-btn" type="button" (click)="closeDialog()"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="closeDialog()"><ph-icon name="x" [size]="18"/></button>
           </div>
 
           <!-- Entry metadata -->
@@ -583,10 +584,10 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
     <!-- Delete warning dialog -->
     @if (deleteDialog(); as dd) {
       <div style="position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:320;display:flex;align-items:center;justify-content:center;" (click)="closeDeleteDialog()">
-        <div style="background:var(--surface);border-radius:8px;padding:24px;max-width:480px;width:90%;display:flex;flex-direction:column;gap:16px;" (click)="$event.stopPropagation()">
+        <div style="background:var(--surface);border-radius:8px;padding:24px;max-width:480px;width:90%;display:flex;flex-direction:column;gap:16px;" [appModal]="'schemaLib.delete.title' | transloco" (dismiss)="closeDeleteDialog()" (click)="$event.stopPropagation()">
           <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
             <h3 style="margin:0;font-size:15px;">{{ 'schemaLib.delete.title' | transloco }}</h3>
-            <button class="icon-btn" type="button" (click)="closeDeleteDialog()"><ph-icon name="x" [size]="18"/></button>
+            <button class="icon-btn" type="button" [attr.aria-label]="'common.close' | transloco" (click)="closeDeleteDialog()"><ph-icon name="x" [size]="18"/></button>
           </div>
           @if (dd.loading) {
             <div style="text-align:center;padding:16px 0;"><span class="spinner"></span></div>


### PR DESCRIPTION
Backlog item **U5** (part 2 of 2 — completes it). Part 1 (#264) added the shared `[appModal]` directive and applied it to the settings-area overlays. This applies it to the **Schema Library page**'s own overlays, which part 1 deferred because they're hand-rolled with verbose inline-styled backdrops.

## What

Applied `[appModal]` (role="dialog" + aria-modal + aria-label + focus trap that captures on open / restores on close + Escape-to-dismiss) to all **8** overlays on `pages/schema-library/schema-library.component.ts`:

- add-catalog, browse-catalog, create library-access-token, token one-time reveal, export-space, apply-group-to-space, the create/edit entry dialog, and the delete dialog.

Also added the missing `[attr.aria-label]="'common.close'"` to their header close buttons (7 buttons — the token-reveal has no header ✕).

Two overlays (export / apply-group) had **identical** panel inline-styles; each edit was disambiguated by its backdrop's distinct close action. The token-reveal has no backdrop-dismiss (a one-time secret reveal) — it still gets `[appModal]` so Escape closes it.

## Verification

- Reused the part-1 directive + its spec — no new abstraction.
- Swept the file: all 8 overlay backdrops now have `[appModal]` on their panels; no `icon-btn` close buttons remain without `aria-label`.
- Client suite: **226 passed**. AOT build clean, no warnings.

**With part 1, every hand-rolled overlay in the app is now an accessible modal.** U5 is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)