### PR TITLE
feat(pipelines): one endpoint that answers "is any of this actually working?"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,6 +735,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`GET /api/admin/pipeline-status` — one read-only answer to "is any of this actually working?"**
+  Every model, sidecar and vector index in the pipeline could previously only be inspected one at a
+  time, and only by asking it to do work. The new endpoint reports all of them in a single payload:
+  sidecar reachability (converter, page renderer, office renderer), the configured model per stage
+  with whether its endpoint both responds *and* lists that model, and the live `$vectorSearch` index
+  state per space and collection.
+  Three properties are deliberate rather than incidental:
+  - **The index state is read from MongoDB, not from `space.indexStatus`.** The stored status is
+    written once when a space is built and never revisited, so an index that later disappears leaves
+    `indexStatus: 'ready'` behind it while recall quietly returns nothing — which is exactly how that
+    failure hid for months. Both values are reported side by side and a `drifted` flag is raised when
+    the claim and the database disagree. It is deliberately one-directional: a stored `building` with
+    a live `ready` is the normal creation race, and flagging it would train an operator to ignore the
+    badge that matters.
+  - **"Not configured", "unreachable" and "reachable but not serving that model" are three separate
+    states**, because they have one symptom (nothing gets extracted) and three different fixes. An
+    optional stage with nothing set reports `unconfigured`, not a fault — a screen that shows red for
+    an unset verify model teaches operators to ignore red.
+  - **One probe per distinct endpoint, not per stage**, cached for 20s and single-flighted. The
+    document VLM, repair and verify stages normally share one Ollama, and that Ollama is the process
+    also transcribing pages; a poll per step per admin would put the status screen's load onto the
+    thing it is reporting on. API keys authenticate the probes and never appear in the response, which
+    a test pins directly.
+  This is the data behind the per-step health dots on the rebuilt Models & Pipelines screen.
+
 - **A processing job now reports which step it is on, so progress can be shown as sections rather than
   a spinner.** The stall heartbeat already fired as each unit of work landed but carried no identity —
   it said *something happened*, not *what*. Each report now carries the current step, the full route

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2074,6 +2074,14 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 
 **Test connection (F11).** `POST /api/admin/media-config/test-connection` (admin + MFA) probes a configured endpoint — `{ "target": "vision" | "stt" | "assist" }` — by listing its models (OpenAI-compatible `/v1/models`, falling back to Ollama `/api/tags`). It performs **no inference and sends no document content**, so it is safe to run before acknowledging egress. External endpoints go through the SSRF-guarded fetch; local (trusted) endpoints use a direct fetch. The response reports `{ reachable, modelPresent?, models, latencyMs, detail? }`. Settings → Models exposes a **Test connection** button per provider card.
 
