### PR TITLE
fix(schema): pre-fill entry-form properties for library-linked () types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -530,6 +530,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Entry forms now pre-fill properties for types linked to a schema-library entry.** When adding an
+  entity/memory/etc. and selecting a type whose schema is a library reference (`$ref`), the properties
+  section came up empty — `GET /api/spaces/:id/meta` returned the bare `{ $ref }` without the linked
+  entry's `propertySchemas`, so the UI had nothing to pre-fill. The meta endpoint now accepts `?resolve=1`
+  to expand `$ref` types to their effective schema (the brain forms request it); the default response stays
+  raw for the edit/round-trip view. The MCP `get_space_meta` tool now always returns the resolved schema so
+  agents see the real fields too. (Reported: schema-selected entry form missing its properties.)
+
 - **Docker: the base `docker-compose.yml` local-agent default no longer contradicts the server's own
   validator.** It shipped `YTHRIL_LOCAL_AGENT_URL=http://localhost:38123`, but the server deliberately
   rejects a DNS-resolved `localhost` host (only numeric `127.0.0.1`/`::1` count as loopback, to keep the

--- a/client/src/app/core/spaces-api.service.ts
+++ b/client/src/app/core/spaces-api.service.ts
@@ -28,7 +28,9 @@ export class SpacesApi {
   }
 
   getSpaceMeta(id: string): Observable<SpaceMetaResponse> {
-    return this.http.get<SpaceMetaResponse>(`/api/spaces/${id}/meta`);
+    // `resolve=1`: expand library `$ref` types so the brain entry forms can pre-fill a selected type's
+    // properties (a bare `{ $ref }` carries no propertySchemas). Edit/round-trip views use the raw meta.
+    return this.http.get<SpaceMetaResponse>(`/api/spaces/${id}/meta?resolve=1`);
   }
 
   /** GET a single type definition from the space's typeSchemas. */

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -537,7 +537,15 @@ spacesRouter.get('/:id/meta', globalRateLimit, requireAuth, async (req, res) => 
     return;
   }
 
-  const meta = space.meta ?? {};
+  // With `?resolve=1`, expand library `$ref` types to their effective schema (propertySchemas from the
+  // linked library entry) so consumers like the brain entry forms — which pre-fill properties from the
+  // selected type — see the real fields, not a bare `{ $ref }`. Default (raw) is preserved for the
+  // edit/round-trip view and existing callers that verify the stored `$ref`.
+  const resolveRefs = req.query['resolve'] === '1' || req.query['resolve'] === 'true';
+  const rawMeta = space.meta ?? {};
+  const meta = resolveRefs
+    ? (await import('../spaces/schema-validation.js')).resolveMetaRefs(rawMeta)
+    : rawMeta;
   const memberIds = resolveMemberSpaces(id);
   const counts = await Promise.all(memberIds.map(async mid => ({
     memories: await col(`${mid}_memories`).countDocuments(),

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -102,7 +102,11 @@ export const get_space_metaTool: ToolHandler = {
     const { callSpace } = ctx;
     const metaCfg = getConfig();
     const metaSpace = metaCfg.spaces.find(s => s.id === callSpace);
-    const metaBlock = metaSpace?.meta ?? {};
+    // Always resolve library `$ref` types so the agent sees the effective schema (propertySchemas from
+    // the linked library entry), not a bare `{ $ref }` — this is a read-for-use surface, like
+    // GET /api/spaces/:id/meta?resolve=1.
+    const { resolveMetaRefs } = await import('../../spaces/schema-validation.js');
+    const metaBlock = resolveMetaRefs(metaSpace?.meta ?? {});
     const metaMemberIds = resolveMemberSpaces(callSpace);
     const metaCounts = await Promise.all(metaMemberIds.map(async mid => ({
       memories: await col(`${mid}_memories`).countDocuments(),

--- a/testing/integration/schema-library.test.js
+++ b/testing/integration/schema-library.test.js
@@ -332,10 +332,19 @@ describe('$ref resolution — space references a library entry', () => {
     }).catch(() => {});
   });
 
-  it('the $ref typeSchema can be saved to a space', async () => {
+  it('the $ref typeSchema can be saved to a space (raw meta preserves the $ref for round-trip)', async () => {
     const r = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.deepEqual(r.body.typeSchemas?.entity?.service, { $ref: `library:${refLibName}` });
+  });
+
+  it('GET /meta?resolve=1 expands the $ref to the library entry\'s effective schema (fixes empty entry-form props)', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta?resolve=1`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const resolved = r.body.typeSchemas?.entity?.service;
+    assert.ok(resolved && !resolved.$ref, `expected the $ref resolved away, got ${JSON.stringify(resolved)}`);
+    // The library schema defines `owner` — it must surface so the UI can pre-fill it on the add form.
+    assert.ok(resolved.propertySchemas?.owner, `resolved type must carry the library propertySchemas (owner), got ${JSON.stringify(resolved.propertySchemas)}`);
   });
 
   it('a write that satisfies the referenced schema succeeds', async () => {


### PR DESCRIPTION
## Bug

Reported: *when adding an entry in the UI, a schema-selected type doesn't list its properties.*

Root cause: when a space type's schema is a **library reference** (`{ $ref: "library:…" }`), `GET /api/spaces/:id/meta` returned it **verbatim** — with no `propertySchemas`. The brain entry forms pre-fill from `typeSchemas[type][name].propertySchemas`, which was `undefined` for `$ref` types, so nothing populated. (The entity *upsert* path resolves refs via `resolveMetaRefs` for validation, but the meta endpoint the UI reads did not.)

## Fix

- **`GET /api/spaces/:id/meta?resolve=1`** expands `$ref` types to their effective schema (the linked library entry's `propertySchemas`). The **default response stays raw** — the edit/round-trip view and the existing tests/callers that verify a stored `$ref` are unchanged.
- The client's **`getSpaceMeta`** (used *only* by the brain forms — verified) requests `?resolve=1`, so the add/edit forms now pre-fill library-linked types.
- The MCP **`get_space_meta`** tool now always returns the resolved schema, so agents see the real fields too.

## Why a param, not resolve-by-default

Two existing tests (and the group-apply flow) use `/meta` to verify a `$ref` was **persisted** — raw is a real contract. `?resolve=1` is additive: it fixes the form without changing the default contract or breaking round-trip/edit reads. The Settings schema tab edits the raw meta from the spaces list (not `/meta`), so it's unaffected.

## Tests

Added an integration test: `GET /meta?resolve=1` expands the `$ref` to the library's `propertySchemas` (kept the raw-default assertion beside it). It's a valid guard — on unfixed code `?resolve=1` is ignored, the response is the bare `$ref`, and the assertion fails. Server `tsc` + client production build both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)