### PR TITLE
feat(mcp): per-record ttlDays on the MCP write tools + bulk (F10 completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Record TTL / auto-expiry (F10).** Records can now expire and be deleted automatically. Every write
-  endpoint (memory, entity, edge, chrono — create and update) accepts an optional per-record `ttlDays`:
-  a positive integer sets an expiry that many days out, `0`/`null` clears it (opting the record out of
-  any space default), and omitting it applies the space default only when the record has no expiry yet
-  (an existing expiry is never silently re-slid). An invalid `ttlDays` is rejected with `400`. Spaces
+  surface — the REST endpoints, the MCP write tools (`remember` / `update_memory` / `upsert_entity` /
+  `update_entity` / `upsert_edge` / `update_edge` / `create_chrono` / `update_chrono`), and per-item in
+  `bulk_write` / `POST /bulk` — accepts an optional per-record `ttlDays`: a positive integer sets an
+  expiry that many days out, `0`/`null` clears it (opting the record out of any space default), and
+  omitting it applies the space default only when the record has no expiry yet (an existing expiry is
+  never silently re-slid). An invalid `ttlDays` is rejected (`400` on REST, a tool error on MCP, a
+  per-item error in bulk). Spaces
   gain a `recordTtlDays` setting — a space-wide auto-TTL applied to every record that doesn't specify its
   own — configurable from the Spaces settings tab and via `PATCH /api/spaces/:id`. Enforcement is an
   app-side sweep that deletes lapsed records **through the normal delete path**, so each deletion writes

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -625,6 +625,10 @@ The expiry surfaces as `_expireAt` (an ISO timestamp) on the record. The sweep r
 instance; expiry is eventual (granularity is days), not to-the-second. A `ttlDays`-only update (no other
 fields) is a valid write — use it to set, extend, or clear an existing record's expiry.
 
+`ttlDays` is accepted on the **MCP** write tools as well (`remember`, `update_memory`, `upsert_entity`,
+`update_entity`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`) and per item in
+`bulk_write` / `POST /bulk`, with the same semantics — so agents can set an expiry directly.
+
 ---
 
 ### Get a Memory by ID

--- a/server/src/brain/bulk.ts
+++ b/server/src/brain/bulk.ts
@@ -55,6 +55,17 @@ function optProps(v: unknown): Record<string, string | number | boolean> | undef
   return v != null && typeof v === 'object' && !Array.isArray(v)
     ? (v as Record<string, string | number | boolean>) : undefined;
 }
+/** Sentinel: a per-item `ttlDays` was present but not a valid integer 0..36500 or null. */
+const TTL_INVALID = Symbol('ttl-invalid');
+/** Per-item TTL (F10): a non-negative integer ≤ 36500 sets an expiry, `null` clears it, absent →
+ *  undefined (space default); anything else is TTL_INVALID so the item is reported and skipped. */
+function bulkTtlDays(v: unknown): number | null | undefined | typeof TTL_INVALID {
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  if (typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 36500) return v;
+  return TTL_INVALID;
+}
+const TTL_INVALID_MSG = '`ttlDays` must be an integer number of days between 0 and 36500, or null to clear the expiry';
 function slice(v: unknown): Record<string, unknown>[] {
   return Array.isArray(v) ? (v.slice(0, BULK_MAX_PER_TYPE) as Record<string, unknown>[]) : [];
 }
@@ -90,10 +101,13 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     if (fact.length > MAX_FACT_LENGTH) { errors.push({ type: 'memory', index: i, reason: '`fact` must not exceed 50 000 characters' }); continue; }
     const type = typeof item['type'] === 'string' && item['type'].trim() ? item['type'] : undefined;
     const properties = optProps(item['properties']);
+    const ttlDays = bulkTtlDays(item['ttlDays']);
+    if (ttlDays === TTL_INVALID) { errors.push({ type: 'memory', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
       if (schemaFails('memory', i, validateMemory(meta ?? {}, { type, properties }))) continue;
       await remember(spaceId, fact, strArray(item['entityIds']), strArray(item['tags']),
-        typeof item['description'] === 'string' ? item['description'] : undefined, properties, undefined, type);
+        typeof item['description'] === 'string' ? item['description'] : undefined, properties, undefined, type,
+        undefined, undefined, ttlDays);
       inserted.memories++;
     } catch (err) { errors.push({ type: 'memory', index: i, reason: err instanceof Error ? err.message : String(err) }); }
   }
@@ -109,13 +123,15 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     const rawId = typeof item['id'] === 'string' ? item['id'].trim() : undefined;
     if (rawId !== undefined && !UUID_V4_RE.test(rawId)) { errors.push({ type: 'entity', index: i, reason: '`id` must be a valid UUID v4' }); continue; }
     const properties = optProps(item['properties']) ?? {};
+    const ttlDays = bulkTtlDays(item['ttlDays']);
+    if (ttlDays === TTL_INVALID) { errors.push({ type: 'entity', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
       if (schemaFails('entity', i, validateEntity(meta ?? {}, { name, type, properties }))) continue;
       const existing = rawId
         ? await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId }))
         : null;
       const result = await upsertEntity(spaceId, name, type, strArray(item['tags']), properties,
-        typeof item['description'] === 'string' ? item['description'] : undefined, rawId);
+        typeof item['description'] === 'string' ? item['description'] : undefined, rawId, undefined, undefined, ttlDays);
       if (existing) updated.entities++; else inserted.entities++;
       if (result.warning) errors.push({ type: 'entity', index: i, reason: result.warning });
     } catch (err) { errors.push({ type: 'entity', index: i, reason: err instanceof Error ? err.message : String(err) }); }
@@ -134,6 +150,8 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     if (strict && !UUID_V4_RE.test(to)) { errors.push({ type: 'edge', index: i, reason: '`to` must be a valid UUID v4 (entity ID), not a name' }); continue; }
     if (!label) { errors.push({ type: 'edge', index: i, reason: 'missing required field: label' }); continue; }
     const properties = optProps(item['properties']);
+    const ttlDays = bulkTtlDays(item['ttlDays']);
+    if (ttlDays === TTL_INVALID) { errors.push({ type: 'edge', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
       if (schemaFails('edge', i, validateEdge(meta ?? {}, { label, properties }))) continue;
       const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }));
@@ -141,7 +159,7 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
         typeof item['weight'] === 'number' ? item['weight'] : undefined,
         typeof item['type'] === 'string' ? item['type'] : undefined,
         typeof item['description'] === 'string' ? item['description'] : undefined,
-        properties, optStrArray(item['tags']));
+        properties, optStrArray(item['tags']), undefined, ttlDays);
       if (existing) updated.edges++; else inserted.edges++;
     } catch (err) { errors.push({ type: 'edge', index: i, reason: err instanceof Error ? err.message : String(err) }); }
   }
@@ -165,6 +183,8 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     // Normalise status to a known value (drop unknowns) — REST did this; MCP did not.
     const status = typeof item['status'] === 'string' && CHRONO_STATUSES.has(item['status'] as ChronoStatus)
       ? item['status'] as ChronoStatus : undefined;
+    const ttlDays = bulkTtlDays(item['ttlDays']);
+    if (ttlDays === TTL_INVALID) { errors.push({ type: 'chrono', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
       if (schemaFails('chrono', i, validateChrono(meta ?? {}, { type, properties }))) continue;
       await createChrono(spaceId, {
@@ -173,7 +193,7 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
         status, confidence: typeof item['confidence'] === 'number' ? item['confidence'] : undefined,
         description: typeof item['description'] === 'string' ? item['description'] : undefined,
         tags: optStrArray(item['tags']), entityIds, memoryIds, properties,
-      });
+      }, undefined, ttlDays);
       inserted.chrono++;
     } catch (err) { errors.push({ type: 'chrono', index: i, reason: err instanceof Error ? err.message : String(err) }); }
   }

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
+import { TTL_DAYS_SCHEMA } from './shared.js';
 import { bulkWrite, bulkWriteTotal } from '../../brain/bulk.js';
 import { resolveWriteTarget } from '../../spaces/proxy.js';
 import { emitWebhookEvent } from '../../webhooks/dispatcher.js';
@@ -33,6 +34,7 @@ export const bulk_writeTool: ToolHandler = {
                   description: { type: 'string', description: 'Optional prose context.' },
                   type:        { type: 'string', description: 'Optional memory type — selects the per-type schema used to validate `properties`.' },
                   properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['fact'],
               },
@@ -49,6 +51,7 @@ export const bulk_writeTool: ToolHandler = {
                   tags:        { type: 'array', items: { type: 'string' } },
                   description: { type: 'string' },
                   properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['name', 'type'],
               },
@@ -67,6 +70,7 @@ export const bulk_writeTool: ToolHandler = {
                   description: { type: 'string' },
                   tags:        { type: 'array', items: { type: 'string' } },
                   properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['from', 'to', 'label'],
               },
@@ -88,6 +92,7 @@ export const bulk_writeTool: ToolHandler = {
                   entityIds:   { type: 'array', items: { type: 'string' } },
                   memoryIds:   { type: 'array', items: { type: 'string' } },
                   properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['title', 'type', 'startsAt'],
               },

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
 import { ChronoFilter, createChrono, listChrono, updateChrono, parseRecurrence } from '../../brain/chrono.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
@@ -41,6 +41,7 @@ export const create_chronoTool: ToolHandler = {
               required: ['freq'],
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'title', 'type', 'startsAt'],
         }),
@@ -106,7 +107,7 @@ export const create_chronoTool: ToolHandler = {
       memoryIds: chronoMemoryIds,
       properties: chronoProps,
       ...(rec.value ? { recurrence: rec.value } : {}),
-    }, ctx.actor);
+    }, ctx.actor, ttlDaysFromArgs(a));
     let text = `Chrono entry '${entry.title}' (${entry.type}) created (ID ${entry._id}, seq ${entry.seq}).`
       + (remQuota.softBreached ? `\n⚠️ Storage warning: ${remQuota.warning}` : '');
     if (chronoMeta?.validationMode === 'warn') {
@@ -152,6 +153,7 @@ export const update_chronoTool: ToolHandler = {
               required: ['freq'],
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
         }),
@@ -196,7 +198,7 @@ export const update_chronoTool: ToolHandler = {
       updates['recurrence'] = rec.value;
     }
 
-    const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2], ctx.actor);
+    const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2], ctx.actor, ttlDaysFromArgs(a));
     if (!entry) throw new Error(`Chrono entry '${id}' not found`);
     return { content: [{ type: 'text' as const, text: `Chrono entry '${entry.title}' updated (seq ${entry.seq}).` }] };
   },

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { traverseGraph, updateEdgeById, upsertEdge } from '../../brain/edges.js';
 import { getConfig } from '../../config/loader.js';
@@ -28,6 +28,7 @@ export const upsert_edgeTool: ToolHandler = {
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'from', 'to', 'label'],
         }),
@@ -61,7 +62,8 @@ export const upsert_edgeTool: ToolHandler = {
       return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(edgeSchemaViolations, null, 2)}` }], isError: true };
     }
 
