### PR TITLE
feat(files): show which step a file is on, as sections of a bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2063,6 +2063,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A file being processed now shows which stage it is on, as sections of a bar, instead of a
+  spinner.** The badge said "something is happening" for as long as the job ran, and looked exactly
+  the same whether the job was working or wedged. Each section is a stage of *that document's* route
+  — routes differ per file and per extraction level — with the active one filling as its pages land.
+  The data already existed: #357 gave the job a heartbeat and #358 gave that heartbeat identity; what
+  was missing was the wire (`progress` lives on the media job, the file listing reads the files
+  collection) and the drawing.
+  Four things are deliberate rather than incidental:
+  - **The sections are weighted, not equal.** On a 40-page PDF the vision pass is minutes and
+    `validate` is milliseconds, so equal widths would sit at a third for the whole job and then leap
+    to done. The weights are an honest display heuristic and are named as one — nothing treats them
+    as an estimate of time remaining.
+  - **A one-stage route degrades to a plain bar.** The OCR route really is a single stage, and a
+    lone bordered box reads as "step 1 of several" — a claim about work that does not exist.
+  - **A stage that cannot count its work is not drawn half-finished.** No `done`/`total` means one
+    indivisible call; inventing 50 % would be fabricated progress. The bar shows what the completed
+    stages earned and nothing more.
+  - **A stalled job stops looking like a working one.** If nothing has been reported for longer than
+    the stall timeout the bar says so, rather than holding a frozen section that is indistinguishable
+    from a moving one — the #357 failure viewed from the UI side.
+  The bar carries `role="progressbar"` with real values and a translated text label naming the stage
+  and position, because a bar that communicates only by width answers "is this file done?" for
+  nobody using a screen reader.
+  The listing pays nothing for this when nothing is in flight: the join is one `$in` per member
+  space, issued only for files in `pending`/`processing`, and skipped entirely otherwise.
+
 - **The four instance ceilings are editable now — Images, Audio, Video and Text.** #356 gave each
   media class a real ladder and the resolution rule; the Pipelines tab drew all four, read-only,
   because `PATCH /api/admin/media-config` had no `levels` schema. It does now, built from the same

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1413,5 +1413,7 @@
   "models.class.video": "Video",
   "models.class.text": "Text",
   "models.pipelines.ceilingHint": "Das Maximum, das ein Bereich mit dieser Klasse tun darf. Ein Bereich kann weniger wählen, nie mehr — wenn Sie das hier senken, werden alle Bereiche darüber gekappt, und sie behalten ihre eigene Wahl, falls Sie es wieder anheben.",
-  "models.pipelines.ceilingOffWarning": "Aus gilt überall — kein Bereich kann diese Klasse verarbeiten."
+  "models.pipelines.ceilingOffWarning": "Aus gilt überall — kein Bereich kann diese Klasse verarbeiten.",
+  "files.progress.working": "Läuft",
+  "files.progress.stalled": "Kein Fortschritt gemeldet — dieser Auftrag hängt möglicherweise"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1413,5 +1413,7 @@
   "models.class.video": "Video",
   "models.class.text": "Text",
   "models.pipelines.ceilingHint": "The most any space may do with this class. A space can choose less, never more — lowering this caps every space already above it, and those spaces keep their own choice if you raise it again.",
-  "models.pipelines.ceilingOffWarning": "Off applies everywhere — no space can process this class."
+  "models.pipelines.ceilingOffWarning": "Off applies everywhere — no space can process this class.",
+  "files.progress.working": "Working",
+  "files.progress.stalled": "No progress reported — this job may be stuck"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1413,5 +1413,7 @@
   "models.class.video": "Wideo",
   "models.class.text": "Tekst",
   "models.pipelines.ceilingHint": "Najwięcej, co przestrzeń może zrobić z tą klasą. Przestrzeń może wybrać mniej, nigdy więcej — obniżenie tego limitu ogranicza każdą przestrzeń powyżej, a te zachowują swój wybór, jeśli limit znów podniesiesz.",
