### PR TITLE
fix(brain): restore Files→File-Meta deep-link + remove dead filteredFileMetas (4c-i follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2328,8 +2328,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The old top-bar search was a client-side substring over just the loaded page; it's replaced by a
   debounced **freetext box under the Path header** that feeds the new server `?search=` (substring over
   path + description, slice 4b) — so it narrows the **whole** list, not only the visible rows, matching
-  the other list tabs. The top-bar client filter (and its `filteredFileMetas` role) is retired here; a
-  **semantic** file top bar follows in a later slice. Client-only.
+  the other list tabs. The top-bar client filter is retired and its dead `filteredFileMetas` /
+  client-substring store code removed; the Files-tab **"open in File Meta" deep-link** still filters the
+  list to the chosen path (it now seeds the docked Path filter). A **semantic** file top bar follows in
+  a later slice. Client-only.
 - **The Brain File Meta list gets sortable headers and a tag column filter, like the other list tabs.**
   The files list endpoint already supported `?sort=` (path / updatedAt / createdAt) and a `?tag=` filter
   server-side, but the client never wired them and the table used plain headers. File Meta now has

--- a/client/src/app/pages/brain/brain-store.service.spec.ts
+++ b/client/src/app/pages/brain/brain-store.service.spec.ts
@@ -9,16 +9,15 @@
  * It does not touch the pure derived state below — which is precisely what A17.9 relocates when the
  * eight tab-views become child components over a shared BrainState. So this pins:
  *
- *   - `filteredFileMetas`: file-meta's client-side filter and the fact that files have NO semantic
- *     mode — the deliberate asymmetry that survives 2b-iii-c. (memories/edges/chrono no longer have a
- *     client-side `filtered*` view: their top bar is semantic and their plain-text search is the
- *     server-side docked column filter, so there is nothing pure left here to pin.)
  *   - the `*TagSuggestions` union of schema suggestions + tags present on loaded records
  *   - `*TypeOptions`: schema names UNION values present, deduped and SORTED
+ *
+ * (No `filtered*` views remain to pin — every tab filters server-side since 4c-i; file-meta's old
+ * client `filteredFileMetas` was removed with the top-bar client filter.)
  */
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect } from 'vitest';
-import type { ChronoEntry, Edge, Entity, FileMeta, Memory, SpaceMetaResponse } from '../../core/api.types';
+import type { ChronoEntry, Edge, Entity, Memory, SpaceMetaResponse } from '../../core/api.types';
 import { BrainStore } from './brain-store.service';
 
 const mem = (fact: string, over: Partial<Memory> = {}): Memory =>
@@ -29,38 +28,12 @@ const edge = (label: string, over: Partial<Edge> = {}): Edge =>
   ({ _id: label, from: 'a', to: 'b', label, tags: [], createdAt: '', ...over } as Edge);
 const chrono = (title: string, over: Partial<ChronoEntry> = {}): ChronoEntry =>
   ({ _id: title, title, type: 'event', tags: [], entityIds: [], memoryIds: [], startsAt: '', status: 'upcoming', ...over } as ChronoEntry);
-const fileMeta = (path: string, over: Partial<FileMeta> = {}): FileMeta =>
-  ({ _id: path, path, tags: [], sizeBytes: 0, spaceId: 'work', createdAt: '', updatedAt: '', ...over } as FileMeta);
 
 function create(): BrainStore {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({ providers: [BrainStore] });
   return TestBed.inject(BrainStore);
 }
