### PR TITLE
fix(security): SSE streams use single-use tickets, not tokens in the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Browser SSE streams no longer carry the auth token in the URL — closed a credential-leak vector.** The
+  live brain-change stream (`GET /api/brain/spaces/:id/events`, F12) and the admin audit-log tail
+  (`GET /api/about/logs/stream`) are opened by the browser `EventSource` API, which cannot set an
+  `Authorization` header — so they previously accepted the bearer token as a `?token=` query parameter. A
+  token in a URL leaks into server/proxy **access logs**, browser **history**, and the `Referer` header.
+  Both streams now authenticate with a **single-use, ~60s, path-bound ticket**: the client first does an
+  authenticated `POST …/ticket` (normal header), then connects with `?ticket=<opaque>`; the server
+  exchanges the ticket back to the bearer once and resolves it exactly as a header would (space-scope, MFA,
+  everything unchanged). A raw `?token=` is now **rejected** on both streams. The `/mcp` transport keeps
+  `?token=` by design — it's an external-agent protocol with a different threat model (the agent already
+  holds the token and may be unable to set headers). New/updated red-team + integration tests assert the
+  raw-token rejection, single-use, and path-binding. (Discovered while debugging the brain request-storm.)
+
 - **Docker hardening: pinned base images + privilege-escalation lockdown on the parser sidecars.** The
   floating `:latest` base images (`ollama`, `faster-whisper-server`, `mongodb-atlas-local`, and `node:22-slim`
   in the app `Dockerfile`) are now pinned to explicit multi-arch manifest **digests**, so a re-pull can't

--- a/client/src/app/core/admin-api.service.ts
+++ b/client/src/app/core/admin-api.service.ts
@@ -21,6 +21,11 @@ export class AdminApi {
     return this.http.get<{ lines: string[] }>(`/api/about/logs?lines=${lines}`);
   }
 
