### PR TITLE
feat(settings): Storage page on the design system (PR-U10, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,6 +927,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Storage on the design system.** The usage bar is now the shared `UsageBar` (retiring the
+  page-local `usage-bar-*` dialect), with a health **status pill** (Healthy / Warning / Full) next to the
+  percentage, and **Refresh keeps the current figures on screen with an inline spinner** instead of blanking
+  the panel to a full-page loader. (The page's empty-vs-error handling — a successful empty load must not
+  look like a failure — was already correct; it's now pinned by a new spec.)
+
 - **Settings → Networks: the Enable-Networks wizard shows a "Step N of 3" progress indicator.** The 3-step
   enable flow now has a segmented progress bar + a "Step N of 3" label in its header, so you can see where
   you are in the (otherwise easy-to-lose-track-of) setup.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1150,5 +1150,8 @@
   "networks.network.votes.tally": "{{ yes }} Ja · {{ veto }} Veto",
   "networks.confirm.vetoTitle": "Diese Runde ablehnen?",
   "networks.confirm.veto": "Ein Veto blockiert diese ausstehende Runde für das gesamte Netzwerk. Dies kann nicht rückgängig gemacht werden.",
-  "networks.wizard.stepLabel": "Schritt {{ current }} von {{ total }}"
+  "networks.wizard.stepLabel": "Schritt {{ current }} von {{ total }}",
+  "metrics.health.ok": "In Ordnung",
+  "metrics.health.warn": "Warnung",
+  "metrics.health.full": "Voll"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1149,5 +1149,8 @@
   "networks.network.votes.tally": "{{ yes }} yes · {{ veto }} veto",
   "networks.confirm.vetoTitle": "Veto this round?",
   "networks.confirm.veto": "A veto blocks this pending round for the whole network. This cannot be undone.",
-  "networks.wizard.stepLabel": "Step {{ current }} of {{ total }}"
+  "networks.wizard.stepLabel": "Step {{ current }} of {{ total }}",
+  "metrics.health.ok": "Healthy",
+  "metrics.health.warn": "Warning",
+  "metrics.health.full": "Full"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1150,5 +1150,8 @@
   "networks.network.votes.tally": "{{ yes }} tak · {{ veto }} weto",
   "networks.confirm.vetoTitle": "Zawetować tę rundę?",
   "networks.confirm.veto": "Weto blokuje tę oczekującą rundę dla całej sieci. Nie można tego cofnąć.",
-  "networks.wizard.stepLabel": "Krok {{ current }} z {{ total }}"
+  "networks.wizard.stepLabel": "Krok {{ current }} z {{ total }}",
+  "metrics.health.ok": "W normie",
+  "metrics.health.warn": "Ostrzeżenie",
+  "metrics.health.full": "Pełny"
 }

--- a/client/src/app/pages/settings/storage.component.spec.ts
+++ b/client/src/app/pages/settings/storage.component.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * StorageComponent — pins the empty-vs-error distinction (the U0 correctness bug: a successful load with
+ * no/zero storage must NOT render the red error state) and the health status pill driven by the shared
+ * UsageBar's level thresholds.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { SpacesApi } from '../../core/spaces-api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { StorageComponent } from './storage.component';
+
+function make(listSpaces: () => unknown) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [StorageComponent, getTranslocoModule()],
+    providers: [{ provide: SpacesApi, useValue: { listSpaces } }],
+  });
+  const f = TestBed.createComponent(StorageComponent);
+  f.detectChanges(); // ngOnInit → load()
+  return f;
+}
+
+describe('StorageComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+  const el = (f: ReturnType<typeof make>) => f.nativeElement as HTMLElement;
+
+  it('a successful empty load shows the info state, NOT the error state', () => {
+    const f = make(() => of({ storage: null }));
+    expect(el(f).querySelector('.alert-error')).toBeNull();
+    expect(el(f).querySelector('.alert-info')).toBeTruthy();
+  });
+
+  it('a load failure shows the error state', () => {
+    const f = make(() => throwError(() => ({})));
+    expect(el(f).querySelector('.alert-error')).toBeTruthy();
+  });
+
+  it('renders the shared usage bar + a health pill when a limit is configured', () => {
+    const f = make(() => of({ storage: { usageGiB: { files: 1, brain: 1, total: 2 }, limits: { totalLimitGiB: 10, warnAtPercent: 80 } } }));
+    expect(el(f).querySelector('app-usage-bar')).toBeTruthy();
+    expect(el(f).querySelector('app-status-pill')).toBeTruthy();
+  });
+
+  it('healthPill reflects the usage level (ok / warn / full), and is null with no limit', () => {
+    const c = make(() => of({ storage: null })).componentInstance;
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 5 }, limits: { totalLimitGiB: 10, warnAtPercent: 80 } } as never);
+    expect(c.healthPill()?.variant).toBe('ok'); // 50%
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 9 }, limits: { totalLimitGiB: 10, warnAtPercent: 80 } } as never);
+    expect(c.healthPill()?.variant).toBe('warn'); // 90%
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 10 }, limits: { totalLimitGiB: 10 } } as never);
+    expect(c.healthPill()?.variant).toBe('error'); // 100%
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 5 } } as never); // no limit
+    expect(c.healthPill()).toBeNull();
+  });
+});

