### PR TITLE
feat(pipelines): images, audio and video get the same ladder — with a real off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1926,6 +1926,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Images, audio and video get the same ladder documents got — including a real "off".** Each class now
+  has a per-space level capped by an instance ceiling under `mediaEmbedding.levels`, settable through
+  `PATCH /api/spaces/:id` as `imageAnalysis` (`off · caption · recognition · auto`), `audioAnalysis`
+  (`off · on · auto`) and `videoAnalysis` (`off · audio · full · auto`). Behaviour is unchanged until an
+  operator sets one: every ceiling defaults to `auto`.
+  - **`off` means the file is stored and never analysed**, and those uploads are recorded as `skipped`
+    rather than queued — a job that will do nothing still leaves the file at `pending` forever, which is
+    indistinguishable from a stuck queue. Re-introducing that shape through a feature switch would have
+    been worse than not having the switch.
+  - **`recognition` is the rung that permits face detection and embedding, and it is gated twice:** the
+    instance-wide `faceRecognition.enabled` must allow it *and* the space must be at `recognition`. A
+    space on `caption` gets described images and no face data. That separation is the reason images have
+    their own ladder instead of riding on the master media switch — the face embeddings are the part of
+    this pipeline with real privacy weight, and they were previously all-or-nothing per instance.
+  - **`videoAnalysis: "full"` (keyframes as images) is reserved and not implemented, so the API rejects
+    it with 400** instead of accepting it and quietly behaving like `audio`. The rung exists so the
+    ladder reads complete; being told keyframe analysis is running when it is not would be worse than
+    the gap.
+  - The cap is one generic lattice operation shared by all three classes rather than four copies —
+    copies are how one class quietly acquires "raising the ceiling also raises every space" while the
+    others keep the opposite rule. Property-style tests assert the invariants for every class and every
+    ceiling/choice pair: capping is idempotent, and the effective level never exceeds the ceiling.
+  - The levels are surfaced on the spaces list, not just the PATCH response, so a UI can render the
+    difference between "follows the instance" and an explicit choice.
+
 - **Document extraction is now a ladder with a real "off", and `auto` means the most that is possible.**
   The levels are `off · ocr · vlm · repair`, plus `auto`. Two things changed beyond the naming:
   - **`auto` now resolves to the highest level the instance can actually run.** It previously routed

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2082,7 +2082,29 @@ The effective level is `min(instance mode, space override)`, which has three con
 - **Raising the instance mode does not raise any space** that chose a specific lower level — only spaces on `"auto"` follow it upward. Capability is granted centrally; using less of it stays with the space.
 - **Instance `"off"` is a floor as well as a ceiling.** Nothing is analysed anywhere, whatever a space asks for.
 
-A space on `"auto"` follows the instance level wherever it moves. Uploads to a space whose effective level is `"off"` are stored and marked `embeddingStatus: "skipped"` — they are never queued, so they do not sit at `pending` waiting for work that will not happen.
+A space on `"auto"` follows the instance level wherever it moves.
+
+**The other media classes work the same way.** `PATCH /api/spaces/:id` also accepts `imageAnalysis`,
+`audioAnalysis` and `videoAnalysis` (send `null` to clear an override), each capped by the matching
+ceiling under `mediaEmbedding.levels`:
+
+| Class | Levels, low to high | `off` means |
+|---|---|---|
+| `imageAnalysis` | `off` · `caption` · `recognition` · `auto` | no caption, no image embedding, no face detection |
+| `audioAnalysis` | `off` · `on` · `auto` | no transcription |
+| `videoAnalysis` | `off` · `audio` · `full` · `auto` | no audio extraction, no transcription |
+
+`recognition` is the rung that permits **face detection and embedding**, and it is gated twice: the
+instance-wide `mediaEmbedding.faceRecognition.enabled` must allow it *and* the space must be at
+`recognition`. A space on `caption` gets described images and no face data — which is the reason
+images have their own ladder rather than riding on the master media switch.
+
+`videoAnalysis: "full"` (keyframes analysed as images) is **reserved and not implemented**. The API
+**rejects it with 400** rather than accepting it and behaving like `audio`, so an operator is never
+told that keyframe analysis is running when nothing of the sort is built.
+
+Uploads to a class whose effective level is `off` are stored and marked `embeddingStatus: "skipped"`.
+They are never queued, so they do not sit at `pending` waiting for work that will not happen. Uploads to a space whose effective level is `"off"` are stored and marked `embeddingStatus: "skipped"` — they are never queued, so they do not sit at `pending` waiting for work that will not happen.
 
 | Field | Default | Description |
 |---|---|---|

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -20,7 +20,7 @@ import { buildSpaceVectorIndexes } from '../spaces/vector-index.js';
 import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../util/ssrf.js';
 import { peerSafeFetch } from '../sync/peer-fetch.js';
 import type { SpaceMeta, KnowledgeType, TypeSchema } from '../config/types.js';
