### PR TITLE
fix(docker): pin base images to digests + privilege-escalation lockdown on parser sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Docker hardening: pinned base images + privilege-escalation lockdown on the parser sidecars.** The
+  floating `:latest` base images (`ollama`, `faster-whisper-server`, `mongodb-atlas-local`, and `node:22-slim`
+  in the app `Dockerfile`) are now pinned to explicit multi-arch manifest **digests**, so a re-pull can't
+  silently substitute a different image (supply-chain reproducibility; the already-pinned
+  `unstructured:0.1.2` and first-party images are unchanged). The untrusted-input parser sidecars
+  (`unstructured`, `ollama`, `whisper`) gain `security_opt: no-new-privileges:true`, and the `doc-render`
+  sidecar gains `cpus` / `pids_limit` ceilings (bounding a malformed-PDF CPU-spin or fork attempt) on top of
+  its existing non-root / `read_only` / `cap_drop: ALL` / memory cap. (Memory/PID/cap-drop/read-only limits
+  for the heavier model servers need live-stack sizing so a cap doesn't OOM inference — tracked as a
+  follow-up.) Also corrected a stale `doc-render` comment that described it as a PyMuPDF service — it is
+  PDFium (pypdfium2), deliberately not AGPL PyMuPDF.
+
 - **Closed SSRF gaps in the schema-catalog proxy and network control-plane calls.** Several outbound
   requests used a bare `fetch()` and relied only on a create-time URL string check (`isSsrfSafeUrl`),
   which does not resolve DNS and does not re-validate redirect targets — so a catalog/peer host could

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ﻿# syntax=docker/dockerfile:1
 # ── Stage 1: Build Angular SPA ───────────────────────────────────────────────
-FROM node:22-slim AS client-builder
+FROM node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS client-builder
 
 WORKDIR /build
 
@@ -17,7 +17,7 @@ RUN npm run build:prod --workspace=client
 # Angular output: client/dist/browser/
 
 # ── Stage 2: Build server ────────────────────────────────────────────────────
