### PR TITLE
feat(files): F11 max-mode repair pass — reconcile VLM output against OCR before OCR fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`max`-mode repair pass for VLM extraction (F11).** When a document's VLM transcription fails the
+  OCR-evidence coverage check, `max` mode now runs **one bounded repair pass** before falling back to OCR:
+  a single text-only reconciliation call hands the model its own draft plus the OCR text and asks it to
+  restore any dropped content, then re-validates. Repair can only turn a fallback into an acceptance — it
+  never degrades a result that already passed, and if it errors or still doesn't validate the extractor
+  falls back to OCR exactly as before (still never worse than plain OCR). By default the repair pass reuses
+  the configured `vlmModel`; set `documentProcessing.repairModel` (`DOC_REPAIR_MODEL`, with optional
+  `repairBaseUrl` / `DOC_REPAIR_URL`) to wire in a stronger model you host yourself. Like `vlmModel`, these
+  are env/config-file only — deliberately not settable through the admin API. `vlm` / `auto` modes are
+  unchanged (single pass, no repair). Consensus (`verify`) remains a later phase.
+
 - **VLM document extractor — the pipeline wiring (F11).** The `vlm` / `auto` / `max` modes are now live in
   the conversion pipeline (they were inert config until now). For a PDF/DOCX/EPUB, the extractor runs OCR
   for *evidence*, rasterizes the pages via the render sidecar, transcribes each page with a local Ollama

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1996,9 +1996,11 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 |---|---|---|
 | `strategy` | `"hi_res"` | Unstructured partition strategy. `"hi_res"`: full Tesseract OCR + layout detection — accurate on scanned PDFs, extracts embedded images and structured tables. `"auto"`: sidecar picks the fastest viable strategy. `"fast"`: pdfminer text-layer only — fastest but no OCR, no image extraction. `"ocr_only"`: force OCR on every page regardless of whether a text layer exists. |
 | `extractImages` | `true` | When `true` and `strategy` is `"hi_res"`, embedded images found in document partitions are decoded and saved as `_extracted/{originalId}/image-{N}.{ext}` subfiles. Each is automatically enqueued for the full media pipeline (caption + face recognition). Has no effect when strategy is not `"hi_res"`. |
-| `mode` | `"ocr"` | Extraction path. `"ocr"` (default) is today's unstructured-sidecar OCR — unchanged. `"vlm"` renders each page and transcribes it with a vision model, using OCR as grounding evidence and falling back to OCR if the result doesn't validate (so it is **never worse than OCR**). `"auto"` uses the VLM only when it is configured and available, else OCR. `"max"` adds validation-driven repair + consensus (later PRs; behaves like `"vlm"` until then). |
+| `mode` | `"ocr"` | Extraction path. `"ocr"` (default) is today's unstructured-sidecar OCR — unchanged. `"vlm"` renders each page and transcribes it with a vision model, using OCR as grounding evidence and falling back to OCR if the result doesn't validate (so it is **never worse than OCR**). `"auto"` uses the VLM only when it is configured and available, else OCR. `"max"` adds a validation-driven **repair** pass (below) on top of `"vlm"`; consensus is a later phase. |
 | `vlmModel` | `""` | Ollama vision model used for `vlm` / `auto` / `max` (e.g. a bundled `moondream`, or a larger model you wire in). Empty ⇒ the VLM path is unavailable and extraction stays on OCR. Env override: `DOC_VLM_MODEL`. |
 | `vlmBaseUrl` | `""` | Endpoint for the VLM. Empty ⇒ falls back to the media vision provider's `baseUrl`, then `http://ollama:11434`. Env override: `DOC_VLM_URL`. |
+| `repairModel` | `""` | **`max` mode only.** Model used for the repair pass when a page's VLM output fails OCR-evidence validation — it reconciles the draft against the OCR text in one extra text-only call. Empty ⇒ reuses `vlmModel`. Set this to wire in a stronger model you host. Env override: `DOC_REPAIR_MODEL`. |
+| `repairBaseUrl` | `""` | Endpoint for the repair model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_REPAIR_URL`. |
 | `renderDpi` | `150` | Page rasterization DPI for the render sidecar (VLM modes only). |
 | `maxPages` | `50` | Cap on pages rendered/transcribed per document (VLM modes only). |
 | `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
@@ -2006,6 +2008,13 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 
 The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,
 Ythril transparently uses OCR — no upload fails because a model isn't wired in yet.
