### PR TITLE
feat(files): F11 VLM document extractor — wire vlm/auto/max modes into the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VLM document extractor — the pipeline wiring (F11).** The `vlm` / `auto` / `max` modes are now live in
+  the conversion pipeline (they were inert config until now). For a PDF/DOCX/EPUB, the extractor runs OCR
+  for *evidence*, rasterizes the pages via the render sidecar, transcribes each page with a local Ollama
+  vision model (`DOC_VLM_MODEL` / `mediaEmbedding.documentProcessing.vlmModel`, `DOC_VLM_URL` for the
+  endpoint), then lets the OCR-evidence-coverage validator decide whether to accept the VLM Markdown or
+  fall back to OCR — so a result is **never worse than plain OCR**. Every capability is optional and
+  degrades cleanly: no render/VLM configured → OCR; OCR down but VLM up → ungrounded VLM; nothing
+  available → the usual "conversion unavailable" surfaces exactly as today. Per-page output is bounded and
+  transcribed at temperature 0. The default `ocr` mode is unchanged. Validation-driven repair, the
+  external hosted-VLM egress path (via `ssrfSafeFetch`), and `max`-mode consensus are the next PRs. See
+  `todo/F11-PLAN.md`.
+
 - **Document page-render sidecar (F11).** A tiny, isolated PDFium (pypdfium2) service (`sidecars/doc-render`) that
   renders PDF pages to PNG images — the one new capability the upcoming VLM document-extraction path needs
   (nothing rasterized pages before). It parses untrusted documents, so it runs non-root on the same

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1981,8 +1981,8 @@ To disable the conversion pipeline entirely, set `CONVERSION_SIDECAR_URL=""` in 
 #### Page-render sidecar (`doc-render`)
 
 The bundled `doc-render` sidecar is a tiny PDFium (pypdfium2) service that renders PDF pages to images. It is
-infrastructure for the forthcoming **VLM document-extraction** path (`mediaEmbedding.documentProcessing.mode`
-of `vlm` / `auto` / `max`) and is **not used by the default `ocr` mode** — you can leave it running (it is
+the rasterization step the **VLM document-extraction** path (`mediaEmbedding.documentProcessing.mode` of
+`vlm` / `auto` / `max`) needs and is **not used by the default `ocr` mode** — you can leave it running (it is
 lightweight and carries no model weights) or stop it with no effect on today's OCR conversion. Like the
 `unstructured` sidecar it parses untrusted documents, so it runs isolated on the internal-only
 `ythril-convert` network (no database, no internet egress), non-root and resource-limited. Ythril reaches
@@ -1996,6 +1996,16 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 |---|---|---|
 | `strategy` | `"hi_res"` | Unstructured partition strategy. `"hi_res"`: full Tesseract OCR + layout detection — accurate on scanned PDFs, extracts embedded images and structured tables. `"auto"`: sidecar picks the fastest viable strategy. `"fast"`: pdfminer text-layer only — fastest but no OCR, no image extraction. `"ocr_only"`: force OCR on every page regardless of whether a text layer exists. |
 | `extractImages` | `true` | When `true` and `strategy` is `"hi_res"`, embedded images found in document partitions are decoded and saved as `_extracted/{originalId}/image-{N}.{ext}` subfiles. Each is automatically enqueued for the full media pipeline (caption + face recognition). Has no effect when strategy is not `"hi_res"`. |
+| `mode` | `"ocr"` | Extraction path. `"ocr"` (default) is today's unstructured-sidecar OCR — unchanged. `"vlm"` renders each page and transcribes it with a vision model, using OCR as grounding evidence and falling back to OCR if the result doesn't validate (so it is **never worse than OCR**). `"auto"` uses the VLM only when it is configured and available, else OCR. `"max"` adds validation-driven repair + consensus (later PRs; behaves like `"vlm"` until then). |
+| `vlmModel` | `""` | Ollama vision model used for `vlm` / `auto` / `max` (e.g. a bundled `moondream`, or a larger model you wire in). Empty ⇒ the VLM path is unavailable and extraction stays on OCR. Env override: `DOC_VLM_MODEL`. |
+| `vlmBaseUrl` | `""` | Endpoint for the VLM. Empty ⇒ falls back to the media vision provider's `baseUrl`, then `http://ollama:11434`. Env override: `DOC_VLM_URL`. |
+| `renderDpi` | `150` | Page rasterization DPI for the render sidecar (VLM modes only). |
+| `maxPages` | `50` | Cap on pages rendered/transcribed per document (VLM modes only). |
+| `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
+| `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
+
+The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,
+Ythril transparently uses OCR — no upload fails because a model isn't wired in yet.
 
 **Example `config.json` excerpt:**
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -621,6 +621,8 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   maxPages: 50,
   pageTimeoutMs: 60_000,
   concurrency: 2,
+  vlmModel: '',    // empty = no VLM configured → vlm/auto/max fall back to OCR
+  vlmBaseUrl: '',  // empty = reuse the media vision provider's (Ollama) URL
 };
 
 /**
@@ -640,6 +642,8 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     maxPages: base.maxPages ?? d.maxPages,
     pageTimeoutMs: base.pageTimeoutMs ?? d.pageTimeoutMs,
     concurrency: base.concurrency ?? d.concurrency,
+    vlmModel: process.env['DOC_VLM_MODEL'] ?? base.vlmModel ?? d.vlmModel,
+    vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
   };
 }
 

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -366,6 +366,17 @@ export interface DocumentProcessingConfig {
   pageTimeoutMs?: number;
   /** F11 — max concurrent per-page model calls within one document. Default 2. */
   concurrency?: number;
