### PR TITLE
feat(brain): entities search bar → Semantic-only; pickers keep name lookup (slice 2b-iii-d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2293,6 +2293,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain Entities tab's search bar is Semantic-only too — finishing the A–Z demotion across all
+  four list tabs.** Entities uses a different component (`app-entity-search`) than the other three, so
+  it kept its A–Z / Semantic pill after 2b-iii-c. Its plain-text half was redundant with the docked
+  **Name** column freetext filter, and it was applying *two* server name filters at once (the bar's
+  exact `?name=` and the column's substring `?search=`). Now: the top bar is a **semantic entity
+  finder** — type for a meaning-ranked dropdown, and **picking a result fills the Name column filter**
+  (the list narrows via the same substring `?search=`), dropping the redundant exact-name list path.
+  **Exact/ID lookups are unaffected** — the **entity pickers** (edge from/to, memory/chrono/file-meta
+  linking) *keep* their A–Z/Semantic toggle and still default to name search, because semantic recall
+  is poor at exact IDs like `ADR002`; a new `showModeToggle` input hides the pill only on the entities
+  bar, never in pickers. Also corrects the user guide, which still described a "text / Semantic" toggle
+  on the Memories/Edges/Chrono bars (removed in 2b-iii-c). Client-only; `app-entity-search` and
+  entities-tab pill/pick behaviour covered by new tests.
 - **The Brain list tabs' top search bar is Semantic-only now — the redundant A–Z half is gone.** Once
   slice 2b-iii docked a plain-text (substring) freetext filter under each list column, the top bar's
   A–Z / Semantic pill had two ways to do the same plain-text search. The A–Z half is removed: the

--- a/client/src/app/pages/brain/entities-tab.component.spec.ts
+++ b/client/src/app/pages/brain/entities-tab.component.spec.ts
@@ -117,15 +117,37 @@ describe('EntitiesTabComponent', () => {
     expect(mutated).toHaveBeenCalled();
   });
 
-  it('the search bar reloads silently with the search term; nextPage advances skip', () => {
+  // 2b-iii-d: the semantic finder no longer runs an exact-`?name=` list filter. PICKING an entity
+  // feeds its name into the Name COLUMN filter — the server's substring `?search=` (6th arg), NOT
+  // `filters.search`/`?name=`. This is what keeps exact lookups (e.g. "ADR002") working without a
+  // redundant second name filter.
+  it('picking an entity sets the Name column filter (server ?search=, not ?name=); nextPage carries it', () => {
     const fixture = make();
     const c = fixture.componentInstance;
     api.listEntities.mockClear();
-    c.onEntitySearchChange('ali');
-    expect(api.listEntities).toHaveBeenCalledWith('work', 20, 0, { search: 'ali' }, undefined, undefined);
+    vi.useFakeTimers();
+    c.onEntitySearchPick({ name: 'ADR002' } as Entity);
+    vi.advanceTimersByTime(250); // setSearchFilter debounce
+    vi.useRealTimers();
+    expect(c.search()).toBe('ADR002');
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 0, {}, undefined, 'ADR002');
     c.nextPage();
     expect(c.skip()).toBe(20);
-    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 20, { search: 'ali' }, undefined, undefined);
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 20, {}, undefined, 'ADR002');
+  });
+
+  it('clearing the finder clears the Name column filter', () => {
+    const fixture = make();
+    const c = fixture.componentInstance;
+    vi.useFakeTimers();
+    c.onEntitySearchPick({ name: 'ADR002' } as Entity);
+    vi.advanceTimersByTime(250);
+    api.listEntities.mockClear();
+    c.onEntitySearchClear();
+    vi.advanceTimersByTime(250);
+    vi.useRealTimers();
+    expect(c.search()).toBe('');
+    expect(api.listEntities).toHaveBeenLastCalledWith('work', 20, 0, {}, undefined, undefined);
   });
 
   it('setSort cycles a column desc → asc → back to default, passing the sort to the API each time', () => {

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -25,8 +25,10 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
  * input; create/delete emit `mutated` so the shell refreshes tab-count stats.
  *
  * Entity delta from memories: both create AND inline-edit strip empty optional properties via the
- * entity schema; entity search uses the <app-entity-search> bar (semantic default) with no per-tab
- * search-mode pill.
+ * entity schema. Search: the top bar is the semantic-only `<app-entity-search>` finder
+ * (`[showModeToggle]="false"`, 2b-iii-d) — typing drives its own dropdown; picking a result feeds the
+ * name into the docked Name column freetext filter (the list's plain-text `?search=` path), so there
+ * is no separate exact-`?name=` list filter. Plain substring list filtering is the column header.
  */
 @Component({
   selector: 'app-entities-tab',
@@ -42,7 +44,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
               [spaceId]="spaceId()"
               placeholder="common.searchEntitiesPlaceholder"
               defaultMode="semantic"
-              (queryChange)="onEntitySearchChange($event)"
+              [showModeToggle]="false"
               (cleared)="onEntitySearchClear()"
               (selected)="onEntitySearchPick($event)"
             />
@@ -233,8 +235,6 @@ export class EntitiesTabComponent extends RecordTabBase {
   /** Emitted after a create/delete so the shell can refresh the space's tab-count stats. */
   readonly mutated = output<void>();
 
-  entitySearch = signal('');
-
   showEntityForm = signal(false);
   creatingEntity = signal(false);
   createEntityError = signal('');
@@ -242,7 +242,6 @@ export class EntitiesTabComponent extends RecordTabBase {
   editEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
 
   protected override resetOnSpaceChange(): void {
-    this.entitySearch.set('');
     this.recordFilter.set({ type: '', tag: '' });
   }
 
@@ -251,8 +250,7 @@ export class EntitiesTabComponent extends RecordTabBase {
     if (!spaceId) return;
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
-    const ef: { search?: string; type?: string; tag?: string } = {};
-    if (this.entitySearch()) ef.search = this.entitySearch();
+    const ef: { type?: string; tag?: string } = {};
     if (this.recordFilter().type) ef.type = this.recordFilter().type;
     if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
     this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef, this.sortParam(), this.searchParam()).subscribe({
@@ -261,34 +259,16 @@ export class EntitiesTabComponent extends RecordTabBase {
     });
   }
 
-  /** Reload without the loading overlay — used by the search bar (keeps focus/typing smooth). */
-  private loadEntitiesSilent(): void {
-    const spaceId = this.spaceId();
-    if (!spaceId) return;
-    const ef: { search?: string; type?: string; tag?: string } = {};
-    if (this.entitySearch()) ef.search = this.entitySearch();
-    if (this.recordFilter().type) ef.type = this.recordFilter().type;
-    if (this.recordFilter().tag) ef.tag = this.recordFilter().tag;
-    this.brainApi.listEntities(spaceId, this.pageSize, this.skip(), ef, this.sortParam(), this.searchParam()).subscribe({
-      next: ({ entities }) => this.store.entities.set(entities),
-      error: () => {},
-    });
-  }
-
-  onEntitySearchChange(q: string): void {
-    this.entitySearch.set(q);
-    this.skip.set(0);
-    this.loadEntitiesSilent();
-  }
+  // The top bar is a SEMANTIC finder now (2b-iii-d): its A–Z half was removed since the docked Name
+  // column freetext filter already does plain-text (substring `?search=`). Typing drives the bar's own
+  // semantic dropdown; PICKING an entity feeds that name into the Name column filter so the list
+  // narrows via the same server `?search=` as typing in the column would — no separate exact-`?name=`
+  // list path (that was a redundant second name filter). Clearing the bar clears the column filter.
   onEntitySearchClear(): void {
-    this.entitySearch.set('');
-    this.skip.set(0);
-    this.loadEntitiesSilent();
+    this.setSearchFilter('');
   }
   onEntitySearchPick(ent: Entity): void {
-    this.entitySearch.set(ent.name);
-    this.skip.set(0);
-    this.loadEntitiesSilent();
+    this.setSearchFilter(ent.name);
   }
 
   openEntityForm(): void {

--- a/client/src/app/shared/entity-search.component.spec.ts
+++ b/client/src/app/shared/entity-search.component.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * EntitySearchComponent — the A–Z / Semantic mode pill gating (2b-iii-d).
+ *
+ * Pickers must keep the toggle (exact name lookup matters when linking a known entity like "ADR002",
+ * where semantic recall struggles). A `bar`-mode consumer can pass `showModeToggle=false` to become
+ * semantic-only (the entities tab) — the pill hides AND the mode locks to semantic.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { getTranslocoModule } from '../testing/transloco-testing';
+import { BrainApi } from '../core/brain-api.service';
+import { EntitySearchComponent } from './entity-search.component';
+
+function make(props: Partial<EntitySearchComponent>) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [EntitySearchComponent, getTranslocoModule()],
+    providers: [{ provide: BrainApi, useValue: { recallBrain: vi.fn(() => of({ results: [], count: 0 })), searchEntitiesByName: vi.fn(() => of({ entities: [] })) } }],
+  });
+  const fixture = TestBed.createComponent(EntitySearchComponent);
+  Object.assign(fixture.componentInstance, { spaceId: 'work', ...props });
+  fixture.detectChanges(); // ngOnInit
+  return fixture;
+}
+
+const hasPill = (f: { nativeElement: HTMLElement }) => !!f.nativeElement.querySelector('.pill-group');
+
+describe('EntitySearchComponent — mode pill gating', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('bar mode shows the pill by default (showModeToggle defaults true)', () => {
+    expect(hasPill(make({ mode: 'bar' }))).toBe(true);
+  });
+
+  it('bar mode with showModeToggle=false hides the pill and locks to semantic', () => {
+    const f = make({ mode: 'bar', showModeToggle: false, defaultMode: 'semantic' });
+    expect(hasPill(f)).toBe(false);
+    expect(f.componentInstance.searchMode()).toBe('semantic');
+  });
+
+  it('showModeToggle=false forces semantic even if defaultMode is name', () => {
+    const f = make({ mode: 'bar', showModeToggle: false, defaultMode: 'name' });
+    expect(hasPill(f)).toBe(false);
+    expect(f.componentInstance.searchMode()).toBe('semantic');
+  });
+
+  it('picker mode ALWAYS keeps the pill (even if showModeToggle=false) and defaults to name', () => {
+    const f = make({ mode: 'picker', showModeToggle: false });
+    expect(hasPill(f)).toBe(true);
+    expect(f.componentInstance.searchMode()).toBe('name');
+  });
+});

--- a/client/src/app/shared/entity-search.component.ts
+++ b/client/src/app/shared/entity-search.component.ts
@@ -12,7 +12,8 @@
  *   spaceId      — Required. Which space to search in.
  *   mode         — 'bar' (default) or 'picker'.
  *   placeholder  — Input placeholder text.
- *   defaultMode  — 'semantic' (default) or 'name'.
+ *   defaultMode  — 'name' (default) or 'semantic'.
+ *   showModeToggle — show the A–Z/Semantic pill (default true; pickers always keep it).
  *   value        — Controlled display value (picker mode).
  *   debounceMs   — Debounce delay (default 280ms).
  *
@@ -200,10 +201,12 @@ import { TranslocoPipe } from '@jsverse/transloco';
         [attr.aria-label]="placeholder | transloco"
         autocomplete="off"
       />
-      <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-        <button type="button" [class.active]="searchMode() === 'name'"     (click)="setMode('name')">{{ 'common.sortAZ' | transloco }}</button>
-        <button type="button" [class.active]="searchMode() === 'semantic'" (click)="setMode('semantic')">{{ 'entitySearch.semantic' | transloco }}</button>
-      </div>
+      @if (mode !== 'bar' || showModeToggle) {
+        <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
+          <button type="button" [class.active]="searchMode() === 'name'"     (click)="setMode('name')">{{ 'common.sortAZ' | transloco }}</button>
+          <button type="button" [class.active]="searchMode() === 'semantic'" (click)="setMode('semantic')">{{ 'entitySearch.semantic' | transloco }}</button>
+        </div>
+      }
       @if (mode === 'bar' && displayValue()) {
         <button type="button" class="btn-clear" (click)="clear()">{{ 'entitySearch.clearButton' | transloco }}</button>
       }
@@ -238,6 +241,14 @@ export class EntitySearchComponent implements OnInit, OnDestroy, OnChanges {
   @Input() mode: 'bar' | 'picker' = 'bar';
   @Input() placeholder = 'entitySearch.defaultPlaceholder';
   @Input() defaultMode: 'name' | 'semantic' = 'name';
+  /**
+   * Show the A–Z / Semantic mode pill. Default true — pickers keep it (exact name lookup matters when
+   * linking a known entity, e.g. "ADR002" among many, where semantic recall struggles). A `bar`-mode
+   * consumer can pass false to become semantic-only (the entities tab, 2b-iii-c/d: its plain-text
+   * lookup is the docked Name column freetext filter now). Ignored in `picker` mode — pickers always
+   * keep the toggle.
+   */
+  @Input() showModeToggle = true;
   /** Controlled display value for picker mode (parent sets this after pick). */
   @Input() value = '';
   @Input() debounceMs = 280;
@@ -267,7 +278,11 @@ export class EntitySearchComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnInit(): void {
-    this.searchMode.set(this.defaultMode);
+    // The pill is hidden only for a bar with the toggle off — there the user can't switch modes, so
+    // lock to semantic regardless of defaultMode. Pickers always keep the pill, so they honour
+    // defaultMode ('name' by default — exact lookup).
+    const pillHidden = this.mode === 'bar' && !this.showModeToggle;
+    this.searchMode.set(pillHidden ? 'semantic' : this.defaultMode);
 
     this.subs.add(
       this.input$.pipe(

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -108,7 +108,7 @@ Memories are the core knowledge unit — plain-language statements you want to r
 
 Click **Save**. The memory is indexed immediately and available for search.
 
-**Searching:** Type in the search bar and press Enter. A toggle beside it switches between **text** matching (plain substring/sort) and **Semantic** (meaning-based) search. Semantic mode returns a ranked set and is not paginated.
+**Searching:** The top search bar is **Semantic** (meaning-based) — type and it returns a ranked, non-paginated set. Plain-text (substring) search moved into the column headers: use the **freetext box under the Fact column** (see Filtering). Clearing the top bar restores the normal paginated list.
 
 **Filtering:** Each column that can be filtered has its control docked directly under the column header — a **freetext box** under the main text column (Name / Relation / Fact) that matches a substring of the row's text, a type/kind dropdown under the **Type**/**Kind** column, and a tag box under the **Tags** column. Clicking a tag or entity badge on a row still fills the matching filter (the active entity filter shows as a chip above the table, with **×** to clear). Filtering happens on the server across the whole list, and clears back to everything when you empty the control.
 
@@ -134,7 +134,7 @@ When a **type** is selected and the space has a schema defined for that type, th
 - **Optional properties** — shown with a remove (×) button; any field left blank when you click Save is silently omitted from the stored record.
 - Switching the type dropdown **immediately rebuilds** the properties form for the newly selected type; values you have already filled in are preserved where the field name matches.
 
-**Searching:** The search bar above the table filters by name in real time.
+**Searching:** The top search bar is a **semantic entity finder** — type to see meaning-ranked matches in a dropdown, then click one to narrow the list to it (it fills the Name column filter). For an **exact / partial name** lookup (e.g. a specific ID like `ADR002`), use the **freetext box under the Name column** — semantic recall is poor at exact IDs, so the column filter is the reliable path. Column filters and sorting work as on Memories.
 
 **Editing:** Click the ⊙ view-details button on any row to open the full editable drawer.
 
@@ -150,7 +150,7 @@ Edges connect two entities and describe the relationship between them (e.g. *ser
 
 Each edge has a **from** entity, a **to** entity, a **label** (the relationship name), and optional **type**, **weight**, **tags**, **description**, and **properties**.
 
-**Searching:** The search bar has a **text / Semantic** toggle, same as Memories — text matches the label/description, Semantic ranks edges by meaning.
+**Searching:** The top search bar is **Semantic** (ranks edges by meaning), same as Memories. Plain-text matching (label / endpoint names) is the **freetext box under the Relation column**.
 
 **Creating an edge:** Click **+ Add edge**. Use the entity pickers to select the source and target, choose or type a label, and click **Save**.
 
@@ -166,7 +166,7 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 
 **Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, and linked entities.
 
-**Searching:** The search bar has a **text / Semantic** toggle — text matches title/description, Semantic ranks entries by meaning.
+**Searching:** The top search bar is **Semantic** (ranks entries by meaning). Plain-text matching (title / description) is the **freetext box under the Title column**.
 
 **Filtering:** The filter bar above the table lets you narrow by tag text and status. Filters apply immediately.
 


### PR DESCRIPTION
## What

Finishes the **demote the A–Z pill** line across all four Brain list tabs. Entities uses a different component (`app-entity-search`) than memories/edges/chrono, so it kept its A–Z / Semantic pill after 2b-iii-c (#382). Its plain-text half was redundant with the docked **Name** column freetext filter — and the tab was applying **two** server name filters at once: the bar's exact `?name=` and the column's substring `?search=`.

## Changes

- **`app-entity-search`: new `showModeToggle` input** (default `true`). On a `bar` with it `false`, the pill is hidden and the mode locks to semantic. **Pickers (`mode="picker"`) always keep the pill and default to name** — exact/ID lookup (e.g. `ADR002`) matters when linking a known entity, and semantic recall is poor at exact IDs. Also fixed a stale doc comment (claimed `defaultMode` defaults to `'semantic'`; it is `'name'`).
- **entities-tab: semantic-only bar** (`[showModeToggle]="false"`) — typing drives the semantic dropdown; **picking a result fills the Name column filter** (`setSearchFilter` → the same substring `?search=` the column uses), dropping the redundant exact-`?name=` list path and the now-vestigial `entitySearch` signal / `loadEntitiesSilent`.
- **userguide**: corrected the per-tab "text / Semantic toggle" descriptions for memories/edges/chrono (removed in 2b-iii-c but the docs were missed — a `docs/**/*.md` grep glob skipped the top-level `userguide.md`) plus the entities search description.

## Why pickers keep name lookup

Per owner: *"when I want to add ADR002 in a space full of ADRXXX, semantic search has a hard time finding the exact one."* So the demotion touches only the entities **list bar**; every entity **picker** keeps its A–Z/name toggle (and defaults to name). Exact lookup in the entities **list** stays available via the Name column filter.

## Verification

- **492 client tests green** — new `entity-search.component.spec` (pill hidden + locked semantic on a no-toggle bar; always shown + name-default in pickers) and updated entities-tab spec (pick → column `?search=`, not `?name=`; clear resets it). Production build clean.
- **E2E on an isolated instance**: entities bar has no pill and typing fires `/recall`; a memory-form entity picker keeps its pill and typing `ADR002` fires `/entities/by-name` (name), **not** `/recall`. 0 NG/zone console errors.
- **Client-only — no new/changed API routes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)