### PR TITLE
feat(settings): order the extraction-mode buttons Auto · OCR · VLM · Max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1063,6 +1063,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Models: the document-extraction mode buttons now read Auto · OCR · VLM · Max.** The picker
+  led with `OCR`; it now leads with **Auto** (the default mode), followed by OCR, VLM, and Max in ascending
+  capability — so the default is first and the order tells the capability story. Button-order only; behaviour
+  and the underlying modes are unchanged.
+
 - **The Ythril brand mark now appears on the sign-in and setup screens too, from one shared component.** The
   orb-with-glowing-Y mark stood only in the top-bar wordmark; the login, first-run setup, and OIDC-callback
   screens still showed a plain-text "ythril" with an old accent dot. A new shared `BrandLogoComponent`

--- a/client/src/app/pages/settings/models.component.ts
+++ b/client/src/app/pages/settings/models.component.ts
@@ -274,7 +274,8 @@ const STAGES = [
 export class ModelsComponent implements OnInit {
   private readonly http = inject(HttpClient);
 
-  readonly MODES: DocMode[] = ['ocr', 'vlm', 'auto', 'max'];
+  // Button order: Auto first (it's the default), then OCR · VLM · Max ascending in capability.
+  readonly MODES: DocMode[] = ['auto', 'ocr', 'vlm', 'max'];
   readonly STAGES = STAGES;
 
   loading = signal(true);


### PR DESCRIPTION
## What

The **Settings → Models** document-extraction mode picker led with `OCR`. It now leads with **Auto** (the default mode), followed by **OCR · VLM · Max** in ascending capability — so the default comes first and the order tells the capability story.

Button-order only: the modes, their descriptions, the pipeline diagram, and all behaviour are unchanged (the labels/diagram are keyed maps, order-independent). Verified with a client build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)