### PR TITLE
refactor(brain): extract app-entity-ref-field, migrate all 6 entity sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2324,6 +2324,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain entity-chip field (linked-entity chips + inline picker) is now one shared component.**
+  The identical block — chips wired to the shared `EntityRefPicker` plus an inline `app-entity-search`
+  — was hand-copied across six create/inline-edit/drawer forms (memory ×3, chrono ×3); drift between
+  those copies is a recurring visual-consistency snag. It's extracted to a single `app-entity-ref-field`
+  and every one of the six call sites now renders it, so all six stay identical by construction.
+  No behaviour change (picking/removing mutate the same form object exactly as before); this unblocks
+  the File Meta edit-surface redo. Client-only, internal refactor.
 - **The Brain File Meta list's freetext search moved into a docked Path-column filter (server-side).**
   The old top-bar search was a client-side substring over just the loaded page; it's replaced by a
   debounced **freetext box under the Path header** that feeds the new server `?search=` (substring over

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -7,7 +7,7 @@ import { ChronoEntry, ChronoType, ChronoStatus } from '../../core/api.types';
 import { BrainApi } from '../../core/brain-api.service';
 import { httpErrorReason } from '../../core/http-error';
 import { TagInputComponent } from '../../shared/tag-input.component';
-import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { EntityRefFieldComponent } from './entity-ref-field.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordDrawerState } from './record-drawer-state.service';
@@ -33,7 +33,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -89,14 +89,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 </div>
                 <div class="field">
                   <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
-                  @if (picker.entityChips(chronoForm.entityIds).length) {
-                    <div class="entity-multi">
-                      @for (chip of picker.entityChips(chronoForm.entityIds); track chip.id) {
-                        <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(chronoForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                      }
-                    </div>
-                  }
-                  <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, chronoForm)" />
+                  <app-entity-ref-field [target]="chronoForm" [spaceId]="spaceId()" />
                 </div>
                 <div class="field">
                   <label>{{ 'brain.chrono.form.memories' | transloco }}</label>
@@ -193,14 +186,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                           </div>
                           <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                             <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
-                            @if (picker.entityChips(editChrono.entityIds).length) {
-                              <div class="entity-multi">
-                                @for (chip of picker.entityChips(editChrono.entityIds); track chip.id) {
-                                  <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editChrono, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                                }
-                              </div>
-                            }
-                            <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, editChrono)" />
+                            <app-entity-ref-field [target]="editChrono" [spaceId]="spaceId()" />
                           </div>
                           <div style="display:flex; gap:6px; align-items:flex-end;">
                             <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditChrono(entry._id)">

--- a/client/src/app/pages/brain/entity-ref-field.component.spec.ts
+++ b/client/src/app/pages/brain/entity-ref-field.component.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * EntityRefFieldComponent — the extracted entity-chip field (chips + inline picker).
+ *
+ * The six create/edit/drawer copies of this block are guarded by their own tab specs; this spec pins
+ * the extracted component's own contract: it renders the picker's chips for the bound `target`, hosts
+ * the inline `app-entity-search`, and picking/removing mutates the SAME target object by reference
+ * (the behaviour every call site depends on).
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainApi } from '../../core/brain-api.service';
+import type { Entity } from '../../core/api.types';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { BrainStore } from './brain-store.service';
+import { EntityRefFieldComponent } from './entity-ref-field.component';
+
+function make(target: { entityIds: string }) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [EntityRefFieldComponent, getTranslocoModule()],
+    providers: [
+      EntityRefPicker, BrainStore,
+      { provide: BrainApi, useValue: { recallBrain: vi.fn(() => of({ results: [], count: 0 })), searchEntitiesByName: vi.fn(() => of({ entities: [] })), getEntitiesByIds: vi.fn(() => of({ entities: [] })) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(EntityRefFieldComponent);
+  fixture.componentRef.setInput('target', target);
+  fixture.componentRef.setInput('spaceId', 'work');
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('EntityRefFieldComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(EntityRefFieldComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('always hosts the inline entity picker', () => {
+    const f = make({ entityIds: '' });
+    expect(f.nativeElement.querySelector('app-entity-search')).toBeTruthy();
+  });
+
+  it('renders a chip per linked id, using the picker name cache for the label', () => {
+    const f = make({ entityIds: 'e1, e2' });
+    const picker = TestBed.inject(EntityRefPicker);
+    picker.entityNameCache.set({ e1: 'Ada' });
+    f.detectChanges();
+    const chips = [...f.nativeElement.querySelectorAll('.chip .chip-name')].map(n => n.textContent?.trim());
+    expect(chips).toEqual(['Ada', 'e2']); // uncached id falls back to the id itself
+  });
+
+  it('picking appends to the bound target by reference', () => {
+    const target = { entityIds: '' };
+    make(target);
+    TestBed.inject(EntityRefPicker).pickEntity({ _id: 'e9', name: 'Grace' } as Entity, target);
+    expect(target.entityIds).toBe('e9');
+  });
+
+  it('removing a chip mutates the bound target by reference', () => {
+    const target = { entityIds: 'e1, e2' };
+    make(target);
+    TestBed.inject(EntityRefPicker).removeEntityId(target, 'e1');
+    expect(target.entityIds).toBe('e2');
+  });
+});

