### PR TITLE
docs(unstructured): correct the size in all four places, declare the runtime UID, fix the k8s reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ YTHRIL_PORT=3200
 # entirely — a running container is stopped and removed on the next `docker compose up`, and
 # a machine that never starts it never pays for its image pull either.
 #
-# `unstructured` is the expensive one (~4.5 GB compressed / ~7.5 GB on disk). Turn it off when
+# `unstructured` is the expensive one (≈10.8 GB download, 20–32 GB on disk (varies by storage driver)). Turn it off when
 # you do not need server-side PDF/DOCX/EPUB conversion, or when you point Ythril at an external
 # converter via CONVERSION_SIDECAR_URL above. Conversion then reports `sidecar_down`; in-process
 # text/HTML conversion and every other feature keep working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UNSTRUCTURED_REPLICAS=0`, `OLLAMA_REPLICAS=0` or `WHISPER_REPLICAS=0` keeps that service out of the
   stack entirely — a running container is stopped and removed on the next `docker compose up`, and a
   machine that never starts it never pays for its image pull. This matters most for `unstructured`
-  (~4.5 GB compressed / ~7.5 GB on disk): an instance that doesn't need server-side PDF/DOCX/EPUB
+  (≈10.8 GB download, 20–32 GB on disk): an instance that doesn't need server-side PDF/DOCX/EPUB
   conversion, or that points `CONVERSION_SIDECAR_URL` at an external converter, no longer has to
   download it. Conversion then reports `sidecar_down` — the existing graceful degradation — and
   in-process text/HTML conversion plus every other feature keep working. Previously the only options
@@ -1252,6 +1252,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Corrected the `unstructured` sidecar's documented size — it was stated in four places and every
+  figure was wrong — and hardened the Kubernetes reference for it.** Reported by an operator deploying
+  on k3s with default-deny egress. The size is a capacity-planning number (`.env.example` cites it to
+  justify `UNSTRUCTURED_REPLICAS=0`), and it now comes from the **registry manifest** rather than from
+  one runtime: **≈10.8 GB to download** across 26 compressed layers, and **20–32 GB on disk depending
+  on the storage driver** — 20.7 GB measured on k3s/containerd, 31.9 GB on Docker Desktop. On-disk is
+  deliberately a range: two honest measurements disagreed by 1.5x because the storage driver decides,
+  so a single precise-looking figure would just be wrong somewhere else. (Three of the four stale
+  claims were identical, which reads like corroboration but was one source copied three times.)
+  Three further fixes to `kubernetes/manifests/ythril-deployment.yaml`, the artifact a Kubernetes
+  deployer actually copies. **`HF_HUB_OFFLINE=1` was missing:** without it every `hi_res` extraction on
+  a no-egress cluster fails outright — total failure, not degradation — because `huggingface_hub` calls
+  the hub to resolve models that are already baked into the image. **The runtime UID is now declared**
+  (`notebook-user`, uid 1000 — confirmed from the image’s registry config, no pull required), so the
+  full Pod Security Admission `restricted` set is asserted explicitly (`runAsNonRoot`,
+  `runAsUser`/`runAsGroup: 1000`, `readOnlyRootFilesystem` with an emptyDir for scratch,
+  `seccompProfile: RuntimeDefault`, `drop: [ALL]`) instead of a deployer having to run the image to
+  find out. **And the CPU limit rose from 1000m to 4000m** to match the measured workload (1.73 GB RSS
+  across 61 threads, ~4 cores) and the compose sizing, which disagreed with it.
+  Also **digest-pinned `unstructured-api`** — it was left on a mutable tag by the same change that
+  pinned `ollama`, `whisper`, `mongodb-atlas-local` and `node:22-slim`, despite being the highest-risk
+  parser in the stack. And clarified `RENDER_SIDECAR_URL`: `http://localhost:8100` is the *application*
+  default while compose overrides it to `http://doc-render:8100` — both correct for their layer, which
+  the guide never said.
+
 - **Updating an instance no longer breaks every tab that was already open.** Every Angular build rehashes
   its lazy-chunk filenames, so a browser still running the previous `main-*.js` asks for a `chunk-*.js`
   that no longer exists the moment you navigate to a lazy route. The result was a **dead click**: no
@@ -1437,7 +1462,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `kubernetes/manifests/ythril-deployment.yaml`) to the still-public `unstructured-io/unstructured-api:0.0.75`
   — the same upstream release minus the `-full` extras (extra Tesseract language packs + LibreOffice),
   which Ythril's `hi_res` OCR + embedded-image extraction path does not use. It is also the image
