### PR TITLE
feat(brain): server-side freetext search on the list endpoints (slice 2b-iii-a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The chrono `?search=` filter no longer passes the raw query to a MongoDB `$regex`.** The value was
+  handed to the engine un-escaped, so a crafted input (e.g. `(a+)+$`) was a regex-injection / ReDoS
+  vector against the list endpoint. It is now escaped and matched as a literal substring, the same as
+  the new entities/edges/memories freetext search. Behaviour for ordinary searches is unchanged.
+
 - **⚠️ UPGRADING WITH AN INTERNAL IdP: the OIDC issuer is now public-only by default. If your IdP
   lives on a private address — Keycloak on `http://keycloak.internal:8080`, Authentik on a cluster
   service, Dex on `10.x` — you must set `oidc.allowPrivateIssuer: true` in `config.json` (or
@@ -825,6 +830,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   AGPL PyMuPDF).
 
 ### Added
+
+- **Freetext substring search on the brain list endpoints.** `entities`, `edges` and `memories` now
+  take `?search=<text>` — a case-insensitive substring over the record's text fields (name/description,
+  label/description, fact/description respectively), applied server-side before pagination so it
+  matches across the whole list, not just the visible page. Previously the entities list `name` param
+  was an exact match (substring lived only on `/entities/by-name`) and memories had no text filter at
+  all; chrono already had `search`. The value is escaped and matched literally. This is the server
+  half that lets the Brain tabs put a freetext filter in a column header; the header controls follow.
 
 - **Brain list filters moved into the column headers.** The type/kind and tag filters that used to
   sit in a separate row above the table now dock directly under the column they filter — the

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1199,6 +1199,23 @@ fall-back to the default order:
 With no `sort` the endpoint keeps its existing default order (entities: insertion order; the others:
 `createdAt` desc; files: `updatedAt` desc).
 
+#### Freetext search (`?search=`)
+
+The entities, edges, memories and chrono list endpoints accept an optional `?search=<text>` that
+matches a **case-insensitive substring** of the record's text fields, applied server-side before
+pagination (so it spans the whole set, like sort). The value is treated as a **literal** — regex
+metacharacters are escaped, so `a.b` matches the three characters `a.b`, not "a, any char, b".
+
+| Collection | Searched fields |
+|------------|-----------------|
+| entities | `name`, `description` |
+| edges | `label`, `description` |
+| memories | `fact`, `description` |
+| chrono | `title`, `description` |
+
+(Files use their own `path` filter; entities also keep the exact `?name=` filter and the semantic
+`/entities/by-name` endpoint.)
+
 ---
 
 ### Delete an Entity

--- a/server/src/api/brain/_shared.ts
+++ b/server/src/api/brain/_shared.ts
@@ -6,6 +6,7 @@
  * validation gate, the memory list filter, and the UUID matcher.
  */
 import { escapeRegex } from '../../util/redos.js';
+import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import type express from 'express';
 import { getConfig } from '../../config/loader.js';
 import { resolveMetaRefs, type SchemaViolation } from '../../spaces/schema-validation.js';
@@ -93,5 +94,9 @@ export function buildMemoryFilter(query: Record<string, unknown>): Record<string
   if (tag) filter['tags'] = { $regex: `^${escapeRegex(tag)}$`, $options: 'i' };
   if (entity) filter['entityIds'] = entity;
   if (type) filter['type'] = type;
+  // Freetext substring over fact + description (2b-iii-a).
+  const search = typeof query['search'] === 'string' ? query['search'] : undefined;
+  const or = textSearchOr(search, SEARCHABLE_FIELDS.memories);
+  if (or) Object.assign(filter, or);
   return filter;
 }

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -113,12 +113,13 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     res.status(400).json({ error: sortParse.error });
     return;
   }
-  const filter: { from?: string; to?: string; label?: string; type?: string; tag?: string } = {};
+  const filter: { from?: string; to?: string; label?: string; type?: string; tag?: string; search?: string } = {};
   if (typeof req.query['from'] === 'string') filter.from = req.query['from'];
   if (typeof req.query['to'] === 'string') filter.to = req.query['to'];
   if (typeof req.query['label'] === 'string') filter.label = req.query['label'];
   if (typeof req.query['type'] === 'string') filter.type = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter.tag = req.query['tag'];
+  if (typeof req.query['search'] === 'string') filter.search = req.query['search'];
   const all = await collectAcrossMembers(spaceId, mid => listEdges(mid, filter, limit, skip, sortParse.sort));
   // Batch-resolve entity names for from/to so the client can display names instead of raw UUIDs
   const allEntityIds = [...new Set(all.flatMap(e => [e.from, e.to]))];

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -13,6 +13,7 @@ import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } fro
 import { getConfig } from '../../config/loader.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
 import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEntity } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
