### PR TITLE
refactor(brain): extract app-memory-ref-field, migrate the 2 memory sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2324,6 +2324,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain memory-reference field (linked-memory chips + inline title typeahead) is now one shared
+  component too.** Sibling of the entity-chip extraction below: the identical "chips + `.mem-pick`
+  search dropdown" block was hand-copied at the chrono create form and the detail drawer's chrono
+  section. It's extracted to `app-memory-ref-field` and both sites render it, so they stay identical by
+  construction. No behaviour change (add/remove mutate the same form object's `memoryIds` exactly as
+  before). File-meta's memory picker uses the separate `fm*` variant and is left for the File Meta
+  edit-surface redo. Client-only, internal refactor.
 - **The Brain entity-chip field (linked-entity chips + inline picker) is now one shared component.**
   The identical block — chips wired to the shared `EntityRefPicker` plus an inline `app-entity-search`
   — was hand-copied across six create/inline-edit/drawer forms (memory ×3, chrono ×3); drift between

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -8,6 +8,7 @@ import { BrainApi } from '../../core/brain-api.service';
 import { httpErrorReason } from '../../core/http-error';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { EntityRefFieldComponent } from './entity-ref-field.component';
+import { MemoryRefFieldComponent } from './memory-ref-field.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordDrawerState } from './record-drawer-state.service';
@@ -33,7 +34,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -93,23 +94,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 </div>
                 <div class="field">
                   <label>{{ 'brain.chrono.form.memories' | transloco }}</label>