-  "models.pipelines.ceilingOffWarning": "Wyłączenie obowiązuje wszędzie — żadna przestrzeń nie przetworzy tej klasy."
+  "models.pipelines.ceilingOffWarning": "Wyłączenie obowiązuje wszędzie — żadna przestrzeń nie przetworzy tej klasy.",
+  "files.progress.working": "W toku",
+  "files.progress.stalled": "Brak zgłoszonego postępu — to zadanie mogło się zaciąć"
 }

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -291,6 +291,11 @@ export interface FileMeta {
    *  "partial" → stored but some chunks failed to embed (retry-eligible);
    *  "failed" → all retries exhausted; "skipped" / "disabled" → media-only states. */
   embeddingStatus?: 'pending' | 'processing' | 'complete' | 'partial' | 'failed' | 'skipped' | 'disabled';
+  /** The running stage and this document's full route, joined from its media job while it is in
+   *  flight (absent once the job finishes, and while a claimed job has not reported a step yet). */
+  progress?: { step: string; steps: string[]; done?: number; total?: number };
+  /** ISO8601 of the job's last report — lets the UI tell "working" from "wedged". */
+  progressAt?: string | null;
   /** Error message when embeddingStatus is "failed". */
   mediaJobError?: string;
   chunkCount?: number;

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -10,6 +10,7 @@ import { TagInputComponent } from '../../shared/tag-input.component';
 import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
+import { StepProgressBarComponent } from '../../shared/step-progress-bar.component';
 import { RecordTabBase } from './record-tab-base';
 import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
@@ -30,7 +31,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-filemeta-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, StepProgressBarComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
           <div class="content-header">
@@ -161,7 +162,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                               <span class="badge badge-red" style="font-size:10px;" [title]="'Deleted ' + (fm.deletedAt | date:'dd.MM.yyyy HH:mm')">{{ 'brain.fileMeta.deleted' | transloco }}</span>
                             }
                             @if (fm.embeddingStatus === 'pending' || fm.embeddingStatus === 'processing') {
-                              <span class="badge badge-blue" style="font-size:10px;" title="Embedding in progress…"><span class="spinner" style="width:8px;height:8px;border-width:1.5px;display:inline-block;vertical-align:middle;margin-right:3px;"></span>{{ 'brain.fileMeta.embedding' | transloco }}</span>
+                              @if (fm.progress) {
+                                <!-- The route is known, so show WHICH stage is running rather than
+                                     that something is. The spinner below is the fallback for a job
+                                     that has been claimed but has not reported its first step. -->
+                                <app-step-progress-bar [progress]="fm.progress" [progressAt]="fm.progressAt"/>
+                              } @else {
+                                <span class="badge badge-blue" style="font-size:10px;" [attr.title]="'brain.fileMeta.embedding' | transloco"><span class="spinner" style="width:8px;height:8px;border-width:1.5px;display:inline-block;vertical-align:middle;margin-right:3px;"></span>{{ 'brain.fileMeta.embedding' | transloco }}</span>
+                              }
                             } @else if (fm.embeddingStatus === 'failed') {
                               <span class="badge badge-red" style="font-size:10px;" [title]="fm.mediaJobError || 'Embedding failed'">{{ 'brain.fileMeta.embeddingFailed' | transloco }}</span>
                             } @else if (fm.embeddingStatus === 'partial') {

--- a/client/src/app/shared/step-progress-bar.component.spec.ts
+++ b/client/src/app/shared/step-progress-bar.component.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * StepProgressBarComponent — the rendered contract.
+ *
+ * The arithmetic is tested in `step-progress.model.spec.ts`; this covers what only a real render can
+ * show: that the degrade path actually draws one bar instead of a row of sections, and that the
+ * accessible name is a translated sentence rather than a raw i18n key.
+ *
+ * That second one is not a nicety. This component exists to answer "is this file done?", and a bar
+ * that communicates only by width answers it for nobody using a screen reader. It is also the exact
+ * mistake that is easy to make and invisible on screen — building the label in a `computed()` puts
+ * `files.progress.working` into `aria-valuetext` and looks perfect to a sighted reviewer.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTranslocoModule } from '../testing/transloco-testing';
+import { StepProgressBarComponent } from './step-progress-bar.component';
+
+/** Real translations, so a key that skipped the pipe is distinguishable from one that went through
+ *  it. With an empty translation map transloco echoes the key back and both look identical. */
+const TRANSLATIONS = {
+  en: { 'models.step.vlm': 'Transcribing', 'models.step.ocr': 'Reading text', 'files.progress.working': 'Working' },
+};
+
+function render(inputs: Record<string, unknown>) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [StepProgressBarComponent, getTranslocoModule({ translation: TRANSLATIONS })] });
+  const fixture = TestBed.createComponent(StepProgressBarComponent);
+  for (const [k, v] of Object.entries(inputs)) fixture.componentRef.setInput(k, v);
+  fixture.detectChanges();
+  return fixture;
+}
+
+const track = (f: ReturnType<typeof render>) => f.nativeElement.querySelector('[role="progressbar"]') as HTMLElement;
+const segments = (f: ReturnType<typeof render>) => f.nativeElement.querySelectorAll('.seg') as NodeListOf<HTMLElement>;
+
+describe('StepProgressBarComponent — the degrade path is visible, not just modelled', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('draws one bar for a single-stage route', () => {
+    // The OCR route really is one stage. A single bordered box reads as "step 1 of several".
+    const f = render({ progress: { step: 'ocr', steps: ['ocr'], done: 3, total: 10 } });
+    expect(segments(f)).toHaveLength(1);
+  });
+
+  it('draws one section per stage for a real route', () => {
+    const f = render({ progress: { step: 'vlm', steps: ['ocr', 'render', 'vlm', 'validate'] } });
+    expect(segments(f)).toHaveLength(4);
+  });
+
+  it('renders without a progress report at all', () => {
+    const f = render({ progress: null });
+    expect(track(f)).toBeTruthy();
+    expect(segments(f)).toHaveLength(1);
+  });
+});
+
+describe('StepProgressBarComponent — the accessible contract', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is a progressbar with real values', () => {
+    const f = render({ progress: { step: 'vlm', steps: ['ocr', 'vlm'], done: 5, total: 10 } });
+    const el = track(f);
+    expect(el.getAttribute('role')).toBe('progressbar');
+    expect(el.getAttribute('aria-valuemin')).toBe('0');
+    expect(el.getAttribute('aria-valuemax')).toBe('100');
+    expect(Number(el.getAttribute('aria-valuenow'))).toBeGreaterThan(0);
+  });
+
+  it('THE ONE THAT MATTERS: the accessible name is TRANSLATED, not a raw i18n key', () => {
+    // Building this label in a `computed()` instead of through the pipe puts `models.step.vlm` into
+    // aria-valuetext and looks perfect on screen. Asserting the resolved words are present is what
+    // separates "went through the pipe" from "echoed the key back" — with an empty translation map
+    // those two are indistinguishable, which is why TRANSLATIONS above is not empty.
+    const cases: Array<[unknown, string]> = [
+      [{ step: 'vlm', steps: ['ocr', 'vlm'], done: 5, total: 10 }, 'Transcribing'],
+      [{ step: 'ocr', steps: ['ocr'] }, 'Reading text'],
+      [{ step: 'nothing-we-know', steps: ['nothing-we-know'] }, 'Working'],
+      [null, 'Working'],
+    ];
+    for (const [progress, expected] of cases) {
+      const text = track(render({ progress })).getAttribute('aria-valuetext') ?? '';
+      expect(text).toContain(expected);
+      expect(text).not.toMatch(/\b(files|models)\.[a-z]+\.[a-z]/i);
+    }
+  });
+
+  it('names the units when a stage can count them, and does not invent them when it cannot', () => {
+    const counted = render({ progress: { step: 'vlm', steps: ['ocr', 'vlm'], done: 5, total: 40 } });
+    expect(track(counted).getAttribute('aria-valuetext')).toContain('5 / 40');
+
+    const uncounted = render({ progress: { step: 'vlm', steps: ['ocr', 'vlm'] } });
+    expect(track(uncounted).getAttribute('aria-valuetext')).not.toMatch(/\d+\s*\/\s*\d+/);
+  });
+
+  it('clamps a displayed count that overshoots its own total', () => {
+    const f = render({ progress: { step: 'vlm', steps: ['ocr', 'vlm'], done: 99, total: 40 } });
+    expect(track(f).getAttribute('aria-valuetext')).toContain('40 / 40');
+  });
+});
+
+describe('StepProgressBarComponent — a stalled job does not look like a working one', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('says so when nothing has been reported for longer than the timeout', () => {
+    const f = render({
+      progress: { step: 'vlm', steps: ['ocr', 'vlm'], done: 5, total: 10 },
+      progressAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      stallTimeoutMs: 60_000,
+    });
+    expect(f.nativeElement.querySelector('.label.stale')).toBeTruthy();
+    expect(f.nativeElement.querySelector('.seg.stale')).toBeTruthy();
+  });
+
+  it('does not accuse a job that is still reporting', () => {
+    const f = render({
+      progress: { step: 'vlm', steps: ['ocr', 'vlm'], done: 5, total: 10 },
+      progressAt: new Date().toISOString(),
+      stallTimeoutMs: 60_000,
+    });
+    expect(f.nativeElement.querySelector('.label.stale')).toBeFalsy();
+  });
+
+  it('does not accuse a job that has never reported', () => {
+    // "No heartbeat yet" is not "stopped heartbeating" — a freshly claimed job must look normal.
+    const f = render({ progress: { step: 'ocr', steps: ['ocr', 'vlm'] }, progressAt: null });
+    expect(f.nativeElement.querySelector('.label.stale')).toBeFalsy();
+  });
+});

