### PR TITLE
fix(auth): bound the OIDC discovery fetch — a hung IdP stalled the login path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A hung identity provider can no longer stall the login path — the OIDC discovery fetch is now
+  bounded.** `getDiscoveryDoc()` called `fetch(url)` on `<issuer>/.well-known/openid-configuration` with no
+  `AbortSignal`, so an IdP that accepted the TCP connection and then never answered held the request until
+  the OS socket timeout — minutes — on the **authentication** path. Because the discovery document is
+  cached with a 5-minute TTL, the stall recurred every time the cache expired rather than happening once.
+  Both outbound calls this module makes now share an explicit 10-second budget (`OIDC_HTTP_TIMEOUT_MS`),
+  and the JWKS handle pins the same value instead of inheriting jose's default, so the budget is policy
+  rather than a library default that could shift. A timeout is reported as
+  `OIDC discovery failed: no response within 10000ms for <url>`, so an operator can tell "it hung" from
+  "it refused" or "it returned 500". New standalone test drives a real server that accepts connections and
+  never responds, proving the call gives up instead of hanging. (Every other outbound call in the server
+  already carried a timeout; this one was the exception. Found in the 2026-07-21 multi-lens audit.)
+
 - **The heavy parser sidecars are now confined: capabilities dropped, root filesystem read-only, memory /
   process / CPU ceilings (Docker hardening, Tier B).** `ollama`, `whisper` and `unstructured` exist to parse
   **untrusted** user-supplied media and documents, which makes them the highest-risk processes in a

--- a/server/src/auth/oidc.ts
+++ b/server/src/auth/oidc.ts
@@ -93,9 +93,21 @@ type JwksHandle = ReturnType<typeof createRemoteJWKSet>;
 let _jwksHandle: JwksHandle | null = null;
 let _cachedIssuerUrl = '';
 
+/**
+ * Ceiling for every outbound call this module makes to the IdP (discovery + JWKS).
+ *
+ * This sits on the AUTHENTICATION path: an IdP that accepts the TCP connection and then never
+ * answers would otherwise hold the request until the OS socket timeout — minutes — and because the
+ * discovery document is cached with a TTL, the stall recurs rather than happening once. Ten seconds
+ * is well beyond any healthy IdP's response time and well below anything a user would wait out.
+ */
+export const OIDC_HTTP_TIMEOUT_MS = 10_000;
+
 function getJwksHandle(jwksUri: string, issuerUrl: string): JwksHandle {
   if (_jwksHandle && _cachedIssuerUrl === issuerUrl) return _jwksHandle;
-  _jwksHandle = createRemoteJWKSet(new URL(jwksUri));
+  // jose defaults to 5s; pin it so the budget is explicit policy rather than a library default that
+  // could change under us — the same reasoning as DEFAULT_OIDC_ALGORITHMS above.
+  _jwksHandle = createRemoteJWKSet(new URL(jwksUri), { timeoutDuration: OIDC_HTTP_TIMEOUT_MS });
   _cachedIssuerUrl = issuerUrl;
   return _jwksHandle;
 }
@@ -127,7 +139,17 @@ export async function getDiscoveryDoc(issuerUrl: string): Promise<DiscoveryDoc> 
 
   validateOidcUrl(issuerUrl, 'issuerUrl');
   const url = issuerUrl.replace(/\/$/, '') + '/.well-known/openid-configuration';
