### PR TITLE
feat(security): HTTPS-only sync peers by default + instance-wide encrypted-transport mode (PR-S1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Sync peers are HTTPS-only by default, with an instance-wide "encrypted transport" switch.** A network
+  member / invite URL is now rejected unless it is `https://`, so sync traffic (record data + bearer
+  tokens) is encrypted in transit. This is independent of address — a loopback or private-range peer must
+  still be HTTPS, because on shared hardware "same host" is not a trust boundary. Plaintext `http://`
+  peers require an explicit opt-out (`allowInsecurePeers` / `SYNC_ALLOW_INSECURE_PEERS`); a pre-existing
+  `http://` peer keeps syncing but warns once per boot. New `requireEncryptedTransport`
+  (`REQUIRE_ENCRYPTED_TRANSPORT`) enforces TLS instance-wide: every inbound request must be HTTPS
+  (plaintext → `403`, except the `/health` `/ready` `/metrics` probes) and `http://` peers are hard-blocked,
+  overriding the opt-out. Requires `trustProxy` to be set when a reverse proxy terminates TLS. Also
+  corrected an inaccurate "stored encrypted at rest" note in the schema-library docs (the access token is
+  write-only + `0600`, not encrypted — encryption at rest is tracked separately).
+
 ### Added
 
 - **Record TTL / auto-expiry (F10).** Records can now expire and be deleted automatically. Every write

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -18,6 +18,8 @@
   "ejectedFromNetworks": [],
   "maxUploadBodyBytes": 5368709120,
   "allowInsecurePlaintext": false,
+  "allowInsecurePeers": false,
+  "requireEncryptedTransport": false,
   "mediaEmbedding": {
     "enabled": true,
     "faceRecognition": {

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -403,6 +403,38 @@ labels:
   - "traefik.http.routers.ythril.middlewares=ythril-hsts"
 ```
 
+### Transport Security (encryption in transit)
+
+Ythril is secure-by-default on the wire, and adds an instance-wide switch to make TLS mandatory.
+
+**Sync peers must use HTTPS.** A network member / invite URL is rejected unless it is `https://`. This
+is deliberately independent of address: a peer on loopback or a private range is still required to be
+HTTPS, because on shared hardware "same host" is **not** a trust boundary — a co-tenant reachable over
+loopback is still untrusted. (Address reachability is governed separately by `allowPrivatePeers`.)
+
+- To permit plaintext `http://` peers on a network where every peer *and* co-tenant is trusted, set
+  `allowInsecurePeers: true` (or env `SYNC_ALLOW_INSECURE_PEERS=true`). This is a clear, explicit opt-out;
+  new peers are HTTPS-only without it. A peer added before this default that is still `http://` continues
+  to sync but logs a one-time warning each boot until you fix its URL or opt in.
+
+**`requireEncryptedTransport` — instance-wide "encrypted only".** Set `requireEncryptedTransport: true`
+(or env `REQUIRE_ENCRYPTED_TRANSPORT=true`) to enforce TLS everywhere:
+
+- every inbound request must have arrived over HTTPS — plaintext requests get `403` (the `/health`,
+  `/ready`, and `/metrics` probes stay reachable so orchestration isn't broken);
+- `http://` sync peers are hard-blocked at admission **and** connection time, overriding
+  `allowInsecurePeers`.
+
+> **Requires `trustProxy`.** When a reverse proxy terminates TLS, Ythril only knows a request was
+> encrypted from the `X-Forwarded-Proto` header, which it trusts **only** once `trustProxy` is set to your
+> proxy hop count. Enable `requireEncryptedTransport` together with a correct `trustProxy`, or every
+> proxied request will look plaintext and be rejected.
+
+**Multi-tenant on shared hardware.** Run each tenant as its own Ythril instance with its **own MongoDB on
+its own encrypted volume/key** — do not share one `mongod` across tenants. That keeps cross-tenant data
+cryptographically isolated (different key + process) while leaving semantic search fully intact, and it
+pairs with `requireEncryptedTransport` for encryption in transit.
+
 ### Resource Requirements
 
 | Component | Minimum | Recommended |
@@ -2936,7 +2968,7 @@ Content-Type: application/json
 | `name` | ✓ | Unique catalog ID: `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$` |
 | `url` | ✓ | Base URL of the remote schema library. Must be HTTPS; private/loopback addresses are rejected (SSRF protection). |
 | `description` | — | Free text, up to 500 characters. |
-| `accessToken` | — | A library access token issued by the remote instance. Required only when the remote's `/public` endpoint is behind an auth proxy (e.g. Cloudflare Access). Stored encrypted at rest; never returned in list or get responses — only `hasAccessToken: true/false` is exposed. |
+| `accessToken` | — | A library access token issued by the remote instance. Required only when the remote's `/public` endpoint is behind an auth proxy (e.g. Cloudflare Access). Write-only: it is never returned in list or get responses — only `hasAccessToken: true/false` is exposed. It is held in the instance config directory, which is created with owner-only (`0600`) permissions. |
 
 **Responses:** `201 { "catalog": { ..., "hasAccessToken": true } }`, `400` (invalid URL/name), `409` (name already exists), `400` (SSRF-blocked URL).
 

--- a/server/src/api/invite.ts
+++ b/server/src/api/invite.ts
@@ -52,6 +52,7 @@ import { buildBraintreeAncestors } from '../util/braintree.js';
 import { makeSignedOwnCast } from '../util/signing.js';
 import { log } from '../util/log.js';
 import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../util/ssrf.js';
+import { isPeerSchemeAllowed, PEER_SCHEME_MESSAGE } from '../config/transport-security.js';
 import type { NetworkMember, VoteRound } from '../config/types.js';
 
 export const inviteRouter = Router();
@@ -113,7 +114,9 @@ const GenerateBody = z.object({
   expectedInstanceId: z.string().uuid().optional(),
 });
 
-const INVITE_SSRF_SAFE_URL = z.string().url().refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE });
+const INVITE_SSRF_SAFE_URL = z.string().url()
+  .refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE })
+  .refine(isPeerSchemeAllowed, { message: PEER_SCHEME_MESSAGE });
 
 const ApplyBody = z.object({
   handshakeId: z.string().uuid(),

--- a/server/src/api/networks/_shared.ts
+++ b/server/src/api/networks/_shared.ts
@@ -7,6 +7,7 @@
 import { z } from 'zod';
 import type { NetworkConfig } from '../../config/types.js';
 import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../../util/ssrf.js';
+import { isPeerSchemeAllowed, PEER_SCHEME_MESSAGE } from '../../config/transport-security.js';
 
 export const BCRYPT_ROUNDS = 12;
 
@@ -20,7 +21,8 @@ export const BCRYPT_ROUNDS = 12;
 export const SSRF_SAFE_URL = z
   .string()
   .url()
-  .refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE });
+  .refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE })
+  .refine(isPeerSchemeAllowed, { message: PEER_SCHEME_MESSAGE });
 
 /** Member list a joiner receives once admitted (credential fields stripped). */
 export function safeMemberList(net: NetworkConfig, excludeInstanceId: string) {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -19,6 +19,7 @@ import { oidcRouter } from './api/oidc.js';
 import { metricsRouter } from './api/metrics.js';
 import { themeRouter } from './api/theme.js';
 import { frameAncestorsDirective } from './config/embed.js';
+import { requireEncryptedTransport } from './config/transport-security.js';
 import { auditRouter } from './api/audit.js';
 import { setupRouter } from './setup/routes.js';
 import { mcpRouter } from './mcp/router.js';
@@ -153,6 +154,17 @@ export function createApp() {
   // ── Prometheus metrics ───────────────────────────────────────────────────
   // Requires auth: Bearer METRICS_TOKEN (if configured) or a valid admin PAT.
   app.use('/metrics', metricsRouter);
+
+  // ── Encrypted-transport enforcement (opt-in, instance-wide) ──────────────
+  // When `requireEncryptedTransport` is set, every request past this point must have arrived over
+  // TLS. `req.secure` reflects X-Forwarded-Proto only once `trust proxy` is configured (set above), so
+  // a reverse proxy that terminates TLS MUST have trustProxy set or every request looks plaintext.
+  // `/health`, `/ready`, and `/metrics` are registered ABOVE this gate, so orchestration probes remain
+  // reachable over plaintext. Read live (not captured) so a config reload takes effect.
+  app.use((req, res, next) => {
+    if (!requireEncryptedTransport() || req.secure) { next(); return; }
+    res.status(403).json({ error: 'This instance accepts encrypted (HTTPS) connections only (requireEncryptedTransport).' });
+  });
 
   // ── HTTP request instrumentation ─────────────────────────────────────────
   // Runs after /health and /metrics so those internal endpoints aren't tracked.

--- a/server/src/config/transport-security.ts
+++ b/server/src/config/transport-security.ts
@@ -1,0 +1,55 @@
+/**
+ * Transport-security policy (PR-S1) — cross-cutting flags read by the app (request TLS gate),
+ * the API (peer-URL admission), and the sync engine (outbound peer fetch).
+ *
+ * Two independent knobs, both secure-by-default:
+ *  - `allowInsecurePeers` — permit `http://` sync peers. Default OFF: peer URLs must be `https://`,
+ *    regardless of address. "Same host" is NOT a trust boundary (on shared hardware a co-tenant on
+ *    loopback is still untrusted), so this is deliberately separate from `allowPrivatePeers` (which
+ *    governs address ranges, not encryption).
+ *  - `requireEncryptedTransport` — instance-wide "encrypted only": every inbound request must be TLS
+ *    and every peer must be `https://`, overriding `allowInsecurePeers`.
+ *
+ * Each flag: env override → config key → safe default (mirrors the `allowPrivatePeers`/`trustProxy`
+ * precedence). The pure `peerSchemeAllowed` takes explicit flags so it is unit-testable without config.
+ */
+import { getConfig } from './loader.js';
+
+/** Instance-wide "encrypted transport only" mode (env `REQUIRE_ENCRYPTED_TRANSPORT` → config → false). */
+export function requireEncryptedTransport(): boolean {
+  if (process.env['REQUIRE_ENCRYPTED_TRANSPORT'] === 'true') return true;
+  try { return getConfig().requireEncryptedTransport === true; } catch { return false; }
+}
+
+/** Raw opt-out: whether `http://` peers are permitted (env `SYNC_ALLOW_INSECURE_PEERS` → config → false).
+ *  Does NOT account for `requireEncryptedTransport` — use {@link insecurePeersAllowed} for the effective policy. */
+export function allowInsecurePeersRaw(): boolean {
+  if (process.env['SYNC_ALLOW_INSECURE_PEERS'] === 'true') return true;
+  try { return getConfig().allowInsecurePeers === true; } catch { return false; }
+}
+
+/** Effective policy: `http://` peers allowed only when opted in AND encrypted-transport mode is off. */
+export function insecurePeersAllowed(): boolean {
+  return !requireEncryptedTransport() && allowInsecurePeersRaw();
+}
+
+/**
+ * Pure peer-URL scheme gate (no config reads — unit-testable). `https://` is always allowed;
+ * `http://` only when `allowInsecure` is set and `requireEncrypted` is not; any other scheme is rejected.
+ */
+export function peerSchemeAllowed(rawUrl: string, opts: { allowInsecure: boolean; requireEncrypted: boolean }): boolean {
+  let scheme: string;
+  try { scheme = new URL(rawUrl).protocol; } catch { return false; }
+  if (scheme === 'https:') return true;
+  if (scheme !== 'http:') return false;
+  return opts.allowInsecure && !opts.requireEncrypted;
+}
+
+/** Config-aware scheme gate used at peer-URL admission. */
+export function isPeerSchemeAllowed(rawUrl: string): boolean {
+  return peerSchemeAllowed(rawUrl, { allowInsecure: allowInsecurePeersRaw(), requireEncrypted: requireEncryptedTransport() });
+}
+
+/** Human-readable reason a peer URL scheme was rejected (for zod messages / API errors). */
+export const PEER_SCHEME_MESSAGE =
+  'Peer URLs must use HTTPS. Set `allowInsecurePeers` (or SYNC_ALLOW_INSECURE_PEERS) to permit `http://` peers on a network where every peer AND co-tenant is trusted — note that "same host" alone is not such a boundary.';

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -748,6 +748,26 @@ export interface Config {
    * unspecified) stay blocked. Overridable via SYNC_ALLOW_PRIVATE_PEERS.
    */
   allowPrivatePeers?: boolean;
+  /**
+   * Allow sync peers to be reached over plaintext `http://`. Default false —
+   * peer URLs must use `https://`, so sync traffic (which carries record data and
+   * bearer tokens) is encrypted in transit. Set true only to permit `http://`
+   * peers on a trusted private network you fully control. Overridable via
+   * SYNC_ALLOW_INSECURE_PEERS. Ignored (forced false) when
+   * `requireEncryptedTransport` is set. See [[transport-security]].
+   */
+  allowInsecurePeers?: boolean;
+  /**
+   * Instance-wide "encrypted transport only" switch. Default false. When true:
+   *  - every inbound request must arrive over HTTPS (`req.secure`) — plaintext
+   *    requests are rejected 403 (loopback is exempted for health checks);
+   *  - `http://` sync peers are hard-blocked at admission AND connection time,
+   *    overriding `allowInsecurePeers`.
+   * Requires `trustProxy` to be set correctly when a reverse proxy terminates TLS
+   * (otherwise `req.secure` is always false behind the proxy). Overridable via
+   * REQUIRE_ENCRYPTED_TRANSPORT.
+   */
+  requireEncryptedTransport?: boolean;
   /** Dynamically-registered OAuth clients (RFC 7591) for the MCP browser
    *  authorization flow. Populated automatically when a client registers; not
    *  meant to be hand-edited. See mcp/oauth.ts. */

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -61,6 +61,14 @@ async function main(): Promise<void> {
         );
       }
     }
