### PR TITLE
fix(brain): stop mount⇄reload storm that made the Brain page unusable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ npm-debug.log*
 # TypeScript build info
 *.tsbuildinfo
 server/dist
+
+# Local one-command preview (not for commit)
+preview.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Brain: fixed an infinite reload loop that made the whole page unusable — opening any space's
+  entities/edges/memories/chrono/files tab showed only a jittering spinner and never loaded.** The five
+  record tabs were mounted inside the `@else` of `@if (recordList.loading())`, but each tab **writes** that
+  shared `recordList.loading` signal during its own `load()`. So a tab set `loading = true` on load, which
+  removed the `@else` branch and **destroyed the tab**; the response set `loading = false`, which
+  **re-created** it → a fresh `load()` → `loading = true` → … an infinite mount⇄reload loop firing the list
+  endpoint ~5×/second, self-sustaining even once the global rate limiter started returning `429`. Tabs now
+  mount on `activeTab()` **alone** and the load spinner floats on top (absolutely positioned), so the active
+  tab instance is never torn down by its own loading state. Added a `BrainComponent`-level regression test
+  that reproduces the mount⇄reload loop (it fails on the old structure). (The self-load effects were also
+  scoped to their real triggers with `untracked()` — a defensive tidy-up, not the cause. Follow-ups: migrate
+  to the reactive `rxResource`/`switchMap` data pattern for request cancellation, and key the rate limiter
+  per real client so a direct-Docker deploy behind no proxy can't share one gateway-IP bucket.)
+
 - **Settings: unsaved duplicate-detection rules no longer vanish silently.** In a space's settings dialog,
   the Duplicates tab is saved by its own button, but its edits were excluded from the dialog's
   unsaved-changes tracking — so editing dupe rules and then switching tabs or closing discarded them with no

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -14,7 +14,7 @@
  * would render empty and this test would fail rather than the bug shipping silently.
  */
 import { TestBed } from '@angular/core/testing';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { SpacesApi } from '../../core/spaces-api.service';
@@ -58,6 +58,48 @@ describe('BrainComponent (OnPush)', () => {
 
   it('is compiled as OnPush', () => {
     expect(BrainComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  // ── Regression: the mount⇄reload request storm (app-unusable P0) ─────────────
+  // The five record tabs each WRITE `recordList.loading` during their own `load()`. They used to be
+  // mounted inside the `@else` of `@if (recordList.loading())`, so a tab set loading=true on load,
+  // which unmounted the tab (removing the @else branch); the response set loading=false, which
+  // re-mounted it → a fresh `load()` → loading=true → … an infinite mount⇄reload loop that hammered
+  // the API (~5 req/s, self-sustaining even once rate-limited to 429s) and froze the page. The fix:
+  // tabs mount on `activeTab()` ALONE and the spinner floats on top, so the active tab instance is
+  // never torn down by its own loading state. This test drives the shared loading signal the way a
+  // real async load does and asserts the active tab is NOT re-created (its `load()` is not re-fired).
+  it('does NOT re-create the active record tab when recordList.loading toggles (storm regression)', () => {
+    const listEntities = vi.fn(() => of({ entities: [] }));
+    TestBed.configureTestingModule({
+      imports: [BrainComponent, getTranslocoModule()],
+      providers: [
+        { provide: SpacesApi, useValue: makeApi() },
+        { provide: BrainApi, useValue: { ...makeApi(), listEntities } },
+        { provide: FilesApi, useValue: makeApi() },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+      ],
+    });
+    const fixture = TestBed.createComponent(BrainComponent);
+    fixture.detectChanges(); // ngOnInit → listSpaces → selectSpace('work')
+
+    fixture.componentInstance.setTab('entities'); // mount the entities tab → it self-loads once
+    fixture.detectChanges();
+    const afterActivate = listEntities.mock.calls.length;
+    expect(afterActivate).toBeGreaterThan(0);
+
+    // Toggle the shared loading signal across change-detection cycles, exactly as an async load does.
+    // On the buggy @else structure each false→true→false cycle unmounted+re-mounted the tab, adding a
+    // fresh load() every time. On the fixed structure the tab persists, so the count must not grow.
+    const recordList = fixture.componentInstance.recordList;
+    for (let i = 0; i < 4; i++) {
+      recordList.loading.set(true);
+      fixture.detectChanges();
+      recordList.loading.set(false);
+      fixture.detectChanges();
+    }
+    expect(listEntities.mock.calls.length).toBe(afterActivate);
   });
 
   // The memories table rendering (row-per-memory, signal re-render) moved to

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -138,6 +138,17 @@ interface SpaceView {
 
     .tab-spacer { flex: 1; }
 
+    /* The active tab's content region. position:relative anchors the floating load spinner so it
+       overlays the tab WITHOUT unmounting it (see the storm note in the template). */
+    .tab-body { position: relative; min-height: 80px; }
+    .loading-overlay--float {
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      z-index: 5;
+      background: color-mix(in srgb, var(--bg) 72%, transparent);
+      border-radius: 8px;
+    }
+
   `],
   template: `
     @if (loadingSpaces()) {
@@ -215,10 +226,16 @@ interface SpaceView {
         }
       </div>
 
-      <!-- Content -->
-      @if (recordList.loading()) {
-        <div class="loading-overlay"><span class="spinner"></span></div>
-      } @else {
+      <!-- Content. Tabs are gated by activeTab() ONLY — NEVER wrapped in @else of
+           @if (recordList.loading()). Each record tab WRITES recordList.loading during its own
+           load(); gating the tab's existence on that signal made the tab unmount itself mid-load and
+           re-mount on the response, an infinite mount⇄reload storm (one full re-create per response,
+           ~5/s, self-sustaining even on 429). The load spinner now floats on top (position:absolute)
+           so the active tab instance is never torn down. -->
+      <div class="tab-body">
+        @if (recordList.loading()) {
+          <div class="loading-overlay loading-overlay--float"><span class="spinner"></span></div>
+        }
 
         <!-- Graph tab -->
         @if (activeTab() === 'graph') {
@@ -247,8 +264,7 @@ interface SpaceView {
 
         <!-- Query -->
         @if (activeTab() === 'query') { <app-query-tab [spaceId]="activeSpaceId()" /> }
-
-      }
+      </div>
 
       <!-- Detail Drawer -->
       <app-record-drawer />

--- a/client/src/app/pages/brain/entities-tab.component.spec.ts
+++ b/client/src/app/pages/brain/entities-tab.component.spec.ts
@@ -51,6 +51,21 @@ describe('EntitiesTabComponent', () => {
     expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, {});
   });
 
+  it('self-load effect depends on spaceId ONLY — no reload on plain change detection', () => {
+    // Scoping guard for the untracked() self-load effect: it must react to `spaceId` alone. It resets
+    // `recordFilter` to a NEW object each run and reads it via load(), so without the untracked() wrapper
+    // it would re-dirty itself. NOTE: this does NOT reproduce the app-freezing request storm — that was a
+    // structural mount⇄reload loop at the brain.component level (tabs gated by @if(recordList.loading()),
+    // which the tab itself writes); it is pinned in brain.component.spec.ts. With spaceId unchanged,
+    // further change detection must trigger no reload.
+    const fixture = make();
+    api.listEntities.mockClear();
+    fixture.detectChanges();
+    fixture.detectChanges();
+    fixture.detectChanges();
+    expect(api.listEntities).not.toHaveBeenCalled();
+  });
+
   it('renders the create form when opened', () => {
     const fixture = make();
     fixture.componentInstance.openEntityForm();

--- a/client/src/app/pages/brain/record-tab-base.ts
+++ b/client/src/app/pages/brain/record-tab-base.ts
@@ -32,23 +32,30 @@ export abstract class RecordTabBase {
 
   constructor() {
     // Self-load on creation (tab activation via the shell's gated @if) and on a space switch while
-    // mounted. The `if (id)` guard keeps it to a single real load until the input settles.
+    // mounted. This effect must depend on `spaceId` ONLY. The reset + load are wrapped in `untracked`
+    // so the signals they touch — critically `resetOnSpaceChange()` writing `recordFilter` to a NEW
+    // object, which `load()` then reads — are NOT registered as effect dependencies. Without this, that
+    // write→read pair self-triggers the effect forever (signals compare by reference, so each reset is a
+    // "change"), storming `load()` on every microtask. Filter/search reloads are driven imperatively by
+    // the tab's own handlers, so the effect has no business reacting to them.
     effect(() => {
       const id = this.spaceId();
-      this.skip.set(0);
-      this.resetOnSpaceChange();
-      if (id) this.load();
+      untracked(() => {
+        this.skip.set(0);
+        this.resetOnSpaceChange();
+        if (id) this.load();
+      });
     });
 
     // Live refresh (F12): when the shell signals a change for this space+collection, reload the CURRENT
     // page (no skip/search reset — keep the user's position). Only the mounted tab has a live effect, so
-    // only the active list reloads. `untracked` keeps this effect off the spaceId dependency so a space
-    // switch doesn't double-load via both effects.
+    // only the active list reloads. Depends on `liveRefreshTick` ONLY — `spaceId` and everything `load()`
+    // reads are untracked so a space switch doesn't double-load and filter reads don't re-trigger it.
     let firstTick = true;
     effect(() => {
       this.store.liveRefreshTick();
       if (firstTick) { firstTick = false; return; }
-      if (untracked(() => this.spaceId())) this.load();
+      untracked(() => { if (this.spaceId()) this.load(); });
     });
   }
 


### PR DESCRIPTION
## The bug
Opening any space's **entities / edges / memories / chrono / files** tab showed only a jittering spinner and never loaded. The list endpoint was fired **~5×/second**, self-sustaining even once the global rate limiter began returning `429` — the whole Brain page was unusable.

## Root cause (structural — in the shell template, not the tab effects)
The five record tabs were mounted inside the `@else` of `@if (recordList.loading())`, but **each tab writes that shared `recordList.loading` signal during its own `load()`**. So:

```
tab mounts → load() sets loading=true → @else (and the tab) is DESTROYED
           → response sets loading=false → @else returns → tab RE-CREATED → load() → ∞
```

A tab that unmounts itself the instant it starts loading, then re-mounts on the response. It hit *every* tab because they all share the one `loading` signal. Confirmed with deployed `console.count()` instrumentation: the tab **ctor, both effects, and `load()` all incremented in lockstep** — one full component re-creation per request.

## Fix
Mount tabs on `activeTab()` **alone**; render the load spinner as a floating overlay (`position:absolute`) over a `position:relative` content region, so the active tab instance is never torn down by its own loading state.

## Tests
- New **`BrainComponent`-level regression test** reproducing the loop (toggling `recordList.loading` must not re-create the active tab / re-fire `load()`). **Proven to fail on the old `@else` structure** (5 loads vs 1) and pass on the fix.
- Corrected the entities-tab spec's over-claiming comment (its "no reload on CD" test guards effect dependency-scoping, not this structural storm).
- All 99 brain specs pass.
- Kept the earlier `untracked()` scoping of the self-load effects — a correct defensive tidy-up, though not the cause.

## Follow-ups (tracked, not in this PR)
- **Security:** the SSE stream passes the token in the URL query string (`?token=`) — leaks into server/proxy logs, browser history, `Referer`. Move to a short-lived single-use ticket or cookie-based SSE auth.
- Migrate the record tabs to `rxResource`/`switchMap` for request cancellation.
- Key the rate limiter per real client so a direct-Docker deploy behind no reverse proxy can't share one gateway-IP bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)