### PR TITLE
feat(files): max-mode consensus pass for document extraction (F11-d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`max`-mode consensus pass for document extraction (F11-d).** When a second document VLM is configured
+  (`documentProcessing.verifyModel` / `DOC_VERIFY_MODEL`), `max` mode now adds one bounded **consensus** step
+  on an already-accepted VLM draft: the verify model independently re-transcribes the pages, that draft is
+  reconciled with the primary against the OCR text, and the **highest-OCR-coverage** of the three candidates
+  (primary, second draft, reconciled) is kept. The primary is always a candidate and ties keep it, so
+  consensus **can only match or beat** the primary — never regress it; any error keeps the primary. It's
+  bounded (one extra transcription set + one reconcile call, same max-pages cap) and off by default (empty
+  `verifyModel` ⇒ unchanged behaviour). Settings → Models shows the verify stage in the pipeline diagram and a
+  read-only verify-model chip. New pure `bestByEvidence` arbitration unit tests.
+
 - **Optional external "assist model" for document extraction — opt-in, acknowledged egress (F11-b).** Until
   now every extraction path was local (the bundled Ollama VLM / OCR sidecar) and no document content ever left
   the instance. You can now point a **bigger, hosted OpenAI-compatible model** at specific tasks under

--- a/client/src/app/pages/settings/models.component.ts
+++ b/client/src/app/pages/settings/models.component.ts
@@ -22,6 +22,7 @@ interface DocProcCfg {
   renderDpi?: number; maxPages?: number; pageTimeoutMs?: number; concurrency?: number;
   // read-only (env/config-file only — never PATCHed from here)
   vlmModel?: string; vlmBaseUrl?: string; repairModel?: string; repairBaseUrl?: string;
+  verifyModel?: string; verifyBaseUrl?: string;
   assistModel?: DocAssistCfg;
 }
 
@@ -42,14 +43,14 @@ const MODE_DESC: Record<DocMode, string> = {
   ocr:  'The OCR sidecar (Tesseract) reads text and tables from each page. Fast, fully local, no vision model needed.',
   vlm:  'Render each page and transcribe it with the vision model, grounded on the OCR text.',
   auto: 'Use the vision model when it’s available, otherwise fall back to OCR automatically.',
-  max:  'VLM plus a repair pass that reconciles the draft against the OCR text before accepting.',
+  max:  'VLM, a repair pass that reconciles the draft against the OCR text, plus an optional second-model consensus pass when a verify model is set.',
 };
 // Which pipeline stages are active per mode (drives the diagram).
 const MODE_STAGES: Record<DocMode, Set<string>> = {
   ocr:  new Set(['ocr']),
   vlm:  new Set(['ocr', 'render', 'vlm', 'validate']),
   auto: new Set(['ocr', 'render', 'vlm', 'validate']),
-  max:  new Set(['ocr', 'render', 'vlm', 'validate', 'repair']),
+  max:  new Set(['ocr', 'render', 'vlm', 'validate', 'repair', 'verify']),
 };
 const STAGES = [
   { key: 'ocr', nm: 'OCR', sub: 'evidence' },
@@ -57,6 +58,7 @@ const STAGES = [
   { key: 'vlm', nm: 'VLM', sub: 'vision' },
   { key: 'validate', nm: 'Validate', sub: 'coverage' },
   { key: 'repair', nm: 'Repair', sub: 'reconcile' },
+  { key: 'verify', nm: 'Verify', sub: 'consensus' },
 ];
 
 @Component({
@@ -243,8 +245,9 @@ const STAGES = [
           <div class="envrow">
             <span class="envchip" [class.empty]="!docCfg().vlmModel"><span class="lbl">vision model</span>{{ docCfg().vlmModel || '— not set' }}</span>
             <span class="envchip" [class.empty]="!docCfg().repairModel"><span class="lbl">repair model</span>{{ docCfg().repairModel || 'reuses vision' }}</span>
+            <span class="envchip" [class.empty]="!docCfg().verifyModel"><span class="lbl">verify model</span>{{ docCfg().verifyModel || '— none (no consensus)' }}</span>
           </div>
-          <p class="hint">Model &amp; endpoint values are set via environment (<code style="font-family:var(--font-mono,monospace)">DOC_VLM_MODEL</code>, <code style="font-family:var(--font-mono,monospace)">DOC_REPAIR_MODEL</code>) and shown read-only — they're egress targets, deliberately kept out of the web API.</p>
+          <p class="hint">Model &amp; endpoint values are set via environment (<code style="font-family:var(--font-mono,monospace)">DOC_VLM_MODEL</code>, <code style="font-family:var(--font-mono,monospace)">DOC_REPAIR_MODEL</code>, <code style="font-family:var(--font-mono,monospace)">DOC_VERIFY_MODEL</code>) and shown read-only. For a bigger <em>hosted</em> model, use the External assist model below.</p>
 
           <details class="adv">
             <summary>Advanced — rendering &amp; limits</summary>

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2028,6 +2028,8 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 | `vlmBaseUrl` | `""` | Endpoint for the VLM. Empty ⇒ falls back to the media vision provider's `baseUrl`, then `http://ollama:11434`. Env override: `DOC_VLM_URL`. |
 | `repairModel` | `""` | **`max` mode only.** Model used for the repair pass when a page's VLM output fails OCR-evidence validation — it reconciles the draft against the OCR text in one extra text-only call. Empty ⇒ reuses `vlmModel`. Set this to wire in a stronger model you host. Env override: `DOC_REPAIR_MODEL`. |
 | `repairBaseUrl` | `""` | Endpoint for the repair model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_REPAIR_URL`. |
+| `verifyModel` | `""` | **`max` mode only (F11-d consensus).** A *second* document VLM. When set, `max` runs it as an independent second transcription of each page, reconciles it with the primary draft against the OCR text, and keeps the highest-coverage result — **never worse** than the primary. Empty ⇒ no consensus pass. Best set to a *different* model than `vlmModel`. Env override: `DOC_VERIFY_MODEL`. |
+| `verifyBaseUrl` | `""` | Endpoint for the verify model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_VERIFY_URL`. |
 | `renderDpi` | `150` | Page rasterization DPI for the render sidecar (VLM modes only). |
 | `maxPages` | `50` | Cap on pages rendered/transcribed per document (VLM modes only). |
 | `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
@@ -2041,7 +2043,16 @@ Ythril transparently uses OCR — no upload fails because a model isn't wired in
 OCR text to `repairModel` (or `vlmModel` if unset) in a single text-only call, asks it to restore any dropped
 content, and re-validates. If the repaired output passes it is accepted; if it errors or still doesn't pass,
 the extractor falls back to OCR — so the result is still never worse than plain OCR. Exactly one repair pass
-runs per document (bounded cost); consensus/verification is a later phase.
+runs per document (bounded cost).
+
+**Consensus pass (`max` mode, F11-d).** When a `verifyModel` is configured, `max` mode adds one bounded
+**consensus** step on top of an already-accepted draft: the verify model independently transcribes the pages
+(a second, ideally different, VLM), that draft is reconciled with the primary against the OCR text, and the
+highest-OCR-coverage of the three candidates (primary, second draft, reconciled) is kept. Because the primary
+is always a candidate and ties keep it, consensus **can only match or beat** the primary's coverage — never
+regress it. It is failure-tolerant (any error keeps the primary) and bounded (one extra transcription set +
+one reconcile call, subject to the same max-pages cap). Empty `verifyModel` ⇒ no consensus pass, unchanged
+behaviour. Consensus arbitrates by OCR-evidence coverage; N-pass entropy voting is a possible future refinement.
 
 **External assist model (F11-b) — hosted egress, opt-in and acknowledged.** By default every extraction path
 is local (the bundled Ollama VLM / OCR sidecar): no document content leaves your instance. You can optionally

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -631,6 +631,8 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   vlmBaseUrl: '',  // empty = reuse the media vision provider's (Ollama) URL
   repairModel: '',   // empty = reuse vlmModel for the max-mode repair pass
   repairBaseUrl: '', // empty = reuse vlmBaseUrl (then the vision URL)
+  verifyModel: '',   // F11-d — empty = no max-mode consensus pass
+  verifyBaseUrl: '', // empty = reuse vlmBaseUrl (then the vision URL)
   assistModel: {},   // F11-b — no external assist model by default (resolved with env overrides above)
 };
 
@@ -655,6 +657,8 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
     repairModel: process.env['DOC_REPAIR_MODEL'] ?? base.repairModel ?? d.repairModel,
     repairBaseUrl: process.env['DOC_REPAIR_URL'] ?? base.repairBaseUrl ?? d.repairBaseUrl,
+    verifyModel: process.env['DOC_VERIFY_MODEL'] ?? base.verifyModel ?? d.verifyModel,
+    verifyBaseUrl: process.env['DOC_VERIFY_URL'] ?? base.verifyBaseUrl ?? d.verifyBaseUrl,
     // F11-b — external assist model. Env (DOC_ASSIST_URL/MODEL) pins baseUrl/model over config; `uses` and
     // `acknowledgedHost` are config-only (they encode operator intent + consent). apiKey lives in secrets —
     // read it via getDocAssistApiKey(). Absent baseUrl ⇒ no external assist model.

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -394,6 +394,19 @@ export interface DocumentProcessingConfig {
    */
   repairBaseUrl?: string;
   /**
+   * F11-d — optional **second** document VLM for the `max`-mode **consensus** pass. When set, `max` mode runs
+   * this model as an independent second transcription of each page, reconciles it with the primary draft
+   * against the OCR evidence, and keeps the highest-OCR-coverage result — so consensus is **never worse**
+   * than the primary. Empty (default) ⇒ no consensus pass. Best paired with a *different* model than
+   * `vlmModel` (two identical deterministic passes agree trivially). Env: `DOC_VERIFY_MODEL`.
+   */
+  verifyModel?: string;
+  /**
+   * F11-d — base URL for the consensus/verify model. Empty (default) reuses `vlmBaseUrl` (then the vision
+   * URL). Env: `DOC_VERIFY_URL`.
+   */
+  verifyBaseUrl?: string;
+  /**
    * F11-b — an **external** "assist model" (a bigger, hosted LLM the operator points Ythril at) and what
    * it is used for. Distinct from the bundled local VLM: this is the only place document content is sent
    * OFF the instance, so it is opt-in and gated by an explicit acknowledgment. `apiKey` is NOT stored here

--- a/server/src/files/converters/extraction-policy.ts
+++ b/server/src/files/converters/extraction-policy.ts
@@ -82,6 +82,25 @@ export function evidenceCoverage(resultText: string, evidenceText: string): numb
   return hit / evidence.size;
 }
 
+/**
+ * F11-d consensus arbitration — pure. Given several candidate transcriptions of the same document (the
+ * primary VLM draft, a second-model draft, and their reconciliation) plus the OCR evidence, pick the one
+ * with the highest OCR-evidence coverage. Ties keep the EARLIER candidate, so callers list the primary
+ * first and consensus can only ever match or beat it — i.e. it is **never worse** than the primary.
+ * `evidence` empty ⇒ every candidate scores 1, so the primary (first) wins unchanged.
+ */
+export function bestByEvidence<T extends { text: string }>(
+  candidates: T[],
+  evidence: string,
+): { candidate: T; coverage: number; index: number } {
+  let best = { candidate: candidates[0]!, coverage: -1, index: 0 };
+  candidates.forEach((c, i) => {
+    const coverage = evidenceCoverage(c.text, evidence);
+    if (coverage > best.coverage) best = { candidate: c, coverage, index: i };
+  });
+  return best;
+}
+
 export interface ValidationResult {
   ok: boolean;
   issues: string[];

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -87,6 +87,28 @@ export async function repairMarkdown(
   );
 }
 
+const CONSENSUS_PROMPT =
+  'You are reconciling TWO independent Markdown transcriptions (DRAFT A and DRAFT B) of the SAME document ' +
+  'page, with the OCR TEXT of that page as ground truth. Produce a single best GitHub-Flavored Markdown ' +
+  'transcription: keep content both drafts agree on; where they differ, prefer the reading supported by the ' +
+  'OCR TEXT; include content that either draft captured and the OCR confirms. Do NOT summarize, translate, ' +
+  'reorder, or invent content, and do not add commentary. Output only the reconciled Markdown.';
+
+/** Reconcile two independent transcriptions of the same document against the OCR evidence (F11-d consensus).
+ *  Text-only, temperature 0, via the local model. Throws on unreachable/HTTP error so the caller can keep the
+ *  primary draft. */
+export async function reconcileConsensus(
+  opts: { baseUrl: string; model: string; draftA: string; draftB: string; evidence: string; timeoutMs?: number },
+): Promise<VlmTranscription> {
+  const content =
+    `${CONSENSUS_PROMPT}\n\n--- DRAFT A ---\n${opts.draftA}\n\n--- DRAFT B ---\n${opts.draftB}\n\n--- OCR TEXT ---\n${opts.evidence}`;
+  return postChat(
+    opts.baseUrl, opts.model,
+    [{ role: 'user', content }], // text-only — no page image
+    opts.timeoutMs ?? 60_000,
+  );
+}
+
 /** Build the shared repair user-message content (draft + OCR evidence + flagged issues). */
 function repairContent(draft: string, evidence: string, issues?: string[]): string {
   const flagged = issues?.length ? `\n\nValidation flagged: ${issues.join('; ')}.` : '';

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -17,8 +17,8 @@ import { getDocumentProcessingConfig, getMediaEmbeddingConfig, getDocAssistApiKe
 import type { DocExtractionMode } from '../../config/types.js';
 import { UnstructuredConverter, type UnstructuredResult } from './unstructured.js';
 import { renderDocumentPages, isRenderAvailableFor } from './renderer.js';
-import { transcribePageImage, repairMarkdown, repairMarkdownExternal } from './vlm-client.js';
-import { decideRoute, validateExtraction } from './extraction-policy.js';
+import { transcribePageImage, repairMarkdown, repairMarkdownExternal, reconcileConsensus } from './vlm-client.js';
+import { decideRoute, validateExtraction, bestByEvidence } from './extraction-policy.js';
 
 const TRANSCRIBE_PROMPT =
   'Transcribe this document page to GitHub-Flavored Markdown, verbatim. Preserve headings, lists, and ' +
@@ -43,7 +43,7 @@ export async function vlmExtractDocument(
   const render = await isRenderAvailableFor(fileName);
   // `repair` reuses the VLM (or a wired-in repairModel), so it's available whenever the VLM is; decideRoute
   // only actually schedules the repair stage for `max` mode.
-  const route = decideRoute(mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: !!cfg.vlmModel, verify: false });
+  const route = decideRoute(mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: !!cfg.vlmModel, verify: !!cfg.verifyModel });
 
   // OCR is evidence + fallback. Tolerate it being down IF the VLM path can still run (ungrounded).
   let ocr: UnstructuredResult | null = null;
@@ -84,6 +84,19 @@ export async function vlmExtractDocument(
     const ranLabel = ocr ? 'ocr+vlm' : 'vlm';   // audit label for what the VLM path actually produced
     const v = validateExtraction(markdown, evidence);
     if (v.ok) {
+      // ── F11-d max-mode consensus: an independent second-VLM pass + reconcile, kept only if it covers the
+      // OCR evidence at least as well as the primary (never worse). Precision step on an ALREADY-accepted
+      // draft; failure-gated to `max` (route has the verify stage) and to a configured verify model.
+      if (route.stages.includes('verify') && cfg.verifyModel && evidence.trim()) {
+        const consensus = await runConsensus(pages, markdown, evidence, cfg, baseUrl).catch(err => {
+          log.warn(`VLM extract: consensus pass errored (${err instanceof Error ? err.message : err}) — keeping primary`);
+          return null;
+        });
+        if (consensus && consensus.text !== markdown) {
+          log.debug(`VLM extract: accepted ${ranLabel}+verify (coverage ${(consensus.coverage * 100).toFixed(0)}%)`);
+          return { markdown: consensus.text, extractedImages: ocr?.extractedImages ?? [], extractionPath: `${ranLabel}+verify` };
+        }
+      }
       log.debug(`VLM extract: accepted ${ranLabel} (${pages.length} pages, coverage ${(v.coverage * 100).toFixed(0)}%)`);
       return { markdown, extractedImages: ocr?.extractedImages ?? [], extractionPath: ranLabel };
     }
@@ -137,6 +150,49 @@ export async function vlmExtractDocument(
     }
     throw err; // nothing produced a result — let the pipeline surface the failure as today
   }
+}
+
+/**
+ * F11-d — one bounded consensus pass. A second VLM (`verifyModel`) independently transcribes the pages; its
+ * draft is reconciled with the primary against the OCR evidence; the highest-OCR-coverage of the three
+ * (primary, second draft, reconciled) is returned. The primary is listed FIRST so ties keep it — consensus
+ * can only match or beat the primary's coverage, never regress it.
+ */
+async function runConsensus(
+  pages: Buffer[],
+  primary: string,
+  evidence: string,
+  cfg: ReturnType<typeof getDocumentProcessingConfig>,
+  baseUrl: string,
+): Promise<{ text: string; coverage: number }> {
+  const verifyBase = cfg.verifyBaseUrl || baseUrl;
+  const parts = await mapLimit(pages, cfg.concurrency, async (img) => {
+    const t = await transcribePageImage(img, {
+      baseUrl: verifyBase, model: cfg.verifyModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
+    });
+    return t.text.trim();
+  });
+  const second = parts.filter(Boolean).join('\n\n---\n\n').trim();
+
+  const candidates: { text: string; label: string }[] = [{ text: primary, label: 'primary' }];
+  if (second) candidates.push({ text: second, label: 'verify' });
+
+  // Reconcile the two drafts (text-only) via the repair/vlm model; add as a third candidate when non-empty.
+  if (second) {
+    try {
+      const r = await reconcileConsensus({
+        baseUrl: cfg.repairBaseUrl || baseUrl, model: cfg.repairModel || cfg.vlmModel,
+        draftA: primary, draftB: second, evidence, timeoutMs: cfg.pageTimeoutMs,
+      });
+      const reconciled = r.text.trim();
+      if (reconciled) candidates.push({ text: reconciled, label: 'consensus' });
+    } catch (err) {
+      log.warn(`VLM extract: consensus reconcile errored (${err instanceof Error ? err.message : err}) — arbitrating on the drafts`);
+    }
+  }
+
+  const best = bestByEvidence(candidates, evidence);
+  return { text: best.candidate.text, coverage: best.coverage };
 }
 
 /** Bounded-concurrency map — at most `limit` in flight, preserving order. */

--- a/testing/standalone/extraction-policy.test.js
+++ b/testing/standalone/extraction-policy.test.js
@@ -10,7 +10,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  decideRoute, validateExtraction, evidenceCoverage, coverageTokens,
+  decideRoute, validateExtraction, evidenceCoverage, coverageTokens, bestByEvidence,
 } from '../../server/dist/files/converters/extraction-policy.js';
 
 const ALL = { ocr: true, render: true, vlm: true, repair: true, verify: true };
@@ -114,5 +114,43 @@ describe('validateExtraction', () => {
   it('no evidence → passes on coverage (nothing to compare)', () => {
     const v = validateExtraction('some output', '');
     assert.equal(v.ok, true);
+  });
+});
+
+describe('bestByEvidence (F11-d consensus arbitration)', () => {
+  const evidence = 'alpha bravo charlie delta echo';
+
+  it('picks the candidate with the highest OCR-evidence coverage', () => {
+    const primary = { text: 'alpha bravo', label: 'primary' };       // 2/5
+    const verify  = { text: 'alpha bravo charlie delta', label: 'verify' }; // 4/5
+    const r = bestByEvidence([primary, verify], evidence);
+    assert.equal(r.candidate.label, 'verify');
+    assert.equal(r.index, 1);
+    assert.ok(Math.abs(r.coverage - 0.8) < 1e-9);
+  });
+
+  it('ties keep the EARLIER candidate → consensus is never worse than the primary (listed first)', () => {
+    const primary = { text: 'alpha bravo charlie', label: 'primary' };
+    const verify  = { text: 'charlie bravo alpha', label: 'verify' }; // same tokens, same coverage
+    const r = bestByEvidence([primary, verify], evidence);
+    assert.equal(r.candidate.label, 'primary');
+    assert.equal(r.index, 0);
+  });
+
+  it('empty evidence → every candidate scores 1, so the primary (first) wins unchanged', () => {
+    const primary = { text: 'anything', label: 'primary' };
+    const verify  = { text: 'longer different text', label: 'verify' };
+    const r = bestByEvidence([primary, verify], '');
+    assert.equal(r.candidate.label, 'primary');
+    assert.equal(r.coverage, 1);
+  });
+
+  it('a reconciled candidate that recovers dropped evidence wins', () => {
+    const primary   = { text: 'alpha bravo', label: 'primary' };          // 2/5
+    const verify    = { text: 'charlie delta', label: 'verify' };         // 2/5
+    const consensus = { text: 'alpha bravo charlie delta echo', label: 'consensus' }; // 5/5
+    const r = bestByEvidence([primary, verify, consensus], evidence);
+    assert.equal(r.candidate.label, 'consensus');
+    assert.equal(r.coverage, 1);
   });
 });

--- a/testing/standalone/media-config.test.js
+++ b/testing/standalone/media-config.test.js
@@ -54,6 +54,7 @@ describe('getMediaEmbeddingConfig', () => {
     'WORKER_CONCURRENCY', 'WORKER_POLL_INTERVAL_MS', 'WORKER_MAX_POLL_INTERVAL_MS',
     'MEDIA_EMBEDDING_FALLBACK_TO_EXTERNAL', 'MAX_FILE_SIZE_BYTES', 'STALLED_JOB_TIMEOUT_MS',
     'DOC_ASSIST_URL', 'DOC_ASSIST_MODEL', 'DOC_ASSIST_API_KEY',
+    'DOC_VERIFY_MODEL', 'DOC_VERIFY_URL',
   ];
 
   function clearEnv() {
@@ -305,6 +306,32 @@ describe('getMediaEmbeddingConfig', () => {
       writeConfig();
       assert.equal(getDocAssistApiKey(), 'sk-env-123');
       assert.ok(getMediaEmbeddingConfig().lockedByInfra?.includes('documentProcessing.assistModel'));
+    });
+  });
+
+  // ── F11-d: consensus / verify model ───────────────────────────────────────────
+  describe('verify model (F11-d)', () => {
+    it('empty by default → no consensus pass', () => {
+      writeConfig();
+      const dp = getDocumentProcessingConfig();
+      assert.equal(dp.verifyModel, '');
+      assert.equal(dp.verifyBaseUrl, '');
+    });
+
+    it('resolves verifyModel/verifyBaseUrl from config.json', () => {
+      writeConfig({ mediaEmbedding: { documentProcessing: { verifyModel: 'second-vlm', verifyBaseUrl: 'http://ollama2:11434' } } });
+      const dp = getDocumentProcessingConfig();
+      assert.equal(dp.verifyModel, 'second-vlm');
+      assert.equal(dp.verifyBaseUrl, 'http://ollama2:11434');
+    });
+
+    it('DOC_VERIFY_MODEL / DOC_VERIFY_URL env override config', () => {
+      process.env['DOC_VERIFY_MODEL'] = 'env-vlm';
+      process.env['DOC_VERIFY_URL'] = 'http://env-ollama:11434';
+      writeConfig({ mediaEmbedding: { documentProcessing: { verifyModel: 'cfg-vlm' } } });
+      const dp = getDocumentProcessingConfig();
+      assert.equal(dp.verifyModel, 'env-vlm');
+      assert.equal(dp.verifyBaseUrl, 'http://env-ollama:11434');
     });
   });
 });


### PR DESCRIPTION
## What

The optional Phase-3 **consensus / self-verification** tier for document extraction. When a second document VLM is configured (`documentProcessing.verifyModel` / `DOC_VERIFY_MODEL`), `max` mode adds one bounded consensus step on an **already-accepted** VLM draft:

1. the verify model independently re-transcribes the pages (a second, ideally *different*, VLM);
2. that draft is reconciled with the primary against the OCR evidence (one text-only call);
3. the **highest-OCR-coverage** of the three candidates (primary, second draft, reconciled) is kept.

## Never worse

The primary is always a candidate and ties keep it (`bestByEvidence` is primary-first), so consensus **can only match or beat** the primary's coverage — never regress it. Any error in the pass keeps the primary. It's **bounded** (one extra transcription set + one reconcile call, same max-pages cap) and **off by default** (empty `verifyModel` ⇒ unchanged behaviour).

## Changes

- **config/loader:** `verifyModel` / `verifyBaseUrl` (+ env `DOC_VERIFY_MODEL` / `DOC_VERIFY_URL`).
- **extraction-policy:** pure `bestByEvidence` arbitration; the `verify` capability was already reserved in `decideRoute` (max-mode stage).
- **vlm-client:** `reconcileConsensus` (two drafts + OCR → merged, temperature 0, local).
- **vlm-extract:** `verify` wired into the route; `runConsensus` inserted at the acceptance point.
- **Settings → Models:** verify stage in the pipeline diagram + a read-only verify-model chip.

## Tests

- `bestByEvidence` arbitration — highest coverage wins, ties keep primary (never worse), empty evidence, reconciled-recovers-content (4 cases).
- `verifyModel`/`verifyBaseUrl` env + config resolution (3 cases).

Server + client build green; standalone suite passes (61); docs lint clean. The existing `vlm-extraction` integration test already covers `max` degrading gracefully when no models are present.

**Verify note:** validated via build + unit tests; end-to-end consensus needs live VLMs (not in CI), so the runtime path isn't Playwright-exercised here. The `never-worse` property is unit-pinned.

Docs: integration-guide (`verifyModel`/`verifyBaseUrl` rows + consensus note); CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)