+    // Sync transport: warn when plaintext peers are permitted (data + tokens unencrypted on the wire).
+    if (cfg.allowInsecurePeers && !cfg.requireEncryptedTransport) {
+      console.warn(
+        `\n${YELLOW}  ⚠  WARNING${RESET}  allowInsecurePeers is true — sync may connect to plaintext\n` +
+        `     http:// peers, so record data and bearer tokens are unencrypted in transit.\n` +
+        `     Use https:// peer URLs, or set requireEncryptedTransport to enforce TLS everywhere.\n`,
+      );
+    }
   }
 
   // Always connect to MongoDB — needed on first run so the setup route can

--- a/server/src/sync/peer-fetch.ts
+++ b/server/src/sync/peer-fetch.ts
@@ -18,6 +18,8 @@
 
 import { ssrfSafeFetch, isPeerUrlSafe } from '../util/ssrf.js';
 import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+import { requireEncryptedTransport, allowInsecurePeersRaw, isPeerSchemeAllowed } from '../config/transport-security.js';
 
 /** Whether sync peers may use private/reserved (non-crown-jewel) addresses. */
 export function allowPrivatePeers(): boolean {
@@ -25,16 +27,34 @@ export function allowPrivatePeers(): boolean {
   try { return getConfig().allowPrivatePeers === true; } catch { return false; }
 }
 
-/** True if a peer-supplied URL may be stored/connected to under the current policy. */
+/** True if a peer-supplied URL may be stored/connected to under the current policy (address + scheme). */
 export function isPeerUrlAllowed(url: string): boolean {
-  return isPeerUrlSafe(url, allowPrivatePeers());
+  return isPeerSchemeAllowed(url) && isPeerUrlSafe(url, allowPrivatePeers());
 }
 
+// Warn at most once per plaintext peer host, so a pre-existing `http://` peer (added before the
+// https-default, without opting in) nags rather than spams every sync cycle.
+const _warnedPlaintextHosts = new Set<string>();
+
 /**
- * SSRF-safe drop-in for `fetch()` used by the sync engine. Resolves + pins + and
- * re-validates redirects against the peer policy. Throws `SsrfBlockedError` when
- * the target (or a redirect hop) resolves to a blocked address.
+ * SSRF-safe drop-in for `fetch()` used by the sync engine. Resolves + pins + re-validates redirects
+ * against the peer policy. Also enforces the transport policy: in `requireEncryptedTransport` mode a
+ * plaintext `http://` peer is refused outright; otherwise a plaintext peer that wasn't explicitly
+ * opted into is allowed (back-compat for peers added before the https default) but warned once.
+ * Throws `SsrfBlockedError` when the target (or a redirect hop) resolves to a blocked address.
  */
 export function peerSafeFetch(rawUrl: string, init: RequestInit = {}): Promise<Response> {
+  let scheme = '';
+  let host = rawUrl;
+  try { const u = new URL(rawUrl); scheme = u.protocol; host = u.host; } catch { /* ssrfSafeFetch will reject */ }
+  if (scheme === 'http:') {
+    if (requireEncryptedTransport()) {
+      return Promise.reject(new Error(`Refusing plaintext sync to ${host}: requireEncryptedTransport is enabled`));
+    }
+    if (!allowInsecurePeersRaw() && !_warnedPlaintextHosts.has(host)) {
+      _warnedPlaintextHosts.add(host);
+      log.warn(`Syncing to plaintext peer ${host} over http:// — data and tokens are unencrypted in transit. Use https:// or set allowInsecurePeers to acknowledge.`);
+    }
+  }
   return ssrfSafeFetch(rawUrl, init, { allowPrivate: allowPrivatePeers() });
 }

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -43,6 +43,7 @@ services:
       MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-a:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
+      SYNC_ALLOW_INSECURE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -99,6 +100,7 @@ services:
       MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-b:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
+      SYNC_ALLOW_INSECURE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -151,6 +153,7 @@ services:
       MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-c:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
+      SYNC_ALLOW_INSECURE_PEERS: "true"
     depends_on:
       ythril-mongo-c:
         condition: service_healthy
@@ -202,6 +205,7 @@ services:
       MONGO_URI: mongodb://ythril:ythril-test-pw@ythril-mongo-d:27017/?directConnection=true&authSource=admin
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
+      SYNC_ALLOW_INSECURE_PEERS: "true"
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"

--- a/testing/standalone/peer-transport-security.test.js
+++ b/testing/standalone/peer-transport-security.test.js
@@ -1,0 +1,84 @@
+/**
+ * PR-S1 — peer transport-security policy (HTTPS-by-default peers).
+ *
+ * `peerSchemeAllowed` is the pure gate (explicit flags, no config) and is exhaustively covered here.
+ * `isPeerSchemeAllowed` / `requireEncryptedTransport` read env-then-config; with no config loaded in a
+ * standalone run they resolve from the env vars alone, which is exactly the override path we assert.
+ *
+ * Run: node --test testing/standalone/peer-transport-security.test.js
+ */
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  peerSchemeAllowed,
+  isPeerSchemeAllowed,
+  requireEncryptedTransport,
+  insecurePeersAllowed,
+} from '../../server/dist/config/transport-security.js';
+
+describe('peerSchemeAllowed (pure)', () => {
+  const combos = [
+    { allowInsecure: false, requireEncrypted: false },
+    { allowInsecure: true, requireEncrypted: false },
+    { allowInsecure: false, requireEncrypted: true },
+    { allowInsecure: true, requireEncrypted: true },
+  ];
+
+  it('https:// is always allowed regardless of flags', () => {
+    for (const c of combos) assert.equal(peerSchemeAllowed('https://peer.example.com', c), true, JSON.stringify(c));
+  });
+
+  it('http:// allowed ONLY when allowInsecure && !requireEncrypted', () => {
+    assert.equal(peerSchemeAllowed('http://peer', { allowInsecure: false, requireEncrypted: false }), false);
+    assert.equal(peerSchemeAllowed('http://peer', { allowInsecure: true, requireEncrypted: false }), true);
+    assert.equal(peerSchemeAllowed('http://peer', { allowInsecure: false, requireEncrypted: true }), false);
+    // requireEncrypted overrides the opt-in
+    assert.equal(peerSchemeAllowed('http://peer', { allowInsecure: true, requireEncrypted: true }), false);
+  });
+
+  it('http:// on loopback is still rejected by default (same host is not a trust boundary)', () => {
+    assert.equal(peerSchemeAllowed('http://127.0.0.1:3200', { allowInsecure: false, requireEncrypted: false }), false);
+    assert.equal(peerSchemeAllowed('http://localhost', { allowInsecure: false, requireEncrypted: false }), false);
+  });
+
+  it('non-http(s) schemes are rejected', () => {
+    for (const u of ['ftp://peer', 'file:///etc/passwd', 'ws://peer', 'gopher://peer']) {
+      assert.equal(peerSchemeAllowed(u, { allowInsecure: true, requireEncrypted: false }), false, u);
+    }
+  });
+
+  it('malformed URLs are rejected', () => {
+    for (const u of ['not a url', '', 'peer.example.com', '://nope']) {
+      assert.equal(peerSchemeAllowed(u, { allowInsecure: true, requireEncrypted: false }), false, JSON.stringify(u));
+    }
+  });
+});
+
+describe('isPeerSchemeAllowed / requireEncryptedTransport (env overrides)', () => {
+  afterEach(() => {
+    delete process.env.SYNC_ALLOW_INSECURE_PEERS;
+    delete process.env.REQUIRE_ENCRYPTED_TRANSPORT;
+  });
+
+  it('default (no env/config): https ok, http rejected', () => {
+    assert.equal(isPeerSchemeAllowed('https://peer'), true);
+    assert.equal(isPeerSchemeAllowed('http://peer'), false);
+    assert.equal(requireEncryptedTransport(), false);
+    assert.equal(insecurePeersAllowed(), false);
+  });
+
+  it('SYNC_ALLOW_INSECURE_PEERS=true permits http peers', () => {
+    process.env.SYNC_ALLOW_INSECURE_PEERS = 'true';
+    assert.equal(insecurePeersAllowed(), true);
+    assert.equal(isPeerSchemeAllowed('http://peer'), true);
+  });
+
+  it('REQUIRE_ENCRYPTED_TRANSPORT=true overrides the opt-in', () => {
+    process.env.SYNC_ALLOW_INSECURE_PEERS = 'true';
+    process.env.REQUIRE_ENCRYPTED_TRANSPORT = 'true';
+    assert.equal(requireEncryptedTransport(), true);
+    assert.equal(insecurePeersAllowed(), false);
+    assert.equal(isPeerSchemeAllowed('http://peer'), false);
+    assert.equal(isPeerSchemeAllowed('https://peer'), true);
+  });
+});


