### PR TITLE
refactor(settings): extract Networks enable-wizard; NetworksComponent 1261→692 lines (PR-U3 slice 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -937,12 +937,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fixed grid to a wrapping layout below 680px. The sync-history expand caret is now a `ph-icon` rather than
   a raw `▲▼`.
 
-- **Internal: the Networks Create and Join dialogs are now their own components.** Extracted
-  `NetworkCreateDialogComponent` and `NetworkJoinDialogComponent` out of the 1261-line `NetworksComponent`
-  — the create form (label/type/space-selection + fallback and voting deadline) and the join flow (invite-
-  bundle validation + space-id collision resolution) now live in focused children that emit results to the
-  host. No behavior change (the create and join characterization tests moved with them); the parent has
-  shed ~250 lines. Next: the Enable-Networks wizard.
+- **Internal: the Networks page's three dialogs are now their own components.** Extracted
+  `NetworkCreateDialogComponent`, `NetworkJoinDialogComponent`, and `NetworkEnableWizardComponent` out of
+  `NetworksComponent` — the create form, the join flow (invite-bundle validation + space-id collision
+  resolution), and the 3-step enable-networks wizard (Cloudflare-tunnel commands + local-agent connector)
+  now live in focused children that emit their results to the host. **No behavior change** (the
+  characterization tests moved with each), and `NetworksComponent` dropped from **1261 to 692 lines** (−45%)
+  — the settings-UX audit's "worst offender" is now maintainable.
 
 - **Settings → Networks: casting a Veto now asks for confirmation.** A veto blocks a pending governance
   round for the whole network and can't be undone, so it now goes through a danger-styled confirm dialog;

--- a/client/src/app/pages/settings/network-enable-wizard.component.spec.ts
+++ b/client/src/app/pages/settings/network-enable-wizard.component.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * NetworkEnableWizardComponent — characterization tests, relocated from networks.component.spec.ts when
+ * the enable-networks wizard was extracted into its own child component (PR-U3). Pins the hostname
+ * validation, the generated Cloudflare commands, the local-agent probe→bootstrap path, and the two
+ * completion paths. The only shape change from the inline version: success now EMITS `enabled(url)` (and
+ * `close` for the confirm-and-adopt finish) instead of mutating the host's URL/needsNetworkEnable.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { NetworksApi } from '../../core/networks-api.service';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { NetworkEnableWizardComponent } from './network-enable-wizard.component';
+
+describe('NetworkEnableWizardComponent (characterization)', () => {
+  let api: any;
+  let confirmResult: boolean;
+  let confirm: ReturnType<typeof vi.fn>;
+
+  function make() {
+    api = {
+      getLocalAgentStatus: vi.fn(() => of({ canExecute: false })),
+      bootstrapLocalAgent: vi.fn(() => of({})),
+      executeEnableNetworksViaLocalAgent: vi.fn(() => of({ message: 'done', publicUrl: 'https://x.example' })),
+    };
+    confirmResult = true;
+    confirm = vi.fn(() => Promise.resolve(confirmResult));
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [NetworkEnableWizardComponent, getTranslocoModule()],
+      providers: [
+        { provide: NetworksApi, useValue: api },
+        { provide: ConfirmDialogService, useValue: { confirm } },
+      ],
+    });
+    return TestBed.createComponent(NetworkEnableWizardComponent).componentInstance;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('initialises at step 1 with clean state and a detected OS', () => {
+    const c = make();
+    c.ngOnInit();
+    expect(c.enableWizardStep()).toBe(1);
+    expect(c.enableWizardError()).toBe('');
+    expect(c.localAgentCanExecute()).toBe(false);
+    expect(['windows', 'linux']).toContain(c.enableOs);
+  });
+
+  it('prepareEnableWizardCommands() rejects an invalid hostname and stays put', () => {
+    const c = make();
+    c.enableWizardStep.set(2);
+    c.enableHostname = 'not a hostname';
+    c.prepareEnableWizardCommands();
+    expect(c.enableWizardError()).toBeTruthy();
+    expect(c.enableWizardStep()).toBe(2);
+    expect(api.getLocalAgentStatus).not.toHaveBeenCalled();
+  });
+
+  it('prepareEnableWizardCommands() builds OS commands (reflecting flags), advances to step 3, probes connector', () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    c.enableOverwriteDns = true;
+    c.prepareEnableWizardCommands();
+    expect(c.enableWindowsCommand()).toContain('brain.example.com');
+    expect(c.enableWindowsCommand()).toContain('--overwrite-dns');
+    expect(c.enableLinuxCommand()).toContain('brain.example.com');
+    expect(c.enableWizardStep()).toBe(3);
+    expect(api.getLocalAgentStatus).toHaveBeenCalled();
+  });
+
+  it('connector already running → no bootstrap needed', () => {
+    const c = make();
+    api.getLocalAgentStatus.mockReturnValue(of({ canExecute: true, message: 'ready' }));
+    c.enableHostname = 'brain.example.com';
+    c.prepareEnableWizardCommands();
+    expect(c.localAgentCanExecute()).toBe(true);
+    expect(api.bootstrapLocalAgent).not.toHaveBeenCalled();
+  });
+
+  it('connector not running → bootstrap attempted', () => {
+    const c = make();
+    api.getLocalAgentStatus.mockReturnValue(of({ canExecute: false }));
+    c.enableHostname = 'brain.example.com';
+    c.prepareEnableWizardCommands();
+    expect(api.bootstrapLocalAgent).toHaveBeenCalled();
+  });
+
+  it('completeEnableWizard() confirms, then emits "enabled" with the URL and "close"', async () => {
+    const c = make();
+    const enabled = vi.fn(); const closed = vi.fn();
+    c.enabled.subscribe(enabled); c.close.subscribe(closed);
+    c.enableHostname = 'brain.example.com';
+    confirmResult = true;
+    await c.completeEnableWizard();
+    expect(enabled).toHaveBeenCalledWith('https://brain.example.com');
+    expect(closed).toHaveBeenCalled();
+  });
+
+  it('completeEnableWizard() declined → no emit', async () => {
+    const c = make();
+    const enabled = vi.fn();
+    c.enabled.subscribe(enabled);
+    c.enableHostname = 'brain.example.com';
+    confirmResult = false;
+    await c.completeEnableWizard();
+    expect(enabled).not.toHaveBeenCalled();
+  });
+
+  it('runEnableNetworksAutomatically() guards on hostname and the critical acknowledgement', () => {
+    const c = make();
+    c.enableHostname = '';
+    c.runEnableNetworksAutomatically();
+    expect(c.enableWizardError()).toBeTruthy();
+    expect(api.executeEnableNetworksViaLocalAgent).not.toHaveBeenCalled();
+
+    c.enableHostname = 'brain.example.com';
+    c.enableAcknowledgeCritical = false;
+    c.runEnableNetworksAutomatically();
+    expect(c.enableWizardError()).toBeTruthy();
+    expect(api.executeEnableNetworksViaLocalAgent).not.toHaveBeenCalled();
+  });
+
+  it('runEnableNetworksAutomatically(): connector down → bootstrap then execute, emits "enabled" on success', () => {
+    const c = make();
+    const enabled = vi.fn();
+    c.enabled.subscribe(enabled);
+    c.enableHostname = 'brain.example.com';
+    c.enableAcknowledgeCritical = true;
+    c.localAgentCanExecute.set(false);
+    c.runEnableNetworksAutomatically();
+    expect(api.bootstrapLocalAgent).toHaveBeenCalled();
+    expect(api.executeEnableNetworksViaLocalAgent).toHaveBeenCalledWith(expect.objectContaining({ hostname: 'brain.example.com' }));
+    expect(enabled).toHaveBeenCalledWith('https://x.example');
+  });
+
+  it('runEnableNetworksAutomatically(): connector ready → execute directly, no bootstrap', () => {
+    const c = make();
+    c.enableHostname = 'brain.example.com';
+    c.enableAcknowledgeCritical = true;
+    c.localAgentCanExecute.set(true);
+    c.runEnableNetworksAutomatically();
+    expect(api.bootstrapLocalAgent).not.toHaveBeenCalled();
+    expect(api.executeEnableNetworksViaLocalAgent).toHaveBeenCalled();
+  });
+});

