### PR TITLE
feat(mcp): make tools/list fully self-describing + harmonise find_similar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -975,6 +975,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP `tools/list` is now fully self-describing, and `find_similar` is harmonised with `recall`.** An agent
+  can discover a tool's entire input contract from its schema alone: closed objects (`additionalProperties:
+  false`) on all 31 tools, plus promoted-from-prose keywords — `enum`s, `minimum`/`maximum`/`default`,
+  `minLength`/`maxLength`, `maxItems` (the bulk-write 500 cap), and UUID `pattern`s on id fields. The
+  structured `query.filter` now lists its allowed MongoDB operator set and depth/regex rules (previously a
+  bare `{type: object}`), the recall/find filter encodes its key allowlist via `propertyNames`, and
+  `query.maxTimeMS` advertises the **real** 10000 ms ceiling (the schema had claimed 30000). The `help` tool
+  and the integration guide now point agents at `tools/list` as the authoritative reference. Separately,
+  **`find_similar` now accepts an optional `space`** — omit it to search across all accessible spaces, exactly
+  like `recall` (it locates the source entry across your spaces) — and **gains `traverse`** for graph
+  expansion; the old `crossSpace` flag is deprecated (omit `space` instead) but still honoured. The REST
+  `find-similar` endpoint is unchanged. New standalone tests pin the schema invariants and the space
+  resolution logic. (Note: schema keywords are advisory — the MCP dispatcher validates in the handlers, not
+  against `inputSchema` — so this is safe for existing callers.)
+
 - **Settings → Space → Schema tab rebuilt as master/detail.** The old 4-level nested accordion — where opening
   a type pushed everything down and opening a property nested further, and expanding one collapsed the last — is
   replaced by a **type list on the left and a stable editor pane on the right**: click a type to edit it without

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1012,7 +1012,7 @@ POST /api/brain/spaces/:spaceId/find-similar
 
 Given an existing entry's `_id`, find other entries with high vector similarity. Unlike `recall` (which re-embeds a text query), `find_similar` uses the entry's **stored embedding vector** directly — no re-embedding step. Ideal for deduplication, "more like this", and merge detection.
 
-> **Also available as MCP tool:** `find_similar`
+> **Also available as MCP tool:** `find_similar` — note the MCP tool makes `space` optional (omit it to search all accessible spaces, like `recall`) and adds `traverse`; its `crossSpace` flag is deprecated in favour of omitting `space`. This REST endpoint keeps `spaceId` in the path and the `crossSpace` body flag.
 
 **Request body:**
 
@@ -5678,7 +5678,9 @@ Ythril exposes a single global MCP server via SSE. Each tool accepts a `space` p
 
 ### Server Instructions
 
-On connect, the server sends global instructions listing all available space IDs and noting that each tool requires a `space` parameter (except `recall` and `list_chrono`, where `space` is optional and enables cross-space results when omitted; and `list_peers`/`sync_now` which are global). Call `list_spaces` to get space IDs, descriptions, and entry counts (memories, entities, edges, chrono) — useful for discovering which spaces are populated before querying. Call `get_space_meta` with a specific space to get its full schema, purpose, and usage notes.
+On connect, the server sends global instructions listing all available space IDs and noting that each tool requires a `space` parameter (except `recall`, `list_chrono`, and `find_similar`, where `space` is optional and enables cross-space results when omitted; and `list_peers`/`sync_now` which are global). Call `list_spaces` to get space IDs, descriptions, and entry counts (memories, entities, edges, chrono) — useful for discovering which spaces are populated before querying. Call `get_space_meta` with a specific space to get its full schema, purpose, and usage notes.
+
+> **Tool inputs are self-describing.** Every tool's complete input contract — each parameter, its allowed values (`enum`), numeric bounds (`minimum`/`maximum`/`default`), string limits, the filter-operator allowlist, and `additionalProperties: false` — is published in its `inputSchema` via `tools/list`. Treat `tools/list` as the authoritative, machine-readable reference and read a tool's schema before constructing arguments; the `help` tool points here too.
 
 ### Read-Only Tokens
 
@@ -5774,7 +5776,7 @@ Content-Type: application/json
 | `delete_memory` | Delete a memory by ID |
 | `recall` | Semantic search across all knowledge types (memories, entities, edges, chrono entries, files). Searches the specified `space`; omit `space` to search across all accessible spaces |
 | `query` | Structured MongoDB filter query (read-only) — supports `memories`, `entities`, `edges`, `chrono`, and `files` collections |
-| `find_similar` | Find entries with high vector similarity to an existing entry by ID — no re-embedding step |
+| `find_similar` | Find entries with high vector similarity to an existing entry by ID — no re-embedding step. Provide `space` to scope to one space, or omit it to search across all accessible spaces (like `recall`). Supports `traverse` (graph expansion). The legacy `crossSpace` flag is deprecated — omit `space` instead |
 | `get_stats` | Return counts of memories, entities, edges, chrono entries, and files |
 | `get_space_meta` | Return the full space schema definition, purpose, usage notes, and stats |
 | `upsert_entity` | Create or update a named entity (with optional properties) |

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -24,11 +24,13 @@ export const bulk_writeTool: ToolHandler = {
             space: s.requiredSpace,
             memories: {
               type: 'array',
-              description: 'Memory entries to insert. Same fields as the `remember` tool.',
+              maxItems: 500,
+              description: 'Memory entries to insert (max 500; excess entries are dropped). Same fields as the `remember` tool.',
               items: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
-                  fact:        { type: 'string', description: 'The fact or memory to store.' },
+                  fact:        { type: 'string', minLength: 1, maxLength: 50000, description: 'The fact or memory to store (1–50 000 characters).' },
                   tags:        { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
                   entityIds:   { type: 'array', items: { type: 'string' }, description: 'Related entity IDs.' },
                   description: { type: 'string', description: 'Optional prose context.' },
@@ -41,9 +43,11 @@ export const bulk_writeTool: ToolHandler = {
             },
             entities: {
               type: 'array',
-              description: 'Entity entries to upsert. Same fields as the `upsert_entity` tool.',
+              maxItems: 500,
+              description: 'Entity entries to upsert (max 500; excess entries are dropped). Same fields as the `upsert_entity` tool.',
               items: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                   id:          { type: 'string', description: 'Optional UUID v4 — if provided, updates the entity with this ID (or inserts with this ID). If omitted, a new entity is always inserted.' },
                   name:        { type: 'string', description: 'Entity name.' },
@@ -58,9 +62,11 @@ export const bulk_writeTool: ToolHandler = {
             },
             edges: {
               type: 'array',
-              description: 'Edge entries to upsert. Same fields as the `upsert_edge` tool.',
+              maxItems: 500,
+              description: 'Edge entries to upsert (max 500; excess entries are dropped). Same fields as the `upsert_edge` tool.',
               items: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                   from:        { type: 'string', description: 'Source entity ID.' },
                   to:          { type: 'string', description: 'Target entity ID.' },
@@ -77,9 +83,11 @@ export const bulk_writeTool: ToolHandler = {
             },
             chrono: {
               type: 'array',
-              description: 'Chrono entries to insert. Same fields as the `create_chrono` tool.',
+              maxItems: 500,
+              description: 'Chrono entries to insert (max 500; excess entries are dropped). Same fields as the `create_chrono` tool.',
               items: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                   title:       { type: 'string' },
                   type:        { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema).' },
@@ -100,6 +108,7 @@ export const bulk_writeTool: ToolHandler = {
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
 import { ChronoFilter, createChrono, listChrono, updateChrono, parseRecurrence } from '../../brain/chrono.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
@@ -15,12 +15,12 @@ export const create_chronoTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            title: { type: 'string', description: 'Entry title.' },
-            type: { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema).' },
-            startsAt: { type: 'string', description: 'ISO 8601 start date/time.' },
+            title: { type: 'string', minLength: 1, description: 'Entry title.' },
+            type: { type: 'string', minLength: 1, description: 'Entry type. Rejected unless it is one of the space\'s allowed chrono types: the defaults are event, deadline, plan, prediction, milestone, or the custom set declared in the space\'s typeSchemas.chrono.' },
+            startsAt: { type: 'string', minLength: 1, description: 'ISO 8601 start date/time.' },
             endsAt: { type: 'string', description: 'Optional ISO 8601 end date/time.' },
-            status: { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], description: 'Status (default: upcoming).' },
-            confidence: { type: 'number', description: 'Confidence level 0–1 (for predictions).' },
+            status: { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], default: 'upcoming', description: 'Status (default: upcoming).' },
+            confidence: unitScoreSchema('Confidence level 0–1 (for predictions).'),
             tags: { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
             entityIds: { type: 'array', items: { type: 'string' }, description: 'Related entity IDs.' },
             memoryIds: { type: 'array', items: { type: 'string' }, description: 'Related memory IDs.' },
@@ -35,15 +35,17 @@ export const create_chronoTool: ToolHandler = {
               description: 'Optional recurrence rule, e.g. { freq: "weekly", interval: 1, until: "2027-01-01T00:00:00Z" }.',
               properties: {
                 freq: { type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'] },
-                interval: { type: 'number', description: 'Repeat every N periods (positive integer, default 1).' },
+                interval: { type: 'integer', minimum: 1, default: 1, description: 'Repeat every N periods (positive integer, default 1).' },
                 until: { type: 'string', description: 'Optional ISO 8601 end date.' },
               },
               required: ['freq'],
+              additionalProperties: false,
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'title', 'type', 'startsAt'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -126,13 +128,13 @@ export const update_chronoTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', description: 'Chrono entry ID.' },
+            id: { type: 'string', minLength: 1, description: 'Chrono entry ID.' },
             title: { type: 'string', description: 'New title.' },
             type: { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema).' },
             startsAt: { type: 'string', description: 'New ISO 8601 start date/time.' },
             endsAt: { type: 'string', description: 'New ISO 8601 end date/time.' },
             status: { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'] },
-            confidence: { type: 'number', description: 'Confidence level 0–1.' },
+            confidence: unitScoreSchema('Confidence level 0–1.'),
             tags: { type: 'array', items: { type: 'string' } },
             entityIds: { type: 'array', items: { type: 'string' } },
             memoryIds: { type: 'array', items: { type: 'string' } },
@@ -147,15 +149,17 @@ export const update_chronoTool: ToolHandler = {
               description: 'Recurrence rule, e.g. { freq: "weekly", interval: 1, until: "2027-01-01T00:00:00Z" }.',
               properties: {
                 freq: { type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'] },
-                interval: { type: 'number', description: 'Repeat every N periods (positive integer, default 1).' },
+                interval: { type: 'integer', minimum: 1, default: 1, description: 'Repeat every N periods (positive integer, default 1).' },
                 until: { type: 'string', description: 'Optional ISO 8601 end date.' },
               },
               required: ['freq'],
+              additionalProperties: false,
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -218,10 +222,11 @@ export const list_chronoTool: ToolHandler = {
             after: { type: 'string', description: 'ISO 8601 timestamp — return entries created after this point in time.' },
             before: { type: 'string', description: 'ISO 8601 timestamp — return entries created before this point in time.' },
             search: { type: 'string', description: 'Case-insensitive substring match on title and description.' },
-            limit: { type: 'number', description: 'Max results (default 20, max 100).' },
-            skip: { type: 'number', description: 'Number of results to skip for pagination (default 0).' },
+            limit: { type: 'number', minimum: 1, maximum: 100, default: 20, description: 'Max results (clamped to 1–100). Default 20.' },
+            skip: { type: 'number', minimum: 0, default: 0, description: 'Number of results to skip for pagination (default 0).' },
           },
           required: [],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, accessibleSpaceIds } = ctx;

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { traverseGraph, updateEdgeById, upsertEdge } from '../../brain/edges.js';
 import { getConfig } from '../../config/loader.js';
@@ -15,11 +15,11 @@ export const upsert_edgeTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            from: { type: 'string', description: 'Source entity ID.' },
-            to: { type: 'string', description: 'Target entity ID.' },
-            label: { type: 'string', description: 'Relationship label (e.g. "works_at", "knows").' },
+            from: { type: 'string', minLength: 1, description: 'Source entity ID (a UUID v4; required to be an existing entity ID when the space uses strict linkage).' },
+            to: { type: 'string', minLength: 1, description: 'Target entity ID (a UUID v4; required to be an existing entity ID when the space uses strict linkage).' },
+            label: { type: 'string', minLength: 1, description: 'Relationship label (e.g. "works_at", "knows").' },
             type: { type: 'string', description: 'Optional edge type (e.g. "causal", "attribution").' },
-            weight: { type: 'number', description: 'Optional edge weight (0–1).' },
+            weight: unitScoreSchema('Optional edge weight (0–1).'),
             tags: { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
             description: { type: 'string', description: 'Optional prose description of why this relationship exists.' },
             properties: {
@@ -31,6 +31,7 @@ export const upsert_edgeTool: ToolHandler = {
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'from', 'to', 'label'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, name } = ctx;
@@ -83,10 +84,10 @@ export const update_edgeTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', description: 'Edge ID to update.' },
+            id: { type: 'string', minLength: 1, description: 'Edge ID to update.' },
             label: { type: 'string', description: 'New relationship label.' },
             type: { type: 'string', description: 'New edge type.' },
-            weight: { type: 'number', description: 'New edge weight (0–1).' },
+            weight: unitScoreSchema('New edge weight (0–1).'),
             description: { type: 'string', description: 'New prose description.' },
             tags: { type: 'array', items: { type: 'string' }, description: 'Tags to merge with existing tags.' },
             properties: {
@@ -99,6 +100,7 @@ export const update_edgeTool: ToolHandler = {
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -137,10 +139,11 @@ export const traverseTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            startId: { type: 'string', description: 'UUID of the starting entity.' },
+            startId: { type: 'string', minLength: 1, description: 'UUID of the starting entity.' },
             direction: {
               type: 'string',
               enum: ['outbound', 'inbound', 'both'],
+              default: 'outbound',
               description: 'Follow edges from the node (outbound), to the node (inbound), or both directions. Default: outbound.',
             },
             edgeLabels: {
@@ -148,10 +151,11 @@ export const traverseTool: ToolHandler = {
               items: { type: 'string' },
               description: 'Filter traversal to specific edge labels only. Omit to traverse all labels.',
             },
-            maxDepth: { type: 'number', description: 'Maximum hops from startId (default 3, max 10).' },
-            limit: { type: 'number', description: 'Maximum total nodes returned (default 100).' },
+            maxDepth: { type: 'number', minimum: 1, maximum: 10, default: 3, description: 'Maximum hops from startId (clamped to 1–10). Default 3.' },
+            limit: { type: 'number', minimum: 1, maximum: 1000, default: 100, description: 'Maximum total nodes returned (clamped to 1–1000). Default 100.' },
           },
           required: ['space', 'startId'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, uuidSchema, unitScoreSchema } from './shared.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { findEntitiesByName, updateEntityById, upsertEntity } from '../../brain/entities.js';
 import { type PropertyResolution, applyResolutions, computeMergePlan, executeMerge, validateResolution } from '../../brain/merge.js';
@@ -16,9 +16,9 @@ export const upsert_entityTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', description: 'Optional UUID v4 — if provided, updates the entity with this ID (or inserts with this ID if it does not exist). If omitted, a new entity is always inserted.' },
-            name: { type: 'string', description: 'Entity name.' },
-            type: { type: 'string', description: 'Entity type (person, place, concept, …).' },
+            id: uuidSchema('Optional UUID v4 — if provided, updates the entity with this ID (or inserts with this ID if it does not exist). If omitted, a new entity is always inserted.'),
+            name: { type: 'string', minLength: 1, description: 'Entity name.' },
+            type: { type: 'string', minLength: 1, description: 'Entity type (person, place, concept, …).' },
             tags: { type: 'array', items: { type: 'string' } },
             description: { type: 'string', description: 'Optional prose description or summary of this entity.' },
             properties: {
@@ -27,11 +27,12 @@ export const upsert_entityTool: ToolHandler = {
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
-            checkDuplicates: { type: 'boolean', description: 'On a NEW entity insert (no id / unknown id), run a semantic near-duplicate check first (default true). Flags highly similar existing entities (id + summary + score) so you can merge or update instead of creating a duplicate. Does not fire on updates. Set false to skip.' },
-            dupeThreshold: { type: 'number', description: 'Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.' },
+            checkDuplicates: { type: 'boolean', default: true, description: 'On a NEW entity insert (no id / unknown id), run a semantic near-duplicate check first (default true). Flags highly similar existing entities (id + summary + score) so you can merge or update instead of creating a duplicate. Does not fire on updates. Set false to skip.' },
+            dupeThreshold: unitScoreSchema('Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.'),
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'name', 'type'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, name } = ctx;
@@ -87,7 +88,7 @@ export const update_entityTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', description: 'Entity ID to update.' },
+            id: { type: 'string', minLength: 1, description: 'Entity ID to update.' },
             name: { type: 'string', description: 'New entity name.' },
             type: { type: 'string', description: 'New entity type.' },
             description: { type: 'string', description: 'New prose description or summary.' },
@@ -101,6 +102,7 @@ export const update_entityTool: ToolHandler = {
             deleteFields: { type: 'array', items: { type: 'string' }, description: 'Dot-notation paths to delete from the entity (e.g. ["properties.oldKey", "description"]). System fields (id, name, type, spaceId, createdAt, updatedAt) cannot be deleted. Deletions are permanent.' },
             ttlDays: TTL_DAYS_SCHEMA,
           },
+          additionalProperties: false,
           required: ['space', 'id'],
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
@@ -140,8 +142,8 @@ export const merge_entitiesTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            survivorId: { type: 'string', description: 'UUID of the entity to keep.' },
-            absorbedId: { type: 'string', description: 'UUID of the entity to absorb and delete.' },
+            survivorId: uuidSchema('UUID v4 of the entity to keep (must differ from absorbedId).'),
+            absorbedId: uuidSchema('UUID v4 of the entity to absorb and delete (must differ from survivorId).'),
             resolutions: {
               type: 'array',
               description: 'Per-property conflict resolutions. Each entry: { key, resolution, customValue? }.',
@@ -149,15 +151,17 @@ export const merge_entitiesTool: ToolHandler = {
                 type: 'object',
                 properties: {
                   key: { type: 'string', description: 'Property key to resolve.' },
-                  resolution: { type: 'string', description: 'One of: "survivor", "absorbed", "custom", or "fn:<name>".' },
+                  resolution: { type: 'string', pattern: '^(survivor|absorbed|custom|fn:(avg|min|max|sum|and|or|xor))$', description: 'One of: "survivor", "absorbed", "custom" (requires customValue), or "fn:<name>" where <name> is a numeric merge (avg, min, max, sum) or boolean merge (and, or, xor).' },
                   customValue: { description: 'Required when resolution is "custom".' },
                 },
                 required: ['key', 'resolution'],
+                additionalProperties: false,
               },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'survivorId', 'absorbedId'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -259,9 +263,10 @@ export const find_entities_by_nameTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            name: { type: 'string', description: 'Exact entity name to look up.' },
+            name: { type: 'string', minLength: 1, description: 'Exact entity name to look up.' },
           },
           required: ['space', 'name'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, name } = ctx;

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -20,9 +20,10 @@ export const read_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', description: 'File path relative to the space root.' },
+            path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
           },
           required: ['space', 'path'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -47,7 +48,7 @@ export const write_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', description: 'File path relative to the space root.' },
+            path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
             content: { type: 'string', description: 'Text content to write.' },
             description: { type: 'string', description: 'Optional human-readable summary stored as file metadata.' },
             tags: { type: 'array', items: { type: 'string' }, description: 'Optional tags for filtering and recall.' },
@@ -60,10 +61,12 @@ export const write_fileTool: ToolHandler = {
             inputFormat: {
               type: 'string',
               enum: ['pdf', 'docx', 'epub', 'html', 'md', 'txt', 'text', 'auto'],
+              default: 'auto',
               description: 'How to process the file. "auto" (default) detects from extension/MIME type. "text" bypasses conversion (single flat embedding). "md"/"txt" use the in-process normaliser+chunker. "pdf"/"docx"/"epub"/"html" use the full conversion pipeline.',
             },
           },
           required: ['space', 'path', 'content'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -110,10 +113,12 @@ export const list_dirTool: ToolHandler = {
             space: s.requiredSpace,
             path: {
               type: 'string',
+              default: '',
               description: 'Directory path relative to space root (default: root).',
             },
           },
           required: ['space'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, name } = ctx;
@@ -148,10 +153,11 @@ export const delete_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', description: 'File path relative to the space root.' },
+            path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'path'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -187,10 +193,11 @@ export const create_dirTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', description: 'Directory path relative to the space root.' },
+            path: { type: 'string', minLength: 1, description: 'Directory path relative to the space root.' },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'path'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -212,11 +219,12 @@ export const move_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            src: { type: 'string', description: 'Source path.' },
-            dst: { type: 'string', description: 'Destination path.' },
+            src: { type: 'string', minLength: 1, description: 'Source path.' },
+            dst: { type: 'string', minLength: 1, description: 'Destination path.' },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'src', 'dst'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;

--- a/server/src/mcp/tools/help.ts
+++ b/server/src/mcp/tools/help.ts
@@ -91,7 +91,7 @@ export const helpTool: ToolHandler = {
     '(spaces, memories, entities, edges, chrono, files), how to choose between query / recall / '
     + 'filtered recall, schema authoring, and the REST API map. Call this first when unsure.',
   // Deliberately not mutating, not admin, not spaceRequired: read-only and instance-global.
-  inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [] }),
+  inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [], additionalProperties: false }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     // Deferred import: help.ts is itself part of the registry in index.ts, so a
     // top-level import would be circular. By call time the registry is complete.
@@ -135,6 +135,8 @@ ${RETRIEVAL_GUIDE}
 ${SCHEMA_GUIDE}
 
 ## Tools available to this token
+
+Each tool's COMPLETE input contract — every parameter, allowed values, numeric bounds, filter operators, and defaults — is published in its \`inputSchema\` via MCP \`tools/list\`, the authoritative machine-readable reference. The list below is a one-line summary per tool; call \`tools/list\` and read the schema before constructing arguments.
 
 ${toolLines}
 

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -13,7 +13,7 @@ import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateMemory } from '../../spaces/schema-validation.js';
-import { TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
+import { TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
 
 export const rememberTool: ToolHandler = {
   name: 'remember',
@@ -24,7 +24,7 @@ export const rememberTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            fact: { type: 'string', description: 'The fact, observation, or memory to store.' },
+            fact: { type: 'string', minLength: 1, maxLength: 50000, description: 'The fact, observation, or memory to store (1–50 000 characters).' },
             entities: {
               type: 'array',
               items: { type: 'string' },
@@ -43,11 +43,12 @@ export const rememberTool: ToolHandler = {
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
-            checkDuplicates: { type: 'boolean', description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar memory already exists, the response flags it (id + summary + score) so you can update it instead of creating a redundant one. The memory is still stored regardless. Set false to skip the check.' },
-            dupeThreshold: { type: 'number', description: 'Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.' },
+            checkDuplicates: { type: 'boolean', default: true, description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar memory already exists, the response flags it (id + summary + score) so you can update it instead of creating a redundant one. The memory is still stored regardless. Set false to skip the check.' },
+            dupeThreshold: unitScoreSchema('Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.'),
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'fact'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -150,6 +151,7 @@ export const update_memoryTool: ToolHandler = {
             ttlDays: TTL_DAYS_SCHEMA,
           },
           required: ['space', 'id'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;
@@ -197,10 +199,11 @@ export const delete_memoryTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', description: 'Memory ID to delete.' },
+            id: { type: 'string', minLength: 1, description: 'Memory ID to delete.' },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'id'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -8,12 +8,36 @@
  */
 
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, type McpRecallTraverseItem } from './shared.js';
+import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreSchema, QUERY_FILTER_OPERATORS, RECALL_FILTER_KEY_PATTERN, type McpRecallTraverseItem } from './shared.js';
 import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
 import { queryBrain } from '../../brain/query.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
 import { resolveMemberSpaces, collectAcrossMembers } from '../../spaces/proxy.js';
+import { NotFoundError } from '../../util/errors.js';
+
+/**
+ * Space scope for find_similar — mirrors recall's omit-space idiom (F1 consistency).
+ *
+ * - `space` given (and not the deprecated `crossSpace`): locate the source in that proxy-resolved space
+ *   and search only there (searchIds `undefined` → findSimilar searches just the base space).
+ * - `space` omitted, or legacy `crossSpace: true`: locate the source across ALL accessible spaces (first
+ *   base that holds the entry wins) and search across all of them.
+ *
+ * Pure (proxy resolver injected) so the scope logic is unit-testable without a database.
+ */
+export function resolveFindSimilarScope(
+  callSpace: string | undefined,
+  crossSpace: boolean,
+  accessibleSpaceIds: string[],
+  resolveMembers: (space: string) => string[],
+): { candidateBases: string[]; searchIds: string[] | undefined } {
+  if (callSpace && !crossSpace) {
+    const members = resolveMembers(callSpace);
+    return { candidateBases: [members[0] ?? callSpace], searchIds: undefined };
+  }
+  return { candidateBases: accessibleSpaceIds, searchIds: accessibleSpaceIds };
+}
 
 export const recallTool: ToolHandler = {
   name: 'recall',
@@ -22,8 +46,8 @@ export const recallTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.optionalSpace,
-            query: { type: 'string', description: 'Natural language search query.' },
-            topK: { type: 'number', description: 'Max results (default 10).' },
+            query: { type: 'string', minLength: 1, description: 'Natural language search query (required, non-empty).' },
+            topK: { type: 'number', minimum: 1, default: 10, description: 'Max results to return. Default 10; no hard cap, but very large values are slower.' },
             tags: { type: 'array', items: { type: 'string' }, description: 'Optional tag filter — only results bearing ALL of these tags are returned (applies to memories, entities, chrono entries, and files).' },
             types: {
               type: 'array',
@@ -35,10 +59,7 @@ export const recallTool: ToolHandler = {
               description: 'Optional minimum result count per type. Guarantees at least that many results of each type if available (e.g. {"entity": 2, "edge": 1}). Omit to use pure score ranking.',
               additionalProperties: { type: 'number' },
             },
-            minScore: {
-              type: 'number',
-              description: 'Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded.',
-            },
+            minScore: unitScoreSchema('Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded.'),
             traverse: {
               type: 'number',
               minimum: 0,
@@ -47,9 +68,11 @@ export const recallTool: ToolHandler = {
             },
             filter: {
               type: 'object',
-              description: 'Optional property equality/comparison filter applied after vector search. Keys must use dot-notation and start with "properties.", "tags", "type", "name", "status", or "label". Each value is an operator object with one or more of: eq, ne, in (array), exists (boolean), gt, gte, lt, lte. Example: { "properties.status": { "eq": "accepted" }, "properties.count": { "gt": 10 } }. Records not matching ALL filter conditions are excluded.',
+              description: 'Optional property equality/comparison filter applied after vector search. Keys must use dot-notation and start with "properties.", "tags", "type", "name", "status", or "label" (any other key is rejected). Each value is an operator object with one or more of: eq, ne, in (array), exists (boolean), gt, gte, lt, lte. Example: { "properties.status": { "eq": "accepted" }, "properties.count": { "gt": 10 } }. Records not matching ALL filter conditions are excluded.',
+              propertyNames: { pattern: RECALL_FILTER_KEY_PATTERN },
               additionalProperties: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                   eq: { description: 'Exact equality.' },
                   ne: { description: 'Not equal.' },
@@ -64,6 +87,7 @@ export const recallTool: ToolHandler = {
             },
           },
           required: ['query'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, accessibleSpaceIds } = ctx;
@@ -143,27 +167,32 @@ export const recallTool: ToolHandler = {
 
 export const find_similarTool: ToolHandler = {
   name: 'find_similar',
-  description: 'Find entries with high vector similarity to an existing entry. Use for deduplication, "more like this", and merge detection. Uses the entry\'s stored embedding — no re-embedding.',
-  spaceRequired: true,
+  description: 'Find entries with high vector similarity to an existing entry. Use for deduplication, "more like this", and merge detection. Uses the entry\'s stored embedding — no re-embedding. Provide `space` to scope to one space, or omit it to search across all accessible spaces (like recall).',
+  spaceRequired: false,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {
-            space: s.requiredSpace,
-            entryId: { type: 'string', description: 'UUID of the source entry.' },
+            space: s.optionalSpace,
+            entryId: uuidSchema('UUID v4 of the source entry.'),
             entryType: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'], description: 'Knowledge type of the source entry.' },
             targetTypes: {
               type: 'array',
               items: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'] },
               description: 'Which knowledge types to search in. Omit to search all types.',
             },
-            topK: { type: 'number', description: 'Max results (default 10).' },
-            minScore: { type: 'number', description: 'Minimum cosine similarity threshold (0.0–1.0). Results below this are excluded.' },
-            crossSpace: { type: 'boolean', description: 'If true, search across all spaces the token can access. Default: false.' },
+            topK: { type: 'number', minimum: 1, maximum: 100, default: 10, description: 'Max results to return (clamped to 1–100). Default 10.' },
+            minScore: unitScoreSchema('Minimum cosine similarity threshold (0.0–1.0). Results below this are excluded.'),
+            traverse: {
+              type: 'number', minimum: 0, maximum: MAX_RECALL_TRAVERSE, default: 0,
+              description: `Optional graph-expansion depth (integer 0–${MAX_RECALL_TRAVERSE}, default 0). When > 0, each similar match is expanded along knowledge-graph edges up to this many hops and the connected entities are returned alongside the matches (annotated with source, hops, and path). With traverse > 0 the response is JSON instead of the plain text summary.`,
+            },
+            crossSpace: { type: 'boolean', default: false, description: 'DEPRECATED — omit `space` instead to search all accessible spaces. When true, forces a cross-space search even if `space` is given.' },
           },
-          required: ['space', 'entryId', 'entryType'],
+          required: ['entryId', 'entryType'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace, cfg, tokenSpaces } = ctx;
+    const { args: a, callSpace, accessibleSpaceIds } = ctx;
     const entryId = String(a['entryId'] ?? '').trim();
     if (!entryId) throw new Error('entryId must not be empty');
     if (!UUID_V4_RE.test(entryId)) throw new Error('entryId must be a valid UUID v4');
@@ -177,39 +206,66 @@ export const find_similarTool: ToolHandler = {
       ? (a['targetTypes'] as unknown[]).filter((t): t is RecallKnowledgeType => typeof t === 'string' && validTypes.has(t))
       : undefined;
 
-    let crossSpaceIds: string[] | undefined;
-    if (crossSpace) {
-      crossSpaceIds = cfg.spaces
-        .filter(s => !tokenSpaces || tokenSpaces.includes(s.id))
-        .map(s => s.id);
+    let traverse = 0;
+    if (a['traverse'] != null) {
+      if (typeof a['traverse'] !== 'number' || !Number.isInteger(a['traverse']) || a['traverse'] < 0 || a['traverse'] > MAX_RECALL_TRAVERSE) {
+        throw new Error(`traverse must be an integer between 0 and ${MAX_RECALL_TRAVERSE}`);
+      }
+      traverse = a['traverse'];
     }
 
-    const memberIds = resolveMemberSpaces(callSpace);
-    const result = await findSimilar(
-      memberIds[0] ?? callSpace,
-      entryId,
-      entryType as RecallKnowledgeType,
-      topK,
-      targetTypes,
-      minScore,
-      crossSpaceIds,
-    );
-
-    const lines: string[] = [];
-    lines.push(`Source: [${result.source.type}] ${formatRecallSummary(result.source)} (ID: ${result.source._id})`);
-    if (result.results.length === 0) {
-      lines.push('No similar entries found.');
-    } else {
-      for (let i = 0; i < result.results.length; i++) {
-        const r = result.results[i]!;
-        const spaceLabel = crossSpace ? ` [${r.spaceId}]` : '';
-        lines.push(`[${i + 1}]${spaceLabel} [${r.type}] (score: ${r.score?.toFixed(3) ?? 'n/a'}) ${formatRecallSummary(r)}`);
+    // Locate the source entry: with a space, use it; without, try each accessible space (first match
+    // wins — the lookup fails fast before any search, so misses are cheap).
+    const { candidateBases, searchIds } = resolveFindSimilarScope(callSpace || undefined, crossSpace, accessibleSpaceIds, resolveMemberSpaces);
+    let result: Awaited<ReturnType<typeof findSimilar>> | undefined;
+    let usedBase: string | undefined;
+    for (const base of candidateBases) {
+      try {
+        result = await findSimilar(base, entryId, entryType as RecallKnowledgeType, topK, targetTypes, minScore, searchIds);
+        usedBase = base;
+        break;
+      } catch (e) {
+        if (e instanceof NotFoundError && candidateBases.length > 1) continue;
+        throw e;
       }
     }
+    if (!result || !usedBase) throw new NotFoundError(`Entry '${entryId}' not found in any accessible space (type: ${entryType}).`);
 
-    return {
-      content: [{ type: 'text' as const, text: lines.join('\n') }],
+    const crossSpaceMode = !callSpace || crossSpace;
+
+    if (traverse === 0) {
+      const lines: string[] = [];
+      lines.push(`Source: [${result.source.type}] ${formatRecallSummary(result.source)} (ID: ${result.source._id})`);
+      if (result.results.length === 0) {
+        lines.push('No similar entries found.');
+      } else {
+        for (let i = 0; i < result.results.length; i++) {
+          const r = result.results[i]!;
+          const spaceLabel = crossSpaceMode ? ` [${r.spaceId}]` : '';
+          lines.push(`[${i + 1}]${spaceLabel} [${r.type}] (score: ${r.score?.toFixed(3) ?? 'n/a'}) ${formatRecallSummary(r)}`);
+        }
+      }
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    }
+
+    // Graph-augmented: expand the similar seeds along edges (mirrors recall's traverse), JSON output.
+    const traverseSpaces = searchIds ?? [usedBase];
+    const totalCap = topK * (traverse + 1) * 4;
+    const neighbours = await traverseRecallSeeds(
+      traverseSpaces,
+      result.results.map(sd => ({ _id: sd._id, spaceId: sd.spaceId })),
+      traverse,
+      Math.max(0, totalCap - result.results.length),
+    );
+    const results: McpRecallTraverseItem[] = [
+      ...result.results.map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, matchedText: formatRecallSummary(r), record: toRecallRecord(r) })),
+      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity', matchedText: `${n.record.name} (${n.record.type})`, record: entityDocToRecord(n.record) })),
+    ];
+    const output = {
+      source: { type: result.source.type, id: result.source._id, matchedText: formatRecallSummary(result.source) },
+      results, count: results.length, traverseDepth: traverse,
     };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
   },
 };
 
@@ -226,15 +282,19 @@ export const queryTool: ToolHandler = {
               enum: ['memories', 'entities', 'edges', 'chrono', 'files'],
               description: 'Collection to query.',
             },
-            filter: { type: 'object', description: 'MongoDB filter document.' },
+            filter: {
+              type: 'object',
+              description: `MongoDB filter document. Only these operators are allowed (any other $-operator is rejected): ${QUERY_FILTER_OPERATORS.join(', ')}. Nesting is capped at depth 8. $regex must be a string, length-limited, and rejected if it risks catastrophic backtracking; $options is allowed only alongside $regex and only with flags i, m, s, x. Results are ordered seq/updatedAt/createdAt descending — there is no sort parameter.`,
+            },
             projection: {
               type: 'object',
-              description: 'Fields to include (1) or exclude (0).',
+              description: 'Fields to include (1) or exclude (0). The `embedding` field is always excluded and cannot be re-included.',
             },
-            limit: { type: 'number', description: 'Max documents (default 20, max 100).' },
-            maxTimeMS: { type: 'number', description: 'Query timeout in ms (max 30000).' },
+            limit: { type: 'number', minimum: 1, maximum: 100, default: 20, description: 'Max documents to return (clamped to 1–100). Default 20.' },
+            maxTimeMS: { type: 'number', minimum: 1, maximum: 10000, default: 5000, description: 'Server-side query timeout in ms. Default 5000, hard-capped at 10000.' },
           },
           required: ['space', 'collection', 'filter'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace } = ctx;

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -27,6 +27,37 @@ export function ttlDaysFromArgs(args: Record<string, unknown>): number | null | 
   return v;
 }
 
+/**
+ * Shared JSON-Schema fragments so `tools/list` fully describes every input (F1 self-describing surface).
+ * The MCP dispatcher does not enforce inputSchema (handlers validate manually), so these keywords are the
+ * machine-readable contract an agent reads to discover valid values/bounds — kept in lockstep with the
+ * handler/brain validators they mirror.
+ */
+
+/** A UUID-v4 id argument (case-insensitive), matching `UUID_V4_RE`. */
+const UUID_V4_PATTERN = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$';
+export function uuidSchema(description: string) {
+  return { type: 'string', pattern: UUID_V4_PATTERN, description } as const;
+}
+
+/** A 0.0–1.0 score/threshold argument. */
+export function unitScoreSchema(description: string) {
+  return { type: 'number', minimum: 0, maximum: 1, description } as const;
+}
+
+/** MongoDB operators the structured `query` filter accepts — mirrors `ALLOWED_OPERATORS` (brain/query.ts). */
+export const QUERY_FILTER_OPERATORS = [
+  '$eq', '$ne', '$gt', '$gte', '$lt', '$lte', '$in', '$nin', '$and', '$or', '$nor', '$not',
+  '$exists', '$type', '$regex', '$options', '$all', '$elemMatch', '$size', '$mod',
+] as const;
+
+/**
+ * `propertyNames` pattern for the recall filter's keys — mirrors `ALLOWED_FILTER_KEY_PREFIXES`
+ * (brain/filter.ts): `properties.<path>`, or exactly `tags`/`type`/`name`/`status`/`label` (optionally
+ * dot-suffixed). Encodes the injection-prevention allowlist so agents see which keys are legal.
+ */
+export const RECALL_FILTER_KEY_PATTERN = '^(properties\\..+|(tags|type|name|status|label)(\\..+)?)$';
+
 /** Format a RecallResult as a single human-readable summary line. */
 export function formatRecallSummary(r: RecallResult): string {
   switch (r.type) {

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -8,7 +8,7 @@ import { updateSpace } from '../../spaces/spaces.js';
 export const list_spacesTool: ToolHandler = {
   name: 'list_spaces',
   description: 'List all accessible spaces with their IDs, labels, descriptions, and entry counts (memories, entities, edges, chrono). Use counts to decide which spaces are populated and worth querying.',
-  inputSchema: (s: ToolSchemas) => ({ type: 'object', properties: {}, required: [] }),
+  inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [], additionalProperties: false }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { accessibleSpaces } = ctx;
     const spaceCountResults = await Promise.allSettled(
@@ -57,6 +57,7 @@ export const get_statsTool: ToolHandler = {
             space: s.requiredSpace,
           },
           required: ['space'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { callSpace } = ctx;
@@ -95,6 +96,7 @@ export const get_space_metaTool: ToolHandler = {
             space: s.requiredSpace,
           },
           required: ['space'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { callSpace } = ctx;
@@ -142,10 +144,11 @@ export const update_spaceTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            label: { type: 'string', description: 'New display label for the space (max 200 chars).' },
-            description: { type: 'string', description: 'New description for the space (max 2000 chars). Surfaced to MCP clients as space-level instructions.' },
+            label: { type: 'string', minLength: 1, maxLength: 200, description: 'New display label for the space (1–200 chars).' },
+            description: { type: 'string', maxLength: 2000, description: 'New description for the space (max 2000 chars). Surfaced to MCP clients as space-level instructions.' },
           },
           required: ['space'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, isAdmin } = ctx;
@@ -191,6 +194,7 @@ export const wipe_spaceTool: ToolHandler = {
             },
           },
           required: ['space'],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a, callSpace, isAdmin } = ctx;

--- a/server/src/mcp/tools/sync.ts
+++ b/server/src/mcp/tools/sync.ts
@@ -5,7 +5,7 @@ export const list_peersTool: ToolHandler = {
   name: 'list_peers',
   description: 'List all configured peer ythril instances (for Brain Networks).',
   admin: true,
-  inputSchema: (s: ToolSchemas) => ({ type: 'object', properties: {}, required: [] }),
+  inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [], additionalProperties: false }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const listPeersCfg = getConfig();
     // Build a flat list of peers across all networks, scrubbing all
@@ -51,10 +51,11 @@ export const sync_nowTool: ToolHandler = {
           properties: {
             peerId: {
               type: 'string',
-              description: 'instanceId of the peer to sync. Omit to sync all networks.',
+              description: 'Exact instanceId of the peer to sync (must be a known member instanceId — never a URL). Omit to sync all networks.',
             },
           },
           required: [],
+          additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { args: a } = ctx;

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -1,0 +1,123 @@
+/**
+ * MCP tool-schema completeness (F1 self-describing surface).
+ *
+ * An agent must be able to discover every possible input, value, bound, and operator for a tool from
+ * `tools/list` alone. These tests pin the machine-readable invariants that make that true across ALL_TOOLS,
+ * plus the highest-value per-tool enrichments (query.filter operators, recall filter key allowlist, the
+ * corrected query.maxTimeMS ceiling, find_similar's omit-space harmonisation) and the pure scope resolver.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ALL_TOOLS } from '../../server/dist/mcp/tools/index.js';
+import { resolveFindSimilarScope } from '../../server/dist/mcp/tools/search.js';
+
+// Stub ToolSchemas (the space fragments the router builds per-connection).
+const schemas = {
+  requiredSpace: { type: 'string', description: 'Space ID to operate on.' },
+  optionalSpace: { type: 'string', description: 'Optional space ID. Omit to search across all accessible spaces.' },
+};
+const schemaOf = (name) => ALL_TOOLS.find(t => t.name === name).inputSchema(schemas);
+
+describe('MCP tool schemas — universal invariants', () => {
+  it('exposes exactly 31 tools', () => {
+    assert.equal(ALL_TOOLS.length, 31);
+  });
+
+  it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {
+    for (const t of ALL_TOOLS) {
+      const s = t.inputSchema(schemas);
+      assert.equal(s.type, 'object', `${t.name}: type must be object`);
+      assert.equal(s.additionalProperties, false, `${t.name}: must set additionalProperties:false so the option set is discoverable as complete`);
+      assert.equal(typeof s.properties, 'object', `${t.name}: properties must be an object`);
+      assert.ok(Array.isArray(s.required), `${t.name}: required must be an array`);
+    }
+  });
+});
+
+describe('MCP tool schemas — high-value enrichments', () => {
+  it('query.filter documents the MongoDB operator allowlist + regex/depth rules', () => {
+    const filter = schemaOf('query').properties.filter;
+    for (const op of ['$eq', '$in', '$regex', '$options', '$elemMatch', '$mod']) {
+      assert.ok(filter.description.includes(op), `query.filter description must list ${op}`);
+    }
+    assert.ok(/depth 8/.test(filter.description), 'query.filter must document the depth-8 cap');
+  });
+
+  it('query.maxTimeMS advertises the REAL 10000 ceiling (not the old prose 30000)', () => {
+    const m = schemaOf('query').properties.maxTimeMS;
+    assert.equal(m.maximum, 10000);
+    assert.equal(m.default, 5000);
+  });
+
+  it('query.limit carries real bounds', () => {
+    const l = schemaOf('query').properties.limit;
+    assert.equal(l.minimum, 1);
+    assert.equal(l.maximum, 100);
+    assert.equal(l.default, 20);
+  });
+
+  it('recall.filter encodes the key allowlist via propertyNames, and traverse/minScore carry bounds', () => {
+    const recall = schemaOf('recall');
+    const pat = recall.properties.filter.propertyNames.pattern;
+    const re = new RegExp(pat);
+    assert.ok(re.test('properties.status'), 'properties.* keys allowed');
+    assert.ok(re.test('tags'), 'tags key allowed');
+    assert.ok(!re.test('evil'), 'arbitrary keys rejected by the pattern');
+    assert.equal(recall.properties.traverse.minimum, 0);
+    assert.equal(recall.properties.traverse.maximum, 5);
+    assert.equal(recall.properties.minScore.minimum, 0);
+    assert.equal(recall.properties.minScore.maximum, 1);
+  });
+
+  it('bulk_write arrays advertise the 500-item cap', () => {
+    const props = schemaOf('bulk_write').properties;
+    for (const k of ['memories', 'entities', 'edges', 'chrono']) {
+      assert.equal(props[k].maxItems, 500, `bulk_write.${k} must cap at 500`);
+    }
+  });
+
+  it('find_similar is harmonised to omit-space (space optional) + traverse, crossSpace deprecated', () => {
+    const fs = schemaOf('find_similar');
+    assert.ok(!fs.required.includes('space'), 'space must be optional (omit → all accessible spaces)');
+    assert.deepEqual(fs.required, ['entryId', 'entryType']);
+    assert.ok(fs.properties.traverse, 'find_similar must expose traverse (parity with recall)');
+    assert.equal(fs.properties.traverse.maximum, 5);
+    assert.ok(/DEPRECATED/i.test(fs.properties.crossSpace.description), 'crossSpace must be marked deprecated');
+    assert.equal(ALL_TOOLS.find(t => t.name === 'find_similar').spaceRequired, false);
+  });
+
+  it('id fields carry a UUID-v4 pattern', () => {
+    const pat = schemaOf('find_similar').properties.entryId.pattern;
+    const re = new RegExp(pat);
+    assert.ok(re.test('3b241101-e2bb-4255-8caf-4136c566a962'), 'valid uuid v4 accepted');
+    assert.ok(!re.test('not-a-uuid'), 'non-uuid rejected by the pattern');
+  });
+});
+
+describe('resolveFindSimilarScope (find_similar space resolution)', () => {
+  const members = (space) => (space === 'proxy' ? ['m1', 'm2'] : [space]);
+  const accessible = ['a', 'b', 'c'];
+
+  it('with a space (no crossSpace): base is the resolved member, search stays in that space', () => {
+    const r = resolveFindSimilarScope('a', false, accessible, members);
+    assert.deepEqual(r.candidateBases, ['a']);
+    assert.equal(r.searchIds, undefined);
+  });
+
+  it('with a proxy space: base is the first member', () => {
+    const r = resolveFindSimilarScope('proxy', false, accessible, members);
+    assert.deepEqual(r.candidateBases, ['m1']);
+  });
+
+  it('omitting the space searches all accessible spaces and probes each for the source', () => {
+    const r = resolveFindSimilarScope(undefined, false, accessible, members);
+    assert.deepEqual(r.candidateBases, accessible);
+    assert.deepEqual(r.searchIds, accessible);
+  });
+
+  it('legacy crossSpace:true forces cross-space even when a space is given', () => {
+    const r = resolveFindSimilarScope('a', true, accessible, members);
+    assert.deepEqual(r.candidateBases, accessible);
+    assert.deepEqual(r.searchIds, accessible);
+  });
+});


### PR DESCRIPTION
## Summary

An MCP agent should be able to discover **everything a tool accepts** — parameters, allowed values, bounds, filter operators, defaults — from `tools/list` alone. This makes all 31 tool schemas self-describing, points agents at `tools/list` from the `help` tool, and (per request) harmonises `find_similar` with `recall`.

Key enabling fact: the dispatcher validates args **in the handlers, not against `inputSchema`** (`router.ts` uses only the SDK envelope schema). So every keyword added here is **advisory metadata** — it improves discovery without changing behavior for any existing call.

## Schema comprehensiveness (all 31 tools)

- **`additionalProperties: false`** everywhere, so the advertised option set reads as complete.
- Prose bounds promoted to real JSON-Schema keywords: `enum`, `minimum`/`maximum`/`default`, `minLength`/`maxLength`, **`maxItems: 500`** (the bulk-write per-array cap, previously a silent truncation), and UUID `pattern` on id fields.
- **`query.filter`** now lists its allowed MongoDB operators (`$eq … $mod`) + the depth-8 / `$regex` / `$options` rules — it was a bare `{type: object}` hiding the entire allowlist.
- **recall/find `filter`** encodes its key allowlist (`properties.`, `tags`, `type`, `name`, `status`, `label`) via `propertyNames`.
- Unit-score fields (`weight`, `confidence`, `minScore`, `dupeThreshold`) carry `0..1` bounds.
- **Bug fix:** `query.maxTimeMS` advertised `max 30000` but the real cap is **10000** (default 5000) — corrected to match the handler.
- Shared fragments in `shared.ts` (`uuidSchema`, `unitScoreSchema`, `QUERY_FILTER_OPERATORS`, `RECALL_FILTER_KEY_PATTERN`).
- The `help` tool and the integration guide now name `tools/list` as the authoritative machine-readable reference.

## `find_similar` harmonised with `recall`

- **`space` is now optional** — omit it to search across all accessible spaces (the source entry is located across them; the lookup fails fast before searching, so misses are cheap).
- **Adds `traverse`** for graph expansion (parity with `recall`; JSON output when `> 0`).
- The legacy **`crossSpace` flag is deprecated** (omit `space` instead) but still honoured.
- Space-selection extracted to a **pure, unit-tested `resolveFindSimilarScope`** helper. `findSimilar`'s brain signature is unchanged, so the REST endpoint and dupe-scanner are unaffected (the REST `find-similar` endpoint keeps `spaceId` in the path + `crossSpace`).

## Testing

- `server tsc` clean; new **`testing/standalone/mcp-tool-schemas.test.js`** (13 tests) pins the universal invariants across `ALL_TOOLS`, the high-value enrichments, and the space-resolution logic. Existing `mcp-help` standalone test still green; no MCP integration/red-team test asserts the old `find_similar` space requirement.

## Docs

CHANGELOG `### Changed`; integration guide updated (MCP space-optional list now includes `find_similar`, a `tools/list`-is-authoritative note, and the REST-vs-MCP `find_similar` distinction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)