### PR TITLE
fix(brain): Description cell fills its column again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -530,6 +530,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Brain tables: the Description cell now fills its column again.** `.desc-cell` set `display: -webkit-box`
+  (for the 3-line clamp) directly on the `<td>`, which overrode `display: table-cell` and dropped the cell
+  out of the table layout, so it no longer filled its column. The clamp moved to an inner wrapper; the `<td>`
+  stays a real table cell. Affects the Memories, Entities, Chrono, and File-meta tables.
+
 - **Entry forms now pre-fill properties for types linked to a schema-library entry.** When adding an
   entity/memory/etc. and selecting a type whose schema is a library reference (`$ref`), the properties
   section came up empty — `GET /api/spaces/:id/meta` returned the bare `{ $ref }` without the linked

--- a/client/src/app/pages/brain/brain-table.styles.ts
+++ b/client/src/app/pages/brain/brain-table.styles.ts
@@ -95,9 +95,13 @@ export const BRAIN_RECORD_TABLE_STYLES = `
       color: var(--error);
     }
     .inline-confirm button { font-size: 11px; }
+    /* The td stays a real table cell so it fills its column; the 3-line clamp lives on an inner box
+       (setting display:-webkit-box on the td itself drops it out of table layout). */
     .desc-cell {
       font-size: 12px;
       color: var(--text-muted);
+    }
+    .desc-cell .desc-clamp {
       overflow: hidden;
       display: -webkit-box;
       -webkit-line-clamp: 3;

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -212,7 +212,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                     <tr>
                       <td>{{ entry.title }}</td>
                       <td class="desc-cell" style="max-width:160px;" [title]="entry.description ?? ''">
-                        {{ entry.description || '—' }}
+                        <div class="desc-clamp">{{ entry.description || '—' }}</div>
                       </td>
                       <td><span class="badge badge-blue">{{ entry.type }}</span></td>
                       <td><span class="badge" [class.badge-purple]="entry.status === 'upcoming'" [class.badge-blue]="entry.status === 'active'" style="font-size:11px">{{ entry.status }}</span></td>

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -165,7 +165,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                         @if (ent.type) { <span class="badge badge-purple">{{ ent.type }}</span> }
                       </td>
                       <td class="desc-cell" style="max-width:200px;" [title]="ent.description ?? ''">
-                        {{ ent.description || '—' }}
+                        <div class="desc-clamp">{{ ent.description || '—' }}</div>
                       </td>
                       <td style="font-size:11px;">
                         @for (tag of (ent.tags ?? []); track tag) { <span class="tag">{{ tag }}</span> }

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -172,7 +172,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                             }
                           </div>
                         </td>
-                        <td class="desc-cell" style="max-width:200px;" [title]="fm.description ?? ''">{{ fm.description || '–' }}</td>
+                        <td class="desc-cell" style="max-width:200px;" [title]="fm.description ?? ''"><div class="desc-clamp">{{ fm.description || '–' }}</div></td>
                         <td>
                           <div class="chip-list">
                             @for (tag of fm.tags; track tag) {

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -193,7 +193,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                     <tr>
                       <td style="max-width:300px; white-space:pre-wrap; word-break:break-word;">{{ mem.fact }}</td>
                       <td class="desc-cell" style="max-width:180px;" [title]="mem.description ?? ''">
-                        {{ mem.description || '—' }}
+                        <div class="desc-clamp">{{ mem.description || '—' }}</div>
                       </td>
                       <td style="font-size:11px;">
                         @for (tag of (mem.tags ?? []); track tag) { <span class="tag tag-clickable" (click)="applyFilter('tag', tag)">{{ tag }}</span> }


### PR DESCRIPTION
## Bug

Reported: *the Description-column `<td>` doesn't fill the whole cell.*

Root cause: `.desc-cell` applied `display: -webkit-box` (for the 3-line line-clamp) **directly on the `<td>`**. Setting `display` to anything other than `table-cell` drops the element out of the table's layout, so the cell no longer sizes to / fills its column.

## Fix

Keep the `<td>` a real table cell; move the clamp to an inner `.desc-clamp` wrapper:

```css
.desc-cell { font-size: 12px; color: var(--text-muted); }        /* stays display:table-cell */
.desc-cell .desc-clamp { display: -webkit-box; -webkit-line-clamp: 3; … }
```

Wrapped the cell content in `<div class="desc-clamp">…</div>` in the **Memories, Entities, Chrono, and File-meta** tables. (Edges already rendered its description with inline table-cell styles, so it was unaffected.)

Client production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)