### PR TITLE
feat(brain): uniform add-forms — one control height, table-column field order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2205,6 +2205,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Brain add-forms are uniform now — same control heights, table-column field order.** The five
+  record tabs had drifted apart: four different control heights on one page (search `5/10`, filter
+  `30`, create-form `5/8`, global `8/12`), the memories create-form in a different field order than
+  its own inline-edit, and `Fact`/`Description` at mismatched sizes. Each tab's Add form is now a
+  vertical stack of rows sharing one control height (`--brain-control-h`, aligned to the tallest
+  existing single-line control so nothing looks cramped): a row of single-line fields at one height,
+  then the tall fields (description alongside properties, or fact alongside description) each free to
+  grow with tops aligned. Field order follows the table columns per tab — memories is now
+  `Fact, Description, tags, entities, properties`; edges `from, relation, to, weight, tags |
+  description, properties`; chrono keeps its required kind/start/end but leads with title then
+  description. Layout only — create/edit payloads are unchanged (the CRUD characterization specs still
+  pass). Verified by booting an isolated instance and screenshotting all four forms (0 change-detection
+  errors). First slice of the Brain UX pass; column-header filters + sort, the inline entity picker,
+  and the File Meta rebuild follow.
+- **`common.form.description` relabelled "Short Description" → "Description".** It read "Short
+  Description" in the memories form and in every record's detail drawer while entities/edges/chrono
+  labelled the same field just "Description" — the inconsistency the feedback called out ("no short",
+  and on the chrono view "short description → description"). Fixed in one shared key across en/de/pl.
+
 - **Per-type tag suggestions are retired — the editor did nothing.** The Schema tab and the Schema
   Library both offered a tag-suggestion editor per type, stored under
   `typeSchemas.<kind>.<type>.tagSuggestions`. It reached **nothing**: the Brain record forms suggest

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -225,7 +225,7 @@
   "common.form.fact": "Fakt",
   "common.form.tags": "Schlagworte",
   "common.form.entities": "Entitäten",
-  "common.form.description": "Kurzbeschreibung",
+  "common.form.description": "Beschreibung",
   "common.form.properties": "Eigenschaften",
   "common.form.title": "Titel",
   "common.form.from": "Aus",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -225,7 +225,7 @@
   "common.form.fact": "Fact",
   "common.form.tags": "Tags",
   "common.form.entities": "Entities",
-  "common.form.description": "Short Description",
+  "common.form.description": "Description",
   "common.form.properties": "Properties",
   "common.form.title": "Title",
   "common.form.from": "From",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -225,7 +225,7 @@
   "common.form.fact": "Fakt",
   "common.form.tags": "Tagi",
   "common.form.entities": "Podmioty",
-  "common.form.description": "Krótki opis",
+  "common.form.description": "Opis",
   "common.form.properties": "Właściwości",
   "common.form.title": "Tytuł",
   "common.form.from": "Z",

