### PR TITLE
feat(pipelines): text completes the ladders — off, embed, or chunk, per space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1985,6 +1985,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Text completes the analysis ladders — all five media classes can now be turned down or off per
+  space.** `textAnalysis` (`off · embed · chunk · auto`) joins documents, images, audio and video,
+  capped by the same instance ceiling. Behaviour is unchanged until an operator sets one.
+  It answers a *different* question from `documentExtraction`: that one governs how a file is **read**,
+  this governs what happens to the text that comes out.
+  - **`chunk`** stores a vector per section, so a recall can quote the passage.
+  - **`embed`** stores one vector for the whole document. It still finds the **file**, but no longer
+    answers "where does it say that?" — a real trade on long documents, and close to free on a space
+    full of short notes. It is deliberately **one** unit rather than zero: producing nothing would make
+    `embed` indistinguishable from `off` and silently cost a space its search, which the tests pin.
+  - **`off`** indexes nothing. The file is still stored and still retrievable — this is about what is
+    findable, not about deleting anything — and the record reaches a terminal state rather than sitting
+    at `pending` forever.
+
 - **BREAKING: every reference between brain records is now a UUID, and one that cannot resolve is
   refused instead of silently stored.** Reported by the owner: `remember` took entity *names* and
   stored the memory **unlinked** when a name did not resolve, `upsert_edge` demanded a UUID v4 and

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2093,11 +2093,18 @@ ceiling under `mediaEmbedding.levels`:
 | `imageAnalysis` | `off` · `caption` · `recognition` · `auto` | no caption, no image embedding, no face detection |
 | `audioAnalysis` | `off` · `on` · `auto` | no transcription |
 | `videoAnalysis` | `off` · `audio` · `full` · `auto` | no audio extraction, no transcription |
+| `textAnalysis` | `off` · `embed` · `chunk` · `auto` | text is never indexed — nothing in the file is findable by search |
 
 `recognition` is the rung that permits **face detection and embedding**, and it is gated twice: the
 instance-wide `mediaEmbedding.faceRecognition.enabled` must allow it *and* the space must be at
 `recognition`. A space on `caption` gets described images and no face data — which is the reason
 images have their own ladder rather than riding on the master media switch.
+
+`textAnalysis` decides what happens to text AFTER a document is read, which is a separate question
+from how it was read (`documentExtraction`). `chunk` stores a vector per section, so a recall can
+quote the passage; `embed` stores one vector for the whole document, which still finds the FILE but
+no longer answers "where does it say that?" — a real trade on long documents, and close to free on
+short notes. `off` stores the file and indexes nothing.
 
 `videoAnalysis: "full"` (keyframes analysed as images) is **reserved and not implemented**. The API
 **rejects it with 400** rather than accepting it and behaving like `audio`, so an operator is never

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -20,7 +20,7 @@ import { buildSpaceVectorIndexes } from '../spaces/vector-index.js';
 import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../util/ssrf.js';
 import { peerSafeFetch } from '../sync/peer-fetch.js';
 import type { SpaceMeta, KnowledgeType, TypeSchema } from '../config/types.js';
-import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
+import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
 import { writeFile as writeSpaceFile } from '../files/files.js';
 
 export const spacesRouter = Router();
@@ -150,8 +150,9 @@ const UpdateSpaceBody = z.object({
   imageAnalysis: z.enum(IMAGE_LEVELS).nullable().optional(),
   audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
   videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
-}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined, {
-  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, or videoAnalysis must be provided',
+  textAnalysis: z.enum(TEXT_LEVELS).nullable().optional(),
+}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
+  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
 });
 
 const ReorderSpacesBody = z.object({
@@ -329,7 +330,7 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     }
   }
 
