### PR TITLE
test(conflicts): stop the conflict tests skipping themselves into a green build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1215,6 +1215,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The conflict-resolution integration tests no longer skip themselves into a green build.** Nine tests
+  in `conflict-resolution.test.js` began with `if (!conflictId) { t.skip('Could not seed conflict'); return; }`,
+  and the `seedConflict()` helper returned `null` on any non-201 instead of failing. Seeding there is a
+  plain `POST /api/conflicts/seed` with no environmental dependency — so the day that endpoint regressed,
+  all nine tests would have skipped and CI would have stayed green with nothing to show for it. The helper
+  now asserts the 201 (with the status and body in the message) and the guards are gone. `conflicts.test.js` had six more escape hatches of the same shape, including one test that
+  skipped and then asserted the very thing it had just guarded on, with unreachable code after the
+  `return`. Running the suite against the live 4-instance stack settled the open question behind them:
+  peer file-sync hash-mismatch detection **does** work there — the dependent tests ran for real and the
+  retry loop lands in roughly two of its six attempts — so those guards are now assertions too. Both files
+  were verified end to end: 15/15 and 10/10 passing with **0 skipped**, three consecutive runs clean, and
+  a mutation check (breaking the seed endpoint) turns 9 silent skips into 9 real failures. (Found in the 2026-07-21 multi-lens audit.)
+
 - **Brain tables: the Description cell now fills its column again.** `.desc-cell` set `display: -webkit-box`
   (for the 3-line clamp) directly on the `<td>`, which overrode `display: table-cell` and dropped the cell
   out of the table layout, so it no longer filled its column. The clamp moved to an inner wrapper; the `<td>`

--- a/testing/integration/conflict-resolution.test.js
+++ b/testing/integration/conflict-resolution.test.js
@@ -83,7 +83,10 @@ async function seedConflict(spaceId, originalPath, conflictPath) {
     peerInstanceLabel: 'Test Peer',
     detectedAt: new Date().toISOString(),
   });
-  if (r.status !== 201) return null;
+  // Assert rather than return null: this is a plain API call with no environmental dependency, so a
+  // non-201 is a regression in the seed endpoint — not a reason for every test below to skip itself
+  // and leave CI green.
+  assert.equal(r.status, 201, `seedConflict(${spaceId}, ${originalPath}) failed: ${r.status} ${JSON.stringify(r.body)}`);
   return id;
 }
 
