### PR TITLE
feat(security): OIDC issuer is public-only by default, with the opt-in shipped alongside

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,16 @@ YTHRIL_PORT=3200
 # It does NOT disable the SSRF guard: DNS-pinning and redirect re-validation still apply, and
 # loopback / link-local / cloud-metadata addresses stay blocked — including when a hostname resolves
 # to one. Reported at startup and in GET /api/about/security.
+#
+# INTERNAL OIDC IdP on a PRIVATE address (Keycloak on http://keycloak.internal:8080, Authentik on a
+# cluster service, Dex on 10.x). The OIDC issuer and the endpoints its discovery document names are
+# public-only by default — WITHOUT THIS, DISCOVERY IS REFUSED AND NOBODY CAN SIGN IN:
+#
+#   YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true
+#
+# Same contract as the model endpoints above: the guard stays on (DNS-pinning, redirect
+# re-validation), loopback / link-local / cloud-metadata stay blocked, and a PUBLIC issuer may still
+# never hand back a private jwks_uri. Reported at startup and in GET /api/about/security.
 
 # Verbose logging:
 #   DEBUG=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **⚠️ UPGRADING WITH AN INTERNAL IdP: the OIDC issuer is now public-only by default. If your IdP
+  lives on a private address — Keycloak on `http://keycloak.internal:8080`, Authentik on a cluster
+  service, Dex on `10.x` — you must set `oidc.allowPrivateIssuer: true` in `config.json` (or
+  `YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true`) as part of this upgrade, or nobody can sign in.** The
+  opt-in ships in the same release as the tightened default, deliberately: shipping the guard first
+  and the flag later would have been an outage for every such deployment. The server now says so at
+  boot rather than at first login — an enabled OIDC config with a private issuer and no flag is a
+  **FAIL** in the startup security posture (`oidc.issuer`, also at `GET /api/about/security`), and
+  under `security.strict` the server refuses to start, instead of leaving you to diagnose a login
+  page that just says "authentication failed".
+
+  **What was wrong.** `validateOidcUrl` rejected exactly four things: non-`http(s)`, embedded
+  credentials, `169.254.*` / `metadata.google.internal`, and `0.0.0.0`. Every general private range —
+  `10.*`, `192.168.*`, `172.16–31.*`, `127.*`, `::1` — was allowed, and so was every non-standard
+  encoding of them (`2130706433`, `0x7f000001`, `127.1`). Discovery was fetched with a plain `fetch`:
+  no DNS pinning, no redirect re-validation. And `jwks_uri` — a URL that arrives **inside the
+  discovery document**, i.e. attacker-influenced input the moment the issuer is — was handed to
+  `createRemoteJWKSet` after only that four-item check. OIDC Discovery §4.3 constrains the document's
+  `issuer` field and nothing beside it, so the endpoints were a free pivot into the internal network.
+
+  **What now happens.** The issuer, `jwks_uri`, `authorization_endpoint`, `token_endpoint` and
+  `end_session_endpoint` all go through the shared SSRF validator, and both outbound calls (discovery
+  *and* JWKS, via jose's `customFetch`) go through `ssrfSafeFetch` — which resolves DNS, pins the
+  resolved IP for the connection, and re-validates every redirect hop. Enabling the flag does **not**
+  turn that off; only the private-address rejection lifts. Loopback, link-local / cloud metadata
+  (IMDS) and the unspecified address stay blocked either way, including when a hostname *resolves* to
+  one. Same contract as `allowPrivateModelEndpoints`.
+
+  The allowance is scoped to the **issuer's own address class**, not to the flag: a *public* issuer
+  may never hand back a private `jwks_uri`, however the operator has configured their own internal
+  IdP. Endpoints on a different *public* host are accepted and normal — Google publishes
+  `accounts.google.com` with a `jwks_uri` on `www.googleapis.com` and a `token_endpoint` on
+  `oauth2.googleapis.com`, so a "must share the issuer's host" rule would have broken Google Sign-In
+  outright; the address-class rule stops the pivot without asserting something false about how IdPs
+  deploy. A test carries that reasoning so it is not re-litigated later.
+
+  25 new standalone tests against the real exported functions, each rule mutation-checked (remove the
+  flag lookup, the endpoint validation, the §4.3 issuer match — exactly the intended assertions fail
+  and nothing else).
+
 - **Face recognition can now be pinned by infra — it was the one model in the pipeline that could not
   be.** Vision, speech-to-text, embedding, the document assist model and both sidecars all had env
   overrides, so an infra-managed deployment could fix every model *except whether faces are detected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outright; the address-class rule stops the pivot without asserting something false about how IdPs
   deploy. A test carries that reasoning so it is not re-litigated later.
 
-  25 new standalone tests against the real exported functions, each rule mutation-checked (remove the
-  flag lookup, the endpoint validation, the §4.3 issuer match — exactly the intended assertions fail
-  and nothing else).
+  **An issuer on `127.0.0.1` / `localhost` is not supported, even with the flag on** — loopback is a
+  crown-jewel address. It could not really work anyway: in the normal Docker deployment the server's
+  loopback is its own container, and the browser is sent to the same `authorization_endpoint`, so the
+  browser's loopback would have to be the server's for the flow to complete. Evaluating on a single
+  machine? Use the host's LAN IP or a hostname (`http://host.docker.internal:8080` from Compose).
+
+  33 new standalone tests against the real exported functions, each rule mutation-checked (remove the
+  flag lookup, the endpoint validation, the §4.3 issuer match, the posture check — exactly the
+  intended assertions fail and nothing else).
+
+- **A whole OIDC end-to-end test suite had been skipped on Windows, and the skip was stale.**
+  `oidc.test.js` carried `skip: process.platform === 'win32'` for an "ESM drive-letter path
+  limitation" that no longer applies — verified by running it unskipped. It hid 17 tests from every
+  local run on Windows, which is precisely how a change that broke them could look green locally and
+  fail in CI. The skip is gone and the suite now runs everywhere; its mock IdP binds to the host's
+  private LAN address (with the opt-in enabled) rather than loopback, so it also serves as a live
+  proof that `allowPrivateIssuer` lets an internal IdP through.
 
 - **Face recognition can now be pinned by infra — it was the one model in the pipeline that could not
   be.** Vision, speech-to-text, embedding, the document assist model and both sidecars all had env

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6435,13 +6435,19 @@ Turning the flag on does **not** disable the guard:
   every redirect hop — so a hostname that resolves inward, or a redirect that pivots inward, is still
   refused.
 - **Loopback, link-local / cloud metadata (IMDS) and the unspecified address stay blocked regardless**,
-  including when a hostname resolves to one. An issuer on the server's own `127.0.0.1` cannot work as
-  OIDC anyway — the browser is sent to the same `authorization_endpoint`, and the browser's loopback
-  is not the server's.
+  including when a hostname resolves to one.
 - The allowance is scoped to the **issuer's own address class**: a *public* issuer may never hand back
   a private `jwks_uri`, `authorization_endpoint` or `token_endpoint`, flag or no flag. OIDC Discovery
   §4.3 constrains only the document's `issuer` field, so the endpoints beside it are validated
   separately.
+
+> **An issuer on `127.0.0.1` / `localhost` is not supported, even with the flag on.** In the normal
+> Docker deployment the server's loopback is its own container, so an IdP there is unreachable anyway;
+> and the browser is sent to the same `authorization_endpoint`, so the browser's loopback would have
+> to be the server's for the flow to complete at all. If you are evaluating Ythril on a single machine
+> with a local IdP, address it by the host's LAN IP or a hostname (for example
+> `http://host.docker.internal:8080` from Compose) rather than `127.0.0.1`, and set
+> `allowPrivateIssuer`.
 
 Endpoints on a *different public host* than the issuer are fine and common — Google publishes
 `accounts.google.com` with a `jwks_uri` on `www.googleapis.com` and a `token_endpoint` on

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6416,6 +6416,41 @@ Add an `oidc` block to `config.json`:
 | `claimMapping` | No | Maps IdP claims to Ythril permissions (see below). |
 | `enforceForBrowser` | No | When `true`, the browser SPA rejects cached PAT sessions and always forces a fresh OIDC login. PATs continue to work for API / MCP bearer-header requests. Default: `false`. |
 | `postLogoutRedirectUri` | No | URI the IdP should redirect to after `end_session`. Passed as `post_logout_redirect_uri`. Defaults to `{origin}/login`. |
