### PR TITLE
feat(config): support self-hosted OpenAI-compatible inference on a private address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,16 @@ YTHRIL_PORT=3200
 # `unstructured` service; set this only to point at an external converter:
 #   CONVERSION_SIDECAR_URL=http://my-unstructured-host:8000
 #
+# Self-hosted inference on a PRIVATE address (llama.cpp llama-server, vLLM, LocalAI on a cluster
+# service). The local/external switch picks a WIRE PROTOCOL, not a trust level — an OpenAI-compatible
+# server needs `external`, which by default refuses private addresses. This permits them:
+#
+#   YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true
+#
+# It does NOT disable the SSRF guard: DNS-pinning and redirect re-validation still apply, and
+# loopback / link-local / cloud-metadata addresses stay blocked — including when a hostname resolves
+# to one. Reported at startup and in GET /api/about/security.
+
 # Verbose logging:
 #   DEBUG=1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Self-hosted OpenAI-compatible inference on a private address is now a supported shape**
+  (`allowPrivateModelEndpoints`). Provider config offered `local` and `external`, and those names look
+  like a trust level but actually select a **wire protocol**: `local` speaks Ollama's `/api/chat`,
+  `external` speaks OpenAI's `/chat/completions`. An operator running llama.cpp `llama-server`, vLLM or
+  LocalAI behind a cluster service therefore had **no usable shape at all** — `local` speaks a protocol
+  their server does not implement, and `external` refused the private address. Reported by an operator
+  running `http://llm-inference-service.llm.svc.cluster.local:8080`.
+  Setting `allowPrivateModelEndpoints: true` in config.json (or `YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true`)
+  permits it for vision, speech-to-text, embedding and the document assist model. **It does not turn the
+  egress guard off:** those calls still go through `ssrfSafeFetch`, which resolves DNS, pins the resolved
+  IP for the connection and re-validates every redirect — only the private-address rejection lifts.
+  Loopback, link-local / cloud metadata (IMDS) and the `localhost` / `metadata.google.internal` hostnames
+  stay blocked either way, **including when a hostname resolves to one** — the DNS-rebinding case, which
+  has its own test. A declared-private `external` endpoint is therefore more tightly guarded than a
+  `local` provider, which uses a plain `fetch` with no guard at all.
+  The flag is **config/env only and deliberately not a field on `PATCH /api/admin/media-config`**: a value
+  that becomes an egress target must never be widenable from the admin API (mirrors `allowPrivatePeers`).
+  It is reported in the startup security posture and at `GET /api/about/security`
+  (`egress.privateModelEndpoints`), and a rejection now names the flag instead of just refusing the URL.
+  Note for anyone who hit this: a private **IP literal** was rejected at save time, but a cluster
+  **DNS name** saved fine and only failed later at inference — the static check cannot resolve. Both
+  enforcement points are covered.
+
 - **Rate limits are now per client, not per source IP — one busy client can no longer 429 everyone else.**
   In the default Docker deployment there is no reverse proxy, so every request reaches Ythril from the same
   Docker gateway address (`::ffff:172.21.0.x`). With the limiters keyed on `req.ip`, that put **every**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `local` provider, which uses a plain `fetch` with no guard at all.
   The flag is **config/env only and deliberately not a field on `PATCH /api/admin/media-config`**: a value
   that becomes an egress target must never be widenable from the admin API (mirrors `allowPrivatePeers`).
+  **Cloud-metadata endpoints are carved out explicitly**, because "RFC-1918 private" and "cloud metadata"
+  are different risk classes that must not share a switch. Two of them live *inside* ranges the opt-in
+  opens — AWS's IPv6 IMDS `fd00:ec2::254` (unique-local `fd00::/8`) and Alibaba Cloud's
+  `100.100.100.200` (CGNAT `100.64.0.0/10`) — so without the carve-out, enabling private endpoints would
+  have silently re-exposed the single highest-value SSRF target on those hosts. They are now blocked with
+  the opt-in on or off, alongside loopback and `169.254.169.254`, while legitimate addresses in the same
+  ranges (a real ULA or CGNAT service) stay reachable. This also hardens the pre-existing
+  `allowPrivatePeers` path, which shares the same range logic and had the same gap.
+  The posture check reports **effective exposure rather than intent**: instead of "the flag is on" it
+  names each configured external endpoint and how it classifies —
+  `vision → 10.43.12.7 (private); documentAssist → api.example.com (hostname)` — since widening egress is
+  the entire reason it is surfaced. A hostname is reported as a hostname, because only the
+  resolution-time guard can know where it points. With the flag OFF, an endpoint pointed at a private
+  address is now called out too, instead of failing silently at inference.
   It is reported in the startup security posture and at `GET /api/about/security`
   (`egress.privateModelEndpoints`), and a rejection now names the flag instead of just refusing the URL.
   Note for anyone who hit this: a private **IP literal** was rejected at save time, but a cluster

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2087,6 +2087,28 @@ point a **bigger, external model** at specific tasks under `documentProcessing.a
 | Field | Description |
 |---|---|
 | `baseUrl` | External **OpenAI-compatible** endpoint (`POST {baseUrl}/v1/chat/completions`). Validated against SSRF on save (must be a public http(s) URL — no private/loopback/metadata addresses) and reached only through the SSRF-guarded fetch. Env: `DOC_ASSIST_URL`. |
+
+> **Self-hosting inference on a private address?** The `local` / `external` choice selects a **wire
+> protocol**, not a trust level: `local` speaks Ollama's (`/api/chat`), `external` speaks OpenAI's
+> (`/chat/completions`, `/v1/embeddings`, `/v1/audio/transcriptions`). A self-hosted OpenAI-compatible
+> server — llama.cpp `llama-server`, vLLM, LocalAI — therefore needs `external`, even when it lives on a
+> cluster address like `http://llm-inference.llm.svc.cluster.local:8080`.
+>
+> Set **`allowPrivateModelEndpoints: true`** in `config.json`, or `YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true`,
+> to permit that. It is config/env only and deliberately **not** settable through
+> `PATCH /api/admin/media-config` — a field that becomes an egress target must never be widenable from
+> the admin API.
+>
+> Enabling it does **not** disable the SSRF guard. Those calls still go through `ssrfSafeFetch`, which
+> resolves DNS, pins the resolved IP for the connection and re-validates every redirect; only the
+> private-address rejection lifts. Loopback, link-local / cloud metadata (IMDS) and the `localhost` /
+> `metadata.google.internal` hostnames stay blocked either way — including when a hostname *resolves* to
+> one, which is the DNS-rebinding case. A declared-private `external` endpoint is therefore more tightly
+> guarded than a `local` provider, which uses a plain `fetch`.
+>
+> The instance reports this in its startup security posture and at `GET /api/about/security`
+> (`egress.privateModelEndpoints`).
+
 | `model` | Model tag to request. Env: `DOC_ASSIST_MODEL`. |
 | `apiKey` | Optional bearer token. Stored in `secrets.json` (never `config.json`), masked in the admin API. Env: `DOC_ASSIST_API_KEY`. |
 | `uses` | Which tasks the external model powers — `["repair"]` today (the `max`-mode repair pass); more are planned. Empty ⇒ configured but inert (no egress). |