+
+**Repair pass (`max` mode).** When a document's VLM transcription fails the OCR-evidence coverage check,
+`max` mode runs one bounded repair pass before falling back to OCR: it sends the draft transcription and the
+OCR text to `repairModel` (or `vlmModel` if unset) in a single text-only call, asks it to restore any dropped
+content, and re-validates. If the repaired output passes it is accepted; if it errors or still doesn't pass,
+the extractor falls back to OCR — so the result is still never worse than plain OCR. Exactly one repair pass
+runs per document (bounded cost); consensus/verification is a later phase.
 
 **Example `config.json` excerpt:**
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -623,6 +623,8 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   concurrency: 2,
   vlmModel: '',    // empty = no VLM configured → vlm/auto/max fall back to OCR
   vlmBaseUrl: '',  // empty = reuse the media vision provider's (Ollama) URL
+  repairModel: '',   // empty = reuse vlmModel for the max-mode repair pass
+  repairBaseUrl: '', // empty = reuse vlmBaseUrl (then the vision URL)
 };
 
 /**
@@ -644,6 +646,8 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     concurrency: base.concurrency ?? d.concurrency,
     vlmModel: process.env['DOC_VLM_MODEL'] ?? base.vlmModel ?? d.vlmModel,
     vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
+    repairModel: process.env['DOC_REPAIR_MODEL'] ?? base.repairModel ?? d.repairModel,
+    repairBaseUrl: process.env['DOC_REPAIR_URL'] ?? base.repairBaseUrl ?? d.repairBaseUrl,
   };
 }
 

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -377,6 +377,18 @@ export interface DocumentProcessingConfig {
    * (the bundled local path, no egress). Env: `DOC_VLM_URL`.
    */
   vlmBaseUrl?: string;
