### PR TITLE
feat(security): startup security-posture check + GET /api/about/security (PR-S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Startup security-posture check + `GET /api/about/security`.** Ythril now prints an aggregated
+  `✓`/`⚠`/`✗` report at boot across transport (TLS enforcement, peer scheme, `trustProxy`), encryption at
+  rest, and MongoDB auth, so a weak or broken setting is visible instead of silently accepted — e.g.
+  `requireEncryptedTransport` on without `trustProxy` (which would 403 every proxied request) is a `fail`.
+  Admins can fetch the same report live at `GET /api/about/security`. New `security.strict`
+  (`YTHRIL_SECURITY_STRICT`) makes any `fail` finding abort boot — the aggregate "don't start if
+  misconfigured" switch on top of the individual `require*` flags. Docs also add a multi-tenant
+  shared-hardware isolation guide (per-instance `mongod` + encrypted volume; why app-level field
+  encryption in a shared `mongod` is intentionally not offered).
+
 - **Encryption at rest for the state files (config / secrets / schema-library / schema-catalogs).**
   Provide a master secret in the environment — `YTHRIL_MASTER_KEY` (32 bytes, base64/hex) or
   `YTHRIL_MASTER_PASSPHRASE` (scrypt, per-file salt) — and Ythril transparently encrypts those files with

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -260,6 +260,22 @@ services:
       YTHRIL_REQUIRE_ENCRYPTED_AT_REST: "true"
 ```
 
+### Security Posture Check
+
+At boot Ythril prints an aggregated **security posture** — one `✓`/`⚠`/`✗` line per check across transport
+(TLS enforcement, peer scheme, `trustProxy`), encryption at rest, and MongoDB auth — so a weak setting is
+visible in the logs instead of silently accepted. Admins can also fetch it live:
+
+```http
+GET /api/about/security      # admin token
+→ { "checks": [ { "id": "transport.tls", "level": "warn", "message": "…" }, … ], "worst": "warn", "strict": false }
+```
+
+Levels are `pass` / `warn` / `fail` (`fail` = actively broken, e.g. `requireEncryptedTransport` on without
+`trustProxy`, so requests would 403). Set **`security.strict`** (config) or **`YTHRIL_SECURITY_STRICT=true`**
+to make any `fail` finding abort boot — the aggregate "don't start if misconfigured" switch, on top of the
+individual `require*` flags.
+
 ### Running Multiple Brains on One Host
 
 You can run any number of Ythril instances on a single server. Each is a fully
@@ -279,6 +295,18 @@ comes entirely from pointing each instance at distinct storage:
 | **Data root** | `DATA_ROOT` | File **bytes** live on the filesystem under `<DATA_ROOT>/files/<spaceId>/` (plus upload chunks and media/face-model files) — **not** in MongoDB. Sharing this directory collides the file stores the same way a shared database collides collections. |
 
 Plus a distinct published **port** per instance.
+
+**Multi-tenant on shared hardware — isolate cryptographically, not just logically.** If the tenants on
+one host don't trust each other (e.g. you resell Ythril), give **each instance its own `mongod` on its
+own encrypted volume with its own key** (LUKS/dm-crypt, a cloud encrypted disk, or MongoDB Enterprise
+at-rest encryption) — do **not** share one `mongod` across tenants. Then one tenant cannot decrypt
+another's data even with full disk access, because it's a different key and a different process, and
+semantic search stays fully intact (each instance queries its own plaintext-in-memory data). Combine
+with [Encryption at Rest](#encryption-at-rest) for the app's own state files and
+[`requireEncryptedTransport`](#transport-security-encryption-in-transit) for the wire. "Same host" is
+not a trust boundary; a co-tenant on loopback is still untrusted. Application-level field encryption in
+a *shared* `mongod` is deliberately **not** offered — it would break vector/text recall (you can't
+cosine-compare or regex encrypted values), so isolation lives at the storage boundary instead.
 
 > **Common pitfall — the silent `ythril` fallback.** Ythril takes the database name
 > from the *path* of `MONGO_URI`. If the path is empty (e.g.

--- a/server/src/api/about.ts
+++ b/server/src/api/about.ts
@@ -7,6 +7,7 @@ import { requireAuth, requireAdmin } from '../auth/middleware.js';
 import { getConfig } from '../config/loader.js';
 import { getMongo } from '../db/mongo.js';
 import { getLogLines, subscribeLogLines } from '../util/log.js';
+import { computeSecurityPosture, securityStrict } from '../config/security-posture.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkgPath = path.resolve(__dirname, '..', '..', 'package.json');
@@ -69,6 +70,12 @@ aboutRouter.get('/', async (_req, res) => {
 aboutRouter.get('/logs', requireAdmin, (_req, res) => {
   const lines = Math.min(Math.max(1, Number(_req.query['lines']) || 200), 1000);
   res.json({ lines: getLogLines(lines) });
+});
+
+// Security posture report (PR-S3). Admin-only — reveals the instance's security configuration.
+aboutRouter.get('/security', requireAdmin, (_req, res) => {
+  const posture = computeSecurityPosture();
+  res.json({ ...posture, strict: securityStrict() });
 });
 
 // SSE stream for real-time log tailing. Admin-only.

--- a/server/src/config/security-posture.ts
+++ b/server/src/config/security-posture.ts
@@ -1,0 +1,102 @@
+/**
+ * Startup security-posture check (PR-S3).
+ *
+ * Aggregates the transport (S1) and at-rest (S2) security settings — plus MongoDB auth — into a single
+ * PASS / WARN / FAIL report, logged at boot and served to admins at `GET /api/about/security`. It does
+ * not enforce on its own (the individual `require*` flags do that); but with `security.strict` (or env
+ * `YTHRIL_SECURITY_STRICT`) any FAIL aborts boot, so a misconfigured instance fails fast instead of
+ * running in a falsely-secure state.
+ */
+import { getConfig, getMongoUri, atRestEncryptionActive } from './loader.js';
+import { requireEncryptedTransport, allowInsecurePeersRaw } from './transport-security.js';
+
+export type PostureLevel = 'pass' | 'warn' | 'fail';
+
+export interface PostureCheck {
+  id: string;
+  level: PostureLevel;
+  message: string;
+}
+
+export interface SecurityPosture {
+  checks: PostureCheck[];
+  /** The most severe level across all checks (`pass` < `warn` < `fail`). */
+  worst: PostureLevel;
+}
+
+/** Whether strict posture enforcement is on (env → config → default false). */
+export function securityStrict(): boolean {
+  if (process.env['YTHRIL_SECURITY_STRICT'] === 'true') return true;
+  try { return getConfig().security?.strict === true; } catch { return false; }
+}
+
+/** True when Express `trust proxy` is configured (needed for `req.secure` behind a TLS-terminating proxy). */
+function trustProxyConfigured(): boolean {
+  if (process.env['TRUST_PROXY']) return true;
+  try {
+    const tp = getConfig().trustProxy;
+    return tp !== undefined && tp !== false && tp !== 0 && tp !== '';
+  } catch { return false; }
+}
+
+/** True when the Mongo connection carries credentials (URI userinfo or MONGO_USERNAME). */
+function mongoAuthenticated(): boolean {
+  if (process.env['MONGO_USERNAME']) return true;
+  try {
+    // Match a userinfo component: scheme://user[:pass]@host
+    return /^[a-z]+(?:\+[a-z]+)?:\/\/[^/@]+@/i.test(getMongoUri());
+  } catch { return false; }
+}
+
+const RANK: Record<PostureLevel, number> = { pass: 0, warn: 1, fail: 2 };
+
+/** Compute the current security posture from config + environment. Pure (no I/O beyond reads). */
+export function computeSecurityPosture(): SecurityPosture {
+  const checks: PostureCheck[] = [];
+  let cfg: ReturnType<typeof getConfig> | undefined;
+  try { cfg = getConfig(); } catch { /* pre-setup — report what we can from env */ }
+
+  const tlsOn = requireEncryptedTransport();
+
+  // ── Transport ──────────────────────────────────────────────────────────────
+  checks.push(tlsOn
+    ? { id: 'transport.tls', level: 'pass', message: 'requireEncryptedTransport is on — plaintext requests are rejected.' }
+    : { id: 'transport.tls', level: 'warn', message: 'requireEncryptedTransport is off — set it (behind a TLS-terminating proxy) to reject plaintext requests instance-wide.' });
+
+  if (tlsOn && !trustProxyConfigured()) {
+    checks.push({ id: 'transport.trustProxy', level: 'fail', message: 'requireEncryptedTransport is on but trustProxy is not set — behind a proxy every request will look plaintext and be rejected (403). Set trustProxy to your proxy hop count.' });
+  }
+
+  checks.push(allowInsecurePeersRaw()
+    ? { id: 'transport.peers', level: 'warn', message: 'allowInsecurePeers is on — sync may use plaintext http:// peers.' }
+    : { id: 'transport.peers', level: 'pass', message: 'Sync peers must use HTTPS.' });
+
+  if (cfg?.allowInsecurePlaintext) {
+    checks.push({ id: 'transport.plaintext', level: 'warn', message: 'allowInsecurePlaintext is on — the plaintext-exposure guard is disabled.' });
+  }
+
+  // ── At rest ──────────────────────────────────────────────────────────────────
+  const atRest = atRestEncryptionActive();
+  checks.push(atRest
+    ? { id: 'atRest.encryption', level: 'pass', message: 'State files are encrypted at rest (master secret configured).' }
+    : { id: 'atRest.encryption', level: 'warn', message: 'State files are NOT encrypted at rest — set YTHRIL_MASTER_KEY or YTHRIL_MASTER_PASSPHRASE.' });
+
+  const wantAtRest = process.env['YTHRIL_REQUIRE_ENCRYPTED_AT_REST'] === 'true' || cfg?.requireEncryptedAtRest === true;
+  if (wantAtRest && !atRest) {
+    checks.push({ id: 'atRest.strict', level: 'fail', message: 'requireEncryptedAtRest is set but no master secret is configured.' });
+  }
+
+  // ── MongoDB ──────────────────────────────────────────────────────────────────
+  checks.push(mongoAuthenticated()
+    ? { id: 'mongo.auth', level: 'pass', message: 'MongoDB connection is authenticated.' }
+    : { id: 'mongo.auth', level: 'warn', message: 'MongoDB connection has no credentials — enable auth on the database. On shared hardware, run a dedicated mongod per tenant on its own encrypted volume (do not share a mongod across tenants).' });
+
+  const worst = checks.reduce<PostureLevel>((w, c) => (RANK[c.level] > RANK[w] ? c.level : w), 'pass');
+  return { checks, worst };
+}
+
+/** Format the posture as human-readable lines for the boot log. */
+export function formatPostureLines(posture: SecurityPosture): string[] {
+  const glyph: Record<PostureLevel, string> = { pass: '✓', warn: '⚠', fail: '✗' };
+  return posture.checks.map(c => `  ${glyph[c.level]} [${c.id}] ${c.message}`);
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -700,6 +700,13 @@ export interface Config {
    */
   requireEncryptedAtRest?: boolean;
   /**
+   * Security posture: when `strict` is true (or env `YTHRIL_SECURITY_STRICT`), any FAIL-level finding in
+   * the startup posture check aborts boot (WARN findings stay advisory). Default false — the individual
+   * `require*` flags remain the authoritative enforcement; this is the aggregate "don't start if
+   * misconfigured" switch.
+   */
+  security?: { strict?: boolean };
+  /**
    * Express `trust proxy` setting. Default `false` — the out-of-the-box compose
    * deployment is exposed directly, so `req.ip` must come from the socket, not a
    * client-supplied X-Forwarded-For (which would let an attacker spoof the IP

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,4 @@
 ﻿import { createServer } from 'http';
-import os from 'os';
 import { configExists, loadConfig, loadSecrets, loadSchemaLibrary, getMongoUri, flushConfig, migrateStateFilesAtRest, requireEncryptedAtRest, atRestEncryptionActive } from './config/loader.js';
 import { connectMongo, closeMongo, checkVectorSearchAvailability } from './db/mongo.js';
 import { createApp } from './app.js';
@@ -58,29 +57,23 @@ async function main(): Promise<void> {
       ensureInstanceKeypair();
     }
 
-    // TLS warning: if non-loopback binding and plaintext allowed
-    const { getConfig } = await import('./config/loader.js');
-    const cfg = getConfig();
-    if (cfg.allowInsecurePlaintext) {
-      const ifaces = Object.values(os.networkInterfaces()).flat();
-      const hasExternal = ifaces.some(
-        iface => iface && !iface.internal && iface.family === 'IPv4',
-      );
-      if (hasExternal) {
-        console.warn(
-          `\n${YELLOW}  ⚠  WARNING${RESET}  allowInsecurePlaintext is true and this host has external\n` +
-          `     network interfaces. All traffic (including tokens) is unencrypted.\n` +
-          `     Deploy behind TLS termination (Nginx/Caddy/ingress) in production.\n`,
-        );
+    // Aggregate security-posture report (PR-S3): one PASS/WARN/FAIL view over transport (S1), at-rest
+    // (S2), and MongoDB auth. Advisory by default; `security.strict` aborts boot on any FAIL.
+    {
+      const { computeSecurityPosture, formatPostureLines, securityStrict } = await import('./config/security-posture.js');
+      const posture = computeSecurityPosture();
+      const issues = posture.checks.filter(c => c.level !== 'pass');
+      if (issues.length === 0) {
+        console.log(`  ${GREEN}✓${RESET} security posture: all checks passed`);
+      } else {
+        console.warn(`\n${YELLOW}  security posture — review the following:${RESET}`);
+        for (const line of formatPostureLines({ checks: issues, worst: posture.worst })) console.warn(line);
+        console.warn('');
       }
-    }
-    // Sync transport: warn when plaintext peers are permitted (data + tokens unencrypted on the wire).
-    if (cfg.allowInsecurePeers && !cfg.requireEncryptedTransport) {
-      console.warn(
-        `\n${YELLOW}  ⚠  WARNING${RESET}  allowInsecurePeers is true — sync may connect to plaintext\n` +
-        `     http:// peers, so record data and bearer tokens are unencrypted in transit.\n` +
-        `     Use https:// peer URLs, or set requireEncryptedTransport to enforce TLS everywhere.\n`,
-      );
+      if (securityStrict() && posture.worst === 'fail') {
+        console.error(`  ${YELLOW}✗ FATAL${RESET}  security.strict is on and the posture has FAIL findings above. Refusing to start.\n`);
+        process.exit(1);
+      }
     }
   }
 

