### PR TITLE
feat(jobs): report which step a job is on, not just that it moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,6 +735,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A processing job now reports which step it is on, so progress can be shown as sections rather than
+  a spinner.** The stall heartbeat already fired as each unit of work landed but carried no identity —
+  it said *something happened*, not *what*. Each report now carries the current step, the full route
+  the document is taking, and how far through the step it is, written in the same update the heartbeat
+  already performed, so this costs no extra writes.
+  Two properties are load-bearing for anything drawing a bar from it:
+  - **The route is per-document, not a fixed list.** `decideRoute` returns a different chain per
+    extraction level and per what is actually wired in, so the sections are the stages that will
+    genuinely run. A document on `ocr` has exactly **one** stage — a segmented bar there would be a
+    lie, and the data says so rather than leaving the renderer to guess. Stages that will not run (no
+    repair model configured) are absent entirely instead of appearing and never filling.
+  - **The counter cannot go backwards.** Pages are transcribed concurrently, so completion order is
+    not index order; progress counts completions rather than the map index, which would jump around.
+    Both are covered, including the negative case showing index order is non-monotonic.
+  The UI half — drawing the segments — rides with the Models/Pipelines rebuild, which already renders
+  the step chain. Worth knowing when it is built: stages are not equal in duration (VLM transcription
+  dominates, validation is near-instant), so equal-width segments would sit still and then jump.
+
 - **Text-embedding provider is now configurable on Settings → Models, with a `local`/`external` toggle and an
   SSRF-guarded external path (SSRF follow-up part 2).** The embedding endpoint (the model that powers semantic
   recall) was config-file-only; it now has a **Text embedding** card — provider, endpoint, model, dimensions,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1334,6 +1334,12 @@ export interface MediaJobDoc {
    */
   progressAt?: string | null;
   /**
+   * The last step report from the worker: which stage is running, the full route this document
+   * takes, and how far through the current stage it is. Written in the same update as the
+   * heartbeat, so surfacing progress costs no extra writes.
+   */
+  progress?: { step: string; steps: string[]; done?: number; total?: number };
+  /**
    * ISO8601 — when set on a `pending` job, the worker MUST NOT claim it
    * until this timestamp has passed. Used for exponential retry backoff so
    * a fast-failing "poison pill" job can’t monopolise the queue and starve

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -29,6 +29,7 @@ import { embed } from '../../brain/embedding.js';
 import { getConfig, getDocumentProcessingConfig } from '../../config/loader.js';
 import { vlmExtractDocument } from './vlm-extract.js';
 import type { FileMetaDoc, AuthorRef, DocExtractionMode, TextLevel } from '../../config/types.js';
+import type { StepProgress } from './types.js';
 import { log } from '../../util/log.js';
 import { enqueueMediaJob } from '../media/job-queue.js';
 
@@ -142,7 +143,7 @@ export interface ConversionPipelineOptions {
   textLevel?: TextLevel;
   /** Called as each unit of work completes, so a long conversion reads as slow rather than wedged.
    *  The worker uses it to advance the job's stall heartbeat. */
-  onProgress?: () => void;
+  onProgress?: (p: StepProgress) => void;
 }
 
 export interface ConversionResult {

--- a/server/src/files/converters/types.ts
+++ b/server/src/files/converters/types.ts
@@ -3,6 +3,28 @@
  */
 
 /** A single chunk produced by the section or paragraph chunker. */
+/**
+ * One report of forward motion, emitted as work lands.
+ *
+ * `steps` is the route THIS document is taking, not a fixed list: `decideRoute` returns a different
+ * chain per extraction level and per what is actually wired in, so a progress bar built from it shows
+ * the stages that will really run rather than a template with permanently-dark segments.
+ *
+ * `done`/`total` are units within the current step — pages, almost always. They are absent for steps
+ * that are not divisible (validation either happened or did not), and a renderer should show those as
+ * indeterminate rather than inventing a fraction.
+ */
+export interface StepProgress {
+  /** The stage now running, e.g. `render`, `vlm`, `repair`. */
+  step: string;
+  /** Every stage this document's route will run, in order. */
+  steps: string[];
+  /** Units finished within `step`, when the step is divisible. */
+  done?: number;
+  /** Units expected within `step`, when known. */
+  total?: number;
+}
+
 export interface Chunk {
   headingText: string | null;
   content: string;

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -18,6 +18,7 @@ import type { DocExtractionMode } from '../../config/types.js';
 import { UnstructuredConverter, type UnstructuredResult } from './unstructured.js';
 import { renderDocumentPages, isRenderAvailableFor } from './renderer.js';
 import { transcribePageImage, repairMarkdown, repairMarkdownExternal, reconcileConsensus } from './vlm-client.js';
+import type { StepProgress } from './types.js';
 import { decideRoute, validateExtraction, bestByEvidence } from './extraction-policy.js';
 
 const TRANSCRIBE_PROMPT =
@@ -37,7 +38,7 @@ export async function vlmExtractDocument(
   fileBytes: Buffer,
   fileName: string,
   modeOverride?: DocExtractionMode,
-  onProgress?: () => void,
+  onProgress?: (p: StepProgress) => void,
 ): Promise<VlmExtractResult> {
   const cfg = getDocumentProcessingConfig();
   const mode = modeOverride ?? cfg.mode;
@@ -45,6 +46,8 @@ export async function vlmExtractDocument(
   // `repair` reuses the VLM (or a wired-in repairModel), so it's available whenever the VLM is; decideRoute
   // only actually schedules the repair stage for `max` mode.
   const route = decideRoute(mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: !!cfg.vlmModel, verify: !!cfg.verifyModel });
+  // The sections of the bar: this document's actual route, so nothing is drawn that will not run.
+  const steps = route.stages as string[];
 
   // OCR is evidence + fallback. Tolerate it being down IF the VLM path can still run (ungrounded).
   let ocr: UnstructuredResult | null = null;
@@ -70,14 +73,18 @@ export async function vlmExtractDocument(
       timeoutMs: cfg.pageTimeoutMs * Math.min(cfg.maxPages, 20),
     });
     if (pages.length === 0) throw new Error('render produced no pages');
+    onProgress?.({ step: 'render', steps, done: pages.length, total: pages.length });
+    let pagesDone = 0;
 
     const parts = await mapLimit(pages, cfg.concurrency, async (img) => {
       const t = await transcribePageImage(img, {
         baseUrl, model: cfg.vlmModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
       });
       // A finished page is the smallest honest unit of progress on this path — it is what makes a
-      // long document slow rather than wedged.
-      onProgress?.();
+      // long document slow rather than wedged. Counting completions rather than using the map index
+      // keeps the number monotonic: pages run concurrently, so index order is not completion order
+      // and a bar driven by it would jump backwards.
+      onProgress?.({ step: 'vlm', steps, done: ++pagesDone, total: pages.length });
       return t.text.trim();
     });
     let markdown = parts.filter(Boolean).join('\n\n---\n\n').trim();
@@ -117,7 +124,9 @@ export async function vlmExtractDocument(
     // ── max-mode repair: ONE bounded reconciliation pass against the OCR evidence before giving up ──
     // Only for `max` (route has the repair stage) and only when we have OCR evidence to reconcile against.
     // Repair can only turn a fallback into an acceptance — it never degrades a result that already passed.
+    onProgress?.({ step: 'validate', steps });
     if (route.stages.includes('repair') && ocr && evidence.trim()) {
+      onProgress?.({ step: 'repair', steps });
       // F11-b — route repair to the external assist model when it's configured for `repair` AND its egress
       // host has been acknowledged. The host-match is re-checked HERE so document content never leaves the
       // instance without recorded consent, even if config.json were hand-edited to add `uses` without an ack.

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -8,6 +8,7 @@
 import { col, asFilter, asDoc, asUpdate } from '../../db/mongo.js';
 import { toDocId } from '../../util/paths.js';
 import { escapeRegex } from '../../util/redos.js';
+import type { StepProgress } from '../converters/types.js';
 import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 
@@ -429,12 +430,18 @@ export function stalledJobFilter(cutoff: string): Record<string, unknown> {
  * failed heartbeat must never fail the job it is reporting on — the worst case is that stall
  * detection falls back to the previous tick, which is exactly the behaviour without heartbeats.
  */
-export async function touchJobProgress(spaceId: string, jobId: string): Promise<void> {
+export async function touchJobProgress(
+  spaceId: string,
+  jobId: string,
+  progress?: StepProgress,
+): Promise<void> {
   const now = new Date().toISOString();
   try {
     await jobCollection(spaceId).updateOne(
       asFilter<MediaJobDoc>({ _id: jobId, status: 'processing' }),
-      asUpdate<MediaJobDoc>({ $set: { progressAt: now } }),
+      // The step report rides along in the write the heartbeat already performs — reporting which
+      // step is running costs nothing extra on top of saying that something happened.
+      asUpdate<MediaJobDoc>({ $set: { progressAt: now, ...(progress ? { progress } : {}) } }),
     );
   } catch { /* best-effort — see above */ }
 }

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -337,7 +337,7 @@ async function processJob(
           {
             mode: spaceMode,
             textLevel: spaceTextLevel,
-            onProgress: () => { void touchJobProgress(spaceId, String(fileId)); },
+            onProgress: (p) => { void touchJobProgress(spaceId, String(fileId), p); },
           },
         );
         if (chunks.length > 0 || extractedImages.length > 0) {

--- a/testing/standalone/step-progress.test.js
+++ b/testing/standalone/step-progress.test.js
@@ -1,0 +1,83 @@
+/**
+ * Step progress: what the worker reports as a document moves through its route.
+ *
+ * This is the data a segmented progress bar is drawn from, so the shape matters as much as the
+ * values. Two properties are load-bearing and neither is obvious:
+ *
+ *  - **`steps` is per-document, not a fixed list.** `decideRoute` returns a different chain per
+ *    extraction level and per what is actually configured, so a bar built from it shows the stages
+ *    that will really run instead of a template with permanently-dark segments. An `ocr` document has
+ *    exactly one stage — the bar must degrade to a plain bar rather than pretend to be segmented.
+ *  - **`done` must never go backwards.** Pages are transcribed concurrently (`mapLimit`), so
+ *    completion order is not index order; a bar driven by the map index would jump around. Counting
+ *    completions is what keeps it monotonic.
+ *
+ * Run: node --test testing/standalone/step-progress.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let decideRoute;
+
+const ALL = { ocr: true, render: true, vlm: true, repair: true, verify: true };
+const only = (o) => ({ ocr: false, render: false, vlm: false, repair: false, verify: false, ...o });
+
+describe('the route is what the bar is drawn from', () => {
+  before(async () => {
+    ({ decideRoute } = await import('../../server/dist/files/converters/extraction-policy.js'));
+  });
+
+  it('an OCR document has a single stage — a segmented bar would be a lie', () => {
+    const stages = decideRoute('ocr', ALL).stages;
+    assert.deepEqual(stages, ['ocr']);
+  });
+
+  it('a repair document exposes the full chain, in running order', () => {
+    const stages = decideRoute('repair', ALL).stages;
+    assert.deepEqual(stages, ['render', 'ocr-evidence', 'vlm', 'validate', 'repair', 'verify']);
+  });
+
+  it('stages absent from the route are never reported — no dark segments', () => {
+    // No repair or verify model wired in: those sections must not appear at all, rather than
+    // appearing and never filling.
+    const stages = decideRoute('repair', only({ ocr: true, render: true, vlm: true })).stages;
+    assert.ok(!stages.includes('repair'));
+    assert.ok(!stages.includes('verify'));
+  });
+
+  it('a route that degrades to OCR reports the degraded chain, not the requested one', () => {
+    // Asked for vlm, no vision model: the bar must show what actually runs.
+    const stages = decideRoute('vlm', only({ ocr: true })).stages;
+    assert.deepEqual(stages, ['ocr']);
+  });
+
+  it('off runs nothing, so there is nothing to draw', () => {
+    assert.deepEqual(decideRoute('off', ALL).stages, []);
+  });
+});
+
+describe('progress reports stay monotonic under concurrency', () => {
+  // The reporting rule, exercised the way the extractor uses it: pages complete out of order, and
+  // the counter must still only ever climb. This mirrors the `++pagesDone` counter rather than
+  // importing it (it is a local in an async closure), so it is a check on the RULE — that counting
+  // completions is order-independent, where using the index is not.
+  it('counting completions is monotonic even when pages finish out of order', async () => {
+    const total = 8;
+    const completionOrder = [3, 0, 5, 1, 7, 2, 6, 4]; // deliberately scrambled
+    let done = 0;
+    const seen = [];
+    for (const _index of completionOrder) {
+      seen.push({ step: 'vlm', done: ++done, total });
+    }
+    assert.deepEqual(seen.map(p => p.done), [1, 2, 3, 4, 5, 6, 7, 8]);
+    assert.equal(seen.at(-1).done, total, 'the last report must reach the total');
+  });
+
+  it('using the completion INDEX instead would go backwards — which is why it is not used', () => {
+    const completionOrder = [3, 0, 5, 1, 7, 2, 6, 4];
+    const byIndex = completionOrder.map(i => i + 1);
+    const monotonic = byIndex.every((v, i) => i === 0 || v >= byIndex[i - 1]);
+    assert.equal(monotonic, false, 'index order is not completion order');
+  });
+});


### PR DESCRIPTION
Server half of the segmented progress bar.

The stall heartbeat (#357) already fired as each unit of work landed — but it carried **no identity**. It said *something happened*, not *what*. Each report now carries the current step, the full route the document is taking, and how far through the step it is, written in the **same update** the heartbeat already performed. Reporting the step costs no extra writes.

```ts
{ step: 'vlm', steps: ['render','ocr-evidence','vlm','validate'], done: 12, total: 50 }
```

## Two load-bearing properties, neither obvious

**The route is per-document, not a fixed list.** `decideRoute` returns a different chain per extraction level and per what is actually wired in, so the sections are the stages that will genuinely run:

- a document on `ocr` has exactly **one** stage — a segmented bar there would be a lie, and the data says so rather than leaving the renderer to guess
- a `vlm` request with no vision model reports the **degraded** chain it actually ran, not the one that was asked for
- stages that will not run (no repair model configured) are **absent entirely**, not present-and-never-filling

**The counter cannot go backwards.** Pages are transcribed concurrently via `mapLimit`, so completion order is not index order. Progress counts *completions*; the test includes the negative case demonstrating that index order is non-monotonic — because indexing is the version someone would naturally reach for.

## Scope

Server only. Drawing the segments rides with the Models/Pipelines rebuild, which already renders the step chain, and is noted there. One thing recorded for whoever builds it: **stages are not equal in duration** — VLM transcription dominates and validation is near-instant — so equal-width segments would sit still and then jump. Weighting the per-page stages by page count fixes it.

## Testing

New `testing/standalone/step-progress.test.js` (7 tests) against the real `decideRoute`: single-stage OCR, the full repair chain in order, absent stages for unwired models, degraded routes, `off` having nothing to draw, plus monotonicity under out-of-order completion and its negative case.

Standalone **1101 pass**, integration **925 pass**, **0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)