### PR TITLE
feat(brain): searchable memory picker for chrono entries (Slice 3c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Chrono entries can link memories through a searchable picker.** A chrono entry could already carry
+  `memoryIds` (the API accepted them and the detail drawer round-tripped them), but the only UI was a
+  raw comma-separated-ID **textarea** in the drawer — you had to paste ids by hand — and the create
+  form had no memory field at all. Both now use an **inline memory picker** (matching the entity one,
+  per "memoryids searchable like entity"): type to find a memory by its fact, click to link it, linked
+  memories show as chips with their fact (resolved even for ids not in the loaded list). Wired into the
+  chrono create and drawer-edit save paths; reuses the existing chrono `memoryIds` API field (no route
+  change).
 - **Copy a whole space's schema into the Schema Library in one step — and import an exported space
   schema file into the library.** Auto-grouping a whole space's `typeSchemas` into reusable library
   entries already existed, but only on the Schema Library page — so it was easy to miss when looking

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -385,6 +385,8 @@
   "brain.chrono.form.kind": "Art",
   "brain.chrono.form.customKind": "Brauch…",
   "brain.chrono.form.startsAt": "Beginnt um",
+  "brain.chrono.form.memories": "Erinnerungen",
+  "brain.chrono.form.searchMemories": "Erinnerungen zum Verknüpfen suchen…",
   "brain.chrono.form.endsAt": "Endet um (optional)",
   "brain.chrono.form.backToPresets": "Zurück zu den Voreinstellungen",
   "brain.chrono.table.title": "Titel",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -385,6 +385,8 @@
   "brain.chrono.form.kind": "Kind",
   "brain.chrono.form.customKind": "Custom…",
   "brain.chrono.form.startsAt": "Starts at",
+  "brain.chrono.form.memories": "Memories",
+  "brain.chrono.form.searchMemories": "Search memories to link…",
   "brain.chrono.form.endsAt": "Ends at (optional)",
   "brain.chrono.form.backToPresets": "Back to presets",
   "brain.chrono.table.title": "Title",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -385,6 +385,8 @@
   "brain.chrono.form.kind": "Uprzejmy",
   "brain.chrono.form.customKind": "Zwyczaj…",
   "brain.chrono.form.startsAt": "Zaczyna się o",
+  "brain.chrono.form.memories": "Wspomnienia",
+  "brain.chrono.form.searchMemories": "Szukaj wspomnień do powiązania…",
   "brain.chrono.form.endsAt": "Kończy się o (opcjonalnie)",
   "brain.chrono.form.backToPresets": "Powrót do ustawień wstępnych",
   "brain.chrono.table.title": "Tytuł",

--- a/client/src/app/pages/brain/brain-form.styles.ts
+++ b/client/src/app/pages/brain/brain-form.styles.ts
@@ -40,6 +40,21 @@ export const BRAIN_CHIP_STYLES = `
       color: var(--text-muted); cursor: pointer;
     }
     .chip-add:hover { border-color: var(--accent); color: var(--accent); }
+    /* Inline memory picker (chrono form + drawer, slice 3c): input + absolute results dropdown. */
+    .mem-pick { position: relative; }
+    .mem-pick-menu {
+      position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 60;
+      background: var(--bg-surface); border: 1px solid var(--border);
+      border-radius: var(--radius-md); box-shadow: var(--shadow-lg);
+      max-height: 200px; overflow-y: auto;
+    }
+    .mem-pick-item {
+      display: block; width: 100%; text-align: left; padding: 6px 10px;
+      background: transparent; border: none; border-bottom: 1px solid var(--border-muted);
+      color: var(--text-primary); font-size: 12px; cursor: pointer;
+    }
+    .mem-pick-item:last-child { border-bottom: none; }
+    .mem-pick-item:hover { background: var(--bg-elevated); }
 `;
 
 /** The detail drawer's own layout (overlay, panel, header, fields, read-only rows). Drawer-only. */

--- a/client/src/app/pages/brain/chrono-tab.component.spec.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.spec.ts
@@ -94,7 +94,7 @@ describe('ChronoTabComponent', () => {
 
   it('createChrono resolves a __custom__ kind to the free-text customKind and ISO-encodes startsAt', () => {
     const c = make().componentInstance;
-    c.chronoForm = { title: 'T', kind: '__custom__', customKind: ' launch ', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '' };
+    c.chronoForm = { title: 'T', kind: '__custom__', customKind: ' launch ', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
     c.createChrono();
     const [, body] = api.createChrono.mock.calls[0];
     expect(body.title).toBe('T');
@@ -103,9 +103,21 @@ describe('ChronoTabComponent', () => {
     expect('endsAt' in body).toBe(false);
   });
 
+  // Slice 3c: linked memoryIds (from the inline memory picker) ride the create payload; omitted when empty.
+  it('createChrono includes memoryIds when the memory picker has linked some (omitted when empty)', () => {
+    const c = make().componentInstance;
+    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: ['m1', 'm2'] };
+    c.createChrono();
+    expect(api.createChrono.mock.calls[0][1].memoryIds).toEqual(['m1', 'm2']);
+    api.createChrono.mockClear();
+    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+    c.createChrono();
+    expect('memoryIds' in api.createChrono.mock.calls[0][1]).toBe(false);
+  });
+
   it('createChrono is a no-op without a title or startsAt', () => {
     const c = make().componentInstance;
-    c.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '' };
+    c.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
     c.createChrono();
     expect(api.createChrono).not.toHaveBeenCalled();
   });
@@ -114,7 +126,7 @@ describe('ChronoTabComponent', () => {
     const c = make().componentInstance;
     c.store.chrono.set([{ _id: 'c1' } as ChronoEntry]);
     c.recordList.editingId.set('c1');
-    c.editChrono = { title: 'T', kind: '__custom__', status: 'active', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '' };
+    c.editChrono = { title: 'T', kind: '__custom__', status: 'active', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
     c.saveEditChrono('c1');
     const [, , body] = api.updateChrono.mock.calls[0];
     expect(body.type).toBe('__custom__'); // sent verbatim, unlike createChrono

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -98,6 +98,26 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                   }
                   <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, chronoForm)" />
                 </div>
+                <div class="field">
+                  <label>{{ 'brain.chrono.form.memories' | transloco }}</label>
+                  @if (chronoForm.memoryIds.length) {
+                    <div class="entity-multi">
+                      @for (id of chronoForm.memoryIds; track id) {
+                        <span class="chip" [title]="id"><span class="chip-name">{{ picker.memoryRefTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeMemoryRef(chronoForm, id)"><ph-icon name="x" [size]="12"/></button></span>
+                      }
+                    </div>
+                  }
+                  <div class="mem-pick">
+                    <input type="search" [value]="picker.memPickQuery()" (input)="picker.onMemPickInput($any($event.target).value)" [placeholder]="'brain.chrono.form.searchMemories' | transloco" [attr.aria-label]="'brain.chrono.form.searchMemories' | transloco" />
+                    @if (picker.memPickResults().length) {
+                      <div class="mem-pick-menu">
+                        @for (mem of picker.memPickResults(); track mem._id) {
+                          <button type="button" class="mem-pick-item" (mousedown)="picker.addMemoryRef(chronoForm, mem)">{{ mem.fact.slice(0, 90) }}{{ mem.fact.length > 90 ? '…' : '' }}</button>
+                        }
+                      </div>
+                    }
+                  </div>
+                </div>
               </div>
               <div style="display:flex; gap:8px;">
                 <button class="btn-primary btn btn-sm" type="submit" [disabled]="creatingChrono() || !chronoForm.title.trim() || !chronoForm.startsAt || (chronoForm.kind === '__custom__' && !chronoForm.customKind.trim())">
@@ -264,8 +284,8 @@ export class ChronoTabComponent extends RecordTabBase {
   showChronoForm = signal(false);
   creatingChrono = signal(false);
   createChronoError = signal('');
-  chronoForm = { title: '', kind: 'event' as ChronoType | '__custom__', customKind: '', startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '' };
-  editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '' };
+  chronoForm = { title: '', kind: 'event' as ChronoType | '__custom__', customKind: '', startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[] };
+  editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[] };
 
   private _chronoSemTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -336,7 +356,7 @@ export class ChronoTabComponent extends RecordTabBase {
   }
 
   openChronoForm(): void {
-    this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '' };
+    this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
     this.showChronoForm.set(true);
   }
 
@@ -359,11 +379,12 @@ export class ChronoTabComponent extends RecordTabBase {
     if (this.chronoForm.description.trim()) body.description = this.chronoForm.description.trim();
     if (this.chronoForm.tags.length) body.tags = this.chronoForm.tags;
     if (entityIds.length) body.entityIds = entityIds;
+    if (this.chronoForm.memoryIds.length) body.memoryIds = this.chronoForm.memoryIds;
     this.brainApi.createChrono(this.spaceId(), body).subscribe({
       next: () => {
         this.creatingChrono.set(false);
         this.showChronoForm.set(false);
-        this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '' };
+        this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
         this.load();
       },
       error: (err) => { this.creatingChrono.set(false); this.createChronoError.set(fmtApiError(err, 'Failed to create chrono entry')); },
@@ -382,7 +403,9 @@ export class ChronoTabComponent extends RecordTabBase {
       description: entry.description ?? '',
       tags: entry.tags ?? [],
       entityIds: (entry.entityIds ?? []).join(', '),
+      memoryIds: [...(entry.memoryIds ?? [])],
     };
+    this.picker.resolveMemoryTitles(entry.memoryIds ?? []);
   }
 
   saveEditChrono(id: string): void {
@@ -397,6 +420,7 @@ export class ChronoTabComponent extends RecordTabBase {
       description: this.editChrono.description.trim(),
       tags: this.editChrono.tags,
       entityIds: this.editChrono.entityIds.split(',').map(s => s.trim()).filter(Boolean),
+      memoryIds: this.editChrono.memoryIds,
     }).subscribe({
       next: (updated) => {
         this.recordList.editSaving.set(false);

--- a/client/src/app/pages/brain/entity-ref-picker.service.ts
+++ b/client/src/app/pages/brain/entity-ref-picker.service.ts
@@ -200,4 +200,59 @@ export class EntityRefPicker {
     const c = this.store.chrono().find(c => c._id === id);
     return c ? c.title.slice(0, 40) + (c.title.length > 40 ? '…' : '') : id.slice(0, 8) + '…';
   }
+
+  // ── Inline memory picker (chrono form; slice 3c "memoryIds searchable like entity") ──────────
+  //
+  // Kept separate from the file-meta `fm*` memory picker above (file-meta rides its own flyout and is
+  // rebuilt in slice 4); these back an INLINE search + a title cache so chips show the memory's fact,
+  // not a truncated id. Reused by the chrono create form and the drawer's chrono edit (never both open
+  // at once). Search is a fact substring, mirroring the file-meta picker.
+
+  memPickQuery = signal('');
+  memPickResults = signal<Memory[]>([]);
+  private _memPickTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Memory id → full fact, for chip display (fed on pick and by `resolveMemoryTitles`). */
+  memoryTitleCache = signal<Record<string, string>>({});
+
+  onMemPickInput(q: string): void {
+    this.memPickQuery.set(q);
+    if (this._memPickTimer) clearTimeout(this._memPickTimer);
+    if (!q.trim()) { this.memPickResults.set([]); return; }
+    this._memPickTimer = setTimeout(() => {
+      this.brainApi.listMemories(this.spaceId(), 8, 0, {}, undefined, q).subscribe({
+        next: ({ memories }) => this.memPickResults.set(memories.slice(0, 6)),
+        error: () => {},
+      });
+    }, 300);
+  }
+
+  /** Cache the picked memory's fact for chip display, append its id to the form, and clear the search. */
+  addMemoryRef(form: { memoryIds: string[] }, mem: Memory): void {
+    this.memoryTitleCache.update(c => ({ ...c, [mem._id]: mem.fact }));
+    if (!form.memoryIds.includes(mem._id)) form.memoryIds.push(mem._id);
+    this.memPickQuery.set('');
+    this.memPickResults.set([]);
+  }
+
+  removeMemoryRef(form: { memoryIds: string[] }, id: string): void {
+    form.memoryIds = form.memoryIds.filter(m => m !== id);
+  }
+
+  /** Chip label for a linked memory: cached fact → loaded list → truncated id, trimmed for display. */
+  memoryRefTitle(id: string): string {
+    const full = this.memoryTitleCache()[id] ?? this.store.memories().find(m => m._id === id)?.fact;
+    return full ? full.slice(0, 40) + (full.length > 40 ? '…' : '') : id.slice(0, 8) + '…';
+  }
+
+  /** Resolve the uncached facts of a memoryIds list (opening a record for editing). Small N → per-id. */
+  resolveMemoryTitles(ids: string[]): void {
+    const spaceId = this.spaceId();
+    if (!spaceId) return;
+    for (const id of ids.filter(i => !this.memoryTitleCache()[i])) {
+      this.brainApi.getMemory(spaceId, id).subscribe({
+        next: (m) => this.memoryTitleCache.update(c => ({ ...c, [m._id]: m.fact })),
+        error: () => {},
+      });
+    }
+  }
 }

--- a/client/src/app/pages/brain/record-drawer-state.service.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.ts
@@ -37,7 +37,7 @@ export class RecordDrawerState {
   drawerEditMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEdge = { label: '', type: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
-  drawerEditChrono = { title: '', kind: 'event' as string, customKind: '', status: 'upcoming' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', confidence: null as number | null, memoryIds: '' };
+  drawerEditChrono = { title: '', kind: 'event' as string, customKind: '', status: 'upcoming' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', confidence: null as number | null, memoryIds: [] as string[] };
 
   /** Re-seed a drawer entity's properties when its type changes (mirrors the create/inline forms). */
   onEntityTypeChange(type: string): void {
@@ -88,8 +88,9 @@ export class RecordDrawerState {
         tags: [...(record.tags ?? [])],
         entityIds: (record.entityIds ?? []).join(', '),
         confidence: record.confidence ?? null,
-        memoryIds: (record.memoryIds ?? []).join(', '),
+        memoryIds: [...(record.memoryIds ?? [])],
       };
+      this.picker.resolveMemoryTitles(record.memoryIds ?? []);
     }
   }
 
@@ -168,7 +169,7 @@ export class RecordDrawerState {
         description: this.drawerEditChrono.description.trim(),
         tags: this.drawerEditChrono.tags,
         entityIds: this.drawerEditChrono.entityIds.split(',').map(s => s.trim()).filter(Boolean),
-        ...(this.drawerEditChrono.memoryIds.trim() ? { memoryIds: this.drawerEditChrono.memoryIds.split(',').map(s => s.trim()).filter(Boolean) } : {}),
+        ...(this.drawerEditChrono.memoryIds.length ? { memoryIds: this.drawerEditChrono.memoryIds } : {}),
         ...(this.drawerEditChrono.confidence != null ? { confidence: this.drawerEditChrono.confidence } : {}),
       }).subscribe({
         next: (updated) => {

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -259,8 +259,24 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                   <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditChrono)" />
                 </div>
                 <div class="drawer-field">
-                  <div class="drawer-label">{{ 'common.memoryIds' | transloco }} <span class="drawer-muted">{{ 'common.commaSeparatedIds' | transloco }}</span></div>
-                  <textarea [(ngModel)]="state.drawerEditChrono.memoryIds" name="drwChronoMemIds" rows="2" style="font-family:var(--font-mono,monospace); font-size:11px;"></textarea>
+                  <div class="drawer-label">{{ 'common.memoryIds' | transloco }}</div>
+                  @if (state.drawerEditChrono.memoryIds.length) {
+                    <div class="entity-multi">
+                      @for (id of state.drawerEditChrono.memoryIds; track id) {
+                        <span class="chip" [title]="id"><span class="chip-name">{{ picker.memoryRefTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeMemoryRef(state.drawerEditChrono, id)"><ph-icon name="x" [size]="12"/></button></span>
+                      }
+                    </div>
+                  }
+                  <div class="mem-pick">
+                    <input type="search" [value]="picker.memPickQuery()" (input)="picker.onMemPickInput($any($event.target).value)" [placeholder]="'brain.chrono.form.searchMemories' | transloco" [attr.aria-label]="'brain.chrono.form.searchMemories' | transloco" />
+                    @if (picker.memPickResults().length) {
+                      <div class="mem-pick-menu">
+                        @for (mem of picker.memPickResults(); track mem._id) {
+                          <button type="button" class="mem-pick-item" (mousedown)="picker.addMemoryRef(state.drawerEditChrono, mem)">{{ mem.fact.slice(0, 90) }}{{ mem.fact.length > 90 ? '…' : '' }}</button>
+                        }
+                      </div>
+                    }
+                  </div>
                 </div>
                 <hr class="drawer-hr">
                 <div class="drawer-field">

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -164,7 +164,7 @@ When a **label** is selected and the space has a schema defined for that label, 
 
 Chrono stores time-anchored entries: events, deadlines, plans, predictions, and milestones.
 
-**Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, and linked entities.
+**Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, linked **entities**, and linked **memories** — the memory field is a searchable picker (type to find a memory by its fact and click to link it; linked memories show as chips). The same memory picker is available when editing an entry in its detail drawer.
 
 **Searching:** The top search bar is **Semantic** (ranks entries by meaning). Plain-text matching (title / description) is the **freetext box under the Title column**.
 


### PR DESCRIPTION
## What

Brain epic **Slice 3c** — *"memoryids searchable like entity."* A chrono entry could already carry `memoryIds` (the API accepted them; the detail drawer round-tripped them), but the only UI was a **raw comma-separated-ID textarea** in the drawer (paste ids by hand), and the create form had **no memory field at all**. Both now use an **inline memory picker** matching the entity one.

## Changes

- **`entity-ref-picker`**: inline memory picker (`memPickQuery`/`memPickResults`/`onMemPickInput` — substring fact search via the memories list endpoint) + a **`memoryTitleCache`** so chips show the memory's *fact*, not a truncated id. `addMemoryRef` caches the fact on pick; `resolveMemoryTitles` fills labels for a record's existing `memoryIds` on open. Kept separate from file-meta's `fm*` picker (that's rebuilt in Slice 4).
- **chrono create form**: new **Memories** field (chips + inline search) beside Entities; `memoryIds` threaded into `chronoForm` and `createChrono`/`updateChrono`.
- **drawer chrono edit**: replaced the raw ID textarea with the same picker; `drawerEditChrono.memoryIds` is now `string[]` (resolved on open, sent on save).
- Shared `.mem-pick` dropdown styles live in `BRAIN_CHIP_STYLES` (both surfaces).

## Slice 3 status

Complete: **3a** inline entity picker (#386), **3b** edges from/to were already button-less autocompletes (no-op), **3c** this PR.

## Verification

- Pure client — reuses the existing chrono `memoryIds` API field, **no route change**.
- **494 client tests green** (added a createChrono `memoryIds` wiring test); prod build clean.
- **E2E on an isolated instance**: chrono create form shows the inline memory picker (no raw textarea), typing fires the memory search (`/memories?search=`), 0 NG/zone console errors.
- i18n en/de/pl; `userguide.md` + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)