### PR TITLE
feat(ui): settings design-system primitives (PR-U1)

### DIFF
--- a/client/src/app/shared/relative-time.component.spec.ts
+++ b/client/src/app/shared/relative-time.component.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * RelativeTime — the pure formatter is the load-bearing bit (deterministic under a fixed `now`).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime, toEpochMs } from './relative-time.component';
+
+const NOW = Date.parse('2026-07-19T12:00:00Z');
+
+describe('toEpochMs', () => {
+  it('parses ISO strings, epoch numbers, and Dates', () => {
+    expect(toEpochMs('2026-07-19T12:00:00Z')).toBe(NOW);
+    expect(toEpochMs(NOW)).toBe(NOW);
+    expect(toEpochMs(new Date(NOW))).toBe(NOW);
+  });
+  it('returns null for null/undefined/garbage', () => {
+    expect(toEpochMs(null)).toBeNull();
+    expect(toEpochMs(undefined)).toBeNull();
+    expect(toEpochMs('not a date')).toBeNull();
+  });
+});
+
+describe('formatRelativeTime (en, fixed now)', () => {
+  const rel = (v: string | number | Date) => formatRelativeTime(v, NOW, 'en');
+
+  it('formats recent past with the largest sensible unit', () => {
+    expect(rel(NOW - 30 * 1000)).toMatch(/30 seconds ago/);
+    expect(rel(NOW - 5 * 60 * 1000)).toMatch(/5 minutes ago/);
+    expect(rel(NOW - 2 * 3600 * 1000)).toMatch(/2 hours ago/);
+    expect(rel(NOW - 3 * 86400 * 1000)).toMatch(/3 days ago/);
+  });
+
+  it('formats the future direction', () => {
+    expect(rel(NOW + 2 * 3600 * 1000)).toMatch(/in 2 hours/);
+    // numeric:'auto' → "next week" for +1 week (nicer than "in 1 week").
+    expect(rel(NOW + 10 * 86400 * 1000)).toMatch(/next week|in \d+ weeks/);
+  });
+
+  it('uses months/years for large gaps', () => {
+    expect(rel(NOW - 60 * 86400 * 1000)).toMatch(/months? ago/);
+    // numeric:'auto' → "last year" for -1 year.
+    expect(rel(NOW - 400 * 86400 * 1000)).toMatch(/last year|years? ago/);
+  });
+
+  it('returns empty string for unparseable input', () => {
+    expect(rel('nope')).toBe('');
+  });
+
+  it('is locale-aware (de differs from en)', () => {
+    const en = formatRelativeTime(NOW - 2 * 3600 * 1000, NOW, 'en');
+    const de = formatRelativeTime(NOW - 2 * 3600 * 1000, NOW, 'de');
+    expect(en).not.toBe(de);      // "2 hours ago" vs "vor 2 Stunden"
+    expect(de).toMatch(/Stunden/);
+  });
+});

