### PR TITLE
feat(files): F11 foundation — extraction-mode config + routing/validation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Document-extraction mode config + routing/validation engine (F11 foundation).** Groundwork for the
+  upcoming VLM document-extraction pipeline: `mediaEmbedding.documentProcessing` is now editable via the
+  admin media-config API (`PATCH /api/admin/media-config`), gaining a `mode` field (`ocr` | `vlm` | `auto`
+  | `max`) plus `renderDpi` / `maxPages` / `pageTimeoutMs` / `concurrency` knobs, and a pure, unit-tested
+  routing + validation policy (capability-availability routing with OCR fallback; OCR-evidence-coverage
+  validation). **No behavior change yet** — the default `ocr` mode is today's OCR-only path and the VLM
+  modes are inert until the extractor lands in follow-up PRs. See `todo/F11-PLAN.md`.
+
 - **Live brain updates via Server-Sent Events (F12).** The Brain page now refreshes its record lists and
   count badges in real time instead of needing a manual reload — most visibly when an MCP agent (or
   another session) mutates the space. A new scoped stream `GET /api/brain/spaces/:spaceId/events` emits

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -47,12 +47,25 @@ const ProviderPatchSchema = z.object({
   label: z.string().max(128).optional(),
 }).strict();
 
+// F11 — document-processing / extraction settings. Shallow-merged like `vision`/`stt`: the client sends
+// the full block. `ocr` mode = today's behaviour; `vlm`/`auto`/`max` opt into the VLM pipeline.
+const DocumentProcessingPatchSchema = z.object({
+  strategy: z.enum(['hi_res', 'auto', 'fast', 'ocr_only']).optional(),
+  extractImages: z.boolean().optional(),
+  mode: z.enum(['ocr', 'vlm', 'auto', 'max']).optional(),
+  renderDpi: z.number().int().min(72).max(600).optional(),
+  maxPages: z.number().int().min(1).max(2_000).optional(),
+  pageTimeoutMs: z.number().int().min(1_000).max(600_000).optional(),
+  concurrency: z.number().int().min(1).max(8).optional(),
+}).strict();
+
 const MediaConfigPatchSchema = z.object({
   enabled: z.boolean().optional(),
   visionProvider: z.enum(['local', 'external']).optional(),
   sttProvider: z.enum(['local', 'external']).optional(),
   vision: ProviderPatchSchema.optional(),
   stt: ProviderPatchSchema.optional(),
+  documentProcessing: DocumentProcessingPatchSchema.optional(),
   workerConcurrency: z.number().int().min(1).max(16).optional(),
   workerPollIntervalMs: z.number().int().min(100).max(60_000).optional(),
   workerMaxPollIntervalMs: z.number().int().min(1_000).max(600_000).optional(),

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -603,6 +603,9 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
     fallbackToExternal: pick('MEDIA_EMBEDDING_FALLBACK_TO_EXTERNAL', 'fallbackToExternal', base.fallbackToExternal, MEDIA_EMBEDDING_DEFAULTS.fallbackToExternal),
     maxFileSizeBytes: pick('MAX_FILE_SIZE_BYTES', 'maxFileSizeBytes', base.maxFileSizeBytes, MEDIA_EMBEDDING_DEFAULTS.maxFileSizeBytes),
     stalledJobTimeoutMs: pick('STALLED_JOB_TIMEOUT_MS', 'stalledJobTimeoutMs', base.stalledJobTimeoutMs, MEDIA_EMBEDDING_DEFAULTS.stalledJobTimeoutMs),
+    // Surface the resolved document-processing/extraction settings (F11) so the admin API GET and the
+    // Models UI can read them back (the worker ignores this block).
+    documentProcessing: getDocumentProcessingConfig(),
     lockedByInfra: locked,
   };
 }
@@ -612,6 +615,12 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
 const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   strategy: 'hi_res',
   extractImages: true,
