### PR TITLE
fix(auth): a token prefix backfill could be lost to a config reload mid-verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1267,6 +1267,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A legacy token's prefix backfill could be silently lost, leaving it on the slow lookup path
+  forever.** `findMatchingToken` reads `config.tokens`, awaits a bcrypt compare — deliberately slow, so
+  a wide window — and then heals the matched record's lookup prefix. Since the config watcher landed, a
+  reload can happen inside that window on a live instance, and a reload replaces the tokens array
+  wholesale: the caller is left holding a **detached record**, so writing the prefix onto it and saving
+  persisted a config with no backfill in it. The token kept authenticating, but via the full bcrypt
+  scan on every request, indefinitely, with nothing reporting it. `healPrefix` now re-resolves the
+  record by id inside the write instead of saving the object it was handed.
+  This is the nested-reference hazard called out when the watcher shipped, with a concrete victim: the
+  in-place config refresh keeps *top-level* references valid, but a reference into `cfg.tokens` (or
+  `cfg.spaces`) is still replaced. It surfaced as an unrelated-looking integration failure that only
+  reproduced in the full suite, because only there did a reload land in the window. New standalone test
+  drives the race deterministically — `reloadConfig()` is synchronous, so calling it immediately after
+  the lookup starts places it inside the bcrypt await — and was verified to fail against the previous
+  code.
+
 - **Characterization tests for the settings `ModelsComponent` (25 tests), landed before it is split.**
   The 643-line page had **no coverage at all** and is about to become three tabs (Models · Pipelines ·
   Tools) with a per-space pipeline surface behind it, so these are proven green against the unmodified

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -1,7 +1,7 @@
 ﻿import { randomBytes } from 'crypto';
 import bcrypt from 'bcrypt';
 import { v4 as uuidv4 } from 'uuid';
-import { getConfig, saveConfig, getSecrets, saveSecrets } from '../config/loader.js';
+import { getConfig, saveConfig, mutateConfig, getSecrets, saveSecrets } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { TokenRecord } from '../config/types.js';
 
@@ -106,7 +106,7 @@ export async function findMatchingToken(
     const ok = await verifyToken(plaintext, record.hash);
     if (!ok) continue;
     if (record.expiresAt && new Date(record.expiresAt) < new Date()) continue;
-    healPrefix(config, record, prefix);
+    healPrefix(record, prefix);
     _tokenCache.set(plaintext, { tokenId: record.id, expiresAt: Date.now() + CACHE_TTL_MS });
     return record;
   }
@@ -122,19 +122,31 @@ export async function findMatchingToken(
     const ok = await verifyToken(plaintext, record.hash);
     if (!ok) continue;
     if (record.expiresAt && new Date(record.expiresAt) < new Date()) continue;
-    healPrefix(config, record, prefix);
+    healPrefix(record, prefix);
     _tokenCache.set(plaintext, { tokenId: record.id, expiresAt: Date.now() + CACHE_TTL_MS });
     return record;
   }
   return null;
 }
 