@@ -148,7 +151,7 @@ describe('Conflict Resolution Actions', () => {
   });
 
   describe('keep-local', () => {
-    it('deletes conflict file, keeps original, removes record', async (t) => {
+    it('deletes conflict file, keeps original, removes record', async () => {
       const origPath = `cr-local-orig-${RUN}.txt`;
       const confPath = `cr-local-conf-${RUN}.txt`;
 
@@ -160,7 +163,6 @@ describe('Conflict Resolution Actions', () => {
 
       // Seed conflict record
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       // Resolve: keep-local
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
@@ -185,7 +187,7 @@ describe('Conflict Resolution Actions', () => {
   });
 
   describe('keep-incoming', () => {
-    it('replaces original with conflict copy, removes record', async (t) => {
+    it('replaces original with conflict copy, removes record', async () => {
       const origPath = `cr-incoming-orig-${RUN}.txt`;
       const confPath = `cr-incoming-conf-${RUN}.txt`;
 
@@ -193,7 +195,6 @@ describe('Conflict Resolution Actions', () => {
       await uploadFile('general', confPath, 'incoming version');
 
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
         action: 'keep-incoming',
@@ -217,7 +218,7 @@ describe('Conflict Resolution Actions', () => {
   });
 
   describe('keep-both', () => {
-    it('keeps both files, removes record', async (t) => {
+    it('keeps both files, removes record', async () => {
       const origPath = `cr-both-orig-${RUN}.txt`;
       const confPath = `cr-both-conf-${RUN}.txt`;
 
@@ -225,7 +226,6 @@ describe('Conflict Resolution Actions', () => {
       await uploadFile('general', confPath, 'incoming version');
 
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
         action: 'keep-both',
@@ -246,7 +246,7 @@ describe('Conflict Resolution Actions', () => {
       assert.equal(check.status, 404);
     });
 
-    it('with rename: renames conflict file', async (t) => {
+    it('with rename: renames conflict file', async () => {
       const origPath = `cr-both-rename-orig-${RUN}.txt`;
       const confPath = `cr-both-rename-conf-${RUN}.txt`;
       const renameTo = `cr-both-renamed-${RUN}.txt`;
@@ -255,7 +255,6 @@ describe('Conflict Resolution Actions', () => {
       await uploadFile('general', confPath, 'incoming version');
 
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
         action: 'keep-both',
@@ -283,7 +282,7 @@ describe('Conflict Resolution Actions', () => {
   });
 
   describe('save-to-space', () => {
-    it('copies conflict file to target space, deletes from source, removes record', async (t) => {
+    it('copies conflict file to target space, deletes from source, removes record', async () => {
       const origPath = `cr-save-orig-${RUN}.txt`;
       const confPath = `cr-save-conf-${RUN}.txt`;
 
@@ -291,7 +290,6 @@ describe('Conflict Resolution Actions', () => {
       await uploadFile('general', confPath, 'incoming version');
 
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       // Resolve: save conflict copy to target space
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
@@ -320,7 +318,7 @@ describe('Conflict Resolution Actions', () => {
       assert.equal(check.status, 404);
     });
 
-    it('with rename: saves to target space under new name', async (t) => {
+    it('with rename: saves to target space under new name', async () => {
       const origPath = `cr-save-rename-orig-${RUN}.txt`;
       const confPath = `cr-save-rename-conf-${RUN}.txt`;
       const renameTo = `cr-save-renamed-${RUN}.txt`;
@@ -329,7 +327,6 @@ describe('Conflict Resolution Actions', () => {
       await uploadFile('general', confPath, 'incoming version');
 
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
         action: 'save-to-space',
@@ -348,7 +345,7 @@ describe('Conflict Resolution Actions', () => {
       assert.equal(confGone, false);
     });
 
-    it('rejects inaccessible targetSpaceId → 403', async (t) => {
+    it('rejects inaccessible targetSpaceId → 403', async () => {
       const origPath = `cr-save-noaccess-orig-${RUN}.txt`;
       const confPath = `cr-save-noaccess-conf-${RUN}.txt`;
 
@@ -356,7 +353,6 @@ describe('Conflict Resolution Actions', () => {
       await uploadFile('general', confPath, 'incoming version');
 
       const conflictId = await seedConflict('general', origPath, confPath);
-      if (!conflictId) { t.skip('Could not seed conflict'); return; }
 
       // Use a non-existent space name
       const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, {
@@ -368,7 +364,7 @@ describe('Conflict Resolution Actions', () => {
   });
 
   describe('bulk-resolve', () => {
-    it('resolves multiple conflicts with keep-local', async (t) => {
+    it('resolves multiple conflicts with keep-local', async () => {
       const conflicts = [];
       for (let i = 0; i < 3; i++) {
         const origPath = `cr-bulk-orig-${i}-${RUN}.txt`;
@@ -376,7 +372,6 @@ describe('Conflict Resolution Actions', () => {
         await uploadFile('general', origPath, `local-${i}`);
         await uploadFile('general', confPath, `incoming-${i}`);
         const id = await seedConflict('general', origPath, confPath);
-        if (!id) { t.skip(`Could not seed conflict ${i}`); return; }
         conflicts.push({ id, origPath, confPath });
       }
 
@@ -398,13 +393,12 @@ describe('Conflict Resolution Actions', () => {
       }
     });
 
-    it('returns partial results when some conflicts fail', async (t) => {
+    it('returns partial results when some conflicts fail', async () => {
       const origPath = `cr-bulk-partial-orig-${RUN}.txt`;
       const confPath = `cr-bulk-partial-conf-${RUN}.txt`;
       await uploadFile('general', origPath, 'local');
       await uploadFile('general', confPath, 'incoming');
       const validId = await seedConflict('general', origPath, confPath);
-      if (!validId) { t.skip('Could not seed conflict'); return; }
 
       const r = await post(INSTANCES.a, tokenA, '/api/conflicts/bulk-resolve', {
         ids: [validId, 'nonexistent-conflict-id'],

--- a/testing/integration/conflicts.test.js
+++ b/testing/integration/conflicts.test.js
@@ -205,17 +205,15 @@ describe('Conflicts API â€” seeded via file sync hash mismatch', () => {
     if (networkId2) await del(INSTANCES.a, tokenA, `/api/networks/${networkId2}`).catch(() => {});
   });
 
-  it('conflict document was created by file hash mismatch detection', async (t) => {
-    // If the sync stack is not fully wired for file sync, skip gracefully.
-    if (!conflictId) {
-      return t.skip('No conflict was seeded â€” file sync peers not fully wired in test stack.');
-      return;
-    }
-    assert.ok(conflictId, 'conflictId must be set');
+  it('conflict document was created by file hash mismatch detection', async () => {
+    // Verified against the live 4-instance stack: the retry loop above (6 x 2s) reliably produces a
+    // conflict, landing in roughly two attempts. This asserts rather than skips, because a run where
+    // no conflict appears means either sync regressed or the harness stopped wiring peer file sync —
+    // both of which are things CI must go red for, not report as green.
+    assert.ok(conflictId, 'no conflict document appeared — peer file-sync hash-mismatch detection did not run');
   });
 
-  it('GET /api/conflicts returns the seeded conflict with correct shape', async (t) => {
-    if (!conflictId) return t.skip('No conflict seeded');
+  it('GET /api/conflicts returns the seeded conflict with correct shape', async () => {
     const r = await get(INSTANCES.a, tokenA, '/api/conflicts');
     assert.equal(r.status, 200);
     const c = r.body.conflicts.find(x => x.id === conflictId);
@@ -229,8 +227,7 @@ describe('Conflicts API â€” seeded via file sync hash mismatch', () => {
     assert.ok(!isNaN(Date.parse(c.detectedAt)), 'conflict.detectedAt must be a valid ISO8601 date');
   });
 
-  it('GET /api/conflicts/:id returns the single conflict record', async (t) => {
-    if (!conflictId) return t.skip('No conflict seeded');
+  it('GET /api/conflicts/:id returns the single conflict record', async () => {
     const r = await get(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.id, conflictId);
@@ -241,8 +238,7 @@ describe('Conflicts API â€” seeded via file sync hash mismatch', () => {
     assert.ok(r.body.detectedAt);
   });
 
-  it('POST /api/conflicts/:id/resolve returns 200 {status:resolved} and removes the record', async (t) => {
-    if (!conflictId) return t.skip('No conflict seeded');
+  it('POST /api/conflicts/:id/resolve returns 200 {status:resolved} and removes the record', async () => {
     const r = await post(INSTANCES.a, tokenA, `/api/conflicts/${conflictId}/resolve`, { action: 'keep-local' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.status, 'resolved');
@@ -252,7 +248,7 @@ describe('Conflicts API â€” seeded via file sync hash mismatch', () => {
     assert.equal(check.status, 404, 'Resolved conflict must return 404');
   });
 
-  it('DELETE /api/conflicts/:id returns 204 and record is gone', async (t) => {
+  it('DELETE /api/conflicts/:id returns 204 and record is gone', async () => {
     // Re-seed: write competing files again on a fresh path
     const path2 = `conflict-test-del-${RUN}.txt`;
     const uploadA = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(path2)}`;
@@ -264,9 +260,9 @@ describe('Conflicts API â€” seeded via file sync hash mismatch', () => {
     });
 
     const rA = await fetch(uploadA, putOpts(tokenA, `del-version-A-${RUN}`));
-    if (![201, 202].includes(rA.status)) return t.skip('Could not write competing file for DELETE test');
+    assert.ok([201, 202].includes(rA.status), `write competing file (rA): ${rA.status}`);
     const rB = await fetch(uploadB, putOpts(tokenB, `del-version-B-${RUN}`));
-    if (![201, 202].includes(rB.status)) return t.skip('Could not write competing file for DELETE test');
+    assert.ok([201, 202].includes(rB.status), `write competing file (rB): ${rB.status}`);
 
     let delConflictId;
     for (let attempt = 0; attempt < 6; attempt++) {
@@ -276,7 +272,7 @@ describe('Conflicts API â€” seeded via file sync hash mismatch', () => {
       const seeded = (check.body?.conflicts ?? []).filter(c => c.originalPath === path2 || c.conflictPath?.startsWith(path2.replace('.txt', '')));
       if (seeded.length > 0) { delConflictId = seeded[0].id; break; }
     }
-    if (!delConflictId) return t.skip('Could not seed second conflict for DELETE test');
+    assert.ok(delConflictId, 'second conflict was not seeded for the DELETE test');
 
     const r = await del(INSTANCES.a, tokenA, `/api/conflicts/${delConflictId}`);
     assert.equal(r.status, 204, JSON.stringify(r.body));


### PR DESCRIPTION
**Must-ship-before-major #3** from the 2026-07-21 multi-lens audit: fifteen tests across two files
**could not fail**.

## The problem

Nine tests in `conflict-resolution.test.js` opened with:

```js
if (!conflictId) { t.skip('Could not seed conflict'); return; }
```

…and `seedConflict()` returned `null` on any non-201 instead of failing — even though seeding there is a
plain `POST /api/conflicts/seed`, a deterministic API call with no environmental dependency.

Six more of the same shape lived in `conflicts.test.js`, including one test that skipped and then
asserted the very thing it had just guarded on, with unreachable code after the `return`:

```js
if (!conflictId) {
  return t.skip('No conflict was seeded — file sync peers not fully wired in test stack.');
  return;                       // ← unreachable
}
assert.ok(conflictId, 'conflictId must be set');
```

So the day any of it regressed, the tests would have skipped themselves and CI would have gone green with
nothing exercised. `_AUDIT-ANGLES.md §10` asks "would this test fail if the code were wrong?" — the answer
was no.

## The fix

Every guard becomes an assertion:

- `seedConflict()` asserts the 201, with status and response body in the message;
- `conflicts.test.js` asserts that peer file-sync produced a conflict, that the competing files were
  written, and that the second conflict was seeded for the DELETE test;
- `t` dropped from the signatures where it existed only for the skip.

## The assumption I had to disprove

The `conflicts.test.js` guards existed because that conflict comes from **real peer file-sync
hash-mismatch detection**, which the harness might not wire — and asserting an environmental dependency
would redden CI for the wrong reason. An earlier revision of this branch marked that test `{ todo: … }` on
exactly that assumption.

Running it settled the question the other way: the harness **does** wire it. The dependent tests execute
for real (`skipped 0`), and the retry loop lands in roughly two of its six attempts. So it asserts like
everything else, and the `todo` marker is gone.

## Verification — against the live 4-instance stack, not left to CI

```text
conflict-resolution.test.js   15/15 pass, 0 skipped
conflicts.test.js             10/10 pass, 0 skipped, 0 todo   (three consecutive runs identical)
```

And the check that matters most — **mutation test**: pointing `seedConflict()` at a bad path turns

```text
before:  pass 6,  fail 0,  skipped 9      ← green build, nothing tested
after:   pass 6,  fail 9,  skipped 0      ← red build, names the broken endpoint
```

Full `test:standalone` with the stack up: 993 pass, 0 fail (the 4 remaining skips are POSIX-permission
tests that Windows cannot run; CI's Linux runner executes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
