### PR TITLE
feat(spaces): tidy the Create-space dialog and stop it understating the result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2331,6 +2331,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Create-space dialog is cleaner and no longer understates what it creates.** The **Purpose**
+  field now starts **empty** — it used to pre-fill a long MCP tool listing that was never meant to be
+  saved as a space's purpose. The **validation controls now default to the fully-strict posture**
+  (`strict` + strict linkage) and are **sent explicitly**, so the form matches the server's new-space
+  default instead of showing `off` while silently creating a strict space. The validation-mode select
+  and strict-linkage toggle now sit **inline on the same row as the Create button**, and the Purpose and
+  Proxy-for fields expand to fill the dialog instead of leaving dead space beneath them.
+
 - **New spaces now start with a fully-strict schema posture.** Creating a space in **Settings → Spaces**
   now defaults it to `validationMode: 'strict'` **and** `strictLinkage: true`, so a fresh space enforces
   its schema and referential integrity from the moment it exists — the strictest, most data-honest

--- a/client/src/app/pages/settings/space-create-dialog.component.spec.ts
+++ b/client/src/app/pages/settings/space-create-dialog.component.spec.ts
@@ -7,7 +7,7 @@
  * now live on this dialog. Nothing was rewritten to make the refactor pass.
  */
 import { TestBed } from '@angular/core/testing';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { of } from 'rxjs';
 import { NetworksApi } from '../../core/networks-api.service';
 import { SpacesApi } from '../../core/spaces-api.service';
@@ -15,13 +15,16 @@ import { getTranslocoModule } from '../../testing/transloco-testing';
 import { SpacesStore } from './spaces-store.service';
 import { SpaceCreateDialogComponent } from './space-create-dialog.component';
 
-function create() {
+function create(createSpaceSpy?: (body: unknown) => unknown) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     imports: [SpaceCreateDialogComponent, getTranslocoModule()],
     providers: [
       SpacesStore,
-      { provide: SpacesApi, useValue: { listSpaces: () => of({ spaces: [] }), createSpace: () => of({ space: {} }) } },
+      { provide: SpacesApi, useValue: {
+        listSpaces: () => of({ spaces: [] }),
+        createSpace: createSpaceSpy ?? (() => of({ space: {} })),
+      } },
       { provide: NetworksApi, useValue: { listNetworks: () => of({ networks: [] }) } },
     ],
   });
