### PR TITLE
docs: sweep the stale claims, and make the face-recognition env pin actually work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,22 @@ YTHRIL_PORT=3200
 # Verbose logging:
 #   DEBUG=1
 
+# ── Face recognition (opt-in, infra-pinnable) ────────────────────────────────
+# Off unless enabled. Detects faces in uploaded images, embeds them, and can auto-label
+# files with a person entity — so it is the setting with the clearest privacy weight, and
+# the one an infra admin most often wants to decide centrally.
+#
+# An env value WINS over config.json, so FACE_RECOGNITION_ENABLED=false guarantees no faces
+# are processed on this instance — including after restoring a backup taken where it was on.
+# Leaving a variable empty means "not set": config.json (then the default) applies.
+# A pinned field is reported in lockedByInfra and renders read-only in Settings → Models.
+#   FACE_RECOGNITION_ENABLED=false
+#   FACE_RECOGNITION_CONFIDENCE_THRESHOLD=0.6      # cosine similarity required to auto-label
+#   FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION=0.05   # ignore faces smaller than this
+#   FACE_RECOGNITION_MODEL_PATH=human-models       # relative to DATA_ROOT
+#   FACE_RECOGNITION_PERSON_ENTITY_TYPES=person    # comma-separated
+#   FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES=true  # also process images arriving via sync
+
 # ── Sidecar on/off switches (infra-managed deployments) ──────────────────────
 # All three heavy sidecars run by default. Set one to 0 to keep it OUT of the deployment
 # entirely — a running container is stopped and removed on the next `docker compose up`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -686,6 +686,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Documentation staleness sweep — one statement was wrong, not merely out of date.** The integration
+  guide told operators that *"any change to the `oidc` block requires `POST /api/admin/reload-config`
+  or a container restart to take effect"*. Since the config watcher landed, an OIDC edit is picked up
+  automatically within about two seconds — and the same document said so elsewhere, so it contradicted
+  itself. It now describes the reload endpoint as the way to make a reload **synchronous**, not
+  mandatory.
+  The user guide had never caught up with several shipped features, and the omissions hid recovery
+  paths rather than just details:
+  - **Rebuild search indexes** — the only user-facing repair for *search silently returns nothing* —
+    was missing from the Danger tab section entirely, while the reindex banner nearby pointed users at
+    **Reindex now**, which cannot fix a missing index. Both now say which repair applies when.
+  - The per-space extraction picker still described the old `OCR / Auto / VLM / Max` set, with the
+    instance value called a "default". It now documents the full ladder, that the instance value is a
+    **ceiling**, and that `off` means documents are stored but never read.
+  - Face recognition documented five of six fields (`modelPath` was missing) and no env vars at all.
+  - The document-upload polling section listed `pending → processing → complete` without `skipped`, so
+    an integrator polling an `off` space would have polled forever.
+  Nine residual `max` references were renamed to `repair` — two of them (`repairModel` / `verifyModel`
+  as *"`max` mode only"*) would have told an operator on `auto` that those models are inert, when they
+  are exactly what changed.
+
 - **User guide: worked example for connecting Ythril to Claude over MCP.** A step-by-step walkthrough in the
   "Connecting an AI assistant (MCP)" section — public HTTPS URL (via the Networks local connector / Cloudflare
   tunnel), creating a **scoped token first** (the connector inherits its permissions), adding the custom
@@ -1266,6 +1287,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of a third-party signed cast, tampered cast rejected).
 
 ### Fixed
