### PR TITLE
test: two suites were checking a copy of the product — and both copies had drifted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1288,6 +1288,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two test files were checking a copy of the product instead of the product — and both copies had
+  drifted.** A sweep prompted by two defects their suites could not see found eight standalone files
+  that re-implement production logic locally and assert against the re-implementation. Such a test
+  passes whatever the product does, including after the product changes or deletes the code entirely.
+  First two converted, chosen because their mirrored rules are **security guards**, where silent drift
+  costs most:
+  - `delete-fields.test.js` copied the path validator **without production's empty-segment rejection**,
+    so `properties..key` behaved differently in the test than in the product, and deleting that
+    traversal guard from production would have failed **nothing**. Now imports the real
+    `validateDeleteFields`/`applyDeleteFields`, with four cases for the missing rule.
+  - `entity-merge.test.js` copied `applyResolutions` **without the prototype-pollution guard**, so the
+    copy wrote `__proto__` where the product refuses to. Now imports the real functions, with the
+    guard pinned.
+
+  Both verified by mutation: disabling the guard in production fails exactly the intended assertions
+  and nothing else — where previously it would have failed none. Writing the second one produced its
+  own miniature of the problem worth recording: the first draft asserted
+  `out['__proto__'] === undefined`, which is true of *any* plain object because the read walks the
+  prototype chain, so it would have been green with or without the guard. It now uses
+  `hasOwnProperty`.
+  `computeConflicts` is deliberately left as a labelled local simplification — the real
+  `computeMergePlan` is async and reads schemas from Mongo — so it is explicitly *not* evidence about
+  that function, which still has no test importing it. The remaining six files are tracked, the
+  largest being a validation-engine copy that tests a data model production no longer has.
+
 - **The crash-recovery and boot paths carried the same detached-reference defect as the rename.**
   Follow-on hardening, in the two places where it matters most because they run *on* the config-reload
   path, so a reload is not merely possible nearby — it is what invoked them.

