### PR TITLE
feat(settings): Tools-tab card consistency + vector-index table cleanup (UI-BUNDLE-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2331,6 +2331,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Models → Tools: consistent cards and a tidier vector-index table.** The **Media
+  splitter** and **Text chunker** now use the same card as the models on the Models tab (side by side),
+  so all three Models tabs share one card vocabulary. The **vector-index table dropped its
+  "Collections" column** — every space lists the same collections, so it only added width — and the
+  **"Recorded" column now carries a tooltip** explaining it's what `config.json` believes, checked
+  against the live "In the database" state to surface drift.
+
 - **Settings → Models → Pipelines: clearer viz and consistent controls.** The extraction mode now
   **marks the steps it actually runs** with an accent border and faint tint, so switching to (say) OCR
   visibly lights up just the OCR → Embed path while the rest stay dimmed. The **Images** and **Text**

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1372,7 +1372,7 @@
   "models.tools.colSpace": "Bereich",
   "models.tools.colLive": "In der Datenbank",
   "models.tools.colStored": "Vermerkt",
-  "models.tools.colCollections": "Sammlungen",
+  "models.tools.colStoredHint": "Was config.json als Indexstatus dieses Space verzeichnet — wird mit dem Live-Status „In der Datenbank“ abgeglichen, um Abweichungen sichtbar zu machen.",
   "models.tools.driftTitle": "{{count}} Bereich(e) melden einen fertigen Index, den die Datenbank nicht hat.",
   "models.tools.driftBody": "Die Suche in diesen Bereichen liefert nichts und meldet keinen Fehler. Ein Neuaufbau der Indizes über die Gefahrenzone des Bereichs behebt das.",
   "models.tools.indexEmpty": "Keine Bereiche mit eigenen Indizes.",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1372,7 +1372,7 @@
   "models.tools.colSpace": "Space",
   "models.tools.colLive": "In the database",
   "models.tools.colStored": "Recorded",
-  "models.tools.colCollections": "Collections",
+  "models.tools.colStoredHint": "What config.json records as this space's index state — checked against the live “In the database” state to surface drift.",
   "models.tools.driftTitle": "{{count}} space(s) claim a ready index the database does not have.",
   "models.tools.driftBody": "Recall in those spaces returns nothing and reports no error. Rebuilding the indexes from the space’s Danger Zone fixes it.",
   "models.tools.indexEmpty": "No spaces with their own indexes.",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1372,7 +1372,7 @@
   "models.tools.colSpace": "Przestrzeń",
   "models.tools.colLive": "W bazie danych",
   "models.tools.colStored": "Zapisane",
-  "models.tools.colCollections": "Kolekcje",
+  "models.tools.colStoredHint": "Co config.json zapisuje jako stan indeksu tej przestrzeni — porównywane ze stanem na żywo „W bazie danych”, aby ujawnić rozbieżności.",
   "models.tools.driftTitle": "{{count}} przestrzeni deklaruje gotowy indeks, którego baza danych nie ma.",
   "models.tools.driftBody": "Wyszukiwanie w tych przestrzeniach nic nie zwraca i nie zgłasza błędu. Przebudowa indeksów ze strefy zagrożenia przestrzeni to naprawia.",
   "models.tools.indexEmpty": "Brak przestrzeni z własnymi indeksami.",

--- a/client/src/app/pages/settings/models/tools-tab.component.ts
+++ b/client/src/app/pages/settings/models/tools-tab.component.ts
@@ -20,6 +20,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
 import { PhIconComponent } from '../../../shared/ph-icon.component';
 import { StatusPillComponent, StatusVariant } from '../../../shared/status-pill.component';
 import { HealthDotComponent } from './health-dot.component';
+import { ModelProviderCardComponent } from './model-provider-card.component';
 import { PipelineStatusService } from './pipeline-status.service';
 import { SpaceIndexStatus } from './models.types';
 
@@ -27,9 +28,12 @@ import { SpaceIndexStatus } from './models.types';
   selector: 'app-tools-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent],
+  imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent, ModelProviderCardComponent],
   styles: [`
     :host { display: block; }
+    /* Splitter + chunker sit side by side as model-style cards, matching the Models tab grid. */
+    .tools-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 16px; margin-bottom: 16px; align-items: stretch; }
     .tool { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px;
       margin-bottom: 16px; overflow: hidden; }
     .tool-h { display: flex; align-items: center; gap: 12px; padding: 14px 18px; }
@@ -49,11 +53,8 @@ import { SpaceIndexStatus } from './models.types';
       text-transform: uppercase; letter-spacing: .06em; padding: 6px 10px 6px 0; }
     td { padding: 7px 10px 7px 0; border-top: 1px solid var(--border-muted); vertical-align: top; }
     td.space { font-weight: 550; }
-    .colls { display: flex; flex-wrap: wrap; gap: 5px; }
-    .coll { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; padding: 2px 7px;
-      border-radius: 6px; border: 1px solid var(--border); background: var(--bg-primary);
-      font-family: var(--font-mono, monospace); }
-    .coll.missing { border-color: var(--error); color: var(--error); }
+    /* The "Recorded" header carries a tooltip; the dotted underline advertises it. */
+    .th-hint { cursor: help; text-decoration: underline dotted; text-underline-offset: 2px; }
 
     .drift { display: flex; align-items: flex-start; gap: 9px; margin-bottom: 14px; padding: 11px 13px;
       border-radius: 9px; font-size: 12.5px; border: 1px solid var(--error-border); background: var(--error-bg); }
@@ -62,35 +63,27 @@ import { SpaceIndexStatus } from './models.types';
     .empty { font-size: 12.5px; color: var(--text-muted); }
   `],
   template: `
-    <!-- ── Media splitter ─────────────────────────────────────────────── -->
-    <section class="tool">
-      <header class="tool-h">
-        <span class="ic"><ph-icon name="scissors" [size]="17"/></span>
-        <div class="t">
-          <h3>{{ 'models.tools.splitter' | transloco }}</h3>
-          <p>{{ 'models.tools.splitterPurpose' | transloco }}</p>
-        </div>
-        <app-status-pill variant="ok">ffmpeg</app-status-pill>
-      </header>
-      <div class="tool-b">
+    <!-- ── Media splitter + Text chunker ──────────────────────────────────
+         Both are in-process, nothing-to-set tools, so they now ride the same
+         app-model-provider-card as the Models tab (in a 2-up grid) rather than a
+         bespoke card, for one card vocabulary across all three Models tabs. -->
+    <div class="tools-grid">
+      <app-model-provider-card id="splitter" icon="scissors"
+        [heading]="'models.tools.splitter' | transloco"
+        [purpose]="'models.tools.splitterPurpose' | transloco"
+        [health]="'ok'">
+        <app-status-pill pill variant="ok">ffmpeg</app-status-pill>
         <div class="meta">{{ 'models.tools.splitterDetail' | transloco }}</div>
-      </div>
-    </section>
+      </app-model-provider-card>
 
-    <!-- ── Text chunker ───────────────────────────────────────────────── -->
-    <section class="tool">
-      <header class="tool-h">
-        <span class="ic"><ph-icon name="text-align-left" [size]="17"/></span>
-        <div class="t">
-          <h3>{{ 'models.tools.chunker' | transloco }}</h3>
-          <p>{{ 'models.tools.chunkerPurpose' | transloco }}</p>
-        </div>
-        <app-status-pill variant="ok">{{ 'models.tools.inProcess' | transloco }}</app-status-pill>
-      </header>
-      <div class="tool-b">
+      <app-model-provider-card id="chunker" icon="text-align-left"
+        [heading]="'models.tools.chunker' | transloco"
+        [purpose]="'models.tools.chunkerPurpose' | transloco"
+        [health]="'ok'">
+        <app-status-pill pill variant="ok">{{ 'models.tools.inProcess' | transloco }}</app-status-pill>
         <div class="meta">{{ 'models.tools.chunkerDetail' | transloco }}</div>
-      </div>
-    </section>
+      </app-model-provider-card>
+    </div>
 
     <!-- ── Vector index ───────────────────────────────────────────────── -->
     <section class="tool">
@@ -126,8 +119,9 @@ import { SpaceIndexStatus } from './models.types';
                 <tr>
                   <th>{{ 'models.tools.colSpace' | transloco }}</th>
                   <th>{{ 'models.tools.colLive' | transloco }}</th>
-                  <th>{{ 'models.tools.colStored' | transloco }}</th>
-                  <th>{{ 'models.tools.colCollections' | transloco }}</th>
+                  <!-- "Recorded" needs a word: it is what config.json believes, which "In the database"
+                       is checked against — a mismatch is the drift this table exists to surface. -->
+                  <th><span class="th-hint" [attr.title]="'models.tools.colStoredHint' | transloco">{{ 'models.tools.colStored' | transloco }}</span></th>
                 </tr>
               </thead>
               <tbody>
@@ -136,20 +130,6 @@ import { SpaceIndexStatus } from './models.types';
                     <td class="space">{{ sp.label }}</td>
                     <td><app-status-pill [variant]="liveVariant(sp)" [dot]="true">{{ 'models.indexState.' + sp.live | transloco }}</app-status-pill></td>
                     <td><app-status-pill [variant]="sp.drifted ? 'error' : 'off'">{{ 'models.indexState.' + sp.stored | transloco }}</app-status-pill></td>
-                    <td>
-                      <div class="colls">
-                        @for (c of sp.collections; track c.indexName) {
-                          <!-- Only red when the index is genuinely absent. When the listing itself
-                               failed (live = unknown) every status is null for want of an answer, and
-                               painting those red would assert a fact we do not have — the same
-                               dishonesty as the stored-vs-live drift this table exists to expose. -->
-                          <span class="coll" [class.missing]="sp.live !== 'unknown' && c.status === null"
-                            [attr.title]="c.indexName + ' · ' + (c.status ?? (('models.indexState.' + (sp.live === 'unknown' ? 'unknown' : 'missing')) | transloco))">
-                            {{ c.collection }}
-                          </span>
-                        }
-                      </div>
-                    </td>
                   </tr>
                 }
               </tbody>

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2135,7 +2135,7 @@ The unstructured sidecar strategy and image extraction behaviour can be tuned un
 
 - **Models** — every model you or infra can set: text embedding, vision, speech-to-text, the assist model, and read-only cards for the page renderer, document converter and face recognition. One shape per card (provider → endpoint → model → credential → test); infra-owned cards are dashed and name the env var that owns them.
 - **Pipelines** — Documents, Images, Audio & video and Text drawn as their real step chains, with the model doing the work named under each step and a health indicator fed by `GET /api/admin/pipeline-status`. Conditional steps (VLM fallback, repair, face vectors) are dashed. Each pipeline's knobs hang off that pipeline, and each carries its own **instance ceiling** picker (see below). Audio and video share a card but have separate ceilings, because they have separate ladders.
-- **Tools** — the components that run but have nothing to set: media splitter (ffmpeg), text chunker, and the vector index. The index is **status-only** (readiness per space and collection); rebuilding is a Danger Zone action, not a button here.
+- **Tools** — the components that run but have nothing to set: media splitter (ffmpeg), text chunker, and the vector index. The index is **status-only** — per space it shows the **live** database state alongside the **recorded** (config.json) state, so drift between them is visible; rebuilding is a Danger Zone action, not a button here.
 
 Switching tabs with unsaved changes prompts rather than discarding them.
 


### PR DESCRIPTION
Third (final) slice of **UI-BUNDLE-3** — the Tools-tab visual half.

## What

- **Media splitter + Text chunker** now use the same `app-model-provider-card` as the Models tab (in a 2-up grid) instead of a bespoke card, so all three Models tabs share one card vocabulary.
- **Vector-index table:**
  - **Dropped the "Collections" column** — every space lists the same collections, so it only added width and repeated the live/recorded state already shown.
  - **The "Recorded" column now has a tooltip** (dotted-underline header) explaining it's what `config.json` believes, checked against the live "In the database" state to surface drift.
  - Removed the orphaned `models.tools.colCollections` i18n key (en/de/pl) and the now-unused `.colls`/`.coll` styles; added `models.tools.colStoredHint`.

## Verification

Isolated scratch stack + Playwright:

- `modelCards: 2` (splitter + chunker as model cards), `oldToolCards: 1` (only the vector-index keeps its full-width card).
- Table headers: `["Space", "In the database", "Recorded"]` — **Collections gone**.
- "Recorded" tooltip present with the drift explanation.
- Screenshot confirms the side-by-side cards + cleaned table.
- **0 console errors.**

## Docs

- CHANGELOG `[Unreleased] → Changed`.
- `docs/integration-guide.md`: the Tools bullet no longer says "readiness per space **and collection**" (the per-collection column is gone) — it now describes the live-vs-recorded drift view.

This completes **UI-BUNDLE-3** except two deliberately-deferred Pipelines items (click-model→navigate regression; inactive-dot uniformity), each tracked as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)