-FROM node:22-slim AS builder
+FROM node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS builder
 
 # Build tools required for bcrypt native C++ addon
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ && rm -rf /var/lib/apt/lists/*
@@ -39,7 +39,7 @@ COPY server/ ./server/
 RUN npm run build --workspace=server
 
 # ── Stage 2: Production ──────────────────────────────────────────────────────
-FROM node:22-slim AS production
+FROM node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS production
 
 LABEL org.opencontainers.image.source="https://github.com/ythril-network/Ythril"
 LABEL org.opencontainers.image.description="Ythril — self-hosted brain & knowledge management platform"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,10 @@
       - ythril-convert   # document-conversion sidecar (isolated: no DB, no internet)
 
   ythril-mongo:
-    # mongodb/mongodb-atlas-local includes mongot — required for $vectorSearch
-    image: mongodb/mongodb-atlas-local:latest
+    # mongodb/mongodb-atlas-local includes mongot — required for $vectorSearch.
+    # Pinned to the current manifest-list digest. Refresh:
+    #   docker buildx imagetools inspect mongodb/mongodb-atlas-local:latest
+    image: mongodb/mongodb-atlas-local:latest@sha256:1cd040bb201bb7f910c7c6ab7f6cb8ab9dd79331f6a213f37025adc6804e96aa
     container_name: ythril-mongo
     # Pin hostname so the replica-set config remains valid across container restarts.
     # Without this, each `docker compose down && up` gets a new random hostname,
@@ -104,9 +106,15 @@
   #      `docker compose up --scale ollama=0 --scale whisper=0` thereafter,
   #      or assigning a non-default profile in docker-compose.override.yml.
   ollama:
-    image: ollama/ollama:latest
+    # Pinned to the current multi-arch manifest-list digest (reproducible; a re-pull can't silently
+    # substitute a different image). Refresh: docker buildx imagetools inspect ollama/ollama:latest.
+    image: ollama/ollama:latest@sha256:6345fbc18bd73a1e16404be681dbc6fd291a027cab43ed541abe78c4c81051b0
     container_name: ythril-ollama
     restart: unless-stopped
+    # Parses untrusted user media — block privilege escalation. (Memory/pid/cap limits for the heavy
+    # model servers are tracked separately: they need live-stack sizing so a cap doesn't OOM inference.)
+    security_opt:
+      - no-new-privileges:true
     # Auto-pull the default vision model on first start so the first upload
     # does not fail with "model not found". Subsequent restarts no-op.
     entrypoint: ["/bin/sh", "-c"]
@@ -131,9 +139,14 @@
       - ythril-media     # deliberately NOT on ythril-db
 
   whisper:
-    image: fedirz/faster-whisper-server:latest-cpu
+    # Pinned to the current multi-arch manifest-list digest. Refresh:
+    #   docker buildx imagetools inspect fedirz/faster-whisper-server:latest-cpu
+    image: fedirz/faster-whisper-server:latest-cpu@sha256:760e5e43d427dc6cfbbc4731934b908b7de9c7e6d5309c6a1f0c8c923a5b6030
     container_name: ythril-whisper
     restart: unless-stopped
+    # Parses untrusted user media — block privilege escalation (see the ollama note re: heavier limits).
+    security_opt:
+      - no-new-privileges:true
     environment:
       WHISPER_MODEL: "base"  # ~140 MB; auto-downloads on first request
     volumes:
@@ -177,6 +190,9 @@
     image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2
     container_name: ythril-unstructured
     restart: unless-stopped
+    # Parses untrusted user documents (OCR) — block privilege escalation (see the ollama note re: heavier limits).
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       # The image is a Python/uvicorn service; probe /healthcheck with the bundled
       # interpreter rather than assuming curl/wget is present.
@@ -189,7 +205,8 @@
       - ythril-convert   # isolated: no DB, no internet
 
   # ── Page-render sidecar (PDF → page PNGs) for the F11 VLM extraction path ──────
-  # A tiny PyMuPDF service. Like `unstructured`, it parses UNTRUSTED user documents, so it sits on the
+  # A tiny PDFium (pypdfium2) service — Apache-2.0/BSD, deliberately NOT AGPL PyMuPDF. Like `unstructured`,
+  # it parses UNTRUSTED user documents, so it sits on the
   # same isolated internal `ythril-convert` network — no database access and no internet egress — and
   # runs non-root (see sidecars/doc-render/Dockerfile). Only used when documentProcessing.mode is
   # vlm/auto/max; NOT a startup dependency (VLM extraction degrades to OCR when it is absent). It is
@@ -206,6 +223,10 @@
     cap_drop:
       - ALL
     mem_limit: 1g
+    # This is our own tiny single-process (uvicorn --workers 1) service, so CPU/PID ceilings are safe to
+    # set here — they bound a malformed-PDF CPU-spin or a fork attempt without risking normal operation.
+    cpus: "1.0"
+    pids_limit: 128
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:8100/health',timeout=3).read() or sys.exit(1)"]
       interval: 30s

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -65,7 +65,7 @@ services:
       - ythril-test
 
   ythril-mongo-a:
-    image: mongodb/mongodb-atlas-local:latest
+    image: mongodb/mongodb-atlas-local:latest@sha256:1cd040bb201bb7f910c7c6ab7f6cb8ab9dd79331f6a213f37025adc6804e96aa
     container_name: ythril-mongo-a
     volumes:
       - ythril-mongo-a-data:/data/db
@@ -119,7 +119,7 @@ services:
       - ythril-test
 
   ythril-mongo-b:
-    image: mongodb/mongodb-atlas-local:latest
+    image: mongodb/mongodb-atlas-local:latest@sha256:1cd040bb201bb7f910c7c6ab7f6cb8ab9dd79331f6a213f37025adc6804e96aa
     container_name: ythril-mongo-b
     volumes:
       - ythril-mongo-b-data:/data/db
@@ -170,7 +170,7 @@ services:
       - ythril-test
 
   ythril-mongo-c:
-    image: mongodb/mongodb-atlas-local:latest
+    image: mongodb/mongodb-atlas-local:latest@sha256:1cd040bb201bb7f910c7c6ab7f6cb8ab9dd79331f6a213f37025adc6804e96aa
     container_name: ythril-mongo-c
     volumes:
       - ythril-mongo-c-data:/data/db
@@ -228,7 +228,7 @@ services:
       - ythril-test
 
   ythril-mongo-d:
-    image: mongodb/mongodb-atlas-local:latest
+    image: mongodb/mongodb-atlas-local:latest@sha256:1cd040bb201bb7f910c7c6ab7f6cb8ab9dd79331f6a213f37025adc6804e96aa
     container_name: ythril-mongo-d
     volumes:
       - ythril-mongo-d-data:/data/db


### PR DESCRIPTION
Whole-repo security audit follow-up (findings F3–F5). Scoped to **Tier A — changes that cannot break a running service**; the thread/memory-sensitive limits are deferred to a validated follow-up (see below) so this can't redden CI.

## Changes
**Pin floating `:latest` base images to multi-arch manifest digests** (supply-chain reproducibility — a re-pull can't silently swap the image):
- `ollama/ollama`, `fedirz/faster-whisper-server:latest-cpu`, `mongodb/mongodb-atlas-local` (main **and** test compose), and `node:22-slim` in the app `Dockerfile`.
- Left as-is: first-party `ghcr.io/ythril-network/ythril` (release pipeline) and the already-pinned `unstructured:0.1.2` / `ythril-doc-render:0.1.0`.
- Every pinned digest verified resolvable with `docker buildx imagetools inspect` (same check the Image Pin Check job runs).

**Privilege-escalation lockdown on the untrusted-input parser sidecars** — `security_opt: no-new-privileges:true` on `unstructured`, `ollama`, `whisper`. Blocks setuid escalation; never breaks a normal HTTP service.

**`doc-render` resource ceilings** — `cpus: "1.0"` + `pids_limit: 128` on top of its existing non-root / `read_only` / `cap_drop: ALL` / `mem_limit: 1g`. Safe because it's our own single-process (`uvicorn --workers 1`) service; bounds a malformed-PDF CPU-spin or fork attempt.

**Doc fix** — corrected a stale comment calling `doc-render` a PyMuPDF service. It's PDFium (pypdfium2), deliberately **not** AGPL PyMuPDF (the whole reason F11 chose it).

## Deferred (Tier B — tracked in SECURITY-TODO.md)
`cap_drop: ALL` / `read_only` (+`tmpfs:[/tmp]`) / `mem_limit` / `pids_limit` / `cpus` on the heavy model servers (`ollama`/`whisper`/`unstructured`). **Why not here:** `pids_limit` counts *threads* (inference spawns many) and a mis-sized `mem_limit` OOM-kills inference — these need the stack brought up and each service confirmed healthy before merging, so they get their own locally-validated PR rather than risking a red CI.

## Verification
- Both `docker-compose.yml` and `testing/docker-compose.test.yml` pass `docker compose config -q`.
- All four pinned digests resolve via `imagetools inspect` (Image Pin Check parity).
- No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)