### PR TITLE
fix(client,server): updating an instance no longer breaks every already-open tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1215,6 +1215,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Updating an instance no longer breaks every tab that was already open.** Every Angular build rehashes
+  its lazy-chunk filenames, so a browser still running the previous `main-*.js` asks for a `chunk-*.js`
+  that no longer exists the moment you navigate to a lazy route. The result was a **dead click**: no
+  message, no network entry (the browser caches the failed dynamic import, so the retry never leaves the
+  page), and only a `TypeError: error loading dynamically imported module` in a console the user is not
+  looking at — with a hard refresh as the only recovery, which nobody has a reason to try. Two things were
+  wrong. **The server answered a missing build asset with `200 text/html`**: the SPA fallback handed back
+  index.html, so the browser received a web page where it had asked for JavaScript and nothing on either
+  side could tell a stale build from a real route. A request for a hashed build asset that does not exist
+  is now a genuine **404**, while navigation paths still receive index.html so deep links keep working.
+  **And the client had no recovery at all** — no navigation-error handler, nothing watching for a failed
+  import. It now detects a chunk-load failure (router hook plus global `error`/`unhandledrejection`
+  listeners, matching the wording Chrome, Firefox and Safari each use) and reloads once, which picks up
+  the new bundle and completes the navigation the user asked for. The guard is a **60-second cooldown
+  timestamp, not a boolean**: a broken deploy boots fine and only fails on navigation, so clearing a flag
+  on successful boot would have turned the one-shot reload into an endless reload loop — there is a test
+  named after exactly that trap. Reported by the instance owner, who lost Spaces and Models after an
+  update; reproduced, and both halves verified against the live test stack (11 new server assertions,
+  8 client).
+
 - **The conflict-resolution integration tests no longer skip themselves into a green build.** Nine tests
   in `conflict-resolution.test.js` began with `if (!conflictId) { t.skip('Could not seed conflict'); return; }`,
   and the `seedConflict()` helper returned `null` on any non-201 instead of failing. Seeding there is a

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideZonelessChangeDetection, APP_INITIALIZER, inject } from '@angular/core';
-import { provideRouter, withComponentInputBinding, TitleStrategy } from '@angular/router';
+import { provideRouter, withComponentInputBinding, withNavigationErrorHandler, TitleStrategy } from '@angular/router';
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideTransloco, provideTranslocoMissingHandler, Translation, TranslocoLoader, TranslocoService } from '@jsverse/transloco';
@@ -10,6 +10,7 @@ import { authInterceptor } from './core/auth.interceptor';
 import { mfaInterceptor } from './core/mfa.interceptor';
 import { ThemeService } from './core/theme.service';
 import { TranslocoTitleStrategy } from './core/title-strategy';
