### PR TITLE
fix(faces): deleting a person now unlinks their face vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1412,6 +1412,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deleting a person did not unlink their face vectors — the biometric link outlived the erasure.**
+  Face descriptors are not stored in a face collection; they are **filemeta** records
+  (`{fileId}#face-chunk{N}`) carrying `faceEmbedding` and, once labelled, `faceEntityId`.
+  `deleteEntity` removed the entity and wrote a tombstone but never touched `${spaceId}_files`, so the
+  only "delete this person" action the product offers left their face descriptors on disk still tagged
+  with the identifier that had just been erased.
+
+  Three things made it worse than a stale pointer. **`strictLinkage` was blind to it** —
+  `findEntityBacklinks` scanned `_edges`, `_memories` and `_chrono` but not `_files`, so the strongest
+  setting available did not look at the one reference class holding biometric data, and a person
+  referenced *only* by faces deleted cleanly. **It propagated rather than decayed** — the gallery
+  search matched new uploads against those orphaned records and returned the dead id, so the next
+  photo of that person was auto-labelled with it too. And **no human action was required**: the TTL
+  sweep routes entity expiry through the same `deleteEntity`, so a person record aging out detached
+  its faces silently.
+
+  Deleting a person now clears `faceEntityId`/`faceScore` from every face that pointed at them, on
+  every path (single delete, bulk wipe, TTL expiry — one shared helper, because being fixed in one
+  caller only is the shape of the original bug). The face record and its descriptor are **kept**: the
+  face belongs to the *file*, which the operator did not delete, so removing it would destroy image
+  metadata as a side effect of deleting a contact. Deleting the image still removes its face records,
+  as it always did. A gallery match whose entity no longer exists is now ignored, which is the only
+  thing that can help records already orphaned before this shipped. Face labels are reported by
+  `findEntityBacklinks` but deliberately do **not** block deletion under `strictLinkage` — they are
+  written by the recogniser rather than by a person and are cleared safely by the delete itself, so
+  blocking would make the subject whose data is biometric the one you cannot remove.
+
+  12 new tests against a **real MongoDB** (the harness this needed shipped first): the cascade is an
+  `updateMany`/`$unset`, and a hand-written fake collection that got either subtly wrong would pass
+  while production kept the labels. Each rule mutation-checked — remove the cascade, the bulk cascade,
+  the `_files` backlink scan, or the gallery existence check, and exactly the intended assertions fail.
+
 - **Asking recall for a `minScore` silently changed the SHAPE of the response.** File chunk results
   are normally enriched with their parent file's path, description and tags, so an agent can tell
   which document a fragment came from. That enrichment ran *after* an early `return` in the

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -566,6 +566,14 @@ Face recognition lets Ythril automatically detect faces in uploaded images and l
 4. **Label a face** — Open the file in the Files view and link it to a person entity (via the entity tag in the file metadata panel). The face embedding is immediately added to the gallery.
 5. **Auto-labeling kicks in** — From this point on, new images containing that person's face are automatically linked to their entity, as long as the match score exceeds the confidence threshold.
 