+  /**
+   * F11 — optional heavyweight "review/repair" model tag used **only in `max` mode** when a page's VLM
+   * output fails OCR-evidence validation: it reconciles the draft against the OCR text in one extra pass.
+   * Empty (default) reuses `vlmModel` for the repair pass (self-contained). Set this to wire in a stronger
+   * model you host yourself. Env: `DOC_REPAIR_MODEL`.
+   */
+  repairModel?: string;
+  /**
+   * F11 — base URL for the repair model. Empty (default) reuses `vlmBaseUrl` (then the vision URL).
+   * Env: `DOC_REPAIR_URL`.
+   */
+  repairBaseUrl?: string;
 }
 
 /** F11 — document-extraction mode: OCR-only (default) vs the VLM precision pipeline. */

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -16,38 +16,70 @@ export interface VlmTranscription {
 
 const MAX_OUTPUT_TOKENS = 4096; // bound per-page output so a hostile page can't drive unbounded generation
 
-/** Transcribe one page image to Markdown via a local Ollama VLM. Throws on unreachable/HTTP error. */
-export async function transcribePageImage(
-  imageBytes: Buffer,
-  opts: { baseUrl: string; model: string; prompt: string; timeoutMs?: number },
+/** POST one non-streamed chat turn to Ollama `/api/chat` (temperature 0, bounded output). Throws on
+ *  unreachable / HTTP error / model error so the caller can fall back. Shared by transcription + repair. */
+async function postChat(
+  baseUrl: string,
+  model: string,
+  messages: Array<Record<string, unknown>>,
+  timeoutMs: number,
 ): Promise<VlmTranscription> {
-  const base = opts.baseUrl.replace(/\/$/, '');
-  const url = `${base}/api/chat`;
-  const b64 = imageBytes.toString('base64');
-
+  const url = `${baseUrl.replace(/\/$/, '')}/api/chat`;
   let res: Response;
   try {
     res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: opts.model,
+        model,
         stream: false,
         options: { temperature: 0, num_predict: MAX_OUTPUT_TOKENS },
-        messages: [{ role: 'user', content: opts.prompt, images: [b64] }],
+        messages,
       }),
-      signal: AbortSignal.timeout(opts.timeoutMs ?? 60_000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err) {
     throw new Error(`VLM unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
   }
-
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     throw new Error(`VLM HTTP ${res.status}: ${body.slice(0, 200)}`);
   }
-
   const json = await res.json() as { message?: { content?: string }; done_reason?: string; error?: string };
   if (json.error) throw new Error(`VLM error: ${json.error}`);
   return { text: json.message?.content ?? '', truncated: json.done_reason === 'length' };
+}
+
+/** Transcribe one page image to Markdown via a local Ollama VLM. Throws on unreachable/HTTP error. */
+export async function transcribePageImage(
+  imageBytes: Buffer,
+  opts: { baseUrl: string; model: string; prompt: string; timeoutMs?: number },
+): Promise<VlmTranscription> {
+  const b64 = imageBytes.toString('base64');
+  return postChat(
+    opts.baseUrl, opts.model,
+    [{ role: 'user', content: opts.prompt, images: [b64] }],
+    opts.timeoutMs ?? 60_000,
+  );
+}
+
+const REPAIR_PROMPT =
+  'You are correcting a Markdown transcription of a document page. You are given the DRAFT transcription ' +
+  'and the OCR TEXT of the same page. The draft may have dropped or garbled content that the OCR captured. ' +
+  'Produce a corrected GitHub-Flavored Markdown that keeps the draft\'s structure and formatting but ' +
+  'restores any content present in the OCR that the draft is missing. Do NOT summarize, translate, ' +
+  'reorder, or invent content, and do not add commentary. Output only the corrected Markdown.';
+
+/** Reconcile a draft VLM transcription against the OCR evidence in one text-only pass (max-mode repair).
+ *  Throws on unreachable/HTTP error so the caller can fall back to OCR. */
+export async function repairMarkdown(
+  opts: { baseUrl: string; model: string; draft: string; evidence: string; issues?: string[]; timeoutMs?: number },
+): Promise<VlmTranscription> {
+  const issues = opts.issues?.length ? `\n\nValidation flagged: ${opts.issues.join('; ')}.` : '';
+  const content = `${REPAIR_PROMPT}${issues}\n\n--- DRAFT ---\n${opts.draft}\n\n--- OCR TEXT ---\n${opts.evidence}`;
+  return postChat(
+    opts.baseUrl, opts.model,
+    [{ role: 'user', content }], // text-only — no page image
+    opts.timeoutMs ?? 60_000,
+  );
 }

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -7,13 +7,16 @@
  * result is never worse than plain OCR. If a capability is missing it degrades: no render/VLM → OCR; OCR
  * down but VLM up → ungrounded VLM; nothing available → the usual ConversionUnavailableError propagates.
  *
- * Repair/consensus (`max`) and the external hosted-VLM path (with ssrfSafeFetch egress) are later phases.
+ * `max` mode adds one bounded **repair** pass: when the VLM output fails OCR-evidence validation, a single
+ * text-only reconciliation call (reusing the VLM, or a wired-in `repairModel`) tries to restore the dropped
+ * content before falling back to OCR. Consensus (`verify`) and the external hosted-VLM egress path
+ * (with ssrfSafeFetch) are later phases.
  */
 import { log } from '../../util/log.js';
 import { getDocumentProcessingConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
 import { UnstructuredConverter, type UnstructuredResult } from './unstructured.js';
 import { renderPdfPages, isRenderAvailable } from './renderer.js';
-import { transcribePageImage } from './vlm-client.js';
+import { transcribePageImage, repairMarkdown } from './vlm-client.js';
 import { decideRoute, validateExtraction } from './extraction-policy.js';
 
 const TRANSCRIBE_PROMPT =
@@ -31,7 +34,9 @@ export interface VlmExtractResult extends UnstructuredResult {
 export async function vlmExtractDocument(fileBytes: Buffer, fileName: string): Promise<VlmExtractResult> {
   const cfg = getDocumentProcessingConfig();
   const render = await isRenderAvailable();
-  const route = decideRoute(cfg.mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: false, verify: false });
+  // `repair` reuses the VLM (or a wired-in repairModel), so it's available whenever the VLM is; decideRoute
+  // only actually schedules the repair stage for `max` mode.
+  const route = decideRoute(cfg.mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: !!cfg.vlmModel, verify: false });
 
   // OCR is evidence + fallback. Tolerate it being down IF the VLM path can still run (ungrounded).
   let ocr: UnstructuredResult | null = null;
@@ -68,15 +73,40 @@ export async function vlmExtractDocument(fileBytes: Buffer, fileName: string): P
 
     // Validate against OCR evidence when we have it; otherwise just require non-empty output.
     const evidence = ocr?.markdown ?? '';
+    const ranLabel = ocr ? 'ocr+vlm' : 'vlm';   // audit label for what the VLM path actually produced
     const v = validateExtraction(markdown, evidence);
     if (v.ok) {
-      log.debug(`VLM extract: accepted ${route.label} (${pages.length} pages, coverage ${(v.coverage * 100).toFixed(0)}%)`);
-      return { markdown, extractedImages: ocr?.extractedImages ?? [], extractionPath: route.label };
+      log.debug(`VLM extract: accepted ${ranLabel} (${pages.length} pages, coverage ${(v.coverage * 100).toFixed(0)}%)`);
+      return { markdown, extractedImages: ocr?.extractedImages ?? [], extractionPath: ranLabel };
+    }
+
+    // ── max-mode repair: ONE bounded reconciliation pass against the OCR evidence before giving up ──
+    // Only for `max` (route has the repair stage) and only when we have OCR evidence to reconcile against.
+    // Repair can only turn a fallback into an acceptance — it never degrades a result that already passed.
+    if (route.stages.includes('repair') && ocr && evidence.trim()) {
+      const repairModel = cfg.repairModel || cfg.vlmModel;
+      const repairBase = cfg.repairBaseUrl || baseUrl;
+      try {
+        log.info(`VLM extract: validation failed (${v.issues.join('; ')}) — repairing with ${repairModel}`);
+        const r = await repairMarkdown({
+          baseUrl: repairBase, model: repairModel, draft: markdown, evidence, issues: v.issues,
+          timeoutMs: cfg.pageTimeoutMs,
+        });
+        const repaired = r.text.trim();
+        const rv = validateExtraction(repaired, evidence, { finishReason: r.truncated ? 'length' : undefined });
+        if (rv.ok) {
+          log.debug(`VLM extract: accepted ${ranLabel}+repair (coverage ${(rv.coverage * 100).toFixed(0)}%)`);
+          return { markdown: repaired, extractedImages: ocr.extractedImages ?? [], extractionPath: `${ranLabel}+repair` };
+        }
+        log.info(`VLM extract: repair still below threshold (${rv.issues.join('; ')}) — falling back to OCR`);
+      } catch (err) {
+        log.warn(`VLM extract: repair errored (${err instanceof Error ? err.message : err}) — falling back to OCR`);
+      }
     }
 
     if (ocr) {
-      log.info(`VLM extract: validation failed (${v.issues.join('; ')}) — falling back to OCR`);
-      return { ...ocr, extractionPath: `${route.label}→ocr` };
+      if (!route.stages.includes('repair')) log.info(`VLM extract: validation failed (${v.issues.join('; ')}) — falling back to OCR`);
+      return { ...ocr, extractionPath: `${ranLabel}→ocr` };
     }
     throw new Error(`VLM output rejected and no OCR evidence to fall back to: ${v.issues.join('; ')}`);
   } catch (err) {

--- a/testing/integration/vlm-extraction.test.js
+++ b/testing/integration/vlm-extraction.test.js
@@ -52,4 +52,17 @@ describe('VLM extraction mode wiring (F11)', () => {
     assert.ok(r.body?.sha256);
     assert.equal(r.body?.embeddingStatus, 'pending');
   });
+
+  it('a PDF uploaded under mode:max (repair tier) also degrades gracefully (202)', async () => {
+    // `max` adds the repair pass on top of `vlm`. With no VLM/render/OCR sidecar in CI the route still
+    // collapses to OCR — the repair tier must never make an upload fail where `vlm`/`ocr` would succeed.
+    const set = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'max' } });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+    assert.equal(set.body?.config?.documentProcessing?.mode, 'max');
+
+    const r = await upload(tokenA, `max-mode-${Date.now()}.pdf`, Buffer.from('%PDF-1.4 test').toString('base64'));
+    assert.equal(r.status, 202, `expected 202 (graceful async), got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.ok(r.body?.sha256);
+    assert.equal(r.body?.embeddingStatus, 'pending');
+  });
 });

