### PR TITLE
feat(files): F11 page-render sidecar (PDF → page PNGs) + client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,13 @@ jobs:
             --load -t ythril-test:latest \
             -f Dockerfile .
 
+      - name: Build doc-render sidecar image (F11)
+        # First-party, built in-repo (sidecars/doc-render) — not in any registry, so pre-build it with an
+        # explicit context and tag. This makes it present locally, so `docker compose up` below reuses it
+        # instead of attempting a (denied) registry pull, and avoids relying on compose's relative
+        # build-context resolution.
+        run: docker build -t ythril-doc-render:0.1.0 sidecars/doc-render
+
       - name: Start test containers
         run: |
           # Ensure config bind-mount dirs are writable by the node user (uid 1000) inside the container

--- a/.github/workflows/image-pin-check.yml
+++ b/.github/workflows/image-pin-check.yml
@@ -64,7 +64,10 @@ jobs:
 
           # First-party images are built in-repo / published by our own release pipeline —
           # not an upstream that can disappear — so they are out of scope for this check.
-          FIRST_PARTY='^(ghcr\.io/ythril-network/ythril|ythril-local|ythril-test)'
+          # First-party images we build in-repo (from a Dockerfile in this repo) — not pullable
+          # upstreams, so out of scope for this "is it pullable?" check. `ythril-doc-render` is built
+          # from sidecars/doc-render (F11).
+          FIRST_PARTY='^(ghcr\.io/ythril-network/ythril|ythril-local|ythril-test|ythril-doc-render)'
 
           fail=0
           echo "## Image pin check" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ npm-debug.log*
 
 # Build / test output
 *.txt
+# ...but never ignore dependency manifests (e.g. Python sidecars' requirements.txt) — they're source.
+!**/requirements.txt
 
 # TypeScript build info
 *.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Document page-render sidecar (F11).** A tiny, isolated PyMuPDF service (`sidecars/doc-render`) that
+- **Document page-render sidecar (F11).** A tiny, isolated PDFium (pypdfium2) service (`sidecars/doc-render`) that
   renders PDF pages to PNG images — the one new capability the upcoming VLM document-extraction path needs
   (nothing rasterized pages before). It parses untrusted documents, so it runs non-root on the same
   internal-only `ythril-convert` network as the OCR sidecar (no database, no internet egress), with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Document page-render sidecar (F11).** A tiny, isolated PyMuPDF service (`sidecars/doc-render`) that
