### PR TITLE
feat(brain): sortable headers + tag column filter for the File Meta list (Slice 4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2301,6 +2301,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain File Meta list gets sortable headers and a tag column filter, like the other list tabs.**
+  The files list endpoint already supported `?sort=` (path / updatedAt / createdAt) and a `?tag=` filter
+  server-side, but the client never wired them and the table used plain headers. File Meta now has
+  `app-sort-th` headers on **Path** and **Updated** and a docked **Tags** filter, threaded through
+  `listFileMeta` (client-only — no server change). First step of the File Meta rebuild; a freetext
+  column filter + semantic top bar + edit-surface redo follow.
 - **The entity picker in the Brain memory/chrono forms is inline now — no more click-to-open flyout.**
   Adding entities to a memory or chrono entry (create form, inline-edit, and the detail drawer) used a
   "+ Add…" button that popped a flyout panel with a search box and a Done button. The search

--- a/client/src/app/core/files-api.service.ts
+++ b/client/src/app/core/files-api.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams, HttpHeaders } from '@angular/common/http';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import type { FileEntry, FileMeta, UploadProgress, ConflictRecord } from './api.types';
+import type { ListSort } from './brain-api.service';
 
 /** File store (listing, upload, download), brain file-metadata, and sync file conflicts. */
 @Injectable({ providedIn: 'root' })