@@ -104,6 +105,8 @@ entitiesRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAut
   if (typeof req.query['name'] === 'string') filter['name'] = req.query['name'];
   if (typeof req.query['type'] === 'string') filter['type'] = req.query['type'];
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
+  const search = textSearchOr(req.query['search'] as string | undefined, SEARCHABLE_FIELDS.entities);
+  if (search) Object.assign(filter, search);
   const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, filter, limit, skip, sortParse.sort));
   res.json({ entities: capPage(all, limit, sortParse.sort), limit, skip });
 });

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -4,6 +4,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { toMongoSort, type SortSpec } from './list-sort.js';
+import { textSearchOr, SEARCHABLE_FIELDS } from './text-search.js';
 import { embed } from './embedding.js';
 import { chronoEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -283,11 +284,10 @@ export async function listChrono(
     query['createdAt'] = range;
   }
 
-  // Full-text substring search on title and/or description
-  if (filter.search && filter.search.trim()) {
-    const regex = { $regex: filter.search.trim(), $options: 'i' };
-    query['$or'] = [{ title: regex }, { description: regex }];
-  }
+  // Full-text substring search on title and/or description. Escaped (2b-iii-a): the raw value used to
+  // reach `$regex` un-escaped, so a value like `(a+)+$` was a ReDoS / regex-injection vector.
+  const search = textSearchOr(filter.search, SEARCHABLE_FIELDS.chrono);
+  if (search) query['$or'] = search.$or;
 
   const entries = await col<ChronoEntry>(`${spaceId}_chrono`)
     .find(asFilter<ChronoEntry>(query))

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -4,6 +4,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { toMongoSort, type SortSpec } from './list-sort.js';
+import { textSearchOr, SEARCHABLE_FIELDS } from './text-search.js';
 import { embed } from './embedding.js';
 import { edgeEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -146,18 +147,21 @@ export async function upsertEdge(
 /** List edges for a space, optionally filtering by from/to entity */
 export async function listEdges(
   spaceId: string,
-  filter: { from?: string; to?: string; label?: string; type?: string; tag?: string } = {},
+  filter: { from?: string; to?: string; label?: string; type?: string; tag?: string; search?: string } = {},
   limit = 50,
   skip = 0,
   sort?: SortSpec,
 ): Promise<EdgeDoc[]> {
-  const q: Record<string, string> = { spaceId };
+  const q: Record<string, unknown> = { spaceId };
   if (filter.from) q['from'] = filter.from;
   if (filter.to) q['to'] = filter.to;
   if (filter.label) q['label'] = filter.label;
   if (filter.type) q['type'] = filter.type;
   // `tags` is an array field; a scalar match is Mongo array-contains (edge HAS this tag).
   if (filter.tag) q['tags'] = filter.tag;
+  // Freetext substring over the edge's text fields (2b-iii-a).
+  const search = textSearchOr(filter.search, SEARCHABLE_FIELDS.edges);
+  if (search) Object.assign(q, search);
   return col<EdgeDoc>(`${spaceId}_edges`)
     .find(asFilter<EdgeDoc>(q))
     .sort(sort ? toMongoSort(sort) : { seq: -1, createdAt: -1, _id: -1 })

--- a/server/src/brain/text-search.ts
+++ b/server/src/brain/text-search.ts
@@ -1,0 +1,35 @@
+/**
+ * Server-side freetext (substring) search for the brain list endpoints — slice 2b-iii-a.
+ *
+ * The docked column filters need a `?search=` that matches a substring of a record's text fields,
+ * across the WHOLE paginated set (same reason the sort in 2a had to be server-side). Chrono already
+ * had one; entities/edges/memories did not — their list `name` param was an EXACT match and memories
+ * had no text param at all. This adds a uniform, escaped substring match to the ones that lacked it.
+ *
+ * The user's text is `escapeRegex`-ed before it reaches `$regex`: an un-escaped user string is a
+ * regex-injection / ReDoS vector (a value like `(a+)+$` handed straight to the engine), so it is
+ * treated as a literal substring, never as a pattern.
+ */
+import { escapeRegex } from '../util/redos.js';
+
+/** Text fields each collection searches, OR-matched. `createdAt`/ids are not text and stay out. */
+export const SEARCHABLE_FIELDS = {
+  entities: ['name', 'description'],
+  edges: ['label', 'description'],
+  memories: ['fact', 'description'],
+  chrono: ['title', 'description'],
+} as const;
+
+/**
+ * Build a case-insensitive substring `$or` over `fields`, or `null` when there's nothing to search
+ * (empty/whitespace). The returned object is merged into a collection's Mongo filter.
+ */
+export function textSearchOr(
+  search: string | undefined,
+  fields: readonly string[],
+): { $or: Record<string, unknown>[] } | null {
+  const q = search?.trim();
+  if (!q) return null;
+  const regex = { $regex: escapeRegex(q), $options: 'i' };
+  return { $or: fields.map(f => ({ [f]: regex })) };
+}

--- a/testing/standalone/brain-text-search-db.test.js
+++ b/testing/standalone/brain-text-search-db.test.js
@@ -1,0 +1,93 @@
+/**
+ * Database-level test: the brain freetext filter (2b-iii-a) matches a substring across the WHOLE
+ * paginated set, and treats the query as a literal — against a real MongoDB.
+ *
+ * The docked column filter needs the match to span every page, not just the visible rows (same reason
+ * the sort had to be server-side). And the escaping only matters if MongoDB really would interpret an
+ * un-escaped value as a pattern — a JS matcher can't show that. Both are asserted here against the
+ * real `col()` via the #371 harness, through the real `listEntities`.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/brain-text-search-db.test.js
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+const SPACE = 'general';
+
+let mongo, listEntities, textSearchOr, entities;
+
+async function insertEntity(_id, name, description = '') {
+  await entities.insertOne({ _id, spaceId: SPACE, name, description, type: 'x', createdAt: '2026-01-01T00:00:00.000Z', seq: 1 });
+}
+
+/** Run listEntities with a freetext search, walking all pages → the full matched set (ids). */
+async function searchAllPages(query, pageSize = 2) {
+  const or = textSearchOr(query, ['name', 'description']);
+  const filter = or ?? {};
+  const ids = [];
+  for (let skipN = 0; ; skipN += pageSize) {
+    const page = await listEntities(SPACE, filter, pageSize, skipN, { field: 'name', dir: 1 });
+    if (page.length === 0) break;
+    ids.push(...page.map(e => String(e._id)));
+    if (page.length < pageSize) break;
+  }
+  return ids.sort();
+}
+
+describe('brain freetext search — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('braintextsearch');
+    ({ listEntities } = await import('../../server/dist/brain/entities.js'));
+    ({ textSearchOr } = await import('../../server/dist/brain/text-search.js'));
+    entities = mongo.col(`${SPACE}_entities`);
+  });
+  after(async () => { await closeTestMongo(); });
+  beforeEach(async () => { await entities.deleteMany({}); });
+
+  it('matches a substring across a PAGE BOUNDARY, not just the visible page', async () => {
+    // Six names contain "ana"; page size 2 → three pages. A page-only filter would miss the rest.
+    await insertEntity('e1', 'Banana');
+    await insertEntity('e2', 'Ananas');
+    await insertEntity('e3', 'Havana');
+    await insertEntity('e4', 'Grape');       // no match
+    await insertEntity('e5', 'Cabana');
+    await insertEntity('e6', 'Nirvana');
+    await insertEntity('e7', 'Analog');
+    const ids = await searchAllPages('ana');
+    assert.deepEqual(ids, ['e1', 'e2', 'e3', 'e5', 'e6', 'e7']);
+  });
+
+  it('is case-insensitive', async () => {
+    await insertEntity('u1', 'Kubernetes');
+    assert.deepEqual(await searchAllPages('KUBER'), ['u1']);
+  });
+
+  it('matches the description field too, not only the name', async () => {
+    await insertEntity('d1', 'Widget', 'a load-bearing gizmo');
+    await insertEntity('d2', 'Gadget', 'unrelated');
+    assert.deepEqual(await searchAllPages('gizmo'), ['d1']);
+  });
+
+  it('treats the query as a LITERAL — a `.` does not match any character', async () => {
+    await insertEntity('l1', 'a.b');   // literal dot
+    await insertEntity('l2', 'axb');   // would match if `.` were a wildcard
+    assert.deepEqual(await searchAllPages('a.b'), ['l1'], '`.` must be literal, so axb is NOT matched');
+  });
+
+  it('a regex payload is a literal, so `a+` does NOT match a run of a-s (distinguishes escaped)', async () => {
+    // As a pattern `a+` matches "aaa"; escaped it is the literal two chars "a+", which appear nowhere.
+    // This fails if escaping is removed — unlike a payload that matches nothing either way.
+    await insertEntity('r1', 'aaa');
+    assert.deepEqual(await searchAllPages('a+'), [], '`a+` must be literal — "aaa" is not the string "a+"');
+  });
+
+  it('empty search returns the full set (no narrowing)', async () => {
+    await insertEntity('a1', 'Alpha');
+    await insertEntity('a2', 'Beta');
+    assert.deepEqual(await searchAllPages(''), ['a1', 'a2']);
+  });
+});

--- a/testing/standalone/brain-text-search-unit.test.js
+++ b/testing/standalone/brain-text-search-unit.test.js
@@ -1,0 +1,53 @@
+/**
+ * Pure tests for `textSearchOr` — the freetext filter builder for the brain list endpoints (2b-iii-a).
+ *
+ * The load-bearing property is that the user's text is treated as a LITERAL substring, never as a
+ * regex: an un-escaped value handed to `$regex` is a regex-injection / ReDoS vector. The DB test
+ * proves MongoDB agrees; this pins the builder's shape and escaping without a database.
+ *
+ * Run: node --test testing/standalone/brain-text-search-unit.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { textSearchOr, SEARCHABLE_FIELDS } from '../../server/dist/brain/text-search.js';
+
+describe('textSearchOr', () => {
+  it('returns null for empty/whitespace/undefined — no filter, list stays unnarrowed', () => {
+    assert.equal(textSearchOr(undefined, ['name']), null);
+    assert.equal(textSearchOr('', ['name']), null);
+    assert.equal(textSearchOr('   ', ['name']), null);
+  });
+
+  it('builds a case-insensitive $or across every field', () => {
+    const f = textSearchOr('ali', ['name', 'description']);
+    assert.deepEqual(f, {
+      $or: [
+        { name: { $regex: 'ali', $options: 'i' } },
+        { description: { $regex: 'ali', $options: 'i' } },
+      ],
+    });
+  });
+
+  it('trims the query before matching', () => {
+    const f = textSearchOr('  bob  ', ['name']);
+    assert.equal(f.$or[0].name.$regex, 'bob');
+  });
+
+  it('ESCAPES regex metacharacters — the value is a literal substring, not a pattern', () => {
+    const f = textSearchOr('a.b(c)+', ['name']);
+    // Every metachar backslash-escaped; no bare `.`/`(`/`+` that the engine would interpret.
+    assert.equal(f.$or[0].name.$regex, 'a\\.b\\(c\\)\\+');
+  });
+
+  it('neutralises a classic ReDoS payload into a literal', () => {
+    const f = textSearchOr('(a+)+$', ['fact']);
+    assert.equal(f.$or[0].fact.$regex, '\\(a\\+\\)\\+\\$');
+  });
+
+  it('each collection has a non-empty searchable field set', () => {
+    for (const [name, fields] of Object.entries(SEARCHABLE_FIELDS)) {
+      assert.ok(fields.length > 0, `${name} must have searchable fields`);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `?search=<text>` to the entities/edges/memories brain list endpoints — a **case-insensitive substring** over each collection's text fields, applied **before** pagination so it matches across the whole set (the same reason 2a's sort had to be server-side). This is the backend half that lets the Brain tabs put a freetext filter in a column header (**2b-iii-b**).

## Why it can't be client-only (grounding)

- **entities**: the list `name` query was an **exact match** — substring lived only on `/entities/by-name`.
- **memories**: `buildMemoryFilter` had **no text param at all**.
- chrono already had `search`; edges had none.

Now uniform via a shared `textSearchOr`: entities (`name`/`description`), edges (`label`/`description`), memories (`fact`/`description`); chrono keeps title/description.

## Security fix (bundled — same code path)

chrono's `search` handed the raw value to `$regex` **un-escaped** — a regex-injection / ReDoS vector (`(a+)+$`). All four collections now `escapeRegex` the query and match it **literally**, so `a.b` means the three characters, not "a, any char, b". Ordinary searches unchanged.

## Tests (char-tests-first, #371 harness)

- DB harness: substring across a **page boundary** (a page-only filter would miss the rest), case-insensitive, description field included, and **literal-escaping proven against a real server** — a `.` doesn't match any char, `a+` doesn't match "aaa".
- **Mutation-checked**: removing the escape fails exactly the literal/injection assertions (the injection test was strengthened from one that passed both ways).
- Pure unit test pins `textSearchOr`'s shape + escaping with no DB.
- Read-only GET additions — route-coverage gate unchanged. 12 new standalone tests green.

## Docs

CHANGELOG `[Unreleased]` (Added + Security), integration-guide freetext-search section.

## Next

**2b-iii-b** docks these freetext filters in the column headers and demotes the A–Z pill (the semantic-search-touching client part, with recall preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)