### PR TITLE
feat(settings): rebuild Preferences on the design system; MFA under "Security" (PR-U12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1019,6 +1019,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Preferences rebuilt on the design system, with MFA grouped under "Security" (PR-U12).** The
+  Preferences page and the MFA panel were the last hand-rolled settings screens; both now use the shared
+  **SettingsCard** (the language switcher on a card with a globe icon, MFA on a card with a lock icon), and
+  MFA's status moves from a raw badge to a **StatusPill** (Enabled/Disabled). MFA is now presented under a
+  **Security** section heading below the language card, so security settings read as their own group. Behaviour
+  is unchanged — the language switch and the full MFA enroll/verify/disable flow are untouched — and pinned by
+  a new PreferencesComponent characterization test (plus the existing MFA spec); verified end-to-end with
+  Playwright (language switch localises the nav; the Security grouping and MFA pill render). The settings
+  section navigation intentionally stays in the global sidebar (a settings-local nav rail would add nesting,
+  not remove it).
+
 - **Settings → Data rebuilt on the design system, with a quarantined Danger Zone (PR-U11).** The 775-line
   hand-rolled page moves onto shared primitives: an **overview SummaryStrip** (database source · maintenance
   state · backup count · active schedule), **SettingsCards** for Database / Backups / Destination / Schedule,

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -73,6 +73,7 @@
   "nav.about": "Über",
   "nav.signOut": "Abmelden",
   "prefs.language.title": "Sprache",
+  "prefs.security.title": "Sicherheit",
   "prefs.language.subtitle": "Wählen Sie die Oberflächensprache.",
   "data.title": "Datenverwaltung",
   "data.time.am": "AM",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -73,6 +73,7 @@
   "nav.about": "About",
   "nav.signOut": "Sign out",
   "prefs.language.title": "Language",
+  "prefs.security.title": "Security",
   "prefs.language.subtitle": "Choose the interface language.",
   "data.title": "Data Management",
   "data.time.am": "AM",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -73,6 +73,7 @@
   "nav.about": "O",
   "nav.signOut": "Wyloguj się",
   "prefs.language.title": "Język",
+  "prefs.security.title": "Bezpieczeństwo",
   "prefs.language.subtitle": "Wybierz język interfejsu.",
   "data.title": "Zarządzanie danymi",
   "data.time.am": "AM",

--- a/client/src/app/pages/settings/mfa.component.ts
+++ b/client/src/app/pages/settings/mfa.component.ts
@@ -5,13 +5,15 @@ import { AuthApi } from '../../core/auth-api.service';
 import { renderSVG } from 'uqr';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { TranslocoService } from '@jsverse/transloco';
+import { SettingsCardComponent } from '../../shared/settings-card.component';
+import { StatusPillComponent } from '../../shared/status-pill.component';
 
 type MfaState = 'idle' | 'enrolling' | 'disabling';
 
 @Component({
   selector: 'app-mfa',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe],
+  imports: [CommonModule, FormsModule, TranslocoPipe, SettingsCardComponent, StatusPillComponent],
   styles: [`
     .qr-wrap { display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
     .secret-box {
@@ -32,15 +34,10 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
     img { border-radius: 8px; background: #fff; padding: 8px; }
   `],
   template: `
-    <div class="card">
-      <div class="card-header">
-        <div>
-          <div class="card-title">{{ 'mfa.title' | transloco }}</div>
-          <div class="card-subtitle">
-            {{ 'mfa.subtitle' | transloco }}
-          </div>
-        </div>
-      </div>
+    <app-settings-card icon="lock" [heading]="'mfa.title' | transloco" [purpose]="'mfa.subtitle' | transloco">
+      @if (!loading() && state() === 'idle') {
+        <app-status-pill pill [variant]="enabled() ? 'ok' : 'off'" [dot]="true">{{ enabled() ? ('mfa.status.enabled' | transloco) : ('mfa.status.disabled' | transloco) }}</app-status-pill>
+      }
 
       @if (loading()) {
         <div class="loading-overlay"><span class="spinner"></span></div>
@@ -48,10 +45,8 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
 
         <div class="status-row">
           @if (enabled()) {
-            <span class="badge badge-green">{{ 'mfa.status.enabled' | transloco }}</span>
             <button class="btn btn-secondary btn-sm" (click)="startDisable()">{{ 'mfa.disableButton' | transloco }}</button>
           } @else {
-            <span class="badge badge-gray">{{ 'mfa.status.disabled' | transloco }}</span>
             <button class="btn btn-primary btn-sm" (click)="startEnroll()">{{ 'mfa.enableButton' | transloco }}</button>
           }
         </div>
@@ -107,7 +102,7 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
       @if (successMsg()) {
         <div class="alert alert-success" style="margin-top:12px;">{{ successMsg() }}</div>
       }
-    </div>
+    </app-settings-card>
   `,
 })
 export class MfaComponent implements OnInit {

--- a/client/src/app/pages/settings/preferences.component.spec.ts
+++ b/client/src/app/pages/settings/preferences.component.spec.ts
@@ -8,13 +8,19 @@
  */
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
 import { TranslocoService } from '@jsverse/transloco';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { PreferencesComponent } from './preferences.component';
+import { AuthApi } from '../../core/auth-api.service';
 
 function make() {
   TestBed.resetTestingModule();
-  TestBed.configureTestingModule({ imports: [PreferencesComponent, getTranslocoModule()] });
+  TestBed.configureTestingModule({
+    imports: [PreferencesComponent, getTranslocoModule()],
+    // The template embeds <app-mfa/>, which calls AuthApi.getMfaStatus() on init.
+    providers: [{ provide: AuthApi, useValue: { getMfaStatus: () => of({ enabled: false }) } }],
+  });
   const fixture = TestBed.createComponent(PreferencesComponent);
   return { fixture, c: fixture.componentInstance, transloco: TestBed.inject(TranslocoService) };
 }
@@ -34,5 +40,16 @@ describe('PreferencesComponent — language switch', () => {
     expect(spy).toHaveBeenCalledWith('de');
     expect(c.activeLang()).toBe('de');
     expect(localStorage.getItem('lang')).toBe('de');
+  });
+
+  // U12 arrangement: language on a SettingsCard, MFA under a Security section.
+  it('renders the language SettingsCard, a Security section, and the MFA component', () => {
+    const { fixture } = make();
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('app-settings-card')).not.toBeNull();
+    expect(el.querySelectorAll('.lang-btn').length).toBe(3);
+    expect(el.querySelector('.section-label')).not.toBeNull();
+    expect(el.querySelector('app-mfa')).not.toBeNull();
   });
 });

