### PR TITLE
refactor(settings): extract Networks Join dialog into its own component (PR-U3 slice 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,11 +924,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Internal: the Networks Create dialog is now its own component.** Extracted `NetworkCreateDialogComponent`
-  out of the 1261-line `NetworksComponent` — the create form (label/type/space-selection + fallback and
-  voting deadline) and its `createNetwork` call now live in a focused child that emits the new network to
-  the host. No behavior change (the create characterization tests moved with it); first step toward
-  splitting the Join and Enable-Networks dialogs out too.
+- **Internal: the Networks Create and Join dialogs are now their own components.** Extracted
+  `NetworkCreateDialogComponent` and `NetworkJoinDialogComponent` out of the 1261-line `NetworksComponent`
+  — the create form (label/type/space-selection + fallback and voting deadline) and the join flow (invite-
+  bundle validation + space-id collision resolution) now live in focused children that emit results to the
+  host. No behavior change (the create and join characterization tests moved with them); the parent has
+  shed ~250 lines. Next: the Enable-Networks wizard.
 
 - **Settings → Networks: casting a Veto now asks for confirmation.** A veto blocks a pending governance
   round for the whole network and can't be undone, so it now goes through a danger-styled confirm dialog;

--- a/client/src/app/pages/settings/network-join-dialog.component.spec.ts
+++ b/client/src/app/pages/settings/network-join-dialog.component.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * NetworkJoinDialogComponent — characterization tests for the join flow, relocated from
+ * networks.component.spec.ts when the Join dialog was extracted into its own child component (PR-U3).
+ * Pins the bundle validation (invalid JSON / incomplete bundle / missing my-URL), the space-id
+ * collision detection + hold-for-resolution, the alias validation in confirmJoin, and the immediate
+ * join path. `myUrl` is a one-way input from the host; success emits `joined`.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { NetworksApi } from '../../core/networks-api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { NetworkJoinDialogComponent } from './network-join-dialog.component';
+
+describe('NetworkJoinDialogComponent (characterization)', () => {
+  let api: { joinRemote: ReturnType<typeof vi.fn> };
+
+  function make(myUrl = 'https://me.example') {
+    api = { joinRemote: vi.fn(() => of({ status: 'joined', networkLabel: 'X' })) };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [NetworkJoinDialogComponent, getTranslocoModule()],
+      providers: [{ provide: NetworksApi, useValue: api }],
+    });
+    const fixture = TestBed.createComponent(NetworkJoinDialogComponent);
+    fixture.componentRef.setInput('myUrl', myUrl);
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('rejects invalid JSON, an incomplete bundle, and a missing "my URL" without calling the API', () => {
+    let c = make().componentInstance;
+    c.joinBundle = 'not json';
+    c.joinNetwork();
+    expect(c.joinError()).toBeTruthy();
+    expect(api.joinRemote).not.toHaveBeenCalled();
+
+    c.joinBundle = JSON.stringify({ handshakeId: 'h' }); // missing inviteUrl/rsaPublicKeyPem/networkId
+    c.joinNetwork();
+    expect(c.joinError()).toBeTruthy();
+    expect(api.joinRemote).not.toHaveBeenCalled();
+
+    c = make('').componentInstance; // no my-URL
+    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1' });
+    c.joinNetwork();
+    expect(c.joinError()).toBeTruthy();
+    expect(api.joinRemote).not.toHaveBeenCalled();
+  });
+
+  it('detects space-id collisions and holds for resolution instead of joining', () => {
+    const f = make();
+    f.componentRef.setInput('availableSpaces', [{ id: 'general', label: 'General' }] as never);
+    const c = f.componentInstance;
+    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1', spaces: ['general', 'remote-only'] });
+    c.joinNetwork();
+    expect(c.joinCollisionSpaces()).toEqual(['general']);
+    expect(api.joinRemote).not.toHaveBeenCalled();
+  });
+
+  it('with no collisions joins immediately and emits "joined" on success', () => {
+    const f = make();
+    f.componentRef.setInput('availableSpaces', [{ id: 'general', label: 'General' }] as never);
+    const c = f.componentInstance;
+    const joined = vi.fn();
+    c.joined.subscribe(joined);
+    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1', spaces: ['remote-only'] });
+    c.joinNetwork();
+    expect(api.joinRemote).toHaveBeenCalledWith(expect.objectContaining({ handshakeId: 'h', myUrl: 'https://me.example', networkId: 'n1' }));
+    expect(joined).toHaveBeenCalled();
+  });
+
+  it('confirmJoin() validates alias inputs, then joins with a spaceMap', () => {
+    const f = make();
+    f.componentRef.setInput('availableSpaces', [{ id: 'general' }] as never);
+    const c = f.componentInstance;
+    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1', spaces: ['general'] });
+    c.joinNetwork(); // → collision, holds
+    expect(c.joinCollisionSpaces()).toEqual(['general']);
+
+    c.onCollisionActionChange('general', 'alias');
+    c.joinSpaceAliases['general'] = ''; // blank alias → error, no join
+    c.confirmJoin();
+    expect(c.joinError()).toBeTruthy();
+    expect(api.joinRemote).not.toHaveBeenCalled();
+
+    c.joinSpaceAliases['general'] = 'general-local'; // valid alias → joins with spaceMap
+    c.confirmJoin();
+    expect(api.joinRemote).toHaveBeenCalledWith(expect.objectContaining({ spaceMap: { general: 'general-local' } }));
+  });
+});

