### PR TITLE
refactor(settings): extract Networks Create dialog into its own component (PR-U3 slice 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal: the Networks Create dialog is now its own component.** Extracted `NetworkCreateDialogComponent`
+  out of the 1261-line `NetworksComponent` — the create form (label/type/space-selection + fallback and
+  voting deadline) and its `createNetwork` call now live in a focused child that emits the new network to
+  the host. No behavior change (the create characterization tests moved with it); first step toward
+  splitting the Join and Enable-Networks dialogs out too.
+
 - **Settings → Networks: casting a Veto now asks for confirmation.** A veto blocks a pending governance
   round for the whole network and can't be undone, so it now goes through a danger-styled confirm dialog;
   a "Yes" vote stays one click. (Pinned by the characterization tests.)

--- a/client/src/app/pages/settings/network-create-dialog.component.spec.ts
+++ b/client/src/app/pages/settings/network-create-dialog.component.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * NetworkCreateDialogComponent — characterization tests for the create form, relocated from
+ * networks.component.spec.ts when the Create dialog was extracted into its own child component (PR-U3).
+ * Behavior is unchanged from the inline version: blank-label guard, the create payload shape, the
+ * comma-separated fallback when the host's spaces list failed to load, and the server-error surface.
+ * The only difference from the old inline version is that success now EMITS the created network (the
+ * host appends + closes) instead of mutating a shared list.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import type { Network } from '../../core/api.types';
+import { NetworksApi } from '../../core/networks-api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { NetworkCreateDialogComponent } from './network-create-dialog.component';
+
+describe('NetworkCreateDialogComponent (characterization)', () => {
+  let api: { createNetwork: ReturnType<typeof vi.fn> };
+
+  function make() {
+    api = { createNetwork: vi.fn((body: unknown) => of({ id: 'new', label: (body as { label: string }).label } as Network)) };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [NetworkCreateDialogComponent, getTranslocoModule()],
+      providers: [{ provide: NetworksApi, useValue: api }],
+    });
+    return TestBed.createComponent(NetworkCreateDialogComponent);
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('createNetwork() is a no-op when the label is blank', () => {
+    const c = make().componentInstance;
+    c.form = { label: '   ', type: 'closed', votingDeadlineHours: 48 };
+    c.createNetwork();
+    expect(api.createNetwork).not.toHaveBeenCalled();
+  });
+
+  it('createNetwork() posts the selected spaces and emits the created network', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    const created = vi.fn();
+    c.created.subscribe(created);
+    c.form = { label: ' Team ', type: 'club', votingDeadlineHours: 24 };
+    c.networkSelectedSpaces = ['a', 'b'];
+    c.createNetwork();
+    expect(api.createNetwork).toHaveBeenCalledWith({ label: 'Team', type: 'club', spaces: ['a', 'b'], votingDeadlineHours: 24 });
+    expect(created).toHaveBeenCalledWith(expect.objectContaining({ id: 'new', label: 'Team' }));
+    expect(c.creating()).toBe(false);
+  });
+
+  it('createNetwork() falls back to the comma-separated spaces field when the spaces list failed to load', () => {
+    const fixture = make();
+    fixture.componentRef.setInput('spacesLoadFailed', true);
+    const c = fixture.componentInstance;
+    c.form = { label: 'X', type: 'closed', votingDeadlineHours: 48 };
+    c.networkSpacesFallback = 'general, personal ,';
+    c.createNetwork();
+    expect(api.createNetwork).toHaveBeenCalledWith(expect.objectContaining({ spaces: ['general', 'personal'] }));
+  });
+
+  it('createNetwork() surfaces the server error into createError', () => {
+    const fixture = make();
+    api.createNetwork.mockReturnValue(throwError(() => ({ error: { error: 'nope' } })));
+    const c = fixture.componentInstance;
+    c.form = { label: 'X', type: 'closed', votingDeadlineHours: 48 };
+    c.createNetwork();
+    expect(c.createError()).toBe('nope');
+    expect(c.creating()).toBe(false);
+  });
+
+  it('toggleNetworkSpace() adds/removes ids and syncs the select-all flag', () => {
+    const fixture = make();
+    fixture.componentRef.setInput('availableSpaces', [{ id: 'a' }, { id: 'b' }] as never);
+    const c = fixture.componentInstance;
+    c.toggleNetworkSpace('a');
+    expect(c.isNetworkSpaceSelected('a')).toBe(true);
+    expect(c.networkSelectAll).toBe(false);
+    c.toggleNetworkSpace('b');
+    expect(c.networkSelectAll).toBe(true); // both selected → all
+    c.toggleNetworkSpace('a');
+    expect(c.isNetworkSpaceSelected('a')).toBe(false);
+    expect(c.networkSelectAll).toBe(false);
+  });
+
+  it('toggleNetworkSelectAll() selects every available space then clears', () => {
+    const fixture = make();
+    fixture.componentRef.setInput('availableSpaces', [{ id: 'a' }, { id: 'b' }, { id: 'c' }] as never);
+    const c = fixture.componentInstance;
+    c.toggleNetworkSelectAll();
+    expect(c.networkSelectedSpaces).toEqual(['a', 'b', 'c']);
+    c.toggleNetworkSelectAll();
+    expect(c.networkSelectedSpaces).toEqual([]);
+  });
+});