+#### Deleting a person
+
+Deleting a person entity **removes their label from every face linked to it**, and stops those faces from auto-labeling anyone in future. This happens on every path a person can disappear by: deleting them from the Brain, wiping all entities in the space, or the entity expiring through its TTL.
+
+The face records themselves are kept, with their label cleared. That is deliberate: the face belongs to the *photo*, which you did not delete — after removing the person, Ythril simply no longer claims to know whose face it is. If you want the face data itself gone, delete the image; that removes its face records along with every other derived artifact.
+
+> Under `strictLinkage`, face labels do **not** block deleting a person. Other references (edges, memories, chrono entries) still do. Faces are written automatically by the recogniser rather than created by you, and they are cleared safely by the deletion itself — so blocking on them would only make the person impossible to remove.
+
 #### Settings
 
 These are set in `config.json` under `mediaEmbedding.faceRecognition`, or pinned by your infrastructure through the matching environment variable (`FACE_RECOGNITION_ENABLED`, `_CONFIDENCE_THRESHOLD`, `_MIN_FACE_SIZE_FRACTION`, `_MODEL_PATH`, `_PERSON_ENTITY_TYPES`, `_REPROCESS_SYNCED_IMAGES`). An environment value wins over `config.json`, so `FACE_RECOGNITION_ENABLED=false` guarantees no faces are processed on that instance — including after restoring a backup taken where it was on. Neither is editable from the UI:

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -161,11 +161,20 @@ entitiesRouter.delete('/spaces/:spaceId/entities/:id', globalRateLimit, requireS
   for (const mid of memberIds) {
     const entity = await getEntityById(mid, id);
     if (!entity) continue;
-    // Check for inbound references before allowing deletion (only when strictLinkage is on)
+    // Check for inbound references before allowing deletion (only when strictLinkage is on).
+    //
+    // Face labels are deliberately NOT blocking, even though findEntityBacklinks now reports them.
+    // strictLinkage exists to stop a delete that would leave a DANGLING reference behind — and a face
+    // label can no longer dangle, because deleteEntity unlabels it in the same operation. Blocking on
+    // them would be actively harmful: face labels are written by the recognition pipeline, not by a
+    // person, so an admin would face a 409 they never created and could only clear by hand-unlabelling
+    // every photo — turning "delete this person" into the one thing you cannot do for the subject whose
+    // data is biometric. Reported (so the UI can warn "this will unlabel N faces"), never blocking.
     if (isStrictLinkage(mid)) {
       const backlinks = await findEntityBacklinks(mid, id);
-      if (backlinks.length > 0) {
-        res.status(409).json({ error: 'Cannot delete: entity has inbound references', backlinks });
+      const blocking = backlinks.filter(b => b.type !== 'face');
+      if (blocking.length > 0) {
+        res.status(409).json({ error: 'Cannot delete: entity has inbound references', backlinks: blocking });
         return;
       }
     }

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -10,12 +10,53 @@ import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './recall.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
-import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc } from '../config/types.js';
+import { log } from '../util/log.js';
+import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc, FileMetaDoc } from '../config/types.js';
 
 /** A backlink entry describing an item that references a given entity. */
 export interface BacklinkEntry {
-  type: 'edge' | 'memory' | 'chrono';
+  type: 'edge' | 'memory' | 'chrono' | 'face';
   _id: string;
+}
+
+/**
+ * Strip a deleted person's label from every face record that pointed at them.
+ *
+ * Face descriptors are not stored in a face collection — they are filemeta records
+ * (`{fileId}#face-chunk{N}`) carrying `faceEmbedding` and, once labelled, `faceEntityId`. So deleting
+ * the entity used to leave the biometric descriptor on disk still tagged with the identifier that was
+ * just erased, and `gallerySearch` kept matching new uploads against it — the dangling label
+ * propagated forward instead of decaying.
+ *
+ * **Unlabel, never delete.** The face record belongs to the *file*, which the operator did not
+ * delete; removing it would destroy someone's image metadata as a side effect of deleting a contact.
+ * "Delete this person" means we stop claiming to know whose face it is, not that the photo loses its
+ * face. An operator who wants the descriptors gone deletes the file — that path already cascades
+ * correctly, because `deleteConversionArtifacts` matches on `parentFileId`.
+ *
+ * Shared by every delete path (single, bulk, TTL sweep) on purpose: this being fixed in one caller
+ * only is the exact shape of the original bug.
+ *
+ * @returns how many face records were unlabelled.
+ */
+export async function unlabelFacesForEntities(spaceId: string, entityIds: string[]): Promise<number> {
+  if (entityIds.length === 0) return 0;
+  return unlabelFacesWhere(spaceId, { faceEntityId: { $in: entityIds } });
+}
+
+/** Clear every face label in a space — for the bulk wipe, where all entities are gone by definition. */
+export async function unlabelAllFaces(spaceId: string): Promise<number> {
+  return unlabelFacesWhere(spaceId, { faceEntityId: { $exists: true } });
+}
+
+async function unlabelFacesWhere(spaceId: string, match: Record<string, unknown>): Promise<number> {
+  const res = await col<FileMetaDoc>(`${spaceId}_files`).updateMany(
+    asFilter<FileMetaDoc>(match),
+    asUpdate<FileMetaDoc>({ $unset: { faceEntityId: '', faceScore: '' } }),
+  );
+  const n = res.modifiedCount ?? 0;
+  if (n > 0) log.info(`Unlabelled ${n} face record(s) in '${spaceId}' after entity deletion`);
+  return n;
 }
 
 export interface UpsertResult {
@@ -305,6 +346,8 @@ export async function deleteEntity(
     asDoc<TombstoneDoc>(tombstone),
     { upsert: true },
   );
+  // Erasure has to reach the biometric copy too — see unlabelFacesForEntities.
+  await unlabelFacesForEntities(spaceId, [entityId]);
   if (actor) emitWebhookEvent({ event: 'entity.deleted', spaceId, entry: { _id: entityId }, ...actor });
   return true;
 }
@@ -344,13 +387,25 @@ export async function bulkDeleteEntities(spaceId: string): Promise<number> {
   }));
   await col<TombstoneDoc>(`${spaceId}_tombstones`).bulkWrite(asBulk<TombstoneDoc>(ops));
   await coll.deleteMany({});
