### PR TITLE
test: PropertySchema validation now uses the real Zod schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2063,6 +2063,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The `PropertySchema` request-validation tests now use the real Zod schema.** The file kept a
+  hand-copy of `PropertySchemaZ` from `api/spaces.ts`, and it had drifted in the direction hardest to
+  notice: **stricter than production**. Because the schema is `.strict()`, three fields production
+  accepts were missing from the copy and were therefore *rejected* by it — `required` (the inline
+  flag the Schema tab sends for every property an operator marks required, so the copy rejected the
+  most ordinary body the product produces), `default`, and `type: 'date'`.
+  A suite that rejects what production accepts cannot catch a real regression: it fails only on
+  bodies the product never sends, and stays silent on the ones it does. `PropertySchemaZ` is exported
+  now and imported directly, so there is nothing left to drift. The `date` branch of the mergeFn
+  compatibility rule gains coverage it never had, since that type did not exist in the copy.
+  Mutation-checked: disabling the type/mergeFn refine fails exactly the four compatibility cases, and
+  dropping `.strict()` fails only the unrecognised-key case.
+
 - **The schema-validation tests now test the schema validator.** `schema-validation.test.js` was
   ~20 KB that re-implemented nine functions — `validateEntity`, `validateEdge`, `validateMemory`,
   `validateChrono`, `validateValue`, `safeRegexTest`, `hasReDoSRisk` and two more — and then tested

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -26,7 +26,12 @@ import { writeFile as writeSpaceFile } from '../files/files.js';
 export const spacesRouter = Router();
 
 // ── Zod schema for PropertySchema ──────────────────────────────────────────
