### PR TITLE
feat(face-recognition): let infra pin every field, like every other model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Face recognition can now be pinned by infra — it was the one model in the pipeline that could not
+  be.** Vision, speech-to-text, embedding, the document assist model and both sidecars all had env
+  overrides, so an infra-managed deployment could fix every model *except whether faces are detected
+  and embedded at all* — the setting with the clearest privacy weight of the lot. Opting out required
+  filesystem access to `config.json`, and it is deliberately absent from
+  `PATCH /api/admin/media-config`, so there was no API path either. Every
+  `mediaEmbedding.faceRecognition` field now takes an env var (`FACE_RECOGNITION_ENABLED`,
+  `_CONFIDENCE_THRESHOLD`, `_MIN_FACE_SIZE_FRACTION`, `_MODEL_PATH`, `_PERSON_ENTITY_TYPES`,
+  `_REPROCESS_SYNCED_IMAGES`) with the same **env → config → default** precedence every other media
+  setting uses. `FACE_RECOGNITION_ENABLED=false` guarantees no face processing on an instance
+  regardless of what `config.json` says — including after restoring a backup taken where it was on.
+  Pinned fields are reported in `lockedByInfra`, so the Settings UI renders them read-only instead of
+  offering a control that silently does nothing. New standalone tests cover precedence, the coercion
+  of each field (booleans, numbers, and the comma-separated entity-type list), and the lock reporting.
+
 - **Self-hosted OpenAI-compatible inference on a private address is now a supported shape**
   (`allowPrivateModelEndpoints`). Provider config offered `local` and `external`, and those names look
   like a trust level but actually select a **wire protocol**: `local` speaks Ollama's `/api/chat`,

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2378,14 +2378,18 @@ When the face recognition feature is first enabled, any existing `initSpace` cal
 
 All settings live under `mediaEmbedding.faceRecognition` in `config.json`. None are controllable via the `PATCH /api/admin/media-config` endpoint (face recognition is a local-only feature; no external service is involved).
 
