### PR TITLE
feat(settings): text-embedding provider on Models — local/external toggle + SSRF guard (SSRF follow-up part 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Text-embedding provider is now configurable on Settings → Models, with a `local`/`external` toggle and an
+  SSRF-guarded external path (SSRF follow-up part 2).** The embedding endpoint (the model that powers semantic
+  recall) was config-file-only; it now has a **Text embedding** card — provider, endpoint, model, dimensions,
+  similarity, and API key. `provider: 'external'` routes the runtime embedding call through `ssrfSafeFetch`
+  (closing the same raw-fetch gap as the media providers); `local` keeps a plain fetch for the bundled ONNX /
+  an internal endpoint. Changing the **model / dimensions / similarity re-indexes every vector**, so the save
+  requires an explicit "I understand this re-indexes and takes a while" confirmation; the existing reindex flow
+  does the work. Honors the infra controls like the rest of the page — `mediaEmbedding.infraManaged` locks the
+  whole thing, and `EMBEDDING_PROVIDER`/`EMBEDDING_URL`/`EMBEDDING_MODEL`/`EMBEDDING_DIMENSIONS`/`EMBEDDING_API_KEY`
+  pin individual fields read-only. The API key lives in `secrets.json` (masked). Also a **Test connection**
+  button for the embedding endpoint.
+
 - **The OCR-sidecar timeout is now configurable (F11).** It was a hardcoded 2-minute ceiling; it's now
   `documentProcessing.ocrTimeoutMs` (env `DOC_OCR_TIMEOUT_MS`, editable under Settings → Models → Advanced),
   default `120000`. It applies to **all** extraction modes — OCR is the sole engine in `ocr` mode and the

--- a/client/src/app/pages/settings/models.component.ts
+++ b/client/src/app/pages/settings/models.component.ts
@@ -15,7 +15,16 @@ interface TestResult {
   ok: boolean; reachable: boolean; status?: number; models?: string[];
   modelPresent?: boolean; detail?: string; latencyMs: number;
 }
-type TestTarget = 'vision' | 'stt' | 'assist';
+type TestTarget = 'vision' | 'stt' | 'assist' | 'embedding';
+
+/** Text-embedding config (top-level config.embedding, surfaced on this page). Changing model/dimensions/
+ *  similarity re-indexes every vector — the save gates those behind an explicit confirmation. */
+interface EmbeddingCfg {
+  provider?: 'local' | 'external';
+  baseUrl?: string | null; model?: string; dimensions?: number;
+  similarity?: 'cosine' | 'dotProduct' | 'euclidean';
+  apiKey?: string;
+}
 
 type DocMode = 'ocr' | 'vlm' | 'auto' | 'max';
 type DocAssistUse = 'repair';
@@ -39,6 +48,7 @@ interface MediaCfg {
   sttProvider?: 'local' | 'external';
   vision?: ProviderCfg;
   stt?: ProviderCfg;
+  embedding?: EmbeddingCfg;
   documentProcessing?: DocProcCfg;
   workerConcurrency?: number;
   fallbackToExternal?: boolean;
@@ -201,6 +211,55 @@ const STAGES = [
       </section>
 
       <div class="cards">
+        <!-- Text embedding -->
+        <app-settings-card class="span-all" icon="database" heading="Text embedding — semantic recall"
+          purpose="Turns text into the vectors that power semantic search across every space.">
+          <app-status-pill pill [variant]="embedding.provider === 'external' ? 'active' : 'ok'">
+            {{ embedding.provider === 'external' ? 'External' : (embedding.baseUrl ? 'Local · HTTP' : 'Bundled · in-process') }}
+          </app-status-pill>
+          <div class="field">
+            <label>Provider @if (embeddingLocked('provider')) { <app-status-pill variant="env">env</app-status-pill> }</label>
+            <select [(ngModel)]="embedding.provider" [disabled]="embeddingLocked('provider')">
+              <option value="local">Local / trusted (bundled ONNX, or an internal endpoint)</option>
+              <option value="external">External (public OpenAI-compatible endpoint)</option>
+            </select>
+          </div>
+          <div class="grid2">
+            <div class="field"><label>Endpoint <span style="font-size:11px;color:var(--text-muted);font-weight:normal;">(blank = bundled in-process model)</span></label><input data-mono type="url" [(ngModel)]="embedding.baseUrl" [disabled]="embeddingLocked('baseUrl')" placeholder="http://ollama:11434 or https://api.example.com" /></div>
+            <div class="field"><label>Model</label><input data-mono [(ngModel)]="embedding.model" [disabled]="embeddingLocked('model')" placeholder="nomic-embed-text" /></div>
+          </div>
+          <div class="grid2">
+            <div class="field"><label>Dimensions</label><input type="number" min="1" max="16384" [(ngModel)]="embedding.dimensions" [disabled]="embeddingLocked('dimensions')" /></div>
+            <div class="field"><label>Similarity</label>
+              <select [(ngModel)]="embedding.similarity" [disabled]="embeddingLocked('model')">
+                <option value="cosine">cosine</option>
+                <option value="dotProduct">dotProduct</option>
+                <option value="euclidean">euclidean</option>
+              </select>
+            </div>
+          </div>
+          <div class="field">
+            <label>API key (external only)</label>
+            <input type="password" [(ngModel)]="embeddingApiKeyInput" [disabled]="embeddingLocked('apiKey')"
+              [placeholder]="embedding.apiKey ? 'Leave blank to keep current' : 'Bearer token (optional)'" />
+          </div>
+          @if (embeddingNeedsReindex()) {
+            <div class="runline warn" style="margin-top:4px;">
+              <ph-icon name="warning" [size]="15"/>
+              <span>Changing the <b>model, dimensions, or similarity</b> re-embeds <b>every vector in every space</b>. You'll confirm on save — recall is degraded until the reindex finishes.</span>
+            </div>
+          }
+          <div class="testrow">
+            <button class="btn btn-sm btn-secondary" type="button" (click)="testConnection('embedding')" [disabled]="testOf('embedding')?.loading || !embedding.baseUrl">
+              {{ testOf('embedding')?.loading ? 'Testing…' : 'Test connection' }}
+            </button>
+            @if (testOf('embedding')?.res; as r) {
+              <app-status-pill [variant]="testPillVariant(r)" [dot]="true">{{ testPillLabel(r) }}</app-status-pill>
+              <span class="hint">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+            }
+          </div>
+        </app-settings-card>
+
         <!-- Vision -->
         <app-settings-card icon="image" heading="Vision — image captioning" purpose="Describes uploaded images and indexes faces for search.">
           <app-status-pill pill [variant]="form.enabled ? 'active' : 'off'">{{ form.visionProvider === 'external' ? 'External' : 'Local · Ollama' }}</app-status-pill>
@@ -385,6 +444,16 @@ export class ModelsComponent implements OnInit {
   visionApiKeyInput = '';
   sttApiKeyInput = '';
   assistApiKeyInput = '';
+  embeddingApiKeyInput = '';
+  // Serialized model|dimensions|similarity at load — changing any of these re-indexes every vector.
+  private embeddingReindexBaseline = '';
+
+  // ── Text embedding ──
+  get embedding(): EmbeddingCfg { return (this.form.embedding ??= {}); }
+  embeddingLocked(field: string): boolean { return this.isLocked(`embedding.${field}`); }
+  private reindexKey(): string { return `${this.embedding.model ?? ''}|${this.embedding.dimensions ?? ''}|${this.embedding.similarity ?? ''}`; }
+  /** True when a reindex-triggering field (model/dimensions/similarity) differs from what was loaded. */
+  embeddingNeedsReindex(): boolean { return this.reindexKey() !== this.embeddingReindexBaseline; }
 
   // ── F11-PR5b: test connection ──
   testState = signal<Partial<Record<TestTarget, { loading?: boolean; res?: TestResult }>>>({});
@@ -440,7 +509,10 @@ export class ModelsComponent implements OnInit {
         this.form = { vision: {}, stt: {}, ...cfg, documentProcessing: dp };
         this.form.vision = { ...cfg.vision, apiKey: undefined };
         this.form.stt = { ...cfg.stt, apiKey: undefined };
+        this.form.embedding = { provider: 'local', ...cfg.embedding };
+        this.embeddingReindexBaseline = this.reindexKey();
         this.assistApiKeyInput = '';
+        this.embeddingApiKeyInput = '';
         this.docCfgSig.set(dp);
         this.docMode.set(dp.mode ?? 'ocr');
         this.loading.set(false);
@@ -505,6 +577,19 @@ export class ModelsComponent implements OnInit {
       assist.acknowledgedHost = host;
     }
 
+    // Reindex confirmation: changing the embedding model / dimensions / similarity re-embeds EVERY vector in
+    // every space. Make the operator acknowledge it — and that it takes a while — before saving.
+    if (this.embeddingNeedsReindex()) {
+      const ok = await this.confirmDialog.confirm({
+        title: 'Change the embedding model — re-index everything?',
+        message: `Changing the embedding model, dimensions, or similarity means every stored vector in every space must be RE-EMBEDDED. Recall is degraded until it finishes, and on a large instance this can take a long while. Only continue if you understand what you're doing.`,
+        confirmLabel: 'Yes, re-index — I understand',
+        cancelLabel: 'Cancel',
+        danger: true,
+      });
+      if (!ok) return;
+    }
+
     this.saving.set(true);
     this.saveError.set('');
     this.saveOk.set('');
@@ -523,6 +608,14 @@ export class ModelsComponent implements OnInit {
       sttProvider: this.form.sttProvider,
       vision: { baseUrl: this.form.vision?.baseUrl, model: this.form.vision?.model, ...(this.visionApiKeyInput ? { apiKey: this.visionApiKeyInput } : {}) },
       stt: { baseUrl: this.form.stt?.baseUrl, model: this.form.stt?.model, ...(this.sttApiKeyInput ? { apiKey: this.sttApiKeyInput } : {}) },
+      embedding: {
+        provider: this.embedding.provider,
+        baseUrl: this.embedding.baseUrl || null,
+        model: this.embedding.model,
+        dimensions: this.embedding.dimensions,
+        similarity: this.embedding.similarity,
+        ...(this.embeddingApiKeyInput ? { apiKey: this.embeddingApiKeyInput } : {}),
+      },
       // Only the PATCH-writable doc fields (vlmModel/repairModel/URLs are env-only, never sent).
       documentProcessing: {
         mode: dp.mode, renderDpi: dp.renderDpi, maxPages: dp.maxPages, pageTimeoutMs: dp.pageTimeoutMs, concurrency: dp.concurrency, ocrTimeoutMs: dp.ocrTimeoutMs,
@@ -539,6 +632,8 @@ export class ModelsComponent implements OnInit {
         this.visionApiKeyInput = '';
         this.sttApiKeyInput = '';
         this.assistApiKeyInput = '';
+        this.embeddingApiKeyInput = '';
+        this.embeddingReindexBaseline = this.reindexKey(); // re-baseline so a second save won't re-prompt
         this.saving.set(false);
         setTimeout(() => this.saveOk.set(''), 3000);
       },

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2224,6 +2224,10 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `stt.baseUrl` | `WHISPER_URL` | `http://whisper:8000` | STT service endpoint |
 | `stt.model` | `WHISPER_MODEL` | `base` | Whisper model size/name |
 | `stt.apiKey` | `STT_API_KEY` | — | API key for external STT provider (stored in `secrets.json`) |
+| `embedding.provider` | `EMBEDDING_PROVIDER` | `local` | Text-embedding endpoint trust: `local` (bundled ONNX or an internal HTTP endpoint, plain fetch) or `external` (public endpoint, reached through the SSRF-guarded fetch). Config lives at top-level `config.embedding` but is edited on **Settings → Models**. |
+| `embedding.baseUrl` | `EMBEDDING_URL` | — | Embedding HTTP endpoint (OpenAI-compatible `/v1/embeddings`). Blank = the bundled in-process ONNX model. |
+| `embedding.model` | `EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5` | Embedding model. **Changing the model / `dimensions` / `similarity` re-indexes every vector** (the UI requires an explicit confirmation; `POST /api/brain/spaces/:id/reindex` runs it). |
+| `embedding.apiKey` | `EMBEDDING_API_KEY` | — | API key for an external embedding endpoint (stored in `secrets.json`, masked in the API). |
 | `workerConcurrency` | `WORKER_CONCURRENCY` | `2` | Max parallel jobs |
 | `workerPollIntervalMs` | `WORKER_POLL_INTERVAL_MS` | `1000` | Base poll interval (ms) |
 | `workerMaxPollIntervalMs` | `WORKER_MAX_POLL_INTERVAL_MS` | `30000` | Max poll interval when idle (ms) |

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -10,7 +10,7 @@
 
 import { Router } from 'express';
 import { z } from 'zod';
-import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets, getDocAssistApiKey } from '../config/loader.js';
+import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets, getDocAssistApiKey, getEmbeddingConfig, getEmbeddingApiKey } from '../config/loader.js';
 import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl, ssrfSafeFetch } from '../util/ssrf.js';
@@ -35,6 +35,9 @@ mediaConfigRouter.get('/', requireAdmin, (req, res) => {
   // restart. Surfacing it lets the UI show "applying…" instead of leaving the
   // operator guessing whether their provider switch is live yet.
   masked['providerReloadPending'] = getActiveProviderSignature() !== providerSignature(cfg);
+  // Text embedding lives at top-level config.embedding but is surfaced here so it's on the Models page.
+  const emb = getEmbeddingConfig();
+  masked['embedding'] = { ...emb, apiKey: emb.apiKey ? '••••••••' : undefined };
   res.json(masked);
 });
 
@@ -71,12 +74,25 @@ const DocumentProcessingPatchSchema = z.object({
   assistModel: AssistModelPatchSchema.optional(),
 }).strict();
 
+// Text-embedding provider. Lives at top-level `config.embedding` (not under mediaEmbedding), but is
+// surfaced/edited here so all model config sits on one page. `model`/`dimensions`/`similarity` changes
+// re-index every vector — the client gates those behind an explicit confirmation. `apiKey` → secrets.json.
+const EmbeddingPatchSchema = z.object({
+  provider: z.enum(['local', 'external']).optional(),
+  baseUrl: z.string().url().optional().nullable(),
+  model: z.string().min(1).max(256).optional(),
+  dimensions: z.number().int().min(1).max(16_384).optional(),
+  similarity: z.enum(['cosine', 'dotProduct', 'euclidean']).optional(),
+  apiKey: z.string().max(512).optional().nullable(),
+}).strict();
+
 const MediaConfigPatchSchema = z.object({
   enabled: z.boolean().optional(),
   visionProvider: z.enum(['local', 'external']).optional(),
   sttProvider: z.enum(['local', 'external']).optional(),
   vision: ProviderPatchSchema.optional(),
   stt: ProviderPatchSchema.optional(),
+  embedding: EmbeddingPatchSchema.optional(),
   documentProcessing: DocumentProcessingPatchSchema.optional(),
   workerConcurrency: z.number().int().min(1).max(16).optional(),
   workerPollIntervalMs: z.number().int().min(100).max(60_000).optional(),
@@ -134,6 +150,13 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     res.status(400).json({ error: 'stt.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
     return;
   }
+  // Text-embedding external endpoint — same SSRF rule (only when the effective provider is external).
+  const effectiveEmbType = parsed.data.embedding?.provider ?? getEmbeddingConfig().provider ?? 'local';
+  if (effectiveEmbType === 'external' && parsed.data.embedding?.baseUrl
+      && !isSsrfSafeUrl(parsed.data.embedding.baseUrl)) {
+    res.status(400).json({ error: 'embedding.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+    return;
+  }
 
   // ── F11-b: external assist model — locked check + SSRF + egress-acknowledgment enforcement ──
   // This is the only path that sends document content OFF the instance, so a `uses`-active endpoint must be
@@ -183,8 +206,12 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     const assistApiKeyChange = (assistPatch && 'apiKey' in assistPatch)
       ? assistPatch.apiKey ?? null
       : undefined;
+    // Text-embedding key → secrets.embedding.apiKey (top-level, matching getEmbeddingConfig()).
+    const embApiKeyChange = (parsed.data.embedding && 'apiKey' in parsed.data.embedding)
+      ? parsed.data.embedding.apiKey ?? null
+      : undefined;
 
-    if (visionApiKeyChange !== undefined || sttApiKeyChange !== undefined || assistApiKeyChange !== undefined) {
+    if (visionApiKeyChange !== undefined || sttApiKeyChange !== undefined || assistApiKeyChange !== undefined || embApiKeyChange !== undefined) {
       const secrets = getSecrets();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sAny = secrets as any;
@@ -200,6 +227,11 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
       if (assistApiKeyChange !== undefined) {
         if (assistApiKeyChange === null || assistApiKeyChange === '') delete sAny.mediaEmbedding.docAssistApiKey;
         else sAny.mediaEmbedding.docAssistApiKey = assistApiKeyChange;
+      }
+      if (embApiKeyChange !== undefined) {
+        sAny.embedding = sAny.embedding ?? {};
+        if (embApiKeyChange === null || embApiKeyChange === '') delete sAny.embedding.apiKey;
+        else sAny.embedding.apiKey = embApiKeyChange;
       }
       saveSecrets(secrets);
     }
@@ -234,11 +266,25 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
       }
       merged['documentProcessing'] = dpMerged;
     }
+    // Text embedding lives at TOP-LEVEL `config.embedding`, not under mediaEmbedding — pull it out of the
+    // media merge and apply it separately (apiKey already routed to secrets above).
+    delete merged['embedding'];
+    if (parsed.data.embedding) {
+      const e = { ...parsed.data.embedding } as Record<string, unknown>;
+      delete e['apiKey']; // never in config.json
+      // null baseUrl clears it (switch back to the bundled local ONNX model).
+      if (e['baseUrl'] === null) delete e['baseUrl'];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cfg.embedding = { ...(cfg.embedding as any ?? {}), ...e };
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cfg.mediaEmbedding = merged as any;
     saveConfig(cfg);
     log.info(`Media embedding config updated by admin`);
-    res.json({ ok: true, config: maskSecrets(getMediaEmbeddingConfig()) });
+    const respBody = maskSecrets(getMediaEmbeddingConfig()) as Record<string, unknown>;
+    const emb = getEmbeddingConfig();
+    respBody['embedding'] = { ...emb, apiKey: emb.apiKey ? '••••••••' : undefined };
+    res.json({ ok: true, config: respBody });
   } catch (err) {
     log.warn(`Failed to save media config: ${err}`);
     res.status(500).json({ error: 'Failed to save configuration' });
@@ -252,7 +298,7 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
 // the media worker reaches them.
 
 const TestConnectionSchema = z.object({
-  target: z.enum(['vision', 'stt', 'assist']),
+  target: z.enum(['vision', 'stt', 'assist', 'embedding']),
 }).strict();
 
 mediaConfigRouter.post('/test-connection', requireAdminMfa, async (req, res) => {
@@ -274,6 +320,10 @@ mediaConfigRouter.post('/test-connection', requireAdminMfa, async (req, res) => 
   } else if (target === 'stt') {
     baseUrl = cfg.stt?.baseUrl; model = cfg.stt?.model; apiKey = cfg.stt?.apiKey;
     external = cfg.sttProvider === 'external';
+  } else if (target === 'embedding') {
+    const e = getEmbeddingConfig();
+    baseUrl = e.baseUrl; model = e.model; apiKey = getEmbeddingApiKey();
+    external = e.provider === 'external';
   } else {
     const a = cfg.documentProcessing?.assistModel;
     baseUrl = a?.baseUrl; model = a?.model; apiKey = getDocAssistApiKey();

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { getDataRoot, getEmbeddingConfig } from '../config/loader.js';
+import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
 import { embeddingDurationSeconds, embeddingQueueDepth } from '../metrics/registry.js';
 
@@ -48,11 +49,18 @@ async function embedViaHttp(
   cfg: ReturnType<typeof getEmbeddingConfig>,
 ): Promise<EmbeddingResult> {
   const url = `${cfg.baseUrl!.replace(/\/$/, '')}/v1/embeddings`;
+  // External endpoints go through the SSRF-guarded fetch (DNS-resolve + IP-pin + redirect re-validation);
+  // a local/trusted endpoint (e.g. on-cluster Ollama, private address) uses a plain fetch, which the guard
+  // would rightly reject. Mirrors the vision/STT provider split (SSRF follow-up part 2).
+  const doFetch = cfg.provider === 'external' ? (ssrfSafeFetch as unknown as typeof fetch) : fetch;
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await doFetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {}),
+      },
       body: JSON.stringify({ model: cfg.model, input: text }),
       signal: AbortSignal.timeout(30_000),
     });

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -434,11 +434,31 @@ export function getEmbeddingConfig() {
   const cfg = getConfig();
   // No baseUrl in the default = use the bundled local ONNX model.
   // Set baseUrl in config.json to override with an HTTP endpoint (e.g. Ollama).
-  return cfg.embedding ?? {
+  const base = cfg.embedding ?? {
     model: 'nomic-ai/nomic-embed-text-v1.5',
     dimensions: 768,
     similarity: 'cosine' as const,
   };
+  // API key: env > secrets.json > legacy inline config. Never surfaced from config.json.
+  let embApiKey: string | undefined = process.env['EMBEDDING_API_KEY'];
+  if (!embApiKey) {
+    try { embApiKey = (getSecrets() as { embedding?: { apiKey?: string } }).embedding?.apiKey; } catch { /* pre-setup */ }
+  }
+  // Env pins ("fix-set" for managed infra) win over config; each pinned field is reported in
+  // lockedByInfra (see getMediaEmbeddingConfig) so the UI renders it read-only.
+  return {
+    ...base,
+    baseUrl: process.env['EMBEDDING_URL'] ?? base.baseUrl,
+    model: process.env['EMBEDDING_MODEL'] ?? base.model,
+    dimensions: process.env['EMBEDDING_DIMENSIONS'] ? Number(process.env['EMBEDDING_DIMENSIONS']) : base.dimensions,
+    provider: (process.env['EMBEDDING_PROVIDER'] as 'local' | 'external' | undefined) ?? base.provider ?? 'local',
+    apiKey: embApiKey ?? base.apiKey,
+  };
+}
+
+/** The external embedding endpoint's API key, resolved (env > secrets). Never in config.json. */
+export function getEmbeddingApiKey(): string | undefined {
+  return getEmbeddingConfig().apiKey;
 }
 
 export function getMongoUri(): string {
@@ -595,6 +615,12 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   if (process.env['DOC_ASSIST_URL'] || process.env['DOC_ASSIST_MODEL'] || process.env['DOC_ASSIST_API_KEY']) {
     locked.push('documentProcessing.assistModel');
   }
+  // Text-embedding env pins ("fix-set" for managed infra) → the matching field renders read-only in the UI.
+  if (process.env['EMBEDDING_PROVIDER']) locked.push('embedding.provider');
+  if (process.env['EMBEDDING_URL']) locked.push('embedding.baseUrl');
+  if (process.env['EMBEDDING_MODEL']) locked.push('embedding.model');
+  if (process.env['EMBEDDING_DIMENSIONS']) locked.push('embedding.dimensions');
+  if (process.env['EMBEDDING_API_KEY']) locked.push('embedding.apiKey');
 
   return {
     enabled,

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -434,23 +434,21 @@ export function getEmbeddingConfig() {
   const cfg = getConfig();
   // No baseUrl in the default = use the bundled local ONNX model.
   // Set baseUrl in config.json to override with an HTTP endpoint (e.g. Ollama).
-  const base = cfg.embedding ?? {
-    model: 'nomic-ai/nomic-embed-text-v1.5',
-    dimensions: 768,
-    similarity: 'cosine' as const,
-  };
+  const base: Partial<EmbeddingConfig> = cfg.embedding ?? {};
   // API key: env > secrets.json > legacy inline config. Never surfaced from config.json.
   let embApiKey: string | undefined = process.env['EMBEDDING_API_KEY'];
   if (!embApiKey) {
     try { embApiKey = (getSecrets() as { embedding?: { apiKey?: string } }).embedding?.apiKey; } catch { /* pre-setup */ }
   }
-  // Env pins ("fix-set" for managed infra) win over config; each pinned field is reported in
-  // lockedByInfra (see getMediaEmbeddingConfig) so the UI renders it read-only.
+  // Defaults are applied PER FIELD, not `cfg.embedding ?? {…}`: a PARTIAL stored block (e.g. after a PATCH
+  // that only changed `provider`) must still yield a complete config — `model`/`dimensions` are load-bearing
+  // for vector-index creation, so they can never be undefined. Env pins ("fix-set") win over config; each
+  // pinned field is reported in lockedByInfra so the UI renders it read-only.
   return {
-    ...base,
     baseUrl: process.env['EMBEDDING_URL'] ?? base.baseUrl,
-    model: process.env['EMBEDDING_MODEL'] ?? base.model,
-    dimensions: process.env['EMBEDDING_DIMENSIONS'] ? Number(process.env['EMBEDDING_DIMENSIONS']) : base.dimensions,
+    model: process.env['EMBEDDING_MODEL'] ?? base.model ?? 'nomic-ai/nomic-embed-text-v1.5',
+    dimensions: process.env['EMBEDDING_DIMENSIONS'] ? Number(process.env['EMBEDDING_DIMENSIONS']) : (base.dimensions ?? 768),
+    similarity: base.similarity ?? ('cosine' as const),
     provider: (process.env['EMBEDDING_PROVIDER'] as 'local' | 'external' | undefined) ?? base.provider ?? 'local',
     apiKey: embApiKey ?? base.apiKey,
   };
@@ -494,7 +492,7 @@ export function getDataRoot(): string {
 
 // ── Media Embedding Config ─────────────────────────────────────────────────
 
-import type { MediaEmbeddingConfig, MediaProviderConfig, FaceRecognitionConfig, DocumentProcessingConfig } from './types.js';
+import type { MediaEmbeddingConfig, MediaProviderConfig, FaceRecognitionConfig, DocumentProcessingConfig, EmbeddingConfig } from './types.js';
 
 const MEDIA_EMBEDDING_DEFAULTS: Required<Omit<MediaEmbeddingConfig, 'vision' | 'stt' | 'ollamaUrl' | 'visionModel' | 'whisperUrl' | 'whisperModel' | 'lockedByInfra' | 'infraManaged' | 'faceRecognition' | 'documentProcessing'>> = {
   // Enabled by default: both K8s manifests (kubernetes/manifests/ollama-deploy.yaml,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -218,6 +218,16 @@ export interface EmbeddingConfig {
   model: string;
   dimensions: number;
   similarity: 'cosine' | 'dotProduct' | 'euclidean';
+  /**
+   * Where the HTTP embedding endpoint lives (only relevant when `baseUrl` is set). `local` (default) = a
+   * trusted internal endpoint (e.g. Ollama on the cluster network) reached with a plain fetch; `external` =
+   * an operator-supplied public endpoint reached through the SSRF-guarded fetch at runtime (SSRF follow-up
+   * part 2). Mirrors `visionProvider`/`sttProvider`. Absent/`local` keeps today's behaviour.
+   */
+  provider?: 'local' | 'external';
+  /** API key for an external embedding endpoint. Stored in `secrets.json` (never `config.json`), masked in
+   *  the admin API. */
+  apiKey?: string;
 }
 
 export interface StorageConfig {

--- a/testing/integration/media-config.test.js
+++ b/testing/integration/media-config.test.js
@@ -144,6 +144,44 @@ describe('Media config — test connection (F11-PR5b)', () => {
   });
 });
 
+// ── Text embedding config on the Models surface (SSRF follow-up part 2) ────────
+
+describe('Media config — text embedding', () => {
+  before(async () => { tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
+  after(async () => {
+    // Restore to the bundled local model so no external/broken endpoint leaks into other suites.
+    await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', baseUrl: null } }).catch(() => {});
+  });
+
+  it('GET surfaces the embedding block', async () => {
+    const r = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    assert.equal(r.status, 200);
+    assert.ok(r.body?.embedding, 'embedding block should be present');
+    assert.ok(typeof r.body.embedding.model === 'string');
+  });
+
+  it('rejects an external embedding endpoint that is not a public URL (SSRF)', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+      { embedding: { provider: 'external', baseUrl: 'http://127.0.0.1:9999' } });
+    assert.equal(r.status, 400, `expected SSRF rejection, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('a provider-only change (no model/dims change) round-trips without reindex', async () => {
+    const r = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local' } });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body?.config?.embedding?.provider, 'local');
+  });
+
+  it('the embedding API key is masked in GET, never returned plaintext', async () => {
+    const set = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', apiKey: 'sk-emb-secret' } });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+    const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
+    const key = reread.body?.embedding?.apiKey;
+    assert.ok(!key || !key.includes('sk-emb-secret'), `key must be masked, got: ${key}`);
+    await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', apiKey: null } }).catch(() => {});
+  });
+});
+
 // ── F11-b — external assist model (hosted egress) ─────────────────────────────
 
 describe('Media config — external assist model (F11-b)', () => {

--- a/testing/standalone/media-config.test.js
+++ b/testing/standalone/media-config.test.js
@@ -46,6 +46,8 @@ describe('getMediaEmbeddingConfig', () => {
   let getMediaEmbeddingConfig;
   let getDocumentProcessingConfig;
   let getDocAssistApiKey;
+  let getEmbeddingConfig;
+  let getEmbeddingApiKey;
 
   const ENV_KEYS = [
     'MEDIA_EMBEDDING_ENABLED', 'VISION_PROVIDER', 'STT_PROVIDER',
@@ -57,6 +59,7 @@ describe('getMediaEmbeddingConfig', () => {
     'DOC_VERIFY_MODEL', 'DOC_VERIFY_URL',
     'YTHRIL_MEDIA_INFRA_MANAGED',
     'DOC_OCR_TIMEOUT_MS',
+    'EMBEDDING_PROVIDER', 'EMBEDDING_URL', 'EMBEDDING_MODEL', 'EMBEDDING_DIMENSIONS', 'EMBEDDING_API_KEY',
   ];
 
   function clearEnv() {
@@ -72,6 +75,8 @@ describe('getMediaEmbeddingConfig', () => {
     getMediaEmbeddingConfig = mod.getMediaEmbeddingConfig;
     getDocumentProcessingConfig = mod.getDocumentProcessingConfig;
     getDocAssistApiKey = mod.getDocAssistApiKey;
+    getEmbeddingConfig = mod.getEmbeddingConfig;
+    getEmbeddingApiKey = mod.getEmbeddingApiKey;
     _reloadConfig = mod.reloadConfig;
     // Must call loadConfig() once to initialise _config before any test runs.
     mod.loadConfig();
@@ -353,6 +358,47 @@ describe('getMediaEmbeddingConfig', () => {
       process.env['DOC_OCR_TIMEOUT_MS'] = '450000';
       writeConfig({ mediaEmbedding: { documentProcessing: { ocrTimeoutMs: 300_000 } } });
       assert.equal(getDocumentProcessingConfig().ocrTimeoutMs, 450_000);
+    });
+  });
+
+  // ── text embedding provider (SSRF follow-up part 2) ──────────────────────────
+  describe('embedding config', () => {
+    it('defaults to provider=local with no apiKey', () => {
+      writeConfig();
+      const e = getEmbeddingConfig();
+      assert.equal(e.provider, 'local');
+      assert.equal(e.apiKey, undefined);
+      assert.equal(getEmbeddingApiKey(), undefined);
+    });
+
+    it('resolves provider/baseUrl/model/dimensions from config.json', () => {
+      writeConfig({ embedding: { provider: 'external', baseUrl: 'https://emb.example.com', model: 'text-embed-3', dimensions: 1536, similarity: 'cosine' } });
+      const e = getEmbeddingConfig();
+      assert.equal(e.provider, 'external');
+      assert.equal(e.baseUrl, 'https://emb.example.com');
+      assert.equal(e.dimensions, 1536);
+    });
+
+    it('EMBEDDING_* env pins override config and appear in lockedByInfra', () => {
+      process.env['EMBEDDING_PROVIDER'] = 'external';
+      process.env['EMBEDDING_URL'] = 'https://env-emb.example.com';
+      process.env['EMBEDDING_MODEL'] = 'env-model';
+      writeConfig({ embedding: { provider: 'local', baseUrl: 'https://cfg.example.com', model: 'cfg-model', dimensions: 768, similarity: 'cosine' } });
+      const e = getEmbeddingConfig();
+      assert.equal(e.provider, 'external');
+      assert.equal(e.baseUrl, 'https://env-emb.example.com');
+      assert.equal(e.model, 'env-model');
+      const locked = getMediaEmbeddingConfig().lockedByInfra ?? [];
+      assert.ok(locked.includes('embedding.provider'));
+      assert.ok(locked.includes('embedding.baseUrl'));
+      assert.ok(locked.includes('embedding.model'));
+    });
+
+    it('EMBEDDING_API_KEY resolves via getEmbeddingApiKey and locks the field', () => {
+      process.env['EMBEDDING_API_KEY'] = 'sk-emb-env';
+      writeConfig();
+      assert.equal(getEmbeddingApiKey(), 'sk-emb-env');
+      assert.ok((getMediaEmbeddingConfig().lockedByInfra ?? []).includes('embedding.apiKey'));
     });
   });
 

--- a/testing/standalone/media-config.test.js
+++ b/testing/standalone/media-config.test.js
@@ -371,6 +371,17 @@ describe('getMediaEmbeddingConfig', () => {
       assert.equal(getEmbeddingApiKey(), undefined);
     });
 
+    it('a PARTIAL stored block still yields complete config (model/dimensions never undefined)', () => {
+      // Regression: a PATCH that wrote only { provider } left cfg.embedding partial; getEmbeddingConfig used
+      // `cfg.embedding ?? defaults`, so model/dimensions went undefined and vector-index creation broke.
+      writeConfig({ embedding: { provider: 'local' } });
+      const e = getEmbeddingConfig();
+      assert.equal(e.provider, 'local');
+      assert.equal(e.model, 'nomic-ai/nomic-embed-text-v1.5');
+      assert.equal(e.dimensions, 768);
+      assert.equal(e.similarity, 'cosine');
+    });
+
     it('resolves provider/baseUrl/model/dimensions from config.json', () => {
       writeConfig({ embedding: { provider: 'external', baseUrl: 'https://emb.example.com', model: 'text-embed-3', dimensions: 1536, similarity: 'cosine' } });
       const e = getEmbeddingConfig();


### PR DESCRIPTION
## What

The text-embedding endpoint (which powers semantic recall) was **config-file-only**. It now has a **Text embedding** card on Settings → Models — provider (`local`/`external`), endpoint, model, dimensions, similarity, and API key — as you asked (everything editable, with a reindex flow).

## Security (the SSRF-follow-up goal)

`provider: 'external'` routes the runtime embedding call through **`ssrfSafeFetch`** — the same raw-fetch gap #335 closed for vision/STT. `local` keeps a plain fetch for the bundled ONNX or an internal endpoint (private address, which the guard would rightly reject). External `baseUrl` is SSRF-validated at save.

## Safety — reindex confirmation

Changing **model / dimensions / similarity** re-embeds **every vector in every space**, so the save requires an explicit *"I understand — re-index"* confirmation (danger dialog). The existing staleness → reindex flow does the actual work.

## Infra controls (as requested — "infra can disable and fix-set")

- Whole-config **infra-managed lock** (`mediaEmbedding.infraManaged` / `YTHRIL_MEDIA_INFRA_MANAGED`) → PATCH 409, UI read-only.
- **Per-field env pins**: `EMBEDDING_PROVIDER` / `EMBEDDING_URL` / `EMBEDDING_MODEL` / `EMBEDDING_DIMENSIONS` / `EMBEDDING_API_KEY` → `lockedByInfra`, that field read-only.
- API key in `secrets.json` (masked, never returned).

Config lives at top-level `config.embedding` but is surfaced/edited via `/api/admin/media-config`. **Test connection** gains an `embedding` target.

## Tests
- 4 standalone loader cases (provider default, config resolution, env-pin override + `lockedByInfra`, `getEmbeddingApiKey`).
- Integration: GET surfaces the block, external-private-URL SSRF rejection, provider-only round-trip, API-key masking.

Server + client build green; standalone suite passes (incl. `audit-route-coverage`); docs lint clean.

## Scope note
This is **part 2a**. **OIDC JWKS (part 2b) is intentionally deferred** — lower value (admin-set issuer, DNS-rebind only) and high blast radius (would break internal IdPs). Recommended later as public-only-default + `oidc.allowPrivateIssuer` opt-in. Tracked in `_TODO-ORDERED` §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)