-  const spaces = visibleSpaces.map(({ id, label, builtIn, folders, maxGiB, flex, description, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, indexStatus }, idx) => ({
+  const spaces = visibleSpaces.map(({ id, label, builtIn, folders, maxGiB, flex, description, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, textAnalysis, indexStatus }, idx) => ({
     id, label, builtIn, folders, maxGiB, flex, description,
     usageGiB: usageGiBByIdx[idx],
     ...(indexStatus ? { indexStatus } : {}),
@@ -347,6 +348,7 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     ...(imageAnalysis ? { imageAnalysis } : {}),
     ...(audioAnalysis ? { audioAnalysis } : {}),
     ...(videoAnalysis ? { videoAnalysis } : {}),
+    ...(textAnalysis ? { textAnalysis } : {}),
     ...(includeCounts && countsBySpaceId[id] ? { counts: countsBySpaceId[id] } : {}),
   }));
   // Include storage usage summary when quota is configured

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -204,6 +204,7 @@ export interface SpaceConfig {
   imageAnalysis?: ImageLevel;
   audioAnalysis?: AudioLevel;
   videoAnalysis?: VideoLevel;
+  textAnalysis?: TextLevel;
   /** Auto-TTL (F10): when set (> 0), every new/updated record in this space is stamped with an expiry
    *  `now + recordTtlDays` and deleted by the TTL sweep once it lapses (through the normal delete path,
    *  so it tombstones + syncs). A per-record `ttlDays` on a write overrides this. Absent = no auto-TTL. */

--- a/server/src/files/converters/media-level.ts
+++ b/server/src/files/converters/media-level.ts
@@ -13,8 +13,8 @@
  */
 import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
 import {
-  IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS,
-  type ImageLevel, type AudioLevel, type VideoLevel,
+  IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS,
+  type ImageLevel, type AudioLevel, type VideoLevel, type TextLevel,
 } from '../../config/types.js';
 
 /** Ladders low to high. `auto` is deliberately excluded — it resolves, it does not rank. */
@@ -22,6 +22,9 @@ const LADDERS = {
   images: IMAGE_LEVELS.filter(l => l !== 'auto'),
   audio: AUDIO_LEVELS.filter(l => l !== 'auto'),
   video: VIDEO_LEVELS.filter(l => l !== 'auto'),
+  // Text is not a media type, but it is the same policy question — how much of this class do we
+  // process — so it shares the ceiling machinery rather than growing a parallel copy of it.
+  text: TEXT_LEVELS.filter(l => l !== 'auto'),
 } as const;
 
 export type MediaClass = keyof typeof LADDERS;
@@ -54,7 +57,9 @@ function ceilingFor(cls: MediaClass): string {
 function spaceChoiceFor(cls: MediaClass, spaceId: string): string {
   const space = getConfig().spaces.find(s => s.id === spaceId);
   if (!space) return 'auto';
-  const field = ({ images: 'imageAnalysis', audio: 'audioAnalysis', video: 'videoAnalysis' } as const)[cls];
+  const field = ({
+    images: 'imageAnalysis', audio: 'audioAnalysis', video: 'videoAnalysis', text: 'textAnalysis',
+  } as const)[cls];
   return (space as unknown as Record<string, string | undefined>)[field] ?? 'auto';
 }
 
@@ -68,6 +73,21 @@ export function effectiveAudioLevel(spaceId: string): AudioLevel {
 
 export function effectiveVideoLevel(spaceId: string): VideoLevel {
   return capMediaLevel('video', ceilingFor('video'), spaceChoiceFor('video', spaceId)) as VideoLevel;
+}
+
+/**
+ * How text content is indexed for this space, low to high:
+ *
+ *   off    stored, never indexed — nothing in it is findable by search
+ *   embed  one vector for the whole document: cheap, and enough to find the FILE
+ *   chunk  a vector per section: finds the PASSAGE, which is what makes recall quotable
+ *   auto   as much as possible, i.e. chunk
+ *
+ * Applies to converted documents and plain text alike — Documents governs how a file is READ,
+ * this governs what is done with the text that comes out.
+ */
+export function effectiveTextLevel(spaceId: string): TextLevel {
+  return capMediaLevel('text', ceilingFor('text'), spaceChoiceFor('text', spaceId)) as TextLevel;
 }
 
 /**

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -28,7 +28,7 @@ import { col, asFilter, asDoc } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig, getDocumentProcessingConfig } from '../../config/loader.js';
 import { vlmExtractDocument } from './vlm-extract.js';
-import type { FileMetaDoc, AuthorRef, DocExtractionMode } from '../../config/types.js';
+import type { FileMetaDoc, AuthorRef, DocExtractionMode, TextLevel } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { enqueueMediaJob } from '../media/job-queue.js';
 
@@ -136,6 +136,10 @@ export interface ConversionPipelineOptions {
   /** F11-c: per-space document-extraction mode override. When set, it wins over the instance-wide
    *  `documentProcessing.mode`; when absent, the instance default applies. */
   mode?: DocExtractionMode;
+  /** Per-space text level. Governs what happens to the text that comes OUT of conversion, which is a
+   *  separate question from how the document was read: `chunk` splits it into passages, `embed`
+   *  keeps it whole, `off` indexes nothing. Absent = the instance level applies. */
+  textLevel?: TextLevel;
 }
 
 export interface ConversionResult {
@@ -156,6 +160,32 @@ export interface ConversionResult {
 // sidecar — an unbounded input pins CPU/RAM for the duration. Documents over
 // the cap are rejected up front with reason 'too_large' (never retried).
 const DEFAULT_MAX_CONVERSION_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Turn converted text into the units that get embedded, per the space's text level.
+ *
+ *   off    nothing — the file is stored and its content is never findable by search
+ *   embed  ONE unit for the whole document: cheaper, and enough to find the FILE
+ *   chunk  a unit per section/paragraph: finds the PASSAGE, which is what makes a recall quotable
+ *   auto   as much as possible, i.e. chunk
+ *
+ * `embed` is not a degraded `chunk` — it is a real trade. One vector per document costs a fraction
+ * of the storage and index time, and for a space full of short notes it loses almost nothing. It
+ * matters for long documents, where a single averaged vector answers "which file mentions this?" but
+ * can no longer answer "where does it say that?".
+ */
+function chunkForLevel(normalised: string, format: ResolvedFormat, opts: ConversionPipelineOptions): Chunk[] {
+  const level = opts.textLevel ?? 'auto';
+  if (level === 'off') return [];
+  if (level === 'embed') {
+    // Whole document as a single unit. An empty body would produce a vector of nothing, so treat it
+    // as having no content rather than storing an embedding that matches everything weakly.
+    return normalised.trim() ? [{ headingText: null, content: normalised, chunkIndex: 0 }] : [];
+  }
+  return format === 'txt'
+    ? paragraphChunk(normalised, { maxChunkLength: opts.maxParagraphChunkLength })
+    : sectionChunk(normalised, { minBodyLength: opts.minChunkBodyLength });
+}
 
 export async function runConversionPipeline(
   fileBytes: Buffer,
@@ -229,7 +259,7 @@ export async function runConversionPipeline(
         extractionPath = result.extractionPath;
       }
       return {
-        chunks: sectionChunk(normaliseMarkdown(richMarkdown), { minBodyLength: opts.minChunkBodyLength }),
+        chunks: chunkForLevel(normaliseMarkdown(richMarkdown), format, opts),
         convertedMarkdown: richMarkdown,
         extractedImages: images,
         ...(extractionPath ? { extractionPath } : {}),
@@ -238,10 +268,7 @@ export async function runConversionPipeline(
   }
 
   const normalised = normaliseMarkdown(markdown);
-
-  const chunks = format === 'txt'
-    ? paragraphChunk(normalised, { maxChunkLength: opts.maxParagraphChunkLength })
-    : sectionChunk(normalised, { minBodyLength: opts.minChunkBodyLength });
+  const chunks = chunkForLevel(normalised, format, opts);
 
   return { chunks, convertedMarkdown, extractedImages: [] };
 }

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -52,6 +52,7 @@ import {
 import type { ResolvedFormat } from '../converters/pipeline.js';
 import { ConversionUnavailableError } from '../converters/types.js';
 import { effectiveDocExtractionMode } from '../converters/extraction-level.js';
+import { effectiveTextLevel } from '../converters/media-level.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { spaceRoot } from '../sandbox.js';
@@ -325,8 +326,11 @@ async function processJob(
         // F11-c: a per-space extraction-mode override wins over the instance-wide default (pipeline
         // falls back to `documentProcessing.mode` when this is undefined).
         const spaceMode = effectiveDocExtractionMode(spaceId);
+        // Documents governs how the file is READ; text governs what happens to the text that
+        // comes out of it. Two ladders, two decisions, one job.
+        const spaceTextLevel = effectiveTextLevel(spaceId);
         const { chunks, convertedMarkdown, extractedImages } = await runConversionPipeline(
-          fileBytes, filePath, resolvedFmt, { mode: spaceMode },
+          fileBytes, filePath, resolvedFmt, { mode: spaceMode, textLevel: spaceTextLevel },
         );
         if (chunks.length > 0 || extractedImages.length > 0) {
           const { chunkCount, convertedFileId, embedFailures } = await storeConversionResults(

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -6,7 +6,7 @@
  */
 import { getConfig, saveConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
-import type { SpaceConfig, SpaceMeta, DupeActionRule, DocExtractionMode, ImageLevel, AudioLevel, VideoLevel } from '../config/types.js';
+import type { SpaceConfig, SpaceMeta, DupeActionRule, DocExtractionMode, ImageLevel, AudioLevel, VideoLevel, TextLevel } from '../config/types.js';
 import { buildSpaceVectorIndexes } from './vector-index.js';
 import { syncSchemaFiles, META_VERSION_CAP } from './_shared.js';
 
@@ -16,7 +16,7 @@ import { syncSchemaFiles, META_VERSION_CAP } from './_shared.js';
  *  Returns the updated SpaceConfig, or null if the space was not found. */
 export function updateSpace(
   spaceId: string,
-  updates: { label?: string; description?: string; maxGiB?: number | null; meta?: SpaceMeta; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | null; documentExtraction?: DocExtractionMode | null; imageAnalysis?: ImageLevel | null; audioAnalysis?: AudioLevel | null; videoAnalysis?: VideoLevel | null },
+  updates: { label?: string; description?: string; maxGiB?: number | null; meta?: SpaceMeta; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | null; documentExtraction?: DocExtractionMode | null; imageAnalysis?: ImageLevel | null; audioAnalysis?: AudioLevel | null; videoAnalysis?: VideoLevel | null; textAnalysis?: TextLevel | null },
 ): SpaceConfig | null {
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === spaceId);
@@ -49,6 +49,7 @@ export function updateSpace(
   if ('imageAnalysis' in updates) space.imageAnalysis = updates.imageAnalysis ?? undefined;
   if ('audioAnalysis' in updates) space.audioAnalysis = updates.audioAnalysis ?? undefined;
   if ('videoAnalysis' in updates) space.videoAnalysis = updates.videoAnalysis ?? undefined;
+  if ('textAnalysis' in updates) space.textAnalysis = updates.textAnalysis ?? undefined;
 
   if (updates.meta !== undefined) {
     const now = new Date().toISOString();

--- a/testing/integration/text-level.test.js
+++ b/testing/integration/text-level.test.js
@@ -1,0 +1,141 @@
+/**
+ * Per-space text level, end to end.
+ *
+ * Text is the fifth and last of the analysis ladders, and the one that decides what a search can
+ * actually find:
+ *
+ *   off    the file is stored and its content is never indexed — nothing in it is findable
+ *   embed  one vector for the whole document: finds the FILE
+ *   chunk  a vector per section: finds the PASSAGE, which is what makes a recall quotable
+ *   auto   as much as possible, i.e. chunk
+ *
+ * `embed` is a real trade rather than a degraded `chunk`: one vector per document costs a fraction of
+ * the storage and index time, and on short notes it loses almost nothing. It matters on long
+ * documents, where an averaged vector still answers "which file mentions this?" but no longer answers
+ * "where does it say that?".
+ *
+ * Run: node --test testing/integration/text-level.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, patch, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+
+const RUN = Date.now();
+let token;
+
+// Several headed sections, each comfortably past the section chunker's minimum body length —
+// short sections get merged into their neighbours, which would make `chunk` and `embed`
+// indistinguishable and the comparison below meaningless.
+const body = (topic) =>
+  `This section concerns ${topic}. `.repeat(12) +
+  `It exists to give the chunker enough material that ${topic} is kept as its own passage ` +
+  `rather than being folded into an adjacent section for being too short to stand alone.`;
+
+const DOC = [
+  '# Alpha', '', body('alpha'), '',
+  '# Beta', '', body('beta'), '',
+  '# Gamma', '', body('gamma'), '',
+].join('\n');
+
+const b64 = (s) => Buffer.from(s).toString('base64');
+
+async function makeSpace(id, textAnalysis) {
+  const created = await post(INSTANCES.a, token, '/api/spaces', { id, label: id });
+  assert.equal(created.status, 201, JSON.stringify(created.body));
+  if (textAnalysis) {
+    const set = await patch(INSTANCES.a, token, `/api/spaces/${id}`, { textAnalysis });
+    assert.equal(set.status, 200, JSON.stringify(set.body));
+  }
+  return id;
+}
+
+const upload = (space, name, content) =>
+  post(INSTANCES.a, token, `/api/files/${space}?path=${encodeURIComponent(name)}`, {
+    content: b64(content), encoding: 'base64',
+  });
+
+/** Poll until the file leaves `pending`, then report its final state.
+ *  The metadata endpoint returns a LIST (`{ files: [...] }`) even when filtered to one path. */
+async function settle(space, name) {
+  let last;
+  for (let i = 0; i < 60; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    const r = await get(INSTANCES.a, token, `/api/brain/spaces/${space}/files?path=${encodeURIComponent(name)}`);
+    last = (r.body?.files ?? [])[0];
+    const status = last?.embeddingStatus;
+    if (status && status !== 'pending' && status !== 'processing') return last;
+  }
+  throw new Error(`file ${space}/${name} never settled (last seen: ${JSON.stringify(last ?? null)})`);
+}
+
+const created = [];
+
+describe('per-space text level', () => {
+  before(() => { token = fs.readFileSync(TOKEN_FILE, 'utf8').trim(); });
+  after(async () => {
+    for (const id of created) {
+      await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+    }
+  });
+
+  it('the level round-trips, shows on the spaces list, and clears with null', async () => {
+    const id = await makeSpace(`text-rt-${RUN}`, 'embed');
+    created.push(id);
+
+    const list = await get(INSTANCES.a, token, '/api/spaces');
+    const space = (list.body?.spaces ?? []).find(s => s.id === id);
+    assert.equal(space?.textAnalysis, 'embed', 'the level must be visible to the UI');
+
+    const cleared = await patch(INSTANCES.a, token, `/api/spaces/${id}`, { textAnalysis: null });
+    assert.equal(cleared.status, 200, JSON.stringify(cleared.body));
+    assert.equal(cleared.body?.space?.textAnalysis, undefined, 'null clears the override');
+  });
+
+  it('an unknown level is refused', async () => {
+    const id = await makeSpace(`text-bad-${RUN}`);
+    created.push(id);
+    const r = await patch(INSTANCES.a, token, `/api/spaces/${id}`, { textAnalysis: 'summarise' });
+    assert.equal(r.status, 400, `expected a validation error, got ${r.status}`);
+  });
+
+  it('chunk splits the document into several passages', async () => {
+    const id = await makeSpace(`text-chunk-${RUN}`, 'chunk');
+    created.push(id);
+    await upload(id, 'doc.md', DOC);
+    const meta = await settle(id, 'doc.md');
+    assert.ok(meta.chunkCount > 1, `expected several chunks, got ${meta.chunkCount}`);
+  });
+
+  it('embed keeps the document whole — one unit, not zero', async () => {
+    // The distinction that matters: `embed` must still index the file. If it produced no units it
+    // would be indistinguishable from `off`, and a space set to `embed` would silently lose search.
+    const id = await makeSpace(`text-embed-${RUN}`, 'embed');
+    created.push(id);
+    await upload(id, 'doc.md', DOC);
+    const meta = await settle(id, 'doc.md');
+    assert.equal(meta.chunkCount, 1, `expected exactly one unit, got ${meta.chunkCount}`);
+  });
+
+  it('off indexes nothing, and the file still reaches a terminal state', async () => {
+    const id = await makeSpace(`text-off-${RUN}`, 'off');
+    created.push(id);
+    await upload(id, 'doc.md', DOC);
+    const meta = await settle(id, 'doc.md');
+    assert.equal(meta.chunkCount ?? 0, 0, 'nothing may be indexed');
+    assert.notEqual(meta.embeddingStatus, 'pending', 'it must not sit pending forever');
+  });
+
+  it('the file itself is still stored and readable when text is off', async () => {
+    // `off` is about indexing, not storage. Losing the file would be a different feature.
+    const id = `text-off-${RUN}`;
+    const r = await get(INSTANCES.a, token, `/api/files/${id}?path=${encodeURIComponent('doc.md')}`);
+    assert.equal(r.status, 200, 'the file must still be retrievable');
+  });
+});


### PR DESCRIPTION
The **fifth and last** of the analysis classes from your list. `textAnalysis` (`off · embed · chunk · auto`) joins documents, images, audio and video under the same instance ceiling. Behaviour is unchanged until an operator sets one.

It answers a **different question** from `documentExtraction`: that one governs how a file is *read*; this governs what happens to the text that comes out of it.

| level | what it stores | what a search can find |
|---|---|---|
| `off` | nothing | nothing in the file |
| `embed` | one vector for the whole document | the **file** |
| `chunk` | a vector per section | the **passage** — quotable |
| `auto` | as much as possible (chunk) | |

## `embed` is a trade, not a degraded `chunk`

One vector per document costs a fraction of the storage and index time, and on a space full of short notes it loses almost nothing. It matters on long documents, where an averaged vector still answers *"which file mentions this?"* but no longer answers *"where does it say that?"*.

The case the tests pin hardest: **`embed` produces exactly one unit, never zero.** Zero would make it indistinguishable from `off` and silently cost a space its search — a feature switch quietly removing functionality is the failure shape this whole ladder series has been guarding against.

`off` is about what is **findable**, not about deleting anything: the file is still stored, still retrievable, and reaches a terminal state rather than sitting at `pending` forever.

## The test caught its own fixture bug

The first draft used three short sections — which the section chunker **merges into one**, so `chunk` and `embed` both produced a single unit and the comparison proved nothing while passing. The fixture now uses sections past the minimum body length, with a comment explaining why. A fixture that cannot show the difference is not evidence of it.

## Testing

- New `testing/integration/text-level.test.js` (6 tests): round-trip + list visibility + null clear, unknown level refused, `chunk` splits, `embed` is one unit, `off` indexes nothing and still settles, and the file remains retrievable when text is off.
- Standalone **1087 pass**, integration **925 pass**, **0 fail**. `lint:docs` clean; integration guide documents the level and the trade.

That completes all five classes: Documents (#349), Images/Audio/Video (#351), Text (here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)