### PR TITLE
feat(settings): danger tab — type-to-confirm Rename + red-tier Wipe (PR-U9 pt1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1001,6 +1001,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Space Danger tab: Rename now requires type-to-confirm, and Wipe is a red-tier action (PR-U9, part 1).**
+  Renaming a space changes its ID — which breaks existing token and MCP references — so **Rename** now uses
+  the same type-the-current-ID confirmation as Wipe and Delete (previously a plain confirm). The **Wipe**
+  section is escalated to the red danger tier to match its irreversibility, and the per-collection count
+  tiles use a responsive `auto-fit` grid instead of a fixed 5-column row. Behaviour is pinned by the danger-
+  tab characterization tests from the previous PR.
+
 - **Settings → Duplicates rebuilt on the design system (PR-U8).** The wide table becomes responsive
   **A-vs-B comparison cards** — each pair shows record A beside record B with a coloured **confidence meter**
   (the match score as a percentage), the space/type, and a relative detected-time. A **SummaryStrip** on top

--- a/client/src/app/pages/settings/space-danger-tab.component.ts
+++ b/client/src/app/pages/settings/space-danger-tab.component.ts
@@ -40,7 +40,7 @@ import { TranslocoService } from '@jsverse/transloco';
   @if (state.dangerRenameError()) { <div class="alert alert-error" style="margin-top:8px;">{{ state.dangerRenameError() }}</div> }
 </div>
 
-<div class="dz-section">
+<div class="dz-section dz-red">
   <div class="dz-section-title">{{ 'spaces.dangerZone.wipeTitle' | transloco }}</div>
   <p style="font-size:13px;color:var(--text-muted);margin-bottom:12px;">{{ 'spaces.dangerZone.wipeDescription' | transloco }}</p>
   @if (state.dangerWipeLoading()) {
@@ -48,7 +48,7 @@ import { TranslocoService } from '@jsverse/transloco';
       <span class="spinner" style="width:14px;height:14px;border-width:2px;"></span> {{ 'spaces.dangerZone.loadingCounts' | transloco }}
     </div>
   } @else if (state.dangerWipeStats()) {
-    <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:8px;margin-bottom:16px;">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(88px,1fr));gap:8px;margin-bottom:16px;">
       @for (col of state.wipeStatCols(); track col.label) {
         <div style="text-align:center;padding:10px 6px;background:var(--bg-elevated);border-radius:var(--radius-sm);">
           <div style="font-size:20px;font-weight:700;font-family:var(--font-mono);">{{ col.value }}</div>
@@ -105,10 +105,15 @@ export class SpaceDangerTabComponent {
     const target = this.state.settingsSpace();
     const newId  = this.state.dangerRenameId.trim();
     if (!target || !newId || newId === target.id) return;
+    // Renaming changes the space id, which breaks existing MCP/token references to it — so require the
+    // operator to type the CURRENT id to confirm (same type-to-confirm ritual as wipe/delete).
     const ok = await this.confirmDialog.confirm({
       title: this.transloco.translate('spaces.dangerZone.confirmRenameTitle'),
       message: this.transloco.translate('spaces.dangerZone.confirmRename', { label: target.label, id: target.id, newId }),
       confirmLabel: this.transloco.translate('spaces.dangerZone.renameButton'),
+      danger: true,
+      requireText: target.id,
+      requireTextLabel: this.transloco.translate('spaces.dangerZone.typeIdToConfirm', { id: target.id }),
     });
     if (!ok) return;
     this.state.dangerRenaming.set(true);

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -380,7 +380,7 @@ Click the gear icon on any space row to open its settings panel. Changes save an
 - **From File** — import a schema from a previously exported JSON file.
 - **Save to Lib** — save the current type schema to the Schema Library for reuse in other spaces.
 
-**Danger tab:** Rename the space ID, wipe all data, or delete the space entirely.
+**Danger tab:** Rename the space ID, wipe all data, or delete the space entirely. All three are guarded: because renaming changes the space ID (which breaks existing token and MCP references to it), **Rename** — like Wipe and Delete — now asks you to type the current space ID to confirm.
 
 Each space row carries only a gear/configure (⚙) button — there is no pencil icon. Renaming, wiping, and deleting all live inside the space's settings panel, on the **Danger** tab.
 


### PR DESCRIPTION
## Summary

First slice of PR-U9, guarded by the danger-tab characterization tests merged in #316. The space **Danger** tab performs the irreversible operations, and this hardens two of them:

- **Rename now requires type-to-confirm.** Renaming changes the space **ID**, which breaks existing token and MCP references to it — a plain confirm was too weak for that. Rename now uses the same *type-the-current-ID* ritual as Wipe and Delete (reusing the proven `requireText` mechanism).
- **Wipe is escalated to the red danger tier** (`dz-red`) to match its irreversibility.
- The per-collection **count tiles** use a responsive `auto-fit`/`minmax` grid instead of a fixed 5-column row.

## Tests

The danger-tab characterization tests (#316) **stay green** — the confirm stub returns true regardless of `requireText`, so the rename/wipe/delete/leave gating assertions are unchanged. Client production build clean. (A 3-tweak change reusing an already-proven mechanism — covered by char-tests + build; no separate E2E warranted.)

## Docs

Userguide Danger-tab note updated (Rename now asks you to type the current ID). CHANGELOG `### Changed` entry.

## Follow-up (U9 part 2)

`spaces` SummaryStrip / load-error / empty-CTA / `ph-icon`, and `space-settings-tab` card grouping + moving the validation controls to the Schema tab — tracked, next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)