-                  @if (chronoForm.memoryIds.length) {
-                    <div class="entity-multi">
-                      @for (id of chronoForm.memoryIds; track id) {
-                        <span class="chip" [title]="id"><span class="chip-name">{{ picker.memoryRefTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeMemoryRef(chronoForm, id)"><ph-icon name="x" [size]="12"/></button></span>
-                      }
-                    </div>
-                  }
-                  <div class="mem-pick">
-                    <input type="search" [value]="picker.memPickQuery()" (input)="picker.onMemPickInput($any($event.target).value)" [placeholder]="'brain.chrono.form.searchMemories' | transloco" [attr.aria-label]="'brain.chrono.form.searchMemories' | transloco" />
-                    @if (picker.memPickResults().length) {
-                      <div class="mem-pick-menu">
-                        @for (mem of picker.memPickResults(); track mem._id) {
-                          <button type="button" class="mem-pick-item" (mousedown)="picker.addMemoryRef(chronoForm, mem)">{{ mem.fact.slice(0, 90) }}{{ mem.fact.length > 90 ? '…' : '' }}</button>
-                        }
-                      </div>
-                    }
-                  </div>
+                  <app-memory-ref-field [target]="chronoForm" />
                 </div>
               </div>
               <div style="display:flex; gap:8px;">

--- a/client/src/app/pages/brain/memory-ref-field.component.spec.ts
+++ b/client/src/app/pages/brain/memory-ref-field.component.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * MemoryRefFieldComponent — the extracted memory-reference field (chips + inline title typeahead).
+ *
+ * Sibling of the entity-ref-field spec. The two call sites (chrono create form + drawer chrono) are
+ * guarded by their own specs; this pins the extracted component's own contract: it renders the picker's
+ * chip titles for the bound `target`, hosts the `.mem-pick` search, and add/remove mutate the SAME
+ * target object's `memoryIds` by reference.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainApi } from '../../core/brain-api.service';
+import type { Memory } from '../../core/api.types';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { BrainStore } from './brain-store.service';
+import { MemoryRefFieldComponent } from './memory-ref-field.component';
+
+function make(target: { memoryIds: string[] }) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [MemoryRefFieldComponent, getTranslocoModule()],
+    providers: [
+      EntityRefPicker, BrainStore,
+      { provide: BrainApi, useValue: { listMemories: vi.fn(() => of({ memories: [] })), getMemory: vi.fn(() => of({} as Memory)) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(MemoryRefFieldComponent);
+  fixture.componentRef.setInput('target', target);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('MemoryRefFieldComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(MemoryRefFieldComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('always hosts the inline memory search', () => {
+    const f = make({ memoryIds: [] });
+    expect(f.nativeElement.querySelector('.mem-pick input[type="search"]')).toBeTruthy();
+  });
+
+  it('renders a chip per linked id, using the picker title cache for the label', () => {
+    const f = make({ memoryIds: ['m1'] });
+    TestBed.inject(EntityRefPicker).memoryTitleCache.set({ m1: 'the cached fact' });
+    f.detectChanges();
+    const chips = [...f.nativeElement.querySelectorAll('.chip .chip-name')].map(n => n.textContent?.trim());
+    expect(chips).toEqual(['the cached fact']);
+  });
+
+  it('adding a memory appends to the bound target by reference and caches its fact', () => {
+    const target = { memoryIds: [] as string[] };
+    make(target);
+    const picker = TestBed.inject(EntityRefPicker);
+    picker.addMemoryRef(target, { _id: 'm9', fact: 'a new fact' } as Memory);
+    expect(target.memoryIds).toEqual(['m9']);
+    expect(picker.memoryRefTitle('m9')).toBe('a new fact');
+  });
+
+  it('removing a memory mutates the bound target by reference', () => {
+    const target = { memoryIds: ['m1', 'm2'] };
+    make(target);
+    TestBed.inject(EntityRefPicker).removeMemoryRef(target, 'm1');
+    expect(target.memoryIds).toEqual(['m2']);
+  });
+});

--- a/client/src/app/pages/brain/memory-ref-field.component.ts
+++ b/client/src/app/pages/brain/memory-ref-field.component.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { BRAIN_CHIP_STYLES } from './brain-form.styles';
+
+/** A memory-linking target: the create/drawer form object whose `memoryIds` this field mutates. */
+export interface MemoryIdTarget { memoryIds: string[]; }
+
+/**
+ * The memory-reference field: linked-memory chips + an inline title typeahead, in one element.
+ *
+ * The sibling of `app-entity-ref-field` (slice 3-refactor). The identical "chips + `.mem-pick` search
+ * dropdown" block (slice 3c) was hand-written at the chrono create form and the detail drawer's chrono
+ * section; drift between the two is the visual/UX snag the composite refactor exists to kill, so it
+ * lives once here. Label-less by design: the caller supplies its own `<label>` / `.drawer-label`.
+ *
+ * Dumb + OnPush: it owns no state. `target` is the caller's form object; adding/removing mutates
+ * `target.memoryIds` by reference and the title cache via the shared `EntityRefPicker`, exactly as the
+ * inline copies did — `addMemoryRef`/`removeMemoryRef`/`memoryRefTitle` are unchanged. The picker's
+ * `memPickQuery`/`memPickResults` are a single shared set (only one memory field is ever visible at a
+ * time — create form OR drawer), preserving the pre-extraction behaviour.
+ *
+ * NOT converted: file-meta's memory picker uses the separate `fm*` picker signals; it folds into the
+ * slice-4d File Meta rebuild rather than switching here.
+ */
+@Component({
+  selector: 'app-memory-ref-field',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [PhIconComponent, TranslocoPipe],
+  styles: [BRAIN_CHIP_STYLES],
+  template: `
+    @if (target().memoryIds.length) {
+      <div class="entity-multi">
+        @for (id of target().memoryIds; track id) {
+          <span class="chip" [title]="id"><span class="chip-name">{{ picker.memoryRefTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeMemoryRef(target(), id)"><ph-icon name="x" [size]="12"/></button></span>
+        }
+      </div>
+    }
+    <div class="mem-pick">
+      <input type="search" [value]="picker.memPickQuery()" (input)="picker.onMemPickInput($any($event.target).value)" [placeholder]="'brain.chrono.form.searchMemories' | transloco" [attr.aria-label]="'brain.chrono.form.searchMemories' | transloco" />
+      @if (picker.memPickResults().length) {
+        <div class="mem-pick-menu">
+          @for (mem of picker.memPickResults(); track mem._id) {
+            <button type="button" class="mem-pick-item" (mousedown)="picker.addMemoryRef(target(), mem)">{{ mem.fact.slice(0, 90) }}{{ mem.fact.length > 90 ? '…' : '' }}</button>
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class MemoryRefFieldComponent {
+  readonly picker = inject(EntityRefPicker);
+  /** The caller's form object; adding/removing edits its `memoryIds`. */
+  readonly target = input.required<MemoryIdTarget>();
+}

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -6,6 +6,7 @@ import { ModalDirective } from '../../shared/modal.directive';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
 import { EntityRefFieldComponent } from './entity-ref-field.component';
+import { MemoryRefFieldComponent } from './memory-ref-field.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
@@ -26,7 +27,7 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
   selector: 'app-record-drawer',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesEditorComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PhIconComponent, ModalDirective],
   styles: [BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES],
   template: `
       @if (state.drawerRecord(); as dr) {
@@ -246,23 +247,7 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.memoryIds' | transloco }}</div>
-                  @if (state.drawerEditChrono.memoryIds.length) {
-                    <div class="entity-multi">
-                      @for (id of state.drawerEditChrono.memoryIds; track id) {
-                        <span class="chip" [title]="id"><span class="chip-name">{{ picker.memoryRefTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeMemoryRef(state.drawerEditChrono, id)"><ph-icon name="x" [size]="12"/></button></span>
-                      }
-                    </div>
-                  }
-                  <div class="mem-pick">
-                    <input type="search" [value]="picker.memPickQuery()" (input)="picker.onMemPickInput($any($event.target).value)" [placeholder]="'brain.chrono.form.searchMemories' | transloco" [attr.aria-label]="'brain.chrono.form.searchMemories' | transloco" />
-                    @if (picker.memPickResults().length) {
-                      <div class="mem-pick-menu">
-                        @for (mem of picker.memPickResults(); track mem._id) {
-                          <button type="button" class="mem-pick-item" (mousedown)="picker.addMemoryRef(state.drawerEditChrono, mem)">{{ mem.fact.slice(0, 90) }}{{ mem.fact.length > 90 ? '…' : '' }}</button>
-                        }
-                      </div>
-                    }
-                  </div>
+                  <app-memory-ref-field [target]="state.drawerEditChrono" />
                 </div>
                 <hr class="drawer-hr">
                 <div class="drawer-field">


### PR DESCRIPTION
## What

Sibling of #394's `app-entity-ref-field`. The "linked-memory chips + inline `.mem-pick` title typeahead" block (slice 3c) was hand-copied at the **chrono create form** and the **detail drawer's chrono section**, each wired to the shared `EntityRefPicker`.

This extracts a single dumb **OnPush** `app-memory-ref-field [target]` and renders it at both sites, completing the composite-field refactor (both entity and memory chip fields are now shared components).

## Behaviour

Unchanged. `addMemoryRef` / `removeMemoryRef` / `memoryRefTitle` still mutate the same form object's `memoryIds` **by reference** and share the picker's `memPick*` signals (only one memory field is ever visible at a time — create form OR drawer). `BRAIN_CHIP_STYLES` already carries the `.mem-pick*` rules and `input[type="search"]` is styled globally, so the field is **pixel-identical**.

## Scope

- **File-meta's memory picker is intentionally left as-is** — it's the separate `fm*` variant, folded onto these shared components in the slice-4d File Meta rebuild.
- Chrono **inline-edit** has no memory field (only create form + drawer), so there are just 2 sites.

## Tests

`memory-ref-field.component.spec.ts` pins the extracted contract (chips render from the title cache, `.mem-pick` search present, add/remove mutate the bound target's `memoryIds`). The chrono-tab + record-drawer specs are the characterization guard. Full build + affected specs pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)