+  // Same cascade as the single delete — a bulk wipe must not be the path that leaves labels behind.
+  // Every entity in the space is gone, so every face label is dangling by definition: clear them
+  // wholesale rather than passing `ids` to a `$in`, which on a 100k-entity wipe would build a 100k
+  // element query for a filter that means "all of them" — the same round-trip trap the seq-block
+  // reservation above exists to avoid.
+  await unlabelAllFaces(spaceId);
   return ids.length;
 }
 
 /**
  * Find all items in a space that hold inbound references to the given entity ID.
- * Checks edges (from/to), memories (entityIds), and chrono entries (entityIds).
+ * Checks edges (from/to), memories (entityIds), chrono entries (entityIds), and labelled face
+ * records (`faceEntityId`).
  * Returns a (possibly empty) list of backlink entries.
+ *
+ * Faces were the gap: this scanned `_edges` / `_memories` / `_chrono` and not `_files`, so under
+ * `strictLinkage` — the strongest setting available — a person referenced *only* by their face
+ * labels deleted cleanly, and the 409 that exists to say "something still points at this" stayed
+ * silent about the one reference class holding biometric data.
  */
 export async function findEntityBacklinks(spaceId: string, entityId: string): Promise<BacklinkEntry[]> {
   const backlinks: BacklinkEntry[] = [];
@@ -372,6 +427,13 @@ export async function findEntityBacklinks(spaceId: string, entityId: string): Pr
     .find(asFilter<ChronoEntry>({ spaceId, entityIds: entityId }), { projection: { _id: 1 } })
     .toArray() as Array<{ _id: string }>;
   for (const c of chronos) backlinks.push({ type: 'chrono', _id: c._id });
+
+  // Face records labelled with this entity. These live in `${spaceId}_files` as face-chunk filemeta
+  // docs, which is why the other three scans missed them.
+  const faces = await col<FileMetaDoc>(`${spaceId}_files`)
+    .find(asFilter<FileMetaDoc>({ faceEntityId: entityId }), { projection: { _id: 1 } })
+    .toArray() as Array<{ _id: string }>;
+  for (const f of faces) backlinks.push({ type: 'face', _id: f._id });
 
   return backlinks;
 }

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -36,7 +36,7 @@ import { getConfig, getDataRoot, getFaceRecognitionConfig } from '../../config/l
 import { faceRecognitionAllowed } from '../converters/media-level.js';
 import { updateFileMeta } from '../file-meta.js';
 import { log } from '../../util/log.js';
-import type { FileMetaDoc, AuthorRef } from '../../config/types.js';
+import type { FileMetaDoc, AuthorRef, EntityDoc } from '../../config/types.js';
 import type { Config as HumanConfig, Result } from '@vladmandic/human';
 
 // ── Singleton Human instance (lazy init) ──────────────────────────────────
