### PR TITLE
fix(security): key rate limits per client, not per source IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Rate limits are now per client, not per source IP — one busy client can no longer 429 everyone else.**
+  In the default Docker deployment there is no reverse proxy, so every request reaches Ythril from the same
+  Docker gateway address (`::ffff:172.21.0.x`). With the limiters keyed on `req.ip`, that put **every**
+  client of the instance into one shared 300/min bucket: a single busy integration — or a buggy one, which
+  is exactly what the brain request storm was — locked out every other client, and the app could 429 its
+  own UI. The global, sync, notify and bulk-wipe limiters now bucket on the **presented credential**
+  (`Authorization: Bearer`, or the MCP `?token=` parameter, which the transport uses by design), hashed
+  before use so the credential never lands in a store key, a log line, or a header. Requests with no
+  credential (login, setup, an anonymous probe) still key on the IP — the only identity they have — with
+  IPv6 normalised to the `/64` so a client cannot rotate through addresses it already owns; the auth
+  limiter stays IP-keyed on purpose, since throttling credential-guessing is precisely a per-source
+  concern. Because per-client keying alone would let a flood of random bearer strings mint unbounded
+  buckets, a **per-IP flood backstop** (3000/min, far above any legitimate single client) now sits in
+  front of every route except `/health`, `/ready` and `/metrics`. `docs/integration-guide.md` documents
+  the keying, the backstop, and why a reverse-proxy deployment must set `TRUST_PROXY` to the exact hop
+  count. (Found in the 2026-07-21 multi-lens audit; the storm had already shown the impact.)
+
 - **A hung identity provider can no longer stall the login path — the OIDC discovery fetch is now
   bounded.** `getDiscoveryDoc()` called `fetch(url)` on `<issuer>/.well-known/openid-configuration` with no
   `AbortSignal`, so an IdP that accepted the TCP connection and then never answered held the request until

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -615,13 +615,34 @@ Extended errors may include:
 
 ## Rate Limits
 
-| Scope | Limit | Applies To |
-|---|---|---|
-| Auth | 10 / min | Token creation, setup, invite/apply |
-| Global | 300 / min | All authenticated endpoints |
-| Sync | 2 000 / min | Sync API endpoints |
-| Notify | 60 / min | `GET /api/notify`, `POST /api/notify`, `POST /api/notify/trigger` |
-| Bulk wipe | 5 / min | `DELETE /api/brain/spaces/:spaceId/{memories,entities,edges,chrono}` |
+| Scope | Limit | Keyed by | Applies To |
+|---|---|---|---|
+| Auth | 10 / min | source IP | Token creation, setup, invite/apply |
+| Global | 300 / min | client | All authenticated endpoints |
+| Sync | 2 000 / min | client (peer) | Sync API endpoints |
+| Notify | 60 / min | client | `GET /api/notify`, `POST /api/notify`, `POST /api/notify/trigger` |
+| Bulk wipe | 5 / min | client | `DELETE /api/brain/spaces/:spaceId/{memories,entities,edges,chrono}` |
+| Flood backstop | 3 000 / min | source IP | Everything except `/health`, `/ready`, `/metrics` |
+
+**"Keyed by client" means your budget is your own.** The limiter buckets on the credential you present —
+the `Authorization: Bearer` token, or the MCP `?token=` parameter — so one busy integration cannot spend
+another's allowance. This matters most in the default Docker deployment: with no reverse proxy in front,
+every request reaches Ythril from the same Docker gateway address, so an IP-keyed limit would be a single
+shared bucket for the whole instance. The credential is hashed before it is used as a key; it never
+appears in a key, a log line, or a header.
+
+Requests with **no** credential (login, setup, an anonymous probe) key on the source IP — that is the only
+identity they have — and IPv6 addresses are normalised to their `/64` so a client cannot rotate through
+addresses it already owns.
+
+The **flood backstop** is a per-IP ceiling in front of every route, set far above any legitimate single
+client. It exists because per-client keying alone would let a flood of random bearer strings mint an
+unbounded number of buckets. You should never see it in normal operation.
+
+> **Behind a reverse proxy, set `TRUST_PROXY`** (see the environment table above) to the exact number of
+> proxy hops. Without it `req.ip` is the proxy's address, so the auth limiter and the flood backstop
+> collapse to one bucket for all traffic through that proxy. Do not use `true`: it trusts the entire
+> client-supplied `X-Forwarded-For` chain, which lets a caller spoof the address those limits key on.
 
 Rate limit headers follow the IETF draft-7 format: a single combined `RateLimit` header plus a `RateLimit-Policy` header (the legacy draft-6 `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` headers are not emitted):
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -31,7 +31,7 @@ import { localAgentRouter } from './api/local-agent.js';
 import { dataRouter } from './api/data.js';
 import { mediaConfigRouter } from './api/media-config.js';
 import { maintenanceMiddleware } from './maintenance.js';
