### PR TITLE
test(settings): characterize the Networks enable-wizard before extracting it (PR-U3 slice 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   settings page shipped with no coverage; these pin its current behavior — create/join validation (blank
   label, invalid/incomplete bundle, missing URL, space-id collision hold), the confirm-guarded destructive
   actions (leave, remove member), and the API-call shapes for invite/schedule/sync/vote — so the upcoming
-  modal-extraction refactor and design-system pass can't change behavior silently.
+  modal-extraction refactor and design-system pass can't change behavior silently. Extended with 10 more
+  tests covering the **Enable-Networks wizard** (hostname validation, generated Cloudflare commands, the
+  local-agent probe→bootstrap path, and automatic vs. confirm-and-adopt completion) before that wizard is
+  itself extracted into a child component.
 
 - **`max`-mode repair pass for VLM extraction (F11).** When a document's VLM transcription fails the
   OCR-evidence coverage check, `max` mode now runs **one bounded repair pass** before falling back to OCR:

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -45,7 +45,8 @@ function makeNetworksApi() {
     getSyncHistory: vi.fn(() => of({ history: [] })),
     castVote: vi.fn(() => of({})),
     bootstrapLocalAgent: vi.fn(() => of({})),
-    getLocalAgentStatus: vi.fn(() => of({})),
+    getLocalAgentStatus: vi.fn(() => of({ canExecute: false })),
+    executeEnableNetworksViaLocalAgent: vi.fn(() => of({ message: 'done', publicUrl: 'https://x.example' })),
   } as any;
 }
 
@@ -276,5 +277,114 @@ describe('NetworksComponent (characterization)', () => {
       { instanceId: 'a', vote: 'yes' }, { instanceId: 'b', vote: 'veto' }, { instanceId: 'c', vote: 'yes' },
     ] }));
     expect(t).toEqual({ yes: 2, veto: 1 });