+
+- **Face recognition is now actually pinnable from a Compose deployment — and an empty env var no
+  longer counts as a pin.** Two halves of the same gap. The documented guarantee that
+  `FACE_RECOGNITION_ENABLED=false` stops all face processing could not hold under the default
+  `docker-compose.yml`, because none of the six variables was passed through to the container — the
+  value never reached the process. They are forwarded now.
+  Forwarding them exposed the second half: Compose passes a variable through as
+  `FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}`, which leaves it **defined but empty**
+  when the operator set nothing. Treating "defined" as "pinned" would have read the empty string as
+  `false` and **forced face recognition off for every Compose deployment**, while reporting all six
+  fields as infra-locked — controls the operator could neither use nor explain. An env var now counts
+  as set only when it has a value, with a test covering it.
+  `.env.example` documents all six, including that an env value wins over `config.json` and survives a
+  restore from a backup taken where the feature was on.
 
 - **A legacy token's prefix backfill could be silently lost, leaving it on the slow lookup path
   forever.** `findMatchingToken` reads `config.tokens`, awaits a bcrypt compare — deliberately slow, so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@
       # `unstructured` service defined below; override to use an external converter (C2).
       CONVERSION_SIDECAR_URL: ${CONVERSION_SIDECAR_URL:-http://unstructured:8000}
       # Page-render sidecar (PDF → page images) for the F11 VLM extraction path. Defaults to the bundled
-      # `doc-render` service below; only used when documentProcessing.mode is vlm/auto/max.
+      # `doc-render` service below; only used when documentProcessing.mode is vlm/auto/repair.
       RENDER_SIDECAR_URL: ${RENDER_SIDECAR_URL:-http://doc-render:8100}
       # Office → page-image rendering (F11-a). Points at the opt-in `doc-office` sidecar (below, enabled
       # with `--profile office`). When that service isn't running, office docs fall back to OCR.
@@ -51,6 +51,16 @@
       #   YTHRIL_LOCAL_AGENT_ALLOW_INSECURE=true             # HTTP is fine: it never leaves the machine
       YTHRIL_LOCAL_AGENT_URL: ${YTHRIL_LOCAL_AGENT_URL:-http://127.0.0.1:38123}
       YTHRIL_LOCAL_AGENT_TOKEN: ${YTHRIL_LOCAL_AGENT_TOKEN:-}
+      # Face recognition (opt-in). Passed through so an infra admin can pin it without
+      # editing config.json inside the container — FACE_RECOGNITION_ENABLED=false is the
+      # documented guarantee that no faces are detected or embedded on this instance,
+      # and it can only hold if the variable actually reaches the process.
+      FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}
+      FACE_RECOGNITION_CONFIDENCE_THRESHOLD: ${FACE_RECOGNITION_CONFIDENCE_THRESHOLD:-}
+      FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION: ${FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION:-}
+      FACE_RECOGNITION_MODEL_PATH: ${FACE_RECOGNITION_MODEL_PATH:-}
+      FACE_RECOGNITION_PERSON_ENTITY_TYPES: ${FACE_RECOGNITION_PERSON_ENTITY_TYPES:-}
+      FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES: ${FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES:-}
       # Pass DEBUG=1 from the host shell to enable verbose logging:
       #   DEBUG=1 docker compose up
       DEBUG: ${DEBUG:-}
@@ -306,7 +316,7 @@
   # it parses UNTRUSTED user documents, so it sits on the
   # same isolated internal `ythril-convert` network — no database access and no internet egress — and
   # runs non-root (see sidecars/doc-render/Dockerfile). Only used when documentProcessing.mode is
-  # vlm/auto/max; NOT a startup dependency (VLM extraction degrades to OCR when it is absent). It is
+  # vlm/auto/repair; NOT a startup dependency (VLM extraction degrades to OCR when it is absent). It is
   # light (~python-slim + pypdfium2, no model weights), so leaving it running is cheap.
   doc-render:
     build: ./sidecars/doc-render

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1954,7 +1954,7 @@ chunks do not exist yet when the call returns. This is true for the REST upload 
 
 | Surface | Returns | How to know conversion finished |
 |---------|---------|--------------------------------|
-| `POST /api/files/:spaceId` (document formats) | `202 Accepted` with `embeddingStatus: "pending"` | poll the filemeta record |
+| `POST /api/files/:spaceId` (document formats) | `202 Accepted` with `embeddingStatus: "pending"` — or `201` with `embeddingStatus: "skipped"` when document extraction is `off` for that space | poll the filemeta record |
 | MCP `write_file` | the write confirmation (sha256) — it reports the **write**, not the conversion | poll the filemeta record |
 
 Poll `GET /api/brain/spaces/:spaceId/files?path=<path>` and watch `embeddingStatus`: `pending` →
@@ -2044,7 +2044,7 @@ Setting `CONVERSION_SIDECAR_URL=""` only disables the **sidecar-backed** formats
 
 The bundled `doc-render` sidecar is a tiny PDFium (pypdfium2) service that renders PDF pages to images. It is
 the rasterization step the **VLM document-extraction** path (`mediaEmbedding.documentProcessing.mode` of
-`vlm` / `auto` / `max`) needs and is **not used by the default `ocr` mode** — you can leave it running (it is
+`vlm` / `auto` / `repair`) needs and is **not used by the `ocr` level** — you can leave it running (it is
 lightweight and carries no model weights) or stop it with no effect on today's OCR conversion. Like the
 `unstructured` sidecar it parses untrusted documents, so it runs isolated on the internal-only
 `ythril-convert` network (no database, no internet egress), non-root and resource-limited. Ythril reaches
@@ -2053,7 +2053,7 @@ it via `RENDER_SIDECAR_URL`. The **application** default is `http://localhost:81
 #### Office-render sidecar (`doc-office`) — optional
 
 `doc-render` only opens PDFs, so **office** documents (DOCX, EPUB, PPTX, XLSX, ODT, RTF…) in a `vlm`/`auto`/
-`max` mode fall back to OCR unless the optional **`doc-office`** sidecar is running. It uses **LibreOffice**
+`repair` fall back to OCR unless the optional **`doc-office`** sidecar is running. It uses **LibreOffice**
 (headless) to convert the document to PDF, then rasterizes it exactly like `doc-render`. Because LibreOffice
 is heavy (≈ +1 GB), it is **opt-in**: start it with
 
@@ -2089,29 +2089,29 @@ A space on `"auto"` follows the instance level wherever it moves. Uploads to a s
 | `strategy` | `"hi_res"` | Unstructured partition strategy. `"hi_res"`: full Tesseract OCR + layout detection — accurate on scanned PDFs, extracts embedded images and structured tables. `"auto"`: sidecar picks the fastest viable strategy. `"fast"`: pdfminer text-layer only — fastest but no OCR, no image extraction. `"ocr_only"`: force OCR on every page regardless of whether a text layer exists. |
 | `extractImages` | `true` | When `true` and `strategy` is `"hi_res"`, embedded images found in document partitions are decoded and saved as `_extracted/{originalId}/image-{N}.{ext}` subfiles. Each is automatically enqueued for the full media pipeline (caption + face recognition). Has no effect when strategy is not `"hi_res"`. |
 | `mode` | `"auto"` | How thoroughly documents are read, low to high: `"off"` · `"ocr"` · `"vlm"` · `"repair"`, plus `"auto"`. **`"off"` means documents are stored but never analysed** — no text is extracted, so nothing in them can be recalled; those uploads are recorded as `skipped` rather than queued. `"ocr"` is OCR-only (the unstructured sidecar). `"vlm"` renders each page and transcribes it with a vision model, using OCR as grounding evidence and falling back to OCR if the result doesn't validate (so it is **never worse than OCR**). `"repair"` adds a validation-driven **repair** pass (below) on top of `"vlm"`, plus a second-model consensus pass when a `verifyModel` is set. `"auto"` (default) means **as much as this instance can actually do** — it resolves to `"repair"` when a repair model is configured, otherwise `"vlm"`, otherwise `"ocr"`, so with no `vlmModel` set it is byte-for-byte the OCR-only path. `"max"` is the previous name for `"repair"` and is still accepted on read. |
-| `vlmModel` | `""` | Ollama vision model used for `vlm` / `auto` / `max` (e.g. a bundled `moondream`, or a larger model you wire in). Empty ⇒ the VLM path is unavailable and extraction stays on OCR. Env override: `DOC_VLM_MODEL`. |
+| `vlmModel` | `""` | Ollama vision model used for `vlm` / `auto` / `repair` (e.g. a bundled `moondream`, or a larger model you wire in). Empty ⇒ the VLM path is unavailable and extraction stays on OCR. Env override: `DOC_VLM_MODEL`. |
 | `vlmBaseUrl` | `""` | Endpoint for the VLM. Empty ⇒ falls back to the media vision provider's `baseUrl`, then `http://ollama:11434`. Env override: `DOC_VLM_URL`. |
-| `repairModel` | `""` | **`max` mode only.** Model used for the repair pass when a page's VLM output fails OCR-evidence validation — it reconciles the draft against the OCR text in one extra text-only call. Empty ⇒ reuses `vlmModel`. Set this to wire in a stronger model you host. Env override: `DOC_REPAIR_MODEL`. |
+| `repairModel` | `""` | Used by the **`repair`** level — and by **`auto`**, which resolves to `repair` whenever this is set. Model used for the repair pass when a page's VLM output fails OCR-evidence validation — it reconciles the draft against the OCR text in one extra text-only call. Empty ⇒ reuses `vlmModel`. Set this to wire in a stronger model you host. Env override: `DOC_REPAIR_MODEL`. |
 | `repairBaseUrl` | `""` | Endpoint for the repair model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_REPAIR_URL`. |
-| `verifyModel` | `""` | **`max` mode only (F11-d consensus).** A *second* document VLM. When set, `max` runs it as an independent second transcription of each page, reconciles it with the primary draft against the OCR text, and keeps the highest-coverage result — **never worse** than the primary. Empty ⇒ no consensus pass. Best set to a *different* model than `vlmModel`. Env override: `DOC_VERIFY_MODEL`. |
+| `verifyModel` | `""` | Engages on the **`repair`** level, and on **`auto`** when a repair model is set (F11-d consensus). A *second* document VLM. When set, the repair level runs it as an independent second transcription of each page, reconciles it with the primary draft against the OCR text, and keeps the highest-coverage result — **never worse** than the primary. Empty ⇒ no consensus pass. Best set to a *different* model than `vlmModel`. Env override: `DOC_VERIFY_MODEL`. |
 | `verifyBaseUrl` | `""` | Endpoint for the verify model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_VERIFY_URL`. |
 | `renderDpi` | `150` | Page rasterization DPI for the render sidecar (VLM modes only). |
 | `maxPages` | `50` | Cap on pages rendered/transcribed per document (VLM modes only). |
 | `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
 | `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
-| `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `max`). Env override: `DOC_OCR_TIMEOUT_MS`. |
+| `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `repair`). Env override: `DOC_OCR_TIMEOUT_MS`. |
 
 The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,
 Ythril transparently uses OCR — no upload fails because a model isn't wired in yet.
 
-**Repair pass (`max` mode).** When a document's VLM transcription fails the OCR-evidence coverage check,
-`max` mode runs one bounded repair pass before falling back to OCR: it sends the draft transcription and the
+**Repair pass (`repair` level).** When a document's VLM transcription fails the OCR-evidence coverage check,
+the `repair` level runs one bounded repair pass before falling back to OCR: it sends the draft transcription and the
 OCR text to `repairModel` (or `vlmModel` if unset) in a single text-only call, asks it to restore any dropped
 content, and re-validates. If the repaired output passes it is accepted; if it errors or still doesn't pass,
 the extractor falls back to OCR — so the result is still never worse than plain OCR. Exactly one repair pass
 runs per document (bounded cost).
 
-**Consensus pass (`max` mode, F11-d).** When a `verifyModel` is configured, `max` mode adds one bounded
+**Consensus pass (`repair` level, F11-d).** When a `verifyModel` is configured, the `repair` level adds one bounded
 **consensus** step on top of an already-accepted draft: the verify model independently transcribes the pages
 (a second, ideally different, VLM), that draft is reconciled with the primary against the OCR text, and the
 highest-OCR-coverage of the three candidates (primary, second draft, reconciled) is kept. Because the primary
@@ -2151,7 +2151,7 @@ point a **bigger, external model** at specific tasks under `documentProcessing.a
 
 | `model` | Model tag to request. Env: `DOC_ASSIST_MODEL`. |
 | `apiKey` | Optional bearer token. Stored in `secrets.json` (never `config.json`), masked in the admin API. Env: `DOC_ASSIST_API_KEY`. |
-| `uses` | Which tasks the external model powers — `["repair"]` today (the `max`-mode repair pass); more are planned. Empty ⇒ configured but inert (no egress). |
+| `uses` | Which tasks the external model powers — `["repair"]` today (the repair pass); more are planned. Empty ⇒ configured but inert (no egress). |
 | `acknowledgedHost` | The endpoint host the operator acknowledged egress to. **Required to match `baseUrl`'s host whenever `uses` is non-empty** — the admin API rejects the save otherwise, and the extractor re-checks it at runtime, so document content never leaves the box without recorded consent. |
 
 ⚠️ **This is the only setting that sends document content off the instance.** When a task is assigned, the
@@ -6393,7 +6393,7 @@ To bypass SSO auto-redirect and use a PAT instead, navigate to `/login?local`.
 3. Add a mapper for `ythril_spaces` (if using space scoping): **User attribute → Token claim** mapping.
 4. Set `issuerUrl` to `https://keycloak.host/realms/<realm>`.
 
-After saving, run `POST /api/admin/reload-config` to apply the OIDC settings without a restart.
+The change is picked up automatically within about two seconds; run `POST /api/admin/reload-config` if you want to apply it synchronously.
 
 ### Entra ID (Azure AD) Setup
 
@@ -6484,7 +6484,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
 > **Note:** Auth0 requires namespaced custom claims (a URL prefix). Replace `https://ythril.example.com/` with your own namespace.
 
-After saving any IdP configuration, run `POST /api/admin/reload-config` to apply the changes without a restart.
+Any IdP configuration change is picked up automatically within about two seconds; run `POST /api/admin/reload-config` to apply it synchronously.
 
 ### Security Notes and Limitations
 
@@ -6493,6 +6493,6 @@ After saving any IdP configuration, run `POST /api/admin/reload-config` to apply
 - **`admin` and `readOnly` cannot both match.**  If both claim rules match the same JWT, `admin: true` takes precedence and `readOnly` is ignored.  Design your IdP roles to be mutually exclusive.
 - **Spaces claim controls visibility (fail-closed).**  When a `spaces` mapping is configured, the OIDC session can only see and modify the spaces named in that claim.  If the mapping is configured but the claim is missing or is not a string array, the allow-list is **empty (deny all)** — not "all spaces".  Users who cannot see expected spaces should check with their administrator that the IdP is emitting the correct claim values.
 - **Config validation.**  When `oidc.enabled` is `true`, `issuerUrl` and `clientId` are required.  The server validates the OIDC config block at startup and on `reload-config` — a malformed block will prevent the server from starting.
-- **Config reload required.**  Any change to the `oidc` block requires `POST /api/admin/reload-config` or a container restart to take effect.  The OIDC discovery document and JWKS key set are cached in memory and flushed on reload.
+- **Config reload.**  A change to the `oidc` block is picked up **automatically within about two seconds** — the server watches `config.json`, and the reload flushes the cached OIDC discovery document and JWKS key set. Call `POST /api/admin/reload-config` when you want the reload to be synchronous (a deploy script that must not race the next login), or restart the container. Neither is required.
 - **Enforcing OIDC for browser sessions.**  Set `enforceForBrowser: true` to prevent users who have a cached PAT in their browser from bypassing the IdP.  When this flag is set the SPA clears any PAT-based localStorage session on startup and forces a fresh OIDC login.  Programmatic callers (API, MCP) that supply an `Authorization: ****** header are not affected.
 - **Sign-out clears all browser auth state.**  Clicking the sign-out button always removes every Ythril auth key from `localStorage` regardless of whether the session was established via OIDC or a PAT.  For OIDC sessions the browser is additionally redirected to the IdP's `end_session_endpoint` (from the discovery document) with an `id_token_hint` so the Keycloak / IdP server-side session is also destroyed.  Without this step, `prompt=none` silent refresh would immediately re-authenticate the user.  Use `postLogoutRedirectUri` to control where the IdP sends the user after sign-out.

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -90,6 +90,8 @@ At the top of the page a row of **space chips** lets you switch space; each chip
 
 If the search index needs rebuilding (for example after the embedding model changes), a banner appears reading *"Embeddings are stale — the embedding model has changed and this space needs reindexing."* Click **Reindex now** to rebuild it.
 
+> **Reindex and rebuild are different repairs.** *Reindex* re-embeds your content against the current model. It does **not** help when the search index itself is missing or broken — the symptom there is search quietly returning nothing at all, with no error. That one needs **Rebuild search indexes** on the space's **Danger** tab (see below).
+
 ### Memories
 
 Memories are the core knowledge unit — plain-language statements you want to remember.
@@ -367,7 +369,11 @@ Click the gear icon on any space row to open its settings panel. Changes save an
 **Settings tab:** Update the display name, purpose, usage notes for AI assistants, storage quota, auto-delete window, and document-extraction mode — grouped into **Identity**, **Purpose**, **Limits**, and **Document extraction** cards. A blank storage quota, auto-delete window, or extraction override shows an **Unlimited** / **No auto-delete** / **Instance default** pill so the default is unmistakable.
 
 - **Auto-delete records after (days)** — an optional space-wide expiry. Every record (memory, entity, edge, chrono entry) created or updated in the space is deleted automatically this many days later. Leave it blank or `0` to keep records forever. Individual writes can override the default (or opt out) with their own per-record TTL via the API. Deletion propagates over sync, so an expired record won't come back from a connected peer.
-- **Extraction mode** — how documents (PDF / DOCX / EPUB) uploaded to *this* space are converted to text. Leave it on **Instance default** to follow the instance-wide setting (**Settings → Models**), or override it just for this space: **OCR** (fastest, text + layout), **Auto** or **VLM** (transcribe pages with a vision model, always falling back to OCR), or **Max** (adds a repair pass). Useful when one space holds scanned archives that need the heavier path while the rest of the instance stays light. This override is local to your instance — it is never synced to connected peers.
+- **Extraction mode** — how thoroughly documents (PDF / DOCX / EPUB) uploaded to *this* space are read. Leave it on **Instance default** to follow the instance-wide setting (**Settings → Models**), or choose one for this space: **Off**, **OCR** (fastest, text + layout), **VLM** (transcribe pages with a vision model, always falling back to OCR), **Repair** (adds a pass that reconciles the transcription against the OCR text), or **Auto** (as much as the instance can do). Useful when one space holds scanned archives that need the heavier path while the rest of the instance stays light.
+
+  The instance setting is a **ceiling, not a default**: a space can ask for less than the instance allows, never more. If the instance is on **OCR**, a space set to **Repair** runs OCR — it keeps its choice and returns to it if the ceiling is raised again. Raising the instance level lifts only spaces on **Auto**.
+
+  **Off means documents are stored but never read.** No text is extracted, so nothing inside them can be found by search — those uploads are marked *skipped* rather than sitting in the processing queue. This override is local to your instance — it is never synced to connected peers.
 
 **Schema tab:** Define what data this space accepts. A **Schema validation** bar at the very top holds the space-wide **Validation mode** and **Strict linkage** controls — these govern *every* type in the space, not the collection you happen to be viewing. Below it, the entity / edge / memory / chrono collections each list their types on the left; click one to edit its rules in a stable panel on the right (you don't lose your place editing a type or property, and several property editors can be open at once).
 
@@ -381,9 +387,13 @@ Click the gear icon on any space row to open its settings panel. Changes save an
 - **From File** — import a schema from a previously exported JSON file.
 - **Save to Lib** — save the current type schema to the Schema Library for reuse in other spaces.
 
-**Danger tab:** Rename the space ID, wipe all data, or delete the space entirely. All three are guarded: because renaming changes the space ID (which breaks existing token and MCP references to it), **Rename** — like Wipe and Delete — now asks you to type the current space ID to confirm.
+**Danger tab:** Rebuild search indexes, rename the space ID, wipe all data, or delete the space entirely.
 
-Each space row carries only a gear/configure (⚙) button — there is no pencil icon. Renaming, wiping, and deleting all live inside the space's settings panel, on the **Danger** tab.
+**Rebuild search indexes** is the repair for *search returns nothing and nothing says why* — a space whose vector indexes are missing or were destroyed (restoring a backup used to do this). It re-creates them from your existing content; search stays empty until it finishes, and nothing is deleted. Reindexing is not a substitute: it re-embeds content against the current model and cannot recreate a missing index. Requires an admin token (and TOTP when MFA is on).
+
+The other three are guarded: because renaming changes the space ID (which breaks existing token and MCP references to it), **Rename** — like Wipe and Delete — now asks you to type the current space ID to confirm.
+
+Each space row carries only a gear/configure (⚙) button — there is no pencil icon. Rebuilding indexes, renaming, wiping, and deleting all live inside the space's settings panel, on the **Danger** tab.
 
 ### Renaming a space
 
@@ -551,14 +561,14 @@ Face recognition lets Ythril automatically detect faces in uploaded images and l
 #### How to use it
 
 1. **Place the model files** — Download `blazeface-back.json`, `blazeface-back.bin`, `faceres.json`, and `faceres.bin` from `https://vladmandic.github.io/human/models/` and place them in the `human-models/` folder inside your data directory.
-2. **Enable the feature** — In `config.json` set `mediaEmbedding.faceRecognition.enabled: true`. No UI toggle is available; this is intentional since enabling it without model files would silently do nothing.
+2. **Enable the feature** — In `config.json` set `mediaEmbedding.faceRecognition.enabled: true`, or set `FACE_RECOGNITION_ENABLED=true` in the environment. No UI toggle is available; this is intentional since enabling it without model files would silently do nothing.
 3. **Upload images** — Any image that goes through the media pipeline is automatically processed. Faces are detected, embedded, and stored. If no gallery exists yet, faces are stored unlabeled.
 4. **Label a face** — Open the file in the Files view and link it to a person entity (via the entity tag in the file metadata panel). The face embedding is immediately added to the gallery.
 5. **Auto-labeling kicks in** — From this point on, new images containing that person's face are automatically linked to their entity, as long as the match score exceeds the confidence threshold.
 
 #### Settings
 
-These are set in `config.json` under `mediaEmbedding.faceRecognition` — they are not editable from the UI:
+These are set in `config.json` under `mediaEmbedding.faceRecognition`, or pinned by your infrastructure through the matching environment variable (`FACE_RECOGNITION_ENABLED`, `_CONFIDENCE_THRESHOLD`, `_MIN_FACE_SIZE_FRACTION`, `_MODEL_PATH`, `_PERSON_ENTITY_TYPES`, `_REPROCESS_SYNCED_IMAGES`). An environment value wins over `config.json`, so `FACE_RECOGNITION_ENABLED=false` guarantees no faces are processed on that instance — including after restoring a backup taken where it was on. Neither is editable from the UI:
 
 | Setting | Default | What it does |
 |---|---|---|

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -865,10 +865,24 @@ const FACE_RECOGNITION_ENV: Record<keyof Required<FaceRecognitionConfig>, string
   reprocessSyncedImages: 'FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES',
 };
 
