### PR TITLE
refactor(brain): fold File Meta pickers onto shared inline ref-fields (slice 4d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2324,6 +2324,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain File Meta edit form's entity / memory / chrono pickers now match every other tab.** They
+  were the last hold-outs on the old click-to-open **flyout** pattern; each is now the same always-inline
+  chips + search field the memory and chrono forms use, via the shared `app-entity-ref-field` /
+  `app-memory-ref-field` and a new `app-chrono-ref-field`. Two concrete improvements fall out: the
+  **memory search is now server-side** (it was a client-side filter over only the first 8 loaded
+  memories), and linked memory/chrono **chips resolve their real titles** when you open a file for
+  editing instead of showing a truncated id. This also let a large slab of now-unreachable picker code
+  go — the entire file-meta `fm*` picker apparatus, including a dead `isDrawer` branch and its four
+  never-read drawer signals. Client-only.
 - **The Brain memory-reference field (linked-memory chips + inline title typeahead) is now one shared
   component too.** Sibling of the entity-chip extraction below: the identical "chips + `.mem-pick`
   search dropdown" block was hand-copied at the chrono create form and the detail drawer's chrono

--- a/client/src/app/pages/brain/chrono-ref-field.component.spec.ts
+++ b/client/src/app/pages/brain/chrono-ref-field.component.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * ChronoRefFieldComponent — the extracted chrono-reference field (chips + inline title typeahead).
+ *
+ * Third sibling of the entity/memory ref-field specs. File-meta (its only consumer) is guarded by its
+ * own spec; this pins the extracted component's contract: it renders the picker's chip titles for the
+ * bound `target`, hosts the `.mem-pick` search, and add/remove mutate the SAME target object's
+ * `chronoIds` by reference.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { BrainApi } from '../../core/brain-api.service';
+import type { ChronoEntry } from '../../core/api.types';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { BrainStore } from './brain-store.service';
+import { ChronoRefFieldComponent } from './chrono-ref-field.component';
+
+function make(target: { chronoIds: string[] }) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [ChronoRefFieldComponent, getTranslocoModule()],
+    providers: [
+      EntityRefPicker, BrainStore,
+      { provide: BrainApi, useValue: { listChrono: vi.fn(() => of({ chrono: [] })), getChrono: vi.fn(() => of({} as ChronoEntry)) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(ChronoRefFieldComponent);
+  fixture.componentRef.setInput('target', target);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('ChronoRefFieldComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(ChronoRefFieldComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('always hosts the inline chrono search', () => {
+    const f = make({ chronoIds: [] });
+    expect(f.nativeElement.querySelector('.mem-pick input[type="search"]')).toBeTruthy();
+  });
+
+  it('renders a chip per linked id, using the picker title cache for the label', () => {
+    const f = make({ chronoIds: ['c1'] });
+    TestBed.inject(EntityRefPicker).chronoTitleCache.set({ c1: 'Launch day' });
+    f.detectChanges();
+    const chips = [...f.nativeElement.querySelectorAll('.chip .chip-name')].map(n => n.textContent?.trim());
+    expect(chips).toEqual(['Launch day']);
+  });
+
+  it('adding a chrono entry appends to the bound target by reference and caches its title', () => {
+    const target = { chronoIds: [] as string[] };
+    make(target);
+    const picker = TestBed.inject(EntityRefPicker);
+    picker.addChronoRef(target, { _id: 'c9', title: 'Q3 review' } as ChronoEntry);
+    expect(target.chronoIds).toEqual(['c9']);
+    expect(picker.chronoRefTitle('c9')).toBe('Q3 review');
+  });
+
+  it('removing a chrono entry mutates the bound target by reference', () => {
+    const target = { chronoIds: ['c1', 'c2'] };
+    make(target);
+    TestBed.inject(EntityRefPicker).removeChronoRef(target, 'c1');
+    expect(target.chronoIds).toEqual(['c2']);
+  });
+});

--- a/client/src/app/pages/brain/chrono-ref-field.component.ts
+++ b/client/src/app/pages/brain/chrono-ref-field.component.ts
@@ -1,0 +1,52 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { BRAIN_CHIP_STYLES } from './brain-form.styles';
+
+/** A chrono-linking target: the form object whose `chronoIds` this field mutates. */
+export interface ChronoIdTarget { chronoIds: string[]; }
+
+/**
+ * The chrono-reference field: linked-chrono chips + an inline title typeahead, in one element.
+ *
+ * The third sibling of `app-entity-ref-field` / `app-memory-ref-field` (slice 4d). Only file-meta links
+ * chrono entries, so this has a single consumer today — but it replaces file-meta's old click-to-open
+ * `fm*` chrono flyout with the same always-inline shape the other two fields use, which is the visual-
+ * consistency win the composite refactor exists for, and it mirrors the memory field one-for-one.
+ *
+ * Dumb + OnPush: it owns no state. `target` is the caller's form object; adding/removing mutates
+ * `target.chronoIds` by reference and the title cache via the shared `EntityRefPicker`. Search is
+ * server-side (`listChrono(?search=)`), unlike the old `fm*` picker's client-side filter.
+ */
+@Component({
+  selector: 'app-chrono-ref-field',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [PhIconComponent, TranslocoPipe],
+  styles: [BRAIN_CHIP_STYLES],
+  template: `
+    @if (target().chronoIds.length) {
+      <div class="entity-multi">
+        @for (id of target().chronoIds; track id) {
+          <span class="chip" [title]="id"><span class="chip-name">{{ picker.chronoRefTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeChronoRef(target(), id)"><ph-icon name="x" [size]="12"/></button></span>
+        }
+      </div>
+    }
+    <div class="mem-pick">
+      <input type="search" [value]="picker.chronoPickQuery()" (input)="picker.onChronoPickInput($any($event.target).value)" [placeholder]="'brain.fileMeta.picker.searchChrono' | transloco" [attr.aria-label]="'brain.fileMeta.picker.searchChrono' | transloco" />
+      @if (picker.chronoPickResults().length) {
+        <div class="mem-pick-menu">
+          @for (c of picker.chronoPickResults(); track c._id) {
+            <button type="button" class="mem-pick-item" (mousedown)="picker.addChronoRef(target(), c)">{{ c.title.slice(0, 90) }}{{ c.title.length > 90 ? '…' : '' }}</button>
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class ChronoRefFieldComponent {
+  readonly picker = inject(EntityRefPicker);
+  /** The caller's form object; adding/removing edits its `chronoIds`. */
+  readonly target = input.required<ChronoIdTarget>();
+}

--- a/client/src/app/pages/brain/entity-ref-picker.service.ts
+++ b/client/src/app/pages/brain/entity-ref-picker.service.ts
@@ -41,25 +41,10 @@ export class EntityRefPicker {
   /** Active brain space. Kept in sync by the shell, whose `activeSpaceId` is nav state. */
   readonly spaceId = signal('');
 
-  // ── Entity picker & flyouts ─────────────────────────────────────────────
+  // ── Entity picker & flyout ───────────────────────────────────────────────
 
   flyoutField = signal('');
   entityNameCache = signal<Record<string, string>>({});
-
-  // ── File-meta memory/chrono pickers ──────────────────────────────────────
-
-  fmMemPickerQuery = signal('');
-  fmMemPickerResults = signal<Memory[]>([]);
-  fmChronoPickerQuery = signal('');
-  fmChronoPickerResults = signal<ChronoEntry[]>([]);
-  fmDrawerMemPickerQuery = signal('');
-  fmDrawerMemPickerResults = signal<Memory[]>([]);
-  fmDrawerChronoPickerQuery = signal('');
-  fmDrawerChronoPickerResults = signal<ChronoEntry[]>([]);
-  private _fmMemTimer: ReturnType<typeof setTimeout> | null = null;
-  private _fmChronoTimer: ReturnType<typeof setTimeout> | null = null;
-  private _fmDrawerMemTimer: ReturnType<typeof setTimeout> | null = null;
-  private _fmDrawerChronoTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Open the flyout for `key`; when a target is given, pre-resolve its uncached entity names. */
   openFlyout(key: string, target?: EntityIdTarget): void {
@@ -115,92 +100,6 @@ export class EntityRefPicker {
     return parts.join(', ');
   }
 
-  onFmMemPickerInput(q: string, isDrawer = false): void {
-    if (isDrawer) {
-      this.fmDrawerMemPickerQuery.set(q);
-      if (this._fmDrawerMemTimer) clearTimeout(this._fmDrawerMemTimer);
-      if (!q.trim()) { this.fmDrawerMemPickerResults.set([]); return; }
-      this._fmDrawerMemTimer = setTimeout(() => {
-        this.brainApi.listMemories(this.spaceId(), 8, 0, {}).subscribe({
-          next: ({ memories }) => this.fmDrawerMemPickerResults.set(
-            memories.filter(m => m.fact.toLowerCase().includes(q.toLowerCase())).slice(0, 6),
-          ),
-          error: () => {},
-        });
-      }, 300);
-    } else {
-      this.fmMemPickerQuery.set(q);
-      if (this._fmMemTimer) clearTimeout(this._fmMemTimer);
-      if (!q.trim()) { this.fmMemPickerResults.set([]); return; }
-      this._fmMemTimer = setTimeout(() => {
-        this.brainApi.listMemories(this.spaceId(), 8, 0, {}).subscribe({
-          next: ({ memories }) => this.fmMemPickerResults.set(
-            memories.filter(m => m.fact.toLowerCase().includes(q.toLowerCase())).slice(0, 6),
-          ),
-          error: () => {},
-        });
-      }, 300);
-    }
-  }
-
-  onFmChronoPickerInput(q: string, isDrawer = false): void {
-    if (isDrawer) {
-      this.fmDrawerChronoPickerQuery.set(q);
-      if (this._fmDrawerChronoTimer) clearTimeout(this._fmDrawerChronoTimer);
-      if (!q.trim()) { this.fmDrawerChronoPickerResults.set([]); return; }
-      this._fmDrawerChronoTimer = setTimeout(() => {
-        this.brainApi.listChrono(this.spaceId(), 8, 0, { search: q }).subscribe({
-          next: ({ chrono }) => this.fmDrawerChronoPickerResults.set(chrono.slice(0, 6)),
-          error: () => {},
-        });
-      }, 300);
-    } else {
-      this.fmChronoPickerQuery.set(q);
-      if (this._fmChronoTimer) clearTimeout(this._fmChronoTimer);
-      if (!q.trim()) { this.fmChronoPickerResults.set([]); return; }
-      this._fmChronoTimer = setTimeout(() => {
-        this.brainApi.listChrono(this.spaceId(), 8, 0, { search: q }).subscribe({
-          next: ({ chrono }) => this.fmChronoPickerResults.set(chrono.slice(0, 6)),
-          error: () => {},
-        });
-      }, 300);
-    }
-  }
-
-  addFmMemoryId(form: { memoryIds: string[] }, id: string): void {
-    if (!form.memoryIds.includes(id)) form.memoryIds.push(id);
-    this.fmMemPickerQuery.set('');
-    this.fmMemPickerResults.set([]);
-    this.fmDrawerMemPickerQuery.set('');
-    this.fmDrawerMemPickerResults.set([]);
-  }
-
-  removeFmMemoryId(form: { memoryIds: string[] }, id: string): void {
-    form.memoryIds = form.memoryIds.filter(m => m !== id);
-  }
-
-  addFmChronoId(form: { chronoIds: string[] }, id: string): void {
-    if (!form.chronoIds.includes(id)) form.chronoIds.push(id);
-    this.fmChronoPickerQuery.set('');
-    this.fmChronoPickerResults.set([]);
-    this.fmDrawerChronoPickerQuery.set('');
-    this.fmDrawerChronoPickerResults.set([]);
-  }
-
-  removeFmChronoId(form: { chronoIds: string[] }, id: string): void {
-    form.chronoIds = form.chronoIds.filter(c => c !== id);
-  }
-
-  fmMemoryTitle(id: string): string {
-    const mem = this.store.memories().find(m => m._id === id);
-    return mem ? mem.fact.slice(0, 40) + (mem.fact.length > 40 ? '…' : '') : id.slice(0, 8) + '…';
-  }
-
-  fmChronoTitle(id: string): string {
-    const c = this.store.chrono().find(c => c._id === id);
-    return c ? c.title.slice(0, 40) + (c.title.length > 40 ? '…' : '') : id.slice(0, 8) + '…';
-  }
-
   // ── Inline memory picker (chrono form; slice 3c "memoryIds searchable like entity") ──────────
   //
   // Kept separate from the file-meta `fm*` memory picker above (file-meta rides its own flyout and is
@@ -251,6 +150,60 @@ export class EntityRefPicker {
     for (const id of ids.filter(i => !this.memoryTitleCache()[i])) {
       this.brainApi.getMemory(spaceId, id).subscribe({
         next: (m) => this.memoryTitleCache.update(c => ({ ...c, [m._id]: m.fact })),
+        error: () => {},
+      });
+    }
+  }
+
+  // ── Inline chrono picker (file-meta; slice 4d "chronoIds searchable like memories") ──────────
+  //
+  // Sibling of the memory picker above, backing app-chrono-ref-field. Replaces the old file-meta `fm*`
+  // chrono flyout; a title cache lets chips show the entry's title (not a truncated id) and search is
+  // server-side via listChrono(?search=), matching the memory picker rather than the old client filter.
+
+  chronoPickQuery = signal('');
+  chronoPickResults = signal<ChronoEntry[]>([]);
+  private _chronoPickTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Chrono id → title, for chip display (fed on pick and by `resolveChronoTitles`). */
+  chronoTitleCache = signal<Record<string, string>>({});
+
+  onChronoPickInput(q: string): void {
+    this.chronoPickQuery.set(q);
+    if (this._chronoPickTimer) clearTimeout(this._chronoPickTimer);
+    if (!q.trim()) { this.chronoPickResults.set([]); return; }
+    this._chronoPickTimer = setTimeout(() => {
+      this.brainApi.listChrono(this.spaceId(), 8, 0, { search: q }).subscribe({
+        next: ({ chrono }) => this.chronoPickResults.set(chrono.slice(0, 6)),
+        error: () => {},
+      });
+    }, 300);
+  }
+
+  /** Cache the picked entry's title for chip display, append its id to the form, and clear the search. */
+  addChronoRef(form: { chronoIds: string[] }, c: ChronoEntry): void {
+    this.chronoTitleCache.update(t => ({ ...t, [c._id]: c.title }));
+    if (!form.chronoIds.includes(c._id)) form.chronoIds.push(c._id);
+    this.chronoPickQuery.set('');
+    this.chronoPickResults.set([]);
+  }
+
+  removeChronoRef(form: { chronoIds: string[] }, id: string): void {
+    form.chronoIds = form.chronoIds.filter(c => c !== id);
+  }
+
+  /** Chip label for a linked chrono entry: cached title → loaded list → truncated id, trimmed. */
+  chronoRefTitle(id: string): string {
+    const full = this.chronoTitleCache()[id] ?? this.store.chrono().find(c => c._id === id)?.title;
+    return full ? full.slice(0, 40) + (full.length > 40 ? '…' : '') : id.slice(0, 8) + '…';
+  }
+
+  /** Resolve the uncached titles of a chronoIds list (opening a record for editing). Small N → per-id. */
+  resolveChronoTitles(ids: string[]): void {
+    const spaceId = this.spaceId();
+    if (!spaceId) return;
+    for (const id of ids.filter(i => !this.chronoTitleCache()[i])) {
+      this.brainApi.getChrono(spaceId, id).subscribe({
+        next: (c) => this.chronoTitleCache.update(t => ({ ...t, [c._id]: c.title })),
         error: () => {},
       });
     }

--- a/client/src/app/pages/brain/filemeta-tab.component.ts
+++ b/client/src/app/pages/brain/filemeta-tab.component.ts
@@ -7,7 +7,9 @@ import { FilesApi } from '../../core/files-api.service';
 import { ToastService } from '../../core/toast.service';
 import { httpErrorReason } from '../../core/http-error';
 import { TagInputComponent } from '../../shared/tag-input.component';
-import { EntitySearchComponent } from '../../shared/entity-search.component';
+import { EntityRefFieldComponent } from './entity-ref-field.component';
+import { MemoryRefFieldComponent } from './memory-ref-field.component';
+import { ChronoRefFieldComponent } from './chrono-ref-field.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { StepProgressBarComponent } from '../../shared/step-progress-bar.component';
@@ -33,7 +35,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-filemeta-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, StepProgressBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, PhIconComponent, ErrorStateComponent, StepProgressBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
           @if (recordList.loading()) {
@@ -80,70 +82,15 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                             </div>
                             <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                               <label>{{ 'brain.fileMeta.table.entities' | transloco }}</label>
-                              <div class="flyout-wrap">
-                                <div class="entity-multi">
-                                  @for (chip of picker.entityChips(editFileMeta.entityIds); track chip.id) {
-                                    <span class="chip" [title]="chip.id"><span class="chip-name">{{ chip.name }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeEntityId(editFileMeta, chip.id)"><ph-icon name="x" [size]="12"/></button></span>
-                                  }
-                                  <button type="button" class="chip-add" (click)="picker.openFlyout('edit-filemeta-entityIds', editFileMeta)">{{ 'common.addMore' | transloco }}</button>
-                                </div>
-                                @if (picker.flyoutField() === 'edit-filemeta-entityIds') {
-                                  <div class="flyout-panel">
-                                    <app-entity-search mode="picker" [spaceId]="spaceId()" placeholder="common.searchEntitiesPlaceholder" (selected)="picker.pickEntity($event, editFileMeta)" />
-                                    <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                                      <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                                    </div>
-                                  </div>
-                                }
-                              </div>
+                              <app-entity-ref-field [target]="editFileMeta" [spaceId]="spaceId()" />
                             </div>
                             <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                               <label>{{ 'brain.fileMeta.table.memories' | transloco }}</label>
-                              <div class="flyout-wrap">
-                                <div class="entity-multi">
-                                  @for (id of editFileMeta.memoryIds; track id) {
-                                    <span class="chip" [title]="id"><span class="chip-name">{{ picker.fmMemoryTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeFmMemoryId(editFileMeta, id)"><ph-icon name="x" [size]="12"/></button></span>
-                                  }
-                                  <button type="button" class="chip-add" (click)="picker.openFlyout('edit-filemeta-memoryIds')">{{ 'common.addMore' | transloco }}</button>
-                                </div>
-                                @if (picker.flyoutField() === 'edit-filemeta-memoryIds') {
-                                  <div class="flyout-panel">
-                                    <input type="text" [value]="picker.fmMemPickerQuery()" (input)="picker.onFmMemPickerInput($any($event.target).value)" [placeholder]="'brain.fileMeta.picker.searchMemories' | transloco" style="width:100%; margin-bottom:6px;" />
-                                    @for (mem of picker.fmMemPickerResults(); track mem._id) {
-                                      <div class="flyout-result" (click)="picker.addFmMemoryId(editFileMeta, mem._id); picker.closeFlyout()" style="cursor:pointer; padding:4px 6px; border-radius:4px;">
-                                        {{ mem.fact.slice(0, 60) }}{{ mem.fact.length > 60 ? '…' : '' }}
-                                      </div>
-                                    }
-                                    <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                                      <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                                    </div>
-                                  </div>
-                                }
-                              </div>
+                              <app-memory-ref-field [target]="editFileMeta" />
                             </div>
                             <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                               <label>{{ 'brain.fileMeta.table.chrono' | transloco }}</label>
-                              <div class="flyout-wrap">
-                                <div class="entity-multi">
-                                  @for (id of editFileMeta.chronoIds; track id) {
-                                    <span class="chip" [title]="id"><span class="chip-name">{{ picker.fmChronoTitle(id) }}</span><button type="button" class="chip-remove" (mousedown)="picker.removeFmChronoId(editFileMeta, id)"><ph-icon name="x" [size]="12"/></button></span>
-                                  }
-                                  <button type="button" class="chip-add" (click)="picker.openFlyout('edit-filemeta-chronoIds')">{{ 'common.addMore' | transloco }}</button>
-                                </div>
-                                @if (picker.flyoutField() === 'edit-filemeta-chronoIds') {
-                                  <div class="flyout-panel">
-                                    <input type="text" [value]="picker.fmChronoPickerQuery()" (input)="picker.onFmChronoPickerInput($any($event.target).value)" [placeholder]="'brain.fileMeta.picker.searchChrono' | transloco" style="width:100%; margin-bottom:6px;" />
-                                    @for (c of picker.fmChronoPickerResults(); track c._id) {
-                                      <div class="flyout-result" (click)="picker.addFmChronoId(editFileMeta, c._id); picker.closeFlyout()" style="cursor:pointer; padding:4px 6px; border-radius:4px;">
-                                        {{ c.title.slice(0, 60) }}{{ c.title.length > 60 ? '…' : '' }}
-                                      </div>
-                                    }
-                                    <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                                      <button type="button" class="btn btn-sm btn-secondary" (click)="picker.closeFlyout()">{{ 'common.done' | transloco }}</button>
-                                    </div>
-                                  </div>
-                                }
-                              </div>
+                              <app-chrono-ref-field [target]="editFileMeta" />
                             </div>
                           </div>
                           @if (recordList.editError()) {
@@ -203,14 +150,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                         <td>
                           <div class="chip-list">
                             @for (id of (fm.memoryIds ?? []); track id) {
-                              <span class="chip" [title]="id">{{ picker.fmMemoryTitle(id) }}</span>
+                              <span class="chip" [title]="id">{{ picker.memoryRefTitle(id) }}</span>
                             }
                           </div>
                         </td>
                         <td>
                           <div class="chip-list">
                             @for (id of (fm.chronoIds ?? []); track id) {
-                              <span class="chip" [title]="id">{{ picker.fmChronoTitle(id) }}</span>
+                              <span class="chip" [title]="id">{{ picker.chronoRefTitle(id) }}</span>
                             }
                           </div>
                         </td>
@@ -286,8 +233,10 @@ export class FilemetaTabComponent extends RecordTabBase {
       memoryIds: [...(entry.memoryIds ?? [])],
       chronoIds: [...(entry.chronoIds ?? [])],
     };
-    // Resolve entity names for chips display
+    // Resolve entity names / memory facts / chrono titles so the chips show labels, not truncated ids.
     this.picker.resolveEntityNamesFor(this.editFileMeta.entityIds);
+    this.picker.resolveMemoryTitles(this.editFileMeta.memoryIds);
+    this.picker.resolveChronoTitles(this.editFileMeta.chronoIds);
   }
 
   saveEditFileMeta(id: string): void {


### PR DESCRIPTION
## What

File Meta's **entity / memory / chrono** link pickers were the last hold-outs on the old click-to-open **flyout** pattern. They now use the same always-inline chips + search field as every other Brain tab:
- entity → `app-entity-ref-field` (#394)
- memory → `app-memory-ref-field` (#395)
- chrono → **new** `app-chrono-ref-field` (third sibling; file-meta is its only consumer today but it mirrors the other two and kills the `fm*` chrono duplication)

This completes the composite-field refactor and the File Meta rebuild (slice 4d).

## Behaviour improvements (fall out of the migration)

- **Memory search is now server-side** (`listMemories(?search=)`) — the old `fm*` variant filtered client-side over only the first 8 loaded memories.
- **Linked memory/chrono chips resolve their real titles on edit-open** (`resolveMemoryTitles` / `resolveChronoTitles`) instead of showing a truncated id.

## Dead code removed

The entire file-meta `fm*` picker apparatus in `EntityRefPicker`, including a **dead `isDrawer` branch** and its **four never-read `fmDrawer*` signals**. Net: −165 lines.

## Deliberately kept

The brain flyout machinery (`flyoutField`/`openFlyout`/`closeFlyout` + the shell backdrop) is now dormant but **kept** — removing it cascades into `record-drawer-state.service` and risks `graph.component.ts`'s own separate flyout copy. A small follow-up (tracked) can retire it once graph is checked.

## Tests

New `chrono-ref-field.component.spec.ts` pins the extracted contract; `filemeta-tab` + `entity-ref-picker` specs are the characterization guard. **Full client suite green (510 tests)**; production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)