### PR TITLE
feat(brain): inline the entity picker in the memory/chrono forms + drawer (Slice 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2293,6 +2293,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The entity picker in the Brain memory/chrono forms is inline now — no more click-to-open flyout.**
+  Adding entities to a memory or chrono entry (create form, inline-edit, and the detail drawer) used a
+  "+ Add…" button that popped a flyout panel with a search box and a Done button. The search
+  autocomplete now sits **inline** in the field: type to find an entity (name or semantic — defaults to
+  name, so exact IDs like `ADR002` resolve), click to link, and it stays put so you can add several in
+  a row; linked entities show as chips above it. Fewer clicks, no popover to dismiss. (File-meta's
+  pickers are unchanged — they're part of the separate File Meta rebuild.) Pure client, no API change.
 - **The Brain search bars now render identically across all five list tabs.** The entities tab's bar
   (`app-entity-search`) had drifted from the other four (`record-search-bar`): taller (`6px` vs `5px`
   vertical padding), a different fill (`--bg-elevated` vs `--bg-surface`), and wider (`520` vs `400px`

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -89,27 +89,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 </div>
                 <div class="field">
                   <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
-                  <div class="flyout-wrap">
+                  @if (picker.entityChips(chronoForm.entityIds).length) {
                     <div class="entity-multi">
                       @for (chip of picker.entityChips(chronoForm.entityIds); track chip.id) {
                         <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(chronoForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
                       }
-                      <button type="button" class="chip-add" (click)="picker.openFlyout('create-chrono-entityIds', chronoForm)">{{ 'common.addMore' | transloco }}</button>
                     </div>
-                    @if (picker.flyoutField() === 'create-chrono-entityIds') {
-                      <div class="flyout-panel">
-                        <app-entity-search
-                          mode="picker"
-                          [spaceId]="spaceId()"
-                          placeholder="common.searchEntitiesPlaceholder"
-                          (selected)="picker.pickEntity($event, chronoForm)"
-                        />
-                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                          <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                        </div>
-                      </div>
-                    }
-                  </div>
+                  }
+                  <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, chronoForm)" />
                 </div>
               </div>
               <div style="display:flex; gap:8px;">
@@ -186,28 +173,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                           </div>
                           <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                             <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
-                            <div class="flyout-wrap">
+                            @if (picker.entityChips(editChrono.entityIds).length) {
                               <div class="entity-multi">
                                 @for (chip of picker.entityChips(editChrono.entityIds); track chip.id) {
                                   <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editChrono, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
                                 }
-                                <button type="button" class="chip-add" (click)="picker.openFlyout('edit-chrono-entityIds', editChrono)">{{ 'common.addMore' | transloco }}</button>
                               </div>
-                              @if (picker.flyoutField() === 'edit-chrono-entityIds') {
-                                <div class="flyout-panel">
-                                  <app-entity-search
-                                    mode="picker"
-                                    [spaceId]="spaceId()"
-                                    placeholder="common.searchEntitiesPlaceholder"
-
-                                    (selected)="picker.pickEntity($event, editChrono)"
-                                  />
-                                  <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                                    <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                                  </div>
-                                </div>
-                              }
-                            </div>
+                            }
+                            <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, editChrono)" />
                           </div>
                           <div style="display:flex; gap:6px; align-items:flex-end;">
                             <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditChrono(entry._id)">

--- a/client/src/app/pages/brain/memories-tab.component.spec.ts
+++ b/client/src/app/pages/brain/memories-tab.component.spec.ts
@@ -88,6 +88,17 @@ describe('MemoriesTabComponent', () => {
     expect(fixture.nativeElement.querySelector('form.create-form')).toBeTruthy();
   });
 
+  // Slice 3a: the entity picker is INLINE — an app-entity-search in the form, no click-to-open flyout.
+  it('the entity picker is inline in the create form (no chip-add button / flyout panel)', () => {
+    const fixture = make();
+    fixture.componentInstance.openMemoryForm();
+    fixture.detectChanges();
+    const form = fixture.nativeElement.querySelector('form.create-form') as HTMLElement;
+    expect(form.querySelector('app-entity-search')).toBeTruthy();
+    expect(form.querySelector('.chip-add')).toBeNull();
+    expect(form.querySelector('.flyout-panel')).toBeNull();
+  });
+
   it('renders a row per memory (signal-driven view updates under OnPush)', () => {
     const fixture = make();
     // set AFTER the initial self-load settles (the effect reruns only on spaceId change)

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -73,27 +73,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 </div>
                 <div class="field">
                   <label>{{ 'common.form.entities' | transloco }}</label>
-                  <div class="flyout-wrap">
+                  @if (picker.entityChips(memoryForm.entityIds).length) {
                     <div class="entity-multi">
                       @for (chip of picker.entityChips(memoryForm.entityIds); track chip.id) {
                         <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(memoryForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
                       }
-                      <button type="button" class="chip-add" (click)="picker.openFlyout('create-memory-entityIds', memoryForm)">{{ 'common.addMore' | transloco }}</button>
                     </div>
-                    @if (picker.flyoutField() === 'create-memory-entityIds') {
-                      <div class="flyout-panel">
-                        <app-entity-search
-                          mode="picker"
-                          [spaceId]="spaceId()"
-                          placeholder="common.searchEntitiesPlaceholder"
-                          (selected)="picker.pickEntity($event, memoryForm)"
-                        />
-                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                          <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                        </div>
-                      </div>
-                    }
-                  </div>
+                  }
+                  <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, memoryForm)" />
                 </div>
                 <div class="field">
                   <label>{{ 'common.form.properties' | transloco }}</label>
@@ -158,28 +145,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                           </div>
                           <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                             <label>{{ 'common.form.entities' | transloco }}</label>
-                            <div class="flyout-wrap">
+                            @if (picker.entityChips(editMemory.entityIds).length) {
                               <div class="entity-multi">
                                 @for (chip of picker.entityChips(editMemory.entityIds); track chip.id) {
                                   <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editMemory, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
                                 }
-                                <button type="button" class="chip-add" (click)="picker.openFlyout('edit-memory-entityIds', editMemory)">{{ 'common.addMore' | transloco }}</button>
                               </div>
-                              @if (picker.flyoutField() === 'edit-memory-entityIds') {
-                                <div class="flyout-panel">
-                                  <app-entity-search
-                                    mode="picker"
-                                    [spaceId]="spaceId()"
-                                    placeholder="common.searchEntitiesPlaceholder"
-
-                                    (selected)="picker.pickEntity($event, editMemory)"
-                                  />
-                                  <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                                    <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                                  </div>
-                                </div>
-                              }
-                            </div>
+                            }
+                            <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, editMemory)" />
                           </div>
                           <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
                             <label>{{ 'common.form.properties' | transloco }}</label>

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -73,22 +73,14 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.entityIds' | transloco }}</div>
-                  <div class="flyout-wrap">
+                  @if (picker.entityChips(state.drawerEditMemory.entityIds).length) {
                     <div class="entity-multi">
                       @for (chip of picker.entityChips(state.drawerEditMemory.entityIds); track chip.id) {
                         <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(state.drawerEditMemory, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
                       }
-                      <button type="button" class="chip-add" (click)="picker.openFlyout('drawer-memory-entityIds', state.drawerEditMemory)">{{ 'common.addMore' | transloco }}</button>
                     </div>
-                    @if (picker.flyoutField() === 'drawer-memory-entityIds') {
-                      <div class="flyout-panel">
-                        <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditMemory)" />
-                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                          <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                        </div>
-                      </div>
-                    }
-                  </div>
+                  }
+                  <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditMemory)" />
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.properties' | transloco }}</div>
@@ -257,22 +249,14 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.entityIds' | transloco }}</div>
-                  <div class="flyout-wrap">
+                  @if (picker.entityChips(state.drawerEditChrono.entityIds).length) {
                     <div class="entity-multi">
                       @for (chip of picker.entityChips(state.drawerEditChrono.entityIds); track chip.id) {
                         <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(state.drawerEditChrono, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
                       }
-                      <button type="button" class="chip-add" (click)="picker.openFlyout('drawer-chrono-entityIds', state.drawerEditChrono)">{{ 'common.addMore' | transloco }}</button>
                     </div>
-                    @if (picker.flyoutField() === 'drawer-chrono-entityIds') {
-                      <div class="flyout-panel">
-                        <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditChrono)" />
-                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                          <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                        </div>
-                      </div>
-                    }
-                  </div>
+                  }
+                  <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditChrono)" />
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.memoryIds' | transloco }} <span class="drawer-muted">{{ 'common.commaSeparatedIds' | transloco }}</span></div>

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -103,7 +103,7 @@ Memories are the core knowledge unit — plain-language statements you want to r
 | **Fact** | The statement to store. Required. |
 | **Description** | Optional context or rationale. Same size as Fact. |
 | **Tags** | Comma-separated keywords for filtering. |
-| **Entities** | Click to open the entity picker. Search by name and click to link. Linked items appear as chips. |
+| **Entities** | Type in the inline entity search to find one (name or semantic) and click a result to link it — add several in a row. Linked items appear as chips above the search; click a chip's × to unlink. |
 | **Properties** | Click to open the JSON editor. Enter any key-value pairs you want to attach. |
 
 Click **Save**. The memory is indexed immediately and available for search.


### PR DESCRIPTION
## What

Brain epic **Slice 3a** — the "flyout could be inline" feedback. Linking entities to a memory or chrono entry used a **"+ Add…" button that opened a flyout panel** (search box + Done). The `app-entity-search` autocomplete now sits **inline** in the field:

- Type to find an entity (name or semantic — defaults to **name**, so exact IDs like `ADR002` resolve reliably), click a result to link it, and the input clears so you can add several in a row.
- Linked entities render as chips **above** the search; click a chip's × to unlink.
- Fewer clicks, no popover to dismiss.

## Scope

Converted all six memory/chrono entity-chip sites: **memories** create + inline-edit, **chrono** create + inline-edit, and the **detail drawer** (memory + chrono). `pickEntity`/`removeEntityId`/`entityChips`/`entityNameCache` are unchanged — only the trigger moved inline.

- **File-meta pickers untouched** — part of the separate File Meta rebuild (Slice 4); the picker service's `flyoutField`/`openFlyout` stay for them.
- **Slice 3b (edges from/to "no button")** — grounded as *already satisfied* (from/to are button-less autocompletes); nothing to do.
- **Slice 3c (chrono `memoryIds` picker)** — separate follow-up (API already accepts the field).

## Verification

- Pure client, no API change.
- **493 client tests green** — added a guard that the create form renders the inline `app-entity-search` with **no** `.chip-add` / `.flyout-panel`. Prod build clean.
- **E2E on an isolated instance**: memories + chrono create forms show the inline picker, zero chip-add buttons / flyout panels, zero NG/zone console errors.
- Doc (`userguide.md`) + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)