-/** Rewrite a record's prefix to the current format (best-effort persist). */
-function healPrefix(config: ReturnType<typeof getConfig>, record: TokenRecord, prefix: string): void {
+/**
+ * Rewrite a record's prefix to the current format (best-effort persist).
+ *
+ * Re-resolves the record by id inside the write instead of saving the object it was handed. The
+ * caller looked the record up out of `config.tokens`, then awaited a bcrypt verify — and a config
+ * reload during that await replaces the tokens array wholesale, leaving the caller holding a detached
+ * record. Mutating that object and saving would persist a config with no backfill in it: the token
+ * keeps authenticating via the slow fallback scan forever, silently, and the migration never lands.
+ * The in-memory object is still updated so the current request sees the healed value.
+ */
+function healPrefix(record: TokenRecord, prefix: string): void {
   if (record.prefix === prefix) return;
   record.prefix = prefix;
   try {
-    saveConfig(config);
+    mutateConfig(cfg => {
+      const live = cfg.tokens.find(t => t.id === record.id);
+      if (live) live.prefix = prefix;
+    });
     log.info(`Migrated lookup prefix for token '${record.name}' (${record.id}) on first use.`);
   } catch { /* best-effort — will persist on the next config save */ }
 }

--- a/testing/standalone/token-heal-reload-race.test.js
+++ b/testing/standalone/token-heal-reload-race.test.js
@@ -1,0 +1,99 @@
+/**
+ * A token's prefix backfill must survive a config reload landing mid-verify.
+ *
+ * `findMatchingToken` reads `config.tokens`, awaits a bcrypt compare, then heals the matched record's
+ * lookup prefix. bcrypt is deliberately slow (~250ms at 12 rounds), so that await is a wide window —
+ * and since the config watcher landed, a reload can happen inside it at any time on a live instance.
+ *
+ * A reload replaces the tokens array wholesale, which leaves the caller holding a DETACHED record.
+ * Writing the prefix onto that object and saving the config persisted a config with no backfill in it:
+ * the token kept working, but via the slow full-scan fallback, forever, and nothing said so. It
+ * surfaced as an unrelated-looking integration failure ("prefix must be backfilled on first use")
+ * that only reproduced in the full suite, because only there did a reload land in the window.
+ *
+ * The reload here is not simulated — `reloadConfig()` is synchronous, so calling it immediately after
+ * `findMatchingToken()` starts places it deterministically inside the bcrypt await.
+ *
+ * Run: node --test testing/standalone/token-heal-reload-race.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-tokheal-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+
+// CONFIG_PATH is read at module-load time — set it BEFORE importing the loader.
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let loader;
+let tokens;
+
+const readDisk = () => JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+describe('token prefix backfill vs. a config reload mid-verify', () => {
+  before(async () => {
+    loader = await import('../../server/dist/config/loader.js');
+    tokens = await import('../../server/dist/auth/tokens.js');
+  });
+
+  it('the backfill still persists when a reload lands during the bcrypt compare', async () => {
+    // A token as it looked before the `prefix` field existed: hash only, no prefix.
+    const plaintext = tokens.generateToken();
+    const hash = await tokens.hashToken(plaintext);
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      instanceId: 'test-instance', instanceLabel: 'test', spaces: [], networks: [],
+      tokens: [{ id: 'legacy-1', name: 'legacy', hash, admin: true }],
+    }, null, 2), { mode: 0o600 });
+    loader.loadConfig();
+
+    assert.equal(readDisk().tokens[0].prefix, undefined, 'precondition: no prefix on disk');
+
+    const pending = tokens.findMatchingToken(plaintext); // starts the bcrypt compare
+    loader.reloadConfig();                               // synchronous — lands inside that await
+    const record = await pending;
+
+    assert.ok(record, 'the legacy token must still authenticate');
+    assert.equal(record.id, 'legacy-1');
+
+    const healed = readDisk().tokens.find(t => t.id === 'legacy-1');
+    assert.ok(
+      healed.prefix,
+      'the prefix backfill was lost: it was written to a record detached by the reload, so the token ' +
+      'keeps taking the slow full-scan path on every request with nothing reporting it',
+    );
+    assert.equal(healed.prefix.length, 8);
+  });
+
+  it('the healed value is visible to the caller in the same request', async () => {
+    const plaintext = tokens.generateToken();
+    const hash = await tokens.hashToken(plaintext);
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      instanceId: 'test-instance', instanceLabel: 'test', spaces: [], networks: [],
+      tokens: [{ id: 'legacy-2', name: 'legacy2', hash, admin: true }],
+    }, null, 2), { mode: 0o600 });
+    loader.loadConfig();
+
+    const record = await tokens.findMatchingToken(plaintext);
+    assert.ok(record.prefix, 'the record handed back must carry the healed prefix');
+  });
+
+  it('a second lookup takes the fast prefix-filtered path', async () => {
+    const plaintext = tokens.generateToken();
+    const hash = await tokens.hashToken(plaintext);
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      instanceId: 'test-instance', instanceLabel: 'test', spaces: [], networks: [],
+      tokens: [{ id: 'legacy-3', name: 'legacy3', hash, admin: true }],
+    }, null, 2), { mode: 0o600 });
+    loader.loadConfig();
+
+    await tokens.findMatchingToken(plaintext);
+    tokens.clearTokenCache(); // force a real lookup rather than the cache hit
+    const again = await tokens.findMatchingToken(plaintext);
+    assert.ok(again, 'the token must still resolve once its prefix is backfilled');
+    assert.equal(again.id, 'legacy-3');
+  });
+});


### PR DESCRIPTION
A regression from #346, found while verifying the pipeline-levels branch — **not** caused by that branch.

## What happens

`findMatchingToken` reads `config.tokens`, awaits a bcrypt compare, then heals the matched record's lookup prefix. bcrypt is deliberately slow (~250ms at 12 rounds), so that await is a wide window — and since the config watcher shipped, a reload can land inside it on a live instance.

A reload replaces the tokens array wholesale, leaving the caller holding a **detached record**. Writing the prefix onto that object and saving persisted a config with no backfill in it. The token kept authenticating, but via the **full bcrypt scan on every request, indefinitely**, with nothing reporting it — the migration simply never landed.

`healPrefix` now re-resolves the record by id inside the write instead of saving the object it was handed.

This is exactly the nested-reference hazard called out when the watcher shipped, now with a concrete victim: the in-place config refresh keeps *top-level* references valid, but a reference **into** `cfg.tokens` (or `cfg.spaces`) is still replaced. The remaining audited sites are tracked.

## How it was found

It surfaced as an unrelated-looking integration failure — `prefix must be backfilled on first use` — that **passed in isolation and only reproduced in the full suite**, because only there did a reload land in the window. The tempting reading was "flake, not my change". Instead: reproduced it twice to confirm it was real, read the path, and identified the mechanism.

## Deterministic test

`reloadConfig()` is synchronous, so calling it immediately after `findMatchingToken()` starts places it **inside** the bcrypt await — no sleeps, no timing luck:

```js
const pending = tokens.findMatchingToken(plaintext); // starts the bcrypt compare
loader.reloadConfig();                               // lands inside that await
const record = await pending;
```

**Verified to fail against the previous code** (`the prefix backfill was lost...`) and pass with the fix.

## Testing

- New `testing/standalone/token-heal-reload-race.test.js` (3 tests).
- Standalone **1045 pass**, integration **906 pass**, **0 fail** — the integration failure that started this is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)