### PR TITLE
test: standalone tests can reach a real MongoDB, and the queue's recovery rule now proves it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,6 +738,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   red-team integration test `testing/sync/vote-forgery.test.js`; the full governance/vote/braintree/
   pubsub/democratic/closed suite continues to pass.
 
+### Testing
+
+- **Standalone tests can now run against a real MongoDB, and the first one proves the queue's
+  recovery rule.** Until now no standalone test could reach a database: the test stack published no
+  Mongo port and nothing connected to one. Query rules were therefore only ever checked against
+  hand-built document fixtures and a small JS matcher — which proves the rule is what its author
+  meant, not that **MongoDB agrees**. Those two things genuinely differ, and `stalledJobFilter` sits
+  exactly on the fault line: in MongoDB `{ progressAt: null }` also matches documents where the field
+  is **missing**, while the obvious JS equivalent (`doc.progressAt === null`) does not, and
+  `{ $lt: '<iso string>' }` matches neither null nor missing because of BSON type bracketing — which
+  is the whole reason the filter needs its extra branches. A fixture test cannot see any of that.
+  `testing/docker-compose.test.yml` now publishes `ythril-mongo-a` on **127.0.0.1:27117** (loopback
+  only — the password is in the compose file, so binding it to every interface would be a gift), and
+  `testing/standalone/_mongo-harness.mjs` points the server's own `getMongoUri()` at a per-suite
+  database and calls the server's own `connectMongo()`. Nothing is stubbed: the code under test is the
+  real `col()` / `asFilter()` / `asUpdate()` against the real driver, because a faked data layer would
+  reintroduce the exact gap the harness exists to close. New `job-stall-rule-db.test.js` covers the
+  stall rule end to end and asserts both MongoDB behaviours directly; removing the filter's
+  never-ticked branches makes exactly three of its assertions fail (a job that can never be recovered
+  is a file that silently never finishes). **In CI the harness refuses to skip** — an unreachable
+  database throws instead, because a database test that quietly no-ops on the machine that gates
+  merges still reports green while covering nothing.
+  *Note for existing local stacks:* `ythril-mongo-a` cannot be recreated in place — the Atlas Local
+  image names the replica set after the container id and stores the old container's hostname as the
+  member, so any compose edit to that service orphans the replica set. Run `npm run test:up` (which
+  does a `down -v`) to pick this change up.
+
 ### Documentation
 
 - **Documentation staleness sweep — one statement was wrong, not merely out of date.** The integration

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -67,6 +67,16 @@ services:
   ythril-mongo-a:
     image: mongodb/mongodb-atlas-local:latest@sha256:1cd040bb201bb7f910c7c6ab7f6cb8ab9dd79331f6a213f37025adc6804e96aa
     container_name: ythril-mongo-a
+    # Published so standalone tests can assert database-LEVEL behaviour — that MongoDB actually agrees
+    # with a query rule, not merely that a JS matcher does. Until this existed, rules like
+    # `stalledJobFilter` were only ever checked against hand-built document fixtures, which cannot see
+    # a MongoDB/JS semantic divergence (`{field: null}` matching missing fields is the canonical one).
+    #
+    # Bound to 127.0.0.1 on purpose, NOT 0.0.0.0: this database has a known password published in this
+    # file, so a bare `27117:27017` would put an unauthenticated-in-practice Mongo on every interface
+    # of the developer's machine and the CI runner. Loopback only, and the test stack only.
+    ports:
+      - "127.0.0.1:27117:27017"
     volumes:
       - ythril-mongo-a-data:/data/db
       - ythril-mongo-a-configdb:/data/configdb

