### PR TITLE
feat(brain): dock the File Meta freetext filter in the Path column, server-side (Slice 4c-i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2324,6 +2324,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain File Meta list's freetext search moved into a docked Path-column filter (server-side).**
+  The old top-bar search was a client-side substring over just the loaded page; it's replaced by a
+  debounced **freetext box under the Path header** that feeds the new server `?search=` (substring over
+  path + description, slice 4b) — so it narrows the **whole** list, not only the visible rows, matching
+  the other list tabs. The top-bar client filter (and its `filteredFileMetas` role) is retired here; a
+  **semantic** file top bar follows in a later slice. Client-only.
 - **The Brain File Meta list gets sortable headers and a tag column filter, like the other list tabs.**
   The files list endpoint already supported `?sort=` (path / updatedAt / createdAt) and a `?tag=` filter
   server-side, but the client never wired them and the table used plain headers. File Meta now has

--- a/client/src/app/core/files-api.service.ts
+++ b/client/src/app/core/files-api.service.ts
@@ -150,8 +150,8 @@ export class FilesApi {
 
   listFileMeta(spaceId: string, limit = 50, skip = 0, filters?: { search?: string; tag?: string }, sort?: ListSort): Observable<{ files: FileMeta[]; limit: number; skip: number }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
-    // `search` maps to the server's `path` filter for now (exact-ish); slice 4b adds a real freetext `?search=`.
-    if (filters?.search) params = params.set('path', filters.search);
+    // `search` → the server's freetext `?search=` (substring over path + description, slice 4b).
+    if (filters?.search) params = params.set('search', filters.search);
     if (filters?.tag) params = params.set('tag', filters.tag);
     if (sort) params = params.set('sort', sort.field).set('dir', sort.dir);
     return this.http.get<{ files: FileMeta[]; limit: number; skip: number }>(`/api/brain/spaces/${spaceId}/files`, { params });

--- a/client/src/app/pages/brain/filemeta-tab.component.spec.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.spec.ts
@@ -61,6 +61,17 @@ describe('FilemetaTabComponent', () => {
     expect(filesApi.listFileMeta).toHaveBeenLastCalledWith('work', 20, 0, { tag: 'code' }, { field: 'updatedAt', dir: 'desc' });
   });
 
+  // Slice 4c-i: the docked Path column freetext filter feeds the server ?search= (debounced).
+  it('the Path column freetext filter flows through as filters.search (debounced)', () => {
+    const c = make().componentInstance;
+    filesApi.listFileMeta.mockClear();
+    vi.useFakeTimers();
+    c.setSearchFilter('readme');
+    vi.advanceTimersByTime(250);
+    vi.useRealTimers();
+    expect(filesApi.listFileMeta).toHaveBeenLastCalledWith('work', 20, 0, { search: 'readme' }, undefined);
+  });
+
   it('saveEditFileMeta sends description/tags/entityIds/memoryIds/chronoIds and clears editingId', () => {
     const c = make().componentInstance;
     c.store.fileMetas.set([{ _id: 'f1', path: '/a.md', description: 'old' } as FileMeta]);

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -12,7 +12,6 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { StepProgressBarComponent } from '../../shared/step-progress-bar.component';
 import { RecordTabBase } from './record-tab-base';
-import { RecordSearchBarComponent } from './record-search-bar.component';
 import { SortableHeaderComponent } from './sortable-header.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
@@ -22,8 +21,9 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
  * The File Meta record tab, extracted from BrainComponent (A17.9b-6g). The odd one of the five:
  * records come from ingested files (NO create form), it uses the FILES api (updateFileMeta /
  * deleteFileMeta by path / retryEmbedding), it wires the shared `fm` memory/chrono pickers on
- * `EntityRefPicker`, and it has NO semantic search — its search is a pure client-side filter via
- * `store.filteredFileMetas` (the loader still passes the term for the server-side first page).
+ * `EntityRefPicker`. Freetext is the docked **Path column** filter → the server's substring `?search=`
+ * (slice 4c-i, matching the other list tabs); the old top-bar client filter (`store.filteredFileMetas`)
+ * is retired here (that store computed is now vestigial pending the 4c-ii semantic top bar + its cleanup).
  *
  * Self-loads via a `spaceId` effect. Two outputs: `mutated` (delete refreshes the space stats) and
  * `openInManager` (navigating to the Files tab is shell nav — the shell handles the emitted path).
@@ -32,12 +32,9 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-filemeta-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, StepProgressBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, StepProgressBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
-          <div class="content-header">
-            <app-record-search-bar [value]="store.fileMetaSearch()" (valueChange)="onFileMetaSearch($event)" placeholder="brain.fileMeta.filterPlaceholder" ariaLabel="brain.fileMeta.filterAriaLabel" />
-          </div>
           @if (recordList.loading()) {
             <div class="empty-state"><span class="spinner"></span></div>
           } @else if (recordList.loadError() !== null) {
@@ -49,7 +46,10 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
               <table>
                 <thead>
                   <tr>
-                    <th app-sort-th field="path" label="brain.fileMeta.table.path" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
+                    <th app-sort-th field="path" label="brain.fileMeta.table.path" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)">
+                      <input class="col-filter-input" type="text" [ngModel]="search()" (ngModelChange)="setSearchFilter($event)"
+                        [placeholder]="'brain.filter.searchPlaceholder' | transloco" [attr.aria-label]="'brain.filter.searchPlaceholder' | transloco" />
+                    </th>
                     <th>{{ 'brain.fileMeta.table.description' | transloco }}</th>
                     <th app-sort-th label="brain.fileMeta.table.tags">
                       <input class="col-filter-input" type="text" [ngModel]="recordFilter().tag" (ngModelChange)="setTagFilter($event)"
@@ -64,7 +64,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                   </tr>
                 </thead>
                 <tbody>
-                  @for (fm of store.filteredFileMetas(); track fm._id) {
+                  @for (fm of store.fileMetas(); track fm._id) {
                     @if (recordList.editingId() === fm._id) {
                       <tr class="edit-row"><td colspan="9">
                         <form class="edit-form" (ngSubmit)="saveEditFileMeta(fm._id)" #fmEditForm="ngForm">
@@ -263,17 +263,12 @@ export class FilemetaTabComponent extends RecordTabBase {
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
     const filters: { search?: string; tag?: string } = {};
-    if (this.store.fileMetaSearch()) filters.search = this.store.fileMetaSearch();
+    if (this.searchParam()) filters.search = this.searchParam();
     if (this.recordFilter().tag) filters.tag = this.recordFilter().tag;
     this.filesApi.listFileMeta(spaceId, this.pageSize, this.skip(), filters, this.sortParam()).subscribe({
       next: ({ files }) => { this.store.fileMetas.set(files); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },
     });
-  }
-
-  onFileMetaSearch(q: string): void {
-    this.store.fileMetaSearch.set(q);
-    // client-side filter via filteredFileMetas computed() — no API call per keystroke
   }
 
   startEditFileMeta(entry: FileMeta): void {

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -215,7 +215,7 @@ The **File Meta** tab lists the metadata records Ythril keeps for uploaded files
 
 Each row can be opened inline to edit its links: you can attach **entities**, **memories**, and **chrono** entries to a file so it surfaces alongside related knowledge. Opening a file from the Files tab's metadata action jumps you straight to its File Meta entry.
 
-Sort by clicking the **Path** or **Updated** column headers (server-side, across the whole list), and narrow by tag with the filter box docked under the **Tags** header — the same header controls the other Brain list tabs use.
+Sort by clicking the **Path** or **Updated** column headers (server-side, across the whole list). Narrow the list with the filter boxes docked under the headers — a **freetext box under Path** (case-insensitive substring over path + description, matched server-side across the whole list) and a **tag box under Tags** — the same header controls the other Brain list tabs use. (Semantic file search in a top bar is coming in a later slice.)
 
 ---
 


### PR DESCRIPTION
## What

The File Meta top-bar search was a **client-side** substring over only the *loaded page*. It's replaced by a debounced **freetext box docked under the Path header**, feeding the new server **`?search=`** (substring over path + description, slice 4b) — so it narrows the **whole** list, not just the visible rows, matching the other list tabs (2b-iii-b pattern).

## Changes (client-only)

- `files-api.listFileMeta`: `filters.search` now maps to the real `?search=` (was the interim exact `?path=` from 4a).
- `filemeta-tab`: docked Path freetext input → base `search()`/`setSearchFilter` → `load()` sends `filters.search = searchParam()`; removed the top-bar `app-record-search-bar` + `onFileMetaSearch`; the table binds `store.fileMetas()` directly.
- The store's `filteredFileMetas` / `fileMetaSearch` are now **vestigial** (nothing consumes them) — left in place; they're removed together with the **4c-ii semantic top bar**, which is **parked**: `file` recall is *chunk-level*, so mapping hits to file rows (dedup by parent + fetch file-meta) needs its own design.

## Verification

- No regression — freetext is still there, now **server-wide + debounced** instead of a page-local client filter.
- **496 client tests green** (added a Path-column-search wiring test); prod build clean.
- `userguide.md` (File Meta) + CHANGELOG updated.

Slice 4 remaining after this: **4c-ii** (semantic top bar) + **4d** (edit-surface redo + composite-field refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)