### PR TITLE
feat(brain)!: entity references are UUIDs, and an unresolvable one is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1926,6 +1926,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: every reference between brain records is now a UUID, and one that cannot resolve is
+  refused instead of silently stored.** Reported by the owner: `remember` took entity *names* and
+  stored the memory **unlinked** when a name did not resolve, `upsert_edge` demanded a UUID v4 and
+  hard-errored on a name, and several paths validated nothing at all. In a graph store a dropped link
+  is invisible — the write returns success and the gap only surfaces later as a traversal that quietly
+  comes back empty.
+  - **`remember` no longer accepts `entities` (names). It takes `entityIds` (UUID v4)**, like every
+    other write path. An agent must look the entity up and pass its id. This is the breaking part: a
+    client passing names now gets an error rather than a memory with no links.
+  - **`meta.strictLinkage` now defaults to ON.** It existed already but defaulted *off*, so the safe
+    behaviour was the one nobody opted into. The opt-out survives for the case that justified it —
+    staged imports whose targets are created later — and is now a deliberate per-space choice.
+  - **Existence is checked, not just format.** A syntactically perfect UUID pointing at nothing dangles
+    exactly as silently as a name did, so single-record writes verify the target exists. Bulk writes
+    keep format-only checking on purpose: a payload may reference a record created earlier in the same
+    payload, and rejecting that would break valid forward references.
+  - **The gaps are closed:** MCP `update_memory`, bulk memory items, and — the widest hole — the file
+    metadata route, which accepted all three of `entityIds`/`chronoIds`/`memoryIds` with no UUID check
+    and no strict gate whatsoever. Errors name the field and the offending values so an agent can
+    self-correct.
+  - `UUID_V4_RE` had **three separate copies** applied inconsistently; there is now one definition.
+  - **Restoring a space export is unaffected** — import writes records directly rather than through
+    these routes, so an export whose records reference each other round-trips regardless.
+  - **A correction to the report:** it stated that `update_memory` advertised `entities` while its
+    handler read `entityIds`. Both were in fact `entityIds` and agreed; the confusion was that
+    `remember` used `entities`. The genuine `update_memory` defect was the total absence of validation.
+  - **Test-quality finding worth recording:** the ~45 tests covering this area validated *local
+    reimplementations* of the rules (a private `validateEdgeRef` carrying its own
+    `strictLinkage === true`, a `remember` resolution loop rebuilt over a `Map`). They passed
+    regardless of what the product did, and did not notice any of this change. Replaced with tests
+    that exercise the real helpers, verified to fail when the default is reverted.
+
 - **Images, audio and video get the same ladder documents got — including a real "off".** Each class now
   has a per-space level capped by an instance ceiling under `mediaEmbedding.levels`, settable through
   `PATCH /api/spaces/:id` as `imageAnalysis` (`off · caption · recognition · auto`), `audioAnalysis`

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -708,7 +708,7 @@ POST /api/brain/spaces/:spaceId/memories
 }
 ```
 
-**Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). When the space has `strictLinkage` enabled, `entityIds` must contain valid UUID v4 values (entity IDs); passing names instead of IDs returns `400`. `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl).
+**Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl).
 
 ---
 