+import { staleBuildNavigationErrorHandler, installStaleBuildGlobalHandler, markBuildLoaded } from './core/stale-build-recovery';
 
 @Injectable({ providedIn: 'root' })
 export class TranslocoHttpLoader implements TranslocoLoader {
@@ -22,10 +23,18 @@ export class TranslocoHttpLoader implements TranslocoLoader {
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
-    provideRouter(routes, withComponentInputBinding()),
+    provideRouter(routes, withComponentInputBinding(), withNavigationErrorHandler(staleBuildNavigationErrorHandler)),
     { provide: TitleStrategy, useClass: TranslocoTitleStrategy },
     provideHttpClient(withInterceptors([authInterceptor, mfaInterceptor])),
     provideAnimationsAsync(),
+    {
+      // Recover from "the app was updated while this tab was open": the stale bundle asks for lazy
+      // chunks that no longer exist, and without this the navigation dies silently — no message, no
+      // network entry, just a dead click. Registered first so it is listening as early as possible.
+      provide: APP_INITIALIZER,
+      useFactory: () => () => { installStaleBuildGlobalHandler(); markBuildLoaded(); },
+      multi: true,
+    },
     {
       provide: APP_INITIALIZER,
       useFactory: (theme: ThemeService) => () => theme.init(),

--- a/client/src/app/core/stale-build-recovery.spec.ts
+++ b/client/src/app/core/stale-build-recovery.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  recoverFromStaleBuild,
+  markBuildLoaded,
+  staleBuildNavigationErrorHandler,
+  RELOAD_COOLDOWN_MS,
+} from './stale-build-recovery';
+
+/**
+ * The failure this recovers from, observed live: after the instance was updated, clicking a lazy route in
+ * an already-open tab did nothing at all — no message, no network entry, only
+ * `TypeError: error loading dynamically imported module: /chunk-FQS44RLV.js` in the console. The tab was
+ * running the previous `main-*.js`, whose chunk filenames no longer exist in the new build.
+ *
+ * The dangerous half of the fix is the guard: a naive "reload once" flag cleared on successful boot turns
+ * a genuinely broken deploy into an endless reload loop, because a broken deploy boots fine and only
+ * fails on navigation. These tests pin that behaviour specifically.
+ */
+
+/** Minimal Window stand-in: real storage semantics, a counted reload, no jsdom navigation. */
+function fakeWindow(store: Record<string, string> = {}) {
+  let reloads = 0;
+  const listeners: Record<string, ((e: unknown) => void)[]> = {};
+  return {
+    reloads: () => reloads,
+    listeners,
+    win: {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => { store[k] = v; },
+        removeItem: (k: string) => { delete store[k]; },
+      },
+      location: { reload: () => { reloads += 1; } },
+      addEventListener: (type: string, fn: (e: unknown) => void) => {
+        (listeners[type] ??= []).push(fn);
+      },
+    } as unknown as Window,
+  };
+}
+
+const chunkError = new Error(
+  'error loading dynamically imported module: https://example.test/chunk-FQS44RLV.js',
+);
+
+describe('stale-build recovery', () => {
+
+  it('reloads once when a lazy chunk cannot be loaded', () => {
+    const w = fakeWindow();
+    expect(recoverFromStaleBuild(chunkError, w.win)).toBe(true);
+    expect(w.reloads()).toBe(1);
+  });
+
+  it('does NOT reload again when the failure repeats immediately — no reload loop', () => {
+    const w = fakeWindow();
+    recoverFromStaleBuild(chunkError, w.win);
+    // A genuinely broken deploy: reloading did not help, and the failure comes straight back.
+    expect(recoverFromStaleBuild(chunkError, w.win)).toBe(false);
+    expect(recoverFromStaleBuild(chunkError, w.win)).toBe(false);
+    expect(w.reloads()).toBe(1);
+  });
+
+  it('a successful boot must NOT clear a recent guard (that is what would create the loop)', () => {
+    const w = fakeWindow();
+    recoverFromStaleBuild(chunkError, w.win);
+    markBuildLoaded(w.win); // the app boots fine — a broken deploy only fails on navigation
+    expect(recoverFromStaleBuild(chunkError, w.win)).toBe(false);
+    expect(w.reloads()).toBe(1);
+  });
+
+  it('recovers again from a LATER update, once the cooldown has passed', () => {
+    const store: Record<string, string> = {
+      'ythril:chunk-reload': String(Date.now() - RELOAD_COOLDOWN_MS - 1_000),
+    };
+    const w = fakeWindow(store);
+    markBuildLoaded(w.win);
+    expect(recoverFromStaleBuild(chunkError, w.win)).toBe(true);
+    expect(w.reloads()).toBe(1);
+  });
+
+  it('ignores errors that are not chunk-load failures', () => {
+    const w = fakeWindow();
+    expect(recoverFromStaleBuild(new Error('Http failure response: 500'), w.win)).toBe(false);
+    expect(recoverFromStaleBuild(undefined, w.win)).toBe(false);
+    expect(w.reloads()).toBe(0);
+  });
+
+  it('matches the wording each browser uses', () => {
+    for (const message of [
+      'error loading dynamically imported module: /chunk-A.js',      // Chrome, Safari
+      'Failed to fetch dynamically imported module: /chunk-B.js',    // Chrome (newer)
+      'error loading module',                                        // Firefox
+      'Importing a module script failed.',                           // Safari
+      'ChunkLoadError: Loading chunk 42 failed',                     // webpack-style
+    ]) {
+      const w = fakeWindow();
+      expect(recoverFromStaleBuild(new Error(message), w.win), message).toBe(true);
+    }
+  });
+
+  it('does nothing when sessionStorage is unavailable, rather than looping unguarded', () => {
+    const w = fakeWindow();
+    (w.win as unknown as { sessionStorage: unknown }).sessionStorage = {
+      getItem() { throw new Error('denied'); },
+      setItem() { throw new Error('denied'); },
+      removeItem() { throw new Error('denied'); },
+    };
+    expect(recoverFromStaleBuild(chunkError, w.win)).toBe(false);
+    expect(w.reloads()).toBe(0);
+  });
+
+  it('unwraps the router NavigationError shape', () => {
+    // The router hands the handler a NavigationError whose `.error` carries the real failure.
+    const w = fakeWindow();
+    staleBuildNavigationErrorHandler({ error: chunkError }, w.win);
+    expect(w.reloads()).toBe(1);
+  });
+});

--- a/client/src/app/core/stale-build-recovery.ts
+++ b/client/src/app/core/stale-build-recovery.ts
@@ -1,0 +1,94 @@
+import type { NavigationError } from '@angular/router';
+
+/**
+ * Recovery for the "the app was updated while your tab was open" failure.
+ *
+ * Every Angular build rehashes its lazy-chunk filenames. A tab that is still running the previous
+ * `main-*.js` therefore asks for a `chunk-*.js` that no longer exists the moment the user navigates to a
+ * lazy route. Without this, the click simply does nothing: no message, no network entry (the browser
+ * caches the failed dynamic import in its module map, so a retry never even leaves the page), and only a
+ * `TypeError: error loading dynamically imported module` in a console the user is not looking at. The
+ * only recovery is a hard refresh they have no reason to try.
+ *
+ * The server half of this fix makes a missing build asset return a real 404 rather than falling back to
+ * index.html — so the browser stops receiving HTML where it asked for JavaScript.
+ *
+ * Reloading picks up the new index.html and its new bundle, so the navigation the user asked for
+ * succeeds. The guard is a TIMESTAMP, not a boolean: a second chunk failure within RELOAD_COOLDOWN_MS of
+ * the last reload means reloading did not help — the deploy is genuinely broken — so the error is left to
+ * surface rather than reloading again. Clearing the flag on successful boot would NOT work: a broken
+ * deploy boots fine and only fails on navigation, so the flag would be cleared before every retry and the
+ * "one shot" would become an endless reload loop.
+ */
+
+const RELOAD_FLAG = 'ythril:chunk-reload';
+/** A repeat failure sooner than this means the reload did not fix anything. */
+export const RELOAD_COOLDOWN_MS = 60_000;
+
+/** Matches the browser-specific wording for "I could not load that module". */
+function isChunkLoadFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return (
+    /error loading dynamically imported module/i.test(message) || // Chrome, Safari
+    /failed to fetch dynamically imported module/i.test(message) || // Chrome (newer)
+    /error loading module|importing a module script failed/i.test(message) || // Firefox, Safari
+    /ChunkLoadError/i.test(message)
+  );
+}
+
+/**
+ * True when the failure was handled by scheduling a reload. False means the caller should surface the
+ * error normally — either it is unrelated to chunk loading, or we already tried reloading once.
+ */
+export function recoverFromStaleBuild(error: unknown, win: Window = window): boolean {
+  if (!isChunkLoadFailure(error)) return false;
+
+  const now = Date.now();
+  try {
+    const last = Number(win.sessionStorage.getItem(RELOAD_FLAG) ?? 0);
+    if (last && now - last < RELOAD_COOLDOWN_MS) return false; // reloading already failed to fix it
+    win.sessionStorage.setItem(RELOAD_FLAG, String(now));
+  } catch {
+    // Private mode / storage disabled: without the guard we cannot bound the attempts, so do nothing
+    // rather than risk an endless reload loop.
+    return false;
+  }
+
+  win.location.reload();
+  return true;
+}
+
+/**
+ * Drops a guard left over from a PREVIOUS session window. Deliberately does NOT clear a recent one:
+ * see the note above about why clearing on boot would create a reload loop.
+ */
+export function markBuildLoaded(win: Window = window): void {
+  try {
+    const last = Number(win.sessionStorage.getItem(RELOAD_FLAG) ?? 0);
+    if (last && Date.now() - last >= RELOAD_COOLDOWN_MS) win.sessionStorage.removeItem(RELOAD_FLAG);
+  } catch {
+    /* storage unavailable — nothing to clear */
+  }
+}
+
+/** Router hook: turns a chunk-load navigation failure into a one-shot reload. */
+export function staleBuildNavigationErrorHandler(
+  navigationError: NavigationError | unknown,
+  win: Window = window,
+): void {
+  const error = (navigationError as NavigationError)?.error ?? navigationError;
+  recoverFromStaleBuild(error, win);
+}
+
+/**
+ * Also catch chunk failures that do not arrive through the router — a lazily loaded standalone
+ * component, a deferred block, or an `import()` inside a service.
+ */
+export function installStaleBuildGlobalHandler(win: Window = window): void {
+  win.addEventListener('unhandledrejection', (event) => {
+    if (recoverFromStaleBuild(event.reason, win)) event.preventDefault();
+  });
+  win.addEventListener('error', (event) => {
+    recoverFromStaleBuild((event as ErrorEvent).error ?? (event as ErrorEvent).message, win);
+  });
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -521,8 +521,23 @@ export function createApp() {
   // index.html so Angular's client-side router handles navigation.
   app.use(express.static(clientDist));
 
-  // ── SPA fallback — return index.html for all unmatched GET requests ───────
-  app.get('/{*path}', (_req, res, next) => {
+  // ── SPA fallback — return index.html for unmatched NAVIGATION requests ────
+  //
+  // The fallback deliberately does NOT cover build assets. Every Angular build rehashes its lazy-chunk
+  // filenames, so a browser that still holds a pre-update `main-*.js` will ask for a `chunk-*.js` that no
+  // longer exists. Answering that with index.html means the browser requested JavaScript and received
+  // HTML: the module import fails with an opaque "error loading dynamically imported module", the route
+  // click does nothing, and nothing on either side can tell a stale build from a real page. (That is
+  // exactly how it presented in practice — a dead click with no network entry and no message.)
+  //
+  // A missing asset is a 404. The client turns that into a one-shot reload; see the chunk-load recovery
+  // in the Angular app config.
+  const ASSET_REQUEST = /\.(?:js|mjs|css|map|json|woff2?|ttf|eot|svg|png|jpe?g|gif|webp|avif|ico)$/i;
+  app.get('/{*path}', (req, res, next) => {
+    if (ASSET_REQUEST.test(req.path)) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
     const indexPath = path.join(clientDist, 'index.html');
     res.sendFile(indexPath, (err) => {
       if (err) next(); // fall through to 404 if index.html not built yet

--- a/testing/standalone/spa-fallback-assets.test.js
+++ b/testing/standalone/spa-fallback-assets.test.js
@@ -1,0 +1,86 @@
+/**
+ * Standalone tests: the SPA fallback must not answer a missing BUILD ASSET with index.html.
+ *
+ * The failure this pins, observed live on 2026-07-21: after updating an instance, clicking a lazy route
+ * in an already-open tab did nothing — no message, no network entry, just
+ * `TypeError: error loading dynamically imported module: /chunk-FQS44RLV.js` in the console.
+ *
+ * Every Angular build rehashes its lazy-chunk filenames, so a tab still running the previous `main-*.js`
+ * asks for chunks that no longer exist. The server answered those with `200 text/html` — the SPA fallback
+ * handing back index.html — so the browser received HTML where it had asked for JavaScript, and nothing
+ * on either side could tell "your build is stale" from "this is a page".
+ *
+ * A missing asset has to be a 404. The client turns that into a one-shot reload
+ * (client/src/app/core/stale-build-recovery.ts); it cannot do that if the server pretends the file exists.
+ *
+ * Run: node --test testing/standalone/spa-fallback-assets.test.js
+ * Pre-requisite: the test stack (`npm run test:up`) — these assert against a running instance.
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { INSTANCES } from '../sync/helpers.js';
+
+const BASE = INSTANCES.a;
+
+/** Filenames shaped like build output — what a stale bundle asks for. */
+const MISSING_ASSETS = [
+  '/chunk-FQS44RLV.js',           // the exact shape that broke the live instance
+  '/main-DEADBEEF.js',
+  '/styles-CAFEBABE.css',
+  '/media/some-font-ABCDEF12.woff2',
+  '/polyfills-00000000.js.map',
+];
+
+/** Paths the Angular router owns — these MUST still receive index.html so deep links work. */
+const NAVIGATION_PATHS = ['/settings/models', '/settings/spaces', '/brain', '/some/deep/link'];
+
+describe('SPA fallback — build assets vs navigation', () => {
+  before(async () => {
+    const health = await fetch(`${BASE}/health`);
+    assert.equal(health.status, 200, 'test stack must be running (npm run test:up)');
+  });
+
+  for (const path of MISSING_ASSETS) {
+    it(`404s a missing build asset: ${path}`, async () => {
+      const res = await fetch(`${BASE}${path}`);
+      assert.equal(
+        res.status,
+        404,
+        `${path} must 404 — answering with index.html is what made a stale tab fail silently`,
+      );
+      assert.ok(
+        !(res.headers.get('content-type') ?? '').includes('text/html'),
+        `${path} must not return HTML: the browser asked for a script`,
+      );
+    });
+  }
+
+  for (const path of NAVIGATION_PATHS) {
+    it(`still serves the SPA for a navigation path: ${path}`, async () => {
+      const res = await fetch(`${BASE}${path}`);
+      assert.equal(res.status, 200, `${path} is a client route and must load the app`);
+      assert.match(
+        res.headers.get('content-type') ?? '',
+        /text\/html/,
+        `${path} must return index.html so the Angular router can take over`,
+      );
+    });
+  }
+
+  it('keeps returning JSON 404s for unknown API paths', async () => {
+    const res = await fetch(`${BASE}/api/definitely-not-a-route`);
+    assert.equal(res.status, 404);
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+  });
+
+  it('still serves an asset that DOES exist', async () => {
+    // Guard against over-correcting into 404ing the whole build: index.html references the real bundle.
+    const index = await fetch(`${BASE}/`);
+    const html = await index.text();
+    const main = /(?:src|href)="\/?(main-[A-Za-z0-9]+\.js)"/.exec(html)?.[1];
+    assert.ok(main, `could not find the main bundle in index.html: ${html.slice(0, 200)}`);
+    const res = await fetch(`${BASE}/${main}`);
+    assert.equal(res.status, 200, `${main} exists and must still be served`);
+  });
+});


### PR DESCRIPTION
Reported by the instance owner in normal use: after updating, clicking **Spaces** or **Models** did
nothing at all. No message, no network entry, no error a user would ever see — just this in a console they
had to be told to open:

```text
TypeError: error loading dynamically imported module: /chunk-FQS44RLV.js
```

The tab was still running the pre-update `main-VUFDQYOJ.js`; the server had moved on to
`main-GM6DULGD.js`, and the old lazy chunks no longer existed. **Every Angular build rehashes chunk
filenames, so this happens on every update to every tab anyone left open** — and the only recovery is a
hard refresh nobody has a reason to try.

Two independent defects.

## 1 · The server lied about a missing asset

`GET /chunk-FQS44RLV.js` returned **`200 text/html`** — the SPA fallback serving `index.html` for anything
it didn't recognise. The browser asked for JavaScript and received a web page, which is why the error is
so opaque, and it left nothing on either side able to distinguish *"your build is stale"* from *"this is a
route"*.

The fallback now covers **navigation only**. A request for a hashed build asset that does not exist gets a
real **404**; deep links still receive `index.html`.

## 2 · The client had no recovery

No navigation-error handler, nothing watching for a failed dynamic import — so the click just died.

`core/stale-build-recovery.ts` now catches chunk-load failures, both through the router
(`withNavigationErrorHandler`) and globally (`error` / `unhandledrejection`, for lazy components,
deferred blocks and `import()` inside services), and **reloads once**. That picks up the new `index.html`
and bundle, so the navigation the user asked for completes.

### The guard is the subtle part

The obvious implementation — a "reload once" flag cleared on successful boot — produces an **endless
reload loop** on a genuinely broken deploy, because such a deploy *boots fine* and only fails on
navigation, so the flag is cleared before every retry. I wrote that version first and caught it in review.

It is therefore a **60-second cooldown timestamp**: a repeat failure inside that window means reloading
didn't help, so the error is left to surface. Two tests are named after that trap. If `sessionStorage` is
unavailable (private mode), recovery is disabled rather than run unguarded.

## Verification — both halves, against the live stack

The **"before"** is not hypothetical: the owner's own instance returned `200 text/html` for the vanished
chunk, which is how the cause was identified.

| | |
|---|---|
| `spa-fallback-assets.test.js` | **11/11** — five build-asset shapes 404 (including the exact `/chunk-FQS44RLV.js` that broke the instance), four navigation paths still serve the SPA, unknown `/api` paths still return JSON 404s, and a real bundle is still served — that last one guards against over-correcting into 404ing the whole build |
| `stale-build-recovery.spec.ts` | **8/8** — including both reload-loop tests and the browser-wording matrix (Chrome, Firefox, Safari, webpack-style) |
| Full suites after the change | standalone **1010 pass / 0 fail**, integration **886 pass / 0 fail** |

## Note

The audit didn't catch this because nothing exercises *"load the app, then deploy over it"*. Worth
remembering as a test-shape gap, not just a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
