### PR TITLE
fix(spaces): space-settings panel no longer discards edits on a backdrop click (B1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1500,6 +1500,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The space-settings panel no longer discards your edits on a stray click outside it.** Clicking the
+  backdrop closed the panel and threw away everything typed. The close guard *did* exist but keyed off
+  `isDirty()`, which only sees **committed** schema state (`buildMeta()`) — so half-typed, not-yet-added
+  schema inputs (a new type/property name, enum values) were invisible to it and vanished on a backdrop
+  misclick with no confirm. The panel now uses the shared `ModalDirective` with backdrop-dismissal
+  **off** (the same guard other data-entry dialogs use): a click outside does nothing; close via ✕ /
+  Cancel / Escape, which still run the unsaved-changes confirm. Also brings the panel a focus trap,
+  Escape handling, and dialog aria for free. Verified end-to-end (a typed-but-uncommitted schema input
+  survives a backdrop click).
 - **The external-assist "Document repair pass" pill said "In use" the moment you ticked the task,
   even with no assist model configured.** The pill keyed off the `uses` toggle alone, so toggling
   "repair" on with an empty Endpoint/Model still read "In use" — claiming an inoperable feature was

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -24,6 +24,7 @@ import { SpaceSettingsTabComponent } from './space-settings-tab.component';
 import { SpaceDuplicatesTabComponent } from './space-duplicates-tab.component';
 import { SpaceDangerTabComponent } from './space-danger-tab.component';
 import { SpaceSchemaTabComponent } from './space-schema-tab.component';
+import { ModalDirective } from '../../shared/modal.directive';
 import { SpaceCreateDialogComponent } from './space-create-dialog.component';
 
 @Component({
@@ -31,7 +32,7 @@ import { SpaceCreateDialogComponent } from './space-create-dialog.component';
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, DragDropModule, PhIconComponent, SummaryStripComponent,
     SpaceSettingsTabComponent, SpaceDuplicatesTabComponent, SpaceDangerTabComponent, SpaceSchemaTabComponent,
-    SpaceCreateDialogComponent],
+    SpaceCreateDialogComponent, ModalDirective],
   // Provided here (not root) so each mount gets its own settings state, with a lifetime tied to
   // this component rather than the app.
   providers: [SpacesStore, SpaceSettingsState],
@@ -45,8 +46,8 @@ import { SpaceCreateDialogComponent } from './space-create-dialog.component';
 
     <!-- SETTINGS POPUP -->
     @if (state.settingsSpace()) {
-      <div class="sp-backdrop" (click)="attemptClose()">
-        <div class="sp-panel" (click)="$event.stopPropagation()">
+      <div class="sp-backdrop">
+        <div class="sp-panel" [appModal]="state.settingsSpace()!.label" (dismiss)="attemptClose()">
           <div class="sp-header">
             <div style="flex:1;min-width:0;">
               <div style="font-weight:600;font-size:16px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ state.settingsSpace()!.label }}</div>

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -369,7 +369,7 @@ Click **Create New Space**. Fill in:
 
 ### Space settings
 
-Click the gear icon on any space row to open its settings panel. Changes save and close automatically.
+Click the gear icon on any space row to open its settings panel. Changes save and close automatically. An accidental click **outside** the panel won't close it (so you can't lose half-typed edits that way) — close it deliberately with **✕**, **Cancel**, or **Escape**; if you have unsaved changes you'll be asked to confirm.
 
 **Settings tab:** Update the display name, purpose, usage notes for AI assistants, storage quota, auto-delete window, and document-extraction mode — grouped into **Identity**, **Purpose**, **Limits**, and **Document extraction** cards. A blank storage quota, auto-delete window, or extraction override shows an **Unlimited** / **No auto-delete** / **Instance default** pill so the default is unmistakable.
 


### PR DESCRIPTION
## What (data-loss bug)

Clicking the **backdrop** of the space-settings panel closed it and **discarded everything typed**. The close guard existed but keyed off `isDirty()`, which compares *committed* schema state (`buildMeta()`) — so half-typed, **not-yet-added** schema inputs (a new type/property name, enum values) were invisible to it and vanished on a backdrop misclick, no confirm.

## Fix (owner-decided: option b, the reusable element)

The panel now uses the shared **`ModalDirective`** with backdrop-dismissal **off** — a click outside does nothing; close deliberately via **✕ / Cancel / Escape**, which still run `attemptClose()`'s unsaved-changes confirm. Removed the hand-rolled `<div class="sp-backdrop" (click)="attemptClose()">` handler and the now-dead panel `(click)="$event.stopPropagation()"`. Also brings a **focus trap**, Escape handling, and dialog `role`/`aria` for free.

## Verification

- Directive behaviour (backdrop-no-close-by-default, Escape-dismisses) is already unit-tested in `modal.directive.spec.ts`; this is trivial wiring on top.
- **495 client tests green**; prod build clean.
- **E2E on an isolated instance:** open a space's settings → Schema tab → type an uncommitted new-type name → click the backdrop → panel **stays open** and the input is **preserved** (0 NG/zone errors).
- `userguide.md` (Space settings) + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)