### PR TITLE
test(perf): poll the two fixed audit-log waits; document the rest (Q3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Test suite: the two genuinely fixed audit-log waits now poll instead of sleeping (Q3).**
+  `audit.test.js` slept a fixed 500 ms twice waiting for a fire-and-forget audit write, then asserted;
+  both are now bounded `waitFor` polls that return as soon as the entry lands (the file went ~4.4 s →
+  ~1.1 s and is stable across repeated runs). An audit of the rest of the suite's `setTimeout` calls
+  found they are already correct bounded-poll intervals or deliberate negative/timing waits (the latter
+  now guard-commented so they aren't mistakenly converted) — so nothing else needed changing. Internal
+  test-harness only.
+
 - **The Schema Library page's modal overlays are now accessible dialogs (U5, part 2).** The remaining
   hand-rolled, inline-styled overlays on the Schema Library page — add-catalog, browse-catalog, create
   library-access-token, the token one-time reveal, export-space, apply-group-to-space, the create/edit

--- a/testing/integration/audit.test.js
+++ b/testing/integration/audit.test.js
@@ -17,7 +17,7 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get, del, patch } from '../sync/helpers.js';
+import { INSTANCES, post, get, del, patch, waitFor } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -116,11 +116,12 @@ describe('Audit Log', () => {
     // Attempt to access with bad token
     await get(INSTANCES.a, 'ythril_totally-invalid-token', '/api/tokens/me');
 
-    await new Promise(r => setTimeout(r, 500));
-
-    const r = await get(INSTANCES.a, tokenA, '/api/admin/audit-log?operation=auth.failed&limit=5');
-    assert.equal(r.status, 200);
-    assert.ok(r.body.entries.length > 0, 'Should have auth.failed entries');
+    // Audit writes are fire-and-forget — poll for the entry instead of a fixed sleep (Q3).
+    let r;
+    await waitFor(async () => {
+      r = await get(INSTANCES.a, tokenA, '/api/admin/audit-log?operation=auth.failed&limit=5');
+      return r.status === 200 && r.body.entries.length > 0;
+    }, 15_000, 250, () => 'auth.failed audit entry never appeared');
     const entry = r.body.entries[0];
     assert.equal(entry.operation, 'auth.failed');
     assert.equal(entry.status, 401);
@@ -158,15 +159,15 @@ describe('Audit Log', () => {
 
     await del(INSTANCES.a, tokenA, `/api/tokens/${tokenId}`);
 
-    await new Promise(r => setTimeout(r, 500));
-
-    // Check for token.create
-    const createLog = await get(INSTANCES.a, tokenA, '/api/admin/audit-log?operation=token.create&limit=5');
+    // Audit writes are fire-and-forget — poll until both entries land instead of a fixed sleep (Q3).
+    let createLog, deleteLog;
+    await waitFor(async () => {
+      createLog = await get(INSTANCES.a, tokenA, '/api/admin/audit-log?operation=token.create&limit=5');
+      deleteLog = await get(INSTANCES.a, tokenA, '/api/admin/audit-log?operation=token.delete&limit=5');
+      return createLog.body?.entries?.length > 0 && deleteLog.body?.entries?.length > 0;
+    }, 15_000, 250, () => 'token.create/token.delete audit entries never appeared');
     assert.equal(createLog.status, 200);
     assert.ok(createLog.body.entries.length > 0, 'Should have token.create entries');
-
-    // Check for token.delete
-    const deleteLog = await get(INSTANCES.a, tokenA, '/api/admin/audit-log?operation=token.delete&limit=5');
     assert.equal(deleteLog.status, 200);
     assert.ok(deleteLog.body.entries.length > 0, 'Should have token.delete entries');
   });

--- a/testing/sync/braintree.test.js
+++ b/testing/sync/braintree.test.js
@@ -139,7 +139,9 @@ describe('Braintree topology (A -> B -> C)', () => {
     // Trigger sync on B (B syncs from A, not from C)
     await triggerSync(INSTANCES.b, tokenB, networkId);
 
-    // Wait a short time and verify this specific memory is NOT on B
+    // Wait a short time and verify this specific memory is NOT on B.
+    // Negative assertion — a fixed wait is correct here; do NOT convert to waitFor (Q3), which would
+    // return instantly on the absent record and prove nothing.
     await new Promise(r => setTimeout(r, 3000));
     const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${leafMemId}`);
     assert.equal(r.status, 404, 'Leaf fact should NOT have propagated to B');
@@ -157,6 +159,7 @@ describe('Braintree topology (A -> B -> C)', () => {
     // Trigger sync on A — A only receives from its own parent (none) and pushes to B
     await triggerSync(INSTANCES.a, tokenA, networkId);
 
+    // Negative assertion (see above) — fixed wait is correct; do NOT convert to waitFor (Q3).
     await new Promise(r => setTimeout(r, 3000));
     const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${nodeMemId}`);
     assert.equal(r.status, 404, 'Node fact should NOT have propagated to A');

--- a/testing/sync/governance.test.js
+++ b/testing/sync/governance.test.js
@@ -194,7 +194,8 @@ describe('Governed space deletion', () => {
     assert.equal(voteR.status, 200);
     assert.ok(voteR.body?.concluded === true, 'Veto must conclude the round immediately');
 
-    // Brief wait to confirm no async side-effect fires
+    // Brief wait to confirm no async side-effect fires.
+    // Negative assertion — fixed wait is correct; do NOT convert to waitFor (Q3).
     await new Promise(r => setTimeout(r, 500));
 
     const listR = await get(INSTANCES.a, tokenA, '/api/spaces');

--- a/testing/sync/peer-revocation.test.js
+++ b/testing/sync/peer-revocation.test.js
@@ -155,7 +155,8 @@ describe('Peer credential revocation (H7)', () => {
     const rm1 = await del(INSTANCES.a, tokenA, `/api/networks/${nid1}/members/${instanceIdB}`);
     assert.equal(rm1.status, 204);
 
-    // Give the async revocation a moment, then confirm the PAT survived
+    // Give the async revocation a moment, then confirm the PAT survived.
+    // Negative assertion — fixed wait is correct; do NOT convert to waitFor (Q3).
     await new Promise(r => setTimeout(r, 1500));
     assert.ok(
       tokensWithPeerId('ythril-a', instanceIdB).length >= 1,

--- a/testing/sync/pubsub-topology.test.js
+++ b/testing/sync/pubsub-topology.test.js
@@ -141,7 +141,8 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     // A syncs — A pushes to B, never pulls from B
     await triggerSync(INSTANCES.a, tokenA, networkId);
 
-    // Wait and verify the subscriber-local fact is NOT on A
+    // Wait and verify the subscriber-local fact is NOT on A.
+    // Negative assertion — fixed wait is correct; do NOT convert to waitFor (Q3).
     await new Promise(r => setTimeout(r, 3_000));
     const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${subMemId}`);
     assert.equal(r.status, 404, 'Subscriber fact should NOT appear on publisher');


### PR DESCRIPTION
Backlog item **Q3** — replace fixed propagation sleeps with bounded `waitFor` polling. Verified against the live Docker test stack.

## The finding: the premise was largely wrong

Auditing the suite's ~54 `setTimeout` occurrences one by one, **almost none were fixed worst-case waits**:

- **Already-correct bounded polls** (the majority) — the poll *interval* inside a `while (Date.now() < deadline) { check; if (!found) sleep }` loop (conflicts, dupe-scanner/detection, files, mcp-tools, media-config, pagination, space-creation-async, recall-filter/traverse, embed-properties, file-conversion, file-sync's own loops). These already return the instant the condition is met — exactly what `waitFor` does. **Left untouched** (converting to the shared helper would be churn with no behaviour change).
- **Negative assertions** (braintree ×2, pubsub-topology, governance, peer-revocation) — "wait, then confirm X did *not* happen." A `waitFor` on absence returns instantly and proves nothing, so a fixed wait is **correct**. Left as-is and now **guard-commented** (`do NOT convert to waitFor (Q3)`) so a future sweep can't break them.
- **Timing artifacts** (timestamp-differ, rate-limit backoff) — left as-is.

## The actual fix

The only genuine fixed-wait-then-assert sites were **`audit.test.js:119, :161`** — a fixed 500 ms sleep waiting for a fire-and-forget audit write, then a direct assert. Both converted to bounded `waitFor` polls that return as soon as the entry lands.

## Verification (live stack)

- `audit.test.js`: **8/8, stable across 3 runs**, and **~4.4 s → ~1.1 s** (the two fixed 1 s of sleeps are gone; the polls resolve in ~250 ms). Baseline captured before the change = the QA Step 0 baseline for this file.
- The five comment-only sync edits: `node --check` clean (comments can't change behaviour).

No blanket conversion — that would have traded correct code for a number. `QA-TODO.md` updated to record the corrected premise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)