### PR TITLE
fix(settings): correctness bugs from the settings UX audit (PR-U0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Settings: unsaved duplicate-detection rules no longer vanish silently.** In a space's settings dialog,
+  the Duplicates tab is saved by its own button, but its edits were excluded from the dialog's
+  unsaved-changes tracking — so editing dupe rules and then switching tabs or closing discarded them with no
+  warning. The dirty check now tracks the duplicates form too (re-baselined after its own save), so the
+  close/leave guard warns as it does for every other tab.
+- **Settings → Storage: an empty result is no longer shown as a load error, and a stale "storage full"
+  alert can't appear.** A successful response with no storage data rendered the red "could not load" error
+  (now a neutral "nothing to report" state), and the usage percentage was a mutable field that could render
+  a false over-limit alert against absent data — it's now derived directly from the loaded data.
+
 - **Test isolation: the bulk-memory-wipe tests no longer wipe the shared `general` space.**
   `brain.test.js`'s wipe block used `WIPE_SPACE = 'general'` and issued a `confirm:true` bulk delete —
   deleting **every** memory in the shared `general` space, other tests' data included. Serial ordering

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -725,6 +725,7 @@
   "metrics.title": "Metriken",
   "metrics.refreshButton": "Aktualisieren",
   "metrics.error.load": "Speicherdaten konnten nicht geladen werden. Stellen Sie sicher, dass der Server erreichbar ist.",
+  "metrics.empty": "Noch keine Speichernutzung vorhanden.",
   "metrics.stat.totalUsed": "Insgesamt verwendet",
   "metrics.stat.brain": "Gehirn (MongoDB)",
   "metrics.stat.files": "Dateien",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -724,6 +724,7 @@
   "metrics.title": "Metrics",
   "metrics.refreshButton": "Refresh",
   "metrics.error.load": "Could not load storage data. Ensure the server is reachable.",
+  "metrics.empty": "No storage usage to report yet.",
   "metrics.stat.totalUsed": "Total used",
   "metrics.stat.brain": "Brain (MongoDB)",
   "metrics.stat.files": "Files",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -725,6 +725,7 @@
   "metrics.title": "Metryka",
   "metrics.refreshButton": "Odświeżać",
   "metrics.error.load": "Nie udało się wczytać danych pamięci. Upewnij się, że serwer jest osiągalny.",
+  "metrics.empty": "Brak danych o użyciu pamięci.",
   "metrics.stat.totalUsed": "Łącznie wykorzystano",
   "metrics.stat.brain": "Mózg (MongoDB)",
   "metrics.stat.files": "Akta",

--- a/client/src/app/pages/settings/space-duplicates-tab.component.ts
+++ b/client/src/app/pages/settings/space-duplicates-tab.component.ts
@@ -137,6 +137,8 @@ export class SpaceDuplicatesTabComponent {
         // Reflect saved state back onto the space object.
         this.state.settingsSpace.set(space);
         this.store.spaces.update(list => list.map(x => x.id === space.id ? space : x));
+        // Re-baseline the dupe dirty snapshot so the close guard doesn't flag freshly-saved rules.
+        this.state.markDupePristine();
       },
       error: (e) => { this.state.dupeSaving.set(false); this.state.dupeError.set(e?.error?.error || this.transloco.translate('spaces.dupe.saveError')); },
     });

--- a/client/src/app/pages/settings/space-schema-tab.component.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.ts
@@ -742,29 +742,6 @@ export class SpaceSchemaTabComponent {
     this._libPickerTarget = null;
   }
 