--- a/client/src/app/pages/brain/brain-table.styles.ts
+++ b/client/src/app/pages/brain/brain-table.styles.ts
@@ -65,28 +65,49 @@ export const BRAIN_RECORD_TABLE_STYLES = `
       transition: opacity var(--transition);
     }
     .tag-clickable:hover, .entity-clickable:hover { opacity: 0.7; }
+    /* Uniform control height across every brain form control. 34px matches app-tag-input's wrap —
+       the tallest single-line control — so aligning to it lifts the plain inputs/selects up to a
+       shared height instead of leaving four different ones on the page (search 5/10, filter 30,
+       create 5/8, global 8/12). Single-line fields become identical; textarea/properties grow. */
+    .create-form { --brain-control-h: 34px; }
     .create-form {
       display: flex;
-      gap: 10px;
-      align-items: flex-start;
-      flex-wrap: wrap;
+      flex-direction: column;
+      gap: 12px;
       padding: 12px 14px;
       border: 1px solid var(--border);
       border-radius: var(--radius-md);
       background: var(--bg-surface);
       margin-bottom: 12px;
     }
-    .create-form .field { margin-bottom: 0; }
+    /* The form is a vertical stack of .form-row blocks. Each tab composes its own rows in
+       table-column order: single-line fields (name/type/tags, from/to/label/weight) go in a plain
+       row at one uniform height; the tall fields (description then properties, or fact then
+       description) go in a .form-row.rich where each field flexes and grows, tops aligned. This makes
+       the feedback's "same input height … description the current height as baseline but expands with
+       properties container" a structure rather than a pile of per-field inline widths. */
+    .create-form .form-row {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+    .create-form .form-row.rich > .field { flex: 1; min-width: 220px; }
+    .create-form .field { margin-bottom: 0; display: flex; flex-direction: column; }
     .create-form label { font-size: 11px; color: var(--text-muted); display: block; margin-bottom: 2px; }
-    .create-form input, .create-form textarea {
-      padding: 5px 8px;
+    .create-form input, .create-form select, .create-form textarea {
+      padding: 6px 8px;
       border: 1px solid var(--border);
       border-radius: var(--radius-sm);
       font-size: 13px;
       background: var(--bg-primary);
       color: var(--text-primary);
+      box-sizing: border-box;
     }
-    .create-form textarea { resize: vertical; }
+    /* Single-line controls (and app-tag-input's wrap, already 34px) share the one height. */
+    .create-form input:not([type=checkbox]), .create-form select { min-height: var(--brain-control-h); }
+    /* Description starts at the single-line height as its baseline and grows from there. */
+    .create-form textarea { resize: vertical; min-height: var(--brain-control-h); }
     .inline-confirm {
       display: inline-flex;
       align-items: center;

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -57,70 +57,79 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 
           @if (showChronoForm()) {
             <form class="create-form" (ngSubmit)="createChrono()">
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'common.form.title' | transloco }}</label>
-                <input type="text" [(ngModel)]="chronoForm.title" name="title" required />
-              </div>
-              <div class="field" style="width:160px;">
-                <label>{{ 'brain.chrono.form.kind' | transloco }}</label>
-                @if (chronoForm.kind !== '__custom__') {
-                  <select [(ngModel)]="chronoForm.kind" name="kind">
-                    @for (k of store.chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
-                    <option value="__custom__">{{ 'brain.chrono.form.customKind' | transloco }}</option>
-                  </select>
-                } @else {
-                  <div style="display:flex; gap:4px;">
-                    <input type="text" [(ngModel)]="chronoForm.customKind" name="customKind" style="flex:1;" />
-                    <button type="button" class="btn-secondary btn btn-sm" style="padding:4px 8px;" (click)="chronoForm.kind = 'event'; chronoForm.customKind = ''" [attr.title]="'brain.chrono.form.backToPresets' | transloco"><ph-icon name="x" [size]="14"/></button>
-                  </div>
-                }
-              </div>
-              <div class="field" style="width:200px;">
-                <label>{{ 'brain.chrono.form.startsAt' | transloco }}</label>
-                <input type="datetime-local" [(ngModel)]="chronoForm.startsAt" name="startsAt" required />
-              </div>
-              <div class="field" style="width:200px;">
-                <label>{{ 'brain.chrono.form.endsAt' | transloco }}</label>
-                <input type="datetime-local" [(ngModel)]="chronoForm.endsAt" name="endsAt" />
-              </div>
-              <div class="field" style="flex:1; min-width:200px;">
-                <label>{{ 'brain.chrono.table.description' | transloco }}</label>
-                <textarea [(ngModel)]="chronoForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'brain.chrono.table.tags' | transloco }}</label>
-                <app-tag-input [(value)]="chronoForm.tags" [suggestions]="store.chronoTagSuggestions()" inputName="chronoFormTags" />
-              </div>
-              <div class="field" style="flex:1; min-width:140px;">
-                <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
-                <div class="flyout-wrap">
-                  <div class="entity-multi">
-                    @for (chip of picker.entityChips(chronoForm.entityIds); track chip.id) {
-                      <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(chronoForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                    }
-                    <button type="button" class="chip-add" (click)="picker.openFlyout('create-chrono-entityIds', chronoForm)">{{ 'common.addMore' | transloco }}</button>
-                  </div>
-                  @if (picker.flyoutField() === 'create-chrono-entityIds') {
-                    <div class="flyout-panel">
-                      <app-entity-search
-                        mode="picker"
-                        [spaceId]="spaceId()"
-                        placeholder="common.searchEntitiesPlaceholder"
-
-                        (selected)="picker.pickEntity($event, chronoForm)"
-                      />
-                      <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                        <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                      </div>
+              <!-- Order follows the feedback (Title, Description, tags, entities) while keeping chrono's
+                   required kind/start/end. Single-line fields share one height; description grows. -->
+              <div class="form-row">
+                <div class="field" style="flex:2; min-width:200px;">
+                  <label>{{ 'common.form.title' | transloco }}</label>
+                  <input type="text" [(ngModel)]="chronoForm.title" name="title" required />
+                </div>
+                <div class="field" style="width:160px;">
+                  <label>{{ 'brain.chrono.form.kind' | transloco }}</label>
+                  @if (chronoForm.kind !== '__custom__') {
+                    <select [(ngModel)]="chronoForm.kind" name="kind">
+                      @for (k of store.chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
+                      <option value="__custom__">{{ 'brain.chrono.form.customKind' | transloco }}</option>
+                    </select>
+                  } @else {
+                    <div style="display:flex; gap:4px;">
+                      <input type="text" [(ngModel)]="chronoForm.customKind" name="customKind" style="flex:1;" />
+                      <button type="button" class="btn-secondary btn btn-sm" style="padding:4px 8px;" (click)="chronoForm.kind = 'event'; chronoForm.customKind = ''" [attr.title]="'brain.chrono.form.backToPresets' | transloco"><ph-icon name="x" [size]="14"/></button>
                     </div>
                   }
                 </div>
+                <div class="field" style="width:200px;">
+                  <label>{{ 'brain.chrono.form.startsAt' | transloco }}</label>
+                  <input type="datetime-local" [(ngModel)]="chronoForm.startsAt" name="startsAt" required />
+                </div>
+                <div class="field" style="width:200px;">
+                  <label>{{ 'brain.chrono.form.endsAt' | transloco }}</label>
+                  <input type="datetime-local" [(ngModel)]="chronoForm.endsAt" name="endsAt" />
+                </div>
               </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingChrono() || !chronoForm.title.trim() || !chronoForm.startsAt || (chronoForm.kind === '__custom__' && !chronoForm.customKind.trim())">
-                @if (creatingChrono()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showChronoForm.set(false)">{{ 'common.cancel' | transloco }}</button>
+              <div class="form-row rich">
+                <div class="field">
+                  <label>{{ 'brain.chrono.table.description' | transloco }}</label>
+                  <textarea [(ngModel)]="chronoForm.description" name="description" rows="3"></textarea>
+                </div>
+              </div>
+              <div class="form-row rich">
+                <div class="field">
+                  <label>{{ 'brain.chrono.table.tags' | transloco }}</label>
+                  <app-tag-input [(value)]="chronoForm.tags" [suggestions]="store.chronoTagSuggestions()" inputName="chronoFormTags" />
+                </div>
+                <div class="field">
+                  <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
+                  <div class="flyout-wrap">
+                    <div class="entity-multi">
+                      @for (chip of picker.entityChips(chronoForm.entityIds); track chip.id) {
+                        <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(chronoForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
+                      }
+                      <button type="button" class="chip-add" (click)="picker.openFlyout('create-chrono-entityIds', chronoForm)">{{ 'common.addMore' | transloco }}</button>
+                    </div>
+                    @if (picker.flyoutField() === 'create-chrono-entityIds') {
+                      <div class="flyout-panel">
+                        <app-entity-search
+                          mode="picker"
+                          [spaceId]="spaceId()"
+                          placeholder="common.searchEntitiesPlaceholder"
+                          (selected)="picker.pickEntity($event, chronoForm)"
+                        />
+                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
+                          <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
+                        </div>
+                      </div>
+                    }
+                  </div>
+                </div>
+              </div>
+              <div style="display:flex; gap:8px;">
+                <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingChrono() || !chronoForm.title.trim() || !chronoForm.startsAt || (chronoForm.kind === '__custom__' && !chronoForm.customKind.trim())">
+                  @if (creatingChrono()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                  {{ 'common.save' | transloco }}
+                </button>
+                <button class="btn-secondary btn btn-sm" type="button" (click)="showChronoForm.set(false)">{{ 'common.cancel' | transloco }}</button>
+              </div>
             </form>
           }
 

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -55,65 +55,70 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 
           @if (showEdgeForm()) {
             <form class="create-form" (ngSubmit)="createEdge()">
-              <div class="field" style="flex:1; min-width:120px;">
-                <label>{{ 'common.form.from' | transloco }}</label>
-                <app-entity-search
-                  mode="picker"
-                  [spaceId]="spaceId()"
-                  placeholder="common.searchEntitiesPlaceholder"
-
-                  [value]="edgeForm.fromDisplay"
-                  (selected)="pickEdgeFrom($event)"
-                />
+              <!-- Field order matches the table columns: from, relation, to, weight, tags | description, properties. -->
+              <div class="form-row">
+                <div class="field" style="flex:1; min-width:120px;">
+                  <label>{{ 'common.form.from' | transloco }}</label>
+                  <app-entity-search
+                    mode="picker"
+                    [spaceId]="spaceId()"
+                    placeholder="common.searchEntitiesPlaceholder"
+                    [value]="edgeForm.fromDisplay"
+                    (selected)="pickEdgeFrom($event)"
+                  />
+                </div>
+                <div class="field" style="flex:1; min-width:120px;">
+                  <label>{{ 'brain.edges.form.relation' | transloco }} <span style="color:var(--error)">*</span></label>
+                  @if (store.edgeLabelNames().length) {
+                    <select [(ngModel)]="edgeForm.label" name="label" required>
+                      @for (l of store.edgeLabelNames(); track l) {
+                        <option [value]="l">{{ l }}</option>
+                      }
+                    </select>
+                  } @else {
+                    <input type="text" [(ngModel)]="edgeForm.label" name="label" required />
+                  }
+                </div>
+                <div class="field" style="flex:1; min-width:120px;">
+                  <label>{{ 'common.form.to' | transloco }}</label>
+                  <app-entity-search
+                    mode="picker"
+                    [spaceId]="spaceId()"
+                    placeholder="common.searchEntitiesPlaceholder"
+                    [value]="edgeForm.toDisplay"
+                    (selected)="pickEdgeTo($event)"
+                  />
+                </div>
+                <div class="field" style="width:90px;">
+                  <label>{{ 'common.form.weight' | transloco }}</label>
+                  <input type="number" [(ngModel)]="edgeForm.weight" name="weight" step="0.1" />
+                </div>
+                <div class="field" style="flex:1; min-width:180px;">
+                  <label>{{ 'brain.edges.table.tags' | transloco }}</label>
+                  <app-tag-input [(value)]="edgeForm.tags" [suggestions]="store.edgeTagSuggestions()" inputName="edgeFormTags" />
+                </div>
               </div>
-              <div class="field" style="flex:1; min-width:120px;">
-                <label>{{ 'brain.edges.form.relation' | transloco }} <span style="color:var(--error)">*</span></label>
-                @if (store.edgeLabelNames().length) {
-                  <select [(ngModel)]="edgeForm.label" name="label" required>
-                    @for (l of store.edgeLabelNames(); track l) {
-                      <option [value]="l">{{ l }}</option>
-                    }
-                  </select>
-                } @else {
-                  <input type="text" [(ngModel)]="edgeForm.label" name="label" required />
-                }
+              <div class="form-row rich">
+                <div class="field">
+                  <label>{{ 'brain.edges.table.description' | transloco }}</label>
+                  <textarea [(ngModel)]="edgeForm.description" name="description" rows="3"></textarea>
+                </div>
+                <div class="field">
+                  <label>{{ 'brain.edges.table.properties' | transloco }}</label>
+                  <app-properties-editor
+                    [schema]="store.edgeSchema(edgeForm.label)"
+                    [required]="store.requiredProps(store.edgeSchema(edgeForm.label))"
+                    [(value)]="edgeForm.properties"
+                  />
+                </div>
               </div>
-              <div class="field" style="flex:1; min-width:120px;">
-                <label>{{ 'common.form.to' | transloco }}</label>
-                <app-entity-search
-                  mode="picker"
-                  [spaceId]="spaceId()"
-                  placeholder="common.searchEntitiesPlaceholder"
-
-                  [value]="edgeForm.toDisplay"
-                  (selected)="pickEdgeTo($event)"
-                />
+              <div style="display:flex; gap:8px;">
+                <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEdge() || !edgeForm.from.trim() || !edgeForm.to.trim() || !edgeForm.label.trim()">
+                  @if (creatingEdge()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                  {{ 'common.save' | transloco }}
+                </button>
+                <button class="btn-secondary btn btn-sm" type="button" (click)="showEdgeForm.set(false)">{{ 'common.cancel' | transloco }}</button>
               </div>
-              <div class="field" style="width:80px;">
-                <label>{{ 'common.form.weight' | transloco }}</label>
-                <input type="number" [(ngModel)]="edgeForm.weight" name="weight" step="0.1" />
-              </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'brain.edges.table.tags' | transloco }}</label>
-                <app-tag-input [(value)]="edgeForm.tags" [suggestions]="store.edgeTagSuggestions()" inputName="edgeFormTags" />
-              </div>
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'brain.edges.table.description' | transloco }}</label>
-                <textarea [(ngModel)]="edgeForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:220px;">
-                <label>{{ 'brain.edges.table.properties' | transloco }}</label>
-                <app-properties-editor
-                  [schema]="store.edgeSchema(edgeForm.label)"
-                  [required]="store.requiredProps(store.edgeSchema(edgeForm.label))"
-                  [(value)]="edgeForm.properties"
-                />
-              </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEdge() || !edgeForm.from.trim() || !edgeForm.to.trim() || !edgeForm.label.trim()">
-                @if (creatingEdge()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showEdgeForm.set(false)">{{ 'common.cancel' | transloco }}</button>
             </form>
           }
 

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -59,43 +59,51 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 
           @if (showEntityForm()) {
             <form class="create-form" (ngSubmit)="createEntity()">
-              <div class="field" style="flex:1; min-width:140px;">
-                <label>{{ 'brain.entities.table.name' | transloco }}</label>
-                <input type="text" [(ngModel)]="entityForm.name" name="name" required />
+              <!-- Row 1: single-line fields, one uniform height (name, type, tags). -->
+              <div class="form-row">
+                <div class="field" style="flex:2; min-width:140px;">
+                  <label>{{ 'brain.entities.table.name' | transloco }}</label>
+                  <input type="text" [(ngModel)]="entityForm.name" name="name" required />
+                </div>
+                <div class="field" style="width:150px;">
+                  <label>{{ 'brain.entities.table.type' | transloco }} @if (store.entityTypeNames().length) { <span style="color:var(--error)">*</span> }</label>
+                  @if (store.entityTypeNames().length) {
+                    <select [(ngModel)]="entityForm.type" name="type" required (ngModelChange)="onEntityTypeChange($event, 'create')">
+                      @for (t of store.entityTypeNames(); track t) {
+                        <option [value]="t">{{ t }}</option>
+                      }
+                    </select>
+                  } @else {
+                    <input type="text" [(ngModel)]="entityForm.type" name="type" [placeholder]="'brain.entities.form.typePlaceholder' | transloco" />
+                  }
+                </div>
+                <div class="field" style="flex:2; min-width:180px;">
+                  <label>{{ 'brain.entities.table.tags' | transloco }}</label>
+                  <app-tag-input [(value)]="entityForm.tags" [suggestions]="store.entityTagSuggestions()" inputName="entFormTags" />
+                </div>
               </div>
-              <div class="field" style="width:140px;">
-                <label>Type @if (store.entityTypeNames().length) { <span style="color:var(--error)">*</span> }</label>
-                @if (store.entityTypeNames().length) {
-                  <select [(ngModel)]="entityForm.type" name="type" required (ngModelChange)="onEntityTypeChange($event, 'create')">
-                    @for (t of store.entityTypeNames(); track t) {
-                      <option [value]="t">{{ t }}</option>
-                    }
-                  </select>
-                } @else {
-                  <input type="text" [(ngModel)]="entityForm.type" name="type" [placeholder]="'brain.entities.form.typePlaceholder' | transloco" />
-                }
+              <!-- Row 2: the tall fields, tops aligned, each grows (description | properties). -->
+              <div class="form-row rich">
+                <div class="field">
+                  <label>{{ 'brain.entities.table.description' | transloco }}</label>
+                  <textarea [(ngModel)]="entityForm.description" name="description" rows="3"></textarea>
+                </div>
+                <div class="field">
+                  <label>{{ 'brain.entities.table.properties' | transloco }}</label>
+                  <app-properties-editor
+                    [schema]="store.entitySchema(entityForm.type)"
+                    [required]="store.requiredProps(store.entitySchema(entityForm.type))"
+                    [(value)]="entityForm.properties"
+                  />
+                </div>
               </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'brain.entities.table.tags' | transloco }}</label>
-                <app-tag-input [(value)]="entityForm.tags" [suggestions]="store.entityTagSuggestions()" inputName="entFormTags" />
+              <div style="display:flex; gap:8px;">
+                <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEntity() || !entityForm.name.trim() || (store.entityTypeNames().length ? !entityForm.type : false)">
+                  @if (creatingEntity()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                  {{ 'common.save' | transloco }}
+                </button>
+                <button class="btn-secondary btn btn-sm" type="button" (click)="showEntityForm.set(false)">{{ 'common.cancel' | transloco }}</button>
               </div>
-              <div class="field" style="flex:1; min-width:200px;">
-                <label>{{ 'brain.entities.table.description' | transloco }}</label>
-                <textarea [(ngModel)]="entityForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:220px;">
-                <label>{{ 'brain.entities.table.properties' | transloco }}</label>
-                <app-properties-editor
-                  [schema]="store.entitySchema(entityForm.type)"
-                  [required]="store.requiredProps(store.entitySchema(entityForm.type))"
-                  [(value)]="entityForm.properties"
-                />
-              </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingEntity() || !entityForm.name.trim() || (store.entityTypeNames().length ? !entityForm.type : false)">
-                @if (creatingEntity()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showEntityForm.set(false)">{{ 'common.cancel' | transloco }}</button>
             </form>
           }
 

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -55,52 +55,59 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
           <!-- Add memory form -->
           @if (showMemoryForm()) {
             <form class="create-form" (ngSubmit)="createMemory()">
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'common.form.fact' | transloco }}</label>
-                <textarea [(ngModel)]="memoryForm.fact" name="fact" rows="2" required style="width:100%;"></textarea>
-              </div>
-              <div class="field" style="flex:1; min-width:180px;">
-                <label>{{ 'common.form.tags' | transloco }}</label>
-                <app-tag-input [(value)]="memoryForm.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memFormTags" />
-              </div>
-              <div class="field" style="flex:1; min-width:140px;">
-                <label>{{ 'common.form.entities' | transloco }}</label>
-                <div class="flyout-wrap">
-                  <div class="entity-multi">
-                    @for (chip of picker.entityChips(memoryForm.entityIds); track chip.id) {
-                      <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(memoryForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                    }
-                    <button type="button" class="chip-add" (click)="picker.openFlyout('create-memory-entityIds', memoryForm)">{{ 'common.addMore' | transloco }}</button>
-                  </div>
-                  @if (picker.flyoutField() === 'create-memory-entityIds') {
-                    <div class="flyout-panel">
-                      <app-entity-search
-                        mode="picker"
-                        [spaceId]="spaceId()"
-                        placeholder="common.searchEntitiesPlaceholder"
-
-                        (selected)="picker.pickEntity($event, memoryForm)"
-                      />
-                      <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                        <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                      </div>
-                    </div>
-                  }
+              <!-- Field order matches the table columns: Fact, Description, tags, entities, properties.
+                   Fact and Description are the two multiline fields and share one size (feedback). -->
+              <div class="form-row rich">
+                <div class="field">
+                  <label>{{ 'common.form.fact' | transloco }}</label>
+                  <textarea [(ngModel)]="memoryForm.fact" name="fact" rows="3" required></textarea>
+                </div>
+                <div class="field">
+                  <label>{{ 'common.form.description' | transloco }}</label>
+                  <textarea [(ngModel)]="memoryForm.description" name="description" rows="3"></textarea>
                 </div>
               </div>
-              <div class="field" style="flex:2; min-width:200px;">
-                <label>{{ 'common.form.description' | transloco }}</label>
-                <textarea [(ngModel)]="memoryForm.description" name="description" rows="3" style="resize:vertical;"></textarea>
+              <div class="form-row rich">
+                <div class="field">
+                  <label>{{ 'common.form.tags' | transloco }}</label>
+                  <app-tag-input [(value)]="memoryForm.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memFormTags" />
+                </div>
+                <div class="field">
+                  <label>{{ 'common.form.entities' | transloco }}</label>
+                  <div class="flyout-wrap">
+                    <div class="entity-multi">
+                      @for (chip of picker.entityChips(memoryForm.entityIds); track chip.id) {
+                        <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(memoryForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
+                      }
+                      <button type="button" class="chip-add" (click)="picker.openFlyout('create-memory-entityIds', memoryForm)">{{ 'common.addMore' | transloco }}</button>
+                    </div>
+                    @if (picker.flyoutField() === 'create-memory-entityIds') {
+                      <div class="flyout-panel">
+                        <app-entity-search
+                          mode="picker"
+                          [spaceId]="spaceId()"
+                          placeholder="common.searchEntitiesPlaceholder"
+                          (selected)="picker.pickEntity($event, memoryForm)"
+                        />
+                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
+                          <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
+                        </div>
+                      </div>
+                    }
+                  </div>
+                </div>
+                <div class="field">
+                  <label>{{ 'common.form.properties' | transloco }}</label>
+                  <app-properties-editor [schema]="store.memorySchema()" [required]="store.requiredProps(store.memorySchema())" [(value)]="memoryForm.properties" />
+                </div>
               </div>
-              <div class="field" style="flex:1; min-width:220px;">
-                <label>{{ 'common.form.properties' | transloco }}</label>
-                <app-properties-editor [schema]="store.memorySchema()" [required]="store.requiredProps(store.memorySchema())" [(value)]="memoryForm.properties" />
+              <div style="display:flex; gap:8px;">
+                <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingMemory() || !memoryForm.fact.trim()">
+                  @if (creatingMemory()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                  {{ 'common.save' | transloco }}
+                </button>
+                <button class="btn-secondary btn btn-sm" type="button" (click)="showMemoryForm.set(false)">{{ 'common.cancel' | transloco }}</button>
               </div>
-              <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingMemory() || !memoryForm.fact.trim()">
-                @if (creatingMemory()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'common.save' | transloco }}
-              </button>
-              <button class="btn-secondary btn btn-sm" type="button" (click)="showMemoryForm.set(false)">{{ 'common.cancel' | transloco }}</button>
             </form>
           }
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -101,9 +101,9 @@ Memories are the core knowledge unit — plain-language statements you want to r
 | Field | Notes |
 |-------|-------|
 | **Fact** | The statement to store. Required. |
+| **Description** | Optional context or rationale. Same size as Fact. |
 | **Tags** | Comma-separated keywords for filtering. |
 | **Entities** | Click to open the entity picker. Search by name and click to link. Linked items appear as chips. |
-| **Description** | Optional context or rationale. |
 | **Properties** | Click to open the JSON editor. Enter any key-value pairs you want to attach. |
 
 Click **Save**. The memory is indexed immediately and available for search.


### PR DESCRIPTION
First slice of the Brain UX pass (owner feedback in `todo/feedback.md`). The full decomposition is in `todo/brain-ux-epic.md`; this is the foundation — form uniformity — with no backend dependency and no design fork.

## What was wrong

The through-line of the feedback is *uniformity*, and the add-forms were the clearest offender:

- **Four different control heights on one page** — search bar `5/10`, filter bar `30`, create-form `5/8`, global `8/12`.
- The **memories create-form was in a different field order than its own inline-edit** (fact, tags, entities, description, … vs the feedback's fact, description, tags, entities, properties).
- `Fact` and `Description` rendered at **mismatched sizes**.

## What changed

Each of the four record tabs' Add forms is now a vertical stack of `.form-row`s sharing one control height (`--brain-control-h` = 34px, the tallest existing single-line control — app-tag-input's wrap — so aligning lifts the shorter controls *up* rather than cramming everything down):

- a `.form-row` of single-line fields at one uniform height, then
- a `.form-row.rich` where the tall fields (description + properties, or fact + description) each flex and grow with **tops aligned** — the feedback's "description the current height as baseline but expands with properties container", made structural rather than a pile of per-field inline widths.

Field order now follows the table columns per tab:

| Tab | Order |
|---|---|
| Entities | name, type, tags \| description, properties |
| Edges | from, relation, to, weight, tags \| description, properties |
| Memories | **Fact, Description, tags, entities, properties** (fact & description same size) |
| Chrono | title, kind, start, end \| description \| tags, entities |

`common.form.description` relabelled **"Short Description" → "Description"** across en/de/pl. It read "Short Description" in the memories form and in every record's detail drawer, while entities/edges/chrono labelled the same field just "Description" — exactly the "no short" note, and the chrono view's "short description → description". One shared key, so the drawer picks it up too.

## Verified visually

Booted an isolated instance (scratch config + Mongo) and screenshotted all four Add forms via Playwright: uniform heights, correct order, description/properties side-by-side, **0 change-detection errors**. A private artifact gallery of the four forms is linked in the review thread for eyeballing.

## Scope

Layout only — create/edit payloads are unchanged and the CRUD characterization specs still pass (**460 client tests green**, locales in parity at 1424 keys).

Deliberately left for later slices, so this one stays reviewable:
- The top search bar's A–Z/Semantic pill, the filter row, and the entity flyout are untouched — **column-header filters + sort is slice 2**, the **inline entity picker is slice 3**, the **File Meta rebuild is slice 4**.
- Inline-edit rows are unreachable dead code (no template trigger — superseded by the drawer); left for a separate cleanup, not restructured.
- Chrono has no properties field today; adding one is feature scope, noted in the epic plan.

## Release-gate note

This changes what the four Brain Add forms look like — belongs on the manual pass before any tag, alongside the other UI changes this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
