### PR TITLE
feat(sync): optional synchronous POST /api/notify/trigger?wait=true (C6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`POST /api/notify/trigger?wait=true` — optional synchronous sync (C6).** The trigger endpoint is
+  fire-and-forget by default (`{status:'triggered'}`); passing `?wait=true` now runs the cycle and
+  returns its outcome (`{status:'completed', synced, errors}`), bounded by `?timeoutMs` (default 30s,
+  clamped 1–120s) so a slow or stuck cycle can't hang the request (`504 {status:'timeout'}`; the cycle
+  keeps running in the background). Backward-compatible — the default behaviour is unchanged. (Also
+  corrected the documented default response, which said `status:'ok'` but has always been `'triggered'`.)
+
 - **Webhooks management UI — Settings → Webhooks (C1).** Webhooks were previously configurable only
   through the admin API; there's now a full page to list, create, edit, test, and delete them, and to
   view recent delivery attempts (event, HTTP status, latency, error). Each webhook shows a status badge

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3732,13 +3732,26 @@ POST /api/notify/trigger
 { "networkId": "net-uuid" }
 ```
 
-Triggers an immediate sync cycle for the given network.
+Triggers an immediate sync cycle for the given network. **Fire-and-forget by default** — it returns as
+soon as the cycle is scheduled:
 
 **Response** `200`:
 
 ```json