--- a/client/src/app/pages/settings/network-enable-wizard.component.ts
+++ b/client/src/app/pages/settings/network-enable-wizard.component.ts
@@ -1,0 +1,355 @@
+import { Component, inject, signal, output, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NetworksApi } from '../../core/networks-api.service';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ModalDirective } from '../../shared/modal.directive';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+
+/**
+ * Enable-Networks wizard, extracted from the (large) NetworksComponent as the last of the three dialogs
+ * (PR-U3). A 3-step flow that helps a locally-reachable brain get a public HTTPS URL (via a Cloudflare
+ * tunnel) so it can join networks: (1) explain, (2) collect hostname + options and generate the OS
+ * commands, (3) either run the setup automatically through the local-agent connector (bootstrapping it if
+ * needed) or copy the commands to run by hand. On success it emits `enabled(url)` — the host adopts that
+ * URL as this brain's own and drops the "enable networks" prompt. Behaviour matches the inline version;
+ * the wizard characterization tests moved here with it.
+ *
+ * Rendered gated by the host (`@if (showEnableNetworksWizard()) { … }`), so it initialises fresh on each
+ * open (ngOnInit) and needs no visibility state of its own.
+ */
+@Component({
+  selector: 'app-network-enable-wizard',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  styles: [`
+    .dialog-backdrop {
+      position: fixed; inset: 0; background: var(--bg-scrim);
+      display: flex; align-items: center; justify-content: center; z-index: 100;
+    }
+    .dialog {
+      background: var(--bg-primary); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: 24px; width: 90%; max-width: 600px;
+      max-height: 90vh; overflow-y: auto;
+    }
+    .dialog-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+    .wizard-steps { display: flex; align-items: center; gap: 6px; margin: 0 0 14px; }
+    .wizard-step-dot { width: 24px; height: 4px; border-radius: 2px; background: var(--border); transition: background var(--transition); }
+    .wizard-step-dot.done { background: var(--accent-dim); }
+    .wizard-step-dot.active { background: var(--accent); }
+    .wizard-step-label { margin-left: auto; font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+    .wizard-note { font-size: 12px; color: var(--text-muted); margin: 0 0 10px; line-height: 1.45; }
+    .wizard-list { margin: 0 0 12px; padding-left: 18px; font-size: 12px; color: var(--text-secondary); line-height: 1.45; }
+    .wizard-status {
+      margin: 8px 0 12px; padding: 8px 10px; border-radius: var(--radius-sm);
+      border: 1px solid var(--border); background: var(--bg-elevated); font-size: 12px; color: var(--text-secondary);
+    }
+  `],
+  template: `
+    <div class="dialog-backdrop" (click)="close.emit()">
+      <div class="dialog" [appModal]="'networks.wizard.title' | transloco" (dismiss)="close.emit()" (click)="$event.stopPropagation()">
+        <div class="dialog-header">
+          <div class="card-title">{{ 'networks.wizard.title' | transloco }}</div>
+          <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="close.emit()"><ph-icon name="x" [size]="14"/></button>
+        </div>
+
+        <div class="wizard-steps">
+          @for (n of [1, 2, 3]; track n) {
+            <span class="wizard-step-dot" [class.active]="enableWizardStep() === n" [class.done]="enableWizardStep() > n"></span>
+          }
+          <span class="wizard-step-label">{{ 'networks.wizard.stepLabel' | transloco: { current: enableWizardStep(), total: 3 } }}</span>
+        </div>
+
+        @if (enableWizardError()) { <div class="alert alert-error">{{ enableWizardError() }}</div> }
+
+        @if (enableWizardStep() === 1) {
+          <p class="wizard-note">{{ 'networks.wizard.step1.p1' | transloco }}</p>
+          <p class="wizard-note">{{ 'networks.wizard.step1.p2' | transloco }}</p>
+          <ul class="wizard-list">
+            <li>{{ 'networks.wizard.step1.whyItem' | transloco }}</li>
+            <li>{{ 'networks.wizard.step1.riskItem' | transloco }}</li>
+            <li>{{ 'networks.wizard.step1.resultItem' | transloco }}</li>
+          </ul>
+          <div style="display:flex; gap:8px; justify-content:flex-end;">
+            <button class="btn-secondary btn" type="button" (click)="close.emit()">{{ 'common.cancel' | transloco }}</button>
+            <button class="btn-primary btn" type="button" (click)="enableWizardStep.set(2)">{{ 'networks.wizard.continue' | transloco }}</button>
+          </div>
+        }
+
+        @if (enableWizardStep() === 2) {
+          @if (localAgentStatusMessage()) { <div class="wizard-status">{{ localAgentStatusMessage() }}</div> }
+          <p class="wizard-note">{{ 'networks.wizard.step2.hostnameHint' | transloco }}</p>
+          <div class="field">
+            <label>{{ 'networks.wizard.step2.publicHostnameLabel' | transloco }}</label>
+            <input type="text" [(ngModel)]="enableHostname" name="enableHostname" [placeholder]="'networks.wizard.step2.publicHostnamePlaceholder' | transloco" />
+          </div>
+          <div class="field">
+            <label>{{ 'networks.wizard.step2.osLabel' | transloco }}</label>
+            <select [(ngModel)]="enableOs" name="enableOs">
+              <option value="windows">{{ 'networks.wizard.step2.os.windows' | transloco }}</option>
+              <option value="linux">{{ 'networks.wizard.step2.os.linux' | transloco }}</option>
+            </select>
+          </div>
+          <div class="field">
+            <label style="display:flex; align-items:center; gap:8px;">
+              <input type="checkbox" [(ngModel)]="enableAutostart" name="enableAutostart" />
+              {{ 'networks.wizard.step2.autostart' | transloco }}
+            </label>
+          </div>
+          <div class="field">
+            <label style="display:flex; align-items:center; gap:8px;">
+              <input type="checkbox" [(ngModel)]="enableOverwriteDns" name="enableOverwriteDns" />
+              {{ 'networks.wizard.step2.overwriteDns' | transloco }}
+            </label>
+            <div class="wizard-note" style="margin-top:6px;">{{ 'networks.wizard.step2.overwriteDnsHint' | transloco }}</div>
+          </div>
+          <div class="field">
+            <label style="display:flex; align-items:flex-start; gap:8px;">
+              <input type="checkbox" [(ngModel)]="enableAcknowledgeCritical" name="enableAcknowledgeCritical" style="margin-top:2px;" />
+              <span>{{ 'networks.wizard.step2.ackCritical' | transloco }}</span>
+            </label>
+          </div>
+          <div style="display:flex; gap:8px; justify-content:flex-end;">
+            <button class="btn-secondary btn" type="button" (click)="enableWizardStep.set(1)">{{ 'networks.wizard.back' | transloco }}</button>
+            <button class="btn-primary btn" type="button" (click)="prepareEnableWizardCommands()">{{ 'networks.wizard.continue' | transloco }}</button>
+          </div>
+        }
+
+        @if (enableWizardStep() === 3) {
+          @if (localAgentChecking()) {
+            <p class="wizard-note">{{ 'networks.wizard.step3.checkingStatus' | transloco }}</p>
+          } @else if (localAgentCanExecute()) {
+            <p class="wizard-note">{{ 'networks.wizard.step3.autoReady' | transloco }}</p>
+          } @else {
+            <p class="wizard-note">{{ 'networks.wizard.step3.autoUnavailable' | transloco }}</p>
+          }
+          @if (localAgentStatusMessage()) { <div class="wizard-status">{{ localAgentStatusMessage() }}</div> }
+          @if (!localAgentCanExecute() && !localAgentChecking()) {
+            @if (enableOs === 'windows') {
+              <div class="code-block" style="white-space:pre-wrap; word-break:break-word; font-size:11px;">{{ enableWindowsCommand() }}</div>
+            } @else {
+              <div class="code-block" style="white-space:pre-wrap; word-break:break-word; font-size:11px;">{{ enableLinuxCommand() }}</div>
+            }
+          }
+          <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:12px;">
+            @if (localAgentCanExecute()) {
+              <button class="btn-primary btn" type="button" [disabled]="enableAutoRunning() || !enableAcknowledgeCritical" (click)="runEnableNetworksAutomatically()">
+                @if (enableAutoRunning()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                {{ 'networks.wizard.step3.runAutomatically' | transloco }}
+              </button>
+            }
+            @if (!localAgentCanExecute() && !localAgentChecking()) {
+              <button class="btn-ghost btn" type="button" (click)="copyEnableWizardCommands()">{{ 'networks.wizard.step3.copyCommands' | transloco }}</button>
+            }
+            <button class="btn-secondary btn" type="button" (click)="enableWizardStep.set(2)">{{ 'networks.wizard.back' | transloco }}</button>
+            @if (!localAgentCanExecute() && !localAgentChecking()) {
+              <button class="btn-primary btn" type="button" (click)="completeEnableWizard()">{{ 'networks.wizard.step3.finishedSetup' | transloco }}</button>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class NetworkEnableWizardComponent implements OnInit {
+  private networksApi = inject(NetworksApi);
+  private transloco = inject(TranslocoService);
+  private confirmDialog = inject(ConfirmDialogService);
+
+  /** Emitted with this brain's now-public URL when setup succeeds — the host adopts it and drops the
+   *  enable prompt. */
+  readonly enabled = output<string>();
+  /** Emitted when the user cancels/dismisses (or after the confirm-and-adopt finish). */
+  readonly close = output<void>();
+
+  enableWizardStep = signal(1);
+  enableWizardError = signal('');
+  enableHostname = '';
+  enableOs: 'windows' | 'linux' = 'windows';
+  enableAutostart = true;
+  enableOverwriteDns = false;
+  enableAcknowledgeCritical = false;
+  enableWindowsCommand = signal('');
+  enableLinuxCommand = signal('');
+  localAgentCanExecute = signal(false);
+  localAgentChecking = signal(false);
+  localAgentStatusMessage = signal('');
+  enableAutoRunning = signal(false);
+
+  ngOnInit(): void {
+    this.enableOs = this.detectLocalOs();
+  }
+
+  prepareEnableWizardCommands(): void {
+    this.enableWizardError.set('');
+    const host = this.enableHostname.trim();
+    if (!/^(?=.{4,253}$)(?!-)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$/.test(host)) {
+      this.enableWizardError.set(this.transloco.translate('networks.wizard.error.invalidHostname'));
+      return;
+    }
+    this.enableWindowsCommand.set(this.buildWindowsCloudflareCommands(host));
+    this.enableLinuxCommand.set(this.buildLinuxCloudflareCommands(host));
+    this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.checkingConnector'));
+    this.localAgentChecking.set(true);
+    this.bootstrapLocalAgent();
+    this.enableWizardStep.set(3);
+  }
+
+  copyEnableWizardCommands(): void {
+    const text = this.enableOs === 'windows' ? this.enableWindowsCommand() : this.enableLinuxCommand();
+    if (!text) return;
+    navigator.clipboard.writeText(text).catch(() => {});
+  }
+
+  async completeEnableWizard(): Promise<void> {
+    const host = this.enableHostname.trim();
+    if (!host) return;
+    const ok = await this.confirmDialog.confirm({
+      title: this.transloco.translate('networks.wizard.confirm.verifyHealthTitle'),
+      message: this.transloco.translate('networks.wizard.confirm.verifyHealth', { host }),
+    });
+    if (!ok) return;
+    this.enabled.emit(`https://${host}`);
+    this.close.emit();
+  }
+
+  runEnableNetworksAutomatically(): void {
+    const host = this.enableHostname.trim();
+    if (!host) {
+      this.enableWizardError.set(this.transloco.translate('networks.wizard.error.enterHostnameFirst'));
+      return;
+    }
+    if (!this.enableAcknowledgeCritical) {
+      this.enableWizardError.set(this.transloco.translate('networks.wizard.error.acknowledgeCritical'));
+      return;
+    }
+    this.enableWizardError.set('');
+    this.enableAutoRunning.set(true);
+    if (!this.localAgentCanExecute()) {
+      this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.bootstrappingConnector'));
+      this.networksApi.bootstrapLocalAgent({ os: this.enableOs }).subscribe({
+        next: () => this.executeEnableNetworks(host),
+        error: (err) => {
+          this.enableAutoRunning.set(false);
+          this.enableWizardError.set(err.error?.error ?? this.transloco.translate('networks.wizard.error.bootstrapFailed'));
+        },
+      });
+      return;
+    }
+    this.executeEnableNetworks(host);
+  }
+
+  private executeEnableNetworks(host: string): void {
+    this.networksApi.executeEnableNetworksViaLocalAgent({
+      hostname: host,
+      os: this.enableOs,
+      autostart: this.enableAutostart,
+      overwriteDns: this.enableOverwriteDns,
+      acknowledgeCriticalChanges: this.enableAcknowledgeCritical,
+    }).subscribe({
+      next: (result) => {
+        this.enableAutoRunning.set(false);
+        this.localAgentStatusMessage.set(result.message ?? this.transloco.translate('networks.wizard.status.autoSetupFinished'));
+        this.enabled.emit(result.publicUrl || `https://${host}`);
+      },
+      error: (err) => {
+        this.enableAutoRunning.set(false);
+        this.enableWizardError.set(err.error?.error ?? this.transloco.translate('networks.wizard.error.autoSetupFailed'));
+      },
+    });
+  }
+
+  private bootstrapLocalAgent(): void {
+    // Try status first — if the connector is already running (feature enabled via env var, or started
+    // manually), automatic mode becomes available without bootstrap.
+    this.networksApi.getLocalAgentStatus().subscribe({
+      next: (status) => {
+        if (status.canExecute) {
+          this.localAgentCanExecute.set(true);
+          this.localAgentChecking.set(false);
+          this.localAgentStatusMessage.set(status.message ?? this.transloco.translate('networks.wizard.status.connectorReady'));
+        } else {
+          this.triggerBootstrap();
+        }
+      },
+      error: () => this.triggerBootstrap(),
+    });
+  }
+
+  private triggerBootstrap(): void {
+    this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.startingConnector'));
+    this.networksApi.bootstrapLocalAgent({ os: this.enableOs }).subscribe({
+      next: (result) => {
+        this.localAgentStatusMessage.set(result.message ?? this.transloco.translate('networks.wizard.status.connectorStarted'));
+        this.refreshLocalAgentStatus();
+      },
+      error: (err) => {
+        this.localAgentCanExecute.set(false);
+        this.localAgentChecking.set(false);
+        const detail = err?.error?.error ?? err?.message ?? `HTTP ${err?.status ?? 'unknown'}`;
+        this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.connectorStartFailed', { detail }));
+      },
+    });
+  }
+
+  private refreshLocalAgentStatus(): void {
+    this.networksApi.getLocalAgentStatus().subscribe({
+      next: (status) => {
+        this.localAgentCanExecute.set(status.canExecute);
+        this.localAgentChecking.set(false);
+        this.localAgentStatusMessage.set(status.message ?? (status.canExecute ? this.transloco.translate('networks.wizard.status.connectorReady') : this.transloco.translate('networks.wizard.status.manualAvailable')));
+      },
+      error: () => {
+        this.localAgentCanExecute.set(false);
+        this.localAgentChecking.set(false);
+        this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.statusEndpointUnreachable'));
+      },
+    });
+  }
+
+  private buildWindowsCloudflareCommands(host: string): string {
+    const serviceBlock = this.enableAutostart
+      ? 'cloudflared service install\nStart-Service cloudflared'
+      : 'cloudflared tunnel run ythril-local';
+    const routeCmd = this.enableOverwriteDns
+      ? `cloudflared tunnel route dns --overwrite-dns ythril-local ${host}`
+      : `cloudflared tunnel route dns ythril-local ${host}`;
+    return [
+      'winget install --id Cloudflare.cloudflared -e',
+      'cloudflared tunnel login',
+      'cloudflared tunnel create ythril-local',
+      routeCmd,
+      '$env:USERPROFILE',
+      '# create %USERPROFILE%\\.cloudflared\\config.yml with hostname and localhost:3200 origin',
+      serviceBlock,
+      `curl https://${host}/health`,
+    ].join('\n');
+  }
+
+  private buildLinuxCloudflareCommands(host: string): string {
+    const serviceBlock = this.enableAutostart
+      ? 'sudo cloudflared service install\nsudo systemctl enable --now cloudflared'
+      : 'cloudflared tunnel run ythril-local';
+    const routeCmd = this.enableOverwriteDns
+      ? `cloudflared tunnel route dns --overwrite-dns ythril-local ${host}`
+      : `cloudflared tunnel route dns ythril-local ${host}`;
+    return [
+      'curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o /tmp/cloudflared.deb',
+      'sudo dpkg -i /tmp/cloudflared.deb',
+      'cloudflared tunnel login',
+      'cloudflared tunnel create ythril-local',
+      routeCmd,
+      '# create ~/.cloudflared/config.yml with hostname and localhost:3200 origin',
+      serviceBlock,
+      `curl https://${host}/health`,
+    ].join('\n');
+  }
+
+  private detectLocalOs(): 'windows' | 'linux' {
+    const ua = navigator.userAgent.toLowerCase();
+    const platform = (navigator.platform || '').toLowerCase();
+    if (ua.includes('windows') || platform.includes('win')) return 'windows';
+    return 'linux';
+  }
+}

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -279,112 +279,13 @@ describe('NetworksComponent (characterization)', () => {
     expect(t).toEqual({ yes: 2, veto: 1 });
   });
 