@@ -126,6 +126,26 @@ async function getHuman(): Promise<HumanInstance> {
 // ── Gallery search ─────────────────────────────────────────────────────────
 
 /**
+ * Does this face label still point at an entity that exists?
+ *
+ * Fail closed when it does not. `deleteEntity` unlabels faces as it deletes, but that cascade cannot
+ * reach records orphaned by a delete that happened BEFORE it shipped — and without this check those
+ * records keep seeding new auto-labels with a dead id, so the dangling reference grows instead of
+ * decaying. Cheap: one `_id` lookup, and only for a match that already cleared the threshold.
+ *
+ * Exported as its own seam so it can be tested without standing up a `$vectorSearch` index — the
+ * gallery query around it needs one, this rule does not, and a rule that can only be exercised
+ * through slow infrastructure tends to end up untested.
+ */
+export async function labelStillResolves(spaceId: string, entityId: string): Promise<boolean> {
+  const person = await col<EntityDoc>(`${spaceId}_entities`)
+    .findOne(asFilter<EntityDoc>({ _id: entityId }), { projection: { _id: 1 } });
+  if (person) return true;
+  log.debug(`Face gallery match in ${spaceId} points at deleted entity ${entityId} — ignoring`);
+  return false;
+}
+
+/**
  * Search the face gallery (labeled face-chunk records in the space) for the
  * closest match to the given 128d descriptor.
  *
@@ -173,7 +193,10 @@ async function gallerySearch(
     if (typeof top._score !== 'number' || top._score < threshold) return null;
     if (!top.faceEntityId) return null;
 
-    return { entityId: top.faceEntityId as string, score: top._score };
+    const entityId = top.faceEntityId as string;
+    if (!await labelStillResolves(spaceId, entityId)) return null;
+
+    return { entityId, score: top._score };
   } catch (err) {
     // The face index may not exist yet (feature just enabled, initSpace pending)
     log.debug(`Face gallery search failed for ${spaceId}: ${err instanceof Error ? err.message : String(err)}`);

--- a/testing/standalone/face-label-cascade.test.js
+++ b/testing/standalone/face-label-cascade.test.js
@@ -1,0 +1,216 @@
+/**
+ * Database-level tests: deleting a person unlinks their face vectors.
+ *
+ * The bug these pin down: face descriptors are not stored in a face collection — they are **filemeta**
+ * records (`{fileId}#face-chunk{N}`) carrying `faceEmbedding` and, once labelled, `faceEntityId`.
+ * `deleteEntity` deleted the entity and wrote a tombstone and never touched `${spaceId}_files`, so the
+ * only "delete this person" action the product offers left their biometric descriptors on disk still
+ * tagged with the identifier that was just erased.
+ *
+ * Three properties are under test, and they are not the same property:
+ *
+ *   1. THE CASCADE FIRES, AND UNLABELS RATHER THAN DELETES. The face record belongs to the *file*,
+ *      which the operator did not delete. "Delete this person" means we stop claiming to know whose
+ *      face it is — not that the photo loses its face. So `faceEntityId`/`faceScore` go and
+ *      `faceEmbedding` stays.
+ *   2. IT FIRES ON EVERY DELETE PATH. Single delete, bulk wipe, and the TTL sweep (which routes
+ *      through `deleteEntity`, so a person entity can expire and detach its faces with no human
+ *      action at all). This being fixed in one caller only is the exact shape of the original bug.
+ *   3. THE BLIND SPOT THAT HID IT IS CLOSED. `findEntityBacklinks` scanned `_edges`/`_memories`/
+ *      `_chrono` and not `_files`, so under `strictLinkage` — the strongest setting available — a
+ *      person referenced *only* by face labels deleted cleanly and the "something still points at
+ *      this" guard stayed silent about the one reference class holding biometric data.
+ *
+ * These run against a REAL MongoDB (see `_mongo-harness.mjs`). That is deliberate and not incidental:
+ * the cascade is an `updateMany` with `$unset` and an `$in` filter, and a hand-written fake collection
+ * that got either subtly wrong would pass here while production kept the labels.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/face-label-cascade.test.js
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+// `deleteEntity` reads `getConfig().instanceId` for the tombstone — set before importing the loader.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-face-cascade-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+const SPACE = 'general';
+const ALICE = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+const BOB   = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
+
+let mongo, entities, files, brain, faceEmbedder;
+
+/** A face-chunk filemeta record, exactly the shape the recogniser writes. */
+function faceChunk(id, parentFileId, entityId) {
+  return {
+    _id: id,
+    spaceId: SPACE,
+    parentFileId,
+    faceEmbedding: Array.from({ length: 128 }, (_, i) => i / 128),
+    faceBbox: [0.1, 0.1, 0.2, 0.2],
+    ...(entityId ? { faceEntityId: entityId, faceScore: 0.91 } : {}),
+  };
+}
+
+const face = (id) => files.findOne({ _id: id });
+
+describe('face labels cascade when their person is deleted', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('facecascade');
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      instanceId: 'face-cascade-test', instanceLabel: 'test', tokens: [], networks: [],
+      spaces: [{ id: SPACE, label: 'General', builtIn: true, folders: [] }],
+    }, null, 2), { mode: 0o600 });
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+
+    brain = await import('../../server/dist/brain/entities.js');
+    faceEmbedder = await import('../../server/dist/files/media/face-embedder.js');
+    entities = mongo.col(`${SPACE}_entities`);
+    files = mongo.col(`${SPACE}_files`);
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => {
+    await entities.deleteMany({});
+    await files.deleteMany({});
+    await mongo.col(`${SPACE}_tombstones`).deleteMany({});
+    await entities.insertOne({ _id: ALICE, spaceId: SPACE, name: 'Alice', type: 'person', tags: [], properties: {} });
+    await entities.insertOne({ _id: BOB, spaceId: SPACE, name: 'Bob', type: 'person', tags: [], properties: {} });
+  });
+
+  // ── 1. The cascade ─────────────────────────────────────────────────────────
+
+  it('strips the label from every face that pointed at the deleted person', async () => {
+    await files.insertOne(faceChunk('photo1.jpg#face-chunk0', 'photo1.jpg', ALICE));
+    await files.insertOne(faceChunk('photo2.jpg#face-chunk0', 'photo2.jpg', ALICE));
+
+    assert.equal(await brain.deleteEntity(SPACE, ALICE), true);
+
+    for (const id of ['photo1.jpg#face-chunk0', 'photo2.jpg#face-chunk0']) {
+      const doc = await face(id);
+      assert.ok(doc, `${id} must still exist — the FILE was not deleted`);
+      assert.equal(doc.faceEntityId, undefined, 'the erased person must not still be named');
+      assert.equal(doc.faceScore, undefined, 'the confidence in a label that no longer exists is meaningless');
+    }
+  });
+
+  it('keeps the descriptor and the rest of the record — unlabel, not delete', async () => {
+    await files.insertOne(faceChunk('photo1.jpg#face-chunk0', 'photo1.jpg', ALICE));
+    await brain.deleteEntity(SPACE, ALICE);
+
+    const doc = await face('photo1.jpg#face-chunk0');
+    assert.equal(doc.faceEmbedding.length, 128, 'the face still exists in the photo');
+    assert.equal(doc.parentFileId, 'photo1.jpg');
+    assert.deepEqual(doc.faceBbox, [0.1, 0.1, 0.2, 0.2]);
+  });
+
+  it('touches nobody else\'s labels', async () => {
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    await files.insertOne(faceChunk('b.jpg#face-chunk0', 'b.jpg', BOB));
+    await files.insertOne(faceChunk('c.jpg#face-chunk0', 'c.jpg', null)); // detected, never labelled
+
+    await brain.deleteEntity(SPACE, ALICE);
+
+    assert.equal((await face('a.jpg#face-chunk0')).faceEntityId, undefined);
+    assert.equal((await face('b.jpg#face-chunk0')).faceEntityId, BOB, 'Bob was not deleted');
+    assert.equal((await face('c.jpg#face-chunk0')).faceEntityId, undefined);
+  });
+
+  it('still deletes the entity and writes its tombstone', async () => {
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    await brain.deleteEntity(SPACE, ALICE);
+
+    assert.equal(await entities.findOne({ _id: ALICE }), null);
+    const tomb = await mongo.col(`${SPACE}_tombstones`).findOne({ _id: ALICE });
+    assert.ok(tomb, 'the cascade must not have displaced the tombstone');
+    assert.equal(tomb.type, 'entity');
+  });
+
+  // ── 2. Every delete path ───────────────────────────────────────────────────
+
+  it('the bulk wipe clears labels too, without an id-per-entity query', async () => {
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    await files.insertOne(faceChunk('b.jpg#face-chunk0', 'b.jpg', BOB));
+
+    const n = await brain.bulkDeleteEntities(SPACE);
+    assert.equal(n, 2);
+    assert.equal((await face('a.jpg#face-chunk0')).faceEntityId, undefined);
+    assert.equal((await face('b.jpg#face-chunk0')).faceEntityId, undefined);
+  });
+
+  it('unlabelFacesForEntities handles several people in one call', async () => {
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    await files.insertOne(faceChunk('b.jpg#face-chunk0', 'b.jpg', BOB));
+
+    const n = await brain.unlabelFacesForEntities(SPACE, [ALICE, BOB]);
+    assert.equal(n, 2);
+  });
+
+  it('unlabelFacesForEntities is a no-op for an empty list — never a whole-collection wipe', async () => {
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    assert.equal(await brain.unlabelFacesForEntities(SPACE, []), 0);
+    assert.equal((await face('a.jpg#face-chunk0')).faceEntityId, ALICE, 'an empty id list must match nothing');
+  });
+
+  it('a person expiring by TTL detaches their faces too — no human action involved', async () => {
+    // The worst version of this bug: `ttl-sweep` routes entity expiry through `deleteEntity`, so a
+    // person record aging out silently orphaned every face labelled with them. Driven through the
+    // real sweep rather than asserting that the two call the same function, because "the cascade is
+    // in the shared helper" is exactly the claim that stops being true when someone adds a fourth
+    // delete path.
+    await entities.updateOne({ _id: ALICE }, { $set: { _expireAt: new Date('2020-01-01T00:00:00Z') } });
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    await files.insertOne(faceChunk('b.jpg#face-chunk0', 'b.jpg', BOB));
+
+    const { sweepExpired } = await import('../../server/dist/brain/ttl-sweep.js');
+    const deleted = await sweepExpired(new Date('2026-07-22T00:00:00Z'));
+
+    assert.equal(deleted, 1, 'only the expired person should go');
+    assert.equal(await entities.findOne({ _id: ALICE }), null);
+    assert.equal((await face('a.jpg#face-chunk0')).faceEntityId, undefined, 'TTL expiry must cascade');
+    assert.equal((await face('b.jpg#face-chunk0')).faceEntityId, BOB, 'Bob did not expire');
+  });
+
+  // ── 3. The blind spot ──────────────────────────────────────────────────────
+
+  it('findEntityBacklinks now reports face references', async () => {
+    await files.insertOne(faceChunk('a.jpg#face-chunk0', 'a.jpg', ALICE));
+    await files.insertOne(faceChunk('b.jpg#face-chunk0', 'b.jpg', ALICE));
+
+    const links = await brain.findEntityBacklinks(SPACE, ALICE);
+    const faces = links.filter(l => l.type === 'face');
+    assert.equal(faces.length, 2, 'faces were the reference class this never looked at');
+    assert.deepEqual(faces.map(f => f._id).sort(), ['a.jpg#face-chunk0', 'b.jpg#face-chunk0']);
+  });
+
+  it('reports nothing for a person with no faces', async () => {
+    await files.insertOne(faceChunk('b.jpg#face-chunk0', 'b.jpg', BOB));
+    const links = await brain.findEntityBacklinks(SPACE, ALICE);
+    assert.deepEqual(links.filter(l => l.type === 'face'), []);
+  });
+
+  // ── The pre-existing orphans no cascade can reach ──────────────────────────
+
+  it('a label pointing at a deleted person no longer seeds new auto-labels', async () => {
+    // Records orphaned by a delete that happened BEFORE the cascade shipped. Without this check the
+    // gallery keeps matching them and the dangling id propagates onto every new photo of that face.
+    assert.equal(await faceEmbedder.labelStillResolves(SPACE, ALICE), true);
+    await entities.deleteOne({ _id: ALICE });
+    assert.equal(await faceEmbedder.labelStillResolves(SPACE, ALICE), false);
+  });
+
+  it('a live label still resolves — the guard is not simply off', async () => {
+    assert.equal(await faceEmbedder.labelStillResolves(SPACE, BOB), true);
+  });
+});


