### PR TITLE
feat(brain): server-side sort for the list endpoints (?sort=&dir=)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -740,6 +740,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **The brain list sort is proven against a real MongoDB across a page boundary — the one thing a
+  client-only sort could never do.** `brain-list-sort-db.test.js` seeds records in a deliberately
+  scrambled order, then walks every page of a sorted list and asserts the concatenation is one
+  globally ordered sequence (not a per-page reshuffle), including a `createdAt`-tie case that only the
+  `_id` tiebreaker keeps stable. A characterization test pins that an un-sorted call still returns
+  insertion order, so no existing caller shifted. Mutation-checked: disabling the `.sort()` fails
+  exactly the ordering assertions, and bypassing the field whitelist fails the `400` test.
+  `brain-list-sort-unit.test.js` covers the pure `parseSortParam`/`capPage` validation (whitelist
+  rejection, dir parsing, and the proxy page-cap honoring the requested sort) with no database.
+
 - **Standalone tests can now run against a real MongoDB, and the first one proves the queue's
   recovery rule.** Until now no standalone test could reach a database: the test stack published no
   Mongo port and nothing connected to one. Query rules were therefore only ever checked against
@@ -815,6 +825,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   AGPL PyMuPDF).
 
 ### Added
+
+- **Server-side sort for the brain list endpoints — entities, edges, memories, chrono and files now
+  take `?sort=<field>&dir=asc|desc`.** The lists are paginated, so this could never be a client-only
+  header click: sorting just the visible page would reorder ~20 rows and lie about the rest of the
+  set. The sort is a Mongo `.sort()` applied **before** `skip`/`limit`, so it orders the whole result
+  set across every page. The sortable field is whitelisted per collection (`createdAt` everywhere,
+  plus each tab's human columns — `name`/`type` for entities, `label`/`from`/`to` for edges,
+  `title`/`startsAt` for chrono, `updatedAt`/`path` for files); an unrecognized field is a `400`, not
+  a silent fall-back to the default order — a silently-ignored sort control is the same dishonesty as
+  a no-op one. `dir` defaults to `desc`. With no `sort` param every endpoint keeps its existing
+  default order, so no existing caller is affected. A stable `_id` tiebreaker makes paging
+  deterministic when the primary field ties. This is the server half of the Brain UX "created needs a
+  sort option" ask; the sortable column headers land in a following client change.
 
 - **`GET /api/admin/pipeline-status` — one read-only answer to "is any of this actually working?"**
   Every model, sidecar and vector index in the pipeline could previously only be inspected one at a

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1163,7 +1163,7 @@ Returns the single entity, or `404` if no entity with that ID exists in the spac
 ### List Entities
 
 ```http
-GET /api/brain/spaces/:spaceId/entities?limit=50&skip=0
+GET /api/brain/spaces/:spaceId/entities?limit=50&skip=0&sort=name&dir=asc
 ```
 
 **Response** `200`:
@@ -1177,6 +1177,27 @@ GET /api/brain/spaces/:spaceId/entities?limit=50&skip=0
 ```
 
 Default limit: 50, max: 500.
+
+#### Sorting (all brain list endpoints)
+
+`GET` list endpoints — entities, edges, memories, chrono, and files — accept an optional
+`?sort=<field>&dir=asc|desc`. The sort is applied server-side **before** pagination, so it orders the
+entire result set across every page, not just the rows on the page you fetch. `dir` defaults to `desc`
+(newest-first) when omitted.
+
+The sortable field per collection is whitelisted; an unrecognized field is a `400`, never a silent
+fall-back to the default order:
+
+| Collection | Sortable fields |
+|------------|-----------------|
+| entities | `createdAt`, `name`, `type` |
+| edges | `createdAt`, `label`, `from`, `to`, `type` |
+| memories | `createdAt`, `type` |
+| chrono | `createdAt`, `title`, `startsAt`, `type` |
+| files | `createdAt`, `updatedAt`, `path` |
+
+With no `sort` the endpoint keeps its existing default order (entities: insertion order; the others:
+`createdAt` desc; files: `updatedAt` desc).
 
 ---
 
@@ -1470,6 +1491,8 @@ GET /api/brain/spaces/:spaceId/chrono?limit=50&skip=0
 | `type` | string | Filter by type (`event`, `deadline`, `plan`, `prediction`, `milestone`) |
 | `limit` | number | Max entries to return (default 50, max 500) |
 | `skip` | number | Pagination offset (default 0) |
+| `sort` | string | Sort field: `createdAt`, `title`, `startsAt`, or `type` (see [Sorting](#sorting-all-brain-list-endpoints)). Unknown field → `400` |
+| `dir` | string | `asc` or `desc` (default `desc`) |
 
 #### Example queries
 
@@ -1689,6 +1712,8 @@ Returns metadata rows stored in the brain collection for files (`path`, tags, de
 | `skip` | Offset for pagination |
 | `tag` | Exact tag filter |
 | `path` | Exact path filter |
+| `sort` | Sort field: `createdAt`, `updatedAt`, or `path` (see [Sorting](#sorting-all-brain-list-endpoints)). Unknown field → `400` |
+| `dir` | `asc` or `desc` (default `desc`) |
 
 **Response** `200`:
 

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -9,6 +9,7 @@ import { globalRateLimit, bulkWipeRateLimit } from '../../rate-limit/middleware.
 import { createChrono, updateChrono, getChronoById, listChrono, deleteChrono, bulkDeleteChrono, parseRecurrence, ChronoFilter } from '../../brain/chrono.js';
 import { getConfig } from '../../config/loader.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
+import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
 import type { ChronoStatus } from '../../config/types.js';
@@ -250,6 +251,11 @@ chronoRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, a
   }
   const limit = parseLimit(req.query['limit'], 50, 500);
   const skip = parseSkip(req.query['skip']);
+  const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.chrono);
+  if ('error' in sortParse) {
+    res.status(400).json({ error: sortParse.error });
+    return;
+  }
   const filter: ChronoFilter = {};
   if (typeof req.query['status'] === 'string') filter.status = req.query['status'];
   if (typeof req.query['type'] === 'string') filter.type = req.query['type'];
@@ -274,8 +280,8 @@ chronoRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, a
   if (typeof req.query['before'] === 'string') filter.before = req.query['before'];
   if (typeof req.query['search'] === 'string') filter.search = req.query['search'];
 
-  const all = await collectAcrossMembers(spaceId, mid => listChrono(mid, filter, limit, skip));
-  res.json({ chrono: capPage(all, limit), limit, skip });
+  const all = await collectAcrossMembers(spaceId, mid => listChrono(mid, filter, limit, skip, sortParse.sort));
+  res.json({ chrono: capPage(all, limit, sortParse.sort), limit, skip });
 });
 
 

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -12,6 +12,7 @@ import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } fro
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
+import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEdge } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
@@ -107,13 +108,18 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
   }
   const limit = parseLimit(req.query['limit'], 50, 200);
   const skip = parseSkip(req.query['skip']);
+  const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.edges);
+  if ('error' in sortParse) {
+    res.status(400).json({ error: sortParse.error });
+    return;
+  }
   const filter: { from?: string; to?: string; label?: string; type?: string; tag?: string } = {};
   if (typeof req.query['from'] === 'string') filter.from = req.query['from'];
   if (typeof req.query['to'] === 'string') filter.to = req.query['to'];
   if (typeof req.query['label'] === 'string') filter.label = req.query['label'];
   if (typeof req.query['type'] === 'string') filter.type = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter.tag = req.query['tag'];
-  const all = await collectAcrossMembers(spaceId, mid => listEdges(mid, filter, limit, skip));
+  const all = await collectAcrossMembers(spaceId, mid => listEdges(mid, filter, limit, skip, sortParse.sort));
   // Batch-resolve entity names for from/to so the client can display names instead of raw UUIDs
   const allEntityIds = [...new Set(all.flatMap(e => [e.from, e.to]))];
   const nameMap = new Map<string, string>();
@@ -125,7 +131,7 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     for (const d of nameDocs) nameMap.set(String(d._id), d.name);
   }
   const enriched = all.map(e => ({ ...e, fromName: nameMap.get(e.from), toName: nameMap.get(e.to) }));
-  res.json({ edges: capPage(enriched, limit), limit, skip });
+  res.json({ edges: capPage(enriched, limit, sortParse.sort), limit, skip });
 });
 
 

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -12,6 +12,7 @@ import { computeMergePlan, applyResolutions, executeMerge, validateResolution, t
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 import { getConfig } from '../../config/loader.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
+import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEntity } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
@@ -94,12 +95,17 @@ entitiesRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAut
   }
   const limit = parseLimit(req.query['limit'], 50, 500);
   const skip = parseSkip(req.query['skip']);
+  const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.entities);
+  if ('error' in sortParse) {
+    res.status(400).json({ error: sortParse.error });
+    return;
+  }
   const filter: Record<string, unknown> = {};
   if (typeof req.query['name'] === 'string') filter['name'] = req.query['name'];
   if (typeof req.query['type'] === 'string') filter['type'] = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
-  const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, filter, limit, skip));
-  res.json({ entities: capPage(all, limit), limit, skip });
+  const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, filter, limit, skip, sortParse.sort));
+  res.json({ entities: capPage(all, limit, sortParse.sort), limit, skip });
 });
 
 

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -19,6 +19,7 @@ import { fileExists } from '../../files/files.js';
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
+import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { fetchJobProgress } from '../../files/media/job-queue.js';
@@ -65,6 +66,12 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   }
   const limit = parseLimit(req.query['limit'], 50, 200);
   const skip = parseSkip(req.query['skip']);
+  const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.files);
+  if ('error' in sortParse) {
+    res.status(400).json({ error: sortParse.error });
+    return;
+  }
+  const mongoSort = sortParse.sort ? toMongoSort(sortParse.sort) : { updatedAt: -1 as const };
   // By default exclude chunk records (parentFileId set) so the file manager only shows
   // top-level files. Pass ?includeChunks=true to see all records (e.g. for debugging).
   const includeChunks = req.query['includeChunks'] === 'true';
@@ -75,7 +82,7 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   const all = await collectAcrossMembers(spaceId, async mid => {
     const files = await col(`${mid}_files`)
       .find(asFilter(filter))
-      .sort({ updatedAt: -1 })
+      .sort(mongoSort)
       .skip(skip)
       .limit(limit)
       .toArray();
@@ -84,7 +91,7 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
     // to that member's job collection, and looking them up in another's would silently find nothing.
     return attachJobProgress(mid, files as Array<Record<string, unknown>>);
   });
-  res.json({ files: capPage(all, limit), limit, skip });
+  res.json({ files: capPage(all, limit, sortParse.sort), limit, skip });
 });
 
 

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -12,6 +12,7 @@ import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } fro
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
+import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { checkQuota, QuotaError } from '../../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateMemory } from '../../spaces/schema-validation.js';
@@ -130,9 +131,14 @@ memoriesRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAut
   }
   const limit = parseLimit(req.query['limit'], 100, 500);
   const skip = parseSkip(req.query['skip']);
+  const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.memories);
+  if ('error' in sortParse) {
+    res.status(400).json({ error: sortParse.error });
+    return;
+  }
   const filter = buildMemoryFilter(req.query as Record<string, unknown>);
-  const all = await collectAcrossMembers(spaceId, mid => listMemories(mid, filter, limit, skip));
-  res.json({ memories: capPage(all, limit), limit, skip });
+  const all = await collectAcrossMembers(spaceId, mid => listMemories(mid, filter, limit, skip, sortParse.sort));
+  res.json({ memories: capPage(all, limit, sortParse.sort), limit, skip });
 });
 
 

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -3,6 +3,7 @@ import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
+import { toMongoSort, type SortSpec } from './list-sort.js';
 import { embed } from './embedding.js';
 import { chronoEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -231,6 +232,7 @@ export async function listChrono(
   filter: ChronoFilter = {},
   limit = 50,
   skip = 0,
+  sort?: SortSpec,
 ): Promise<ChronoEntry[]> {
   const now = new Date();
   const query: Record<string, unknown> = { spaceId };
@@ -289,7 +291,7 @@ export async function listChrono(
 
   const entries = await col<ChronoEntry>(`${spaceId}_chrono`)
     .find(asFilter<ChronoEntry>(query))
-    .sort({ createdAt: -1 })
+    .sort(sort ? toMongoSort(sort) : { createdAt: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
     .toArray() as ChronoEntry[];

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -3,6 +3,7 @@ import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
+import { toMongoSort, type SortSpec } from './list-sort.js';
 import { embed } from './embedding.js';
 import { edgeEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -148,6 +149,7 @@ export async function listEdges(
   filter: { from?: string; to?: string; label?: string; type?: string; tag?: string } = {},
   limit = 50,
   skip = 0,
+  sort?: SortSpec,
 ): Promise<EdgeDoc[]> {
   const q: Record<string, string> = { spaceId };
   if (filter.from) q['from'] = filter.from;
@@ -158,7 +160,7 @@ export async function listEdges(
   if (filter.tag) q['tags'] = filter.tag;
   return col<EdgeDoc>(`${spaceId}_edges`)
     .find(asFilter<EdgeDoc>(q))
-    .sort({ seq: -1, createdAt: -1, _id: -1 })
+    .sort(sort ? toMongoSort(sort) : { seq: -1, createdAt: -1, _id: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
     .toArray() as Promise<EdgeDoc[]>;

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -3,6 +3,7 @@ import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
+import { toMongoSort, type SortSpec } from './list-sort.js';
 import { embed } from './embedding.js';
 import { entityEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -309,9 +310,14 @@ export async function listEntities(
   filter: Record<string, unknown> = {},
   limit = 50,
   skip = 0,
+  sort?: SortSpec,
 ): Promise<EntityDoc[]> {
-  return col<EntityDoc>(`${spaceId}_entities`)
-    .find(asFilter<EntityDoc>({ ...filter, spaceId }))
+  const cursor = col<EntityDoc>(`${spaceId}_entities`)
+    .find(asFilter<EntityDoc>({ ...filter, spaceId }));
+  // Default is natural (insertion) order — unchanged for every existing caller. A sort is only
+  // applied when one is explicitly requested.
+  if (sort) cursor.sort(toMongoSort(sort));
+  return cursor
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
     .toArray() as Promise<EntityDoc[]>;

--- a/server/src/brain/list-sort.ts
+++ b/server/src/brain/list-sort.ts
@@ -1,0 +1,80 @@
+/**
+ * Server-side sort for the brain list endpoints.
+ *
+ * The brain lists are paginated (`limit`/`skip`), so sorting can never be a client-only header
+ * click: reordering just the visible page would lie about the rest of the set. The sort therefore
+ * has to be a Mongo `.sort()` applied before `.skip().limit()`, threaded from the route into the
+ * list function — which is what this module parses and validates.
+ *
+ * The field set is whitelisted per collection. A Mongo sort key is not injectable the way a
+ * `$where` is, but an unbounded field set invites index misses and surprises, and a silently
+ * ignored sort is the same dishonesty as a no-op control — so an unknown field is a 400, never a
+ * quiet fall-back to natural order.
+ */
+
+/** A validated sort request: a whitelisted field and a direction (1 asc, -1 desc). */
+export interface SortSpec {
+  field: string;
+  dir: 1 | -1;
+}
+
+/**
+ * Sortable fields per collection. `createdAt` everywhere; the human-meaningful columns each tab
+ * shows are added where they exist as stored, comparable fields. Derived values (e.g. chrono's
+ * `overdue` status, which is computed from the due moment and never stored) are deliberately left
+ * out — sorting by a stored `status` that disagrees with the displayed one would mislead.
+ */
+export const SORTABLE_FIELDS = {
+  entities: new Set<string>(['createdAt', 'name', 'type']),
+  edges: new Set<string>(['createdAt', 'label', 'from', 'to', 'type']),
+  memories: new Set<string>(['createdAt', 'type']),
+  chrono: new Set<string>(['createdAt', 'title', 'startsAt', 'type']),
+  files: new Set<string>(['createdAt', 'updatedAt', 'path']),
+} as const;
+
+/** Result of parsing `?sort=&dir=`: a spec, an explicit no-sort, or a client error to 400 on. */
+export type SortParse = { sort: SortSpec } | { sort: undefined } | { error: string };
+
+/** Parse a `dir` query value. Empty/absent defaults to descending (newest-first). */
+function parseDir(raw: unknown): 1 | -1 | null {
+  if (raw === undefined || raw === '') return -1;
+  if (typeof raw !== 'string') return null;
+  const s = raw.toLowerCase();
+  if (s === 'asc' || s === '1') return 1;
+  if (s === 'desc' || s === '-1') return -1;
+  return null;
+}
+
+/**
+ * Parse `?sort=field&dir=asc|desc` against a collection's whitelist.
+ *
+ * No `sort` at all → `{ sort: undefined }`, and the list function keeps its existing default order
+ * (a characterization guarantee: no existing caller shifts). A `sort` outside the whitelist, or a
+ * malformed `dir`, → `{ error }` for the route to answer with 400.
+ */
+export function parseSortParam(
+  rawField: unknown,
+  rawDir: unknown,
+  allowed: ReadonlySet<string>,
+): SortParse {
+  if (rawField === undefined || rawField === '') return { sort: undefined };
+  if (typeof rawField !== 'string') {
+    return { error: '`sort` must be a single field name' };
+  }
+  if (!allowed.has(rawField)) {
+    return { error: `Cannot sort by '${rawField}'. Sortable fields: ${[...allowed].join(', ')}` };
+  }
+  const dir = parseDir(rawDir);
+  if (dir === null) {
+    return { error: "`dir` must be 'asc' or 'desc'" };
+  }
+  return { sort: { field: rawField, dir } };
+}
+
+/**
+ * Build the Mongo sort document for a validated spec, appending `_id` as a stable tiebreaker so
+ * pagination is deterministic across a page boundary when the primary field has ties.
+ */
+export function toMongoSort(sort: SortSpec): Record<string, 1 | -1> {
+  return { [sort.field]: sort.dir, _id: sort.dir };
+}

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -10,6 +10,7 @@ import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
+import { toMongoSort, type SortSpec } from './list-sort.js';
 import { embed } from './embedding.js';
 import { memoryEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -214,11 +215,12 @@ export async function listMemories(
   filter: Record<string, unknown> = {},
   limit = 20,
   skip = 0,
+  sort?: SortSpec,
 ) {
   return col<MemoryDoc>(`${spaceId}_memories`)
     .find(asFilter<MemoryDoc>(filter))
     .project({ embedding: 0 })
-    .sort({ createdAt: -1 })
+    .sort(sort ? toMongoSort(sort) : { createdAt: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))
     .toArray();

--- a/server/src/util/pagination.ts
+++ b/server/src/util/pagination.ts
@@ -24,12 +24,19 @@ export function parseSkip(raw: unknown): number {
 /**
  * Cap a merged, cross-space (proxy) list result to `limit`. Each member space is
  * already limited to `limit`, so a proxy of N members can return up to N × limit
- * rows; this bounds the response to the requested page size. Only re-sorts (by
- * `createdAt` desc) when it actually overflows, so single-space results — already
- * sorted and limited by the query — are returned untouched.
+ * rows; this bounds the response to the requested page size. Only re-sorts when it
+ * actually overflows, so single-space results — already sorted and limited by the
+ * query — are returned untouched.
+ *
+ * The re-sort must agree with what the query asked for: when the route requested a
+ * `sort`, a proxy overflow re-sorts by that same field/direction, otherwise it would
+ * silently reorder the merged page against the caller's sort. With no requested sort
+ * it falls back to `createdAt` desc — the collections' natural default.
  */
-export function capPage<T>(rows: T[], limit: number): T[] {
+export function capPage<T>(rows: T[], limit: number, sort?: { field: string; dir: 1 | -1 }): T[] {
   if (rows.length <= limit) return rows;
-  const ts = (r: T) => String((r as { createdAt?: string }).createdAt ?? '');
-  return [...rows].sort((a, b) => ts(b).localeCompare(ts(a))).slice(0, limit);
+  const field = sort?.field ?? 'createdAt';
+  const dir = sort?.dir ?? -1;
+  const val = (r: T) => String((r as Record<string, unknown>)[field] ?? '');
+  return [...rows].sort((a, b) => dir * val(a).localeCompare(val(b))).slice(0, limit);
 }

--- a/testing/standalone/brain-list-sort-db.test.js
+++ b/testing/standalone/brain-list-sort-db.test.js
@@ -1,0 +1,135 @@
+/**
+ * Database-level test: the brain list endpoints sort the FULL result set, not just a page.
+ *
+ * "created needs a sort option" (owner feedback) cannot be a client-only header click: the lists are
+ * paginated (`limit`/`skip`), so sorting only the visible page would reorder ~20 rows and lie about
+ * the rest. The fix is a Mongo `.sort()` applied BEFORE `.skip().limit()`, threaded from the route
+ * into the list function. The thing that proves it works is exactly the thing a client-only sort
+ * could never do: walk the pages of a sorted list across a page boundary and get one globally
+ * ordered sequence back.
+ *
+ * A fixture/JS test could not prove this — the ordering has to be MongoDB's, applied to the real
+ * `col()` cursor, or it proves nothing about the query that ships. So this runs against a real
+ * server via the #371 harness.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/brain-list-sort-db.test.js
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+
+let mongo;
+let listEntities;
+let listChrono;
+let entities;
+let chrono;
+
+/** Insert a raw entity doc — bypassing upsert/embedding, which is the read/sort path under test. */
+async function insertEntity(_id, name, type, createdAt) {
+  await entities.insertOne({ _id, spaceId: SPACE, name, type, createdAt, seq: 1 });
+}
+
+/** Walk every page of a sorted listEntities and concatenate — the full ordered set. */
+async function walkEntityPages(sort, pageSize) {
+  const ids = [];
+  for (let skip = 0; ; skip += pageSize) {
+    const page = await listEntities(SPACE, {}, pageSize, skip, sort);
+    if (page.length === 0) break;
+    ids.push(...page.map(e => String(e._id)));
+    if (page.length < pageSize) break;
+  }
+  return ids;
+}
+
+describe('brain list sort — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('brainsort');
+    ({ listEntities } = await import('../../server/dist/brain/entities.js'));
+    ({ listChrono } = await import('../../server/dist/brain/chrono.js'));
+    entities = mongo.col(`${SPACE}_entities`);
+    chrono = mongo.col(`${SPACE}_chrono`);
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => {
+    await entities.deleteMany({});
+    await chrono.deleteMany({});
+  });
+
+  // Insertion order is deliberately NOT alphabetical and NOT createdAt order, so a page-only sort
+  // (or no sort at all) is visibly distinguishable from a real full-set sort.
+  async function seedFive() {
+    await insertEntity('id-banana', 'banana', 'fruit', '2026-03-02T00:00:00.000Z');
+    await insertEntity('id-apple', 'apple', 'fruit', '2026-03-05T00:00:00.000Z');
+    await insertEntity('id-cherry', 'cherry', 'fruit', '2026-03-01T00:00:00.000Z');
+    await insertEntity('id-date', 'date', 'fruit', '2026-03-04T00:00:00.000Z');
+    await insertEntity('id-elder', 'elderberry', 'fruit', '2026-03-03T00:00:00.000Z');
+  }
+
+  it('CHARACTERIZATION: no sort preserves natural (insertion) order — no existing caller shifts', async () => {
+    await seedFive();
+    const got = await listEntities(SPACE, {}, 50, 0);
+    assert.deepEqual(
+      got.map(e => String(e._id)),
+      ['id-banana', 'id-apple', 'id-cherry', 'id-date', 'id-elder'],
+      'without a sort arg the list must return docs in insertion order, exactly as before this change',
+    );
+  });
+
+  it('sorts by name asc across a PAGE BOUNDARY — the full set, not just the visible page', async () => {
+    await seedFive();
+    // Page size 2 over 5 docs → three pages. If the sort were applied only per-page, concatenating
+    // the pages would NOT be globally alphabetical. It is, because the .sort() precedes skip/limit.
+    const ids = await walkEntityPages({ field: 'name', dir: 1 }, 2);
+    assert.deepEqual(ids, ['id-apple', 'id-banana', 'id-cherry', 'id-date', 'id-elder']);
+  });
+
+  it('sorts by createdAt desc across a page boundary (the "created" ask, newest first)', async () => {
+    await seedFive();
+    const ids = await walkEntityPages({ field: 'createdAt', dir: -1 }, 2);
+    assert.deepEqual(ids, ['id-apple', 'id-date', 'id-elder', 'id-banana', 'id-cherry']);
+  });
+
+  it('sorts by createdAt asc across a page boundary (oldest first)', async () => {
+    await seedFive();
+    const ids = await walkEntityPages({ field: 'createdAt', dir: 1 }, 2);
+    assert.deepEqual(ids, ['id-cherry', 'id-banana', 'id-elder', 'id-date', 'id-apple']);
+  });
+
+  it('breaks ties deterministically by _id so a page boundary never drops or duplicates a row', async () => {
+    // All four share one createdAt: without the _id tiebreaker, the order within the tie is
+    // unspecified and a row could shift between pages. The _id tiebreaker makes paging stable.
+    const t = '2026-04-01T00:00:00.000Z';
+    await insertEntity('id-04', 'd', 'x', t);
+    await insertEntity('id-01', 'a', 'x', t);
+    await insertEntity('id-03', 'c', 'x', t);
+    await insertEntity('id-02', 'b', 'x', t);
+    const ids = await walkEntityPages({ field: 'createdAt', dir: 1 }, 2);
+    assert.deepEqual(ids, ['id-01', 'id-02', 'id-03', 'id-04'], 'tie order must follow _id asc');
+  });
+
+  it('listChrono: default order is createdAt desc (unchanged); an explicit title sort reorders', async () => {
+    const mk = (id, title, createdAt) => chrono.insertOne({
+      _id: id, spaceId: SPACE, title, type: 'event', status: 'completed',
+      startsAt: createdAt, tags: [], createdAt,
+    });
+    await mk('c-mid', 'Middle', '2026-05-02T00:00:00.000Z');
+    await mk('c-new', 'Alpha', '2026-05-03T00:00:00.000Z');
+    await mk('c-old', 'Zeta', '2026-05-01T00:00:00.000Z');
+
+    const def = await listChrono(SPACE, {}, 50, 0);
+    assert.deepEqual(def.map(e => String(e._id)), ['c-new', 'c-mid', 'c-old'],
+      'default chrono order must remain createdAt desc');
+
+    const byTitle = await listChrono(SPACE, {}, 50, 0, { field: 'title', dir: 1 });
+    assert.deepEqual(byTitle.map(e => String(e._id)), ['c-new', 'c-mid', 'c-old'],
+      'title asc: Alpha, Middle, Zeta');
+  });
+});

--- a/testing/standalone/brain-list-sort-unit.test.js
+++ b/testing/standalone/brain-list-sort-unit.test.js
@@ -1,0 +1,99 @@
+/**
+ * Pure-function tests for the brain list-sort validation and the proxy page-cap.
+ *
+ * These need no database — they pin the two decisions that a database test cannot see cleanly:
+ *
+ *   1. `parseSortParam` is the whole of the "reject an unknown sort with 400" contract. The route
+ *      only maps its `{ error }` to a 400, so if the whitelist stops rejecting, the route silently
+ *      falls back to natural order — the exact no-op-control dishonesty the feature exists to avoid.
+ *   2. `capPage` is what keeps a PROXY overflow honest: when the merged result is re-sorted, it must
+ *      use the field/direction the caller asked for, not always `createdAt`. A client-only sort could
+ *      never reorder across members; a server sort that capPage then overrode would be a lie too.
+ *
+ * Run: node --test testing/standalone/brain-list-sort-unit.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../server/dist/brain/list-sort.js';
+import { capPage } from '../../server/dist/util/pagination.js';
+
+describe('parseSortParam — the 400-on-unknown-sort contract', () => {
+  const allowed = SORTABLE_FIELDS.entities; // createdAt, name, type
+
+  it('returns no sort when the param is absent — default order is preserved', () => {
+    assert.deepEqual(parseSortParam(undefined, undefined, allowed), { sort: undefined });
+    assert.deepEqual(parseSortParam('', 'asc', allowed), { sort: undefined });
+  });
+
+  it('accepts a whitelisted field and maps asc/desc to 1/-1', () => {
+    assert.deepEqual(parseSortParam('name', 'asc', allowed), { sort: { field: 'name', dir: 1 } });
+    assert.deepEqual(parseSortParam('createdAt', 'desc', allowed), { sort: { field: 'createdAt', dir: -1 } });
+  });
+
+  it('defaults an absent dir to descending (newest-first)', () => {
+    assert.deepEqual(parseSortParam('createdAt', undefined, allowed), { sort: { field: 'createdAt', dir: -1 } });
+  });
+
+  it('also accepts numeric 1/-1 directions', () => {
+    assert.deepEqual(parseSortParam('name', '1', allowed), { sort: { field: 'name', dir: 1 } });
+    assert.deepEqual(parseSortParam('name', '-1', allowed), { sort: { field: 'name', dir: -1 } });
+  });
+
+  it('REJECTS a field outside the whitelist — not a silent natural-order fallback', () => {
+    const r = parseSortParam('embedding', 'asc', allowed);
+    assert.ok('error' in r, 'an un-whitelisted field must be an error the route turns into 400');
+    assert.match(r.error, /Cannot sort by 'embedding'/);
+  });
+
+  it('rejects a malformed direction', () => {
+    const r = parseSortParam('name', 'sideways', allowed);
+    assert.ok('error' in r);
+    assert.match(r.error, /dir/);
+  });
+
+  it('rejects a non-string field (repeated ?sort= param arrives as an array)', () => {
+    const r = parseSortParam(['name', 'type'], 'asc', allowed);
+    assert.ok('error' in r);
+  });
+
+  it('each collection whitelist contains createdAt', () => {
+    for (const [name, set] of Object.entries(SORTABLE_FIELDS)) {
+      assert.ok(set.has('createdAt'), `${name} must allow sorting by createdAt`);
+    }
+  });
+});
+
+describe('toMongoSort — deterministic paging tiebreaker', () => {
+  it('appends _id in the same direction so a page boundary is stable under ties', () => {
+    assert.deepEqual(toMongoSort({ field: 'name', dir: 1 }), { name: 1, _id: 1 });
+    assert.deepEqual(toMongoSort({ field: 'createdAt', dir: -1 }), { createdAt: -1, _id: -1 });
+  });
+});
+
+describe('capPage — proxy overflow honors the requested sort', () => {
+  const rows = [
+    { _id: 'b', name: 'banana', createdAt: '2026-01-02' },
+    { _id: 'a', name: 'apple', createdAt: '2026-01-03' },
+    { _id: 'c', name: 'cherry', createdAt: '2026-01-01' },
+  ];
+
+  it('returns rows untouched when under the limit (single-space path)', () => {
+    assert.deepEqual(capPage(rows, 50), rows);
+  });
+
+  it('with no requested sort, an overflow falls back to createdAt desc (unchanged behavior)', () => {
+    const out = capPage(rows, 2);
+    assert.deepEqual(out.map(r => r._id), ['a', 'b']); // newest createdAt first
+  });
+
+  it('with a requested name-asc sort, an overflow re-sorts by name asc — NOT createdAt', () => {
+    const out = capPage(rows, 2, { field: 'name', dir: 1 });
+    assert.deepEqual(out.map(r => r._id), ['a', 'b']); // apple, banana
+  });
+
+  it('with a requested name-desc sort, an overflow re-sorts by name desc', () => {
+    const out = capPage(rows, 2, { field: 'name', dir: -1 });
+    assert.deepEqual(out.map(r => r._id), ['c', 'b']); // cherry, banana
+  });
+});


### PR DESCRIPTION
## What

Adds an optional `?sort=<field>&dir=asc|desc` to the five brain **GET** list endpoints — entities, edges, memories, chrono and files. Slice 2a of the Brain UX epic (slice 1 was #375); this is server + API only, the sortable column headers are the following client slice.

## Why server-side, and why its own PR

"created needs a sort option" (owner Brain UX feedback) **cannot** be a client-only header click: the lists are paginated (`limit`/`skip`), so sorting only the visible page would reorder ~20 rows and lie about the rest of the set. The sort has to be a Mongo `.sort()` applied **before** `.skip().limit()`, threaded from the route into the list function.

## Shape

- Each list function takes an optional `sort` (`{ field, dir }`), applied via `.sort()` before skip/limit, with a stable `_id` tiebreaker so paging is deterministic under ties. **With no sort the existing default order is kept exactly** (entities: insertion order; edges/memories/chrono: `createdAt` desc; files: `updatedAt` desc) — no existing caller shifts.
- The sortable field is **whitelisted per collection** (`createdAt` everywhere plus each tab's human columns). An unrecognized field is a **`400`**, never a silent fall-back to natural order — a silently-ignored sort control is the same dishonesty as a no-op one. `dir` defaults to `desc`.
- `capPage` is made sort-aware so a **proxy** overflow re-sorts the merged page by the requested field/direction instead of always `createdAt`, otherwise a server sort would be silently overridden on multi-member spaces.

## Tests (char-tests-first, #371 Mongo harness)

- `brain-list-sort-db.test.js` — against a real MongoDB: walks every page of a sorted list and asserts the concatenation is **one globally ordered set across a page boundary** (the thing a client-only sort could not do), plus a `createdAt`-tie case only the `_id` tiebreaker keeps stable, plus a **characterization** test that an un-sorted call still returns insertion order.
- `brain-list-sort-unit.test.js` — pure `parseSortParam` / `capPage` validation (whitelist rejection, dir parsing, proxy cap honoring the requested sort), no database.
- **Mutation-checked**: disabling the `.sort()` fails exactly the ordering assertions; bypassing the whitelist fails the `400` test.

## Docs / gate

- CHANGELOG `[Unreleased]` entries (Added + Testing).
- integration-guide: a "Sorting (all brain list endpoints)" section with the per-collection whitelist, plus `sort`/`dir` rows in the chrono and files query-param tables.
- Route-coverage audit gate re-run (these are read-only GETs; no mutating-verb change): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)