+/**
+ * An env var counts as "set" only when it has a value.
+ *
+ * docker-compose passes these through as `FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}`,
+ * which leaves the variable **defined but empty** when the operator did not set it. Treating defined
+ * as pinned would read the empty string as `false` and force face recognition off for every Compose
+ * deployment — while also reporting all six fields as infra-locked, so the UI would show controls the
+ * operator cannot use and could not explain.
+ */
+function envSet(key: string): string | undefined {
+  const raw = process.env[key];
+  return raw !== undefined && raw !== '' ? raw : undefined;
+}
+
 /** Field names (as `faceRecognition.<field>`) currently pinned by an env var. */
 export function lockedFaceRecognitionFields(): string[] {
   return (Object.entries(FACE_RECOGNITION_ENV) as Array<[string, string]>)
-    .filter(([, envKey]) => process.env[envKey] !== undefined)
+    .filter(([, envKey]) => envSet(envKey) !== undefined)
     .map(([field]) => `faceRecognition.${field}`);
 }
 
@@ -883,7 +897,7 @@ export function getFaceRecognitionConfig(): Required<FaceRecognitionConfig> {
     field: K,
     parse: (raw: string) => Required<FaceRecognitionConfig>[K],
   ): Required<FaceRecognitionConfig>[K] => {
-    const rawEnv = process.env[FACE_RECOGNITION_ENV[field]];
+    const rawEnv = envSet(FACE_RECOGNITION_ENV[field]);
     if (rawEnv !== undefined) return parse(rawEnv);
     return (base[field] ?? FACE_RECOGNITION_DEFAULTS[field]) as Required<FaceRecognitionConfig>[K];
   };