-  /** Import the library entry's schema as an inline TypeSchemaState (merges into current). */
-  importFromLibraryInline(entry: SchemaLibraryEntry): void {
-    const target = this._libPickerTarget;
-    if (!target) return;
-    const typeName = target.name || entry.typeName;
-    if (!typeName) return;
-    const s = entry.schema;
-    const imported: TypeSchemaState = {
-      namingPattern:   s.namingPattern ?? '',
-      tagSuggestions:  [...(s.tagSuggestions ?? [])],
-      propertySchemas: Object.entries(s.propertySchemas ?? {}).map(([k, v]) => ({
-        key: k, s: { ...v }, _enumInput: '',
-      })),
-      _newPropInput: '',
-      _newTagInput:  '',
-    };
-    this.state.schTypeSchemas = {
-      ...this.state.schTypeSchemas,
-      [target.kt]: { ...(this.state.schTypeSchemas[target.kt] ?? {}), [typeName]: imported },
-    };
-    this.closeLibPicker();
-  }
-
   /** Set the space's type to use a $ref pointing at this library entry. */
   importFromLibraryRef(entry: SchemaLibraryEntry): void {
     const target = this._libPickerTarget;

--- a/client/src/app/pages/settings/space-settings-state.service.ts
+++ b/client/src/app/pages/settings/space-settings-state.service.ts
@@ -169,12 +169,14 @@ export class SpaceSettingsState {
 
   // ── unsaved-changes tracking (U4) ────────────────────────────────────────────
   private initialSnapshot = '';
+  private dupeInitialSnapshot = '';
 
   /**
-   * Serializes exactly what a save persists — label + maxGiB + `buildMeta()` — so it ignores
-   * transient input buffers and UI state (the active tab, expanded rows, half-typed new-property
-   * inputs) automatically. The duplicates tab has its own save/saved affordance and is intentionally
-   * excluded.
+   * Serializes exactly what the footer save persists — label + maxGiB + recordTtlDays + `buildMeta()` —
+   * so it ignores transient input buffers and UI state (the active tab, expanded rows, half-typed
+   * new-property inputs) automatically. The duplicates tab persists through its OWN save button, so its
+   * edits are snapshotted separately by `dupeSnapshot()` — but BOTH feed `isDirty()`, so unsaved dupe
+   * edits still trip the close guard (previously they were silently dropped with no warning).
    */
   snapshot(): string {
     return JSON.stringify({
@@ -185,12 +187,28 @@ export class SpaceSettingsState {
     });
   }
 
-  /** Re-baseline the dirty snapshot — called after opening a space (and safe to call after a save). */
-  markPristine(): void { this.initialSnapshot = this.snapshot(); }
+  /** Serializes the duplicates-tab form. Baselined independently because that tab has its own save. */
+  dupeSnapshot(): string {
+    return JSON.stringify({
+      rules: this.dupeRulesState,
+      survivor: this.dupeSurvivor,
+      onInsert: this.dupeOnInsert,
+    });
+  }
 
-  /** True when the settings/schema editor has unsaved edits that a save would persist. */
+  /** Re-baseline both dirty snapshots — called after opening a space. */
+  markPristine(): void {
+    this.initialSnapshot = this.snapshot();
+    this.dupeInitialSnapshot = this.dupeSnapshot();
+  }
+
+  /** Re-baseline ONLY the duplicates snapshot — called after the duplicates tab's own successful save. */
+  markDupePristine(): void { this.dupeInitialSnapshot = this.dupeSnapshot(); }
+
+  /** True when the settings/schema editor OR the duplicates tab has unsaved edits. */
   isDirty(): boolean {
-    return this.settingsSpace() !== null && this.snapshot() !== this.initialSnapshot;
+    if (this.settingsSpace() === null) return false;
+    return this.snapshot() !== this.initialSnapshot || this.dupeSnapshot() !== this.dupeInitialSnapshot;
   }
 
   /** Build the meta payload sent on save. Reads the settings tab AND the schema tab. */

--- a/client/src/app/pages/settings/space-settings-state.unsaved.spec.ts
+++ b/client/src/app/pages/settings/space-settings-state.unsaved.spec.ts
@@ -2,9 +2,10 @@
  * U4 — unsaved-changes tracking in SpaceSettingsState.
  *
  * `isDirty()` drives the guard on all three editor exits (modal close, route leave, reload). It must
- * baseline clean on open, flip on any persisted edit (settings + schema), ignore transient/UI-only
- * state, and re-baseline on markPristine — otherwise the guard either nags on a pristine dialog or
- * lets real edits vanish silently.
+ * baseline clean on open, flip on any persisted edit (settings + schema + duplicates), ignore
+ * transient/UI-only state, and re-baseline on markPristine — otherwise the guard either nags on a
+ * pristine dialog or lets real edits vanish silently. The duplicates tab has its OWN save button, so
+ * it's snapshotted separately (`dupeSnapshot`/`markDupePristine`) but still feeds `isDirty()`.
  */
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -78,6 +79,31 @@ describe('SpaceSettingsState — unsaved-changes (U4)', () => {
     state.openSettings(space());
     state.stForm.purpose = 'edited';
     state.closeSettings();
+    expect(state.isDirty()).toBe(false);
+  });
+
+  // ── duplicates tab (previously untracked → silent data loss on tab-switch/close) ──
+  it('goes dirty when a duplicate rule is added', () => {
+    state.openSettings(space());
+    state.addDupeRule();
+    expect(state.isDirty()).toBe(true);
+  });
+
+  it('goes dirty when the duplicate survivor policy or on-insert flag changes', () => {
+    state.openSettings(space());
+    state.dupeSurvivor = 'newer';
+    expect(state.isDirty()).toBe(true);
+    state.dupeSurvivor = 'older';
+    expect(state.isDirty()).toBe(false);
+    state.dupeOnInsert = true;
+    expect(state.isDirty()).toBe(true);
+  });
+
+  it('markDupePristine re-baselines the duplicates snapshot after its own save', () => {
+    state.openSettings(space());
+    state.addDupeRule();
+    expect(state.isDirty()).toBe(true);
+    state.markDupePristine();          // what saveDupeRules() calls on success
     expect(state.isDirty()).toBe(false);
   });
 });

--- a/client/src/app/pages/settings/storage.component.ts
+++ b/client/src/app/pages/settings/storage.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -51,9 +51,12 @@ interface StorageData {
 
     @if (loading()) {
       <div class="loading-overlay"><span class="spinner"></span></div>
-    } @else if (!data()) {
+    } @else if (error()) {
       <div class="alert alert-error">{{ 'metrics.error.load' | transloco }}</div>
+    } @else if (!data()) {
+      <div class="alert alert-info">{{ 'metrics.empty' | transloco }}</div>
     } @else {
+      @let pct = usagePct();
       <div class="stat-grid">
         <div class="stat-card">
           <div class="stat-label">{{ 'metrics.stat.totalUsed' | transloco }}</div>
@@ -80,7 +83,6 @@ interface StorageData {
       </div>
 
       @if (data()!.limits?.totalLimitGiB) {
-        @let pct = usagePct();
         <div class="card" style="margin-bottom:20px;">
           <div class="row">
             <span class="label">{{ 'metrics.bar.usage' | transloco }}</span>
@@ -100,14 +102,16 @@ interface StorageData {
         </div>
       }
 
-      @if (pct >= 95) {
-        <div class="alert alert-error">
-          {{ 'metrics.alert.full' | transloco }}
-        </div>
-      } @else if (pct >= (data()?.limits?.warnAtPercent ?? 80)) {
-        <div class="alert alert-warning">
-          {{ 'metrics.alert.warning' | transloco }}
-        </div>
+      @if (data()!.limits?.totalLimitGiB) {
+        @if (pct >= 95) {
+          <div class="alert alert-error">
+            {{ 'metrics.alert.full' | transloco }}
+          </div>
+        } @else if (pct >= (data()!.limits?.warnAtPercent ?? 80)) {
+          <div class="alert alert-warning">
+            {{ 'metrics.alert.warning' | transloco }}
+          </div>
+        }
       }
     }
   `,
@@ -118,26 +122,29 @@ export class StorageComponent implements OnInit {
 
   data = signal<StorageData | null>(null);
   loading = signal(true);
-  pct = 0;
+  /** Distinct from `!data()`: a load *failure*, so a successful-but-empty response isn't shown as an error. */
+  error = signal(false);
+
+  /** Derived from `data()` so it can never render a stale percentage against a prior/absent load. */
+  usagePct = computed(() => {
+    const d = this.data();
+    const limit = d?.limits?.totalLimitGiB;
+    return limit ? (d!.usageGiB.total / limit) * 100 : 0;
+  });
 
   ngOnInit(): void { this.load(); }
 
   load(): void {
     this.loading.set(true);
+    this.error.set(false);
     this.spacesApi.listSpaces().subscribe({
       next: ({ storage }) => {
-        if (storage) {
-          this.data.set(storage as StorageData);
-          const limit = storage.limits?.totalLimitGiB;
-          this.pct = limit ? (storage.usageGiB.total / limit) * 100 : 0;
-        }
+        this.data.set(storage ? (storage as StorageData) : null);
         this.loading.set(false);
       },
-      error: () => this.loading.set(false),
+      error: () => { this.error.set(true); this.loading.set(false); },
     });
   }
-
-  usagePct(): number { return this.pct; }
 
   fmt(v: number): string { return v.toFixed(2); }
 }

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -206,7 +206,6 @@ import { ModalDirective } from '../../shared/modal.directive';
     }
     .dot-active { background: var(--success); }
     .dot-expired { background: var(--error); }
-    .dot-never-used { background: var(--text-muted); }
     .styled-input {
       padding: 5px 8px;
       border: 1px solid var(--border);


### PR DESCRIPTION
First PR of the settings-UX track (`SETTINGS-UX-TODO.md`). Ships the **three real defects** the review surfaced — correctness only, no redesign — so they land independent of the design-system work.

## Fixes

### 1. Duplicate-detection rules could be silently discarded (data loss)
In a space's settings dialog, the **Duplicates** tab saves via its own button, but its edits were deliberately excluded from the dialog's unsaved-changes tracking (`snapshot()`/`isDirty()`). Editing dupe rules → switching tab or closing → **changes gone, no warning.**
→ Added a separate `dupeSnapshot()` fed into `isDirty()` (re-baselined via `markDupePristine()` after the tab's own save), so the close/leave guard now warns like every other tab. **+3 regression tests** in `space-settings-state.unsaved.spec.ts` (this spec previously *pinned* the buggy "excluded" behavior).

### 2. Storage page: empty shown as error + possible false "storage full" alert
`@else if (!data())` rendered the red load-error for BOTH a real failure and a successful-but-empty response; and `pct` was a mutable field that could paint an over-limit alert against absent/errored data.
→ Added a distinct `error` signal (empty ≠ error → neutral empty state) and made `usagePct` a `computed` derived from `data()`; gated the alerts inside the limit guard. **+`metrics.empty`** in en/de/pl.

### 3. Dead code
Removed the never-bound `.dot-never-used` CSS (tokens) and the uncalled `importFromLibraryInline` method (space-schema).

## Scope note
The data-page **Maintenance-toggle** inverted-color + missing-confirm gap moved to **PR-U11**, where that toggle gets proper Danger-Zone gating anyway (avoids editing the flow twice).

## Verification
- `tsc -p tsconfig.app.json` clean; full `ng build` succeeds (AOT template check).
- `space-settings-state.unsaved` + `.service` vitest specs **32/32** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)