### PR TITLE
feat(settings): Networks rows don't overflow a narrow iframe (PR-U3 slice 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Networks: rows stop overflowing on a narrow (iframe) width.** The member row (peer id /
+  label / direction / **endpoint URL** / remove) now wraps and truncates the long endpoint with an
+  ellipsis instead of pushing the card wider than its container, and the sync-history row collapses from a
+  fixed grid to a wrapping layout below 680px. The sync-history expand caret is now a `ph-icon` rather than
+  a raw `▲▼`.
+
 - **Internal: the Networks Create and Join dialogs are now their own components.** Extracted
   `NetworkCreateDialogComponent` and `NetworkJoinDialogComponent` out of the 1261-line `NetworksComponent`
   — the create form (label/type/space-selection + fallback and voting deadline) and the join flow (invite-

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -59,6 +59,17 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
       padding: 8px 0;
       border-bottom: 1px solid var(--border-muted);
       font-size: 13px;
+      flex-wrap: wrap; /* narrow iframe: the endpoint URL + delete wrap to the next line, never overflow */
+    }
+    /* The peer endpoint can be a long URL — let it shrink and ellipsize instead of pushing the row wide. */
+    .member-endpoint {
+      flex: 1 1 160px;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 11px;
+      color: var(--text-muted);
     }
 
     .member-row:last-child { border-bottom: none; }
@@ -82,6 +93,11 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
       padding: 6px 0;
       border-bottom: 1px solid var(--border-muted);
       font-size: 12px;
+    }
+    .history-row > span:nth-child(3) { min-width: 0; } /* let the counts cell shrink instead of overflowing */
+    /* Narrow iframe: drop the fixed grid and let the cells wrap. */
+    @media (max-width: 680px) {
+      .history-row { display: flex; flex-wrap: wrap; }
     }
 
     .history-row:last-child { border-bottom: none; }
@@ -264,8 +280,8 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
 
               <!-- Sync History -->
               <div style="margin-bottom:16px;">
-                <div class="section-title" style="cursor:pointer;" (click)="toggleHistory(net.id)">
-                  {{ 'networks.network.syncHistory.title' | transloco }} {{ historyExpanded() === net.id ? '▲' : '▼' }}
+                <div class="section-title" style="cursor:pointer; display:inline-flex; align-items:center; gap:4px;" (click)="toggleHistory(net.id)">
+                  {{ 'networks.network.syncHistory.title' | transloco }} <ph-icon [name]="historyExpanded() === net.id ? 'caret-up' : 'caret-down'" [size]="12" />
                 </div>
                 @if (historyExpanded() === net.id) {
                   @if (historyLoading()) {
@@ -309,9 +325,7 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
                   <span class="mono badge badge-gray" style="font-size:11px;">{{ m.instanceId.slice(0, 8) }}</span>
                   <span style="font-weight:500; flex:1;">{{ m.label }}</span>
                   <span class="badge badge-gray" style="font-size:11px;">{{ m.syncDirection ?? 'both' }}</span>
-                  <a [href]="m.endpoint" target="_blank" rel="noopener" style="font-size:11px; color:var(--text-muted);">
-                    {{ m.endpoint }}
-                  </a>
+                  <a class="member-endpoint" [href]="m.endpoint" target="_blank" rel="noopener" [attr.title]="m.endpoint">{{ m.endpoint }}</a>
                   <button
                     class="btn-danger btn btn-sm"
                     style="padding:2px 8px;"


### PR DESCRIPTION
Responsive fixes for the two overflow-prone rows on the Networks page (the embedded/iframe deploy is a first-class target).

## Changes
- **Member row**: now wraps (`flex-wrap`), and the peer **endpoint URL** truncates with an ellipsis (`.member-endpoint`: flex-shrink + `min-width:0` + `text-overflow`) instead of pushing the card wider than its container. A `title` attribute keeps the full URL on hover.
- **Sync-history row**: switches from a fixed `140px 70px 1fr auto` grid to a wrapping flex layout below 680px; the counts cell gets `min-width:0`.
- **Caret glyph**: the sync-history expand caret is now a `ph-icon` (`caret-up`/`caret-down`) rather than a raw `▲▼`.

## Notes
- CSS/template only — **no logic change**. 18 networks specs pass; AOT build clean.
- The inline `↓↑` pulled/pushed count arrows are left for a separate glyph pass (they're inline data indicators, not navigation).

## Next
Extract the **Enable-Networks wizard** (last dialog), then `SettingsCard` grouping of the expanded body finishes PR-U3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)