### PR TITLE
feat(pipelines): the four instance ceilings are editable — and merge per class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2063,6 +2063,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The four instance ceilings are editable now — Images, Audio, Video and Text.** #356 gave each
+  media class a real ladder and the resolution rule; the Pipelines tab drew all four, read-only,
+  because `PATCH /api/admin/media-config` had no `levels` schema. It does now, built from the same
+  `*_LEVELS` constants the resolver uses so the API and the ladder cannot drift apart, with a picker
+  per class on **Settings → Models → Pipelines**. Audio and video share a card but get separate
+  controls, because they have separate ladders.
+  - **Each class merges independently**, and that is the load-bearing part. An absent class reads
+    back as `auto`, so the obvious whole-object replace would have silently *raised* the ceiling on
+    every class a request did not mention — a capability grant nobody asked for, on the one setting
+    whose entire job is to withhold capability, with nothing reporting it. A unit test pins it and
+    the mutation was checked: the naive replace fails exactly the three intended assertions.
+  - **`video: "full"` is rejected** with `400` here as well as on `PATCH /api/spaces/:id`. The rung
+    stays visible-but-disabled so the ladder reads complete, but accepting it as a ceiling would let
+    every `auto` space resolve to a level that does nothing.
+  - The consequences are stated **at the control** rather than in a doc: the hint says a space may
+    choose less but never more, and that lowering a ceiling caps spaces already above it while
+    leaving their stored choice intact. Choosing `off` adds a line saying it applies everywhere —
+    `off` is a floor as well as a ceiling, and that is easy to miss next to three controls that only
+    affect thoroughness.
+
 - **Settings → Models is three tabs now — Models · Pipelines · Tools.** The page was 656 lines with six
   cards in the order they were added rather than any order a reader would choose. The layout complaint
   was mostly a missing component: four provider cards written inline in one file each invented their

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1323,7 +1323,6 @@
   "models.pipelines.textPurpose": "Was mit dem Text passiert, der aus allen anderen Pipelines herauskommt.",
   "models.pipelines.extractionMode": "Extraktionsmodus",
   "models.pipelines.ceiling": "Obergrenze der Instanz",
-  "models.pipelines.ceilingReadOnly": "Das Maximum, das ein Bereich nutzen darf. Wird in der Konfiguration gesetzt, nicht hier.",
   "models.pipelines.statusUnavailable": "Der Live-Status konnte nicht gelesen werden, deshalb sind die Statusanzeigen unbekannt statt aus: {{detail}}",
   "models.step.ocr": "OCR",
   "models.step.render": "Rendern",
@@ -1408,5 +1407,11 @@
   "models.confirm.discardTitle": "Ungespeicherte Änderungen verwerfen?",
   "models.confirm.discardMessage": "Auf diesem Tab gibt es ungespeicherte Änderungen. Ein Tab-Wechsel verwirft sie.",
   "models.confirm.discardConfirm": "Verwerfen",
-  "models.confirm.discardCancel": "Hier bleiben"
+  "models.confirm.discardCancel": "Hier bleiben",
+  "models.class.images": "Bilder",
+  "models.class.audio": "Audio",
+  "models.class.video": "Video",
+  "models.class.text": "Text",
+  "models.pipelines.ceilingHint": "Das Maximum, das ein Bereich mit dieser Klasse tun darf. Ein Bereich kann weniger wählen, nie mehr — wenn Sie das hier senken, werden alle Bereiche darüber gekappt, und sie behalten ihre eigene Wahl, falls Sie es wieder anheben.",
+  "models.pipelines.ceilingOffWarning": "Aus gilt überall — kein Bereich kann diese Klasse verarbeiten."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1323,7 +1323,6 @@
   "models.pipelines.textPurpose": "What happens to the text that comes out of every other pipeline.",
   "models.pipelines.extractionMode": "Extraction mode",
   "models.pipelines.ceiling": "Instance ceiling",
-  "models.pipelines.ceilingReadOnly": "The most any space may do. Set in configuration, not here.",
   "models.pipelines.statusUnavailable": "Could not read live status, so the health indicators are unknown rather than off: {{detail}}",
   "models.step.ocr": "OCR",
   "models.step.render": "Render",
@@ -1408,5 +1407,11 @@
   "models.confirm.discardTitle": "Discard unsaved changes?",
   "models.confirm.discardMessage": "You have unsaved changes on this tab. Switching tabs discards them.",
   "models.confirm.discardConfirm": "Discard",
