### PR TITLE
test(settings): characterization tests for the Duplicates screens before their U8 rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Characterization tests for the Duplicates screens (11 tests), landed before their UX rework.** Both the
+  `DuplicatesComponent` settings page and the per-space `SpaceDuplicatesTabComponent` shipped with no coverage;
+  these pin the behavior the PR-U8 rework must preserve — load/error states, the optimistic Dismiss (removes on
+  the "open" filter, marks dismissed otherwise — the current *unguarded* behavior, so U8 adding a confirm is
+  explicit), the confirm-guarded Merge, the 403-vs-other scan messages, and the save-rules logic (notify-URL
+  validation, the auto-merge confirmation gate, and minScore clamping into `[0,1]` in the persisted payload).
+
 - **Characterization tests for the space Schema tab (11 tests), landed before its master/detail redesign.**
   The 772-line `SpaceSchemaTabComponent` shipped with no coverage; these pin its current behavior before
   the PR-U4 rework — the schema accordion's single-expand semantics on `SpaceSettingsState` (auto-expand on

--- a/client/src/app/pages/settings/duplicates.component.spec.ts
+++ b/client/src/app/pages/settings/duplicates.component.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * DuplicatesComponent characterization tests.
+ *
+ * Written BEFORE the PR-U8 UX rework (comparison cards, confidence meter, guarded Dismiss, SummaryStrip)
+ * and proven green against the ORIGINAL component. Pins the load/scan/dismiss/merge behaviour that must
+ * survive — including the CURRENT unguarded Dismiss (U8 adds a confirm; this test documents today's
+ * behaviour so that change is explicit) and the confirm-guarded Merge.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { DuplicatesComponent } from './duplicates.component';
+import { DuplicatesApi } from '../../core/duplicates-api.service';
+import { ToastService } from '../../core/toast.service';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+import type { DuplicateRecord } from '../../core/api.types';
+
+const rec = (over: Partial<DuplicateRecord> = {}): DuplicateRecord => ({
+  id: 'd1', spaceId: 's', type: 'entity', aId: 'a', aSummary: 'A', bId: 'b', bSummary: 'B',
+  score: 0.9, status: 'open', detectedAt: '2026-01-01', updatedAt: '2026-01-01', ...over,
+});
+
+function setup(api: Partial<Record<string, unknown>> = {}, confirmResult = true) {
+  const toastErrors: string[] = [];
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [DuplicatesComponent, getTranslocoModule()],
+    providers: [
+      { provide: DuplicatesApi, useValue: {
+        listDuplicates: () => of({ duplicates: [] }),
+        scanDuplicates: () => of({}),
+        dismissDuplicate: () => of({ status: 'ok' }),
+        mergeDuplicate: () => of({ status: 'ok' }),
+        ...api,
+      } },
+      { provide: ToastService, useValue: { error: (m: string) => toastErrors.push(m), success: () => {}, show: () => {} } },
+      { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(confirmResult) } },
+    ],
+  });
+  const f = TestBed.createComponent(DuplicatesComponent);
+  f.detectChanges(); // ngOnInit → load()
+  return { f, c: f.componentInstance, toastErrors };
+}
+
+describe('DuplicatesComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('load populates rows and clears loading', () => {
+    const { c } = setup({ listDuplicates: () => of({ duplicates: [rec(), rec({ id: 'd2' })] }) });
+    expect(c.rows().length).toBe(2);
+    expect(c.loading()).toBe(false);
+    expect(c.error()).toBe(false);
+  });
+
+  it('a load failure sets the error state', () => {
+    const { c } = setup({ listDuplicates: () => throwError(() => ({})) });
+    expect(c.error()).toBe(true);
+    expect(c.loading()).toBe(false);
+  });
+
+  it('dismiss on the "open" filter removes the row optimistically', () => {
+    const { c } = setup();
+    c.statusFilter = 'open';
+    c.rows.set([rec({ id: 'd1' }), rec({ id: 'd2' })]);
+    c.dismiss(rec({ id: 'd1' }));
+    expect(c.rows().map(r => r.id)).toEqual(['d2']);
+  });
+
+  it('dismiss on the "all" filter keeps the row but marks it dismissed', () => {
+    const { c } = setup();
+    c.statusFilter = 'all';
+    c.rows.set([rec({ id: 'd1', status: 'open' })]);
+    c.dismiss(rec({ id: 'd1' }));
+    expect(c.rows()[0]).toMatchObject({ id: 'd1', status: 'dismissed' });
+  });
+
+  it('merge asks for confirmation and, when confirmed, calls the API and removes the row', async () => {
+    const mergeSpy = vi.fn().mockReturnValue(of({ status: 'ok' }));
+    const { c } = setup({ mergeDuplicate: mergeSpy }, true);
+    c.rows.set([rec({ id: 'd1' }), rec({ id: 'd2' })]);
+    await c.merge(rec({ id: 'd1' }));
+    expect(mergeSpy).toHaveBeenCalledWith('d1');
+    expect(c.rows().map(r => r.id)).toEqual(['d2']);
+  });
+
+  it('merge does nothing when the confirmation is cancelled', async () => {
+    const mergeSpy = vi.fn().mockReturnValue(of({ status: 'ok' }));
+    const { c } = setup({ mergeDuplicate: mergeSpy }, false);
+    c.rows.set([rec({ id: 'd1' })]);
+    await c.merge(rec({ id: 'd1' }));
+    expect(mergeSpy).not.toHaveBeenCalled();
+    expect(c.rows().map(r => r.id)).toEqual(['d1']);
+  });
+
+  it('scan surfaces a distinct message for 403 vs other errors', () => {
+    const forbidden = setup({ scanDuplicates: () => throwError(() => ({ status: 403 })) });
+    forbidden.c.scan();
+    expect(forbidden.toastErrors).toContain('duplicates.scanForbidden');
+
+    const other = setup({ scanDuplicates: () => throwError(() => ({ status: 500 })) });
+    other.c.scan();
+    expect(other.toastErrors).toContain('duplicates.scanError');
+  });
+});

