### PR TITLE
feat(brain): chrono records can carry schema-defined properties in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Chrono entries can now carry schema-defined properties in the UI.** A chrono type's schema could
+  already declare `propertySchemas` and the server validated + persisted a chrono's `properties`, but no
+  client form ever surfaced them — so the field was invisible and effectively unusable. The chrono
+  **create form, inline-edit row, and detail drawer** now all show the same `app-properties-editor` the
+  entity / edge / memory forms use, driven by a new `store.chronoSchema(type)` accessor; switching the
+  chrono kind reseeds the property defaults, and values are stripped of empty optionals before saving
+  (reusing the existing chrono create/update `properties` API field — no route change). Client-only.
 - **The File Meta list endpoint gains a freetext `?search=`.** `GET /api/brain/spaces/:id/files` now
   accepts a `?search=<text>` that matches a case-insensitive **substring** of a file record's `path` +
   `description`, applied server-side before pagination (spans the whole list) and escaped as a literal —

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -397,6 +397,7 @@
   "brain.chrono.table.ends": "Endet",
   "brain.chrono.table.tags": "Schlagworte",
   "brain.chrono.table.entities": "Entitäten",
+  "brain.chrono.table.properties": "Eigenschaften",
   "brain.chrono.empty.noMatchQuery": "Für diese Suche stimmen keine Timeline-Einträge überein.",
   "brain.chrono.empty.title": "Keine Chronoeinträge",
   "brain.chrono.deleteAriaLabel": "Chronoeintrag löschen",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -397,6 +397,7 @@
   "brain.chrono.table.ends": "Ends",
   "brain.chrono.table.tags": "Tags",
   "brain.chrono.table.entities": "Entities",
+  "brain.chrono.table.properties": "Properties",
   "brain.chrono.empty.noMatchQuery": "No timeline entries match this search.",
   "brain.chrono.empty.title": "No chrono entries",
   "brain.chrono.deleteAriaLabel": "Delete chrono entry",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -397,6 +397,7 @@
   "brain.chrono.table.ends": "Kończy się",
   "brain.chrono.table.tags": "Tagi",
   "brain.chrono.table.entities": "Podmioty",
+  "brain.chrono.table.properties": "Właściwości",
   "brain.chrono.empty.noMatchQuery": "Żaden wpis na osi czasu nie pasuje do tego wyszukiwania.",
   "brain.chrono.empty.title": "Brak wpisów chronologicznych",
   "brain.chrono.deleteAriaLabel": "Usuń wpis chronologiczny",

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -195,6 +195,7 @@ export interface ChronoEntry {
   tags: string[];
   entityIds: string[];
   memoryIds: string[];
+  properties?: Record<string, string | number | boolean>;
   recurrence?: { freq: string; interval?: number; until?: string };
   author: { instanceId: string; instanceLabel: string };
   createdAt: string;

--- a/client/src/app/core/brain-api.service.ts
+++ b/client/src/app/core/brain-api.service.ts
@@ -194,11 +194,11 @@ export class BrainApi {
     return this.http.get<any>(`/api/brain/spaces/${spaceId}/chrono`, { params });
   }
 
-  createChrono(spaceId: string, body: { title: string; type: ChronoType; startsAt: string; endsAt?: string; status?: ChronoStatus; confidence?: number; tags?: string[]; entityIds?: string[]; memoryIds?: string[]; description?: string }): Observable<ChronoEntry> {
+  createChrono(spaceId: string, body: { title: string; type: ChronoType; startsAt: string; endsAt?: string; status?: ChronoStatus; confidence?: number; tags?: string[]; entityIds?: string[]; memoryIds?: string[]; description?: string; properties?: Record<string, string | number | boolean> }): Observable<ChronoEntry> {
     return this.http.post<ChronoEntry>(`/api/brain/spaces/${spaceId}/chrono`, body);
   }
 
-  updateChrono(spaceId: string, id: string, body: Partial<{ title: string; type: ChronoType; startsAt: string; endsAt: string; status: ChronoStatus; confidence: number; tags: string[]; entityIds: string[]; memoryIds: string[]; description: string }>): Observable<ChronoEntry> {
+  updateChrono(spaceId: string, id: string, body: Partial<{ title: string; type: ChronoType; startsAt: string; endsAt: string; status: ChronoStatus; confidence: number; tags: string[]; entityIds: string[]; memoryIds: string[]; description: string; properties: Record<string, string | number | boolean> }>): Observable<ChronoEntry> {
     return this.http.post<ChronoEntry>(`/api/brain/spaces/${spaceId}/chrono/${id}`, body);
   }
 

--- a/client/src/app/pages/brain/brain-store.service.spec.ts
+++ b/client/src/app/pages/brain/brain-store.service.spec.ts
@@ -136,6 +136,16 @@ describe('BrainStore — buildPropertiesObject (schema-seeded defaults)', () => 
   });
 });
 