### PR DESCRIPTION
First of a security-hardening series. Makes **encryption in transit secure-by-default** and adds a hard instance-wide "encrypted only" switch — a prerequisite for running Ythril multi-tenant on shared hardware, where **"same host" is not a trust boundary** (a co-tenant reachable over loopback is still an attacker).

## Peer transport
- **Sync peer / invite URLs must be `https://`.** The gate is **address-independent** — a loopback or private-range peer must still be HTTPS. This is deliberately separate from `allowPrivatePeers` (which governs address ranges): *reachable* never implies *plaintext-OK*.
- **Explicit opt-out** `allowInsecurePeers` (env `SYNC_ALLOW_INSECURE_PEERS`) permits `http://` peers on a fully-trusted network — clear intent required. A pre-existing `http://` peer keeps syncing but **warns once per boot**; new peers are HTTPS-only without the opt-out.

## `requireEncryptedTransport` — instance-wide "encrypted only"
Env `REQUIRE_ENCRYPTED_TRANSPORT`. When on:
- every inbound request must have arrived over TLS — plaintext → **403** (with `/health`, `/ready`, `/metrics` left reachable so orchestration isn't broken);
- `http://` peers are **hard-blocked** at admission *and* connection time, overriding `allowInsecurePeers`.
- Relies on `req.secure`, so pair it with a correct **`trustProxy`** behind a TLS-terminating proxy (documented).

## Structure
- New leaf module `config/transport-security.ts` — the cross-cutting policy: a **pure, unit-tested** `peerSchemeAllowed(url, {allowInsecure, requireEncrypted})` plus env→config flag readers. `app`, `api`, and `sync` import it (no `app → sync` layering smell).
- Peer-URL admission zods (`networks/_shared`, `invite`) and the runtime `isPeerUrlAllowed` gain the scheme gate; `peerSafeFetch` enforces encrypted-only and warns on legacy plaintext peers; startup warning in `index.ts`; secure defaults in `config.example.json`.

## Also
- Fixes the docs' inaccurate **"stored encrypted at rest"** claim for the schema-library access token (it's write-only + `0600`, not encrypted — real at-rest encryption is the next PR).
- CI test stack opts into insecure peers (`SYNC_ALLOW_INSECURE_PEERS`) since its peers are internal `http://` docker URLs — the intended "trusted network, explicit opt-out" shape.

## Tests
`testing/standalone/peer-transport-security.test.js` — pure gate (https always ok; http only when opted-in and not encrypted-only; loopback http still rejected; non-http(s)/malformed rejected) + env-override policy. Full suites green against a rebuilt stack: **standalone 829, sync 191, red-team 272, integration 852 — 0 failures.**

## Next in series
PR-S2 config/secrets encrypted at rest (per-instance key, verified migration, strict mode); PR-S3 guided per-tenant `mongod` + encrypted volume + HTTPS/Mongo posture check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)