-    const edge = await upsertEdge(wt.target, from, to, label, weight, edgeType, description, edgeProps, edgeTags, ctx.actor);
+    const edgeTtlDays = ttlDaysFromArgs(a);
+    const edge = await upsertEdge(wt.target, from, to, label, weight, edgeType, description, edgeProps, edgeTags, ctx.actor, edgeTtlDays);
     let edgeMsg = `Edge '${label}' (${from} → ${to}) upserted (ID ${edge._id}).`;
     if (edgeMeta?.validationMode === 'warn') {
       for (const v of edgeSchemaViolations) edgeMsg += `\n⚠️ Schema: ${v.field} — ${v.reason}`;
@@ -94,6 +96,7 @@ export const update_edgeTool: ToolHandler = {
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             deleteFields: { type: 'array', items: { type: 'string' }, description: 'Dot-notation paths to delete from the edge (e.g. ["properties.oldKey", "description"]). System fields (id, name, type, spaceId, createdAt, updatedAt) cannot be deleted. Deletions are permanent.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
         }),
@@ -116,8 +119,9 @@ export const update_edgeTool: ToolHandler = {
     }
     if (typeof a['weight'] === 'number') updates.weight = a['weight'] as number;
     if (typeof a['type'] === 'string') updates.type = (a['type'] as string).trim();
-    if (Object.keys(updates).length === 0 && !dfPaths) throw new Error('At least one of label, description, tags, properties, weight, type, or deleteFields must be provided');
-    const updatedEdge = await findFirstAcrossMembers(wt.target, mid => updateEdgeById(mid, id, updates, dfPaths, ctx.actor));
+    const ttlDays = ttlDaysFromArgs(a);
+    if (Object.keys(updates).length === 0 && !dfPaths && ttlDays === undefined) throw new Error('At least one of label, description, tags, properties, weight, type, deleteFields, or ttlDays must be provided');
+    const updatedEdge = await findFirstAcrossMembers(wt.target, mid => updateEdgeById(mid, id, updates, dfPaths, ctx.actor, ttlDays));
     if (!updatedEdge) throw new Error(`Edge '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Edge '${updatedEdge.label}' updated (ID ${updatedEdge._id}, seq ${updatedEdge.seq}).` }],

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { findEntitiesByName, updateEntityById, upsertEntity } from '../../brain/entities.js';
 import { type PropertyResolution, applyResolutions, computeMergePlan, executeMerge, validateResolution } from '../../brain/merge.js';