+  // F11 — default `ocr` keeps today's OCR-only behaviour; the VLM pipeline is strictly opt-in.
+  mode: 'ocr',
+  renderDpi: 150,
+  maxPages: 50,
+  pageTimeoutMs: 60_000,
+  concurrency: 2,
 };
 
 /**
@@ -622,9 +631,15 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
 export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig> {
   const mediaCfg = getConfig().mediaEmbedding;
   const base: DocumentProcessingConfig = mediaCfg?.documentProcessing ?? {};
+  const d = DOCUMENT_PROCESSING_DEFAULTS;
   return {
-    strategy: base.strategy ?? DOCUMENT_PROCESSING_DEFAULTS.strategy,
-    extractImages: base.extractImages ?? DOCUMENT_PROCESSING_DEFAULTS.extractImages,
+    strategy: base.strategy ?? d.strategy,
+    extractImages: base.extractImages ?? d.extractImages,
+    mode: base.mode ?? d.mode,
+    renderDpi: base.renderDpi ?? d.renderDpi,
+    maxPages: base.maxPages ?? d.maxPages,
+    pageTimeoutMs: base.pageTimeoutMs ?? d.pageTimeoutMs,
+    concurrency: base.concurrency ?? d.concurrency,
   };
 }
 

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -350,7 +350,26 @@ export interface DocumentProcessingConfig {
    * Has no effect when strategy is not `hi_res`.
    */
   extractImages?: boolean;
+  /**
+   * F11 — document-extraction mode. `ocr` (default) uses only the unstructured sidecar (today's
+   * behaviour, unchanged). `vlm`/`auto`/`max` opt into the VLM precision pipeline
+   * (render → OCR-grounded VLM → validate → repair/consensus). Requires the render sidecar + a VLM to be
+   * wired in; the router falls back to OCR when a needed capability is absent, so it is never worse than
+   * plain OCR. See `todo/F11-PLAN.md`.
+   */
+  mode?: DocExtractionMode;
+  /** F11 — DPI for page rasterization in VLM modes. Default 150. */
+  renderDpi?: number;
+  /** F11 — max pages rasterized + sent to the VLM per document (cost/latency bound). Default 50. */
+  maxPages?: number;
+  /** F11 — per-page model-call timeout in ms (VLM/repair). Default 60000. */
+  pageTimeoutMs?: number;
+  /** F11 — max concurrent per-page model calls within one document. Default 2. */
+  concurrency?: number;
 }