-const PropertySchemaZ = z.object({
+/**
+ * Exported for the standalone tests, which used to keep a hand-copy of this schema and drifted:
+ * the copy was missing `required`, `default` and `type: "date"`, so it REJECTED bodies this accepts —
+ * including every property the Schema tab sends, since `required` is an inline flag on the property.
+ */
+export const PropertySchemaZ = z.object({
   type: z.enum(['string', 'number', 'boolean', 'date']).optional(),
   enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
   minimum: z.number().optional(),

--- a/testing/standalone/mergefn-schema.test.js
+++ b/testing/standalone/mergefn-schema.test.js
@@ -1,99 +1,125 @@
 /**
- * Unit tests: mergeFn validation in PropertySchema Zod schema
+ * `PropertySchema` request validation — against the REAL Zod schema.
  *
- * Covers:
- *  - Valid mergeFn for number type (avg, min, max, sum, first, last)
- *  - Valid mergeFn for boolean type (and, or, xor)
- *  - Rejected: numeric mergeFn on boolean type
- *  - Rejected: boolean mergeFn on number type
- *  - Rejected: mergeFn on string type
- *  - Allowed: mergeFn without type declaration (type-agnostic)
+ * This file used to keep a hand-copy of `PropertySchemaZ` from `api/spaces.ts` and test that. The
+ * copy drifted, and it drifted in the direction that is hardest to notice: it became **stricter than
+ * production**, so every test passed while the schema under test accepted less than the real one.
  *
- * Run with:
- *   node --test testing/standalone/mergefn-schema.test.js
+ * Three fields production accepts were missing from the copy, and because the schema is `.strict()`
+ * their absence meant *rejection*, not laxity:
+ *
+ *   - `required` — an inline boolean on the property. This is the one that matters: it is what the
+ *     Schema tab sends for every property an operator marks required, so the copy rejected the most
+ *     ordinary body the product produces.
+ *   - `default` — the seed value used when a record omits the property.
+ *   - `type: 'date'` — a fourth declared type, stored as an ISO string.
+ *
+ * A test suite that rejects what production accepts cannot catch a real regression: it fails only on
+ * bodies the product never sends, and stays silent on the ones it does. Importing the real schema
+ * removes the whole class of problem — there is nothing left to drift.
+ *
+ * Run: node --test testing/standalone/mergefn-schema.test.js
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { z } from 'zod';
 
-// ── Replicated Zod schema from spaces.ts ──
+const { PropertySchemaZ } = await import('../../server/dist/api/spaces.js');
 
-const PropertySchemaZ = z.object({
-  type: z.enum(['string', 'number', 'boolean']).optional(),
-  enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
-  minimum: z.number().optional(),
-  maximum: z.number().optional(),
-  pattern: z.string().max(500).optional(),
-  mergeFn: z.enum(['avg', 'min', 'max', 'sum', 'and', 'or', 'xor']).optional(),
-}).strict().refine(data => {
-  if (!data.mergeFn) return true;
-  const numericFns = new Set(['avg', 'min', 'max', 'sum']);
-  const booleanFns = new Set(['and', 'or', 'xor']);
-  if (data.type === 'number') return numericFns.has(data.mergeFn);
-  if (data.type === 'boolean') return booleanFns.has(data.mergeFn);
-  if (data.type === 'string') return false;
-  return numericFns.has(data.mergeFn) || booleanFns.has(data.mergeFn);
-}, {
-  message: 'mergeFn is incompatible with the declared type',
+const accepts = (input, why = '') => assert.ok(
+  PropertySchemaZ.safeParse(input).success,
+  `expected accepted${why ? ' (' + why + ')' : ''}: ${JSON.stringify(input)}`,
+);
+const rejects = (input, why = '') => assert.ok(
+  !PropertySchemaZ.safeParse(input).success,
+  `expected rejected${why ? ' (' + why + ')' : ''}: ${JSON.stringify(input)}`,
+);
+
+const NUMERIC = ['avg', 'min', 'max', 'sum'];
+const BOOLEAN = ['and', 'or', 'xor'];
+
+describe('mergeFn must match the declared type', () => {
+  it('numeric mergeFns are accepted on a number', () => {
+    for (const mergeFn of NUMERIC) accepts({ type: 'number', mergeFn });
+  });
+
+  it('boolean mergeFns are accepted on a boolean', () => {
+    for (const mergeFn of BOOLEAN) accepts({ type: 'boolean', mergeFn });
+  });
+
+  it('numeric mergeFns are rejected on a boolean', () => {
+    for (const mergeFn of NUMERIC) rejects({ type: 'boolean', mergeFn });
+  });
+
+  it('boolean mergeFns are rejected on a number', () => {
+    for (const mergeFn of BOOLEAN) rejects({ type: 'number', mergeFn });
+  });
+
+  it('no mergeFn is valid on a string — there is nothing to merge numerically or logically', () => {
+    for (const mergeFn of [...NUMERIC, ...BOOLEAN]) rejects({ type: 'string', mergeFn });
+  });
+
+  it('no mergeFn is valid on a date either', () => {
+    // `date` did not exist in the hand-copy at all, so this branch of the refine was never exercised.
+    for (const mergeFn of [...NUMERIC, ...BOOLEAN]) rejects({ type: 'date', mergeFn });
+  });
+
+  it('a mergeFn with no declared type is allowed, so long as it is a real one', () => {
+    for (const mergeFn of [...NUMERIC, ...BOOLEAN]) accepts({ mergeFn });
+  });
+
+  it('an unknown mergeFn is rejected however it is declared', () => {
+    rejects({ mergeFn: 'frobnicate' });
+    rejects({ type: 'number', mergeFn: 'concat' });
+    rejects({ type: 'number', mergeFn: '' });
+  });
+
+  it('a schema with no mergeFn is fine', () => {
+    accepts({ type: 'number' });
+    accepts({});
+  });
 });
 
-// ── Tests ──
-
-describe('PropertySchema Zod — mergeFn validation', () => {
-  it('accepts number type with numeric mergeFns', () => {
-    for (const fn of ['avg', 'min', 'max', 'sum']) {
-      const result = PropertySchemaZ.safeParse({ type: 'number', mergeFn: fn });
-      assert.ok(result.success, `type: number + mergeFn: ${fn} should be valid`);
-    }
+describe('the fields the hand-copy was missing — the drift this file existed to have caught', () => {
+  it('accepts `required`, which is what the Schema tab sends for every required property', () => {
+    // The copy was .strict() without this key, so it rejected the most ordinary body in the product.
+    accepts({ type: 'string', required: true }, 'required is an inline flag on the property');
+    accepts({ required: false });
   });
 
-  it('accepts boolean type with boolean mergeFns', () => {
-    for (const fn of ['and', 'or', 'xor']) {
-      const result = PropertySchemaZ.safeParse({ type: 'boolean', mergeFn: fn });
-      assert.ok(result.success, `type: boolean + mergeFn: ${fn} should be valid`);
-    }
+  it('accepts `default`', () => {
+    accepts({ type: 'string', default: 'unset' });
+    accepts({ type: 'number', default: 0 });
+    accepts({ type: 'boolean', default: false });
   });
 
-  it('rejects numeric mergeFns on boolean type', () => {
-    for (const fn of ['avg', 'min', 'max', 'sum']) {
-      const result = PropertySchemaZ.safeParse({ type: 'boolean', mergeFn: fn });
-      assert.ok(!result.success, `type: boolean + mergeFn: ${fn} should be rejected`);
-    }
+  it("accepts type 'date'", () => {
+    accepts({ type: 'date' });
+    accepts({ type: 'date', pattern: '^\\d{4}-\\d{2}-\\d{2}' });
   });
 
-  it('rejects boolean mergeFns on number type', () => {
-    for (const fn of ['and', 'or', 'xor']) {
-      const result = PropertySchemaZ.safeParse({ type: 'number', mergeFn: fn });
-      assert.ok(!result.success, `type: number + mergeFn: ${fn} should be rejected`);
-    }
+  it('a realistic property from the Schema tab round-trips', () => {
+    accepts({ type: 'string', enum: ['active', 'deprecated'], required: true, default: 'active' });
+    accepts({ type: 'number', minimum: 0, maximum: 100, mergeFn: 'avg', required: false });
+  });
+});
+
+describe('the schema is still strict about what it does not know', () => {
+  it('rejects an unrecognised key rather than ignoring it', () => {
+    // .strict() is deliberate: a typo like `requried` must be an error, not a silently dropped
+    // constraint that leaves the operator believing the property is required.
+    rejects({ type: 'string', requried: true }, 'typo must not be silently dropped');
+    rejects({ type: 'string', unknownThing: 1 });
   });
 
-  it('rejects any mergeFn on string type', () => {
-    for (const fn of ['avg', 'min', 'max', 'sum', 'first', 'last', 'and', 'or', 'xor']) {
-      const result = PropertySchemaZ.safeParse({ type: 'string', mergeFn: fn });
-      assert.ok(!result.success, `type: string + mergeFn: ${fn} should be rejected`);
-    }
+  it('rejects a wrong-typed value for a known key', () => {
+    rejects({ type: 'number', minimum: 'zero' });
+    rejects({ required: 'yes' });
+    rejects({ type: 'nonsense' });
   });
 
-  it('accepts mergeFn without type declaration', () => {
-    // This is allowed because the type can be inferred at runtime
-    const result = PropertySchemaZ.safeParse({ mergeFn: 'avg' });
-    assert.ok(result.success, 'mergeFn without type should be allowed');
-  });
-
-  it('accepts schema without mergeFn', () => {
-    const result = PropertySchemaZ.safeParse({ type: 'number', minimum: 0, maximum: 100 });
-    assert.ok(result.success, 'schema without mergeFn should be valid');
-  });
-
-  it('accepts empty schema', () => {
-    const result = PropertySchemaZ.safeParse({});
-    assert.ok(result.success, 'empty schema should be valid');
-  });
-
-  it('rejects unknown mergeFn values', () => {
-    const result = PropertySchemaZ.safeParse({ type: 'number', mergeFn: 'bogus' });
-    assert.ok(!result.success, 'unknown mergeFn should be rejected');
+  it('caps the pattern length, which is the ReDoS-adjacent input', () => {
+    accepts({ type: 'string', pattern: 'a'.repeat(500) });
+    rejects({ type: 'string', pattern: 'a'.repeat(501) });
   });
 });


### PR DESCRIPTION
Second of the six simulation files. Small, but the drift here is instructive.

## It had drifted the dangerous way: stricter than production

The file kept a hand-copy of `PropertySchemaZ` from `api/spaces.ts`. Every test passed while the schema under test accepted **less** than the real one — which is the direction you never notice, because nothing fails.

The schema is `.strict()`, so three fields production accepts were missing from the copy and therefore **rejected** by it:

| field | what it is |
|---|---|
| `required` | the inline boolean the Schema tab sends for **every** property an operator marks required |
| `default` | the seed value used when a record omits the property |
| `type: 'date'` | a fourth declared type, stored as an ISO string |

`required` is the one that matters: the copy rejected the most ordinary body the product produces.

**A suite that rejects what production accepts cannot catch a real regression.** It fails only on bodies the product never sends, and stays silent on the ones it does. That is a worse failure mode than being too lax — a lax copy at least still exercises the real paths.

## The fix removes the class of problem

`PropertySchemaZ` is exported now and imported directly. There is nothing left to drift.

Two things gain coverage they never had:

- the **`date` branch** of the mergeFn compatibility rule, since that type did not exist in the copy;
- the **unrecognised-key** case, which is the whole reason `.strict()` is there — a typo like `requried` must be an error, not a silently dropped constraint that leaves an operator believing the property is required.

## Mutation results

- disabling the type/mergeFn refine → exactly the four compatibility cases fail
- dropping `.strict()` → only the unrecognised-key case fails

Standalone 1156 pass, 0 fail. Route-coverage gate passes. Server build and CHANGELOG lint clean.

Four files remain: `multi-type-recall` (37 KB, ~10 mirrored functions including the `*EmbedText` builders whose divergence already caused a real bug), `vector-search-check`, `mongo-db-name`, plus the tautologies to delete outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)