@@ -29,6 +29,7 @@ export const upsert_entityTool: ToolHandler = {
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             checkDuplicates: { type: 'boolean', description: 'On a NEW entity insert (no id / unknown id), run a semantic near-duplicate check first (default true). Flags highly similar existing entities (id + summary + score) so you can merge or update instead of creating a duplicate. Does not fire on updates. Set false to skip.' },
             dupeThreshold: { type: 'number', description: 'Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'name', 'type'],
         }),
@@ -60,8 +61,9 @@ export const upsert_entityTool: ToolHandler = {
     // (only fires on inserts, not updates — see upsertEntity).
     const entDupeCheck = a['checkDuplicates'] !== false;
     const entDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
+    const entTtlDays = ttlDaysFromArgs(a);
     const { entity, warning, similar } = await upsertEntity(wt.target, eName, eType, tags, props, description, rawId,
-      { checkDuplicates: entDupeCheck, dupeThreshold: entDupeThreshold }, ctx.actor);
+      { checkDuplicates: entDupeCheck, dupeThreshold: entDupeThreshold }, ctx.actor, entTtlDays);
     let msg = `Entity '${entity.name}' (${entity.type}) upserted (ID ${entity._id}).${warning ? `\n⚠️ ${warning}` : ''}`;
     if (similar && similar.length > 0) {
       msg += `\n⚠️ Possible duplicate — ${similar.length} existing entit${similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. Pass checkDuplicates:false to skip, or provide the existing id to update it instead.`;
@@ -97,6 +99,7 @@ export const update_entityTool: ToolHandler = {
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             deleteFields: { type: 'array', items: { type: 'string' }, description: 'Dot-notation paths to delete from the entity (e.g. ["properties.oldKey", "description"]). System fields (id, name, type, spaceId, createdAt, updatedAt) cannot be deleted. Deletions are permanent.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
         }),
@@ -118,8 +121,9 @@ export const update_entityTool: ToolHandler = {
     if (a['properties'] != null && typeof a['properties'] === 'object' && !Array.isArray(a['properties'])) {
       updates.properties = a['properties'] as Record<string, string | number | boolean>;
     }
-    if (Object.keys(updates).length === 0 && !dfPaths) throw new Error('At least one of name, type, description, tags, properties, or deleteFields must be provided');
-    const updatedEnt = await findFirstAcrossMembers(wt.target, mid => updateEntityById(mid, id, updates, dfPaths, ctx.actor));
+    const ttlDays = ttlDaysFromArgs(a);
+    if (Object.keys(updates).length === 0 && !dfPaths && ttlDays === undefined) throw new Error('At least one of name, type, description, tags, properties, deleteFields, or ttlDays must be provided');
+    const updatedEnt = await findFirstAcrossMembers(wt.target, mid => updateEntityById(mid, id, updates, dfPaths, ctx.actor, ttlDays));
     if (!updatedEnt) throw new Error(`Entity '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Entity '${updatedEnt.name}' (${updatedEnt.type}) updated (ID ${updatedEnt._id}, seq ${updatedEnt.seq}).` }],

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -13,6 +13,7 @@ import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateMemory } from '../../spaces/schema-validation.js';
+import { TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
 
 export const rememberTool: ToolHandler = {
   name: 'remember',
@@ -44,6 +45,7 @@ export const rememberTool: ToolHandler = {
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             checkDuplicates: { type: 'boolean', description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar memory already exists, the response flags it (id + summary + score) so you can update it instead of creating a redundant one. The memory is still stored regardless. Set false to skip the check.' },
             dupeThreshold: { type: 'number', description: 'Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'fact'],
         }),
@@ -100,8 +102,9 @@ export const rememberTool: ToolHandler = {
     // Insert-time duplicate check defaults ON for the interactive remember tool.
     const remDupeCheck = a['checkDuplicates'] !== false;
     const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
+    const remTtlDays = ttlDaysFromArgs(a);
     const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames, memType,
-      { checkDuplicates: remDupeCheck, dupeThreshold: remDupeThreshold }, ctx.actor);
+      { checkDuplicates: remDupeCheck, dupeThreshold: remDupeThreshold }, ctx.actor, remTtlDays);
     const warnings: string[] = [];
     if (mem.similar && mem.similar.length > 0) {
       warnings.push(`⚠️ Possible duplicate — ${mem.similar.length} existing memor${mem.similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${mem.similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.`);
@@ -144,6 +147,7 @@ export const update_memoryTool: ToolHandler = {
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             deleteFields: { type: 'array', items: { type: 'string' }, description: 'Dot-notation paths to delete from the memory (e.g. ["properties.oldKey", "description"]). System fields (id, name, type, spaceId, createdAt, updatedAt) cannot be deleted. Deletions are permanent.' },
+            ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
         }),
@@ -172,10 +176,11 @@ export const update_memoryTool: ToolHandler = {
       updates.properties = a['properties'] as Record<string, string | number | boolean>;
     }
 
-    if (Object.keys(updates).length === 0 && !dfPaths) throw new Error('At least one of fact, tags, entityIds, description, properties, or deleteFields must be provided');
+    const ttlDays = ttlDaysFromArgs(a);
+    if (Object.keys(updates).length === 0 && !dfPaths && ttlDays === undefined) throw new Error('At least one of fact, tags, entityIds, description, properties, deleteFields, or ttlDays must be provided');
 
     // Search member spaces sequentially — consistent with REST endpoint behaviour.
-    const updated = await findFirstAcrossMembers(wt.target, mid => updateMemory(mid, id, updates, dfPaths, ctx.actor));
+    const updated = await findFirstAcrossMembers(wt.target, mid => updateMemory(mid, id, updates, dfPaths, ctx.actor, ttlDays));
     if (!updated) throw new Error(`Memory '${id}' not found`);
     return {
       content: [{ type: 'text' as const, text: `Memory updated (ID ${updated._id}, seq ${updated.seq}).` }],

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -4,6 +4,29 @@ import type { RecallResult } from '../../brain/recall.js';
 
 export const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+/** JSON-schema fragment for the per-record TTL arg (F10), shared by every MCP write tool. */
+export const TTL_DAYS_SCHEMA = {
+  type: ['integer', 'null'],
+  minimum: 0,
+  maximum: 36500,
+  description: 'Auto-delete this record after N days. A positive integer sets the expiry; 0 or null means never expire (overriding any space-wide default); omit to inherit the space default.',
+} as const;
+
+/**
+ * Parse + validate `ttlDays` from MCP tool args (F10): a non-negative integer ≤ 36500 sets an expiry,
+ * `null` clears it, and absent → `undefined` (inherit the space default). Throws on a present-but-invalid
+ * value so the MCP surface fails loud like REST rather than silently dropping the intent.
+ */
+export function ttlDaysFromArgs(args: Record<string, unknown>): number | null | undefined {
+  const v = args['ttlDays'];
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  if (typeof v !== 'number' || !Number.isInteger(v) || v < 0 || v > 36500) {
+    throw new Error('ttlDays must be an integer number of days between 0 and 36500, or null to clear the expiry');
+  }
+  return v;
+}
+
 /** Format a RecallResult as a single human-readable summary line. */
 export function formatRecallSummary(r: RecallResult): string {
   switch (r.type) {

--- a/testing/integration/mcp-tools.test.js
+++ b/testing/integration/mcp-tools.test.js
@@ -1755,3 +1755,83 @@ describe('MCP schema validation — strict mode must actually block (parity with
     );
   });
 });
+
+// ── F10: per-record ttlDays through the MCP write tools ──────────────────────
+
+describe('MCP brain tools — per-record TTL (F10)', () => {
+  let session;
+  const RUN = Date.now();
+  const DAY_MS = 86_400_000;
+
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    session = await openMcpSession(tokenA);
+  });
+  after(() => session?.close());
+
+  const idFrom = (result) => (result?.content?.[0]?.text ?? '').match(/ID ([a-f0-9-]{36})/i)?.[1];
+  function assertAboutDaysFromNow(iso, days) {
+    assert.ok(iso, `expected an _expireAt, got ${iso}`);
+    assert.ok(Math.abs(new Date(iso).getTime() - (Date.now() + days * DAY_MS)) < DAY_MS, `expected ~${days}d out, got ${iso}`);
+  }
+
+  it('upsert_entity with ttlDays stamps _expireAt (visible over REST)', async () => {
+    const r = await session.callTool('upsert_entity', { space: 'general', name: `McpTtlEnt-${RUN}`, type: 'concept', ttlDays: 10 });
+    assert.ok(!r?.isError, `upsert_entity error: ${JSON.stringify(r)}`);
+    const id = idFrom(r);
+    const g = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`);
+    assertAboutDaysFromNow((g.body.entity ?? g.body)._expireAt, 10);
+    await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`).catch(() => {});
+  });
+
+  it('upsert_entity with ttlDays 0 gets no _expireAt', async () => {
+    const r = await session.callTool('upsert_entity', { space: 'general', name: `McpTtlZero-${RUN}`, type: 'concept', ttlDays: 0 });
+    const id = idFrom(r);
+    const g = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`);
+    assert.equal((g.body.entity ?? g.body)._expireAt, undefined);
+    await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`).catch(() => {});
+  });
+
+  it('update_entity can set a TTL-only change, then clear it', async () => {
+    const created = await session.callTool('upsert_entity', { space: 'general', name: `McpTtlUpd-${RUN}`, type: 'concept' });
+    const id = idFrom(created);
+
+    const set = await session.callTool('update_entity', { space: 'general', id, ttlDays: 5 });
+    assert.ok(!set?.isError, `update_entity ttl-only error: ${JSON.stringify(set)}`);
+    let g = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`);
+    assertAboutDaysFromNow((g.body.entity ?? g.body)._expireAt, 5);
+
+    const clear = await session.callTool('update_entity', { space: 'general', id, ttlDays: 0 });
+    assert.ok(!clear?.isError, `update_entity clear error: ${JSON.stringify(clear)}`);
+    g = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`);
+    assert.equal((g.body.entity ?? g.body)._expireAt, undefined);
+    await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${id}`).catch(() => {});
+  });
+
+  it('invalid ttlDays is rejected with a tool error', async () => {
+    const r = await session.callTool('upsert_entity', { space: 'general', name: `McpTtlBad-${RUN}`, type: 'concept', ttlDays: -3 });
+    assert.ok(r?.isError, `expected isError for ttlDays:-3, got ${JSON.stringify(r)}`);
+    assert.match(r?.content?.[0]?.text ?? '', /ttlDays/, 'error should name ttlDays');
+  });
+
+  it('bulk_write threads per-item ttlDays and reports invalid ones', async () => {
+    const good = `McpBulkTtl-${RUN}`;
+    const r = await session.callTool('bulk_write', {
+      space: 'general',
+      entities: [
+        { name: good, type: 'concept', ttlDays: 7 },   // valid → stamped
+        { name: `McpBulkTtlBad-${RUN}`, type: 'concept', ttlDays: 999999 }, // invalid → error, not aborting
+      ],
+    });
+    assert.ok(!r?.isError, `bulk_write error: ${JSON.stringify(r)}`);
+    const text = r?.content?.[0]?.text ?? '';
+    assert.ok(text.includes('errors: ') && !text.includes('errors: 0'), `expected the invalid item reported: ${text}`);
+
+    // The valid entity should exist with an expiry.
+    const q = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities?limit=1000`);
+    const found = (q.body.entities ?? q.body ?? []).find(e => e.name === good);
+    assert.ok(found, 'the valid bulk entity should have been created');
+    assertAboutDaysFromNow(found._expireAt, 7);
+    await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/entities/${found._id}`).catch(() => {});
+  });
+});


### PR DESCRIPTION
## What & why

Follow-up to **#271** (record TTL / auto-expiry). #271 added per-record `ttlDays` to every REST write endpoint, but the **MCP write tools — the surface agents actually use — couldn't set or clear a per-record TTL**: they called the shared writers without the argument, so an MCP write could only inherit the space-wide default. This closes that gap so "every write endpoint can provide a TTL" holds on MCP too.

## Changes

- `ttlDays` threaded through every MCP write tool: `remember`, `update_memory`, `upsert_entity`, `update_entity`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono` — and per item in `bulk_write`.
- Same semantics as REST: `>0` sets an expiry, `0`/`null` clears it (opting out of the space default), omitted inherits the default (only when the record has no expiry yet). A `ttlDays`-only update is a valid write.
- **Fail-loud**, matching REST: an invalid `ttlDays` is a tool error on the single-write tools and a per-item error in bulk (the rest of the batch still runs).
- `bulk_write` and REST `POST /bulk` share `bulkWrite()`, so adding per-item `ttlDays` there gives the **REST bulk route** the same capability for free.
- New shared helpers (`mcp/tools/shared.ts`: `TTL_DAYS_SCHEMA`, `ttlDaysFromArgs`; `brain/bulk.ts`: `bulkTtlDays`) mirror REST's `ttlDaysError`/`ttlDaysFromBody` — one agreed bound (integer 0..36500) across all TTL surfaces.

## Tests

5 new MCP integration cases (stamp via `upsert_entity`, opt-out with `0`, TTL-only update then clear, invalid → tool error, `bulk_write` per-item + invalid-item reporting), verified against the live stack. Full `mcp-tools` suite green (99). Docs (integration-guide Record Expiry + MCP note) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)