### PR TITLE
feat(settings): Audit Log on the design system (PR-U5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -918,6 +918,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Audit Log on the design system.** The status column now uses the shared status-pill
+  vocabulary (ok / warn / error) instead of a page-local badge dialect, and rows worth noticing get a
+  leading severity stripe (5xx → error, 4xx / `auth.failed` → warn) so problems read at a glance. A
+  **summary strip** rolls up what's in view (shown · client errors · server errors · auth failures), the
+  **status filter is now derived from the statuses actually present** rather than a fixed guess-list, and
+  timestamps render as relative times (with an absolute tooltip) in `tabular-nums`. The detail view is now
+  a **structured labelled panel** (timestamp, token/user, operation, method+path, status, IP, duration,
+  space) with the full raw JSON tucked into a collapsible block instead of a wall of `{ … }`.
+
 - **Document extraction now defaults to `auto`.** `mediaEmbedding.documentProcessing.mode` defaults to `auto`
   (was `ocr`): use the VLM when one is configured and reachable, otherwise fall back to OCR. With no
   `vlmModel` set this is byte-for-byte the old OCR-only path, so installs without a vision model are

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1134,5 +1134,12 @@
   "brain.error.loadFileMeta": "Dateidatensätze konnten nicht geladen werden.",
   "files.error.loadFiles": "Dateien konnten nicht geladen werden.",
   "schemaLib.error.load": "Schema-Bibliothek konnte nicht geladen werden.",
-  "graph.error.load": "Graph konnte nicht geladen werden."
+  "graph.error.load": "Graph konnte nicht geladen werden.",
+  "auditLog.summary.shown": "Angezeigt",
+  "auditLog.summary.clientErrors": "Client-Fehler",
+  "auditLog.summary.serverErrors": "Server-Fehler",
+  "auditLog.summary.authFailures": "Auth-Fehler",
+  "auditLog.detail.request": "Anfrage",
+  "auditLog.detail.entryId": "Eintrags-ID",
+  "auditLog.detail.rawJson": "Roh-JSON"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1133,5 +1133,12 @@
   "brain.error.loadFileMeta": "Couldn't load file records.",
   "files.error.loadFiles": "Couldn't load files.",
   "schemaLib.error.load": "Couldn't load the schema library.",
-  "graph.error.load": "Couldn't load the graph."
+  "graph.error.load": "Couldn't load the graph.",
+  "auditLog.summary.shown": "Shown",
+  "auditLog.summary.clientErrors": "Client errors",
+  "auditLog.summary.serverErrors": "Server errors",
+  "auditLog.summary.authFailures": "Auth failures",
+  "auditLog.detail.request": "Request",
+  "auditLog.detail.entryId": "Entry ID",
+  "auditLog.detail.rawJson": "Raw JSON"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1134,5 +1134,12 @@
   "brain.error.loadFileMeta": "Nie udało się załadować rekordów plików.",
   "files.error.loadFiles": "Nie udało się załadować plików.",
   "schemaLib.error.load": "Nie udało się załadować biblioteki schematów.",
-  "graph.error.load": "Nie udało się załadować grafu."
+  "graph.error.load": "Nie udało się załadować grafu.",
+  "auditLog.summary.shown": "Wyświetlone",
+  "auditLog.summary.clientErrors": "Błędy klienta",
+  "auditLog.summary.serverErrors": "Błędy serwera",
+  "auditLog.summary.authFailures": "Błędy uwierzytelniania",
+  "auditLog.detail.request": "Żądanie",
+  "auditLog.detail.entryId": "ID wpisu",
+  "auditLog.detail.rawJson": "Surowy JSON"
 }

--- a/client/src/app/pages/settings/audit-log.component.spec.ts
+++ b/client/src/app/pages/settings/audit-log.component.spec.ts
@@ -104,4 +104,72 @@ describe('AuditLogComponent (OnPush)', () => {
     expect(body(fixture)).toContain('token.delete');
     expect(body(fixture)).not.toContain('memory.create');
   });