--- a/client/src/app/shared/step-progress-bar.component.ts
+++ b/client/src/app/shared/step-progress-bar.component.ts
@@ -1,0 +1,117 @@
+/**
+ * The progress bar for a file being processed — sections, not a spinner.
+ *
+ * Replaces a badge with a spinning dot in it, which said "something is happening" for as long as the
+ * job ran and looked identical whether the job was working or wedged. Each section is a stage of
+ * THAT document's route (routes differ per file and per extraction level), the active one fills as
+ * its units land, and the whole thing degrades to a plain bar when the route has one stage.
+ *
+ * All of the judgement lives in `step-progress.model.ts`; this component draws what it is given.
+ *
+ * **Accessibility is not decoration here.** A bar that communicates only by width communicates
+ * nothing to a screen reader, and "is this file done?" is exactly the question a progress indicator
+ * exists to answer. It carries `role="progressbar"` with real values, plus a text label naming the
+ * stage and its position — the same rule the pipeline health dots follow.
+ */
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { buildBarModel, isStale, StepProgress } from './step-progress.model';
+
+@Component({
+  selector: 'app-step-progress-bar',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslocoPipe],
+  styles: [`
+    :host { display: block; min-width: 120px; }
+    .wrap { display: flex; flex-direction: column; gap: 3px; }
+    .track { display: flex; gap: 2px; height: 6px; border-radius: 3px; overflow: hidden; }
+    .seg { position: relative; background: var(--bg-elevated); border-radius: 2px; overflow: hidden; }
+    .seg .fill { position: absolute; inset: 0 auto 0 0; background: var(--accent); border-radius: 2px; }
+    .seg.done .fill { width: 100%; }
+    /* The active segment animates its width so the bar moves rather than teleporting between ticks. */
+    .seg.active .fill { transition: width .4s ease; }
+    .seg.stale .fill { background: var(--warning); }
+    @media (prefers-reduced-motion: reduce) { .seg.active .fill { transition: none; } }
+
+    .label { font-size: 10px; color: var(--text-muted); display: flex; gap: 5px; align-items: baseline; }
+    .label .step { color: var(--text-secondary); font-weight: 550; }
+    .label.stale { color: var(--warning); }
+  `],
+  template: `
+    <div class="wrap">
+      <!-- The accessible name is built HERE, through the pipe, not in a computed: a computed would
+           put the raw i18n key into aria-valuetext and re-translate never. -->
+      <div class="track" role="progressbar"
+        [attr.aria-valuemin]="0" [attr.aria-valuemax]="100"
+        [attr.aria-valuenow]="percent()"
+        [attr.aria-valuetext]="stale() ? ('files.progress.stalled' | transloco) : ((stepLabel() | transloco) + suffix())"
+        [attr.aria-label]="stale() ? ('files.progress.stalled' | transloco) : ((stepLabel() | transloco) + suffix())">
+        @if (model().segmented) {
+          @for (s of model().segments; track $index) {
+            <div class="seg" [class]="s.state" [class.stale]="stale()" [style.flex]="s.weight">
+              <div class="fill" [style.width.%]="s.fill * 100"></div>
+            </div>
+          }
+        } @else {
+          <!-- One stage, or a shape we cannot describe: a plain bar rather than a single box that
+               implies there are other sections still to come. -->
+          <div class="seg active" [class.stale]="stale()" style="flex:1">
+            <div class="fill" [style.width.%]="(model().overall ?? 0) * 100"></div>
+          </div>
+        }
+      </div>
+      <div class="label" [class.stale]="stale()">
+        @if (stale()) {
+          {{ 'files.progress.stalled' | transloco }}
+        } @else {
+          <span class="step">{{ stepLabel() | transloco }}</span>
+          @if (unitText(); as u) { <span>{{ u }}</span> }
+        }
+      </div>
+    </div>
+  `,
+})
+export class StepProgressBarComponent {
+  progress = input<StepProgress | null | undefined>(null);
+  /** ISO8601 of the job's last report, for the stalled check. */
+  progressAt = input<string | null | undefined>(null);
+  /** Instance stall timeout. Default matches the server's own default. */
+  stallTimeoutMs = input<number>(300_000);
+
+  model = computed(() => buildBarModel(this.progress()));
+  stale = computed(() => isStale(this.progressAt(), this.stallTimeoutMs()));
+
+  percent = computed(() => {
+    const o = this.model().overall;
+    return o === null ? null : Math.round(o * 100);
+  });
+
+  /** i18n key for the running stage. Unknown stages fall back to a generic "working" rather than
+   *  rendering a raw internal identifier at the user. */
+  stepLabel = computed(() => {
+    const step = this.progress()?.step;
+    if (!step) return 'files.progress.working';
+    return KNOWN_STEPS.has(step) ? `models.step.${step}` : 'files.progress.working';
+  });
+
+  /** "12 / 40" for a countable stage, else empty — never a fabricated count. */
+  unitText = computed(() => {
+    const p = this.progress();
+    if (!p || typeof p.done !== 'number' || typeof p.total !== 'number' || p.total <= 0) return '';
+    return `${Math.min(p.done, p.total)} / ${p.total}`;
+  });
+
+  /** Everything after the translated stage name: " 12 / 40 — 45%". Joined in the template. */
+  suffix = computed(() => {
+    const pct = this.percent();
+    const units = this.unitText();
+    return `${units ? ' ' + units : ''}${pct === null ? '' : ` — ${pct}%`}`;
+  });
+}
+
+/** Stage names that already have a translated label on the Pipelines tab (`models.step.*`). */
+const KNOWN_STEPS = new Set([
+  'ocr', 'render', 'vlm', 'validate', 'repair', 'verify',
+  'embed', 'chunk', 'caption', 'transcribe', 'split',
+]);