-  "models.confirm.discardCancel": "Stay here"
+  "models.confirm.discardCancel": "Stay here",
+  "models.class.images": "Images",
+  "models.class.audio": "Audio",
+  "models.class.video": "Video",
+  "models.class.text": "Text",
+  "models.pipelines.ceilingHint": "The most any space may do with this class. A space can choose less, never more — lowering this caps every space already above it, and those spaces keep their own choice if you raise it again.",
+  "models.pipelines.ceilingOffWarning": "Off applies everywhere — no space can process this class."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1323,7 +1323,6 @@
   "models.pipelines.textPurpose": "Co dzieje się z tekstem, który wychodzi z każdego innego potoku.",
   "models.pipelines.extractionMode": "Tryb ekstrakcji",
   "models.pipelines.ceiling": "Limit instancji",
-  "models.pipelines.ceilingReadOnly": "Najwięcej, na co może pozwolić sobie przestrzeń. Ustawiane w konfiguracji, nie tutaj.",
   "models.pipelines.statusUnavailable": "Nie udało się odczytać statusu na żywo, więc wskaźniki są nieznane, a nie wyłączone: {{detail}}",
   "models.step.ocr": "OCR",
   "models.step.render": "Renderowanie",
@@ -1408,5 +1407,11 @@
   "models.confirm.discardTitle": "Odrzucić niezapisane zmiany?",
   "models.confirm.discardMessage": "Na tej karcie są niezapisane zmiany. Przełączenie karty je odrzuci.",
   "models.confirm.discardConfirm": "Odrzuć",
-  "models.confirm.discardCancel": "Zostań tutaj"
+  "models.confirm.discardCancel": "Zostań tutaj",
+  "models.class.images": "Obrazy",
+  "models.class.audio": "Audio",
+  "models.class.video": "Wideo",
+  "models.class.text": "Tekst",
+  "models.pipelines.ceilingHint": "Najwięcej, co przestrzeń może zrobić z tą klasą. Przestrzeń może wybrać mniej, nigdy więcej — obniżenie tego limitu ogranicza każdą przestrzeń powyżej, a te zachowują swój wybór, jeśli limit znów podniesiesz.",
+  "models.pipelines.ceilingOffWarning": "Wyłączenie obowiązuje wszędzie — żadna przestrzeń nie przetworzy tej klasy."
 }

--- a/client/src/app/pages/settings/models/models-state.service.spec.ts
+++ b/client/src/app/pages/settings/models/models-state.service.spec.ts
@@ -183,6 +183,23 @@ describe('ModelsStateService — save payload', () => {
     expect(sent(patch)['documentProcessing']).not.toHaveProperty('assistModel');
   });
 