--- a/testing/integration/security-posture.test.js
+++ b/testing/integration/security-posture.test.js
@@ -1,0 +1,42 @@
+/**
+ * Integration: GET /api/about/security — the security-posture report (PR-S3), admin-gated.
+ *
+ * Run: node --test testing/integration/security-posture.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, get } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+let tokenA;
+
+describe('security posture endpoint (F/S3)', () => {
+  before(() => { tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
+
+  it('returns a structured posture report to an admin', async () => {
+    const r = await get(INSTANCES.a, tokenA, '/api/about/security');
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.ok(Array.isArray(r.body.checks), 'checks must be an array');
+    assert.ok(r.body.checks.length > 0, 'expected at least one check');
+    for (const c of r.body.checks) {
+      assert.ok(typeof c.id === 'string' && c.id, 'check id');
+      assert.ok(['pass', 'warn', 'fail'].includes(c.level), `check level: ${c.level}`);
+      assert.ok(typeof c.message === 'string' && c.message, 'check message');
+    }
+    assert.ok(['pass', 'warn', 'fail'].includes(r.body.worst), `worst: ${r.body.worst}`);
+    assert.equal(typeof r.body.strict, 'boolean');
+    // The test stack opts into insecure peers, so that check should be present and WARN.
+    const peers = r.body.checks.find(c => c.id === 'transport.peers');
+    assert.ok(peers, 'transport.peers check present');
+    assert.equal(peers.level, 'warn');
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    const r = await get(INSTANCES.a, '', '/api/about/security');
+    assert.equal(r.status, 401);
+  });
+});

--- a/testing/standalone/security-posture.test.js
+++ b/testing/standalone/security-posture.test.js
@@ -1,0 +1,92 @@
+/**
+ * PR-S3 — startup security-posture check (`config/security-posture.ts`).
+ *
+ * With no config loaded (standalone), the checks resolve from env + defaults — exactly the override
+ * paths. Covers each PASS/WARN/FAIL transition the boot log and `security.strict` gate depend on.
+ *
+ * Run: node --test testing/standalone/security-posture.test.js
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { computeSecurityPosture, securityStrict } from '../../server/dist/config/security-posture.js';
+
+const ENV_KEYS = [
+  'REQUIRE_ENCRYPTED_TRANSPORT', 'SYNC_ALLOW_INSECURE_PEERS', 'TRUST_PROXY',
+  'YTHRIL_MASTER_KEY', 'YTHRIL_MASTER_PASSPHRASE', 'YTHRIL_REQUIRE_ENCRYPTED_AT_REST',
+  'YTHRIL_SECURITY_STRICT', 'MONGO_USERNAME', 'MONGO_URI',
+];
+function clearEnv() { for (const k of ENV_KEYS) delete process.env[k]; }
+const find = (posture, id) => posture.checks.find(c => c.id === id);
+
+describe('computeSecurityPosture', () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  it('default posture: transport/at-rest/mongo all WARN, peers PASS, worst=warn', () => {
+    const p = computeSecurityPosture();
+    assert.equal(find(p, 'transport.tls').level, 'warn');
+    assert.equal(find(p, 'transport.peers').level, 'pass');
+    assert.equal(find(p, 'atRest.encryption').level, 'warn');
+    assert.equal(find(p, 'mongo.auth').level, 'warn');
+    assert.equal(p.worst, 'warn');
+  });
+
+  it('requireEncryptedTransport without trustProxy → FAIL', () => {
+    process.env.REQUIRE_ENCRYPTED_TRANSPORT = 'true';
+    const p = computeSecurityPosture();
+    assert.equal(find(p, 'transport.tls').level, 'pass');
+    assert.equal(find(p, 'transport.trustProxy').level, 'fail');
+    assert.equal(p.worst, 'fail');
+  });
+
+  it('requireEncryptedTransport WITH trustProxy → no trustProxy failure', () => {
+    process.env.REQUIRE_ENCRYPTED_TRANSPORT = 'true';
+    process.env.TRUST_PROXY = '1';
+    const p = computeSecurityPosture();
+    assert.equal(find(p, 'transport.tls').level, 'pass');
+    assert.equal(find(p, 'transport.trustProxy'), undefined);
+  });
+
+  it('allowInsecurePeers env → peers WARN', () => {
+    process.env.SYNC_ALLOW_INSECURE_PEERS = 'true';
+    assert.equal(find(computeSecurityPosture(), 'transport.peers').level, 'warn');
+  });
+
+  it('master key present → at-rest PASS', () => {
+    process.env.YTHRIL_MASTER_KEY = crypto.randomBytes(32).toString('base64');
+    assert.equal(find(computeSecurityPosture(), 'atRest.encryption').level, 'pass');
+  });
+
+  it('requireEncryptedAtRest without a key → at-rest strict FAIL', () => {
+    process.env.YTHRIL_REQUIRE_ENCRYPTED_AT_REST = 'true';
+    const p = computeSecurityPosture();
+    assert.equal(find(p, 'atRest.strict').level, 'fail');
+    assert.equal(p.worst, 'fail');
+  });
+
+  it('Mongo credentials (env user) → mongo auth PASS', () => {
+    process.env.MONGO_USERNAME = 'u';
+    assert.equal(find(computeSecurityPosture(), 'mongo.auth').level, 'pass');
+  });
+
+  it('Mongo URI with userinfo → mongo auth PASS', () => {
+    process.env.MONGO_URI = 'mongodb://user:pass@host:27017/db';
+    assert.equal(find(computeSecurityPosture(), 'mongo.auth').level, 'pass');
+  });
+
+  it('a fully-hardened env passes every check', () => {
+    process.env.REQUIRE_ENCRYPTED_TRANSPORT = 'true';
+    process.env.TRUST_PROXY = '1';
+    process.env.YTHRIL_MASTER_KEY = crypto.randomBytes(32).toString('base64');
+    process.env.MONGO_USERNAME = 'u';
+    const p = computeSecurityPosture();
+    assert.equal(p.worst, 'pass', JSON.stringify(p.checks.filter(c => c.level !== 'pass')));
+  });
+
+  it('securityStrict reads the env flag', () => {
+    assert.equal(securityStrict(), false);
+    process.env.YTHRIL_SECURITY_STRICT = 'true';
+    assert.equal(securityStrict(), true);
+  });
+});


### PR DESCRIPTION
Final piece of the security-hardening series (builds on #273 transport + #274 at-rest). Turns the individual security flags into a single, visible **posture report** — the "highly recommended / guided / enforceable" layer you asked for.

## What it does
- **Boot report:** one `✓`/`⚠`/`✗` line per check across **transport** (TLS enforcement, peer scheme, `trustProxy`), **encryption at rest** (master secret present), and **MongoDB auth** — so a weak setting shows up in the logs instead of being silently accepted. Replaces the scattered ad-hoc transport warnings with one aggregated view.
- **`GET /api/about/security`** (admin) serves the same `{ checks, worst, strict }` report for the UI.
- **Enforce:** `security.strict` (config) / `YTHRIL_SECURITY_STRICT` aborts boot on any `fail` — the aggregate "don't start if misconfigured" switch, on top of the individual `require*` flags. (The S2 `requireEncryptedAtRest` hard-gate still fires independently and earlier.)

A `fail` means actively broken, not just weak — e.g. `requireEncryptedTransport` on **without** `trustProxy`, which would 403 every proxied request.

## Docs
- integration-guide **"Security Posture Check"** section.
- A **multi-tenant on shared hardware** isolation guide: per-instance `mongod` + encrypted volume/key, and an explicit note on why app-level field encryption in a *shared* `mongod` is deliberately **not** offered (it would break vector/text recall — isolation lives at the storage boundary instead).

## Tests
- `testing/standalone/security-posture.test.js` — every PASS/WARN/FAIL transition driven by env (10 cases).
- `testing/integration/security-posture.test.js` — admin endpoint shape + 401.
- Full standalone **856** green; integration posture test green.

## Note
The setup-wizard UI (toggle flags / show a generated key at first run) is intentionally **not** in this PR — the master key must live in the env (never on disk), so a wizard can only display a key + instruct a restart, which is a convenience over already-documented env config. Happy to build it with a no-brick design if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)