-  // ── Enable-Networks wizard (characterization, before extracting it into its own component) ──
-  it('openEnableNetworksWizard() resets wizard state and opens at step 1', () => {
+  // Enable-Networks wizard behavior moved to network-enable-wizard.component.spec.ts when the wizard
+  // became its own child component. The parent only adopts the URL the wizard reports:
+  it('onEnabled() adopts the reported URL and clears the enable prompt', () => {
     const c = make();
-    c.enableWizardStep.set(3);
-    c.enableWizardError.set('boom');
-    c.localAgentCanExecute.set(true);
-    c.openEnableNetworksWizard();
-    expect(c.showEnableNetworksWizard()).toBe(true);
-    expect(c.enableWizardStep()).toBe(1);
-    expect(c.enableWizardError()).toBe('');
-    expect(c.localAgentCanExecute()).toBe(false);
-  });
-
-  it('prepareEnableWizardCommands() rejects an invalid hostname and stays put', () => {
-    const c = make();
-    c.enableWizardStep.set(2);
-    c.enableHostname = 'not a hostname';
-    c.prepareEnableWizardCommands();
-    expect(c.enableWizardError()).toBeTruthy();
-    expect(c.enableWizardStep()).toBe(2);
-    expect(api.getLocalAgentStatus).not.toHaveBeenCalled();
-  });
-
-  it('prepareEnableWizardCommands() builds OS commands (reflecting the flags), advances to step 3, probes the connector', () => {
-    const c = make();
-    c.enableHostname = 'brain.example.com';
-    c.enableOverwriteDns = true;
-    c.prepareEnableWizardCommands();
-    expect(c.enableWindowsCommand()).toContain('brain.example.com');
-    expect(c.enableWindowsCommand()).toContain('--overwrite-dns');
-    expect(c.enableLinuxCommand()).toContain('brain.example.com');
-    expect(c.enableWizardStep()).toBe(3);
-    expect(api.getLocalAgentStatus).toHaveBeenCalled();
-  });
-
-  it('prepareEnableWizardCommands(): connector already running → no bootstrap needed', () => {
-    const c = make();
-    api.getLocalAgentStatus.mockReturnValue(of({ canExecute: true, message: 'ready' }));
-    c.enableHostname = 'brain.example.com';
-    c.prepareEnableWizardCommands();
-    expect(c.localAgentCanExecute()).toBe(true);
-    expect(api.bootstrapLocalAgent).not.toHaveBeenCalled();
-  });
-
-  it('prepareEnableWizardCommands(): connector not running → bootstrap is attempted', () => {
-    const c = make();
-    api.getLocalAgentStatus.mockReturnValue(of({ canExecute: false }));
-    c.enableHostname = 'brain.example.com';
-    c.prepareEnableWizardCommands();
-    expect(api.bootstrapLocalAgent).toHaveBeenCalled();
-  });
-
-  it('completeEnableWizard() confirms, then adopts the URL and clears the enable prompt', async () => {
-    const c = make();
-    c.enableHostname = 'brain.example.com';
-    confirmResult = true;
-    await c.completeEnableWizard();
+    c.needsNetworkEnable.set(true);
+    c.onEnabled('https://brain.example.com');
     expect(c.joinMyUrl).toBe('https://brain.example.com');
     expect(c.needsNetworkEnable()).toBe(false);
-    expect(c.showEnableNetworksWizard()).toBe(false);
-  });
-
-  it('completeEnableWizard() declined → no change', async () => {
-    const c = make();
-    c.enableHostname = 'brain.example.com';
-    c.needsNetworkEnable.set(true);
-    c.showEnableNetworksWizard.set(true);
-    confirmResult = false;
-    await c.completeEnableWizard();
-    expect(c.needsNetworkEnable()).toBe(true);
-    expect(c.showEnableNetworksWizard()).toBe(true); // still open — decline is a no-op
-  });
-
-  it('runEnableNetworksAutomatically() guards on hostname and the critical-change acknowledgement', () => {
-    const c = make();
-    c.enableHostname = '';
-    c.runEnableNetworksAutomatically();
-    expect(c.enableWizardError()).toBeTruthy();
-    expect(api.executeEnableNetworksViaLocalAgent).not.toHaveBeenCalled();
-
-    c.enableHostname = 'brain.example.com';
-    c.enableAcknowledgeCritical = false;
-    c.runEnableNetworksAutomatically();
-    expect(c.enableWizardError()).toBeTruthy();
-    expect(api.executeEnableNetworksViaLocalAgent).not.toHaveBeenCalled();
-  });
-
-  it('runEnableNetworksAutomatically(): bootstraps when the connector can\'t execute, then runs setup and clears the prompt', () => {
-    const c = make();
-    c.enableHostname = 'brain.example.com';
-    c.enableAcknowledgeCritical = true;
-    c.localAgentCanExecute.set(false);
-    c.needsNetworkEnable.set(true);
-    c.runEnableNetworksAutomatically();
-    expect(api.bootstrapLocalAgent).toHaveBeenCalled();
-    expect(api.executeEnableNetworksViaLocalAgent).toHaveBeenCalledWith(expect.objectContaining({ hostname: 'brain.example.com' }));
-    expect(c.needsNetworkEnable()).toBe(false); // execute success set it
-  });
-
-  it('runEnableNetworksAutomatically(): connector ready → runs setup directly, no bootstrap', () => {
-    const c = make();
-    c.enableHostname = 'brain.example.com';
-    c.enableAcknowledgeCritical = true;
-    c.localAgentCanExecute.set(true);
-    c.runEnableNetworksAutomatically();
-    expect(api.bootstrapLocalAgent).not.toHaveBeenCalled();
-    expect(api.executeEnableNetworksViaLocalAgent).toHaveBeenCalled();
   });
 });

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -10,16 +10,16 @@ import { TranslocoService } from '@jsverse/transloco';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import { PhIconComponent } from '../../shared/ph-icon.component';
-import { ModalDirective } from '../../shared/modal.directive';
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { NetworkCreateDialogComponent } from './network-create-dialog.component';
 import { NetworkJoinDialogComponent } from './network-join-dialog.component';