+
+  // ── PR-U5: design-system redesign ───────────────────────────────────────────
+  it('renders a StatusPill per row with the variant mapped from the HTTP status', () => {
+    const fixture = create([
+      entry({ status: 200, operation: 'a' }),
+      entry({ status: 404, operation: 'b' }),
+      entry({ status: 503, operation: 'c' }),
+    ]);
+    const pills = Array.from(
+      fixture.nativeElement.querySelectorAll('table.audit-table tbody app-status-pill .pill'),
+    ) as HTMLElement[];
+    expect(pills.length).toBe(3);
+    const classes = pills.map(p => p.className);
+    expect(classes.some(c => c.includes('ok'))).toBe(true);    // 200
+    expect(classes.some(c => c.includes('warn'))).toBe(true);  // 404
+    expect(classes.some(c => c.includes('error'))).toBe(true); // 503
+  });
+
+  it('gives 5xx rows a row-error stripe and auth failures a row-warn stripe (200 gets none)', () => {
+    const fixture = create([
+      entry({ status: 500, operation: 'a' }),
+      entry({ status: 401, operation: 'auth.failed' }),
+      entry({ status: 200, operation: 'b' }),
+    ]);
+    const rows = fixture.nativeElement.querySelectorAll('table.audit-table tbody tr');
+    expect(rows[0].className).toContain('row-error');
+    expect(rows[1].className).toContain('row-warn');
+    expect(rows[2].className).not.toContain('row-');
+  });
+
+  it('summary strip counts client/server errors and auth failures in view', () => {
+    const fixture = create([
+      entry({ status: 404, operation: 'a' }),
+      entry({ status: 500, operation: 'b' }),
+      entry({ status: 401, operation: 'auth.failed' }),
+      entry({ status: 200, operation: 'c' }),
+    ]);
+    expect(fixture.nativeElement.querySelector('app-summary-strip')).toBeTruthy();
+    const items = fixture.componentInstance.summaryItems();
+    const val = (frag: string) => items.find(i => i.label.includes(frag))?.value;
+    expect(val('shown')).toBe(4);
+    expect(val('clientErrors')).toBe(2); // 404 + 401
+    expect(val('serverErrors')).toBe(1); // 500
+    expect(val('authFailures')).toBe(1); // auth.failed
+  });
+
+  it('detail panel shows structured fields (method+path) and a collapsible raw-JSON block', () => {
+    const fixture = create([entry()]);
+    fixture.componentInstance.showDetail(
+      entry({ operation: 'space.wipe', method: 'POST', path: '/api/admin/spaces/x/wipe', status: 500 }),
+    );
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.detail-panel');
+    expect(panel.querySelector('dl.detail-grid')).toBeTruthy();
+    expect(panel.textContent).toContain('POST');
+    expect(panel.textContent).toContain('/api/admin/spaces/x/wipe');
+    expect(panel.querySelector('app-status-pill')).toBeTruthy();
+    expect(panel.querySelector('details.detail-raw')).toBeTruthy(); // raw JSON is collapsible, not the whole panel
+  });
+
+  it('status filter options are derived from the statuses present in the results', () => {
+    const fixture = create([
+      entry({ status: 200, operation: 'a' }),
+      entry({ status: 200, operation: 'b' }),
+      entry({ status: 404, operation: 'c' }),
+    ]);
+    expect(fixture.componentInstance.statusOptions()).toEqual([200, 404]);
+  });
 });

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -1,10 +1,13 @@
-import { ChangeDetectionStrategy, Component, inject, signal, OnInit, OnDestroy, effect } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, OnDestroy, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { type AuditLogEntry, type AuditLogParams, type Space } from '../../core/api.types';
 import { AdminApi } from '../../core/admin-api.service';
 import { SpacesApi } from '../../core/spaces-api.service';