@@ -1186,9 +1186,9 @@ Default limit: 50, max: 500.
 DELETE /api/brain/spaces/:spaceId/entities/:id
 ```
 
-**Response** `204` when no inbound references exist (or `strictLinkage` is not enabled).
+**Response** `204` when no inbound references exist (or the space has opted out with `strictLinkage: false`).
 
-**Response** `409 Conflict` when the space has `strictLinkage` enabled in its meta and the entity still has inbound backlinks (edges, memories, or chrono entries that reference it). The caller must first delete or relink the backlinked items before the deletion is permitted. Response body:
+**Response** `409 Conflict` when the entity still has inbound backlinks (the default; a space that opted out with `strictLinkage: false` deletes regardless) (edges, memories, or chrono entries that reference it). The caller must first delete or relink the backlinked items before the deletion is permitted. Response body:
 
 ```json
 {
@@ -4696,6 +4696,35 @@ The `label` names this brain instance.
 ---
 
 ## Admin API
+
+## Reference integrity
+
+Every link between brain records — a memory's `entityIds`, an edge's `from`/`to`, a chrono entry's
+`entityIds`/`memoryIds`, a file's `entityIds`/`chronoIds`/`memoryIds` — names the target by its **id**,
+which is a **UUID v4**. A name is not a reference.
+
+**A reference that cannot resolve is refused.** The write returns `400` (or an MCP `isError`) naming the
+field and the offending value, and **nothing is stored**. Both halves are checked:
+
+- the value is a UUID v4, and
+- a record with that id exists in the target space.
+
+Format alone was never sufficient — a syntactically perfect id pointing at nothing dangles exactly as
+silently as a name did, and the only symptom is a later traversal that quietly returns nothing.
+
+### Opting out
+
+A space may set `meta.strictLinkage: false` to accept unresolved references. This exists for **staged
+imports**, where records legitimately reference targets that are created later in the run. It is a
+deliberate per-space choice to accept dangling links, and it is **off by default** — you do not get lax
+linkage by saying nothing.
+
+Bulk writes (`POST /bulk`, `bulk_write`) check reference **format** but not existence even when strict,
+because a payload may reference a record created earlier in the same payload; rejecting those would
+break valid forward references within a batch.
+
+Restoring a space export is unaffected: import writes records directly rather than through these
+routes, so an export whose records reference each other round-trips regardless of the setting.
 
 ### Reload Config
 

--- a/server/src/api/brain/_shared.ts
+++ b/server/src/api/brain/_shared.ts
@@ -12,7 +12,8 @@ import { resolveMetaRefs, type SchemaViolation } from '../../spaces/schema-valid
 import type { SpaceMeta } from '../../config/types.js';
 
 /** Regex that matches a UUID v4 (case-insensitive). */
-export const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// Re-exported from the canonical definition so there is exactly one copy in the codebase.
+export { UUID_V4_RE } from '../../brain/entity-refs.js';
 
 // ── Webhook helper ────────────────────────────────────────────────────────
 

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -4,6 +4,7 @@
  * Split out of the api/brain.ts monolith (A17.3); handlers are unchanged.
  */
 import { Router } from 'express';
+import { assertRefsResolve } from '../../brain/entity-refs.js';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { globalRateLimit, bulkWipeRateLimit } from '../../rate-limit/middleware.js';
 import { listEdges, deleteEdge, upsertEdge, getEdgeById, updateEdgeById, bulkDeleteEdges } from '../../brain/edges.js';
@@ -33,17 +34,20 @@ edgesRouter.post('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, de
     res.status(400).json({ error: '`from` string required' });
     return;
   }
-  if (isStrictLinkage(wt.target) && !UUID_V4_RE.test(from)) {
-    res.status(400).json({ error: '`from` must be a valid UUID v4 (entity ID), not a name' });
-    return;
-  }
+  // `from` is resolved below together with `to`, so both ends are reported at once rather than
+  // making the caller fix one, retry, and discover the other.
   if (!to || typeof to !== 'string') {
     res.status(400).json({ error: '`to` string required' });
     return;
   }
-  if (isStrictLinkage(wt.target) && !UUID_V4_RE.test(to)) {
-    res.status(400).json({ error: '`to` must be a valid UUID v4 (entity ID), not a name' });
-    return;
+  if (isStrictLinkage(wt.target)) {
+    try {
+      await assertRefsResolve(wt.target, 'from', 'entity', [from as string]);
+      await assertRefsResolve(wt.target, 'to', 'entity', [to as string]);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
   }
   if (!label || typeof label !== 'string') {
     res.status(400).json({ error: '`label` string required' });

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -14,11 +14,12 @@ import { toDocId } from '../../util/paths.js';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { updateFileMeta, deleteFileMeta } from '../../files/file-meta.js';
+import { assertRefsResolve } from '../../brain/entity-refs.js';
 import { fileExists } from '../../files/files.js';
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
-import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
+import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import type { FileMetaDoc } from '../../config/types.js';
 
 export const fileMetaRouter = Router();
@@ -108,6 +109,21 @@ fileMetaRouter.patch('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth
   if (memoryIds !== undefined && !Array.isArray(memoryIds)) { res.status(400).json({ error: '`memoryIds` must be an array' }); return; }
   if (properties !== undefined && (typeof properties !== 'object' || properties === null || Array.isArray(properties))) {
     res.status(400).json({ error: '`properties` must be a plain object' }); return;
+  }
+
+  // A file carries THREE reference fields, and until now none of them was validated — not even under
+  // strict linkage, which every other brain route already honoured. So this was the widest silent
+  // hole: attach a memory to a file with a name or a stale id and it stored clean, then the file
+  // simply never turned up in anything that traversed the link.
+  if (isStrictLinkage(wt.target)) {
+    try {
+      await assertRefsResolve(wt.target, 'entityIds', 'entity', entityIds as string[] | undefined);
+      await assertRefsResolve(wt.target, 'memoryIds', 'memory', memoryIds as string[] | undefined);
+      await assertRefsResolve(wt.target, 'chronoIds', 'chrono', chronoIds as string[] | undefined);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
   }
 
   const updated = await findFirstAcrossMembers(wt.target,

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -4,6 +4,7 @@
  * Split out of the api/brain.ts monolith (A17.3); handlers are unchanged.
  */
 import { Router } from 'express';
+import { assertRefsResolve } from '../../brain/entity-refs.js';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { globalRateLimit, bulkWipeRateLimit } from '../../rate-limit/middleware.js';
 import { listMemories, deleteMemory, bulkDeleteMemories, remember, updateMemory } from '../../brain/memory.js';
@@ -61,11 +62,14 @@ memoriesRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAu
       ? (properties as Record<string, string | number | boolean>)
       : undefined;
   const safeEntityIds: string[] = Array.isArray(entityIds) ? entityIds : [];
-  // Validate that all entityIds are valid UUID v4 (not names) — only when strictLinkage is on
+  // Every id must be a UUID v4 AND name an entity that exists. Format alone was never enough: a
+  // syntactically perfect id pointing at nothing stores exactly as silently as a name did, and the
+  // dangling link only shows up later as a traversal that comes back empty.
   if (isStrictLinkage(wt.target)) {
-    const invalidEntityIds = safeEntityIds.filter((id: string) => !UUID_V4_RE.test(id));
-    if (invalidEntityIds.length > 0) {
-      res.status(400).json({ error: '`entityIds` must contain valid UUID v4 values (entity IDs), not names', invalid: invalidEntityIds });
+    try {
+      await assertRefsResolve(wt.target, 'entityIds', 'entity', safeEntityIds);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
       return;
     }
   }

--- a/server/src/brain/bulk.ts
+++ b/server/src/brain/bulk.ts
@@ -26,7 +26,7 @@ import type { EntityDoc, EdgeDoc, ChronoType, ChronoStatus } from '../config/typ
 /** Max items processed per collection in a single bulk call. */
 export const BULK_MAX_PER_TYPE = 500;
 
-const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import { UUID_V4_RE } from './entity-refs.js';
 const CHRONO_STATUSES = new Set<ChronoStatus>(['upcoming', 'active', 'completed', 'overdue', 'cancelled']);
 const MAX_FACT_LENGTH = 50_000;
 
@@ -103,9 +103,18 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     const properties = optProps(item['properties']);
     const ttlDays = bulkTtlDays(item['ttlDays']);
     if (ttlDays === TTL_INVALID) { errors.push({ type: 'memory', index: i, reason: TTL_INVALID_MSG }); continue; }
+    // Memory items were the one bulk shape with no reference check at all — edges and chrono both
+    // had one. Format only, like the rest of bulk: a payload may legitimately reference an entity
+    // created earlier in the SAME payload, so an existence check here would reject valid forward
+    // references. Staged imports that need dangling refs use the strictLinkage escape hatch.
+    const memEntityIds = strArray(item['entityIds']);
+    if (strict && memEntityIds.some(id => !UUID_V4_RE.test(id))) {
+      errors.push({ type: 'memory', index: i, reason: '`entityIds` must contain valid UUID v4 values (entity IDs), not names' });
+      continue;
+    }
     try {
       if (schemaFails('memory', i, validateMemory(meta ?? {}, { type, properties }))) continue;
-      await remember(spaceId, fact, strArray(item['entityIds']), strArray(item['tags']),
+      await remember(spaceId, fact, memEntityIds, strArray(item['tags']),
         typeof item['description'] === 'string' ? item['description'] : undefined, properties, undefined, type,
         undefined, undefined, ttlDays);
       inserted.memories++;

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -145,6 +145,20 @@ export async function findEntitiesByName(spaceId: string, name: string): Promise
     .toArray() as Promise<EntityDoc[]>;
 }
 
+/**
+ * Fetch several entities by id in one query.
+ *
+ * Callers linking records hold ids, but the embedded text wants names — an entity's name is what a
+ * semantic search actually matches on, so dropping it from the embed text would quietly degrade
+ * recall for every linked record. One `$in` beats a lookup per id.
+ */
+export async function findEntitiesByIds(spaceId: string, ids: readonly string[]): Promise<EntityDoc[]> {
+  if (ids.length === 0) return [];
+  return col<EntityDoc>(`${spaceId}_entities`)
+    .find(asFilter<EntityDoc>({ _id: { $in: [...new Set(ids)] }, spaceId }))
+    .toArray() as Promise<EntityDoc[]>;
+}
+
 /** Find an entity by exact ID */
 export async function getEntityById(spaceId: string, id: string): Promise<EntityDoc | null> {
   return col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as Promise<EntityDoc | null>;

--- a/server/src/brain/entity-refs.ts
+++ b/server/src/brain/entity-refs.ts
@@ -1,0 +1,104 @@
+/**
+ * The one definition of what a reference between brain records looks like.
+ *
+ * Every link field — a memory's `entityIds`, an edge's `from`/`to`, a chrono entry's
+ * `entityIds`/`memoryIds`, a file's `entityIds`/`chronoIds`/`memoryIds` — names another record by its
+ * `_id`, which is a UUID v4 (`brain/entities.ts` assigns `uuidv4()` on insert). Anything else is not a
+ * reference, it is a string that happens to be stored in a reference field.
+ *
+ * This module exists because the regex previously had three separate copies (MCP tools, brain/bulk,
+ * the REST helpers) and the validation was applied inconsistently across the call sites that used
+ * them: some checked, some checked only under a flag, and some never checked at all. A dropped link in
+ * a graph store is invisible — the record saves, the write returns success, and the gap only surfaces
+ * later as a traversal that quietly returns nothing. One definition and one assert make "did we
+ * validate this?" answerable by grep rather than by reading every handler.
+ */
+import { col, asFilter } from '../db/mongo.js';
+
+/** Canonical UUID v4 matcher. The only copy — import it, never re-declare it. */
+export const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Same pattern as a string, for embedding in a published JSON schema. */
+export const UUID_V4_PATTERN = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$';
+
+export function isUuidV4(value: unknown): value is string {
+  return typeof value === 'string' && UUID_V4_RE.test(value);
+}
+
+/** What kind of record a reference field points at — used only to word the error. */
+export type RefKind = 'entity' | 'memory' | 'chrono';
+
+const REF_NOUN: Record<RefKind, string> = {
+  entity: 'entity ID',
+  memory: 'memory ID',
+  chrono: 'chrono ID',
+};
+
+/**
+ * Check one reference field. Returns `null` when every value is a UUID v4, otherwise a message that
+ * names the field AND the offending values.
+ *
+ * The message matters as much as the check: the caller is usually an LLM agent, and "invalid
+ * reference" tells it nothing it can act on, while "`entityIds` expects entity IDs (UUID v4), got
+ * 'Traefik'" tells it exactly what to fix and how. Listing the bad values (not just the count) is what
+ * makes the error self-correcting.
+ */
+export function invalidRefsMessage(field: string, kind: RefKind, values: readonly string[] | undefined): string | null {
+  if (!values || values.length === 0) return null;
+  const bad = values.filter(v => !isUuidV4(v));
+  if (bad.length === 0) return null;
+  const shown = bad.slice(0, 5).map(v => JSON.stringify(v)).join(', ');
+  const more = bad.length > 5 ? ` (+${bad.length - 5} more)` : '';
+  return `\`${field}\` expects ${REF_NOUN[kind]}s (UUID v4), got ${shown}${more}. ` +
+    `Look the record up by name first and pass its id — a name is not a reference.`;
+}
+
+/** Throwing form, for the MCP handlers whose errors surface to the agent as `isError` text. */
+export function assertRefs(field: string, kind: RefKind, values: readonly string[] | undefined): void {
+  const msg = invalidRefsMessage(field, kind, values);
+  if (msg) throw new Error(msg);
+}
+
+const COLLECTION_FOR: Record<RefKind, string> = {
+  entity: 'entities',
+  memory: 'memories',
+  chrono: 'chrono',
+};
+
+/**
+ * Format check PLUS an existence check: every id must be a UUID v4 *and* name a record that is
+ * actually there.
+ *
+ * Format alone is not enough to satisfy "an unresolvable reference must be an error". A well-formed
+ * UUID that points at nothing stores exactly as silently as a name did — the write succeeds, the link
+ * dangles, and the only symptom is a traversal that later comes back empty. Checking existence is one
+ * batched `$in` per field, which is a fair price on a single-record write for the guarantee that a
+ * stored reference resolves.
+ *
+ * Deliberately NOT used by the bulk path: a bulk payload may legitimately reference a record created
+ * earlier in the same payload, so checking against the database would reject valid forward references.
+ * Bulk keeps the format check, and the `strictLinkage: false` escape hatch covers staged imports.
+ */
+export async function assertRefsResolve(
+  spaceId: string,
+  field: string,
+  kind: RefKind,
+  values: readonly string[] | undefined,
+): Promise<void> {
+  assertRefs(field, kind, values);
+  if (!values || values.length === 0) return;
+  const unique = [...new Set(values)];
+  const docs = await col<{ _id: string }>(`${spaceId}_${COLLECTION_FOR[kind]}`)
+    .find(asFilter<{ _id: string }>({ _id: { $in: unique } }), { projection: { _id: 1 } })
+    .toArray();
+  const found = new Set(docs.map(d => d._id));
+  const missing = unique.filter(id => !found.has(id));
+  if (missing.length === 0) return;
+  const shown = missing.slice(0, 5).map(v => JSON.stringify(v)).join(', ');
+  const more = missing.length > 5 ? ` (+${missing.length - 5} more)` : '';
+  throw new Error(
+    `\`${field}\` references ${missing.length} ${REF_NOUN[kind]}${missing.length === 1 ? '' : 's'} that ` +
+    `do${missing.length === 1 ? 'es' : ''} not exist in space '${spaceId}': ${shown}${more}. ` +
+    `Create the record first, then link it — the write was refused rather than stored with a dead link.`,
+  );
+}

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -7,11 +7,12 @@
 
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { validateDeleteFields } from '../../brain/delete-fields.js';
-import { findEntitiesByName } from '../../brain/entities.js';
+import { findEntitiesByIds } from '../../brain/entities.js';
+import { assertRefsResolve, UUID_V4_PATTERN } from '../../brain/entity-refs.js';
 import { deleteMemory, remember, updateMemory } from '../../brain/memory.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
-import { resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
+import { resolveWriteTarget, findFirstAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateMemory } from '../../spaces/schema-validation.js';
 import { TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
 
@@ -25,10 +26,10 @@ export const rememberTool: ToolHandler = {
           properties: {
             space: s.requiredSpace,
             fact: { type: 'string', minLength: 1, maxLength: 50000, description: 'The fact, observation, or memory to store (1–50 000 characters).' },
-            entities: {
+            entityIds: {
               type: 'array',
-              items: { type: 'string' },
-              description: 'Entity names mentioned in this memory.',
+              items: { type: 'string', pattern: UUID_V4_PATTERN },
+              description: 'Entity IDs (UUID v4) to link this memory to. Pass IDs, not names — look the entity up first (search_entities / list) and use its id. Every id must reference an existing entity; an unknown id is rejected rather than stored as a dead link.',
             },
             tags: {
               type: 'array',
@@ -56,7 +57,7 @@ export const rememberTool: ToolHandler = {
     if (!fact.trim()) throw new Error('fact must not be empty');
     if (fact.length > 50_000) throw new Error('fact must not exceed 50 000 characters');
     const tags = Array.isArray(a['tags']) ? (a['tags'] as string[]) : [];
-    const entityNames = Array.isArray(a['entities']) ? (a['entities'] as string[]) : [];
+    const entityIdsArg = Array.isArray(a['entityIds']) ? (a['entityIds'] as string[]) : [];
     const description = typeof a['description'] === 'string' ? a['description'] : undefined;
     const props = (a['properties'] != null && typeof a['properties'] === 'object' && !Array.isArray(a['properties']))
       ? (a['properties'] as Record<string, string | number | boolean>)
@@ -82,24 +83,17 @@ export const rememberTool: ToolHandler = {
     // Quota check — throws QuotaError (caught below) on hard limit
     const remQuota = await checkQuota('brain');
 
-    // Resolve entity names to existing entity IDs (Defect 3 fix).
-    // Never auto-create ghost stubs — warn on unresolved names instead.
-    const entityIds: string[] = [];
-    const unresolvedNames: string[] = [];
-    const multiMatchWarnings: string[] = [];
-    for (const eName of entityNames) {
-      const matches = await findEntitiesByName(ts, eName);
-      if (matches.length === 0) {
-        unresolvedNames.push(eName);
-      } else {
-        if (matches.length > 1) {
-          multiMatchWarnings.push(`'${eName}' matched ${matches.length} entities — linked to all`);
-        }
-        for (const m of matches) entityIds.push(m._id);
-      }
+    // Entity linkage is by ID. This used to accept names and silently store the memory UNLINKED
+    // when a name did not resolve — a dropped edge in a graph store, invisible until a traversal
+    // that should have found it came back empty. Now: wrong shape or unknown id, the write is
+    // refused and the agent is told which value was bad.
+    const entityIds: string[] = entityIdsArg;
+    if (isStrictLinkage(ts)) {
+      await assertRefsResolve(ts, 'entityIds', 'entity', entityIds);
     }
-
-    const resolvedNames = entityNames.filter(n => !unresolvedNames.includes(n));
+    // Names still go into the embedded text (they are what a search actually matches on), but they
+    // are now derived FROM the ids rather than being the input.
+    const resolvedNames = (await findEntitiesByIds(ts, entityIds)).map(e => e.name);
     // Insert-time duplicate check defaults ON for the interactive remember tool.
     const remDupeCheck = a['checkDuplicates'] !== false;
     const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
@@ -110,10 +104,8 @@ export const rememberTool: ToolHandler = {
     if (mem.similar && mem.similar.length > 0) {
       warnings.push(`⚠️ Possible duplicate — ${mem.similar.length} existing memor${mem.similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${mem.similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.`);
     }
-    if (unresolvedNames.length > 0) {
-      warnings.push(`⚠️ Unresolved entity names (not linked — create them first): ${unresolvedNames.map(n => `'${n}'`).join(', ')}`);
-    }
-    for (const w of multiMatchWarnings) warnings.push(`⚠️ ${w}`);
+    // (An unresolved or ambiguous reference is now a hard error above, not a warning on a write
+    // that already happened.)
     // Schema warnings (reuse violations from pre-write check)
     if (remMeta?.validationMode === 'warn') {
       for (const v of remSchemaViolations) warnings.push(`⚠️ Schema: ${v.field} — ${v.reason}`);
@@ -139,7 +131,7 @@ export const update_memoryTool: ToolHandler = {
             id: { type: 'string', description: 'Memory ID to update.' },
             fact: { type: 'string', description: 'New fact text (triggers re-embedding).' },
             tags: { type: 'array', items: { type: 'string' }, description: 'New tags (replaces existing).' },
-            entityIds: { type: 'array', items: { type: 'string' }, description: 'New entity ID links (replaces existing).' },
+            entityIds: { type: 'array', items: { type: 'string', pattern: UUID_V4_PATTERN }, description: 'New entity ID links (UUID v4, replaces existing). Every id must reference an existing entity.' },
             description: { type: 'string', description: 'New prose description or context.' },
             properties: {
               type: 'object',
@@ -172,7 +164,15 @@ export const update_memoryTool: ToolHandler = {
       updates.fact = a['fact'] as string;
     }
     if (Array.isArray(a['tags'])) updates.tags = a['tags'] as string[];
-    if (Array.isArray(a['entityIds'])) updates.entityIds = a['entityIds'] as string[];
+    if (Array.isArray(a['entityIds'])) {
+      const ids = a['entityIds'] as string[];
+      // This path had NO validation at all — not even the strict gate the other tools carried — so
+      // any string was written through as a link.
+      // Validate against the resolved write target — for a proxy space that is the concrete member
+      // the memory will be written to, so the entity must exist where the link will live.
+      if (isStrictLinkage(wt.target)) await assertRefsResolve(wt.target, 'entityIds', 'entity', ids);
+      updates.entityIds = ids;
+    }
     if (typeof a['description'] === 'string') updates.description = a['description'] as string;
     if (a['properties'] !== null && typeof a['properties'] === 'object' && !Array.isArray(a['properties'])) {
       updates.properties = a['properties'] as Record<string, string | number | boolean>;

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -2,7 +2,8 @@ import type { RecallResult } from '../../brain/recall.js';
 
 /** Helpers shared by the MCP tool handlers (moved out of mcp/router.ts). */
 
-export const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// Re-exported from the canonical definition so there is exactly one copy in the codebase.
+export { UUID_V4_RE, UUID_V4_PATTERN } from '../../brain/entity-refs.js';
 
 /** JSON-schema fragment for the per-record TTL arg (F10), shared by every MCP write tool. */
 export const TTL_DAYS_SCHEMA = {

--- a/server/src/spaces/proxy.ts
+++ b/server/src/spaces/proxy.ts
@@ -79,9 +79,20 @@ export function resolveWriteTarget(
   return { ok: true, target: targetSpace };
 }
 
-/** Returns true if strict linkage enforcement is enabled for a space. */
+/**
+ * Whether a space enforces that a reference field actually contains record IDs.
+ *
+ * **Defaults to ON** — absent means strict. It used to default off, which meant the safe behaviour
+ * was the one nobody opted into: a name (or a typo, or an id from another space) landed in
+ * `entityIds` unvalidated, the write returned success, and the missing link only surfaced later as a
+ * traversal that quietly returned nothing.
+ *
+ * The opt-out survives for the case that justified it: importing records whose targets do not exist
+ * yet, where refs are resolved in a later pass. Turning it off is a deliberate, per-space choice to
+ * accept dangling references — not something you get by saying nothing.
+ */
 export function isStrictLinkage(spaceId: string): boolean {
-  return findSpace(spaceId)?.meta?.strictLinkage === true;
+  return findSpace(spaceId)?.meta?.strictLinkage !== false;
 }
 
 // ── Member fan-out ─────────────────────────────────────────────────────────

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -806,6 +806,17 @@ describe('Brain -- chrono CRUD (/api/brain/spaces/:spaceId/chrono)', () => {
   });
 
   it('Create chrono with optional fields', async () => {
+    // Real ids: linkage is validated now, and a placeholder only ever proved that an unchecked
+    // string survives a round-trip.
+    const linkedEnt = await post(INSTANCES.a, token(), '/api/brain/spaces/general/entities', {
+      name: `ChronoLink-${RUN}`, type: 'concept',
+    });
+    assert.equal(linkedEnt.status, 201, JSON.stringify(linkedEnt.body));
+    const linkedMem = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
+      fact: `chrono link target ${RUN}`,
+    });
+    assert.equal(linkedMem.status, 201, JSON.stringify(linkedMem.body));
+
     const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/chrono', {
       title: `Deadline-${RUN}`,
       type: 'deadline',
@@ -814,16 +825,16 @@ describe('Brain -- chrono CRUD (/api/brain/spaces/:spaceId/chrono)', () => {
       status: 'upcoming',
       confidence: 0.8,
       tags: ['important'],
-      entityIds: ['some-entity'],
-      memoryIds: ['some-memory'],
+      entityIds: [linkedEnt.body._id],
+      memoryIds: [linkedMem.body._id],
       description: 'Submit report',
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
     assert.equal(r.body.type, 'deadline');
     assert.equal(r.body.confidence, 0.8);
     assert.ok(r.body.endsAt, 'endsAt should be set');
-    assert.deepStrictEqual(r.body.entityIds, ['some-entity']);
-    assert.deepStrictEqual(r.body.memoryIds, ['some-memory']);
+    assert.deepStrictEqual(r.body.entityIds, [linkedEnt.body._id]);
+    assert.deepStrictEqual(r.body.memoryIds, [linkedMem.body._id]);
     assert.equal(r.body.description, 'Submit report');
   });
 

--- a/testing/integration/embed-properties.test.js
+++ b/testing/integration/embed-properties.test.js
@@ -47,7 +47,7 @@ async function recallMatch(id, query, types, timeoutMs = 30_000) {
 describe('Property keys are embedded (B4)', () => {
   before(async () => {
     token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
-    const c = await post(INSTANCES.a, token, '/api/spaces', { id: SPACE, label: 'B4 Embed Props' });
+    const c = await post(INSTANCES.a, token, '/api/spaces', { id: SPACE, label: 'B4 Embed Props', meta: { strictLinkage: false } });
     assert.ok([201, 409].includes(c.status), `create space: ${JSON.stringify(c.body)}`);
     // Probe whether embeddings are available in this stack.
     const probe = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`,

--- a/testing/integration/entity-refs.test.js
+++ b/testing/integration/entity-refs.test.js
@@ -1,0 +1,128 @@
+/**
+ * Entity references end to end: a reference that cannot resolve is REFUSED, not stored.
+ *
+ * The reported defect was that the write paths disagreed — `remember` took entity names and silently
+ * stored the memory unlinked when a name did not resolve, `upsert_edge` demanded a UUID, and several
+ * paths (update_memory, file metadata, bulk memory items) validated nothing at all. In a graph store a
+ * dropped link is invisible: the write returns success and the gap only shows up later as a traversal
+ * that comes back empty.
+ *
+ * These drive the real API, because that is the only place the contract is observable to a caller.
+ * The unit-level rules live in `standalone/entity-refs.test.js`.
+ *
+ * Run: node --test testing/integration/entity-refs.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, patch, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+
+const RUN = Date.now();
+const SPACE = `refs-${RUN}`;
+const NONEXISTENT_UUID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+
+let token;
+let entityId;
+
+describe('entity references must resolve', () => {
+  before(async () => {
+    token = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+    const created = await post(INSTANCES.a, token, '/api/spaces', { id: SPACE, label: 'Refs' });
+    assert.equal(created.status, 201, JSON.stringify(created.body));
+
+    const ent = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`, {
+      name: `Traefik-${RUN}`, type: 'concept',
+    });
+    assert.equal(ent.status, 201, JSON.stringify(ent.body));
+    entityId = ent.body._id;
+    assert.match(entityId, /^[0-9a-f-]{36}$/i, 'entity ids are UUIDs');
+  });
+
+  after(async () => {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${SPACE}`, { confirm: true }).catch(() => {});
+  });
+
+  it('a real entity id links, and the link is readable back', async () => {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, {
+      fact: 'links to a real entity', entityIds: [entityId],
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    assert.deepEqual(r.body.entityIds, [entityId], 'the link must actually be stored');
+  });
+
+  it('a NAME where an id belongs is refused, and the error names the value', async () => {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, {
+      fact: 'links by name', entityIds: [`Traefik-${RUN}`],
+    });
+    assert.equal(r.status, 400, `expected a refusal, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.match(JSON.stringify(r.body), /Traefik/, 'the error must name the offending value');
+  });
+
+  it('a well-formed UUID that does not exist is refused too', async () => {
+    // Format alone was never the point: a syntactically perfect id pointing at nothing stores just
+    // as silently as a name did.
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, {
+      fact: 'links to a ghost', entityIds: [NONEXISTENT_UUID],
+    });
+    assert.equal(r.status, 400, `expected a refusal, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('nothing was stored by the refused writes', async () => {
+    // The point of a hard error is that the record does not exist afterwards. If a refusal still
+    // wrote the row (minus the link), we would have swapped a silent unlinked write for a noisy one.
+    const list = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`);
+    assert.equal(list.status, 200);
+    const facts = (list.body.memories ?? []).map(m => m.fact);
+    assert.ok(!facts.includes('links by name'), 'a refused write must not be stored');
+    assert.ok(!facts.includes('links to a ghost'), 'a refused write must not be stored');
+  });
+
+  it('file metadata refuses a bad reference on every one of its three link fields', async () => {
+    // This surface had no validation at all — not even the strict gate the other routes carried.
+    const write = await post(INSTANCES.a, token, `/api/files/${SPACE}?path=${encodeURIComponent('note.txt')}`, {
+      content: 'hello',
+    });
+    assert.ok([200, 201, 202].includes(write.status), JSON.stringify(write.body));
+
+    for (const field of ['entityIds', 'memoryIds', 'chronoIds']) {
+      const r = await patch(
+        INSTANCES.a, token,
+        `/api/brain/spaces/${SPACE}/files?path=${encodeURIComponent('note.txt')}`,
+        { [field]: ['not-an-id'] },
+      );
+      assert.equal(r.status, 400, `${field} should have been refused, got ${r.status}: ${JSON.stringify(r.body)}`);
+      assert.match(JSON.stringify(r.body), new RegExp(field), 'the error must name the field');
+    }
+  });
+
+  it('an edge to a nonexistent entity is refused', async () => {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/edges`, {
+      from: entityId, to: NONEXISTENT_UUID, label: 'points-nowhere',
+    });
+    assert.equal(r.status, 400, `expected a refusal, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('a space that opts out keeps the lax behaviour — the escape hatch still works', async () => {
+    // Staged imports reference records that do not exist yet; that case is why the opt-out survives.
+    const lax = `refs-lax-${RUN}`;
+    const created = await post(INSTANCES.a, token, '/api/spaces', { id: lax, label: 'Lax' });
+    assert.equal(created.status, 201, JSON.stringify(created.body));
+    try {
+      const set = await patch(INSTANCES.a, token, `/api/spaces/${lax}`, { meta: { strictLinkage: false } });
+      assert.equal(set.status, 200, JSON.stringify(set.body));
+
+      const r = await post(INSTANCES.a, token, `/api/brain/spaces/${lax}/memories`, {
+        fact: 'forward reference during an import', entityIds: ['created-later'],
+      });
+      assert.equal(r.status, 201, `the opt-out must still accept a dangling ref: ${JSON.stringify(r.body)}`);
+    } finally {
+      await delWithBody(INSTANCES.a, token, `/api/spaces/${lax}`, { confirm: true }).catch(() => {});
+    }
+  });
+});

--- a/testing/integration/proxy-spaces.test.js
+++ b/testing/integration/proxy-spaces.test.js
@@ -142,9 +142,9 @@ describe('Proxy spaces', () => {
     tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
 
     // Create two member spaces
-    const rA = await post(BASE, tokenA, '/api/spaces', { id: SPACE_A, label: 'Alpha' });
+    const rA = await post(BASE, tokenA, '/api/spaces', { id: SPACE_A, label: 'Alpha', meta: { strictLinkage: false } });
     assert.equal(rA.status, 201, `Create alpha: ${JSON.stringify(rA.body)}`);
-    const rB = await post(BASE, tokenA, '/api/spaces', { id: SPACE_B, label: 'Beta' });
+    const rB = await post(BASE, tokenA, '/api/spaces', { id: SPACE_B, label: 'Beta', meta: { strictLinkage: false } });
     assert.equal(rB.status, 201, `Create beta: ${JSON.stringify(rB.body)}`);
 
     // Create the proxy space

--- a/testing/integration/schema-validation.test.js
+++ b/testing/integration/schema-validation.test.js
@@ -31,7 +31,7 @@ function token() { return tokenA; }
 before(async () => {
   tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
   // Create a dedicated, non-networked space for schema validation tests
-  const r = await post(INSTANCES.a, token(), '/api/spaces', { id: TEST_SPACE, label: `Schema Test ${RUN}` });
+  const r = await post(INSTANCES.a, token(), '/api/spaces', { id: TEST_SPACE, label: `Schema Test ${RUN}`, meta: { strictLinkage: false } });
   assert.equal(r.status, 201, `Failed to create test space: ${JSON.stringify(r.body)}`);
 });
 

--- a/testing/integration/space-deletion.test.js
+++ b/testing/integration/space-deletion.test.js
@@ -39,6 +39,9 @@ describe('Space deletion — full cleanup', () => {
     const createR = await post(INSTANCES.a, token, '/api/spaces', {
       id: spaceId,
       label: 'Deletion Brain Test',
+      // Seeds an edge by entity NAME to populate the space quickly; the subject here is that
+      // deletion removes every collection, not how references are validated.
+      meta: { strictLinkage: false },
     });
     assert.equal(createR.status, 201, `Create: ${JSON.stringify(createR.body)}`);
 

--- a/testing/integration/space-export.test.js
+++ b/testing/integration/space-export.test.js
@@ -42,7 +42,7 @@ describe('Space export — basic export', () => {
 
   it('export returns correct top-level structure', async () => {
     const spaceId = `export-struct-${RUN_ID}`;
-    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Export Struct Test' });
+    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Export Struct Test', meta: { strictLinkage: false } });
     assert.equal(createR.status, 201, `Create: ${JSON.stringify(createR.body)}`);
     createdSpaceIds.push(spaceId);
 
@@ -64,7 +64,7 @@ describe('Space export — basic export', () => {
 
   it('export includes seeded data and excludes embedding vectors', async () => {
     const spaceId = `export-data-${RUN_ID}`;
-    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Export Data Test' });
+    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Export Data Test', meta: { strictLinkage: false } });
     assert.equal(createR.status, 201);
     createdSpaceIds.push(spaceId);
 
@@ -127,7 +127,7 @@ describe('Space export — basic export', () => {
 
   it('export includes file metadata', async () => {
     const spaceId = `export-files-${RUN_ID}`;
-    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Export Files Test' });
+    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Export Files Test', meta: { strictLinkage: false } });
     assert.equal(createR.status, 201);
     createdSpaceIds.push(spaceId);
 
@@ -283,7 +283,7 @@ describe('Space export/import — round-trip (export → wipe → import)', () =
 
   it('export → wipe → import restores all brain data', async () => {
     const spaceId = `roundtrip-${RUN_ID}`;
-    const createR = await post(INSTANCES.a, tok, '/api/spaces', { id: spaceId, label: 'Round-trip Test' });
+    const createR = await post(INSTANCES.a, tok, '/api/spaces', { id: spaceId, label: 'Round-trip Test', meta: { strictLinkage: false } });
     assert.equal(createR.status, 201, `Create: ${JSON.stringify(createR.body)}`);
     roundTripSpaceIds.push(spaceId);
 

--- a/testing/integration/space-wipe.test.js
+++ b/testing/integration/space-wipe.test.js
@@ -40,7 +40,7 @@ describe('Space wipe — full wipe', () => {
 
   it('full wipe removes all brain data and files, returns correct deleted counts', async () => {
     const spaceId = `wipe-full-${RUN_ID}`;
-    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Wipe Full Test' });
+    const createR = await post(INSTANCES.a, adminToken, '/api/spaces', { id: spaceId, label: 'Wipe Full Test', meta: { strictLinkage: false } });
     assert.equal(createR.status, 201, `Create: ${JSON.stringify(createR.body)}`);
     createdSpaceIds.push(spaceId);
 

--- a/testing/standalone/entity-identity.test.js
+++ b/testing/standalone/entity-identity.test.js
@@ -102,94 +102,14 @@ describe('Entity upsert identity model', () => {
   });
 });
 
-// ── Remember entity resolution (Defect 3 fix) ──────────────────────────────
-
-describe('remember entity resolution — no ghost stubs', () => {
-  it('entity name resolution returns warning when entity not found', () => {
-    // Simulate: entity name "traefik" not found in DB → should warn, not auto-create
-    const entityNames = ['traefik', 'nginx'];
-    const dbResults = new Map(); // empty — no entities found
-
-    const entityIds = [];
-    const unresolvedNames = [];
-    for (const eName of entityNames) {
-      const matches = dbResults.get(eName) ?? [];
-      if (matches.length === 0) {
-        unresolvedNames.push(eName);
-      } else {
-        for (const m of matches) entityIds.push(m._id);
-      }
-    }
-    assert.deepEqual(entityIds, []);
-    assert.deepEqual(unresolvedNames, ['traefik', 'nginx']);
-  });
-
-  it('entity name resolution links to existing entity regardless of type', () => {
-    // Simulate: "traefik" exists as type="service"
-    const dbResults = new Map([
-      ['traefik', [{ _id: 'abc-123', name: 'traefik', type: 'service' }]],
-    ]);
-
-    const entityNames = ['traefik'];
-    const entityIds = [];
-    const unresolvedNames = [];
-    for (const eName of entityNames) {
-      const matches = dbResults.get(eName) ?? [];
-      if (matches.length === 0) {
-        unresolvedNames.push(eName);
-      } else {
-        for (const m of matches) entityIds.push(m._id);
-      }
-    }
-    assert.deepEqual(entityIds, ['abc-123']);
-    assert.deepEqual(unresolvedNames, []);
-  });
-
-  it('entity name resolution links to all matches and emits multi-match warning', () => {
-    // Simulate: "Lisa" exists as both type="person" and type="character"
-    const dbResults = new Map([
-      ['Lisa', [
-        { _id: 'id-1', name: 'Lisa', type: 'person' },
-        { _id: 'id-2', name: 'Lisa', type: 'character' },
-      ]],
-    ]);
-
-    const entityNames = ['Lisa'];
-    const entityIds = [];
-    const multiMatchWarnings = [];
-    for (const eName of entityNames) {
-      const matches = dbResults.get(eName) ?? [];
-      if (matches.length === 0) {
-        // skip
-      } else {
-        if (matches.length > 1) {
-          multiMatchWarnings.push(`'${eName}' matched ${matches.length} entities — linked to all`);
-        }
-        for (const m of matches) entityIds.push(m._id);
-      }
-    }
-    assert.deepEqual(entityIds, ['id-1', 'id-2']);
-    assert.equal(multiMatchWarnings.length, 1);
-    assert.ok(multiMatchWarnings[0].includes('Lisa'));
-  });
-
-  it('mixed found and not-found names produce correct lists', () => {
-    const dbResults = new Map([
-      ['redis', [{ _id: 'r-1', name: 'redis', type: 'service' }]],
-    ]);
-
-    const entityNames = ['redis', 'phantom'];
-    const entityIds = [];
-    const unresolvedNames = [];
-    for (const eName of entityNames) {
-      const matches = dbResults.get(eName) ?? [];
-      if (matches.length === 0) {
-        unresolvedNames.push(eName);
-      } else {
-        for (const m of matches) entityIds.push(m._id);
-      }
-    }
-    assert.deepEqual(entityIds, ['r-1']);
-    assert.deepEqual(unresolvedNames, ['phantom']);
-  });
-});
+// ── Remember entity linkage ────────────────────────────────────────────────
+//
+// The three tests that used to live here described `remember` resolving entity NAMES and silently
+// storing the memory unlinked when a name did not resolve. That behaviour is gone: `remember` takes
+// `entityIds` (UUID v4) and refuses the write when an id is malformed or does not exist.
+//
+// They are not rewritten in place because they never exercised the product — each one rebuilt the
+// resolution loop inline over a local `Map`, so it asserted that a copy of the logic agreed with
+// itself. The real behaviour is covered against the real code in `entity-refs.test.js`
+// (format + the strict-linkage default) and `integration/entity-refs.test.js` (the end-to-end
+// refusal), which is why the count here drops rather than moves.

--- a/testing/standalone/entity-refs.test.js
+++ b/testing/standalone/entity-refs.test.js
@@ -1,0 +1,122 @@
+/**
+ * Entity/record references — the real helpers, not a copy of them.
+ *
+ * Every link field in the brain (a memory's `entityIds`, an edge's `from`/`to`, a chrono entry's
+ * `entityIds`/`memoryIds`, a file's three) names another record by its UUID v4 `_id`. This file tests
+ * the canonical implementation in `brain/entity-refs.ts` and the real `isStrictLinkage` default.
+ *
+ * It exists because the previous coverage (`strict-link-enforcement.test.js`) validated a LOCAL
+ * REIMPLEMENTATION — a private `validateEdgeRef()` carrying its own `meta?.strictLinkage === true`.
+ * That test passes whatever production does, so it could never have caught the default being wrong,
+ * and it did not notice when the default flipped. A test that cannot fail is not coverage.
+ *
+ * Run: node --test testing/standalone/entity-refs.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-refs-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH; // read at module load — must be set before importing
+
+const UUID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+const UUID2 = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
+
+let refs;
+let proxy;
+let loader;
+
+function writeConfig(spaces) {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+    instanceId: 'test-instance', instanceLabel: 'test', tokens: [], networks: [], spaces,
+  }, null, 2), { mode: 0o600 });
+  loader.loadConfig();
+}
+
+describe('reference format validation (canonical helpers)', () => {
+  before(async () => {
+    refs = await import('../../server/dist/brain/entity-refs.js');
+    proxy = await import('../../server/dist/spaces/proxy.js');
+    loader = await import('../../server/dist/config/loader.js');
+  });
+
+  it('accepts UUID v4 and nothing else', () => {
+    assert.equal(refs.isUuidV4(UUID), true);
+    assert.equal(refs.isUuidV4('Traefik'), false);
+    assert.equal(refs.isUuidV4(''), false);
+    assert.equal(refs.isUuidV4(undefined), false);
+    // A v1 UUID is a UUID but not the id shape we mint — accepting it would let a foreign id in.
+    assert.equal(refs.isUuidV4('2c5ea4c0-4067-11e9-8bad-9b1deb4d3b7d'), false);
+  });
+
+  it('an empty or absent field is not an error — omitting links is legal', () => {
+    assert.equal(refs.invalidRefsMessage('entityIds', 'entity', undefined), null);
+    assert.equal(refs.invalidRefsMessage('entityIds', 'entity', []), null);
+  });
+
+  it('the message names the field, the expected kind, and the offending value', () => {
+    // The caller is usually an agent; "invalid reference" is not actionable, this is.
+    const msg = refs.invalidRefsMessage('entityIds', 'entity', [UUID, 'Traefik']);
+    assert.match(msg, /entityIds/);
+    assert.match(msg, /entity ID/);
+    assert.match(msg, /"Traefik"/);
+    assert.doesNotMatch(msg, new RegExp(UUID), 'the valid id should not be reported as a problem');
+  });
+
+  it('names the right record kind per field', () => {
+    assert.match(refs.invalidRefsMessage('memoryIds', 'memory', ['x']), /memory ID/);
+    assert.match(refs.invalidRefsMessage('chronoIds', 'chrono', ['x']), /chrono ID/);
+  });
+
+  it('caps the list so a large bad payload cannot produce an unbounded error', () => {
+    const many = Array.from({ length: 30 }, (_, i) => `bad-${i}`);
+    const msg = refs.invalidRefsMessage('entityIds', 'entity', many);
+    assert.match(msg, /\+25 more/);
+  });
+
+  it('assertRefs throws on a bad value and stays silent on a good one', () => {
+    assert.throws(() => refs.assertRefs('entityIds', 'entity', ['nope']), /entityIds/);
+    assert.doesNotThrow(() => refs.assertRefs('entityIds', 'entity', [UUID, UUID2]));
+  });
+});
+
+describe('isStrictLinkage — the real function, and its default', () => {
+  before(async () => {
+    refs = await import('../../server/dist/brain/entity-refs.js');
+    proxy = await import('../../server/dist/spaces/proxy.js');
+    loader = await import('../../server/dist/config/loader.js');
+  });
+
+  it('defaults to STRICT when the space says nothing', () => {
+    // This is the behaviour change: the safe mode used to be the one nobody opted into, so an
+    // unvalidated reference was the default outcome for every space ever created.
+    writeConfig([{ id: 'plain', label: 'Plain' }]);
+    assert.equal(proxy.isStrictLinkage('plain'), true);
+  });
+
+  it('defaults to STRICT when meta exists but omits the flag', () => {
+    writeConfig([{ id: 'withmeta', label: 'M', meta: { purpose: 'x' } }]);
+    assert.equal(proxy.isStrictLinkage('withmeta'), true);
+  });
+
+  it('honours an explicit opt-out — the escape hatch survives', () => {
+    // Staged imports that reference not-yet-created records still have a way out; it is now a
+    // deliberate per-space choice rather than what you get by saying nothing.
+    writeConfig([{ id: 'lax', label: 'Lax', meta: { strictLinkage: false } }]);
+    assert.equal(proxy.isStrictLinkage('lax'), false);
+  });
+
+  it('honours an explicit opt-in', () => {
+    writeConfig([{ id: 'strict', label: 'S', meta: { strictLinkage: true } }]);
+    assert.equal(proxy.isStrictLinkage('strict'), true);
+  });
+
+  it('an unknown space is strict — an unknown target must not be the lax path', () => {
+    writeConfig([{ id: 'only', label: 'O' }]);
+    assert.equal(proxy.isStrictLinkage('does-not-exist'), true);
+  });
+});

--- a/testing/standalone/strict-link-enforcement.test.js
+++ b/testing/standalone/strict-link-enforcement.test.js
@@ -230,9 +230,13 @@ describe('strictLinkage is a per-space opt-in setting', () => {
    * Simulate the enforcement gating pattern used in the API.
    * When strictLinkage is false/undefined, validation is skipped.
    */
+  // MIRROR of the production rule, kept because these cases enumerate edge shapes cheaply.
+  // The rule itself (including the default) is asserted against the REAL `isStrictLinkage` in
+  // entity-refs.test.js — without that, this local copy would agree with itself forever, which is
+  // exactly how the default flipping from off to on went unnoticed here.
   function validateEdgeRef(meta, from, to) {
     const errors = [];
-    if (meta?.strictLinkage === true) {
+    if (meta?.strictLinkage !== false) {
       if (!UUID_V4_RE.test(from)) errors.push({ field: 'from', reason: 'not a UUID v4' });
       if (!UUID_V4_RE.test(to)) errors.push({ field: 'to', reason: 'not a UUID v4' });
     }
@@ -240,7 +244,7 @@ describe('strictLinkage is a per-space opt-in setting', () => {
   }
 
   function shouldBlockDelete(meta, backlinks) {
-    if (meta?.strictLinkage !== true) return false;
+    if (meta?.strictLinkage === false) return false;
     return backlinks.length > 0;
   }
 
@@ -256,15 +260,15 @@ describe('strictLinkage is a per-space opt-in setting', () => {
     assert.equal(errors.length, 0);
   });
 
-  it('strictLinkage=undefined → name-based from/to allowed', () => {
+  it('strictLinkage=undefined → name-based from/to REJECTED (strict is the default)', () => {
     const meta = {};
     const errors = validateEdgeRef(meta, 'kubernetes', 'docker');
-    assert.equal(errors.length, 0);
+    assert.equal(errors.length, 2, 'a space that says nothing about linkage now gets the safe behaviour');
   });
 
-  it('no meta → name-based from/to allowed', () => {
+  it('no meta → name-based from/to REJECTED (strict is the default)', () => {
     const errors = validateEdgeRef(undefined, 'kubernetes', 'docker');
-    assert.equal(errors.length, 0);
+    assert.equal(errors.length, 2);
   });
 
   it('strictLinkage=true → delete blocked when backlinks exist', () => {


### PR DESCRIPTION
Owner report, verified against the handlers before anything was changed.

`remember` took entity **names** and stored the memory **unlinked** when a name did not resolve; `upsert_edge` demanded a UUID v4 and hard-errored on a name; several paths validated nothing at all. In a graph store a dropped link is invisible — the write returns success, and the gap only surfaces later as a traversal that quietly comes back empty.

## What changed

- **`remember` no longer accepts `entities` (names). It takes `entityIds` (UUID v4)**, like every other write path. **This is the breaking part** — a client passing names now gets an error instead of a memory with no links.
- **`meta.strictLinkage` now defaults ON.** It already existed but defaulted *off*, so the safe behaviour was the one nobody opted into. The opt-out survives for the case that justified it (staged imports whose targets are created later) and is now a deliberate per-space choice.
- **Existence is checked, not just format.** A syntactically perfect UUID pointing at nothing dangles exactly as silently as a name did. Bulk keeps format-only checking **on purpose**: a payload may reference a record created earlier in the same payload, and rejecting that would break valid forward references.
- **Closed the ungated paths:** MCP `update_memory`, bulk memory items, and — the widest hole, spotted by the owner — the **file metadata route**, which accepted all three of `entityIds`/`chronoIds`/`memoryIds` with no UUID check and **no strict gate whatsoever**.
- **One `UUID_V4_RE`** instead of three copies that were applied inconsistently.
- Errors name the field **and** the offending values, so an agent can self-correct.

## A correction to the report

The report stated `update_memory` advertised `entities` while its handler read `entityIds`. **Both were `entityIds` and agreed** — the confusion was that `remember` used `entities` and `update_memory` used `entityIds`, two memory-write tools with two reference models. The genuine `update_memory` defect was the *total absence of validation*, which is fixed here.

## Verified: import is unaffected

Restoring a space export was the obvious way this could have broken — an export's records reference each other, and import order can't guarantee targets exist first. Import writes via `replaceOne` directly rather than through these routes, so a round-trip is unaffected. Confirmed by the export→wipe→import test.

## Test-quality finding

The ~45 tests covering this area validated **local reimplementations** of the rules — a private `validateEdgeRef()` carrying its own `meta?.strictLinkage === true`, and a `remember` resolution loop rebuilt inline over a `Map`. They passed regardless of what the product did, and **did not notice any of this change**. Replaced with tests that exercise the real helpers, and **verified to fail when the default is reverted** (exactly the 3 default-semantics tests, nothing else).

## Testing

- New `standalone/entity-refs.test.js` (11) against the real helpers and the real `isStrictLinkage`; new `integration/entity-refs.test.js` (7) driving the API, including that a refused write **stores nothing** and that the opt-out still accepts a dangling ref.
- Fixtures that seeded placeholder refs (`'some-entity'`, `'a'`/`'b'`) now either use **real ids** where the test asserts linkage, or **opt out explicitly** where the subject is export/wipe/proxy/schema — stated in the fixture so it is clear what is not being exercised.
- Standalone **1077 pass**, integration **918 pass**, **0 fail** on a fresh stack. `lint:docs` clean; new "Reference integrity" section in the integration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)