--- a/client/src/app/shared/relative-time.component.ts
+++ b/client/src/app/shared/relative-time.component.ts
@@ -1,0 +1,59 @@
+/**
+ * RelativeTime — one timestamp treatment for the whole app (settings design system, PR-U1).
+ *
+ * Before this, three date formats coexisted (`dd.MM.yyyy`, `date:'short'`, `toLocaleString()`), none
+ * tabular, none relative — so scanning "which token expires soonest / which webhook failed most
+ * recently" down a column was hard. This renders a locale-aware relative label ("2 hours ago") with the
+ * absolute time on hover, tabular-nums, and a machine-readable <time datetime>.
+ *
+ * Usage:  <app-relative-time [value]="token.lastUsed"/>
+ */
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
+
+type TimeValue = string | number | Date | null | undefined;
+
+/** Parse an ISO string / epoch-ms / Date to epoch-ms, or null if unparseable. Exported for testing. */
+export function toEpochMs(value: TimeValue): number | null {
+  if (value == null) return null;
+  const t = value instanceof Date ? value.getTime() : typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(t) ? t : null;
+}
+
+/**
+ * Locale-aware "2 hours ago" / "in 3 days" via `Intl.RelativeTimeFormat`. Pure — pass `nowMs` (and
+ * optionally a locale) so it's deterministic under test. Picks the largest sensible unit.
+ */
+export function formatRelativeTime(value: TimeValue, nowMs: number, locale = 'en'): string {
+  const t = toEpochMs(value);
+  if (t === null) return '';
+  const diff = t - nowMs;            // negative = past
+  const a = Math.abs(diff);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  const S = 1000, M = 60 * S, H = 60 * M, D = 24 * H, W = 7 * D, MO = 30 * D, Y = 365 * D;
+  if (a < M)  return rtf.format(Math.round(diff / S),  'second');
+  if (a < H)  return rtf.format(Math.round(diff / M),  'minute');
+  if (a < D)  return rtf.format(Math.round(diff / H),  'hour');
+  if (a < W)  return rtf.format(Math.round(diff / D),  'day');
+  if (a < MO) return rtf.format(Math.round(diff / W),  'week');
+  if (a < Y)  return rtf.format(Math.round(diff / MO), 'month');
+  return rtf.format(Math.round(diff / Y), 'year');
+}
+
+@Component({
+  selector: 'app-relative-time',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`time { font-variant-numeric: tabular-nums; white-space: nowrap; }`],
+  template: `<time [attr.datetime]="iso()" [title]="absolute()">{{ rel() }}</time>`,
+})
+export class RelativeTimeComponent {
+  private transloco = inject(TranslocoService);
+  value = input.required<TimeValue>();
+
+  private locale = () => this.transloco.getActiveLang() || 'en';
+  protected iso = computed(() => { const t = toEpochMs(this.value()); return t === null ? '' : new Date(t).toISOString(); });
+  protected absolute = computed(() => { const t = toEpochMs(this.value()); return t === null ? '' : new Date(t).toLocaleString(this.locale()); });
+  // Date.now() is read on each change-detection pass — fresh enough for settings screens (no live ticking).
+  protected rel = computed(() => formatRelativeTime(this.value(), Date.now(), this.locale()));
+}

--- a/client/src/app/shared/settings-card.component.ts
+++ b/client/src/app/shared/settings-card.component.ts
@@ -1,0 +1,52 @@
+/**
+ * SettingsCard — the standard grouping primitive for settings screens (design system, PR-U1).
+ *
+ * Replaces ad-hoc `.section` blocks / raw label-value grids / inline-styled `div`s with one card:
+ * header (icon + title + one-line purpose + a status-pill slot) over a body. Keeps every settings
+ * page visually consistent and scannable.
+ *
+ * Usage:
+ *   <app-settings-card icon="image" heading="Vision" purpose="Captions uploaded images.">
+ *     <app-status-pill pill variant="active">Local · Ollama</app-status-pill>
+ *     ...body...
+ *   </app-settings-card>
+ */
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { PhIconComponent } from './ph-icon.component';
+
+@Component({
+  selector: 'app-settings-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [PhIconComponent],
+  styles: [`
+    .card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+    .card-h { display: flex; align-items: center; gap: 12px; padding: 15px 18px; }
+    .ic { width: 34px; height: 34px; border-radius: 9px; display: grid; place-items: center; flex: none;
+          background: var(--bg-elevated); border: 1px solid var(--border); color: var(--accent); }
+    .t { flex: 1; min-width: 0; }
+    .t h3 { margin: 0; font-size: 15px; font-weight: 620; }
+    .t p  { margin: 2px 0 0; font-size: 12.5px; color: var(--text-secondary); }
+    .pillslot { display: flex; align-items: center; gap: 8px; }
+    .card-b { padding: 4px 18px 18px; border-top: 1px solid var(--border-muted); }
+  `],
+  template: `
+    <section class="card">
+      <header class="card-h">
+        @if (icon()) { <span class="ic"><ph-icon [name]="icon()" [size]="18"/></span> }
+        <div class="t">
+          <h3>{{ heading() }}</h3>
+          @if (purpose()) { <p>{{ purpose() }}</p> }
+        </div>
+        <div class="pillslot"><ng-content select="[pill]"/></div>
+      </header>
+      <div class="card-b"><ng-content/></div>
+    </section>
+  `,
+})
+export class SettingsCardComponent {
+  /** Optional leading ph-icon name. */
+  icon = input<string>('');
+  heading = input.required<string>();
+  purpose = input<string>('');
+}

