### PR TITLE
fix(spaces): the crash-recovery and boot paths commit through fresh references too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1288,6 +1288,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The crash-recovery and boot paths carried the same detached-reference defect as the rename.**
+  Follow-on hardening, in the two places where it matters most because they run *on* the config-reload
+  path, so a reload is not merely possible nearby — it is what invoked them.
+  - `reconcilePendingSpaceOp` held the space object across `await moveSpaceData` and then committed
+    it. This is the code that repairs a half-finished rename, so a reload landing mid-recovery
+    produced **exactly the half-finished rename it exists to fix** — and cleared the pending-op marker
+    on the way out, destroying the record a later retry needed.
+  - The delete branch rebuilt `cfg.spaces` from an array captured before `dropSpaceData`.
+  - `initAllSpaces` held every space object across a loop of `initSpace` calls, each of which waits
+    for index readiness. The `indexStatus` flips afterwards were written to orphans, so a space could
+    stay stuck reporting `building` forever with nothing to explain it.
+
+  All three re-resolve by id inside the write. `createSpace` is deliberately unchanged and now carries
+  a comment saying why, because the distinction is the whole bug class: it holds a **top-level** `cfg`
+  reference (refreshed in place by a reload, so still current) and pushes a **newly built** object —
+  not a record looked up before an await.
+
 - **A space rename could silently not happen — collections moved, API returned 200, config kept the
   old id.** `renameSpace` looked the space up, then awaited `moveSpaceData`, which renames every
   collection and takes seconds. A config reload landing in that window replaces `cfg.spaces` wholesale

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -8,7 +8,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { getDb, col } from '../db/mongo.js';
-import { getConfig, saveConfig, getEmbeddingConfig, getDataRoot } from '../config/loader.js';
+import { getConfig, saveConfig, mutateConfig, getEmbeddingConfig, getDataRoot } from '../config/loader.js';
 import { ensureSpaceFilesDir } from '../files/files.js';
 import { invalidateUsageCache } from '../quota/quota.js';
 import { log } from '../util/log.js';