--- a/client/src/app/pages/settings/preferences.component.spec.ts
+++ b/client/src/app/pages/settings/preferences.component.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * PreferencesComponent — CHARACTERIZATION tests.
+ *
+ * The Preferences page shipped with no coverage and is a design-system laggard (hand-rolled `.card` +
+ * `.lang-btn`). PR-U12 rebuilds it on `SettingsCard` and groups MFA under a "Security" heading. The page's
+ * only logic is the language switch, so these pin exactly that — green against the ORIGINAL code — so the
+ * redesign (purely presentational for this component) is a reviewable diff, not a silent behaviour change.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TranslocoService } from '@jsverse/transloco';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { PreferencesComponent } from './preferences.component';
+
+function make() {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [PreferencesComponent, getTranslocoModule()] });
+  const fixture = TestBed.createComponent(PreferencesComponent);
+  return { fixture, c: fixture.componentInstance, transloco: TestBed.inject(TranslocoService) };
+}
+
+describe('PreferencesComponent — language switch', () => {
+  beforeEach(() => { TestBed.resetTestingModule(); localStorage.clear(); });
+
+  it('offers exactly en / de / pl', () => {
+    const { c } = make();
+    expect(c.languages.map(l => l.code)).toEqual(['en', 'de', 'pl']);
+  });
+
+  it('setLang switches the active language, updates the signal, and persists to localStorage', () => {
+    const { c, transloco } = make();
+    const spy = vi.spyOn(transloco, 'setActiveLang');
+    c.setLang('de');
+    expect(spy).toHaveBeenCalledWith('de');
+    expect(c.activeLang()).toBe('de');
+    expect(localStorage.getItem('lang')).toBe('de');
+  });
+});