--- a/testing/standalone/face-recognition-env.test.js
+++ b/testing/standalone/face-recognition-env.test.js
@@ -88,4 +88,24 @@ describe('face recognition — infra-settable', () => {
     // A control that looks editable but is overridden by env is worse than one that says so.
     assert.ok(!locked.includes('faceRecognition.modelPath'), 'unpinned fields must stay editable');
   });
+
+  // docker-compose passes these as `FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}`, which
+  // leaves the variable DEFINED BUT EMPTY when the operator set nothing. Reading "defined" as "pinned"
+  // would parse '' as false and force the feature off for every Compose deployment, while reporting
+  // all six fields as infra-locked — controls the operator cannot use and could not explain.
+  it('an empty env var is not a pin — it means the operator set nothing', () => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('FACE_RECOGNITION_')) delete process.env[key];
+    }
+    process.env['FACE_RECOGNITION_ENABLED'] = '';
+    process.env['FACE_RECOGNITION_MODEL_PATH'] = '';
+    process.env['FACE_RECOGNITION_PERSON_ENTITY_TYPES'] = '';
+
+    assert.deepEqual(lockedFaceRecognitionFields(), [], 'an empty value must not lock anything');
+    const cfg = getFaceRecognitionConfig();
+    assert.equal(cfg.enabled, false, 'still the default');
+    assert.equal(cfg.modelPath, 'human-models', 'the default path, not an empty string');
+    assert.deepEqual(cfg.personEntityTypes, ['person'], 'the default list, not an empty list');
+  });
+
 });


