### PR TITLE
feat(settings): Models tab header + card visual polish (UI-BUNDLE-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2331,6 +2331,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Models tab: header and Models-card visual polish.** The page header dropped its
+  redundant title + explanatory subtitle (the sidebar nav and the Models/Pipelines/Tools tabs already
+  say where you are), leaving just the global media-embedding toggle. Pressing **Test connection** no
+  longer jolts the layout — the result row keeps a fixed height and the detail truncates instead of
+  wrapping, so the whole equal-height card row stays put. And the **External assist** card's *Document
+  repair pass* checkbox now sits beside its normal-case label instead of floating above an ALL-CAPS
+  caption (it was being caught by the shared field-caption styling).
+
 - **The Settings → About cards are now a uniform size.** The **Instance** and **System** cards sat at
   their own content heights, so the shorter Instance card stopped short of the taller System card. They
   now stretch to an equal height across the row, for a tidy, aligned pair. Purely visual — same

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1249,7 +1249,6 @@
   "spaces.dangerZone.rebuildIndexesStarted": "Suchindizes werden neu aufgebaut — bis zum Abschluss sind die Suchergebnisse unvollständig.",
   "spaces.dangerZone.rebuildIndexesFailed": "Der Index-Neuaufbau konnte nicht gestartet werden.",
   "models.page.title": "Modelle & Pipelines",
-  "models.page.subtitle": "Die Modelle, die Ihre Dateien lesen, die Pipelines, in denen sie laufen, und ob davon gerade etwas funktioniert.",
   "models.page.mediaEmbedding": "Medien-Embedding",
   "models.page.unsaved": "Ungespeicherte Änderungen",
   "models.page.managedBanner": "Diese Modelle werden auf dieser Instanz <b>von der Infrastruktur verwaltet</b> — die Einstellungen sind schreibgeschützt. Ändern Sie sie in <code>config.json</code> oder in der Umgebung. <b>Verbindung testen</b> funktioniert weiterhin.",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1249,7 +1249,6 @@
   "spaces.dangerZone.rebuildIndexesStarted": "Rebuilding search indexes — search results will be incomplete until it finishes.",
   "spaces.dangerZone.rebuildIndexesFailed": "Could not start the index rebuild.",
   "models.page.title": "Models & Pipelines",
-  "models.page.subtitle": "The models that read your files, the pipelines they run in, and whether any of it is working right now.",
   "models.page.mediaEmbedding": "Media embedding",
   "models.page.unsaved": "Unsaved changes",
   "models.page.managedBanner": "These models are <b>managed by infrastructure</b> on this instance — settings are read-only. Change them in <code>config.json</code> or the environment. You can still <b>Test connection</b> below.",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1249,7 +1249,6 @@
   "spaces.dangerZone.rebuildIndexesStarted": "Trwa odbudowa indeksów wyszukiwania — do jej zakończenia wyniki będą niepełne.",
   "spaces.dangerZone.rebuildIndexesFailed": "Nie udało się rozpocząć odbudowy indeksów.",
   "models.page.title": "Modele i potoki",
-  "models.page.subtitle": "Modele, które czytają Twoje pliki, potoki, w których działają, i to, czy cokolwiek z tego działa w tej chwili.",
   "models.page.mediaEmbedding": "Osadzanie multimediów",
   "models.page.unsaved": "Niezapisane zmiany",
   "models.page.managedBanner": "Te modele są na tej instancji <b>zarządzane przez infrastrukturę</b> — ustawienia są tylko do odczytu. Zmień je w <code>config.json</code> lub w środowisku. <b>Testuj połączenie</b> nadal działa.",

--- a/client/src/app/pages/settings/models/models-page.component.ts
+++ b/client/src/app/pages/settings/models/models-page.component.ts
@@ -45,9 +45,10 @@ type Tab = 'models' | 'pipelines' | 'tools';
   ],
   styles: [`
     :host { display: block; }
-    .page-header { display: flex; justify-content: space-between; align-items: flex-start;
+    /* Header debloated to just the global media-embedding toggle, right-aligned; the sidebar nav and
+       the tab strip already say where you are, so the old title + explanatory subtitle were redundant. */
+    .page-header { display: flex; justify-content: flex-end; align-items: center;
       gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
-    .page-header .sub { font-size: 13px; color: var(--text-secondary); margin-top: 4px; max-width: 56ch; }
     .master { display: flex; align-items: center; gap: 9px; font-size: 13px; }
 
     /* Tabs sized to content, at the top of the panel — not a full-width strip. */
@@ -75,10 +76,6 @@ type Tab = 'models' | 'pipelines' | 'tools';
   `],
   template: `
     <div class="page-header">
-      <div>
-        <div class="card-title">{{ 'models.page.title' | transloco }}</div>
-        <div class="sub">{{ 'models.page.subtitle' | transloco }}</div>
-      </div>
       <label class="master">
         <input type="checkbox" [(ngModel)]="s.form.enabled" [disabled]="s.isLocked('enabled')"
           (ngModelChange)="s.touched.set(true)" name="mediaEnabled" />

--- a/client/src/app/pages/settings/models/models-tab.component.ts
+++ b/client/src/app/pages/settings/models/models-tab.component.ts
@@ -47,12 +47,22 @@ import { TestTarget } from './models.types';
       border-radius: 9px; font-size: 12.5px; border: 1px solid var(--warning-border); background: var(--warning-bg); }
     .warnline ph-icon { flex: none; margin-top: 1px; }
     .checkrow { display: flex; align-items: flex-start; gap: 8px; font-size: 12.5px;
-      color: var(--text-secondary); font-weight: normal; }
-    .checkrow input { margin-top: 2px; flex: none; }
+      color: var(--text-secondary); font-weight: normal;
+      /* Undo the global ".field label" caption styling (uppercase + tracking) — a checkbox's own
+         label is a normal sentence, not a field caption. */
+      text-transform: none; letter-spacing: normal; }
+    /* width:auto keeps a checkbox in a checkrow from being stretched to 100% by the .field input
+       rule when the checkrow sits inside a .field (assist card's repair-pass toggle). */
+    .checkrow input { margin-top: 2px; flex: none; width: auto; }
     .switchrow { margin-bottom: 13px; }
     .switchrow .hint { margin-left: 22px; }   /* line up under the label, not the checkbox */
-    .testrow { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
-    .testrow .hint { margin: 0; }
+    /* Keep the test row a single fixed-height line so pressing Test (which reveals the status pill +
+       latency/detail) never wraps to a second line and jolts the whole equal-height card row. The
+       button and pill stay their natural size; the detail truncates with an ellipsis (full text on
+       hover) rather than pushing the layout. */
+    .testrow { display: flex; gap: 10px; align-items: center; flex-wrap: nowrap; min-height: 34px; }
+    .testrow > :not(.hint) { flex: none; }
+    .testrow .hint { margin: 0; min-width: 0; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   `],
   template: `
     <div class="cards">
@@ -117,7 +127,7 @@ import { TestTarget } from './models.types';
           </button>
           @if (s.testOf('embedding')?.res; as r) {
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
-            <span class="hint">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+            <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
           }
         </div>
       </app-model-provider-card>
@@ -159,7 +169,7 @@ import { TestTarget } from './models.types';
           </button>
           @if (s.testOf('vision')?.res; as r) {
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
-            <span class="hint">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+            <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
           }
         </div>
       </app-model-provider-card>
@@ -201,7 +211,7 @@ import { TestTarget } from './models.types';
           </button>
           @if (s.testOf('stt')?.res; as r) {
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
-            <span class="hint">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+            <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
           }
         </div>
       </app-model-provider-card>
@@ -235,11 +245,16 @@ import { TestTarget } from './models.types';
         </div>
         <div class="field">
           <label>{{ 'models.assist.usedFor' | transloco }}</label>
-          <label class="checkrow">
-            <input type="checkbox" [checked]="s.assistUses('repair')"
-              (change)="s.toggleAssistUse('repair', $any($event.target).checked)" [disabled]="s.assistLocked()" />
-            <span>{{ 'models.assist.useRepair' | transloco }}</span>
-          </label>
+          <!-- The checkrow is deliberately NOT a direct-child label of .field: that rule renders a
+               field-caption (block + uppercase), which floated the checkbox above an all-caps label.
+               Wrapping it keeps the checkbox beside its own normal-case label (same fix as the face card). -->
+          <div class="switchrow" style="margin-bottom:0;">
+            <label class="checkrow">
+              <input type="checkbox" [checked]="s.assistUses('repair')"
+                (change)="s.toggleAssistUse('repair', $any($event.target).checked)" [disabled]="s.assistLocked()" />
+              <span>{{ 'models.assist.useRepair' | transloco }}</span>
+            </label>
+          </div>
         </div>
         <div class="warnline">
           <ph-icon name="warning" [size]="15"/>
@@ -256,7 +271,7 @@ import { TestTarget } from './models.types';
           </button>
           @if (s.testOf('assist')?.res; as r) {
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
-            <span class="hint">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+            <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
           }
         </div>
       </app-model-provider-card>


### PR DESCRIPTION
First slice of **UI-BUNDLE-3** — the Models-page/Models-tab visual half.

## What

- **Header debloat** — dropped the redundant page title ("Models & Pipelines") + the explanatory subtitle. The sidebar nav and the Models/Pipelines/Tools tab strip already establish location; the header now carries just the global media-embedding toggle. Removed the orphaned `models.page.subtitle` key (en/de/pl); `models.page.title` stays as the tab strip's `aria-label`.
- **Test Connection no longer jumps the layout** — the result row is a single fixed-height line (`nowrap`), and the latency/detail truncates with an ellipsis (full text on hover) rather than wrapping and growing the card. Because the cards are an equal-height grid, one card growing used to jolt the whole row.
- **"Document repair pass" checkbox** (External assist card) now sits **beside its normal-case label** instead of floating above an ALL-CAPS caption. Root cause: the checkrow was a direct-child `<label>` of `.field` (so it inherited the field-caption block + uppercase from the global `.field label` rule) **and** its checkbox was stretched to `width:100%` by `.field input`. Fixed by wrapping it out of the caption path, pinning the checkbox to `width:auto`, and resetting the transform.

**Already correct — no change (ground-truthed via the running UI):** the *auto-label threshold* + *minimum face size* inputs are already horizontally aligned (grid), and the face card's "Runs" is a read-only value, not the freetext input the original note described.

**Excluded (not UI-only):** repair-pass "in use" pill bug + face-recognition person-entity-types dropdown-from-library — both are [BUG]/[BEHV] items.

## Verification

Isolated scratch stack + Playwright:

- Header: no "Models & Pipelines" title / subtitle text present ✅
- Test Connection: embedding-card height delta **0px** on press (was 21px) ✅
- Repair-pass checkbox beside a **normal-case** label (screenshot) ✅
- **0 console errors.**

## Docs

- CHANGELOG `[Unreleased] → Changed`. (No userguide change — the repair-pass functional docs and the "Used for" wording are unchanged; the header removal is cosmetic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)