### PR TITLE
test(settings): characterization tests for the space Danger tab before its U9 rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Characterization tests for the space Danger tab (6 tests), landed before its PR-U9 rework.** The
+  `SpaceDangerTabComponent` performs the irreversible space operations — rename, wipe, delete, leave-network —
+  and shipped with no coverage. These pin the confirm-gating the rework must not weaken: a cancelled confirm
+  never calls the API, and a confirmed one hits the right endpoint and updates state (rename reflects the new
+  id; delete closes the dialog). Ships before the rework that escalates Wipe to a red tier and adds
+  type-to-confirm to Rename.
+
 - **Characterization tests for the Duplicates screens (11 tests), landed before their UX rework.** Both the
   `DuplicatesComponent` settings page and the per-space `SpaceDuplicatesTabComponent` shipped with no coverage;
   these pin the behavior the PR-U8 rework must preserve — load/error states, the optimistic Dismiss (removes on

--- a/client/src/app/pages/settings/space-danger-tab.component.spec.ts
+++ b/client/src/app/pages/settings/space-danger-tab.component.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * SpaceDangerTabComponent characterization tests.
+ *
+ * Written BEFORE the PR-U9 rework (escalate Wipe to a red tier, add type-to-confirm to Rename, responsive
+ * tiles) and proven green against the ORIGINAL component. The danger tab performs the IRREVERSIBLE space
+ * operations — rename, wipe, delete, leave-network — each behind a confirm. These tests pin that gating so
+ * the redesign can't weaken it: a cancelled confirm must never call the API, and a confirmed one calls the
+ * right endpoint and updates state. (Wipe/Delete already use type-to-confirm; the rework adds it to Rename.)
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { signal } from '@angular/core';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { SpaceDangerTabComponent } from './space-danger-tab.component';
+import { SpaceSettingsState } from './space-settings-state.service';
+import { SpacesApi } from '../../core/spaces-api.service';
+import { SpacesStore } from './spaces-store.service';
+import { NetworksApi } from '../../core/networks-api.service';
+import { ToastService } from '../../core/toast.service';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+
+function setup(confirmResult: boolean, api: Partial<Record<string, unknown>> = {}) {
+  const spacesApi = {
+    renameSpace: vi.fn().mockReturnValue(of({ space: { id: 'renamed', label: 'S' } })),
+    wipeSpace: vi.fn().mockReturnValue(of({})),
+    deleteSpace: vi.fn().mockReturnValue(of({})),
+    getSpaceStats: vi.fn().mockReturnValue(of({})),
+    ...api,
+  };
+  const networksApi = {
+    listNetworks: vi.fn().mockReturnValue(of({ networks: [] })),
+    leaveNetwork: vi.fn().mockReturnValue(of({})),
+  };
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [SpaceDangerTabComponent, getTranslocoModule()],
+    providers: [
+      SpaceSettingsState,
+      { provide: SpacesApi, useValue: spacesApi },
+      { provide: NetworksApi, useValue: networksApi },
+      { provide: SpacesStore, useValue: { spaces: signal([]), networks: signal([]), refreshNetworks: () => {} } },
+      { provide: ToastService, useValue: { error: () => {}, success: () => {}, show: () => {} } },
+      { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(confirmResult) } },
+    ],
+  });
+  const c = TestBed.createComponent(SpaceDangerTabComponent).componentInstance;
+  const state = TestBed.inject(SpaceSettingsState);
+  state.settingsSpace.set({ id: 'proj', label: 'Project' } as never);
+  return { c, state, spacesApi, networksApi };
+}
+
+describe('SpaceDangerTabComponent — irreversible ops are confirm-gated', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('rename: no-op when the new id is blank or unchanged', async () => {
+    const { c, state, spacesApi } = setup(true);
+    state.dangerRenameId = '';
+    await c.submitDangerRename();
+    state.dangerRenameId = 'proj'; // same as current
+    await c.submitDangerRename();
+    expect(spacesApi.renameSpace).not.toHaveBeenCalled();
+  });
+
+  it('rename: a cancelled confirm does not call the API', async () => {
+    const { c, state, spacesApi } = setup(false);
+    state.dangerRenameId = 'proj-2';
+    await c.submitDangerRename();
+    expect(spacesApi.renameSpace).not.toHaveBeenCalled();
+  });
+
+  it('rename: confirmed calls renameSpace(old,new) and reflects the new space', async () => {
+    const { c, state, spacesApi } = setup(true, {
+      renameSpace: vi.fn().mockReturnValue(of({ space: { id: 'proj-2', label: 'Project' } })),
+    });
+    state.dangerRenameId = 'proj-2';
+    await c.submitDangerRename();
+    expect(spacesApi.renameSpace).toHaveBeenCalledWith('proj', 'proj-2');
+    expect(state.settingsSpace()?.id).toBe('proj-2');
+  });
+
+  it('wipe: cancelled does not call the API; confirmed does', async () => {
+    const cancelled = setup(false);
+    await cancelled.c.confirmDangerWipe();
+    expect(cancelled.spacesApi.wipeSpace).not.toHaveBeenCalled();
+
+    const ok = setup(true);
+    await ok.c.confirmDangerWipe();
+    expect(ok.spacesApi.wipeSpace).toHaveBeenCalledWith('proj');
+  });
+
+  it('delete: cancelled does not call the API; confirmed deletes and closes the dialog', async () => {
+    const cancelled = setup(false);
+    await cancelled.c.confirmDangerDelete();
+    expect(cancelled.spacesApi.deleteSpace).not.toHaveBeenCalled();
+
+    const ok = setup(true);
+    await ok.c.confirmDangerDelete();
+    expect(ok.spacesApi.deleteSpace).toHaveBeenCalledWith('proj');
+    expect(ok.state.settingsSpace()).toBeNull(); // closeSettings()
+  });
+
+  it('leave network: cancelled does not call the API; confirmed leaves', async () => {
+    const cancelled = setup(false);
+    await cancelled.c.leaveNetworkDanger('net1');
+    expect(cancelled.networksApi.leaveNetwork).not.toHaveBeenCalled();
+
+    const ok = setup(true);
+    await ok.c.leaveNetworkDanger('net1');
+    expect(ok.networksApi.leaveNetwork).toHaveBeenCalledWith('net1');
+  });
+});


### PR DESCRIPTION
## Summary

The `SpaceDangerTabComponent` performs the **irreversible** space operations — rename, wipe, delete, leave-network — and shipped with **zero coverage**. PR-U9 will rework it (escalate Wipe to a red tier, add **type-to-confirm to Rename**, responsive tiles). Per the repo's characterization-tests-before-refactor rule, this lands the safety net **first** — 6 tests, proven green against the original.

## What's pinned

The confirm-gating that the rework must not weaken:
- **rename** — no-op on a blank/unchanged id; a **cancelled** confirm never calls the API; **confirmed** → `renameSpace(old, new)` and `settingsSpace` reflects the new id.
- **wipe / delete** — cancelled → no API call; confirmed → the right endpoint (delete also **closes the dialog**).
- **leave network** — cancelled → no call; confirmed → `leaveNetwork(id)`.

## Notes

Test-only; no production code touched. `spaces.component` already has a spec, and `space-settings-tab` is presentational (card grouping), so the danger tab is the piece that needed coverage before its rework. CHANGELOG `### Added` entry included. First of two PRs for U9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)