### PR TITLE
feat(brain): sortable column headers on the list tabs (slice 2b-i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -826,6 +826,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Sortable column headers on the Brain list tabs.** Clicking a column header with a caret sorts
+  the list by that column; clicking again flips the direction, and a third click returns to the
+  default order. The caret fills and points to show the active sort, and `aria-sort` reflects it for
+  assistive tech. It drives the server-side sort added alongside, so the order spans the whole list
+  across every page — not just the visible rows, which a client-only sort under pagination could
+  never do honestly. Sortable columns per tab: Name/Type/Created (entities), From/Relation/To/Created
+  (edges), Created (memories), Title/Kind/Starts (chrono) — exactly the fields the server whitelists,
+  so a header can never request a sort the API would reject. A shared `th[app-sort-th]` primitive
+  keeps all four tables uniform. The existing type/tag filter row is unchanged for now; folding
+  filters into the headers is the next slice.
+
 - **Server-side sort for the brain list endpoints — entities, edges, memories, chrono and files now
   take `?sort=<field>&dir=asc|desc`.** The lists are paginated, so this could never be a client-only
   header click: sorting just the visible page would reorder ~20 rows and lie about the rest of the

--- a/client/src/app/core/brain-api.list-sort.spec.ts
+++ b/client/src/app/core/brain-api.list-sort.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * BrainApi list methods thread the slice-2b sort into the request as `?sort=&dir=` — and omit both
+ * when no sort is active. This is the client half of slice 2a's server sort: the tab passes a
+ * `ListSort`, the server orders the full set. If these params silently went missing, the header caret
+ * would spin with no effect.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { BrainApi } from './brain-api.service';
+
+describe('BrainApi — list sort params (2b)', () => {
+  let api: BrainApi;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [BrainApi, provideHttpClient(), provideHttpClientTesting()] });
+    api = TestBed.inject(BrainApi);
+    http = TestBed.inject(HttpTestingController);
+  });
+  afterEach(() => http.verify());
+
+  it('listEntities appends sort + dir when a sort is given', () => {
+    api.listEntities('work', 50, 0, undefined, { field: 'name', dir: 'asc' }).subscribe();
+    const r = http.expectOne(req => req.url === '/api/brain/spaces/work/entities');
+    expect(r.request.params.get('sort')).toBe('name');
+    expect(r.request.params.get('dir')).toBe('asc');
+    r.flush({ entities: [] });
+  });
+
+  it('listEntities sends NO sort/dir when none is given — the endpoint keeps its default order', () => {
+    api.listEntities('work', 50, 0).subscribe();
+    const r = http.expectOne(req => req.url === '/api/brain/spaces/work/entities');
+    expect(r.request.params.has('sort')).toBe(false);
+    expect(r.request.params.has('dir')).toBe(false);
+    r.flush({ entities: [] });
+  });
+
+  it('listEdges / listMemories / listChrono all carry the sort', () => {
+    api.listEdges('work', 50, 0, undefined, { field: 'label', dir: 'desc' }).subscribe();
+    const e = http.expectOne(req => req.url === '/api/brain/spaces/work/edges');
+    expect(e.request.params.get('sort')).toBe('label');
+    expect(e.request.params.get('dir')).toBe('desc');
+    e.flush({ edges: [] });
+
+    api.listMemories('work', 20, 0, undefined, { field: 'createdAt', dir: 'desc' }).subscribe();
+    const m = http.expectOne(req => req.url === '/api/brain/spaces/work/memories');
+    expect(m.request.params.get('sort')).toBe('createdAt');
+    m.flush({ memories: [], limit: 20, skip: 0 });
+
+    api.listChrono('work', 50, 0, undefined, { field: 'startsAt', dir: 'asc' }).subscribe();
+    const c = http.expectOne(req => req.url === '/api/brain/spaces/work/chrono');
+    expect(c.request.params.get('sort')).toBe('startsAt');
+    expect(c.request.params.get('dir')).toBe('asc');
+    c.flush({ chrono: [] });
+  });
+
+  it('sort composes with existing filters rather than replacing them', () => {
+    api.listEntities('work', 50, 0, { type: 'person', tag: 'vip' }, { field: 'createdAt', dir: 'desc' }).subscribe();
+    const r = http.expectOne(req => req.url === '/api/brain/spaces/work/entities');
+    expect(r.request.params.get('type')).toBe('person');
+    expect(r.request.params.get('tag')).toBe('vip');
+    expect(r.request.params.get('sort')).toBe('createdAt');
+    r.flush({ entities: [] });
+  });
+});

