### PR TITLE
feat(files): make the OCR-sidecar timeout configurable (F11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The OCR-sidecar timeout is now configurable (F11).** It was a hardcoded 2-minute ceiling; it's now
+  `documentProcessing.ocrTimeoutMs` (env `DOC_OCR_TIMEOUT_MS`, editable under Settings → Models → Advanced),
+  default `120000`. It applies to **all** extraction modes — OCR is the sole engine in `ocr` mode and the
+  grounding evidence + fallback floor in the VLM modes — so a large or complex scanned document that needs
+  longer than two minutes can now finish instead of silently failing to OCR, which matters most under `max`.
+
 - **`max`-mode consensus pass for document extraction (F11-d).** When a second document VLM is configured
   (`documentProcessing.verifyModel` / `DOC_VERIFY_MODEL`), `max` mode now adds one bounded **consensus** step
   on an already-accepted VLM draft: the verify model independently re-transcribes the pages, that draft is

--- a/client/src/app/pages/settings/models.component.ts
+++ b/client/src/app/pages/settings/models.component.ts
@@ -26,7 +26,7 @@ interface DocAssistCfg {
 }
 interface DocProcCfg {
   mode?: DocMode;
-  renderDpi?: number; maxPages?: number; pageTimeoutMs?: number; concurrency?: number;
+  renderDpi?: number; maxPages?: number; pageTimeoutMs?: number; concurrency?: number; ocrTimeoutMs?: number;
   // read-only (env/config-file only — never PATCHed from here)
   vlmModel?: string; vlmBaseUrl?: string; repairModel?: string; repairBaseUrl?: string;
   verifyModel?: string; verifyBaseUrl?: string;
@@ -296,6 +296,7 @@ const STAGES = [
               <div class="field"><label>Max pages per document</label><input type="number" min="1" max="2000" [(ngModel)]="form.documentProcessing!.maxPages" [disabled]="managed" /></div>
               <div class="field"><label>Per-page timeout (ms)</label><input type="number" min="1000" max="600000" [(ngModel)]="form.documentProcessing!.pageTimeoutMs" [disabled]="managed" /></div>
               <div class="field"><label>Page concurrency</label><input type="number" min="1" max="8" [(ngModel)]="form.documentProcessing!.concurrency" [disabled]="managed" /></div>
+              <div class="field"><label>OCR timeout (ms)</label><input type="number" min="10000" max="1800000" [(ngModel)]="form.documentProcessing!.ocrTimeoutMs" [disabled]="managed" /></div>
             </div>
           </details>
         </app-settings-card>
@@ -432,7 +433,7 @@ export class ModelsComponent implements OnInit {
     this.http.get<MediaCfg>('/api/admin/media-config').subscribe({
       next: cfg => {
         this.lockedByInfra = cfg.lockedByInfra ?? [];
-        const dp: DocProcCfg = { mode: 'auto', renderDpi: 150, maxPages: 50, pageTimeoutMs: 60000, concurrency: 2, ...cfg.documentProcessing };
+        const dp: DocProcCfg = { mode: 'auto', renderDpi: 150, maxPages: 50, pageTimeoutMs: 60000, concurrency: 2, ocrTimeoutMs: 120000, ...cfg.documentProcessing };
         // F11-b — keep a copy of the assist model with `uses` always an array; the masked apiKey stays only
         // so the template can show "key set" — it is never sent back (assistApiKeyInput carries changes).
         dp.assistModel = { uses: [], ...cfg.documentProcessing?.assistModel };
@@ -524,7 +525,7 @@ export class ModelsComponent implements OnInit {
       stt: { baseUrl: this.form.stt?.baseUrl, model: this.form.stt?.model, ...(this.sttApiKeyInput ? { apiKey: this.sttApiKeyInput } : {}) },
       // Only the PATCH-writable doc fields (vlmModel/repairModel/URLs are env-only, never sent).
       documentProcessing: {
-        mode: dp.mode, renderDpi: dp.renderDpi, maxPages: dp.maxPages, pageTimeoutMs: dp.pageTimeoutMs, concurrency: dp.concurrency,
+        mode: dp.mode, renderDpi: dp.renderDpi, maxPages: dp.maxPages, pageTimeoutMs: dp.pageTimeoutMs, concurrency: dp.concurrency, ocrTimeoutMs: dp.ocrTimeoutMs,
         ...(assistPayload ? { assistModel: assistPayload } : {}),
       },
       fallbackToExternal: this.form.fallbackToExternal,

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2038,6 +2038,7 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 | `maxPages` | `50` | Cap on pages rendered/transcribed per document (VLM modes only). |
 | `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
 | `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
+| `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `max`). Env override: `DOC_OCR_TIMEOUT_MS`. |
 
 The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,
 Ythril transparently uses OCR — no upload fails because a model isn't wired in yet.

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -67,6 +67,7 @@ const DocumentProcessingPatchSchema = z.object({
   maxPages: z.number().int().min(1).max(2_000).optional(),
   pageTimeoutMs: z.number().int().min(1_000).max(600_000).optional(),
   concurrency: z.number().int().min(1).max(8).optional(),
+  ocrTimeoutMs: z.number().int().min(10_000).max(1_800_000).optional(),
   assistModel: AssistModelPatchSchema.optional(),
 }).strict();
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -630,6 +630,7 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   maxPages: 50,
   pageTimeoutMs: 60_000,
   concurrency: 2,
+  ocrTimeoutMs: 120_000, // 2 min — the historical hardcoded OCR-sidecar ceiling, now tunable
   vlmModel: '',    // empty = no VLM configured → vlm/auto/max fall back to OCR
   vlmBaseUrl: '',  // empty = reuse the media vision provider's (Ollama) URL
   repairModel: '',   // empty = reuse vlmModel for the max-mode repair pass
@@ -656,6 +657,7 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     maxPages: base.maxPages ?? d.maxPages,
     pageTimeoutMs: base.pageTimeoutMs ?? d.pageTimeoutMs,
     concurrency: base.concurrency ?? d.concurrency,
+    ocrTimeoutMs: process.env['DOC_OCR_TIMEOUT_MS'] ? Number(process.env['DOC_OCR_TIMEOUT_MS']) : (base.ocrTimeoutMs ?? d.ocrTimeoutMs),
     vlmModel: process.env['DOC_VLM_MODEL'] ?? base.vlmModel ?? d.vlmModel,
     vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
     repairModel: process.env['DOC_REPAIR_MODEL'] ?? base.repairModel ?? d.repairModel,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -378,6 +378,13 @@ export interface DocumentProcessingConfig {
   /** F11 — max concurrent per-page model calls within one document. Default 2. */
   concurrency?: number;
   /**
+   * F11 — timeout (ms) for a single OCR-sidecar (unstructured) call. Default 120000 (2 min). Applies to ALL
+   * modes: OCR is both the sole engine in `ocr` mode and the grounding-evidence + fallback floor in the VLM
+   * modes, so a large/complex scanned document can exceed a fixed ceiling — raise this to let it finish
+   * (trading latency for completeness) especially under `max`. Env: `DOC_OCR_TIMEOUT_MS`.
+   */
+  ocrTimeoutMs?: number;
+  /**
    * F11 — the document-transcription VLM model tag (e.g. a small Qwen2-VL / MiniCPM-V on the bundled
    * Ollama). Empty (default) means no VLM is configured, so `vlm`/`auto`/`max` modes fall back to OCR.
    * Env: `DOC_VLM_MODEL`.

--- a/server/src/files/converters/unstructured.ts
+++ b/server/src/files/converters/unstructured.ts
@@ -142,7 +142,7 @@ export class UnstructuredConverter implements FileConverter {
       response = await fetch(`${SIDECAR_URL}/general/v0/general`, {
         method: 'POST',
         body: form,
-        signal: AbortSignal.timeout(120_000), // 2 min max for OCR
+        signal: AbortSignal.timeout(docCfg.ocrTimeoutMs), // configurable OCR-sidecar timeout (default 2 min)
       });
     } catch (err) {
       throw new ConversionUnavailableError(

--- a/testing/standalone/media-config.test.js
+++ b/testing/standalone/media-config.test.js
@@ -56,6 +56,7 @@ describe('getMediaEmbeddingConfig', () => {
     'DOC_ASSIST_URL', 'DOC_ASSIST_MODEL', 'DOC_ASSIST_API_KEY',
     'DOC_VERIFY_MODEL', 'DOC_VERIFY_URL',
     'YTHRIL_MEDIA_INFRA_MANAGED',
+    'DOC_OCR_TIMEOUT_MS',
   ];
 
   function clearEnv() {
@@ -333,6 +334,25 @@ describe('getMediaEmbeddingConfig', () => {
       const dp = getDocumentProcessingConfig();
       assert.equal(dp.verifyModel, 'env-vlm');
       assert.equal(dp.verifyBaseUrl, 'http://env-ollama:11434');
+    });
+  });
+
+  // ── configurable OCR-sidecar timeout ─────────────────────────────────────────
+  describe('OCR timeout', () => {
+    it('defaults to 120000 (2 min)', () => {
+      writeConfig();
+      assert.equal(getDocumentProcessingConfig().ocrTimeoutMs, 120_000);
+    });
+
+    it('resolves ocrTimeoutMs from config.json', () => {
+      writeConfig({ mediaEmbedding: { documentProcessing: { ocrTimeoutMs: 300_000 } } });
+      assert.equal(getDocumentProcessingConfig().ocrTimeoutMs, 300_000);
+    });
+
+    it('DOC_OCR_TIMEOUT_MS env overrides config', () => {
+      process.env['DOC_OCR_TIMEOUT_MS'] = '450000';
+      writeConfig({ mediaEmbedding: { documentProcessing: { ocrTimeoutMs: 300_000 } } });
+      assert.equal(getDocumentProcessingConfig().ocrTimeoutMs, 450_000);
     });
   });
 


### PR DESCRIPTION
## What

The unstructured/OCR sidecar call was a **hardcoded** `AbortSignal.timeout(120_000)` (2 min). It's now `documentProcessing.ocrTimeoutMs` — env `DOC_OCR_TIMEOUT_MS`, editable under **Settings → Models → Advanced**, default `120000` (the historical ceiling, now tunable).

## Why

OCR isn't just the `ocr`-mode engine — in the VLM modes it's the **grounding evidence for every page AND the fallback floor**. A large or complex scanned document can exceed a fixed 2-minute ceiling and then silently fail to OCR. Making the timeout configurable lets operators trade latency for completeness — **especially under `max`**, where OCR grounds every VLM page. (Was the one loose end left in the F11 plan; pulled from `_TODO-ORDERED.md`.)

## Changes
- `documentProcessing.ocrTimeoutMs` on the type; loader resolution (env > config > `120000`).
- `MediaConfigPatchSchema` accepts it (10s–30min bound); `unstructured.ts` uses `docCfg.ocrTimeoutMs`.
- An **OCR timeout (ms)** field in the Models page Advanced section (honors the infra-managed lock).
- Tests: `ocrTimeoutMs` env/config/default resolution. Docs: integration-guide row; CHANGELOG.

Server + client build green; standalone tests pass (incl. `audit-route-coverage`, run proactively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)