--- a/client/src/app/pages/brain/entity-ref-field.component.ts
+++ b/client/src/app/pages/brain/entity-ref-field.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { EntityRefPicker, EntityIdTarget } from './entity-ref-picker.service';
+import { BRAIN_CHIP_STYLES } from './brain-form.styles';
+
+/**
+ * The entity-chip field: linked-entity chips + an inline entity autocomplete, in one element.
+ *
+ * Extracted (slice 3-refactor) from the ~6 hand-written copies of this exact block — memories/chrono
+ * create + inline-edit forms and the detail drawer (memory + chrono). Each copy was chips + an inline
+ * `app-entity-search` wired to the shared `EntityRefPicker`; drift between them is what the visual/UX
+ * lens keeps flagging, so it lives once here. Label-less by design: the caller supplies its own
+ * `<label>` / `.drawer-label` and field wrapper, so the component drops into both the form and the
+ * drawer contexts unchanged.
+ *
+ * Dumb + OnPush: it owns no state. `target` is the caller's form object (any `{ entityIds: string }`);
+ * picking mutates `target.entityIds` and the shared name cache via the picker, exactly as the inline
+ * copies did — `pickEntity`/`removeEntityId`/`entityChips` are unchanged, so behaviour is preserved.
+ */
+@Component({
+  selector: 'app-entity-ref-field',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [EntitySearchComponent, PhIconComponent],
+  styles: [BRAIN_CHIP_STYLES],
+  template: `
+    @if (picker.entityChips(target().entityIds).length) {
+      <div class="entity-multi">
+        @for (chip of picker.entityChips(target().entityIds); track chip.id) {
+          <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(target(), chip.id)"><ph-icon name="x" [size]="12"/></button></span>
+        }
+      </div>
+    }
+    <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, target())" />
+  `,
+})
+export class EntityRefFieldComponent {
+  readonly picker = inject(EntityRefPicker);
+  /** The caller's form object; picking appends to its `entityIds`. */
+  readonly target = input.required<EntityIdTarget>();
+  readonly spaceId = input.required<string>();
+}

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -9,7 +9,7 @@ import { httpErrorReason } from '../../core/http-error';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { PropertiesViewComponent } from '../../shared/properties-view.component';
 import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
-import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { EntityRefFieldComponent } from './entity-ref-field.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordDrawerState } from './record-drawer-state.service';
@@ -40,7 +40,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-memories-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -73,14 +73,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 </div>
                 <div class="field">
                   <label>{{ 'common.form.entities' | transloco }}</label>
