### PR TITLE
feat(spaces): new spaces default to a fully-strict schema posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2331,12 +2331,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **New spaces now start with a fully-strict schema posture.** Creating a space in **Settings → Spaces**
+  now defaults it to `validationMode: 'strict'` **and** `strictLinkage: true`, so a fresh space enforces
+  its schema and referential integrity from the moment it exists — the strictest, most data-honest
+  default. You can still turn either off per space from the Schema tab, and an explicit value in the
+  create request always wins. **Existing spaces are not migrated**, and the strict default is **not**
+  applied to spaces created by joining a federation network (those keep the lenient default so incoming
+  federated records are never rejected on ingest). With no per-type schemas defined yet, `strict` still
+  accepts every type — nothing to violate — so a brand-new empty space is never blocked.
+
 - **Token permission pills are now colour-coded by privilege (Settings → Tokens).** The permission
   badge in the token list mapped to design-system colours that didn't track privilege — admin was
   green, standard was neutral grey. Following owner feedback, the pills now read at a glance:
   **admin = red** (the most-powerful, most-dangerous token), **standard = green**, **read-only =
   yellow** (schema-library keeps its distinct blue). Purely the pill colour vocabulary — no change to
   permissions, the create flow, or any behaviour.
+
 - **The Brain File Meta edit form's entity / memory / chrono pickers now match every other tab.** They
   were the last hold-outs on the old click-to-open **flyout** pattern; each is now the same always-inline
   chips + search field the memory and chrono forms use, via the shared `app-entity-ref-field` /

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -367,6 +367,12 @@ Click **Create New Space**. Fill in:
 - **Proxy for** — optionally mark this as a proxy space standing in for one or more other spaces (tick individual spaces or "all").
 - **Validation mode** — the schema-validation posture for the new space: `off`, `warn`, or `strict`.
 
+> **New spaces start strict.** A freshly created space now defaults to **`strict` validation** *and*
+> **strict linkage** — it enforces its schema and referential integrity from day one. You can relax
+> either from the space's **Schema tab** at any time. (Until you define per-type schemas there's nothing
+> to violate, so a brand-new empty space still accepts anything.) Spaces created by joining a federation
+> network are the exception — they stay lenient so incoming federated records are never rejected.
+
 ### Space settings
 
 Click the gear icon on any space row to open its settings panel. Changes save and close automatically. An accidental click **outside** the panel won't close it (so you can't lose half-typed edits that way) — close it deliberately with **✕**, **Cancel**, or **Escape**; if you have unsaved changes you'll be asked to confirm.

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -396,8 +396,20 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
     }
   }
 
+  // New user-created spaces default to a fully-strict schema posture (owner decision 2026-07-25):
+  // validationMode:'strict' + strictLinkage:true, so a space enforces its schema and referential
+  // integrity from day one. An explicit value in the request wins (spread last). Proxy spaces hold no
+  // data of their own, so they are left un-defaulted. The federation-join path (networks/join) calls
+  // createSpace directly and is intentionally NOT affected — defaulting strict there would reject
+  // incoming off-schema federated records on ingest. With no typeSchemas yet defined, 'strict' still
+  // accepts every type/label (nothing to violate), so this never blocks a brand-new empty space.
+  const requestMeta = meta as SpaceMeta | undefined;
+  const seededMeta: SpaceMeta | undefined = proxyFor
+    ? requestMeta
+    : { validationMode: 'strict', strictLinkage: true, ...(requestMeta ?? {}) };
+
   try {
-    const space = await createSpace({ id, label, description, folders, maxGiB, proxyFor, meta: meta as SpaceMeta | undefined });
+    const space = await createSpace({ id, label, description, folders, maxGiB, proxyFor, meta: seededMeta });
     res.status(201).json({ space });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/testing/integration/spaces.test.js
+++ b/testing/integration/spaces.test.js
@@ -58,6 +58,30 @@ describe('Space management', () => {
     createdSpaceIds.push(`explicit-test-space-${RUN_ID}`);
   });
 
+  it('New space defaults to a fully-strict schema posture (owner decision 2026-07-25)', async () => {
+    const id = `strict-default-space-${RUN_ID}`;
+    const r = await post(INSTANCES.a, tokenA, '/api/spaces', { id, label: 'Strict Default Space' });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    createdSpaceIds.push(id);
+    // New user-created spaces enforce their schema + referential integrity from day one.
+    assert.equal(r.body.space?.meta?.validationMode, 'strict', 'new space should default to strict validation');
+    assert.equal(r.body.space?.meta?.strictLinkage, true, 'new space should default to strict linkage');
+  });
+
+  it('Explicit meta values override the strict defaults', async () => {
+    const id = `lenient-override-space-${RUN_ID}`;
+    const r = await post(INSTANCES.a, tokenA, '/api/spaces', {
+      id,
+      label: 'Lenient Override Space',
+      meta: { validationMode: 'off', strictLinkage: false },
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    createdSpaceIds.push(id);
+    // A caller who explicitly asks for a lenient posture gets it — the default only fills the gaps.
+    assert.equal(r.body.space?.meta?.validationMode, 'off', 'explicit validationMode should win');
+    assert.equal(r.body.space?.meta?.strictLinkage, false, 'explicit strictLinkage should win');
+  });
+
   it('Duplicate space ID is rejected', async () => {
     const r = await post(INSTANCES.a, tokenA, '/api/spaces', {
       id: `explicit-test-space-${RUN_ID}`,


### PR DESCRIPTION
## What

New spaces created in **Settings → Spaces** now default to `validationMode: 'strict'` **and** `strictLinkage: true`, so a space enforces its schema and referential integrity from the moment it exists — the strictest, most data-honest default.

Owner decision (2026-07-25).

## How

- The strict default is applied at the **`POST /api/spaces` route handler** only, filling in the two flags when the request didn't specify them (an explicit value in the request still wins).
- The **federation-join path** (`networks/join.ts` → `createSpace`) is intentionally **not** affected — defaulting strict there would reject incoming off-schema federated records on ingest.
- **Proxy spaces** (which hold no data of their own) are left un-defaulted.
- With no per-type schemas defined yet, `strict` still accepts every type (nothing to violate), so a brand-new empty space is never blocked.
- **Existing spaces are not migrated.**

## Tests

- `testing/integration/spaces.test.js`: a new space comes out strict on both flags; explicit lenient `meta` overrides the defaults.
- Server type-checks clean; `audit-route-coverage` standalone gate green (POST /spaces already audited as `space.create`).

## Docs

- CHANGELOG `[Unreleased] → Changed` entry.
- `docs/userguide.md` Settings → Spaces "Creating a space" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)