### PR TITLE
fix(spaces): a rename could silently not happen — 200 returned, old id kept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1288,6 +1288,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A space rename could silently not happen — collections moved, API returned 200, config kept the
+  old id.** `renameSpace` looked the space up, then awaited `moveSpaceData`, which renames every
+  collection and takes seconds. A config reload landing in that window replaces `cfg.spaces` wholesale
+  and leaves the looked-up object **orphaned**, so the commit that followed mutated a detached record:
+  the physical move succeeded, the write reported success, and the space kept its **old** id. Every
+  subsequent lookup under the new id then 404'd, with nothing anywhere reporting a failure. The commit
+  now re-resolves the space by id inside the write.
+  This is the second instance of the same mechanism, after the token-prefix backfill in the previous
+  release: the in-place config refresh keeps a *top-level* reference (`const cfg = getConfig()`) valid,
+  but a reference **into** it (one `space` out of `cfg.spaces`, one token out of `cfg.tokens`) is
+  replaced. New standalone test pins the mechanism itself without a database — including that
+  committing through an orphan loses the change *and reports success* — so the next read-modify-write
+  across an await has something to fail against.
+  Found by chasing an intermittent CI failure whose stated symptom ("files survive rename") pointed at
+  the file path rather than the rename; the first hypothesis (a `createSpace` write race) did not
+  survive scrutiny and was discarded rather than shipped.
+
 - **Face recognition is now actually pinnable from a Compose deployment — and an empty env var no
   longer counts as a pin.** Two halves of the same gap. The documented guarantee that
   `FACE_RECOGNITION_ENABLED=false` stops all face processing could not hold under the default

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -8,7 +8,7 @@ import { escapeRegex } from '../util/redos.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { getDb, col, asDoc, asFilter } from '../db/mongo.js';
-import { getConfig, saveConfig, getDataRoot } from '../config/loader.js';
+import { getConfig, saveConfig, getDataRoot, mutateConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { Config, SpaceConfig } from '../config/types.js';
 import { repairStaleSpaceIds, pendingOpConflictMessage } from './_shared.js';
@@ -237,11 +237,31 @@ export async function renameSpace(oldId: string, newId: string): Promise<SpaceCo
     );
   }
 
-  // Commit: physical move done — apply the logical config change and clear the
-  // marker in one atomic write.
-  applySpaceRenameToConfig(cfg, space, oldId, newId);
-  delete cfg.pendingSpaceOp;
-  saveConfig(cfg);
+  // Commit: physical move done — apply the logical config change and clear the marker in one
+  // atomic write.
+  //
+  // Re-resolve the space by id inside the write instead of committing the `space` object looked up
+  // at the top. That lookup happened before `moveSpaceData`, which renames every collection and takes
+  // seconds; a config reload landing in that window replaces `cfg.spaces` wholesale and leaves the
+  // reference orphaned. Mutating the orphan and saving produced the worst possible outcome: the API
+  // returned 200, the collections had moved, and config still carried the OLD id — so the rename
+  // silently did not happen and every lookup under the new id 404'd.
+  let renamed: SpaceConfig | undefined;
+  mutateConfig(fresh => {
+    const live = fresh.spaces.find(s => s.id === oldId);
+    if (!live) return; // already committed by a concurrent resume — nothing left to do
+    applySpaceRenameToConfig(fresh, live, oldId, newId);
+    delete fresh.pendingSpaceOp;
+    renamed = live;
+  });
+  if (!renamed) {
+    // The physical move succeeded, so treat an already-committed config as success rather than
+    // failing a rename that has, in fact, happened.
+    const committed = getConfig().spaces.find(s => s.id === newId);
+    if (!committed) throw new Error(`Space '${oldId}' rename committed no config change — refusing to report success`);
+    log.info(`Renamed space '${oldId}' → '${newId}' (config already committed)`);
+    return committed;
+  }
   log.info(`Renamed space '${oldId}' → '${newId}'`);
-  return space;
+  return renamed;
 }

