### PR TITLE
feat(brain): live brain updates via Server-Sent Events (F12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live brain updates via Server-Sent Events (F12).** The Brain page now refreshes its record lists and
+  count badges in real time instead of needing a manual reload — most visibly when an MCP agent (or
+  another session) mutates the space. A new scoped stream `GET /api/brain/spaces/:spaceId/events` emits
+  one `data:` event per REST/MCP write (`memory.created`, `entity.updated`, `bulk.write`, …); an
+  in-process bus tapped at the single `emitWebhookEvent` choke point feeds it, so every write surface is
+  covered. Space-scoped auth (read-only tokens may subscribe) with a `?token=` query fallback since
+  `EventSource` can't set headers. The Angular client subscribes per active space and debounces a
+  `loadStats` + active-tab reload. Sync-applied changes aren't streamed (they appear on the next load).
+
 - **Record TTL / auto-expiry (F10).** Records can now expire and be deleted automatically. Every write
   surface — the REST endpoints, the MCP write tools (`remember` / `update_memory` / `upsert_entity` /
   `update_entity` / `upsert_edge` / `update_edge` / `create_chrono` / `update_chrono`), and per-item in

--- a/client/src/app/pages/brain/brain-store.service.ts
+++ b/client/src/app/pages/brain/brain-store.service.ts
@@ -32,6 +32,9 @@ export class BrainStore {
   fileMetas = signal<FileMeta[]>([]);
   // Settings tab (schema only — UI lives in Admin → Spaces)
   spaceMeta = signal<SpaceMetaResponse | null>(null);
+  /** Live-update tick (F12): the shell bumps this when a brain-change SSE event lands for the active
+   *  space+collection, and the mounted record tab reloads its current page in response. */
+  liveRefreshTick = signal(0);
   memorySearch = signal('');
   edgeSearch = signal('');
   chronoSearch = signal('');

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -1,4 +1,4 @@
-﻿import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit } from '@angular/core';
+﻿import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
@@ -255,7 +255,7 @@ interface SpaceView {
     }
   `,
 })
-export class BrainComponent implements OnInit {
+export class BrainComponent implements OnInit, OnDestroy {
   readonly store = inject(BrainStore);
   readonly picker = inject(EntityRefPicker);
   readonly drawerState = inject(RecordDrawerState);
@@ -320,10 +320,60 @@ export class BrainComponent implements OnInit {
     });
   }
 
+  ngOnDestroy(): void {
+    this.closeLiveStream();
+    clearTimeout(this.liveRefreshTimer);
+  }
+
+  // ── Live updates (F12) ──────────────────────────────────────────────────────
+  private liveStream?: EventSource;
+  private liveRefreshTimer?: ReturnType<typeof setTimeout>;
+  private static readonly TAB_FOR_COLLECTION: Record<string, BrainTab> = {
+    memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'filemeta',
+  };
+
+  /** (Re)open the SSE stream for a space. EventSource can't send an Authorization header, so the token
+   *  goes in the query string (the server allowlists this GET path for query-token auth). */
+  private openLiveStream(spaceId: string): void {
+    this.closeLiveStream();
+    if (typeof EventSource === 'undefined') return; // non-browser (SSR/test) environment
+    const token = localStorage.getItem('ythril_token') ?? '';
+    if (!spaceId || !token) return;
+    const url = `/api/brain/spaces/${encodeURIComponent(spaceId)}/events?token=${encodeURIComponent(token)}`;
+    const es = new EventSource(url);
+    es.onmessage = (e) => {
+      let payload: { event?: string };
+      try { payload = JSON.parse(e.data); } catch { return; }
+      this.onLiveEvent(spaceId, payload.event ?? '');
+    };
+    // On error the browser auto-reconnects with backoff; nothing to do.
+    this.liveStream = es;
+  }
+
+  private closeLiveStream(): void {
+    this.liveStream?.close();
+    this.liveStream = undefined;
+  }
+
+  /** Debounced refresh: any change updates the count badges; a change to the ACTIVE tab's collection
+   *  (or any bulk write) also reloads its current page via the store tick. */
+  private onLiveEvent(spaceId: string, event: string): void {
+    if (spaceId !== this.activeSpaceId()) return;
+    clearTimeout(this.liveRefreshTimer);
+    this.liveRefreshTimer = setTimeout(() => {
+      this.loadStats(spaceId);
+      const collection = event.split('.')[0] ?? '';
+      if (event.startsWith('bulk') || BrainComponent.TAB_FOR_COLLECTION[collection] === this.activeTab()) {
+        this.store.liveRefreshTick.update(t => t + 1);
+      }
+    }, 250);
+  }
+
   selectSpace(id: string): void {
     this.activeSpaceId.set(id);
     this.picker.spaceId.set(id);
     this.drawerState.spaceId.set(id);
+    this.openLiveStream(id);
     this.store.memorySearch.set('');
     this.store.edgeSearch.set('');
     this.store.chronoSearch.set('');

--- a/client/src/app/pages/brain/record-tab-base.ts
+++ b/client/src/app/pages/brain/record-tab-base.ts
@@ -1,4 +1,4 @@
-import { Directive, effect, inject, input, signal } from '@angular/core';
+import { Directive, effect, inject, input, signal, untracked } from '@angular/core';
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordListState } from './record-list-state.service';
@@ -38,6 +38,17 @@ export abstract class RecordTabBase {
       this.skip.set(0);
       this.resetOnSpaceChange();
       if (id) this.load();
+    });
+
+    // Live refresh (F12): when the shell signals a change for this space+collection, reload the CURRENT
+    // page (no skip/search reset — keep the user's position). Only the mounted tab has a live effect, so
+    // only the active list reloads. `untracked` keeps this effect off the spaceId dependency so a space
+    // switch doesn't double-load via both effects.
+    let firstTick = true;
+    effect(() => {
+      this.store.liveRefreshTick();
+      if (firstTick) { firstTick = false; return; }
+      if (untracked(() => this.spaceId())) this.load();
     });
   }
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -729,6 +729,36 @@ Entities, edges, and chrono entries have the same bulk-wipe endpoint shape — `
 
 ---
 
+### Live Change Stream (Server-Sent Events)
+
+```http
+GET /api/brain/spaces/:spaceId/events
+```
+
+A [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) stream that emits
+one message per brain mutation in the space, so a UI can refresh live instead of polling. Each message:
+
+```text
+data: {"event":"memory.created","id":"a1b2c3d4-..."}
+```
+
+`event` is the change type (`memory.created` / `entity.updated` / `edge.deleted` / `chrono.created` / …,
+or `bulk.write` for a batch); `id` is the affected record's ID when applicable. Comments (`:\n\n`) are
+sent on connect and every 30 s as a keep-alive.
+
+- **Auth:** space-scoped; read-only tokens may subscribe. A browser `EventSource` cannot set an
+  `Authorization` header, so this endpoint accepts the token as a `?token=` query parameter (like the
+  MCP and log-stream SSE endpoints). Prefer the header form for non-browser clients.
+- **Scope:** events fire for writes made through the REST and MCP APIs on this instance. Changes applied
+  by the **sync engine** (pulled from a peer) are not emitted here — they appear on the next load.
+
+```js
+const es = new EventSource(`/api/brain/spaces/${space}/events?token=${token}`);
+es.onmessage = (e) => { const { event, id } = JSON.parse(e.data); /* refresh the affected view */ };
+```
+
+---
+
 ### Semantic Search (Recall)
 
 Available as both:

--- a/server/src/api/brain/events.ts
+++ b/server/src/api/brain/events.ts
@@ -1,0 +1,54 @@
+/**
+ * /api/brain/spaces/:spaceId/events — Server-Sent Events stream of brain changes (F12).
+ *
+ * Every REST/MCP write funnels through `emitWebhookEvent`, which publishes to the in-process
+ * `brain-events` bus (see brain/brain-events.ts); this endpoint fans those out to the browser so the
+ * Brain page can refresh its lists and count badges live — most valuably when an MCP agent (or another
+ * session) mutates the space. Changes applied by the SYNC engine are intentionally not surfaced here
+ * (they don't emit an attributed webhook event); those still appear on the next load.
+ *
+ * Auth: space-scoped, read-only tokens allowed (watching is a read). EventSource cannot set an
+ * Authorization header, so the token is passed as `?token=` — this path is added to the auth layer's
+ * query-token allowlist. Modeled on the admin log-stream SSE in api/about.ts.
+ */
+import { Router } from 'express';
+import { globalRateLimit } from '../../rate-limit/middleware.js';
+import { requireSpaceAuth } from '../../auth/middleware.js';
+import { getConfig } from '../../config/loader.js';
+import { subscribeBrainChanges } from '../../brain/brain-events.js';
+
+export const brainEventsRouter = Router();
+
+brainEventsRouter.get('/spaces/:spaceId/events', globalRateLimit, requireSpaceAuth, (req, res) => {
+  const spaceId = req.params['spaceId'] as string;
+  if (!getConfig().spaces.some(s => s.id === spaceId)) {
+    res.status(404).json({ error: `Space '${spaceId}' not found` });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  res.write(':\n\n'); // open the stream
+
+  const unsubscribe = subscribeBrainChanges(spaceId, (ev) => {
+    if (res.destroyed) { unsubscribe(); return; }
+    const id = (ev.entry as { _id?: unknown })?._id;
+    // Minimal payload — the client uses `event` (e.g. "memory.created") to refresh the right tab/badges.
+    res.write(`data: ${JSON.stringify({ event: ev.event, id: typeof id === 'string' ? id : undefined })}\n\n`);
+  });
+
+  const heartbeat = setInterval(() => {
+    if (res.destroyed) { clearInterval(heartbeat); unsubscribe(); return; }
+    res.write(':\n\n');
+  }, 30_000);
+  heartbeat.unref?.();
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+  });
+});