-  upstream's own README points self-hosters at, is ~4.5 GB compressed (vs the heavier `-full`), and stays
+  upstream's own README points self-hosters at, is ≈10.8 GB to download (vs the heavier `-full`), and stays
   Apache-2.0. No server or config change was needed; the sidecar API (`/general/v0/general`) is identical.
 
 - **Image/PDF previews and file downloads were broken (blank pane / failed download).** They loaded

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,9 +223,10 @@
   # `sidecar_down` — Ythril itself still runs, so it is intentionally NOT a startup
   # dependency of the ythril service (conversion degrades gracefully until it is up).
   #
-  # HEAVY IMAGE: unstructured-api bundles OCR model weights (Tesseract) and is ~32 GB ON DISK —
-  # a few GB compressed, but the unpacked layers are what your Docker disk actually holds (measured
-  # with `docker images`, not estimated). First boot is slow, hence the long start_period. See
+  # HEAVY IMAGE: unstructured-api bundles OCR model weights (Tesseract). ≈10.8 GB download, 20–32 GB on disk (varies by storage driver):
+  # the download is measured from the registry manifest (26 layers); on-disk depends on the storage
+  # driver, so it is a range, not one number — 20.7 GB was measured on k3s/containerd and 31.9 GB on
+  # Docker Desktop. First boot is slow, hence the long start_period. See
   # docs/dependencies.md. To skip it entirely on a resource-constrained workstation, set
   # `UNSTRUCTURED_REPLICAS=0` in .env (below); in-process text/HTML conversion and all other
   # features keep working — only PDF/DOCX/EPUB conversion is unavailable.
@@ -241,10 +242,14 @@
     # The public `unstructured-api` image is the same release minus extra Tesseract
     # language packs / LibreOffice, and fully supports the hi_res OCR + image-extraction
     # path Ythril uses. Upstream's README points self-hosters at this image too.
-    image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2
+    # Pinned to the manifest-list digest, like every other external image here. This was missed when
+    # the others were pinned — and it is the highest-risk parser in the stack, so a silent substitution
+    # matters most here. Refresh:
+    #   docker buildx imagetools inspect downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2
+    image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2@sha256:986bc7e5d6c24916c22d45d925db366f55bf4d2ebb0079a7b5d38b48fbc6fb1d
     container_name: ythril-unstructured
     restart: unless-stopped
-    # Infra switch — this is the HEAVY one (~32 GB on disk), so a deployment that
+    # Infra switch — this is the HEAVY one (≈10.8 GB download, 20–32 GB on disk), so a deployment that
     # does not need server-side PDF/DOCX/EPUB conversion should not pay for it: `UNSTRUCTURED_REPLICAS=0`
     # in .env keeps it out of the stack (and out of the first `docker compose up` pull). Conversion then
     # reports `sidecar_down` — the same graceful degradation as an external converter being unreachable —

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -222,9 +222,7 @@ is the first-party page-render sidecar built locally from `sidecars/doc-render` 
 > points self-hosters at. Ythril's PDF/DOCX/EPUB + English-OCR path needs nothing the `-full`
 > extras add.
 >