--- a/client/src/app/pages/settings/preferences.component.ts
+++ b/client/src/app/pages/settings/preferences.component.ts
@@ -1,19 +1,21 @@
 import { Component, inject, signal } from '@angular/core';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { MfaComponent } from './mfa.component';
+import { SettingsCardComponent } from '../../shared/settings-card.component';
 
 @Component({
   selector: 'app-preferences',
   standalone: true,
-  imports: [TranslocoPipe, MfaComponent],
+  imports: [TranslocoPipe, MfaComponent, SettingsCardComponent],
   styles: [`
-    .pref-section { margin-bottom: 32px; }
+    .prefs-page { display: flex; flex-direction: column; gap: 16px; max-width: 720px; }
+    .section-label { margin: 12px 0 0; font-size: 12px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--text-muted); }
 
     .lang-grid {
       display: flex;
       flex-wrap: wrap;
       gap: 10px;
-      margin-top: 12px;
     }
 
     .lang-btn {
@@ -36,14 +38,8 @@ import { MfaComponent } from './mfa.component';
     }
   `],
   template: `
-    <div class="pref-section">
-      <div class="card">
-        <div class="card-header">
-          <div>
-            <div class="card-title">{{ 'prefs.language.title' | transloco }}</div>
-            <div class="card-subtitle">{{ 'prefs.language.subtitle' | transloco }}</div>
-          </div>
-        </div>
+    <div class="prefs-page">
+      <app-settings-card icon="globe" [heading]="'prefs.language.title' | transloco" [purpose]="'prefs.language.subtitle' | transloco">
         <div class="lang-grid">
           @for (lang of languages; track lang.code) {
             <button
@@ -54,10 +50,9 @@ import { MfaComponent } from './mfa.component';
             </button>
           }
         </div>
-      </div>
-    </div>
+      </app-settings-card>
 
-    <div class="pref-section">
+      <h2 class="section-label">{{ 'prefs.security.title' | transloco }}</h2>
       <app-mfa />
     </div>
   `,

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -433,7 +433,7 @@ Your current session token is marked **(current session)** in the list.
 
 ## Multi-factor authentication (MFA)
 
-MFA adds a one-time code requirement for admin actions (creating tokens, managing spaces). Normal data operations are not affected. There is no separate "MFA" page — the MFA panel lives inside **Settings → Preferences**.
+MFA adds a one-time code requirement for admin actions (creating tokens, managing spaces). Normal data operations are not affected. There is no separate "MFA" page — the MFA panel lives inside **Settings → Preferences**, under the **Security** heading (the language switcher sits above it).
 
 ### Enrolling
 


### PR DESCRIPTION
## What

Rebuilds **Settings → Preferences** and the **MFA** panel — the last hand-rolled settings screens — on the shared design system, and groups MFA under a **Security** heading.

- **Preferences:** the language switcher moves onto a `SettingsCard` (globe icon). MFA is presented under a new **Security** section heading below it.
- **MFA:** rebuilt on `SettingsCard` (lock icon); its status badge becomes a `StatusPill` (Enabled/Disabled). The enroll / verify / disable flow is unchanged.

## Scope note (deliberate)

The tracker's "settings shell + section rail" idea is **deferred**: the settings navigation lives in the global sidebar today, and relocating it into a settings-local rail would *add* a nesting level rather than remove one — the always-visible global nav is good UX. `settings.component` stays a bare outlet. (Recorded in the tracker.)

## Tests

- **Char-test first** (`test(settings): characterize PreferencesComponent`), green against the original code — pins the language switch (`setActiveLang` + `localStorage` + signal). A second test pins the new arrangement (language SettingsCard + Security section + MFA). The existing MFA spec still passes (its assertions are on component signals, not DOM).
- Full client suite green (**375**); **AOT** build green.
- **Playwright-verified** end-to-end: the language SettingsCard, "SECURITY" section, and MFA card with its status pill render; switching to **Deutsch** localises the global nav (`Sign out` → `Abmelden`); no `NG0`/zone console errors.

## Docs / i18n

- `docs/userguide.md` MFA section notes the panel now sits under the **Security** heading.
- CHANGELOG `[Unreleased]` entry added.
- New i18n key `prefs.security.title` (en/de/pl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)