### PR TITLE
feat(brain): files list freetext ?search= (Slice 4b, server)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The File Meta list endpoint gains a freetext `?search=`.** `GET /api/brain/spaces/:id/files` now
+  accepts a `?search=<text>` that matches a case-insensitive **substring** of a file record's `path` +
+  `description`, applied server-side before pagination (spans the whole list) and escaped as a literal —
+  the same builder (`textSearchOr` / `SEARCHABLE_FIELDS.files`) the other brain list endpoints use
+  (2b-iii-a). Distinct from the existing exact `?path=` filter. Groundwork for the File Meta list's
+  docked freetext column filter (client wiring follows); char-tested (unit + DB harness).
 - **Chrono entries can link memories through a searchable picker.** A chrono entry could already carry
   `memoryIds` (the API accepted them and the detail drawer round-tripped them), but the only UI was a
   raw comma-separated-ID **textarea** in the drawer — you had to paste ids by hand — and the create

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1201,8 +1201,8 @@ With no `sort` the endpoint keeps its existing default order (entities: insertio
 
 #### Freetext search (`?search=`)
 
-The entities, edges, memories and chrono list endpoints accept an optional `?search=<text>` that
-matches a **case-insensitive substring** of the record's text fields, applied server-side before
+The entities, edges, memories, chrono and file-meta list endpoints accept an optional `?search=<text>`
+that matches a **case-insensitive substring** of the record's text fields, applied server-side before
 pagination (so it spans the whole set, like sort). The value is treated as a **literal** — regex
 metacharacters are escaped, so `a.b` matches the three characters `a.b`, not "a, any char, b".
 
@@ -1212,9 +1212,10 @@ metacharacters are escaped, so `a.b` matches the three characters `a.b`, not "a,
 | edges | `label`, `description` |
 | memories | `fact`, `description` |
 | chrono | `title`, `description` |
+| files | `path`, `description` |
 
-(Files use their own `path` filter; entities also keep the exact `?name=` filter and the semantic
-`/entities/by-name` endpoint.)
+(Files also keep their exact `?path=` filter — distinct from this substring `?search=`; entities keep
+the exact `?name=` filter and the semantic `/entities/by-name` endpoint.)
 
 ---
 

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -20,6 +20,7 @@ import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { fetchJobProgress } from '../../files/media/job-queue.js';
@@ -79,6 +80,10 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   if (!includeChunks) filter['parentFileId'] = { $exists: false };
   if (typeof req.query['tag'] === 'string') filter['tags'] = req.query['tag'];
   if (typeof req.query['path'] === 'string') filter['path'] = toDocId(req.query['path']);
+  // Freetext substring over path + description (escaped, mirrors 2b-iii-a on the other collections).
+  // Distinct from the exact `?path=` filter above; the client's docked freetext box feeds this.
+  const search = textSearchOr(req.query['search'] as string | undefined, SEARCHABLE_FIELDS.files);
+  if (search) Object.assign(filter, search);
   const all = await collectAcrossMembers(spaceId, async mid => {
     const files = await col(`${mid}_files`)
       .find(asFilter(filter))

--- a/server/src/brain/text-search.ts
+++ b/server/src/brain/text-search.ts
@@ -18,6 +18,7 @@ export const SEARCHABLE_FIELDS = {
   edges: ['label', 'description'],
   memories: ['fact', 'description'],
   chrono: ['title', 'description'],
+  files: ['path', 'description'],
 } as const;
 
 /**

--- a/testing/standalone/brain-text-search-db.test.js
+++ b/testing/standalone/brain-text-search-db.test.js
@@ -18,7 +18,7 @@ import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness
 const skip = await mongoSkipReason();
 const SPACE = 'general';
 
-let mongo, listEntities, textSearchOr, entities;
+let mongo, listEntities, textSearchOr, SEARCHABLE_FIELDS, entities, files;
 
 async function insertEntity(_id, name, description = '') {
   await entities.insertOne({ _id, spaceId: SPACE, name, description, type: 'x', createdAt: '2026-01-01T00:00:00.000Z', seq: 1 });
@@ -42,11 +42,12 @@ describe('brain freetext search — against a real MongoDB', { skip }, () => {
   before(async () => {
     mongo = await openTestMongo('braintextsearch');
     ({ listEntities } = await import('../../server/dist/brain/entities.js'));
-    ({ textSearchOr } = await import('../../server/dist/brain/text-search.js'));
+    ({ textSearchOr, SEARCHABLE_FIELDS } = await import('../../server/dist/brain/text-search.js'));
     entities = mongo.col(`${SPACE}_entities`);
+    files = mongo.col(`${SPACE}_files`);
   });
   after(async () => { await closeTestMongo(); });
-  beforeEach(async () => { await entities.deleteMany({}); });
+  beforeEach(async () => { await entities.deleteMany({}); await files.deleteMany({}); });
 
   it('matches a substring across a PAGE BOUNDARY, not just the visible page', async () => {
     // Six names contain "ana"; page size 2 → three pages. A page-only filter would miss the rest.
@@ -89,5 +90,21 @@ describe('brain freetext search — against a real MongoDB', { skip }, () => {
     await insertEntity('a1', 'Alpha');
     await insertEntity('a2', 'Beta');
     assert.deepEqual(await searchAllPages(''), ['a1', 'a2']);
+  });
+
+  // Slice 4b: file-meta list gains the same freetext filter, over path + description.
+  it('files freetext matches path and description (SEARCHABLE_FIELDS.files)', async () => {
+    const insertFile = (id, path, description = '') =>
+      files.insertOne({ _id: id, spaceId: SPACE, path, description, tags: [], sizeBytes: 0, createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' });
+    await insertFile('f1', 'docs/readme.md', 'project intro');
+    await insertFile('f2', 'src/main.ts', 'entry point');
+    await insertFile('f3', 'notes/todo.txt', 'the readme is stale');  // matches on description
+    const found = async (q) => {
+      const filter = textSearchOr(q, SEARCHABLE_FIELDS.files) ?? {};
+      return (await files.find(filter).toArray()).map(f => String(f._id)).sort();
+    };
+    assert.deepEqual(await found('readme'), ['f1', 'f3'], 'path (f1) + description (f3)');
+    assert.deepEqual(await found('main.ts'), ['f2'], 'path substring');
+    assert.deepEqual(await found('a.b'), [], 'literal dot — no wildcard match');
   });
 });

--- a/testing/standalone/brain-text-search-unit.test.js
+++ b/testing/standalone/brain-text-search-unit.test.js
@@ -50,4 +50,15 @@ describe('textSearchOr', () => {
       assert.ok(fields.length > 0, `${name} must have searchable fields`);
     }
   });
+
+  it('files search over path + description (slice 4b)', () => {
+    assert.deepEqual(SEARCHABLE_FIELDS.files, ['path', 'description']);
+    const f = textSearchOr('readme', SEARCHABLE_FIELDS.files);
+    assert.deepEqual(f, {
+      $or: [
+        { path: { $regex: 'readme', $options: 'i' } },
+        { description: { $regex: 'readme', $options: 'i' } },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## What

`GET /api/brain/spaces/:id/files` now accepts **`?search=<text>`** — a case-insensitive **substring** over a file record's `path` + `description`, applied server-side **before pagination** (spans the whole list) and **escaped as a literal**. Same builder the other brain list endpoints use (2b-iii-a): added `files: ['path','description']` to `SEARCHABLE_FIELDS` and wired `textSearchOr` into the file-meta list handler. Distinct from the existing exact `?path=` filter.

Groundwork for the File Meta list's docked freetext **column filter** (client wiring in 4c).

## Char-tests-first (mirrors 2b-iii-a)

- **Unit** (`brain-text-search-unit.test.js`): pins `SEARCHABLE_FIELDS.files` + the `textSearchOr` shape for files — **ran green locally** (7 pass).
- **DB harness** (`brain-text-search-db.test.js`): proves `path` + `description` substring match and literal-dot (no wildcard) against **real Mongo**. Runs in CI's test stack; skips locally without the `:27117` test Mongo (per the tiny-disk caution I didn't boot the full Docker stack locally — CI covers it, and auto-merge only fires on green).

## Notes

- **Read-only GET** — no new/changed route; route-coverage gate unchanged.
- Server `tsc` clean. `docs/integration-guide.md` (Freetext search table) + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)