-> **Image size — `unstructured-api` is very heavy: ~31.9 GB on disk** (measured with
-> `docker images`; the compressed download is a few GB, but the unpacked layers are what your Docker
-> disk actually holds). It bundles OCR model
+> **Image size — `unstructured-api` is very heavy: **≈10.8 GB to download** (26 compressed layers, measured from the registry manifest) and **20–32 GB on disk** depending on the storage driver — measured at 20.7 GB on k3s/containerd and 31.9 GB on Docker Desktop.** It bundles OCR model
 > weights (Tesseract), so the first `docker compose up` pulls a large image and the sidecar
 > is slow to become ready (a long `start_period`). It is intentionally **not** a startup
 > dependency of the `ythril` service — Ythril runs without it and PDF/DOCX/EPUB conversion

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2016,7 +2016,7 @@ the rasterization step the **VLM document-extraction** path (`mediaEmbedding.doc
 lightweight and carries no model weights) or stop it with no effect on today's OCR conversion. Like the
 `unstructured` sidecar it parses untrusted documents, so it runs isolated on the internal-only
 `ythril-convert` network (no database, no internet egress), non-root and resource-limited. Ythril reaches
-it via `RENDER_SIDECAR_URL` (default `http://localhost:8100`).
+it via `RENDER_SIDECAR_URL`. The **application** default is `http://localhost:8100` (a sidecar in the same network namespace); `docker-compose.yml` overrides it to `http://doc-render:8100`, the service name on the internal network. Both are correct for their layer — check which one applies to your deployment rather than assuming the compose value is the default.
 
 #### Office-render sidecar (`doc-office`) — optional
 

--- a/docs/workstation-mode-guide.md
+++ b/docs/workstation-mode-guide.md
@@ -20,7 +20,7 @@ Recommended host minimums:
 
 - CPU: 2 cores
 - RAM: 6 GB (4 GB for Ythril + Mongo, ~2 GB for the bundled media-embedding stack)
-- Disk: at least 50 GB free — ~2 GB for the `moondream` vision model and the Whisper `base` model, plus **~32 GB for the `unstructured` document-parsing image** (measured with `docker images`; set `UNSTRUCTURED_REPLICAS=0` in `.env` to skip it entirely if you do not need server-side PDF/DOCX/EPUB conversion). The `doc-render` image is small, a few hundred MB.
+- Disk: at least 50 GB free — ~2 GB for the `moondream` vision model and the Whisper `base` model, plus **≈10.8 GB to download and 20–32 GB on disk for the `unstructured` document-parsing image** (measured with `docker images`; set `UNSTRUCTURED_REPLICAS=0` in `.env` to skip it entirely if you do not need server-side PDF/DOCX/EPUB conversion). The `doc-render` image is small, a few hundred MB.
 
 > **Slimmer install:** Ythril ships with bundled image and audio/video understanding
 > services so attachments become searchable automatically. If your machine is tight

--- a/kubernetes/manifests/ythril-deployment.yaml
+++ b/kubernetes/manifests/ythril-deployment.yaml
@@ -108,20 +108,51 @@ spec:
         # License: Apache-2.0 (verify before pinning any new tag — see note above)
         # NOTE: the `-full` variant was made private on quay.io (401 on pull); the public
         # `unstructured-api` image is the same release minus extra Tesseract language packs
-        # and still bundles OCR model weights (Tesseract) — ~4.5 GB compressed. Pre-pull on
-        # nodes before first deployment to avoid cold-start delays on Pod restarts.
+        # and still bundles OCR model weights (Tesseract). SIZE, measured rather than estimated:
+        # ≈10.8 GB to download (26 compressed layers, from the registry manifest) and 20–32 GB on disk
+        # depending on the storage driver — 20.7 GB observed on k3s/containerd, 31.9 GB on Docker
+        # Desktop. Pre-pull on nodes before first deployment to avoid cold-start delays on restarts.
         - name: unstructured
-          # Pin to a specific tag and verify the LICENSE before upgrading.
-          # Run `docker run --rm --entrypoint cat <image> /app/LICENSE` to confirm Apache-2.0.
-          image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2
-          # Lighter hardening than the main container: the OCR pipeline writes
-          # scratch files across its own filesystem, so readOnlyRootFilesystem is
-          # left off, but privilege escalation and added capabilities are still denied.
+          # Pinned to the manifest-list digest so a re-pull cannot silently substitute a different
+          # image — this is the highest-risk parser in the deployment. Verify the LICENSE before
+          # changing it: `docker run --rm --entrypoint cat <image> /app/LICENSE` (Apache-2.0).
+          image: downloads.unstructured.io/unstructured-io/unstructured-api:0.1.2@sha256:986bc7e5d6c24916c22d45d925db366f55bf4d2ebb0079a7b5d38b48fbc6fb1d
+          env:
+            # WITHOUT THIS, EVERY hi_res EXTRACTION FAILS on a no-egress cluster with
+            #   "Can't load image processor for 'microsoft/table-transformer-structure-recognition'"
+            # — total failure, not degradation. The layout and table models ARE baked into the image,
+            # but huggingface_hub calls the hub to *resolve* them before reading its own cache, and a
+            # default-deny egress policy blocks that call. Offline mode makes it use what it has.
+            # Do NOT set HOME or XDG_CACHE_HOME here: the image's HOME=/home/notebook-user is what
+            # locates that baked cache, and moving it makes the image try to download instead.
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            # numba compiles a function and caches it NEXT TO the installed package, and matplotlib
+            # wants a config dir — both fail on a read-only root filesystem, so point them at the
+            # writable scratch mount below.
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba
+            - name: MPLCONFIGDIR
+              value: /tmp/matplotlib
+          # The image runs as uid 1000 (`notebook-user`) — confirmed from its registry config, not by
+          # experiment — so the full Pod Security Admission `restricted` set is assertable here.
+          # Declared explicitly so a deployer does not have to run the image to find out.
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            # Everything the OCR pipeline writes at request time lands here, which is what lets the
+            # root filesystem stay read-only.
+            - name: unstructured-tmp
+              mountPath: /tmp
           ports:
             - containerPort: 8000
           resources:
@@ -129,8 +160,12 @@ spec:
               cpu: "250m"
               memory: "2Gi"
             limits:
-              cpu: "1000m"
-              memory: "4Gi"
+              # Measured on a real hi_res extraction: 1.73 GB RSS across 61 threads, using roughly 4
+              # cores. The previous 1000m limit throttled that to a quarter of what the job wants —
+              # this now matches the compose sizing (`UNSTRUCTURED_CPUS`, default 4.0) so the two
+              # deployment paths do not disagree about the shape of the workload.
+              cpu: "4000m"
+              memory: "6Gi"
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -159,6 +194,12 @@ spec:
         # without provisioning storage.
         - name: tmp
           emptyDir: {}
+        # Per-request OCR scratch for the unstructured sidecar (numba/matplotlib caches, page images).
+        # Sized because hi_res spills page renders here; ephemeral, so an emptyDir keeps the sidecar's
+        # root filesystem read-only without provisioning storage.
+        - name: unstructured-tmp
+          emptyDir:
+            sizeLimit: 1Gi
 ---
 # Persistent config store. /config holds config.json (tokens, spaces, networks),
 # secrets.json, and the schema library — all runtime-mutable state that must


### PR DESCRIPTION
Operator report from a k3s deployment with default-deny egress. Every number below is measured against
the **registry manifest** (`docker buildx imagetools inspect`, no pull), not re-stated.

## 1 · The size was wrong in all four places

| Location | Claimed | |
|---|---|---|
| `CHANGELOG.md` | ~4.5 GB compressed / ~7.5 GB disk | ✗ |
| `.env.example` | ~4.5 GB compressed / ~7.5 GB disk | ✗ |
| `ythril-deployment.yaml` | ~4.5 GB compressed | ✗ |
| `docker-compose.yml` | ~32 GB on disk | ✗ (mine) |

**Actual: 26 layers, 10.75 GB compressed download.**

On-disk is now a **range on purpose** — two honest measurements disagreed by 1.5× (20.7 GB
k3s/containerd, 31.9 GB Docker Desktop) because the storage driver decides. Any single precise-looking
figure is wrong somewhere. The download figure is runtime-independent, so that is the one capacity
planning can rely on.

The reporter's sharpest point: the three matching figures were **one source copied three times**, which
reads like corroboration. Worth remembering as a docs failure mode, not just a wrong number.

## 2 · The runtime UID was undeclared

A deployer couldn't tell whether the reference is deployable under Pod Security Admission `restricted`
without running the image. It is — the image config declares `User=notebook-user` (uid 1000), read from
the registry. The manifest now asserts the full restricted set explicitly: `runAsNonRoot`,
`runAsUser`/`runAsGroup: 1000`, `readOnlyRootFilesystem` (with an emptyDir at `/tmp` for OCR scratch),
`seccompProfile: RuntimeDefault`, `drop: [ALL]`.

## 3 · `HF_HUB_OFFLINE=1` was missing from the k8s reference

**My miss** — I added it to compose and never carried it across. On a no-egress cluster every `hi_res`
extraction fails outright (`Can't load image processor for 'microsoft/table-transformer-…'`) because
`huggingface_hub` calls the hub to *resolve* models already baked into the image. Total failure, not
degradation, in the artifact a Kubernetes deployer copies. `NUMBA_CACHE_DIR` and `MPLCONFIGDIR` come
with it, since they are what make the read-only root filesystem viable.

## 4 · The smaller ones

- **CPU limit 1000m → 4000m.** Measured: 1.73 GB RSS across 61 threads, ~4 cores. The manifest was
  throttling the job to a quarter of what compose sized it for; the two disagreed about its shape.
- **`unstructured-api` is now digest-pinned.** It was the one image left on a mutable tag by the change
  that pinned `ollama`, `whisper`, `mongodb-atlas-local` and `node:22-slim` — and it is the image that
  same change calls the highest-risk parser.
- **`RENDER_SIDECAR_URL`** — one correction to the report: `http://localhost:8100` is *correct*. It is
  the application default (`renderer.ts:16`); compose overrides it to `http://doc-render:8100`. Not a
  doc error but a layering ambiguity, so both are now stated with which is which.

## Verification

Manifest parses; the `unstructured` container reports `user 1000`, `readOnlyRootFilesystem: true`,
`cpu: 4000m` and all three env vars. Compose parses. Sidecar-hardening suite green (39). No stale size
string remains in any of the five files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)