### PR TITLE
style(brain): unify the search-bar look across all five list tabs (Slice 2c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2293,6 +2293,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain search bars now render identically across all five list tabs.** The entities tab's bar
+  (`app-entity-search`) had drifted from the other four (`record-search-bar`): taller (`6px` vs `5px`
+  vertical padding), a different fill (`--bg-elevated` vs `--bg-surface`), and wider (`520` vs `400px`
+  max). Its input now matches the shared spec exactly — verified in-app, all five bars compute to the
+  same padding / height (32px) / background / font / radius. The duplicate `.content-header
+  input[type=search]` rule was removed so the plain bar has a single self-contained style that can't
+  drift again, and `app-entity-search` carries a note keeping it in lockstep. Pure CSS — no behavior
+  change. (First step of a broader Brain visual-consistency pass.)
 - **The Brain Entities tab's search bar is Semantic-only too — finishing the A–Z demotion across all
   four list tabs.** Entities uses a different component (`app-entity-search`) than the other three, so
   it kept its A–Z / Semantic pill after 2b-iii-c. Its plain-text half was redundant with the docked

--- a/client/src/app/pages/brain/brain-table.styles.ts
+++ b/client/src/app/pages/brain/brain-table.styles.ts
@@ -16,21 +16,13 @@ export const BRAIN_RECORD_TABLE_STYLES = `
       margin-bottom: 16px;
       flex-wrap: wrap;
     }
-    .content-header input[type=search] {
-      flex: 1;
-      min-width: 180px;
-      max-width: 400px;
-      padding: 5px 10px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
-      font-size: 13px;
-      background: var(--bg-surface);
-      color: var(--text-primary);
-    }
+    /* The plain search input styles itself (record-search-bar.component.ts) and app-entity-search
+       matches that spec — see the note there. Both are capped to the same width here so the entities
+       bar and the other tabs' bars line up. */
     .content-header app-entity-search {
       flex: 1;
       min-width: 180px;
-      max-width: 520px;
+      max-width: 400px; /* match the plain search input above (was 520 — the entities bar rendered wider) */
     }
     /* A slim row above the table, now only carrying the memories tab's active ENTITY-filter chip
        (the type/tag filters moved into the headers in 2b-ii). */

--- a/client/src/app/shared/entity-search.component.ts
+++ b/client/src/app/shared/entity-search.component.ts
@@ -57,15 +57,19 @@ import { TranslocoPipe } from '@jsverse/transloco';
       gap: 8px;
     }
 
+    /* Visual spec kept in lockstep with the record tabs' plain search input
+       (.content-header input[type=search] in brain-table.styles.ts) so the entities bar and the
+       memories/edges/chrono/file-meta bars render identically. Only the layout props (flex/min-width)
+       differ, because this component lives in a .search-row rather than as a display:contents child. */
     input[type="search"],
     input[type="text"] {
       flex: 1;
       min-width: 0;
-      background: var(--bg-elevated);
+      background: var(--bg-surface);
       border: 1px solid var(--border);
       border-radius: var(--radius-sm);
       color: var(--text-primary);
-      padding: 6px 10px;
+      padding: 5px 10px;
       font-size: 13px;
     }
     input:focus { outline: none; border-color: var(--accent); }


### PR DESCRIPTION
## What

First step of the Brain **visual-consistency** pass (owner's UI-review theme). The entities tab's search bar (`app-entity-search`) had drifted from the other four tabs (`record-search-bar`):

| | before (entities) | others (4 tabs) | now |
|---|---|---|---|
| vertical padding | `6px` | `5px` | `5px` |
| background | `--bg-elevated` | `--bg-surface` | `--bg-surface` |
| max-width | `520px` | `400px` | `400px` |

All five tab bars now compute to the **same** padding / height (32px) / background / font / radius — verified in the running app.

## Changes

- `app-entity-search` input → matches the record-tabs spec (`5px 10px`, `--bg-surface`); it carries a note to stay in lockstep.
- entities bar `max-width` `520→400`.
- Removed the duplicate `.content-header input[type=search]` rule — it re-styled `record-search-bar`'s input identically to the component's own styles (a drift trap). The plain bar now has one self-contained source.

## Notes / decisions

- **Height:** kept the existing 32px (matches the "+ Add" button beside it) rather than bumping to the 34px form-control height — per owner.
- **Deferred to the broader sweep:** the entities placeholder still reads "Search entities…" vs the others' "Semantic …" — that key is shared with the name-mode entity *pickers*, so it needs a bar-only key; out of scope here.
- **Pure CSS — no behavior change.** 492 client tests green; prod build clean. Verified in an isolated instance (computed styles identical across all five tabs).

Follow-up tracked: a systematic Brain visual audit (control heights, buttons, chips/badges, spacing, empty states, light/dark parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)