### PR TITLE
fix(models): repair-pass pill claimed "in use" with no assist model configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1478,6 +1478,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The external-assist "Document repair pass" pill said "In use" the moment you ticked the task,
+  even with no assist model configured.** The pill keyed off the `uses` toggle alone, so toggling
+  "repair" on with an empty Endpoint/Model still read "In use" — claiming an inoperable feature was
+  active (the repair pass can't run without an endpoint to call). It now shows "In use" only when the
+  task is toggled **and** a base URL + model are set, matching what the user guide already promised
+  ("off unless you both fill in an Endpoint + Model and tick a task"); otherwise it reads "Not
+  configured".
+
 - **A network join or reparent could return `200` with the membership change silently absent.**
   `POST /api/invite/finalize` looked up `net = cfg.networks.find(...)`, then `await bcrypt.hash(...)`,
   then mutated `net` and called `saveConfig(cfg)`. The config object's nested arrays are replaced

--- a/client/src/app/pages/settings/models/models-state.service.spec.ts
+++ b/client/src/app/pages/settings/models/models-state.service.spec.ts
@@ -483,3 +483,39 @@ describe('ModelsStateService — the cross-tab unsaved-changes guard', () => {
     expect(c.isDirty()).toBe(false);
   });
 });
+
+describe('ModelsStateService — assist "in use" reflects real configuration (repair-pass pill bug)', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  const withAssist = (assist: Record<string, unknown>) =>
+    make(cfgFixture({
+      documentProcessing: {
+        mode: 'ocr', renderDpi: 150, maxPages: 50, pageTimeoutMs: 60000, concurrency: 2, ocrTimeoutMs: 120000,
+        assistModel: { uses: [], baseUrl: '', model: '', ...assist },
+      },
+    })).c;
+
+  it('is NOT in use when repair is toggled on but no assist model is configured (the reported bug)', () => {
+    const c = withAssist({ uses: ['repair'], baseUrl: '', model: '' });
+    expect(c.assistUses('repair')).toBe(true);       // the toggle is on…
+    expect(c.assistConfigured()).toBe(false);        // …but there is no endpoint
+    expect(c.assistInUse('repair')).toBe(false);     // so the pill must not say "in use"
+  });
+
+  it('is NOT in use when configured but repair is not toggled on', () => {
+    const c = withAssist({ uses: [], baseUrl: 'https://api.example.com/v1', model: 'gpt-4o' });
+    expect(c.assistConfigured()).toBe(true);
+    expect(c.assistInUse('repair')).toBe(false);
+  });
+
+  it('IS in use only when repair is toggled AND a base URL + model are set', () => {
+    const c = withAssist({ uses: ['repair'], baseUrl: 'https://api.example.com/v1', model: 'gpt-4o' });
+    expect(c.assistInUse('repair')).toBe(true);
+  });
+
+  it('a base URL without a model is not configured (both are required to call an endpoint)', () => {
+    const c = withAssist({ uses: ['repair'], baseUrl: 'https://api.example.com/v1', model: '' });
+    expect(c.assistConfigured()).toBe(false);
+    expect(c.assistInUse('repair')).toBe(false);
+  });
+});

--- a/client/src/app/pages/settings/models/models-state.service.ts
+++ b/client/src/app/pages/settings/models/models-state.service.ts
@@ -91,6 +91,13 @@ export class ModelsStateService {
   get assist(): DocAssistCfg { return (this.form.documentProcessing ??= {}).assistModel ??= {}; }
   assistLocked(): boolean { return this.isLocked('documentProcessing.assistModel'); }
   assistUses(u: DocAssistUse): boolean { return this.assist.uses?.includes(u) ?? false; }
+  /** True when the external assist model is actually configured — a base URL AND a model to call.
+   *  Without both there is no endpoint, so nothing it is "used" for can run. */
+  assistConfigured(): boolean { return !!this.assist.baseUrl?.trim() && !!this.assist.model?.trim(); }
+  /** True when `u` is BOTH toggled on AND the model is configured — i.e. actually operational. The
+   *  "in use" pill keys off this, not the toggle alone: a repair pass toggled on but with no assist
+   *  model configured does not run, so the pill must not claim it is in use. */
+  assistInUse(u: DocAssistUse): boolean { return this.assistUses(u) && this.assistConfigured(); }
   toggleAssistUse(u: DocAssistUse, on: boolean): void {
     const set = new Set(this.assist.uses ?? []);
     if (on) set.add(u); else set.delete(u);

--- a/client/src/app/pages/settings/models/models-tab.component.ts
+++ b/client/src/app/pages/settings/models/models-tab.component.ts
@@ -211,8 +211,8 @@ import { TestTarget } from './models.types';
         [heading]="'models.assist.title' | transloco"
         [purpose]="'models.assist.purpose' | transloco"
         [health]="pipeline.modelState('assist')">
-        <app-status-pill pill [variant]="s.assistLocked() ? 'env' : (s.assistUses('repair') ? 'active' : 'off')">
-          {{ (s.assistLocked() ? 'models.pill.env' : (s.assistUses('repair') ? 'models.assist.pillInUse' : 'models.assist.pillUnset')) | transloco }}
+        <app-status-pill pill [variant]="s.assistLocked() ? 'env' : (s.assistInUse('repair') ? 'active' : 'off')">
+          {{ (s.assistLocked() ? 'models.pill.env' : (s.assistInUse('repair') ? 'models.assist.pillInUse' : 'models.assist.pillUnset')) | transloco }}
         </app-status-pill>
         <!-- Moved out of the footer, where it was effectively invisible. -->
         @if (s.assist.acknowledgedHost && !s.assistNeedsAck()) {


### PR DESCRIPTION
## What

The external-assist **"Document repair pass"** pill read **"In use"** the moment you ticked the task — even with an empty Endpoint/Model. It keyed off the `uses` toggle alone, so it claimed an inoperable feature was active (the repair pass has no endpoint to call without a configured assist model).

From the owner's UI/UX feedback pass — one of the three integrity bugs promoted to **must-ship**.

## Fix

`assistInUse(u)` now requires the task toggled **and** the model configured (`assistConfigured()` = a base URL **and** a model set). The pill shows **"In use"** only then; otherwise **"Not configured"** — exactly what the user guide already promised:

> *"It's off unless you both fill in an Endpoint + Model and tick a task under Used for."*

The code was violating its own documented contract; this aligns them. Template change is a two-token swap (`assistUses` → `assistInUse`), type-checked by the build.

## Tests

4 unit tests covering every quadrant:
- toggled-but-unconfigured (**the reported bug**) → not in use
- configured-but-untoggled → not in use
- both → in use
- base-URL-without-model → not configured

485 client tests green. No E2E boot: the pill state is a fully unit-tested boolean and the template change is a mechanical, type-checked swap — a Models-page boot would be disproportionate for a one-line derivation gate.

## Docs

No doc change — the user guide already described the correct behavior; CHANGELOG `[Unreleased]` Fixed entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)