### PR TITLE
feat(settings): Networks status at a glance — summary strip + vote pills/tally (PR-U3 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Networks: status at a glance.** A summary strip tops the page (networks · need-your-vote ·
+  members), each network card header shows an amber **"N pending"** vote pill when a governance round is open
+  (using the shared status-pill vocabulary), and each open vote row now shows its **deadline** as a relative
+  time plus a **yes/veto tally**. (Second design-system slice for Networks; still behavior-preserving —
+  covered by the characterization tests.)
+
 - **Settings → Networks: in-flight feedback on every async action.** Generate-invite, Save-schedule,
   Sync-now, and the vote Yes/Veto buttons now show a spinner and disable themselves while the request is in
   flight, so a slow network op reads as *working* (and can't be double-fired) instead of looking dead. The

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1141,5 +1141,11 @@
   "auditLog.summary.authFailures": "Auth-Fehler",
   "auditLog.detail.request": "Anfrage",
   "auditLog.detail.entryId": "Eintrags-ID",
-  "auditLog.detail.rawJson": "Roh-JSON"
+  "auditLog.detail.rawJson": "Roh-JSON",
+  "networks.summary.networks": "Netzwerke",
+  "networks.summary.needVote": "Ihre Stimme nötig",
+  "networks.summary.members": "Mitglieder",
+  "networks.header.pendingVote": "ausstehend",
+  "networks.network.votes.deadline": "Frist",
+  "networks.network.votes.tally": "{{ yes }} Ja · {{ veto }} Veto"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1140,5 +1140,11 @@
   "auditLog.summary.authFailures": "Auth failures",
   "auditLog.detail.request": "Request",
   "auditLog.detail.entryId": "Entry ID",
-  "auditLog.detail.rawJson": "Raw JSON"
+  "auditLog.detail.rawJson": "Raw JSON",
+  "networks.summary.networks": "Networks",
+  "networks.summary.needVote": "Need your vote",
+  "networks.summary.members": "Members",
+  "networks.header.pendingVote": "pending",
+  "networks.network.votes.deadline": "Deadline",
+  "networks.network.votes.tally": "{{ yes }} yes · {{ veto }} veto"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1141,5 +1141,11 @@
   "auditLog.summary.authFailures": "Błędy uwierzytelniania",
   "auditLog.detail.request": "Żądanie",
   "auditLog.detail.entryId": "ID wpisu",
-  "auditLog.detail.rawJson": "Surowy JSON"
+  "auditLog.detail.rawJson": "Surowy JSON",
+  "networks.summary.networks": "Sieci",
+  "networks.summary.needVote": "Wymaga Twojego głosu",
+  "networks.summary.members": "Członkowie",
+  "networks.header.pendingVote": "oczekujące",
+  "networks.network.votes.deadline": "Termin",
+  "networks.network.votes.tally": "{{ yes }} tak · {{ veto }} weto"
 }

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -283,4 +283,33 @@ describe('NetworksComponent (characterization)', () => {
     sy.error({});
     expect(c.syncingNet['n1']).toBeUndefined();
   });
+
+  it('summaryItems() counts networks and total members', () => {
+    const c = make();
+    c.networks.set([
+      net({ id: 'n1', members: [{}, {}, {}] as never }),
+      net({ id: 'n2', members: [{}] as never }),
+    ]);
+    const items = c.summaryItems();
+    const val = (frag: string) => items.find(i => i.label.includes(frag))?.value;
+    expect(val('networks')).toBe(2);
+    expect(val('members')).toBe(4);
+    expect(val('needVote')).toBe(0);
+  });
+
+  it('summaryItems() needs-vote count reflects networks with open rounds after load', () => {
+    const c = make();
+    api.listNetworks.mockReturnValue(of({ networks: [net({ id: 'n1' }), net({ id: 'n2' })] }));
+    api.listVotes.mockImplementation((id: string) => of({ rounds: id === 'n1' ? [round({ status: 'open' })] : [] }));
+    c.load();
+    expect(c.summaryItems().find(i => i.label.includes('needVote'))?.value).toBe(1);
+  });
+
+  it('voteTally() counts yes and veto votes', () => {
+    const c = make();
+    const t = c.voteTally(round({ votes: [
+      { instanceId: 'a', vote: 'yes' }, { instanceId: 'b', vote: 'veto' }, { instanceId: 'c', vote: 'yes' },
+    ] }));
+    expect(t).toEqual({ yes: 2, veto: 1 });
+  });
 });

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { InviteBundle, Network, Space, SyncHistoryRecord, VoteRound } from '../../core/api.types';
@@ -11,10 +11,13 @@ import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ModalDirective } from '../../shared/modal.directive';
+import { StatusPillComponent } from '../../shared/status-pill.component';
+import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
+import { RelativeTimeComponent } from '../../shared/relative-time.component';
 @Component({
   selector: 'app-networks',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent],
   styles: [`
     .network-card {
       background: var(--bg-surface);
@@ -188,12 +191,17 @@ import { ModalDirective } from '../../shared/modal.directive';
         <p>{{ 'networks.empty.body' | transloco }}</p>
       </div>
     } @else {
+      <app-summary-strip [items]="summaryItems()" style="display:block; margin-bottom:16px;" />
       @for (net of networks(); track net.id) {
         <div class="network-card">
           <div class="network-card-header" (click)="toggleNetwork(net.id)">
             <span class="network-name">{{ net.label }}</span>
             <span class="badge" [ngClass]="typeBadge(net.type)">{{ net.type }}</span>
             <span class="badge badge-gray">{{ net.members.length }} {{ net.members.length === 1 ? ('networks.memberBadge.singular' | transloco) : ('networks.memberBadge.plural' | transloco) }}</span>
+            @if (openVotes(net.id).length > 0) {
+              <app-status-pill variant="warn" [dot]="true">{{ openVotes(net.id).length }} {{ 'networks.header.pendingVote' | transloco }}</app-status-pill>
+            }
+            <span style="flex:1;"></span>
             <span style="color:var(--text-muted); display:inline-flex;"><ph-icon [name]="expanded() === net.id ? 'caret-up' : 'caret-down'" [size]="14" /></span>
           </div>
 
@@ -320,6 +328,12 @@ import { ModalDirective } from '../../shared/modal.directive';
                   @for (round of openVotes(net.id); track round.id) {
                     <div class="vote-row">
                       <span style="flex:1;">{{ round.type }}: {{ round.subject }}</span>
+                      <span style="font-size:11px; color:var(--text-muted); white-space:nowrap;">
+                        {{ 'networks.network.votes.deadline' | transloco }} <app-relative-time [value]="round.deadline" />
+                      </span>
+                      <span class="num" style="font-size:11px; color:var(--text-muted); white-space:nowrap;">
+                        {{ 'networks.network.votes.tally' | transloco: { yes: voteTally(round).yes, veto: voteTally(round).veto } }}
+                      </span>
                       <button class="btn-primary btn btn-sm" [disabled]="votingRound[round.id]" (click)="castVote(net.id, round.id, 'yes')">
                         @if (votingRound[round.id]) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> }
                         {{ 'networks.network.votes.yes' | transloco }}
@@ -678,6 +692,28 @@ export class NetworksComponent implements OnInit {
   inviteBundle(id: string): InviteBundle | undefined { return this.inviteBundles[id]; }
   bundleJson(bundle: InviteBundle): string { return JSON.stringify(bundle, null, 2); }
   syncResult(id: string): { ok: boolean } | undefined { return this.syncResults[id]; }
+
+  /** At-a-glance rollup atop the page. Recomputes when `networks` changes — and `loadVotes` always
+   *  bumps `networks` after updating the vote cache, so the "need your vote" count stays live. */
+  readonly summaryItems = computed<SummaryItem[]>(() => {
+    const tr = (k: string) => this.transloco.translate(k);
+    const nets = this.networks();
+    const needVote = nets.filter(n => this.openVotes(n.id).length > 0).length;
+    const members = nets.reduce((sum, n) => sum + (n.members?.length ?? 0), 0);
+    return [
+      { label: tr('networks.summary.networks'), value: nets.length },
+      { label: tr('networks.summary.needVote'), value: needVote, variant: needVote ? 'warn' : undefined },
+      { label: tr('networks.summary.members'), value: members },
+    ];
+  });
+
+  /** Yes/veto counts for an open vote round (for the row tally). */
+  voteTally(round: VoteRound): { yes: number; veto: number } {
+    return {
+      yes: round.votes.filter(v => v.vote === 'yes').length,
+      veto: round.votes.filter(v => v.vote === 'veto').length,
+    };
+  }
 
   ngOnInit(): void {
     this.enableOs = this.detectLocalOs();


### PR DESCRIPTION
Second design-system slice for the **Networks** page — behavior-preserving (the #293 characterization tests stay green).

## Changes
- **Page-top SummaryStrip**: *networks · need-your-vote · members* (need-your-vote emphasized amber when non-zero).
- **Pending-vote pill** on each network card header: an amber **"N pending"** `StatusPill` when the network has open governance rounds.
- **Vote rows** now show the round's **deadline** as a `RelativeTime` (with absolute tooltip) plus a **yes/veto tally**.

## Tests
- New `summaryItems` computed + `voteTally` helper, pinned by **3 new characterization tests** (summary counts, needs-vote count after load, vote tally). 21 networks specs pass; AOT build clean. i18n keys added to en/de/pl.

## Next slice
Modal extraction (Create/Join/Enable → child components) to tame the 1261-line file; then vote confirm-on-veto + responsive/SettingsCard polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)