### PR TITLE
fix(security): route external media-provider egress through ssrfSafeFetch (SSRF follow-up, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **External media providers now route their egress through the SSRF-guarded fetch at runtime (SSRF
+  follow-up, part 1).** The external vision and speech-to-text providers (`ExternalVisionProvider`,
+  `ExternalWhisperProvider`) validated their operator-supplied endpoint URL only at config-save time, then
+  called it with a raw `fetch` — leaving a DNS-rebinding / redirect-to-internal window (the same gap F11-b
+  closed for the document assist model). Their runtime calls now go through `ssrfSafeFetch` (DNS-resolve +
+  IP-pin + redirect re-validation). The **bundled local** Ollama/Whisper providers keep a plain `fetch` — their
+  addresses are private by design and the guard would rightly reject them — so local deploys are byte-for-byte
+  unchanged. New standalone test proves the guard is applied to the external providers and *not* the local
+  ones. (Embedding + OIDC-JWKS egress are part 2 — see `_TODO-ORDERED.md`.)
+
 - **Browser SSE streams no longer carry the auth token in the URL — closed a credential-leak vector.** The
   live brain-change stream (`GET /api/brain/spaces/:id/events`, F12) and the admin audit-log tail
   (`GET /api/about/logs/stream`) are opened by the browser `EventSource` API, which cannot set an

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2147,6 +2147,8 @@ Required services (bundled by default; override only when you point at external 
 
 Kubernetes manifests are provided in `kubernetes/manifests/ollama-deploy.yaml` and `kubernetes/manifests/whisper-deploy.yaml`. Dual `NetworkPolicy` + `CiliumNetworkPolicy` resources are in `media-netpol.yaml` and `media-cilium-netpol.yaml`.
 
+When you point vision/STT at an **external** provider, its endpoint URL is validated against SSRF on save (must be a public http(s) URL) **and** reached only through the SSRF-guarded fetch at runtime (DNS-resolve + IP-pin + redirect re-validation) — so a DNS-rebind or redirect can't turn it into a request to an internal address. The bundled local Ollama/Whisper providers use a direct fetch (their addresses are private by design).
+
 #### Upload Response
 
 When a media file is uploaded, the response includes an `embeddingStatus` field:

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -14,6 +14,17 @@
 
 import type { MediaProviderConfig } from '../../config/types.js';
 import { log } from '../../util/log.js';
+import { ssrfSafeFetch } from '../../util/ssrf.js';
+
+/**
+ * Runtime egress guard. **External** (operator-supplied, public) provider endpoints go through
+ * `ssrfSafeFetch` — DNS-resolve + IP-pin + redirect re-validation — closing the save-time-only URL check
+ * against DNS-rebinding / redirect-to-internal. **Local** providers (bundled Ollama / Whisper on the trusted
+ * internal network) keep a plain `fetch`: their addresses are private, which `ssrfSafeFetch` would (rightly)
+ * reject. The provider CLASS already encodes which is which (Ollama/Whisper = local; External* = external).
+ */
+const egressFetch = (external: boolean): typeof fetch =>
+  external ? (ssrfSafeFetch as unknown as typeof fetch) : fetch;
 
 // ── Bounded JSON response reader ──────────────────────────────────────────────────────
 //
@@ -151,7 +162,8 @@ export class ExternalVisionProvider implements VisionProvider {
 
     let res: Response;
     try {
-      res = await fetch(url, {
+      // External endpoint → SSRF-guarded egress.
+      res = await egressFetch(true)(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -197,6 +209,10 @@ export class ExternalVisionProvider implements VisionProvider {
 export class WhisperProvider implements SttProvider {
   constructor(private readonly cfg: MediaProviderConfig) {}
 
+  /** Local (bundled Whisper) by default → plain fetch. `ExternalWhisperProvider` flips this so its egress
+   *  is routed through `ssrfSafeFetch`. */
+  protected readonly external: boolean = false;
+
   async transcribe(audioBytes: Buffer, mimeType: string): Promise<SttResult> {
     const base = (this.cfg.baseUrl ?? 'http://whisper.ythril.svc.cluster.local:8000').replace(/\/$/, '');
     const model = this.cfg.model ?? 'base';
@@ -217,7 +233,8 @@ export class WhisperProvider implements SttProvider {
 
     let res: Response;
     try {
-      res = await fetch(url, {
+      // Local Whisper → plain fetch (private address); external → SSRF-guarded egress.
+      res = await egressFetch(this.external)(url, {
         method: 'POST',
         headers: this.cfg.apiKey ? { Authorization: `Bearer ${this.cfg.apiKey}` } : {},
         body: form,
@@ -252,8 +269,11 @@ export class WhisperProvider implements SttProvider {
 
 // ── External Whisper API ──────────────────────────────────────────────────
 
-/** Delegates to the same WhisperProvider implementation — OpenAI Whisper API is compatible. */
-export class ExternalWhisperProvider extends WhisperProvider {}
+/** Delegates to the same WhisperProvider implementation — OpenAI Whisper API is compatible — but marks the
+ *  egress external so it is routed through `ssrfSafeFetch`. */
+export class ExternalWhisperProvider extends WhisperProvider {
+  protected override readonly external = true;
+}
 
 // ── Factory ───────────────────────────────────────────────────────────────
 

--- a/testing/standalone/media-egress-ssrf.test.js
+++ b/testing/standalone/media-egress-ssrf.test.js
@@ -1,0 +1,47 @@
+/**
+ * SSRF follow-up — media provider egress guard. EXTERNAL providers (ExternalVisionProvider /
+ * ExternalWhisperProvider) must route through `ssrfSafeFetch`, so pointing one at a private/loopback address
+ * is SSRF-BLOCKED before any connection. LOCAL providers (OllamaVisionProvider / WhisperProvider) keep a
+ * plain fetch — their addresses are private by design — so the same URL yields a plain connection error,
+ * NOT an SSRF block. That difference is exactly the guard being applied selectively.
+ *
+ * Deterministic: 127.0.0.1:9 is a literal loopback address the SSRF guard rejects up front.
+ *
+ * Run: node --test testing/standalone/media-egress-ssrf.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+const LOOPBACK = 'http://127.0.0.1:9'; // discard port; the SSRF guard blocks it before any connect
+let P;
+before(async () => { P = await import('../../server/dist/files/media/providers.js'); });
+
+async function errorOf(fn) {
+  try { await fn(); return null; } catch (e) { return e instanceof Error ? e.message : String(e); }
+}
+
+describe('media provider egress SSRF guard', () => {
+  it('ExternalVisionProvider is SSRF-guarded — a private endpoint is blocked', async () => {
+    const msg = await errorOf(() => new P.ExternalVisionProvider({ baseUrl: LOOPBACK }).caption(Buffer.from('x'), 'image/png'));
+    assert.ok(msg, 'should throw');
+    assert.match(msg, /Blocked SSRF target/, `expected an SSRF block, got: ${msg}`);
+  });
+
+  it('ExternalWhisperProvider is SSRF-guarded — a private endpoint is blocked', async () => {
+    const msg = await errorOf(() => new P.ExternalWhisperProvider({ baseUrl: LOOPBACK }).transcribe(Buffer.from('x'), 'audio/wav'));
+    assert.ok(msg, 'should throw');
+    assert.match(msg, /Blocked SSRF target/, `expected an SSRF block, got: ${msg}`);
+  });
+
+  it('OllamaVisionProvider (local) is NOT SSRF-guarded — a private endpoint is a plain connection error', async () => {
+    const msg = await errorOf(() => new P.OllamaVisionProvider({ baseUrl: LOOPBACK }).caption(Buffer.from('x'), 'image/png'));
+    assert.ok(msg, 'should throw');
+    assert.doesNotMatch(msg, /Blocked SSRF target/, `local provider must reach the private endpoint, not be SSRF-blocked: ${msg}`);
+  });
+
+  it('WhisperProvider (local) is NOT SSRF-guarded — a private endpoint is a plain connection error', async () => {
+    const msg = await errorOf(() => new P.WhisperProvider({ baseUrl: LOOPBACK }).transcribe(Buffer.from('x'), 'audio/wav'));
+    assert.ok(msg, 'should throw');
+    assert.doesNotMatch(msg, /Blocked SSRF target/, `local provider must reach the private endpoint, not be SSRF-blocked: ${msg}`);
+  });
+});


### PR DESCRIPTION
## What

`ExternalVisionProvider` and `ExternalWhisperProvider` validated their operator-supplied endpoint URL only at **config-save** time, then called it with a **raw `fetch`** — leaving a DNS-rebinding / redirect-to-internal window (the same gap F11-b closed for the document assist model). Their runtime calls now go through **`ssrfSafeFetch`** (DNS-resolve + IP-pin + redirect re-validation), via a small `egressFetch(external)` selector.

## Never breaks local

The bundled **local** Ollama/Whisper providers keep a plain `fetch` — their addresses are private by design and `ssrfSafeFetch` would (rightly) reject them — so default local deploys are **byte-for-byte unchanged**. The provider *class* already encodes external-vs-local (Ollama/Whisper = local; `External*` = external); `WhisperProvider` gains a `protected external` flag that `ExternalWhisperProvider` flips.

## Test (selective guard, deterministic)

Pointing an `External*` provider at a loopback address is **SSRF-blocked** (`Blocked SSRF target …`); pointing a **local** provider at the same address is a plain connection error — proving the guard is applied to external egress and *not* the trusted local path.

Server-only change; docs lint clean; standalone tests pass (incl. `audit-route-coverage`, no new route).

## Scope

Part 1 = media providers. **Part 2** (embedding HTTP endpoint — needs a local/external signal since a local Ollama embedding URL is private; and OIDC JWKS — needs a fetch injected into jose's `createRemoteJWKSet`) is tracked in `_TODO-ORDERED.md` §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)