### PR TITLE
fix(config): reload config.json when it changes, so a hand edit is not reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1267,6 +1267,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An edit made to `config.json` on a running instance is no longer reverted by the server.** The server
+  treats its in-memory config as authoritative and writes the whole file back on every change — creating
+  a space, renaming one, saving settings. That made the in-memory copy stale the moment anyone edited the
+  file directly, so the next write silently reverted the edit. No error, no log line. `POST /api/admin/reload-config`
+  existed precisely to support hand edits, but nothing forced you to call it *before* the server next
+  wrote, and the failure was invisible when you didn't.
+  The server now **watches `config.json` and reloads within about two seconds** of a foreign change,
+  running the same work the reload endpoint does — so a space added by hand is initialised, not merely
+  parsed. `fs.watchFile` stat-polling is used rather than `fs.watch`/inotify, because the file normally
+  lives on a bind mount where inotify events are unreliable; our own writes are recognised by mtime and
+  ignored. Fixing the staleness rather than the writes means all **67 `saveConfig` call sites across 21
+  files** become correct without being touched — and, unlike converting them, cannot be undone by the
+  next handler someone writes.
+  A reload now **refreshes the config object in place instead of replacing it**, because ten call sites
+  hold a config across an `await` before saving it; replacing the object would detach those references
+  and write pre-reload content, reverting the very edit the reload just picked up.
+  **Remaining window, stated plainly:** an edit can still be lost if a config write lands in the ~2
+  seconds before the watcher notices — the exposure goes from *forever* to *one poll interval*, not to
+  zero. The test proves this both ways: it passes with the watcher given time to poll, and still fails
+  when the write races it. Calling the reload endpoint after a hand edit closes the window.
+
 - **A background config write could erase a change made to `config.json` by someone else.**
   `saveConfig()` serialises the whole in-memory config, so the ordinary read-mutate-save shape is
   last-writer-wins: anything written to the file after that snapshot was taken is silently dropped.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -4677,7 +4677,9 @@ X-TOTP-Code: <code>   # required when MFA is enabled
 
 **Requires admin token** (and TOTP code when MFA is enabled). Re-reads `config.json` from disk. Useful after manual edits. Any spaces added to the config since the last load are automatically initialized (MongoDB collections, indexes, vector search index, and file directories created). The built-in `general` space is ensured to exist.
 
-> **Reload promptly after a manual edit.** The running server holds `config.json` in memory and writes the whole file back whenever anything changes it — creating a space, renaming one, saving settings. Until you reload, that in-memory copy does not know about your edit, so the next such write reverts it. Edit and reload as one step; do not leave a hand-edited config unreloaded on a live instance. Stopping the server, editing, and starting it again is always safe.
+> **Manual edits are picked up automatically.** The server watches `config.json` and reloads within about two seconds of the file changing, running the same work this endpoint does — including initialising any space you added by hand. You do not have to call it after an edit; it remains available for scripts that want the reload to be synchronous, and for reloading `secrets.json` at a moment of your choosing.
+>
+> **One caveat:** the server holds the config in memory and writes the whole file back whenever anything changes it. An edit made in the ~2-second window *before* the watcher notices can still be overwritten by a config write that lands in between (creating a space, saving settings). If you are editing by hand on a busy instance, call this endpoint straight after saving to close that window, or stop the server, edit, and start it again — which is always safe.
 
 Reloading also flushes the token and OIDC caches, so a token revoked by a manual edit — or an updated OIDC block — takes effect immediately rather than after the cache expires. Legacy tokens that lack a `prefix` field are **not** removed: `findMatchingToken()` verifies them via a fallback scan and backfills the prefix on first use, so a reload never invalidates existing tokens.
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,7 +32,7 @@ import { dataRouter } from './api/data.js';
 import { mediaConfigRouter } from './api/media-config.js';
 import { maintenanceMiddleware } from './maintenance.js';
 import { globalRateLimit, ipFloodBackstop } from './rate-limit/middleware.js';
-import { configExists, reloadConfig, getConfig, saveConfig, loadSecrets } from './config/loader.js';
+import { configExists, reloadConfig, getConfig, saveConfig, loadSecrets, startConfigWatcher } from './config/loader.js';
 import { requireAuth, requireAdminMfa, requireAdminMfaScoped } from './auth/middleware.js';
 import { clearTokenCache } from './auth/tokens.js';
 import { clearOidcCache } from './auth/oidc.js';