+import { NetworkEnableWizardComponent } from './network-enable-wizard.component';
 @Component({
   selector: 'app-networks',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, NetworkCreateDialogComponent, NetworkJoinDialogComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, NetworkCreateDialogComponent, NetworkJoinDialogComponent, NetworkEnableWizardComponent],
   styles: [`
     .network-card {
       background: var(--bg-surface);
@@ -138,68 +138,6 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
     .space-toggle-item:hover { background: var(--bg-elevated); }
     .space-toggle-item input[type=checkbox] { width: 13px; height: 13px; margin: 0; flex-shrink: 0; }
     .space-toggle-item .space-id { color: var(--text-muted); font-size: 11px; font-family: var(--font-mono); }
-    .dialog-backdrop {
-      position: fixed;
-      inset: 0;
-      background: var(--bg-scrim);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 100;
-    }
-    .dialog {
-      background: var(--bg-primary);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      padding: 24px;
-      width: 90%;
-      max-width: 600px;
-      max-height: 90vh;
-      overflow-y: auto;
-    }
-    .dialog-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin-bottom: 16px;
-    }
-    .wizard-note {
-      font-size: 12px;
-      color: var(--text-muted);
-      margin: 0 0 10px;
-      line-height: 1.45;
-    }
-    .wizard-list {
-      margin: 0 0 12px;
-      padding-left: 18px;
-      font-size: 12px;
-      color: var(--text-secondary);
-      line-height: 1.45;
-    }
-    .wizard-status {
-      margin: 8px 0 12px;
-      padding: 8px 10px;
-      border-radius: var(--radius-sm);
-      border: 1px solid var(--border);
-      background: var(--bg-elevated);
-      font-size: 12px;
-      color: var(--text-secondary);
-    }
-    /* "Step N of 3" progress indicator at the top of the enable-networks wizard. */
-    .wizard-steps { display: flex; align-items: center; gap: 6px; margin: 0 0 14px; }
-    .wizard-step-dot {
-      width: 24px; height: 4px; border-radius: 2px;
-      background: var(--border);
-      transition: background var(--transition);
-    }
-    .wizard-step-dot.done { background: var(--accent-dim); }
-    .wizard-step-dot.active { background: var(--accent); }
-    .wizard-step-label {
-      margin-left: auto;
-      font-size: 11px;
-      color: var(--text-muted);
-      font-variant-numeric: tabular-nums;
-    }
   `],
   template: `
     <!-- Network list (shown first) -->
@@ -207,7 +145,7 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
       <div class="card-title">{{ 'networks.title' | transloco }}</div>
       <div style="display:flex; gap:8px;">
         @if (needsNetworkEnable()) {
-          <button class="btn-primary btn btn-sm" (click)="openEnableNetworksWizard()">{{ 'networks.enableButton' | transloco }}</button>
+          <button class="btn-primary btn btn-sm" (click)="showEnableNetworksWizard.set(true)">{{ 'networks.enableButton' | transloco }}</button>
         } @else {
           <button class="btn-primary btn btn-sm" (click)="showCreateDialog.set(true)">{{ 'networks.createButton' | transloco }}</button>
           <button class="btn-secondary btn btn-sm" (click)="showJoinDialog.set(true)">{{ 'networks.joinButton' | transloco }}</button>
@@ -407,121 +345,10 @@ import { NetworkJoinDialogComponent } from './network-join-dialog.component';
 
     <!-- Enable Networks wizard -->
     @if (showEnableNetworksWizard()) {
-      <div class="dialog-backdrop" (click)="showEnableNetworksWizard.set(false)">
-        <div class="dialog" [appModal]="'networks.wizard.title' | transloco" (dismiss)="showEnableNetworksWizard.set(false)" (click)="$event.stopPropagation()">
-          <div class="dialog-header">
-            <div class="card-title">{{ 'networks.wizard.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showEnableNetworksWizard.set(false)"><ph-icon name="x" [size]="14"/></button>
-          </div>
-
-          <div class="wizard-steps">
-            @for (n of [1, 2, 3]; track n) {
-              <span class="wizard-step-dot" [class.active]="enableWizardStep() === n" [class.done]="enableWizardStep() > n"></span>
-            }
-            <span class="wizard-step-label">{{ 'networks.wizard.stepLabel' | transloco: { current: enableWizardStep(), total: 3 } }}</span>
-          </div>
-
-          @if (enableWizardError()) { <div class="alert alert-error">{{ enableWizardError() }}</div> }
-
-          @if (enableWizardStep() === 1) {
-            <p class="wizard-note">
-              {{ 'networks.wizard.step1.p1' | transloco }}
-            </p>
-            <p class="wizard-note">
-              {{ 'networks.wizard.step1.p2' | transloco }}
-            </p>
-            <ul class="wizard-list">
-              <li>{{ 'networks.wizard.step1.whyItem' | transloco }}</li>
-              <li>{{ 'networks.wizard.step1.riskItem' | transloco }}</li>
-              <li>{{ 'networks.wizard.step1.resultItem' | transloco }}</li>
-            </ul>
-            <div style="display:flex; gap:8px; justify-content:flex-end;">
-              <button class="btn-secondary btn" type="button" (click)="showEnableNetworksWizard.set(false)">{{ 'common.cancel' | transloco }}</button>
-              <button class="btn-primary btn" type="button" (click)="enableWizardStep.set(2)">{{ 'networks.wizard.continue' | transloco }}</button>
-            </div>
-          }
-
-          @if (enableWizardStep() === 2) {
-            @if (localAgentStatusMessage()) {
-              <div class="wizard-status">{{ localAgentStatusMessage() }}</div>
-            }
-            <p class="wizard-note">
-              {{ 'networks.wizard.step2.hostnameHint' | transloco }}
-            </p>
-            <div class="field">
-              <label>{{ 'networks.wizard.step2.publicHostnameLabel' | transloco }}</label>
-              <input type="text" [(ngModel)]="enableHostname" name="enableHostname" [placeholder]="'networks.wizard.step2.publicHostnamePlaceholder' | transloco" />
-            </div>
-            <div class="field">
-              <label>{{ 'networks.wizard.step2.osLabel' | transloco }}</label>
-              <select [(ngModel)]="enableOs" name="enableOs">
-                <option value="windows">{{ 'networks.wizard.step2.os.windows' | transloco }}</option>
-                <option value="linux">{{ 'networks.wizard.step2.os.linux' | transloco }}</option>
-              </select>
-            </div>
-            <div class="field">
-              <label style="display:flex; align-items:center; gap:8px;">
-                <input type="checkbox" [(ngModel)]="enableAutostart" name="enableAutostart" />
-                {{ 'networks.wizard.step2.autostart' | transloco }}
-              </label>
-            </div>
-            <div class="field">
-              <label style="display:flex; align-items:center; gap:8px;">
-                <input type="checkbox" [(ngModel)]="enableOverwriteDns" name="enableOverwriteDns" />
-                {{ 'networks.wizard.step2.overwriteDns' | transloco }}
-              </label>
-              <div class="wizard-note" style="margin-top:6px;">
-                {{ 'networks.wizard.step2.overwriteDnsHint' | transloco }}
-              </div>
-            </div>
-            <div class="field">
-              <label style="display:flex; align-items:flex-start; gap:8px;">
-                <input type="checkbox" [(ngModel)]="enableAcknowledgeCritical" name="enableAcknowledgeCritical" style="margin-top:2px;" />
-                <span>{{ 'networks.wizard.step2.ackCritical' | transloco }}</span>
-              </label>
-            </div>
-            <div style="display:flex; gap:8px; justify-content:flex-end;">
-              <button class="btn-secondary btn" type="button" (click)="enableWizardStep.set(1)">{{ 'networks.wizard.back' | transloco }}</button>
-              <button class="btn-primary btn" type="button" (click)="prepareEnableWizardCommands()">{{ 'networks.wizard.continue' | transloco }}</button>
-            </div>
-          }
-
-          @if (enableWizardStep() === 3) {
-            @if (localAgentChecking()) {
-              <p class="wizard-note">{{ 'networks.wizard.step3.checkingStatus' | transloco }}</p>
-            } @else if (localAgentCanExecute()) {
-              <p class="wizard-note">{{ 'networks.wizard.step3.autoReady' | transloco }}</p>
-            } @else {
-              <p class="wizard-note">{{ 'networks.wizard.step3.autoUnavailable' | transloco }}</p>
-            }
-            @if (localAgentStatusMessage()) {
-              <div class="wizard-status">{{ localAgentStatusMessage() }}</div>
-            }
-            @if (!localAgentCanExecute() && !localAgentChecking()) {
-              @if (enableOs === 'windows') {
-                <div class="code-block" style="white-space:pre-wrap; word-break:break-word; font-size:11px;">{{ enableWindowsCommand() }}</div>
-              } @else {
-                <div class="code-block" style="white-space:pre-wrap; word-break:break-word; font-size:11px;">{{ enableLinuxCommand() }}</div>
-              }
-            }
-            <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:12px;">
-              @if (localAgentCanExecute()) {
-                <button class="btn-primary btn" type="button" [disabled]="enableAutoRunning() || !enableAcknowledgeCritical" (click)="runEnableNetworksAutomatically()">
-                  @if (enableAutoRunning()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                  {{ 'networks.wizard.step3.runAutomatically' | transloco }}
-                </button>
-              }
-              @if (!localAgentCanExecute() && !localAgentChecking()) {
-                <button class="btn-ghost btn" type="button" (click)="copyEnableWizardCommands()">{{ 'networks.wizard.step3.copyCommands' | transloco }}</button>
-              }
-              <button class="btn-secondary btn" type="button" (click)="enableWizardStep.set(2)">{{ 'networks.wizard.back' | transloco }}</button>
-              @if (!localAgentCanExecute() && !localAgentChecking()) {
-                <button class="btn-primary btn" type="button" (click)="completeEnableWizard()">{{ 'networks.wizard.step3.finishedSetup' | transloco }}</button>
-              }
-            </div>
-          }
-        </div>
-      </div>
+      <app-network-enable-wizard
+        (enabled)="onEnabled($event)"
+        (close)="showEnableNetworksWizard.set(false)"
+      />
     }
   `,
 })