-import { DOC_EXTRACTION_MODES_IN, normalizeDocExtractionMode } from '../config/types.js';
+import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
 import { writeFile as writeSpaceFile } from '../files/files.js';
 
 export const spacesRouter = Router();
@@ -145,8 +145,13 @@ const UpdateSpaceBody = z.object({
   // F11-c: per-space document-extraction mode override. null clears it (inherit the instance default).
   // `max` is accepted as the legacy spelling of `repair` and normalised on the way in.
   documentExtraction: z.enum(DOC_EXTRACTION_MODES_IN).nullable().optional(),
-}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined, {
-  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, or documentExtraction must be provided',
+  // Per-space analysis level for the other media classes, capped by the instance ceiling.
+  // null clears the override so the space follows the instance again.
+  imageAnalysis: z.enum(IMAGE_LEVELS).nullable().optional(),
+  audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
+  videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
+}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined, {
+  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, or videoAnalysis must be provided',
 });
 
 const ReorderSpacesBody = z.object({
@@ -324,7 +329,7 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     }
   }
 
-  const spaces = visibleSpaces.map(({ id, label, builtIn, folders, maxGiB, flex, description, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, indexStatus }, idx) => ({
+  const spaces = visibleSpaces.map(({ id, label, builtIn, folders, maxGiB, flex, description, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, indexStatus }, idx) => ({
     id, label, builtIn, folders, maxGiB, flex, description,
     usageGiB: usageGiBByIdx[idx],
     ...(indexStatus ? { indexStatus } : {}),
@@ -337,6 +342,11 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     ...(dupeRulesOnInsert ? { dupeRulesOnInsert } : {}),
     ...(recordTtlDays ? { recordTtlDays } : {}),
     ...(documentExtraction ? { documentExtraction } : {}),
+    // Only present when the space overrides the instance — an absent field means 'follows the
+    // instance', which the UI renders differently from an explicit choice.
+    ...(imageAnalysis ? { imageAnalysis } : {}),
+    ...(audioAnalysis ? { audioAnalysis } : {}),
+    ...(videoAnalysis ? { videoAnalysis } : {}),
     ...(includeCounts && countsBySpaceId[id] ? { counts: countsBySpaceId[id] } : {}),
   }));
   // Include storage usage summary when quota is configured
@@ -435,6 +445,14 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
 
   // Per-space extraction-mode override (F11-c) is local/operational (like dupe rules) — apply
   // immediately, never voted. null clears the override so the space inherits the instance default.
+  if (parsed.data.videoAnalysis === 'full') {
+    res.status(400).json({
+      error: "video level 'full' is reserved but not implemented yet — keyframe analysis is not built. " +
+             "Use 'audio' to transcribe the audio track, or 'auto'.",
+    });
+    return;
+  }
+
   if (parsed.data.documentExtraction !== undefined) {
     updateSpace(id, { documentExtraction: normalizeDocExtractionMode(parsed.data.documentExtraction) });
   }

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -621,6 +621,9 @@ const MEDIA_EMBEDDING_DEFAULTS: Required<Omit<MediaEmbeddingConfig, 'vision' | '
   // in both environments via the short service name (Docker bridge DNS in compose;
   // ClusterFirst DNS in the `ythril` namespace in K8s).
   enabled: true,
+  // Per-class ceilings default to `auto`: no policy limit of their own, so behaviour is
+  // unchanged until an operator sets one.
+  levels: { images: 'auto', audio: 'auto', video: 'auto', text: 'auto' },
   visionProvider: 'local',
   sttProvider: 'local',
   workerConcurrency: 2,
@@ -742,6 +745,14 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
 
   return {
     enabled,
+    // Per-class ceilings, filled per field so a partial `levels` block cannot drop the classes it
+    // does not mention (the same trap the embedding defaults hit).
+    levels: {
+      images: base.levels?.images ?? MEDIA_EMBEDDING_DEFAULTS.levels.images,
+      audio: base.levels?.audio ?? MEDIA_EMBEDDING_DEFAULTS.levels.audio,
+      video: base.levels?.video ?? MEDIA_EMBEDDING_DEFAULTS.levels.video,
+      text: base.levels?.text ?? MEDIA_EMBEDDING_DEFAULTS.levels.text,
+    },
     visionProvider,
     sttProvider,
     vision,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -198,6 +198,12 @@ export interface SpaceConfig {
    *  like dupeRules): when set, documents uploaded to THIS space use this mode instead of the
    *  instance-wide `documentProcessing.mode`. Absent = inherit the instance default. */
   documentExtraction?: DocExtractionMode;
+  /** Per-space level for images / audio / video, capped by the matching instance ceiling in
+   *  `mediaEmbedding.levels`. Same contract as `documentExtraction`: local/operational, never governed
+   *  or synced, and absent means "follow the instance". See `media-level.ts` for the ladders. */
+  imageAnalysis?: ImageLevel;
+  audioAnalysis?: AudioLevel;
+  videoAnalysis?: VideoLevel;
   /** Auto-TTL (F10): when set (> 0), every new/updated record in this space is stamped with an expiry
    *  `now + recordTtlDays` and deleted by the TTL sweep once it lapses (through the normal delete path,
    *  so it tombstones + syncs). A per-record `ttlDays` on a write overrides this. Absent = no auto-TTL. */
@@ -295,6 +301,10 @@ export interface MediaProviderConfig {
 export interface MediaEmbeddingConfig {
   /** Master switch — when false, media files store with embeddingStatus="disabled". */
   enabled?: boolean;
+  /** Instance CEILINGS per media class — the most a space is allowed to do, not a default a space
+   *  inherits. Absent = `auto` (no policy limit). Documents have their own under
+   *  `documentProcessing.mode`, which predates this block. */
+  levels?: MediaLevelCeilings;
   /** "local" → bundled cluster endpoint (Ollama); "external" → user-supplied API. */
   visionProvider?: 'local' | 'external';
   /** "local" → bundled cluster endpoint (faster-whisper-server); "external" → user-supplied API. */
@@ -481,6 +491,35 @@ export const DOC_EXTRACTION_MODES_IN = ['off', 'ocr', 'vlm', 'repair', 'auto', '
 export function normalizeDocExtractionMode(mode: string | undefined | null): DocExtractionMode | undefined {
   if (mode === null || mode === undefined) return undefined;
   return (mode === 'max' ? 'repair' : mode) as DocExtractionMode;
+}
+
+/**
+ * The other media ladders, same shape as documents: low to high, plus `auto` meaning "as much as this
+ * instance can do". `off` always means the file is stored but never analysed — not "analysed cheaply".
+ *
+ *   images   caption      describe the image for search
+ *            recognition  caption plus face detection/embedding (opt-in, privacy-weighted)
+ *   audio    on           transcribe
+ *   video    audio        pull the audio track and transcribe it
+ *            full         keyframes as images as well — NOT BUILT YET; reserved so the ladder reads
+ *                         complete, and rejected rather than silently treated as `audio`
+ */
+export type ImageLevel = 'off' | 'caption' | 'recognition' | 'auto';
+export type AudioLevel = 'off' | 'on' | 'auto';
+export type VideoLevel = 'off' | 'audio' | 'full' | 'auto';
+export type TextLevel = 'off' | 'embed' | 'chunk' | 'auto';
+
+export const IMAGE_LEVELS = ['off', 'caption', 'recognition', 'auto'] as const;
+export const AUDIO_LEVELS = ['off', 'on', 'auto'] as const;
+export const VIDEO_LEVELS = ['off', 'audio', 'full', 'auto'] as const;
+export const TEXT_LEVELS = ['off', 'embed', 'chunk', 'auto'] as const;
+
+/** Instance ceilings for the media classes. Absent = `auto` (no policy limit of its own). */
+export interface MediaLevelCeilings {
+  images?: ImageLevel;
+  audio?: AudioLevel;
+  video?: VideoLevel;
+  text?: TextLevel;
 }
 
 /**

--- a/server/src/files/converters/media-level.ts
+++ b/server/src/files/converters/media-level.ts
@@ -1,0 +1,97 @@
+/**
+ * Effective analysis level per media class (images / audio / video).
+ *
+ * Same contract documents already follow: the instance setting is a **ceiling, not a default**, a space
+ * may choose anything up to it and nothing beyond it, and `auto` means "as much as is allowed and
+ * possible". The capability question — is a vision model actually configured? — is answered by the
+ * pipeline, not here; this module only resolves policy.
+ *
+ * The cap is one generic lattice operation rather than four copies, because four copies is how the
+ * ladders drift apart: a class quietly gaining "raising the ceiling also raises every space" while the
+ * others keep the opposite rule is exactly the kind of divergence nobody notices until a space starts
+ * processing something its owner turned off.
+ */
+import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
+import {
+  IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS,
+  type ImageLevel, type AudioLevel, type VideoLevel,
+} from '../../config/types.js';
+
+/** Ladders low to high. `auto` is deliberately excluded — it resolves, it does not rank. */
+const LADDERS = {
+  images: IMAGE_LEVELS.filter(l => l !== 'auto'),
+  audio: AUDIO_LEVELS.filter(l => l !== 'auto'),
+  video: VIDEO_LEVELS.filter(l => l !== 'auto'),
+} as const;
+
+export type MediaClass = keyof typeof LADDERS;
+
+/**
+ * Cap a space's choice by the instance ceiling.
+ *
+ * - `auto` as the choice  → follow the ceiling ("as much as allowed").
+ * - `auto` as the ceiling → the instance imposes no policy limit, so the choice stands.
+ * - anything above the ceiling → capped. The space KEEPS its stored choice and returns to it if the
+ *   ceiling rises again; only the effective value moves.
+ * - an unrecognised value → returned untouched. Silently downgrading something we failed to parse is
+ *   how a class ends up analysing less than an operator asked for with nothing reporting it.
+ */
+export function capMediaLevel<L extends string>(cls: MediaClass, ceiling: L, choice: L): L {
+  if (choice === 'auto') return ceiling;
+  if (ceiling === 'auto') return choice;
+  const ladder = LADDERS[cls] as readonly string[];
+  const ci = ladder.indexOf(choice);
+  const li = ladder.indexOf(ceiling);
+  if (ci < 0 || li < 0) return choice;
+  return ci <= li ? choice : ceiling;
+}
+
+function ceilingFor(cls: MediaClass): string {
+  const levels = getMediaEmbeddingConfig().levels ?? {};
+  return (levels as Record<string, string | undefined>)[cls] ?? 'auto';
+}
+
+function spaceChoiceFor(cls: MediaClass, spaceId: string): string {
+  const space = getConfig().spaces.find(s => s.id === spaceId);
+  if (!space) return 'auto';
+  const field = ({ images: 'imageAnalysis', audio: 'audioAnalysis', video: 'videoAnalysis' } as const)[cls];
+  return (space as unknown as Record<string, string | undefined>)[field] ?? 'auto';
+}
+
+export function effectiveImageLevel(spaceId: string): ImageLevel {
+  return capMediaLevel('images', ceilingFor('images'), spaceChoiceFor('images', spaceId)) as ImageLevel;
+}
+
+export function effectiveAudioLevel(spaceId: string): AudioLevel {
+  return capMediaLevel('audio', ceilingFor('audio'), spaceChoiceFor('audio', spaceId)) as AudioLevel;
+}
+
+export function effectiveVideoLevel(spaceId: string): VideoLevel {
+  return capMediaLevel('video', ceilingFor('video'), spaceChoiceFor('video', spaceId)) as VideoLevel;
+}
+
+/**
+ * True when this media type is not analysed at all for this space.
+ *
+ * The caller records a terminal `skipped` rather than enqueuing a job: work that will do nothing
+ * still leaves the file at `pending` forever, which looks exactly like a stuck queue — a spinner that
+ * never resolves and recall that returns nothing, with neither saying why.
+ */
+export function mediaIsOff(spaceId: string, mediaType: 'image' | 'audio' | 'video'): boolean {
+  if (mediaType === 'image') return effectiveImageLevel(spaceId) === 'off';
+  if (mediaType === 'audio') return effectiveAudioLevel(spaceId) === 'off';
+  return effectiveVideoLevel(spaceId) === 'off';
+}
+
+/**
+ * Whether faces may be detected/embedded for this space.
+ *
+ * Two gates, and both must allow it: the instance-wide `faceRecognition.enabled` (which infra can pin),
+ * and the space being at the `recognition` rung. A space on `caption` gets described images and no face
+ * data — which is the whole point of giving images their own ladder, since face embeddings are the
+ * part of this pipeline with real privacy weight.
+ */
+export function faceRecognitionAllowed(spaceId: string): boolean {
+  const level = effectiveImageLevel(spaceId);
+  return level === 'recognition' || level === 'auto';
+}

--- a/server/src/files/dispatch.ts
+++ b/server/src/files/dispatch.ts
@@ -22,6 +22,7 @@ import { getMediaEmbeddingConfig, DEFAULT_MEDIA_MAX_FILE_SIZE_BYTES } from '../c
 import { resolveInputFormat, deleteConversionArtifacts, isMediaFormat, type ResolvedFormat } from './converters/pipeline.js';
 import { enqueueMediaJob, enqueueTextJob } from './media/job-queue.js';
 import { documentsAreOff } from './converters/extraction-level.js';
+import { mediaIsOff } from './converters/media-level.js';
 import { toDocId } from '../util/paths.js';
 import { log } from '../util/log.js';
 
@@ -76,6 +77,14 @@ export async function dispatchFileProcessing(
     if (input.bytes > maxBytes) {
       await setMediaStatus('skipped');
       log.info(`Media file ${spaceId}/${filePath} skipped: ${input.bytes} bytes exceeds maxFileSizeBytes (${maxBytes})`);
+      return { resolvedFormat, embeddingStatus: 'skipped' };
+    }
+    // This class is off for this space: store the file, analyse nothing, and say so terminally.
+    // Enqueuing a job that will do nothing leaves the file at `pending` forever — indistinguishable
+    // from a stuck queue, and the reason recall comes back empty would be nowhere to be found.
+    if (mediaIsOff(spaceId, mediaType)) {
+      await setMediaStatus('skipped');
+      log.info(`Media file ${spaceId}/${filePath} not analysed: ${mediaType} analysis is off for this space`);
       return { resolvedFormat, embeddingStatus: 'skipped' };
     }
     await setMediaStatus('pending');

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -33,6 +33,7 @@ import { authorRef } from '../../config/author.js';
 import sharp from 'sharp';
 import { col, asDoc, asFilter } from '../../db/mongo.js';
 import { getConfig, getDataRoot, getFaceRecognitionConfig } from '../../config/loader.js';
+import { faceRecognitionAllowed } from '../converters/media-level.js';
 import { updateFileMeta } from '../file-meta.js';
 import { log } from '../../util/log.js';
 import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
@@ -199,6 +200,15 @@ export async function embedFaces(
   imageBytes: Buffer,
 ): Promise<void> {
   const faceCfg = getFaceRecognitionConfig();
+
+  // Two gates, and both must allow it: the instance-wide switch (which infra can pin) and the space
+  // sitting at the `recognition` rung of the image ladder. A space on `caption` gets its images
+  // described and no face data — which is the reason images have their own ladder at all, since the
+  // face embeddings are the part of this pipeline carrying real privacy weight.
+  if (!faceRecognitionAllowed(spaceId)) {
+    log.debug(`Face recogniser: skipped for space '${spaceId}' — image analysis is below 'recognition'`);
+    return;
+  }
 
   let human: HumanInstance;
   try {

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -6,7 +6,7 @@
  */
 import { getConfig, saveConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
-import type { SpaceConfig, SpaceMeta, DupeActionRule, DocExtractionMode } from '../config/types.js';
+import type { SpaceConfig, SpaceMeta, DupeActionRule, DocExtractionMode, ImageLevel, AudioLevel, VideoLevel } from '../config/types.js';
 import { buildSpaceVectorIndexes } from './vector-index.js';
 import { syncSchemaFiles, META_VERSION_CAP } from './_shared.js';
 
@@ -16,7 +16,7 @@ import { syncSchemaFiles, META_VERSION_CAP } from './_shared.js';
  *  Returns the updated SpaceConfig, or null if the space was not found. */
 export function updateSpace(
   spaceId: string,
-  updates: { label?: string; description?: string; maxGiB?: number | null; meta?: SpaceMeta; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | null; documentExtraction?: DocExtractionMode | null },
+  updates: { label?: string; description?: string; maxGiB?: number | null; meta?: SpaceMeta; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | null; documentExtraction?: DocExtractionMode | null; imageAnalysis?: ImageLevel | null; audioAnalysis?: AudioLevel | null; videoAnalysis?: VideoLevel | null },
 ): SpaceConfig | null {
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === spaceId);
@@ -45,6 +45,10 @@ export function updateSpace(
   if ('documentExtraction' in updates) {
     space.documentExtraction = updates.documentExtraction ?? undefined;
   }
+  // The other media ladders, same contract: local/operational, `in` so an explicit clear removes it.
+  if ('imageAnalysis' in updates) space.imageAnalysis = updates.imageAnalysis ?? undefined;
+  if ('audioAnalysis' in updates) space.audioAnalysis = updates.audioAnalysis ?? undefined;
+  if ('videoAnalysis' in updates) space.videoAnalysis = updates.videoAnalysis ?? undefined;
 
   if (updates.meta !== undefined) {
     const now = new Date().toISOString();

--- a/testing/integration/media-levels.test.js
+++ b/testing/integration/media-levels.test.js
@@ -1,0 +1,100 @@
+/**
+ * Per-space media levels, end to end.
+ *
+ * The assertion that matters is not "the level round-trips" — it is that a class set to `off` reaches
+ * a TERMINAL state. A file that is never analysed must not sit at `embeddingStatus: pending`, because
+ * that is indistinguishable from a stuck queue: a spinner that never resolves, recall that returns
+ * nothing, and nothing anywhere saying why. That failure shape is what the vector-index work was
+ * about, and re-introducing it through a feature switch would be worse, not better.
+ *
+ * Run: node --test testing/integration/media-levels.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, get, patch } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+
+// A 1x1 PNG — enough to be resolved as an image without shipping a fixture.
+const PNG_1x1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+let token;
+
+async function upload(filePath, contentB64) {
+  const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ content: contentB64, encoding: 'base64' }),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+const setLevel = (body) => patch(INSTANCES.a, token, '/api/spaces/general', body);
+
+describe('per-space media levels', () => {
+  before(() => { token = fs.readFileSync(TOKEN_FILE, 'utf8').trim(); });
+
+  // Always hand the space back, so the ordering of later tests never depends on this file.
+  after(async () => {
+    await setLevel({ imageAnalysis: null, audioAnalysis: null, videoAnalysis: null }).catch(() => {});
+  });
+
+  it('an image uploaded with image analysis off is skipped, not left pending', async () => {
+    const set = await setLevel({ imageAnalysis: 'off' });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+    assert.equal(set.body?.space?.imageAnalysis, 'off');
+
+    const r = await upload(`levels-off-${Date.now()}.png`, PNG_1x1);
+    assert.ok(r.status === 201 || r.status === 202, `unexpected status ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.equal(
+      r.body?.embeddingStatus, 'skipped',
+      'an unanalysed image must reach a terminal state, not sit at pending forever',
+    );
+  });
+
+  it('the same upload is queued again once the level is restored', async () => {
+    // Guards the obvious way to get the first test passing for the wrong reason: switching the class
+    // off permanently, or the short-circuit swallowing every upload regardless of level.
+    const set = await setLevel({ imageAnalysis: 'caption' });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+
+    const r = await upload(`levels-on-${Date.now()}.png`, PNG_1x1);
+    assert.ok(r.status === 201 || r.status === 202, `unexpected status ${r.status}`);
+    assert.notEqual(r.body?.embeddingStatus, 'skipped', 'a captioned space must still enqueue the job');
+  });
+
+  it('the override round-trips, appears on the spaces list, and clears with null', async () => {
+    const set = await setLevel({ audioAnalysis: 'off', videoAnalysis: 'audio' });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+    assert.equal(set.body?.space?.audioAnalysis, 'off');
+    assert.equal(set.body?.space?.videoAnalysis, 'audio');
+
+    const list = await get(INSTANCES.a, token, '/api/spaces');
+    const general = (list.body?.spaces ?? []).find(s => s.id === 'general');
+    assert.equal(general?.audioAnalysis, 'off', 'the level must be visible to the UI');
+
+    const clear = await setLevel({ audioAnalysis: null, videoAnalysis: null });
+    assert.equal(clear.status, 200, JSON.stringify(clear.body));
+    assert.equal(clear.body?.space?.audioAnalysis, undefined, 'null clears the override');
+    assert.equal(clear.body?.space?.videoAnalysis, undefined);
+  });
+
+  it("video 'full' is rejected rather than silently behaving like 'audio'", async () => {
+    // The rung is reserved so the ladder reads complete. Accepting it would tell an operator that
+    // keyframes are being analysed when nothing of the sort is built.
+    const r = await setLevel({ videoAnalysis: 'full' });
+    assert.equal(r.status, 400, `expected a refusal, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.match(r.body?.error ?? '', /not implemented/i);
+  });
+
+  it('an unknown level is refused by the schema', async () => {
+    const r = await setLevel({ imageAnalysis: 'transcribe-everything' });
+    assert.equal(r.status, 400, `expected a validation error, got ${r.status}`);
+  });
+});

--- a/testing/standalone/media-levels.test.js
+++ b/testing/standalone/media-levels.test.js
@@ -1,0 +1,108 @@
+/**
+ * Per-class media analysis levels (images / audio / video) — the ceiling lattice, pure.
+ *
+ * Same contract documents follow: the instance setting is a CEILING, not a default. A space may
+ * choose anything up to it and nothing beyond it; `auto` means "as much as is allowed"; `off` means
+ * the file is stored but never analysed.
+ *
+ * The cap is one generic operation rather than four copies, and these tests exist mostly to keep it
+ * that way — four hand-written ladders is how one class quietly acquires "raising the ceiling also
+ * raises every space" while the others keep the opposite rule, and nobody notices until a space starts
+ * processing something its owner switched off.
+ *
+ * Run: node --test testing/standalone/media-levels.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { capMediaLevel } from '../../server/dist/files/converters/media-level.js';
+
+describe('capMediaLevel — images', () => {
+  it('a space may choose anything at or below the ceiling', () => {
+    assert.equal(capMediaLevel('images', 'recognition', 'off'), 'off');
+    assert.equal(capMediaLevel('images', 'recognition', 'caption'), 'caption');
+    assert.equal(capMediaLevel('images', 'recognition', 'recognition'), 'recognition');
+  });
+
+  it('a choice above the ceiling is capped — this is the privacy-relevant one', () => {
+    // An instance that allows captioning but not face recognition must not have a space opt itself
+    // into face embeddings. That is the whole reason images have their own ladder.
+    assert.equal(capMediaLevel('images', 'caption', 'recognition'), 'caption');
+  });
+
+  it("instance 'off' is a floor as well as a ceiling", () => {
+    for (const choice of ['off', 'caption', 'recognition', 'auto']) {
+      assert.equal(capMediaLevel('images', 'off', choice), 'off');
+    }
+  });
+
+  it("a space on 'auto' follows the ceiling wherever it moves", () => {
+    assert.equal(capMediaLevel('images', 'caption', 'auto'), 'caption');
+    assert.equal(capMediaLevel('images', 'recognition', 'auto'), 'recognition');
+    assert.equal(capMediaLevel('images', 'off', 'auto'), 'off');
+  });
+
+  it('raising the ceiling does not raise a space that chose a lower rung', () => {
+    // Capability grows centrally; the decision to use less of it stays local.
+    assert.equal(capMediaLevel('images', 'recognition', 'caption'), 'caption');
+  });
+});
+
+describe('capMediaLevel — audio and video', () => {
+  it('audio is a two-rung ladder and behaves like the others', () => {
+    assert.equal(capMediaLevel('audio', 'on', 'off'), 'off');
+    assert.equal(capMediaLevel('audio', 'off', 'on'), 'off');
+    assert.equal(capMediaLevel('audio', 'on', 'auto'), 'on');
+  });
+
+  it('video caps full down to audio', () => {
+    assert.equal(capMediaLevel('video', 'audio', 'full'), 'audio');
+    assert.equal(capMediaLevel('video', 'full', 'audio'), 'audio');
+    assert.equal(capMediaLevel('video', 'full', 'auto'), 'full');
+  });
+});
+
+describe('capMediaLevel — invariants that hold for every class', () => {
+  const CASES = [
+    ['images', ['off', 'caption', 'recognition']],
+    ['audio', ['off', 'on']],
+    ['video', ['off', 'audio', 'full']],
+  ];
+
+  it('an unrecognised value is never silently downgraded', () => {
+    for (const [cls] of CASES) {
+      assert.equal(capMediaLevel(cls, 'off', 'something-new'), 'something-new');
+    }
+  });
+
+  it("an 'auto' ceiling imposes no policy limit", () => {
+    for (const [cls, rungs] of CASES) {
+      for (const rung of rungs) assert.equal(capMediaLevel(cls, 'auto', rung), rung);
+    }
+  });
+
+  it('capping is idempotent — applying it twice changes nothing', () => {
+    for (const [cls, rungs] of CASES) {
+      for (const ceiling of rungs) {
+        for (const choice of rungs) {
+          const once = capMediaLevel(cls, ceiling, choice);
+          assert.equal(capMediaLevel(cls, ceiling, once), once, `${cls}: ${ceiling}/${choice}`);
+        }
+      }
+    }
+  });
+
+  it('the effective level never exceeds the ceiling, for every pair', () => {
+    for (const [cls, rungs] of CASES) {
+      for (const ceiling of rungs) {
+        for (const choice of [...rungs, 'auto']) {
+          const effective = capMediaLevel(cls, ceiling, choice);
+          assert.ok(
+            rungs.indexOf(effective) <= rungs.indexOf(ceiling),
+            `${cls}: ceiling=${ceiling} choice=${choice} produced ${effective}, which is above the ceiling`,
+          );
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Documents shipped the ladder in #349; this brings the other media classes onto it. Per-space level capped by an instance ceiling under `mediaEmbedding.levels`, settable via `PATCH /api/spaces/:id`:

| Field | Levels, low to high |
|---|---|
| `imageAnalysis` | `off` · `caption` · `recognition` · `auto` |
| `audioAnalysis` | `off` · `on` · `auto` |
| `videoAnalysis` | `off` · `audio` · `full` · `auto` |

**Behaviour is unchanged until an operator sets one** — every ceiling defaults to `auto`.

## Three things done deliberately

- **`off` records a terminal `skipped` and never enqueues.** A job that will do nothing still leaves the file at `pending` forever, which is indistinguishable from a stuck queue: a spinner that never resolves, recall that returns nothing, and neither saying why. That is the failure shape #344 was about — re-introducing it *through a feature switch* would be worse than not having the switch.
- **`recognition` is the rung that permits face detection and embedding, and it is gated twice:** the instance-wide `faceRecognition.enabled` **and** the space's level. A space on `caption` gets described images and **no face data**. That separation is precisely why images need their own ladder rather than riding on the master media switch — face embeddings are the part of this pipeline with real privacy weight, and they were all-or-nothing per instance before.
- **`videoAnalysis: "full"` is reserved and not built, so the API rejects it with 400** rather than accepting it and quietly behaving like `audio`. The rung exists so the ladder reads complete; being told keyframe analysis is running when nothing of the sort exists is worse than the gap.

## One generic cap, not four ladders

Four hand-written copies is how one class quietly acquires *"raising the ceiling also raises every space"* while the others keep the opposite rule — and nobody notices until a space starts processing something its owner switched off. The cap is a single lattice operation, with tests asserting the invariants across **every class and every ceiling/choice pair**: capping is idempotent, and the effective level never exceeds the ceiling.

## Caught by the tests

The levels are surfaced on the spaces **list**, not just the PATCH response. The round-trip test caught that gap — without it a UI could set a level and then never see it again, since the list projects an explicit field set.

## Testing

- New `testing/standalone/media-levels.test.js` (11 tests, pure) and `testing/integration/media-levels.test.js` (5 tests, end-to-end including the `off` → `skipped` upload and the reserved-`full` refusal).
- The integration file also asserts the same upload **is** queued once the level is restored — otherwise the first test would pass just as well if the short-circuit swallowed everything.
- Standalone **1070 pass**, integration **912 pass**, **0 fail**. `lint:docs` clean; integration guide documents the fields, the double gate on `recognition`, and the `skipped` status.

**Text** (`off · embed · chunk · auto`) is the one class still to do — it lands in the text/chunking path rather than media dispatch, so it gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)