--- a/client/src/app/shared/status-pill.component.spec.ts
+++ b/client/src/app/shared/status-pill.component.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * StatusPill — variant drives the colour class; icon/dot are mutually exclusive leading markers.
+ */
+import { ComponentRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { StatusPillComponent } from './status-pill.component';
+
+describe('StatusPillComponent', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<StatusPillComponent>>;
+  let ref: ComponentRef<StatusPillComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [StatusPillComponent] });
+    fixture = TestBed.createComponent(StatusPillComponent);
+    ref = fixture.componentRef;
+  });
+
+  it('applies the variant as a class alongside .pill', () => {
+    ref.setInput('variant', 'warn');
+    fixture.detectChanges();
+    const pill = fixture.nativeElement.querySelector('.pill') as HTMLElement;
+    expect(pill.classList.contains('warn')).toBe(true);
+    expect(pill.classList.contains('pill')).toBe(true);
+  });
+
+  it('renders a leading dot when dot=true and no icon', () => {
+    ref.setInput('variant', 'active');
+    ref.setInput('dot', true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.dot')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('svg')).toBeNull();
+  });
+
+  it('prefers an icon over the dot when both are set', () => {
+    ref.setInput('variant', 'error');
+    ref.setInput('dot', true);
+    ref.setInput('icon', 'warning');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('svg')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.dot')).toBeNull();
+  });
+
+  it('is OnPush', () => {
+    expect(StatusPillComponent.ɵcmp?.onPush).toBe(true);
+  });
+});

--- a/client/src/app/shared/status-pill.component.ts
+++ b/client/src/app/shared/status-pill.component.ts
@@ -1,0 +1,50 @@
+/**
+ * StatusPill — the ONE status-badge vocabulary for the app (settings design system, PR-U1).
+ *
+ * Before this, three divergent badge dialects existed (`badge-red/green/gray`, `badge-active/failing`,
+ * `badge-2xx/4xx`). Every "what state is this in?" signal now goes through one component with one
+ * colour map, so a pill reads the same on tokens, webhooks, networks, storage, etc.
+ *
+ * Usage:  <app-status-pill variant="warn" [dot]="true">Expiring</app-status-pill>
+ *         <app-status-pill variant="error" icon="warning">Failing</app-status-pill>
+ */
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { PhIconComponent } from './ph-icon.component';
+
+/** active/ok = good · warn = attention · error = bad · off/env = inert · pending = in-progress. */
+export type StatusVariant = 'active' | 'ok' | 'warn' | 'error' | 'off' | 'env' | 'pending';
+
+@Component({
+  selector: 'app-status-pill',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [PhIconComponent],
+  styles: [`
+    .pill {
+      display: inline-flex; align-items: center; gap: 5px;
+      font-size: 11.5px; font-weight: 600; letter-spacing: .01em; line-height: 1.5;
+      padding: 2px 9px; border-radius: 999px; border: 1px solid transparent; white-space: nowrap;
+    }
+    .pill.active  { color: var(--accent);  background: rgba(206,255,128,.12); border-color: rgba(206,255,128,.28); }
+    .pill.ok      { color: var(--success); background: rgba(63,185,80,.13);   border-color: rgba(63,185,80,.30); }
+    .pill.warn    { color: var(--warning); background: rgba(210,153,34,.14);  border-color: rgba(210,153,34,.32); }
+    .pill.error   { color: var(--error);   background: rgba(248,81,73,.10);   border-color: rgba(248,81,73,.30); }
+    .pill.pending { color: var(--info);    background: rgba(88,166,255,.13);  border-color: rgba(88,166,255,.30); }
+    .pill.off, .pill.env { color: var(--text-muted); background: var(--bg-elevated); border-color: var(--border); }
+    .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex: none; }
+  `],
+  template: `
+    <span [class]="'pill ' + variant()">
+      @if (icon()) { <ph-icon [name]="icon()" [size]="12"/> }
+      @else if (dot()) { <span class="dot"></span> }
+      <ng-content/>
+    </span>
+  `,
+})
+export class StatusPillComponent {
+  variant = input<StatusVariant>('off');
+  /** Optional leading ph-icon name; takes precedence over the dot. */
+  icon = input<string>('');
+  /** Show a leading status dot (ignored when an icon is set). */
+  dot = input<boolean>(false);
+}