-| Field | Default | Description |
-|---|---|---|
-| `enabled` | `false` | Master switch. When false, face detection is completely skipped. |
-| `confidenceThreshold` | `0.6` | Cosine similarity score (0–1) required for auto-labeling. Lower values label more aggressively; higher values require a closer match. Tune upward as your gallery grows. |
-| `minFaceSizeFraction` | `0.05` | Minimum face bounding-box size as a fraction of the image's shorter side. Faces smaller than this are skipped (avoids noise from crowd shots or background faces). |
-| `modelPath` | `"human-models"` | Path relative to `DATA_ROOT` where the BlazeFace and FaceRes model files are located. |
-| `personEntityTypes` | `["person"]` | Entity type names that qualify as people. Only entities with a `type` in this list are eligible to enter the face gallery. Extend this list if you use custom type names like `"contact"` or `"employee"`. |
-| `reprocessSyncedImages` | `true` | When true, images received via network sync are automatically re-enqueued for face processing if they haven't been processed yet. Set to false to keep gallery building local-origin only. |
+Each field can also be **pinned by an infra admin** through the env var below, with the same precedence as every other media setting: **env → `config.json` → default**. A pinned field is reported in `lockedByInfra` on `GET /api/admin/media-config`, so the Settings UI renders it read-only rather than offering a control that silently does nothing. This is why the env vars exist at all: every other model in the pipeline (vision, speech-to-text, embedding, the assist model, both sidecars) could already be pinned, so an infra-managed deployment could fix every model *except* whether faces are detected and embedded — the setting with the clearest privacy weight of the lot.
+
+| Field | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FACE_RECOGNITION_ENABLED` | `false` | Master switch. When false, face detection is completely skipped. |
+| `confidenceThreshold` | `FACE_RECOGNITION_CONFIDENCE_THRESHOLD` | `0.6` | Cosine similarity score (0–1) required for auto-labeling. Lower values label more aggressively; higher values require a closer match. Tune upward as your gallery grows. |
+| `minFaceSizeFraction` | `FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION` | `0.05` | Minimum face bounding-box size as a fraction of the image's shorter side. Faces smaller than this are skipped (avoids noise from crowd shots or background faces). |
+| `modelPath` | `FACE_RECOGNITION_MODEL_PATH` | `"human-models"` | Path relative to `DATA_ROOT` where the BlazeFace and FaceRes model files are located. |
+| `personEntityTypes` | `FACE_RECOGNITION_PERSON_ENTITY_TYPES` | `["person"]` | Entity type names that qualify as people. Only entities with a `type` in this list are eligible to enter the face gallery. Extend this list if you use custom type names like `"contact"` or `"employee"`. **Comma-separated** as an env var: `FACE_RECOGNITION_PERSON_ENTITY_TYPES=person,employee`. |
+| `reprocessSyncedImages` | `FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES` | `true` | When true, images received via network sync are automatically re-enqueued for face processing if they haven't been processed yet. Set to false to keep gallery building local-origin only. |
+
+> Booleans accept `true` or `1`; anything else reads as false. Pinning `FACE_RECOGNITION_ENABLED=false` is the way to guarantee no face processing happens on an instance regardless of what is in `config.json` — including after a restore from a backup taken on an instance where it was on.
 
 **Example `config.json` excerpt:**
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -658,7 +658,7 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
     // Surface the resolved document-processing/extraction settings (F11) so the admin API GET and the
     // Models UI can read them back (the worker ignores this block).
     documentProcessing: getDocumentProcessingConfig(),
-    lockedByInfra: locked,
+    lockedByInfra: [...locked, ...lockedFaceRecognitionFields()],
     // F11 — infra-managed lock (like YTHRIL_MONGO_INFRA_MANAGED): env OR config marks the whole media/model
     // config as managed by infrastructure, so the admin API refuses edits and the UI is read-only.
     infraManaged: process.env['YTHRIL_MEDIA_INFRA_MANAGED'] === 'true' || base.infraManaged === true,
@@ -748,15 +748,51 @@ const FACE_RECOGNITION_DEFAULTS: Required<FaceRecognitionConfig> = {
  *
  * Returns defaults with `enabled: false` when no config block is present.
  */
+/**
+ * Env keys that pin face recognition, mirroring the media-provider pattern. Face recognition was the
+ * only model in the pipeline an infra admin could not set — every other one (vision, STT, embedding,
+ * assist, both sidecars) already had an override, so an infra-managed deployment could pin everything
+ * except whether faces are processed at all. That is the setting with the clearest privacy weight.
+ */
+const FACE_RECOGNITION_ENV: Record<keyof Required<FaceRecognitionConfig>, string> = {
+  enabled: 'FACE_RECOGNITION_ENABLED',
+  confidenceThreshold: 'FACE_RECOGNITION_CONFIDENCE_THRESHOLD',
+  minFaceSizeFraction: 'FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION',
+  modelPath: 'FACE_RECOGNITION_MODEL_PATH',
+  personEntityTypes: 'FACE_RECOGNITION_PERSON_ENTITY_TYPES',
+  reprocessSyncedImages: 'FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES',
+};
+
+/** Field names (as `faceRecognition.<field>`) currently pinned by an env var. */
+export function lockedFaceRecognitionFields(): string[] {
+  return (Object.entries(FACE_RECOGNITION_ENV) as Array<[string, string]>)
+    .filter(([, envKey]) => process.env[envKey] !== undefined)
+    .map(([field]) => `faceRecognition.${field}`);
+}
+
 export function getFaceRecognitionConfig(): Required<FaceRecognitionConfig> {
-  const mediaCfg = getConfig().mediaEmbedding;
-  const base: FaceRecognitionConfig = mediaCfg?.faceRecognition ?? {};
+  // Tolerate config not being loaded: an infra env pin must apply during early boot too, and this is
+  // read from paths that can run before the first successful load.
+  let base: FaceRecognitionConfig = {};
+  try { base = getConfig().mediaEmbedding?.faceRecognition ?? {}; } catch { /* pre-setup */ }
+
+  // env → config → default, matching getMediaEmbeddingConfig's precedence exactly.
+  const pick = <K extends keyof Required<FaceRecognitionConfig>>(
+    field: K,
+    parse: (raw: string) => Required<FaceRecognitionConfig>[K],
+  ): Required<FaceRecognitionConfig>[K] => {
+    const rawEnv = process.env[FACE_RECOGNITION_ENV[field]];
+    if (rawEnv !== undefined) return parse(rawEnv);
+    return (base[field] ?? FACE_RECOGNITION_DEFAULTS[field]) as Required<FaceRecognitionConfig>[K];
+  };
+
   return {
-    enabled: base.enabled ?? FACE_RECOGNITION_DEFAULTS.enabled,
-    confidenceThreshold: base.confidenceThreshold ?? FACE_RECOGNITION_DEFAULTS.confidenceThreshold,
-    minFaceSizeFraction: base.minFaceSizeFraction ?? FACE_RECOGNITION_DEFAULTS.minFaceSizeFraction,
-    modelPath: base.modelPath ?? FACE_RECOGNITION_DEFAULTS.modelPath,
-    personEntityTypes: base.personEntityTypes ?? FACE_RECOGNITION_DEFAULTS.personEntityTypes,
-    reprocessSyncedImages: base.reprocessSyncedImages ?? FACE_RECOGNITION_DEFAULTS.reprocessSyncedImages,
+    enabled: pick('enabled', v => v === 'true' || v === '1'),
+    confidenceThreshold: pick('confidenceThreshold', v => Number(v)),
+    minFaceSizeFraction: pick('minFaceSizeFraction', v => Number(v)),
+    modelPath: pick('modelPath', v => v),
+    // Comma-separated: FACE_RECOGNITION_PERSON_ENTITY_TYPES=person,employee
+    personEntityTypes: pick('personEntityTypes', v => v.split(',').map(t => t.trim()).filter(Boolean)),
+    reprocessSyncedImages: pick('reprocessSyncedImages', v => v === 'true' || v === '1'),
   };
 }

--- a/testing/standalone/face-recognition-env.test.js
+++ b/testing/standalone/face-recognition-env.test.js
@@ -1,0 +1,91 @@
+/**
+ * Standalone tests: face recognition is settable by infra.
+ *
+ * It was the one model in the whole media pipeline with no env override. Vision, speech-to-text,
+ * embedding, the assist model and both sidecars could all be pinned by an infra admin — so an
+ * infra-managed deployment could fix every model EXCEPT whether faces get detected and embedded at all,
+ * which is the setting with the clearest privacy weight of the lot.
+ *
+ * These pin the precedence (env → config → default), the coercion of each field, and that a pinned
+ * field is reported in `lockedByInfra` so the Settings UI renders it read-only rather than offering a
+ * control that silently does nothing.
+ *
+ * Run: node --test testing/standalone/face-recognition-env.test.js
+ */
+
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+let getFaceRecognitionConfig;
+let lockedFaceRecognitionFields;
+
+const ENV_KEYS = [
+  'FACE_RECOGNITION_ENABLED',
+  'FACE_RECOGNITION_CONFIDENCE_THRESHOLD',
+  'FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION',
+  'FACE_RECOGNITION_MODEL_PATH',
+  'FACE_RECOGNITION_PERSON_ENTITY_TYPES',
+  'FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES',
+];
+const saved = {};
+
+describe('face recognition — infra-settable', () => {
+  before(async () => {
+    ({ getFaceRecognitionConfig, lockedFaceRecognitionFields } = await import('../../server/dist/config/loader.js'));
+  });
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k];
+    }
+  });
+
+  it('is off by default — enabling it stays a deliberate act', () => {
+    assert.equal(getFaceRecognitionConfig().enabled, false);
+    assert.deepEqual(lockedFaceRecognitionFields(), []);
+  });
+
+  it('can be switched on from the environment', () => {
+    process.env['FACE_RECOGNITION_ENABLED'] = 'true';
+    assert.equal(getFaceRecognitionConfig().enabled, true);
+  });
+
+  it('accepts 1 as well as true, and treats anything else as off', () => {
+    process.env['FACE_RECOGNITION_ENABLED'] = '1';
+    assert.equal(getFaceRecognitionConfig().enabled, true);
+    for (const v of ['yes', 'TRUE', 'on', '']) {
+      process.env['FACE_RECOGNITION_ENABLED'] = v;
+      assert.equal(getFaceRecognitionConfig().enabled, false, `"${v}" must not enable face recognition`);
+    }
+  });
+
+  it('coerces the numeric thresholds', () => {
+    process.env['FACE_RECOGNITION_CONFIDENCE_THRESHOLD'] = '0.82';
+    process.env['FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION'] = '0.05';
+    const cfg = getFaceRecognitionConfig();
+    assert.equal(cfg.confidenceThreshold, 0.82);
+    assert.equal(cfg.minFaceSizeFraction, 0.05);
+  });
+
+  it('parses the person entity types as a comma-separated list', () => {
+    process.env['FACE_RECOGNITION_PERSON_ENTITY_TYPES'] = 'person, employee ,contractor';
+    assert.deepEqual(getFaceRecognitionConfig().personEntityTypes, ['person', 'employee', 'contractor']);
+  });
+
+  it('takes the model path verbatim', () => {
+    process.env['FACE_RECOGNITION_MODEL_PATH'] = '/opt/models/human';
+    assert.equal(getFaceRecognitionConfig().modelPath, '/opt/models/human');
+  });
+
+  it('reports every pinned field so the UI can render it read-only', () => {
+    process.env['FACE_RECOGNITION_ENABLED'] = 'true';
+    process.env['FACE_RECOGNITION_CONFIDENCE_THRESHOLD'] = '0.9';
+    const locked = lockedFaceRecognitionFields();
+    assert.deepEqual(locked.sort(), ['faceRecognition.confidenceThreshold', 'faceRecognition.enabled']);
+    // A control that looks editable but is overridden by env is worse than one that says so.
+    assert.ok(!locked.includes('faceRecognition.modelPath'), 'unpinned fields must stay editable');
+  });
+});


### PR DESCRIPTION
Face recognition was the one model in the media pipeline an infra admin could not set.

Vision, speech-to-text, embedding, the document assist model and both sidecars all had env overrides — so an infra-managed deployment could fix every model **except whether faces are detected and embedded at all**, which is the setting with the clearest privacy weight of the lot. It is also deliberately absent from `PATCH /api/admin/media-config` (local-only feature, no external service), so opting out meant filesystem access to `config.json` and nothing else.

## What changed

Every `mediaEmbedding.faceRecognition` field now takes an env var, with the same **env → config → default** precedence every other media setting uses:

| Field | Env var |
|---|---|
| `enabled` | `FACE_RECOGNITION_ENABLED` |
| `confidenceThreshold` | `FACE_RECOGNITION_CONFIDENCE_THRESHOLD` |
| `minFaceSizeFraction` | `FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION` |
| `modelPath` | `FACE_RECOGNITION_MODEL_PATH` |
| `personEntityTypes` | `FACE_RECOGNITION_PERSON_ENTITY_TYPES` (comma-separated) |
| `reprocessSyncedImages` | `FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES` |

Pinned fields are reported in `lockedByInfra`, so the Settings UI renders them read-only rather than offering a control that silently does nothing — the same contract the media providers already use.

`FACE_RECOGNITION_ENABLED=false` now guarantees no face processing on an instance whatever `config.json` says — **including after restoring a backup taken on an instance where it was on**, which was the gap with real consequences.

## Testing

- 7 new standalone tests: precedence, per-field coercion (booleans, numbers, the comma-separated entity-type list), and lock reporting.
- Ran against a fresh stack alongside the media-config / config-loader / reload-config / config-write-safety suites: **70 pass, 0 fail, 1 todo** (the pre-existing handler-clobber TODO from #344).
- `lint:docs` clean; env table added to the face-recognition configuration reference in the integration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)