+  // Instance ceilings became editable here. The rule that matters is that ALL FOUR classes are sent,
+  // every time: the server merges per class, but a client that sent only the class it changed would
+  // still be correct only by accident — and the loader reads an absent class as `auto`, so any path
+  // that drops one raises that ceiling to the top rung with nothing reporting it.
+  it('sends every media-class ceiling, not just the one that changed', async () => {
+    const { c, patch } = make(cfgFixture({ levels: { images: 'caption', audio: 'off', video: 'audio', text: 'embed' } }));
+    await c.save();
+    expect(sent(patch)['levels']).toEqual({ images: 'caption', audio: 'off', video: 'audio', text: 'embed' });
+  });
+
+  it('carries an edited ceiling through to the payload without disturbing the others', async () => {
+    const { c, patch } = make(cfgFixture({ levels: { images: 'recognition', audio: 'on', video: 'audio', text: 'chunk' } }));
+    c.form.levels = { ...c.form.levels, images: 'off' };
+    await c.save();
+    expect(sent(patch)['levels']).toEqual({ images: 'off', audio: 'on', video: 'audio', text: 'chunk' });
+  });
+
   it('clears the typed key inputs after a successful save so a re-save cannot resend them', async () => {
     const { c } = make();
     c.visionApiKeyInput = 'sk-1';

--- a/client/src/app/pages/settings/models/models-state.service.ts
+++ b/client/src/app/pages/settings/models/models-state.service.ts
@@ -203,8 +203,12 @@ export class ModelsStateService {
    */
   private payload(): MediaCfg {
     const dp = this.form.documentProcessing ?? {};
+    const levels = this.form.levels ?? {};
     return {
       enabled: this.form.enabled,
+      // Instance ceilings, sent per class. The server merges class by class for the same reason this
+      // sends all four: a partial block would let the classes it omits default back up to `auto`.
+      levels: { images: levels.images, audio: levels.audio, video: levels.video, text: levels.text },
       visionProvider: this.form.visionProvider,
       sttProvider: this.form.sttProvider,
       vision: { baseUrl: this.form.vision?.baseUrl, model: this.form.vision?.model },

--- a/client/src/app/pages/settings/models/models.types.ts
+++ b/client/src/app/pages/settings/models/models.types.ts
@@ -54,6 +54,21 @@ export interface MediaLevelCeilings {
   images?: string; audio?: string; video?: string; text?: string;
 }
 
+/** The four classes that have their own ladder. Documents has its own control (`documentProcessing.mode`). */
+export type MediaClass = 'images' | 'audio' | 'video' | 'text';
+
+/**
+ * The ladders, low → high, mirroring `server/src/config/types.ts`.
+ *
+ * `auto` is listed FIRST in each because it is the default and means "as much as is possible" — it
+ * does not rank, so putting it at the top of a list ordered by capability would be a lie about where
+ * it sits. The server validates against its own copy; these only drive the pickers.
+ */
+export const IMAGE_LEVELS = ['auto', 'off', 'caption', 'recognition'] as const;
+export const AUDIO_LEVELS = ['auto', 'off', 'on'] as const;
+export const VIDEO_LEVELS = ['auto', 'off', 'audio', 'full'] as const;
+export const TEXT_LEVELS = ['auto', 'off', 'embed', 'chunk'] as const;
+
 export interface MediaCfg {
   enabled?: boolean;
   levels?: MediaLevelCeilings;

--- a/client/src/app/pages/settings/models/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/models/pipelines-tab.component.ts
@@ -13,10 +13,9 @@
  *     is how an operator concludes a stage ran when it never could.
  *   - **The actor names the model, never the state — the dot is the state.** Writing "off" where a
  *     model name belongs conflates what a step *is* with whether it is *working*.
- *   - **The ceilings for Images/Audio/Video/Text are read-only** and name the config key that owns
- *     them. `PATCH /api/admin/media-config` has no schema for `levels`, so a picker here would be a
- *     control that silently does nothing — the exact dishonesty this rebuild is meant to remove.
- *     Documents keeps its editable mode, because that one really is PATCH-writable.
+ *   - **Each pipeline carries its own instance ceiling** — the most any space may do with that class,
+ *     not a default a space inherits. Lowering one silently caps every space above it, and "off"
+ *     takes the class offline everywhere — so both facts are stated at the control, not in a doc.
  */
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -26,7 +25,7 @@ import { StatusPillComponent } from '../../../shared/status-pill.component';
 import { HealthDotComponent } from './health-dot.component';
 import { ModelsStateService } from './models-state.service';
 import { PipelineStatusService } from './pipeline-status.service';
-import { HealthState, MODE_STAGES } from './models.types';
+import { HealthState, MODE_STAGES, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, MediaClass } from './models.types';
 
 /** One drawn step. `actor` is a model or tool name; `health` is looked up from the status payload. */
 interface Step {
@@ -86,8 +85,19 @@ interface Step {
     .modedesc ::ng-deep b { color: var(--text-primary); }
 
     .ceiling { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; font-size: 12.5px;
-      color: var(--text-secondary); }
-    .ceiling code { font-family: var(--font-mono, monospace); font-size: 11.5px; color: var(--text-muted); }
+      color: var(--text-secondary); margin-bottom: 9px; }
+    .ceiling:last-child { margin-bottom: 0; }
+    .ceiling > label { min-width: 108px; font-weight: 500; }
+    /* The global select rule sets width:100%, which would take the whole row and wrap the label above
+       it — these read as a labelled row, not a stack of full-width fields. */
+    .ceiling select { background: var(--bg-primary); color: var(--text-primary); font-size: 13px;
+      border: 1px solid var(--border); border-radius: 8px; padding: 7px 10px;
+      width: auto; min-width: 190px; max-width: 260px; }
+    .ceiling select:disabled { opacity: .6; cursor: not-allowed; }
+    .ceiling-hint { font-size: 12px; color: var(--text-muted); margin: 0 0 11px; max-width: 70ch; }
+    /* Not a warning box: choosing "off" is legitimate. It states the blast radius, which is easy to
+       miss when the control sits next to three that only affect thoroughness. */
+    .ceiling-warn { color: var(--warning); font-size: 11.5px; }
 
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px 16px; margin-top: 14px; }
     .field > label { display: block; font-size: 12px; color: var(--text-secondary); margin-bottom: 5px; font-weight: 500; }
@@ -199,13 +209,29 @@ interface Step {
 
         <div class="knobs">
           <div class="knobs-h">{{ 'models.pipelines.ceiling' | transloco }}</div>
-          <div class="ceiling">
-            <app-status-pill [variant]="p.ceiling === 'off' ? 'off' : 'active'">
-              {{ 'models.level.' + p.ceiling | transloco }}
-            </app-status-pill>
-            <span>{{ 'models.pipelines.ceilingReadOnly' | transloco }}</span>
-            <code>mediaEmbedding.levels.{{ p.id }}</code>
-          </div>
+          <p class="ceiling-hint">{{ 'models.pipelines.ceilingHint' | transloco }}</p>
+          @for (c of p.ceilings; track c.cls) {
+            <div class="ceiling">
+              <label [attr.for]="'ceiling-' + c.cls">{{ 'models.class.' + c.cls | transloco }}</label>
+              <select [attr.id]="'ceiling-' + c.cls" [ngModel]="ceilingOf(c.cls)"
+                (ngModelChange)="setCeiling(c.cls, $any($event))" [disabled]="s.isLocked('levels.' + c.cls) || s.managed"
+                [name]="'ceiling-' + c.cls">
+                @for (rung of c.ladder; track rung) {
+                  <!-- Video "full" is reserved and not built. Rendered disabled rather than omitted
+                       so the ladder reads complete — and the server rejects it either way. -->
+                  <option [value]="rung" [disabled]="c.cls === 'video' && rung === 'full'">
+                    {{ 'models.level.' + rung | transloco }}{{ c.cls === 'video' && rung === 'full' ? notYet : '' }}
+                  </option>
+                }
+              </select>
+              @if (s.isLocked('levels.' + c.cls)) { <app-status-pill variant="env">{{ 'models.pill.env' | transloco }}</app-status-pill> }
+              @if (ceilingOf(c.cls) === 'off') {
+                <!-- "off" is a floor as well as a ceiling: it takes the class offline for every space,
+                     whatever that space asked for. Worth saying where it is chosen, not in a doc. -->
+                <span class="ceiling-warn">{{ 'models.pipelines.ceilingOffWarning' | transloco }}</span>
+              }
+            </div>
+          }
         </div>
       </section>
     }
@@ -234,6 +260,22 @@ export class PipelinesTabComponent {
 
   private notSet = '—';
 
+  /** Suffix on the reserved video rung. A disabled option with no explanation reads as a bug. */
+  readonly notYet = ' — not built yet';
+
+  /** The stored ceiling for a class, defaulting to `auto` (no policy limit of its own). */
+  ceilingOf(cls: MediaClass): string { return (this.s.form.levels ?? {})[cls] ?? 'auto'; }
+
+  /**
+   * Set one class's ceiling. Writes only that class, mirroring the server's per-class merge — the
+   * whole `levels` block is sent on save, so replacing the object here would be harmless, but keeping
+   * the two sides shaped the same way is what stops them drifting apart later.
+   */
+  setCeiling(cls: MediaClass, value: string): void {
+    this.s.form.levels = { ...(this.s.form.levels ?? {}), [cls]: value };
+    this.s.touched.set(true);
+  }
+
   documentSteps = computed<Step[]>(() => {
     const doc = this.s.docCfg();
     const ps = this.pipeline;
@@ -252,12 +294,11 @@ export class PipelinesTabComponent {
 
   mediaPipelines = computed(() => {
     const ps = this.pipeline;
-    const levels = this.s.form.levels ?? {};
     const embedModel = this.s.embedding.model || this.notSet;
     return [
       {
         id: 'images', icon: 'image', title: 'models.pipelines.images', purpose: 'models.pipelines.imagesPurpose',
-        ceiling: levels.images ?? 'auto',
+        ceilings: [{ cls: 'images' as MediaClass, ladder: IMAGE_LEVELS }],
         steps: [
           { key: 'caption', name: 'models.step.caption', actor: this.s.form.vision?.model || this.notSet, health: ps.modelState('vision'), conditional: false, cardId: 'vision' },
           { key: 'img-embed', name: 'models.step.embed', actor: embedModel, health: ps.modelState('embedding'), conditional: false, cardId: 'embedding' },
@@ -267,7 +308,8 @@ export class PipelinesTabComponent {
       },
       {
         id: 'audio', icon: 'microphone', title: 'models.pipelines.audio', purpose: 'models.pipelines.audioPurpose',
-        ceiling: levels.audio ?? 'auto',
+        // This card covers TWO classes: audio files and video files have separate ladders.
+        ceilings: [{ cls: 'audio' as MediaClass, ladder: AUDIO_LEVELS }, { cls: 'video' as MediaClass, ladder: VIDEO_LEVELS }],
         steps: [
           // Video only: audio files skip straight to transcription.
           { key: 'split', name: 'models.step.split', actor: 'ffmpeg', health: null, conditional: true },
@@ -277,7 +319,7 @@ export class PipelinesTabComponent {
       },
       {
         id: 'text', icon: 'text-align-left', title: 'models.pipelines.text', purpose: 'models.pipelines.textPurpose',
-        ceiling: levels.text ?? 'auto',
+        ceilings: [{ cls: 'text' as MediaClass, ladder: TEXT_LEVELS }],
         steps: [
           // Chunking only happens at the `chunk` rung; `embed` produces one vector for the whole document.
           { key: 'chunk', name: 'models.step.chunk', actor: 'text chunker', health: null, conditional: true },

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2073,7 +2073,7 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 **The admin page has three tabs**, one route:
 
 - **Models** — every model you or infra can set: text embedding, vision, speech-to-text, the assist model, and read-only cards for the page renderer, document converter and face recognition. One shape per card (provider → endpoint → model → credential → test); infra-owned cards are dashed and name the env var that owns them.
-- **Pipelines** — Documents, Images, Audio & video and Text drawn as their real step chains, with the model doing the work named under each step and a health indicator fed by `GET /api/admin/pipeline-status`. Conditional steps (VLM fallback, repair, face vectors) are dashed. Each pipeline's knobs hang off that pipeline. The per-class ceilings for Images/Audio/Video/Text are shown **read-only** — `PATCH /api/admin/media-config` has no `levels` schema, so they are config/env-owned; Documents' `mode` is editable because it is PATCH-writable.
+- **Pipelines** — Documents, Images, Audio & video and Text drawn as their real step chains, with the model doing the work named under each step and a health indicator fed by `GET /api/admin/pipeline-status`. Conditional steps (VLM fallback, repair, face vectors) are dashed. Each pipeline's knobs hang off that pipeline, and each carries its own **instance ceiling** picker (see below). Audio and video share a card but have separate ceilings, because they have separate ladders.
 - **Tools** — the components that run but have nothing to set: media splitter (ffmpeg), text chunker, and the vector index. The index is **status-only** (readiness per space and collection); rebuilding is a Danger Zone action, not a button here.
 
 Switching tabs with unsaved changes prompts rather than discarding them.
@@ -2110,6 +2110,14 @@ ceiling under `mediaEmbedding.levels`:
 | `audioAnalysis` | `off` · `on` · `auto` | no transcription |
 | `videoAnalysis` | `off` · `audio` · `full` · `auto` | no audio extraction, no transcription |
 | `textAnalysis` | `off` · `embed` · `chunk` · `auto` | text is never indexed — nothing in the file is findable by search |
+
+**Setting the ceilings.** `PATCH /api/admin/media-config` accepts a `levels` block — `{ "levels": { "images": "caption" } }` — or use the pickers on **Settings → Models → Pipelines**. Three things about it are deliberate:
+
+- **Each class is merged independently.** A patch naming only `images` leaves the other three exactly as they were. This matters more than it looks: an absent class reads back as `auto`, so a whole-object replace would silently *raise* the ceiling on every class the request did not mention.
+- **`video: "full"` is rejected** with `400`, on this route and on `PATCH /api/spaces/:id` alike. The rung is reserved so the ladder reads complete, but keyframe analysis is not built — accepting it as a ceiling would let every `auto` space resolve to a level that does nothing. The Pipelines picker renders it disabled rather than hiding it.
+- **Env-pinned levels are refused** with `403` and reported in `lockedByInfra`, like every other media field.
+
+Remember what a ceiling does before lowering one: it caps every space already above it (those spaces keep their stored choice and return to it if you raise the ceiling again), and `off` is a floor as well as a ceiling — the class is not processed anywhere, whatever a space asked for.
 
 `recognition` is the rung that permits **face detection and embedding**, and it is gated twice: the
 instance-wide `mediaEmbedding.faceRecognition.enabled` must allow it *and* the space must be at

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -11,7 +11,8 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets, getDocAssistApiKey, getEmbeddingConfig, getEmbeddingApiKey } from '../config/loader.js';
-import { DOC_EXTRACTION_MODES_IN, normalizeDocExtractionMode } from '../config/types.js';
+import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
+import type { MediaLevelCeilings } from '../config/types.js';
 import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl, ssrfSafeFetch } from '../util/ssrf.js';
@@ -89,8 +90,28 @@ const EmbeddingPatchSchema = z.object({
   apiKey: z.string().max(512).optional().nullable(),
 }).strict();
 
+/**
+ * Instance CEILINGS per media class — the most any space is allowed to do, not a default it inherits.
+ *
+ * Built from the same `*_LEVELS` constants the lattice in `files/converters/media-level.ts` uses, so
+ * the API and the ladder cannot drift apart. Four hand-written enums here is exactly how one class
+ * quietly acquires a rung the resolver has never heard of.
+ *
+ * Each field is independently optional and the handler merges per class: a patch that names only
+ * `images` must not drop `audio`/`video`/`text`. They would not stay dropped either — the loader
+ * defaults an absent class to `auto` — so a whole-object replace would silently RAISE the ceiling on
+ * every class the client did not mention.
+ */
+const LevelsPatchSchema = z.object({
+  images: z.enum(IMAGE_LEVELS).optional(),
+  audio: z.enum(AUDIO_LEVELS).optional(),
+  video: z.enum(VIDEO_LEVELS).optional(),
+  text: z.enum(TEXT_LEVELS).optional(),
+}).strict();
+
 const MediaConfigPatchSchema = z.object({
   enabled: z.boolean().optional(),
+  levels: LevelsPatchSchema.optional(),
   visionProvider: z.enum(['local', 'external']).optional(),
   sttProvider: z.enum(['local', 'external']).optional(),
   vision: ProviderPatchSchema.optional(),
@@ -120,6 +141,17 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     res.status(409).json({
       error: 'Media & model configuration is infra-managed on this instance (YTHRIL_MEDIA_INFRA_MANAGED=true or mediaEmbedding.infraManaged). Update it in your infrastructure config (config.json / environment) instead.',
       code: 'INFRA_MANAGED',
+    });
+    return;
+  }
+
+  // Video `full` (keyframes as images) is a reserved rung with no implementation behind it. Rejected
+  // rather than silently treated as `audio`, and rejected here as well as on the per-space route —
+  // accepting it as a CEILING would let every `auto` space resolve to a level that does nothing.
+  if (parsed.data.levels?.video === 'full') {
+    res.status(400).json({
+      error: "video level 'full' is reserved but not implemented yet — keyframe analysis is not built. " +
+             "Use 'audio' to transcribe the audio track, or 'auto'.",
     });
     return;
   }
@@ -258,6 +290,7 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
       delete s['apiKey'];
       merged['stt'] = s;
     }
+    if (parsed.data.levels) merged['levels'] = mergeLevelCeilings(existing.levels, parsed.data.levels);
     // F11-b — DEEP-merge documentProcessing so a patch that omits `assistModel` (e.g. just changing `mode`)
     // does NOT wipe the stored external-assist config, and strip its apiKey out to secrets.json.
     if (parsed.data.documentProcessing) {
@@ -356,6 +389,28 @@ mediaConfigRouter.post('/test-connection', requireAdminMfa, async (req, res) => 
 });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Merge a `levels` patch into the stored ceilings, CLASS BY CLASS.
+ *
+ * The obvious `{...existing, ...patch}` at the top level of the config would replace the whole
+ * `levels` object — and because `getMediaEmbeddingConfig()` defaults an absent class to `auto`, the
+ * classes the patch did not mention would not merely be forgotten, they would come back as **`auto`**.
+ * Saving a change to `images` alone would silently RAISE the ceiling on audio, video and text: a
+ * capability grant nobody asked for, on the one setting whose entire job is to withhold capability.
+ *
+ * Exported for unit testing — this rule is the reason the function exists.
+ */
+export function mergeLevelCeilings(
+  existing: MediaLevelCeilings | undefined,
+  patch: Partial<MediaLevelCeilings>,
+): MediaLevelCeilings {
+  const out = { ...(existing ?? {}) } as Record<string, unknown>;
+  // Only keys actually present in the patch overwrite — an explicit `undefined` is not a value, and
+  // treating it as one would clear a ceiling the client never mentioned.
+  for (const [k, v] of Object.entries(patch)) if (v !== undefined) out[k] = v;
+  return out as MediaLevelCeilings;
+}
 
 interface ProbeResult {
   ok: boolean;

--- a/testing/standalone/media-level-ceilings.test.js
+++ b/testing/standalone/media-level-ceilings.test.js
@@ -1,0 +1,109 @@
+/**
+ * Instance level CEILINGS — the write path.
+ *
+ * #356 built the ladders and the resolution rule; #361 drew them on the Pipelines tab, read-only,
+ * because `PATCH /api/admin/media-config` had no `levels` schema. This is that schema, and these test
+ * the two things about it that can go wrong quietly.
+ *
+ * The load-bearing one is the **per-class merge**. `{...existing, ...patch}` at the top level replaces
+ * the whole `levels` object, and because `getMediaEmbeddingConfig()` defaults an absent class to
+ * `auto`, the classes a patch did not mention would not merely be forgotten — they would come back as
+ * `auto`. Saving a change to `images` alone would RAISE the ceiling on audio, video and text: a
+ * capability grant nobody asked for, on the one setting whose whole job is to withhold capability.
+ * Nothing would report it, and the only symptom is an instance quietly processing more than it was
+ * told to.
+ *
+ * Run: node --test testing/standalone/media-level-ceilings.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { mergeLevelCeilings } = await import('../../server/dist/api/media-config.js');
+const { capMediaLevel } = await import('../../server/dist/files/converters/media-level.js');
+const { IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS } = await import('../../server/dist/config/types.js');
+
+describe('mergeLevelCeilings — a patch must not touch classes it does not name', () => {
+  const stored = { images: 'caption', audio: 'off', video: 'audio', text: 'embed' };
+
+  it('changes only the named class', () => {
+    assert.deepEqual(mergeLevelCeilings(stored, { images: 'recognition' }),
+      { images: 'recognition', audio: 'off', video: 'audio', text: 'embed' });
+  });
+
+  it('THE ONE THAT MATTERS: an unnamed class keeps its ceiling rather than reverting to auto', () => {
+    // A whole-object replace would drop audio/video/text here. They would not stay dropped — the
+    // loader reads an absent class as `auto` — so every one of them would silently rise to the top
+    // rung because an admin edited a different class.
+    const out = mergeLevelCeilings(stored, { images: 'off' });
+    assert.equal(out.audio, 'off', 'audio was silently raised');
+    assert.equal(out.video, 'audio', 'video was silently raised');
+    assert.equal(out.text, 'embed', 'text was silently raised');
+  });
+
+  it('an explicit undefined does not clear a stored ceiling', () => {
+    // zod leaves absent optional keys undefined; treating that as a value would erase a ceiling the
+    // client never mentioned — the same silent raise by another route.
+    assert.deepEqual(mergeLevelCeilings(stored, { images: undefined, audio: 'on' }),
+      { images: 'caption', audio: 'on', video: 'audio', text: 'embed' });
+  });
+
+  it('starts from nothing when no ceilings are stored yet', () => {
+    assert.deepEqual(mergeLevelCeilings(undefined, { text: 'chunk' }), { text: 'chunk' });
+  });
+
+  it('does not mutate the stored object it was handed', () => {
+    const before = { ...stored };
+    mergeLevelCeilings(stored, { images: 'off' });
+    assert.deepEqual(stored, before);
+  });
+
+  it('can lower every class in one patch', () => {
+    assert.deepEqual(mergeLevelCeilings(stored, { images: 'off', audio: 'off', video: 'off', text: 'off' }),
+      { images: 'off', audio: 'off', video: 'off', text: 'off' });
+  });
+});
+
+describe('the ceiling values the API accepts are exactly the ladder', () => {
+  // The PATCH enums are built FROM these constants rather than hand-written beside them. If someone
+  // adds a rung to a ladder and forgets the API, this is what notices — a rung the resolver knows and
+  // the API rejects is a level an operator can never actually select.
+  it('every ladder rung survives a merge unchanged', () => {
+    for (const [cls, ladder] of [['images', IMAGE_LEVELS], ['audio', AUDIO_LEVELS], ['video', VIDEO_LEVELS], ['text', TEXT_LEVELS]]) {
+      for (const rung of ladder) {
+        assert.equal(mergeLevelCeilings({}, { [cls]: rung })[cls], rung, `${cls}=${rung} did not survive`);
+      }
+    }
+  });
+
+  it('the ladders still contain the rungs the resolver relies on', () => {
+    // A guard on the guard: if a ladder were emptied or renamed, the loop above would pass vacuously.
+    assert.ok(IMAGE_LEVELS.includes('recognition') && IMAGE_LEVELS.includes('off'));
+    assert.ok(AUDIO_LEVELS.includes('on') && AUDIO_LEVELS.includes('off'));
+    assert.ok(VIDEO_LEVELS.includes('audio') && VIDEO_LEVELS.includes('full'));
+    assert.ok(TEXT_LEVELS.includes('chunk') && TEXT_LEVELS.includes('embed'));
+  });
+});
+
+describe('what an editable ceiling now does to spaces — the consequences worth stating', () => {
+  // These exercise the production lattice directly. They are here because making ceilings editable
+  // from the admin UI is what turns these from documentation into things an operator can trigger by
+  // clicking, and the UI has to be honest about all three.
+
+  it('lowering the ceiling caps a space above it, without changing what the space chose', () => {
+    assert.equal(capMediaLevel('images', 'caption', 'recognition'), 'caption');
+    // Raising it back restores the space to its own choice — the stored value was never touched.
+    assert.equal(capMediaLevel('images', 'recognition', 'recognition'), 'recognition');
+  });
+
+  it("'off' is a floor as well as a ceiling — the class is off everywhere", () => {
+    for (const choice of IMAGE_LEVELS) assert.equal(capMediaLevel('images', 'off', choice), 'off');
+    for (const choice of TEXT_LEVELS) assert.equal(capMediaLevel('text', 'off', choice), 'off');
+  });
+
+  it('raising the ceiling does NOT raise a space that chose a specific lower rung', () => {
+    // Capability grows centrally; consent stays local. Only `auto` spaces follow it upward.
+    assert.equal(capMediaLevel('images', 'recognition', 'caption'), 'caption');
+    assert.equal(capMediaLevel('images', 'recognition', 'auto'), 'recognition');
+  });
+});


### PR DESCRIPTION
Item 1 in the ordered plan, per the owner: *"make sure the other part is the next PR."*

#356 gave Images/Audio/Video/Text real ladders and the resolution rule. #361 drew all four on the Pipelines tab — **read-only**, because `PATCH /api/admin/media-config` had no `levels` schema. It does now, with a picker per class. Audio and video share a card but get separate controls, because they have separate ladders.

The schema is built from the same `*_LEVELS` constants the resolver uses rather than hand-written beside them. Four hand-copied enums is how one class quietly acquires a rung the resolver has never heard of — or rejects one it relies on, which is a level an operator can see and never select.

## The load-bearing part: the per-class merge

`{...existing, ...patch}` would replace the whole `levels` object. Because the loader reads an absent class as `auto`, the classes a patch did not name would not merely be forgotten — **they would come back as `auto`**. Saving a change to `images` alone would *raise* the ceiling on audio, video and text: a capability grant nobody asked for, on the one setting whose entire job is to withhold capability, with nothing reporting it. The only symptom is an instance processing more than it was told to.

Extracted as `mergeLevelCeilings` so the rule is testable rather than buried in a request handler. Mutation-checked: substituting the naive replace fails exactly the three intended assertions and nothing else.

## Other deliberate choices

- **`video: "full"` is rejected with `400`** here as well as on `PATCH /api/spaces/:id`. The rung stays rendered-but-disabled so the ladder reads complete, but accepting it as a *ceiling* would let every `auto` space resolve to a level that does nothing.
- **The consequences are stated at the control**, not in a doc: a space may choose less but never more; lowering a ceiling caps spaces already above it while leaving their stored choice intact, so raising it again restores them. Choosing `off` adds a line saying it applies everywhere — `off` is a floor as well as a ceiling, which is easy to miss next to three controls that only affect thoroughness.
- **Env-pinned levels** are refused with `403` and reported in `lockedByInfra`, like every other media field.

## Not in scope, deliberately

The audit entry records `config.media.update` with no old/new values — the same granularity every other field on this route already has. Giving audit entries a detail payload means touching ~100 route rules and the audit-log UI; that is its own change, filed rather than bolted on here. The route-coverage gate passes (no new route, and the existing PATCH is already audited).

Also unchanged: the space-side surfaces. Only Documents has a per-space picker today; Images/Audio/Video/Text exist in `SpaceConfig` but have no UI, so there is nothing yet for a "your choice is capped" indicator to attach to. That is its own item.

## Verification

17 checks against a real isolated instance. The two that matter are end-to-end rather than structural:

- setting all four ceilings and saving persists all four;
- then changing **one** and saving leaves the other three exactly as they were, instead of resetting them to `auto`.

Plus: the server refuses `full` and an off-ladder value when the UI is bypassed entirely, every picker has an associated label, the blast-radius note appears only for `off`, German renders with no raw keys and no untranslated English, and 420px width does not scroll the body sideways.

Standalone 1139 pass, client 425 pass, both builds clean, docs and CHANGELOG lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)