--- a/testing/standalone/_mongo-harness.mjs
+++ b/testing/standalone/_mongo-harness.mjs
@@ -1,0 +1,120 @@
+/**
+ * Database-level test harness — run a standalone test against a REAL MongoDB.
+ *
+ * ## Why this exists
+ *
+ * Standalone tests could not reach a database. The test stack published no Mongo port and nothing
+ * connected to one, so every query rule in the codebase was only ever checked against hand-built
+ * document fixtures and a minimal JS matcher. That checks *the rule as the author imagined it*, not
+ * that MongoDB agrees — and those two things genuinely differ. The canonical example, live in this
+ * repo: `{ progressAt: null }` matches documents where the field is **missing** in MongoDB, but a JS
+ * matcher written the obvious way (`doc.progressAt === null`) does not. A fixture test cannot see
+ * that; a database test cannot miss it.
+ *
+ * It is the same failure shape as the 204-null-body bug — a stand-in that passed while the real path
+ * was broken. `_AUDIT-ANGLES.md §10` names it: "a mock that would pass even if the real code is
+ * broken".
+ *
+ * ## What it connects to
+ *
+ * `ythril-mongo-a` from `testing/docker-compose.test.yml`, published on **127.0.0.1:27117**. Bring it
+ * up with `npm run test:up`. CI already has the stack running when it invokes `test:standalone`, so
+ * these tests execute there on every run.
+ *
+ * ## What it does NOT do
+ *
+ * It does not stub, wrap or re-implement the data layer. `withMongo()` points the server's own
+ * `getMongoUri()` at the test database and calls the server's own `connectMongo()`, so the code under
+ * test is the real `col()` / `asFilter()` / `asUpdate()` — production's Mongo layer, against
+ * production's driver, against a real server. A harness that faked any of that would reintroduce the
+ * exact gap it was built to close.
+ *
+ * Each caller gets its own database (`ythril_harness_<suite>`), dropped on entry and exit, so the
+ * harness can never see or corrupt the data the integration/sync suites are using on the same server.
+ */
+
+import net from 'node:net';
+
+/** Host/port of the published test Mongo. Override for a non-default stack. */
+export const TEST_MONGO_HOST = process.env['YTHRIL_TEST_MONGO_HOST'] ?? '127.0.0.1';
+export const TEST_MONGO_PORT = Number(process.env['YTHRIL_TEST_MONGO_PORT'] ?? 27117);
+
+const CREDS = 'ythril:ythril-test-pw';
+
+/** Connection URI for a dedicated harness database. */
+export function testMongoUri(dbName) {
+  return `mongodb://${CREDS}@${TEST_MONGO_HOST}:${TEST_MONGO_PORT}/${dbName}` +
+    '?directConnection=true&authSource=admin';
+}
+
+/**
+ * Fast reachability probe. `connectMongo()` waits 10s on server selection, which is a long time to
+ * spend discovering that a developer simply has not run `npm run test:up`.
+ */
+export async function isTestMongoUp(timeoutMs = 1500) {
+  return new Promise(resolve => {
+    const sock = new net.Socket();
+    const done = (ok) => { sock.destroy(); resolve(ok); };
+    sock.setTimeout(timeoutMs);
+    sock.once('connect', () => done(true));
+    sock.once('timeout', () => done(false));
+    sock.once('error', () => done(false));
+    sock.connect(TEST_MONGO_PORT, TEST_MONGO_HOST);
+  });
+}
+
+/**
+ * Reason to pass to `describe(..., { skip })`, or `false` when the database is available.
+ *
+ * **In CI this never skips — it throws.** A database test that silently turns into a no-op on the one
+ * machine that gates merges is worse than no test at all: the suite still reports green, and the
+ * coverage it claims does not exist. Locally, skipping with an actionable message is the right
+ * behaviour; on CI, an unreachable database is a broken harness and must fail loudly.
+ */
+export async function mongoSkipReason() {
+  if (await isTestMongoUp()) return false;
+  const where = `${TEST_MONGO_HOST}:${TEST_MONGO_PORT}`;
+  if (process.env['CI']) {
+    throw new Error(
+      `Database-level test harness cannot reach MongoDB at ${where}, but CI is set. ` +
+      'The test stack must be up for standalone tests in CI — refusing to skip and report green. ' +
+      'Check that testing/docker-compose.test.yml still publishes the ythril-mongo-a port.',
+    );
+  }
+  return `needs the test MongoDB at ${where} — run \`npm run test:up\``;
+}
+
+let _mongo = null;
+
+/**
+ * Connect the server's real Mongo layer to a dedicated harness database. Call from `before()`.
+ *
+ * `MONGO_URI` is set before importing `db/mongo.js` because `getMongoUri()` reads the environment
+ * first — that is the documented override for infra-managed deployments, and reusing it here means
+ * the harness needs no test-only branch inside production code.
+ *
+ * @param suite short slug — becomes the database name, so two suites never share state.
+ * @returns the live `db/mongo.js` module namespace (`col`, `asFilter`, `asUpdate`, `getDb`, …).
+ */
+export async function openTestMongo(suite) {
+  process.env['MONGO_URI'] = testMongoUri(`ythril_harness_${suite}`);
+
+  const mongo = await import('../../server/dist/db/mongo.js');
+  mongo._resetDbName?.();
+  await mongo.connectMongo();
+
+  // Drop on ENTRY as well as exit: a previous run killed mid-test (Ctrl-C, CI timeout) would
+  // otherwise leave documents behind and the next run would inherit them, which is how a
+  // database-backed suite starts passing for the wrong reason.
+  await mongo.getDb().dropDatabase();
+  _mongo = mongo;
+  return mongo;
+}
+
+/** Drop the harness database and disconnect. Call from `after()`. */
+export async function closeTestMongo() {
+  if (!_mongo) return;
+  try { await _mongo.getDb().dropDatabase(); } catch { /* best-effort */ }
+  await _mongo.closeMongo();
+  _mongo = null;
+}