+| `allowPrivateIssuer` | No | Permit an issuer on a **private address** (`10.x`, `192.168.x`, `172.16–31.x`, IPv6 ULA). Default `false` — public issuers only. Env: `YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true`. **An internal IdP needs this or nobody can sign in** — see below. |
+
+### Internal IdPs on a private address
+
+> **If your IdP lives on a private address — Keycloak on `http://keycloak.internal:8080`, Authentik on
+> a cluster service, Dex on `10.x` — you must set `oidc.allowPrivateIssuer: true` (or
+> `YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true`). Without it, discovery is refused and no one can sign in.**
+
+The server makes two outbound calls on the authentication path: the discovery document at
+`{issuerUrl}/.well-known/openid-configuration`, and the JWKS at whatever `jwks_uri` that document
+names. The second is a URL the server was *told* to fetch, which makes it an SSRF target, so both now
+go through the same egress guard as sync peers and model endpoints. The default is public-only.
+
+Turning the flag on does **not** disable the guard:
+
+- Discovery and JWKS still resolve DNS, **pin the resolved IP** for the connection, and re-validate
+  every redirect hop — so a hostname that resolves inward, or a redirect that pivots inward, is still
+  refused.
+- **Loopback, link-local / cloud metadata (IMDS) and the unspecified address stay blocked regardless**,
+  including when a hostname resolves to one. An issuer on the server's own `127.0.0.1` cannot work as
+  OIDC anyway — the browser is sent to the same `authorization_endpoint`, and the browser's loopback
+  is not the server's.
+- The allowance is scoped to the **issuer's own address class**: a *public* issuer may never hand back
+  a private `jwks_uri`, `authorization_endpoint` or `token_endpoint`, flag or no flag. OIDC Discovery
+  §4.3 constrains only the document's `issuer` field, so the endpoints beside it are validated
+  separately.
+
+Endpoints on a *different public host* than the issuer are fine and common — Google publishes
+`accounts.google.com` with a `jwks_uri` on `www.googleapis.com` and a `token_endpoint` on
+`oauth2.googleapis.com`.
+
+At boot, an enabled OIDC config with a private issuer literal and no flag is reported as a **FAIL** in
+the security posture (`oidc.issuer`, visible at `GET /api/about/security`), and with
+`security.strict` the server refuses to start — rather than letting you find out from a login page
+that just says "authentication failed".
 
 ### Claim Mapping
 

--- a/server/src/auth/oidc.ts
+++ b/server/src/auth/oidc.ts
@@ -11,10 +11,12 @@
  * are never routed through this module.
  */
 
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
 import type { JWTPayload } from 'jose';
 import { getConfig } from '../config/loader.js';
+import { allowPrivateOidcIssuer } from '../config/oidc-egress-policy.js';
 import { log } from '../util/log.js';