@@ -2237,8 +2259,8 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | Field | Env var | Default | Description |
 |---|---|---|---|
 | `enabled` | `MEDIA_EMBEDDING_ENABLED` | `true` | Master on/off switch |
-| `visionProvider` | `VISION_PROVIDER` | `local` | `local` (Ollama) or `external` (OpenAI-compatible) |
-| `sttProvider` | `STT_PROVIDER` | `local` | `local` (Whisper) or `external` (OpenAI-compatible) |
+| `visionProvider` | `VISION_PROVIDER` | `local` | Wire protocol, not trust level: `local` (Ollama `/api/chat`) or `external` (OpenAI `/chat/completions`). A self-hosted OpenAI-compatible server needs `external` — see `allowPrivateModelEndpoints` for one on a private address. |
+| `sttProvider` | `STT_PROVIDER` | `local` | Wire protocol, not trust level: `local` (bundled Whisper) or `external` (OpenAI-compatible). Both speak `/v1/audio/transcriptions`. |
 | `vision.baseUrl` | `OLLAMA_URL` | `http://ollama:11434` | Vision service endpoint (short name resolves in both Docker Compose and the K8s `ythril` namespace) |
 | `vision.model` | `VISION_MODEL` | `moondream` | Vision model name |
 | `vision.apiKey` | `VISION_API_KEY` | — | API key for external vision provider (stored in `secrets.json`, never in `config.json`) |

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -14,6 +14,7 @@ import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets
 import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl, ssrfSafeFetch } from '../util/ssrf.js';
+import { allowPrivateModelEndpoints } from '../config/model-egress-policy.js';
 import { log } from '../util/log.js';
 import { providerSignature, getActiveProviderSignature } from '../files/media/worker.js';
 
@@ -138,23 +139,26 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
   // Local providers are trusted (cluster DNS — `*.svc.cluster.local`, addressed
   // via NetworkPolicy). External providers are admin-typed URLs that must
   // resolve to a public endpoint, never to private networks or cloud metadata.