+  /**
+   * F11 — the document-transcription VLM model tag (e.g. a small Qwen2-VL / MiniCPM-V on the bundled
+   * Ollama). Empty (default) means no VLM is configured, so `vlm`/`auto`/`max` modes fall back to OCR.
+   * Env: `DOC_VLM_MODEL`.
+   */
+  vlmModel?: string;
+  /**
+   * F11 — base URL of the VLM endpoint. Empty (default) reuses the media `vision` provider's Ollama URL
+   * (the bundled local path, no egress). Env: `DOC_VLM_URL`.
+   */
+  vlmBaseUrl?: string;
 }
 
 /** F11 — document-extraction mode: OCR-only (default) vs the VLM precision pipeline. */

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -26,7 +26,8 @@ import { writeFile, writeFileBytes } from '../files.js';
 import { resolveSafePathChecked } from '../sandbox.js';
 import { col, asFilter, asDoc } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
-import { getConfig } from '../../config/loader.js';
+import { getConfig, getDocumentProcessingConfig } from '../../config/loader.js';
+import { vlmExtractDocument } from './vlm-extract.js';
 import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { enqueueMediaJob } from '../media/job-queue.js';
@@ -138,6 +139,7 @@ export interface ConversionResult {
   chunks: Chunk[];
   convertedMarkdown: string | null; // null for md/txt (source IS the markdown)
   extractedImages: ExtractedImage[];  // populated for pdf/docx/epub when hi_res extraction is on
+  extractionPath?: string;            // F11: which extraction path ran (ocr / ocr+vlm / ocr+vlm→ocr / …)
 }
 
 /**
@@ -206,14 +208,27 @@ export async function runConversionPipeline(
     case 'pdf':
     case 'docx':
     case 'epub': {
-      const conv = new UnstructuredConverter();
-      const result = await conv.convertRich(fileBytes, fileName);
-      markdown = result.markdown;
-      convertedMarkdown = markdown;
+      // F11: `ocr` mode (default) is the unchanged path; `vlm`/`auto`/`max` run the capability extractor,
+      // which itself falls back to OCR when render/VLM are absent or the VLM output fails validation.
+      const mode = getDocumentProcessingConfig().mode;
+      let extractionPath: string | undefined;
+      let richMarkdown: string;
+      let images = [] as ExtractedImage[];
+      if (mode === 'ocr') {
+        const result = await new UnstructuredConverter().convertRich(fileBytes, fileName);
+        richMarkdown = result.markdown;
+        images = result.extractedImages;
+      } else {
+        const result = await vlmExtractDocument(fileBytes, fileName);
+        richMarkdown = result.markdown;
+        images = result.extractedImages;
+        extractionPath = result.extractionPath;
+      }
       return {
-        chunks: sectionChunk(normaliseMarkdown(result.markdown), { minBodyLength: opts.minChunkBodyLength }),
-        convertedMarkdown,
-        extractedImages: result.extractedImages,
+        chunks: sectionChunk(normaliseMarkdown(richMarkdown), { minBodyLength: opts.minChunkBodyLength }),
+        convertedMarkdown: richMarkdown,
+        extractedImages: images,
+        ...(extractionPath ? { extractionPath } : {}),
       };
     }
   }

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -1,0 +1,53 @@
+/**
+ * VLM client for document transcription (F11) — local Ollama path.
+ *
+ * Sends a rendered page image + a strict verbatim-transcription prompt to an Ollama vision model
+ * (`/api/chat` with `images`), mirroring the media vision provider's request shape. Output is bounded
+ * (`num_predict`) and temperature 0 for determinism. Throws on unreachable/error so the extractor can
+ * fall back to OCR. External (hosted OpenAI-compatible) endpoints — and routing their egress through
+ * `ssrfSafeFetch` — are a later phase; this is the bundled, no-egress path.
+ */
+
+export interface VlmTranscription {
+  text: string;
+  /** True when the model hit its output cap (Ollama `done_reason === 'length'`) — signals truncation. */
+  truncated: boolean;
+}
+
+const MAX_OUTPUT_TOKENS = 4096; // bound per-page output so a hostile page can't drive unbounded generation
+
+/** Transcribe one page image to Markdown via a local Ollama VLM. Throws on unreachable/HTTP error. */
+export async function transcribePageImage(
+  imageBytes: Buffer,
+  opts: { baseUrl: string; model: string; prompt: string; timeoutMs?: number },
+): Promise<VlmTranscription> {
+  const base = opts.baseUrl.replace(/\/$/, '');
+  const url = `${base}/api/chat`;
+  const b64 = imageBytes.toString('base64');
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: opts.model,
+        stream: false,
+        options: { temperature: 0, num_predict: MAX_OUTPUT_TOKENS },
+        messages: [{ role: 'user', content: opts.prompt, images: [b64] }],
+      }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 60_000),
+    });
+  } catch (err) {
+    throw new Error(`VLM unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`VLM HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const json = await res.json() as { message?: { content?: string }; done_reason?: string; error?: string };
+  if (json.error) throw new Error(`VLM error: ${json.error}`);
+  return { text: json.message?.content ?? '', truncated: json.done_reason === 'length' };
+}

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -1,0 +1,103 @@
+/**
+ * VLM document extractor (F11) — composes the capability pipeline for `vlm`/`auto`/`max` modes.
+ *
+ * Blueprint Path 2, adapted to Markdown output: run OCR (the unstructured sidecar) for both grounding
+ * *evidence* and the fallback floor; render the pages; transcribe each with the VLM; then let the
+ * validator (OCR-evidence coverage) decide whether to accept the VLM output or fall back to OCR — so the
+ * result is never worse than plain OCR. If a capability is missing it degrades: no render/VLM → OCR; OCR
+ * down but VLM up → ungrounded VLM; nothing available → the usual ConversionUnavailableError propagates.
+ *
+ * Repair/consensus (`max`) and the external hosted-VLM path (with ssrfSafeFetch egress) are later phases.
+ */
+import { log } from '../../util/log.js';
+import { getDocumentProcessingConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
+import { UnstructuredConverter, type UnstructuredResult } from './unstructured.js';
+import { renderPdfPages, isRenderAvailable } from './renderer.js';
+import { transcribePageImage } from './vlm-client.js';
+import { decideRoute, validateExtraction } from './extraction-policy.js';
+
+const TRANSCRIBE_PROMPT =
+  'Transcribe this document page to GitHub-Flavored Markdown, verbatim. Preserve headings, lists, and ' +
+  'tables (use Markdown tables; use minimal HTML only if a table is too complex for Markdown). Do NOT ' +
+  'summarize, translate, reorder, or invent content. Output only the transcription — no preamble, no commentary.';
+
+export interface VlmExtractResult extends UnstructuredResult {
+  /** Audit trail of which path produced the result: `ocr`, `ocr+vlm`, `ocr+vlm→ocr`, `vlm`, … */
+  extractionPath: string;
+}
+
+/** Run the configured extraction mode for a document. `mode: 'ocr'` never calls this — the pipeline uses
+ *  the plain OCR converter directly. */
+export async function vlmExtractDocument(fileBytes: Buffer, fileName: string): Promise<VlmExtractResult> {
+  const cfg = getDocumentProcessingConfig();
+  const render = await isRenderAvailable();
+  const route = decideRoute(cfg.mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: false, verify: false });
+
+  // OCR is evidence + fallback. Tolerate it being down IF the VLM path can still run (ungrounded).
+  let ocr: UnstructuredResult | null = null;
+  try {
+    ocr = await new UnstructuredConverter().convertRich(fileBytes, fileName);
+  } catch (err) {
+    if (route.ocrOnly) throw err; // no VLM path to fall through to — surface the OCR error as today
+    log.warn(`VLM extract: OCR evidence unavailable (${err instanceof Error ? err.message : err}) — VLM will run ungrounded`);
+  }
+
+  if (route.ocrOnly) {
+    if (route.fallbackReason) log.info(`VLM extract: ${route.fallbackReason}`);
+    return { ...(ocr as UnstructuredResult), extractionPath: 'ocr' };
+  }
+
+  // ── VLM path ────────────────────────────────────────────────────────────────
+  const baseUrl = cfg.vlmBaseUrl || getMediaEmbeddingConfig().vision?.baseUrl || 'http://ollama:11434';
+  try {
+    const { pages, truncated } = await renderPdfPages(fileBytes, {
+      dpi: cfg.renderDpi,
+      maxPages: cfg.maxPages,
+      timeoutMs: cfg.pageTimeoutMs * Math.min(cfg.maxPages, 20),
+    });
+    if (pages.length === 0) throw new Error('render produced no pages');
+
+    const parts = await mapLimit(pages, cfg.concurrency, async (img) => {
+      const t = await transcribePageImage(img, {
+        baseUrl, model: cfg.vlmModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
+      });
+      return t.text.trim();
+    });
+    let markdown = parts.filter(Boolean).join('\n\n---\n\n').trim();
+    if (truncated) markdown += `\n\n<!-- document truncated to ${pages.length} pages -->`;
+
+    // Validate against OCR evidence when we have it; otherwise just require non-empty output.
+    const evidence = ocr?.markdown ?? '';
+    const v = validateExtraction(markdown, evidence);
+    if (v.ok) {
+      log.debug(`VLM extract: accepted ${route.label} (${pages.length} pages, coverage ${(v.coverage * 100).toFixed(0)}%)`);
+      return { markdown, extractedImages: ocr?.extractedImages ?? [], extractionPath: route.label };
+    }
+
+    if (ocr) {
+      log.info(`VLM extract: validation failed (${v.issues.join('; ')}) — falling back to OCR`);
+      return { ...ocr, extractionPath: `${route.label}→ocr` };
+    }
+    throw new Error(`VLM output rejected and no OCR evidence to fall back to: ${v.issues.join('; ')}`);
+  } catch (err) {
+    if (ocr) {
+      log.warn(`VLM extract failed (${err instanceof Error ? err.message : err}) — falling back to OCR`);
+      return { ...ocr, extractionPath: `${route.label}→ocr` };
+    }
+    throw err; // nothing produced a result — let the pipeline surface the failure as today
+  }
+}
+
+/** Bounded-concurrency map — at most `limit` in flight, preserving order. */
+async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T, i: number) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let idx = 0;
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    while (idx < items.length) {
+      const i = idx++;
+      results[i] = await fn(items[i]!, i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/testing/integration/vlm-extraction.test.js
+++ b/testing/integration/vlm-extraction.test.js
@@ -1,0 +1,55 @@
+/**
+ * Integration: F11 VLM extraction wiring — proves `documentProcessing.mode: 'vlm'` is wired into the
+ * conversion pipeline and degrades gracefully. In CI there is no doc-VLM model and no OCR sidecar, so a
+ * PDF uploaded under `vlm` mode must still be accepted (202, async) and fall back exactly like `ocr`
+ * mode — never a 5xx, never a broken upload.
+ *
+ * Run: node --test testing/integration/vlm-extraction.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, get, patch } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN_FILE_A = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+let tokenA;
+
+async function upload(token, filePath, contentB64) {
+  const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ content: contentB64, encoding: 'base64' }),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+describe('VLM extraction mode wiring (F11)', () => {
+  let originalDp;
+  before(async () => {
+    tokenA = fs.readFileSync(TOKEN_FILE_A, 'utf8').trim();
+    const cur = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    originalDp = cur.body?.documentProcessing;
+  });
+  after(async () => {
+    // Restore OCR mode so this doesn't leak into other suites.
+    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: originalDp ?? { mode: 'ocr' } }).catch(() => {});
+  });
+
+  it('a PDF uploaded under mode:vlm is still accepted (202) and degrades to the async path', async () => {
+    const set = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'vlm' } });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+    assert.equal(set.body?.config?.documentProcessing?.mode, 'vlm');
+
+    const r = await upload(tokenA, `vlm-mode-${Date.now()}.pdf`, Buffer.from('%PDF-1.4 test').toString('base64'));
+    // No VLM/OCR available in CI → the extractor falls back; the upload is still accepted for async
+    // processing (the failure is the worker's problem, exactly as in ocr mode).
+    assert.equal(r.status, 202, `expected 202 (graceful async), got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.ok(r.body?.sha256);
+    assert.equal(r.body?.embeddingStatus, 'pending');
+  });
+});

--- a/testing/standalone/vlm-client.test.js
+++ b/testing/standalone/vlm-client.test.js
@@ -1,0 +1,69 @@
+/**
+ * F11 — VLM client (`files/converters/vlm-client.ts`), tested against a mock Ollama /api/chat server so
+ * no real model is needed. Covers request shaping (image + prompt), response parsing, truncation
+ * detection, and error/unreachable paths.
+ *
+ * Run: node --test testing/standalone/vlm-client.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+const state = { status: 200, body: null, lastRequest: null };
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/chat' && req.method === 'POST') {
+    let raw = '';
+    req.on('data', (c) => (raw += c));
+    req.on('end', () => {
+      try { state.lastRequest = JSON.parse(raw); } catch { state.lastRequest = null; }
+      res.writeHead(state.status, { 'content-type': 'application/json' });
+      res.end(state.body ?? JSON.stringify({ message: { content: '# Page\n\nHello world.' }, done_reason: 'stop' }));
+    });
+    return;
+  }
+  res.writeHead(404); res.end();
+});
+const base = await new Promise((r) => server.listen(0, '127.0.0.1', () => r(`http://127.0.0.1:${server.address().port}`)));
+
+const { transcribePageImage } = await import('../../server/dist/files/converters/vlm-client.js');
+
+describe('VLM client', () => {
+  it('sends the image (base64) + prompt + model to /api/chat and returns the content', async () => {
+    state.status = 200; state.body = null;
+    const r = await transcribePageImage(Buffer.from('PNGDATA'), { baseUrl: base, model: 'doc-vlm', prompt: 'Transcribe.' });
+    assert.equal(r.text, '# Page\n\nHello world.');
+    assert.equal(r.truncated, false);
+    // Verify the request shape the model receives.
+    const req = state.lastRequest;
+    assert.equal(req.model, 'doc-vlm');
+    assert.equal(req.stream, false);
+    assert.equal(req.messages[0].content, 'Transcribe.');
+    assert.equal(req.messages[0].images[0], Buffer.from('PNGDATA').toString('base64'));
+    assert.equal(req.options.temperature, 0);
+    assert.ok(req.options.num_predict > 0, 'output is bounded');
+  });
+
+  it('flags truncation when done_reason is length', async () => {
+    state.body = JSON.stringify({ message: { content: 'partial…' }, done_reason: 'length' });
+    const r = await transcribePageImage(Buffer.from('x'), { baseUrl: base, model: 'm', prompt: 'p' });
+    assert.equal(r.truncated, true);
+    state.body = null;
+  });
+
+  it('throws on an Ollama error payload', async () => {
+    state.body = JSON.stringify({ error: 'model not found' });
+    await assert.rejects(() => transcribePageImage(Buffer.from('x'), { baseUrl: base, model: 'nope', prompt: 'p' }), /VLM error: model not found/);
+    state.body = null;
+  });
+
+  it('throws on a non-200 status', async () => {
+    state.status = 500; state.body = 'boom';
+    await assert.rejects(() => transcribePageImage(Buffer.from('x'), { baseUrl: base, model: 'm', prompt: 'p' }), /VLM HTTP 500/);
+    state.status = 200; state.body = null;
+  });
+
+  it('throws when the endpoint is unreachable', async () => {
+    await new Promise((r) => server.close(r));
+    await assert.rejects(() => transcribePageImage(Buffer.from('x'), { baseUrl: base, model: 'm', prompt: 'p' }), /unreachable/);
+  });
+});


### PR DESCRIPTION
**Stacked on #278** (`feat/f11-render-sidecar`). GitHub retargets this to `main` when #278 merges; review this PR's diff in isolation meanwhile.

## What

The `vlm` / `auto` / `max` extraction modes have been inert config since F11-PR1. This PR wires the **capability extractor** into the PDF/DOCX/EPUB conversion path so those modes actually run.

For a non-`ocr` mode, `vlmExtractDocument`:
1. runs OCR (the unstructured sidecar) for **grounding evidence** + the fallback floor,
2. rasterizes the pages via the `doc-render` sidecar (#278),
3. transcribes each page with a local Ollama vision model (temperature 0, bounded output),
4. lets the **OCR-evidence-coverage validator** (F11-PR1) decide: accept the VLM Markdown, or fall back to OCR.

**The result is never worse than plain OCR.** Every capability is optional and degrades cleanly:
- no render / no `vlmModel` → OCR (today's behaviour),
- OCR sidecar down but VLM up → ungrounded VLM,
- nothing available → the usual "conversion unavailable" surfaces exactly as before.

The default `ocr` mode is **unchanged** — it never calls the new code path.

## Config

- `mediaEmbedding.documentProcessing.vlmModel` (`DOC_VLM_MODEL`) — Ollama vision model; empty ⇒ VLM path unavailable ⇒ stays on OCR.
- `mediaEmbedding.documentProcessing.vlmBaseUrl` (`DOC_VLM_URL`) — endpoint; empty ⇒ media vision `baseUrl` ⇒ `http://ollama:11434`.
- Reuses the existing `renderDpi` / `maxPages` / `pageTimeoutMs` / `concurrency` knobs.

## Files

- `vlm-client.ts` — Ollama `/api/chat` page transcription; throws on unreachable/HTTP error so the extractor can fall back. **5 unit tests** (mock Ollama).
- `vlm-extract.ts` — composes OCR-evidence + render + VLM + validate + fallback; `extractionPath` audit trail.
- `pipeline.ts` — mode gate; surfaces `extractionPath` on `ConversionResult`.
- Integration test — `mode:vlm` PDF upload degrades gracefully (202 async) when no VLM/OCR is available.
- CHANGELOG `[Unreleased]` + integration-guide docs (modes table + render-sidecar note updated from "forthcoming" to live).

## Deferred (next PRs)

- **F11-PR4:** `max`-mode validation-driven **repair** promotion + per-space mode override.
- External **hosted-VLM egress** via `ssrfSafeFetch` (this PR is the bundled, no-egress local path only).
- **F11-PR6:** consensus tier.

## Verification

- `tsc --noEmit` clean; `server` builds clean.
- `testing/standalone/vlm-client.test.js` — 5/5 pass locally.
- Integration test runs in CI against the branch-built 2-instance stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)