+
+/** F11 — document-extraction mode: OCR-only (default) vs the VLM precision pipeline. */
+export type DocExtractionMode = 'ocr' | 'vlm' | 'auto' | 'max';
 
 /**
  * Configuration for the face recognition pipeline.

--- a/server/src/files/converters/extraction-policy.ts
+++ b/server/src/files/converters/extraction-policy.ts
@@ -1,0 +1,116 @@
+/**
+ * Document-extraction routing + validation policy (F11) — pure, no I/O.
+ *
+ * The "capability registry / orchestrator" of the OCR-Blueprint, miniaturised to a decision function:
+ * given the configured `mode` and which capabilities are reachable, `decideRoute` picks the stages to run
+ * (blueprint "if available" routing), always degrading gracefully to plain OCR so the VLM path is never
+ * worse than today. `validateExtraction` is the control signal (blueprint "validation as the steering
+ * wheel") — its OCR-evidence coverage check decides whether to accept, promote to a repair model, or fall
+ * back to OCR. Kept pure so it is exhaustively unit-testable without a sidecar or a model.
+ */
+import type { DocExtractionMode } from '../../config/types.js';
+
+/** Which extraction capabilities are currently configured + reachable. */
+export interface CapabilityAvailability {
+  ocr: boolean;     // unstructured sidecar — text/table evidence + the OCR fallback floor
+  render: boolean;  // page rasterizer sidecar (PDF/doc → page images)
+  vlm: boolean;     // document VLM (OCR-grounded page → Markdown)
+  repair: boolean;  // heavyweight review/repair model (promotion on validation failure)
+  verify: boolean;  // optional consensus model
+}
+
+export type ExtractionStage = 'ocr' | 'render' | 'ocr-evidence' | 'vlm' | 'validate' | 'repair' | 'verify';
+
+export interface ExtractionRoute {
+  /** Ordered stages the extractor will run. */
+  stages: ExtractionStage[];
+  /** True when this is the plain-OCR path (no VLM). */
+  ocrOnly: boolean;
+  /** Short audit label recorded per document, e.g. `ocr`, `ocr+vlm`, `ocr+vlm+repair`. */
+  label: string;
+  /** Set when a VLM mode degraded to OCR because a required capability was absent. */
+  fallbackReason?: string;
+}
+
+const OCR_ROUTE: ExtractionRoute = { stages: ['ocr'], ocrOnly: true, label: 'ocr' };
+
+/**
+ * Decide the extraction route. Never throws: VLM modes that lack `render` or `vlm` degrade to OCR (with a
+ * reason); `ocr` mode always runs OCR. If OCR itself is unavailable the extractor surfaces the usual
+ * `ConversionUnavailableError` downstream — routing does not mask that.
+ */
+export function decideRoute(mode: DocExtractionMode, avail: CapabilityAvailability): ExtractionRoute {
+  if (mode === 'ocr') return OCR_ROUTE;
+
+  // Every VLM mode needs page rasterization AND a VLM; otherwise fall back to OCR.
+  if (!avail.render || !avail.vlm) {
+    const missing = [!avail.render ? 'render' : null, !avail.vlm ? 'vlm' : null].filter(Boolean).join(' + ');
+    return { ...OCR_ROUTE, fallbackReason: `mode '${mode}' needs ${missing}; fell back to OCR` };
+  }
+
+  const stages: ExtractionStage[] = ['render'];
+  const label: string[] = [];
+  if (avail.ocr) { stages.push('ocr-evidence'); label.push('ocr'); } // OCR grounding (blueprint Path 2)
+  stages.push('vlm', 'validate');
+  label.push('vlm');
+
+  // `max` composes the heavyweight tiers when they're wired in (promotion is runtime, gated on validation).
+  if (mode === 'max' && avail.repair) { stages.push('repair'); label.push('repair'); }
+  if (mode === 'max' && avail.verify) { stages.push('verify'); label.push('verify'); }
+
+  return { stages, ocrOnly: false, label: label.join('+') };
+}
+
+// ── Validation (the control signal) ─────────────────────────────────────────
+
+/** Coverage tokens: lowercased alphanumeric runs of length ≥ 3 (ignores punctuation/short noise). */
+export function coverageTokens(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]{3,}/g) ?? [];
+}
+
+/**
+ * Fraction (0..1) of the OCR-evidence tokens that survive into the result — the load-bearing check that
+ * the VLM didn't silently drop or hallucinate away the OCR-grounded content. Returns 1 when there is no
+ * evidence to compare against (nothing to violate).
+ */
+export function evidenceCoverage(resultText: string, evidenceText: string): number {
+  const evidence = new Set(coverageTokens(evidenceText));
+  if (evidence.size === 0) return 1;
+  const result = new Set(coverageTokens(resultText));
+  let hit = 0;
+  for (const t of evidence) if (result.has(t)) hit++;
+  return hit / evidence.size;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  issues: string[];
+  /** OCR-evidence coverage that was measured (0..1). */
+  coverage: number;
+}
+
+export interface ValidateOptions {
+  /** Minimum evidence-coverage fraction to accept. Default 0.6. */
+  minCoverage?: number;
+  /** The model's finish reason, when known — `'length'` signals truncation. */
+  finishReason?: string;
+}
+
+/**
+ * Validate an extraction result against the OCR evidence. A failing result drives promotion (to a repair
+ * model in `max` mode) or, at the floor, a fall back to plain OCR — the extractor decides which based on
+ * the route.
+ */
+export function validateExtraction(resultText: string, evidenceText: string, opts: ValidateOptions = {}): ValidationResult {
+  const issues: string[] = [];
+  if (!resultText.trim()) issues.push('empty output');
+  if (opts.finishReason === 'length') issues.push('truncated (hit max tokens)');
+
+  const coverage = evidenceCoverage(resultText, evidenceText);
+  const minCoverage = opts.minCoverage ?? 0.6;
+  if (evidenceText.trim() && coverage < minCoverage) {
+    issues.push(`low OCR-evidence coverage ${(coverage * 100).toFixed(0)}% (< ${(minCoverage * 100).toFixed(0)}%)`);
+  }
+
+  return { ok: issues.length === 0, issues, coverage };
+}

--- a/testing/integration/media-config.test.js
+++ b/testing/integration/media-config.test.js
@@ -85,3 +85,41 @@ describe('Media config hot-reload (A6)', () => {
     assert.equal(reread.body?.vision?.model, probeModel, 'patched vision.model must round-trip through GET');
   });
 });