--- a/client/src/app/shared/summary-strip.component.ts
+++ b/client/src/app/shared/summary-strip.component.ts
@@ -1,0 +1,62 @@
+/**
+ * SummaryStrip — the operator-first "what's the state" row that sits atop a settings/list page
+ * (design system, PR-U1). No page had one before; it's the highest-leverage shared add from the audit.
+ *
+ * Give it the headline stats (counts / rollups) and colour the ones that need attention; project extra
+ * content (e.g. a usage bar) after them.
+ *
+ * Usage:
+ *   <app-summary-strip heading="Tokens"
+ *     [items]="[{label:'Active', value:4}, {label:'Expiring', value:1, variant:'warn'}]"/>
+ */
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import type { StatusVariant } from './status-pill.component';
+
+export interface SummaryItem {
+  label: string;
+  value: string | number;
+  /** Optional emphasis — colours the value when it's a state worth noticing (e.g. warn/error). */
+  variant?: StatusVariant;
+}
+
+@Component({
+  selector: 'app-summary-strip',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    .summary { border: 1px solid var(--border); border-radius: 10px;
+               background: linear-gradient(180deg, var(--bg-surface), var(--bg-primary)); overflow: hidden; }
+    .summary-h { display: flex; align-items: center; gap: 8px; padding: 10px 16px 8px;
+                 color: var(--text-muted); font-size: 11px; font-weight: 600;
+                 text-transform: uppercase; letter-spacing: .07em; }
+    .items { display: flex; flex-wrap: wrap; gap: 8px 28px; padding: 12px 16px;
+             border-top: 1px solid var(--border-muted); align-items: center; }
+    .item { display: flex; flex-direction: column; gap: 1px; }
+    .v { font-size: 20px; font-weight: 650; line-height: 1.1; font-variant-numeric: tabular-nums; color: var(--text-primary); }
+    .v.active, .v.ok { color: var(--accent); }
+    .v.warn  { color: var(--warning); }
+    .v.error { color: var(--error); }
+    .v.pending { color: var(--info); }
+    .l { font-size: 11.5px; color: var(--text-secondary); }
+    .extra { margin-left: auto; display: flex; align-items: center; gap: 12px; flex: 1; min-width: 180px; justify-content: flex-end; }
+    @media (max-width: 560px) { .items { gap: 12px 20px; } .extra { margin-left: 0; justify-content: flex-start; } }
+  `],
+  template: `
+    <div class="summary">
+      @if (heading()) { <div class="summary-h">{{ heading() }}</div> }
+      <div class="items">
+        @for (it of items(); track it.label) {
+          <div class="item">
+            <span class="v" [class]="it.variant ?? ''">{{ it.value }}</span>
+            <span class="l">{{ it.label }}</span>
+          </div>
+        }
+        <div class="extra"><ng-content/></div>
+      </div>
+    </div>
+  `,
+})
+export class SummaryStripComponent {
+  heading = input<string>('');
+  items = input<SummaryItem[]>([]);
+}

--- a/client/src/app/shared/usage-bar.component.spec.ts
+++ b/client/src/app/shared/usage-bar.component.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * UsageBar — level classifier (pure) + a render check that width/level track the inputs.
+ */
+import { ComponentRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { UsageBarComponent, usageLevel } from './usage-bar.component';
+
+describe('usageLevel', () => {
+  it('classifies ok / warn / danger against the threshold', () => {
+    expect(usageLevel(10, 80)).toBe('ok');
+    expect(usageLevel(79.9, 80)).toBe('ok');
+    expect(usageLevel(80, 80)).toBe('warn');
+    expect(usageLevel(94, 80)).toBe('warn');
+    expect(usageLevel(95, 80)).toBe('danger');
+    expect(usageLevel(120, 80)).toBe('danger');
+  });
+});
+
+describe('UsageBarComponent', () => {
+  let fixture: ReturnType<typeof TestBed.createComponent<UsageBarComponent>>;
+  let ref: ComponentRef<UsageBarComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [UsageBarComponent] });
+    fixture = TestBed.createComponent(UsageBarComponent);
+    ref = fixture.componentRef;
+  });
+
+  it('renders a fill whose width is the clamped percentage and class is the level', () => {
+    ref.setInput('used', 90);
+    ref.setInput('total', 100);
+    fixture.detectChanges();
+    const fill = fixture.nativeElement.querySelector('.fill') as HTMLElement;
+    expect(fill.style.width).toBe('90%');
+    expect(fill.classList.contains('warn')).toBe(true);
+  });
+
+  it('clamps over-limit width to 100% and flags danger', () => {
+    ref.setInput('used', 150);
+    ref.setInput('total', 100);
+    fixture.detectChanges();
+    const fill = fixture.nativeElement.querySelector('.fill') as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+    expect(fill.classList.contains('danger')).toBe(true);
+  });
+
+  it('is 0% (ok) when no total is provided', () => {
+    ref.setInput('used', 5);
+    ref.setInput('total', null);
+    fixture.detectChanges();
+    const fill = fixture.nativeElement.querySelector('.fill') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+    expect(fill.classList.contains('ok')).toBe(true);
+  });
+});

--- a/client/src/app/shared/usage-bar.component.ts
+++ b/client/src/app/shared/usage-bar.component.ts
@@ -1,0 +1,46 @@
+/**
+ * UsageBar — one "X of Y used" bar with health thresholds (settings design system, PR-U1).
+ *
+ * Consolidates two separate implementations (storage's `usage-bar-*` and about's `disk-bar-*`) that
+ * rendered the same concept differently. Colour tracks the fill level: ok → warn (≥ warnAtPercent) →
+ * danger (≥ 95%).
+ *
+ * Usage:  <app-usage-bar [used]="usedGiB" [total]="limitGiB" [warnAtPercent]="80"/>
+ */
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+export type UsageLevel = 'ok' | 'warn' | 'danger';
+
+/** Pure level classifier — exported for testing. */
+export function usageLevel(pct: number, warnAtPercent: number): UsageLevel {
+  if (pct >= 95) return 'danger';
+  if (pct >= warnAtPercent) return 'warn';
+  return 'ok';
+}
+
+@Component({
+  selector: 'app-usage-bar',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    .track { height: 8px; background: var(--bg-elevated); border-radius: 4px; overflow: hidden; }
+    .fill  { height: 100%; border-radius: 4px; transition: width .4s ease, background .2s ease; }
+    .fill.ok     { background: var(--accent); }
+    .fill.warn   { background: var(--warning); }
+    .fill.danger { background: var(--error); }
+  `],
+  template: `
+    <div class="track" role="progressbar" [attr.aria-valuenow]="pct().toFixed(0)" aria-valuemin="0" aria-valuemax="100">
+      <div class="fill" [class]="level()" [style.width.%]="width()"></div>
+    </div>
+  `,
+})
+export class UsageBarComponent {
+  used = input.required<number>();
+  total = input<number | null>(null);
+  warnAtPercent = input<number>(80);
+
+  protected pct = computed(() => { const t = this.total(); return t && t > 0 ? (this.used() / t) * 100 : 0; });
+  protected width = computed(() => Math.min(Math.max(this.pct(), 0), 100));
+  protected level = computed(() => usageLevel(this.pct(), this.warnAtPercent()));
+}