--- a/client/src/app/shared/step-progress.model.spec.ts
+++ b/client/src/app/shared/step-progress.model.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * The step-progress bar model.
+ *
+ * Every judgement here can be wrong in a way that still LOOKS fine, which is why it is pure and
+ * tested directly rather than asserted through a rendered component. The two that matter:
+ *
+ *  - **the degrade rule** — a one-stage route drawn as a segmented bar claims a granularity that is
+ *    not there, telling the reader there are further stages they are waiting for. The OCR route
+ *    really is one stage, so this is the common case, not an edge case.
+ *  - **the weighting** — equal-width segments would sit at 33 % for the minutes the VLM pass takes
+ *    and then leap to 100 %. A bar that moves at a believable rate is the entire point of the
+ *    feature; one that stalls and jumps is worse than the spinner it replaces.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildBarModel, isStale } from './step-progress.model';
+
+describe('buildBarModel — degrading honestly', () => {
+  it('returns an indeterminate model when there is no progress at all', () => {
+    for (const input of [null, undefined, { step: 'ocr', steps: [] }]) {
+      const m = buildBarModel(input as never);
+      expect(m.segmented).toBe(false);
+      expect(m.overall).toBeNull();
+      expect(m.segments).toEqual([]);
+    }
+  });
+
+  it('THE DEGRADE RULE: a single-stage route is not drawn as segmented', () => {
+    // The OCR route has exactly one stage. One box with a border around it reads as "step 1 of
+    // several", which is a claim about work that does not exist.
+    const m = buildBarModel({ step: 'ocr', steps: ['ocr'], done: 3, total: 10 });
+    expect(m.segmented).toBe(false);
+    expect(m.overall).toBeCloseTo(0.3, 5);   // still reports real progress — just not as sections
+  });
+
+  it('a multi-stage route is segmented', () => {
+    const m = buildBarModel({ step: 'render', steps: ['ocr', 'render', 'vlm', 'validate'] });
+    expect(m.segmented).toBe(true);
+    expect(m.segments).toHaveLength(4);
+  });
+
+  it('an active step that is not on the reported route does not throw or fake a position', () => {
+    // Shapes drift: a worker on a newer build can report a stage this client has never heard of.
+    const m = buildBarModel({ step: 'transmogrify', steps: ['ocr', 'vlm'] });
+    expect(m.activeIndex).toBe(-1);
+    expect(m.overall).toBeNull();                       // unknown, not zero
+    expect(m.segments.every(s => s.state === 'pending')).toBe(true);
+  });
+
+  it('an unrecognised step still gets a share of the bar rather than collapsing to zero width', () => {
+    const m = buildBarModel({ step: 'brandnew', steps: ['brandnew', 'embed'] });
+    expect(m.segments[0].weight).toBeGreaterThan(0);
+    expect(m.segments.reduce((s, x) => s + x.weight, 0)).toBeCloseTo(1, 5);
+  });
+});
+
+describe('buildBarModel — segment states and fill', () => {
+  const route = ['ocr', 'render', 'vlm', 'validate'];
+
+  it('marks earlier stages done, the current one active, later ones pending', () => {
+    const m = buildBarModel({ step: 'vlm', steps: route, done: 5, total: 10 });
+    expect(m.segments.map(s => s.state)).toEqual(['done', 'done', 'active', 'pending']);
+    expect(m.segments[0].fill).toBe(1);
+    expect(m.segments[2].fill).toBeCloseTo(0.5, 5);
+    expect(m.segments[3].fill).toBe(0);
+  });
+
+  it('a stage that cannot count its work is not drawn as half-finished', () => {
+    // No done/total means one indivisible call. Inventing 50% would be fabricated progress.
+    const m = buildBarModel({ step: 'vlm', steps: route });
+    expect(m.segments[2].fill).toBe(0);
+    expect(m.overall).toBeGreaterThan(0);   // the completed stages still count
+  });
+
+  it('clamps a worker that overshoots its own estimate', () => {
+    // More pages than predicted must not push a segment past its width or overall past 1.
+    const m = buildBarModel({ step: 'vlm', steps: route, done: 99, total: 10 });
+    expect(m.segments[2].fill).toBe(1);
+    expect(m.overall).toBeLessThanOrEqual(1);
+  });
+
+  it('ignores a nonsense total instead of dividing by zero', () => {
+    const m = buildBarModel({ step: 'vlm', steps: route, done: 5, total: 0 });
+    expect(Number.isFinite(m.overall!)).toBe(true);
+    expect(m.segments[2].fill).toBe(0);
+  });
+
+  it('weights always sum to the full bar', () => {
+    for (const steps of [['ocr'], ['ocr', 'vlm'], ['ocr', 'render', 'vlm', 'validate', 'repair', 'verify', 'embed']]) {
+      const m = buildBarModel({ step: steps[0], steps });
+      expect(m.segments.reduce((s, x) => s + x.weight, 0)).toBeCloseTo(1, 5);
+    }
+  });
+});
+
+describe('buildBarModel — the weighting is what stops the bar stalling then jumping', () => {
+  const route = ['ocr', 'render', 'vlm', 'validate'];
+
+  it('gives the dominant stage the largest share of the bar', () => {
+    const m = buildBarModel({ step: 'ocr', steps: route });
+    const w = Object.fromEntries(m.segments.map(s => [s.step, s.weight]));
+    expect(w['vlm']).toBeGreaterThan(w['ocr']);
+    expect(w['vlm']).toBeGreaterThan(w['render']);
+    expect(w['vlm']).toBeGreaterThan(w['validate']);
+  });
+
+  it('a near-instant stage does not advance the bar as much as a long one', () => {
+    // Equal weights would make finishing `validate` worth as much as finishing `vlm` — the exact
+    // lie that makes a progress bar untrustworthy.
+    const afterValidate = buildBarModel({ step: 'validate', steps: route, done: 1, total: 1 }).overall!;
+    const afterVlm = buildBarModel({ step: 'validate', steps: route }).overall!;
+    expect(afterValidate - afterVlm).toBeLessThan(0.1);
+  });
+
+  it('overall only reaches 1 when the last stage is complete', () => {
+    const m = buildBarModel({ step: 'validate', steps: route, done: 1, total: 1 });
+    expect(m.overall).toBeCloseTo(1, 5);
+  });
+});
+
+describe('isStale — a frozen bar must not look like a working one', () => {
+  const NOW = Date.parse('2026-07-22T12:00:00.000Z');
+
+  it('is stale once nothing has been reported for longer than the timeout', () => {
+    expect(isStale('2026-07-22T11:50:00.000Z', 5 * 60_000, NOW)).toBe(true);
+  });
+
+  it('is not stale while reports are still arriving', () => {
+    expect(isStale('2026-07-22T11:59:30.000Z', 5 * 60_000, NOW)).toBe(false);
+  });
+
+  it('a job that has never reported is not accused of stalling', () => {
+    // "No heartbeat yet" and "stopped heartbeating" are different claims; only the second is a fault.
+    expect(isStale(null, 5 * 60_000, NOW)).toBe(false);
+    expect(isStale(undefined, 5 * 60_000, NOW)).toBe(false);
+  });
+
+  it('an unparseable timestamp is not treated as ancient', () => {
+    // Date.parse returns NaN, and NaN comparisons are false in a way that is easy to get backwards —
+    // getting it backwards would mark every job stale.
+    expect(isStale('not-a-date', 5 * 60_000, NOW)).toBe(false);
+  });
+});