@@ -147,9 +148,12 @@ export class FilesApi {
 
   // ── File metadata (brain) ─────────────────────────────────────────────────
 
-  listFileMeta(spaceId: string, limit = 50, skip = 0, search?: string): Observable<{ files: FileMeta[]; limit: number; skip: number }> {
+  listFileMeta(spaceId: string, limit = 50, skip = 0, filters?: { search?: string; tag?: string }, sort?: ListSort): Observable<{ files: FileMeta[]; limit: number; skip: number }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
-    if (search) params = params.set('path', search);
+    // `search` maps to the server's `path` filter for now (exact-ish); slice 4b adds a real freetext `?search=`.
+    if (filters?.search) params = params.set('path', filters.search);
+    if (filters?.tag) params = params.set('tag', filters.tag);
+    if (sort) params = params.set('sort', sort.field).set('dir', sort.dir);
     return this.http.get<{ files: FileMeta[]; limit: number; skip: number }>(`/api/brain/spaces/${spaceId}/files`, { params });
   }
 

--- a/client/src/app/pages/brain/filemeta-tab.component.spec.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.spec.ts
@@ -46,9 +46,19 @@ describe('FilemetaTabComponent', () => {
     expect(FilemetaTabComponent.ɵcmp?.onPush).toBe(true);
   });
 
-  it('self-loads on the spaceId input (files API, no search term)', () => {
+  it('self-loads on the spaceId input (files API, no filters/sort)', () => {
     make();
-    expect(filesApi.listFileMeta).toHaveBeenCalledWith('work', 20, 0, undefined);
+    expect(filesApi.listFileMeta).toHaveBeenCalledWith('work', 20, 0, {}, undefined);
+  });
+
+  // Slice 4a: file-meta list wires the (already server-supported) sort + tag column filter.
+  it('sort + tag column filter flow through to the files list endpoint', () => {
+    const c = make().componentInstance;
+    filesApi.listFileMeta.mockClear();
+    c.setTagFilter('code');
+    expect(filesApi.listFileMeta).toHaveBeenLastCalledWith('work', 20, 0, { tag: 'code' }, undefined);
+    c.setSort('updatedAt'); // first click → desc
+    expect(filesApi.listFileMeta).toHaveBeenLastCalledWith('work', 20, 0, { tag: 'code' }, { field: 'updatedAt', dir: 'desc' });
   });
 
   it('saveEditFileMeta sends description/tags/entityIds/memoryIds/chronoIds and clears editingId', () => {

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -13,6 +13,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { StepProgressBarComponent } from '../../shared/step-progress-bar.component';
 import { RecordTabBase } from './record-tab-base';
 import { RecordSearchBarComponent } from './record-search-bar.component';
+import { SortableHeaderComponent } from './sortable-header.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
@@ -31,7 +32,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-filemeta-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, StepProgressBarComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, StepProgressBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
           <div class="content-header">
@@ -48,14 +49,17 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
               <table>
                 <thead>
                   <tr>
-                    <th>{{ 'brain.fileMeta.table.path' | transloco }}</th>
+                    <th app-sort-th field="path" label="brain.fileMeta.table.path" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
                     <th>{{ 'brain.fileMeta.table.description' | transloco }}</th>
-                    <th>{{ 'brain.fileMeta.table.tags' | transloco }}</th>
+                    <th app-sort-th label="brain.fileMeta.table.tags">
+                      <input class="col-filter-input" type="text" [ngModel]="recordFilter().tag" (ngModelChange)="setTagFilter($event)"
+                        [placeholder]="'brain.filter.tagPlaceholder' | transloco" [attr.aria-label]="'brain.filter.tagPlaceholder' | transloco" />
+                    </th>
                     <th>{{ 'brain.fileMeta.table.entities' | transloco }}</th>
                     <th>{{ 'brain.fileMeta.table.memories' | transloco }}</th>
                     <th>{{ 'brain.fileMeta.table.chrono' | transloco }}</th>
                     <th>{{ 'brain.fileMeta.table.size' | transloco }}</th>
-                    <th>{{ 'brain.fileMeta.table.updated' | transloco }}</th>
+                    <th app-sort-th field="updatedAt" label="brain.fileMeta.table.updated" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
                     <th>{{ 'brain.fileMeta.table.actions' | transloco }}</th>
                   </tr>
                 </thead>
@@ -249,14 +253,19 @@ export class FilemetaTabComponent extends RecordTabBase {
   retryingEmbedding = signal<Set<string>>(new Set());
   editFileMeta = { description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[], chronoIds: [] as string[] };
 
-  // No resetOnSpaceChange override: file-meta has no filter bar, so the base's skip reset is enough.
+  protected override resetOnSpaceChange(): void {
+    this.recordFilter.set({ type: '', tag: '' });
+  }
 
   protected override load(): void {
     const spaceId = this.spaceId();
     if (!spaceId) return;
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
-    this.filesApi.listFileMeta(spaceId, this.pageSize, this.skip(), this.store.fileMetaSearch() || undefined).subscribe({
+    const filters: { search?: string; tag?: string } = {};
+    if (this.store.fileMetaSearch()) filters.search = this.store.fileMetaSearch();
+    if (this.recordFilter().tag) filters.tag = this.recordFilter().tag;
+    this.filesApi.listFileMeta(spaceId, this.pageSize, this.skip(), filters, this.sortParam()).subscribe({
       next: ({ files }) => { this.store.fileMetas.set(files); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -215,6 +215,8 @@ The **File Meta** tab lists the metadata records Ythril keeps for uploaded files
 
 Each row can be opened inline to edit its links: you can attach **entities**, **memories**, and **chrono** entries to a file so it surfaces alongside related knowledge. Opening a file from the Files tab's metadata action jumps you straight to its File Meta entry.
 
+Sort by clicking the **Path** or **Updated** column headers (server-side, across the whole list), and narrow by tag with the filter box docked under the **Tags** header — the same header controls the other Brain list tabs use.
+
 ---
 
 ## Graph


### PR DESCRIPTION
## What

First step of the **File Meta rebuild** (Slice 4). The files list endpoint already supported `?sort=` (path / updatedAt / createdAt, from slice 2a) and a `?tag=` filter server-side, but the client never wired them and the table used plain headers — so File Meta lagged the other Brain list tabs.

## Changes (client-only — no server change)

- `files-api.listFileMeta`: now accepts `filters?: { search?; tag? }` + `sort?: ListSort`. (`search` still maps to the exact `?path=` for now; a real freetext `?search=` is slice 4c.)
- `filemeta-tab`: adopts `record-tab-base`'s `sortField`/`setSort` + `recordFilter`/`setTagFilter`; **`app-sort-th`** headers on **Path** and **Updated**; a docked **Tags** filter; resets the tag filter on space change. `load()` threads sort + tag.

## Scope

- **No regression** — the top bar is untouched this slice; its semantic + freetext-column rebuild is slices 4b/4c, and the edit-surface redo is 4d.

## Verification

- **495 client tests green** (added a test that sort + tag flow through to `listFileMeta`); prod build clean.
- No E2E screenshot: the File Meta table only renders with ingested files (can't seed without embeddings in the scratch stack), and this reuses the `app-sort-th` primitive already E2E-proven on the other tabs.
- Doc (`userguide.md` File Meta section) + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)