+  // Instance-wide opt-in for self-hosted endpoints on private addresses (env/config only — never a
+  // field on this PATCH, so the admin API cannot widen its own egress).
+  const allowPrivate = allowPrivateModelEndpoints();
   const effectiveVisionType = parsed.data.visionProvider ?? activeCfg.visionProvider ?? 'local';
   const effectiveSttType    = parsed.data.sttProvider    ?? activeCfg.sttProvider    ?? 'local';
   if (effectiveVisionType === 'external' && parsed.data.vision?.baseUrl
-      && !isSsrfSafeUrl(parsed.data.vision.baseUrl)) {
-    res.status(400).json({ error: 'vision.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+      && !isSsrfSafeUrl(parsed.data.vision.baseUrl, allowPrivate)) {
+    res.status(400).json({ error: 'vision.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
     return;
   }
   if (effectiveSttType === 'external' && parsed.data.stt?.baseUrl
-      && !isSsrfSafeUrl(parsed.data.stt.baseUrl)) {
-    res.status(400).json({ error: 'stt.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+      && !isSsrfSafeUrl(parsed.data.stt.baseUrl, allowPrivate)) {
+    res.status(400).json({ error: 'stt.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
     return;
   }
   // Text-embedding external endpoint — same SSRF rule (only when the effective provider is external).
   const effectiveEmbType = parsed.data.embedding?.provider ?? getEmbeddingConfig().provider ?? 'local';
   if (effectiveEmbType === 'external' && parsed.data.embedding?.baseUrl
-      && !isSsrfSafeUrl(parsed.data.embedding.baseUrl)) {
-    res.status(400).json({ error: 'embedding.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+      && !isSsrfSafeUrl(parsed.data.embedding.baseUrl, allowPrivate)) {
+    res.status(400).json({ error: 'embedding.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
     return;
   }
 
@@ -176,7 +180,7 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     const effUses = assistPatch.uses ?? existingAssist.uses ?? [];
     const effAck = assistPatch.acknowledgedHost ?? existingAssist.acknowledgedHost;
     if (effUses.length > 0 && effBaseUrl) {
-      if (!isSsrfSafeUrl(effBaseUrl)) {
+      if (!isSsrfSafeUrl(effBaseUrl, allowPrivate)) {
         res.status(400).json({ error: 'assistModel.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
         return;
       }
@@ -335,7 +339,7 @@ mediaConfigRouter.post('/test-connection', requireAdminMfa, async (req, res) => 
     return;
   }
   // External endpoints must be public — refuse to probe private/loopback/metadata addresses.
-  if (external && !isSsrfSafeUrl(baseUrl)) {
+  if (external && !isSsrfSafeUrl(baseUrl, allowPrivateModelEndpoints())) {
     res.status(400).json({ error: `The ${target} endpoint is not a public http(s) URL (SSRF-blocked).` });
     return;
   }

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { getDataRoot, getEmbeddingConfig } from '../config/loader.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
+import { allowPrivateModelEndpoints } from '../config/model-egress-policy.js';
 import { log } from '../util/log.js';
 import { embeddingDurationSeconds, embeddingQueueDepth } from '../metrics/registry.js';
 
@@ -52,7 +53,13 @@ async function embedViaHttp(
   // External endpoints go through the SSRF-guarded fetch (DNS-resolve + IP-pin + redirect re-validation);
   // a local/trusted endpoint (e.g. on-cluster Ollama, private address) uses a plain fetch, which the guard
   // would rightly reject. Mirrors the vision/STT provider split (SSRF follow-up part 2).
-  const doFetch = cfg.provider === 'external' ? (ssrfSafeFetch as unknown as typeof fetch) : fetch;
+  // External → SSRF-guarded. `allowPrivateModelEndpoints` lets a self-hosted OpenAI-compatible
+  // embedding server live on a cluster address without dropping the guard: DNS-pinning and redirect
+  // re-validation still apply, only the private-address rejection lifts.
+  const doFetch = cfg.provider === 'external'
+    ? (((url: string, init?: RequestInit) =>
+        ssrfSafeFetch(url, init ?? {}, { allowPrivate: allowPrivateModelEndpoints() })) as unknown as typeof fetch)
+    : fetch;
   let response: Response;
   try {
     response = await doFetch(url, {

--- a/server/src/config/model-egress-exposure.ts
+++ b/server/src/config/model-egress-exposure.ts
@@ -1,0 +1,81 @@
+/**
+ * Effective model/media egress exposure — what the instance can actually reach, not what a flag says.
+ *
+ * `allowPrivateModelEndpoints is on` reports intent. It does not tell an operator whether anything is
+ * *using* that permission, or which endpoint went where. Since the whole reason the flag is surfaced is
+ * that it widens egress, the check has to name the exposure or it is decorative:
+ *
+ *     egress.privateModelEndpoints  vision → 10.43.12.7 (private); documentAssist → api.example.com (public)
+ *
+ * Classification is deliberately synchronous — the posture check is pure, and resolving DNS at boot would
+ * make it fail on a slow resolver. An IP literal is classified exactly; a hostname is reported as such,
+ * because only the resolution-time guard inside `ssrfSafeFetch` can know where it actually points.
+ */
+import { getConfig, getMediaEmbeddingConfig, getEmbeddingConfig } from './loader.js';
+import { isSsrfSafeUrl } from '../util/ssrf.js';
+
+export type EndpointClass = 'public' | 'private' | 'hostname' | 'invalid';
+
+export interface EndpointExposure {
+  /** Which provider this endpoint serves: vision, stt, embedding, documentAssist. */
+  provider: string;
+  /** Host as configured (never the full URL — a query string could carry a key). */
+  host: string;
+  klass: EndpointClass;
+}
+
+/**
+ * Classify a configured endpoint without resolving it.
+ *  - `private`  — an IP literal that only the opt-in permits (10/8, 172.16/12, 192.168/16, CGNAT, ULA…)
+ *  - `public`   — passes the guard with the opt-in off
+ *  - `hostname` — not an IP literal; where it points is decided at call time
+ *  - `invalid`  — unparseable, or blocked even with the opt-in on (a crown jewel)
+ */
+export function classifyEndpoint(raw: string): { host: string; klass: EndpointClass } {
+  let host: string;
+  try {
+    host = new URL(raw).hostname;
+  } catch {
+    return { host: raw.slice(0, 60), klass: 'invalid' };
+  }
+  if (isSsrfSafeUrl(raw, false)) {
+    // Passes with the opt-in OFF. A bare hostname also lands here, so separate the two: only an IP
+    // literal can be called "public" on a static check.
+    const isLiteral = /^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(':');
+    return { host, klass: isLiteral ? 'public' : 'hostname' };
+  }
+  if (isSsrfSafeUrl(raw, true)) return { host, klass: 'private' }; // only the opt-in permits it
+  return { host, klass: 'invalid' };                               // blocked either way — crown jewel
+}
+
+/** Every EXTERNAL provider endpoint currently configured, with its classification. */
+export function modelEndpointExposure(): EndpointExposure[] {
+  const out: EndpointExposure[] = [];
+  const add = (provider: string, url: string | undefined | null) => {
+    if (!url) return;
+    out.push({ provider, ...classifyEndpoint(url) });
+  };
+
+  try {
+    const media = getMediaEmbeddingConfig();
+    if (media.visionProvider === 'external') add('vision', media.vision?.baseUrl);
+    if (media.sttProvider === 'external') add('stt', media.stt?.baseUrl);
+  } catch { /* pre-setup */ }
+
+  try {
+    const emb = getEmbeddingConfig();
+    if (emb.provider === 'external') add('embedding', emb.baseUrl);
+  } catch { /* pre-setup */ }
+
+  try {
+    // The assist model is external by definition (F11-b) — no provider switch to check.
+    add('documentAssist', getConfig().mediaEmbedding?.documentProcessing?.assistModel?.baseUrl);
+  } catch { /* pre-setup */ }
+
+  return out;
+}
+
+/** One-line summary for the posture check: `vision → 10.43.12.7 (private); stt → api.x.com (public)`. */
+export function formatExposure(exposure: EndpointExposure[]): string {
+  return exposure.map(e => `${e.provider} → ${e.host} (${e.klass})`).join('; ');
+}

--- a/server/src/config/model-egress-policy.ts
+++ b/server/src/config/model-egress-policy.ts
@@ -1,0 +1,31 @@
+/**
+ * Model/media egress policy — where the **external** provider endpoints are allowed to live.
+ *
+ * The provider shapes encode a PROTOCOL, not a trust level: `local` speaks Ollama's wire protocol,
+ * `external` speaks OpenAI's. That left one real deployment with no usable shape at all — a self-hosted
+ * OpenAI-compatible server (llama.cpp `llama-server`, vLLM, LocalAI) on a private cluster address:
+ * `local` speaks a protocol it does not implement, and `external` rejected the address on save.
+ *
+ * `allowPrivateModelEndpoints` closes that. It is deliberately NOT "turn the guard off":
+ * `ssrfSafeFetch` still DNS-resolves, pins the resolved IP for the connection and re-validates every
+ * redirect — only the private-address rejection relaxes. A declared-private external endpoint therefore
+ * ends up better protected than a `local` provider, which uses a plain `fetch` with no guard at all.
+ *
+ * Env override → config key → safe default, matching `allowPrivatePeers` / `trustProxy` precedence.
+ * It is read here rather than passed through the media-config API on purpose: a field that turns into an
+ * egress target must never be widenable from the admin surface.
+ */
+import { getConfig } from './loader.js';
+
+/**
+ * True when external provider endpoints may resolve to private/reserved addresses
+ * (env `YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS` → config `allowPrivateModelEndpoints` → false).
+ */
+export function allowPrivateModelEndpoints(): boolean {
+  if (process.env['YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS'] === 'true') return true;
+  try {
+    return getConfig().allowPrivateModelEndpoints === true;
+  } catch {
+    return false; // config not loaded yet (first run) — stay closed
+  }
+}

--- a/server/src/config/security-posture.ts
+++ b/server/src/config/security-posture.ts
@@ -10,6 +10,7 @@
 import { getConfig, getMongoUri, atRestEncryptionActive } from './loader.js';
 import { requireEncryptedTransport, allowInsecurePeersRaw } from './transport-security.js';
 import { allowPrivateModelEndpoints } from './model-egress-policy.js';
+import { modelEndpointExposure, formatExposure } from './model-egress-exposure.js';
 
 export type PostureLevel = 'pass' | 'warn' | 'fail';
 
@@ -79,12 +80,36 @@ export function computeSecurityPosture(): SecurityPosture {
   // Widening where model/media egress may point is a deliberate operator decision, so it is reported
   // rather than silent — but it is NOT a `fail`: the guard itself stays on (DNS-pinning, redirect
   // re-validation, crown-jewel ranges still blocked), only private addresses become reachable.
+  //
+  // Report the EXPOSURE, not the flag. "allowPrivateModelEndpoints is on" tells an operator what they
+  // set; "vision → 10.43.12.7 (private)" tells them what it actually reaches, which is the thing that
+  // makes this check load-bearing. A hostname is named as a hostname — only the resolution-time guard
+  // knows where it points, and claiming otherwise here would be a guess.
   if (allowPrivateModelEndpoints()) {
-    checks.push({
-      id: 'egress.privateModelEndpoints',
-      level: 'warn',
-      message: 'allowPrivateModelEndpoints is on — external model/media endpoints may resolve to private addresses (self-hosted inference). SSRF guarding, IP-pinning and redirect re-validation still apply; loopback and link-local/IMDS stay blocked.',
-    });
+    const exposure = modelEndpointExposure();
+    const privateOnes = exposure.filter(e => e.klass === 'private');
+    checks.push(exposure.length === 0
+      ? {
+          id: 'egress.privateModelEndpoints',
+          level: 'warn',
+          message: 'allowPrivateModelEndpoints is on but no external model/media endpoint is configured — nothing is using the permission.',
+        }
+      : {
+          id: 'egress.privateModelEndpoints',
+          level: 'warn',
+          message: `allowPrivateModelEndpoints is on — ${privateOnes.length} of ${exposure.length} external endpoint(s) resolve to private addresses. ${formatExposure(exposure)}. SSRF guarding, IP-pinning and redirect re-validation still apply; loopback, link-local/IMDS and cloud-metadata addresses stay blocked.`,
+        });
+  } else {
+    // Flag off, but an endpoint may still be pointed at a private literal — that config cannot work, and
+    // silently failing at inference is exactly what the reporter hit. Say so.
+    const stuck = modelEndpointExposure().filter(e => e.klass === 'private' || e.klass === 'invalid');
+    if (stuck.length > 0) {
+      checks.push({
+        id: 'egress.privateModelEndpoints',
+        level: 'warn',
+        message: `External model endpoint(s) point at addresses this instance will refuse to call: ${formatExposure(stuck)}. Set allowPrivateModelEndpoints (or YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true) for a self-hosted endpoint on a private address; cloud-metadata addresses stay blocked regardless.`,
+      });
+    }
   }
 
   // ── At rest ──────────────────────────────────────────────────────────────────

--- a/server/src/config/security-posture.ts
+++ b/server/src/config/security-posture.ts
@@ -9,6 +9,7 @@
  */
 import { getConfig, getMongoUri, atRestEncryptionActive } from './loader.js';
 import { requireEncryptedTransport, allowInsecurePeersRaw } from './transport-security.js';
+import { allowPrivateModelEndpoints } from './model-egress-policy.js';
 
 export type PostureLevel = 'pass' | 'warn' | 'fail';
 
@@ -73,6 +74,17 @@ export function computeSecurityPosture(): SecurityPosture {
 
   if (cfg?.allowInsecurePlaintext) {
     checks.push({ id: 'transport.plaintext', level: 'warn', message: 'allowInsecurePlaintext is on — the plaintext-exposure guard is disabled.' });
+  }
+
+  // Widening where model/media egress may point is a deliberate operator decision, so it is reported
+  // rather than silent — but it is NOT a `fail`: the guard itself stays on (DNS-pinning, redirect
+  // re-validation, crown-jewel ranges still blocked), only private addresses become reachable.
+  if (allowPrivateModelEndpoints()) {
+    checks.push({
+      id: 'egress.privateModelEndpoints',
+      level: 'warn',
+      message: 'allowPrivateModelEndpoints is on — external model/media endpoints may resolve to private addresses (self-hosted inference). SSRF guarding, IP-pinning and redirect re-validation still apply; loopback and link-local/IMDS stay blocked.',
+    });
   }
 
   // ── At rest ──────────────────────────────────────────────────────────────────

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -888,6 +888,26 @@ export interface Config {
    * REQUIRE_ENCRYPTED_TRANSPORT.
    */
   requireEncryptedTransport?: boolean;
+  /**
+   * Allow the **external** model/media provider endpoints (vision, STT, embedding, document assist) to
+   * live on private/reserved addresses — a self-hosted OpenAI-compatible inference service behind a
+   * cluster address, e.g. `http://llm-inference.llm.svc.cluster.local:8080`.
+   *
+   * Why this exists: `external` selects the OpenAI wire protocol and `local` selects Ollama's, so an
+   * operator running llama.cpp/vLLM/LocalAI on a private address had NO usable shape — `local` speaks a
+   * protocol their server does not implement, and `external` rejected the address at save time.
+   *
+   * Enabling it does NOT drop the egress guard: those calls still go through `ssrfSafeFetch`, which
+   * DNS-resolves, pins the resolved IP for the connection and re-validates every redirect — only the
+   * private-address rejection relaxes. A declared-private external endpoint is therefore *better*
+   * protected than a `local` provider, which uses a plain `fetch`. Crown-jewel addresses (loopback,
+   * link-local / cloud IMDS, unspecified) stay blocked either way.
+   *
+   * Env/config only, deliberately NOT settable through `PATCH /api/admin/media-config`: an endpoint that
+   * becomes an egress target must never be widenable from the admin API. Mirrors `allowPrivatePeers`.
+   * Overridable via YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS.
+   */
+  allowPrivateModelEndpoints?: boolean;
   /** Dynamically-registered OAuth clients (RFC 7591) for the MCP browser
    *  authorization flow. Populated automatically when a client registers; not
    *  meant to be hand-edited. See mcp/oauth.ts. */

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -12,6 +12,7 @@
  * acknowledgment (enforced at config-save time).
  */
 import { ssrfSafeFetch } from '../../util/ssrf.js';
+import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
 
 export interface VlmTranscription {
   text: string;
@@ -140,6 +141,11 @@ export async function repairMarkdownExternal(
         messages: [{ role: 'user', content: repairContent(opts.draft, opts.evidence, opts.issues) }],
       }),
       signal: AbortSignal.timeout(opts.timeoutMs ?? 60_000),
+    }, {
+      // Lets a self-hosted OpenAI-compatible assist model live on a private cluster address. The guard
+      // itself stays on: DNS-resolve, IP-pin and redirect re-validation all still apply — only the
+      // private-address rejection lifts, and crown-jewel ranges remain blocked.
+      allowPrivate: allowPrivateModelEndpoints(),
     });
   } catch (err) {
     throw new Error(`assist model unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -15,6 +15,7 @@
 import type { MediaProviderConfig } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { ssrfSafeFetch } from '../../util/ssrf.js';
+import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
 
 /**
  * Runtime egress guard. **External** (operator-supplied, public) provider endpoints go through
@@ -23,8 +24,17 @@ import { ssrfSafeFetch } from '../../util/ssrf.js';
  * internal network) keep a plain `fetch`: their addresses are private, which `ssrfSafeFetch` would (rightly)
  * reject. The provider CLASS already encodes which is which (Ollama/Whisper = local; External* = external).
  */
-const egressFetch = (external: boolean): typeof fetch =>
-  external ? (ssrfSafeFetch as unknown as typeof fetch) : fetch;
+const egressFetch = (external: boolean): typeof fetch => {
+  if (!external) return fetch;
+  // An operator running a self-hosted OpenAI-compatible server on a cluster address needs the EXTERNAL
+  // protocol at a PRIVATE address. Note what this relaxes and what it does not: ssrfSafeFetch still
+  // resolves DNS, pins the resolved IP for the connection and re-validates redirects — only the
+  // private-address rejection lifts, and crown-jewel ranges (loopback, link-local/IMDS) stay blocked
+  // either way. This path therefore stays better guarded than a `local` provider, which uses plain fetch.
+  const allowPrivate = allowPrivateModelEndpoints();
+  return ((url: string, init?: RequestInit) =>
+    ssrfSafeFetch(url, init ?? {}, { allowPrivate })) as unknown as typeof fetch;
+};
 
 // ── Bounded JSON response reader ──────────────────────────────────────────────────────
 //

--- a/server/src/util/ssrf.ts
+++ b/server/src/util/ssrf.ts
@@ -109,16 +109,27 @@ function isBlockedIpv4Int(n: number): boolean {
 }
 
 /**
- * "Crown-jewel" IPv4 ranges that are blocked even for peers allowed to use private
- * addresses (`allowPrivatePeers`): loopback, link-local incl. cloud IMDS, the
- * unspecified address, and broadcast. No legitimate peer ever lives on these, and
- * they are the highest-value SSRF targets (169.254.169.254 → cloud credentials).
+ * "Crown-jewel" IPv4 ranges, blocked even when private addresses are permitted
+ * (`allowPrivatePeers`, `allowPrivateModelEndpoints`): loopback, link-local incl.
+ * cloud IMDS, the unspecified address, broadcast, and Alibaba Cloud metadata.
+ *
+ * The distinction matters: "RFC-1918 private" and "cloud metadata endpoint" are
+ * DIFFERENT RISK CLASSES. An operator opting into private addresses wants their
+ * 10.x cluster service reachable; nobody wants 169.254.169.254 or 100.100.100.200
+ * reachable. Metadata endpoints that happen to live inside an otherwise-private
+ * range therefore need an explicit carve-out, or the opt-in silently re-exposes
+ * the single highest-value SSRF target on that host (→ cloud credentials).
  */
 const ALWAYS_BLOCKED_IPV4_CIDRS: ReadonlyArray<readonly [number, number]> = [
   [0x00000000, 0xff000000], // 0.0.0.0/8      unspecified
   [0x7f000000, 0xff000000], // 127.0.0.0/8    loopback
-  [0xa9fe0000, 0xffff0000], // 169.254.0.0/16 link-local incl. IMDS
+  [0xa9fe0000, 0xffff0000], // 169.254.0.0/16 link-local incl. IMDS (AWS/GCP/Azure/Oracle/DO/Hetzner)
   [0xffffffff, 0xffffffff], // 255.255.255.255 broadcast
+  // Alibaba Cloud's metadata endpoint. It sits in 100.64.0.0/10 (CGNAT), which "allow private" opens —
+  // so without this carve-out, opting into private addresses would hand back the one target that
+  // matters most on an Alibaba host. "RFC-1918 private" and "cloud metadata" are different risk
+  // classes and must not share a switch.
+  [0x646464c8, 0xffffffff], // 100.100.100.200 Alibaba Cloud IMDS
 ];
 
 function isCrownJewelIpv4Int(n: number): boolean {
@@ -197,6 +208,10 @@ function isCrownJewelIpv6Expanded(h: number[]): boolean {
   if (h.slice(0, 6).every(x => x === 0) && (h[6] !== 0 || h[7] !== 0)) {
     return isCrownJewelIpv4Int((((h[6]! << 16) >>> 0) | h[7]!) >>> 0);
   }
+  // AWS's IPv6 instance-metadata endpoint, fd00:ec2::254. It lives in fd00::/8 (unique-local) — a range
+  // "allow private" deliberately opens — so it needs the same explicit carve-out as 169.254.169.254 and
+  // 100.100.100.200, or enabling private endpoints on an IPv6 EC2 host would quietly re-expose IMDS.
+  if (h[0] === 0xfd00 && h[1] === 0x0ec2) return true;                // fd00:ec2::/32 AWS IMDS (IPv6)
   return false;
 }
 

--- a/server/src/util/ssrf.ts
+++ b/server/src/util/ssrf.ts
@@ -258,7 +258,13 @@ function isIpLiteral(host: string): boolean {
  * address will pass here — call `assertUrlSafeResolved` / `ssrfSafeFetch` before
  * actually making the request.
  */
-export function isSsrfSafeUrl(raw: string): boolean {
+/**
+ * @param allowPrivate permit private/reserved ranges (RFC-1918, CGNAT, IPv6 ULA) — for an
+ *   operator-declared self-hosted endpoint on a cluster address. Crown-jewel addresses (loopback,
+ *   link-local / cloud IMDS, unspecified) and the `localhost` / metadata hostnames stay blocked
+ *   regardless, exactly as for sync peers. Default false keeps every existing caller unchanged.
+ */
+export function isSsrfSafeUrl(raw: string, allowPrivate = false): boolean {
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -270,7 +276,7 @@ export function isSsrfSafeUrl(raw: string): boolean {
 
   const host = normaliseHost(parsed.hostname);
   if (host === 'localhost' || host === 'metadata.google.internal') return false;
-  if (isBlockedIp(host)) return false;
+  if (isPeerBlockedIp(host, allowPrivate)) return false;
   return true;
 }
 

--- a/testing/standalone/private-model-endpoints.test.js
+++ b/testing/standalone/private-model-endpoints.test.js
@@ -32,6 +32,7 @@ import assert from 'node:assert/strict';
 let isSsrfSafeUrl;
 let assertUrlSafeResolved;
 let allowPrivateModelEndpoints;
+let classifyEndpoint;
 
 const ENV_KEY = 'YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS';
 let savedEnv;
@@ -61,6 +62,7 @@ describe('private model endpoints — operator opt-in', () => {
   before(async () => {
     ({ isSsrfSafeUrl, assertUrlSafeResolved } = await import('../../server/dist/util/ssrf.js'));
     ({ allowPrivateModelEndpoints } = await import('../../server/dist/config/model-egress-policy.js'));
+    ({ classifyEndpoint } = await import('../../server/dist/config/model-egress-exposure.js'));
   });
 
   beforeEach(() => { savedEnv = process.env[ENV_KEY]; delete process.env[ENV_KEY]; });
@@ -156,6 +158,69 @@ describe('private model endpoints — operator opt-in', () => {
         () => assertUrlSafeResolved(CLUSTER_URL, { lookup: multi, allowPrivate: true }),
         /169\.254\.169\.254/,
       );
+    });
+  });
+
+  describe('cloud metadata is a different risk class from RFC-1918 private', () => {
+    // Reviewer catch, and it was a real hole: two metadata endpoints live INSIDE ranges that the
+    // opt-in deliberately opens, so before the carve-outs, enabling private endpoints made them
+    // reachable again — the single highest-value SSRF target on those hosts.
+    //
+    //   fd00:ec2::254    AWS IPv6 IMDS, inside fd00::/8 unique-local
+    //   100.100.100.200  Alibaba Cloud IMDS, inside 100.64.0.0/10 CGNAT
+    //
+    // Nobody enabling "reach my 10.43.x.x cluster service" is asking for those.
+    const METADATA = [
+      ['http://[fd00:ec2::254]/latest/meta-data/', 'AWS IPv6 IMDS'],
+      ['http://[fd00:ec2::]/', 'AWS IPv6 IMDS prefix'],
+      ['http://100.100.100.200/latest/meta-data/', 'Alibaba Cloud IMDS'],
+      ['http://169.254.169.254/', 'IMDS (IPv4)'],
+      ['http://metadata.google.internal/', 'GCP metadata hostname'],
+    ];
+
+    for (const [url, label] of METADATA) {
+      it(`blocks ${label} even with the opt-in on`, () => {
+        assert.equal(isSsrfSafeUrl(url, true), false, `${url} must stay blocked`);
+        assert.equal(isSsrfSafeUrl(url, false), false);
+      });
+    }
+
+    it('still permits legitimate addresses in those same ranges', () => {
+      // The carve-outs must be surgical: a real ULA or CGNAT service stays reachable.
+      for (const url of ['http://[fd12:3456::1]:8080', 'http://100.64.1.1:8080', 'http://100.100.100.100/']) {
+        assert.equal(isSsrfSafeUrl(url, true), true, `${url} is a legitimate private address`);
+      }
+    });
+
+    it('blocks a hostname that RESOLVES to a metadata endpoint, opt-in on', async () => {
+      for (const address of ['169.254.169.254', '100.100.100.200']) {
+        await assert.rejects(
+          () => assertUrlSafeResolved('http://inference.internal/', { lookup: resolvesTo(address), allowPrivate: true }),
+          /Blocked SSRF target/,
+          `${address} must stay blocked at resolution time too`,
+        );
+      }
+    });
+  });
+
+  describe('posture reports effective exposure, not intent', () => {
+    // "allowPrivate is on" states the flag; "vision → 10.43.12.7 (private)" states the exposure. The
+    // second is what makes the check load-bearing, since widening egress is the whole reason it exists.
+    it('classifies a private literal, a public one, and a hostname distinctly', () => {
+      assert.deepEqual(classifyEndpoint('http://10.43.12.7:8080'), { host: '10.43.12.7', klass: 'private' });
+      assert.deepEqual(classifyEndpoint('https://140.82.121.4/v1'), { host: '140.82.121.4', klass: 'public' });
+      // Honest about what a static check cannot know: a hostname is a hostname until it resolves.
+      assert.deepEqual(classifyEndpoint('https://api.example.com/v1'), { host: 'api.example.com', klass: 'hostname' });
+    });
+
+    it('marks a crown-jewel endpoint invalid, not private — it is unreachable either way', () => {
+      for (const url of ['http://169.254.169.254/', 'http://100.100.100.200/', 'http://[fd00:ec2::254]/']) {
+        assert.equal(classifyEndpoint(url).klass, 'invalid', url);
+      }
+    });
+
+    it('does not throw on an unparseable endpoint', () => {
+      assert.equal(classifyEndpoint('not a url').klass, 'invalid');
     });
   });
 });

--- a/testing/standalone/private-model-endpoints.test.js
+++ b/testing/standalone/private-model-endpoints.test.js
@@ -1,0 +1,161 @@
+/**
+ * Standalone tests: self-hosted OpenAI-compatible inference on a PRIVATE address.
+ *
+ * The reported gap (customer, 2026-07-21): provider config offered two shapes, and neither fit a
+ * self-hosted OpenAI-compatible server on a cluster address
+ * (`http://llm-inference-service.llm.svc.cluster.local:8080`):
+ *
+ *   local    → Ollama wire protocol (`/api/chat`) — llama.cpp's llama-server does not speak it
+ *   external → OpenAI wire protocol (`/chat/completions`) — right protocol, address rejected
+ *
+ * The shapes encode a PROTOCOL, not a trust level, which is why there was no way to express
+ * "OpenAI-compatible, and it lives on my cluster".
+ *
+ * TWO enforcement points, and they behave differently — worth being precise about, because it decides
+ * where the fix has to land:
+ *
+ *   - SAVE TIME (`isSsrfSafeUrl`) is a static string check. It rejects private IP LITERALS, but a DNS
+ *     name like `*.svc.cluster.local` sails through — nothing has resolved it yet.
+ *   - RESOLUTION TIME (`assertUrlSafeResolved`, inside `ssrfSafeFetch`) is what actually stops a cluster
+ *     hostname: it resolves, then checks every returned address.
+ *
+ * So a config could save and only fail later at inference. `allowPrivateModelEndpoints` therefore has to
+ * relax BOTH, and these tests cover both. What it must never relax is the crown jewels — loopback,
+ * link-local / cloud IMDS, the metadata hostnames — which stay blocked at both points either way.
+ *
+ * Run: node --test testing/standalone/private-model-endpoints.test.js
+ */
+
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+let isSsrfSafeUrl;
+let assertUrlSafeResolved;
+let allowPrivateModelEndpoints;
+
+const ENV_KEY = 'YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS';
+let savedEnv;
+
+/** Private IP literals a self-hoster might configure directly. */
+const PRIVATE_IPS = [
+  'http://10.1.2.3:8080/v1',
+  'http://192.168.1.50:11434',
+  'http://172.16.0.9:8000',
+];
+
+/** Must stay blocked even with the flag on — these are what SSRF actually targets. */
+const CROWN_JEWELS = [
+  'http://127.0.0.1:8080',
+  'http://localhost:8080',
+  'http://169.254.169.254/latest/meta-data/',
+  'http://metadata.google.internal/computeMetadata/v1/',
+  'http://[::1]:8080',
+  'http://0.0.0.0:8080',
+];
+
+/** The reporter's endpoint: a cluster DNS name that resolves to a private address. */
+const CLUSTER_URL = 'http://llm-inference-service.llm.svc.cluster.local:8080';
+const resolvesTo = (address, family = 4) => async () => [{ address, family }];
+
+describe('private model endpoints — operator opt-in', () => {
+  before(async () => {
+    ({ isSsrfSafeUrl, assertUrlSafeResolved } = await import('../../server/dist/util/ssrf.js'));
+    ({ allowPrivateModelEndpoints } = await import('../../server/dist/config/model-egress-policy.js'));
+  });
+
+  beforeEach(() => { savedEnv = process.env[ENV_KEY]; delete process.env[ENV_KEY]; });
+  afterEach(() => { if (savedEnv === undefined) delete process.env[ENV_KEY]; else process.env[ENV_KEY] = savedEnv; });
+
+  describe('the flag itself', () => {
+    it('is OFF by default', () => {
+      assert.equal(allowPrivateModelEndpoints(), false);
+    });
+
+    it('turns on from the environment', () => {
+      process.env[ENV_KEY] = 'true';
+      assert.equal(allowPrivateModelEndpoints(), true);
+    });
+
+    it('only the exact string "true" enables it', () => {
+      for (const value of ['1', 'yes', 'TRUE', 'on', '']) {
+        process.env[ENV_KEY] = value;
+        assert.equal(allowPrivateModelEndpoints(), false, `"${value}" must not enable private endpoints`);
+      }
+    });
+  });
+
+  describe('save time — static URL admission', () => {
+    it('rejects private IP literals by default', () => {
+      for (const url of PRIVATE_IPS) assert.equal(isSsrfSafeUrl(url), false, `${url} rejected by default`);
+    });
+
+    it('accepts them once opted in', () => {
+      for (const url of PRIVATE_IPS) assert.equal(isSsrfSafeUrl(url, true), true, `${url} permitted with opt-in`);
+    });
+
+    it('cannot judge a DNS name either way — that is resolution-time work', () => {
+      // Documents why the fix cannot stop at save time: nothing has resolved this yet, so the static
+      // check passes even with the flag off, and the config saves. The block comes later, at inference.
+      assert.equal(isSsrfSafeUrl(CLUSTER_URL), true);
+    });
+
+    it('still blocks crown jewels — opt-in or not', () => {
+      for (const url of CROWN_JEWELS) {
+        assert.equal(isSsrfSafeUrl(url, false), false, `${url} blocked (default)`);
+        assert.equal(isSsrfSafeUrl(url, true), false, `${url} STAYS blocked with the opt-in`);
+      }
+    });
+
+    it('still rejects non-http(s) schemes and embedded credentials with the opt-in on', () => {
+      for (const url of ['file:///etc/passwd', 'gopher://10.1.2.3/', 'http://user:pw@10.1.2.3/']) {
+        assert.equal(isSsrfSafeUrl(url, true), false, `${url} rejected regardless of the opt-in`);
+      }
+    });
+
+    it('leaves public endpoints working exactly as before', () => {
+      for (const url of ['https://api.openai.com/v1', 'https://api.example.com:8443/v1']) {
+        assert.equal(isSsrfSafeUrl(url), true);
+        assert.equal(isSsrfSafeUrl(url, true), true);
+      }
+    });
+  });
+
+  describe('resolution time — what actually blocked the cluster endpoint', () => {
+    it('blocks the cluster hostname by default, once resolved', async () => {
+      await assert.rejects(
+        () => assertUrlSafeResolved(CLUSTER_URL, { lookup: resolvesTo('10.43.12.7') }),
+        /blocked address 10\.43\.12\.7/,
+        'this is the failure the reporter actually hit',
+      );
+    });
+
+    it('permits it with the opt-in', async () => {
+      const { addresses } = await assertUrlSafeResolved(CLUSTER_URL, {
+        lookup: resolvesTo('10.43.12.7'),
+        allowPrivate: true,
+      });
+      assert.deepEqual(addresses, ['10.43.12.7']);
+    });
+
+    it('STILL blocks a hostname that resolves to loopback or IMDS, opt-in or not', async () => {
+      for (const address of ['127.0.0.1', '169.254.169.254']) {
+        await assert.rejects(
+          () => assertUrlSafeResolved('http://evil.example.com/', { lookup: resolvesTo(address), allowPrivate: true }),
+          /Blocked SSRF target/,
+          `${address} must stay blocked even with the opt-in — this is the DNS-rebind case`,
+        );
+      }
+    });
+
+    it('keeps checking EVERY resolved address, not just the first', async () => {
+      const multi = async () => [
+        { address: '10.43.12.7', family: 4 },
+        { address: '169.254.169.254', family: 4 }, // smuggled alongside a legitimate one
+      ];
+      await assert.rejects(
+        () => assertUrlSafeResolved(CLUSTER_URL, { lookup: multi, allowPrivate: true }),
+        /169\.254\.169\.254/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes the operator report: *"Media/model providers: no supported shape for a self-hosted
OpenAI-compatible endpoint at a private address."*

## The gap

| Shape | Wire protocol | Address |
|---|---|---|
| `local` | Ollama `/api/chat` | private, plain `fetch` |
| `external` | OpenAI `/chat/completions` | **public only**, `ssrfSafeFetch` |

`local` / `external` *look* like a trust level but actually select a **protocol**. So an operator running
llama.cpp `llama-server`, vLLM or LocalAI behind a cluster service
(`http://llm-inference-service.llm.svc.cluster.local:8080`) had **no usable shape at all**: `local` speaks
a protocol their server doesn't implement, `external` refused the address.

## Answering the reporter's determining question

They asked whether the vision/VLM inference call is dual-protocol or Ollama-only, because it decides
whether the address fix alone is enough.

**Neither — it's protocol-per-shape.** `OllamaVisionProvider` POSTs `/api/chat`; `ExternalVisionProvider`
already POSTs `/chat/completions` with an `image_url` data URL. The external path is genuinely
OpenAI-compatible, so **relaxing the address check is sufficient** — no OpenAI-compatible vision inference
had to be written. Same for STT (both whisper providers use `/v1/audio/transcriptions`) and the embedding
external path from #336.

## The fix

`allowPrivateModelEndpoints` (config) / `YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS` (env) — **instance-wide**,
covering vision, STT, embedding and the F11-b assist model.

### It does not turn the guard off

The report suggested mirroring `allowPrivatePeers`, and the refinement that matters: these calls keep
going through `ssrfSafeFetch` with `allowPrivate: true` rather than dropping to a plain `fetch` the way
`local` does. DNS resolution, IP-pinning for the connection and redirect re-validation **all still apply** —
only the private-address rejection lifts, and crown-jewel ranges stay blocked.

**A declared-private `external` endpoint is therefore better protected than a `local` provider is today.**

### Two enforcement points, and they behave differently

This is the part worth knowing, and it decides where the fix has to land:

- **Save time** (`isSsrfSafeUrl`) is a static string check. It rejected private **IP literals** — but a
  cluster **DNS name** passed, so the config saved and only failed later at inference.
- **Resolution time** (`assertUrlSafeResolved`, inside `ssrfSafeFetch`) is what actually blocked the
  reporter's hostname.

Both are covered. `isSsrfSafeUrl` gains the same optional `allowPrivate` switch `isPeerUrlSafe` already
had; with the flag off the behaviour is byte-identical, since `isPeerBlockedIp(host, false)` **is**
`isBlockedIp(host)`.

### Not settable from the admin API

Config/env only, deliberately **not** a field on `PATCH /api/admin/media-config` — a value that becomes an
egress target must never be widenable from the admin surface. That's the standing guard already recorded
in `SECURITY-TODO.md`. It's reported in the startup posture check and `GET /api/about/security`
(`egress.privateModelEndpoints`), and a rejection now **names the flag** instead of just refusing the URL.

## Tests

13 new assertions — the flag (off by default, env parsing, only the exact string `true`), save-time
admission, and resolution time. The ones that matter most:

```text
✔ blocks the cluster hostname by default, once resolved      ← the reporter's actual failure
✔ permits it with the opt-in
✔ STILL blocks a hostname that resolves to loopback or IMDS, opt-in or not   ← DNS rebinding
✔ keeps checking EVERY resolved address, not just the first
✔ still blocks crown jewels — opt-in or not
```

The existing SSRF suites (`ssrf-hardening`, `ssrf-ip-pinning`, `media-egress-ssrf` — **73 assertions**) are
untouched and green, so the default posture is provably unchanged.

## Docs

The pages the reporter cited by name are corrected: the *"must be a public http(s) URL"* claim in
`integration-guide.md` is now conditional, the `visionProvider` / `sttProvider` rows say **"wire protocol,
not trust level"**, and `.env.example` documents the flag with what it does and does not relax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