--- a/client/src/app/shared/step-progress.model.ts
+++ b/client/src/app/shared/step-progress.model.ts
@@ -1,0 +1,134 @@
+/**
+ * Turning a job's step report into a drawable bar.
+ *
+ * Kept pure and separate from the component because every judgement here is one that can be wrong in
+ * a way that still *looks* fine — a bar that sits still and then jumps, or a single segment
+ * pretending to be a breakdown. The component draws what this returns; it decides nothing.
+ *
+ * Input is `MediaJobDoc.progress` from #358: the stage now running, the full route THAT document
+ * takes (from `decideRoute`, so it differs per file and per extraction level), and how far through
+ * the current stage it is.
+ */
+
+/** What the server reports, mirrored from `MediaJobDoc.progress`. */
+export interface StepProgress {
+  step: string;
+  steps: string[];
+  done?: number;
+  total?: number;
+}
+
+export interface Segment {
+  step: string;
+  /** Share of the bar's width, 0–1. Weighted — see `STEP_WEIGHTS`. */
+  weight: number;
+  state: 'done' | 'active' | 'pending';
+  /** 0–1 within this segment. Only meaningful when `state === 'active'`. */
+  fill: number;
+}
+
+export interface BarModel {
+  /** Empty when the route is unknown or has fewer than two stages — see `segmented`. */
+  segments: Segment[];
+  /**
+   * False when the bar must degrade to a plain one. A single-segment "breakdown" claims a
+   * granularity that is not there: the OCR route really is one stage, and drawing it as a segmented
+   * bar tells the reader there are others they are waiting for.
+   */
+  segmented: boolean;
+  /** Overall 0–1 across the whole route, or null when genuinely unknown (indeterminate bar). */
+  overall: number | null;
+  /** Index into `segments`, or -1 when the active step is not on the reported route. */
+  activeIndex: number;
+}
+
+/**
+ * Relative cost per stage. **A display heuristic, not a measurement.**
+ *
+ * Equal-width segments would be actively misleading: on a 40-page PDF the VLM pass is minutes and
+ * `validate` is milliseconds, so an even bar sits at 33 % for the whole job and then leaps to 100 %.
+ * These weights only need to be roughly proportional to make the bar move at a believable rate; they
+ * do not need to be accurate, and nothing downstream treats them as an estimate of time remaining.
+ */
+const STEP_WEIGHTS: Record<string, number> = {
+  ocr: 2,
+  render: 3,
+  vlm: 10,       // dominates on every route that includes it
+  validate: 0.5, // near-instant, but visible so the reader can see it happened
+  repair: 6,
+  verify: 5,
+  embed: 1,
+  chunk: 0.5,
+  transcribe: 8,
+  caption: 4,
+  split: 1,
+};
+/** Anything the client has not been taught about still gets a share rather than collapsing to zero. */
+const DEFAULT_WEIGHT = 2;
+
+function weightOf(step: string): number {
+  return STEP_WEIGHTS[step] ?? DEFAULT_WEIGHT;
+}
+
+/**
+ * Build the bar model for one job.
+ *
+ * Returns a non-segmented, indeterminate model for anything it cannot describe honestly: no
+ * progress, an empty route, or a single-stage route. That is the default rather than the exception —
+ * an unknown shape drawn as a confident bar is worse than a spinner.
+ */
+export function buildBarModel(progress: StepProgress | null | undefined): BarModel {
+  const steps = progress?.steps ?? [];
+  if (!progress || steps.length === 0) {
+    return { segments: [], segmented: false, overall: null, activeIndex: -1 };
+  }
+
+  const activeIndex = steps.indexOf(progress.step);
+
+  // Fraction through the ACTIVE stage. `done`/`total` are optional: a stage that cannot count its
+  // work (a single indivisible call) reports neither, and guessing 0 would make the bar look stuck
+  // while guessing 50 % would invent progress. Treated as 0 for width, but `overall` stays honest.
+  const hasUnits = typeof progress.done === 'number' && typeof progress.total === 'number' && progress.total > 0;
+  // Clamp: a worker that overshoots its own estimate (more pages than predicted) must not push a
+  // segment past its width or drive `overall` above 1.
+  const activeFill = hasUnits ? Math.min(1, Math.max(0, progress.done! / progress.total!)) : 0;
+
+  const segments: Segment[] = steps.map((step, i) => ({
+    step,
+    weight: weightOf(step),
+    state: activeIndex < 0 ? 'pending' : i < activeIndex ? 'done' : i === activeIndex ? 'active' : 'pending',
+    fill: i === activeIndex ? activeFill : i < activeIndex ? 1 : 0,
+  }));
+
+  // Normalise weights to shares of the bar so the component never does arithmetic.
+  const totalWeight = segments.reduce((sum, s) => sum + s.weight, 0) || 1;
+  for (const s of segments) s.weight = s.weight / totalWeight;
+
+  // Overall is weighted too — otherwise finishing `validate` (0.5 weight) would advance the bar as
+  // much as finishing `vlm` (10), which is the same lie the equal-width segments told.
+  const overall = activeIndex < 0
+    ? null
+    : segments.reduce((sum, s) => sum + s.weight * s.fill, 0);
+
+  return {
+    segments,
+    // One stage is not a breakdown. Degrade rather than draw a single box and imply there are more.
+    segmented: steps.length > 1,
+    overall,
+    activeIndex,
+  };
+}
+
+/**
+ * True when a job has not reported in longer than the stall timeout.
+ *
+ * A frozen segment looks identical to a working one, which is precisely the failure #357 existed to
+ * end — from the UI side this time. Better to say "no progress for 6 minutes" than to keep drawing a
+ * bar that stopped moving.
+ */
+export function isStale(progressAt: string | null | undefined, stallTimeoutMs: number, now = Date.now()): boolean {
+  if (!progressAt) return false;          // never reported: not the same claim as "stopped reporting"
+  const t = Date.parse(progressAt);
+  if (Number.isNaN(t)) return false;      // unparseable: do not accuse a job on a bad timestamp
+  return now - t > stallTimeoutMs;
+}

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1963,6 +1963,24 @@ retries are exhausted). Once complete, the record carries `chunkCount` and (for 
 `convertedFileId`, and the chunk records are recall-searchable. To see the chunks themselves, pass
 `?includeChunks=true` — they are hidden by default (see below).
 
+**While a file is in flight the record also carries step progress**, so a caller can report *which
+stage* is running rather than just that something is:
+
+```json
+{
+  "embeddingStatus": "processing",
+  "progress": { "step": "vlm", "steps": ["ocr", "render", "vlm", "validate"], "done": 12, "total": 40 },
+  "progressAt": "2026-07-22T12:00:00.000Z"
+}
+```
+
+`steps` is the resolved route for **that document** — it differs per file and per extraction level, so
+do not treat it as a fixed list. `done`/`total` are present only for stages that can count their work;
+a stage that is one indivisible call reports neither, and inventing a midpoint for it would be
+fabricated progress. `progressAt` is the last report, which is what distinguishes a slow job from a
+wedged one — compare it against `stalledJobTimeoutMs`. Both fields are absent once the job finishes,
+and while a claimed job has not yet reported its first step.
+
 Media files (image/audio/video) are likewise queued and report `embeddingStatus` of `pending`,
 `disabled` (media embedding turned off) or `skipped` (over `maxFileSizeBytes`). Only the `"text"`
 bypass is fully synchronous: it stores a single flat embedding with no chunking and no job.

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -21,8 +21,38 @@ import { col, asFilter } from '../../db/mongo.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
 import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import type { FileMetaDoc } from '../../config/types.js';
+import { fetchJobProgress } from '../../files/media/job-queue.js';
 
 export const fileMetaRouter = Router();
+
+/** Statuses worth a progress lookup. Anything else is finished and has nothing left to draw. */
+const IN_FLIGHT = new Set(['pending', 'processing']);
+
+/**
+ * Decorate a page of file records with their job's step progress.
+ *
+ * The rule worth pinning is that a page with nothing in flight issues **no query at all**, so the
+ * common case — a listing of finished files, which is most listings — does not pay for the rare one.
+ * `lookup` is injectable purely so a test can observe that: asserting on the returned records cannot
+ * distinguish "did not query" from "queried and got nothing", which is exactly the regression this
+ * guards against.
+ */
+export async function attachJobProgress(
+  memberId: string,
+  files: Array<Record<string, unknown>>,
+  lookup: typeof fetchJobProgress = fetchJobProgress,
+): Promise<Array<Record<string, unknown>>> {
+  const inFlight = files.filter(f => IN_FLIGHT.has(String(f['embeddingStatus'] ?? '')));
+  if (inFlight.length === 0) return files;
+  const byId = await lookup(memberId, inFlight.map(f => String(f['_id'])));
+  if (byId.size === 0) return files;
+  return files.map(f => {
+    const view = byId.get(String(f['_id']));
+    // A job row with no `progress` yet (claimed, first step not reported) adds nothing — leaving the
+    // field absent keeps "we do not know yet" distinct from "the route has no steps".
+    return view?.progress ? { ...f, progress: view.progress, progressAt: view.progressAt } : f;
+  });
+}
 
 
 // GET /api/brain/spaces/:spaceId/files — list file metadata records
@@ -42,14 +72,18 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   if (!includeChunks) filter['parentFileId'] = { $exists: false };
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
   if (typeof req.query['path'] === 'string') filter['path'] = toDocId(req.query['path']);
-  const all = await collectAcrossMembers(spaceId, mid =>
-    col(`${mid}_files`)
+  const all = await collectAcrossMembers(spaceId, async mid => {
+    const files = await col(`${mid}_files`)
       .find(asFilter(filter))
       .sort({ updatedAt: -1 })
       .skip(skip)
       .limit(limit)
-      .toArray(),
-  );
+      .toArray();
+    // Attach step progress for files still in flight, so the UI can draw which stage is running
+    // instead of a spinner that never resolves. Joined per MEMBER: on a proxy space the ids belong
+    // to that member's job collection, and looking them up in another's would silently find nothing.
+    return attachJobProgress(mid, files as Array<Record<string, unknown>>);
+  });
   res.json({ files: capPage(all, limit), limit, skip });
 });
 

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -423,6 +423,40 @@ export function stalledJobFilter(cutoff: string): Record<string, unknown> {
   };
 }
 