--- a/testing/standalone/config-detached-refs.test.js
+++ b/testing/standalone/config-detached-refs.test.js
@@ -1,0 +1,112 @@
+/**
+ * A nested config reference held across an await is orphaned by a reload — and the write that
+ * commits it then lands nowhere.
+ *
+ * The config watcher reloads `config.json` whenever it changes on disk. `reloadConfig` refreshes the
+ * config object IN PLACE, so a top-level reference (`const cfg = getConfig()`) survives. A reference
+ * INTO it does not: `cfg.spaces` and `cfg.tokens` are replaced wholesale, so a `space` or `token`
+ * object looked up before the await is a detached orphan afterwards.
+ *
+ * That is not theoretical. It has now produced two real defects:
+ *
+ *   - a token's lookup-prefix backfill written to an orphaned record, leaving the token on the slow
+ *     full-scan path forever (fixed in #348);
+ *   - a space rename committed to an orphaned space object, so the collections moved, the API
+ *     returned 200, and config kept the OLD id — a rename that silently did not happen.
+ *
+ * The rename case is the nastier of the two because every signal says success. These tests pin the
+ * mechanism itself, without a database, so the next read-modify-write across an await has something
+ * to fail against.
+ *
+ * Run: node --test testing/standalone/config-detached-refs.test.js
+ */
+
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-detach-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH; // read at module load — set before importing
+
+let loader;
+
+const readDisk = () => JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+function seed() {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+    instanceId: 'test-instance', instanceLabel: 'test', tokens: [], networks: [],
+    spaces: [{ id: 'alpha', label: 'Alpha', builtIn: false, folders: [] }],
+  }, null, 2), { mode: 0o600 });
+  loader.loadConfig();
+}
+
+describe('a reload detaches nested references', () => {
+  before(async () => { loader = await import('../../server/dist/config/loader.js'); });
+  beforeEach(() => seed());
+
+  it('the config object itself survives a reload — that is why top-level writes are safe', () => {
+    const cfg = loader.getConfig();
+    loader.reloadConfig();
+    assert.equal(cfg, loader.getConfig(), 'refreshed in place, so the same object stays current');
+  });
+
+  it('but a reference INTO it does not', () => {
+    const cfg = loader.getConfig();
+    const space = cfg.spaces.find(s => s.id === 'alpha');
+    loader.reloadConfig();
+    assert.notEqual(
+      space, loader.getConfig().spaces.find(s => s.id === 'alpha'),
+      'cfg.spaces is replaced wholesale, so the held object is now an orphan',
+    );
+  });
+
+  it('committing through the orphan loses the change — and reports success', () => {
+    // This is the shape that produced the silent rename: look up, await something slow, mutate the
+    // object you looked up, save. Nothing throws. Nothing warns.
+    const cfg = loader.getConfig();
+    const space = cfg.spaces.find(s => s.id === 'alpha');
+
+    loader.reloadConfig();          // stands in for the watcher firing mid-await
+
+    space.id = 'renamed';           // mutating the orphan
+    loader.saveConfig(cfg);
+
+    assert.equal(
+      readDisk().spaces[0].id, 'alpha',
+      'the rename was lost: the write "succeeded" and the id never changed',
+    );
+  });
+
+  it('re-resolving by id inside mutateConfig commits it', () => {
+    const cfg = loader.getConfig();
+    const space = cfg.spaces.find(s => s.id === 'alpha');
+    const heldId = space.id;
+
+    loader.reloadConfig();          // orphan the reference again
+
+    loader.mutateConfig(fresh => {
+      const live = fresh.spaces.find(s => s.id === heldId);
+      live.id = 'renamed';
+    });
+
+    assert.equal(readDisk().spaces[0].id, 'renamed', 'the rename lands');
+  });
+
+  it('mutateConfig also preserves a change another writer made meanwhile', () => {
+    // Re-reading is what makes this safe, so it must not trample the file it re-read.
+    const cfg = loader.getConfig();
+    cfg.spaces.push({ id: 'beta', label: 'Beta', builtIn: false, folders: [] });
+    loader.saveConfig(cfg);
+
+    loader.mutateConfig(fresh => {
+      fresh.spaces.find(s => s.id === 'alpha').label = 'Alpha Renamed';
+    });
+
+    const disk = readDisk();
+    assert.equal(disk.spaces.find(s => s.id === 'alpha').label, 'Alpha Renamed');
+    assert.ok(disk.spaces.some(s => s.id === 'beta'), 'the other writer\'s space must survive');
+  });
+});


### PR DESCRIPTION
`renameSpace` looked the space up, then awaited `moveSpaceData` — which renames every collection and takes **seconds**. A config reload landing in that window replaces `cfg.spaces` wholesale and leaves the looked-up object **orphaned**, so the commit that followed mutated a detached record.

Result: the collections moved, the API returned **200**, and config kept the **old** id. Every lookup under the new id then 404'd, with nothing anywhere reporting a failure. A rename that silently did not happen is worse than one that fails, because every signal says it worked.

The commit now re-resolves the space by id inside the write.

## Same mechanism as #348

The in-place config refresh keeps a **top-level** reference (`const cfg = getConfig()`) valid — which is why it looked safe. A reference **into** it does not survive: one `space` out of `cfg.spaces`, one token out of `cfg.tokens`. That's now bitten twice (token-prefix backfill, this), so the new standalone test pins **the mechanism** rather than either symptom — without a database, including the part that makes it dangerous:

```js
space.id = 'renamed';        // mutating the orphan
loader.saveConfig(cfg);
// disk still says 'alpha' — the write "succeeded" and the id never changed
```

## On how this was diagnosed

Worth stating because the first answer was wrong. This came from an intermittent CI failure I **could not reproduce in six isolated runs**. My initial hypothesis was a `createSpace` config-write race — but tracing it showed the in-place refresh already makes that path safe, so the theory didn't survive and **I discarded it instead of shipping it**. The rename path was on the same audited list from #346 and does carry the defect, and its symptom — a 200 that changes nothing — matches exactly what CI saw.

I can't claim certainty that this *was* the CI flake, since I never reproduced it. What I can say is that this is a real defect in the failing code path, it produces precisely that symptom, and it's now covered.

## Testing

- New `testing/standalone/config-detached-refs.test.js` (5 tests): the object survives a reload, a nested reference does not, committing through an orphan loses the change and reports success, re-resolving inside `mutateConfig` commits it, and `mutateConfig` doesn't trample a concurrent writer.
- `space-rename` + `space-op-recovery` pass; standalone **1082**, integration **919**, **0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)