--- a/client/src/app/pages/settings/network-create-dialog.component.ts
+++ b/client/src/app/pages/settings/network-create-dialog.component.ts
@@ -1,0 +1,200 @@
+import { Component, inject, signal, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Network, Space } from '../../core/api.types';
+import { NetworksApi } from '../../core/networks-api.service';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ModalDirective } from '../../shared/modal.directive';
+
+/**
+ * Create-network dialog, extracted from the (large) NetworksComponent as the first slice of taming that
+ * 1261-line file (PR-U3). Owns the whole create form — label / type / space selection (with a
+ * comma-separated fallback when the spaces list can't load) and the voting-deadline field — and performs
+ * the `createNetwork` API call itself, emitting the created `Network` to the host (which appends it and
+ * closes the dialog). Behaviour is unchanged from the inline version; the create characterization tests
+ * moved here with it (network-create-dialog.component.spec.ts).
+ *
+ * Host renders it gated: `@if (showCreateDialog()) { <app-network-create-dialog … /> }`, so this
+ * component is only alive while open and needs no visibility state of its own.
+ */
+@Component({
+  selector: 'app-network-create-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  styles: [`
+    .dialog-backdrop {
+      position: fixed;
+      inset: 0;
+      background: var(--bg-scrim);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 100;
+    }
+    .dialog {
+      background: var(--bg-primary);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 24px;
+      width: 90%;
+      max-width: 600px;
+      max-height: 90vh;
+      overflow-y: auto;
+    }
+    .dialog-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+  `],
+  template: `
+    <div class="dialog-backdrop" (click)="close.emit()">
+      <div class="dialog" [appModal]="'networks.dialog.create.title' | transloco" (dismiss)="close.emit()" (click)="$event.stopPropagation()">
+        <div class="dialog-header">
+          <div class="card-title">{{ 'networks.dialog.create.title' | transloco }}</div>
+          <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="close.emit()"><ph-icon name="x" [size]="14"/></button>
+        </div>
+
+        @if (createError()) { <div class="alert alert-error">{{ createError() }}</div> }
+
+        <form (ngSubmit)="createNetwork()" style="display:grid; grid-template-columns:1fr 1fr; gap:12px; align-items:end;">
+          <div class="field" style="margin-bottom:0;">
+            <label>{{ 'networks.dialog.create.label' | transloco }}</label>
+            <input type="text" [(ngModel)]="form.label" name="label" [placeholder]="'networks.dialog.create.labelPlaceholder' | transloco" required />
+          </div>
+          <div class="field" style="margin-bottom:0;">
+            <label>{{ 'networks.dialog.create.type' | transloco }}</label>
+            <select [(ngModel)]="form.type" name="type">
+              <option value="closed">{{ 'networks.type.closed' | transloco }}</option>
+              <option value="democratic">{{ 'networks.type.democratic' | transloco }}</option>
+              <option value="club">{{ 'networks.type.club' | transloco }}</option>
+              <option value="braintree">{{ 'networks.type.braintree' | transloco }}</option>
+              <option value="pubsub">{{ 'networks.type.pubsub' | transloco }}</option>
+            </select>
+          </div>
+          <div class="field" style="margin-bottom:0; grid-column:span 2;">
+            <label>{{ 'networks.dialog.create.spaces' | transloco }}</label>
+            @if (spacesLoadFailed()) {
+              <div class="alert alert-error" style="margin-bottom:6px; font-size:12px;">{{ 'networks.dialog.create.spacesLoadFailed' | transloco }}</div>
+              <input type="text" [(ngModel)]="networkSpacesFallback" name="spaces" [placeholder]="'networks.dialog.create.spacesFallbackPlaceholder' | transloco" />
+            } @else if (availableSpaces().length === 0) {
+              <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'networks.dialog.create.loadingSpaces' | transloco }}</div>
+            } @else {
+              <div class="table-wrapper" style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
+                <table style="margin:0;">
+                  <thead>
+                    <tr>
+                      <th style="width:40px; text-align:center;">
+                        <input type="checkbox" [checked]="networkSelectAll" (change)="toggleNetworkSelectAll()" [attr.title]="'networks.dialog.create.allSpacesTitle' | transloco" />
+                      </th>
+                      <th>{{ 'spaces.table.column.label' | transloco }}</th>
+                      <th>{{ 'spaces.table.column.id' | transloco }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @for (s of availableSpaces(); track s.id) {
+                      <tr style="cursor:pointer;" (click)="toggleNetworkSpace(s.id)">
+                        <td style="text-align:center;">
+                          <input type="checkbox" [checked]="isNetworkSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleNetworkSpace(s.id)" />
+                        </td>
+                        <td>{{ s.label }}</td>
+                        <td><span class="badge badge-gray mono" style="font-size:11px;">{{ s.id }}</span></td>
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              </div>
+            }
+          </div>
+          @if (form.type !== 'pubsub') {
+            <div class="field" style="margin-bottom:0; grid-column:span 2;">
+              <label>{{ 'networks.dialog.create.votingDeadline' | transloco }}</label>
+              <input type="number" [(ngModel)]="form.votingDeadlineHours" name="deadline" min="1" max="72" />
+            </div>
+          }
+          <div style="grid-column:span 2; display:flex; gap:8px; justify-content:flex-end;">
+            <button class="btn-secondary btn" type="button" (click)="close.emit()">{{ 'common.cancel' | transloco }}</button>
+            <button class="btn-primary btn" type="submit" [disabled]="creating() || !form.label.trim()">
+              @if (creating()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+              {{ 'networks.dialog.create.submitButton' | transloco }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `,
+})
+export class NetworkCreateDialogComponent {
+  private networksApi = inject(NetworksApi);
+  private transloco = inject(TranslocoService);
+
+  /** Local spaces to offer for selection (resolved by the host). */
+  readonly availableSpaces = input<Space[]>([]);
+  /** When the host's spaces list failed to load, fall back to a comma-separated ids field. */
+  readonly spacesLoadFailed = input(false);
+
+  /** Emitted with the newly-created network — the host appends it and closes this dialog. */
+  readonly created = output<Network>();
+  /** Emitted when the user cancels/dismisses. */
+  readonly close = output<void>();
+
+  form = { label: '', type: 'closed', votingDeadlineHours: 48 };
+  networkSpacesFallback = '';
+  networkSelectedSpaces: string[] = [];
+  networkSelectAll = false;
+  creating = signal(false);
+  createError = signal('');
+
+  createNetwork(): void {
+    if (!this.form.label.trim()) return;
+    this.creating.set(true);
+    this.createError.set('');
+
+    let spaces: string[];
+    if (this.spacesLoadFailed()) {
+      spaces = this.networkSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
+    } else {
+      spaces = [...this.networkSelectedSpaces];
+    }
+
+    this.networksApi.createNetwork({
+      label: this.form.label.trim(),
+      type: this.form.type,
+      spaces,
+      votingDeadlineHours: this.form.votingDeadlineHours,
+    }).subscribe({
+      next: (net) => {
+        this.creating.set(false);
+        this.created.emit(net);
+      },
+      error: (err) => {
+        this.creating.set(false);
+        this.createError.set(err.error?.error ?? this.transloco.translate('networks.error.createFailed'));
+      },
+    });
+  }
+
+  isNetworkSpaceSelected(id: string): boolean {
+    return this.networkSelectedSpaces.includes(id);
+  }
+
+  toggleNetworkSpace(id: string): void {
+    if (this.networkSelectedSpaces.includes(id)) {
+      this.networkSelectedSpaces = this.networkSelectedSpaces.filter(s => s !== id);
+    } else {
+      this.networkSelectedSpaces = [...this.networkSelectedSpaces, id];
+    }
+    this.networkSelectAll = this.networkSelectedSpaces.length === this.availableSpaces().length;
+  }
+
+  toggleNetworkSelectAll(): void {
+    this.networkSelectAll = !this.networkSelectAll;
+    if (this.networkSelectAll) {
+      this.networkSelectedSpaces = this.availableSpaces().map(s => s.id);
+    } else {
+      this.networkSelectedSpaces = [];
+    }
+  }
+}

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -87,42 +87,17 @@ describe('NetworksComponent (characterization)', () => {
     expect(c.openVotes('n1').map(r => r.id)).toEqual(['open1']); // closed round filtered out
   });
 
-  it('createNetwork() is a no-op when the label is blank', () => {
-    const c = make();
-    c.form = { label: '   ', type: 'closed', votingDeadlineHours: 48 };
-    c.createNetwork();
-    expect(api.createNetwork).not.toHaveBeenCalled();
-  });
+  // Create-dialog behavior (blank-label guard, space payload, CSV fallback, error) moved to
+  // network-create-dialog.component.spec.ts when the Create dialog became its own child component.
+  // The parent only appends the emitted network and closes — pinned by the onNetworkCreated test below.
 
-  it('createNetwork() posts the selected spaces, appends the result, resets the form and closes the dialog', () => {
+  it('onNetworkCreated() appends the created network and closes the dialog', () => {
     const c = make();
-    c.form = { label: ' Team ', type: 'club', votingDeadlineHours: 24 };
-    c.networkSelectedSpaces = ['a', 'b'];
+    c.networks.set([net({ id: 'n1' })]);
     c.showCreateDialog.set(true);
-    c.createNetwork();
-    expect(api.createNetwork).toHaveBeenCalledWith({ label: 'Team', type: 'club', spaces: ['a', 'b'], votingDeadlineHours: 24 });
-    expect(c.networks().some(n => n.label === 'Team')).toBe(true);
+    c.onNetworkCreated(net({ id: 'new', label: 'Fresh' }));
+    expect(c.networks().map(n => n.id)).toEqual(['n1', 'new']);
     expect(c.showCreateDialog()).toBe(false);
-    expect(c.form.label).toBe('');
-    expect(c.networkSelectedSpaces).toEqual([]);
-  });
-
-  it('createNetwork() falls back to the comma-separated spaces field when the spaces list failed to load', () => {
-    const c = make();
-    c.spacesLoadFailed.set(true);
-    c.form = { label: 'X', type: 'closed', votingDeadlineHours: 48 };
-    c.networkSpacesFallback = 'general, personal ,';
-    c.createNetwork();
-    expect(api.createNetwork).toHaveBeenCalledWith(expect.objectContaining({ spaces: ['general', 'personal'] }));
-  });
-
-  it('createNetwork() surfaces the server error into createError', () => {
-    const c = make();
-    api.createNetwork.mockReturnValue(throwError(() => ({ error: { error: 'nope' } })));
-    c.form = { label: 'X', type: 'closed', votingDeadlineHours: 48 };
-    c.createNetwork();
-    expect(c.createError()).toBe('nope');
-    expect(c.creating()).toBe(false);
   });
 
   it('leaveNetwork() removes the network only after the confirm dialog is accepted', async () => {

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -14,10 +14,11 @@ import { ModalDirective } from '../../shared/modal.directive';
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
+import { NetworkCreateDialogComponent } from './network-create-dialog.component';
 @Component({
   selector: 'app-networks',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, NetworkCreateDialogComponent],
   styles: [`
     .network-card {
       background: var(--bg-surface);
@@ -356,80 +357,12 @@ import { RelativeTimeComponent } from '../../shared/relative-time.component';
 
     <!-- Create Network dialog -->
     @if (showCreateDialog()) {
-      <div class="dialog-backdrop" (click)="showCreateDialog.set(false)">
-        <div class="dialog" [appModal]="'networks.dialog.create.title' | transloco" (dismiss)="showCreateDialog.set(false)" (click)="$event.stopPropagation()">
-          <div class="dialog-header">
-            <div class="card-title">{{ 'networks.dialog.create.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
-          </div>
-
-          @if (createError()) { <div class="alert alert-error">{{ createError() }}</div> }
-
-          <form (ngSubmit)="createNetwork()" style="display:grid; grid-template-columns:1fr 1fr; gap:12px; align-items:end;">
-            <div class="field" style="margin-bottom:0;">
-              <label>{{ 'networks.dialog.create.label' | transloco }}</label>
-              <input type="text" [(ngModel)]="form.label" name="label" [placeholder]="'networks.dialog.create.labelPlaceholder' | transloco" required />
-            </div>
-            <div class="field" style="margin-bottom:0;">
-              <label>{{ 'networks.dialog.create.type' | transloco }}</label>
-              <select [(ngModel)]="form.type" name="type">
-                <option value="closed">{{ 'networks.type.closed' | transloco }}</option>
-                <option value="democratic">{{ 'networks.type.democratic' | transloco }}</option>
-                <option value="club">{{ 'networks.type.club' | transloco }}</option>
-                <option value="braintree">{{ 'networks.type.braintree' | transloco }}</option>
-                <option value="pubsub">{{ 'networks.type.pubsub' | transloco }}</option>
-              </select>
-            </div>
-            <div class="field" style="margin-bottom:0; grid-column:span 2;">
-              <label>{{ 'networks.dialog.create.spaces' | transloco }}</label>
-              @if (spacesLoadFailed()) {
-                <div class="alert alert-error" style="margin-bottom:6px; font-size:12px;">{{ 'networks.dialog.create.spacesLoadFailed' | transloco }}</div>
-                <input type="text" [(ngModel)]="networkSpacesFallback" name="spaces" [placeholder]="'networks.dialog.create.spacesFallbackPlaceholder' | transloco" />
-              } @else if (availableSpaces().length === 0) {
-                <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'networks.dialog.create.loadingSpaces' | transloco }}</div>
-              } @else {
-                <div class="table-wrapper" style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
-                  <table style="margin:0;">
-                    <thead>
-                      <tr>
-                        <th style="width:40px; text-align:center;">
-                          <input type="checkbox" [checked]="networkSelectAll" (change)="toggleNetworkSelectAll()" [attr.title]="'networks.dialog.create.allSpacesTitle' | transloco" />
-                        </th>
-                        <th>{{ 'spaces.table.column.label' | transloco }}</th>
-                        <th>{{ 'spaces.table.column.id' | transloco }}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      @for (s of availableSpaces(); track s.id) {
-                        <tr style="cursor:pointer;" (click)="toggleNetworkSpace(s.id)">
-                          <td style="text-align:center;">
-                            <input type="checkbox" [checked]="isNetworkSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleNetworkSpace(s.id)" />
-                          </td>
-                          <td>{{ s.label }}</td>
-                          <td><span class="badge badge-gray mono" style="font-size:11px;">{{ s.id }}</span></td>
-                        </tr>
-                      }
-                    </tbody>
-                  </table>
-                </div>
-              }
-            </div>
-            @if (form.type !== 'pubsub') {
-              <div class="field" style="margin-bottom:0; grid-column:span 2;">
-                <label>{{ 'networks.dialog.create.votingDeadline' | transloco }}</label>
-                <input type="number" [(ngModel)]="form.votingDeadlineHours" name="deadline" min="1" max="72" />
-              </div>
-            }
-            <div style="grid-column:span 2; display:flex; gap:8px; justify-content:flex-end;">
-              <button class="btn-secondary btn" type="button" (click)="showCreateDialog.set(false)">{{ 'common.cancel' | transloco }}</button>
-              <button class="btn-primary btn" type="submit" [disabled]="creating() || !form.label.trim()">
-                @if (creating()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'networks.dialog.create.submitButton' | transloco }}
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
+      <app-network-create-dialog
+        [availableSpaces]="availableSpaces()"
+        [spacesLoadFailed]="spacesLoadFailed()"
+        (created)="onNetworkCreated($event)"
+        (close)="showCreateDialog.set(false)"
+      />
     }
 
     <!-- Join Network dialog -->
@@ -629,20 +562,14 @@ export class NetworksComponent implements OnInit {
 
   networks = signal<Network[]>([]);
   loading = signal(true);
-  creating = signal(false);
-  createError = signal('');
   showCreateDialog = signal(false);
   showJoinDialog = signal(false);
   expanded = signal('');
 
-  form = { label: '', type: 'closed', votingDeadlineHours: 48 };
   netSchedule: Record<string, string> = {};
 
   availableSpaces = signal<Space[]>([]);
   spacesLoadFailed = signal(false);
-  networkSelectedSpaces: string[] = [];
-  networkSpacesFallback = '';
-  networkSelectAll = false;
 
   private inviteBundles: Record<string, InviteBundle> = {};
   private syncResults: Record<string, { ok: boolean }> = {};
@@ -977,59 +904,10 @@ export class NetworksComponent implements OnInit {
     this.expanded.update(v => v === id ? '' : id);
   }
 
-  createNetwork(): void {
-    if (!this.form.label.trim()) return;
-    this.creating.set(true);
-    this.createError.set('');
-
-    let spaces: string[];
-    if (this.spacesLoadFailed()) {
-      spaces = this.networkSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
-    } else {
-      spaces = [...this.networkSelectedSpaces];
-    }
-
-    this.networksApi.createNetwork({
-      label: this.form.label.trim(),
-      type: this.form.type,
-      spaces,
-      votingDeadlineHours: this.form.votingDeadlineHours,
-    }).subscribe({
-      next: (net) => {
-        this.creating.set(false);
-        this.showCreateDialog.set(false);
-        this.networks.update(list => [...list, net]);
-        this.form = { label: '', type: 'closed', votingDeadlineHours: 48 };
-        this.networkSelectedSpaces = [];
-        this.networkSpacesFallback = '';
-      },
-      error: (err) => {
-        this.creating.set(false);
-        this.createError.set(err.error?.error ?? this.transloco.translate('networks.error.createFailed'));
-      },
-    });
-  }
-
-  isNetworkSpaceSelected(id: string): boolean {
-    return this.networkSelectedSpaces.includes(id);
-  }
-
-  toggleNetworkSpace(id: string): void {
-    if (this.networkSelectedSpaces.includes(id)) {
-      this.networkSelectedSpaces = this.networkSelectedSpaces.filter(s => s !== id);
-    } else {
-      this.networkSelectedSpaces = [...this.networkSelectedSpaces, id];
-    }
-    this.networkSelectAll = this.networkSelectedSpaces.length === this.availableSpaces().length;
-  }
-
-  toggleNetworkSelectAll(): void {
-    this.networkSelectAll = !this.networkSelectAll;
-    if (this.networkSelectAll) {
-      this.networkSelectedSpaces = this.availableSpaces().map(s => s.id);
-    } else {
-      this.networkSelectedSpaces = [];
-    }
+  /** The create dialog (child component) emits the new network; append it and close. */
+  onNetworkCreated(net: Network): void {
+    this.networks.update(list => [...list, net]);
+    this.showCreateDialog.set(false);
   }
 
   async leaveNetwork(net: Network): Promise<void> {


### PR DESCRIPTION
First **structural** slice of taming the 1261-line `NetworksComponent`: pull the **Create dialog** out into a focused child, `NetworkCreateDialogComponent`.

## Change
- The child owns the create form (label / type / space-selection with the comma-separated fallback / voting deadline) and performs the `createNetwork` API call, **emitting the new network** (`created`) to the host; the host just appends it and closes (`onNetworkCreated`) and gates visibility with `@if (showCreateDialog())`.
- Parent shrinks ~125 lines (dialog template + 4 methods + 6 fields removed). The component-scoped dialog CSS the child needs (`.dialog-backdrop/.dialog/.dialog-header`) moved with it; the rest (`.field/.alert/…`) is global.
- **No behavior change.**

## Tests (behavior stays pinned)
- The four create characterization tests **moved** to `network-create-dialog.component.spec.ts` (success now asserts the `created` output instead of a shared-list mutation), plus 2 tests for the space-selection toggles.
- The parent keeps a test that `onNetworkCreated` appends + closes.
- **26 networks specs pass**; AOT production build clean.

## Next
Extract the **Join** dialog (the gnarliest — collision resolution) and the **Enable-Networks wizard** the same way, then responsive/`SettingsCard` polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)