@@ -35,6 +38,33 @@ describe('SpaceCreateDialogComponent', () => {
     // Matches the house pattern (brain, file-manager, graph, audit-log all assert this). Every child
     // extracted in A17.8b is OnPush from birth rather than retrofitted onto the old 1600-line parent.
     expect(SpaceCreateDialogComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('starts with an empty Purpose and a fully-strict validation default', () => {
+    // The Purpose field no longer pre-fills the long MCP tool listing (owner feedback), and validation
+    // defaults to strict to match the server's new-space default (#400) — the form must not understate
+    // what will actually be created.
+    const c = create().componentInstance;
+    expect(c.form.purpose).toBe('');
+    expect(c.form.validationMode).toBe('strict');
+    expect(c.form.strictLinkage).toBe(true);
+  });
+
+  it('sends the validation choices explicitly, even when the user picks the lenient options', () => {
+    // If the form quietly omitted an "off"/unchecked choice, the server default (strict) would create a
+    // strict space while the user was shown "off" — so both flags are always sent.
+    const spy = vi.fn(() => of({ space: {} }));
+    const c = create(spy).componentInstance;
+    c.form.label = 'My Space';
+    c.form.validationMode = 'off';
+    c.form.strictLinkage = false;
+    c.createSpace();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const body = spy.mock.calls[0][0] as { meta?: { validationMode?: string; strictLinkage?: boolean; purpose?: string } };
+    expect(body.meta?.validationMode).toBe('off');
+    expect(body.meta?.strictLinkage).toBe(false);
+    // An empty Purpose is not sent as a blank string.
+    expect(body.meta?.purpose).toBeUndefined();
   });
 
   it('toggleProxyFor adds then removes an id', () => {

--- a/client/src/app/pages/settings/space-create-dialog.component.ts
+++ b/client/src/app/pages/settings/space-create-dialog.component.ts
@@ -44,15 +44,15 @@ import { SpaceMeta, ValidationMode } from '../../core/api.types';
         <label>{{ 'spaces.create.maxGiB' | transloco }}</label>
         <input type="number" [(ngModel)]="form.maxGiB" name="maxGiB" min="0" step="0.1" placeholder="—" />
       </div>
-      <div style="display:flex;gap:12px;flex-basis:100%;">
-        <div class="field" style="flex:1;margin-bottom:0;">
+      <div style="display:flex;gap:12px;flex-basis:100%;align-items:stretch;">
+        <div class="field" style="flex:1;margin-bottom:0;display:flex;flex-direction:column;">
           <label>{{ 'spaces.create.purpose' | transloco }}</label>
-          <textarea [(ngModel)]="form.purpose" name="purpose" maxlength="4000" rows="5" style="resize:vertical;" [placeholder]="'spaces.create.purposePlaceholder' | transloco"></textarea>
+          <textarea [(ngModel)]="form.purpose" name="purpose" maxlength="4000" rows="8" style="resize:vertical;flex:1;min-height:160px;" [placeholder]="'spaces.create.purposePlaceholder' | transloco"></textarea>
         </div>
-        <div class="field" style="flex:1;margin-bottom:0;">
+        <div class="field" style="flex:1;margin-bottom:0;display:flex;flex-direction:column;">
           <label>{{ 'spaces.create.proxyFor' | transloco }}</label>
           @if (store.spaces().length > 0) {
-            <div class="table-wrapper" style="max-height:180px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius-sm);">
+            <div class="table-wrapper" style="flex:1;min-height:160px;max-height:240px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius-sm);">
               <table style="margin:0;">
                 <thead><tr><th style="width:40px;"></th><th>{{ 'spaces.table.column.label' | transloco }}</th><th>{{ 'spaces.table.column.id' | transloco }}</th></tr></thead>
                 <tbody>
@@ -75,20 +75,16 @@ import { SpaceMeta, ValidationMode } from '../../core/api.types';
           }
         </div>
       </div>
-      <div style="display:flex;gap:12px;flex-basis:100%;align-items:flex-start;">
+      <div style="display:flex;gap:12px;flex-basis:100%;align-items:flex-end;">
         <div class="field" style="margin-bottom:0;">
           <label>{{ 'spaces.create.validationMode' | transloco }}</label>
           <select [(ngModel)]="form.validationMode" name="validationMode" style="width:140px;">
             <option value="off">{{ 'spaces.create.validation.off' | transloco }}</option><option value="warn">{{ 'spaces.create.validation.warn' | transloco }}</option><option value="strict">{{ 'spaces.create.validation.strict' | transloco }}</option>
           </select>
         </div>
-        <div class="field" style="margin-bottom:0;padding-top:22px;">
-          <label style="display:flex;align-items:center;gap:8px;font-weight:normal;cursor:pointer;">
-            <input type="checkbox" [(ngModel)]="form.strictLinkage" name="strictLinkage" />{{ 'spaces.create.strictLinkage' | transloco }}
-          </label>
-        </div>
-      </div>
-      <div style="display:flex;gap:8px;flex-basis:100%;">
+        <label class="field" style="margin-bottom:0;display:flex;flex-direction:row;align-items:center;gap:8px;font-weight:normal;cursor:pointer;height:34px;">
+          <input type="checkbox" [(ngModel)]="form.strictLinkage" name="strictLinkage" />{{ 'spaces.create.strictLinkage' | transloco }}
+        </label>
         <button class="btn btn-primary" type="submit" style="margin-left:auto;" [disabled]="creating()||!form.label.trim()">
           @if (creating()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }{{ 'spaces.create.submitButton' | transloco }}
         </button>
@@ -106,52 +102,6 @@ export class SpaceCreateDialogComponent {
   /** The page owns whether this dialog is shown; tell it to close. */
   readonly closed = output<void>();
 
-  static readonly DEFAULT_PURPOSE = [
-    'MCP endpoint for this space. Available tools:',
-    '',
-    'Spaces:',
-    '  list_spaces()                                      — list all accessible spaces with IDs, labels, counts',
-    '  get_stats(space)                                   — counts of memories, entities, edges, chrono',
-    '  get_space_meta(space)                              — schema, purpose, validation mode, entry counts',
-    '  update_space(space, label?, description?)          — update space label or description (admin)',
-    '  wipe_space(space, types?)                          — wipe all or specific collections (admin)',
-    '',
-    'Knowledge Graph — Memory:',
-    '  remember(space, fact, entities?, tags?, properties?) — store a fact with semantic embedding',
-    '  recall(query, space?, topK?, types?, filter?)      — semantic search; omit space for cross-space',
-    '  find_similar(space, entryId, entryType, topK?, ...) — find similar entries by stored embedding',
-    '  update_memory(space, id, fact?, tags?, entityIds?) — update memory (re-embeds on fact change)',
-    '  delete_memory(space, id)                           — delete memory',
-    '  query(space, collection, filter, projection?, limit?) — structured read-only MongoDB query',
-    '  bulk_write(space, memories?, entities?, edges?, chrono?) — batch upsert across all types',
-    '',
-    'Knowledge Graph — Entities & Edges:',
-    '  upsert_entity(space, name, type, tags?, properties?) — create or update named entity',
-    '  find_entities_by_name(space, name)                 — find entities by exact name',
-    '  update_entity(space, id, ...)                      — update entity fields',
-    '  merge_entities(space, survivorId, absorbedId, resolutions?) — merge two entities into one',
-    '  upsert_edge(space, from, to, label, type?, weight?) — create or update relationship edge',
-    '  update_edge(space, id, ...)                        — update edge fields',
-    '  traverse(space, startId, direction?, edgeLabels?, maxDepth?) — traverse the knowledge graph',
-    '',
-    'Knowledge Graph — Chrono:',
-    '  create_chrono(space, title, type, startsAt, ...)   — create event/deadline/plan/milestone',
-    '  update_chrono(space, id, ...)                      — update chronological entry',
-    '  list_chrono(space?, status?, type?, tags?, limit?) — list chrono entries; omit space for cross-space',
-    '',
-    'Files:',
-    '  read_file(space, path)                   — read file contents',
-    '  write_file(space, path, content, inputFormat?) — write file; auto-converts pdf/docx/epub/html',
-    '  list_dir(space, path?)                   — list directory contents',
-    '  delete_file(space, path)                 — delete a file',
-    '  create_dir(space, path)                  — create directory tree',
-    '  move_file(space, src, dst)               — move or rename file/directory',
-    '',
-    'Sync:',
-    '  list_peers()                             — list connected peer instances',
-    '  sync_now(peerId?)                        — trigger immediate sync cycle',
-  ].join('\n');
-
   // create dialog
   creating         = signal(false);
 
@@ -161,11 +111,15 @@ export class SpaceCreateDialogComponent {
 
   proxyForAll = false;
 
+  // The Purpose field starts empty — it used to pre-fill a long MCP tool listing, which the owner
+  // never wanted persisted (it is exposed over MCP anyway). Validation defaults to the fully-strict
+  // posture, matching the server's new-space default (#400), so the form never understates what will
+  // actually be created.
   form = {
     label: '', id: '', maxGiB: null as number | null,
-    purpose: SpaceCreateDialogComponent.DEFAULT_PURPOSE,
-    validationMode: 'off' as ValidationMode,
-    strictLinkage: false,
+    purpose: '',
+    validationMode: 'strict' as ValidationMode,
+    strictLinkage: true,
   };
 
   isProxyForSelected(id: string): boolean { return this.proxyForSelected.includes(id); }
@@ -191,11 +145,16 @@ export class SpaceCreateDialogComponent {
     if (this.form.maxGiB) body.maxGiB = this.form.maxGiB;
     if (this.proxyForAll) body.proxyFor = ['*'];
     else if (this.proxyForSelected.length) body.proxyFor = [...this.proxyForSelected];
-    const meta: Partial<SpaceMeta> = {};
+    // Send the validation choices EXPLICITLY, always. The server now defaults a new space to a
+    // fully-strict posture when they are omitted (#400); if the form quietly dropped an 'off'/unchecked
+    // choice it would create a strict space while showing the user 'off' — so the form must be
+    // authoritative over its own visible values.
+    const meta: Partial<SpaceMeta> = {
+      validationMode: this.form.validationMode,
+      strictLinkage: this.form.strictLinkage,
+    };
     if (this.form.purpose.trim()) meta.purpose = this.form.purpose.trim();
-    if (this.form.validationMode !== 'off') meta.validationMode = this.form.validationMode;
-    if (this.form.strictLinkage) meta.strictLinkage = true;
-    if (Object.keys(meta).length) body.meta = meta;
+    body.meta = meta;
     this.spacesApi.createSpace(body).pipe(
       timeout(30_000),
       finalize(() => this.creating.set(false)),
@@ -203,7 +162,7 @@ export class SpaceCreateDialogComponent {
       next: ({ space }) => {
         this.closed.emit();
         this.store.spaces.update(list => [...list, space]);
-        this.form = { label: '', id: '', maxGiB: null, purpose: SpaceCreateDialogComponent.DEFAULT_PURPOSE, validationMode: 'off', strictLinkage: false };
+        this.form = { label: '', id: '', maxGiB: null, purpose: '', validationMode: 'strict', strictLinkage: true };
         this.proxyForSelected = [];
         this.proxyForAll = false;
         // Vector indexes finish building server-side (B1); poll so the "preparing


### PR DESCRIPTION
## What

Three owner-feedback fixes to the **Create-space dialog** (Settings → Spaces):

1. **Purpose starts empty.** It used to pre-fill a long MCP tool listing that was never meant to be persisted as a space's purpose (it's exposed over MCP anyway).
2. **Validation defaults to the fully-strict posture** (`strict` + strict linkage) and both flags are now **sent explicitly**. After #400 the server defaults an omitted posture to strict — so the old form, which showed `off`/unchecked and dropped them, would create a *strict* space while telling the user `off`. The form is now authoritative over its own visible values.
3. **Layout:** the validation-mode select and strict-linkage toggle **dock inline on the Create button's row**, and the Purpose / Proxy-for fields **expand to fill** the dialog instead of leaving dead space beneath them.

## Verification

Booted an isolated scratch stack and drove the real UI with Playwright:

- Form state on open: `purpose=""`, `validationMode="strict"`, `strictLinkage=checked` ✅
- Layout confirmed by screenshot: validation controls inline with Create, fields expanded, no dead space ✅
- **0 console errors.**

## Tests

- `space-create-dialog.component.spec.ts`: empty-Purpose + strict defaults; validation choices sent explicitly even when the user picks the lenient options (guards the "form must not understate the result" invariant).

## Docs

- CHANGELOG `[Unreleased] → Changed` entry. (No userguide change: the Purpose field was never documented as pre-filled, and the strict default is already covered by #400's note.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)