--- a/testing/standalone/vlm-client.test.js
+++ b/testing/standalone/vlm-client.test.js
@@ -25,7 +25,7 @@ const server = http.createServer((req, res) => {
 });
 const base = await new Promise((r) => server.listen(0, '127.0.0.1', () => r(`http://127.0.0.1:${server.address().port}`)));
 
-const { transcribePageImage } = await import('../../server/dist/files/converters/vlm-client.js');
+const { transcribePageImage, repairMarkdown } = await import('../../server/dist/files/converters/vlm-client.js');
 
 describe('VLM client', () => {
   it('sends the image (base64) + prompt + model to /api/chat and returns the content', async () => {
@@ -41,6 +41,27 @@ describe('VLM client', () => {
     assert.equal(req.messages[0].images[0], Buffer.from('PNGDATA').toString('base64'));
     assert.equal(req.options.temperature, 0);
     assert.ok(req.options.num_predict > 0, 'output is bounded');
+  });
+
+  it('repairMarkdown reconciles a draft against OCR evidence in one text-only call', async () => {
+    state.status = 200;
+    state.body = JSON.stringify({ message: { content: '# Fixed\n\nfull content' }, done_reason: 'stop' });
+    const r = await repairMarkdown({
+      baseUrl: base, model: 'repair-model',
+      draft: '# Draft', evidence: 'the full OCR text', issues: ['low OCR-evidence coverage 40%'],
+    });
+    assert.equal(r.text, '# Fixed\n\nfull content');
+    assert.equal(r.truncated, false);
+    const req = state.lastRequest;
+    assert.equal(req.model, 'repair-model');
+    assert.equal(req.stream, false);
+    assert.equal(req.options.temperature, 0);
+    // Text-only: no page image, and the prompt carries both the draft and the OCR evidence + the issues.
+    assert.equal(req.messages[0].images, undefined, 'repair is a text-only turn (no image)');
+    assert.match(req.messages[0].content, /# Draft/);
+    assert.match(req.messages[0].content, /the full OCR text/);
+    assert.match(req.messages[0].content, /low OCR-evidence coverage 40%/);
+    state.body = null;
   });
 
   it('flags truncation when done_reason is length', async () => {


### PR DESCRIPTION
Fourth F11 PR (follows #280, merged). Implements the **validation-driven repair** tier the earlier PRs deferred.

## What
`max` mode now runs **one bounded repair pass** when a document's VLM transcription fails the OCR-evidence coverage check, before falling back to OCR:

1. VLM transcribes the pages → draft Markdown.
2. `validateExtraction(draft, ocrEvidence)` fails (low coverage / truncation).
3. **Repair:** a single **text-only** `/api/chat` call hands the model its own draft + the OCR text + the specific validation issues, asking it to restore dropped content (no summarizing/inventing).
4. Re-validate. Pass → accept (`extractionPath: ocr+vlm+repair`). Still failing / errored → OCR fallback, exactly as before.

**Invariant preserved:** repair can only turn a fallback into an acceptance — it never degrades a result that already passed, and the floor is still plain OCR (never worse).

## Bounded by design
- **Exactly one** repair pass per document (not per page) — a 50-page doc can't fan out into 50 repair calls.
- Text-only (no image), temperature 0, `num_predict`-bounded output. If a large doc's repair truncates, re-validation catches it → OCR fallback.
- Runs only when the route includes repair (`max` + VLM available) **and** OCR evidence exists to reconcile against.

## Config (wire-in your own repair model)
- `documentProcessing.repairModel` (`DOC_REPAIR_MODEL`) — defaults to reusing `vlmModel`; set it to point the repair pass at a stronger model you host.
- `documentProcessing.repairBaseUrl` (`DOC_REPAIR_URL`) — defaults to `vlmBaseUrl`.
- **Env/config-file only — deliberately NOT in the `media-config` PATCH schema**, same posture as `vlmModel`: these are egress targets and must not be settable through the admin API (consistent with the SSRF guidance from the recent audit).

## Files
- `config/types.ts` + `loader.ts` — `repairModel` / `repairBaseUrl`.
- `vlm-client.ts` — extracted a shared `postChat()` helper; added `repairMarkdown()` (text-only turn).
- `vlm-extract.ts` — repair stage between validation-fail and OCR-fallback; `extractionPath` audit trail (`ocr+vlm+repair`, `ocr+vlm+repair→ocr`).
- Tests: `repairMarkdown` request-shape unit test; integration test that `mode:max` degrades gracefully (202) with no VLM/OCR in CI. `decideRoute` already had repair-route coverage.
- CHANGELOG `[Unreleased]` + integration-guide (repair rows + explanation).

## Verification
- `tsc --noEmit` clean.
- `vlm-client` + `extraction-policy` standalone = **24/24** green.
- `vlm`/`auto` modes untouched; default `ocr` path never enters this code.

## Deferred
- Consensus (`verify`) tier → F11-PR6.
- Per-space mode override → needs space-settings infra (with F11-PR5 Models UI).
- External hosted-VLM egress via `ssrfSafeFetch` → later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)