-  const res = await fetch(url);
+  let res: Response;
+  try {
+    res = await fetch(url, { signal: AbortSignal.timeout(OIDC_HTTP_TIMEOUT_MS) });
+  } catch (err) {
+    // An unreachable IdP and one that hangs are the same failure to the caller, and both must be
+    // reported as such rather than surfacing an opaque AbortError from deep in the auth path.
+    const reason = err instanceof Error && err.name === 'TimeoutError'
+      ? `no response within ${OIDC_HTTP_TIMEOUT_MS}ms`
+      : err instanceof Error ? err.message : String(err);
+    throw new Error(`OIDC discovery failed: ${reason} for ${url}`);
+  }
   if (!res.ok) {
     throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText} for ${url}`);
   }

--- a/testing/standalone/oidc-discovery-timeout.test.js
+++ b/testing/standalone/oidc-discovery-timeout.test.js
@@ -1,0 +1,85 @@
+/**
+ * Standalone tests: the OIDC discovery fetch is bounded by a timeout.
+ *
+ * Why this matters more than a normal missing-timeout: `getDiscoveryDoc()` runs on the
+ * AUTHENTICATION path, and its result is cached with a TTL — so an IdP that accepts the TCP
+ * connection and then never answers does not stall one request, it stalls a request every time the
+ * cache expires, each one held until the OS socket timeout (minutes). Every other outbound call in
+ * the server already carries an `AbortSignal.timeout`; this one did not.
+ *
+ * The test drives a real HTTP server that deliberately never responds, so it proves the behaviour
+ * end to end rather than asserting that a constant exists.
+ *
+ * Run: node --test testing/standalone/oidc-discovery-timeout.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+let getDiscoveryDoc;
+let clearOidcCache;
+let OIDC_HTTP_TIMEOUT_MS;
+
+/** A server that accepts the connection and then holds it open, answering nothing. */
+let blackHole;
+let blackHolePort;
+const heldSockets = [];
+
+describe('OIDC discovery — timeout', () => {
+  before(async () => {
+    ({ getDiscoveryDoc, clearOidcCache, OIDC_HTTP_TIMEOUT_MS } = await import(
+      '../../server/dist/auth/oidc.js'
+    ));
+
+    blackHole = http.createServer((req) => {
+      // Never write a response, never end it: the classic "hung IdP".
+      heldSockets.push(req.socket);
+    });
+    await new Promise((resolve) => blackHole.listen(0, '127.0.0.1', resolve));
+    blackHolePort = blackHole.address().port;
+  });
+
+  after(async () => {
+    for (const s of heldSockets) s.destroy();
+    if (blackHole) await new Promise((resolve) => blackHole.close(resolve));
+    clearOidcCache?.();
+  });
+
+  it('exposes an explicit, sane HTTP budget', () => {
+    assert.equal(typeof OIDC_HTTP_TIMEOUT_MS, 'number');
+    assert.ok(
+      OIDC_HTTP_TIMEOUT_MS > 0 && OIDC_HTTP_TIMEOUT_MS <= 30_000,
+      `expected a bounded budget, got ${OIDC_HTTP_TIMEOUT_MS}ms`,
+    );
+  });
+
+  it('rejects instead of hanging when the IdP never responds', async () => {
+    clearOidcCache();
+    const started = Date.now();
+    await assert.rejects(
+      () => getDiscoveryDoc(`http://127.0.0.1:${blackHolePort}`),
+      (err) => {
+        assert.match(err.message, /OIDC discovery failed/);
+        // The operator has to be able to tell "it hung" from "it refused" or "it 500'd".
+        assert.match(err.message, /no response within \d+ms/);
+        return true;
+      },
+      'a hung IdP must surface as a discovery failure, not an unbounded await',
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(
+      elapsed < OIDC_HTTP_TIMEOUT_MS * 3,
+      `expected the call to give up near ${OIDC_HTTP_TIMEOUT_MS}ms, took ${elapsed}ms`,
+    );
+  });
+
+  it('reports an unreachable IdP as a discovery failure too', async () => {
+    clearOidcCache();
+    // Port 1 on loopback: connection refused immediately — the other half of the same failure mode.
+    await assert.rejects(
+      () => getDiscoveryDoc('http://127.0.0.1:1'),
+      /OIDC discovery failed/,
+    );
+  });
+});


### PR DESCRIPTION
First item off the **must-ship-before-major** list from the 2026-07-21 multi-lens audit
(`_AUDIT-ANGLES.md` sweep run after the queue drained).

## The bug

`getDiscoveryDoc()` fetched the IdP's discovery document with no `AbortSignal`:

```ts
const url = issuerUrl.replace(/\/$/, '') + '/.well-known/openid-configuration';
const res = await fetch(url);          // ← unbounded
```

An IdP that accepts the TCP connection and then never answers holds that request until the **OS socket
timeout** — minutes. This is the **authentication** path, and because the discovery document is cached
with a 5-minute TTL, the stall does not happen once: it recurs every time the cache expires.

Every other outbound call in the server already carries an `AbortSignal.timeout` (21 sites). This one was
the exception.

## The fix

Both outbound calls this module makes now share one explicit budget, `OIDC_HTTP_TIMEOUT_MS` (10 s):

- **discovery** — `fetch(url, { signal: AbortSignal.timeout(OIDC_HTTP_TIMEOUT_MS) })`
- **JWKS** — `createRemoteJWKSet(url, { timeoutDuration: OIDC_HTTP_TIMEOUT_MS })`. jose already defaults
  to 5 s, so this is not a behaviour fix; pinning it makes the budget **explicit policy** rather than a
  library default that can shift under us — the same reasoning the file already applies to
  `DEFAULT_OIDC_ALGORITHMS`.

10 s is well beyond any healthy IdP's response time and well below anything a user would wait out.

A timeout is reported as:

```text
OIDC discovery failed: no response within 10000ms for <url>
```

rather than an opaque `AbortError` surfacing from deep in the auth path — so an operator can tell *"it
hung"* apart from *"it refused"* and *"it returned 500"*.

## Verification

`testing/standalone/oidc-discovery-timeout.test.js` drives a **real HTTP server that accepts the
connection and never responds**, so it proves the behaviour end to end instead of asserting that a
constant exists:

```text
✔ exposes an explicit, sane HTTP budget
✔ rejects instead of hanging when the IdP never responds (10009ms)
✔ reports an unreachable IdP as a discovery failure too
```

The message assertion (`/no response within \d+ms/`) only matches the new code path, so the test cannot
pass against the old behaviour. `npm run build:server` clean.

## Scope note

This is deliberately **not** the deferred SSRF part 2b (guarding OIDC egress behind `ssrfSafeFetch` with
an `allowPrivateIssuer` opt-in). That call stands — it has real blast radius on internal IdPs. This is the
independent, zero-risk half of the same file: a timeout changes nothing about which hosts are reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
