### PR TITLE
fix(docker): align local-agent compose default with the loopback validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -515,6 +515,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Docker: the base `docker-compose.yml` local-agent default no longer contradicts the server's own
+  validator.** It shipped `YTHRIL_LOCAL_AGENT_URL=http://localhost:38123`, but the server deliberately
+  rejects a DNS-resolved `localhost` host (only numeric `127.0.0.1`/`::1` count as loopback, to keep the
+  bearer token on-box) — so enabling the feature with the compose default was silently refused unless
+  `YTHRIL_LOCAL_AGENT_ALLOW_REMOTE=true`. The base default is now `http://127.0.0.1:38123`, matching the
+  server's fallback, with a comment pointing to `docker-compose.override.yml` (which sets host-gateway plus
+  ALLOW_REMOTE and ALLOW_INSECURE) for real Docker workstation mode. The loopback check and shared default
+  are extracted to
+  a dependency-free `local-agent-url.ts` and pinned by a test that also documents why `localhost` stays
+  rejected. (Found during the docs-vs-code audit.)
+
 - **Brain: fixed an infinite reload loop that made the whole page unusable — opening any space's
   entities/edges/memories/chrono/files tab showed only a jittering spinner and never loaded.** The five
   record tabs were mounted inside the `@else` of `@if (recordList.loading())`, but each tab **writes** that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,17 @@
       # `doc-render` service below; only used when documentProcessing.mode is vlm/auto/max.
       RENDER_SIDECAR_URL: ${RENDER_SIDECAR_URL:-http://doc-render:8100}
       YTHRIL_LOCAL_AGENT_ENABLED: ${YTHRIL_LOCAL_AGENT_ENABLED:-}
-      YTHRIL_LOCAL_AGENT_URL: ${YTHRIL_LOCAL_AGENT_URL:-http://localhost:38123}
+      # Numeric loopback on purpose: the server rejects a non-loopback (or DNS-resolved `localhost`)
+      # host unless YTHRIL_LOCAL_AGENT_ALLOW_REMOTE=true, to keep the bearer token on-box. The feature is
+      # off by default (YTHRIL_LOCAL_AGENT_ENABLED empty above), so this is just a sane accepted default.
+      #
+      # To use it in Docker, the connector runs on the HOST, not in this container, so `127.0.0.1` here
+      # can't reach it. Set these three (via `.env`, or a gitignored docker-compose.override.yml — see
+      # docs/workstation-mode-guide.md), adding an `extra_hosts: ["host-gateway:host-gateway"]` mapping:
+      #   YTHRIL_LOCAL_AGENT_URL=http://host-gateway:38123   # reach the host across the Docker bridge
+      #   YTHRIL_LOCAL_AGENT_ALLOW_REMOTE=true               # host-gateway isn't loopback from in here
+      #   YTHRIL_LOCAL_AGENT_ALLOW_INSECURE=true             # HTTP is fine: it never leaves the machine
+      YTHRIL_LOCAL_AGENT_URL: ${YTHRIL_LOCAL_AGENT_URL:-http://127.0.0.1:38123}
       YTHRIL_LOCAL_AGENT_TOKEN: ${YTHRIL_LOCAL_AGENT_TOKEN:-}
       # Pass DEBUG=1 from the host shell to enable verbose logging:
       #   DEBUG=1 docker compose up

--- a/server/src/api/local-agent-url.ts
+++ b/server/src/api/local-agent-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Local-agent URL validation — isolated here (dependency-free) so the security-critical loopback
+ * check is unit-testable without pulling in the whole router/auth/rate-limit graph.
+ *
+ * The local agent (Cloudflare-tunnel connector) is reached over a bearer-authenticated HTTP call.
+ * Unless `YTHRIL_LOCAL_AGENT_ALLOW_REMOTE=true` is set, the target host MUST be a numeric loopback
+ * address so the token can never be sent off-box by a misconfigured or tampered URL.
+ */
+
+/** The default target when `YTHRIL_LOCAL_AGENT_URL` is unset/empty. Numeric loopback on purpose. */
+export const LOCAL_AGENT_DEFAULT_URL = 'http://127.0.0.1:38123';
+
+/**
+ * True only for numeric loopback addresses. `localhost` is intentionally EXCLUDED because it is
+ * resolved via DNS/hosts and could be remapped to a non-loopback address on a compromised system —
+ * do not "fix" a config mismatch by adding it here; align the config to `127.0.0.1` instead.
+ */
+export function isLoopbackHost(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === '127.0.0.1' || h === '::1';
+}

--- a/server/src/api/local-agent.ts
+++ b/server/src/api/local-agent.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { requireAdminMfa } from '../auth/middleware.js';
 import { log } from '../util/log.js';
+import { isLoopbackHost, LOCAL_AGENT_DEFAULT_URL } from './local-agent-url.js';
 
 export const localAgentRouter = Router();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -47,21 +48,13 @@ export function isLocalAgentFeatureEnabled(): boolean {
   return envTrue('YTHRIL_LOCAL_AGENT_ENABLED') || runtimeLocalAgentEnabled;
 }
 
-function isLoopbackHost(host: string): boolean {
-  // Only accept numeric loopback addresses. 'localhost' is intentionally excluded
-  // because it is resolved via DNS/hosts and could be remapped to a non-loopback
-  // address on a compromised system.
-  const h = host.toLowerCase();
-  return h === '127.0.0.1' || h === '::1';
-}
-
 function getAgentConfig(): { baseUrl: string | null; token: string | null } {
   if (!isLocalAgentFeatureEnabled()) {
     return { baseUrl: null, token: null };
   }
 
   // Use || not ?? so an empty-string env var falls back to the default loopback URL.
-  const raw = process.env['YTHRIL_LOCAL_AGENT_URL']?.trim() || 'http://127.0.0.1:38123';
+  const raw = process.env['YTHRIL_LOCAL_AGENT_URL']?.trim() || LOCAL_AGENT_DEFAULT_URL;
   let token = process.env['YTHRIL_LOCAL_AGENT_TOKEN']?.trim() || null;
   // Prefer runtime token (pre-generated at spawn); fall back to token file.
   if (!token) token = runtimeConnectorToken;

--- a/testing/standalone/local-agent-url.test.js
+++ b/testing/standalone/local-agent-url.test.js
@@ -1,0 +1,39 @@
+/**
+ * Local-agent URL loopback validation.
+ *
+ * Guards a deliberate security decision AND a config↔code alignment that had drifted:
+ *
+ *  - `isLoopbackHost` accepts ONLY numeric loopback (127.0.0.1 / ::1). `localhost` is intentionally
+ *    rejected — it resolves via DNS/hosts and could be remapped to a non-loopback address, which would
+ *    let the bearer token be sent off-box. Someone "fixing" a config mismatch by adding `localhost`
+ *    here would reopen that hole; this test makes that regression fail loudly.
+ *  - `LOCAL_AGENT_DEFAULT_URL` is the numeric-loopback default the server falls back to, and is the
+ *    value docker-compose.yml's base default must match (it previously shipped `http://localhost:38123`,
+ *    which the validator then rejected unless YTHRIL_LOCAL_AGENT_ALLOW_REMOTE=true).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isLoopbackHost, LOCAL_AGENT_DEFAULT_URL } from '../../server/dist/api/local-agent-url.js';
+
+describe('local-agent URL validation', () => {
+  it('accepts numeric loopback hosts', () => {
+    assert.equal(isLoopbackHost('127.0.0.1'), true);
+    assert.equal(isLoopbackHost('::1'), true);
+  });
+
+  it('rejects localhost (DNS/hosts-resolved — deliberately not loopback)', () => {
+    assert.equal(isLoopbackHost('localhost'), false);
+    assert.equal(isLoopbackHost('LOCALHOST'), false);
+  });
+
+  it('rejects other/non-loopback hosts', () => {
+    for (const h of ['0.0.0.0', 'host-gateway', 'example.com', '10.0.0.5', '169.254.1.1', '127.0.0.1.evil.com', '']) {
+      assert.equal(isLoopbackHost(h), false, `expected ${JSON.stringify(h)} to be rejected`);
+    }
+  });
+
+  it('the default URL is a numeric-loopback host the validator accepts (matches compose base default)', () => {
+    assert.equal(LOCAL_AGENT_DEFAULT_URL, 'http://127.0.0.1:38123');
+    assert.equal(isLoopbackHost(new URL(LOCAL_AGENT_DEFAULT_URL).hostname), true);
+  });
+});


### PR DESCRIPTION
## Summary

The last item from the docs-vs-code audit — the one genuine **code** defect.

The base `docker-compose.yml` shipped `YTHRIL_LOCAL_AGENT_URL=http://localhost:38123`, but the server **deliberately** rejects a DNS-resolved `localhost` host (`isLoopbackHost` accepts only numeric `127.0.0.1` / `::1`, so a tampered/remapped URL can't send the bearer token off-box). Result: enabling the local-agent feature with the shipped compose default was **silently refused** unless `YTHRIL_LOCAL_AGENT_ALLOW_REMOTE=true`.

## Changes

- **Base compose default → `http://127.0.0.1:38123`**, matching the server's own fallback, so the committed stack no longer contradicts its own validator.
- **Self-contained comment**: the env block now explains — without depending on any other file — that the feature is off by default, that `127.0.0.1` can't reach a host-side connector from *inside* the container, and the exact three vars + `extra_hosts` mapping to set for Docker workstation mode (`host-gateway:38123` + `ALLOW_REMOTE` + `ALLOW_INSECURE`), pointing to `docs/workstation-mode-guide.md` for the full walkthrough.
- **Extracted** `isLoopbackHost` + the shared default into a dependency-free `server/src/api/local-agent-url.ts`, so the security-critical check is unit-testable without the router/auth graph. `local-agent.ts` imports from it — no behavior change.

## Why not "just accept localhost"?

That's the tempting wrong fix. `localhost` resolves via DNS/hosts and can be remapped to a non-loopback address on a compromised host, which would let the token leave the box. The exclusion is intentional; the fix is to align the *config* to `127.0.0.1`, not weaken the validator.

## Tests

New `testing/standalone/local-agent-url.test.js` (4 tests, all green) pins:
- `127.0.0.1` / `::1` accepted;
- `localhost` (and `0.0.0.0`, `host-gateway`, `example.com`, `127.0.0.1.evil.com`, …) rejected — and **documents why**, so a future config-alignment can't silently reopen the hole;
- the default URL is loopback and equals the compose base default.

Server build (`tsc`) is clean.

## Docs / tracker

Docs already showed the correct `host-gateway:38123` for Docker (no doc change needed). CHANGELOG `### Fixed` entry added. With this, **everything from the docs-vs-code audit is resolved**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)