### PR TITLE
feat(settings): make the About page cards a uniform size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2331,6 +2331,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Settings → About cards are now a uniform size.** The **Instance** and **System** cards sat at
+  their own content heights, so the shorter Instance card stopped short of the taller System card. They
+  now stretch to an equal height across the row, for a tidy, aligned pair. Purely visual — same
+  information, same layout otherwise — and scoped to the About page (the shared settings-card primitive
+  is untouched).
+
 - **The space Settings tab drops three redundant status pills.** The **Limits** and **Document
   extraction** cards used to show an "Unlimited" / "No auto-delete" / "Instance default" pill next to a
   field that *already* said the same thing through its placeholder ("Unlimited" / "No expiry") or its

--- a/client/src/app/pages/settings/about.component.ts
+++ b/client/src/app/pages/settings/about.component.ts
@@ -16,8 +16,12 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
       gap: 16px;
-      align-items: start;
+      align-items: stretch;
     }
+    /* Uniform card size: stretch each card to fill its (equal-height) grid row. The host becomes a
+       grid so its single .card child fills the row height — scoped to About, the shared SettingsCard
+       is untouched. */
+    .grid app-settings-card { display: grid; }
     .kv { display: grid; grid-template-columns: minmax(84px, 132px) 1fr; gap: 7px 14px; font-size: 13px; }
     .kv .k { color: var(--text-secondary); }
     .kv .v { color: var(--text-primary); word-break: break-word; }


### PR DESCRIPTION
## What

On **Settings → About**, the **Instance** and **System** cards sat at their own content heights (the grid used `align-items: start`), so the shorter Instance card ended above the taller System card. Owner feedback: **uniform card size across the About page.**

The grid rows now `stretch` and each card fills its row (`.grid app-settings-card { display: grid }` lets the card's single child fill the stretched host), giving an equal-height pair.

Scoped entirely to the About page — the shared `SettingsCard` primitive is untouched, so no other settings page changes.

## Verification

Booted an isolated scratch stack and drove the real UI with Playwright:

- Card heights measured: **both 270px, same row top, equal height ✅**
- Screenshot confirms the two cards align to the same bottom edge.
- **0 console errors.**

## Docs

- CHANGELOG `[Unreleased] → Changed`. (No userguide change — the About page's content/behaviour is unchanged; this is a purely cosmetic equal-height tweak.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)