+
+// ── F11 — documentProcessing extraction config ───────────────────────────────
+
+describe('Media config — documentProcessing (F11)', () => {
+  let originalDp;
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+    const cur = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    originalDp = cur.body?.documentProcessing;
+  });
+  after(async () => {
+    // Restore to OCR so the (inert in this PR) mode doesn't leak into other suites.
+    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: originalDp ?? { mode: 'ocr' } }).catch(() => {});
+  });
+
+  it('accepts and round-trips a documentProcessing.mode change', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: { mode: 'vlm', maxPages: 10, renderDpi: 200 } });
+    assert.equal(r.status, 200, `PATCH failed: ${JSON.stringify(r.body)}`);
+    assert.equal(r.body?.config?.documentProcessing?.mode, 'vlm');
+    const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    assert.equal(reread.body?.documentProcessing?.mode, 'vlm');
+    assert.equal(reread.body?.documentProcessing?.maxPages, 10);
+  });
+
+  it('rejects an invalid mode', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: { mode: 'magic' } });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+  });
+
+  it('rejects out-of-range knobs', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: { renderDpi: 5000 } });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+  });
+});

--- a/testing/standalone/extraction-policy.test.js
+++ b/testing/standalone/extraction-policy.test.js
@@ -1,0 +1,118 @@
+/**
+ * F11 — document-extraction routing + validation policy (pure).
+ *
+ * `decideRoute` is the blueprint's "if available" routing, miniaturised; `validateExtraction` is the
+ * control signal (OCR-evidence coverage) that drives promotion/fallback. Both pure — exhaustively tested
+ * here against the real compiled module.
+ *
+ * Run: node --test testing/standalone/extraction-policy.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  decideRoute, validateExtraction, evidenceCoverage, coverageTokens,
+} from '../../server/dist/files/converters/extraction-policy.js';
+
+const ALL = { ocr: true, render: true, vlm: true, repair: true, verify: true };
+const none = (o) => ({ ocr: false, render: false, vlm: false, repair: false, verify: false, ...o });
+
+describe('decideRoute', () => {
+  it("mode 'ocr' is always the OCR-only path, regardless of availability", () => {
+    for (const avail of [ALL, none()]) {
+      const r = decideRoute('ocr', avail);
+      assert.deepEqual(r.stages, ['ocr']);
+      assert.equal(r.ocrOnly, true);
+      assert.equal(r.label, 'ocr');
+      assert.equal(r.fallbackReason, undefined);
+    }
+  });
+
+  it("mode 'vlm' with everything available → OCR-grounded VLM (no repair/verify)", () => {
+    const r = decideRoute('vlm', ALL);
+    assert.deepEqual(r.stages, ['render', 'ocr-evidence', 'vlm', 'validate']);
+    assert.equal(r.ocrOnly, false);
+    assert.equal(r.label, 'ocr+vlm');
+  });
+
+  it("mode 'vlm' without OCR → ungrounded VLM (no ocr-evidence stage)", () => {
+    const r = decideRoute('vlm', none({ render: true, vlm: true }));
+    assert.deepEqual(r.stages, ['render', 'vlm', 'validate']);
+    assert.equal(r.label, 'vlm');
+  });
+
+  it('a VLM mode falls back to OCR when render is missing', () => {
+    const r = decideRoute('vlm', none({ ocr: true, vlm: true })); // no render
+    assert.equal(r.ocrOnly, true);
+    assert.deepEqual(r.stages, ['ocr']);
+    assert.match(r.fallbackReason, /render/);
+  });
+
+  it('a VLM mode falls back to OCR when the VLM is missing', () => {
+    const r = decideRoute('auto', none({ ocr: true, render: true })); // no vlm
+    assert.equal(r.ocrOnly, true);
+    assert.match(r.fallbackReason, /vlm/);
+  });
+
+  it("mode 'max' composes repair + verify when wired in", () => {
+    const r = decideRoute('max', ALL);
+    assert.deepEqual(r.stages, ['render', 'ocr-evidence', 'vlm', 'validate', 'repair', 'verify']);
+    assert.equal(r.label, 'ocr+vlm+repair+verify');
+  });
+
+  it("mode 'max' omits repair/verify when they aren't available", () => {
+    const r = decideRoute('max', none({ ocr: true, render: true, vlm: true }));
+    assert.deepEqual(r.stages, ['render', 'ocr-evidence', 'vlm', 'validate']);
+    assert.equal(r.label, 'ocr+vlm');
+  });
+
+  it("mode 'auto' never forces the max-only repair/verify tiers even when available", () => {
+    const r = decideRoute('auto', ALL);
+    assert.ok(!r.stages.includes('repair'));
+    assert.ok(!r.stages.includes('verify'));
+  });
+});
+
+describe('evidenceCoverage / coverageTokens', () => {
+  it('tokenizes alphanumeric runs of length ≥ 3, lowercased', () => {
+    assert.deepEqual(coverageTokens('The Cat, a 42x dog!'), ['the', 'cat', '42x', 'dog']);
+  });
+  it('full coverage = 1', () => {
+    assert.equal(evidenceCoverage('the quick brown fox', 'quick brown'), 1);
+  });
+  it('partial coverage is the hit fraction', () => {
+    assert.equal(evidenceCoverage('alpha bravo', 'alpha bravo charlie delta'), 0.5);
+  });
+  it('no evidence → coverage 1 (nothing to violate)', () => {
+    assert.equal(evidenceCoverage('anything', ''), 1);
+  });
+  it('empty result with real evidence → coverage 0', () => {
+    assert.equal(evidenceCoverage('', 'some evidence tokens'), 0);
+  });
+});
+
+describe('validateExtraction', () => {
+  it('accepts well-covered non-empty output', () => {
+    const v = validateExtraction('the quick brown fox jumped', 'quick brown fox');
+    assert.equal(v.ok, true);
+    assert.deepEqual(v.issues, []);
+    assert.equal(v.coverage, 1);
+  });
+  it('flags empty output', () => {
+    const v = validateExtraction('   ', 'evidence here');
+    assert.equal(v.ok, false);
+    assert.ok(v.issues.some(i => /empty/.test(i)));
+  });
+  it('flags truncation on finishReason length', () => {
+    const v = validateExtraction('text', 'text', { finishReason: 'length' });
+    assert.ok(v.issues.some(i => /truncat/.test(i)));
+  });
+  it('flags low OCR-evidence coverage below the threshold', () => {
+    const v = validateExtraction('alpha', 'alpha bravo charlie delta echo', { minCoverage: 0.6 });
+    assert.equal(v.ok, false);
+    assert.ok(v.issues.some(i => /coverage/.test(i)));
+  });
+  it('no evidence → passes on coverage (nothing to compare)', () => {
+    const v = validateExtraction('some output', '');
+    assert.equal(v.ok, true);
+  });
+});


### PR DESCRIPTION
First step of **F11** (VLM document extraction — see `todo/F11-PLAN.md`), deliberately scoped as a **safe, inert-by-default foundation**: no conversion behavior changes, so it's low-risk to land ahead of the pipeline itself.

## What's in it
- **Config surface.** `mediaEmbedding.documentProcessing` gains a `mode` (`ocr` | `vlm` | `auto` | `max`) plus `renderDpi` / `maxPages` / `pageTimeoutMs` / `concurrency` knobs. The whole block is now editable via the admin media-config API (`PATCH /api/admin/media-config`, MFA-gated) and returned on GET, with zod validation (mode enum + bounded knobs).
- **Pure policy engine** (`files/converters/extraction-policy.ts`, no I/O):
  - `decideRoute(mode, availability)` — the blueprint's "if available" routing, miniaturised: composes `render → OCR-evidence → VLM → validate (→ repair/verify in max)`, and **always degrades to plain OCR** when a capability is absent, so the VLM path is never worse than today.
  - `validateExtraction` — the control signal: **OCR-evidence coverage** (catches VLM omission/hallucination) + emptiness + truncation. Drives promotion (repair) / fallback in later PRs.

## Why inert
Default `mode: 'ocr'` is today's OCR-only path, and the router/validators aren't wired into `runConversionPipeline` yet — that (plus the render sidecar + the VLM extractor) lands in follow-up PRs per the phased plan. This PR is just the tested decision logic + the config it will read.

## Tests
- `testing/standalone/extraction-policy.test.js` — 18 cases covering every route (ocr / vlm / auto / max, with/without each capability, OCR fallback) and every validator transition.
- `testing/integration/media-config.test.js` — `documentProcessing` round-trip through PATCH/GET + invalid-mode / out-of-range rejection.
- Full suites green: **standalone 874, media-config 4, file-conversion 8 — 0 failures** (OCR conversion path byte-unchanged).

Plan + a security/performance audit of the whole task tree are in `todo/F11-PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)