--- a/client/src/app/core/brain-api.service.ts
+++ b/client/src/app/core/brain-api.service.ts
@@ -6,10 +6,25 @@ import type {
   QueryCollection, QueryResult, RecallKnowledgeType, RecallResponse, TraverseResult,
 } from './api.types';
 
+/**
+ * A server-side sort request for a brain list endpoint. `field` must be one the server whitelists
+ * for that collection (see the integration guide); an un-whitelisted field is a 400, so callers pass
+ * only the columns the tab exposes a caret for.
+ */
+export interface ListSort {
+  field: string;
+  dir: 'asc' | 'desc';
+}
+
 /** Brain knowledge graph — memories, entities, edges, chrono, plus query/recall/traverse. */
 @Injectable({ providedIn: 'root' })
 export class BrainApi {
   private http = inject(HttpClient);
+
+  /** Append `sort`/`dir` to a list request when a sort is active; a no-op otherwise. */
+  private withSort(params: HttpParams, sort?: ListSort): HttpParams {
+    return sort ? params.set('sort', sort.field).set('dir', sort.dir) : params;
+  }
 
   /** Mint a single-use ticket to open the live-change SSE stream. EventSource can't send an
    *  Authorization header and a raw token in the URL leaks into logs/history, so the stream is opened
@@ -51,11 +66,12 @@ export class BrainApi {
 
   // ── Brain — memories ──────────────────────────────────────────────────────
 
-  listMemories(spaceId: string, limit = 20, skip = 0, filters?: { tag?: string; entity?: string; type?: string }): Observable<{ memories: Memory[]; limit: number; skip: number }> {
+  listMemories(spaceId: string, limit = 20, skip = 0, filters?: { tag?: string; entity?: string; type?: string }, sort?: ListSort): Observable<{ memories: Memory[]; limit: number; skip: number }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.tag) params = params.set('tag', filters.tag);
     if (filters?.entity) params = params.set('entity', filters.entity);
     if (filters?.type) params = params.set('type', filters.type);
+    params = this.withSort(params, sort);
     return this.http.get<any>(`/api/brain/spaces/${spaceId}/memories`, { params });
   }
 
@@ -79,11 +95,12 @@ export class BrainApi {
 
   // ── Brain — entities ──────────────────────────────────────────────────────
 
-  listEntities(spaceId: string, limit = 50, skip = 0, filters?: { search?: string; type?: string; tag?: string }): Observable<{ entities: Entity[] }> {
+  listEntities(spaceId: string, limit = 50, skip = 0, filters?: { search?: string; type?: string; tag?: string }, sort?: ListSort): Observable<{ entities: Entity[] }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.search) params = params.set('name', filters.search);
     if (filters?.type) params = params.set('type', filters.type);
     if (filters?.tag) params = params.set('tag', filters.tag);
+    params = this.withSort(params, sort);
     return this.http.get<any>(`/api/brain/spaces/${spaceId}/entities`, { params });
   }
 
@@ -101,10 +118,11 @@ export class BrainApi {
 
   // ── Brain — edges ─────────────────────────────────────────────────────────
 
-  listEdges(spaceId: string, limit = 50, skip = 0, filters?: { type?: string; tag?: string }): Observable<{ edges: Edge[] }> {
+  listEdges(spaceId: string, limit = 50, skip = 0, filters?: { type?: string; tag?: string }, sort?: ListSort): Observable<{ edges: Edge[] }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.type) params = params.set('type', filters.type);
     if (filters?.tag) params = params.set('tag', filters.tag);
+    params = this.withSort(params, sort);
     return this.http.get<any>(`/api/brain/spaces/${spaceId}/edges`, { params });
   }
 
@@ -155,7 +173,7 @@ export class BrainApi {
 
   // ── Brain — chrono ──────────────────────────────────────────────────────
 
-  listChrono(spaceId: string, limit = 50, skip = 0, filters?: { tags?: string; tagsAny?: string; tag?: string; type?: string; status?: string; after?: string; before?: string; search?: string }): Observable<{ chrono: ChronoEntry[] }> {
+  listChrono(spaceId: string, limit = 50, skip = 0, filters?: { tags?: string; tagsAny?: string; tag?: string; type?: string; status?: string; after?: string; before?: string; search?: string }, sort?: ListSort): Observable<{ chrono: ChronoEntry[] }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.tags) params = params.set('tags', filters.tags);
     if (filters?.tagsAny) params = params.set('tagsAny', filters.tagsAny);
@@ -167,6 +185,7 @@ export class BrainApi {
     if (filters?.after) params = params.set('after', filters.after);
     if (filters?.before) params = params.set('before', filters.before);
     if (filters?.search) params = params.set('search', filters.search);
+    params = this.withSort(params, sort);
     return this.http.get<any>(`/api/brain/spaces/${spaceId}/chrono`, { params });
   }
 

--- a/client/src/app/pages/brain/chrono-tab.component.spec.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.spec.ts
@@ -49,7 +49,7 @@ describe('ChronoTabComponent', () => {
 
   it('self-loads on the spaceId input', () => {
     make();
-    expect(api.listChrono).toHaveBeenCalledWith('work', 20, 0, {});
+    expect(api.listChrono).toHaveBeenCalledWith('work', 20, 0, {}, undefined);
   });
 
   it('createChrono resolves a __custom__ kind to the free-text customKind and ISO-encodes startsAt', () => {

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -13,6 +13,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
+import { SortableHeaderComponent } from './sortable-header.component';
 import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError, toLocalDatetime } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
@@ -33,7 +34,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -141,7 +142,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <table>
               <thead>
                 <tr>
-                  <th>{{ 'brain.chrono.table.title' | transloco }}</th><th>{{ 'brain.chrono.table.description' | transloco }}</th><th>{{ 'brain.chrono.table.kind' | transloco }}</th><th>{{ 'brain.chrono.table.status' | transloco }}</th><th>{{ 'brain.chrono.table.starts' | transloco }}</th><th>{{ 'brain.chrono.table.ends' | transloco }}</th><th>{{ 'brain.chrono.table.tags' | transloco }}</th><th>{{ 'brain.chrono.table.entities' | transloco }}</th><th></th>
+                  <th app-sort-th field="title" label="brain.chrono.table.title" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.chrono.table.description' | transloco }}</th><th app-sort-th field="type" label="brain.chrono.table.kind" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.chrono.table.status' | transloco }}</th><th app-sort-th field="startsAt" label="brain.chrono.table.starts" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.chrono.table.ends' | transloco }}</th><th>{{ 'brain.chrono.table.tags' | transloco }}</th><th>{{ 'brain.chrono.table.entities' | transloco }}</th><th></th>
                 </tr>
               </thead>
               <tbody>
@@ -309,7 +310,7 @@ export class ChronoTabComponent extends RecordTabBase {
     if (this.store.chronoSearch()) cf.search = this.store.chronoSearch();
     if (this.recordFilter().type) cf.type = this.recordFilter().type;
     if (this.recordFilter().tag) cf.tag = this.recordFilter().tag;
-    this.brainApi.listChrono(spaceId, this.pageSize, this.skip(), cf).subscribe({
+    this.brainApi.listChrono(spaceId, this.pageSize, this.skip(), cf, this.sortParam()).subscribe({
       next: ({ chrono }) => {
         this.store.chrono.set(chrono);
         const ids = [...new Set(chrono.flatMap(e => e.entityIds ?? []))];

--- a/client/src/app/pages/brain/edges-tab.component.spec.ts
+++ b/client/src/app/pages/brain/edges-tab.component.spec.ts
@@ -49,7 +49,7 @@ describe('EdgesTabComponent', () => {
 
   it('self-loads on the spaceId input', () => {
     make();
-    expect(api.listEdges).toHaveBeenCalledWith('work', 20, 0, {});
+    expect(api.listEdges).toHaveBeenCalledWith('work', 20, 0, {}, undefined);
   });
 
   it('createEdge requires from+to+label, spreads weight only when set, and emits mutated', () => {

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -13,6 +13,7 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
+import { SortableHeaderComponent } from './sortable-header.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
 import { RecordSearchBarComponent } from './record-search-bar.component';
@@ -33,7 +34,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-edges-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -129,7 +130,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <table>
               <thead>
                 <tr>
-                  <th>{{ 'brain.edges.table.from' | transloco }}</th><th>{{ 'brain.edges.table.relation' | transloco }}</th><th>{{ 'brain.edges.table.to' | transloco }}</th><th>{{ 'brain.edges.table.weight' | transloco }}</th><th>{{ 'brain.edges.table.tags' | transloco }}</th><th>{{ 'brain.edges.table.description' | transloco }}</th><th>{{ 'brain.edges.table.properties' | transloco }}</th><th>{{ 'brain.edges.table.created' | transloco }}</th><th></th>
+                  <th app-sort-th field="from" label="brain.edges.table.from" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="label" label="brain.edges.table.relation" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="to" label="brain.edges.table.to" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.edges.table.weight' | transloco }}</th><th>{{ 'brain.edges.table.tags' | transloco }}</th><th>{{ 'brain.edges.table.description' | transloco }}</th><th>{{ 'brain.edges.table.properties' | transloco }}</th><th app-sort-th field="createdAt" label="brain.edges.table.created" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th></th>
                 </tr>
               </thead>
               <tbody>
@@ -273,7 +274,7 @@ export class EdgesTabComponent extends RecordTabBase {
     const gf: { type?: string; tag?: string } = {};
     if (this.recordFilter().type) gf.type = this.recordFilter().type;
     if (this.recordFilter().tag) gf.tag = this.recordFilter().tag;
-    this.brainApi.listEdges(spaceId, this.pageSize, this.skip(), gf).subscribe({
+    this.brainApi.listEdges(spaceId, this.pageSize, this.skip(), gf, this.sortParam()).subscribe({
       next: ({ edges }) => { this.store.edges.set(edges); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });

--- a/client/src/app/pages/brain/entities-tab.component.spec.ts
+++ b/client/src/app/pages/brain/entities-tab.component.spec.ts
@@ -48,7 +48,7 @@ describe('EntitiesTabComponent', () => {
 
   it('self-loads on the spaceId input (page size + skip 0 + no filter)', () => {
     make();
-    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, {});
+    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, {}, undefined);
   });
 
   it('self-load effect depends on spaceId ONLY — no reload on plain change detection', () => {
@@ -122,9 +122,44 @@ describe('EntitiesTabComponent', () => {
     const c = fixture.componentInstance;
     api.listEntities.mockClear();
     c.onEntitySearchChange('ali');
-    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, { search: 'ali' });
+    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, { search: 'ali' }, undefined);
     c.nextPage();
     expect(c.skip()).toBe(20);
-    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 20, { search: 'ali' });
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 20, { search: 'ali' }, undefined);
+  });
+
+  it('setSort cycles a column desc → asc → back to default, passing the sort to the API each time', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    api.listEntities.mockClear();
+
+    c.setSort('name');
+    expect(c.sortState('name')).toBe('desc');
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 0, {}, { field: 'name', dir: 'desc' });
+
+    c.setSort('name');
+    expect(c.sortState('name')).toBe('asc');
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 0, {}, { field: 'name', dir: 'asc' });
+
+    c.setSort('name');
+    expect(c.sortState('name')).toBeNull();
+    // Back to the endpoint's default order — no sort param.
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 0, {}, undefined);
+  });
+
+  it('sorting a different column starts it at desc and drops the previous column', () => {
+    const c = make().componentInstance;
+    c.setSort('name');
+    c.setSort('createdAt');
+    expect(c.sortState('name')).toBeNull();
+    expect(c.sortState('createdAt')).toBe('desc');
+  });
+
+  it('changing the sort resets paging to the first page', () => {
+    const c = make().componentInstance;
+    c.nextPage();
+    expect(c.skip()).toBe(20);
+    c.setSort('name');
+    expect(c.skip()).toBe(0);
   });
 });

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -12,6 +12,7 @@ import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
+import { SortableHeaderComponent } from './sortable-header.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
 import { fmtApiError } from './brain-format';
@@ -32,7 +33,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-entities-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -115,7 +116,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <table>
               <thead>
                 <tr>
-                  <th>{{ 'brain.entities.table.name' | transloco }}</th><th>{{ 'brain.entities.table.type' | transloco }}</th><th>{{ 'brain.entities.table.description' | transloco }}</th><th>{{ 'brain.entities.table.tags' | transloco }}</th><th>{{ 'brain.entities.table.properties' | transloco }}</th><th>{{ 'brain.entities.table.created' | transloco }}</th><th></th>
+                  <th app-sort-th field="name" label="brain.entities.table.name" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="type" label="brain.entities.table.type" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.entities.table.description' | transloco }}</th><th>{{ 'brain.entities.table.tags' | transloco }}</th><th>{{ 'brain.entities.table.properties' | transloco }}</th><th app-sort-th field="createdAt" label="brain.entities.table.created" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th></th>
                 </tr>
               </thead>
               <tbody>
@@ -247,7 +248,7 @@ export class EntitiesTabComponent extends RecordTabBase {
     if (this.entitySearch()) ef.search = this.entitySearch();
     if (this.recordFilter().type) ef.type = this.recordFilter().type;
     if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef).subscribe({
+    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef, this.sortParam()).subscribe({
       next: ({ entities }) => { this.store.entities.set(entities); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
@@ -261,7 +262,7 @@ export class EntitiesTabComponent extends RecordTabBase {
     if (this.entitySearch()) ef.search = this.entitySearch();
     if (this.recordFilter().type) ef.type = this.recordFilter().type;
     if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef).subscribe({
+    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef, this.sortParam()).subscribe({
       next: ({ entities }) => this.store.entities.set(entities),
       error: () => {},
     });

--- a/client/src/app/pages/brain/memories-tab.component.spec.ts
+++ b/client/src/app/pages/brain/memories-tab.component.spec.ts
@@ -51,7 +51,7 @@ describe('MemoriesTabComponent', () => {
 
   it('self-loads on the spaceId input (sends page size + skip 0 + no filter)', () => {
     make();
-    expect(api.listMemories).toHaveBeenCalledWith('work', 20, 0, {});
+    expect(api.listMemories).toHaveBeenCalledWith('work', 20, 0, {}, undefined);
   });
 
   it('renders the create form when opened (plain ngModel model under OnPush)', () => {
@@ -141,7 +141,7 @@ describe('MemoriesTabComponent', () => {
     api.listMemories.mockClear();
     c.nextPage();
     expect(c.skip()).toBe(20);
-    expect(api.listMemories).toHaveBeenCalledWith('work', 20, 20, { tag: 'urgent', entity: 'e9', type: 'note' });
+    expect(api.listMemories).toHaveBeenCalledWith('work', 20, 20, { tag: 'urgent', entity: 'e9', type: 'note' }, undefined);
     c.prevPage(); c.prevPage(); // clamp at 0
     expect(c.skip()).toBe(0);
   });

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -15,6 +15,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordFilterBarComponent, type RecordFilter } from '../../shared/record-filter-bar.component';
 import { RecordDrawerState } from './record-drawer-state.service';
 import { RecordTabBase } from './record-tab-base';
+import { SortableHeaderComponent } from './sortable-header.component';
 import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
@@ -40,7 +41,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-memories-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordFilterBarComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -132,7 +133,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <table>
               <thead>
                 <tr>
-                  <th>{{ 'brain.memories.table.fact' | transloco }}</th><th>{{ 'brain.memories.table.description' | transloco }}</th><th>{{ 'brain.memories.table.tags' | transloco }}</th><th>{{ 'brain.memories.table.entities' | transloco }}</th><th>{{ 'brain.memories.table.properties' | transloco }}</th><th>{{ 'brain.memories.table.created' | transloco }}</th><th></th>
+                  <th>{{ 'brain.memories.table.fact' | transloco }}</th><th>{{ 'brain.memories.table.description' | transloco }}</th><th>{{ 'brain.memories.table.tags' | transloco }}</th><th>{{ 'brain.memories.table.entities' | transloco }}</th><th>{{ 'brain.memories.table.properties' | transloco }}</th><th app-sort-th field="createdAt" label="brain.memories.table.created" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th></th>
                 </tr>
               </thead>
               <tbody>
@@ -293,7 +294,7 @@ export class MemoriesTabComponent extends RecordTabBase {
     if (this.recordFilter().tag) filters.tag = this.recordFilter().tag;
     if (this.filterEntity()) filters.entity = this.filterEntity();
     if (this.recordFilter().type) filters.type = this.recordFilter().type;
-    this.brainApi.listMemories(spaceId, this.pageSize, this.skip(), filters).subscribe({
+    this.brainApi.listMemories(spaceId, this.pageSize, this.skip(), filters, this.sortParam()).subscribe({
       next: ({ memories }) => {
         this.store.memories.set(memories);
         const ids = [...new Set(memories.flatMap(m => m.entityIds ?? []))];

--- a/client/src/app/pages/brain/record-tab-base.ts
+++ b/client/src/app/pages/brain/record-tab-base.ts
@@ -2,6 +2,7 @@ import { Directive, effect, inject, input, signal, untracked } from '@angular/co
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordListState } from './record-list-state.service';
+import type { ListSort } from '../../core/brain-api.service';
 
 /**
  * Shared machinery for the five record-tab components (memories/entities/edges/chrono/filemeta),
@@ -30,6 +31,15 @@ export abstract class RecordTabBase {
 
   skip = signal(0);
 
+  /**
+   * Column sort state, wired to the server's `?sort=&dir=` (slice 2a). `sortField === ''` means "no
+   * sort" — the endpoint keeps its own default order, exactly as before any header was clicked. Only
+   * fields the server whitelists for the collection are ever set here (the tab only renders a caret on
+   * those columns), so a click can never produce a 400.
+   */
+  sortField = signal('');
+  sortDir = signal<'asc' | 'desc'>('desc');
+
   constructor() {
     // Self-load on creation (tab activation via the shell's gated @if) and on a space switch while
     // mounted. This effect must depend on `spaceId` ONLY. The reset + load are wrapped in `untracked`
@@ -42,6 +52,8 @@ export abstract class RecordTabBase {
       const id = this.spaceId();
       untracked(() => {
         this.skip.set(0);
+        this.sortField.set('');
+        this.sortDir.set('desc');
         this.resetOnSpaceChange();
         if (id) this.load();
       });
@@ -69,6 +81,36 @@ export abstract class RecordTabBase {
 
   prevPage(): void { this.skip.update(s => Math.max(0, s - this.pageSize)); this.load(); }
   nextPage(): void { this.skip.update(s => s + this.pageSize); this.load(); }
+
+  /**
+   * Cycle the sort for a column header: unsorted → desc → asc → back to the endpoint's default.
+   * Clicking a different column starts it at desc. Any change resets paging to the first page — a new
+   * order makes the current `skip` meaningless — and reloads from the server (the whole point: the
+   * sort spans every page, not just the visible rows).
+   */
+  setSort(field: string): void {
+    if (this.sortField() !== field) {
+      this.sortField.set(field);
+      this.sortDir.set('desc');
+    } else if (this.sortDir() === 'desc') {
+      this.sortDir.set('asc');
+    } else {
+      this.sortField.set('');
+      this.sortDir.set('desc');
+    }
+    this.skip.set(0);
+    this.load();
+  }
+
+  /** The active sort for the current column, or `null` when this column is not the sort key. */
+  sortState(field: string): 'asc' | 'desc' | null {
+    return this.sortField() === field ? this.sortDir() : null;
+  }
+
+  /** The `ListSort` to hand the API, or `undefined` when no column sort is active. */
+  protected sortParam(): ListSort | undefined {
+    return this.sortField() ? { field: this.sortField(), dir: this.sortDir() } : undefined;
+  }
 
   requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
   cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }

--- a/client/src/app/pages/brain/sortable-header.component.spec.ts
+++ b/client/src/app/pages/brain/sortable-header.component.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * SortableHeaderComponent (slice 2b-i) — the sortable `<th>` primitive shared by the Brain list
+ * tables. Verifies it renders the label, emits its field on click, and reflects the active sort
+ * state (caret + `aria-sort`) so the header honestly shows what the server is ordering by.
+ */
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { SortableHeaderComponent } from './sortable-header.component';
+
+@Component({
+  standalone: true,
+  imports: [SortableHeaderComponent],
+  template: `
+    <table><thead><tr>
+      <th app-sort-th
+        field="name"
+        label="brain.entities.table.name"
+        [activeField]="active()"
+        [dir]="dir()"
+        (sort)="last = $event"></th>
+    </tr></thead></table>`,
+})
+class HostComponent {
+  active = signal('');
+  dir = signal<'asc' | 'desc'>('desc');
+  last: string | null = null;
+}
+
+function mount() {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [HostComponent, getTranslocoModule()] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('SortableHeaderComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(SortableHeaderComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders the translated label', () => {
+    const fixture = mount();
+    const btn = fixture.nativeElement.querySelector('.sort-btn') as HTMLButtonElement;
+    // getTranslocoModule echoes the key when no translation is registered.
+    expect(btn.textContent).toContain('brain.entities.table.name');
+  });
+
+  it('emits its field on click', () => {
+    const fixture = mount();
+    const host = fixture.componentInstance;
+    (fixture.nativeElement.querySelector('.sort-btn') as HTMLButtonElement).click();
+    expect(host.last).toBe('name');
+  });
+
+  it('is aria-sort=none and the caret is inactive when this column is not the sort key', () => {
+    const fixture = mount();
+    const th = fixture.nativeElement.querySelector('th') as HTMLElement;
+    expect(th.getAttribute('aria-sort')).toBe('none');
+    expect(fixture.nativeElement.querySelector('.sort-caret.active')).toBeNull();
+  });
+
+  it('reflects an active ascending sort in aria-sort and the caret', () => {
+    const fixture = mount();
+    fixture.componentInstance.active.set('name');
+    fixture.componentInstance.dir.set('asc');
+    fixture.detectChanges();
+    const th = fixture.nativeElement.querySelector('th') as HTMLElement;
+    expect(th.getAttribute('aria-sort')).toBe('ascending');
+    expect(fixture.nativeElement.querySelector('.sort-caret.active')).toBeTruthy();
+  });
+
+  it('reflects an active descending sort as aria-sort=descending', () => {
+    const fixture = mount();
+    fixture.componentInstance.active.set('name');
+    fixture.componentInstance.dir.set('desc');
+    fixture.detectChanges();
+    const th = fixture.nativeElement.querySelector('th') as HTMLElement;
+    expect(th.getAttribute('aria-sort')).toBe('descending');
+  });
+});

--- a/client/src/app/pages/brain/sortable-header.component.ts
+++ b/client/src/app/pages/brain/sortable-header.component.ts
@@ -1,0 +1,73 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+
+/**
+ * A sortable `<th>` for the Brain list tables (slice 2b-i). Applied as an attribute on the header
+ * cell — `<th app-sort-th field="name" label="brain.entities.table.name" …>` — so the table markup
+ * stays valid `<thead><tr><th>`.
+ *
+ * The whole cell is the sort control: clicking it emits `sort(field)`, which the tab base cycles
+ * (unsorted → desc → asc → default). A dimmed caret marks a sortable-but-inactive column; the active
+ * column shows a full-strength up/down caret matching the current direction. `aria-sort` on the host
+ * reflects the state for assistive tech.
+ *
+ * Only columns backed by a server-whitelisted field (slice 2a) get one of these; the rest stay plain
+ * `<th>`, so a click can never ask the server to sort by a field it will 400 on.
+ */
+@Component({
+  selector: 'th[app-sort-th]',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslocoPipe, PhIconComponent],
+  host: {
+    '[attr.aria-sort]': 'ariaSort()',
+    'class': 'sort-th',
+  },
+  styles: [`
+    .sort-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      background: none;
+      border: none;
+      padding: 0;
+      margin: 0;
+      font: inherit;
+      color: inherit;
+      cursor: pointer;
+      text-align: left;
+      white-space: nowrap;
+    }
+    .sort-btn:hover { color: var(--text-primary); }
+    .sort-caret { display: inline-flex; opacity: 0.3; transition: opacity 0.1s; }
+    .sort-btn:hover .sort-caret { opacity: 0.6; }
+    .sort-caret.active { opacity: 1; color: var(--accent); }
+  `],
+  template: `
+    <button type="button" class="sort-btn"
+      (click)="sort.emit(field())"
+      [attr.aria-label]="(label() | transloco)">
+      {{ label() | transloco }}
+      <span class="sort-caret" [class.active]="active()">
+        <ph-icon [name]="active() && dir() === 'asc' ? 'caret-up' : 'caret-down'" [size]="12" />
+      </span>
+    </button>
+  `,
+})
+export class SortableHeaderComponent {
+  /** Server sort field this column maps to (must be whitelisted for the collection). */
+  readonly field = input.required<string>();
+  /** i18n key for the column label. */
+  readonly label = input.required<string>();
+  /** The currently-sorted field across the table (`''` when nothing is sorted). */
+  readonly activeField = input<string>('');
+  /** Direction of the active sort. */
+  readonly dir = input<'asc' | 'desc'>('desc');
+
+  readonly sort = output<string>();
+
+  protected readonly active = computed(() => this.activeField() === this.field());
+  protected readonly ariaSort = computed(() =>
+    this.active() ? (this.dir() === 'asc' ? 'ascending' : 'descending') : 'none');
+}

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -112,6 +112,8 @@ Click **Save**. The memory is indexed immediately and available for search.
 
 **Filtering:** Click any tag or entity badge on a memory row to filter the list. Active filters appear as chips above the table. Click **×** on a chip to remove it, or **Clear all** to reset.
 
+**Sorting:** Click a column header with a caret (▾) to sort the list by that column — click again to flip the direction, and a third time to return to the default order. The caret fills in and points up or down to show the active sort. Sorting happens on the server, so it orders the **whole** list across every page, not just the rows currently on screen. Sortable columns vary by tab (e.g. Name/Type/Created on Entities; Created on Memories; Title/Kind/Starts on Chrono).
+
 **Deleting:** Each row has a **✕** button. A small inline confirmation appears — click **Yes** to confirm, **No** to cancel.
 
 **Wiping everything:** There is no "Wipe all" button on the Brain toolbar. To clear a space's data, go to **Settings → Spaces → (space) → Danger tab** and use **Wipe all data**. You will be asked to type the space ID to confirm.


### PR DESCRIPTION
## What

Wires the Brain list tables (entities, edges, memories, chrono) to the **server-side sort** shipped in #376. Clicking a column header sorts the **whole** list by that column across every page — the thing a client-only sort under pagination could never do honestly.

Brain UX epic, slice 2b-i. (2b was split into **2b-i sort** / **2b-ii filters** once it proved large — the #316→#317 foundation-first cadence. Sort-first is the direct "created needs a sort option" ask and keeps each PR reviewable. 2b-ii folds the filters into the headers next, as the docked-row layout the owner picked.)

## Shape

- A shared **`th[app-sort-th]`** primitive (`SortableHeaderComponent`): column label + a sort caret that fills and points to show the active direction, with `aria-sort` on the cell for assistive tech. An attribute on the `<th>`, so the table markup stays valid `<thead><tr><th>`.
- **`record-tab-base`** gains `sortField`/`sortDir` and a `setSort` cycle — unsorted → desc → asc → back to the endpoint's default. Any change resets paging to page 1 (a new order makes the current `skip` meaningless) and reloads; sort resets on a space switch.
- The four brain-api list methods take an optional `ListSort` and append `?sort=&dir=`, **omitted when no column is sorted** so the default order is untouched.
- Only columns backed by a **server-whitelisted** field get a caret (Name/Type/Created on entities; From/Relation/To/Created on edges; Created on memories; Title/Kind/Starts on chrono), so a header click can never ask the server to sort by a field it would `400` on.
- The existing type/tag filter row is left as-is — folding filters into the headers is **2b-ii**.

## Tests

- `SortableHeaderComponent` spec (label / click emits field / caret + `aria-sort` reflect state).
- `brain-api.list-sort` spec — `sort`/`dir` are appended when given, **omitted when absent**, and compose with existing filters.
- Sort-cycle tests through the entities tab: desc→asc→default, cross-column switch, skip reset.
- Existing tab specs updated for the new list-method arg. **473 client tests green.**

## Verified end-to-end

Booted an isolated instance (scratch config + scratch Mongo), seeded five entities in **non-alphabetical** order (Zebra, Apple, Mango, Delta, Rho), and drove the UI with Playwright:

- Default list = **insertion order preserved** (`aria-sort=none`).
- Name **desc** → `Zebra, Rho, Mango, Delta, Apple` (`aria-sort=descending`).
- Name **asc** → `Apple, Delta, Mango, Rho, Zebra` (`aria-sort=ascending`).
- Third click → back to default, `aria-sort=none`.
- Caret fills green on the active column; Type/Created show dimmed inactive carets; non-sortable columns have none.

(Only console noise was the documented benign first-run `Config not loaded` 500, before setup completes — unrelated to this change.)

## Docs

CHANGELOG `[Unreleased]` (Added), and a "Sorting" note in the userguide's Brain section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)