--- a/server/src/api/brain/index.ts
+++ b/server/src/api/brain/index.ts
@@ -14,6 +14,7 @@ import { chronoRouter } from './chrono.js';
 import { fileMetaRouter } from './file-meta.js';
 import { searchRouter } from './search.js';
 import { bulkRouter } from './bulk.js';
+import { brainEventsRouter } from './events.js';
 
 export const brainRouter = Router();
 brainRouter.use(memoriesRouter);
@@ -23,3 +24,4 @@ brainRouter.use(chronoRouter);
 brainRouter.use(fileMetaRouter);
 brainRouter.use(searchRouter);
 brainRouter.use(bulkRouter);
+brainRouter.use(brainEventsRouter);

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -77,10 +77,17 @@ const QUERY_TOKEN_PATHS = new Set([
   '/mcp',                    // MCP SSE transport (EventSource)
 ]);
 
+// Parameterised SSE paths that can't be listed literally. Kept deliberately narrow (anchored, single
+// path segment for the id) so the query-token fallback stays confined to these GET streams.
+const QUERY_TOKEN_PATH_PATTERNS: RegExp[] = [
+  /^\/api\/brain\/spaces\/[^/]+\/events$/, // live brain-change stream (F12, EventSource)
+];
+
 function allowsQueryToken(req: Request): boolean {
   if (req.method !== 'GET') return false;
   const pathOnly = (req.originalUrl.split('?')[0] ?? '').replace(/\/+$/, '');
-  return QUERY_TOKEN_PATHS.has(pathOnly || '/');
+  const p = pathOnly || '/';
+  return QUERY_TOKEN_PATHS.has(p) || QUERY_TOKEN_PATH_PATTERNS.some(re => re.test(p));
 }
 
 function extractBearer(req: Request): string | null {

--- a/server/src/brain/brain-events.ts
+++ b/server/src/brain/brain-events.ts
@@ -1,0 +1,42 @@
+/**
+ * In-process brain-change event bus (F12 — live updates).
+ *
+ * A pure leaf (only `node:events`, no brain/webhook imports) so the webhook dispatcher can publish to
+ * it without creating an import cycle. Every brain write already funnels through `emitWebhookEvent`
+ * (webhooks/dispatcher.ts), which now also calls `publishBrainChange` here; the per-space SSE endpoint
+ * subscribes and fans each change out to connected browsers. This is process-local — it drives live UI
+ * on the instance that made the write; cross-instance propagation is the sync layer's job, and a synced
+ * write lands as a normal local write on the peer, which re-publishes here.
+ */
+import { EventEmitter } from 'node:events';
+
+/** Shape published on every brain mutation. `event` is a `WebhookEventType`; `entry` is the record (or summary). */
+export interface BrainChangeEvent {
+  event: string;
+  spaceId: string;
+  entry: Record<string, unknown>;
+}
+
+const _emitter = new EventEmitter();
+// SSE fans out to potentially many concurrent browser tabs; lift the default 10-listener warning cap.
+_emitter.setMaxListeners(0);
+
+/** Publish a brain change to in-process subscribers. Fire-and-forget; a bad subscriber never breaks a write. */
+export function publishBrainChange(ev: BrainChangeEvent): void {
+  try {
+    _emitter.emit('change', ev);
+  } catch {
+    /* a listener throwing must never propagate into the write path */
+  }
+}
+
+/** Subscribe to changes for a single space. Returns an unsubscribe function. */
+export function subscribeBrainChanges(spaceId: string, listener: (ev: BrainChangeEvent) => void): () => void {
+  const handler = (ev: BrainChangeEvent): void => {
+    if (ev.spaceId === spaceId) {
+      try { listener(ev); } catch { /* isolate one subscriber's failure from the others */ }
+    }
+  };
+  _emitter.on('change', handler);
+  return () => { _emitter.off('change', handler); };
+}

--- a/server/src/webhooks/dispatcher.ts
+++ b/server/src/webhooks/dispatcher.ts
@@ -16,6 +16,7 @@ import { col } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
+import { publishBrainChange } from '../brain/brain-events.js';
 import type { WebhookEventType, WebhookEventPayload, WebhookDelivery, WebhookSubscription } from './types.js';
 
 /** Retry schedule in milliseconds: 10s, 30s, 1m, 5m, 30m, 1h */
@@ -144,6 +145,10 @@ export interface EmitWebhookEventOptions {
  * dispatched asynchronously. Failures are retried via the MongoDB retry queue.
  */
 export function emitWebhookEvent(opts: EmitWebhookEventOptions): void {
+  // F12: mirror every brain mutation onto the in-process bus that drives live SSE updates. Done here,
+  // the single choke point every write already funnels through, so it fires regardless of whether any
+  // webhook subscription matches.
+  publishBrainChange({ event: opts.event, spaceId: opts.spaceId, entry: opts.entry });
   _emitAsync(opts).catch(err => {
     log.warn(`Webhook emit error: ${err}`);
   });

--- a/testing/integration/brain-events-sse.test.js
+++ b/testing/integration/brain-events-sse.test.js
@@ -1,0 +1,89 @@
+/**
+ * Integration: live brain-change SSE stream (F12) — GET /api/brain/spaces/:spaceId/events
+ *
+ *  - a REST write on the space pushes a `data:` event to a subscribed EventSource-style client
+ *  - the event names the collection (`memory.created`) so the client can refresh the right tab
+ *  - the query-token fallback authenticates the stream (EventSource can't set headers)
+ *  - no token → 401
+ *
+ * Run: node --test testing/integration/brain-events-sse.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, del } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+let tokenA;
+
+/** Open a raw SSE request; resolves with { res, req } once response headers arrive. */
+function openSse(urlPath, token) {
+  const u = new URL(INSTANCES.a);
+  const query = token === undefined ? '' : `?token=${encodeURIComponent(token)}`;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: u.hostname, port: Number(u.port || 80), path: `${urlPath}${query}`, method: 'GET', headers: { Accept: 'text/event-stream' } },
+      (res) => resolve({ res, req }),
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Resolve with the first parsed `data:` JSON object that has an `event` field. */
+function nextEvent(res) {
+  return new Promise((resolve) => {
+    let buf = '';
+    res.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+      const lines = buf.split('\n');
+      buf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.startsWith('data:')) {
+          try { const d = JSON.parse(line.slice(5).trim()); if (d && d.event) resolve(d); } catch { /* partial */ }
+        }
+      }
+    });
+  });
+}
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe('brain events SSE (F12)', () => {
+  before(() => { tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
+
+  it('a REST write pushes a matching event to a subscribed client', async () => {
+    const { res, req } = await openSse('/api/brain/spaces/general/events', tokenA);
+    try {
+      assert.equal(res.statusCode, 200, 'SSE should authenticate via query token');
+      assert.match(res.headers['content-type'] ?? '', /text\/event-stream/);
+
+      const eventP = nextEvent(res);
+      await delay(300); // ensure the server-side subscription is active before we write
+
+      const w = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/memories', { fact: `sse-probe-${Date.now()}` });
+      assert.equal(w.status, 201, JSON.stringify(w.body));
+
+      const ev = await Promise.race([eventP, delay(10_000).then(() => { throw new Error('no SSE event within 10s'); })]);
+      assert.equal(ev.event, 'memory.created', `unexpected event: ${JSON.stringify(ev)}`);
+      assert.equal(ev.id, w.body._id, 'event should carry the new record id');
+
+      await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${w.body._id}`).catch(() => {});
+    } finally {
+      req.destroy();
+    }
+  });
+
+  it('rejects an unauthenticated stream (no token) with 401', async () => {
+    const { res, req } = await openSse('/api/brain/spaces/general/events', undefined);
+    try {
+      assert.equal(res.statusCode, 401);
+    } finally {
+      req.destroy();
+    }
+  });
+});


### PR DESCRIPTION
The Brain page now refreshes its record lists and count badges **in real time** instead of needing a manual reload — most visibly when an **MCP agent** (or another session) mutates the space.

## Server
- **`GET /api/brain/spaces/:spaceId/events`** — an SSE stream emitting one `data: {event, id}` per brain mutation (`memory.created`, `entity.updated`, `bulk.write`, …). Space-scoped auth (read-only tokens may subscribe), 30s keep-alive comments. Modeled on the admin log-stream SSE.
- **One tap, every surface:** an in-process `brain/brain-events.ts` bus is published from the single `emitWebhookEvent` choke point that all REST/MCP writes already funnel through — no per-writer changes. Sync-applied changes aren't streamed (they carry no attributed event) and appear on the next load.
- `EventSource` can't send an `Authorization` header, so the auth layer's query-token allowlist gains a **narrow, anchored** pattern for `/api/brain/spaces/:id/events` (GET only), next to the existing exact paths.

## Client
- `BrainStore.liveRefreshTick` + a decoupled effect in the record-tab base: the mounted tab reloads its **current page** (no skip/search reset — keeps your position) when the tick bumps. `untracked` keeps that effect off the `spaceId` dependency so a space switch doesn't double-load.
- `BrainComponent` opens an `EventSource` per active space (token via query, guarded for SSR/test) and, on a change, **debounces (250ms)** a `loadStats` (badges) plus a tick for the active collection or any bulk write. Stream closed on space switch and `ngOnDestroy`.

## Tests
`testing/integration/brain-events-sse.test.js` — subscribe → REST write → assert the `memory.created` event (with id) arrives; 401 without a token. Full suites green against a rebuilt stack: **integration 859, red-team 272, client 236 — 0 failures.** Docs (integration-guide "Live Change Stream") + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)