### PR DESCRIPTION
Second PR of the settings-UX track. Builds the **shared primitives** that every subsequent page refactor consumes — so the redesign is a *system*, not 14 one-offs. **No page consumes them yet**, so there's no user-facing change and no CHANGELOG entry here (those land with the first consuming page, PR-U2 Models).

## Why
The 5-reviewer audit found ~6 *repeated* gaps, not 14 unique ones — most notably: no page has an operator-first summary, the status-badge vocabulary splintered into 3 dialects, and timestamps use 3 inconsistent formats. These primitives fix each *once*.

## Components (all `client/src/app/shared/`, standalone + OnPush + signal inputs)
- **`StatusPill`** — the ONE status vocabulary: `active/ok/warn/error/off/env/pending` with a single colour map. Retires `badge-red/green/gray`, `badge-active/failing`, `badge-2xx/4xx`.
- **`RelativeTime`** — locale-aware "2 hours ago" (`Intl.RelativeTimeFormat`, `numeric:'auto'`), `tabular-nums`, absolute time on hover, machine-readable `<time datetime>`. Pure `formatRelativeTime()` / `toEpochMs()` for testing.
- **`UsageBar`** — one "X of Y used" bar with ok/warn/danger thresholds; consolidates storage's `usage-bar-*` and about's `disk-bar-*`. Pure `usageLevel()`.
- **`SettingsCard`** — header (icon + title + purpose + pill slot) over a body; replaces ad-hoc sections/grids.
- **`SummaryStrip`** — the operator-first summary row (the single biggest universal gap — no page had one).

## Verification
- 15 unit tests (pure helpers + TestBed render/template-check) — green.
- `tsc -p tsconfig.app.json` clean; full `ng build` succeeds.

## Next
PR-U2 rebuilds the **Models** page on these (its mockup is already approved), proving the system end-to-end; then the high-priority pages roll onto them one PR at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)