-                  @if (picker.entityChips(memoryForm.entityIds).length) {
-                    <div class="entity-multi">
-                      @for (chip of picker.entityChips(memoryForm.entityIds); track chip.id) {
-                        <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(memoryForm, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                      }
-                    </div>
-                  }
-                  <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, memoryForm)" />
+                  <app-entity-ref-field [target]="memoryForm" [spaceId]="spaceId()" />
                 </div>
                 <div class="field">
                   <label>{{ 'common.form.properties' | transloco }}</label>
@@ -145,14 +138,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                           </div>
                           <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                             <label>{{ 'common.form.entities' | transloco }}</label>
-                            @if (picker.entityChips(editMemory.entityIds).length) {
-                              <div class="entity-multi">
-                                @for (chip of picker.entityChips(editMemory.entityIds); track chip.id) {
-                                  <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editMemory, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                                }
-                              </div>
-                            }
-                            <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, editMemory)" />
+                            <app-entity-ref-field [target]="editMemory" [spaceId]="spaceId()" />
                           </div>
                           <div class="field" style="flex:1; min-width:220px; margin-bottom:0;">
                             <label>{{ 'common.form.properties' | transloco }}</label>

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -5,7 +5,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
 import { ModalDirective } from '../../shared/modal.directive';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
-import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { EntityRefFieldComponent } from './entity-ref-field.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
@@ -26,7 +26,7 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
   selector: 'app-record-drawer',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ModalDirective],
   styles: [BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES],
   template: `
       @if (state.drawerRecord(); as dr) {
@@ -73,14 +73,7 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.entityIds' | transloco }}</div>
-                  @if (picker.entityChips(state.drawerEditMemory.entityIds).length) {
-                    <div class="entity-multi">
-                      @for (chip of picker.entityChips(state.drawerEditMemory.entityIds); track chip.id) {
-                        <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(state.drawerEditMemory, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                      }
-                    </div>
-                  }
-                  <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditMemory)" />
+                  <app-entity-ref-field [target]="state.drawerEditMemory" [spaceId]="state.spaceId()" />
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.properties' | transloco }}</div>
@@ -249,14 +242,7 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.entityIds' | transloco }}</div>
-                  @if (picker.entityChips(state.drawerEditChrono.entityIds).length) {
-                    <div class="entity-multi">
-                      @for (chip of picker.entityChips(state.drawerEditChrono.entityIds); track chip.id) {
-                        <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(state.drawerEditChrono, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                      }
-                    </div>
-                  }
-                  <app-entity-search mode="picker" [spaceId]="state.spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, state.drawerEditChrono)" />
+                  <app-entity-ref-field [target]="state.drawerEditChrono" [spaceId]="state.spaceId()" />
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.memoryIds' | transloco }}</div>


### PR DESCRIPTION
## What

The "linked-entity chips + inline `app-entity-search`" block was hand-copied at **six** create / inline-edit / drawer sites (memory ×3, chrono ×3), each wired to the shared `EntityRefPicker`. Drift between those copies is a recurring visual-consistency snag — it's why slice 3a had to touch six places at once.

This extracts a single dumb **OnPush** `app-entity-ref-field [target] [spaceId]` and renders it at every one of the six sites, so they stay identical by construction.

## Behaviour

Unchanged. `pickEntity` / `removeEntityId` / `entityChips` still mutate the **same form object by reference**, and the chips re-render off the picker's `entityNameCache` signal (so the OnPush child updates on async name resolution). The now-unused `EntitySearchComponent` import is dropped from the three tab/drawer files.

## Scope

- **File-meta's entity picker is intentionally left as-is** — it's still the click-to-open **flyout** variant, folded into the slice-4d rebuild rather than switched to inline here (that would be a UX change, not a refactor).
- `app-memory-ref-field` (the remaining duplicated block: 3c memory picker in chrono form + drawer + file-meta) follows next / as the first part of Slice 4d.

## Tests

Existing tab specs are the characterization guard (all green). A dedicated `entity-ref-field.component.spec.ts` pins the extracted component's contract (chips render from the cache, inline picker present, pick/remove mutate the bound target). Full build + affected specs pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)