@@ -567,21 +394,10 @@ export class NetworksComponent implements OnInit {
   expandedError = signal('');
   private historyByNetwork: Record<string, SyncHistoryRecord[]> = {};
 
+  // Whether this brain looks locally-reachable (so it needs the enable-networks wizard to get a public
+  // URL before it can join). Derived from its own URL in ngOnInit; cleared when the wizard reports success.
   needsNetworkEnable = signal(false);
   showEnableNetworksWizard = signal(false);
-  enableWizardStep = signal(1);
-  enableWizardError = signal('');
-  enableHostname = '';
-  enableOs: 'windows' | 'linux' = 'windows';
-  enableAutostart = true;
-  enableOverwriteDns = false;
-  enableAcknowledgeCritical = false;
-  enableWindowsCommand = signal('');
-  enableLinuxCommand = signal('');
-  localAgentCanExecute = signal(false);
-  localAgentChecking = signal(false);
-  localAgentStatusMessage = signal('');
-  enableAutoRunning = signal(false);
 
   inviteBundle(id: string): InviteBundle | undefined { return this.inviteBundles[id]; }
   bundleJson(bundle: InviteBundle): string { return JSON.stringify(bundle, null, 2); }
@@ -610,7 +426,6 @@ export class NetworksComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.enableOs = this.detectLocalOs();
     this.load();
     this.spacesApi.listSpaces().subscribe({
       next: ({ spaces }) => this.availableSpaces.set(spaces),
@@ -641,192 +456,12 @@ export class NetworksComponent implements OnInit {
     });
   }
 
-  openEnableNetworksWizard(): void {
-    this.enableWizardError.set('');
-    this.enableWizardStep.set(1);
-    this.enableHostname = '';
-    this.enableWindowsCommand.set('');
-    this.enableLinuxCommand.set('');
-    this.enableOverwriteDns = false;
-    this.enableAcknowledgeCritical = false;
-    this.localAgentCanExecute.set(false);
-    this.localAgentChecking.set(false);
-    this.localAgentStatusMessage.set('');
-    this.showEnableNetworksWizard.set(true);
-  }
-
-  prepareEnableWizardCommands(): void {
-    this.enableWizardError.set('');
-    const host = this.enableHostname.trim();
-    if (!/^(?=.{4,253}$)(?!-)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$/.test(host)) {
-      this.enableWizardError.set(this.transloco.translate('networks.wizard.error.invalidHostname'));
-      return;
-    }
-
-    this.enableWindowsCommand.set(this.buildWindowsCloudflareCommands(host));
-    this.enableLinuxCommand.set(this.buildLinuxCloudflareCommands(host));
-    this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.checkingConnector'));
-    this.localAgentChecking.set(true);
-    this.bootstrapLocalAgent();
-    this.enableWizardStep.set(3);
-  }
-
-  copyEnableWizardCommands(): void {
-    const text = this.enableOs === 'windows' ? this.enableWindowsCommand() : this.enableLinuxCommand();
-    if (!text) return;
-    navigator.clipboard.writeText(text).catch(() => {});
-  }
-
-  async completeEnableWizard(): Promise<void> {
-    const host = this.enableHostname.trim();
-    if (!host) return;
-    const ok = await this.confirmDialog.confirm({
-      title: this.transloco.translate('networks.wizard.confirm.verifyHealthTitle'),
-      message: this.transloco.translate('networks.wizard.confirm.verifyHealth', { host }),
-    });
-    if (!ok) return;
-    const url = `https://${host}`;
+  /** The enable-networks wizard (child) reports success with this brain's now-public URL; adopt it and
+   *  drop the enable prompt. */
+  onEnabled(url: string): void {
     this.joinMyUrl = url;
     this.joinMyUrlAutoFilled.set(true);
     this.needsNetworkEnable.set(false);
-    this.showEnableNetworksWizard.set(false);
-  }
-
-  runEnableNetworksAutomatically(): void {
-    const host = this.enableHostname.trim();
-    if (!host) {
-      this.enableWizardError.set(this.transloco.translate('networks.wizard.error.enterHostnameFirst'));
-      return;
-    }
-    if (!this.enableAcknowledgeCritical) {
-      this.enableWizardError.set(this.transloco.translate('networks.wizard.error.acknowledgeCritical'));
-      return;
-    }
-    this.enableWizardError.set('');
-    this.enableAutoRunning.set(true);
-    if (!this.localAgentCanExecute()) {
-      this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.bootstrappingConnector'));
-      this.networksApi.bootstrapLocalAgent({ os: this.enableOs }).subscribe({
-        next: () => this.executeEnableNetworks(host),
-        error: (err) => {
-          this.enableAutoRunning.set(false);
-          this.enableWizardError.set(err.error?.error ?? this.transloco.translate('networks.wizard.error.bootstrapFailed'));
-        },
-      });
-      return;
-    }
-
-    this.executeEnableNetworks(host);
-  }
-
-  private executeEnableNetworks(host: string): void {
-    this.networksApi.executeEnableNetworksViaLocalAgent({
-      hostname: host,
-      os: this.enableOs,
-      autostart: this.enableAutostart,
-      overwriteDns: this.enableOverwriteDns,
-      acknowledgeCriticalChanges: this.enableAcknowledgeCritical,
-    }).subscribe({
-      next: (result) => {
-        this.enableAutoRunning.set(false);
-        this.localAgentStatusMessage.set(result.message ?? this.transloco.translate('networks.wizard.status.autoSetupFinished'));
-        const url = result.publicUrl || `https://${host}`;
-        this.joinMyUrl = url;
-        this.joinMyUrlAutoFilled.set(true);
-        this.needsNetworkEnable.set(false);
-      },
-      error: (err) => {
-        this.enableAutoRunning.set(false);
-        this.enableWizardError.set(err.error?.error ?? this.transloco.translate('networks.wizard.error.autoSetupFailed'));
-      },
-    });
-  }
-
-  private bootstrapLocalAgent(): void {
-    // Try status first — if the connector is already running (e.g. feature enabled via env var,
-    // or connector was started manually), automatic mode becomes available without bootstrap.
-    this.networksApi.getLocalAgentStatus().subscribe({
-      next: (status) => {
-        if (status.canExecute) {
-          this.localAgentCanExecute.set(true);
-          this.localAgentChecking.set(false);
-          this.localAgentStatusMessage.set(status.message ?? this.transloco.translate('networks.wizard.status.connectorReady'));
-        } else {
-          // Connector not ready — try to spawn it via bootstrap.
-          this.triggerBootstrap();
-        }
-      },
-      error: () => this.triggerBootstrap(),
-    });
-  }
-
-  private triggerBootstrap(): void {
-    this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.startingConnector'));
-    this.networksApi.bootstrapLocalAgent({ os: this.enableOs }).subscribe({
-      next: (result) => {
-        this.localAgentStatusMessage.set(result.message ?? this.transloco.translate('networks.wizard.status.connectorStarted'));
-        this.refreshLocalAgentStatus();
-      },
-      error: (err) => {
-        this.localAgentCanExecute.set(false);
-        this.localAgentChecking.set(false);
-        const detail = err?.error?.error ?? err?.message ?? `HTTP ${err?.status ?? 'unknown'}`;
-        this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.connectorStartFailed', { detail }));
-      },
-    });
-  }
-
-  private refreshLocalAgentStatus(): void {
-    this.networksApi.getLocalAgentStatus().subscribe({
-      next: (status) => {
-        this.localAgentCanExecute.set(status.canExecute);
-        this.localAgentChecking.set(false);
-        this.localAgentStatusMessage.set(status.message ?? (status.canExecute ? this.transloco.translate('networks.wizard.status.connectorReady') : this.transloco.translate('networks.wizard.status.manualAvailable')));
-      },
-      error: () => {
-        this.localAgentCanExecute.set(false);
-        this.localAgentChecking.set(false);
-        this.localAgentStatusMessage.set(this.transloco.translate('networks.wizard.status.statusEndpointUnreachable'));
-      },
-    });
-  }
-
-  private buildWindowsCloudflareCommands(host: string): string {
-    const serviceBlock = this.enableAutostart
-      ? "cloudflared service install\nStart-Service cloudflared"
-      : "cloudflared tunnel run ythril-local";
-    const routeCmd = this.enableOverwriteDns
-      ? `cloudflared tunnel route dns --overwrite-dns ythril-local ${host}`
-      : `cloudflared tunnel route dns ythril-local ${host}`;
-    return [
-      'winget install --id Cloudflare.cloudflared -e',
-      'cloudflared tunnel login',
-      'cloudflared tunnel create ythril-local',
-      routeCmd,
-      '$env:USERPROFILE',
-      '# create %USERPROFILE%\\.cloudflared\\config.yml with hostname and localhost:3200 origin',
-      serviceBlock,
-      `curl https://${host}/health`,
-    ].join('\n');
-  }
-
-  private buildLinuxCloudflareCommands(host: string): string {
-    const serviceBlock = this.enableAutostart
-      ? 'sudo cloudflared service install\nsudo systemctl enable --now cloudflared'
-      : 'cloudflared tunnel run ythril-local';
-    const routeCmd = this.enableOverwriteDns
-      ? `cloudflared tunnel route dns --overwrite-dns ythril-local ${host}`
-      : `cloudflared tunnel route dns ythril-local ${host}`;
-    return [
-      'curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o /tmp/cloudflared.deb',
-      'sudo dpkg -i /tmp/cloudflared.deb',
-      'cloudflared tunnel login',
-      'cloudflared tunnel create ythril-local',
-      routeCmd,
-      '# create ~/.cloudflared/config.yml with hostname and localhost:3200 origin',
-      serviceBlock,
-      `curl https://${host}/health`,
-    ].join('\n');
   }
 
   private isLocalOrPrivateUrl(raw: string): boolean {
@@ -847,12 +482,6 @@ export class NetworksComponent implements OnInit {
     }
   }
 
-  private detectLocalOs(): 'windows' | 'linux' {
-    const ua = navigator.userAgent.toLowerCase();
-    const platform = (navigator.platform || '').toLowerCase();
-    if (ua.includes('windows') || platform.includes('win')) return 'windows';
-    return 'linux';
-  }
 
   load(): void {
     this.loading.set(true);


### PR DESCRIPTION
Third and final dialog extraction — the Networks page's **worst-offender** component is now maintainable.

## Change
- Pulled the 3-step **Enable-Networks wizard** into `NetworkEnableWizardComponent`: hostname + options, the generated **Cloudflare-tunnel commands** (Windows/Linux), and the local-agent connector **probe → bootstrap → execute** path. It emits **`enabled(url)`** when this brain gets a public URL; the host adopts it and clears `needsNetworkEnable`.
- `detectLocalOs` moved with it; `isLocalOrPrivateUrl` stays (host `ngOnInit` still derives `needsNetworkEnable`).
- Removed the now-dead dialog/wizard CSS and the unused `ModalDirective` import from the parent.
- **No behavior change.**

## Result
With all three dialogs extracted, **`NetworksComponent` drops from 1261 → 692 lines (−45%)**. Children: create 200 / join 273 / enable 355.

## Tests
- The 10 enable-wizard characterization tests **moved** to `network-enable-wizard.component.spec.ts` (success asserts the `enabled`/`close` outputs); parent keeps an `onEnabled` test.
- **39 networks specs across 4 files pass**; AOT build clean.

## Next
`SettingsCard` grouping of the expanded card body finishes PR-U3; then the settings-UX queue continues (space-schema → duplicates → spaces → …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)