-import { globalRateLimit } from './rate-limit/middleware.js';
+import { globalRateLimit, ipFloodBackstop } from './rate-limit/middleware.js';
 import { configExists, reloadConfig, getConfig, saveConfig, loadSecrets } from './config/loader.js';
 import { requireAuth, requireAdminMfa, requireAdminMfaScoped } from './auth/middleware.js';
 import { clearTokenCache } from './auth/tokens.js';
@@ -195,6 +195,14 @@ export function createApp() {
   // Runs after metrics so durationMs is accurate; before routes so it sees
   // the 'finish' event for every response.
   app.use(auditMiddleware);
+
+  // ── Flood backstop ───────────────────────────────────────────────────────
+  // The per-route limiters key on the CLIENT (see rate-limit/middleware.ts), which is what stops one
+  // busy client starving the others. That keying alone would let a flood of random bearer strings mint
+  // an unbounded number of buckets, so this per-IP ceiling sits in front of everything as the outer
+  // bound. It is set far above any legitimate single client and is invisible in normal operation.
+  // Mounted after the probe/metrics routes above so /health, /ready and /metrics are never throttled.
+  app.use(ipFloodBackstop);
 
   // ── Maintenance mode ─────────────────────────────────────────────────────
   // When active, blocks all API traffic except /health, /ready, /metrics and

--- a/server/src/rate-limit/middleware.ts
+++ b/server/src/rate-limit/middleware.ts
@@ -1,5 +1,36 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'node:crypto';
+import type { Request } from 'express';
 import { log } from '../util/log.js';
+
+/**
+ * Bucket requests by CLIENT, not by source IP.
+ *
+ * Why: behind no reverse proxy (`trustProxy=false`) — which is the default Docker deployment — every
+ * request arrives from the Docker gateway address (`::ffff:172.21.0.x`). Keying on the IP therefore puts
+ * *every* client of the instance into ONE bucket, so a single busy client (or a client bug — the brain
+ * request storm was exactly this) locks out everyone else, and the app can 429 itself.
+ *
+ * The key is derived from the presented credential rather than from `req.authToken`, because the limiters
+ * run BEFORE the auth middleware that would populate it. It is a SHA-256 of the bearer, truncated — the
+ * credential itself never lands in a store key, a log line, or a header.
+ *
+ * Requests with no credential (login, setup, an anonymous probe) still key on the IP, which is the only
+ * identity they have. `ipKeyGenerator` is used for that half so IPv6 addresses are normalised to their /64
+ * — an IPv6 client can otherwise trivially rotate through addresses it already owns.
+ */
+export function clientRateLimitKey(req: Request): string {
+  const header = req.get?.('authorization') ?? '';
+  const bearer = /^Bearer\s+(.+)$/i.exec(header)?.[1]?.trim();
+  // The MCP transport passes the token as a query parameter by design (an external agent may be unable
+  // to set headers), so it has to be recognised here too or every MCP client shares the IP bucket.
+  const query = typeof req.query?.['token'] === 'string' ? req.query['token'].trim() : '';
+  const credential = bearer || query;
+  if (credential) {
+    return `c:${createHash('sha256').update(credential).digest('base64url').slice(0, 22)}`;
+  }
+  return `ip:${ipKeyGenerator(req.ip ?? '')}`;
+}
 
 /**
  * The `SKIP_*_RATE_LIMIT` kill-switches exist only for the test harness. They are
@@ -40,12 +71,13 @@ export const authRateLimit = rateLimit({
   skip: () => skipRateLimit('SKIP_AUTH_RATE_LIMIT'),
 });
 
-/** 60 requests/minute per IP — used for notification and setup endpoints */
+/** 60 requests/minute per CLIENT — notification and setup endpoints */
 export const notifyRateLimit = rateLimit({
   windowMs: 60_000,
   max: 60,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  keyGenerator: clientRateLimitKey,
   message: { error: 'Too many requests, please try again later.' },
   handler: (req, res, _next, options) => {
     log.warn(`notifyRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
@@ -61,12 +93,36 @@ export const notifyRateLimit = rateLimit({
   skip: () => skipRateLimit('SKIP_SYNC_RATE_LIMIT'),
 });
 
-/** 300 requests/minute per IP — general API and MCP endpoints */
+/**
+ * 3000 requests/minute per SOURCE IP — the flood backstop, mounted once in front of every route.
+ *
+ * Per-client keying (below) is what stops one client starving the others, but on its own it hands an
+ * attacker an escape hatch: every distinct bearer string mints a fresh bucket, so a flood of random
+ * credentials would never hit a limit. This limiter closes that — it is keyed purely on the IP and set
+ * far above any legitimate single client, so it is invisible in normal operation and only bites a flood.
+ *
+ * It deliberately does NOT replace the per-route limiters; it sits behind them as the outer bound.
+ */
+export const ipFloodBackstop = rateLimit({
+  windowMs: 60_000,
+  max: 3000,
+  standardHeaders: false,
+  legacyHeaders: false,
+  message: { error: 'Rate limit exceeded, please slow down.' },
+  handler: (req, res, _next, options) => {
+    log.warn(`ipFloodBackstop hit: ${req.ip} on ${req.method} ${req.path}`);
+    res.status(options.statusCode).json(options.message);
+  },
+  skip: () => skipRateLimit('SKIP_GLOBAL_RATE_LIMIT'),
+});
+
+/** 300 requests/minute per CLIENT — general API and MCP endpoints */
 export const globalRateLimit = rateLimit({
   windowMs: 60_000,
   max: 300,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  keyGenerator: clientRateLimitKey,
   message: { error: 'Rate limit exceeded, please slow down.' },
   handler: (req, res, _next, options) => {
     log.warn(`globalRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
@@ -78,7 +134,7 @@ export const globalRateLimit = rateLimit({
   skip: () => skipRateLimit('SKIP_GLOBAL_RATE_LIMIT'),
 });
 
-/** 2000 requests/minute per IP — machine-to-machine sync endpoints.
+/** 2000 requests/minute per CLIENT (peer) — machine-to-machine sync endpoints.
  *  Sync pushes one request per item; with large data sets and multiple
  *  networks the per-minute volume can easily exceed the global limit. */
 export const syncRateLimit = rateLimit({
@@ -86,6 +142,7 @@ export const syncRateLimit = rateLimit({
   max: 2000,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  keyGenerator: clientRateLimitKey,
   message: { error: 'Sync rate limit exceeded, please slow down.' },
   handler: (req, res, _next, options) => {
     log.warn(`syncRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
@@ -94,12 +151,13 @@ export const syncRateLimit = rateLimit({
   skip: () => skipRateLimit('SKIP_SYNC_RATE_LIMIT'),
 });
 
-/** 5 requests/minute per IP — destructive bulk operations (memory wipe) */
+/** 5 requests/minute per CLIENT — destructive bulk operations (memory wipe) */
 export const bulkWipeRateLimit = rateLimit({
   windowMs: 60_000,
   max: 5,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  keyGenerator: clientRateLimitKey,
   message: { error: 'Bulk delete rate limit exceeded, please try again later.' },
   handler: (req, res, _next, options) => {
     log.warn(`bulkWipeRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);

--- a/testing/standalone/rate-limit-client-key.test.js
+++ b/testing/standalone/rate-limit-client-key.test.js
@@ -1,0 +1,76 @@
+/**
+ * Standalone tests: rate-limit buckets are keyed per CLIENT, not per source IP.
+ *
+ * Why this is a real bug and not a tuning preference: with no reverse proxy in front
+ * (`trustProxy=false`, the default Docker deployment) every request arrives from the Docker gateway
+ * address, so an IP-keyed limiter puts EVERY client of the instance into one 300/min bucket. One busy
+ * client — or one buggy one, which is exactly what the brain request storm was — then 429s everybody,
+ * including the app's own UI.
+ *
+ * `clientRateLimitKey` derives the bucket from the presented credential instead. It runs BEFORE the auth
+ * middleware (that is where the limiters sit in the chain), so it works off the raw bearer rather than
+ * `req.authToken`, and it must never leak that credential into a store key or a log line.
+ *
+ * Run: node --test testing/standalone/rate-limit-client-key.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let clientRateLimitKey;
+
+/** Minimal Express-request stand-in: only the fields the key generator reads. */
+function req({ bearer, token, ip = '::ffff:172.21.0.5' } = {}) {
+  const headers = bearer ? { authorization: `Bearer ${bearer}` } : {};
+  return {
+    ip,
+    query: token ? { token } : {},
+    get(name) { return headers[name.toLowerCase()]; },
+  };
+}
+
+describe('clientRateLimitKey', () => {
+  before(async () => {
+    ({ clientRateLimitKey } = await import('../../server/dist/rate-limit/middleware.js'));
+  });
+
+  it('gives two different tokens two different buckets, from the same IP', () => {
+    const a = clientRateLimitKey(req({ bearer: 'ythril_aaaaaaaaaaaaaaaa' }));
+    const b = clientRateLimitKey(req({ bearer: 'ythril_bbbbbbbbbbbbbbbb' }));
+    assert.notEqual(a, b, 'one noisy client must not consume another client’s budget');
+  });
+
+  it('gives the same token the same bucket across requests', () => {
+    const a = clientRateLimitKey(req({ bearer: 'ythril_stable' }));
+    const b = clientRateLimitKey(req({ bearer: 'ythril_stable', ip: '10.9.9.9' }));
+    assert.equal(a, b, 'the bucket follows the client, not the source address');
+  });
+
+  it('recognises the MCP query-parameter credential', () => {
+    // The MCP transport passes ?token= by design; without this every MCP client shares the IP bucket.
+    const viaQuery = clientRateLimitKey(req({ token: 'ythril_mcp' }));
+    const viaHeader = clientRateLimitKey(req({ bearer: 'ythril_mcp' }));
+    assert.equal(viaQuery, viaHeader);
+    assert.notEqual(viaQuery, clientRateLimitKey(req({ token: 'ythril_other' })));
+  });
+
+  it('falls back to the IP when no credential is presented', () => {
+    const anon = clientRateLimitKey(req());
+    assert.match(anon, /^ip:/, 'an anonymous request has no identity but its address');
+    assert.notEqual(anon, clientRateLimitKey(req({ ip: '10.1.2.3' })));
+  });
+
+  it('never puts the raw credential in the key', () => {
+    const secret = 'ythril_super_secret_value_1234567890';
+    const key = clientRateLimitKey(req({ bearer: secret }));
+    assert.ok(!key.includes(secret), 'the key ends up in store keys and debug output');
+    assert.ok(!key.includes('super_secret'), 'not even a fragment of it');
+    assert.match(key, /^c:[A-Za-z0-9_-]{22}$/, 'expected a truncated hash, got ' + key);
+  });
+
+  it('normalises IPv6 so a client cannot rotate through its own /64', () => {
+    const a = clientRateLimitKey(req({ ip: '2001:db8:1:2::1' }));
+    const b = clientRateLimitKey(req({ ip: '2001:db8:1:2::beef' }));
+    assert.equal(a, b, 'addresses in one /64 belong to one client');
+  });
+});


### PR DESCRIPTION
**Must-ship-before-major #2** from the 2026-07-21 multi-lens audit. The impact was already demonstrated
in production, by the brain request storm.

## The bug

In the default Docker deployment there is no reverse proxy (`trustProxy=false`), so **every** request
reaches Ythril from the same Docker gateway address (`::ffff:172.21.0.x`). The limiters keyed on `req.ip`:

```ts
export const globalRateLimit = rateLimit({ windowMs: 60_000, max: 300, /* keyed on req.ip */ });
```

So every client of the instance shared **one** 300/min bucket. One busy integration — or one buggy one,
which is exactly what the storm was — locked out every other client, and the app 429'd its own UI.

## The fix

Global, sync, notify and bulk-wipe now bucket on the **presented credential**:

- `Authorization: Bearer <token>`, **or** the MCP `?token=` parameter — that transport passes the token in
  the query string by design, so it has to be recognised here or every MCP client falls back to sharing
  the IP bucket;
- derived from the **raw** credential rather than `req.authToken`, because the limiters run *before* the
  auth middleware that would populate it;
- SHA-256'd and truncated, so the credential never lands in a store key, a log line, or a header (there is
  an explicit test for that).

Requests with **no** credential (login, setup, an anonymous probe) still key on the IP — the only identity
they have — through `ipKeyGenerator`, which normalises IPv6 to the `/64` so a client cannot rotate through
addresses it already owns.

`authRateLimit` **stays IP-keyed on purpose**: throttling credential-guessing is precisely a per-source
concern, and those requests carry no credential to key on anyway.

## The part that isn't obvious: a flood backstop

Per-client keying on its own hands an attacker an escape hatch — every distinct bearer string mints a
fresh bucket, so a flood of random credentials would never hit any limit at all. A per-IP
**`ipFloodBackstop`** (3000/min, far above any legitimate single client) now sits in front of every route,
mounted *after* `/health`, `/ready` and `/metrics` so orchestration probes are never throttled. It is
invisible in normal operation and only bites a flood.

## Verification

`testing/standalone/rate-limit-client-key.test.js` — 6/6 green:

```text
✔ gives two different tokens two different buckets, from the same IP
✔ gives the same token the same bucket across requests
✔ recognises the MCP query-parameter credential
✔ falls back to the IP when no credential is presented
✔ never puts the raw credential in the key
✔ normalises IPv6 so a client cannot rotate through its own /64
```

`npm run build:server` clean; `audit-route-coverage` 4/4; docs + CHANGELOG lint clean.

## Docs

`docs/integration-guide.md`'s Rate Limits table gains a **Keyed by** column and the backstop row, plus the
reverse-proxy note the tracker asked for: without `TRUST_PROXY` set to the exact hop count, the IP-keyed
halves collapse to one bucket for everything behind that proxy — and `true` is not the answer, because it
trusts a client-spoofable `X-Forwarded-For` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
