### PR TITLE
chore(brain): retire the dormant entity-picker flyout machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3739,6 +3739,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **The dormant Brain entity-picker flyout machinery is gone (internal, no behaviour change).** The old
+  click-to-open flyout was fronted by `EntityRefPicker.flyoutField`/`openFlyout`/`closeFlyout`, a
+  shell-level `.flyout-backdrop`, and a block of `.flyout-*` rules in the shared chip styles. Slice 4d
+  moved File Meta — the last flyout user — onto the inline ref-field components, leaving all of that with
+  zero live consumers (the field was never set non-empty again). It's now removed, along with the
+  drawer-close `closeFlyout()` no-op and the obsolete picker-spec cases. The Graph page keeps its own,
+  independent flyout (separate component-local state + styles) and is unaffected.
 - **BREAKING: the legacy `/api/brain/:spaceId/memories` route shape is removed.** Space memory
   endpoints used to be registered under two URL shapes — canonical `/api/brain/spaces/:spaceId/…` and
   legacy `/api/brain/:spaceId/…` — with the handler bodies **copy-pasted** between them (and the

--- a/client/src/app/pages/brain/brain-form.styles.ts
+++ b/client/src/app/pages/brain/brain-form.styles.ts
@@ -6,23 +6,9 @@
  * the drawer, so it does not import it).
  */
 
-/** Entity-chip + reference-picker flyout styling, used by every form and the drawer. */
+/** Entity-chip + inline reference-picker styling, used by every form, the ref-field components, and
+ *  the drawer. (The old click-to-open flyout was retired once file-meta moved to the inline pickers.) */
 export const BRAIN_CHIP_STYLES = `
-    .flyout-backdrop { position: fixed; inset: 0; z-index: 55; }
-    .flyout-wrap { position: relative; display: block; width: 100%; }
-    .flyout-trigger {
-      display: inline-flex; align-items: center; gap: 6px;
-      padding: 5px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm);
-      font-size: 12px; background: var(--bg-primary); color: var(--text-secondary);
-      cursor: pointer; width: 100%; text-align: left; transition: border-color var(--transition);
-    }
-    .flyout-trigger:hover { border-color: var(--accent); color: var(--text-primary); }
-    .flyout-trigger.has-value { color: var(--text-primary); }
-    .flyout-panel {
-      position: absolute; top: calc(100% + 4px); left: 0; min-width: 300px; z-index: 60;
-      background: var(--bg-primary); border: 1px solid var(--border);
-      border-radius: var(--radius-md); box-shadow: var(--shadow-lg); padding: 12px;
-    }
     .chip-list { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 8px; min-height: 24px; }
     .chip {
       display: inline-flex; align-items: center; gap: 3px; padding: 2px 8px;

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -42,9 +42,6 @@ interface SpaceView {
   imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, FilemetaTabComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [`
-    /* The shared entity-picker flyout backdrop is rendered at the shell level (the panels live in the
-       tab components). It is the only chip/flyout style the shell itself uses. */
-    .flyout-backdrop { position: fixed; inset: 0; z-index: 55; }
     .space-tabs {
       display: flex;
       gap: 8px;
@@ -161,8 +158,6 @@ interface SpaceView {
         <p>{{ 'brain.emptySpaces.body' | transloco }}</p>
       </div>
     } @else {
-
-      @if (picker.flyoutField()) { <div class="flyout-backdrop" (click)="picker.closeFlyout()"></div> }
 
       <!-- Space selector -->
       <div class="space-tabs">

--- a/client/src/app/pages/brain/entity-ref-picker.service.spec.ts
+++ b/client/src/app/pages/brain/entity-ref-picker.service.spec.ts
@@ -12,8 +12,6 @@
  *     driving several distinct targets
  *   - `appendEntityId` de-dups and re-joins with ', '; `removeEntityId` drops one id and re-joins
  *   - `entityChips` resolves names from the cache, falls back to the raw id, trims and drops blanks
- *   - `openFlyout(key, target)` sets the active field and resolves the target's *uncached* ids; with
- *     no target (the memory/chrono file-meta pickers) it resolves nothing
  *   - `resolveEntityNames` / `resolveEntityNamesFor` hit the API only for uncached ids
  *
  * The edge from/to endpoints did NOT move here — they set display fields on the shell's `edgeForm`
@@ -100,22 +98,14 @@ describe('EntityRefPicker (characterization)', () => {
     ]);
   });
 