+  });
+
+  // ── Enable-Networks wizard (characterization, before extracting it into its own component) ──
+  it('openEnableNetworksWizard() resets wizard state and opens at step 1', () => {
+    const c = make();
+    c.enableWizardStep.set(3);
+    c.enableWizardError.set('boom');
+    c.localAgentCanExecute.set(true);
+    c.openEnableNetworksWizard();
+    expect(c.showEnableNetworksWizard()).toBe(true);
+    expect(c.enableWizardStep()).toBe(1);
+    expect(c.enableWizardError()).toBe('');
+    expect(c.localAgentCanExecute()).toBe(false);
+  });
+
+  it('prepareEnableWizardCommands() rejects an invalid hostname and stays put', () => {
+    const c = make();
+    c.enableWizardStep.set(2);
+    c.enableHostname = 'not a hostname';
+    c.prepareEnableWizardCommands();
+    expect(c.enableWizardError()).toBeTruthy();
+    expect(c.enableWizardStep()).toBe(2);
+    expect(api.getLocalAgentStatus).not.toHaveBeenCalled();
+  });
+
+  it('prepareEnableWizardCommands() builds OS commands (reflecting the flags), advances to step 3, probes the connector', () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    c.enableOverwriteDns = true;
+    c.prepareEnableWizardCommands();
+    expect(c.enableWindowsCommand()).toContain('brain.example.com');
+    expect(c.enableWindowsCommand()).toContain('--overwrite-dns');
+    expect(c.enableLinuxCommand()).toContain('brain.example.com');
+    expect(c.enableWizardStep()).toBe(3);
+    expect(api.getLocalAgentStatus).toHaveBeenCalled();
+  });
+
+  it('prepareEnableWizardCommands(): connector already running → no bootstrap needed', () => {
+    const c = make();
+    api.getLocalAgentStatus.mockReturnValue(of({ canExecute: true, message: 'ready' }));
+    c.enableHostname = 'brain.example.com';
+    c.prepareEnableWizardCommands();
+    expect(c.localAgentCanExecute()).toBe(true);
+    expect(api.bootstrapLocalAgent).not.toHaveBeenCalled();
+  });
+
+  it('prepareEnableWizardCommands(): connector not running → bootstrap is attempted', () => {
+    const c = make();
+    api.getLocalAgentStatus.mockReturnValue(of({ canExecute: false }));
+    c.enableHostname = 'brain.example.com';
+    c.prepareEnableWizardCommands();
+    expect(api.bootstrapLocalAgent).toHaveBeenCalled();
+  });
+
+  it('completeEnableWizard() confirms, then adopts the URL and clears the enable prompt', async () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    confirmResult = true;
+    await c.completeEnableWizard();
+    expect(c.joinMyUrl).toBe('https://brain.example.com');
+    expect(c.needsNetworkEnable()).toBe(false);
+    expect(c.showEnableNetworksWizard()).toBe(false);
+  });
+
+  it('completeEnableWizard() declined → no change', async () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    c.needsNetworkEnable.set(true);
+    c.showEnableNetworksWizard.set(true);
+    confirmResult = false;
+    await c.completeEnableWizard();
+    expect(c.needsNetworkEnable()).toBe(true);
+    expect(c.showEnableNetworksWizard()).toBe(true); // still open — decline is a no-op
+  });
+
+  it('runEnableNetworksAutomatically() guards on hostname and the critical-change acknowledgement', () => {
+    const c = make();
+    c.enableHostname = '';
+    c.runEnableNetworksAutomatically();
+    expect(c.enableWizardError()).toBeTruthy();
+    expect(api.executeEnableNetworksViaLocalAgent).not.toHaveBeenCalled();
+
+    c.enableHostname = 'brain.example.com';
+    c.enableAcknowledgeCritical = false;
+    c.runEnableNetworksAutomatically();
+    expect(c.enableWizardError()).toBeTruthy();
+    expect(api.executeEnableNetworksViaLocalAgent).not.toHaveBeenCalled();
+  });
+
+  it('runEnableNetworksAutomatically(): bootstraps when the connector can\'t execute, then runs setup and clears the prompt', () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    c.enableAcknowledgeCritical = true;
+    c.localAgentCanExecute.set(false);
+    c.needsNetworkEnable.set(true);
+    c.runEnableNetworksAutomatically();
+    expect(api.bootstrapLocalAgent).toHaveBeenCalled();
+    expect(api.executeEnableNetworksViaLocalAgent).toHaveBeenCalledWith(expect.objectContaining({ hostname: 'brain.example.com' }));
+    expect(c.needsNetworkEnable()).toBe(false); // execute success set it
+  });
+
+  it('runEnableNetworksAutomatically(): connector ready → runs setup directly, no bootstrap', () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    c.enableAcknowledgeCritical = true;
+    c.localAgentCanExecute.set(true);
+    c.runEnableNetworksAutomatically();
+    expect(api.bootstrapLocalAgent).not.toHaveBeenCalled();
+    expect(api.executeEnableNetworksViaLocalAgent).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The **Enable-Networks wizard** — the last and most-coupled Networks dialog (local-agent bootstrap/status polling + `needsNetworkEnable` + URL adoption) — had **no test coverage**. Per the characterization-tests-before-refactor discipline that's carried the whole Networks rebuild, this pins its behavior **before** the wizard is extracted into its own child component.

## 10 new characterization tests
- `openEnableNetworksWizard` resets state + opens at step 1
- `prepareEnableWizardCommands`: invalid-hostname guard; valid → builds the OS commands (reflecting `overwriteDns`), advances to step 3, probes the connector; connector-ready → no bootstrap, connector-down → bootstrap
- `completeEnableWizard`: confirm → adopt URL + clear `needsNetworkEnable` + close; decline → no-op
- `runEnableNetworksAutomatically`: hostname + critical-acknowledgement guards; connector-down → bootstrap then execute; connector-ready → execute directly; success → clears `needsNetworkEnable`

**Test-only, no production change.** 28 networks specs pass. The next PR extracts the wizard into a child, guarded by these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)