-import { TranslocoPipe } from '@jsverse/transloco';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { StatusPillComponent, type StatusVariant } from '../../shared/status-pill.component';
+import { RelativeTimeComponent } from '../../shared/relative-time.component';
+import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
 
 @Component({
   selector: 'app-audit-log',
@@ -15,7 +18,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
   // when state changes and skips the whole-tree sweep otherwise — this page renders up to a
   // 100-row table plus a live-streaming server log, both in the CD hot path.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe],
+  imports: [CommonModule, FormsModule, TranslocoPipe, StatusPillComponent, RelativeTimeComponent, SummaryStripComponent],
   styles: [`
     .audit-toolbar {
       display: flex;
@@ -76,18 +79,33 @@ import { TranslocoPipe } from '@jsverse/transloco';
     }
     .audit-table tr:hover { background: var(--bg-elevated); }
 
-    .badge-status {
-      display: inline-block;
-      padding: 1px 6px;
-      border-radius: 4px;
-      font-size: 11px;
-      font-weight: 600;
-    }
-    .badge-2xx { background: var(--success-bg);  color: var(--success); }
-    .badge-4xx { background: var(--warning-bg);  color: var(--warning); }
-    .badge-5xx { background: var(--error-bg);    color: var(--error); }
-
     .mono { font-family: var(--font-mono, monospace); font-size: 12px; }
+    .num { font-variant-numeric: tabular-nums; }
+
+    /* Rows worth noticing get a leading severity stripe (semantic colour, not the accent) so an auth
+       failure or a 5xx reads at a glance without relying on the status pill alone. */
+    .audit-table tr.row-warn td:first-child { box-shadow: inset 3px 0 0 var(--warning); }
+    .audit-table tr.row-error td:first-child { box-shadow: inset 3px 0 0 var(--error); }
+    .audit-table tr.row-error td:nth-child(3) { color: var(--error); font-weight: 600; }
+
+    /* Structured detail panel — a labelled field grid + a collapsible raw-JSON block. */
+    .detail-grid {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 6px 16px;
+      align-items: baseline;
+      margin: 4px 0 14px;
+      font-size: 13px;
+    }
+    .detail-grid dt {
+      color: var(--text-muted);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .detail-grid dd { margin: 0; color: var(--text-primary); word-break: break-word; }
+    .detail-raw { margin-top: 8px; }
+    .detail-raw summary { cursor: pointer; font-size: 12px; color: var(--text-secondary); }
 
     .pagination {
       display: flex;
@@ -225,14 +243,9 @@ import { TranslocoPipe } from '@jsverse/transloco';
         {{ 'auditLog.filter.status' | transloco }}
         <select [(ngModel)]="filterStatus">
           <option value="">{{ 'common.all' | transloco }}</option>
-          <option value="200">200</option>
-          <option value="201">201</option>
-          <option value="204">204</option>
-          <option value="400">400</option>
-          <option value="401">401</option>
-          <option value="403">403</option>
-          <option value="404">404</option>
-          <option value="500">500</option>
+          @for (s of statusOptions(); track s) {
+            <option [value]="s">{{ s }}</option>
+          }
         </select>
       </label>
       <label>
@@ -258,6 +271,10 @@ import { TranslocoPipe } from '@jsverse/transloco';
       <p class="error-msg">{{ error() }}</p>
     }
 
+    @if (!loading() && entries().length > 0) {
+      <app-summary-strip [items]="summaryItems()" />
+    }
+
     @if (loading()) {
       <p>{{ 'common.loading' | transloco }}</p>
     } @else if (entries().length === 0) {
@@ -278,19 +295,14 @@ import { TranslocoPipe } from '@jsverse/transloco';
         </thead>
         <tbody>
           @for (e of entries(); track e._id) {
-            <tr>
-              <td class="mono">{{ formatTs(e.timestamp) }}</td>
+            <tr [class]="rowClass(e)">
+              <td><app-relative-time [value]="e.timestamp" /></td>
               <td>{{ e.tokenLabel ?? e.oidcSubject ?? '—' }}</td>
               <td class="mono">{{ e.operation }}</td>
               <td>{{ e.spaceId ?? '—' }}</td>
-              <td>
-                <span class="badge-status"
-                      [class.badge-2xx]="e.status >= 200 && e.status < 300"
-                      [class.badge-4xx]="e.status >= 400 && e.status < 500"
-                      [class.badge-5xx]="e.status >= 500">{{ e.status }}</span>
-              </td>
+              <td><app-status-pill [variant]="statusVariant(e.status)">{{ e.status }}</app-status-pill></td>
               <td class="mono">{{ e.ip }}</td>
-              <td>{{ e.durationMs }}ms</td>
+              <td class="num">{{ e.durationMs }}ms</td>
               <td><button class="detail-close" style="padding:2px 8px;font-size:11px" (click)="showDetail(e)">{{ 'auditLog.table.detailButton' | transloco }}</button></td>
             </tr>
           }
@@ -307,11 +319,36 @@ import { TranslocoPipe } from '@jsverse/transloco';
     }
 
     <!-- Detail panel -->
-    @if (selectedEntry()) {
+    @if (selectedEntry(); as e) {
       <div class="detail-overlay" (click)="selectedEntry.set(null)">
         <div class="detail-panel" (click)="$event.stopPropagation()">
           <h3>{{ 'auditLog.detail.title' | transloco }}</h3>
-          <pre>{{ selectedEntry() | json }}</pre>
+          <dl class="detail-grid">
+            <dt>{{ 'auditLog.table.timestamp' | transloco }}</dt>
+            <dd><app-relative-time [value]="e.timestamp" /></dd>
+            <dt>{{ 'auditLog.table.tokenUser' | transloco }}</dt>
+            <dd>{{ e.tokenLabel ?? e.oidcSubject ?? '—' }}<span class="mono" style="color:var(--text-muted)">@if (e.authMethod) { &nbsp;· {{ e.authMethod }} }</span></dd>
+            <dt>{{ 'auditLog.table.operation' | transloco }}</dt>
+            <dd class="mono">{{ e.operation }}</dd>
+            <dt>{{ 'auditLog.detail.request' | transloco }}</dt>
+            <dd class="mono">{{ e.method }} {{ e.path }}</dd>
+            <dt>{{ 'auditLog.table.status' | transloco }}</dt>
+            <dd><app-status-pill [variant]="statusVariant(e.status)">{{ e.status }}</app-status-pill></dd>
+            <dt>{{ 'auditLog.table.space' | transloco }}</dt>
+            <dd>{{ e.spaceId ?? '—' }}</dd>
+            <dt>{{ 'auditLog.table.ip' | transloco }}</dt>
+            <dd class="mono">{{ e.ip }}</dd>
+            <dt>{{ 'auditLog.table.duration' | transloco }}</dt>
+            <dd class="num">{{ e.durationMs }}ms</dd>
+            @if (e.entryId) {
+              <dt>{{ 'auditLog.detail.entryId' | transloco }}</dt>
+              <dd class="mono">{{ e.entryId }}</dd>
+            }
+          </dl>
+          <details class="detail-raw">
+            <summary>{{ 'auditLog.detail.rawJson' | transloco }}</summary>
+            <pre>{{ e | json }}</pre>
+          </details>
           <button class="detail-close" (click)="selectedEntry.set(null)">{{ 'auditLog.detail.closeButton' | transloco }}</button>
         </div>
       </div>
@@ -323,6 +360,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
 export class AuditLogComponent implements OnInit, OnDestroy {
   private adminApi = inject(AdminApi);
   private spacesApi = inject(SpacesApi);
+  private transloco = inject(TranslocoService);
 
   activeLogTab = signal<'audit' | 'server'>('audit');
   loading = signal(true);
@@ -334,6 +372,25 @@ export class AuditLogComponent implements OnInit, OnDestroy {
   spaces = signal<Space[]>([]);
   selectedEntry = signal<AuditLogEntry | null>(null);
   retentionDays = signal(90);
+
+  /** Status codes present in the current result set — the filter offers only what's actually there
+   *  instead of a fixed guess-list. */
+  statusOptions = computed(() => [...new Set(this.entries().map(e => e.status))].sort((a, b) => a - b));
+
+  /** At-a-glance rollup of what's currently in view, with warn/error emphasis when non-zero. */
+  summaryItems = computed<SummaryItem[]>(() => {
+    const tr = (k: string) => this.transloco.translate(k);
+    const es = this.entries();
+    const c4 = es.filter(e => e.status >= 400 && e.status < 500).length;
+    const c5 = es.filter(e => e.status >= 500).length;
+    const authFailed = es.filter(e => e.operation === 'auth.failed').length;
+    return [
+      { label: tr('auditLog.summary.shown'), value: es.length },
+      { label: tr('auditLog.summary.clientErrors'), value: c4, variant: c4 ? 'warn' : undefined },
+      { label: tr('auditLog.summary.serverErrors'), value: c5, variant: c5 ? 'error' : undefined },
+      { label: tr('auditLog.summary.authFailures'), value: authFailed, variant: authFailed ? 'error' : undefined },
+    ];
+  });
 
   filterAfter = '';
   filterBefore = '';
@@ -445,9 +502,19 @@ export class AuditLogComponent implements OnInit, OnDestroy {
     });
   }
 
-  formatTs(iso: string): string {
-    const d = new Date(iso);
-    return d.toLocaleString();
+  /** Map an HTTP status to the shared status-pill vocabulary. */
+  statusVariant(status: number): StatusVariant {
+    if (status >= 500) return 'error';
+    if (status >= 400) return 'warn';
+    if (status >= 300) return 'off';
+    return 'ok';
+  }
+
+  /** Leading severity stripe for rows worth noticing: 5xx → error, 4xx / auth failure → warn. */
+  rowClass(e: AuditLogEntry): string {
+    if (e.status >= 500) return 'row-error';
+    if (e.status >= 400 || e.operation === 'auth.failed') return 'row-warn';
+    return '';
   }
 
   exportJson(): void {


### PR DESCRIPTION
Rebuilds **Settings → Audit Log** on the shared settings design-system primitives (PR-U5 of the settings-UX rollout).

## Changes
- **StatusPill** (ok/warn/error) for the status column + detail — retires the page-local `badge-2xx/4xx/5xx` dialect (the "third badge dialect" the UX audit flagged).
- **Severity row stripe** — rows worth noticing get a leading colored stripe: `5xx → error`, `4xx` / `auth.failed → warn`, so an operational problem reads at a glance (semantic color, not the accent).
- **SummaryStrip** atop the table: *shown · client errors · server errors · auth failures*, emphasized when non-zero.
- **Dynamic status filter** — options derived from the statuses actually present, instead of a fixed guess-list.
- **RelativeTime** (+ absolute tooltip) on timestamps (table + detail); `tabular-nums` on status/duration.
- **Structured detail panel** — replaces `<pre>{{ entry | json }}</pre>` with a labelled field grid (timestamp, token/user + auth method, operation, method+path, status pill, IP, duration, space, entry id) and the full raw JSON in a collapsible `<details>`.
- i18n keys added to **en/de/pl** (CRLF + literal-unicode preserved).

## Not done (intentional)
- Did **not** wrap the page in `SettingsCard` — low value for a single dense table; kept the existing table markup and `.empty` state.

## Tests
- 10 audit-log specs (5 new: pill variants, severity stripes, summary counts, structured detail + collapsible raw, dynamic filter options).
- Full **124 settings + shared specs** pass; **AOT production build** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)