--- a/testing/standalone/job-stall-rule-db.test.js
+++ b/testing/standalone/job-stall-rule-db.test.js
@@ -1,0 +1,134 @@
+/**
+ * Database-level test: MongoDB agrees with `stalledJobFilter`.
+ *
+ * `job-stall-rule.test.js` already checks the rule against hand-built fixtures and a minimal JS
+ * matcher. That proves the rule is what its author meant. It cannot prove the thing that actually
+ * matters — that **MongoDB** selects the same documents — because the matcher is the test's own code,
+ * and a matcher and a database can disagree.
+ *
+ * They do disagree here, and it is load-bearing. `stalledJobFilter` has three `$or` branches:
+ *
+ *     { progressAt: { $lt: cutoff } }                              // ticked, but too long ago
+ *     { progressAt: { $exists: false }, claimedAt: { $lt: cutoff } } // never ticked (old build)
+ *     { progressAt: null,              claimedAt: { $lt: cutoff } } // ticked null
+ *
+ * In MongoDB, `{ progressAt: null }` matches documents where the field is **missing** as well as
+ * those where it is explicitly null — so branch 3 already subsumes branch 2. Written the obvious way
+ * in JS (`doc.progressAt === null`) it does not, so the fixture test believes branches 2 and 3 are
+ * independent. Equally, `{ $lt: '<iso string>' }` does **not** match a null or missing value in
+ * MongoDB (BSON type bracketing), which is precisely why branches 2 and 3 have to exist at all — but
+ * a JS matcher doing `null < '2026-…'` gets `false` for its own unrelated reason, so it agrees by
+ * accident rather than by rule.
+ *
+ * Both facts are asserted below against a real server. This is the queue's recovery path: a job that
+ * this filter fails to select is a job that never gets recovered, and nothing surfaces it.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/job-stall-rule-db.test.js
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const CUTOFF = '2026-07-22T12:00:00.000Z';
+const OLD = '2026-07-22T11:00:00.000Z'; // before the cutoff → stalled
+const NEW = '2026-07-22T13:00:00.000Z'; // after the cutoff  → alive
+
+let mongo;
+let stalledJobFilter;
+let jobs;
+
+/** Insert a job document, omitting `progressAt` entirely when it is `undefined`. */
+async function insertJob(_id, status, claimedAt, progressAt) {
+  const doc = { _id, spaceId: 'general', status, claimedAt };
+  if (progressAt !== undefined) doc.progressAt = progressAt;
+  await jobs.insertOne(doc);
+}
+
+/** Ids MongoDB selects for the given cutoff, sorted — the real query, not a re-implementation. */
+async function selected(cutoff = CUTOFF) {
+  const found = await jobs.find(mongo.asFilter(stalledJobFilter(cutoff))).toArray();
+  return found.map(d => d._id).sort();
+}
+
+describe('stalledJobFilter — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('jobstall');
+    ({ stalledJobFilter } = await import('../../server/dist/files/media/job-queue.js'));
+    jobs = mongo.col('general_media_jobs');
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => { await jobs.deleteMany({}); });
+
+  it('selects a job whose heartbeat went quiet before the cutoff', async () => {
+    await insertJob('stale-tick', 'processing', OLD, OLD);
+    assert.deepEqual(await selected(), ['stale-tick']);
+  });
+
+  it('leaves a job that ticked after the cutoff alone', async () => {
+    await insertJob('alive', 'processing', OLD, NEW);
+    assert.deepEqual(await selected(), []);
+  });
+
+  it('selects a job claimed long ago that has NO progressAt field at all', async () => {
+    // The "claimed by a build older than the heartbeat" case. Without this the job is immortal:
+    // nothing ever recovers it, and the file silently never finishes.
+    await insertJob('never-ticked', 'processing', OLD, undefined);
+    assert.deepEqual(await selected(), ['never-ticked']);
+  });
+
+  it('selects a job claimed long ago whose progressAt is explicitly null', async () => {
+    await insertJob('null-tick', 'processing', OLD, null);
+    assert.deepEqual(await selected(), ['null-tick']);
+  });
+
+  it('does NOT select a never-ticked job that was claimed recently', async () => {
+    await insertJob('fresh-claim', 'processing', NEW, undefined);
+    await insertJob('fresh-null', 'processing', NEW, null);
+    assert.deepEqual(await selected(), []);
+  });
+
+  it('ignores jobs that are not processing, however old', async () => {
+    for (const status of ['pending', 'done', 'failed', 'partial']) {
+      await insertJob(`${status}-old`, status, OLD, OLD);
+    }
+    assert.deepEqual(await selected(), []);
+  });
+
+  // ── The divergences the fixture test cannot see ────────────────────────────
+
+  it('MongoDB treats `{progressAt: null}` as matching a MISSING field — branch 3 subsumes branch 2', async () => {
+    // The fact itself, asserted directly rather than inferred. If a future edit "simplifies" the
+    // filter by deleting the $exists branch, this is what says that is safe; if MongoDB ever changed
+    // this behaviour, this is what says it is not.
+    await insertJob('missing-field', 'processing', OLD, undefined);
+    const byNull = await jobs.find(mongo.asFilter({ progressAt: null })).toArray();
+    assert.deepEqual(byNull.map(d => d._id), ['missing-field'],
+      '{progressAt: null} must match a document with no progressAt field');
+  });
+
+  it('MongoDB does NOT match null/missing values with `$lt: <string>` — which is why branches 2 and 3 exist', async () => {
+    // BSON type bracketing: a range predicate only matches values of the compared type. So the first
+    // branch alone can never recover a job that has not ticked, no matter how old it is.
+    await insertJob('null-tick', 'processing', OLD, null);
+    await insertJob('missing-tick', 'processing', OLD, undefined);
+    const byLt = await jobs.find(mongo.asFilter({ progressAt: { $lt: CUTOFF } })).toArray();
+    assert.deepEqual(byLt.map(d => d._id), [],
+      '$lt on a string must not match null or missing — if it did, branches 2/3 would be dead code');
+  });
+
+  it('picks exactly the stalled jobs out of a mixed queue', async () => {
+    await insertJob('a-stale-tick', 'processing', OLD, OLD);
+    await insertJob('b-alive', 'processing', OLD, NEW);
+    await insertJob('c-never-ticked', 'processing', OLD, undefined);
+    await insertJob('d-null-tick', 'processing', OLD, null);
+    await insertJob('e-fresh-claim', 'processing', NEW, undefined);
+    await insertJob('f-done', 'done', OLD, OLD);
+    assert.deepEqual(await selected(), ['a-stale-tick', 'c-never-ticked', 'd-null-tick']);
+  });
+});