-
-describe('BrainStore — filteredFileMetas', () => {
-  it('searches path, description and tags', () => {
-    const c = create();
-    c.fileMetas.set([
-      fileMeta('docs/readme.md', { description: 'intro' }),
-      fileMeta('src/main.ts', { tags: ['code'] }),
-    ]);
-    const found = (q: string) => { c.fileMetaSearch.set(q); return c.filteredFileMetas().map(f => f.path); };
-    expect(found('readme')).toEqual(['docs/readme.md']); // path
-    expect(found('intro')).toEqual(['docs/readme.md']);  // description
-    expect(found('code')).toEqual(['src/main.ts']);      // tag
-  });
-
-  it('files have NO semantic bypass — unlike memories/chrono/edges, the filter always applies', () => {
-    // Deliberate asymmetry in the original: there is no fileMetaSearchMode at all. Pinned so a split
-    // does not "tidy" the four filters into one shape and silently change file search.
-    const c = create();
-    c.fileMetas.set([fileMeta('a.md'), fileMeta('b.md')]);
-    c.fileMetaSearch.set('a.md');
-    expect(c.filteredFileMetas().map(f => f.path)).toEqual(['a.md']);
-    expect('fileMetaSearchMode' in c).toBe(false);
-  });
-});
 
 describe('BrainStore — tag suggestions', () => {
   const meta = (tagSuggestions: string[]) => ({ tagSuggestions, typeSchemas: {} } as unknown as SpaceMetaResponse);

--- a/client/src/app/pages/brain/brain-store.service.ts
+++ b/client/src/app/pages/brain/brain-store.service.ts
@@ -8,19 +8,17 @@ import {
  * Records for the active brain space, and the client-side view of them.
  *
  * Extracted from the 3701-line BrainComponent (A17.9b). Owns the five record lists, the space meta,
- * the per-collection top-bar search text, and everything derived from them: the file-meta
- * `filteredFileMetas` view, the `*TagSuggestions`, and the schema-backed `*TypeOptions`. This is the
- * cohesive "a list and the way it is being viewed" — splitting a list from its own filter would be
- * artificial.
+ * the per-collection top-bar search text, and everything derived from them: the `*TagSuggestions` and
+ * the schema-backed `*TypeOptions`.
  *
  * What is NOT here (stays with the component, moves to its own owner in a later step): the shell's
  * navigation (space list, activeTab, activeSpaceId), the loaders that populate these signals, the
  * create/edit forms per tab, the query/recall tab state, and the record drawer.
  *
- * Search shape (post 2b-iii-c): memories/edges/chrono have a SEMANTIC top bar (the server ranks and
- * returns the list, bound directly) plus a server-side docked column freetext filter; there is no
- * client-side `filtered*` view for them. File-meta is the asymmetry — it has no semantic mode, so its
- * search is a pure client-side filter (`filteredFileMetas`). Keep that asymmetry.
+ * Search shape (post 4c-i): every record tab filters SERVER-SIDE — memories/edges/chrono have a
+ * semantic top bar plus a docked column freetext filter; file-meta has a docked column freetext filter
+ * (its top bar / semantic recall is a later slice). No client-side `filtered*` views remain; templates
+ * bind `store.<collection>()` directly.
  *
  * Provided by BrainComponent (not root): one instance per mounted page.
  */
@@ -38,8 +36,10 @@ export class BrainStore {
    *  space+collection, and the mounted record tab reloads its current page in response. */
   liveRefreshTick = signal(0);
   // The record tabs' TOP-BAR search text. For memories/edges/chrono this is a SEMANTIC recall query
-  // (2b-iii-c demoted the old A–Z text mode into the docked column freetext filter); for file-meta it
-  // is a plain client-side filter term (files have no semantic mode). See `filteredFileMetas`.
+  // (2b-iii-c demoted the old A–Z text mode into the docked column freetext filter). For file-meta,
+  // `fileMetaSearch` is now just the shell→tab DEEP-LINK seed: the Files-tab "open in File Meta" action
+  // writes the file's path here, and the File Meta tab reads it into its docked Path-column freetext
+  // filter on open (4c-i). File-meta has no semantic top bar yet (4c-ii).
   memorySearch = signal('');
   edgeSearch = signal('');
   chronoSearch = signal('');
@@ -68,19 +68,9 @@ export class BrainStore {
     ...this.chrono().flatMap(c => c.tags ?? []),
   ])]);
 
-  // memories/edges/chrono have NO client-side `filtered*` view: their top bar is semantic (the server
-  // ranks and returns the list) and their plain-text search is the docked column freetext filter,
-  // applied server-side in `load()`. The template binds `store.memories()`/`edges()`/`chrono()`
-  // directly. Only file-meta keeps a client-side filter (it has no semantic mode).
-  filteredFileMetas = computed(() => {
-    const q = this.fileMetaSearch().toLowerCase().trim();
-    if (!q) return this.fileMetas();
-    return this.fileMetas().filter(fm =>
-      fm.path.toLowerCase().includes(q) ||
-      (fm.description ?? '').toLowerCase().includes(q) ||
-      fm.tags.some(t => t.toLowerCase().includes(q)),
-    );
-  });
+  // No client-side `filtered*` views remain: every record tab now filters server-side (semantic top bar
+  // for memories/edges/chrono; docked column freetext for all four, incl. file-meta since 4c-i). The
+  // templates bind `store.<collection>()` directly.
 
   // ── Schema-derived accessors + filter-bar type options ──────────────────────
   entityTypeNames(): string[] {

--- a/client/src/app/pages/brain/filemeta-tab.component.spec.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.spec.ts
@@ -61,6 +61,15 @@ describe('FilemetaTabComponent', () => {
     expect(filesApi.listFileMeta).toHaveBeenLastCalledWith('work', 20, 0, { tag: 'code' }, { field: 'updatedAt', dir: 'desc' });
   });
 
+  // Slice 4c-i: the Files-tab "open in File Meta" deep-link seeds the Path column filter via
+  // store.fileMetaSearch (consumed in resetOnSpaceChange) — regression guard for that navigation.
+  it('seeds the Path column filter from the deep-link term (store.fileMetaSearch)', () => {
+    const c = make().componentInstance;
+    c.store.fileMetaSearch.set('docs/readme.md');
+    (c as unknown as { resetOnSpaceChange(): void }).resetOnSpaceChange();
+    expect(c.search()).toBe('docs/readme.md');
+  });
+
   // Slice 4c-i: the docked Path column freetext filter feeds the server ?search= (debounced).
   it('the Path column freetext filter flows through as filters.search (debounced)', () => {
     const c = make().componentInstance;

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -22,8 +22,9 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
  * records come from ingested files (NO create form), it uses the FILES api (updateFileMeta /
  * deleteFileMeta by path / retryEmbedding), it wires the shared `fm` memory/chrono pickers on
  * `EntityRefPicker`. Freetext is the docked **Path column** filter → the server's substring `?search=`
- * (slice 4c-i, matching the other list tabs); the old top-bar client filter (`store.filteredFileMetas`)
- * is retired here (that store computed is now vestigial pending the 4c-ii semantic top bar + its cleanup).
+ * (slice 4c-i, matching the other list tabs). The shell's Files-tab "open in File Meta" deep-link seeds
+ * that column filter via `store.fileMetaSearch` (consumed in `resetOnSpaceChange`). A **semantic** file
+ * top bar is a later slice (4c-ii).
  *
  * Self-loads via a `spaceId` effect. Two outputs: `mutated` (delete refreshes the space stats) and
  * `openInManager` (navigating to the Files tab is shell nav — the shell handles the emitted path).
@@ -255,6 +256,10 @@ export class FilemetaTabComponent extends RecordTabBase {
 
   protected override resetOnSpaceChange(): void {
     this.recordFilter.set({ type: '', tag: '' });
+    // Seed the Path-column freetext from the deep-link term the shell may have set (Files-tab
+    // "open in File Meta" → `store.fileMetaSearch(path)`), so that navigation still filters the list.
+    // Runs after the base's `search.set('')`; a normal open (empty seed) leaves the filter clear.
+    this.search.set(this.store.fileMetaSearch());
   }
 
   protected override load(): void {


### PR DESCRIPTION
## What (regression fix from 4c-i)

4c-i moved File Meta's freetext into the docked Path column and stopped the tab from reading `store.fileMetaSearch` — which **silently broke the Files-tab "open in File Meta" deep-link**: `openFileMetaEntry(path)` writes the path to `store.fileMetaSearch`, but the tab no longer read it, so navigating from a file preview stopped filtering the list to that file.

## Fix

- `store.fileMetaSearch` is repurposed as the shell→tab **deep-link seed**: the File Meta tab's `resetOnSpaceChange` reads it into its docked Path-column freetext `search()` on open, so the deep-link filters again (now via the server `?search=`). Regression-guard test added.

## Cleanup

- The client-side `filteredFileMetas` computed had **no consumers** after 4c-i — removed it (+ its store-spec block, the unused `fileMeta` test helper, and the `FileMeta` import). No `filtered*` views remain; every tab filters server-side. Store doc comments updated.

## Verification

- **495 client tests green** (removed 2 obsolete `filteredFileMetas` tests, added the deep-link seed guard); prod build clean. Client-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)