--- a/testing/standalone/delete-fields.test.js
+++ b/testing/standalone/delete-fields.test.js
@@ -14,70 +14,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-// ── Replicated logic (matches server/src/brain/delete-fields.ts) ──────────
-
-const SYSTEM_FIELDS = new Set([
-  'id', '_id', 'name', 'type', 'spaceId', 'createdAt', 'updatedAt',
-]);
-
-const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-function validateDeleteFields(deleteFields) {
-  if (deleteFields === undefined || deleteFields === null) return { ok: true };
-  if (!Array.isArray(deleteFields)) {
-    return { ok: false, error: '`deleteFields` must be an array of strings' };
-  }
-  for (const p of deleteFields) {
-    if (typeof p !== 'string' || !p.trim()) {
-      return { ok: false, error: '`deleteFields` entries must be non-empty strings' };
-    }
-    const segments = p.split('.');
-    for (const seg of segments) {
-      if (PROTO_KEYS.has(seg)) {
-        return { ok: false, error: `Invalid deleteFields path segment '${seg}'` };
-      }
-    }
-    const topLevel = segments[0] ?? '';
-    if (SYSTEM_FIELDS.has(topLevel)) {
-      return { ok: false, error: `Cannot delete system field '${topLevel}' via deleteFields` };
-    }
-  }
-  return { ok: true };
-}
-
-function applyDeleteFields(obj, deleteFields) {
-  const affected = new Set();
-  for (const path of deleteFields) {
-    const segments = path.split('.');
-    if (segments.length === 0) continue;
-    const firstSeg = segments[0] ?? '';
-    affected.add(firstSeg);
-    if (segments.length === 1) {
-      if (!PROTO_KEYS.has(firstSeg)) {
-        delete obj[firstSeg];
-      }
-    } else {
-      let current = obj;
-      let safe = true;
-      for (let i = 0; i < segments.length - 1; i++) {
-        const seg = segments[i] ?? '';
-        if (PROTO_KEYS.has(seg)) { safe = false; break; }
-        if (current == null || typeof current !== 'object' || Array.isArray(current)) {
-          current = undefined;
-          break;
-        }
-        current = current[seg];
-      }
-      const leafSeg = segments[segments.length - 1] ?? '';
-      if (safe && !PROTO_KEYS.has(leafSeg) && current != null && typeof current === 'object' && !Array.isArray(current)) {
-        delete current[leafSeg];
-      }
-    }
-  }
-  return affected;
-}
-
-// ── Tests ──────────────────────────────────────────────────────────────────
+// The real implementation — imported, not re-implemented.
+//
+// This file used to carry a local copy of both functions, and the copy had already DRIFTED: it was
+// missing production's empty-segment rejection (`delete-fields.ts`, "contains empty segments"), so
+// `properties..key` behaved differently here than in the product and removing that traversal guard
+// from production would not have failed anything. A test that asserts a copy agrees with itself
+// cannot notice the copy going stale — which is the entire reason it went stale.
+const { validateDeleteFields, applyDeleteFields } = await import('../../server/dist/brain/delete-fields.js');
 
 describe('validateDeleteFields', () => {
   it('accepts undefined (no deleteFields)', () => {
@@ -187,6 +131,27 @@ describe('validateDeleteFields', () => {
     const r = validateDeleteFields(['prototype']);
     assert.equal(r.ok, false);
     assert.ok(r.error.includes('prototype'));
+  });
+});
+
+describe('validateDeleteFields — rules the previous local copy did not have', () => {
+  it('rejects a path with an empty segment', () => {
+    // 'properties..key' — the copy in this file omitted this branch entirely.
+    const r = validateDeleteFields(['properties..key']);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /empty segment/i);
+  });
+
+  it('rejects a leading empty segment', () => {
+    assert.equal(validateDeleteFields(['.key']).ok, false);
+  });
+
+  it('rejects a trailing empty segment', () => {
+    assert.equal(validateDeleteFields(['key.']).ok, false);
+  });
+
+  it('still accepts a well-formed nested path', () => {
+    assert.equal(validateDeleteFields(['properties.key']).ok, true);
   });
 });
 

--- a/testing/standalone/entity-merge.test.js
+++ b/testing/standalone/entity-merge.test.js
@@ -35,56 +35,18 @@ const BOOLEAN_FNS = {
 const VALID_NUMERIC_FNS = new Set(['avg', 'min', 'max', 'sum']);
 const VALID_BOOLEAN_FNS = new Set(['and', 'or', 'xor']);
 
-function validateResolution(resolution, type, hasCustomValue) {
-  if (resolution === 'survivor' || resolution === 'absorbed') return null;
-  if (resolution === 'custom') {
-    if (!hasCustomValue) return 'resolution "custom" requires a customValue';
-    return null;
-  }
-  if (resolution.startsWith('fn:')) {
-    const fnName = resolution.slice(3);
-    if (type === 'number') {
-      if (!VALID_NUMERIC_FNS.has(fnName)) return `unknown numeric merge function: ${fnName}`;
-      return null;
-    }
-    if (type === 'boolean') {
-      if (!VALID_BOOLEAN_FNS.has(fnName)) return `unknown boolean merge function: ${fnName}`;
-      return null;
-    }
-    return `fn: resolutions require type "number" or "boolean", got "${type}"`;
-  }
-  return `unknown resolution: ${resolution}`;
-}
-
-function applyResolutions(survivorProps, absorbedProps, conflicts, absorbedOnly) {
-  const result = { ...survivorProps };
-
-  for (const p of absorbedOnly) {
-    result[p.key] = p.value;
-  }
-
-  for (const c of conflicts) {
-    const resolution = c.resolution;
-    if (resolution === 'survivor') {
-      continue;
-    } else if (resolution === 'absorbed') {
-      result[c.key] = c.absorbedValue;
-    } else if (resolution === 'custom') {
-      if (c.customValue !== undefined) {
-        result[c.key] = c.customValue;
-      }
-    } else if (resolution.startsWith('fn:')) {
-      const fnName = resolution.slice(3);
-      if (c.type === 'number' && NUMERIC_FNS[fnName]) {
-        result[c.key] = NUMERIC_FNS[fnName](c.survivorValue, c.absorbedValue);
-      } else if (c.type === 'boolean' && BOOLEAN_FNS[fnName]) {
-        result[c.key] = BOOLEAN_FNS[fnName](c.survivorValue, c.absorbedValue);
-      }
-    }
-  }
-
-  return result;
-}
+// The real implementations — imported, not re-implemented.
+//
+// `applyResolutions` was mirrored here WITHOUT production's prototype-pollution guard
+// (`merge.ts`: `if (!isSafeKey(p.key)) continue`), so the copy happily wrote `__proto__` where the
+// product refuses to. `validateResolution` was a byte-identical copy — no drift yet, but no way to
+// notice one either, since asserting a copy against itself always passes.
+//
+// NOTE: `computeConflicts` below is deliberately NOT the product. The real `computeMergePlan` is
+// async and reads the space's schemas from Mongo, so it cannot run here; this is a simplification
+// used to build fixtures. It is therefore NOT evidence about `computeMergePlan`, which currently has
+// no test that imports it at all — tracked in QA-TODO.
+const { validateResolution, applyResolutions } = await import('../../server/dist/brain/merge.js');
 
 function resolvePropertyType(key, value, schemas) {
   const schema = schemas?.[key];
@@ -340,6 +302,24 @@ describe('Entity merge — resolution application', () => {
     assert.equal(result.score, 90);
     assert.equal(result.name, 'Bob');
     assert.equal(result.extra, true);
+  });
+});
+
+describe('Entity merge — the guard the mirrored copy omitted', () => {
+  it('refuses to write a prototype-polluting key from absorbed-only properties', () => {
+    const out = applyResolutions({ safe: 1 }, {}, [], [
+      { key: '__proto__', value: 'polluted' },
+      { key: 'constructor', value: 'polluted' },
+      { key: 'legit', value: 'kept' },
+    ]);
+    // Own-property checks, not value checks: `out['__proto__']` reads Object.prototype through the
+    // chain and `out['constructor']` reads Object, so both are non-undefined on any plain object.
+    // Asserting on the value would pass whether or not the guard exists.
+    const own = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    assert.equal(own(out, '__proto__'), false, 'must not write __proto__ as an own property');
+    assert.equal(own(out, 'constructor'), false, 'must not write constructor as an own property');
+    assert.equal(out['legit'], 'kept', 'ordinary keys still apply');
+    assert.equal(({}).polluted, undefined, 'the global prototype must be untouched');
   });
 });
 


### PR DESCRIPTION
A sweep prompted by two defects their suites could not see (#348, #353) found **eight standalone files that re-implement production logic locally and assert against the re-implementation**. Such a test passes whatever the product does — including after the product changes or deletes the code entirely.

These are the first two converted, chosen because their mirrored rules are **security guards**, where silent drift costs most.

## What the copies were missing

- **`delete-fields.test.js`** copied the path validator **without production's empty-segment rejection**. So `properties..key` behaved differently in the test than in the product, and deleting that traversal guard from production would have failed **nothing**.
- **`entity-merge.test.js`** copied `applyResolutions` **without the prototype-pollution guard**, so the copy wrote `__proto__` where the product refuses to.

Both now import from `server/dist`, with cases pinning the rules the copies omitted.

## Verified by mutation, not by a green tick

Disabling each guard in production fails **exactly** the intended assertions and nothing else — where previously it would have failed none.

That discipline earned its keep immediately. My first draft of the prototype-pollution assertion was:

```js
assert.equal(out['__proto__'], undefined);   // green with OR without the guard
```

which is true of *any* plain object, because the read walks the prototype chain to `Object.prototype`. A mirror-test in miniature, written while fixing mirror-tests. It now uses `hasOwnProperty`.

## What is deliberately left alone

`computeConflicts` stays a **labelled local simplification** — the real `computeMergePlan` is async and reads schemas from Mongo, so it cannot run in a standalone test. The label matters: it is explicitly *not* evidence about `computeMergePlan`, which still has no test importing it at all.

## Remaining

Six files tracked in `QA-TODO`. The largest is a validation-engine copy (~20 KB) testing a data model production **no longer has** — its `requiredProperties` / `namingPatterns` fields have zero hits in `server/src`. Those cases need rewriting onto `typeSchemas`, which is the finding rather than a side-effect of it.

Standalone **1087 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)