-{ "status": "ok", "networkId": "net-uuid" }
+{ "status": "triggered", "networkId": "net-uuid" }
 ```
+
+**Synchronous mode** — add `?wait=true` to run the cycle and get its outcome in the response. Bounded by
+`?timeoutMs` (default `30000`, clamped to `1000`–`120000`) so a slow or stuck cycle can't hang the
+request; on timeout the cycle keeps running in the background.
+
+```http
+POST /api/notify/trigger?wait=true&timeoutMs=15000
+```
+
+**Response** `200` (completed): `{ "status": "completed", "networkId": "…", "synced": 12, "errors": 0 }`
+· `504` (timed out, still running): `{ "status": "timeout", "networkId": "…", "timeoutMs": 15000 }`
+· `500` (the cycle failed): `{ "status": "error", "networkId": "…", "error": "…" }`
 
 ---
 

--- a/server/src/api/notify.ts
+++ b/server/src/api/notify.ts
@@ -207,14 +207,47 @@ notifyRouter.get('/', notifyRateLimit, requireAuth, (req, res) => {
 });
 
 // ── POST /api/notify/trigger — manually trigger a sync (admin) ────────────
+//
+// Fire-and-forget by default (`{ status: 'triggered' }`). Pass `?wait=true` (C6) to run the cycle
+// synchronously and get its outcome — bounded by `?timeoutMs` (default 30s, clamped 1s–120s) so a
+// slow or stuck sync can never hang the request; on timeout the cycle keeps running in the background.
 
-notifyRouter.post('/trigger', notifyRateLimit, requireAuth, (req, res) => {
+const TIMEOUT_SENTINEL = Symbol('sync-trigger-timeout');
+
+notifyRouter.post('/trigger', notifyRateLimit, requireAuth, async (req, res) => {
   const { networkId } = req.body as { networkId?: string };
   if (!networkId) { res.status(400).json({ error: 'networkId required' }); return; }
+  const wait = req.query['wait'] === 'true' || req.query['wait'] === '1';
 
-  import('../sync/engine.js').then(({ runSyncForNetwork }) => {
-    void runSyncForNetwork(networkId);
-  }).catch(err => log.error(`trigger import: ${err}`));
+  let runSyncForNetwork: (id: string) => Promise<{ synced: number; errors: number }>;
+  try {
+    ({ runSyncForNetwork } = await import('../sync/engine.js'));
+  } catch (err) {
+    log.error(`trigger import: ${err}`);
+    res.status(500).json({ error: 'Sync engine unavailable' });
+    return;
+  }
 
-  res.json({ status: 'triggered', networkId });
+  if (!wait) {
+    void runSyncForNetwork(networkId).catch(err => log.error(`Triggered sync for ${networkId} failed: ${err}`));
+    res.json({ status: 'triggered', networkId });
+    return;
+  }
+
+  const timeoutMs = Math.min(Math.max(parseInt(String(req.query['timeoutMs'] ?? ''), 10) || 30_000, 1_000), 120_000);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => { timer = setTimeout(() => reject(TIMEOUT_SENTINEL), timeoutMs); });
+  try {
+    const result = await Promise.race([runSyncForNetwork(networkId), timeout]);
+    res.json({ status: 'completed', networkId, synced: result.synced, errors: result.errors });
+  } catch (err) {
+    if (err === TIMEOUT_SENTINEL) {
+      res.status(504).json({ status: 'timeout', networkId, timeoutMs });
+    } else {
+      log.error(`Synchronous trigger for ${networkId} failed: ${err}`);
+      res.status(500).json({ status: 'error', networkId, error: err instanceof Error ? err.message : String(err) });
+    }
+  } finally {
+    clearTimeout(timer);
+  }
 });

--- a/testing/integration/notify-trigger-wait.test.js
+++ b/testing/integration/notify-trigger-wait.test.js
@@ -1,0 +1,46 @@
+/**
+ * C6 — POST /api/notify/trigger gains an opt-in synchronous mode.
+ *
+ * Default is fire-and-forget (200 `{status:'triggered'}`). With `?wait=true` the request awaits the
+ * sync cycle and reports its outcome, bounded by `?timeoutMs`. We prove the two paths differ using an
+ * unknown network, whose sync throws: fire-and-forget swallows it (200), while `?wait=true` surfaces it
+ * synchronously (500 `{status:'error'}`) — which is exactly the "sync and tell me the result" affordance.
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const MISSING_NET = `no-such-network-${RUN}`;
+
+describe('notify/trigger — synchronous ?wait=true (C6)', () => {
+  let tokenA;
+  before(() => { tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
+
+  it('requires networkId', async () => {
+    const r = await post(INSTANCES.a, tokenA, '/api/notify/trigger', {});
+    assert.equal(r.status, 400);
+  });
+
+  it('fire-and-forget (default) returns 200 {status:triggered} even for an unknown network', async () => {
+    const r = await post(INSTANCES.a, tokenA, '/api/notify/trigger', { networkId: MISSING_NET });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.status, 'triggered');
+    assert.equal(r.body.networkId, MISSING_NET);
+  });
+
+  it('?wait=true awaits the cycle and surfaces the outcome synchronously', async () => {
+    // Unknown network → the sync cycle throws "Network … not found"; ?wait=true reports it as an error
+    // status (500), unlike the fire-and-forget path above which 200s and only logs.
+    const r = await post(INSTANCES.a, tokenA, `/api/notify/trigger?wait=true`, { networkId: MISSING_NET });
+    assert.equal(r.status, 500, JSON.stringify(r.body));
+    assert.equal(r.body.status, 'error');
+    assert.match(r.body.error, /not found/i);
+    assert.equal(r.body.networkId, MISSING_NET);
+  });
+});


### PR DESCRIPTION
Backlog item **C6**. `POST /api/notify/trigger` was fire-and-forget only — you couldn't "sync and be told the result." This adds an opt-in synchronous mode.

## What

- **Default unchanged** — fire-and-forget, returns `{ status: 'triggered', networkId }` as soon as the cycle is scheduled.
- **`?wait=true`** — awaits the cycle and returns its outcome: `{ status: 'completed', networkId, synced, errors }`.
- **Bounded** by `?timeoutMs` (default `30000`, clamped `1000`–`120000`) so a slow or stuck cycle can't hang the request → `504 { status: 'timeout' }` (the cycle keeps running in the background).
- **Errors surfaced** — a failed cycle returns `500 { status: 'error', error }` instead of only being logged.

Backward-compatible and additive; the handler just gained an awaited/raced branch.

## Tests / verification

- New `notify-trigger-wait.test.js` (3 cases) proves the two paths differ using an unknown network (whose cycle throws `Network … not found`): the default path **200s and swallows** it; `?wait=true` **surfaces it as 500** `{status:'error'}`. Also covers the `400` missing-networkId case. **3/3 pass** against a freshly-rebuilt test stack.
- Server build clean; `lint:docs` clean.
- Docs: the integration-guide "Trigger Sync" section now documents `?wait=true`/`timeoutMs` and the response shapes — and I corrected its default response, which claimed `status:'ok'` but has always been `'triggered'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)