### PR DESCRIPTION
Standalone tests could not reach a database. The test stack published no Mongo port and nothing connected to one, so **every query rule in the codebase was only ever checked against hand-built document fixtures and a small JS matcher**. That proves the rule is what its author meant. It does not prove the thing that matters — that MongoDB agrees — and those two genuinely differ.

## Why now

Promoted ahead of the face-label cascade (must-ship) because it is a **prerequisite** for testing it. That fix is a Mongo `updateMany`/`$unset`, and the alternatives were all worse:

- the HTTP integration suite cannot create a face-chunk fixture without the recognition models, which CI does not have;
- a hand-faked `db/mongo.js` is the mock-hides-the-bug pattern — the same shape as the 204-null-body case, and exactly what `_AUDIT-ANGLES.md §10` warns about.

## `stalledJobFilter` sits on the fault line

It has three `$or` branches, and the reason it needs three is a MongoDB/JS divergence a fixture test structurally cannot see:

- **`{ progressAt: null }` also matches documents where the field is MISSING** in MongoDB. Written the obvious way in JS (`doc.progressAt === null`) it does not — so the fixture test believed two branches were independent when one subsumes the other.
- **`{ $lt: '<iso string>' }` matches neither null nor missing** (BSON type bracketing). That is *why* the extra branches must exist at all. The JS matcher agreed by accident, not by rule.

