### PR TITLE
feat(settings): Networks enable-wizard "Step N of 3" progress indicator (PR-U3 slice 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Networks: the Enable-Networks wizard shows a "Step N of 3" progress indicator.** The 3-step
+  enable flow now has a segmented progress bar + a "Step N of 3" label in its header, so you can see where
+  you are in the (otherwise easy-to-lose-track-of) setup.
+
 - **Settings → Networks: rows stop overflowing on a narrow (iframe) width.** The member row (peer id /
   label / direction / **endpoint URL** / remove) now wraps and truncates the long endpoint with an
   ellipsis instead of pushing the card wider than its container, and the sync-history row collapses from a

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1149,5 +1149,6 @@
   "networks.network.votes.deadline": "Frist",
   "networks.network.votes.tally": "{{ yes }} Ja · {{ veto }} Veto",
   "networks.confirm.vetoTitle": "Diese Runde ablehnen?",
-  "networks.confirm.veto": "Ein Veto blockiert diese ausstehende Runde für das gesamte Netzwerk. Dies kann nicht rückgängig gemacht werden."
+  "networks.confirm.veto": "Ein Veto blockiert diese ausstehende Runde für das gesamte Netzwerk. Dies kann nicht rückgängig gemacht werden.",
+  "networks.wizard.stepLabel": "Schritt {{ current }} von {{ total }}"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1148,5 +1148,6 @@
   "networks.network.votes.deadline": "Deadline",
   "networks.network.votes.tally": "{{ yes }} yes · {{ veto }} veto",
   "networks.confirm.vetoTitle": "Veto this round?",
-  "networks.confirm.veto": "A veto blocks this pending round for the whole network. This cannot be undone."
+  "networks.confirm.veto": "A veto blocks this pending round for the whole network. This cannot be undone.",
+  "networks.wizard.stepLabel": "Step {{ current }} of {{ total }}"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1149,5 +1149,6 @@
   "networks.network.votes.deadline": "Termin",
   "networks.network.votes.tally": "{{ yes }} tak · {{ veto }} weto",
   "networks.confirm.vetoTitle": "Zawetować tę rundę?",
-  "networks.confirm.veto": "Weto blokuje tę oczekującą rundę dla całej sieci. Nie można tego cofnąć."
+  "networks.confirm.veto": "Weto blokuje tę oczekującą rundę dla całej sieci. Nie można tego cofnąć.",
+  "networks.wizard.stepLabel": "Krok {{ current }} z {{ total }}"
 }

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -185,6 +185,21 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
       font-size: 12px;
       color: var(--text-secondary);
     }
+    /* "Step N of 3" progress indicator at the top of the enable-networks wizard. */
+    .wizard-steps { display: flex; align-items: center; gap: 6px; margin: 0 0 14px; }
+    .wizard-step-dot {
+      width: 24px; height: 4px; border-radius: 2px;
+      background: var(--border);
+      transition: background var(--transition);
+    }
+    .wizard-step-dot.done { background: var(--accent-dim); }
+    .wizard-step-dot.active { background: var(--accent); }
+    .wizard-step-label {
+      margin-left: auto;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-variant-numeric: tabular-nums;
+    }
   `],
   template: `
     <!-- Network list (shown first) -->
@@ -397,6 +412,13 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
           <div class="dialog-header">
             <div class="card-title">{{ 'networks.wizard.title' | transloco }}</div>
             <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showEnableNetworksWizard.set(false)"><ph-icon name="x" [size]="14"/></button>
+          </div>
+
+          <div class="wizard-steps">
+            @for (n of [1, 2, 3]; track n) {
+              <span class="wizard-step-dot" [class.active]="enableWizardStep() === n" [class.done]="enableWizardStep() > n"></span>
+            }
+            <span class="wizard-step-label">{{ 'networks.wizard.stepLabel' | transloco: { current: enableWizardStep(), total: 3 } }}</span>
           </div>
 
           @if (enableWizardError()) { <div class="alert alert-error">{{ enableWizardError() }}</div> }


### PR DESCRIPTION
The 3-step **Enable-Networks wizard** now shows where you are: a segmented progress bar (done / active / upcoming) plus a **"Step N of 3"** label in the header.

- Template + CSS + one i18n key (en/de/pl). **No logic change.**
- 18 networks specs pass; AOT build clean.

Small UX slice of PR-U3. Remaining: extract the Enable-Networks wizard into its own component (the last, most-coupled dialog) + `SettingsCard` grouping of the expanded card body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)