### PR TITLE
feat(files): external assist model for document extraction — opt-in, acknowledged egress (F11-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Optional external "assist model" for document extraction — opt-in, acknowledged egress (F11-b).** Until
+  now every extraction path was local (the bundled Ollama VLM / OCR sidecar) and no document content ever left
+  the instance. You can now point a **bigger, hosted OpenAI-compatible model** at specific tasks under
+  Settings → Models → **External assist model** (or `documentProcessing.assistModel` in config). It's assigned
+  per task — `repair` (the `max`-mode reconciliation pass) today, more planned — so it's off unless you both
+  configure an endpoint **and** assign it a use. Because this is the one path that sends document content
+  off-box, it is gated: the endpoint is **SSRF-validated** and reached only through the SSRF-guarded fetch;
+  the API key lives in `secrets.json` (masked, never returned); and assigning a task pops an **acknowledgment
+  dialog** naming exactly what egresses (OCR text + draft transcriptions, page images for image tasks) to
+  which host. That consent is recorded as `acknowledgedHost` and **enforced server-side and re-checked at
+  runtime** — content never leaves the box to an unacknowledged host, even if `config.json` is hand-edited.
+  Pinning `DOC_ASSIST_URL`/`DOC_ASSIST_MODEL`/`DOC_ASSIST_API_KEY` locks the block read-only. With nothing
+  configured, the repair pass stays entirely local, exactly as before.
+
 - **Per-space document-extraction mode override (F11-c).** A single space can now override the
   instance-wide extraction `mode` — run one archive of scanned PDFs under `max` (VLM + repair) while the
   rest of the instance stays on fast `ocr`, or vice versa. Set it from the space's **Settings → Document

--- a/client/src/app/pages/settings/models.component.ts
+++ b/client/src/app/pages/settings/models.component.ts
@@ -6,15 +6,23 @@ import { TranslocoPipe } from '@jsverse/transloco';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { SettingsCardComponent } from '../../shared/settings-card.component';
 import { StatusPillComponent, StatusVariant } from '../../shared/status-pill.component';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 
 interface ProviderCfg { label?: string; baseUrl?: string; model?: string; apiKey?: string; }
 
 type DocMode = 'ocr' | 'vlm' | 'auto' | 'max';
+type DocAssistUse = 'repair';
+/** F11-b — external "assist model": a bigger, hosted LLM (own endpoint) assigned to specific tasks. The
+ *  only path that sends document content off the instance, so it's gated by an egress acknowledgment. */
+interface DocAssistCfg {
+  baseUrl?: string; model?: string; apiKey?: string; uses?: DocAssistUse[]; acknowledgedHost?: string;
+}
 interface DocProcCfg {
   mode?: DocMode;
   renderDpi?: number; maxPages?: number; pageTimeoutMs?: number; concurrency?: number;
   // read-only (env/config-file only — never PATCHed from here)
   vlmModel?: string; vlmBaseUrl?: string; repairModel?: string; repairBaseUrl?: string;
+  assistModel?: DocAssistCfg;
 }
 
 interface MediaCfg {
@@ -249,6 +257,40 @@ const STAGES = [
           </details>
         </app-settings-card>
 
+        <!-- External assist model (F11-b) -->
+        <app-settings-card class="span-all" icon="globe" heading="External assist model"
+          purpose="An optional bigger, hosted model you assign to specific tasks. This is the only setting that sends document content off this instance.">
+          <app-status-pill pill [variant]="assistLocked() ? 'env' : (assistUses('repair') ? 'active' : 'off')">
+            {{ assistLocked() ? 'env' : (assistUses('repair') ? 'In use' : 'Not configured') }}
+          </app-status-pill>
+          <div class="grid2">
+            <div class="field"><label>Endpoint (OpenAI-compatible)</label><input data-mono type="url" [(ngModel)]="assist.baseUrl" [disabled]="assistLocked()" placeholder="https://api.example.com" /></div>
+            <div class="field"><label>Model</label><input data-mono [(ngModel)]="assist.model" [disabled]="assistLocked()" placeholder="e.g. a hosted GPT / Llama" /></div>
+          </div>
+          <div class="field">
+            <label>API key</label>
+            <input type="password" [(ngModel)]="assistApiKeyInput" [disabled]="assistLocked()"
+              [placeholder]="assist.apiKey ? 'Leave blank to keep current' : 'Bearer token (optional)'" />
+          </div>
+          <div class="field" style="margin-bottom:0;">
+            <label>Used for</label>
+            <label style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-secondary);font-weight:normal;">
+              <input type="checkbox" [checked]="assistUses('repair')" (change)="toggleAssistUse('repair', $any($event.target).checked)" [disabled]="assistLocked()" />
+              Document repair pass (<code>max</code> mode) — reconcile a page's VLM draft against the OCR text
+            </label>
+          </div>
+          <div class="runline warn" style="margin-top:14px;">
+            <ph-icon name="warning" [size]="15"/>
+            <span>
+              When assigned a task, this model receives document content — OCR-extracted text and draft
+              transcriptions (and rendered page images for image-based tasks). <b>That data leaves your
+              instance.</b>
+              @if (assistNeedsAck()) { You'll confirm egress to <code>{{ assistHost() }}</code> when you save. }
+              @else if (assist.acknowledgedHost) { Egress to <code>{{ assist.acknowledgedHost }}</code> is acknowledged. }
+            </span>
+          </div>
+        </app-settings-card>
+
         <!-- Advanced worker -->
         <app-settings-card icon="gear" heading="Advanced" purpose="Worker and upload limits for the media pipeline.">
           <div class="grid2">
@@ -273,6 +315,7 @@ const STAGES = [
 })
 export class ModelsComponent implements OnInit {
   private readonly http = inject(HttpClient);
+  private readonly confirmDialog = inject(ConfirmDialogService);
 
   // Button order: Auto first (it's the default), then OCR · VLM · Max ascending in capability.
   readonly MODES: DocMode[] = ['auto', 'ocr', 'vlm', 'max'];
@@ -288,6 +331,25 @@ export class ModelsComponent implements OnInit {
   lockedByInfra: string[] = [];
   visionApiKeyInput = '';
   sttApiKeyInput = '';
+  assistApiKeyInput = '';
+
+  // ── F11-b: external assist model ──
+  /** Live handle to the editable assist-model block (lazily initialised so the template can bind fields). */
+  get assist(): DocAssistCfg { return (this.form.documentProcessing ??= {}).assistModel ??= {}; }
+  assistLocked(): boolean { return this.isLocked('documentProcessing.assistModel'); }
+  assistUses(u: DocAssistUse): boolean { return this.assist.uses?.includes(u) ?? false; }
+  toggleAssistUse(u: DocAssistUse, on: boolean): void {
+    const set = new Set(this.assist.uses ?? []);
+    if (on) set.add(u); else set.delete(u);
+    this.assist.uses = [...set];
+  }
+  /** The endpoint host (for the egress acknowledgment), or '' when the URL is empty/invalid. */
+  assistHost(): string { try { return this.assist.baseUrl ? new URL(this.assist.baseUrl).host : ''; } catch { return ''; } }
+  /** True when a task is assigned to an endpoint whose host hasn't been acknowledged yet — save will prompt. */
+  assistNeedsAck(): boolean {
+    const host = this.assistHost();
+    return !!host && (this.assist.uses?.length ?? 0) > 0 && this.assist.acknowledgedHost !== host;
+  }
 
   /** The loaded doc-processing config (read-only fields like vlmModel live here). */
   private docCfgSig = signal<DocProcCfg>({});
@@ -299,9 +361,13 @@ export class ModelsComponent implements OnInit {
       next: cfg => {
         this.lockedByInfra = cfg.lockedByInfra ?? [];
         const dp: DocProcCfg = { mode: 'auto', renderDpi: 150, maxPages: 50, pageTimeoutMs: 60000, concurrency: 2, ...cfg.documentProcessing };
+        // F11-b — keep a copy of the assist model with `uses` always an array; the masked apiKey stays only
+        // so the template can show "key set" — it is never sent back (assistApiKeyInput carries changes).
+        dp.assistModel = { uses: [], ...cfg.documentProcessing?.assistModel };
         this.form = { vision: {}, stt: {}, ...cfg, documentProcessing: dp };
         this.form.vision = { ...cfg.vision, apiKey: undefined };
         this.form.stt = { ...cfg.stt, apiKey: undefined };
+        this.assistApiKeyInput = '';
         this.docCfgSig.set(dp);
         this.docMode.set(dp.mode ?? 'ocr');
         this.loading.set(false);
@@ -342,11 +408,38 @@ export class ModelsComponent implements OnInit {
   capVariant(model?: string): StatusVariant { return this.form.enabled ? (model ? 'active' : 'warn') : 'off'; }
   capLabel(model?: string): string { return !this.form.enabled ? 'Off' : (model ? 'Active' : 'No model'); }
 
-  save(): void {
+  async save(): Promise<void> {
+    const dp = this.form.documentProcessing ?? {};
+    const assist = dp.assistModel ?? {};
+    const uses = assist.uses ?? [];
+    const host = this.assistHost();
+
+    // F11-b — egress acknowledgment: assigning a task to an external endpoint whose host isn't yet
+    // acknowledged requires an explicit confirmation that document content leaves the instance.
+    if (!this.assistLocked() && this.assistNeedsAck()) {
+      const ok = await this.confirmDialog.confirm({
+        title: 'Send document content to an external model?',
+        message: `The model at ${host} will receive document content — OCR-extracted text and draft transcriptions (and rendered page images for image-based tasks). This data leaves your instance and is subject to that provider's handling. Enable egress to ${host}?`,
+        confirmLabel: 'Enable — I understand',
+        cancelLabel: 'Cancel',
+        danger: true,
+      });
+      if (!ok) return;              // not acknowledged → abort the whole save
+      assist.acknowledgedHost = host;
+    }
+
     this.saving.set(true);
     this.saveError.set('');
     this.saveOk.set('');
-    const dp = this.form.documentProcessing ?? {};
+    // Assist block: send baseUrl/model/uses/acknowledgedHost (+ apiKey only when the operator typed a new
+    // one — the masked value from GET is never echoed back). Omitted when locked by env.
+    const assistPayload: DocAssistCfg | undefined = this.assistLocked() ? undefined : {
+      baseUrl: assist.baseUrl || undefined,
+      model: assist.model || undefined,
+      uses,
+      acknowledgedHost: assist.acknowledgedHost,
+      ...(this.assistApiKeyInput ? { apiKey: this.assistApiKeyInput } : {}),
+    };
     const payload: MediaCfg = {
       enabled: this.form.enabled,
       visionProvider: this.form.visionProvider,
@@ -354,7 +447,10 @@ export class ModelsComponent implements OnInit {
       vision: { baseUrl: this.form.vision?.baseUrl, model: this.form.vision?.model, ...(this.visionApiKeyInput ? { apiKey: this.visionApiKeyInput } : {}) },
       stt: { baseUrl: this.form.stt?.baseUrl, model: this.form.stt?.model, ...(this.sttApiKeyInput ? { apiKey: this.sttApiKeyInput } : {}) },
       // Only the PATCH-writable doc fields (vlmModel/repairModel/URLs are env-only, never sent).
-      documentProcessing: { mode: dp.mode, renderDpi: dp.renderDpi, maxPages: dp.maxPages, pageTimeoutMs: dp.pageTimeoutMs, concurrency: dp.concurrency },
+      documentProcessing: {
+        mode: dp.mode, renderDpi: dp.renderDpi, maxPages: dp.maxPages, pageTimeoutMs: dp.pageTimeoutMs, concurrency: dp.concurrency,
+        ...(assistPayload ? { assistModel: assistPayload } : {}),
+      },
       fallbackToExternal: this.form.fallbackToExternal,
       maxFileSizeBytes: this.form.maxFileSizeBytes,
       workerConcurrency: this.form.workerConcurrency,
@@ -365,6 +461,7 @@ export class ModelsComponent implements OnInit {
         this.saveOk.set('Saved');
         this.visionApiKeyInput = '';
         this.sttApiKeyInput = '';
+        this.assistApiKeyInput = '';
         this.saving.set(false);
         setTimeout(() => this.saveOk.set(''), 3000);
       },

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2043,6 +2043,25 @@ content, and re-validates. If the repaired output passes it is accepted; if it e
 the extractor falls back to OCR — so the result is still never worse than plain OCR. Exactly one repair pass
 runs per document (bounded cost); consensus/verification is a later phase.
 
+**External assist model (F11-b) — hosted egress, opt-in and acknowledged.** By default every extraction path
+is local (the bundled Ollama VLM / OCR sidecar): no document content leaves your instance. You can optionally
+point a **bigger, external model** at specific tasks under `documentProcessing.assistModel`:
+
+| Field | Description |
+|---|---|
+| `baseUrl` | External **OpenAI-compatible** endpoint (`POST {baseUrl}/v1/chat/completions`). Validated against SSRF on save (must be a public http(s) URL — no private/loopback/metadata addresses) and reached only through the SSRF-guarded fetch. Env: `DOC_ASSIST_URL`. |
+| `model` | Model tag to request. Env: `DOC_ASSIST_MODEL`. |
+| `apiKey` | Optional bearer token. Stored in `secrets.json` (never `config.json`), masked in the admin API. Env: `DOC_ASSIST_API_KEY`. |
+| `uses` | Which tasks the external model powers — `["repair"]` today (the `max`-mode repair pass); more are planned. Empty ⇒ configured but inert (no egress). |
+| `acknowledgedHost` | The endpoint host the operator acknowledged egress to. **Required to match `baseUrl`'s host whenever `uses` is non-empty** — the admin API rejects the save otherwise, and the extractor re-checks it at runtime, so document content never leaves the box without recorded consent. |
+
+⚠️ **This is the only setting that sends document content off the instance.** When a task is assigned, the
+external model receives OCR-extracted text and draft transcriptions (and, for future image-based tasks,
+rendered page images). Settings → Models surfaces an **acknowledgment dialog** on save that states exactly
+what egresses to which host; that acknowledgment sets `acknowledgedHost`. Pinning `DOC_ASSIST_URL` (etc.) via
+env locks the whole block read-only in the UI. When no assist model is configured, or its `uses` is empty, the
+repair pass stays entirely local exactly as before.
+
 **Example `config.json` excerpt:**
 
 ```json

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -534,6 +534,12 @@ Fields shown with an **env** badge cannot be changed from the UI — they are pi
 
 When both providers are set to *Local*, no file content ever leaves your instance. Switching to *External* sends image frames or audio segments to the configured endpoint — review your data residency policy before doing so.
 
+### External assist model (documents)
+
+The **External assist model** card lets you point a bigger, hosted model at specific document tasks — currently the **document repair pass** used by `max` extraction mode. It's off unless you both fill in an **Endpoint** + **Model** *and* tick a task under **Used for**.
+
+This is the one document setting that sends content off your instance: when a task is assigned, the model receives OCR-extracted text and draft transcriptions (and, for future image tasks, rendered page images). Because of that, saving with a task assigned pops an **acknowledgment dialog** naming exactly what data goes to which host — you must confirm before it's enabled, and Ythril records that consent so content is never sent to a host you didn't acknowledge. Endpoints are checked to be public addresses, and the API key is stored in the encrypted secrets file. Leave it unconfigured (or untick every task) to keep document processing fully local.
+
 ---
 
 ### Face Recognition

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -10,7 +10,7 @@
 
 import { Router } from 'express';
 import { z } from 'zod';
-import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets } from '../config/loader.js';
+import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets, getDocAssistApiKey } from '../config/loader.js';
 import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl } from '../util/ssrf.js';
@@ -49,6 +49,16 @@ const ProviderPatchSchema = z.object({
 
 // F11 — document-processing / extraction settings. Shallow-merged like `vision`/`stt`: the client sends
 // the full block. `ocr` mode = today's behaviour; `vlm`/`auto`/`max` opt into the VLM pipeline.
+// F11-b — external assist model. `apiKey` is split into secrets.json (like vision/stt). `acknowledgedHost`
+// records the operator's egress consent; the handler requires it to match `baseUrl`'s host when `uses` is set.
+const AssistModelPatchSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  model: z.string().max(128).optional(),
+  apiKey: z.string().max(512).optional().nullable(),
+  uses: z.array(z.enum(['repair'])).max(8).optional(),
+  acknowledgedHost: z.string().max(255).optional(),
+}).strict();
+
 const DocumentProcessingPatchSchema = z.object({
   strategy: z.enum(['hi_res', 'auto', 'fast', 'ocr_only']).optional(),
   extractImages: z.boolean().optional(),
@@ -57,6 +67,7 @@ const DocumentProcessingPatchSchema = z.object({
   maxPages: z.number().int().min(1).max(2_000).optional(),
   pageTimeoutMs: z.number().int().min(1_000).max(600_000).optional(),
   concurrency: z.number().int().min(1).max(8).optional(),
+  assistModel: AssistModelPatchSchema.optional(),
 }).strict();
 
 const MediaConfigPatchSchema = z.object({
@@ -112,6 +123,40 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     return;
   }
 
+  // ── F11-b: external assist model — locked check + SSRF + egress-acknowledgment enforcement ──
+  // This is the only path that sends document content OFF the instance, so a `uses`-active endpoint must be
+  // (a) SSRF-safe and (b) acknowledged: `acknowledgedHost` must match the endpoint host. The client's
+  // acknowledgment modal sets that field; enforcing it here makes the consent auditable, not just UI.
+  const assistPatch = parsed.data.documentProcessing?.assistModel;
+  if (assistPatch !== undefined && locked.has('documentProcessing.assistModel')) {
+    res.status(403).json({
+      error: 'The external assist model is locked by infrastructure env vars and cannot be changed via the UI',
+      locked: ['documentProcessing.assistModel'],
+    });
+    return;
+  }
+  if (assistPatch) {
+    const existingAssist = activeCfg.documentProcessing?.assistModel ?? {};
+    const effBaseUrl = assistPatch.baseUrl ?? existingAssist.baseUrl;
+    const effUses = assistPatch.uses ?? existingAssist.uses ?? [];
+    const effAck = assistPatch.acknowledgedHost ?? existingAssist.acknowledgedHost;
+    if (effUses.length > 0 && effBaseUrl) {
+      if (!isSsrfSafeUrl(effBaseUrl)) {
+        res.status(400).json({ error: 'assistModel.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+        return;
+      }
+      let host: string;
+      try { host = new URL(effBaseUrl).host; } catch { res.status(400).json({ error: 'assistModel.baseUrl is not a valid URL' }); return; }
+      if (effAck !== host) {
+        res.status(400).json({
+          error: `Egress to ${host} must be acknowledged before the external assist model can be used: document content (OCR text, and page images for image-based uses) would be sent there.`,
+          needsAcknowledgment: host,
+        });
+        return;
+      }
+    }
+  }
+
   try {
     // ── Split sensitive fields into secrets.json ─────────────────────────────
     // API keys are credentials and live alongside peerTokens / TOTP secret in
@@ -122,8 +167,12 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     const sttApiKeyChange = (parsed.data.stt && 'apiKey' in parsed.data.stt)
       ? parsed.data.stt.apiKey ?? null
       : undefined;
+    // F11-b — the external assist model's key lives in secrets too (mediaEmbedding.docAssistApiKey).
+    const assistApiKeyChange = (assistPatch && 'apiKey' in assistPatch)
+      ? assistPatch.apiKey ?? null
+      : undefined;
 
-    if (visionApiKeyChange !== undefined || sttApiKeyChange !== undefined) {
+    if (visionApiKeyChange !== undefined || sttApiKeyChange !== undefined || assistApiKeyChange !== undefined) {
       const secrets = getSecrets();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sAny = secrets as any;
@@ -135,6 +184,10 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
       if (sttApiKeyChange !== undefined) {
         if (sttApiKeyChange === null || sttApiKeyChange === '') delete sAny.mediaEmbedding.sttApiKey;
         else sAny.mediaEmbedding.sttApiKey = sttApiKeyChange;
+      }
+      if (assistApiKeyChange !== undefined) {
+        if (assistApiKeyChange === null || assistApiKeyChange === '') delete sAny.mediaEmbedding.docAssistApiKey;
+        else sAny.mediaEmbedding.docAssistApiKey = assistApiKeyChange;
       }
       saveSecrets(secrets);
     }
@@ -155,6 +208,20 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
       delete s['apiKey'];
       merged['stt'] = s;
     }
+    // F11-b — DEEP-merge documentProcessing so a patch that omits `assistModel` (e.g. just changing `mode`)
+    // does NOT wipe the stored external-assist config, and strip its apiKey out to secrets.json.
+    if (parsed.data.documentProcessing) {
+      const dpMerged: Record<string, unknown> = {
+        ...(existing.documentProcessing as Record<string, unknown> ?? {}),
+        ...parsed.data.documentProcessing,
+      };
+      if (assistPatch) {
+        const a = { ...assistPatch } as Record<string, unknown>;
+        delete a['apiKey']; // never in config.json
+        dpMerged['assistModel'] = a;
+      }
+      merged['documentProcessing'] = dpMerged;
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cfg.mediaEmbedding = merged as any;
     saveConfig(cfg);
@@ -170,9 +237,15 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
 
 function maskSecrets(cfg: ReturnType<typeof getMediaEmbeddingConfig>): unknown {
   const mask = (v: string | undefined) => v ? '••••••••' : undefined;
+  // F11-b — the assist model's key lives in secrets, not in the resolved documentProcessing block; surface a
+  // masked indicator so the UI can show "key set" without ever returning the secret.
+  const dp = cfg.documentProcessing;
   return {
     ...cfg,
     vision: cfg.vision ? { ...cfg.vision, apiKey: mask(cfg.vision.apiKey) } : cfg.vision,
     stt: cfg.stt ? { ...cfg.stt, apiKey: mask(cfg.stt.apiKey) } : cfg.stt,
+    documentProcessing: dp?.assistModel
+      ? { ...dp, assistModel: { ...dp.assistModel, apiKey: mask(getDocAssistApiKey()) } }
+      : dp,
   };
 }

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -591,6 +591,11 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   if (sttModelEnv) locked.push('stt.model');
   if (sttApiKeyEnv) locked.push('stt.apiKey');
 
+  // F11-b — when the external assist model's endpoint is pinned by env, lock the whole block in the UI.
+  if (process.env['DOC_ASSIST_URL'] || process.env['DOC_ASSIST_MODEL'] || process.env['DOC_ASSIST_API_KEY']) {
+    locked.push('documentProcessing.assistModel');
+  }
+
   return {
     enabled,
     visionProvider,
@@ -626,6 +631,7 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   vlmBaseUrl: '',  // empty = reuse the media vision provider's (Ollama) URL
   repairModel: '',   // empty = reuse vlmModel for the max-mode repair pass
   repairBaseUrl: '', // empty = reuse vlmBaseUrl (then the vision URL)
+  assistModel: {},   // F11-b — no external assist model by default (resolved with env overrides above)
 };
 
 /**
@@ -649,7 +655,23 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
     repairModel: process.env['DOC_REPAIR_MODEL'] ?? base.repairModel ?? d.repairModel,
     repairBaseUrl: process.env['DOC_REPAIR_URL'] ?? base.repairBaseUrl ?? d.repairBaseUrl,
+    // F11-b — external assist model. Env (DOC_ASSIST_URL/MODEL) pins baseUrl/model over config; `uses` and
+    // `acknowledgedHost` are config-only (they encode operator intent + consent). apiKey lives in secrets —
+    // read it via getDocAssistApiKey(). Absent baseUrl ⇒ no external assist model.
+    assistModel: {
+      baseUrl: process.env['DOC_ASSIST_URL'] ?? base.assistModel?.baseUrl,
+      model: process.env['DOC_ASSIST_MODEL'] ?? base.assistModel?.model,
+      uses: base.assistModel?.uses ?? [],
+      acknowledgedHost: base.assistModel?.acknowledgedHost,
+    },
   };
+}
+
+/** F11-b — the external assist model's API key: env (DOC_ASSIST_API_KEY) > secrets.json. Never in config.json. */
+export function getDocAssistApiKey(): string | undefined {
+  if (process.env['DOC_ASSIST_API_KEY']) return process.env['DOC_ASSIST_API_KEY'];
+  try { return (getSecrets().mediaEmbedding as { docAssistApiKey?: string } | undefined)?.docAssistApiKey; }
+  catch { return undefined; }
 }
 
 // ── Face Recognition Config ──────────────────────────────────────────────────

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -393,7 +393,30 @@ export interface DocumentProcessingConfig {
    * Env: `DOC_REPAIR_URL`.
    */
   repairBaseUrl?: string;
+  /**
+   * F11-b — an **external** "assist model" (a bigger, hosted LLM the operator points Ythril at) and what
+   * it is used for. Distinct from the bundled local VLM: this is the only place document content is sent
+   * OFF the instance, so it is opt-in and gated by an explicit acknowledgment. `apiKey` is NOT stored here
+   * — it lives in `secrets.json` (`mediaEmbedding.docAssistApiKey`). Absent = no external assist model.
+   */
+  assistModel?: DocAssistModelConfig;
 }
+
+/** F11-b — external assist-model configuration. OpenAI-compatible endpoint reached via `ssrfSafeFetch`. */
+export interface DocAssistModelConfig {
+  /** External OpenAI-compatible base URL (e.g. `https://api.example.com`). SSRF-validated on save. */
+  baseUrl?: string;
+  /** Model tag to request (e.g. `gpt-4o`, a hosted Llama, …). */
+  model?: string;
+  /** What the external model powers. `repair` (the max-mode reconciliation pass) today; more TBD. */
+  uses?: DocAssistUse[];
+  /** The host (`new URL(baseUrl).host`) the operator acknowledged document egress to. Must match `baseUrl`'s
+   *  host while `uses` is non-empty — re-acknowledged when the endpoint host changes. Records consent. */
+  acknowledgedHost?: string;
+}
+
+/** F11-b — tasks an external assist model can be assigned to. Extensible (transcribe / verify are later). */
+export type DocAssistUse = 'repair';
 
 /** F11 — document-extraction mode: OCR-only (default) vs the VLM precision pipeline. */
 export type DocExtractionMode = 'ocr' | 'vlm' | 'auto' | 'max';

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -1,12 +1,17 @@
 /**
- * VLM client for document transcription (F11) — local Ollama path.
+ * VLM client for document transcription (F11).
  *
  * Sends a rendered page image + a strict verbatim-transcription prompt to an Ollama vision model
  * (`/api/chat` with `images`), mirroring the media vision provider's request shape. Output is bounded
  * (`num_predict`) and temperature 0 for determinism. Throws on unreachable/error so the extractor can
- * fall back to OCR. External (hosted OpenAI-compatible) endpoints — and routing their egress through
- * `ssrfSafeFetch` — are a later phase; this is the bundled, no-egress path.
+ * fall back to OCR.
+ *
+ * `repairMarkdown` uses the bundled local Ollama (no egress). `repairMarkdownExternal` (F11-b) is the ONE
+ * path that sends document content OFF the instance — to an operator-configured external OpenAI-compatible
+ * "assist model" — so it is routed through `ssrfSafeFetch` and is only reached after an explicit egress
+ * acknowledgment (enforced at config-save time).
  */
+import { ssrfSafeFetch } from '../../util/ssrf.js';
 
 export interface VlmTranscription {
   text: string;
@@ -75,11 +80,54 @@ const REPAIR_PROMPT =
 export async function repairMarkdown(
   opts: { baseUrl: string; model: string; draft: string; evidence: string; issues?: string[]; timeoutMs?: number },
 ): Promise<VlmTranscription> {
-  const issues = opts.issues?.length ? `\n\nValidation flagged: ${opts.issues.join('; ')}.` : '';
-  const content = `${REPAIR_PROMPT}${issues}\n\n--- DRAFT ---\n${opts.draft}\n\n--- OCR TEXT ---\n${opts.evidence}`;
   return postChat(
     opts.baseUrl, opts.model,
-    [{ role: 'user', content }], // text-only — no page image
+    [{ role: 'user', content: repairContent(opts.draft, opts.evidence, opts.issues) }], // text-only — no page image
     opts.timeoutMs ?? 60_000,
   );
+}
+
+/** Build the shared repair user-message content (draft + OCR evidence + flagged issues). */
+function repairContent(draft: string, evidence: string, issues?: string[]): string {
+  const flagged = issues?.length ? `\n\nValidation flagged: ${issues.join('; ')}.` : '';
+  return `${REPAIR_PROMPT}${flagged}\n\n--- DRAFT ---\n${draft}\n\n--- OCR TEXT ---\n${evidence}`;
+}
+
+/**
+ * F11-b — reconcile a draft against OCR evidence via an **external** OpenAI-compatible chat endpoint (the
+ * operator-configured "assist model"). Routed through `ssrfSafeFetch` — this is the one path that sends
+ * document content (draft + OCR text) off the instance — and Bearer-authenticated when an `apiKey` is given.
+ * Throws on unreachable/HTTP error so the caller falls back to the local repair, then OCR.
+ */
+export async function repairMarkdownExternal(
+  opts: { baseUrl: string; model: string; apiKey?: string; draft: string; evidence: string; issues?: string[]; timeoutMs?: number },
+): Promise<VlmTranscription> {
+  const url = `${opts.baseUrl.replace(/\/$/, '')}/v1/chat/completions`;
+  let res: Response;
+  try {
+    res = await ssrfSafeFetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(opts.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : {}),
+      },
+      body: JSON.stringify({
+        model: opts.model,
+        temperature: 0,
+        max_tokens: MAX_OUTPUT_TOKENS,
+        messages: [{ role: 'user', content: repairContent(opts.draft, opts.evidence, opts.issues) }],
+      }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 60_000),
+    });
+  } catch (err) {
+    throw new Error(`assist model unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`assist model HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = await res.json() as { choices?: Array<{ message?: { content?: string }; finish_reason?: string }>; error?: unknown };
+  if (json.error) throw new Error(`assist model error: ${typeof json.error === 'string' ? json.error : JSON.stringify(json.error).slice(0, 200)}`);
+  const choice = json.choices?.[0];
+  return { text: choice?.message?.content ?? '', truncated: choice?.finish_reason === 'length' };
 }

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -13,11 +13,11 @@
  * (with ssrfSafeFetch) are later phases.
  */
 import { log } from '../../util/log.js';
-import { getDocumentProcessingConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
+import { getDocumentProcessingConfig, getMediaEmbeddingConfig, getDocAssistApiKey } from '../../config/loader.js';
 import type { DocExtractionMode } from '../../config/types.js';
 import { UnstructuredConverter, type UnstructuredResult } from './unstructured.js';
 import { renderDocumentPages, isRenderAvailableFor } from './renderer.js';
-import { transcribePageImage, repairMarkdown } from './vlm-client.js';
+import { transcribePageImage, repairMarkdown, repairMarkdownExternal } from './vlm-client.js';
 import { decideRoute, validateExtraction } from './extraction-policy.js';
 
 const TRANSCRIBE_PROMPT =
@@ -92,14 +92,27 @@ export async function vlmExtractDocument(
     // Only for `max` (route has the repair stage) and only when we have OCR evidence to reconcile against.
     // Repair can only turn a fallback into an acceptance — it never degrades a result that already passed.
     if (route.stages.includes('repair') && ocr && evidence.trim()) {
-      const repairModel = cfg.repairModel || cfg.vlmModel;
-      const repairBase = cfg.repairBaseUrl || baseUrl;
+      // F11-b — route repair to the external assist model when it's configured for `repair` AND its egress
+      // host has been acknowledged. The host-match is re-checked HERE so document content never leaves the
+      // instance without recorded consent, even if config.json were hand-edited to add `uses` without an ack.
+      const assist = cfg.assistModel;
+      let useExternal = false;
+      if (assist?.baseUrl && assist.model && assist.uses?.includes('repair')) {
+        try { useExternal = assist.acknowledgedHost === new URL(assist.baseUrl).host; } catch { useExternal = false; }
+        if (!useExternal) log.warn('VLM extract: assist model set for repair but its egress host is not acknowledged — using local repair');
+      }
+      const repairModel = useExternal ? assist!.model! : (cfg.repairModel || cfg.vlmModel);
       try {
-        log.info(`VLM extract: validation failed (${v.issues.join('; ')}) — repairing with ${repairModel}`);
-        const r = await repairMarkdown({
-          baseUrl: repairBase, model: repairModel, draft: markdown, evidence, issues: v.issues,
-          timeoutMs: cfg.pageTimeoutMs,
-        });
+        log.info(`VLM extract: validation failed (${v.issues.join('; ')}) — repairing with ${useExternal ? 'external ' : ''}${repairModel}`);
+        const r = useExternal
+          ? await repairMarkdownExternal({
+              baseUrl: assist!.baseUrl!, model: assist!.model!, apiKey: getDocAssistApiKey(),
+              draft: markdown, evidence, issues: v.issues, timeoutMs: cfg.pageTimeoutMs,
+            })
+          : await repairMarkdown({
+              baseUrl: cfg.repairBaseUrl || baseUrl, model: repairModel, draft: markdown, evidence, issues: v.issues,
+              timeoutMs: cfg.pageTimeoutMs,
+            });
         const repaired = r.text.trim();
         const rv = validateExtraction(repaired, evidence, { finishReason: r.truncated ? 'length' : undefined });
         if (rv.ok) {

--- a/testing/integration/media-config.test.js
+++ b/testing/integration/media-config.test.js
@@ -123,3 +123,56 @@ describe('Media config — documentProcessing (F11)', () => {
     assert.equal(r.status, 400, JSON.stringify(r.body));
   });
 });
+
+// ── F11-b — external assist model (hosted egress) ─────────────────────────────
+
+describe('Media config — external assist model (F11-b)', () => {
+  before(async () => {
+    tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  });
+  after(async () => {
+    // Disable egress (uses: []) so no external routing leaks into other suites.
+    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: { assistModel: { uses: [] } } }).catch(() => {});
+  });
+
+  it('assigning a use to an endpoint WITHOUT acknowledgment is rejected (egress gate)', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', {
+      documentProcessing: { assistModel: { baseUrl: 'https://assist.example.com', model: 'big', uses: ['repair'] } },
+    });
+    // Rejected either as unacknowledged egress or (if DNS unavailable) as SSRF-unsafe — both are 400.
+    assert.equal(r.status, 400, `expected rejection, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('configuring the endpoint with NO uses is allowed (no egress yet) and round-trips', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', {
+      documentProcessing: { assistModel: { baseUrl: 'https://assist.example.com', model: 'big', uses: [] } },
+    });
+    assert.equal(r.status, 200, `expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
+    const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    assert.equal(reread.body?.documentProcessing?.assistModel?.baseUrl, 'https://assist.example.com');
+    assert.deepEqual(reread.body?.documentProcessing?.assistModel?.uses, []);
+  });
+
+  it('a mode-only documentProcessing PATCH does not wipe the assist config (deep-merge)', async () => {
+    // (endpoint set by the previous test) — change only the mode.
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'ocr' } });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    assert.equal(reread.body?.documentProcessing?.assistModel?.baseUrl, 'https://assist.example.com',
+      'assist config must survive a mode-only patch');
+  });
+
+  it('the assist API key is never returned in plaintext (masked in GET)', async () => {
+    const set = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', {
+      documentProcessing: { assistModel: { baseUrl: 'https://assist.example.com', model: 'big', uses: [], apiKey: 'sk-secret-xyz' } },
+    });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+    const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    const key = reread.body?.documentProcessing?.assistModel?.apiKey;
+    assert.ok(key && !key.includes('sk-secret-xyz'), `key must be masked, got: ${key}`);
+    // Clear the stored key.
+    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { documentProcessing: { assistModel: { uses: [], apiKey: null } } }).catch(() => {});
+  });
+});

--- a/testing/standalone/media-config.test.js
+++ b/testing/standalone/media-config.test.js
@@ -44,6 +44,8 @@ function writeConfig(extra = {}) {
 
 describe('getMediaEmbeddingConfig', () => {
   let getMediaEmbeddingConfig;
+  let getDocumentProcessingConfig;
+  let getDocAssistApiKey;
 
   const ENV_KEYS = [
     'MEDIA_EMBEDDING_ENABLED', 'VISION_PROVIDER', 'STT_PROVIDER',
@@ -51,6 +53,7 @@ describe('getMediaEmbeddingConfig', () => {
     'WHISPER_URL', 'WHISPER_MODEL', 'STT_API_KEY',
     'WORKER_CONCURRENCY', 'WORKER_POLL_INTERVAL_MS', 'WORKER_MAX_POLL_INTERVAL_MS',
     'MEDIA_EMBEDDING_FALLBACK_TO_EXTERNAL', 'MAX_FILE_SIZE_BYTES', 'STALLED_JOB_TIMEOUT_MS',
+    'DOC_ASSIST_URL', 'DOC_ASSIST_MODEL', 'DOC_ASSIST_API_KEY',
   ];
 
   function clearEnv() {
@@ -64,6 +67,8 @@ describe('getMediaEmbeddingConfig', () => {
     // Dynamic import AFTER env is set so CONFIG_PATH is read at correct time.
     const mod = await import('../../server/dist/config/loader.js');
     getMediaEmbeddingConfig = mod.getMediaEmbeddingConfig;
+    getDocumentProcessingConfig = mod.getDocumentProcessingConfig;
+    getDocAssistApiKey = mod.getDocAssistApiKey;
     _reloadConfig = mod.reloadConfig;
     // Must call loadConfig() once to initialise _config before any test runs.
     mod.loadConfig();
@@ -260,6 +265,46 @@ describe('getMediaEmbeddingConfig', () => {
       assert.ok(cfg.lockedByInfra?.includes('vision.baseUrl'));
       assert.ok(cfg.lockedByInfra?.includes('vision.model'));
       assert.ok(cfg.lockedByInfra?.includes('stt.baseUrl'));
+    });
+  });
+
+  // ── F11-b: external assist model ──────────────────────────────────────────────
+  describe('assist model (F11-b)', () => {
+    it('absent by default → empty block, no key, no lock', () => {
+      writeConfig();
+      const dp = getDocumentProcessingConfig();
+      assert.equal(dp.assistModel.baseUrl, undefined);
+      assert.deepEqual(dp.assistModel.uses, []);
+      assert.equal(getDocAssistApiKey(), undefined);
+      assert.equal(getMediaEmbeddingConfig().lockedByInfra?.includes('documentProcessing.assistModel'), false);
+    });
+
+    it('resolves baseUrl/model/uses/acknowledgedHost from config.json', () => {
+      writeConfig({ mediaEmbedding: { documentProcessing: { assistModel: {
+        baseUrl: 'https://api.example.com', model: 'big-llm', uses: ['repair'], acknowledgedHost: 'api.example.com',
+      } } } });
+      const dp = getDocumentProcessingConfig();
+      assert.equal(dp.assistModel.baseUrl, 'https://api.example.com');
+      assert.equal(dp.assistModel.model, 'big-llm');
+      assert.deepEqual(dp.assistModel.uses, ['repair']);
+      assert.equal(dp.assistModel.acknowledgedHost, 'api.example.com');
+    });
+
+    it('DOC_ASSIST_URL / DOC_ASSIST_MODEL env override config and lock the block', () => {
+      process.env['DOC_ASSIST_URL'] = 'https://env.example.com';
+      process.env['DOC_ASSIST_MODEL'] = 'env-model';
+      writeConfig({ mediaEmbedding: { documentProcessing: { assistModel: { baseUrl: 'https://cfg.example.com', model: 'cfg-model' } } } });
+      const dp = getDocumentProcessingConfig();
+      assert.equal(dp.assistModel.baseUrl, 'https://env.example.com', 'env baseUrl wins');
+      assert.equal(dp.assistModel.model, 'env-model', 'env model wins');
+      assert.ok(getMediaEmbeddingConfig().lockedByInfra?.includes('documentProcessing.assistModel'));
+    });
+
+    it('getDocAssistApiKey reads DOC_ASSIST_API_KEY from env', () => {
+      process.env['DOC_ASSIST_API_KEY'] = 'sk-env-123';
+      writeConfig();
+      assert.equal(getDocAssistApiKey(), 'sk-env-123');
+      assert.ok(getMediaEmbeddingConfig().lockedByInfra?.includes('documentProcessing.assistModel'));
     });
   });
 });


### PR DESCRIPTION
## What

Adds an optional **external** (hosted, OpenAI-compatible) model that an operator assigns to specific document tasks — `repair` (the `max`-mode reconciliation pass) today, extensible. It is the **only** path that sends document content off the instance, so it's gated end-to-end.

## Egress contract (opt-in + clearly marked)

- **Off by default.** Requires both an endpoint **and** an assigned task (`uses`) — otherwise inert.
- **SSRF-validated** endpoint, reached only through `ssrfSafeFetch`.
- **Acknowledgment gate:** assigning a task pops a danger dialog naming exactly what egresses (OCR text + draft transcriptions, page images for image tasks) to which host. Consent is recorded as `acknowledgedHost` and **enforced server-side + re-checked at runtime** — content never leaves the box to an unacknowledged host, even if `config.json` is hand-edited.
- **API key** in `secrets.json` (masked in GET, never echoed back).
- Env-pinning (`DOC_ASSIST_URL`/`DOC_ASSIST_MODEL`/`DOC_ASSIST_API_KEY`) locks the block read-only.

## Where it plugs in

`vlm-extract` routes the `max`-mode repair pass to the external model when it's configured for `repair` and acknowledged; otherwise the existing **local** repair runs, else OCR — so it's never worse than before.

## Tests

- 4 standalone loader cases (assistModel resolution, `DOC_ASSIST_*` env override + `lockedByInfra`, `getDocAssistApiKey`).
- 4 media-config integration cases (egress gate rejects unacknowledged use, no-use config allowed, mode-only PATCH preserves assist config via deep-merge, API key masked in GET).

Server + client build green; standalone suite passes; docs lint clean.

**Verify note:** validated via build + unit + integration tests; a live Playwright pass of the acknowledgment-dialog flow wasn't run for this PR (the CI integration suite exercises the server-side gate live). Happy to run it if preferred.

Docs: integration-guide (`assistModel` table + egress warning) + userguide (privacy note); CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)