### PR DESCRIPTION
Owner asked for a staleness check. The docs had drifted behind four merged PRs — and one statement was **wrong**, not merely out of date.

## The wrong one

> "**Config reload required.** Any change to the `oidc` block requires `POST /api/admin/reload-config` or a container restart to take effect."

The config watcher (#346) made that false: an OIDC edit is picked up automatically within ~2s, and the *same document* said so elsewhere, so it contradicted itself. The endpoint is now described as the way to make a reload **synchronous**, not mandatory.

## The user guide had never caught up — and the gaps hid recovery paths

- **Rebuild search indexes** — the only user-facing repair for *search silently returns nothing*, the exact failure #344 shipped to fix — was missing from the Danger tab section entirely. Meanwhile the reindex banner nearby pointed users at **Reindex now**, which re-embeds content and **cannot** recreate a missing index. Someone with dead recall would have clicked it, waited, and still had nothing. Both now say which repair applies when.
- The per-space extraction picker still described `OCR / Auto / VLM / Max` with the instance value as a "default". It now documents the full ladder, the **ceiling** semantics, and that `off` means documents are stored but never read.
- Face recognition documented five of six fields (`modelPath` missing) and no env vars.
- Document-upload polling listed `pending → processing → complete` without `skipped` — an integrator polling an `off` space would poll forever.

Nine residual `max` references renamed to `repair`. Two mattered: `repairModel` and `verifyModel` were labelled *"`max` mode only"*, which reads as "inert" to an operator on `auto` — when `auto` resolving to `repair` is exactly what changed.

## The substantive fix: the Compose promise could not hold

The guide promises `FACE_RECOGNITION_ENABLED=false` guarantees no face processing. **None of the six variables was passed through to the container**, so on the default Compose deployment the value never reached the process. They are forwarded now.

Forwarding them exposed the second half. Compose passes a variable as `${FACE_RECOGNITION_ENABLED:-}`, leaving it **defined but empty** when the operator set nothing — and #345 treated "defined" as "pinned". The naive fix would have parsed `''` as `false` and **forced face recognition off for every Compose deployment**, while reporting all six fields as infra-locked: controls the operator could neither use nor explain. An env var now counts as set only when it has a value.

`.env.example` documents all six, including that an env value wins over `config.json` and survives a restore from a backup taken where the feature was on.

## Testing

- `face-recognition-env` 7 → 8 tests (the empty-var case).
- `media-config` + face-env: **52 pass, 0 fail** on a fresh stack. `docker compose config` validates. `lint:docs` clean.
- Gitignored trackers swept separately: 13 completed items closed, every stale `IN FLIGHT` marker cleared, `max` → `repair`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)