### PR TITLE
fix(server): auto-derive chrono `overdue` status on read (C5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Chrono entries now go `overdue` automatically (C5).** `overdue` is a valid chrono status, but
+  nothing ever set it — a passed deadline kept its `upcoming`/`active` status, so
+  `list_chrono({status: "overdue"})` returned nothing. It is now **derived on read**: an entry whose due
+  moment (its `endsAt`, or `startsAt` when it has none) has passed and that isn't `completed`/`cancelled`
+  is returned as `overdue` across the REST list/detail endpoints, MCP `list_chrono`, and `recall`.
+  Filtering by `overdue` returns exactly those entries, and filtering by `upcoming`/`active` excludes
+  the ones that are now overdue. No writes and no scheduled sweep — the status is computed at read time,
+  so it's always current. (Embeddings still reflect the stored status, so semantic search for "overdue"
+  won't rank a derived-overdue entry.)
+
 - **Brain space/tab record counts now refresh right after an upload, not only after a delete.** The
   embedded file manager already told the Brain page to reload its counts when a file was deleted, but
   an upload completing emitted nothing, so the Files / File Meta counters stayed stale until you left

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1243,7 +1243,9 @@ POST /api/brain/spaces/:spaceId/chrono
 ```
 
 - `type` — `event`, `deadline`, `plan`, `prediction`, `milestone`
-- `status` — `upcoming` (default), `active`, `completed`, `overdue`, `cancelled`
+- `status` — `upcoming` (default), `active`, `completed`, `overdue`, `cancelled`. You never need to set
+  `overdue` yourself: it is **derived on read** — an entry whose due moment (`endsAt`, or `startsAt` if
+  it has none) has passed and that is not `completed`/`cancelled` is returned as `overdue`.
 - `confidence` — `0`–`1` (optional, useful for predictions)
 - `entityIds` — array of UUID v4 entity IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled
 - `memoryIds` — array of UUID v4 memory IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled
@@ -1279,7 +1281,7 @@ GET /api/brain/spaces/:spaceId/chrono?limit=50&skip=0
 | `tags` | comma-separated strings | Return entries where `tags` contains **ALL** listed values (AND semantics) |
 | `tagsAny` | comma-separated strings | Return entries where `tags` contains **ANY** listed value (OR semantics) |
 | `search` | string | Case-insensitive substring match on `title` and `description` |
-| `status` | string | Filter by status (`upcoming`, `active`, `completed`, `overdue`, `cancelled`) |
+| `status` | string | Filter by status (`upcoming`, `active`, `completed`, `overdue`, `cancelled`). `overdue` is derived on read (past due + not completed/cancelled); filtering by `upcoming`/`active` excludes now-overdue entries |
 | `type` | string | Filter by type (`event`, `deadline`, `plan`, `prediction`, `milestone`) |
 | `limit` | number | Max entries to return (default 50, max 500) |
 | `skip` | number | Pagination offset (default 0) |

--- a/docs/usecase-examples.md
+++ b/docs/usecase-examples.md
@@ -339,7 +339,7 @@ graph TD
 
 **Wow factor:**
 
-- `list_chrono({status: "overdue"})` — lists every obligation **explicitly marked** `overdue`. (Status lives on the entry; a passed `startsAt` does not auto-flag it — mark deadlines overdue as you triage them.)
+- `list_chrono({status: "overdue"})` — lists every obligation whose due moment (its `endsAt`, or `startsAt` when it has none) has passed and that isn't `completed`/`cancelled`. `overdue` is **derived on read**, so a passed deadline surfaces automatically — you don't have to mark it.
 - `create_chrono({type: "deadline", title: "DORA ICT risk assessment due", startsAt: "2026-06-30", entityIds: ["DORA", "ICT-risk"]})` → departments' LLMs can ask "What compliance deadlines do we have this quarter?" and get structured answers, not just documents.
 - Braintree pushes mean the legal team publishes once and all departments receive. Departments **cannot** alter the authoritative deadline — temporal integrity by architecture.
 - `query(chrono, {type: "prediction", confidence: {$gte: 0.5}})` → the legal team can even log risk predictions ("60% chance of regulatory change in Q3") and track them.

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -168,8 +168,38 @@ export async function updateChrono(
   return updatedChrono;
 }
 
+/**
+ * C5 — derive `overdue` on read.
+ *
+ * An entry is overdue when its due moment (its `endsAt`, or `startsAt` when it has no end) has passed
+ * and it is not yet `completed`/`cancelled`. Nothing writes the `overdue` status — it is computed at
+ * read time so there is no write churn, no scheduled sweep, and no sync traffic, and it is always
+ * accurate to the second. Because the STORED status stays `upcoming`/`active`, this must be applied at
+ * every chrono read path (see `getChronoById` and `listChrono`), and the `listChrono` status filter is
+ * translated to match (below).
+ *
+ * Known limitation: the entry's embedding is built from the stored status, so a derived-`overdue` entry
+ * still embeds as `upcoming` — semantic search for "overdue" won't rank it. That is the trade-off for
+ * not re-embedding on a clock tick.
+ */
+export function deriveChronoStatus(
+  entry: Pick<ChronoEntry, 'status' | 'startsAt' | 'endsAt'>,
+  now: Date = new Date(),
+): ChronoStatus {
+  if (entry.status !== 'upcoming' && entry.status !== 'active') return entry.status;
+  const due = entry.endsAt ?? entry.startsAt;
+  return due && new Date(due).getTime() < now.getTime() ? 'overdue' : entry.status;
+}
+
+/** Return the entry with its derived status applied (a shallow copy only when the status changes). */
+function withDerivedStatus(entry: ChronoEntry, now: Date = new Date()): ChronoEntry {
+  const status = deriveChronoStatus(entry, now);
+  return status === entry.status ? entry : { ...entry, status };
+}
+
 export async function getChronoById(spaceId: string, id: string): Promise<ChronoEntry | null> {
-  return col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as Promise<ChronoEntry | null>;
+  const entry = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as ChronoEntry | null;
+  return entry ? withDerivedStatus(entry) : null;
 }
 
 export interface ChronoFilter {
@@ -193,9 +223,25 @@ export async function listChrono(
   limit = 50,
   skip = 0,
 ): Promise<ChronoEntry[]> {
+  const now = new Date();
   const query: Record<string, unknown> = { spaceId };
 
-  if (filter.status !== undefined) query['status'] = filter.status;
+  // Status filter is `overdue`-aware (C5): `overdue` is derived from the due moment, never stored.
+  if (filter.status !== undefined) {
+    // The due moment: endsAt, or startsAt when there is no end. `$toDate` so mixed-offset ISO strings
+    // compare chronologically, not lexically.
+    const refDate = { $toDate: { $ifNull: ['$endsAt', '$startsAt'] } };
+    if (filter.status === 'overdue') {
+      query['status'] = { $in: ['upcoming', 'active'] };
+      query['$expr'] = { $lt: [refDate, now] };
+    } else if (filter.status === 'upcoming' || filter.status === 'active') {
+      // Exclude entries that are now derived-overdue so they don't surface under their stored status.
+      query['status'] = filter.status;
+      query['$expr'] = { $gte: [refDate, now] };
+    } else {
+      query['status'] = filter.status; // completed / cancelled — no derivation
+    }
+  }
   if (filter.type !== undefined) query['type'] = filter.type;
 
   // tags ALL (AND): every tag in the array must be present
@@ -232,12 +278,14 @@ export async function listChrono(
     query['$or'] = [{ title: regex }, { description: regex }];
   }
 
-  return col<ChronoEntry>(`${spaceId}_chrono`)
+  const entries = await col<ChronoEntry>(`${spaceId}_chrono`)
     .find(asFilter<ChronoEntry>(query))
     .sort({ createdAt: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
-    .toArray() as Promise<ChronoEntry[]>;
+    .toArray() as ChronoEntry[];
+  // Present the derived status (same `now` as the filter, so the returned status agrees with it).
+  return entries.map(e => withDerivedStatus(e, now));
 }
 
 export async function deleteChrono(

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -12,6 +12,8 @@ import { getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
 import { vectorFilterFieldsFor } from '../spaces/vector-index.js';
 import { FilterExpression, buildMongoFilter, toNativeVectorFilter } from './filter.js';
+import { deriveChronoStatus } from './chrono.js';
+import type { ChronoStatus } from '../config/types.js';
 
 export type RecallKnowledgeType = 'memory' | 'entity' | 'edge' | 'chrono' | 'file';
 
@@ -263,7 +265,7 @@ async function recallByType(
   } else if (knowledgeType === 'edge') {
     typeProject = { from: 1, to: 1, label: 1, weight: 1, type: 1, tags: 1, description: 1, properties: 1 };
   } else if (knowledgeType === 'chrono') {
-    typeProject = { title: 1, description: 1, type: 1, status: 1, startsAt: 1, tags: 1, entityIds: 1, properties: 1 };
+    typeProject = { title: 1, description: 1, type: 1, status: 1, startsAt: 1, endsAt: 1, tags: 1, entityIds: 1, properties: 1 };
   } else if (knowledgeType === 'file') {
     typeProject = { path: 1, description: 1, tags: 1, sizeBytes: 1, properties: 1, headingText: 1, content: 1, parentFileId: 1, chunkIndex: 1, mediaType: 1, embeddingStatus: 1, chunkOffsetMs: 1, chunkDurationMs: 1 };
   }
@@ -366,7 +368,7 @@ function mapToRecallResult(doc: Record<string, unknown>, knowledgeType: RecallKn
     case 'edge':
       return { ...base, type: 'edge', from: doc['from'] as string, to: doc['to'] as string, label: doc['label'] as string, weight: doc['weight'] as number | undefined, edgeType: doc['type'] as string | undefined };
     case 'chrono':
-      return { ...base, type: 'chrono', title: doc['title'] as string, chronoType: doc['type'] as string, startsAt: doc['startsAt'] as string, status: doc['status'] as string | undefined, entityIds: doc['entityIds'] as string[] | undefined };
+      return { ...base, type: 'chrono', title: doc['title'] as string, chronoType: doc['type'] as string, startsAt: doc['startsAt'] as string, status: deriveChronoStatus({ status: doc['status'] as ChronoStatus, startsAt: doc['startsAt'] as string, endsAt: doc['endsAt'] as string | undefined }), entityIds: doc['entityIds'] as string[] | undefined };
     case 'file':
       return { ...base, type: 'file', path: doc['path'] as string, sizeBytes: doc['sizeBytes'] as number | undefined, headingText: doc['headingText'] as string | null | undefined, content: doc['content'] as string | undefined, parentFileId: doc['parentFileId'] as string | undefined, chunkIndex: doc['chunkIndex'] as number | undefined, mediaType: doc['mediaType'] as 'image' | 'audio' | 'video' | undefined, embeddingStatus: doc['embeddingStatus'] as RecallFile['embeddingStatus'], chunkOffsetMs: doc['chunkOffsetMs'] as number | undefined, chunkDurationMs: doc['chunkDurationMs'] as number | undefined };
   }

--- a/testing/standalone/chrono-overdue.test.js
+++ b/testing/standalone/chrono-overdue.test.js
@@ -1,0 +1,39 @@
+/**
+ * C5 — deriveChronoStatus: `overdue` is computed on read from the due moment (endsAt ?? startsAt),
+ * only for entries that aren't yet completed/cancelled. This pure rule is what both the read-mapping
+ * (listChrono/getChronoById/recall) and the listChrono status-filter translation rely on.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveChronoStatus } from '../../server/dist/brain/chrono.js';
+
+const NOW = new Date('2026-07-18T12:00:00Z');
+const PAST = '2026-07-01T00:00:00Z';
+const FUTURE = '2026-08-01T00:00:00Z';
+
+describe('deriveChronoStatus (C5)', () => {
+  it('upcoming past its startsAt (no endsAt) becomes overdue', () => {
+    assert.equal(deriveChronoStatus({ status: 'upcoming', startsAt: PAST }, NOW), 'overdue');
+  });
+
+  it('active past its endsAt becomes overdue', () => {
+    assert.equal(deriveChronoStatus({ status: 'active', startsAt: PAST, endsAt: PAST }, NOW), 'overdue');
+  });
+
+  it('uses endsAt over startsAt — a started-but-not-ended range is NOT overdue', () => {
+    assert.equal(deriveChronoStatus({ status: 'active', startsAt: PAST, endsAt: FUTURE }, NOW), 'active');
+  });
+
+  it('a future entry stays upcoming', () => {
+    assert.equal(deriveChronoStatus({ status: 'upcoming', startsAt: FUTURE }, NOW), 'upcoming');
+  });
+
+  it('completed/cancelled are never re-derived, even when past due', () => {
+    assert.equal(deriveChronoStatus({ status: 'completed', startsAt: PAST }, NOW), 'completed');
+    assert.equal(deriveChronoStatus({ status: 'cancelled', startsAt: PAST }, NOW), 'cancelled');
+  });
+
+  it('an already-overdue stored status is returned as-is', () => {
+    assert.equal(deriveChronoStatus({ status: 'overdue', startsAt: PAST }, NOW), 'overdue');
+  });
+});


### PR DESCRIPTION
Backlog item **C5**. `overdue` is a valid `ChronoStatus`, but **nothing ever set it** — a passed deadline kept its `upcoming`/`active` status, so `list_chrono({status: "overdue"})` (which usecase-examples implied surfaces missed obligations) returned nothing.

## Fix — derive on read

Chosen over a periodic sweep: **no writes, no scheduled job, no sync churn, and always accurate to the second.** An entry is `overdue` when its due moment (`endsAt`, or `startsAt` when it has none) has passed and it isn't `completed`/`cancelled`.

- **`deriveChronoStatus(entry, now)`** helper in `brain/chrono.ts`.
- Applied at every read path so the value is consistent: **`listChrono`** and **`getChronoById`** (covers the REST list/detail endpoints and MCP `list_chrono`), and **`recall`**'s chrono projection (added `endsAt` to the projection so ranged events use the correct reference moment).
- **Status filter made overdue-aware** (the tricky bit — since the stored status stays `upcoming`/`active`):
  - `status: 'overdue'` → `status ∈ {upcoming, active}` **and** due-moment `< now` (via `$expr`/`$toDate`/`$ifNull`, so mixed-offset ISO strings compare chronologically).
  - `status: 'upcoming'`/`'active'` → keep the equality **and** exclude entries now derived-overdue, so the filter agrees with the returned status.
  - `completed`/`cancelled` → unchanged.

## Known limitation (commented in code)

Embeddings are built from the **stored** status, so a derived-`overdue` entry still embeds as `upcoming` — semantic search for the word "overdue" won't rank it. That's the deliberate trade-off for not re-embedding on a clock tick.

## Tests / verification

- New standalone unit test (6 cases) for the derivation rule: upcoming-past-due → overdue; endsAt takes precedence (a started-but-not-ended range isn't overdue); future stays upcoming; completed/cancelled never re-derived; already-overdue returned as-is.
- Server build clean.
- Docs: `usecase-examples.md` and `integration-guide.md` updated — both previously stated `overdue` was **not** auto-derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)