--- a/client/src/app/pages/settings/network-join-dialog.component.ts
+++ b/client/src/app/pages/settings/network-join-dialog.component.ts
@@ -1,0 +1,273 @@
+import { Component, inject, signal, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Space } from '../../core/api.types';
+import { NetworksApi } from '../../core/networks-api.service';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ModalDirective } from '../../shared/modal.directive';
+
+/**
+ * Join-network dialog, extracted from the (large) NetworksComponent (PR-U3). Owns the invite-bundle
+ * textarea, the bundle validation (JSON / required fields / this brain's URL), the space-id
+ * **collision-resolution** UI (merge vs alias, with alias validation), and the `joinRemote` call.
+ *
+ * `myUrl` is a one-way input: the host computes this brain's own URL (used to gate the enable-networks
+ * flow) and passes it in; the join dialog never lets the user edit it, it only needs it to submit. On a
+ * successful join the dialog shows its result message and emits `joined` so the host reloads the network
+ * list and refreshes its spaces (a join can create new local spaces). Behaviour matches the inline
+ * version; the join characterization tests moved here with it.
+ */
+@Component({
+  selector: 'app-network-join-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  styles: [`
+    .dialog-backdrop {
+      position: fixed;
+      inset: 0;
+      background: var(--bg-scrim);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 100;
+    }
+    .dialog {
+      background: var(--bg-primary);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 24px;
+      width: 90%;
+      max-width: 600px;
+      max-height: 90vh;
+      overflow-y: auto;
+    }
+    .dialog-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+  `],
+  template: `
+    <div class="dialog-backdrop" (click)="close.emit()">
+      <div class="dialog" [appModal]="'networks.dialog.join.title' | transloco" (dismiss)="close.emit()" (click)="$event.stopPropagation()">
+        <div class="dialog-header">
+          <div class="card-title">{{ 'networks.dialog.join.title' | transloco }}</div>
+          <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="close.emit()"><ph-icon name="x" [size]="14"/></button>
+        </div>
+
+        @if (joinError()) { <div class="alert alert-error">{{ joinError() }}</div> }
+        @if (joinSuccess()) { <div class="alert alert-success">{{ joinSuccess() }}</div> }
+
+        <div class="field">
+          <label>{{ 'networks.dialog.join.bundleLabel' | transloco }}</label>
+          <textarea
+            [(ngModel)]="joinBundle"
+            name="joinBundle"
+            rows="5"
+            [placeholder]="'networks.dialog.join.bundlePlaceholder' | transloco"
+            [attr.aria-label]="'networks.dialog.join.bundleAriaLabel' | transloco"
+            style="font-family:var(--font-mono); font-size:12px; resize:vertical;"
+          ></textarea>
+        </div>
+
+        @if (joinCollisionSpaces().length > 0) {
+          <div style="margin:0 0 12px; padding:12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-elevated);">
+            <div style="font-weight:600; font-size:13px; margin-bottom:8px;">{{ 'networks.dialog.join.collisions.title' | transloco }}</div>
+            <p style="font-size:12px; color:var(--text-muted); margin:0 0 12px;">
+              {{ 'networks.dialog.join.collisions.body' | transloco }}
+            </p>
+            @for (remoteId of joinCollisionSpaces(); track remoteId) {
+              <div style="display:flex; align-items:center; gap:8px; margin-bottom:8px;">
+                <span class="badge badge-gray mono" style="min-width:80px;">{{ remoteId }}</span>
+                <select
+                  [ngModel]="joinSpaceActions[remoteId]"
+                  (ngModelChange)="onCollisionActionChange(remoteId, $event)"
+                  [name]="'collision-' + remoteId"
+                  style="width:140px;"
+                >
+                  <option value="merge">{{ 'networks.dialog.join.collision.merge' | transloco }}</option>
+                  <option value="alias">{{ 'networks.dialog.join.collision.alias' | transloco }}</option>
+                </select>
+                @if (joinSpaceActions[remoteId] === 'alias') {
+                  <input
+                    type="text"
+                    [(ngModel)]="joinSpaceAliases[remoteId]"
+                    [name]="'alias-' + remoteId"
+                    [placeholder]="'networks.dialog.join.aliasPlaceholder' | transloco"
+                    pattern="[a-z0-9-]+"
+                    maxlength="40"
+                    style="width:140px; padding:4px 8px; font-size:12px;"
+                    required
+                  />
+                }
+              </div>
+            }
+          </div>
+        }
+
+        <div style="display:flex; gap:8px; justify-content:flex-end;">
+          <button class="btn-secondary btn" type="button" (click)="close.emit()">{{ 'common.cancel' | transloco }}</button>
+          <button
+            class="btn-primary btn"
+            (click)="joinCollisionSpaces().length > 0 ? confirmJoin() : joinNetwork()"
+            [disabled]="joining() || !joinBundle.trim() || !myUrl().trim()"
+          >
+            @if (joining()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+            {{ joinCollisionSpaces().length > 0 ? ('networks.dialog.join.confirmJoinButton' | transloco) : ('networks.dialog.join.submitButton' | transloco) }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class NetworkJoinDialogComponent {
+  private networksApi = inject(NetworksApi);
+  private transloco = inject(TranslocoService);
+
+  /** Local spaces (for collision detection). */
+  readonly availableSpaces = input<Space[]>([]);
+  /** This brain's own URL, computed by the host — used to submit the join (never edited here). */
+  readonly myUrl = input('');
+
+  /** Emitted after a successful join so the host reloads networks and refreshes its spaces list. */
+  readonly joined = output<void>();
+  /** Emitted when the user cancels/dismisses. */
+  readonly close = output<void>();
+
+  joinBundle = '';
+  joining = signal(false);
+  joinError = signal('');
+  joinSuccess = signal('');
+  joinCollisionSpaces = signal<string[]>([]);
+  joinSpaceActions: Record<string, 'merge' | 'alias'> = {};
+  joinSpaceAliases: Record<string, string> = {};
+  private joinParsedBundle: any = null;
+
+  joinNetwork(): void {
+    this.joinError.set('');
+    this.joinSuccess.set('');
+    this.joinCollisionSpaces.set([]);
+    let bundle: any;
+    try {
+      bundle = JSON.parse(this.joinBundle);
+    } catch {
+      this.joinError.set(this.transloco.translate('networks.dialog.join.error.invalidJson'));
+      return;
+    }
+    if (!bundle.handshakeId || !bundle.inviteUrl || !bundle.rsaPublicKeyPem || !bundle.networkId) {
+      this.joinError.set(this.transloco.translate('networks.dialog.join.error.incompleteBundle'));
+      return;
+    }
+    if (!this.myUrl().trim()) {
+      this.joinError.set(this.transloco.translate('networks.dialog.join.error.missingMyUrl'));
+      return;
+    }
+
+    // Detect space name collisions — show resolution UI if any overlap
+    if (bundle.spaces?.length) {
+      const localIds = new Set(this.availableSpaces().map(s => s.id));
+      const overlap = (bundle.spaces as string[]).filter((s: string) => localIds.has(s));
+      if (overlap.length > 0) {
+        this.joinParsedBundle = bundle;
+        this.joinSpaceActions = {};
+        this.joinSpaceAliases = {};
+        for (const id of overlap) {
+          this.joinSpaceActions[id] = 'merge';
+          this.joinSpaceAliases[id] = '';
+        }
+        this.joinCollisionSpaces.set(overlap);
+        return; // wait for user to resolve collisions
+      }
+    }
+
+    this.joinParsedBundle = bundle;
+    this.executeJoin();
+  }
+
+  onCollisionActionChange(remoteId: string, action: 'merge' | 'alias'): void {
+    this.joinSpaceActions[remoteId] = action;
+    if (action === 'alias' && !this.joinSpaceAliases[remoteId]) {
+      this.joinSpaceAliases[remoteId] = remoteId + '-local';
+    }
+  }
+
+  confirmJoin(): void {
+    // Validate alias inputs
+    for (const remoteId of this.joinCollisionSpaces()) {
+      if (this.joinSpaceActions[remoteId] === 'alias') {
+        const alias = this.joinSpaceAliases[remoteId]?.trim();
+        if (!alias) {
+          this.joinError.set(this.transloco.translate('networks.dialog.join.error.aliasRequired', { remoteId }));
+          return;
+        }
+        if (!/^[a-z0-9-]+$/.test(alias)) {
+          this.joinError.set(this.transloco.translate('networks.dialog.join.error.aliasInvalid', { alias }));
+          return;
+        }
+        const localIds = new Set(this.availableSpaces().map(s => s.id));
+        if (localIds.has(alias)) {
+          this.joinError.set(this.transloco.translate('networks.dialog.join.error.aliasExists', { alias }));
+          return;
+        }
+      }
+    }
+    this.executeJoin();
+  }
+
+  private executeJoin(): void {
+    const bundle = this.joinParsedBundle;
+    if (!bundle) return;
+
+    // Build spaceMap from collision resolutions
+    const spaceMap: Record<string, string> = {};
+    for (const remoteId of this.joinCollisionSpaces()) {
+      if (this.joinSpaceActions[remoteId] === 'alias') {
+        spaceMap[remoteId] = this.joinSpaceAliases[remoteId].trim();
+      }
+    }
+
+    this.joining.set(true);
+    this.networksApi.joinRemote({
+      handshakeId: bundle.handshakeId,
+      inviteUrl:   bundle.inviteUrl,
+      rsaPublicKeyPem: bundle.rsaPublicKeyPem,
+      networkId:   bundle.networkId,
+      myUrl:       this.myUrl().trim(),
+      expiresAt:   bundle.expiresAt,
+      ...(Object.keys(spaceMap).length > 0 ? { spaceMap } : {}),
+    }).subscribe({
+      next: (result) => {
+        this.joining.set(false);
+        // Vote-governed networks hold the join in a vote round on the inviter's
+        // side; sync begins once the members/ancestors approve.
+        const successKey = result.status === 'vote_pending'
+          ? 'networks.dialog.join.success.votePending'
+          : 'networks.dialog.join.success.joined';
+        let msg = this.transloco.translate(successKey, { networkLabel: result.networkLabel });
+        if (result.createdSpaces?.length) {
+          msg += ` ${this.transloco.translate('networks.dialog.join.success.createdSpaces', { spaces: result.createdSpaces.join(', ') })}`;
+        }
+        if (result.existingSpaces?.length) {
+          msg += ` ${this.transloco.translate('networks.dialog.join.success.existingSpaces', { spaces: result.existingSpaces.join(', ') })}`;
+        }
+        if (result.spaceMap && Object.keys(result.spaceMap).length > 0) {
+          const aliases = Object.entries(result.spaceMap).map(([r, l]) => `${r} → ${l}`).join(', ');
+          msg += ` ${this.transloco.translate('networks.dialog.join.success.aliases', { aliases })}`;
+        }
+        this.joinSuccess.set(msg);
+        this.joinBundle = '';
+        this.joinParsedBundle = null;
+        this.joinCollisionSpaces.set([]);
+        this.joinSpaceActions = {};
+        this.joinSpaceAliases = {};
+        this.joined.emit(); // host reloads networks + refreshes spaces (a join can create local spaces)
+      },
+      error: (err) => {
+        this.joining.set(false);
+        this.joinError.set(err.error?.error ?? this.transloco.translate('networks.error.joinFailed'));
+      },
+    });
+  }
+}

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -131,42 +131,13 @@ describe('NetworksComponent (characterization)', () => {
     expect(c.networks()[0].syncSchedule).toBe('0 * * * *');
   });
 
-  it('joinNetwork() rejects invalid JSON, an incomplete bundle, and a missing "my URL" without calling the API', () => {
+  // Join-dialog behavior (bundle validation, collision detection, immediate join) moved to
+  // network-join-dialog.component.spec.ts when the Join dialog became its own child component. The
+  // parent only reloads on the child's `joined` output — pinned here.
+  it('onJoined() reloads the network list', () => {
     const c = make();
-    c.joinBundle = 'not json';
-    c.joinNetwork();
-    expect(c.joinError()).toBeTruthy();
-    expect(api.joinRemote).not.toHaveBeenCalled();
-
-    c.joinBundle = JSON.stringify({ handshakeId: 'h' }); // missing inviteUrl/rsaPublicKeyPem/networkId
-    c.joinNetwork();
-    expect(c.joinError()).toBeTruthy();
-    expect(api.joinRemote).not.toHaveBeenCalled();
-
-    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1' });
-    c.joinMyUrl = '';
-    c.joinNetwork();
-    expect(c.joinError()).toBeTruthy();
-    expect(api.joinRemote).not.toHaveBeenCalled();
-  });
-
-  it('joinNetwork() detects space-id collisions and holds for resolution instead of joining', () => {
-    const c = make();
-    c.availableSpaces.set([{ id: 'general', label: 'General' } as never]);
-    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1', spaces: ['general', 'remote-only'] });
-    c.joinMyUrl = 'https://me.example';
-    c.joinNetwork();
-    expect(c.joinCollisionSpaces()).toEqual(['general']);
-    expect(api.joinRemote).not.toHaveBeenCalled();
-  });
-
-  it('joinNetwork() with no collisions joins immediately', () => {
-    const c = make();
-    c.availableSpaces.set([{ id: 'general', label: 'General' } as never]);
-    c.joinBundle = JSON.stringify({ handshakeId: 'h', inviteUrl: 'u', rsaPublicKeyPem: 'k', networkId: 'n1', spaces: ['remote-only'] });
-    c.joinMyUrl = 'https://me.example';
-    c.joinNetwork();
-    expect(api.joinRemote).toHaveBeenCalledWith(expect.objectContaining({ handshakeId: 'h', myUrl: 'https://me.example', networkId: 'n1' }));
+    c.onJoined();
+    expect(api.listNetworks).toHaveBeenCalled(); // load()
   });
 
   it('sync() records the result on success and an {ok:false} result on error', () => {

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -15,10 +15,11 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
 import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { NetworkCreateDialogComponent } from './network-create-dialog.component';
+import { NetworkJoinDialogComponent } from './network-join-dialog.component';
 @Component({
   selector: 'app-networks',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, NetworkCreateDialogComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, NetworkCreateDialogComponent, NetworkJoinDialogComponent],
   styles: [`
     .network-card {
       background: var(--bg-surface);
@@ -367,76 +368,12 @@ import { NetworkCreateDialogComponent } from './network-create-dialog.component'
 
     <!-- Join Network dialog -->
     @if (showJoinDialog()) {
-      <div class="dialog-backdrop" (click)="showJoinDialog.set(false)">
-        <div class="dialog" [appModal]="'networks.dialog.join.title' | transloco" (dismiss)="showJoinDialog.set(false)" (click)="$event.stopPropagation()">
-          <div class="dialog-header">
-            <div class="card-title">{{ 'networks.dialog.join.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showJoinDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
-          </div>
-
-          @if (joinError()) { <div class="alert alert-error">{{ joinError() }}</div> }
-          @if (joinSuccess()) { <div class="alert alert-success">{{ joinSuccess() }}</div> }
-
-          <div class="field">
-            <label>{{ 'networks.dialog.join.bundleLabel' | transloco }}</label>
-            <textarea
-              [(ngModel)]="joinBundle"
-              name="joinBundle"
-              rows="5"
-              [placeholder]="'networks.dialog.join.bundlePlaceholder' | transloco"
-              [attr.aria-label]="'networks.dialog.join.bundleAriaLabel' | transloco"
-              style="font-family:var(--font-mono); font-size:12px; resize:vertical;"
-            ></textarea>
-          </div>
-
-          @if (joinCollisionSpaces().length > 0) {
-            <div style="margin:0 0 12px; padding:12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-elevated);">
-              <div style="font-weight:600; font-size:13px; margin-bottom:8px;">{{ 'networks.dialog.join.collisions.title' | transloco }}</div>
-              <p style="font-size:12px; color:var(--text-muted); margin:0 0 12px;">
-                {{ 'networks.dialog.join.collisions.body' | transloco }}
-              </p>
-              @for (remoteId of joinCollisionSpaces(); track remoteId) {
-                <div style="display:flex; align-items:center; gap:8px; margin-bottom:8px;">
-                  <span class="badge badge-gray mono" style="min-width:80px;">{{ remoteId }}</span>
-                  <select
-                    [ngModel]="joinSpaceActions[remoteId]"
-                    (ngModelChange)="onCollisionActionChange(remoteId, $event)"
-                    [name]="'collision-' + remoteId"
-                    style="width:140px;"
-                  >
-                    <option value="merge">{{ 'networks.dialog.join.collision.merge' | transloco }}</option>
-                    <option value="alias">{{ 'networks.dialog.join.collision.alias' | transloco }}</option>
-                  </select>
-                  @if (joinSpaceActions[remoteId] === 'alias') {
-                    <input
-                      type="text"
-                      [(ngModel)]="joinSpaceAliases[remoteId]"
-                      [name]="'alias-' + remoteId"
-                      [placeholder]="'networks.dialog.join.aliasPlaceholder' | transloco"
-                      pattern="[a-z0-9-]+"
-                      maxlength="40"
-                      style="width:140px; padding:4px 8px; font-size:12px;"
-                      required
-                    />
-                  }
-                </div>
-              }
-            </div>
-          }
-
-          <div style="display:flex; gap:8px; justify-content:flex-end;">
-            <button class="btn-secondary btn" type="button" (click)="showJoinDialog.set(false)">{{ 'common.cancel' | transloco }}</button>
-            <button
-              class="btn-primary btn"
-              (click)="joinCollisionSpaces().length > 0 ? confirmJoin() : joinNetwork()"
-              [disabled]="joining() || !joinBundle.trim() || !joinMyUrl.trim()"
-            >
-              @if (joining()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-              {{ joinCollisionSpaces().length > 0 ? ('networks.dialog.join.confirmJoinButton' | transloco) : ('networks.dialog.join.submitButton' | transloco) }}
-            </button>
-          </div>
-        </div>
-      </div>
+      <app-network-join-dialog
+        [availableSpaces]="availableSpaces()"
+        [myUrl]="joinMyUrl"
+        (joined)="onJoined()"
+        (close)="showJoinDialog.set(false)"
+      />
     }
 
     <!-- Enable Networks wizard -->
@@ -576,16 +513,10 @@ export class NetworksComponent implements OnInit {
   private votesByNetwork: Record<string, VoteRound[]> = {};
 
   copiedInvite = signal('');
-  joinBundle = '';
+  // This brain's own URL — computed in ngOnInit (and the enable-networks flow) and passed to the join
+  // dialog as its `myUrl`; also gates whether the enable-networks wizard is offered.
   joinMyUrl = '';
   joinMyUrlAutoFilled = signal(false);
-  joining = signal(false);
-  joinError = signal('');
-  joinSuccess = signal('');
-  joinCollisionSpaces = signal<string[]>([]);
-  joinSpaceActions: Record<string, 'merge' | 'alias'> = {};
-  joinSpaceAliases: Record<string, string> = {};
-  private joinParsedBundle: any = null;
   removingMember: Record<string, boolean> = {};
   // Per-network / per-round in-flight flags so each async action shows a spinner and disables its button
   // (default change detection re-renders on the settling HTTP response).
@@ -965,136 +896,13 @@ export class NetworksComponent implements OnInit {
     });
   }
 
-  joinNetwork(): void {
-    this.joinError.set('');
-    this.joinSuccess.set('');
-    this.joinCollisionSpaces.set([]);
-    let bundle: any;
-    try {
-      bundle = JSON.parse(this.joinBundle);
-    } catch {
-      this.joinError.set(this.transloco.translate('networks.dialog.join.error.invalidJson'));
-      return;
-    }
-    if (!bundle.handshakeId || !bundle.inviteUrl || !bundle.rsaPublicKeyPem || !bundle.networkId) {
-      this.joinError.set(this.transloco.translate('networks.dialog.join.error.incompleteBundle'));
-      return;
-    }
-    if (!this.joinMyUrl.trim()) {
-      this.joinError.set(this.transloco.translate('networks.dialog.join.error.missingMyUrl'));
-      return;
-    }
-
-    // Detect space name collisions — show resolution UI if any overlap
-    if (bundle.spaces?.length) {
-      const localIds = new Set(this.availableSpaces().map(s => s.id));
-      const overlap = (bundle.spaces as string[]).filter((s: string) => localIds.has(s));
-      if (overlap.length > 0) {
-        this.joinParsedBundle = bundle;
-        this.joinSpaceActions = {};
-        this.joinSpaceAliases = {};
-        for (const id of overlap) {
-          this.joinSpaceActions[id] = 'merge';
-          this.joinSpaceAliases[id] = '';
-        }
-        this.joinCollisionSpaces.set(overlap);
-        return; // wait for user to resolve collisions
-      }
-    }
-
-    this.joinParsedBundle = bundle;
-    this.executeJoin();
-  }
-
-  onCollisionActionChange(remoteId: string, action: 'merge' | 'alias'): void {
-    this.joinSpaceActions[remoteId] = action;
-    if (action === 'alias' && !this.joinSpaceAliases[remoteId]) {
-      this.joinSpaceAliases[remoteId] = remoteId + '-local';
-    }
-  }
-
-  confirmJoin(): void {
-    // Validate alias inputs
-    for (const remoteId of this.joinCollisionSpaces()) {
-      if (this.joinSpaceActions[remoteId] === 'alias') {
-        const alias = this.joinSpaceAliases[remoteId]?.trim();
-        if (!alias) {
-          this.joinError.set(this.transloco.translate('networks.dialog.join.error.aliasRequired', { remoteId }));
-          return;
-        }
-        if (!/^[a-z0-9-]+$/.test(alias)) {
-          this.joinError.set(this.transloco.translate('networks.dialog.join.error.aliasInvalid', { alias }));
-          return;
-        }
-        const localIds = new Set(this.availableSpaces().map(s => s.id));
-        if (localIds.has(alias)) {
-          this.joinError.set(this.transloco.translate('networks.dialog.join.error.aliasExists', { alias }));
-          return;
-        }
-      }
-    }
-    this.executeJoin();
-  }
-
-  private executeJoin(): void {
-    const bundle = this.joinParsedBundle;
-    if (!bundle) return;
-
-    // Build spaceMap from collision resolutions
-    const spaceMap: Record<string, string> = {};
-    for (const remoteId of this.joinCollisionSpaces()) {
-      if (this.joinSpaceActions[remoteId] === 'alias') {
-        spaceMap[remoteId] = this.joinSpaceAliases[remoteId].trim();
-      }
-    }
-
-    this.joining.set(true);
-    this.networksApi.joinRemote({
-      handshakeId: bundle.handshakeId,
-      inviteUrl:   bundle.inviteUrl,
-      rsaPublicKeyPem: bundle.rsaPublicKeyPem,
-      networkId:   bundle.networkId,
-      myUrl:       this.joinMyUrl.trim(),
-      expiresAt:   bundle.expiresAt,
-      ...(Object.keys(spaceMap).length > 0 ? { spaceMap } : {}),
-    }).subscribe({
-      next: (result) => {
-        this.joining.set(false);
-        // Vote-governed networks hold the join in a vote round on the inviter's
-        // side; sync begins once the members/ancestors approve.
-        const successKey = result.status === 'vote_pending'
-          ? 'networks.dialog.join.success.votePending'
-          : 'networks.dialog.join.success.joined';
-        let msg = this.transloco.translate(successKey, { networkLabel: result.networkLabel });
-        if (result.createdSpaces?.length) {
-          msg += ` ${this.transloco.translate('networks.dialog.join.success.createdSpaces', { spaces: result.createdSpaces.join(', ') })}`;
-        }
-        if (result.existingSpaces?.length) {
-          msg += ` ${this.transloco.translate('networks.dialog.join.success.existingSpaces', { spaces: result.existingSpaces.join(', ') })}`;
-        }
-        if (result.spaceMap && Object.keys(result.spaceMap).length > 0) {
-          const aliases = Object.entries(result.spaceMap).map(([r, l]) => `${r} → ${l}`).join(', ');
-          msg += ` ${this.transloco.translate('networks.dialog.join.success.aliases', { aliases })}`;
-        }
-        this.joinSuccess.set(msg);
-        this.joinBundle = '';
-        this.joinMyUrl  = '';
-        this.joinMyUrlAutoFilled.set(false);
-        this.joinParsedBundle = null;
-        this.joinCollisionSpaces.set([]);
-        this.joinSpaceActions = {};
-        this.joinSpaceAliases = {};
-        this.load();
-        // Refresh spaces list to include newly created spaces
-        this.spacesApi.listSpaces().subscribe({
-          next: ({ spaces }) => this.availableSpaces.set(spaces),
-          error: () => {},
-        });
-      },
-      error: (err) => {
-        this.joining.set(false);
-        this.joinError.set(err.error?.error ?? this.transloco.translate('networks.error.joinFailed'));
-      },
+  /** The join dialog (child) emits after a successful join; reload networks and refresh the spaces list
+   *  (a join can create new local spaces). */
+  onJoined(): void {
+    this.load();
+    this.spacesApi.listSpaces().subscribe({
+      next: ({ spaces }) => this.availableSpaces.set(spaces),
+      error: () => {},
     });
   }
 


### PR DESCRIPTION
Second structural slice of taming the 1261-line `NetworksComponent`: pull the **Join dialog** out into `NetworkJoinDialogComponent`.

## Change
- The child owns the invite-bundle textarea, the bundle **validation** (JSON / required fields / this brain's URL), the space-id **collision-resolution UI** (merge vs alias, with alias validation), and the `joinRemote` call.
- **`myUrl` is a one-way input** — the host computes this brain's own URL (also used to gate the enable-networks flow); the join dialog never lets the user edit it, it only needs it to submit.
- A successful join **emits `joined`** so the host reloads the network list and refreshes its spaces (a join can create new local spaces).
- **No behavior change.**

## Tests
- Join characterization tests **moved** to `network-join-dialog.component.spec.ts` — bundle validation, collision hold-for-resolution, **alias validation in `confirmJoin`** (added coverage), immediate-join + `joined` emit. Parent keeps an `onJoined` reload test.
- **28 networks specs pass**; AOT build clean. Parent has shed **~250 lines** across the Create + Join extractions.

## Next
Extract the **Enable-Networks wizard** (last of the three dialogs), then responsive/`SettingsCard` polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)