+describe('BrainStore — chronoSchema', () => {
+  it('returns the propertySchemas for a chrono type, undefined when none / no type', () => {
+    const c = create();
+    c.spaceMeta.set({ typeSchemas: { chrono: { deadline: { propertySchemas: { dueBy: { type: 'string' } } } } } } as unknown as SpaceMetaResponse);
+    expect(c.chronoSchema('deadline')).toEqual({ dueBy: { type: 'string' } });
+    expect(c.chronoSchema('event')).toBeUndefined();
+    expect(c.chronoSchema(undefined)).toBeUndefined();
+  });
+});
+
 describe('BrainStore — stripEmptyOptionalProps', () => {
   it('drops empty OPTIONAL props but keeps empty REQUIRED ones (and all non-empty)', () => {
     const c = create();

--- a/client/src/app/pages/brain/brain-store.service.ts
+++ b/client/src/app/pages/brain/brain-store.service.ts
@@ -97,6 +97,12 @@ export class BrainStore {
     return Object.values(ts)[0]?.propertySchemas;
   }
 
+  /** Property schema for a chrono type (kind or custom-kind name); undefined when none is defined. */
+  chronoSchema(typeName: string | undefined): Record<string, PropertySchema> | undefined {
+    if (!typeName) return undefined;
+    return this.spaceMeta()?.typeSchemas?.chrono?.[typeName]?.propertySchemas;
+  }
+
   requiredProps(schema: Record<string, PropertySchema> | undefined): string[] {
     if (!schema) return [];
     return Object.entries(schema).filter(([, s]) => s.required).map(([k]) => k);

--- a/client/src/app/pages/brain/chrono-tab.component.spec.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.spec.ts
@@ -94,7 +94,7 @@ describe('ChronoTabComponent', () => {
 
   it('createChrono resolves a __custom__ kind to the free-text customKind and ISO-encodes startsAt', () => {
     const c = make().componentInstance;
-    c.chronoForm = { title: 'T', kind: '__custom__', customKind: ' launch ', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+    c.chronoForm = { title: 'T', kind: '__custom__', customKind: ' launch ', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: {} };
     c.createChrono();
     const [, body] = api.createChrono.mock.calls[0];
     expect(body.title).toBe('T');
@@ -106,18 +106,50 @@ describe('ChronoTabComponent', () => {
   // Slice 3c: linked memoryIds (from the inline memory picker) ride the create payload; omitted when empty.
   it('createChrono includes memoryIds when the memory picker has linked some (omitted when empty)', () => {
     const c = make().componentInstance;
-    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: ['m1', 'm2'] };
+    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: ['m1', 'm2'], properties: {} };
     c.createChrono();
     expect(api.createChrono.mock.calls[0][1].memoryIds).toEqual(['m1', 'm2']);
     api.createChrono.mockClear();
-    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: {} };
     c.createChrono();
     expect('memoryIds' in api.createChrono.mock.calls[0][1]).toBe(false);
   });
 
+  // Chrono properties editor (client-only gap fix): schema-defined properties ride the create payload,
+  // stripped of empty optionals, and are omitted entirely when nothing is set.
+  it('createChrono includes non-empty properties (omitted when empty)', () => {
+    const c = make().componentInstance;
+    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: { severity: 'high', note: '' } };
+    c.createChrono();
+    // No schema loaded → stripEmptyOptionalProps passes values through; '' optionals stay only if no schema.
+    expect(api.createChrono.mock.calls[0][1].properties).toEqual({ severity: 'high', note: '' });
+    api.createChrono.mockClear();
+    c.chronoForm = { title: 'T', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: {} };
+    c.createChrono();
+    expect('properties' in api.createChrono.mock.calls[0][1]).toBe(false);
+  });
+
+  it('saveEditChrono sends properties from the inline editor', () => {
+    const c = make().componentInstance;
+    c.store.chrono.set([{ _id: 'c1' } as ChronoEntry]);
+    c.recordList.editingId.set('c1');
+    c.editChrono = { title: 'T', kind: 'event', status: 'active', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: { owner: 'ada' } };
+    c.saveEditChrono('c1');
+    expect(api.updateChrono.mock.calls[0][2].properties).toEqual({ owner: 'ada' });
+  });
+
+  it('changing the create-form kind reseeds properties from the new kind schema', () => {
+    const c = make().componentInstance;
+    // With a schema for 'deadline', switching kind seeds its keys with typed defaults.
+    c.store.spaceMeta.set({ typeSchemas: { chrono: { deadline: { propertySchemas: { dueBy: { type: 'string' } } } } } } as never);
+    c.chronoForm = { title: '', kind: 'deadline', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: {} };
+    c.onChronoFormKindChange();
+    expect(c.chronoForm.properties).toEqual({ dueBy: '' });
+  });
+
   it('createChrono is a no-op without a title or startsAt', () => {
     const c = make().componentInstance;
-    c.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+    c.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '2026-03-04T09:07', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: {} };
     c.createChrono();
     expect(api.createChrono).not.toHaveBeenCalled();
   });
@@ -126,7 +158,7 @@ describe('ChronoTabComponent', () => {
     const c = make().componentInstance;
     c.store.chrono.set([{ _id: 'c1' } as ChronoEntry]);
     c.recordList.editingId.set('c1');
-    c.editChrono = { title: 'T', kind: '__custom__', status: 'active', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+    c.editChrono = { title: 'T', kind: '__custom__', status: 'active', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: {} };
     c.saveEditChrono('c1');
     const [, , body] = api.updateChrono.mock.calls[0];
     expect(body.type).toBe('__custom__'); // sent verbatim, unlike createChrono

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -9,6 +9,7 @@ import { httpErrorReason } from '../../core/http-error';
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { EntityRefFieldComponent } from './entity-ref-field.component';
 import { MemoryRefFieldComponent } from './memory-ref-field.component';
+import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { RecordDrawerState } from './record-drawer-state.service';
@@ -34,7 +35,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -57,13 +58,13 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 <div class="field" style="width:160px;">
                   <label>{{ 'brain.chrono.form.kind' | transloco }}</label>
                   @if (chronoForm.kind !== '__custom__') {
-                    <select [(ngModel)]="chronoForm.kind" name="kind">
+                    <select [(ngModel)]="chronoForm.kind" name="kind" (ngModelChange)="onChronoFormKindChange()">
                       @for (k of store.chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
                       <option value="__custom__">{{ 'brain.chrono.form.customKind' | transloco }}</option>
                     </select>
                   } @else {
                     <div style="display:flex; gap:4px;">
-                      <input type="text" [(ngModel)]="chronoForm.customKind" name="customKind" style="flex:1;" />
+                      <input type="text" [(ngModel)]="chronoForm.customKind" name="customKind" style="flex:1;" (ngModelChange)="onChronoFormKindChange()" />
                       <button type="button" class="btn-secondary btn btn-sm" style="padding:4px 8px;" (click)="chronoForm.kind = 'event'; chronoForm.customKind = ''" [attr.title]="'brain.chrono.form.backToPresets' | transloco"><ph-icon name="x" [size]="14"/></button>
                     </div>
                   }
@@ -95,6 +96,16 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                 <div class="field">
                   <label>{{ 'brain.chrono.form.memories' | transloco }}</label>
                   <app-memory-ref-field [target]="chronoForm" />
+                </div>
+              </div>
+              <div class="form-row rich">
+                <div class="field" style="flex:1;">
+                  <label>{{ 'brain.chrono.table.properties' | transloco }}</label>
+                  <app-properties-editor
+                    [schema]="store.chronoSchema(chronoFormKind())"
+                    [required]="store.requiredProps(store.chronoSchema(chronoFormKind()))"
+                    [(value)]="chronoForm.properties"
+                  />
                 </div>
               </div>
               <div style="display:flex; gap:8px;">
@@ -143,7 +154,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                           </div>
                           <div class="field" style="width:130px; margin-bottom:0;">
                             <label>{{ 'brain.chrono.form.kind' | transloco }}</label>
-                            <select [(ngModel)]="editChrono.kind" name="editChronoKind">
+                            <select [(ngModel)]="editChrono.kind" name="editChronoKind" (ngModelChange)="onEditChronoKindChange()">
                               @for (k of store.chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
                             </select>
                           </div>
@@ -172,6 +183,14 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                           <div class="field" style="flex:1; min-width:140px; margin-bottom:0;">
                             <label>{{ 'brain.chrono.table.entities' | transloco }}</label>
                             <app-entity-ref-field [target]="editChrono" [spaceId]="spaceId()" />
+                          </div>
+                          <div class="field" style="flex:1; min-width:180px; margin-bottom:0;">
+                            <label>{{ 'brain.chrono.table.properties' | transloco }}</label>
+                            <app-properties-editor
+                              [schema]="store.chronoSchema(editChrono.kind)"
+                              [required]="store.requiredProps(store.chronoSchema(editChrono.kind))"
+                              [(value)]="editChrono.properties"
+                            />
                           </div>
                           <div style="display:flex; gap:6px; align-items:flex-end;">
                             <button class="btn btn-sm btn-primary" [disabled]="recordList.editSaving()" (click)="saveEditChrono(entry._id)">
@@ -255,8 +274,8 @@ export class ChronoTabComponent extends RecordTabBase {
   showChronoForm = signal(false);
   creatingChrono = signal(false);
   createChronoError = signal('');
-  chronoForm = { title: '', kind: 'event' as ChronoType | '__custom__', customKind: '', startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[] };
-  editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[] };
+  chronoForm = { title: '', kind: 'event' as ChronoType | '__custom__', customKind: '', startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[], properties: {} as Record<string, string | number | boolean> };
+  editChrono = { title: '', kind: '' as string, status: '' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[], properties: {} as Record<string, string | number | boolean> };
 
   private _chronoSemTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -326,9 +345,24 @@ export class ChronoTabComponent extends RecordTabBase {
     });
   }
 
+  /** Effective chrono type for schema lookup: the free-text custom kind, else the selected preset. */
+  chronoFormKind(): string {
+    return this.chronoForm.kind === '__custom__' ? this.chronoForm.customKind.trim() : this.chronoForm.kind;
+  }
+
   openChronoForm(): void {
-    this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+    this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: this.store.buildPropertiesObject('chrono', {}, 'event') };
     this.showChronoForm.set(true);
+  }
+
+  /** Reseed the create form's properties from the newly selected kind's schema (preserving values). */
+  onChronoFormKindChange(): void {
+    this.chronoForm.properties = this.store.buildPropertiesObject('chrono', this.chronoForm.properties, this.chronoFormKind());
+  }
+
+  /** Reseed the inline-edit form's properties from the newly selected kind's schema. */
+  onEditChronoKindChange(): void {
+    this.editChrono.properties = this.store.buildPropertiesObject('chrono', this.editChrono.properties, this.editChrono.kind);
   }
 
   createChrono(): void {
@@ -351,11 +385,13 @@ export class ChronoTabComponent extends RecordTabBase {
     if (this.chronoForm.tags.length) body.tags = this.chronoForm.tags;
     if (entityIds.length) body.entityIds = entityIds;
     if (this.chronoForm.memoryIds.length) body.memoryIds = this.chronoForm.memoryIds;
+    const props = this.store.stripEmptyOptionalProps(this.chronoForm.properties, this.store.chronoSchema(resolvedKind));
+    if (Object.keys(props).length) body.properties = props;
     this.brainApi.createChrono(this.spaceId(), body).subscribe({
       next: () => {
         this.creatingChrono.set(false);
         this.showChronoForm.set(false);
-        this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [] };
+        this.chronoForm = { title: '', kind: 'event', customKind: '', startsAt: '', endsAt: '', description: '', tags: [], entityIds: '', memoryIds: [], properties: this.store.buildPropertiesObject('chrono', {}, 'event') };
         this.load();
       },
       error: (err) => { this.creatingChrono.set(false); this.createChronoError.set(fmtApiError(err, 'Failed to create chrono entry')); },
@@ -375,6 +411,7 @@ export class ChronoTabComponent extends RecordTabBase {
       tags: entry.tags ?? [],
       entityIds: (entry.entityIds ?? []).join(', '),
       memoryIds: [...(entry.memoryIds ?? [])],
+      properties: this.store.buildPropertiesObject('chrono', entry.properties ?? {}, entry.type),
     };
     this.picker.resolveMemoryTitles(entry.memoryIds ?? []);
   }
@@ -392,6 +429,7 @@ export class ChronoTabComponent extends RecordTabBase {
       tags: this.editChrono.tags,
       entityIds: this.editChrono.entityIds.split(',').map(s => s.trim()).filter(Boolean),
       memoryIds: this.editChrono.memoryIds,
+      properties: this.store.stripEmptyOptionalProps(this.editChrono.properties, this.store.chronoSchema(this.editChrono.kind)),
     }).subscribe({
       next: (updated) => {
         this.recordList.editSaving.set(false);

--- a/client/src/app/pages/brain/record-drawer-state.service.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.ts
@@ -37,11 +37,21 @@ export class RecordDrawerState {
   drawerEditMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEdge = { label: '', type: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
-  drawerEditChrono = { title: '', kind: 'event' as string, customKind: '', status: 'upcoming' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', confidence: null as number | null, memoryIds: [] as string[] };
+  drawerEditChrono = { title: '', kind: 'event' as string, customKind: '', status: 'upcoming' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', confidence: null as number | null, memoryIds: [] as string[], properties: {} as Record<string, string | number | boolean> };
 
   /** Re-seed a drawer entity's properties when its type changes (mirrors the create/inline forms). */
   onEntityTypeChange(type: string): void {
     this.drawerEditEntity.properties = this.store.buildPropertiesObject('entity', this.drawerEditEntity.properties, type);
+  }
+
+  /** Effective chrono type for schema lookup: the free-text custom kind, else the selected preset. */
+  drawerChronoKind(): string {
+    return this.drawerEditChrono.kind === '__custom__' ? this.drawerEditChrono.customKind.trim() : this.drawerEditChrono.kind;
+  }
+
+  /** Re-seed the drawer chrono's properties when its kind changes (mirrors the create/inline forms). */
+  onDrawerChronoKindChange(): void {
+    this.drawerEditChrono.properties = this.store.buildPropertiesObject('chrono', this.drawerEditChrono.properties, this.drawerChronoKind());
   }
 
   open(kind: 'memory' | 'entity' | 'edge' | 'chrono', record: any): void {
@@ -89,6 +99,7 @@ export class RecordDrawerState {
         entityIds: (record.entityIds ?? []).join(', '),
         confidence: record.confidence ?? null,
         memoryIds: [...(record.memoryIds ?? [])],
+        properties: this.store.buildPropertiesObject('chrono', record.properties ?? {}, record.type),
       };
       this.picker.resolveMemoryTitles(record.memoryIds ?? []);
     }
@@ -160,6 +171,7 @@ export class RecordDrawerState {
       const resolvedKind = this.drawerEditChrono.kind === '__custom__'
         ? (this.drawerEditChrono.customKind.trim() as ChronoType)
         : this.drawerEditChrono.kind as ChronoType;
+      const chronoProps = this.store.stripEmptyOptionalProps(this.drawerEditChrono.properties, this.store.chronoSchema(resolvedKind));
       this.brainApi.updateChrono(spaceId, id, {
         title: this.drawerEditChrono.title.trim(),
         type: resolvedKind,
@@ -171,6 +183,7 @@ export class RecordDrawerState {
         entityIds: this.drawerEditChrono.entityIds.split(',').map(s => s.trim()).filter(Boolean),
         ...(this.drawerEditChrono.memoryIds.length ? { memoryIds: this.drawerEditChrono.memoryIds } : {}),
         ...(this.drawerEditChrono.confidence != null ? { confidence: this.drawerEditChrono.confidence } : {}),
+        ...(Object.keys(chronoProps).length ? { properties: chronoProps } : {}),
       }).subscribe({
         next: (updated) => {
           this.drawerSaving.set(false);

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -204,13 +204,13 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.kind' | transloco }} <span style="color:var(--error)">*</span></div>
                   @if (state.drawerEditChrono.kind !== '__custom__') {
-                    <select [(ngModel)]="state.drawerEditChrono.kind" name="drwChronoKind">
+                    <select [(ngModel)]="state.drawerEditChrono.kind" name="drwChronoKind" (ngModelChange)="state.onDrawerChronoKindChange()">
                       @for (k of store.chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
                       <option value="__custom__">{{ 'brain.chrono.form.customKind' | transloco }}</option>
                     </select>
                   } @else {
                     <div style="display:flex; gap:4px;">
-                      <input type="text" [(ngModel)]="state.drawerEditChrono.customKind" name="drwChronoCustomKind" style="flex:1;" />
+                      <input type="text" [(ngModel)]="state.drawerEditChrono.customKind" name="drwChronoCustomKind" style="flex:1;" (ngModelChange)="state.onDrawerChronoKindChange()" />
                       <button type="button" class="btn-secondary btn btn-sm" style="padding:4px 8px;" (click)="state.drawerEditChrono.kind = 'event'; state.drawerEditChrono.customKind = ''" [attr.title]="'brain.chrono.form.backToPresets' | transloco"><ph-icon name="x" [size]="14"/></button>
                     </div>
                   }
@@ -248,6 +248,10 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.memoryIds' | transloco }}</div>
                   <app-memory-ref-field [target]="state.drawerEditChrono" />
+                </div>
+                <div class="drawer-field">
+                  <div class="drawer-label">{{ 'brain.chrono.table.properties' | transloco }}</div>
+                  <app-properties-editor [schema]="store.chronoSchema(state.drawerChronoKind())" [required]="store.requiredProps(store.chronoSchema(state.drawerChronoKind()))" [(value)]="state.drawerEditChrono.properties" />
                 </div>
                 <hr class="drawer-hr">
                 <div class="drawer-field">

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -164,7 +164,7 @@ When a **label** is selected and the space has a schema defined for that label, 
 
 Chrono stores time-anchored entries: events, deadlines, plans, predictions, and milestones.
 
-**Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, linked **entities**, and linked **memories** — the memory field is a searchable picker (type to find a memory by its fact and click to link it; linked memories show as chips). The same memory picker is available when editing an entry in its detail drawer.
+**Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, linked **entities**, linked **memories**, and **properties** — the memory field is a searchable picker (type to find a memory by its fact and click to link it; linked memories show as chips), and the properties editor lets you fill in any fields the chrono type's schema defines (switching the type reseeds its property fields). The same pickers and properties editor are available when editing an entry in its detail drawer.
 
 **Searching:** The top search bar is **Semantic** (ranks entries by meaning). Plain-text matching (title / description) is the **freetext box under the Title column**.
 


### PR DESCRIPTION
## What

A chrono type's schema could already declare `propertySchemas`, and the server **validated + persisted** a chrono's `properties` — but **no client form surfaced the field**, so it was invisible and effectively unusable (owner-spotted 2026-07-25).

This wires the same `app-properties-editor` the entity / edge / memory forms use into the chrono **create form, inline-edit row, and detail drawer**, driven by a new `store.chronoSchema(type)` accessor.

## Details

- Switching the chrono **kind reseeds** the property defaults (`buildPropertiesObject`); values are **stripped of empty optionals** before saving.
- Added `properties` to the client `ChronoEntry` type and the `createChrono`/`updateChrono` body types — reusing the existing chrono API field, **no route change**.
- Added i18n key `brain.chrono.table.properties` (en/de/pl).
- Read-only viewing rides the drawer's edit surface; **no chrono table column** was added (the table is already 9 columns, wider than the entities table).

## Tests

create includes/omits properties, inline-edit sends them, kind-change reseeds defaults, and a `chronoSchema` store unit. **Full client suite green (514)**; production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)