### PR TITLE
fix(config): the invite finalize commit persisted a pre-reload snapshot, silently dropping the join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1412,6 +1412,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A network join or reparent could return `200` with the membership change silently absent.**
+  `POST /api/invite/finalize` looked up `net = cfg.networks.find(...)`, then `await bcrypt.hash(...)`,
+  then mutated `net` and called `saveConfig(cfg)`. The config object's nested arrays are replaced
+  wholesale on a reload, so if the config watcher fired during the hash, every mutation landed on an
+  orphaned object and the save persisted the **pre-reload** snapshot — reverting the join and
+  clobbering any unrelated config edit made in the same window. The window is not incidental:
+  `bcrypt.hash` is deliberately slow, which makes this one of the widest reload windows in the
+  codebase. Same silent-success shape as the space rename (#353) and the config clobber (#346).
+
+  Finalize now re-reads the live config immediately before mutating — after the last `await`, with no
+  awaits between the re-read and the save — mirroring what `api/networks/join.ts` already does. A
+  network deleted during the handshake now returns a clean `409` instead of being resurrected from the
+  stale snapshot. The same re-read was applied to `PUT /api/spaces/:id/schema`, which held a `space`
+  reference across the `await` that writes the schema backup and would drop a concurrent edit to that
+  space's `purpose` / `usageNotes` / `validationMode` on a schema save.
+
+  Pinned by new cases in `config-detached-refs.test.js` for the networks array specifically (the old
+  coverage only demonstrated spaces); mutation-checked against the loader's detach behaviour. Fixing
+  the remaining sites and the ~2s watcher-lag window are tracked separately.
+
 - **Deleting a person did not unlink their face vectors — the biometric link outlived the erasure.**
   Face descriptors are not stored in a face collection; they are **filemeta** records
   (`{fileId}#face-chunk{N}`) carrying `faceEmbedding` and, once labelled, `faceEntityId`.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -4108,6 +4108,12 @@ leaf under a braintree **root** — still conclude immediately and return `"join
 open the joiner's provisioned peer token is refused on `/api/sync/*`; sync starts automatically once
 the vote passes. If the round is vetoed or expires, the provisioned credentials are revoked.
 
+**Errors:** `401` for an invalid or expired handshake, `400` if `/apply` has not run for the session,
+and `409` **`Network was removed while the handshake was in flight`** if the target network is deleted
+between `/apply` and `/finalize`. The finalize commit re-reads the live config immediately before
+writing, so a network removed mid-handshake fails cleanly rather than being silently recreated from a
+stale snapshot.
+
 ---
 
 ### Check Invite Status

--- a/server/src/api/invite.ts
+++ b/server/src/api/invite.ts
@@ -372,10 +372,12 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
 
   const { instanceId, instanceLabel, instanceUrl } = session.pendingMember;
 
-  // Commit to config
-  const cfg = getConfig();
-  const net = cfg.networks.find(n => n.id === session.networkId);
-  if (!net) { res.status(404).json({ error: 'Network not found' }); return; }
+  // Fail fast on a network that does not exist, before doing expensive work. This read is only a
+  // guard — the object it returns must NOT be carried across the await below (see the re-read after).
+  if (!getConfig().networks.some(n => n.id === session.networkId)) {
+    res.status(404).json({ error: 'Network not found' });
+    return;
+  }
 
   // Hash B's token for inbound validation (stored in member record)
   const tokenHash = await bcrypt.hash(peerToken, BCRYPT_ROUNDS);
@@ -384,6 +386,29 @@ inviteRouter.post('/finalize', authRateLimit, async (req, res) => {
   const secrets = getSecrets();
   secrets.peerTokens[instanceId] = peerToken;
   saveSecrets(secrets);
+
+  // ── Re-read AFTER the last await, immediately before mutating ────────────────────────────────
+  //
+  // `getConfig()` returns the live object, and the config watcher replaces its nested contents on
+  // reload. A reference taken before an await is therefore orphaned if a reload lands during it —
+  // the mutations below would apply to a detached object and `saveConfig(cfg)` at the end would
+  // persist the PRE-reload snapshot, silently reverting whatever else changed and losing this join.
+  //
+  // The window here is not theoretical: `bcrypt.hash` is *deliberately* slow (that is its whole
+  // purpose), which makes this one of the widest reload windows in the codebase. The failure is
+  // silent in the worst way — the caller gets 200 and the membership change simply is not there.
+  // Same shape as the silent rename (#353) and the config clobber (#346).
+  //
+  // Mirrors what `api/networks/join.ts` already does (`freshCfg`); a second spelling of the same
+  // idea would be its own kind of bug.
+  const cfg = getConfig();
+  const net = cfg.networks.find(n => n.id === session.networkId);
+  if (!net) {
+    // The network was deleted while we hashed. Do NOT recreate it from the stale snapshot — a join
+    // must never resurrect a network an admin just removed.
+    res.status(409).json({ error: 'Network was removed while the handshake was in flight' });
+    return;
+  }
 
   let responseStatus: 'joined' | 'reparented' | 'vote_pending';
   let pendingRoundId: string | undefined;

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -589,9 +589,19 @@ spacesRouter.put('/:id/schema', globalRateLimit, requireAdminMfaScoped('id'), as
     }
   }
 
+  // Re-read AFTER the backup write. `space` was found before `await writeSpaceFile` above, and a
+  // config reload during that write orphans it — the spread below would then carry the PRE-reload
+  // meta, so any concurrent edit to this space's purpose / usageNotes / validationMode is silently
+  // dropped on a schema save. Same class as the invite finalize path and #353; cheap to avoid.
+  const freshSpace = getConfig().spaces.find(s => s.id === id);
+  if (!freshSpace) {
+    res.status(409).json({ error: `Space '${id}' was removed while the schema backup was being written` });
+    return;
+  }
+
   // Replace the entire typeSchemas (full-replace semantics)
   const newMeta: SpaceMeta = {
-    ...(space.meta ?? {}),
+    ...(freshSpace.meta ?? {}),
     typeSchemas: parsed.data.typeSchemas as SpaceMeta['typeSchemas'],
   };
 

--- a/testing/standalone/config-detached-refs.test.js
+++ b/testing/standalone/config-detached-refs.test.js
@@ -37,7 +37,9 @@ const readDisk = () => JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 
 function seed() {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify({
-    instanceId: 'test-instance', instanceLabel: 'test', tokens: [], networks: [],
+    instanceId: 'test-instance', instanceLabel: 'test', tokens: [], networks: [
+      { id: 'net1', label: 'Net 1', type: 'club', spaces: [], members: [], pendingRounds: [], createdAt: '2026-01-01T00:00:00Z' },
+    ],
     spaces: [{ id: 'alpha', label: 'Alpha', builtIn: false, folders: [] }],
   }, null, 2), { mode: 0o600 });
   loader.loadConfig();
@@ -108,5 +110,64 @@ describe('a reload detaches nested references', () => {
     const disk = readDisk();
     assert.equal(disk.spaces.find(s => s.id === 'alpha').label, 'Alpha Renamed');
     assert.ok(disk.spaces.some(s => s.id === 'beta'), 'the other writer\'s space must survive');
+  });
+
+  // ── The invite finalize shape: push into a nested array across a slow await ──────────────────
+  //
+  // `POST /api/invite/finalize` looks up `net = cfg.networks.find(...)`, then `await bcrypt.hash`
+  // (deliberately slow), then pushes the new member into `net.members` and saves. If the watcher
+  // reloads during the hash, `net` is an orphan and the join is written to nowhere — the caller gets
+  // 200 with the membership silently absent. Same failure as the rename above; this pins it for the
+  // networks array specifically, which is the collection the invite path mutates.
+
+  it('a network member pushed through a pre-reload reference is lost — and reports success', () => {
+    const cfg = loader.getConfig();
+    const net = cfg.networks.find(n => n.id === 'net1');   // taken BEFORE the (simulated) await
+
+    loader.reloadConfig();                                  // watcher fires during bcrypt
+
+    net.members.push({ instanceId: 'joiner', label: 'Joiner' }); // mutating the orphan
+    loader.saveConfig(cfg);
+
+    assert.equal(
+      readDisk().networks.find(n => n.id === 'net1').members.length, 0,
+      'the join was lost: saveConfig persisted the pre-reload snapshot',
+    );
+  });
+
+  it('re-finding the network AFTER the reload commits the join — the finalize fix', () => {
+    const cfg = loader.getConfig();
+    cfg.networks.find(n => n.id === 'net1');                // the stale lookup the old code kept
+
+    loader.reloadConfig();                                  // watcher fires during bcrypt
+
+    // The fix: re-read and re-find immediately before mutating, exactly as invite.ts now does.
+    const fresh = loader.getConfig();
+    const liveNet = fresh.networks.find(n => n.id === 'net1');
+    liveNet.members.push({ instanceId: 'joiner', label: 'Joiner' });
+    loader.saveConfig(fresh);
+
+    const persisted = readDisk().networks.find(n => n.id === 'net1').members;
+    assert.equal(persisted.length, 1, 'the join lands');
+    assert.equal(persisted[0].instanceId, 'joiner');
+  });
+
+  it('a network deleted during the window is not resurrected by the fresh re-find', () => {
+    // invite.ts returns 409 rather than recreating the network from a stale snapshot. The primitive
+    // that makes that possible: after a reload that removed the network, re-finding it yields
+    // undefined, so the handler can detect the deletion instead of pushing into a ghost.
+    const cfg = loader.getConfig();
+    cfg.networks.find(n => n.id === 'net1');
+
+    // Another writer deletes the network, then the watcher reloads our view from that new state.
+    const other = loader.getConfig();
+    other.networks = other.networks.filter(n => n.id !== 'net1');
+    loader.saveConfig(other);
+    loader.reloadConfig();
+
+    assert.equal(
+      loader.getConfig().networks.find(n => n.id === 'net1'), undefined,
+      'the fresh re-find must report the network gone, so finalize can 409 instead of resurrecting it',
+    );
   });
 });


### PR DESCRIPTION
The highest-value remaining detached-reference site — same silent-loss class as #346 / #348 / #353.

## The bug

`POST /api/invite/finalize`:

```ts
const cfg = getConfig();
const net = cfg.networks.find(n => n.id === session.networkId);
const tokenHash = await bcrypt.hash(peerToken, BCRYPT_ROUNDS);  // ← reload window
// … mutate net.members …
saveConfig(cfg);                                                 // ← persists the STALE object
```

The config object's nested arrays are replaced wholesale on a reload, so if the config watcher fires during the hash, every mutation lands on an **orphaned** `net` and `saveConfig(cfg)` persists the pre-reload snapshot. The join or reparent returns **`200` with the membership change silently absent**, and any unrelated config edit made in the same window is clobbered.

**The window is not incidental.** `bcrypt.hash` is *deliberately* slow — that is its whole purpose — which makes this one of the widest reload windows in the codebase, not a theoretical microsecond.

## The fix

Finalize re-reads the live config immediately before mutating — after the last `await`, with **no awaits between the re-read and the save**. This mirrors `api/networks/join.ts`, and is actually *tighter*: join.ts still runs a second `bcrypt` after its re-read, leaving a residual window; finalize has none.

A network deleted during the handshake now returns a clean **`409`** instead of being resurrected from the stale snapshot — the fresh re-find reports it gone, so the handler refuses rather than pushing into a ghost.

**Why not `mutateConfig`?** It always saves after its callback, but finalize has three conditional `res.status(4xx); return;` paths (reparent-mismatch `403`, target-missing `400`, already-member `409`) that must abort *without* writing. The guarded manual re-read is the right shape for a handler with early-return-without-save branches.

Same treatment for **`PUT /api/spaces/:id/schema`**, which held a `space` reference across the `await writeSpaceFile` that writes the schema backup, then read `space.meta` to build the replacement — dropping a concurrent edit to that space's `purpose` / `usageNotes` / `validationMode` on a schema save.

## Grounding note

Writing the plan corrected the tracker: it had listed three remaining sites, but `api/networks/join.ts` was **already fixed** (re-reads `freshCfg`), and `api/invite.ts:179` (generate) holds a reference across an await but only **reads** it for the response body — no lost write. Only the two stale *writes* fixed here actually lose data.

## Testing

The route-level race can't be won deterministically from outside: the watcher has a ~2s debounce, so a reload won't land inside the bcrypt window on cue. That is exactly why `config-detached-refs.test.js` tests the mechanism synchronously. I extended it with the **networks-array shape** the invite path mutates (the old coverage only demonstrated the spaces array):

- a member pushed through a pre-reload reference is lost, and reports success (the bug);
- re-finding the network after the reload commits the join (the fix);
- a network deleted during the window is not resurrected (the 409 path's premise).

**Mutation-checked**: make `reloadConfig` stop detaching nested arrays and the "join is lost" assertion flips — confirming the test depends on the real mechanism rather than passing regardless. Route-level wiring is covered by mirroring the shipped join.ts pattern and by the sync suite's real joins.

Standalone suite: **1151 tests, 0 failures**. New `409` documented on finalize in the integration guide.

## Still tracked (not in this PR)

- `api/invite.ts:179` generate — holds a ref but only reads it; no lost write.
- The ~2s external-edit watcher-lag window — needs `mutateConfig`'s disk re-read; the in-memory `getConfig()` re-read used here does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
