### PR TITLE
test: stop the bulk-wipe tests from wiping the shared `general` space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Test isolation: the bulk-memory-wipe tests no longer wipe the shared `general` space.**
+  `brain.test.js`'s wipe block used `WIPE_SPACE = 'general'` and issued a `confirm:true` bulk delete —
+  deleting **every** memory in the shared `general` space, other tests' data included. Serial ordering
+  hid it, but it would corrupt a concurrent test the moment the suite runs in parallel. Moved to a
+  dedicated `wipe-${RUN}` space (created/torn down per run). An audit of all 14 `general`-touching test
+  files found this was the *only* genuine cross-file bleed — the rest assert on their own unique-id/tag
+  data, not on a clean space. Internal test-harness only; unblocks parallelization (Q4).
+
 - **Chrono entries now go `overdue` automatically (C5).** `overdue` is a valid chrono status, but
   nothing ever set it — a passed deadline kept its `upcoming`/`active` status, so
   `list_chrono({status: "overdue"})` returned nothing. It is now **derived on read**: an entry whose due

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -629,12 +629,16 @@ describe('Brain â€” memory fact validation', () => {
 
 describe('Brain — bulk memory wipe', () => {
   const RUN = Date.now();
-  const WIPE_SPACE = 'general';
+  // Dedicated space (not `general`): these tests WIPE the whole space, so pointing them at the shared
+  // `general` would delete other files' data — a real cross-file bleed and a hard blocker for running
+  // the suite in parallel (Q4). Namespaced per run and torn down in `after`.
+  const WIPE_SPACE = `wipe-${RUN}`;
   let seededIds;
   let seqBefore;
 
   before(async () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: WIPE_SPACE, label: 'Bulk Wipe Test' });
 
     // Seed 10 memories for the wipe test
     seededIds = [];
@@ -642,7 +646,7 @@ describe('Brain — bulk memory wipe', () => {
     for (let i = 0; i < 10; i++) {
       const id = `wipe-${RUN}-${i}`;
       seededIds.push(id);
-      const r = await post(INSTANCES.a, tokenA, '/api/sync/memories?spaceId=general', {
+      const r = await post(INSTANCES.a, tokenA, `/api/sync/memories?spaceId=${WIPE_SPACE}`, {
         _id: id, spaceId: WIPE_SPACE, fact: `Wipe test memory ${i}`,
         tags: ['wipe-test'], entityIds: [], embedding: [],
         seq: seqBase++, author: { instanceId: 'test', instanceLabel: 'Test' },
@@ -720,7 +724,7 @@ describe('Brain — bulk memory wipe', () => {
     // Seed a couple of memories first
     let seqBase = Date.now();
     for (let i = 0; i < 3; i++) {
-      await post(INSTANCES.a, tokenA, '/api/sync/memories?spaceId=general', {
+      await post(INSTANCES.a, tokenA, `/api/sync/memories?spaceId=${WIPE_SPACE}`, {
         _id: `wipe-long-${RUN}-${i}`, spaceId: WIPE_SPACE, fact: `Long-form wipe ${i}`,
         tags: ['wipe-long'], entityIds: [], embedding: [],
         seq: seqBase++, author: { instanceId: 'test', instanceLabel: 'Test' },
@@ -737,6 +741,10 @@ describe('Brain — bulk memory wipe', () => {
   it('Wipe on unknown space returns 404', async () => {
     const r = await delWithBody(INSTANCES.a, tokenA, '/api/brain/spaces/no-such-space/memories', { confirm: true });
     assert.equal(r.status, 404, `expected 404, got ${r.status}`);
+  });
+
+  after(async () => {
+    await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${WIPE_SPACE}`, { confirm: true }).catch(() => {});
   });
 });
 


### PR DESCRIPTION
Backlog item: **per-file test data isolation** (the QA Q1 guard, and the prerequisite for parallelizing the suite, Q4).

## The finding

Auditing all **14 test files that touch the shared `general` space** showed the isolation debt was much smaller than the tracker feared — the same lesson as Q3. The suite is written defensively: `general` assertions are by-unique-id, by-unique-`${RUN}`-tag, shape/status (`typeof === number`, `Array.isArray`, 200/404/401), or "at-least-mine" inclusion — **never an exact count or an empty-space precondition**. No file makes a clean-`general` assertion, and the isolation-proof the guard wanted already exists (`spaces.test.js` writes to another space and asserts its record is absent from `general` by id).

## The one genuine bleed (fixed)

`brain.test.js`'s bulk-memory-wipe block had:

```js
const WIPE_SPACE = 'general';
…
await delWithBody(INSTANCES.a, tokenA, `/api/brain/spaces/${WIPE_SPACE}/memories`, { confirm: true });
```

That wipes **every memory in the shared `general` space** — other test files' data included. Serial ordering hid it, but under Q4 parallelism it would delete a concurrent test's data mid-run. **Moved to a dedicated `wipe-${RUN}` space** (created in `before`, torn down in `after`).

The other apparent `general`-destructive ops are **negative/permission tests**, not destructive: `space-deletion.test.js` asserts deleting the built-in `general` is *rejected*; `space-wipe.test.js` asserts a non-admin wipe is *403*.

## Verification (live stack)

- `brain.test.js`: **183/183 pass** with the dedicated wipe space.
- No blanket per-file namespacing needed — the audit shows the rest of the suite is already free of cross-file space bleed. The residual Q4 concern is instance-level (config/network) contention, which is Q4's own scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)