Both facts are now asserted directly against a real server, so a future "simplification" of the filter has something that objects. This is the queue's recovery path: a job this filter fails to select is a file that silently never finishes.

## What the harness does — and deliberately does not do

`testing/docker-compose.test.yml` publishes `ythril-mongo-a` on **`127.0.0.1:27117`**. Loopback, not `0.0.0.0`: this database's password is published in that same file, so binding it to every interface of a dev machine or CI runner would be a gift.

`testing/standalone/_mongo-harness.mjs` points the server's **own** `getMongoUri()` at a per-suite database and calls the server's **own** `connectMongo()`. Nothing is stubbed — the code under test is the real `col()` / `asFilter()` / `asUpdate()` against the real driver. A faked data layer would reintroduce the exact gap the harness exists to close. Each suite gets its own database (`ythril_harness_<suite>`), dropped on entry *and* exit, so it can never see or corrupt what the integration/sync suites are doing on the same server.

**In CI it refuses to skip.** An unreachable database throws instead of skipping, because a database test that quietly no-ops on the machine that gates merges still reports green while covering nothing. Locally it skips with an actionable message (`run npm run test:up`).

## Verification

- 9 new tests, all green against the live stack.
- **Mutation-checked**: removing the filter's never-ticked branches fails exactly three assertions — an immortal job that nothing ever recovers, which the fixture test could not have caught.
- Skip/CI behaviour verified both ways: with an unreachable port it skips with a reason locally, and throws under `CI=1`.
- Full standalone suite: **1136 tests, 0 failures**.

## Note for existing local stacks

`ythril-mongo-a` **cannot be recreated in place.** The Atlas Local image names the replica set after the container id and stores the *old* container's hostname as the member, so any compose edit to that service orphans it (`RSGhost`, `getaddrinfo() failed` on the previous id — I hit this while building it). Recovery is `npm run test:up`, which does a `down -v`. Documented in the CHANGELOG and the QA tracker so the next person does not have to rediscover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