@@ -114,19 +114,27 @@ export async function initSpace(
 
 /** Initialise all spaces defined in config */
 export async function initAllSpaces(): Promise<void> {
-  const cfg = getConfig();
-  let dirty = false;
-  for (const space of cfg.spaces) {
-    log.debug(`Initialising space: ${space.id}`);
-    await initSpace(space.id);
+  // Collect ids, not space objects: `initSpace` waits for index readiness, so this loop holds its
+  // references across many seconds of awaits. A config reload in that window replaces cfg.spaces and
+  // every held object becomes an orphan — the status flips below would then be written to detached
+  // records and lost, leaving spaces stuck reporting 'building' forever with nothing to explain it.
+  const readyAgain: string[] = [];
+  for (const spaceId of getConfig().spaces.map(s => s.id)) {
+    log.debug(`Initialising space: ${spaceId}`);
+    await initSpace(spaceId);
     // initSpace waited for READY here, so a space left mid-build by a crash during
     // createSpace's async finalize (B1) is now ready — clear the stale marker.
-    if (space.indexStatus === 'building' || space.indexStatus === 'failed') {
-      space.indexStatus = 'ready';
-      dirty = true;
-    }
+    const current = getConfig().spaces.find(s => s.id === spaceId);
+    if (current?.indexStatus === 'building' || current?.indexStatus === 'failed') readyAgain.push(spaceId);
   }
-  if (dirty) saveConfig(cfg);
+  if (readyAgain.length > 0) {
+    mutateConfig(fresh => {
+      for (const spaceId of readyAgain) {
+        const live = fresh.spaces.find(s => s.id === spaceId);
+        if (live) live.indexStatus = 'ready';
+      }
+    });
+  }
 }
 
 /** Ensure the built-in 'general' space exists in config and MongoDB */
@@ -178,6 +186,12 @@ export async function createSpace(opts: {
     await initSpace(opts.id, { waitForVectorReady: false });
     space.indexStatus = 'building';
   }
+  // Safe to commit the `cfg` captured before the await, and worth knowing why, because the same
+  // shape is NOT safe a few functions down: `cfg` is a TOP-LEVEL reference, and a reload refreshes
+  // that object in place, so it stays current. `space` is a newly built object being added — not a
+  // record looked up before the await. The dangerous version is holding a reference INTO the config
+  // (one entry out of `cfg.spaces`) across an await and then mutating it; see `renameSpace` and
+  // `reconcilePendingSpaceOp`, which both re-resolve by id inside the write for that reason.
   cfg.spaces.push(space);
   saveConfig(cfg);
   if (!opts.proxyFor) {
@@ -449,9 +463,19 @@ export async function reconcilePendingSpaceOp(): Promise<void> {
         log.error(`Could not complete pending rename ${target}; marker kept for next restart. Errors: ${errors.join('; ')}`);
         return;
       }
-      applySpaceRenameToConfig(cfg, space, op.spaceId, op.newId);
-      delete cfg.pendingSpaceOp;
-      saveConfig(cfg);
+      // Re-resolve inside the write. `space` was looked up before `moveSpaceData`, which renames
+      // every collection and takes seconds; a config reload in that window replaces cfg.spaces and
+      // leaves it orphaned, so committing it would move the data, clear the marker, and keep the OLD
+      // id — the same silent half-rename this recovery path exists to repair. This one runs ON the
+      // reload path, so a reload is not just possible here, it is nearby by construction.
+      // Capture before the callback: the `op.newId` narrowing from the guard above does not survive
+      // into a closure.
+      const { spaceId: fromId, newId: toId } = { spaceId: op.spaceId, newId: op.newId };
+      mutateConfig(fresh => {
+        const live = fresh.spaces.find(sp => sp.id === fromId);
+        if (live) applySpaceRenameToConfig(fresh, live, fromId, toId);
+        delete fresh.pendingSpaceOp;
+      });
       log.info(`Completed interrupted rename ${target}`);
     } else if (op.type === 'delete') {
       const errors = await dropSpaceData(op.spaceId);
@@ -459,9 +483,12 @@ export async function reconcilePendingSpaceOp(): Promise<void> {
         log.error(`Could not complete pending delete ${target}; marker kept for next restart. Errors: ${errors.join('; ')}`);
         return;
       }
-      cfg.spaces = cfg.spaces.filter(s => s.id !== op.spaceId);
-      delete cfg.pendingSpaceOp;
-      saveConfig(cfg);
+      // Same treatment: `dropSpaceData` is slow, so re-read before committing rather than writing
+      // a spaces array captured before it.
+      mutateConfig(fresh => {
+        fresh.spaces = fresh.spaces.filter(sp => sp.id !== op.spaceId);
+        delete fresh.pendingSpaceOp;
+      });
       log.info(`Completed interrupted deletion ${target}`);
     } else {
       log.error(`Unknown pendingSpaceOp type '${op.type}' — clearing marker`);


### PR DESCRIPTION
Follow-on from #353. The same detached-reference shape sits in the two places where it matters most — because they run **on** the config-reload path, so a reload isn't merely possible nearby, it's what invoked them.

- **`reconcilePendingSpaceOp`** held the space object across `await moveSpaceData` and then committed it. This is the code that repairs a half-finished rename, so a reload landing mid-recovery produced **exactly the half-finished rename it exists to fix** — and cleared the pending-op marker on the way out, destroying the record a later retry needed.
- The **delete branch** rebuilt `cfg.spaces` from an array captured before `dropSpaceData`.
- **`initAllSpaces`** held every space object across a loop of `initSpace` calls, each of which waits for index readiness. The `indexStatus` flips afterwards were written to orphans, so a space could stay stuck reporting `building` forever with nothing to explain it.

All three re-resolve by id inside the write.

## `createSpace` is deliberately unchanged

It now carries a comment explaining why, because this distinction *is* the bug class — and getting it wrong is what sent me down a blind alley on #353:

- `cfg` is a **top-level** reference. A reload refreshes that object **in place**, so it stays current.
- `space` is a **newly built** object being pushed — not a record looked up before an await.

The dangerous version is holding a reference **into** the config (one entry out of `cfg.spaces`) across an await and then mutating it. Anyone reading `createSpace` and copying its shape into a lookup-then-await function would reintroduce this, so the comment names the trap rather than leaving the next reader to infer it.

## Testing

Covered by the mechanism tests added in #353 (`config-detached-refs.test.js`) plus the existing crash-recovery suite. Standalone **1082 pass**, integration **919 pass**, **0 fail** on a fresh stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)