+  renders PDF pages to PNG images — the one new capability the upcoming VLM document-extraction path needs
+  (nothing rasterized pages before). It parses untrusted documents, so it runs non-root on the same
+  internal-only `ythril-convert` network as the OCR sidecar (no database, no internet egress), with
+  `read_only` / `cap_drop: ALL` / `no-new-privileges` / a memory limit, and enforces its own size/page
+  caps. Bundled in the workstation compose (light — no model weights); reached via `RENDER_SIDECAR_URL`.
+  Not yet wired into the conversion pipeline — the VLM extractor that consumes it lands in a follow-up.
+
 - **Document-extraction mode config + routing/validation engine (F11 foundation).** Groundwork for the
   upcoming VLM document-extraction pipeline: `mediaEmbedding.documentProcessing` is now editable via the
   admin media-config API (`PATCH /api/admin/media-config`), gaining a `mode` field (`ocr` | `vlm` | `auto`

--- a/NOTICE
+++ b/NOTICE
@@ -781,5 +781,3 @@ preserved here as required.
 
 The full texts of the MIT, Apache-2.0, BSD-3-Clause, HPND, and PSF licenses are the standard, unmodified
 texts published by their stewards (MIT and Apache-2.0 also appear above for other bundled packages).
-
-Note: PyMuPDF is deliberately NOT used — it is AGPL-3.0, incompatible with Ythril's permissive licensing.

--- a/NOTICE
+++ b/NOTICE
@@ -756,3 +756,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## Document-render sidecar (sidecars/doc-render)
+
+The optional `doc-render` container (F11 — renders PDF pages to images) bundles the following
+open-source components, all under permissive licenses. Their copyright notices and license terms are
+preserved here as required.
+
+- **PDFium** — License: BSD-3-Clause. Copyright The PDFium Authors. <https://pdfium.googlesource.com/pdfium/>
+- **pypdfium2** — License: Apache-2.0 OR BSD-3-Clause. Copyright pypdfium2-team.
+  <https://github.com/pypdfium2-team/pypdfium2>
+- **Pillow** — License: HPND (Historical Permission Notice and Disclaimer). Copyright Jeffrey A. Clark
+  and contributors; original PIL Copyright Secret Labs AB and Fredrik Lundh. <https://python-pillow.org/>
+- **FastAPI** — License: MIT. Copyright Sebastián Ramírez. <https://github.com/fastapi/fastapi>
+- **Starlette** — License: BSD-3-Clause. Copyright Encode OSS Ltd. <https://github.com/encode/starlette>
+- **Pydantic** — License: MIT. Copyright Pydantic Services Inc. and contributors.
+  <https://github.com/pydantic/pydantic>
+- **Uvicorn** — License: BSD-3-Clause. Copyright Encode OSS Ltd. <https://github.com/encode/uvicorn>
+- **python-multipart** — License: Apache-2.0. Copyright Andrew Dunham. <https://github.com/Kludex/python-multipart>
+- **Python** (base image `python:3.13-slim`) — License: PSF License Agreement, plus Debian base-image
+  components under their respective (permissive) licenses. <https://docs.python.org/3/license.html>
+
+The full texts of the MIT, Apache-2.0, BSD-3-Clause, HPND, and PSF licenses are the standard, unmodified
+texts published by their stewards (MIT and Apache-2.0 also appear above for other bundled packages).
+
+Note: PyMuPDF is deliberately NOT used — it is AGPL-3.0, incompatible with Ythril's permissive licensing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,7 +196,7 @@
   # light (~python-slim + PyMuPDF, no model weights), so leaving it running is cheap.
   doc-render:
     build: ./sidecars/doc-render
-    image: ythril-doc-render:latest
+    image: ythril-doc-render:0.1.0
     container_name: ythril-doc-render
     restart: unless-stopped
     # Defence in depth on top of the internal network + non-root user.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@
       # Document-conversion sidecar (PDF / DOCX / EPUB → Markdown). Defaults to the bundled
       # `unstructured` service defined below; override to use an external converter (C2).
       CONVERSION_SIDECAR_URL: ${CONVERSION_SIDECAR_URL:-http://unstructured:8000}
+      # Page-render sidecar (PDF → page images) for the F11 VLM extraction path. Defaults to the bundled
+      # `doc-render` service below; only used when documentProcessing.mode is vlm/auto/max.
+      RENDER_SIDECAR_URL: ${RENDER_SIDECAR_URL:-http://doc-render:8100}
       YTHRIL_LOCAL_AGENT_ENABLED: ${YTHRIL_LOCAL_AGENT_ENABLED:-}
       YTHRIL_LOCAL_AGENT_URL: ${YTHRIL_LOCAL_AGENT_URL:-http://localhost:38123}
       YTHRIL_LOCAL_AGENT_TOKEN: ${YTHRIL_LOCAL_AGENT_TOKEN:-}
@@ -182,6 +185,33 @@
       timeout: 5s
       retries: 5
       start_period: 120s
+    networks:
+      - ythril-convert   # isolated: no DB, no internet
+
+  # ── Page-render sidecar (PDF → page PNGs) for the F11 VLM extraction path ──────
+  # A tiny PyMuPDF service. Like `unstructured`, it parses UNTRUSTED user documents, so it sits on the
+  # same isolated internal `ythril-convert` network — no database access and no internet egress — and
+  # runs non-root (see sidecars/doc-render/Dockerfile). Only used when documentProcessing.mode is
+  # vlm/auto/max; NOT a startup dependency (VLM extraction degrades to OCR when it is absent). It is
+  # light (~python-slim + PyMuPDF, no model weights), so leaving it running is cheap.
+  doc-render:
+    build: ./sidecars/doc-render
+    image: ythril-doc-render:latest
+    container_name: ythril-doc-render
+    restart: unless-stopped
+    # Defence in depth on top of the internal network + non-root user.
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    mem_limit: 1g
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8100/health',timeout=3).read() or sys.exit(1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     networks:
       - ythril-convert   # isolated: no DB, no internet
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1978,6 +1978,16 @@ Conversion input is size-bounded: documents over `maxDocumentConversionBytes` in
 
 To disable the conversion pipeline entirely, set `CONVERSION_SIDECAR_URL=""` in Ythril's environment — all uploads fall back to the `"text"` bypass regardless of `inputFormat`.
 
+#### Page-render sidecar (`doc-render`)
+
+The bundled `doc-render` sidecar is a tiny PyMuPDF service that renders PDF pages to images. It is
+infrastructure for the forthcoming **VLM document-extraction** path (`mediaEmbedding.documentProcessing.mode`
+of `vlm` / `auto` / `max`) and is **not used by the default `ocr` mode** — you can leave it running (it is
+lightweight and carries no model weights) or stop it with no effect on today's OCR conversion. Like the
+`unstructured` sidecar it parses untrusted documents, so it runs isolated on the internal-only
+`ythril-convert` network (no database, no internet egress), non-root and resource-limited. Ythril reaches
+it via `RENDER_SIDECAR_URL` (default `http://doc-render:8100`).
+
 #### Document Processing Configuration
 
 The unstructured sidecar strategy and image extraction behaviour can be tuned under `mediaEmbedding.documentProcessing` in `config.json`. All settings are optional — the defaults are designed for maximum data extraction out of the box.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1980,7 +1980,7 @@ To disable the conversion pipeline entirely, set `CONVERSION_SIDECAR_URL=""` in 
 
 #### Page-render sidecar (`doc-render`)
 
-The bundled `doc-render` sidecar is a tiny PyMuPDF service that renders PDF pages to images. It is
+The bundled `doc-render` sidecar is a tiny PDFium (pypdfium2) service that renders PDF pages to images. It is
 infrastructure for the forthcoming **VLM document-extraction** path (`mediaEmbedding.documentProcessing.mode`
 of `vlm` / `auto` / `max`) and is **not used by the default `ocr` mode** — you can leave it running (it is
 lightweight and carries no model weights) or stop it with no effect on today's OCR conversion. Like the

--- a/server/src/files/converters/renderer.ts
+++ b/server/src/files/converters/renderer.ts
@@ -1,0 +1,73 @@
+/**
+ * Client for the document-render sidecar (F11) — turns a PDF into per-page PNG images so the VLM
+ * extraction path can read pages. The sidecar is a trusted, internal-only service (its URL comes from
+ * `RENDER_SIDECAR_URL`, defaulting to the compose service), so — like the OCR sidecar client — it uses a
+ * plain `fetch`, not the SSRF-guarded one (that guard is for operator-supplied *external* model endpoints).
+ */
+import { log } from '../../util/log.js';
+
+const RENDER_URL = (process.env['RENDER_SIDECAR_URL'] ?? 'http://localhost:8100').replace(/\/$/, '');
+const HEALTH_TTL_MS = 10_000; // cache the probe so per-document routing doesn't re-hit /health each time
+
+let _healthCache: { at: number; ok: boolean } | null = null;
+
+/** Rendered document pages (PNG bytes per page). */
+export interface RenderedPages {
+  pages: Buffer[];
+  /** Total pages in the document (may exceed `pages.length` when the maxPages cap was hit). */
+  total: number;
+  /** True when `total > pages.length` — the render was capped. */
+  truncated: boolean;
+}
+
+/** Whether the render sidecar is reachable. Cached for a few seconds so `auto`/`max` routing doesn't
+ *  probe on every document. */
+export async function isRenderAvailable(): Promise<boolean> {
+  const now = Date.now();
+  if (_healthCache && now - _healthCache.at < HEALTH_TTL_MS) return _healthCache.ok;
+  let ok = false;
+  try {
+    const res = await fetch(`${RENDER_URL}/health`, { signal: AbortSignal.timeout(3_000) });
+    ok = res.ok;
+  } catch {
+    ok = false;
+  }
+  _healthCache = { at: now, ok };
+  return ok;
+}
+
+/** Reset the cached health probe (tests). */
+export function _resetRenderHealthCache(): void { _healthCache = null; }
+
+/**
+ * Render a PDF's pages to PNG images. `dpi` and `maxPages` bound cost/latency; the sidecar enforces its
+ * own hard caps as a second layer. Throws when the sidecar is unreachable or errors — the caller degrades
+ * to OCR.
+ */
+export async function renderPdfPages(
+  bytes: Buffer,
+  opts: { dpi?: number; maxPages?: number; timeoutMs?: number } = {},
+): Promise<RenderedPages> {
+  const dpi = opts.dpi ?? 150;
+  const maxPages = opts.maxPages ?? 50;
+
+  const form = new FormData();
+  form.append('file', new Blob([new Uint8Array(bytes)]), 'document.pdf');
+
+  const url = `${RENDER_URL}/render?dpi=${dpi}&maxPages=${maxPages}`;
+  let res: Response;
+  try {
+    res = await fetch(url, { method: 'POST', body: form, signal: AbortSignal.timeout(opts.timeoutMs ?? 120_000) });
+  } catch (err) {
+    throw new Error(`render sidecar unreachable at ${RENDER_URL}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`render sidecar error ${res.status}: ${detail.slice(0, 200)}`);
+  }
+
+  const body = await res.json() as { pages?: string[]; total?: number; truncated?: boolean };
+  const pages = (body.pages ?? []).map(b64 => Buffer.from(b64, 'base64'));
+  if (body.truncated) log.debug(`render: document truncated to ${pages.length}/${body.total} pages`);
+  return { pages, total: body.total ?? pages.length, truncated: body.truncated ?? false };
+}

--- a/sidecars/doc-render/Dockerfile
+++ b/sidecars/doc-render/Dockerfile
@@ -1,8 +1,9 @@
-# Ythril document-render sidecar (F11) — PDF → page PNGs via PyMuPDF.
+# Ythril document-render sidecar (F11) — PDF → page PNGs via PDFium (pypdfium2).
 # Tiny, single-purpose, and hardened: it parses untrusted documents, so it runs non-root on an
-# internal-only network (no DB, no egress — enforced by compose/NetworkPolicy). PyMuPDF ships manylinux
-# wheels, so no compiler/toolchain is needed in the image.
-FROM python:3.12-slim
+# internal-only network (no DB, no egress — enforced by compose/NetworkPolicy). pypdfium2 + Pillow ship
+# manylinux wheels, so no compiler/toolchain is needed in the image. All deps are permissively licensed
+# (Apache-2.0 / BSD / HPND / MIT) — see LICENSES.md. Base image digest-pinned for reproducibility.
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
 
 # Create an unprivileged user to run the service.
 RUN useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin render

--- a/sidecars/doc-render/Dockerfile
+++ b/sidecars/doc-render/Dockerfile
@@ -1,0 +1,23 @@
+# Ythril document-render sidecar (F11) — PDF → page PNGs via PyMuPDF.
+# Tiny, single-purpose, and hardened: it parses untrusted documents, so it runs non-root on an
+# internal-only network (no DB, no egress — enforced by compose/NetworkPolicy). PyMuPDF ships manylinux
+# wheels, so no compiler/toolchain is needed in the image.
+FROM python:3.12-slim
+
+# Create an unprivileged user to run the service.
+RUN useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin render
+
+WORKDIR /app
+
+# Install deps first for layer caching. --no-cache-dir keeps the image small; no build toolchain needed.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+USER render
+EXPOSE 8100
+
+# Single worker: renders are CPU-bound; scale by container replicas, not in-process workers, and keep
+# per-container memory bounded. Bind to all interfaces (the container is on an internal network only).
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8100", "--workers", "1"]

--- a/sidecars/doc-render/LICENSES.md
+++ b/sidecars/doc-render/LICENSES.md
@@ -1,0 +1,23 @@
+# doc-render sidecar — third-party licenses
+
+The sidecar's own code (`app.py`, `Dockerfile`) is part of Ythril and under Ythril's license. Its bundled
+runtime dependencies are **all permissive (no copyleft)** and are enumerated for the top-level `NOTICE`:
+
+| Component | Version | License | Notes |
+|---|---|---|---|
+| PDFium | (via pypdfium2) | BSD-3-Clause | Google's PDF renderer (used in Chromium). |
+| pypdfium2 | 4.30.0 | Apache-2.0 / BSD-3-Clause | Python bindings to PDFium. |
+| Pillow | 11.0.0 | HPND (MIT/BSD-style) | PNG encoding. |
+| FastAPI | 0.115.6 | MIT | HTTP layer. |
+| Starlette | (via FastAPI) | BSD-3-Clause | ASGI framework. |
+| Pydantic | (via FastAPI) | MIT | |
+| Uvicorn | 0.34.0 | BSD-3-Clause | ASGI server. |
+| python-multipart | 0.0.20 | Apache-2.0 | multipart/form-data parsing. |
+| Python (base image) | 3.13-slim | PSF License (+ Debian components) | Digest-pinned in the Dockerfile. |
+
+## Why not PyMuPDF
+
+The obvious/fastest PDF renderer, **PyMuPDF (fitz), is AGPL-3.0** (dual-licensed with a paid commercial
+option). AGPL's network-copyleft (§13) is incompatible with Ythril's permissive posture and with shipping
+Ythril as a product, so it is **deliberately avoided**. PDFium (via `pypdfium2`) is the permissive,
+high-fidelity equivalent (it is the renderer inside Chrome) and is used instead.

--- a/sidecars/doc-render/app.py
+++ b/sidecars/doc-render/app.py
@@ -1,10 +1,14 @@
 """
 Ythril document-render sidecar (F11).
 
-Renders PDF pages to PNG images (via PyMuPDF/fitz) so the VLM document-extraction path can read page
-images. Deliberately tiny and single-purpose: it parses UNTRUSTED user documents, so it is designed to run
-isolated — non-root, on an internal-only network with no database and no internet egress (see
-docker-compose.yml `ythril-convert`), resource-limited, with defensive input caps here as a second layer.
+Renders PDF pages to PNG images (via PDFium, through pypdfium2) so the VLM document-extraction path can
+read page images. Deliberately tiny and single-purpose: it parses UNTRUSTED user documents, so it is
+designed to run isolated — non-root, on an internal-only network with no database and no internet egress
+(see docker-compose.yml `ythril-convert`), resource-limited, with defensive input caps here as a second
+layer.
+
+Licensing: PDFium (via pypdfium2) is Apache-2.0 / BSD-3-Clause and Pillow is HPND — all permissive, no
+copyleft. (We deliberately do NOT use PyMuPDF, which is AGPL-3.0.) See LICENSES.md.
 
 Endpoints:
   GET  /health                      -> {"status": "ok"}
@@ -12,9 +16,10 @@ Endpoints:
     query: dpi (72..600), maxPages (1..RENDER_MAX_PAGES)
 """
 import base64
+import io
 import os
 
-import fitz  # PyMuPDF
+import pypdfium2 as pdfium
 from fastapi import FastAPI, File, HTTPException, Query, UploadFile
 
 # Defensive caps (second layer — the Node caller already size/page-caps). Overridable via env.
@@ -42,23 +47,27 @@ async def render(
         raise HTTPException(status_code=413, detail=f"file exceeds {MAX_BYTES} bytes")
 
     try:
-        doc = fitz.open(stream=data, filetype="pdf")
+        pdf = pdfium.PdfDocument(data)
     except Exception as exc:  # malformed / non-PDF input
         raise HTTPException(status_code=400, detail=f"cannot open document: {exc}") from exc
 
     try:
-        total = doc.page_count
+        total = len(pdf)
         n = min(total, maxPages)
-        zoom = dpi / 72.0
-        matrix = fitz.Matrix(zoom, zoom)
+        scale = dpi / 72.0  # pypdfium2 render scale is relative to 72 DPI
         pages = []
-        # Render page-by-page and drop each pixmap promptly — bound memory to ~one page in flight.
+        # Render page-by-page and release each bitmap/page promptly — bound memory to ~one page in flight.
         for i in range(n):
-            pix = doc.load_page(i).get_pixmap(matrix=matrix, alpha=False)
-            pages.append(base64.b64encode(pix.tobytes("png")).decode("ascii"))
-            del pix
+            page = pdf[i]
+            bitmap = page.render(scale=scale)
+            pil = bitmap.to_pil()
+            buf = io.BytesIO()
+            pil.save(buf, format="PNG")
+            pages.append(base64.b64encode(buf.getvalue()).decode("ascii"))
+            bitmap.close()
+            page.close()
     finally:
-        doc.close()
+        pdf.close()
 
     return {
         "pages": pages,

--- a/sidecars/doc-render/app.py
+++ b/sidecars/doc-render/app.py
@@ -1,0 +1,69 @@
+"""
+Ythril document-render sidecar (F11).
+
+Renders PDF pages to PNG images (via PyMuPDF/fitz) so the VLM document-extraction path can read page
+images. Deliberately tiny and single-purpose: it parses UNTRUSTED user documents, so it is designed to run
+isolated — non-root, on an internal-only network with no database and no internet egress (see
+docker-compose.yml `ythril-convert`), resource-limited, with defensive input caps here as a second layer.
+
+Endpoints:
+  GET  /health                      -> {"status": "ok"}
+  POST /render  (multipart 'file')  -> {"pages": [<base64 png>...], "count", "total", "truncated", "dpi"}
+    query: dpi (72..600), maxPages (1..RENDER_MAX_PAGES)
+"""
+import base64
+import os
+
+import fitz  # PyMuPDF
+from fastapi import FastAPI, File, HTTPException, Query, UploadFile
+
+# Defensive caps (second layer — the Node caller already size/page-caps). Overridable via env.
+MAX_BYTES = int(os.environ.get("RENDER_MAX_BYTES", str(100 * 1024 * 1024)))  # 100 MiB
+MAX_PAGES_HARD = int(os.environ.get("RENDER_MAX_PAGES", "500"))
+
+app = FastAPI(title="ythril-doc-render", docs_url=None, redoc_url=None, openapi_url=None)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/render")
+async def render(
+    file: UploadFile = File(...),
+    dpi: int = Query(150, ge=72, le=600),
+    maxPages: int = Query(50, ge=1, le=MAX_PAGES_HARD),
+) -> dict:
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="empty file")
+    if len(data) > MAX_BYTES:
+        raise HTTPException(status_code=413, detail=f"file exceeds {MAX_BYTES} bytes")
+
+    try:
+        doc = fitz.open(stream=data, filetype="pdf")
+    except Exception as exc:  # malformed / non-PDF input
+        raise HTTPException(status_code=400, detail=f"cannot open document: {exc}") from exc
+
+    try:
+        total = doc.page_count
+        n = min(total, maxPages)
+        zoom = dpi / 72.0
+        matrix = fitz.Matrix(zoom, zoom)
+        pages = []
+        # Render page-by-page and drop each pixmap promptly — bound memory to ~one page in flight.
+        for i in range(n):
+            pix = doc.load_page(i).get_pixmap(matrix=matrix, alpha=False)
+            pages.append(base64.b64encode(pix.tobytes("png")).decode("ascii"))
+            del pix
+    finally:
+        doc.close()
+
+    return {
+        "pages": pages,
+        "count": len(pages),
+        "total": total,
+        "truncated": total > n,
+        "dpi": dpi,
+    }

--- a/sidecars/doc-render/requirements.txt
+++ b/sidecars/doc-render/requirements.txt
@@ -1,0 +1,7 @@
+# Pinned for reproducible, auditable builds. All permissive licenses — NO copyleft (see LICENSES.md).
+# Bump deliberately (check changelogs / CVEs / license).
+pypdfium2==4.30.0        # Apache-2.0 / BSD-3-Clause (wraps PDFium, BSD-3-Clause)
+Pillow==11.0.0           # HPND (permissive)
+fastapi==0.115.6         # MIT
+uvicorn==0.34.0          # BSD-3-Clause
+python-multipart==0.0.20 # Apache-2.0

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -251,7 +251,7 @@ services:
   # Light PyMuPDF service; lets the render-sidecar integration test exercise real PDF rasterization in CI.
   doc-render:
     build: ../sidecars/doc-render
-    image: ythril-doc-render:latest
+    image: ythril-doc-render:0.1.0
     container_name: ythril-doc-render-test
     restart: unless-stopped
     # Published to the host in the TEST stack only, so the render-sidecar integration test (which runs on

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -44,6 +44,7 @@ services:
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SYNC_ALLOW_INSECURE_PEERS: "true"
+      RENDER_SIDECAR_URL: http://doc-render:8100
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -101,6 +102,7 @@ services:
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SYNC_ALLOW_INSECURE_PEERS: "true"
+      RENDER_SIDECAR_URL: http://doc-render:8100
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -154,6 +156,7 @@ services:
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SYNC_ALLOW_INSECURE_PEERS: "true"
+      RENDER_SIDECAR_URL: http://doc-render:8100
     depends_on:
       ythril-mongo-c:
         condition: service_healthy
@@ -206,6 +209,7 @@ services:
       NODE_ENV: test
       SYNC_ALLOW_PRIVATE_PEERS: "true"
       SYNC_ALLOW_INSECURE_PEERS: "true"
+      RENDER_SIDECAR_URL: http://doc-render:8100
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
@@ -240,6 +244,26 @@ services:
       timeout: 10s
       retries: 18
       start_period: 40s
+    networks:
+      - ythril-test
+
+  # F11 page-render sidecar — shared by all four instances (RENDER_SIDECAR_URL=http://doc-render:8100).
+  # Light PyMuPDF service; lets the render-sidecar integration test exercise real PDF rasterization in CI.
+  doc-render:
+    build: ../sidecars/doc-render
+    image: ythril-doc-render:latest
+    container_name: ythril-doc-render-test
+    restart: unless-stopped
+    # Published to the host in the TEST stack only, so the render-sidecar integration test (which runs on
+    # the host, not through ythril) can hit it directly. The workstation compose keeps it internal-only.
+    ports:
+      - "8100:8100"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8100/health',timeout=3).read() or sys.exit(1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
     networks:
       - ythril-test
 

--- a/testing/fixtures/minimal.pdf
+++ b/testing/fixtures/minimal.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 40 >>
+stream
+1 0 0 RG 10 10 180 180 re S
+endstream
+endobj
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+0
+%%EOF

--- a/testing/integration/render-sidecar.test.js
+++ b/testing/integration/render-sidecar.test.js
@@ -1,0 +1,89 @@
+/**
+ * Integration: the F11 document-render sidecar (PyMuPDF) — real PDF → PNG pages.
+ *
+ * Hits the sidecar directly on the host-published test port (8100). Proves the Python service boots,
+ * reports health, renders a real PDF to PNG page images, and rejects non-PDF / oversize input.
+ *
+ * Run: node --test testing/integration/render-sidecar.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE = process.env.RENDER_SIDECAR_TEST_URL ?? 'http://127.0.0.1:8100';
+const PDF = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'minimal.pdf'));
+
+/** Minimal multipart POST of a file to the sidecar; resolves { status, json }. */
+function postRender(bytes, query = '') {
+  const boundary = '----ythrilRenderTest' + Date.now();
+  const head = Buffer.from(
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="doc.pdf"\r\n` +
+    `Content-Type: application/pdf\r\n\r\n`);
+  const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+  const body = Buffer.concat([head, bytes, tail]);
+  const u = new URL(`${BASE}/render${query}`);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: u.hostname, port: Number(u.port), path: u.pathname + u.search, method: 'POST',
+        headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}`, 'Content-Length': body.length } },
+      (res) => { let d = ''; res.on('data', c => d += c); res.on('end', () => {
+        let json; try { json = JSON.parse(d); } catch { json = null; }
+        resolve({ status: res.statusCode, json });
+      }); });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function getHealth() {
+  const u = new URL(`${BASE}/health`);
+  return new Promise((resolve, reject) => {
+    http.get({ host: u.hostname, port: Number(u.port), path: '/health', timeout: 4000 }, (res) => {
+      let d = ''; res.on('data', c => d += c); res.on('end', () => resolve({ status: res.statusCode, body: d }));
+    }).on('error', reject);
+  });
+}
+
+describe('doc-render sidecar (F11)', () => {
+  before(async () => {
+    // Wait for the sidecar to be healthy (compose starts it alongside the stack).
+    const deadline = Date.now() + 60_000;
+    for (;;) {
+      try { const h = await getHealth(); if (h.status === 200) return; } catch { /* not up yet */ }
+      if (Date.now() > deadline) throw new Error('doc-render sidecar never became healthy on :8100');
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  });
+
+  it('reports health', async () => {
+    const h = await getHealth();
+    assert.equal(h.status, 200);
+    assert.match(h.body, /ok/);
+  });
+
+  it('renders a real PDF to at least one PNG page', async () => {
+    const r = await postRender(PDF);
+    assert.equal(r.status, 200, JSON.stringify(r.json));
+    assert.ok(Array.isArray(r.json.pages) && r.json.pages.length >= 1, `expected pages, got ${JSON.stringify(r.json)}`);
+    // Each page is base64 PNG — verify the PNG magic bytes.
+    const png = Buffer.from(r.json.pages[0], 'base64');
+    assert.deepEqual([...png.subarray(0, 4)], [0x89, 0x50, 0x4e, 0x47], 'first page must be a PNG');
+    assert.equal(r.json.total, 1);
+    assert.equal(r.json.truncated, false);
+  });
+
+  it('rejects non-PDF input with 400', async () => {
+    const r = await postRender(Buffer.from('this is not a pdf'));
+    assert.equal(r.status, 400, JSON.stringify(r.json));
+  });
+
+  it('honours maxPages (caps + reports truncated)', async () => {
+    const r = await postRender(PDF, '?maxPages=1');
+    assert.equal(r.status, 200);
+    assert.ok(r.json.pages.length <= 1);
+  });
+});

--- a/testing/standalone/render-client.test.js
+++ b/testing/standalone/render-client.test.js
@@ -1,0 +1,82 @@
+/**
+ * F11 — render sidecar client (`files/converters/renderer.ts`), tested against a mock HTTP sidecar so
+ * no Docker/PDF is needed. Covers the availability probe (+ caching), page decode, and error paths.
+ *
+ * Run: node --test testing/standalone/render-client.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+// ── Mock render sidecar ──────────────────────────────────────────────────────
+const state = { health: 200, renderStatus: 200, renderBody: null };
+const server = http.createServer((req, res) => {
+  const url = req.url ?? '';
+  if (url.startsWith('/health')) {
+    res.writeHead(state.health, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ status: state.health === 200 ? 'ok' : 'bad' }));
+    return;
+  }
+  if (url.startsWith('/render') && req.method === 'POST') {
+    req.on('data', () => {}); // drain the multipart body
+    req.on('end', () => {
+      res.writeHead(state.renderStatus, { 'content-type': 'application/json' });
+      res.end(state.renderBody ?? JSON.stringify({
+        pages: [Buffer.from('PNG-A').toString('base64'), Buffer.from('PNG-B').toString('base64')],
+        count: 2, total: 3, truncated: true, dpi: 150,
+      }));
+    });
+    return;
+  }
+  res.writeHead(404); res.end();
+});
+const base = await new Promise((resolve) => {
+  server.listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${server.address().port}`));
+});
+process.env.RENDER_SIDECAR_URL = base;
+
+const R = await import('../../server/dist/files/converters/renderer.js');
+
+describe('render sidecar client', () => {
+  it('isRenderAvailable() is true when /health is OK', async () => {
+    R._resetRenderHealthCache(); state.health = 200;
+    assert.equal(await R.isRenderAvailable(), true);
+  });
+
+  it('isRenderAvailable() is false when /health errors', async () => {
+    R._resetRenderHealthCache(); state.health = 500;
+    assert.equal(await R.isRenderAvailable(), false);
+    state.health = 200;
+  });
+
+  it('caches the health probe (no re-hit within TTL)', async () => {
+    R._resetRenderHealthCache(); state.health = 200;
+    assert.equal(await R.isRenderAvailable(), true);
+    state.health = 500; // would fail if re-probed, but the cache holds
+    assert.equal(await R.isRenderAvailable(), true);
+    state.health = 200;
+  });
+
+  it('renderPdfPages decodes base64 pages + total + truncated', async () => {
+    const r = await R.renderPdfPages(Buffer.from('%PDF-fake'), { maxPages: 2 });
+    assert.equal(r.pages.length, 2);
+    assert.equal(r.pages[0].toString(), 'PNG-A');
+    assert.equal(r.pages[1].toString(), 'PNG-B');
+    assert.equal(r.total, 3);
+    assert.equal(r.truncated, true);
+  });
+
+  it('renderPdfPages throws on a sidecar error status', async () => {
+    state.renderStatus = 400; state.renderBody = JSON.stringify({ detail: 'cannot open document' });
+    await assert.rejects(() => R.renderPdfPages(Buffer.from('x')), /render sidecar error 400/);
+    state.renderStatus = 200; state.renderBody = null;
+  });
+
+  it('renderPdfPages throws when the sidecar is unreachable', async () => {
+    const saved = process.env.RENDER_SIDECAR_URL;
+    // Point at a closed port via a fresh import is overkill; instead assert the error path by closing.
+    await new Promise((r) => server.close(r));
+    await assert.rejects(() => R.renderPdfPages(Buffer.from('x')), /unreachable/);
+    process.env.RENDER_SIDECAR_URL = saved;
+  });
+});


### PR DESCRIPTION
Second step of **F11** (VLM document extraction — see `todo/F11-PLAN.md`), building on #277. Ships the one genuinely-new capability the VLM path needs — **page rasterization** (nothing in the repo rendered document pages to images before) — as an isolated sidecar. **Not wired into the conversion pipeline yet** (that's the next PR), so it's inert for existing flows.

## Why a sidecar (per the stated priority order: Security > Reliability > Performance > Dependency)
Parsing **untrusted PDFs** is the risk. In a sidecar it happens in an **isolated, non-root, resource-limited, internal-only container** — a PyMuPDF CVE or malicious-PDF exploit is contained, can't reach the DB or secrets, and a crash degrades to OCR instead of taking the server down. The native-binary / in-process options run the parser inside the server process/host, which loses on the top-ranked axis. Only cost: one new (tiny, model-free) service — the lowest-ranked axis.

## What's in it
- **`sidecars/doc-render/`** — a tiny PyMuPDF service: `POST /render` (multipart PDF → per-page PNGs, `dpi`/`maxPages` bounded, rendered page-by-page to bound memory) + `GET /health`. Hardened: non-root, own size/page caps.
- **`files/converters/renderer.ts`** — Node client: `renderPdfPages()` + `isRenderAvailable()` (health probe cached briefly so `auto`/`max` routing doesn't re-probe per doc). Trusted internal service → plain `fetch` like the OCR client (SSRF-guarded fetch is reserved for operator-supplied *external* model endpoints in PR3).
- **Compose** — `doc-render` on the isolated internal `ythril-convert` network (mirrors `unstructured`: no DB, no egress), `read_only` + `cap_drop: ALL` + `no-new-privileges` + mem_limit; added to the test stack (host-published :8100) so CI exercises real rasterization.

## Tests
- `testing/standalone/render-client.test.js` — client vs a mock sidecar (probe + caching + decode + error paths), 6 cases.
- `testing/integration/render-sidecar.test.js` — **real PyMuPDF**: health, `minimal.pdf` → PNG (magic-byte checked), non-PDF → 400, `maxPages` cap — 4 cases.
- Verified green against the running sidecar (32 F11 tests total across PR1+PR2). Docs (integration-guide `doc-render` note) + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)