### PR TITLE
docs: worked example for connecting Ythril to Claude over MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **User guide: worked example for connecting Ythril to Claude over MCP.** A step-by-step walkthrough in the
+  "Connecting an AI assistant (MCP)" section — public HTTPS URL (via the Networks local connector / Cloudflare
+  tunnel), creating a **scoped token first** (the connector inherits its permissions), adding the custom
+  connector in Claude, the OAuth consent step, enabling it per-conversation, and how to change or revoke its
+  access — so operators can scope exactly what Claude can see and do.
+
 - **Full `docs/`-vs-code audit — 49 discrepancies corrected across 8 documents.** An 8-reviewer sweep of
   every file in `docs/` against the current codebase surfaced 49 drifted or missing statements; all are now
   fixed in one pass. Highlights: the **integration guide** now documents the real auth tier on every write

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -841,6 +841,18 @@ One connection entry is all you need — every space the token can access is ava
 
 Static-token clients like Claude Desktop, Cursor, and VS Code just send the `Authorization: Bearer ythril_…` header shown above. Browser-based connectors that use the claude.ai-style OAuth flow instead — connect Ythril's `/mcp` URL and you'll be sent through an OAuth **consent** screen where you paste a valid Ythril token to approve. On approval Ythril mints a fresh PAT with the same privileges as the approving token; it appears under **Settings → Tokens** named **`MCP connector: <client>`**. This flow requires the instance to know its own public HTTPS URL (`publicUrl` / `PUBLIC_BASE_URL`).
 
+### Example: connect Ythril to Claude
+
+Claude's web app (and Claude Code on the web) can add Ythril as a **custom connector** over MCP. A full walkthrough:
+
+1. **Give your instance a public HTTPS address.** Claude's web app runs in the cloud, so it cannot reach `localhost` or a private IP — it needs a public URL over HTTPS with a valid certificate. The simplest route is Ythril's built-in **Settings → Networks → local connector** (a Cloudflare tunnel), which publishes your instance at a `https://…` address. Make sure the instance's **public URL** is set (so the OAuth details it generates point at the right host).
+2. **Create a scoped token first** (**Settings → Tokens**). The connector inherits *exactly* this token's permissions, so decide up front: read-only vs. read-write, admin or not, and which spaces. For example, a **read-only token scoped to a single space** gives Claude search access to just that space and nothing else. Name it something recognisable like `Claude web — read-only`.
+3. **Add the connector in Claude.** Open **Settings → Connectors → Add custom connector** and enter your instance's MCP URL: `https://<your-instance>/mcp`. (On Team/Enterprise plans an admin adds it once under **Admin settings → Connectors**; members then authenticate individually.)
+4. **Approve the connection.** Claude sends you to Ythril's **consent screen** — paste the token you created in step 2 and approve. Ythril issues the connector a fresh token with the same permissions, which appears under **Settings → Tokens** as `MCP connector: <client>` (so you can see and revoke it at any time).
+5. **Enable it in a conversation.** Turn the connector on with the **+** in the chat. Claude first calls `list_spaces` and `help` to orient itself, then it can recall, remember, query, and manage your knowledge graph — limited to whatever the token allows (a read-only token, for instance, won't even see the write tools).
+
+**To change what Claude can do,** issue a differently-scoped token (read-only, or a different set of spaces) and reconnect. **To cut it off,** revoke its `MCP connector` token under **Settings → Tokens**. If you'd rather skip the OAuth flow entirely, connectors that accept custom headers can instead send an `Authorization: Bearer ythril_…` header directly — same scoping (the header token's permissions), no consent step.
+
 ### What the AI can do
 
 Once connected, your AI assistant can:


### PR DESCRIPTION
## Summary

Adds a step-by-step **"Example: connect Ythril to Claude"** to the user guide's *Connecting an AI assistant (MCP)* section, so operators have a concrete walkthrough (not just the generic OAuth note).

Covers, in order:
1. Give the instance a **public HTTPS URL** (Networks local connector / Cloudflare tunnel).
2. **Create a scoped token first** — the connector inherits *exactly* its permissions (read-only vs. read-write, admin or not, which spaces).
3. Add the **custom connector** in Claude (`https://<host>/mcp`; Team/Enterprise admins add it under Admin settings).
4. Approve via Ythril's **OAuth consent** (paste the scoped token; Ythril mints an equivalent connector token).
5. **Enable per-conversation** and go — the agent orients with `list_spaces` / `help`.

Plus how to change scope (issue a differently-scoped token and reconnect) and how to revoke (remove the `MCP connector` token), and a note on the bearer-header alternative.

The emphasis is **token-first scoping** so operators control exactly what Claude can see and do — which lines up with the MCP self-describing/enforced-schema work already merged.

Docs-only. CHANGELOG `### Documentation` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)