+**Pipeline status.** `GET /api/admin/pipeline-status` (admin) returns the health of the whole pipeline in one read-only payload — it mutates nothing and sends no document content. It reports three things:
+
+- `sidecars[]` — reachability of the document converter, page renderer and office renderer, each with the env var that owns its URL (`CONVERSION_SIDECAR_URL`, `RENDER_SIDECAR_URL`, `RENDER_OFFICE_SIDECAR_URL`).
+- `models[]` — per stage (`embedding`, `vision`, `stt`, `doc-vlm`, `doc-repair`, `doc-verify`, `assist`): the configured model, the endpoint **host** (never the full URL), and a `state` of `ok` / `degraded` / `down` / `blocked` / `off` / `unconfigured`. `degraded` means the endpoint answered but does not list the configured model, and `unconfigured` means nothing is set — an optional stage left empty is not reported as a fault. API keys authenticate the probes and never appear in the response.
+- `index.spaces[]` — per space, the **live** `$vectorSearch` index state read from MongoDB (`live`) alongside what `config.json` claims (`stored`), plus a `drifted` flag when `stored` says `ready` and the database disagrees. Proxy spaces own no collections and are omitted. A deployment whose MongoDB has no Atlas Search support reports `unknown` rather than `missing`.
+
+Results are cached for 20 seconds and single-flighted, so several admins on **Settings → Models & Pipelines** produce one set of probes rather than one per viewer per step. Stages sharing an endpoint (typically `doc-vlm` / `doc-repair` / `doc-verify` on one Ollama) are probed once.
+
 **Per-space override (F11-c).** The `mode` above is a **ceiling, not a default**: a space may choose anything up to it and nothing beyond it. Set the override from the space's **Settings → Document extraction** picker, or via `PATCH /api/spaces/:id` with `{ "documentExtraction": "off" | "ocr" | "vlm" | "repair" | "auto" }` (send `null` to clear it and follow the instance setting again). Like dupe rules and record-TTL, this is a **local, per-instance** operational setting: it is never governed or synced across a network.
 
 The effective level is `min(instance mode, space override)`, which has three consequences worth stating outright:

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -1,0 +1,360 @@
+/**
+ * Read-only pipeline status — one payload answering "is any of this actually working?".
+ *
+ *   GET /api/admin/pipeline-status
+ *
+ * The Models & Pipelines screen draws a health dot on every pipeline step. Those dots must come from
+ * ONE request: a poll per step would multiply outbound probes by the number of steps on screen, and
+ * the sidecars this probes are the same processes doing the real work.
+ *
+ * What it reports, and why each one is here rather than inferred from config:
+ *
+ *   - **sidecars** — reachability of the conversion / page-render / office-render services. Config can
+ *     only say what URL was configured; it cannot say whether anything is listening on it.
+ *   - **models** — per stage: which model is configured, and whether its endpoint both responds AND
+ *     lists that model. "Configured", "reachable" and "serving that model" are three different
+ *     failures with one symptom (nothing gets extracted), so they are reported separately.
+ *   - **index** — the LIVE `$vectorSearch` index state per space and collection, read from MongoDB
+ *     rather than from `space.indexStatus`. That distinction is the entire point: the stored status is
+ *     written once when a space is built and never revisited, so an index that later vanishes leaves
+ *     `indexStatus: 'ready'` behind it and recall quietly returns nothing. Reading both and reporting
+ *     them side by side turns that divergence into something visible instead of something fatal.
+ *
+ * Nothing here mutates, and nothing here is on a request path a user waits on — so it is cached and
+ * single-flighted rather than fast.
+ */
+
+import { Router } from 'express';
+import { getConfig, getMediaEmbeddingConfig, getEmbeddingConfig, getEmbeddingApiKey, getDocumentProcessingConfig, getDocAssistApiKey, getFaceRecognitionConfig } from '../config/loader.js';
+import { requireAdmin } from '../auth/middleware.js';
+import { globalRateLimit } from '../rate-limit/middleware.js';
+import { isSsrfSafeUrl } from '../util/ssrf.js';
+import { allowPrivateModelEndpoints } from '../config/model-egress-policy.js';
+import { probeModelEndpoint } from './media-config.js';
+import { getDb } from '../db/mongo.js';
+import { VECTOR_INDEXED_COLLECTIONS } from '../spaces/vector-index.js';
+import { log } from '../util/log.js';
+
+export const pipelineStatusRouter = Router();
+
+/** How long a probe result is served before the next request re-probes. */
+const CACHE_TTL_MS = 20_000;
+/** Ceiling on a single sidecar health check. Shorter than the model probe: these are local services. */
+const SIDECAR_TIMEOUT_MS = 3_000;
+
+// ── Shapes ────────────────────────────────────────────────────────────────────
+
+/** Why a thing is not green. Not a boolean, because "never configured" is not a fault. */
+export type HealthState =
+  | 'ok'            // reachable, and the configured model was listed
+  | 'degraded'      // reachable, but the configured model was NOT listed
+  | 'down'          // configured, and did not respond
+  | 'blocked'       // an external endpoint that fails the SSRF policy — never probed
+  | 'off'           // deliberately disabled
+  | 'unconfigured'; // nothing set, so nothing to be wrong
+
+export interface SidecarStatus {
+  key: string;
+  label: string;
+  /** The env var that owns this URL, so the UI can name it on an infra-set card. */
+  envVar: string;
+  url: string;
+  state: HealthState;
+  latencyMs?: number;
+  detail?: string;
+}
+
+export interface ModelStageStatus {
+  key: string;
+  label: string;
+  model: string | null;
+  /** Host only — never the full URL, which may carry a credential in its query. */
+  endpoint: string | null;
+  external: boolean;
+  state: HealthState;
+  latencyMs?: number;
+  detail?: string;
+}
+
+export interface CollectionIndexStatus {
+  collection: string;
+  indexName: string;
+  /** MongoDB's own status string (READY / PENDING / …), or null when the index does not exist. */
+  status: string | null;
+}
+
+export interface SpaceIndexStatus {
+  id: string;
+  label: string;
+  /** What `config.json` believes. Kept beside `live` precisely so the two can disagree visibly. */
+  stored: 'building' | 'ready' | 'failed' | 'unknown';
+  /** From the live listing: 'ready' only when every expected index reports READY. */
+  live: 'ready' | 'building' | 'missing' | 'unknown';
+  collections: CollectionIndexStatus[];
+  /** True when `stored` claims ready and the live listing disagrees — the silent-loss signature. */
+  drifted: boolean;
+}
+
+export interface PipelineStatus {
+  checkedAt: string;
+  sidecars: SidecarStatus[];
+  models: ModelStageStatus[];
+  index: { spaces: SpaceIndexStatus[]; unavailable?: string };
+  faceRecognition: { state: HealthState };
+}
+
+// ── Sidecars ──────────────────────────────────────────────────────────────────
+
+/** The HTTP services the document pipeline calls out to, with the health path each one exposes. */
+const SIDECARS: Array<{ key: string; label: string; envVar: string; fallback: string; healthPath: string }> = [
+  { key: 'unstructured', label: 'Document converter', envVar: 'CONVERSION_SIDECAR_URL', fallback: 'http://localhost:8000', healthPath: '/healthcheck' },
+  { key: 'doc-render', label: 'Page renderer', envVar: 'RENDER_SIDECAR_URL', fallback: 'http://localhost:8100', healthPath: '/health' },
+  { key: 'doc-office', label: 'Office renderer', envVar: 'RENDER_OFFICE_SIDECAR_URL', fallback: 'http://localhost:8101', healthPath: '/health' },
+];
+
+async function probeSidecar(s: (typeof SIDECARS)[number]): Promise<SidecarStatus> {
+  const url = (process.env[s.envVar] ?? s.fallback).replace(/\/$/, '');
+  const base = { key: s.key, label: s.label, envVar: s.envVar, url };
+  const started = Date.now();
+  try {
+    // Plain fetch, deliberately: the SSRF policy governs operator-supplied model endpoints, not
+    // infrastructure the deployment defines for itself. These URLs come from env, not from a user.
+    const res = await fetch(`${url}${s.healthPath}`, { method: 'GET', signal: AbortSignal.timeout(SIDECAR_TIMEOUT_MS) });
+    const latencyMs = Date.now() - started;
+    if (res.ok) return { ...base, state: 'ok', latencyMs };
+    return { ...base, state: 'down', latencyMs, detail: `HTTP ${res.status}` };
+  } catch (err) {
+    return { ...base, state: 'down', latencyMs: Date.now() - started, detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ── Model stages ──────────────────────────────────────────────────────────────
+
+export interface StageSpec {
+  key: string;
+  label: string;
+  model?: string;
+  baseUrl?: string;
+  /** Never appears in the response — it exists only to authenticate the probe. */
+  apiKey?: string;
+  external: boolean;
+}
+
+/** What a probe of one endpoint concluded. `blocked` is a refusal to probe, not a failed probe. */
+export type ProbeOutcome =
+  | { blocked: true }
+  | { reachable: boolean; models?: string[]; detail?: string; latencyMs: number };
+
+/** Every model-backed stage, resolved from config. Stages sharing an endpoint are probed once. */
+function modelStages(): StageSpec[] {
+  const media = getMediaEmbeddingConfig();
+  const emb = getEmbeddingConfig();
+  const doc = getDocumentProcessingConfig();
+  return [
+    // A blank embedding baseUrl means the bundled in-process ONNX model — no endpoint to reach.
+    { key: 'embedding', label: 'Text embedding', model: emb.model, baseUrl: emb.baseUrl ?? undefined, apiKey: getEmbeddingApiKey(), external: emb.provider === 'external' },
+    { key: 'vision', label: 'Vision', model: media.vision?.model, baseUrl: media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: media.visionProvider === 'external' },
+    { key: 'stt', label: 'Speech-to-text', model: media.stt?.model, baseUrl: media.stt?.baseUrl, apiKey: media.stt?.apiKey, external: media.sttProvider === 'external' },
+    // The document stages fall back to the vision endpoint exactly as the pipeline itself does, so the
+    // dot reports the endpoint that would really be called rather than the one nominally configured.
+    { key: 'doc-vlm', label: 'Document VLM', model: doc.vlmModel, baseUrl: doc.vlmBaseUrl || media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: false },
+    { key: 'doc-repair', label: 'Document repair', model: doc.repairModel || doc.vlmModel, baseUrl: doc.repairBaseUrl || doc.vlmBaseUrl || media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: false },
+    { key: 'doc-verify', label: 'Document verify', model: doc.verifyModel, baseUrl: doc.verifyBaseUrl || doc.vlmBaseUrl || media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: false },
+    // The assist model is external by definition — it is the one path that sends content off-instance.
+    { key: 'assist', label: 'Assist model', model: doc.assistModel?.model, baseUrl: doc.assistModel?.baseUrl, apiKey: getDocAssistApiKey(), external: true },
+  ];
+}
+
+/** Host of a URL, or the URL itself when it will not parse. Never the path or query. */
+export function hostOf(url: string | undefined): string | null {
+  if (!url) return null;
+  try { return new URL(url).host; } catch { return url; }
+}
+
+/** The key identifying one endpoint+credential pair. Stages sharing it share a single probe. */
+export function endpointId(s: StageSpec): string {
+  return `${s.baseUrl} ${s.external} ${s.apiKey ?? ''}`;
+}
+
+/**
+ * Group the stages that need probing by DISTINCT endpoint.
+ *
+ * The document VLM, repair and verify stages normally point at the same Ollama, so probing per stage
+ * would triple the load on the very process that is also transcribing pages. Stages with no model or
+ * no endpoint are dropped — there is nothing to ask.
+ */
+export function groupStagesByEndpoint(stages: StageSpec[]): Map<string, StageSpec[]> {
+  const byEndpoint = new Map<string, StageSpec[]>();
+  for (const s of stages) {
+    if (!s.model || !s.baseUrl) continue;
+    const id = endpointId(s);
+    const group = byEndpoint.get(id);
+    if (group) group.push(s); else byEndpoint.set(id, [s]);
+  }
+  return byEndpoint;
+}
+
+/**
+ * Turn one stage plus its endpoint's probe outcome into a reportable status.
+ *
+ * Pure, and deliberately the only place a `HealthState` is chosen. The distinction between "nothing
+ * configured", "configured but unreachable" and "reachable but not serving that model" is the whole
+ * value of the screen, and three symptoms that all look like "extraction produced nothing" collapse
+ * back into one the moment this logic is spread across call sites.
+ *
+ * The result is built field by field rather than by spreading `s`, because `s` carries the API key.
+ * A spread here would leak it into the response, so there is a test pinning exactly that.
+ */
+export function classifyStage(s: StageSpec, res: ProbeOutcome | undefined): ModelStageStatus {
+  const base = { key: s.key, label: s.label, model: s.model || null, endpoint: hostOf(s.baseUrl), external: s.external };
+  if (!s.model) return { ...base, state: 'unconfigured' };
+  // No endpoint + a model name = the bundled in-process model. There is nothing to reach, and
+  // reporting it as `down` would put a red dot on the one component that cannot fail that way.
+  if (!s.baseUrl) return { ...base, state: 'ok', detail: 'in-process' };
+  if (!res) return { ...base, state: 'unconfigured' };
+  if ('blocked' in res) return { ...base, state: 'blocked', detail: 'endpoint is not a public http(s) URL (SSRF-blocked)' };
+  if (!res.reachable) return { ...base, state: 'down', latencyMs: res.latencyMs, detail: res.detail };
+
+  // The endpoint answered — but does it serve the model this stage names? Ollama tags carry a `:tag`
+  // suffix, so an exact match or a `<model>:` prefix both count. An endpoint that lists nothing is not
+  // evidence either way, so it stays `ok` rather than being accused of a missing model.
+  const models = res.models ?? [];
+  const present = models.length === 0 ? undefined : models.some(m => m === s.model || m.startsWith(`${s.model}:`));
+  if (present === false) return { ...base, state: 'degraded', latencyMs: res.latencyMs, detail: `endpoint is up but does not list "${s.model}"` };
+  return { ...base, state: 'ok', latencyMs: res.latencyMs };
+}
+
+async function probeModelStages(): Promise<ModelStageStatus[]> {
+  const stages = modelStages();
+  const byEndpoint = groupStagesByEndpoint(stages);
+
+  const results = new Map<string, ProbeOutcome>();
+  await Promise.all([...byEndpoint.entries()].map(async ([id, group]) => {
+    const { baseUrl, external, apiKey } = group[0];
+    if (external && !isSsrfSafeUrl(baseUrl!, allowPrivateModelEndpoints())) {
+      results.set(id, { blocked: true });
+      return;
+    }
+    // No `model` is passed: one probe serves several stages, so the per-stage match happens in
+    // classifyStage against the returned list.
+    const res = await probeModelEndpoint({ baseUrl: baseUrl!, apiKey, external })
+      .catch(err => ({ reachable: false, detail: err instanceof Error ? err.message : String(err), latencyMs: 0 }));
+    results.set(id, res);
+  }));
+
+  return stages.map(s => classifyStage(s, results.get(endpointId(s))));
+}
+
+// ── Vector index ──────────────────────────────────────────────────────────────
+
+/**
+ * Collapse a space's per-collection listing into one live state.
+ *
+ * `unknown` outranks everything: a deployment whose MongoDB has no Atlas Search support throws on
+ * every listing, and calling that `missing` would paint every space red on an instance where nothing
+ * is wrong. Absence of evidence is reported as absence of evidence.
+ */
+export function deriveLiveIndexState(collections: CollectionIndexStatus[], listingFailed: boolean): SpaceIndexStatus['live'] {
+  if (listingFailed) return 'unknown';
+  if (collections.some(c => c.status === null)) return 'missing';
+  return collections.every(c => c.status === 'READY') ? 'ready' : 'building';
+}
+
+/**
+ * The silent-loss signature: config says the space is ready, the database says otherwise.
+ *
+ * Only flagged in that direction. `stored: 'building'` with a live `ready` is the normal race right
+ * after a space is created — the background finalizer simply has not written its result yet — and
+ * flagging it would train the operator to ignore the badge that matters.
+ */
+export function isDrifted(stored: SpaceIndexStatus['stored'], live: SpaceIndexStatus['live']): boolean {
+  return stored === 'ready' && (live === 'missing' || live === 'building');
+}
+
+async function indexStatus(): Promise<{ spaces: SpaceIndexStatus[]; unavailable?: string }> {
+  let spaces;
+  try { spaces = getConfig().spaces; } catch { return { spaces: [], unavailable: 'configuration is not loaded' }; }
+
+  const faceEnabled = getFaceRecognitionConfig().enabled;
+  const db = (() => { try { return getDb(); } catch { return null; } })();
+  if (!db) return { spaces: [], unavailable: 'database is not connected' };
+
+  const out = await Promise.all(spaces
+    // Proxy spaces aggregate other spaces' reads and own no collections, so they have no indexes to
+    // be missing. Listing them would pin a permanent red dot on a space that is working correctly.
+    .filter(s => !s.proxyFor)
+    .map(async (space): Promise<SpaceIndexStatus> => {
+      const expected: Array<{ collection: string; indexName: string }> = VECTOR_INDEXED_COLLECTIONS.map(suffix => ({
+        collection: suffix, indexName: `${space.id}_${suffix}_embedding`,
+      }));
+      if (faceEnabled) expected.push({ collection: 'files', indexName: `${space.id}_files_faceEmbedding` });
+
+      const collections: CollectionIndexStatus[] = [];
+      let listingFailed = false;
+      await Promise.all(expected.map(async e => {
+        try {
+          const found = await db.collection(`${space.id}_${e.collection}`).listSearchIndexes(e.indexName).toArray() as Array<{ status?: string }>;
+          collections.push({ ...e, status: found[0]?.status ?? null });
+        } catch (err) {
+          listingFailed = true;
+          log.debug(`pipeline-status: could not list search indexes for ${space.id}_${e.collection}: ${err instanceof Error ? err.message : String(err)}`);
+          collections.push({ ...e, status: null });
+        }
+      }));
+
+      const stored = space.indexStatus ?? 'unknown';
+      const live = deriveLiveIndexState(collections, listingFailed);
+      return { id: space.id, label: space.label, stored, live, collections, drifted: isDrifted(stored, live) };
+    }));
+
+  return { spaces: out };
+}
+
+// ── Assembly, cached and single-flighted ──────────────────────────────────────
+
+let cached: { at: number; value: PipelineStatus } | null = null;
+let inFlight: Promise<PipelineStatus> | null = null;
+
+async function collect(): Promise<PipelineStatus> {
+  const face = getFaceRecognitionConfig();
+  const [sidecars, models, index] = await Promise.all([
+    Promise.all(SIDECARS.map(probeSidecar)),
+    probeModelStages(),
+    indexStatus(),
+  ]);
+  return {
+    checkedAt: new Date().toISOString(),
+    sidecars,
+    models,
+    index,
+    // Face recognition runs in-process (BlazeFace + FaceRes), so there is no endpoint to probe —
+    // enabled or not is the whole of its health.
+    faceRecognition: { state: face.enabled ? 'ok' : 'off' },
+  };
+}
+
+/** Cached + single-flighted: several admins on this screen must not multiply the outbound probes. */
+export async function getPipelineStatus(): Promise<PipelineStatus> {
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.value;
+  if (inFlight) return inFlight;
+  inFlight = collect()
+    .then(value => { cached = { at: Date.now(), value }; return value; })
+    .finally(() => { inFlight = null; });
+  return inFlight;
+}
+
+/** Test seam — drops the cache so a test never observes a previous test's probes. */
+export function resetPipelineStatusCache(): void { cached = null; inFlight = null; }
+
+pipelineStatusRouter.use(globalRateLimit);
+
+// requireAdmin, not requireAdminMfa: this reads status and mutates nothing. It does disclose which
+// models and hosts are configured, which is admin-only information — so not anonymous either.
+pipelineStatusRouter.get('/', requireAdmin, async (_req, res) => {
+  try {
+    res.json(await getPipelineStatus());
+  } catch (err) {
+    log.warn(`pipeline-status failed: ${err instanceof Error ? err.message : String(err)}`);
+    res.status(500).json({ error: 'Failed to collect pipeline status' });
+  }
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -30,6 +30,7 @@ import { schemaLibraryRouter } from './api/schema-library.js';
 import { localAgentRouter } from './api/local-agent.js';
 import { dataRouter } from './api/data.js';
 import { mediaConfigRouter } from './api/media-config.js';
+import { pipelineStatusRouter } from './api/pipeline-status.js';
 import { maintenanceMiddleware } from './maintenance.js';
 import { globalRateLimit, ipFloodBackstop } from './rate-limit/middleware.js';
 import { configExists, reloadConfig, getConfig, saveConfig, loadSecrets, startConfigWatcher } from './config/loader.js';
@@ -261,6 +262,7 @@ export function createApp() {
   app.use('/api/admin/local-agent', localAgentRouter);
   app.use('/api/admin/data', dataRouter);
   app.use('/api/admin/media-config', mediaConfigRouter);
+  app.use('/api/admin/pipeline-status', pipelineStatusRouter);
   app.use('/api/schema-library', schemaLibraryRouter);
 
   // ── Admin: space wipe ─────────────────────────────────────────────────────

--- a/testing/standalone/pipeline-status.test.js
+++ b/testing/standalone/pipeline-status.test.js
@@ -1,0 +1,200 @@
+/**
+ * Pipeline status — the decision logic behind the health dots.
+ *
+ * These test the PRODUCTION functions from `server/dist/api/pipeline-status.js`, not a copy of them.
+ * The probing itself is I/O and is not re-implemented here; what is pinned is every judgement the
+ * endpoint makes about what a probe result MEANS, because that is where a status screen goes wrong in
+ * the way that matters — by reporting green.
+ *
+ * Two of these exist because of specific ways this feature could quietly become useless:
+ *
+ *   - the drift check, which is the only thing that would have surfaced a vector index disappearing
+ *     while `config.json` still said `ready`;
+ *   - the API-key round-trip, because every field on a stage is available to the function that builds
+ *     the response and exactly one of them must never reach it.
+ *
+ * Run: node --test testing/standalone/pipeline-status.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  classifyStage, groupStagesByEndpoint, endpointId, hostOf,
+  deriveLiveIndexState, isDrifted,
+} = await import('../../server/dist/api/pipeline-status.js');
+
+const stage = (over = {}) => ({ key: 'vision', label: 'Vision', model: 'moondream', baseUrl: 'http://ollama:11434', external: false, ...over });
+const up = (models, over = {}) => ({ reachable: true, models, latencyMs: 12, ...over });
+
+describe('classifyStage — the three failures that all look like "nothing was extracted"', () => {
+  it('reachable and serving the model is the only ok', () => {
+    const r = classifyStage(stage(), up(['moondream:latest']));
+    assert.equal(r.state, 'ok');
+    assert.equal(r.latencyMs, 12);
+  });
+
+  it('reachable but NOT serving the model is degraded, not ok and not down', () => {
+    // The operator typed a model name the endpoint has never heard of. The endpoint is fine; the
+    // extraction will still produce nothing. Reporting this as `down` would send them to check the
+    // wrong thing entirely.
+    const r = classifyStage(stage(), up(['llava:7b', 'qwen2.5:3b']));
+    assert.equal(r.state, 'degraded');
+    assert.match(r.detail, /does not list "moondream"/);
+  });
+
+  it('configured but unreachable is down, and carries the reason', () => {
+    const r = classifyStage(stage(), { reachable: false, detail: 'connect ECONNREFUSED', latencyMs: 5 });
+    assert.equal(r.state, 'down');
+    assert.equal(r.detail, 'connect ECONNREFUSED');
+  });
+
+  it('no model configured is `unconfigured` — an empty slot is not a fault', () => {
+    // This is the distinction that stops the screen crying wolf. A verify model is optional; showing
+    // it red on every instance that has not set one trains the operator to ignore red.
+    assert.equal(classifyStage(stage({ model: '' }), undefined).state, 'unconfigured');
+    assert.equal(classifyStage(stage({ model: undefined }), undefined).state, 'unconfigured');
+  });
+
+  it('a model with no endpoint is the bundled in-process one, which cannot be unreachable', () => {
+    const r = classifyStage(stage({ key: 'embedding', model: 'nomic-embed-text', baseUrl: undefined }), undefined);
+    assert.equal(r.state, 'ok');
+    assert.equal(r.detail, 'in-process');
+  });
+
+  it('an SSRF-blocked external endpoint is `blocked` — it was refused, not tried', () => {
+    const r = classifyStage(stage({ external: true, baseUrl: 'http://169.254.169.254' }), { blocked: true });
+    assert.equal(r.state, 'blocked');
+    assert.match(r.detail, /SSRF/);
+  });
+
+  it('an endpoint that lists no models at all is not accused of missing one', () => {
+    // Some OpenAI-compatible servers answer /v1/models with an empty list. That is not evidence the
+    // model is absent, and treating it as such would show `degraded` on a working instance.
+    assert.equal(classifyStage(stage(), up([])).state, 'ok');
+  });
+
+  it('matches an Ollama `:tag` suffix as well as an exact name', () => {
+    assert.equal(classifyStage(stage({ model: 'moondream' }), up(['moondream:v2'])).state, 'ok');
+    assert.equal(classifyStage(stage({ model: 'moondream' }), up(['moondream'])).state, 'ok');
+    // ...but not a different model that merely starts with the same letters.
+    assert.equal(classifyStage(stage({ model: 'llama' }), up(['llama-guard'])).state, 'degraded');
+  });
+});
+
+describe('classifyStage — what must never reach the response', () => {
+  it('the API key does not survive into the status payload', () => {
+    // Every field of the stage is in scope where the response object is built. One spread of `s`
+    // instead of the explicit fields would publish the key to any admin loading the page, and nothing
+    // else in the system would notice.
+    const secret = 'sk-live-DO-NOT-LEAK-9f3a';
+    for (const res of [up(['moondream']), { reachable: false, detail: 'x', latencyMs: 1 }, { blocked: true }, undefined]) {
+      const out = classifyStage(stage({ apiKey: secret, external: true }), res);
+      assert.ok(!JSON.stringify(out).includes(secret), `key leaked with probe result ${JSON.stringify(res)}`);
+      assert.equal(out.apiKey, undefined);
+    }
+  });
+
+  it('reports the endpoint HOST only, never a URL that could carry a credential in its query', () => {
+    const out = classifyStage(stage({ baseUrl: 'https://api.example.com/v1?access_token=leaked' }), up(['moondream']));
+    assert.equal(out.endpoint, 'api.example.com');
+    assert.ok(!JSON.stringify(out).includes('leaked'));
+  });
+
+  it('hostOf returns the input unchanged when it will not parse, rather than throwing', () => {
+    assert.equal(hostOf('not a url'), 'not a url');
+    assert.equal(hostOf(undefined), null);
+  });
+});
+
+describe('groupStagesByEndpoint — one probe per endpoint, not per stage', () => {
+  it('collapses the document stages that share an Ollama into a single probe', () => {
+    // vlm / repair / verify normally all resolve to the same endpoint. Probing per stage would put
+    // three times the load on the process that is also transcribing pages.
+    const stages = [
+      stage({ key: 'doc-vlm', model: 'a' }),
+      stage({ key: 'doc-repair', model: 'b' }),
+      stage({ key: 'doc-verify', model: 'c' }),
+    ];
+    const groups = groupStagesByEndpoint(stages);
+    assert.equal(groups.size, 1);
+    assert.deepEqual([...groups.values()][0].map(s => s.key), ['doc-vlm', 'doc-repair', 'doc-verify']);
+  });
+
+  it('keeps distinct endpoints, and distinct credentials for one endpoint, apart', () => {
+    const groups = groupStagesByEndpoint([
+      stage({ key: 'a', baseUrl: 'http://one:1' }),
+      stage({ key: 'b', baseUrl: 'http://two:2' }),
+      stage({ key: 'c', baseUrl: 'http://one:1', apiKey: 'k' }),
+    ]);
+    assert.equal(groups.size, 3);
+  });
+
+  it('drops stages with nothing to ask — no model or no endpoint', () => {
+    const groups = groupStagesByEndpoint([
+      stage({ key: 'nomodel', model: '' }),
+      stage({ key: 'inprocess', baseUrl: undefined }),
+      stage({ key: 'real' }),
+    ]);
+    assert.equal(groups.size, 1);
+    assert.deepEqual([...groups.values()][0].map(s => s.key), ['real']);
+  });
+
+  it('the grouping key is the same one classifyStage looks results up by', () => {
+    // If these two ever diverge, every stage silently reports `unconfigured` — the probes would run
+    // and their results would simply never be found again.
+    const s = stage({ apiKey: 'k', external: true });
+    const groups = groupStagesByEndpoint([s]);
+    assert.ok(groups.has(endpointId(s)));
+  });
+});
+
+describe('deriveLiveIndexState — what the database actually says', () => {
+  const coll = (status) => ({ collection: 'memories', indexName: 'x', status });
+
+  it('every index READY is ready', () => {
+    assert.equal(deriveLiveIndexState([coll('READY'), coll('READY')], false), 'ready');
+  });
+
+  it('a missing index outranks a building one — absent is worse than not-yet', () => {
+    assert.equal(deriveLiveIndexState([coll('READY'), coll(null)], false), 'missing');
+    assert.equal(deriveLiveIndexState([coll('PENDING'), coll(null)], false), 'missing');
+  });
+
+  it('present but not READY is building', () => {
+    assert.equal(deriveLiveIndexState([coll('READY'), coll('PENDING')], false), 'building');
+  });
+
+  it('a failed listing is `unknown`, never `missing`', () => {
+    // A MongoDB without Atlas Search support throws on every listing. Reporting that as `missing`
+    // would paint every space on the instance red when nothing is wrong with any of them.
+    assert.equal(deriveLiveIndexState([coll(null), coll(null)], true), 'unknown');
+    assert.equal(deriveLiveIndexState([coll('READY')], true), 'unknown');
+  });
+});
+
+describe('isDrifted — the silent index loss this endpoint exists to catch', () => {
+  it('stored ready + live missing is drift', () => {
+    // This is the exact shape of the failure that hid behind an empty result set for months:
+    // config.json says the space is ready, the index is gone, and recall returns nothing forever.
+    assert.equal(isDrifted('ready', 'missing'), true);
+  });
+
+  it('stored ready + live building is also drift — ready is a claim that stopped being true', () => {
+    assert.equal(isDrifted('ready', 'building'), true);
+  });
+
+  it('stored building + live ready is NOT drift — that is the normal creation race', () => {
+    // The background finalizer writes `ready` after polling. Flagging the gap would put a warning on
+    // every freshly created space and teach the operator to ignore the badge that matters.
+    assert.equal(isDrifted('building', 'ready'), false);
+  });
+
+  it('never claims drift from an unknown live state', () => {
+    assert.equal(isDrifted('ready', 'unknown'), false);
+  });
+
+  it('a stored `failed` is not drift — it is already reported honestly', () => {
+    assert.equal(isDrifted('failed', 'missing'), false);
+  });
+});


### PR DESCRIPTION
Groundwork for must-ship #1 (the Models · Pipelines · Tools rebuild): the read-only status endpoint the per-step health dots draw from.

Every model, sidecar and vector index in the pipeline could previously only be inspected one at a time, and only by asking it to do work. `GET /api/admin/pipeline-status` reports all of them in one payload.

## Three properties that are deliberate, not incidental

**The index state is read from MongoDB, not from `space.indexStatus`.** The stored status is written once when a space is built and never revisited — so an index that later disappears leaves `indexStatus: 'ready'` behind it while recall quietly returns nothing. That is exactly the failure that hid for months behind an empty result set. Both values are reported side by side, and `drifted` is raised when the claim and the database disagree.

It is one-directional on purpose: a stored `building` with a live `ready` is the normal creation race (the background finalizer just hasn't written yet), and flagging it would train an operator to ignore the badge that matters.

**"Not configured", "unreachable" and "reachable but not serving that model" are three separate states.** They share one symptom — nothing gets extracted — and have three different fixes. An optional stage left empty reports `unconfigured`, not a fault; a screen showing red for an unset verify model teaches operators to ignore red.

**One probe per distinct endpoint, not per stage**, cached 20s and single-flighted. `doc-vlm`/`doc-repair`/`doc-verify` normally share one Ollama, and that Ollama is the process also transcribing pages — a poll per step per admin would put the status screen's load onto the thing it is reporting on.

## Security

- API keys authenticate the probes and never appear in the response — pinned by a test that runs a known secret through every branch of `classifyStage`.
- Endpoints are reported as **host only**, never a full URL that could carry a credential in its query.
- External endpoints stay under the existing `allowPrivateModelEndpoints` SSRF policy; a blocked one reports `blocked` (refused) rather than `down` (tried and failed).
- `requireAdmin`, not `requireAdminMfa` — it mutates nothing, but it does disclose configured models and hosts, so it is not anonymous either.
- Read-only GET, so no `audit-route-coverage` entry is required; that gate was run and passes.

## Testing

24 standalone cases against the **production** functions, not a copy — the decision logic is extracted pure so the probing I/O does not need mocking.

Mutation-verified, each caught exactly its intended assertions and nothing else:
- spreading the stage into the response → the key-leak test fails
- neutering `isDrifted` → exactly the two drift assertions fail
- dropping the `unknown` guard → the test keeping a search-less MongoDB from painting every space red fails

Full standalone suite: 1128 pass, 0 fail. Docs lint clean.

## Next

PR after this draws the three approved tabs on top of this payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)