### PR DESCRIPTION
The last must-ship item from the second audit pass — the privacy cascade-deletion lens.

## The bug

Face descriptors are not stored in a face collection. They are **filemeta records** (`{fileId}#face-chunk{N}`) carrying `faceEmbedding` and, once labelled, `faceEntityId`. `deleteEntity` removed the entity and wrote a tombstone and **never touched `${spaceId}_files`** — so the only "delete this person" action the product offers left their biometric descriptors on disk, still tagged with the identifier that had just been erased.

Three things made it worse than a stale pointer:

- **`strictLinkage` was blind to it.** `findEntityBacklinks` scanned `_edges`, `_memories` and `_chrono` but **not `_files`** — so the strongest setting available did not look at the one reference class holding biometric data, and a person referenced *only* by faces deleted cleanly.
- **It propagated rather than decaying.** The gallery search matched new uploads against those orphaned records and returned the dead id, so the *next* photo of that person was auto-labelled with it too.
- **No human action was required.** `ttl-sweep` routes entity expiry through the same `deleteEntity`, so a person record aging out detached its faces silently.

## The fix

Deleting a person clears `faceEntityId`/`faceScore` from every face that pointed at them, on **every** path — single delete, bulk wipe, TTL expiry — through one shared helper, because being fixed in one caller only is the shape of the original bug. The bulk path clears wholesale instead of passing every id to an `$in`, which on a 100k-entity wipe would build a 100k-element query meaning "all of them".