+  /** Mint a single-use ticket to open the log-stream SSE (keeps the admin token out of the URL). */
+  mintLogsTicket(): Observable<{ ticket: string; expiresInMs: number }> {
+    return this.http.post<{ ticket: string; expiresInMs: number }>('/api/about/logs/ticket', {});
+  }
+
   // ── Audit Log ───────────────────────────────────────────────────────────
 
   getAuditLog(params: AuditLogParams = {}): Observable<AuditLogResponse> {

--- a/client/src/app/core/brain-api.service.ts
+++ b/client/src/app/core/brain-api.service.ts
@@ -11,6 +11,13 @@ import type {
 export class BrainApi {
   private http = inject(HttpClient);
 
+  /** Mint a single-use ticket to open the live-change SSE stream. EventSource can't send an
+   *  Authorization header and a raw token in the URL leaks into logs/history, so the stream is opened
+   *  with `?ticket=` instead. The ticket is single-use, short-lived, and bound to this space's stream. */
+  mintEventsTicket(spaceId: string): Observable<{ ticket: string; expiresInMs: number }> {
+    return this.http.post<{ ticket: string; expiresInMs: number }>(`/api/brain/spaces/${spaceId}/events/ticket`, {});
+  }
+
   queryBrain(
     spaceId: string,
     body: {

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -34,6 +34,7 @@ function makeApi() {
     getSpaceMeta: () => of({ tagSuggestions: [], typeSchemas: {} }),
     listMemories: () => of({ memories: [] }),
     getEntitiesByIds: () => of({ entities: [] }),
+    mintEventsTicket: () => of({ ticket: 't', expiresInMs: 60000 }),
   } as any;
 }
 

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -14,6 +14,7 @@ import { FilemetaTabComponent } from './filemeta-tab.component';
 import { FormsModule } from '@angular/forms';
 import { Space, SpaceStats } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
+import { BrainApi } from '../../core/brain-api.service';
 import { GraphComponent } from '../graph/graph.component';
 import { FileManagerComponent } from '../files/file-manager.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
@@ -277,6 +278,7 @@ export class BrainComponent implements OnInit, OnDestroy {
   readonly drawerState = inject(RecordDrawerState);
   readonly recordList = inject(RecordListState);
   private spacesApi = inject(SpacesApi);
+  private brainApi = inject(BrainApi);
   private transloco = inject(TranslocoService);
 
   collectionTabs: { key: BrainTab; label: string; statsKey?: keyof SpaceStats }[] = [
@@ -344,29 +346,54 @@ export class BrainComponent implements OnInit, OnDestroy {
   // ── Live updates (F12) ──────────────────────────────────────────────────────
   private liveStream?: EventSource;
   private liveRefreshTimer?: ReturnType<typeof setTimeout>;
+  private liveReconnectTimer?: ReturnType<typeof setTimeout>;
+  private static readonly LIVE_RECONNECT_MS = 3000;
   private static readonly TAB_FOR_COLLECTION: Record<string, BrainTab> = {
     memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'filemeta',
   };
 
-  /** (Re)open the SSE stream for a space. EventSource can't send an Authorization header, so the token
-   *  goes in the query string (the server allowlists this GET path for query-token auth). */
+  /** (Re)open the live-change SSE stream for a space. EventSource can't send an Authorization header, and
+   *  a raw token in the URL leaks into logs/history/Referer, so we mint a single-use `?ticket=` first. */
   private openLiveStream(spaceId: string): void {
     this.closeLiveStream();
     if (typeof EventSource === 'undefined') return; // non-browser (SSR/test) environment
-    const token = localStorage.getItem('ythril_token') ?? '';
-    if (!spaceId || !token) return;
-    const url = `/api/brain/spaces/${encodeURIComponent(spaceId)}/events?token=${encodeURIComponent(token)}`;
-    const es = new EventSource(url);
-    es.onmessage = (e) => {
-      let payload: { event?: string };
-      try { payload = JSON.parse(e.data); } catch { return; }
-      this.onLiveEvent(spaceId, payload.event ?? '');
-    };
-    // On error the browser auto-reconnects with backoff; nothing to do.
-    this.liveStream = es;
+    if (!spaceId) return;
+    this.connectLiveStream(spaceId);
+  }
+
+  /** Mint a ticket, then open the stream. Because the ticket is single-use, the browser's native
+   *  auto-reconnect (which would replay the now-dead ticket) is useless — so on error we close and
+   *  reconnect ourselves with a FRESH ticket after a fixed backoff, and only while this space is still
+   *  active. The backoff + active-space guard keep a persistently-failing stream to ~1 attempt / 3s
+   *  (never a request storm) and stop it entirely once the user navigates away. */
+  private connectLiveStream(spaceId: string): void {
+    if (spaceId !== this.activeSpaceId()) return; // space switched (or torn down) before we got here
+    this.brainApi.mintEventsTicket(spaceId).subscribe({
+      next: ({ ticket }) => {
+        if (spaceId !== this.activeSpaceId()) return; // switched while minting — drop this ticket
+        const url = `/api/brain/spaces/${encodeURIComponent(spaceId)}/events?ticket=${encodeURIComponent(ticket)}`;
+        const es = new EventSource(url);
+        es.onmessage = (e) => {
+          let payload: { event?: string };
+          try { payload = JSON.parse(e.data); } catch { return; }
+          this.onLiveEvent(spaceId, payload.event ?? '');
+        };
+        es.onerror = () => {
+          es.close();
+          if (this.liveStream === es) this.liveStream = undefined;
+          clearTimeout(this.liveReconnectTimer);
+          this.liveReconnectTimer = setTimeout(() => this.connectLiveStream(spaceId), BrainComponent.LIVE_RECONNECT_MS);
+        };
+        this.liveStream = es;
+      },
+      // Mint failed (auth / rate limit / offline): stay closed — the next space switch retries. Not
+      // retried on a timer here to avoid hammering the mint endpoint when auth is genuinely broken.
+      error: () => { /* no-op */ },
+    });
   }
 
   private closeLiveStream(): void {
+    clearTimeout(this.liveReconnectTimer);
     this.liveStream?.close();
     this.liveStream = undefined;
   }

--- a/client/src/app/pages/settings/audit-log.component.spec.ts
+++ b/client/src/app/pages/settings/audit-log.component.spec.ts
@@ -36,6 +36,7 @@ function makeApi(entries: AuditLogEntry[]) {
     listSpaces: () => of({ spaces: [] }),
     getAuditLog: () => of({ entries, total: entries.length, hasMore: false, retentionDays: 90 }),
     getAboutLogs: () => of({ lines: [] }),
+    mintLogsTicket: () => of({ ticket: 't', expiresInMs: 60000 }),
   } as any;
 }
 

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -500,22 +500,29 @@ export class AuditLogComponent implements OnInit, OnDestroy {
   }
 
   private startServerLogStream(): void {
-    // First load existing lines, then start SSE stream
+    // First load existing lines, then start the SSE stream. EventSource can't send an Authorization
+    // header and a raw token in the URL leaks into logs/history, so mint a single-use ticket first, then
+    // open the stream with ?ticket=.
     this.loadServerLogs();
-    const token = localStorage.getItem('ythril_token') ?? '';
-    const es = new EventSource(`/api/about/logs/stream?token=${encodeURIComponent(token)}`);
-    es.onmessage = (event) => {
-      this.serverLogLines.update(lines => {
-        const updated = [...lines, event.data];
-        return updated.length > 1000 ? updated.slice(-1000) : updated;
-      });
-    };
-    es.onerror = () => {
-      // SSE connection lost — stop streaming
-      this.stopServerLogStream();
-    };
-    this.serverLogEventSource = es;
-    this.serverLogStreaming.set(true);
+    this.serverLogStreaming.set(true); // optimistic so the toggle button reflects intent immediately
+    this.adminApi.mintLogsTicket().subscribe({
+      next: ({ ticket }) => {
+        if (typeof EventSource === 'undefined' || !this.serverLogStreaming()) return; // stopped while minting
+        const es = new EventSource(`/api/about/logs/stream?ticket=${encodeURIComponent(ticket)}`);
+        es.onmessage = (event) => {
+          this.serverLogLines.update(lines => {
+            const updated = [...lines, event.data];
+            return updated.length > 1000 ? updated.slice(-1000) : updated;
+          });
+        };
+        es.onerror = () => {
+          // SSE connection lost — stop streaming (the ticket is single-use; the user can restart).
+          this.stopServerLogStream();
+        };
+        this.serverLogEventSource = es;
+      },
+      error: () => this.stopServerLogStream(), // mint failed (auth / rate limit)
+    });
   }
 
   private stopServerLogStream(): void {

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -559,7 +559,7 @@ Authorization: Bearer ythril_<base62-encoded-token>
 
 Tokens are created during first-run setup or via `POST /api/tokens`. The plaintext token is shown **once** — store it securely.
 
-> **The token must travel in the header.** A `?token=…` query parameter is accepted **only** on the two SSE streams — `GET /api/about/logs/stream` and `GET /mcp` — because the browser `EventSource` API cannot set headers. On every other route a query-string token is ignored and the request returns `401`. Query strings end up in access logs, proxy logs, browser history, and `Referer` headers, which is why the fallback is not available API-wide.
+> **The token must travel in the header.** A `?token=…` query parameter is ignored on every route → `401`, with one exception: the `GET /mcp` transport (an external-agent protocol whose clients may be unable to set headers). Query strings end up in access logs, proxy logs, browser history, and `Referer` headers, so a long-lived token must never ride in a URL. The **browser** SSE streams — `GET /api/brain/spaces/:id/events` and `GET /api/about/logs/stream` — instead use a **single-use ticket**: `POST` the paired `…/ticket` endpoint with the normal `Authorization` header to get a short-lived opaque ticket, then open the stream with `?ticket=<ticket>` (see the live-events section below).
 
 ### Token Scoping
 
@@ -808,14 +808,22 @@ or `bulk.write` for a batch); `id` is the affected record's ID when applicable. 
 sent on connect and every 30 s as a keep-alive.
 
 - **Auth:** space-scoped; read-only tokens may subscribe. A browser `EventSource` cannot set an
-  `Authorization` header, so this endpoint accepts the token as a `?token=` query parameter (like the
-  MCP and log-stream SSE endpoints). Prefer the header form for non-browser clients.
+  `Authorization` header, and a raw token in the URL leaks into logs/history — so authenticate with a
+  **single-use ticket**: `POST /api/brain/spaces/:id/events/ticket` with the normal `Authorization`
+  header returns `{ ticket, expiresInMs }`; open the stream with `?ticket=<ticket>`. The ticket is
+  single-use (mint a fresh one per connect, including reconnects), expires in ~60 s, and is bound to this
+  space's stream. A non-browser client that can set headers should just use `Authorization` directly.
 - **Scope:** events fire for writes made through the REST and MCP APIs on this instance. Changes applied
   by the **sync engine** (pulled from a peer) are not emitted here — they appear on the next load.
 
 ```js
-const es = new EventSource(`/api/brain/spaces/${space}/events?token=${token}`);
+// Browser: mint a single-use ticket (token stays in the header), then open the stream with it.
+const { ticket } = await fetch(`/api/brain/spaces/${space}/events/ticket`, {
+  method: 'POST', headers: { Authorization: `Bearer ${token}` },
+}).then((r) => r.json());
+const es = new EventSource(`/api/brain/spaces/${space}/events?ticket=${encodeURIComponent(ticket)}`);
 es.onmessage = (e) => { const { event, id } = JSON.parse(e.data); /* refresh the affected view */ };
+// On es.onerror, mint a new ticket before reconnecting — the old one is already spent.
 ```
 
 ---
@@ -5532,6 +5540,9 @@ Real-time stream of log lines as Server-Sent Events.
 - Admin token required
 - Sends heartbeat comments periodically to keep the connection alive
 - Each event payload is a single escaped log line (`data: ...`)
+- **Browser clients** (which can't set headers on `EventSource`) authenticate with a single-use ticket:
+  `POST /api/about/logs/ticket` with the `Authorization` header returns `{ ticket, expiresInMs }`; open the
+  stream with `?ticket=<ticket>`. A raw `?token=` in the URL is rejected (it would leak into logs/history).
 
 Close the HTTP connection to stop streaming.
 

--- a/server/src/api/about.ts
+++ b/server/src/api/about.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { requireAuth, requireAdmin } from '../auth/middleware.js';
+import { mintSseTicket } from '../auth/sse-ticket.js';
 import { getConfig } from '../config/loader.js';
 import { getMongo } from '../db/mongo.js';
 import { getLogLines, subscribeLogLines } from '../util/log.js';
@@ -76,6 +77,18 @@ aboutRouter.get('/logs', requireAdmin, (_req, res) => {
 aboutRouter.get('/security', requireAdmin, (_req, res) => {
   const posture = computeSecurityPosture();
   res.json({ ...posture, strict: securityStrict() });
+});
+
+// Mint a single-use ticket for the log-stream SSE below (EventSource can't send an Authorization header;
+// a raw token in the URL would leak into logs/history). Admin-only, single-use, ~1 min, bound to the
+// stream path only. The client POSTs here, then opens the stream with `?ticket=`.
+aboutRouter.post('/logs/ticket', requireAdmin, (req, res) => {
+  const bearer = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim();
+  if (!bearer) {
+    res.status(400).json({ error: 'Ticket minting requires an Authorization: Bearer header' });
+    return;
+  }
+  res.json(mintSseTicket(bearer, '/api/about/logs/stream'));
 });
 
 // SSE stream for real-time log tailing. Admin-only.

--- a/server/src/api/brain/events.ts
+++ b/server/src/api/brain/events.ts
@@ -14,10 +14,31 @@
 import { Router } from 'express';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { requireSpaceAuth } from '../../auth/middleware.js';
+import { mintSseTicket } from '../../auth/sse-ticket.js';
 import { getConfig } from '../../config/loader.js';
 import { subscribeBrainChanges } from '../../brain/brain-events.js';
 
 export const brainEventsRouter = Router();
+
+/**
+ * Mint a single-use ticket for the SSE stream below. `EventSource` can't set an `Authorization` header,
+ * and a raw token in the URL would leak into logs/history/`Referer` — so the client POSTs here
+ * (authenticated normally, space-scope enforced), then opens the stream with `?ticket=`. The ticket
+ * aliases this request's bearer, is single-use, expires in ~1 min, and is bound to THIS space's stream.
+ */
+brainEventsRouter.post('/spaces/:spaceId/events/ticket', globalRateLimit, requireSpaceAuth, (req, res) => {
+  const spaceId = req.params['spaceId'] as string;
+  if (!getConfig().spaces.some(s => s.id === spaceId)) {
+    res.status(404).json({ error: `Space '${spaceId}' not found` });
+    return;
+  }
+  const bearer = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim();
+  if (!bearer) {
+    res.status(400).json({ error: 'Ticket minting requires an Authorization: Bearer header' });
+    return;
+  }
+  res.json(mintSseTicket(bearer, `/api/brain/spaces/${spaceId}/events`));
+});
 
 brainEventsRouter.get('/spaces/:spaceId/events', globalRateLimit, requireSpaceAuth, (req, res) => {
   const spaceId = req.params['spaceId'] as string;

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -182,6 +182,11 @@ const ROUTE_RULES: RouteRule[] = [
 
   // ── Traverse ─────────────────────────────────────────────────────────────
   { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/traverse$/,   operation: 'brain.traverse', spaceGroup: 1, read: true },
+
+  // ── SSE ticket mints (read-shaped: they mint a single-use ticket to WATCH a stream, no state
+  //    change worth auditing; the streams themselves are reads) ──────────────
+  { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/events\/ticket$/, operation: 'brain.events.ticket', spaceGroup: 1, read: true },
+  { method: 'POST',   pattern: /^\/api\/about\/logs\/ticket$/,                      operation: 'about.logs.ticket', read: true },
 ];
 
 // Pre-group rules by HTTP method for O(1) method lookup instead of linear scan.

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { findMatchingToken, touchToken } from './tokens.js';
+import { consumeSseTicket } from './sse-ticket.js';
 import { isMfaEnabled, verifyMfaCode } from './totp.js';
 import { validateOidcJwt, getOidcConfig } from './oidc.js';
 import type { TokenRecord } from '../config/types.js';
@@ -17,6 +18,10 @@ declare global {
       authToken?: Omit<TokenRecord, 'hash'> | OidcTokenRecord;
       resolvedSpaceId?: string;
       requestId?: string;
+      /** Bearer exchanged from a single-use SSE ticket, cached so multiple auth middlewares in the same
+       *  request (e.g. a router-level requireAuth + a route-level requireAdmin) don't each try to consume
+       *  it. `null` means the ticket was invalid; `undefined` means not yet exchanged. */
+      sseTicketBearer?: string | null;
     }
   }
 }
@@ -64,36 +69,60 @@ export function denyReadOnly(req: Request, res: Response, next: NextFunction): v
 }
 
 /**
- * Endpoints where a `?token=` query parameter is accepted in place of the
- * Authorization header. Only the SSE streams qualify: the browser `EventSource`
- * API cannot set headers, so there is no alternative there.
- *
- * A token in a query string leaks into access logs, proxy logs, browser history
- * and `Referer` headers, so the fallback must NOT be available instance-wide —
- * it previously was, on every route and every method.
+ * Query-string auth for streams the browser `EventSource` API opens (it cannot set an `Authorization`
+ * header). A token in a URL leaks into access logs, proxy logs, browser history and `Referer`, so the
+ * two BROWSER streams no longer take the raw token — they take a single-use `?ticket=` (minted by an
+ * authenticated `POST …/ticket`, exchanged back to the bearer here; see auth/sse-ticket.ts). Only the
+ * `/mcp` transport still accepts a raw `?token=`: it's an external-agent protocol with a different threat
+ * model (the agent already holds the token and may not be able to set headers). All lists stay anchored
+ * and GET-only so the fallbacks can't widen to other routes.
  */
 const QUERY_TOKEN_PATHS = new Set([
-  '/api/about/logs/stream',  // audit-log live tail (EventSource)
-  '/mcp',                    // MCP SSE transport (EventSource)
+  '/mcp', // MCP SSE transport (external agents) — raw ?token= retained by design
 ]);
 
-// Parameterised SSE paths that can't be listed literally. Kept deliberately narrow (anchored, single
-// path segment for the id) so the query-token fallback stays confined to these GET streams.
-const QUERY_TOKEN_PATH_PATTERNS: RegExp[] = [
+// Browser SSE streams authenticated via a single-use ?ticket= (never the raw token).
+const TICKET_PATHS = new Set([
+  '/api/about/logs/stream', // admin audit-log live tail (EventSource)
+]);
+const TICKET_PATH_PATTERNS: RegExp[] = [
   /^\/api\/brain\/spaces\/[^/]+\/events$/, // live brain-change stream (F12, EventSource)
 ];
 
-function allowsQueryToken(req: Request): boolean {
-  if (req.method !== 'GET') return false;
+/** Request path without query string or trailing slash (`/` when empty). */
+function pathOf(req: Request): string {
   const pathOnly = (req.originalUrl.split('?')[0] ?? '').replace(/\/+$/, '');
-  const p = pathOnly || '/';
-  return QUERY_TOKEN_PATHS.has(p) || QUERY_TOKEN_PATH_PATTERNS.some(re => re.test(p));
+  return pathOnly || '/';
+}
+
+function allowsQueryToken(req: Request): boolean {
+  return req.method === 'GET' && QUERY_TOKEN_PATHS.has(pathOf(req));
+}
+
+function allowsTicket(req: Request): boolean {
+  if (req.method !== 'GET') return false;
+  const p = pathOf(req);
+  return TICKET_PATHS.has(p) || TICKET_PATH_PATTERNS.some(re => re.test(p));
 }
 
 function extractBearer(req: Request): string | null {
   const auth = req.headers.authorization;
   if (auth && auth.startsWith('Bearer ')) return auth.slice('Bearer '.length).trim();
-  // Fallback: query parameter — SSE endpoints only (EventSource cannot set headers)
+  // Browser SSE: exchange the single-use ticket back to its bearer (keeps the token out of the URL).
+  // Bound to this exact path, so a ticket can't cross to another space's stream or the log stream. A
+  // request can pass through more than one auth middleware (a router-level requireAuth + a route-level
+  // requireAdmin), so exchange the ticket ONCE and cache it on the request — single-use is enforced
+  // across requests (each gets a fresh req), but stays consistent within one.
+  if (allowsTicket(req)) {
+    if (req.sseTicketBearer !== undefined) return req.sseTicketBearer;
+    const ticket = req.query['ticket'];
+    const bearer = (typeof ticket === 'string' && ticket.trim())
+      ? consumeSseTicket(ticket.trim(), pathOf(req))
+      : null;
+    req.sseTicketBearer = bearer;
+    return bearer;
+  }
+  // MCP SSE transport only: legacy raw-token fallback (see note above).
   if (allowsQueryToken(req)) {
     const queryToken = req.query['token'];
     if (typeof queryToken === 'string' && queryToken.trim()) return queryToken.trim();

--- a/server/src/auth/sse-ticket.ts
+++ b/server/src/auth/sse-ticket.ts
@@ -1,0 +1,70 @@
+/**
+ * Short-lived, single-use tickets for browser Server-Sent Events streams.
+ *
+ * The browser `EventSource` API cannot set an `Authorization` header, so SSE endpoints historically
+ * accepted the bearer token in the URL query string (`?token=`). A token in a URL leaks into server and
+ * proxy **access logs**, browser **history**, and the `Referer` header — a real credential-exposure
+ * problem for a long-lived PAT. This module replaces that for the browser streams: the client first does
+ * an authenticated `POST …/ticket` (normal `Authorization` header), receives an opaque single-use ticket,
+ * and connects the stream with `?ticket=<t>`. The ticket is a transient alias for the bearer — the auth
+ * layer exchanges it back to the bearer and resolves it exactly as a header would, so space-scope, MFA and
+ * all downstream checks are unchanged; only the URL exposure is gone.
+ *
+ * Properties: opaque 256-bit CSPRNG value; ≤ TTL_MS lifetime; consumed on first use (single-use);
+ * bound to the exact stream path it was minted for (so a brain-space ticket can't open another space's
+ * stream or the admin log stream). In-memory + per-process: the browser mints and connects to the same
+ * instance (same-origin), so no shared store is needed. NOT used for the `/mcp` transport, which is an
+ * external-agent protocol with a different threat model (the agent already holds the token).
+ */
+import { randomBytes } from 'node:crypto';
+
+/** Ticket lifetime. Long enough for the client to mint-then-connect (incl. a reconnect), short enough
+ *  that a leaked ticket is near-useless. */
+const TTL_MS = 60_000;
+
+interface TicketEntry {
+  /** The bearer this ticket aliases (PAT plaintext or OIDC JWT) — resolved normally on exchange. */
+  bearer: string;
+  /** The exact stream path the ticket is valid for, e.g. `/api/brain/spaces/work/events`. */
+  path: string;
+  /** Absolute expiry (ms epoch). */
+  exp: number;
+}
+
+const tickets = new Map<string, TicketEntry>();
+
+/** Drop expired entries. Cheap (called on mint); the map only holds unconsumed, unexpired tickets. */
+function sweep(now: number): void {
+  for (const [t, e] of tickets) {
+    if (e.exp <= now) tickets.delete(t);
+  }
+}
+
+/**
+ * Mint a single-use ticket that aliases `bearer` for the stream at `path`. The caller must already be
+ * authenticated for that path (the mint route runs the normal auth middleware first).
+ */
+export function mintSseTicket(bearer: string, path: string, now: number = Date.now()): { ticket: string; expiresInMs: number } {
+  sweep(now);
+  const ticket = randomBytes(32).toString('base64url');
+  tickets.set(ticket, { bearer, path, exp: now + TTL_MS });
+  return { ticket, expiresInMs: TTL_MS };
+}
+
+/**
+ * Exchange a ticket back to its bearer, consuming it. Returns null (and consumes any match) when the
+ * ticket is unknown, expired, or was minted for a different path. Single-use: a matched ticket is always
+ * removed, so a replay finds nothing.
+ */
+export function consumeSseTicket(ticket: string, path: string, now: number = Date.now()): string | null {
+  const entry = tickets.get(ticket);
+  if (!entry) return null;
+  tickets.delete(ticket); // single-use — remove on any match, valid or not
+  if (entry.exp <= now || entry.path !== path) return null;
+  return entry.bearer;
+}
+
+/** Test-only: clear all tickets between cases. */
+export function _clearSseTickets(): void {
+  tickets.clear();
+}

--- a/testing/integration/brain-events-sse.test.js
+++ b/testing/integration/brain-events-sse.test.js
@@ -3,8 +3,10 @@
  *
  *  - a REST write on the space pushes a `data:` event to a subscribed EventSource-style client
  *  - the event names the collection (`memory.created`) so the client can refresh the right tab
- *  - the query-token fallback authenticates the stream (EventSource can't set headers)
- *  - no token → 401
+ *  - the stream authenticates via a single-use `?ticket=` minted by an authenticated POST (EventSource
+ *    can't set headers; a raw token in the URL would leak into logs/history)
+ *  - a raw `?token=` is REJECTED (the query-token fallback was removed from browser SSE)
+ *  - a ticket is single-use, and no auth → 401
  *
  * Run: node --test testing/integration/brain-events-sse.test.js
  */
@@ -20,10 +22,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
 let tokenA;
 
-/** Open a raw SSE request; resolves with { res, req } once response headers arrive. */
-function openSse(urlPath, token) {
+/** Open a raw SSE request with an arbitrary query string; resolves with { res, req } on headers. */
+function openSse(urlPath, query = '') {
   const u = new URL(INSTANCES.a);
-  const query = token === undefined ? '' : `?token=${encodeURIComponent(token)}`;
   return new Promise((resolve, reject) => {
     const req = http.request(
       { host: u.hostname, port: Number(u.port || 80), path: `${urlPath}${query}`, method: 'GET', headers: { Accept: 'text/event-stream' } },
@@ -32,6 +33,14 @@ function openSse(urlPath, token) {
     req.on('error', reject);
     req.end();
   });
+}
+
+/** Mint a single-use SSE ticket for `streamPath` via the authenticated POST endpoint. */
+async function mintTicket(streamPath, token) {
+  const r = await post(INSTANCES.a, token, `${streamPath}/ticket`, {});
+  assert.equal(r.status, 200, `ticket mint failed: ${JSON.stringify(r.body)}`);
+  assert.ok(typeof r.body.ticket === 'string' && r.body.ticket.length >= 20, 'ticket should be an opaque string');
+  return r.body.ticket;
 }
 
 /** Resolve with the first parsed `data:` JSON object that has an `event` field. */
@@ -57,9 +66,10 @@ describe('brain events SSE (F12)', () => {
   before(() => { tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
 
   it('a REST write pushes a matching event to a subscribed client', async () => {
-    const { res, req } = await openSse('/api/brain/spaces/general/events', tokenA);
+    const ticket = await mintTicket('/api/brain/spaces/general/events', tokenA);
+    const { res, req } = await openSse('/api/brain/spaces/general/events', `?ticket=${encodeURIComponent(ticket)}`);
     try {
-      assert.equal(res.statusCode, 200, 'SSE should authenticate via query token');
+      assert.equal(res.statusCode, 200, 'SSE should authenticate via the minted ticket');
       assert.match(res.headers['content-type'] ?? '', /text\/event-stream/);
 
       const eventP = nextEvent(res);
@@ -78,10 +88,46 @@ describe('brain events SSE (F12)', () => {
     }
   });
 
-  it('rejects an unauthenticated stream (no token) with 401', async () => {
-    const { res, req } = await openSse('/api/brain/spaces/general/events', undefined);
+  it('rejects an unauthenticated stream (no ticket) with 401', async () => {
+    const { res, req } = await openSse('/api/brain/spaces/general/events');
     try {
       assert.equal(res.statusCode, 401);
+    } finally {
+      req.destroy();
+    }
+  });
+
+  it('rejects a raw ?token= on the stream (query-token fallback removed for browser SSE)', async () => {
+    const { res, req } = await openSse('/api/brain/spaces/general/events', `?token=${encodeURIComponent(tokenA)}`);
+    try {
+      assert.equal(res.statusCode, 401, 'VULNERABILITY: raw token in the URL still authenticates the stream');
+    } finally {
+      req.destroy();
+    }
+  });
+
+  it('a ticket is single-use — replaying it is rejected', async () => {
+    const ticket = await mintTicket('/api/brain/spaces/general/events', tokenA);
+    const first = await openSse('/api/brain/spaces/general/events', `?ticket=${encodeURIComponent(ticket)}`);
+    try {
+      assert.equal(first.res.statusCode, 200, 'first use of the ticket should connect');
+    } finally {
+      first.req.destroy();
+    }
+    const second = await openSse('/api/brain/spaces/general/events', `?ticket=${encodeURIComponent(ticket)}`);
+    try {
+      assert.equal(second.res.statusCode, 401, 'VULNERABILITY: a consumed ticket was accepted again');
+    } finally {
+      second.req.destroy();
+    }
+  });
+
+  it('a ticket minted for one space does not open another space stream', async () => {
+    const ticket = await mintTicket('/api/brain/spaces/general/events', tokenA);
+    // Bound to /general/events — using it on a different space path must fail (unknown ticket for path).
+    const { res, req } = await openSse('/api/brain/spaces/personal/events', `?ticket=${encodeURIComponent(ticket)}`);
+    try {
+      assert.equal(res.statusCode, 401, 'VULNERABILITY: a ticket crossed to another space stream');
     } finally {
       req.destroy();
     }

--- a/testing/red-team-tests/auth-surface-hardening.test.js
+++ b/testing/red-team-tests/auth-surface-hardening.test.js
@@ -1,10 +1,12 @@
 /**
  * Red-team tests: auth surface hardening (M2, M8, M9, L1, L2)
  *
- * M2 — the `?token=` query-param fallback is accepted ONLY on the SSE endpoints
- *      (EventSource cannot set headers). On every other route a query token must
- *      be ignored → 401, so a token cannot be smuggled through access logs,
- *      proxy logs, or a Referer header.
+ * M2 — a raw `?token=` query param is ignored on every route except the `/mcp`
+ *      transport → 401. The browser SSE streams (brain events, audit-log tail) now
+ *      authenticate via a single-use `?ticket=` minted by an authenticated POST, so
+ *      no long-lived token is ever placed in a URL (access/proxy logs, Referer,
+ *      browser history). EventSource still can't set headers — the ticket is what
+ *      keeps the token out of the URL.
  * M8 — a TOTP code is single-use: replaying a code that is still inside its
  *      ±1-step validity window must be refused.
  * M9 — the instance-level MCP tools (`list_peers`, `sync_now`) require an admin
@@ -83,18 +85,40 @@ describe('M2 — ?token= is accepted only on the SSE endpoints', () => {
     assert.equal(r.status, 401, 'VULNERABILITY: POST accepted a token from the query string');
   });
 
-  it('still accepts a query-param token on the log-stream SSE endpoint (EventSource)', async () => {
+  it('rejects a raw ?token= on the log-stream SSE endpoint (query-token fallback removed)', async () => {
+    const r = await fetch(`${INSTANCES.a}/api/about/logs/stream?token=${encodeURIComponent(adminToken)}`);
+    assert.equal(r.status, 401, 'VULNERABILITY: raw token in the URL still authenticates the log stream');
+  });
+
+  it('rejects a raw ?token= on the brain-events SSE stream', async () => {
+    const r = await fetch(`${INSTANCES.a}/api/brain/spaces/general/events?token=${encodeURIComponent(adminToken)}`);
+    assert.equal(r.status, 401, 'VULNERABILITY: raw token in the URL still authenticates the brain stream');
+  });
+
+  it('authenticates the log-stream SSE via a single-use ticket (EventSource)', async () => {
+    const mint = await post(INSTANCES.a, adminToken, '/api/about/logs/ticket', {});
+    assert.equal(mint.status, 200, `ticket mint failed: ${JSON.stringify(mint.body)}`);
+    const ticket = mint.body.ticket;
+    assert.ok(typeof ticket === 'string' && ticket.length >= 20, 'ticket should be opaque');
     // The SSE stream never ends — abort as soon as headers arrive.
     const ac = new AbortController();
     const r = await fetch(
-      `${INSTANCES.a}/api/about/logs/stream?token=${encodeURIComponent(adminToken)}`,
+      `${INSTANCES.a}/api/about/logs/stream?ticket=${encodeURIComponent(ticket)}`,
       { signal: ac.signal },
     );
     const status = r.status;
     const ctype = r.headers.get('content-type') ?? '';
     ac.abort();
-    assert.equal(status, 200, 'the audit-log EventSource must keep working');
+    assert.equal(status, 200, 'the audit-log EventSource must authenticate via a ticket');
     assert.match(ctype, /text\/event-stream/);
+  });
+
+  it('rejects an unknown/forged ticket on the log-stream SSE endpoint', async () => {
+    const ac = new AbortController();
+    const r = await fetch(`${INSTANCES.a}/api/about/logs/stream?ticket=not-a-real-ticket`, { signal: ac.signal });
+    const status = r.status;
+    ac.abort();
+    assert.equal(status, 401, 'an unknown ticket must not authenticate');
   });
 
   it('the Authorization header still works everywhere (regression)', async () => {

--- a/testing/standalone/route-guard-coverage.test.js
+++ b/testing/standalone/route-guard-coverage.test.js
@@ -86,6 +86,9 @@ const READ_SHAPED_POSTS = [
   '/spaces/:spaceId/recall',
   '/spaces/:spaceId/find-similar',
   '/spaces/:spaceId/traverse',
+  // Minting a single-use ticket to WATCH the live-events stream is a read (the stream itself allows
+  // read-only tokens — "watching is a read"), so it must not be blocked for a read-only token.
+  '/spaces/:spaceId/events/ticket',
   '/recall',
   '/:id/validate-schema',
   '/export-space',


### PR DESCRIPTION
## The problem
The browser `EventSource` API can't set an `Authorization` header, so two SSE streams accepted the bearer token as a `?token=` query parameter:
- `GET /api/brain/spaces/:id/events` — live brain-change stream (F12)
- `GET /api/about/logs/stream` — admin audit-log tail

A token in a URL **leaks into server/proxy access logs, browser history, and the `Referer` header** — a real exposure for a long-lived PAT. (Flagged by the owner while we were debugging the brain request-storm.)

## The fix — single-use tickets
Both browser streams now authenticate with a **short-lived, single-use, path-bound ticket** that aliases the bearer, so the rest of the auth chain (resolve → space-scope → MFA) is unchanged — only the URL exposure is removed.

- **`server/src/auth/sse-ticket.ts`** — mint/consume an opaque 256-bit CSPRNG ticket: ≤60s TTL, single-use (deleted on first exchange), bound to the exact stream path.
- **Mint endpoints** (authenticated by header): `POST /api/brain/spaces/:id/events/ticket` (`requireSpaceAuth`) and `POST /api/about/logs/ticket` (`requireAdmin`).
- **`auth/middleware.ts`** — browser SSE paths accept `?ticket=` (exchanged back to the bearer); a raw `?token=` is now **rejected** on them. The ticket is exchanged **once per request and cached on `req`**, so a route that runs auth twice (the `/api/about` router-level `requireAuth` + route-level `requireAdmin`) doesn't consume a single-use ticket twice. `/mcp` **keeps** `?token=` by design — external-agent transport, different threat model.
- **Clients** mint a ticket then connect. The brain stream reconnects with a **fresh** ticket on error (single-use ⇒ native auto-reconnect can't replay a dead ticket) behind a **3s backoff + active-space guard**, so it can never become a request storm.

## Verification
- **Integration** (`brain-events-sse`) and **red-team** (`auth-surface-hardening` M2) rewritten and **run green against the Docker test stack**: ticket auth works, raw `?token=` is rejected on both streams, tickets are single-use, and a ticket is bound to its own stream path (can't cross spaces).
- Server typechecks; client AOT build clean; 19 client unit specs pass (mint mocks added).
- CHANGELOG (Security) + `docs/integration-guide.md` updated.

## Not in scope (tracked)
- `/mcp` query-token (intentional).
- Rate-limiter shared-gateway-IP keying (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)