-  // ── openFlyout / closeFlyout + name resolution ─────────────────────────────
+  // ── resolveEntityNamesFor (a form's comma-separated entityIds, used on edit-open) ───────────
 
-  it('openFlyout sets the active field; closeFlyout clears it', () => {
-    const picker = create();
-    picker.openFlyout('create-memory-entityIds', { entityIds: '' });
-    expect(picker.flyoutField()).toBe('create-memory-entityIds');
-    picker.closeFlyout();
-    expect(picker.flyoutField()).toBe('');
-  });
-
-  it("openFlyout with a target resolves the target's UNCACHED ids and patches the cache", () => {
+  it("resolveEntityNamesFor resolves a CSV field's UNCACHED ids and patches the cache", () => {
     const picker = create();
     picker.entityNameCache.set({ e1: 'Alice' }); // e1 known → only e2 requested
     getEntitiesByIds.mockReturnValue(of({ entities: [entity('e2', 'Bob')] }));
 
-    picker.openFlyout('create-memory-entityIds', { entityIds: 'e1, e2' });
+    picker.resolveEntityNamesFor('e1, e2');
 
     expect(getEntitiesByIds).toHaveBeenCalledTimes(1);
     expect(getEntitiesByIds).toHaveBeenCalledWith('work', ['e2']);
@@ -123,17 +113,10 @@ describe('EntityRefPicker (characterization)', () => {
     expect(picker.entityNameCache()['e1']).toBe('Alice'); // preserved
   });
 
-  it('openFlyout does not call the API when every id is already cached', () => {
+  it('resolveEntityNamesFor does not call the API when every id is already cached', () => {
     const picker = create();
     picker.entityNameCache.set({ e1: 'Alice' });
-    picker.openFlyout('create-chrono-entityIds', { entityIds: 'e1' });
-    expect(getEntitiesByIds).not.toHaveBeenCalled();
-  });
-
-  it('openFlyout without a target (memory/chrono file-meta pickers) resolves nothing', () => {
-    const picker = create();
-    picker.openFlyout('edit-filemeta-memoryIds');
-    expect(picker.flyoutField()).toBe('edit-filemeta-memoryIds');
+    picker.resolveEntityNamesFor('e1');
     expect(getEntitiesByIds).not.toHaveBeenCalled();
   });
 

--- a/client/src/app/pages/brain/entity-ref-picker.service.ts
+++ b/client/src/app/pages/brain/entity-ref-picker.service.ts
@@ -16,13 +16,14 @@ export interface EntityIdTarget {
 /**
  * The brain page's shared entity/memory/chrono reference picker.
  *
- * Extracted from BrainComponent (A17.9b). One flyout and one entity-name cache serve every form on
- * the page. Previously they were wired by a string-keyed god-switch — `pickEntity(ent, mode, field)`
- * and `resolveEntityNamesForFlyout(key)` branched on a field key like `'drawer-memory-entityIds'` and
- * reached directly into the matching form object, so the flyout could not leave the shell. This
- * service replaces that switch with a target-based API: the caller passes its OWN form ref, exactly
- * as `removeEntityId(target, id)` already did. That is the seam that lets the drawer and the tab views
- * become their own components (A17.9b-4/5), each holding its own edit models and calling this picker.
+ * Extracted from BrainComponent (A17.9b). Shared name/title caches plus the inline entity / memory /
+ * chrono pickers serve every form on the page. Previously they were wired by a string-keyed god-switch
+ * — `pickEntity(ent, mode, field)` branched on a field key like `'drawer-memory-entityIds'` and reached
+ * directly into the matching form object. This service replaces that switch with a target-based API:
+ * the caller passes its OWN form ref, exactly as `removeEntityId(target, id)` already did. That is the
+ * seam that lets the drawer and the tab views become their own components (A17.9b-4/5), each holding
+ * its own edit models and calling this picker. (The old click-to-open flyout that once fronted these
+ * pickers was retired in slice 4d, when file-meta — its last user — moved to the inline ref-fields.)
  *
  * Behaviour preserved verbatim (pinned by the A17.9b-2 characterization tests): picking an entity
  * updates the name cache and appends the id to the target's `entityIds`; edge endpoints (from/to) are
@@ -41,20 +42,9 @@ export class EntityRefPicker {
   /** Active brain space. Kept in sync by the shell, whose `activeSpaceId` is nav state. */
   readonly spaceId = signal('');
 
-  // ── Entity picker & flyout ───────────────────────────────────────────────
+  // ── Entity picker ────────────────────────────────────────────────────────
 
-  flyoutField = signal('');
   entityNameCache = signal<Record<string, string>>({});
-
-  /** Open the flyout for `key`; when a target is given, pre-resolve its uncached entity names. */
-  openFlyout(key: string, target?: EntityIdTarget): void {
-    this.flyoutField.set(key);
-    if (target) this.resolveEntityNamesFor(target.entityIds);
-  }
-
-  closeFlyout(): void {
-    this.flyoutField.set('');
-  }
 
   removeEntityId(target: { entityIds: string }, id: string): void {
     const parts = target.entityIds.split(',').map(s => s.trim()).filter(s => s && s !== id);
@@ -100,12 +90,11 @@ export class EntityRefPicker {
     return parts.join(', ');
   }
 
-  // ── Inline memory picker (chrono form; slice 3c "memoryIds searchable like entity") ──────────
+  // ── Inline memory picker (slice 3c "memoryIds searchable like entity") ───────────────────────
   //
-  // Kept separate from the file-meta `fm*` memory picker above (file-meta rides its own flyout and is
-  // rebuilt in slice 4); these back an INLINE search + a title cache so chips show the memory's fact,
-  // not a truncated id. Reused by the chrono create form and the drawer's chrono edit (never both open
-  // at once). Search is a fact substring, mirroring the file-meta picker.
+  // Backs app-memory-ref-field: an INLINE search + a title cache so chips show the memory's fact, not a
+  // truncated id. Server-searched via listMemories(?search=). Used by the chrono create form, the
+  // drawer's chrono edit, and (since slice 4d) the file-meta edit form — only ever one open at a time.
 
   memPickQuery = signal('');
   memPickResults = signal<Memory[]>([]);

--- a/client/src/app/pages/brain/record-drawer-state.service.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.ts
@@ -108,7 +108,6 @@ export class RecordDrawerState {
   close(): void {
     this.drawerRecord.set(null);
     this.drawerError.set('');
-    this.picker.closeFlyout();
   }
 
   save(): void {


### PR DESCRIPTION
## What

Slice 4d (#396) moved File Meta — the **last consumer** that set `EntityRefPicker.flyoutField` — onto the inline ref-field components. That left the whole flyout apparatus with no live consumers: the field was never set non-empty again, so the shell backdrop never rendered.

This removes the now-dead machinery:
- `EntityRefPicker.flyoutField` / `openFlyout` / `closeFlyout`
- the shell-level `flyout-backdrop` render + its style in `brain.component`
- the no-op `picker.closeFlyout()` call in `RecordDrawerState.close()`
- the `.flyout-*` rules in `BRAIN_CHIP_STYLES` (backdrop / wrap / trigger / panel)
- the obsolete `openFlyout`/`closeFlyout` cases in the picker spec — the entity-name resolution they exercised is **retained**, now driven through `resolveEntityNamesFor`

## Safety

The **Graph page keeps its own independent flyout** (component-local `flyoutField`/`openFlyout`/`closeFlyout` + its own `.flyout-wrap`/`.flyout-panel` styles, and does **not** import `BRAIN_CHIP_STYLES`) — verified by grep, so it's unaffected. Stale flyout docstrings in the picker service/spec refreshed.

## Tests

No behaviour change. Full client suite green (512); production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)