--- a/client/src/app/pages/settings/storage.component.ts
+++ b/client/src/app/pages/settings/storage.component.ts
@@ -2,6 +2,8 @@ import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { UsageBarComponent, usageLevel } from '../../shared/usage-bar.component';
+import { StatusPillComponent, type StatusVariant } from '../../shared/status-pill.component';
 
 interface StorageData {
   usageGiB: { files: number; brain: number; total: number };
@@ -11,25 +13,8 @@ interface StorageData {
 @Component({
   selector: 'app-storage',
   standalone: true,
-  imports: [CommonModule, TranslocoPipe],
+  imports: [CommonModule, TranslocoPipe, UsageBarComponent, StatusPillComponent],
   styles: [`
-    .usage-bar-track {
-      height: 8px;
-      background: var(--bg-elevated);
-      border-radius: 4px;
-      overflow: hidden;
-      margin-top: 6px;
-    }
-
-    .usage-bar-fill {
-      height: 100%;
-      background: var(--accent);
-      border-radius: 4px;
-      transition: width 0.4s ease;
-    }
-
-    .usage-bar-fill.warn { background: var(--warning); }
-    .usage-bar-fill.danger { background: var(--error); }
 
     .row {
       display: flex;
@@ -47,14 +32,19 @@ interface StorageData {
       <div class="card-title">{{ 'metrics.title' | transloco }}</div>
     </div>
 
-    <button class="btn-secondary btn btn-sm" style="margin-bottom:20px;" (click)="load()">{{ 'metrics.refreshButton' | transloco }}</button>
+    <button class="btn-secondary btn btn-sm" style="margin-bottom:20px;" [disabled]="loading()" (click)="load()">
+      @if (loading()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+      {{ 'metrics.refreshButton' | transloco }}
+    </button>
 
-    @if (loading()) {
-      <div class="loading-overlay"><span class="spinner"></span></div>
-    } @else if (error()) {
+    @if (error()) {
       <div class="alert alert-error">{{ 'metrics.error.load' | transloco }}</div>
     } @else if (!data()) {
-      <div class="alert alert-info">{{ 'metrics.empty' | transloco }}</div>
+      @if (loading()) {
+        <div class="loading-overlay"><span class="spinner"></span></div>
+      } @else {
+        <div class="alert alert-info">{{ 'metrics.empty' | transloco }}</div>
+      }
     } @else {
       @let pct = usagePct();
       <div class="stat-grid">
@@ -85,18 +75,19 @@ interface StorageData {
       @if (data()!.limits?.totalLimitGiB) {
         <div class="card" style="margin-bottom:20px;">
           <div class="row">
-            <span class="label">{{ 'metrics.bar.usage' | transloco }}</span>
+            <span class="label" style="display:inline-flex; align-items:center; gap:8px;">
+              {{ 'metrics.bar.usage' | transloco }}
+              @if (healthPill(); as h) { <app-status-pill [variant]="h.variant">{{ h.key | transloco }}</app-status-pill> }
+            </span>
             <span class="value">{{ pct.toFixed(1) }}%</span>
           </div>
-          <div class="usage-bar-track">
-            <div
-              class="usage-bar-fill"
-              [class.warn]="pct >= (data()!.limits?.warnAtPercent ?? 80)"
-              [class.danger]="pct >= 95"
-              [style.width.%]="Math.min(pct, 100)"
-            ></div>
-          </div>
-          <div style="font-size:11px; color:var(--text-muted); margin-top:6px;">
+          <app-usage-bar
+            [used]="data()!.usageGiB.total"
+            [total]="data()!.limits!.totalLimitGiB!"
+            [warnAtPercent]="data()!.limits?.warnAtPercent ?? 80"
+            style="display:block; margin:8px 0 6px;"
+          />
+          <div style="font-size:11px; color:var(--text-muted);">
             {{ fmt(data()!.usageGiB.total) }} of {{ data()!.limits!.totalLimitGiB }} GiB
           </div>
         </div>
@@ -130,6 +121,18 @@ export class StorageComponent implements OnInit {
     const d = this.data();
     const limit = d?.limits?.totalLimitGiB;
     return limit ? (d!.usageGiB.total / limit) * 100 : 0;
+  });
+
+  /** Storage health as a status pill — only meaningful when a limit is configured. */
+  healthPill = computed<{ variant: StatusVariant; key: string } | null>(() => {
+    const d = this.data();
+    if (!d?.limits?.totalLimitGiB) return null;
+    const level = usageLevel(this.usagePct(), d.limits.warnAtPercent ?? 80);
+    return {
+      ok:     { variant: 'ok' as StatusVariant,    key: 'metrics.health.ok' },
+      warn:   { variant: 'warn' as StatusVariant,  key: 'metrics.health.warn' },
+      danger: { variant: 'error' as StatusVariant, key: 'metrics.health.full' },
+    }[level];
   });
 
   ngOnInit(): void { this.load(); }

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -576,9 +576,9 @@ These settings live in `config.json` under `mediaEmbedding.documentProcessing`:
 
 ## Settings — Storage
 
-**Settings → Storage** shows how much disk space each space is using and the configured quota limits.
+**Settings → Storage** shows how much disk space your Brain data and files are using against the configured quota. A usage bar with a **Healthy / Warning / Full** indicator shows how close total usage is to the limit; **Refresh** re-checks the current figures.
 
-When a space approaches its quota limit, writes will first return warnings and eventually be rejected. Contact your administrator to raise the quota.
+When usage approaches the quota limit, writes will first return warnings and eventually be rejected. Contact your administrator to raise the quota.
 
 ---
 


### PR DESCRIPTION
Folds **Settings → Storage** onto the shared design-system primitives.

## Changes
- Usage bar → the shared **`UsageBar`** (retires the page-local `usage-bar-*` CSS dialect).
- A **health `StatusPill`** (Healthy / Warning / Full) next to the usage %, driven by the shared `usageLevel` thresholds.
- **Refresh keeps the current figures on screen** with an inline button spinner instead of blanking the panel to a full-page loader (load/error/empty conditionals restructured).

## Correctness (already fixed, now pinned)
The U0 audit bugs — a successful **empty** load must not render as an **error**, and `usagePct` must derive from `data()` so a stale % can't fire a "full" alert — were already correct in the code. Added a **new spec (4 tests)** pinning the empty-vs-error distinction + the health pill; the tracker item is reconciled.

AOT build clean; `metrics.health.*` i18n keys added to en/de/pl.

## Next
The **about** info page is the other half of U10 (grouped `SettingsCard`s + `UsageBar` for disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)