--- a/client/src/app/pages/settings/space-duplicates-tab.component.spec.ts
+++ b/client/src/app/pages/settings/space-duplicates-tab.component.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * SpaceDuplicatesTabComponent characterization tests.
+ *
+ * Written BEFORE the PR-U8 rework (empty state, minScore-as-percent/slider) and proven green against the
+ * ORIGINAL component. Pins the save-rules logic that must survive: notify-URL validation, the auto-merge
+ * confirmation gate, and score clamping in the persisted payload.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { signal } from '@angular/core';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { SpaceDuplicatesTabComponent } from './space-duplicates-tab.component';
+import { SpaceSettingsState } from './space-settings-state.service';
+import { SpacesApi } from '../../core/spaces-api.service';
+import { SpacesStore } from './spaces-store.service';
+import { ToastService } from '../../core/toast.service';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+import type { DupeActionRule } from '../../core/api.types';
+
+function setup(updateSpace = vi.fn().mockReturnValue(of({ space: { id: 's1', label: 'S1' } })), confirmResult = true) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [SpaceDuplicatesTabComponent, getTranslocoModule()],
+    providers: [
+      SpaceSettingsState,
+      { provide: SpacesApi, useValue: { updateSpace } },
+      { provide: SpacesStore, useValue: { spaces: signal([]) } },
+      { provide: ToastService, useValue: { error: () => {}, success: () => {}, show: () => {} } },
+      { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(confirmResult) } },
+    ],
+  });
+  const f = TestBed.createComponent(SpaceDuplicatesTabComponent);
+  const c = f.componentInstance;
+  const state = TestBed.inject(SpaceSettingsState);
+  state.settingsSpace.set({ id: 's1', label: 'S1' } as never);
+  return { c, state, updateSpace };
+}
+
+describe('SpaceDuplicatesTabComponent — saveDupeRules', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('rejects an invalid notify webhook URL without saving', async () => {
+    const { c, state, updateSpace } = setup();
+    state.dupeRulesState = [{ minScore: 0.9, action: 'notify', webhookUrl: 'not-a-url' } as DupeActionRule];
+    await c.saveDupeRules();
+    expect(updateSpace).not.toHaveBeenCalled();
+    expect(state.dupeError()).toBeTruthy();
+  });
+
+  it('does not save when the auto-merge confirmation is cancelled', async () => {
+    const { c, state, updateSpace } = setup(vi.fn().mockReturnValue(of({ space: {} })), false);
+    state.dupeRulesState = [{ minScore: 0.95, action: 'automerge' } as DupeActionRule];
+    await c.saveDupeRules();
+    expect(updateSpace).not.toHaveBeenCalled();
+  });
+
+  it('clamps minScore into [0,1] and persists survivor + onInsert', async () => {
+    const { c, state, updateSpace } = setup();
+    state.dupeRulesState = [
+      { minScore: 1.5, action: 'flag' } as DupeActionRule,
+      { minScore: -0.2, action: 'flag' } as DupeActionRule,
+    ];
+    state.dupeSurvivor = 'newer';
+    state.dupeOnInsert = true;
+    await c.saveDupeRules();
+    expect(updateSpace).toHaveBeenCalledTimes(1);
+    const [id, body] = updateSpace.mock.calls[0];
+    expect(id).toBe('s1');
+    expect(body.dupeRules.map((r: DupeActionRule) => r.minScore)).toEqual([1, 0]);
+    expect(body.dupeMergeSurvivor).toBe('newer');
+    expect(body.dupeRulesOnInsert).toBe(true);
+  });
+
+  it('marks saved + pristine after a successful save', async () => {
+    const { c, state } = setup();
+    state.dupeRulesState = [{ minScore: 0.9, action: 'flag' } as DupeActionRule];
+    await c.saveDupeRules();
+    expect(state.dupeSaved()).toBe(true);
+    expect(state.dupeSaving()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The `DuplicatesComponent` settings page and the per-space `SpaceDuplicatesTabComponent` both shipped with **zero coverage**, and PR-U8 will rework their UX (comparison cards, confidence meter, a **guarded Dismiss**, SummaryStrip, minScore-as-slider). Per the repo's characterization-tests-before-refactor rule, this lands the safety net **first** — 11 tests, proven green against the *originals*.

## What's pinned

**`DuplicatesComponent` (7):**
- `load` populates rows / a failure sets the error state
- **Dismiss is optimistic**: removes the row on the `open` filter, marks it `dismissed` on `all` — the *current unguarded* behavior, so U8 adding a confirm shows up explicitly in that diff
- **Merge is confirm-guarded**: confirmed → API called + row removed; cancelled → no-op
- `scan` surfaces distinct messages for `403` vs other errors

**`SpaceDuplicatesTabComponent` (4):**
- `saveDupeRules` rejects an invalid notify webhook URL without saving
- the **auto-merge confirmation gate** blocks the save when cancelled
- `minScore` is clamped into `[0,1]` and `survivor` + `onInsert` are persisted in the payload
- saved + pristine flags set after a successful save

## Testing

`11 passed` locally against the unchanged components. No production code touched — test-only. CHANGELOG `### Added` entry included; no docs change. First of two PRs for U8; the UX rework follows on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)