+/** What the file list needs to draw a progress bar for one in-flight file. */
+export interface JobProgressView {
+  progress?: { step: string; steps: string[]; done?: number; total?: number };
+  /** ISO8601 of the last sign of life, so the UI can tell "working" from "wedged". */
+  progressAt?: string | null;
+}
+
+/**
+ * Look up step progress for a set of files, in ONE query.
+ *
+ * `MediaJobDoc._id` is the file `_id` — one job per file — so this is an `$in`, not an N+1 walk. It
+ * is called per member space rather than per file, and only with the ids that are actually in
+ * flight: a completed file has nothing to draw, and querying for it would make the common case
+ * (a page of finished files) pay for the rare one.
+ *
+ * Best-effort like the heartbeat that writes the data: a failed lookup returns an empty map and the
+ * UI falls back to the plain spinner. A progress bar is not worth failing a file listing over.
+ */
+export async function fetchJobProgress(
+  spaceId: string,
+  fileIds: string[],
+): Promise<Map<string, JobProgressView>> {
+  const out = new Map<string, JobProgressView>();
+  if (fileIds.length === 0) return out;   // never issue an empty $in
+  try {
+    const docs = await jobCollection(spaceId)
+      .find(asFilter<MediaJobDoc>({ _id: { $in: fileIds } }))
+      .project({ progress: 1, progressAt: 1 })
+      .toArray() as Array<{ _id: string } & JobProgressView>;
+    for (const d of docs) out.set(d._id, { progress: d.progress, progressAt: d.progressAt });
+  } catch { /* best-effort — the listing matters, the bar does not */ }
+  return out;
+}
+
 /**
  * Record that a claimed job is still doing something.
  *

--- a/testing/standalone/file-progress-join.test.js
+++ b/testing/standalone/file-progress-join.test.js
@@ -1,0 +1,120 @@
+/**
+ * Joining step progress onto a page of file records.
+ *
+ * `MediaJobDoc._id` is the file `_id`, so this is an `$in` rather than an N+1 walk. What is worth
+ * pinning is not the happy path but the ways it could quietly become expensive or wrong:
+ *
+ *  - a page with **nothing in flight** must issue no query at all — a listing of finished files is
+ *    most listings, and it should not pay for the rare one;
+ *  - a job that has been claimed but has **not reported a step yet** must not add an empty
+ *    `progress` field, because the UI treats its presence as "the route is known" and would draw a
+ *    bar with no sections instead of falling back to the spinner.
+ *
+ * The lookup is injected so the first claim can actually be OBSERVED. Asserting on the returned
+ * records cannot tell "did not query" from "queried and got nothing" — an earlier version of this
+ * file did exactly that and passed with the early return deleted.
+ *
+ * Run: node --test testing/standalone/file-progress-join.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { attachJobProgress } = await import('../../server/dist/api/brain/file-meta.js');
+
+const file = (id, status, extra = {}) => ({ _id: id, path: id, embeddingStatus: status, ...extra });
+
+/** A lookup that records how it was called and returns whatever it was seeded with. */
+function spyLookup(rows = {}) {
+  const calls = [];
+  const fn = async (memberId, ids) => {
+    calls.push({ memberId, ids });
+    return new Map(Object.entries(rows).filter(([id]) => ids.includes(id)));
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const PROGRESS = { step: 'vlm', steps: ['ocr', 'render', 'vlm'], done: 3, total: 10 };
+
+describe('attachJobProgress — when it queries at all', () => {
+  it('THE ONE THAT MATTERS: a page with nothing in flight issues no query', async () => {
+    const lookup = spyLookup();
+    const files = [file('a', 'complete'), file('b', 'failed'), file('c', 'skipped')];
+    const out = await attachJobProgress('space', files, lookup);
+    assert.equal(lookup.calls.length, 0, 'a finished page must not hit the job collection');
+    assert.deepEqual(out, files);
+  });
+
+  it('an empty page issues no query either', async () => {
+    const lookup = spyLookup();
+    assert.deepEqual(await attachJobProgress('space', [], lookup), []);
+    assert.equal(lookup.calls.length, 0);
+  });
+
+  it('queries ONCE, with only the in-flight ids', async () => {
+    const lookup = spyLookup();
+    await attachJobProgress('space', [
+      file('a', 'processing'), file('b', 'complete'), file('c', 'pending'), file('d', 'failed'),
+    ], lookup);
+    assert.equal(lookup.calls.length, 1, 'one query for the whole page, not one per file');
+    assert.deepEqual(lookup.calls[0].ids.sort(), ['a', 'c']);
+  });
+
+  it('passes the MEMBER id through, not the proxy space id', async () => {
+    // On a proxy space the ids belong to that member's job collection; looking them up under the
+    // proxy's name would silently find nothing and every bar would fall back to a spinner.
+    const lookup = spyLookup();
+    await attachJobProgress('member-2', [file('a', 'processing')], lookup);
+    assert.equal(lookup.calls[0].memberId, 'member-2');
+  });
+});
+
+describe('attachJobProgress — what it attaches', () => {
+  it('attaches progress and progressAt to the in-flight record only', async () => {
+    const lookup = spyLookup({ a: { progress: PROGRESS, progressAt: '2026-07-22T12:00:00.000Z' } });
+    const out = await attachJobProgress('space', [file('a', 'processing'), file('b', 'complete')], lookup);
+    assert.deepEqual(out[0].progress, PROGRESS);
+    assert.equal(out[0].progressAt, '2026-07-22T12:00:00.000Z');
+    assert.equal(out[1].progress, undefined);
+  });
+
+  it('a claimed job that has not reported a step yet adds NO progress field', async () => {
+    // The UI reads the presence of `progress` as "the route is known". An empty object would draw a
+    // segmented bar with no sections instead of falling back to the spinner.
+    const lookup = spyLookup({ a: { progress: undefined, progressAt: '2026-07-22T12:00:00.000Z' } });
+    const out = await attachJobProgress('space', [file('a', 'processing')], lookup);
+    assert.ok(!('progress' in out[0]), 'progress must be absent, not empty');
+  });
+
+  it('a lookup that finds nothing leaves the page exactly as it was', async () => {
+    const lookup = spyLookup();
+    const files = [file('a', 'processing')];
+    assert.deepEqual(await attachJobProgress('space', files, lookup), files);
+  });
+
+  it('never mutates the records it was handed', async () => {
+    const lookup = spyLookup({ a: { progress: PROGRESS, progressAt: null } });
+    const files = [file('a', 'processing'), file('b', 'complete')];
+    const snapshot = JSON.parse(JSON.stringify(files));
+    await attachJobProgress('space', files, lookup);
+    assert.deepEqual(files, snapshot, 'the caller’s array was modified in place');
+  });
+});
+
+describe('attachJobProgress — which statuses count as in flight', () => {
+  it('pending and processing count; every finished state does not', async () => {
+    // `pending` matters as much as `processing`: a queued job is exactly the case where someone is
+    // staring at the row wondering whether anything is happening at all.
+    for (const s of ['pending', 'processing']) {
+      const lookup = spyLookup();
+      await attachJobProgress('space', [file('x', s)], lookup);
+      assert.equal(lookup.calls.length, 1, `${s} should be looked up`);
+    }
+    for (const s of ['complete', 'partial', 'failed', 'skipped', 'disabled', '', undefined]) {
+      const lookup = spyLookup();
+      await attachJobProgress('space', [file('x', s)], lookup);
+      assert.equal(lookup.calls.length, 0, `${s} must not trigger a lookup`);
+    }
+  });
+});


### PR DESCRIPTION
Must-ship item 1. The last piece of the chain that #357, #358 and #361 were building toward.

The badge said "something is happening" for as long as the job ran, and looked identical whether the job was working or wedged. Each section is now a stage of *that document's* route — routes differ per file and per extraction level — with the active one filling as its pages land.

**The data already existed.** #357 gave the job a heartbeat; #358 gave that heartbeat identity. What was missing was the wire and the drawing: `progress` lives on the media job while the file listing reads the files collection, so it never reached the client.

## Four decisions that are deliberate

- **Sections are weighted, not equal.** On a 40-page PDF the vision pass is minutes and `validate` is milliseconds — equal widths would sit at a third for the whole job and then leap to done. The weights are an honest display heuristic and are named as one in the code; nothing treats them as time remaining.
- **A one-stage route degrades to a plain bar.** The OCR route really *is* a single stage, and a lone bordered box reads as "step 1 of several" — a claim about work that does not exist. This is the common case, not an edge case.
- **A stage that cannot count its work is not drawn half-finished.** No `done`/`total` means one indivisible call. Inventing 50 % would be fabricated progress.
- **A stalled job stops looking like a working one.** Nothing reported for longer than the stall timeout says so, rather than holding a frozen section indistinguishable from a moving one — #357's failure mode viewed from the UI side.

## Accessibility

`role="progressbar"` with real values plus a **translated** text label naming the stage and position. A bar that communicates only by width answers "is this file done?" for nobody using a screen reader.

Building that label in a `computed()` instead of through the pipe puts `models.step.vlm` into `aria-valuetext` and looks perfect on screen — so the test supplies real translations and asserts the resolved words appear. With an empty translation map, "went through the pipe" and "echoed the key back" are indistinguishable, which is exactly how this would ship broken.

## Cost

The listing pays nothing when nothing is in flight: one `$in` per member space, issued only for `pending`/`processing` files, skipped entirely otherwise. Joined per **member**, because on a proxy space the ids belong to that member's job collection.

That claim needed a real seam to test. **An earlier version of the test asserted on the returned records — and passed with the early return deleted**, because that cannot distinguish "did not query" from "queried and got nothing". The lookup is injected now, and the mutation fails three tests.

## Testing

Mutation-verified throughout, each catching exactly its intended assertions:

| mutation | fails |
|---|---|
| always segmented | the degrade test |
| equal weights | both weighting tests |
| `aria-label` from a `computed()` | the a11y test |
| no-query early return removed | three join tests |

Client 452 pass, standalone 1148 pass, both builds clean, docs + CHANGELOG lint clean.

**On verification:** the model and the rendered contract are covered by unit and component specs rather than a browser run. A live bar needs a genuine in-flight job, which needs the sidecars and a model — the scratch stack can produce a text-pipeline job but it completes in milliseconds, so catching it mid-flight would be racy and prove less than the deterministic specs do. Flagging that rather than claiming a screenshot I did not take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)