@@ -454,30 +454,41 @@ export function createApp() {
   // Reload config.json from disk without a container restart.  Useful when the
   // operator edits config.json directly or when integration tests inject new
   // settings.  Requires a valid Bearer PAT (same auth as all other API routes).
+  //
+  // Also runs automatically when the file changes on disk (see startConfigWatcher
+  // below): an operator's edit is otherwise reverted by the next config write, and
+  // reloading is only half the job — a space added by hand still needs initialising.
+  // Both paths therefore go through this one function rather than the watcher doing
+  // a bare re-parse.
+  async function applyConfigFromDisk(): Promise<void> {
+    const oldSpaceIds = new Set(getConfig().spaces.map(s => s.id));
+    reloadConfig();
+    loadSecrets(); // Also reload secrets.json (peer tokens injected by tests/scripts)
+    // Prefix-less (legacy) tokens are NOT stripped — findMatchingToken()
+    // verifies them via a fallback scan and backfills the prefix on first use.
+    // Flush caches so revoked tokens and updated OIDC config take effect immediately
+    clearTokenCache();
+    clearOidcCache();
+    // Ensure the built-in general space survives config edits
+    await ensureGeneralSpace();
+    // Complete any space rename/delete interrupted by a crash whose marker is
+    // present in the (re)loaded config. Idempotent and a no-op without a marker;
+    // gives operators a restart-free way to finish a stuck op. Runs before the
+    // new-space init below so a rename isn't shadowed by re-creating its old id.
+    await reconcilePendingSpaceOp();
+    // Initialise any spaces that were added to the config file
+    const newCfg = getConfig();
+    for (const space of newCfg.spaces) {
+      if (!oldSpaceIds.has(space.id) && !space.proxyFor) {
+        await initSpace(space.id);
+      }
+    }
+  }
+
+  startConfigWatcher(() => applyConfigFromDisk());
   app.post('/api/admin/reload-config', globalRateLimit, requireAdminMfa, async (_req, res) => {
     try {
-      const oldSpaceIds = new Set(getConfig().spaces.map(s => s.id));
-      reloadConfig();
-      loadSecrets(); // Also reload secrets.json (peer tokens injected by tests/scripts)
-      // Prefix-less (legacy) tokens are NOT stripped — findMatchingToken()
-      // verifies them via a fallback scan and backfills the prefix on first use.
-      // Flush caches so revoked tokens and updated OIDC config take effect immediately
-      clearTokenCache();
-      clearOidcCache();
-      // Ensure the built-in general space survives config edits
-      await ensureGeneralSpace();
-      // Complete any space rename/delete interrupted by a crash whose marker is
-      // present in the (re)loaded config. Idempotent and a no-op without a marker;
-      // gives operators a restart-free way to finish a stuck op. Runs before the
-      // new-space init below so a rename isn't shadowed by re-creating its old id.
-      await reconcilePendingSpaceOp();
-      // Initialise any spaces that were added to the config file
-      const newCfg = getConfig();
-      for (const space of newCfg.spaces) {
-        if (!oldSpaceIds.has(space.id) && !space.proxyFor) {
-          await initSpace(space.id);
-        }
-      }
+      await applyConfigFromDisk();
       res.json({ ok: true });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -214,10 +214,31 @@ export function reloadConfig(): Config {
   parsed.tokens ??= [];
   parsed.networks ??= [];
   validateOidcBlock(parsed);
-  _config = parsed;
+  // Refresh the EXISTING object in place rather than swapping in a new one.
+  //
+  // Callers routinely do `const cfg = getConfig()`, await something, then
+  // `saveConfig(cfg)`. If a reload replaced `_config`, that held reference would
+  // be detached, and saving it would write pre-reload content — reverting the very
+  // edit the reload just picked up. Ten such call sites exist (spaces lifecycle,
+  // rename, invite, tokens, network join); mutating in place keeps every one of
+  // them pointing at fresh data, so their own change merges on top instead of
+  // replacing it.
+  //
+  // Caveat worth knowing: a reference held to a NESTED object (a single `space`
+  // out of `cfg.spaces`) is still detached, because the arrays are replaced
+  // wholesale. Those sites are listed in ARCHITECTURE-TODO and want `mutateConfig`.
+  if (_config) {
+    const mutable = _config as unknown as Record<string, unknown>;
+    for (const key of Object.keys(mutable)) delete mutable[key];
+    Object.assign(_config, parsed);
+    parsed = _config;
+  } else {
+    _config = parsed;
+  }
   // Fix permission bits without rewriting content — avoids overwriting a
   // host-side edit that hasn't propagated through the bind-mount yet.
   try { fs.chmodSync(CONFIG_PATH, 0o600); } catch { /* non-POSIX host — ignore */ }
+  recordConfigMtime(); // we are now in sync with what is on disk
   return parsed;
 }
 
@@ -289,6 +310,80 @@ export function saveConfig(config: Config): void {
   // Ensure permissions after write
   fs.chmodSync(CONFIG_PATH, 0o600);
   if (gen > _flushedGeneration) _flushedGeneration = gen;
+  recordConfigMtime();
+}
+
+// ── External-change watcher ────────────────────────────────────────────────
+//
+// The running server treats its in-memory config as authoritative and writes the
+// whole thing back on every change. That makes the copy stale the moment anyone
+// edits config.json directly, and the next write silently reverts their edit —
+// with no error and no log line. `mutateConfig` fixes this for a single writer;
+// it cannot fix the 67 call sites that save a config they already hold, and
+// converting them all would still leave the next one someone writes exposed.
+//
+// So watch the file instead of policing the writes: reload when it changes
+// underneath us, and every existing call site becomes correct untouched.
+//
+// `fs.watchFile` (stat polling) rather than `fs.watch` (inotify): config.json
+// normally lives on a Docker Desktop bind mount, where inotify events are
+// unreliable and can be missed entirely — see the propagation note on
+// reloadConfig. Polling a single stat every couple of seconds costs nothing and
+// works the same on every host.
+
+let _configWatchActive = false;
+let _lastKnownMtimeMs = 0;
+let _reloadChain: Promise<void> = Promise.resolve();
+
+/** Remember the mtime we just produced, so our own writes don't look foreign. */
+function recordConfigMtime(): void {
+  try { _lastKnownMtimeMs = fs.statSync(CONFIG_PATH).mtimeMs; } catch { /* file may not exist yet */ }
+}
+
+/**
+ * Reload config.json whenever it changes on disk by any hand but ours.
+ *
+ * `onExternalChange` receives control after the file has been detected as
+ * changed and is responsible for the actual reload — it lives in the caller so
+ * this module stays free of dependencies on spaces, auth and secrets. It runs
+ * the same path as `POST /api/admin/reload-config`, because a hand-added space
+ * needs initialising, not merely parsing.
+ */
+export function startConfigWatcher(
+  onExternalChange: () => Promise<void> | void,
+  intervalMs = 2000,
+): void {
+  if (_configWatchActive) return;
+  _configWatchActive = true;
+  recordConfigMtime();
+
+  fs.watchFile(CONFIG_PATH, { interval: intervalMs, persistent: false }, curr => {
+    if (curr.mtimeMs === 0) return;                    // removed, or mid-replace
+    if (curr.mtimeMs === _lastKnownMtimeMs) return;    // our own write
+    // A write of ours is in flight — either the coalesced flush has not run yet, or
+    // it has renamed the file but not yet recorded the resulting mtime. Reloading now
+    // would read our own bytes back as if they were foreign and, worse, discard the
+    // in-memory change that is still waiting to be flushed. Skip; the next poll sees
+    // any genuinely foreign edit.
+    if (_writeGeneration > _flushedGeneration) return;
+    // Claim this version before reloading. If the reload throws — an operator
+    // saved half a file — we do not retry the same broken bytes every tick; the
+    // next edit changes the mtime and we try again.
+    _lastKnownMtimeMs = curr.mtimeMs;
+    log.info('config.json changed on disk — reloading');
+    _reloadChain = _reloadChain
+      .catch(() => { /* a prior failure must not break the chain */ })
+      .then(() => onExternalChange())
+      .then(() => { recordConfigMtime(); })
+      .catch(err => log.error(`Reload after external config change failed; keeping current config: ${err}`));
+  });
+}
+
+/** Stop watching (tests, and shutdown). */
+export function stopConfigWatcher(): void {
+  if (!_configWatchActive) return;
+  fs.unwatchFile(CONFIG_PATH);
+  _configWatchActive = false;
 }
 
 /**
@@ -331,6 +426,7 @@ async function writeConfigAsync(): Promise<void> {
   await fs.promises.rename(tmp, CONFIG_PATH);
   try { await fs.promises.chmod(CONFIG_PATH, 0o600); } catch { /* non-POSIX host — ignore */ }
   if (gen > _flushedGeneration) _flushedGeneration = gen;
+  recordConfigMtime(); // ours, not foreign — the watcher must not react to it
 }
 
 /**

--- a/testing/standalone/config-write-safety.test.js
+++ b/testing/standalone/config-write-safety.test.js
@@ -66,41 +66,39 @@ describe('config.json write safety', () => {
   });
 
   after(async () => {
-    // Never leave a marker behind — the next boot would try to reconcile it.
-    const cfg = readConfig();
-    if (cfg.pendingSpaceOp?.spaceId?.startsWith('cfgsafe-')) {
-      delete cfg.pendingSpaceOp;
-      writeConfig(cfg);
-    }
     for (const id of createdSpaceIds) {
       await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
     }
   });
 
-  // KNOWN DEFECT (tracked, not fixed here): request handlers still save from the in-memory
-  // config, which goes stale the moment anyone edits config.json directly — so an operator's
-  // hand edit is reverted by the next config-writing request unless they reload first. Fixing
-  // it means routing every handler through mutateConfig, which is its own change with its own
-  // risk; this release-blocker fix covers the background writer, where the window is minutes
-  // rather than milliseconds. Left as TODO so the gap stays visible instead of unasserted.
-  it('an on-disk change survives a later server-side config write', { todo: 'handlers still save a stale in-memory config' }, async () => {
+  // Was TODO until the config watcher landed: handlers save from the in-memory config, which
+  // went stale the moment anyone edited config.json directly, so an operator's hand edit was
+  // reverted by the next config-writing request. The watcher reloads within its poll interval,
+  // and the reload refreshes the config object in place, so a handler holding a reference
+  // across an await now merges onto fresh data instead of writing pre-reload content.
+  it('an on-disk change survives a later server-side config write', async () => {
     const victim = `cfgsafe-victim-${RUN_ID}`;
     const renamed = `${victim}-renamed`;
     const createR = await post(INSTANCES.a, token, '/api/spaces', { id: victim, label: 'Config Safety' });
     assert.equal(createR.status, 201, JSON.stringify(createR.body));
     createdSpaceIds.push(renamed);
 
-    // A third party writes to config.json — here a crash marker for an unrelated space,
-    // which is exactly what the crash-recovery path depends on surviving.
+    // A third party edits config.json — an operator relabelling a space by hand, which is
+    // exactly the workflow `POST /api/admin/reload-config` exists to support. Deliberately
+    // NOT a pendingSpaceOp marker: markers are consumed by the crash-recovery path, so one
+    // would be cleared by the very reload under test and would also block the rename below.
+    const edited = `cfgsafe-edited-${RUN_ID}`;
+    const editedR = await post(INSTANCES.a, token, '/api/spaces', { id: edited, label: 'Before' });
+    assert.equal(editedR.status, 201, JSON.stringify(editedR.body));
+    createdSpaceIds.push(edited);
+
     const cfg = readConfig();
-    cfg.pendingSpaceOp = {
-      type: 'rename',
-      spaceId: `cfgsafe-other-${RUN_ID}`,
-      newId: `cfgsafe-other-${RUN_ID}-dst`,
-      startedAt: new Date(RUN_ID).toISOString(),
-    };
+    cfg.spaces.find(s => s.id === edited).label = 'Edited By Hand';
     writeConfig(cfg);
-    await new Promise(r => setTimeout(r, 600)); // let the bind-mount propagate
+    // Let the bind-mount propagate AND the config watcher's stat poll (2s) notice.
+    // Without this the request below would race the watcher and the test would be
+    // asserting the old behaviour half the time.
+    await new Promise(r => setTimeout(r, 4000));
 
     // Now make the server persist config from its own copy, via an unrelated change.
     const renameR = await patch(INSTANCES.a, token, `/api/spaces/${victim}/rename`, { newId: renamed, confirm: true });
@@ -108,32 +106,28 @@ describe('config.json write safety', () => {
     await new Promise(r => setTimeout(r, 600));
 
     const after = readConfig();
-    assert.ok(
-      after.pendingSpaceOp,
+    assert.equal(
+      after.spaces.find(s => s.id === edited)?.label,
+      'Edited By Hand',
       'a config change written to disk was erased by a later server-side write — ' +
-      'any concurrent operator edit or crash marker is lost the same way',
+      'any operator edit is lost the same way',
     );
-    assert.equal(after.pendingSpaceOp.spaceId, `cfgsafe-other-${RUN_ID}`);
     // ...and the server's own change is there too: this is a merge, not a stalemate.
     assert.ok(after.spaces.some(s => s.id === renamed), 'the rename should still have been applied');
   });
 
-  it('index-readiness finalisation does not erase a marker written while it polled', async () => {
+  it('index-readiness finalisation does not erase an edit written while it polled', async () => {
     // The exact CI failure, in miniature: create a space (readiness polling starts in the
-    // background), inject a marker while it runs, and assert the marker is still there once
-    // the space reports ready. Before the fix the background write clobbered it.
+    // background), edit config.json while it runs, and assert the edit is still there once
+    // the space reports ready. Before the fix, that background write — which holds its
+    // snapshot for as long as the index builds take — silently reverted the edit.
     const id = `cfgsafe-ready-${RUN_ID}`;
     const createR = await post(INSTANCES.a, token, '/api/spaces', { id, label: 'Readiness Race' });
     assert.equal(createR.status, 201, JSON.stringify(createR.body));
     createdSpaceIds.push(id);
 
     const cfg = readConfig();
-    cfg.pendingSpaceOp = {
-      type: 'rename',
-      spaceId: `cfgsafe-ready-other-${RUN_ID}`,
-      newId: `cfgsafe-ready-other-${RUN_ID}-dst`,
-      startedAt: new Date(RUN_ID).toISOString(),
-    };
+    cfg.spaces.find(s => s.id === id).label = 'Relabelled Mid-Build';
     writeConfig(cfg);
 
     // Wait for readiness to actually land (that write is the one under test).
@@ -144,9 +138,10 @@ describe('config.json write safety', () => {
     }
     assert.ok(ready, `space '${id}' never reached indexStatus=ready`);
 
-    assert.ok(
-      readConfig().pendingSpaceOp,
-      'background index-readiness write erased a marker written while it was polling',
+    assert.equal(
+      readConfig().spaces.find(s => s.id === id)?.label,
+      'Relabelled Mid-Build',
+      'the background index-readiness write erased an edit made while it was polling',
     );
   });
 });


### PR DESCRIPTION
Found while diagnosing #344's CI failure, where the same defect erased a `pendingSpaceOp` crash marker. #344 fixed the background writer; this fixes the general case.

## The defect

The server treats its in-memory config as authoritative and writes the **whole file** back on every change — creating a space, renaming one, saving settings. So the in-memory copy goes stale the moment anyone edits `config.json` directly, and the next write silently reverts the edit. No error, no log line.

`POST /api/admin/reload-config` exists precisely to support hand edits, but nothing forced you to call it *before* the server next wrote, and the failure was invisible when you didn't.

## Why a watcher instead of converting the call sites

Converting handlers to `mutateConfig` was the obvious fix until I counted: **67 `saveConfig` call sites across 21 files**, including the sync engine's high-frequency coalesced path. A watcher makes all of them correct without being touched — and unlike a convention, it cannot be undone by the next handler someone writes.

- **`fs.watchFile` stat-polling, not `fs.watch`/inotify** — `config.json` normally lives on a Docker Desktop bind mount where inotify events are unreliable, which `loader.ts` already documents for reload propagation. Our own writes are recognised by mtime and ignored.
- **The watcher runs the same path as the reload endpoint.** A bare re-parse would leave a hand-added space uninitialised, so both now share one `applyConfigFromDisk()`.
- **`reloadConfig` refreshes the config object in place instead of replacing it.** Ten call sites hold a config across an `await` before saving it (audited: spaces lifecycle ×4, rename, spaces API, invite, tokens, network join). Swapping the object would detach those references and write pre-reload content — reverting the very edit the reload just picked up.
- **The watcher skips a tick while one of our own writes is in flight**, so it can't read our own bytes back as foreign and discard an in-memory change still waiting to be flushed.

## Honest limitation

The window shrinks from *forever* to *one poll interval* — **not to zero**. An edit is still lost if a config write lands in the ~2s before the watcher notices. The test proves this both ways: it passes with the watcher given time to poll, and **still fails when the write races it** (verified by shortening the wait to 300ms). Docs now say so, and point at the reload endpoint to close the window.

## Testing

- The `todo` test left by #344 is now un-marked and passing; both cases rewritten to use a benign operator edit (relabelling a space) rather than a `pendingSpaceOp` marker — markers are consumed by the crash-recovery path, so one would be cleared by the very reload under test.
- Standalone **1042 pass**, sync **191**, integration **906**, **0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)