**Unlabel, not delete.** The face record belongs to the *file*, which the operator did not delete; removing it would destroy image metadata as a side effect of deleting a contact. "Delete this person" now means we stop claiming to know whose face it is. Deleting the *image* still removes its face records, as it always did (`deleteConversionArtifacts` matches on `parentFileId`).

A gallery match whose entity no longer exists is now ignored. That is the only thing that can help records already orphaned before this shipped — no cascade reaches those retroactively. Extracted as `labelStillResolves` so the rule is testable without standing up a `$vectorSearch` index; a rule reachable only through slow infrastructure is a rule that ends up untested.

## One judgement call worth flagging

**Face labels are reported by `findEntityBacklinks` but deliberately do NOT block deletion under `strictLinkage`.** Other reference types still do.

`strictLinkage` exists to stop a delete that would leave a *dangling* reference — and a face label can no longer dangle, because the delete clears it in the same operation. Blocking would be actively harmful: face labels are written by the recogniser, not by a person, so an admin would hit a 409 they never created and could only clear by hand-unlabelling every photo. That makes the subject whose data is biometric the one person you cannot remove, which inverts the point of the fix.

I checked the blast radius of the new `'face'` backlink type: `findEntityBacklinks` has exactly one production consumer (the DELETE route, which filters faces out of the 409 body), and the client has no backlink handling at all — so nothing downstream switches on the type.

## Testing

12 tests against a **real MongoDB**, using the harness from #371. That is not incidental — the cascade is an `updateMany`/`$unset` with an `$in` filter, and a hand-written fake collection that got either subtly wrong would pass here while production kept the labels.

**Mutation-checked**, four ways: remove the cascade, the bulk cascade, the `_files` backlink scan, or the gallery existence check — each time exactly the intended assertions fail. (One mutation had to be redone: my first cut left an orphaned `push` referencing an undefined variable, so the function threw and *two* tests failed. A mutation that fails for the wrong reason proves nothing.)

The TTL case is driven through the real `sweepExpired` rather than asserting that it and `deleteEntity` share a helper — "the cascade lives in the shared function" is precisely the claim that stops being true when someone adds a fourth delete path.

Full standalone suite: **1148 tests, 0 failures.**

## Release-gate note

This changes what deleting a person *does* in the UI, so it belongs on the manual pass before any tag — alongside the Models page rebuild, the editable ceilings and the face-recognition switch. Documented in `docs/userguide.md` under Face Recognition → Deleting a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
