### PR TITLE
feat(settings): Networks — confirm before casting a Veto (PR-U3 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Networks: casting a Veto now asks for confirmation.** A veto blocks a pending governance
+  round for the whole network and can't be undone, so it now goes through a danger-styled confirm dialog;
+  a "Yes" vote stays one click. (Pinned by the characterization tests.)
+
 - **Settings → Networks: status at a glance.** A summary strip tops the page (networks · need-your-vote ·
   members), each network card header shows an amber **"N pending"** vote pill when a governance round is open
   (using the shared status-pill vocabulary), and each open vote row now shows its **deadline** as a relative

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1147,5 +1147,7 @@
   "networks.summary.members": "Mitglieder",
   "networks.header.pendingVote": "ausstehend",
   "networks.network.votes.deadline": "Frist",
-  "networks.network.votes.tally": "{{ yes }} Ja · {{ veto }} Veto"
+  "networks.network.votes.tally": "{{ yes }} Ja · {{ veto }} Veto",
+  "networks.confirm.vetoTitle": "Diese Runde ablehnen?",
+  "networks.confirm.veto": "Ein Veto blockiert diese ausstehende Runde für das gesamte Netzwerk. Dies kann nicht rückgängig gemacht werden."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1146,5 +1146,7 @@
   "networks.summary.members": "Members",
   "networks.header.pendingVote": "pending",
   "networks.network.votes.deadline": "Deadline",
-  "networks.network.votes.tally": "{{ yes }} yes · {{ veto }} veto"
+  "networks.network.votes.tally": "{{ yes }} yes · {{ veto }} veto",
+  "networks.confirm.vetoTitle": "Veto this round?",
+  "networks.confirm.veto": "A veto blocks this pending round for the whole network. This cannot be undone."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1147,5 +1147,7 @@
   "networks.summary.members": "Członkowie",
   "networks.header.pendingVote": "oczekujące",
   "networks.network.votes.deadline": "Termin",
-  "networks.network.votes.tally": "{{ yes }} tak · {{ veto }} weto"
+  "networks.network.votes.tally": "{{ yes }} tak · {{ veto }} weto",
+  "networks.confirm.vetoTitle": "Zawetować tę rundę?",
+  "networks.confirm.veto": "Weto blokuje tę oczekującą rundę dla całej sieci. Nie można tego cofnąć."
 }

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -212,8 +212,27 @@ describe('NetworksComponent (characterization)', () => {
     expect(api.listVotes).toHaveBeenCalledWith('n1'); // reload
 
     api.castVote.mockReturnValue(throwError(() => ({ error: { error: 'boom' } })));
-    c.castVote('n1', 'r1', 'veto');
+    c.castVote('n1', 'r1', 'yes');
     expect(toastError).toHaveBeenCalled();
+  });
+
+  it('castVote "veto" confirms first and only proceeds when accepted', async () => {
+    const c = make();
+    confirmResult = false;
+    await c.castVote('n1', 'r1', 'veto');
+    expect(confirm).toHaveBeenCalled();
+    expect(api.castVote).not.toHaveBeenCalled();
+
+    confirmResult = true;
+    await c.castVote('n1', 'r1', 'veto');
+    expect(api.castVote).toHaveBeenCalledWith('n1', 'r1', 'veto');
+  });
+
+  it('castVote "yes" does NOT ask for confirmation', () => {
+    const c = make();
+    c.castVote('n1', 'r1', 'yes');
+    expect(confirm).not.toHaveBeenCalled();
+    expect(api.castVote).toHaveBeenCalledWith('n1', 'r1', 'yes');
   });
 
   it('removeMember() is confirm-guarded and reloads on success', async () => {

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -1306,7 +1306,18 @@ export class NetworksComponent implements OnInit {
     return this.votesByNetwork[networkId] ?? [];
   }
 
-  castVote(networkId: string, roundId: string, vote: 'yes' | 'veto'): void {
+  async castVote(networkId: string, roundId: string, vote: 'yes' | 'veto'): Promise<void> {
+    // A veto is destructive — it blocks a pending join/governance round — so confirm it first. A "yes"
+    // is safe and stays one click.
+    if (vote === 'veto') {
+      const ok = await this.confirmDialog.confirm({
+        title: this.transloco.translate('networks.confirm.vetoTitle'),
+        message: this.transloco.translate('networks.confirm.veto'),
+        confirmLabel: this.transloco.translate('networks.network.votes.veto'),
+        danger: true,
+      });
+      if (!ok) return;
+    }
     this.votingRound[roundId] = true;
     this.networksApi.castVote(networkId, roundId, vote).subscribe({
       next: () => { delete this.votingRound[roundId]; this.loadVotes(networkId); },


### PR DESCRIPTION
A **veto** blocks a pending governance round for the whole network and can't be undone — but it was a single unguarded click next to the "Yes" button. It now routes through a **danger-styled confirm dialog** first; a "Yes" vote stays one click and unconfirmed.

## Change
- `castVote(..., 'veto')` awaits a confirm dialog (title/message/danger) before calling the API; `castVote(..., 'yes')` is unchanged.

## Tests
- Characterization tests updated/added: veto confirms then proceeds only when accepted, declined veto makes no API call, "yes" never confirms. **23 networks specs pass**; i18n keys added to en/de/pl; AOT build clean.

## Next slice
The modal extraction (Create/Join/Enable → child components) to tame the 1261-line file — its own focused PR (moves the relevant char-tests with the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)