### PR TITLE
feat(settings): colour-code token permission pills by privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2331,6 +2331,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Token permission pills are now colour-coded by privilege (Settings → Tokens).** The permission
+  badge in the token list mapped to design-system colours that didn't track privilege — admin was
+  green, standard was neutral grey. Following owner feedback, the pills now read at a glance:
+  **admin = red** (the most-powerful, most-dangerous token), **standard = green**, **read-only =
+  yellow** (schema-library keeps its distinct blue). Purely the pill colour vocabulary — no change to
+  permissions, the create flow, or any behaviour.
 - **The Brain File Meta edit form's entity / memory / chrono pickers now match every other tab.** They
   were the last hold-outs on the old click-to-open **flyout** pattern; each is now the same always-inline
   chips + search field the memory and chrono forms use, via the shared `app-entity-ref-field` /

--- a/client/src/app/pages/settings/tokens.component.spec.ts
+++ b/client/src/app/pages/settings/tokens.component.spec.ts
@@ -57,6 +57,29 @@ describe('TokensComponent — permission → create payload', () => {
   });
 });
 
+describe('TokensComponent — permission pill colour semantics (UI-BUNDLE-1)', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  // Owner feedback 2026-07-23: admin=red, standard=green, read-only=yellow. The list pills map to the
+  // design-system StatusPill variants error / ok / warn respectively (schema-library stays pending/blue).
+  it('renders the permission pill with the level-coded StatusPill variant', () => {
+    const cases = [
+      { tok: { id: 't1', admin: true }, variant: 'error' },
+      { tok: { id: 't2' }, variant: 'ok' }, // standard = no flags
+      { tok: { id: 't3', readOnly: true }, variant: 'warn' },
+      { tok: { id: 't4', schemaLibrary: true }, variant: 'pending' },
+    ] as const;
+    for (const { tok, variant } of cases) {
+      const { fixture, c } = make();
+      c.tokens.set([{ spaces: [], ...tok } as never]);
+      fixture.detectChanges();
+      const pill = fixture.nativeElement.querySelector('tbody tr td:nth-child(2) .pill');
+      expect(pill, `token ${tok.id}`).not.toBeNull();
+      expect(pill.classList.contains(variant), `token ${tok.id} → ${variant}`).toBe(true);
+    }
+  });
+});
+
 describe('TokensComponent — permission capability help (U6)', () => {
   beforeEach(() => TestBed.resetTestingModule());
 

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -383,10 +383,10 @@ import { RelativeTimeComponent } from '../../shared/relative-time.component';
                     @if (t.id === selfToken()?.id) { <span style="margin-left:6px;font-size:0.75rem;color:var(--text-muted);">{{ 'tokens.table.currentSession' | transloco }}</span> }
                   </td>
                   <td>
-                    @if (t.admin) { <app-status-pill variant="ok">{{ 'tokens.badge.admin' | transloco }}</app-status-pill> }
+                    @if (t.admin) { <app-status-pill variant="error">{{ 'tokens.badge.admin' | transloco }}</app-status-pill> }
                     @else if (t.schemaLibrary) { <app-status-pill variant="pending">{{ 'tokens.badge.schemaLibrary' | transloco }}</app-status-pill> }
                     @else if (t.readOnly) { <app-status-pill variant="warn">{{ 'tokens.badge.readOnly' | transloco }}</app-status-pill> }
-                    @else { <app-status-pill variant="off">{{ 'tokens.badge.standard' | transloco }}</app-status-pill> }
+                    @else { <app-status-pill variant="ok">{{ 'tokens.badge.standard' | transloco }}</app-status-pill> }
                   </td>
                   <td><app-relative-time [value]="t.createdAt"/></td>
                   <td>

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -432,7 +432,7 @@ Tokens can also be **space-scoped** — restricted to a specific list of spaces.
 
 ### Creating a token
 
-Click **Create Token**. Enter a name, choose a permission level, optionally set an expiry date, and optionally restrict it to specific spaces. A help line under the permission choices spells out exactly what the selected level can and cannot do (Read-only reads only; Standard reads and writes data; Admin adds token/space/config management). Click **Create** — the token value is shown **once**. Copy it immediately. The tokens list shows each token's permission level and space scope at any time.
+Click **Create Token**. Enter a name, choose a permission level, optionally set an expiry date, and optionally restrict it to specific spaces. A help line under the permission choices spells out exactly what the selected level can and cannot do (Read-only reads only; Standard reads and writes data; Admin adds token/space/config management). Click **Create** — the token value is shown **once**. Copy it immediately. The tokens list shows each token's permission level and space scope at any time, with the permission pill **colour-coded by privilege** so the riskiest tokens stand out at a glance: **admin is red**, **standard is green**, and **read-only is yellow** (Library Access tokens keep their own blue).
 
 This dialog has no "Library Access" toggle. Library Access tokens (for sharing your schema library with other instances) are created separately, from the **Schema Library** page's own **Create token** dialog — see [Schema Library](#schema-library).
 


### PR DESCRIPTION
## What

The token-list permission badge (Settings → Tokens) mapped to design-system colours that didn't track privilege — **admin** rendered green and **standard** rendered neutral grey. Per owner feedback (UI-BUNDLE-1, 2026-07-23), the pills now read at a glance by privilege:

| Level | Pill | Colour |
|---|---|---|
| admin | `error` | **red** — most-powerful / most-dangerous token |
| standard | `ok` | **green** |
| read-only | `warn` | **yellow** (unchanged) |
| schema-library | `pending` | blue (unchanged, distinct 4th state) |

## Scope

Only the `StatusPill` colour vocabulary changes — permissions, the create flow, and all behaviour are untouched. The create-time permission tooltip, uniform icon-buttons, and empty-state CTA already shipped in earlier PR-U6 work, so **item-10's Tokens asks are now complete**.

## Tests

Added a spec pinning the permission → `StatusPill` variant mapping for each level. Production build clean; tokens spec green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)