+import { isSsrfSafeUrl, ssrfSafeFetch, SsrfBlockedError } from '../util/ssrf.js';
 import type { OidcConfig, OidcClaimRule, OidcClaimMapping } from '../config/types.js';
 
 /**
@@ -39,13 +41,24 @@ export const DEFAULT_OIDC_ALGORITHMS = [
 ];
 
 // ── OIDC URL validation ───────────────────────────────────────────────────
-// Unlike the full isSsrfSafeUrl check (designed for user-supplied peer URLs),
-// this allows private IPs and loopback because internal IdPs (e.g. Keycloak on
-// a corporate network) are a legitimate and common deployment pattern.  It
-// blocks cloud instance metadata endpoints — the primary SSRF exfiltration
-// target — and basic URL shape issues.
 
-function validateOidcUrl(raw: string, label: string): void {
+/** Hint appended to every rejection that `oidc.allowPrivateIssuer` would have permitted. */
+export const OIDC_PRIVATE_ISSUER_HINT =
+  'set oidc.allowPrivateIssuer (or YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true) to permit an internal IdP on a private address';
+
+/**
+ * Validate a URL this module is about to fetch (or hand to the browser).
+ *
+ * Shape checks first, so the operator gets a specific message; then the address class is delegated
+ * to `isSsrfSafeUrl`, which is the single place that knows every encoding of every blocked range.
+ * This module used to carry its own two-line approximation (`169.254.*`, `metadata.google.internal`,
+ * `0.0.0.0`) that let `10.*`, `192.168.*`, `172.16-31.*`, `127.*` and `::1` straight through.
+ *
+ * @param allowPrivate permit private/reserved ranges. Crown jewels (loopback, link-local / cloud
+ *   IMDS, unspecified) are refused regardless — the flag widens where an IdP may live, it does not
+ *   hand out the one address class SSRF is actually after.
+ */
+export function validateOidcUrl(raw: string, label: string, allowPrivate: boolean): void {
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -58,13 +71,26 @@ function validateOidcUrl(raw: string, label: string): void {
   if (parsed.username || parsed.password) {
     throw new Error(`OIDC ${label} must not contain embedded credentials`);
   }
-  const host = parsed.hostname.toLowerCase();
-  if (/^169\.254\./.test(host) || host === 'metadata.google.internal') {
-    throw new Error(`OIDC ${label} must not target cloud metadata endpoints`);
+  if (!isSsrfSafeUrl(raw, allowPrivate)) {
+    throw new Error(allowPrivate
+      ? `OIDC ${label} targets an always-blocked address (${parsed.hostname}): loopback, link-local / cloud metadata, or unspecified. allowPrivateIssuer permits private addresses, never these.`
+      : `OIDC ${label} must be a public http(s) URL — ${parsed.hostname} is a private, loopback or cloud-metadata address. If this is an internal IdP, ${OIDC_PRIVATE_ISSUER_HINT}.`);
   }
-  if (host === '0.0.0.0') {
-    throw new Error(`OIDC ${label} must not target 0.0.0.0`);
-  }
+}
+
+/**
+ * True when `issuerUrl` is reachable ONLY because the opt-in is on — i.e. it is a private address
+ * rather than a public one.
+ *
+ * This is what scopes the allowance for the discovered endpoints. A private issuer may name private
+ * endpoints (an internal Keycloak's `jwks_uri` is on the same internal network, naturally); a
+ * PUBLIC issuer may not, flag or no flag. That asymmetry is the actual guard: the attack worth
+ * stopping is a public — or spoofed — discovery document steering the server at `http://10.0.0.5/`,
+ * and a global "private is fine now" flag would otherwise hand that over as a side effect of an
+ * operator wanting their own Keycloak to work.
+ */
+export function issuerIsPrivate(issuerUrl: string): boolean {
+  return !isSsrfSafeUrl(issuerUrl, false) && isSsrfSafeUrl(issuerUrl, true);
 }
 
 // ── Lightweight synthetic token record ────────────────────────────────────
@@ -103,18 +129,27 @@ let _cachedIssuerUrl = '';
  */
 export const OIDC_HTTP_TIMEOUT_MS = 10_000;
 
-function getJwksHandle(jwksUri: string, issuerUrl: string): JwksHandle {
+function getJwksHandle(jwksUri: string, issuerUrl: string, allowPrivate: boolean): JwksHandle {
   if (_jwksHandle && _cachedIssuerUrl === issuerUrl) return _jwksHandle;
   // jose defaults to 5s; pin it so the budget is explicit policy rather than a library default that
   // could change under us — the same reasoning as DEFAULT_OIDC_ALGORITHMS above.
-  _jwksHandle = createRemoteJWKSet(new URL(jwksUri), { timeoutDuration: OIDC_HTTP_TIMEOUT_MS });
+  //
+  // The JWKS fetch goes through `ssrfSafeFetch` for the same reason discovery does, and more so:
+  // `jwks_uri` is a URL that arrived in a document, so it is the one target here an attacker gets to
+  // choose. Validating the string is half a guard — jose would otherwise resolve and connect on its
+  // own, with no DNS pinning and no redirect re-validation, so a name that passes the string check
+  // and then resolves inward would sail through.
+  _jwksHandle = createRemoteJWKSet(new URL(jwksUri), {
+    timeoutDuration: OIDC_HTTP_TIMEOUT_MS,
+    [customFetch]: (url, options) => ssrfSafeFetch(url, options as RequestInit, { allowPrivate }),
+  });
   _cachedIssuerUrl = issuerUrl;
   return _jwksHandle;
 }
 
 // ── Discovery document cache ───────────────────────────────────────────────
 
-interface DiscoveryDoc {
+export interface DiscoveryDoc {
   issuer: string;
   jwks_uri: string;
   authorization_endpoint: string;
@@ -127,6 +162,61 @@ let _discoveryIssuerUrl = '';
 let _discoveryFetchedAt = 0;
 const DISCOVERY_TTL_MS = 5 * 60 * 1000; // re-fetch every 5 minutes
 
+/**
+ * Validate a fetched discovery document against the configured issuer.
+ *
+ * Two separate rules, and it is worth being precise about which one does what:
+ *
+ *  1. **OIDC Discovery §4.3** — the document's own `issuer` MUST equal the configured URL. This is
+ *     the one thing standing between a compromised document and a full takeover, and it predates
+ *     this guard. Keep it first.
+ *  2. **Every endpoint the document names is no more private than the issuer itself.** A discovery
+ *     document is attacker-influenced input the moment the issuer is, and §4.3 constrains only the
+ *     `issuer` field, not the endpoints beside it. So `jwks_uri` and friends go back through
+ *     `validateOidcUrl` with the allowance derived from the *issuer's* address class — never from
+ *     the global flag (see `issuerIsPrivate`).
+ *
+ * **Why not "the endpoints must share the issuer's host":** because that rule is wrong about real
+ * IdPs, not merely strict. Google publishes `issuer: https://accounts.google.com` with
+ * `jwks_uri: https://www.googleapis.com/oauth2/v3/certs` and
+ * `token_endpoint: https://oauth2.googleapis.com/token` — three different origins, and not even a
+ * shared registrable domain (`google.com` vs `googleapis.com`). Same-origin would break Google
+ * Sign-In outright, which is the same class of upgrade outage this whole change exists to avoid.
+ * The address-class rule above stops the attack that host-matching was reaching for — a public
+ * document steering the server at an internal address — without asserting something false about how
+ * IdPs deploy.
+ *
+ * @param allowPrivate whether the ISSUER is private (from `issuerIsPrivate`), not the global flag.
+ */
+export function validateDiscoveryDocument(
+  doc: DiscoveryDoc,
+  issuerUrl: string,
+  allowPrivate: boolean,
+): void {
+  // OIDC Discovery §4.3: issuer in the document MUST match the configured URL.
+  const normCfg = issuerUrl.replace(/\/$/, '');
+  const normDoc = String(doc.issuer ?? '').replace(/\/$/, '');
+  if (normDoc !== normCfg) {
+    throw new Error(
+      `OIDC discovery issuer (${doc.issuer}) does not match configured issuerUrl (${issuerUrl})`,
+    );
+  }
+
+  // `jwks_uri` is REQUIRED by the spec and the server fetches it directly — no document without it
+  // is usable, and an absent value must not fall through the checks below as `undefined`.
+  if (!doc.jwks_uri) {
+    throw new Error(`OIDC discovery document for ${issuerUrl} has no jwks_uri`);
+  }
+
+  // The endpoints the server fetches, plus the two the browser is sent to. All four are read out of
+  // the same attacker-influenceable document, so all four are validated; the optional ones only when
+  // present (omitting one breaks the flow, it does not evade anything).
+  validateOidcUrl(doc.jwks_uri, 'jwks_uri', allowPrivate);
+  if (doc.authorization_endpoint) validateOidcUrl(doc.authorization_endpoint, 'authorization_endpoint', allowPrivate);
+  if (doc.token_endpoint) validateOidcUrl(doc.token_endpoint, 'token_endpoint', allowPrivate);
+  if (doc.end_session_endpoint) validateOidcUrl(doc.end_session_endpoint, 'end_session_endpoint', allowPrivate);
+}
+
 export async function getDiscoveryDoc(issuerUrl: string): Promise<DiscoveryDoc> {
   const now = Date.now();
   if (
@@ -137,12 +227,23 @@ export async function getDiscoveryDoc(issuerUrl: string): Promise<DiscoveryDoc> 
     return _discoveryDoc;
   }
 
-  validateOidcUrl(issuerUrl, 'issuerUrl');
+  const allowPrivate = allowPrivateOidcIssuer();
+  validateOidcUrl(issuerUrl, 'issuerUrl', allowPrivate);
+  // Scope what the DOCUMENT may name to the issuer's own address class, not to the flag.
+  const endpointsMayBePrivate = issuerIsPrivate(issuerUrl);
+
   const url = issuerUrl.replace(/\/$/, '') + '/.well-known/openid-configuration';
   let res: Response;
   try {
-    res = await fetch(url, { signal: AbortSignal.timeout(OIDC_HTTP_TIMEOUT_MS) });
+    // `ssrfSafeFetch`, not `fetch`: the string check above cannot see where a hostname resolves, and
+    // this call sits on the authentication path where a rebind would be repeated every TTL.
+    res = await ssrfSafeFetch(url, { signal: AbortSignal.timeout(OIDC_HTTP_TIMEOUT_MS) }, { allowPrivate });
   } catch (err) {
+    // A blocked target is not "the IdP is down" — say which it was, and name the flag that would
+    // permit it, so an operator whose Keycloak just stopped answering knows why in one line.
+    if (err instanceof SsrfBlockedError) {
+      throw new Error(`OIDC discovery blocked: ${err.message}${allowPrivate ? '' : ` — if this is an internal IdP, ${OIDC_PRIVATE_ISSUER_HINT}`}`);
+    }
     // An unreachable IdP and one that hangs are the same failure to the caller, and both must be
     // reported as such rather than surfacing an opaque AbortError from deep in the auth path.
     const reason = err instanceof Error && err.name === 'TimeoutError'
@@ -155,17 +256,7 @@ export async function getDiscoveryDoc(issuerUrl: string): Promise<DiscoveryDoc> 
   }
   const doc = await res.json() as DiscoveryDoc;
 
-  // OIDC Discovery §4.3: issuer in the document MUST match the configured URL.
-  const normCfg = issuerUrl.replace(/\/$/, '');
-  const normDoc = doc.issuer.replace(/\/$/, '');
-  if (normDoc !== normCfg) {
-    throw new Error(
-      `OIDC discovery issuer (${doc.issuer}) does not match configured issuerUrl (${issuerUrl})`,
-    );
-  }
-
-  // Validate derived URLs before the server fetches them (defence-in-depth).
-  validateOidcUrl(doc.jwks_uri, 'jwks_uri');
+  validateDiscoveryDocument(doc, issuerUrl, endpointsMayBePrivate);
 
   _discoveryDoc = doc;
   _discoveryIssuerUrl = issuerUrl;
@@ -282,7 +373,8 @@ export async function validateOidcJwt(bearer: string): Promise<OidcTokenRecord |
 
   try {
     const discovery = await getDiscoveryDoc(oidcCfg.issuerUrl);
-    const jwks = getJwksHandle(discovery.jwks_uri, oidcCfg.issuerUrl);
+    // Same allowance as the discovery fetch: the issuer's own class, not the global flag.
+    const jwks = getJwksHandle(discovery.jwks_uri, oidcCfg.issuerUrl, issuerIsPrivate(oidcCfg.issuerUrl));
 
     const audience = oidcCfg.audience ?? oidcCfg.clientId;
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -91,6 +91,12 @@ function validateOidcBlock(cfg: Config): void {
       throw new Error('oidc.scopes must be an array of strings when provided');
     }
   }
+  // Typed strictly on purpose: `"allowPrivateIssuer": "true"` is not `true`, so it would read as OFF
+  // and an internal IdP would stop authenticating with no indication why — the precise failure this
+  // flag exists to prevent. A quoted boolean in hand-edited JSON is a common enough slip to catch here.
+  if (oidc.allowPrivateIssuer !== undefined && typeof oidc.allowPrivateIssuer !== 'boolean') {
+    throw new Error('oidc.allowPrivateIssuer must be a boolean (true/false, unquoted) when provided');
+  }
 }
 
 // ── At-rest encryption (PR-S2) ─────────────────────────────────────────────

--- a/server/src/config/model-egress-exposure.ts
+++ b/server/src/config/model-egress-exposure.ts
@@ -26,6 +26,10 @@ export interface EndpointExposure {
 
 /**
  * Classify a configured endpoint without resolving it.
+ *
+ * Provider-agnostic despite the module name — the OIDC issuer posture check
+ * (`security-posture.ts`, `oidc.issuer`) uses it too, for the same reason: reporting *which class of
+ * address* a configured URL is, without a DNS round-trip at boot.
  *  - `private`  — an IP literal that only the opt-in permits (10/8, 172.16/12, 192.168/16, CGNAT, ULA…)
  *  - `public`   — passes the guard with the opt-in off
  *  - `hostname` — not an IP literal; where it points is decided at call time

--- a/server/src/config/oidc-egress-policy.ts
+++ b/server/src/config/oidc-egress-policy.ts
@@ -1,0 +1,37 @@
+/**
+ * OIDC issuer egress policy — where the IdP is allowed to live.
+ *
+ * The server makes two outbound calls on the authentication path: the discovery document at
+ * `<issuer>/.well-known/openid-configuration`, and the JWKS at whatever `jwks_uri` that document
+ * names. Both are SSRF-relevant, and the second one is a URL the server was *told* to fetch.
+ *
+ * Default is public-only. But an internal IdP on a private address is a normal, supported
+ * deployment — Keycloak on `http://keycloak.internal:8080`, Authentik on a cluster service, Dex on
+ * `10.x` — so the default cannot tighten without an opt-in shipping in the same release, or every
+ * such instance loses login on upgrade.
+ *
+ * `oidc.allowPrivateIssuer` is that opt-in, and it is deliberately NOT "turn the guard off":
+ * `ssrfSafeFetch` still DNS-resolves, pins the resolved IP for the connection and re-validates every
+ * redirect — only the private-address rejection relaxes. Crown-jewel addresses (loopback,
+ * link-local / cloud IMDS, unspecified) stay blocked either way, including when a hostname
+ * *resolves* to one. Exactly the contract `allowPrivateModelEndpoints` already ships.
+ *
+ * Env override → config key → safe default. Read here rather than passed through any API: OIDC
+ * config is not settable over HTTP at all today, and a setting that widens egress must never become
+ * the first thing that is.
+ */
+import { getConfig } from './loader.js';
+
+/**
+ * True when the OIDC issuer (and the endpoints its discovery document names) may resolve to
+ * private/reserved addresses — env `YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER` → config
+ * `oidc.allowPrivateIssuer` → false.
+ */
+export function allowPrivateOidcIssuer(): boolean {
+  if (process.env['YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER'] === 'true') return true;
+  try {
+    return getConfig().oidc?.allowPrivateIssuer === true;
+  } catch {
+    return false; // config not loaded yet (first run) — stay closed
+  }
+}

--- a/server/src/config/security-posture.ts
+++ b/server/src/config/security-posture.ts
@@ -10,7 +10,8 @@
 import { getConfig, getMongoUri, atRestEncryptionActive } from './loader.js';
 import { requireEncryptedTransport, allowInsecurePeersRaw } from './transport-security.js';
 import { allowPrivateModelEndpoints } from './model-egress-policy.js';
-import { modelEndpointExposure, formatExposure } from './model-egress-exposure.js';
+import { allowPrivateOidcIssuer } from './oidc-egress-policy.js';
+import { modelEndpointExposure, formatExposure, classifyEndpoint } from './model-egress-exposure.js';
 
 export type PostureLevel = 'pass' | 'warn' | 'fail';
 
@@ -109,6 +110,28 @@ export function computeSecurityPosture(): SecurityPosture {
         level: 'warn',
         message: `External model endpoint(s) point at addresses this instance will refuse to call: ${formatExposure(stuck)}. Set allowPrivateModelEndpoints (or YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true) for a self-hosted endpoint on a private address; cloud-metadata addresses stay blocked regardless.`,
       });
+    }
+  }
+
+  // ── OIDC issuer egress ───────────────────────────────────────────────────────
+  // The one check here that can be a FAIL rather than a WARN, and deliberately so: an enabled OIDC
+  // config whose issuer sits on a private address with the opt-in absent means NOBODY CAN SIGN IN.
+  // Discovering that from a login page that says "authentication failed" is the bad version of this
+  // change; discovering it from a named line at boot (and, under security.strict, from a refusal to
+  // start at all) is the good one.
+  if (cfg?.oidc?.enabled && cfg.oidc.issuerUrl) {
+    const { host, klass } = classifyEndpoint(cfg.oidc.issuerUrl);
+    const allowPrivate = allowPrivateOidcIssuer();
+    if (klass === 'invalid') {
+      checks.push({ id: 'oidc.issuer', level: 'fail', message: `oidc.enabled is on but issuerUrl (${host}) is unusable — unparseable, or a loopback / link-local / cloud-metadata address that is blocked regardless of oidc.allowPrivateIssuer. No one can sign in.` });
+    } else if (klass === 'private' && !allowPrivate) {
+      checks.push({ id: 'oidc.issuer', level: 'fail', message: `oidc.enabled is on and issuerUrl (${host}) is a private address, but oidc.allowPrivateIssuer is not set — discovery will be refused and no one can sign in. Set oidc.allowPrivateIssuer: true (or YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true) for an internal IdP.` });
+    } else if (allowPrivate) {
+      // Report the exposure, not the flag — same rule as the model endpoints above. A hostname is
+      // named as a hostname: only the resolution-time guard knows where it points.
+      checks.push(klass === 'private'
+        ? { id: 'oidc.issuer', level: 'warn', message: `oidc.allowPrivateIssuer is on — issuer ${host} is a private address. SSRF guarding, IP-pinning and redirect re-validation still apply; loopback, link-local/IMDS and cloud-metadata addresses stay blocked, and a public issuer could not name a private jwks_uri.` }
+        : { id: 'oidc.issuer', level: 'warn', message: `oidc.allowPrivateIssuer is on but issuer ${host} is not a private address (${klass}) — nothing is using the permission; unset it.` });
     }
   }
 

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -743,6 +743,23 @@ export interface OidcConfig {
    * Defaults to the instance origin (i.e. the login page).
    */
   postLogoutRedirectUri?: string;
+  /**
+   * Allow the issuer — and the endpoints its discovery document names — to live on a
+   * private/reserved address. An internal IdP is a normal deployment (Keycloak on
+   * `http://keycloak.internal:8080`, Authentik on a cluster service, Dex on `10.x`), and the
+   * default is public-only, so **that deployment needs this flag or nobody can sign in**.
+   *
+   * Enabling it does NOT drop the egress guard: discovery and JWKS still go through
+   * `ssrfSafeFetch`, which DNS-resolves, pins the resolved IP for the connection and re-validates
+   * every redirect — only the private-address rejection relaxes. Crown-jewel addresses (loopback,
+   * link-local / cloud IMDS, unspecified) stay blocked either way, including when a hostname
+   * resolves to one.
+   *
+   * The allowance is scoped to the issuer's own address class: a PUBLIC issuer may never hand back
+   * a private `jwks_uri`, flag or no flag. Mirrors `allowPrivateModelEndpoints`.
+   * Overridable via YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER.
+   */
+  allowPrivateIssuer?: boolean;
 }
 
 // ── Audit log types ────────────────────────────────────────────────────────

--- a/testing/standalone/_private-address.mjs
+++ b/testing/standalone/_private-address.mjs
@@ -1,0 +1,29 @@
+/**
+ * The host's own non-loopback IPv4 — a PRIVATE address the SSRF guards permit under an opt-in.
+ *
+ * Why tests need this: since the OIDC issuer guard (SSRF part 2b), loopback is a crown-jewel address
+ * that stays blocked even with `oidc.allowPrivateIssuer` on. Any test that stands up a mock IdP and
+ * expects the server to actually fetch it therefore cannot bind to `127.0.0.1` — the request is
+ * refused before a socket opens, and the test proves nothing about the behaviour it names.
+ *
+ * Binding to the machine's LAN address instead keeps the mock reachable and, as a side effect, makes
+ * those tests a live proof that the private-issuer opt-in works — which is the half of that change
+ * that turns into an upgrade outage if it ever breaks.
+ *
+ * Returns null on a host with no non-loopback IPv4 (rare; callers should skip with a clear reason).
+ */
+import os from 'node:os';
+
+export function privateHostAddress() {
+  for (const addrs of Object.values(os.networkInterfaces())) {
+    for (const a of addrs ?? []) {
+      if (a.family === 'IPv4' && !a.internal) return a.address;
+    }
+  }
+  return null;
+}
+
+/** Skip reason for a suite that needs a reachable non-loopback address, or false when one exists. */
+export function privateAddressSkipReason() {
+  return privateHostAddress() ? false : 'no non-loopback IPv4 on this host';
+}

--- a/testing/standalone/oidc-discovery-timeout.test.js
+++ b/testing/standalone/oidc-discovery-timeout.test.js
@@ -27,7 +27,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
-import os from 'node:os';
+import { privateHostAddress } from './_private-address.mjs';
 
 let getDiscoveryDoc;
 let clearOidcCache;
@@ -41,16 +41,6 @@ const heldSockets = [];
 
 const ENV_KEY = 'YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER';
 let savedEnv;
-
-/** The host's own non-loopback IPv4 — a private address the guard permits once opted in. */
-function privateHostAddress() {
-  for (const addrs of Object.values(os.networkInterfaces())) {
-    for (const a of addrs ?? []) {
-      if (a.family === 'IPv4' && !a.internal) return a.address;
-    }
-  }
-  return null;
-}
 
 describe('OIDC discovery — timeout', () => {
   before(async () => {

--- a/testing/standalone/oidc-discovery-timeout.test.js
+++ b/testing/standalone/oidc-discovery-timeout.test.js
@@ -10,12 +10,24 @@
  * The test drives a real HTTP server that deliberately never responds, so it proves the behaviour
  * end to end rather than asserting that a constant exists.
  *
+ * WHY THE BLACK HOLE IS NOT ON LOOPBACK (changed with the SSRF part-2b guard): discovery now goes
+ * through `ssrfSafeFetch`, and loopback is a crown-jewel address that stays blocked even with
+ * `oidc.allowPrivateIssuer` on. A `127.0.0.1` issuer would therefore be refused before any socket
+ * opened and this test would prove nothing about timeouts.
+ *
+ * That is not a limitation worth working around — an issuer on the *server's* loopback cannot work as
+ * OIDC anyway: the browser is sent to the same `authorization_endpoint`, and the browser's 127.0.0.1
+ * is not the server's. So the test binds to the host's own private LAN address and opts in, which
+ * incidentally makes it an end-to-end proof that `allowPrivateIssuer` really does let an internal IdP
+ * through — the half of the change that, if broken, is an upgrade outage.
+ *
  * Run: node --test testing/standalone/oidc-discovery-timeout.test.js
  */
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
+import os from 'node:os';
 
 let getDiscoveryDoc;
 let clearOidcCache;
@@ -23,8 +35,22 @@ let OIDC_HTTP_TIMEOUT_MS;
 
 /** A server that accepts the connection and then holds it open, answering nothing. */
 let blackHole;
+let blackHoleHost;
 let blackHolePort;
 const heldSockets = [];
+
+const ENV_KEY = 'YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER';
+let savedEnv;
+
+/** The host's own non-loopback IPv4 — a private address the guard permits once opted in. */
+function privateHostAddress() {
+  for (const addrs of Object.values(os.networkInterfaces())) {
+    for (const a of addrs ?? []) {
+      if (a.family === 'IPv4' && !a.internal) return a.address;
+    }
+  }
+  return null;
+}
 
 describe('OIDC discovery — timeout', () => {
   before(async () => {
@@ -32,11 +58,16 @@ describe('OIDC discovery — timeout', () => {
       '../../server/dist/auth/oidc.js'
     ));
 
+    savedEnv = process.env[ENV_KEY];
+    process.env[ENV_KEY] = 'true'; // an internal IdP on a private address — the supported deployment
+
+    blackHoleHost = privateHostAddress();
+    if (!blackHoleHost) return; // no LAN address on this host; the tests below skip
     blackHole = http.createServer((req) => {
       // Never write a response, never end it: the classic "hung IdP".
       heldSockets.push(req.socket);
     });
-    await new Promise((resolve) => blackHole.listen(0, '127.0.0.1', resolve));
+    await new Promise((resolve) => blackHole.listen(0, blackHoleHost, resolve));
     blackHolePort = blackHole.address().port;
   });
 
@@ -44,6 +75,7 @@ describe('OIDC discovery — timeout', () => {
     for (const s of heldSockets) s.destroy();
     if (blackHole) await new Promise((resolve) => blackHole.close(resolve));
     clearOidcCache?.();
+    if (savedEnv === undefined) delete process.env[ENV_KEY]; else process.env[ENV_KEY] = savedEnv;
   });
 
   it('exposes an explicit, sane HTTP budget', () => {
@@ -54,11 +86,11 @@ describe('OIDC discovery — timeout', () => {
     );
   });
 
-  it('rejects instead of hanging when the IdP never responds', async () => {
+  it('rejects instead of hanging when the IdP never responds', { skip: !privateHostAddress() && 'no non-loopback IPv4 on this host' }, async () => {
     clearOidcCache();
     const started = Date.now();
     await assert.rejects(
-      () => getDiscoveryDoc(`http://127.0.0.1:${blackHolePort}`),
+      () => getDiscoveryDoc(`http://${blackHoleHost}:${blackHolePort}`),
       (err) => {
         assert.match(err.message, /OIDC discovery failed/);
         // The operator has to be able to tell "it hung" from "it refused" or "it 500'd".
@@ -74,12 +106,26 @@ describe('OIDC discovery — timeout', () => {
     );
   });
 
-  it('reports an unreachable IdP as a discovery failure too', async () => {
+  it('reports an unreachable IdP as a discovery failure too', { skip: !privateHostAddress() && 'no non-loopback IPv4 on this host' }, async () => {
     clearOidcCache();
-    // Port 1 on loopback: connection refused immediately — the other half of the same failure mode.
+    // Port 1: connection refused immediately — the other half of the same failure mode.
     await assert.rejects(
-      () => getDiscoveryDoc('http://127.0.0.1:1'),
+      () => getDiscoveryDoc(`http://${blackHoleHost}:1`),
       /OIDC discovery failed/,
+    );
+  });
+
+  it('a blocked issuer is reported as blocked, not as "the IdP is down"', async () => {
+    clearOidcCache();
+    // Still opted in (the env flag is on for this suite) — loopback is refused anyway, and the
+    // operator must be able to tell a policy refusal from an unreachable IdP.
+    await assert.rejects(
+      () => getDiscoveryDoc('http://127.0.0.1:8080/realms/main'),
+      (err) => {
+        assert.match(err.message, /always-blocked address/);
+        assert.doesNotMatch(err.message, /OIDC discovery failed/);
+        return true;
+      },
     );
   });
 });

--- a/testing/standalone/oidc-issuer-ssrf.test.js
+++ b/testing/standalone/oidc-issuer-ssrf.test.js
@@ -1,0 +1,374 @@
+/**
+ * Standalone tests: OIDC issuer + discovery-document SSRF guard (SSRF part 2b).
+ *
+ * What this module looked like before: `validateOidcUrl` rejected exactly four things — non-http(s),
+ * embedded credentials, `169.254.*` / `metadata.google.internal`, and `0.0.0.0`. Every general
+ * private range (`10.*`, `192.168.*`, `172.16-31.*`, `127.*`, `::1`) was allowed, discovery was
+ * fetched with a plain `fetch` (no DNS pinning, no redirect re-validation), and `jwks_uri` — a URL
+ * that arrives inside a document — was handed to `createRemoteJWKSet` after only that four-item
+ * check.
+ *
+ * Three properties are under test here, and they are not the same property:
+ *
+ *   1. THE DEFAULT IS PUBLIC-ONLY, AND THE OPT-IN EXISTS. Tightening the default without
+ *      `oidc.allowPrivateIssuer` shipping alongside it is an outage for every Keycloak-on-10.x
+ *      deployment, so "private is refused by default" and "private is permitted with the flag" are
+ *      both requirements, tested together.
+ *   2. THE OPT-IN NEVER REACHES THE CROWN JEWELS. Loopback, link-local / cloud IMDS and the metadata
+ *      hostnames stay refused with the flag ON. "Private address" and "cloud metadata endpoint" are
+ *      different risk classes and must not share a switch.
+ *   3. A PUBLIC ISSUER MAY NOT NAME A PRIVATE ENDPOINT — flag or no flag. This is the actual attack
+ *      and the case with no coverage at all before: OIDC Discovery §4.3 constrains the document's
+ *      `issuer` field and nothing else, so `jwks_uri` was a free pivot into the internal network.
+ *      The allowance for discovered endpoints is therefore derived from the ISSUER's address class,
+ *      not from the global flag.
+ *
+ * Everything below runs against the real exported functions in `server/dist` — no hand-copied
+ * validator (see `_REFERENCE.md`, QA METHOD).
+ *
+ * Run: node --test testing/standalone/oidc-issuer-ssrf.test.js
+ */
+
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Read at loader module-load time — must be set before any dist import below.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-oidc-ssrf-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let validateOidcUrl;
+let issuerIsPrivate;
+let validateDiscoveryDocument;
+let getDiscoveryDoc;
+let clearOidcCache;
+let allowPrivateOidcIssuer;
+let computeSecurityPosture;
+let loader;
+
+const ENV_KEY = 'YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER';
+let savedEnv;
+
+/** Internal IdPs an operator legitimately runs — refused by default, permitted by the opt-in. */
+const PRIVATE_ISSUERS = [
+  'http://10.1.2.3:8080/realms/main',
+  'http://192.168.1.50:8080/realms/main',
+  'http://172.16.0.9:8080/realms/main',
+  'https://[fd00::5]/realms/main',
+];
+
+/** Refused with the flag ON as well — the opt-in widens where an IdP may live, nothing more. */
+const CROWN_JEWELS = [
+  'http://127.0.0.1:8080/realms/main',
+  'http://localhost:8080/realms/main',
+  'http://169.254.169.254/latest/meta-data/',
+  'http://metadata.google.internal/computeMetadata/v1/',
+  'http://100.100.100.200/latest/meta-data/',
+  'http://[::1]:8080/realms/main',
+  'http://0.0.0.0:8080/realms/main',
+];
+
+const PUBLIC_ISSUER = 'https://keycloak.example.com/realms/main';
+
+/** Write a config to disk and load it. `oidc` omitted → a config with no OIDC block at all. */
+function seedConfig(oidc) {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+    instanceId: 'oidc-ssrf-test', instanceLabel: 'test', tokens: [], networks: [],
+    spaces: [{ id: 'general', label: 'General', builtIn: true, folders: [] }],
+    ...(oidc ? { oidc } : {}),
+  }, null, 2), { mode: 0o600 });
+  loader.loadConfig();
+}
+
+/** A well-formed document for `issuer`, with every endpoint on the issuer's own origin. */
+function docFor(issuer, overrides = {}) {
+  const base = issuer.replace(/\/$/, '');
+  return {
+    issuer,
+    jwks_uri: `${base}/protocol/openid-connect/certs`,
+    authorization_endpoint: `${base}/protocol/openid-connect/auth`,
+    token_endpoint: `${base}/protocol/openid-connect/token`,
+    ...overrides,
+  };
+}
+
+describe('OIDC issuer + discovery SSRF guard', () => {
+  before(async () => {
+    ({ validateOidcUrl, issuerIsPrivate, validateDiscoveryDocument, getDiscoveryDoc, clearOidcCache } =
+      await import('../../server/dist/auth/oidc.js'));
+    ({ allowPrivateOidcIssuer } = await import('../../server/dist/config/oidc-egress-policy.js'));
+    ({ computeSecurityPosture } = await import('../../server/dist/config/security-posture.js'));
+    loader = await import('../../server/dist/config/loader.js');
+  });
+
+  // Both the env var AND the on-disk config feed `allowPrivateOidcIssuer()`, so both are reset
+  // between tests — a config left enabled by one case would silently permit a private issuer in the
+  // next, and the assertion that noticed would be a 10s network timeout rather than a clear failure.
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    seedConfig(null);
+  });
+  afterEach(() => { if (savedEnv === undefined) delete process.env[ENV_KEY]; else process.env[ENV_KEY] = savedEnv; });
+
+  // ── The opt-in ─────────────────────────────────────────────────────────────
+  describe('the flag itself', () => {
+    it('is OFF by default', () => {
+      assert.equal(allowPrivateOidcIssuer(), false);
+    });
+
+    it('turns on from the environment', () => {
+      process.env[ENV_KEY] = 'true';
+      assert.equal(allowPrivateOidcIssuer(), true);
+    });
+
+    it('only the exact string "true" enables it', () => {
+      for (const value of ['1', 'yes', 'TRUE', 'on', '']) {
+        process.env[ENV_KEY] = value;
+        assert.equal(allowPrivateOidcIssuer(), false, `"${value}" must not enable a private issuer`);
+      }
+    });
+  });
+
+  // ── Issuer admission ───────────────────────────────────────────────────────
+  describe('issuer URL admission', () => {
+    it('accepts a public issuer with the flag off', () => {
+      assert.doesNotThrow(() => validateOidcUrl(PUBLIC_ISSUER, 'issuerUrl', false));
+    });
+
+    it('refuses a private issuer by default — this is the behaviour change', () => {
+      for (const url of PRIVATE_ISSUERS) {
+        assert.throws(() => validateOidcUrl(url, 'issuerUrl', false), /must be a public http\(s\) URL/, url);
+      }
+    });
+
+    it('names the flag in the rejection, so an operator can act on it', () => {
+      assert.throws(
+        () => validateOidcUrl('http://10.1.2.3:8080/realms/main', 'issuerUrl', false),
+        /oidc\.allowPrivateIssuer.*YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true/s,
+      );
+    });
+
+    it('accepts a private issuer once opted in — the internal-Keycloak deployment', () => {
+      for (const url of PRIVATE_ISSUERS) {
+        assert.doesNotThrow(() => validateOidcUrl(url, 'issuerUrl', true), url);
+      }
+    });
+
+    it('refuses loopback, link-local/IMDS and the metadata hostnames REGARDLESS of the flag', () => {
+      for (const url of CROWN_JEWELS) {
+        assert.throws(() => validateOidcUrl(url, 'issuerUrl', false), /OIDC issuerUrl/, `${url} (flag off)`);
+        assert.throws(() => validateOidcUrl(url, 'issuerUrl', true), /always-blocked address/, `${url} (flag ON)`);
+      }
+    });
+
+    it('still refuses non-http(s) schemes and embedded credentials', () => {
+      assert.throws(() => validateOidcUrl('file:///etc/passwd', 'issuerUrl', true), /must use http or https/);
+      assert.throws(() => validateOidcUrl('ftp://idp.example.com/', 'issuerUrl', true), /must use http or https/);
+      assert.throws(() => validateOidcUrl('https://user:pw@idp.example.com/', 'issuerUrl', true), /embedded credentials/);
+      assert.throws(() => validateOidcUrl('not a url', 'issuerUrl', true), /is not a valid URL/);
+    });
+
+    it('sees through non-standard IPv4 encodings — the guard is not a string match', () => {
+      // 2130706433 === 0x7f000001 === 127.0.0.1. The old four-item check missed every one of these.
+      for (const url of ['http://2130706433:8080/', 'http://0x7f000001:8080/', 'http://127.1:8080/']) {
+        assert.throws(() => validateOidcUrl(url, 'issuerUrl', true), /always-blocked address/, url);
+      }
+    });
+  });
+
+  // ── Issuer address class ───────────────────────────────────────────────────
+  describe('issuerIsPrivate — what scopes the document allowance', () => {
+    it('is true only for an issuer that the opt-in alone makes reachable', () => {
+      for (const url of PRIVATE_ISSUERS) assert.equal(issuerIsPrivate(url), true, url);
+    });
+
+    it('is false for a public issuer and for a bare hostname', () => {
+      assert.equal(issuerIsPrivate(PUBLIC_ISSUER), false);
+      assert.equal(issuerIsPrivate('https://accounts.google.com'), false);
+      // A hostname is not classifiable statically — only the resolution-time guard knows where it
+      // points, so it must NOT be treated as private (which would widen what its document may name).
+      assert.equal(issuerIsPrivate('http://keycloak.internal:8080/realms/main'), false);
+    });
+
+    it('is false for a crown jewel — it is blocked, not "private"', () => {
+      assert.equal(issuerIsPrivate('http://127.0.0.1:8080/'), false);
+      assert.equal(issuerIsPrivate('http://169.254.169.254/'), false);
+    });
+  });
+
+  // ── Discovery document ─────────────────────────────────────────────────────
+  describe('discovery document — §4.3 issuer match', () => {
+    it('rejects a document whose issuer does not match the configured URL', () => {
+      const doc = docFor('https://evil.example.com/realms/main');
+      assert.throws(
+        () => validateDiscoveryDocument(doc, PUBLIC_ISSUER, false),
+        /does not match configured issuerUrl/,
+      );
+    });
+
+    it('tolerates a trailing-slash difference, which is not a mismatch', () => {
+      const doc = docFor(PUBLIC_ISSUER + '/');
+      assert.doesNotThrow(() => validateDiscoveryDocument(doc, PUBLIC_ISSUER, false));
+    });
+
+    it('rejects a document with no issuer field at all', () => {
+      const doc = docFor(PUBLIC_ISSUER);
+      delete doc.issuer;
+      assert.throws(() => validateDiscoveryDocument(doc, PUBLIC_ISSUER, false), /does not match configured issuerUrl/);
+    });
+  });
+
+  describe('discovery document — the endpoints beside the issuer', () => {
+    it('REJECTS a public issuer that names a private jwks_uri — the attack with no prior coverage', () => {
+      const doc = docFor(PUBLIC_ISSUER, { jwks_uri: 'http://10.0.0.5/keys' });
+      assert.throws(() => validateDiscoveryDocument(doc, PUBLIC_ISSUER, false), /OIDC jwks_uri/);
+    });
+
+    it('rejects it even when the global opt-in is on — the allowance follows the ISSUER, not the flag', () => {
+      process.env[ENV_KEY] = 'true';
+      // `issuerIsPrivate(PUBLIC_ISSUER)` is false, so a public issuer's document is validated with
+      // allowPrivate=false no matter what the operator enabled for their own internal IdP.
+      const doc = docFor(PUBLIC_ISSUER, { jwks_uri: 'http://10.0.0.5/keys' });
+      assert.throws(
+        () => validateDiscoveryDocument(doc, PUBLIC_ISSUER, issuerIsPrivate(PUBLIC_ISSUER)),
+        /OIDC jwks_uri/,
+      );
+    });
+
+    it('rejects a private authorization_endpoint, token_endpoint or end_session_endpoint too', () => {
+      for (const field of ['authorization_endpoint', 'token_endpoint', 'end_session_endpoint']) {
+        const doc = docFor(PUBLIC_ISSUER, { [field]: 'http://192.168.4.4/pivot' });
+        assert.throws(() => validateDiscoveryDocument(doc, PUBLIC_ISSUER, false), new RegExp(`OIDC ${field}`), field);
+      }
+    });
+
+    it('rejects a document with no jwks_uri rather than passing undefined down the line', () => {
+      const doc = docFor(PUBLIC_ISSUER);
+      delete doc.jwks_uri;
+      assert.throws(() => validateDiscoveryDocument(doc, PUBLIC_ISSUER, false), /has no jwks_uri/);
+    });
+
+    it('ACCEPTS endpoints on a different public origin — Google, and why same-origin was not shipped', () => {
+      // These are Google's real published values. `accounts.google.com` publishes a jwks_uri on
+      // `www.googleapis.com` and a token_endpoint on `oauth2.googleapis.com` — three origins, and
+      // not even a shared registrable domain. A "endpoints must share the issuer's host" rule would
+      // break Google Sign-In outright, which is the same class of upgrade outage this change exists
+      // to avoid. If someone reaches for that rule later, this test is the reason not to.
+      const google = 'https://accounts.google.com';
+      const doc = {
+        issuer: google,
+        jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs',
+        authorization_endpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+        token_endpoint: 'https://oauth2.googleapis.com/token',
+      };
+      assert.doesNotThrow(() => validateDiscoveryDocument(doc, google, issuerIsPrivate(google)));
+    });
+
+    it('accepts a private issuer naming private endpoints — the internal-Keycloak document', () => {
+      const internal = 'http://10.1.2.3:8080/realms/main';
+      const doc = docFor(internal);
+      assert.doesNotThrow(() => validateDiscoveryDocument(doc, internal, issuerIsPrivate(internal)));
+    });
+
+    it('still refuses a crown-jewel endpoint from a private issuer', () => {
+      const internal = 'http://10.1.2.3:8080/realms/main';
+      const doc = docFor(internal, { jwks_uri: 'http://169.254.169.254/latest/meta-data/' });
+      assert.throws(
+        () => validateDiscoveryDocument(doc, internal, issuerIsPrivate(internal)),
+        /always-blocked address/,
+      );
+    });
+  });
+
+  // ── The boot signal ────────────────────────────────────────────────────────
+  // Getting the guard right and letting an operator discover it from a login page that says
+  // "authentication failed" would be a bad change shipped correctly. This is the half that makes the
+  // upgrade survivable, so it is tested like a feature, not like logging.
+  describe('startup security posture', () => {
+    const oidcCheck = () => computeSecurityPosture().checks.find(c => c.id === 'oidc.issuer');
+
+    const BASE = { enabled: true, clientId: 'ythril' };
+
+    it('FAILS the posture when an enabled private issuer has no opt-in — the upgrade outage', () => {
+      seedConfig({ ...BASE, issuerUrl: 'http://10.1.2.3:8080/realms/main' });
+      const check = oidcCheck();
+      assert.ok(check, 'expected an oidc.issuer posture check');
+      assert.equal(check.level, 'fail');
+      assert.match(check.message, /no one can sign in/i);
+      assert.match(check.message, /oidc\.allowPrivateIssuer/);
+      assert.match(check.message, /YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true/);
+    });
+
+    it('drops to a warn once the operator opts in — and still names the exposure', () => {
+      process.env[ENV_KEY] = 'true';
+      seedConfig({ ...BASE, issuerUrl: 'http://10.1.2.3:8080/realms/main' });
+      const check = oidcCheck();
+      assert.equal(check.level, 'warn');
+      assert.match(check.message, /10\.1\.2\.3/, 'report the address, not just the flag');
+      assert.match(check.message, /still apply/, 'say the guard is still on');
+    });
+
+    it('FAILS for a crown-jewel issuer even with the opt-in — no flag reaches these', () => {
+      process.env[ENV_KEY] = 'true';
+      seedConfig({ ...BASE, issuerUrl: 'http://169.254.169.254/realms/main' });
+      assert.equal(oidcCheck().level, 'fail');
+    });
+
+    it('says nothing at all for a public issuer with the flag off — no noise', () => {
+      seedConfig({ ...BASE, issuerUrl: PUBLIC_ISSUER });
+      assert.equal(oidcCheck(), undefined);
+    });
+
+    it('flags an opt-in that nothing is using', () => {
+      process.env[ENV_KEY] = 'true';
+      seedConfig({ ...BASE, issuerUrl: PUBLIC_ISSUER });
+      const check = oidcCheck();
+      assert.equal(check.level, 'warn');
+      assert.match(check.message, /nothing is using the permission/);
+    });
+
+    it('says nothing when OIDC is disabled, whatever the issuer looks like', () => {
+      seedConfig({ ...BASE, enabled: false, issuerUrl: 'http://10.1.2.3:8080/realms/main' });
+      assert.equal(oidcCheck(), undefined);
+    });
+
+    it('refuses to load a quoted boolean rather than reading it as OFF', () => {
+      // `"allowPrivateIssuer": "true"` is a string, so `=== true` is false — the internal IdP would
+      // stop authenticating and the config would look correct to whoever wrote it.
+      assert.throws(
+        () => seedConfig({ ...BASE, issuerUrl: PUBLIC_ISSUER, allowPrivateIssuer: 'true' }),
+        /allowPrivateIssuer must be a boolean/,
+      );
+    });
+
+    it('accepts the config key itself, not just the env var', () => {
+      seedConfig({ ...BASE, issuerUrl: 'http://10.1.2.3:8080/realms/main', allowPrivateIssuer: true });
+      assert.equal(allowPrivateOidcIssuer(), true);
+      assert.equal(oidcCheck().level, 'warn', 'the config key must clear the FAIL the same way the env var does');
+    });
+  });
+
+  // ── End to end, without a network ──────────────────────────────────────────
+  describe('getDiscoveryDoc', () => {
+    beforeEach(() => clearOidcCache());
+
+    it('refuses a private issuer before it opens a socket', async () => {
+      await assert.rejects(
+        () => getDiscoveryDoc('http://10.1.2.3:8080/realms/main'),
+        /must be a public http\(s\) URL/,
+      );
+    });
+
+    it('refuses a crown-jewel issuer with the opt-in on', async () => {
+      process.env[ENV_KEY] = 'true';
+      await assert.rejects(
+        () => getDiscoveryDoc('http://169.254.169.254/realms/main'),
+        /always-blocked address/,
+      );
+    });
+  });
+});

--- a/testing/standalone/oidc.test.js
+++ b/testing/standalone/oidc.test.js
@@ -15,6 +15,19 @@
  *  - validateOidcJwt() returns null for invalid / disabled OIDC
  *  - claimMapping.requireMatch: true rejects tokens matching no rule
  *
+ * WHERE THE MOCK IdP LIVES (changed with the SSRF part-2b issuer guard): the mock binds to the host's
+ * **private LAN address**, not `127.0.0.1`, and the suite enables `YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER`.
+ * Loopback is a crown-jewel address that stays blocked even with that opt-in on, so a mock on
+ * 127.0.0.1 is refused before a socket opens and every end-to-end case below would assert on a `null`
+ * that never reached the IdP. Binding to a private address is the supported "internal IdP" shape, so
+ * these tests now also prove the opt-in actually works.
+ *
+ * The suite previously carried `skip: process.platform === 'win32'` for an "ESM drive-letter path
+ * limitation". That was stale — verified by running it unskipped on Windows — and it was actively
+ * harmful: it hid this entire end-to-end suite from every local run on Windows, which is how a
+ * breaking change to it reached CI green-locally. Skipping now depends only on the host having a
+ * non-loopback IPv4.
+ *
  * Run: node --test testing/standalone/oidc.test.js
  */
 
@@ -31,10 +44,16 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
+import { privateHostAddress, privateAddressSkipReason } from './_private-address.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DIST_AUTH   = path.resolve(__dirname, '../../server/dist/auth');
 const DIST_CONFIG = path.resolve(__dirname, '../../server/dist/config');
+
+/** Where the mock IdP binds — see the note above on why this is not loopback. */
+const MOCK_IDP_HOST = privateHostAddress() ?? '127.0.0.1';
+// An internal IdP on a private address is exactly what this opt-in exists for.
+process.env['YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER'] = 'true';
 
 // ── Key material ──────────────────────────────────────────────────────────
 
@@ -230,7 +249,7 @@ describe('JWT sign / verify roundtrip', () => {
 // phase — even when pathToFileURL is used.  Skip on Windows; the real CI
 // runs inside a Linux Docker container.
 
-describe('OIDC server module (compiled)', { skip: process.platform === 'win32' && 'Windows ESM drive-letter path limitation' }, () => {
+describe('OIDC server module (compiled)', { skip: privateAddressSkipReason() }, () => {
   let oidcMod, loaderMod;
 
   before(async () => {
@@ -306,10 +325,10 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else if (req.url === '/jwks') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -319,13 +338,13 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
 
       writeFullConfig({ ...makeOidcConfig(), issuerUrl, audience: 'ythril' });
       loaderMod.loadConfig();
@@ -371,10 +390,10 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else if (req.url === '/jwks') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -382,13 +401,13 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       } else { res.writeHead(404); res.end(); }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       writeFullConfig({ ...makeOidcConfig(), issuerUrl, audience: 'ythril' });
       loaderMod.loadConfig();
       oidcMod.clearOidcCache();
@@ -454,30 +473,30 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
-          end_session_endpoint:    `http://127.0.0.1:${serverPort}/logout`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
+          end_session_endpoint:    `http://${MOCK_IDP_HOST}:${serverPort}/logout`,
         }));
       } else {
         res.writeHead(404); res.end();
       }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       writeFullConfig({ ...makeOidcConfig(), issuerUrl });
       loaderMod.loadConfig();
       oidcMod.clearOidcCache();
 
       const doc = await oidcMod.getDiscoveryDoc(issuerUrl);
-      assert.equal(doc.end_session_endpoint, `http://127.0.0.1:${serverPort}/logout`,
+      assert.equal(doc.end_session_endpoint, `http://${MOCK_IDP_HOST}:${serverPort}/logout`,
         'end_session_endpoint must be preserved from the discovery document');
     } finally {
       await new Promise(resolve => server.close(resolve));
@@ -498,10 +517,10 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else if (req.url === '/jwks') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -509,13 +528,13 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       } else { res.writeHead(404); res.end(); }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       writeFullConfig({
         ...makeOidcConfig(),
         issuerUrl,
@@ -560,10 +579,10 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else if (req.url === '/jwks') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -571,13 +590,13 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       } else { res.writeHead(404); res.end(); }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       writeFullConfig({
         ...makeOidcConfig(),
         issuerUrl,
@@ -622,10 +641,10 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else if (req.url === '/jwks') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -633,13 +652,13 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       } else { res.writeHead(404); res.end(); }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       writeFullConfig({
         ...makeOidcConfig(),
         issuerUrl,
@@ -684,10 +703,10 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       if (req.url === '/.well-known/openid-configuration') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else if (req.url === '/jwks') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -695,13 +714,13 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
       } else { res.writeHead(404); res.end(); }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       // requireMatch absent — unmatched tokens are accepted but fail closed
       writeFullConfig({ ...makeOidcConfig(), issuerUrl, audience: 'ythril' });
       loaderMod.loadConfig();
@@ -742,23 +761,23 @@ describe('OIDC server module (compiled)', { skip: process.platform === 'win32' &
         res.writeHead(200, { 'Content-Type': 'application/json' });
         // Deliberately omit end_session_endpoint
         res.end(JSON.stringify({
-          issuer:                  `http://127.0.0.1:${serverPort}`,
-          authorization_endpoint:  `http://127.0.0.1:${serverPort}/authorize`,
-          token_endpoint:          `http://127.0.0.1:${serverPort}/token`,
-          jwks_uri:                `http://127.0.0.1:${serverPort}/jwks`,
+          issuer:                  `http://${MOCK_IDP_HOST}:${serverPort}`,
+          authorization_endpoint:  `http://${MOCK_IDP_HOST}:${serverPort}/authorize`,
+          token_endpoint:          `http://${MOCK_IDP_HOST}:${serverPort}/token`,
+          jwks_uri:                `http://${MOCK_IDP_HOST}:${serverPort}/jwks`,
         }));
       } else {
         res.writeHead(404); res.end();
       }
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise(resolve => server.listen(0, MOCK_IDP_HOST, () => {
       serverPort = server.address().port;
       resolve();
     }));
 
     try {
-      const issuerUrl = `http://127.0.0.1:${serverPort}`;
+      const issuerUrl = `http://${MOCK_IDP_HOST}:${serverPort}`;
       writeFullConfig({ ...makeOidcConfig(), issuerUrl });
       loaderMod.loadConfig();
       oidcMod.clearOidcCache();


### PR DESCRIPTION
SSRF part 2b — the last of the egress guards, and the one that could lock people out of their own instance if shipped carelessly.

## ⚠️ Upgrade note (this is the headline, not a footnote)

**If your IdP lives on a private address — Keycloak on `http://keycloak.internal:8080`, Authentik on a cluster service, Dex on `10.x` — you must set `oidc.allowPrivateIssuer: true` (or `YTHRIL_OIDC_ALLOW_PRIVATE_ISSUER=true`) as part of this upgrade, or nobody can sign in.**

The opt-in ships in the same commit as the tightened default, deliberately. Guard-first-flag-later would have been an outage for every such deployment, which is exactly why this item sat parked.

And the instance now says so **at boot**, not at first login: an enabled OIDC config with a private issuer and no flag is a `fail` in the startup security posture (`oidc.issuer`, also at `GET /api/about/security`), and under `security.strict` the server refuses to start. Diagnosing this from a login page that just says "authentication failed" was the bad version of this change.

## What was wrong

`validateOidcUrl` rejected exactly four things: non-`http(s)`, embedded credentials, `169.254.*` / `metadata.google.internal`, and `0.0.0.0`. So:

- every general private range was allowed — `10.*`, `192.168.*`, `172.16–31.*`, `127.*`, `::1`
- so was every non-standard encoding of them (`2130706433`, `0x7f000001`, `127.1`)
- discovery used a plain `fetch`: no DNS pinning, no redirect re-validation
- `jwks_uri` — a URL that arrives **inside the discovery document**, i.e. attacker-influenced input the moment the issuer is — was handed to `createRemoteJWKSet` after only that four-item check

OIDC Discovery §4.3 constrains the document's `issuer` field and nothing beside it, so the endpoints were a free pivot into the internal network.

## What now happens

- Issuer, `jwks_uri`, `authorization_endpoint`, `token_endpoint` and `end_session_endpoint` all go through the shared `isSsrfSafeUrl` validator — one place that knows every encoding of every blocked range, instead of a local two-line approximation.
- Both outbound calls go through `ssrfSafeFetch`: discovery directly, JWKS via jose's `[customFetch]`. DNS is resolved, the resolved IP is **pinned** for the connection, and every redirect hop is re-validated.
- Enabling the flag does **not** turn the guard off — only the private-address rejection lifts. Loopback, link-local / cloud IMDS and the unspecified address stay blocked either way, including when a hostname *resolves* to one. Same contract as `allowPrivateModelEndpoints`.
- The allowance for the discovered endpoints is scoped to the **issuer's own address class**, not to the global flag: a *public* issuer may never hand back a private `jwks_uri`, however the operator configured their own internal IdP.
- `oidc.allowPrivateIssuer` is config/env only, never an API field, and a quoted `"true"` is now a hard config error rather than silently reading as off — that slip would produce precisely the outage this flag exists to prevent.

## One deliberate deviation from the plan

The plan called for "the discovered endpoints must share the issuer's host family". **Not shipped**, because it is wrong about real IdPs rather than merely strict:

```
issuer                 https://accounts.google.com
jwks_uri               https://www.googleapis.com/oauth2/v3/certs
token_endpoint         https://oauth2.googleapis.com/token
```

Three origins, and not even a shared registrable domain (`google.com` vs `googleapis.com`). Same-origin would break Google Sign-In outright — the same class of upgrade outage this whole change exists to avoid.

The address-class rule stops the attack host-matching was reaching for (a public document steering the server at an internal address) without asserting something false about how IdPs deploy. A test carries Google's real published values so this is not re-litigated later.

## Testing

- **33 new standalone tests** (`oidc-issuer-ssrf.test.js`) against the real exported functions — no hand-copied validator.
- **Every rule mutation-checked**: remove the flag lookup, the `jwks_uri` validation, the other endpoint validations, the §4.3 issuer match, the posture `fail` branch — each time exactly the intended assertions failed and nothing else.
- **Runtime ground truth**: a probe confirmed jose 6.2.3 actually routes the JWKS request through `[customFetch]`. A type-check could not have told us that, and if jose ignored the option the guard would have been decorative.
- `oidc-discovery-timeout.test.js` moved off loopback and now binds the host's private LAN address with the opt-in on — which makes it a real end-to-end proof that `allowPrivateIssuer` lets an internal IdP through, the half that is an outage if broken. Loopback is now permanently blocked, and that costs nothing real: an issuer on the *server's* `127.0.0.1` cannot work as OIDC anyway, since the browser is sent to the same `authorization_endpoint` and the browser's loopback is not the server's.
- Full standalone suite: **1110 tests, 0 failures**. `lint:docs` clean.

Pre-push gate: CHANGELOG `[Unreleased]` entry (with the upgrade warning in those words), `docs/integration-guide.md` gains an "Internal IdPs on a private address" section plus the config-table row, `.env.example` documents the env var, trackers reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
