### PR TITLE
feat(settings): online dots for in-process tools + uniform inactive dots (UI-BUNDLE-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2338,6 +2338,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings → Models → Pipelines: the always-on tools now show an "online" dot, and inactive dots read
+  as one uniform grey.** The in-process **Extract audio** (ffmpeg) and **Chunk** (text chunker) steps
+  are bundled and always available, so they now show a green online dot instead of an "unknown" no-probe
+  marker. And the inactive indicators no longer mix a grey bead with a hollow dashed ring: `unknown`,
+  `off` and `unconfigured` share one grey bead. The states stay distinct where it matters — the dot's
+  accessible name / tooltip still says "unknown" vs "off" for screen readers — but the *visual* is now
+  a single uniform grey, per owner review.
+
 - **Settings → Models → Tools: consistent cards and a tidier vector-index table.** The **Media
   splitter** and **Text chunker** now use the same card as the models on the Models tab (side by side),
   so all three Models tabs share one card vocabulary. The **vector-index table dropped its

--- a/client/src/app/pages/settings/models/health-dot.component.ts
+++ b/client/src/app/pages/settings/models/health-dot.component.ts
@@ -8,8 +8,11 @@
  *
  * **Colour is never the only carrier.** Every dot has an accessible name and a `title`, because the
  * entire purpose of this component is reporting status and a status a screen-reader user cannot hear
- * is not reported. `unknown` (status not loaded, or the fetch failed) is a distinct state rather than
- * being drawn as `off` — "we could not tell" and "it is switched off" are different facts.
+ * is not reported. `unknown` (status not loaded, or the fetch failed) stays a distinct *state* — "we
+ * could not tell" and "it is switched off" are different facts, and the accessible name/title still
+ * says so. Its *visual* now matches `off`/`unconfigured` (a plain grey bead) rather than a dashed
+ * hollow ring: per owner review the inactive dots must read as one uniform grey, not a grey-vs-empty
+ * mix, so the distinction lives in the name a screen reader announces, not in a second dot shape.
  */
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
@@ -45,12 +48,13 @@ import { HealthState } from './models.types';
       --ring:  color-mix(in srgb, var(--base) 20%, transparent);
       --bloom: color-mix(in srgb, var(--base) 42%, transparent);
     }
-    /* Matte: no bloom, no highlight, flat fill. Deliberately not a colour variant of the others. */
+    /* Matte: no bloom, no highlight, flat fill. Deliberately not a colour variant of the others.
+       off / unconfigured / unknown share one grey bead — inactive dots read as a single uniform grey
+       (owner review); the states stay distinct only in the accessible name, not a second dot shape. */
     .off, .unknown, .unconfigured {
       background: var(--bg-elevated); box-shadow: inset 0 0 0 1px var(--border);
     }
     .off::after, .unknown::after, .unconfigured::after { display: none; }
-    .unknown { border: 1px dashed var(--border); box-sizing: border-box; background: transparent; box-shadow: none; }
     @media (prefers-reduced-motion: reduce) { .dot { box-shadow: 0 0 0 2.5px var(--ring); } }
   `],
   template: `

--- a/client/src/app/pages/settings/models/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/models/pipelines-tab.component.ts
@@ -360,8 +360,9 @@ export class PipelinesTabComponent {
         // This card covers TWO classes: audio files and video files have separate ladders.
         ceilings: [{ cls: 'audio' as MediaClass, ladder: AUDIO_LEVELS }, { cls: 'video' as MediaClass, ladder: VIDEO_LEVELS }],
         steps: [
-          // Video only: audio files skip straight to transcription.
-          { key: 'split', name: 'models.step.split', actor: 'ffmpeg', health: null, conditional: true },
+          // Video only: audio files skip straight to transcription. ffmpeg is bundled and always
+          // available in-process, so it reports 'ok' (online) rather than an "unknown" no-probe dot.
+          { key: 'split', name: 'models.step.split', actor: 'ffmpeg', health: 'ok', conditional: true },
           { key: 'transcribe', name: 'models.step.transcribe', actor: this.s.form.stt?.model || this.notSet, health: ps.modelState('stt'), conditional: false, cardId: 'stt' },
           { key: 'aud-embed', name: 'models.step.embed', actor: embedModel, health: ps.modelState('embedding'), conditional: false, cardId: 'embedding' },
         ] as Step[],
@@ -370,8 +371,9 @@ export class PipelinesTabComponent {
         id: 'text', icon: 'text-align-left', title: 'models.pipelines.text', purpose: 'models.pipelines.textPurpose',
         ceilings: [{ cls: 'text' as MediaClass, ladder: TEXT_LEVELS }],
         steps: [
-          // Chunking only happens at the `chunk` rung; `embed` produces one vector for the whole document.
-          { key: 'chunk', name: 'models.step.chunk', actor: 'text chunker', health: null, conditional: true },
+          // Chunking only happens at the `chunk` rung; `embed` produces one vector for the whole
+          // document. The chunker is bundled and always available in-process, so it reports 'ok'.
+          { key: 'chunk', name: 'models.step.chunk', actor: 'text chunker', health: 'ok', conditional: true },
           { key: 'txt-embed', name: 'models.step.embed', actor: embedModel, health: ps.modelState('embedding'), conditional: false, cardId: 'embedding' },
         ] as Step[],
       },


### PR DESCRIPTION
The second (and last) deferred Pipelines item from UI-BUNDLE-3.

## What

Two owner-feedback fixes to the Pipelines viz health dots:

1. **Missing "online" indicators added.** The in-process **Extract audio** (ffmpeg) and **Chunk** (text chunker) steps are bundled and always available, so they now report `health: 'ok'` — a green online dot — instead of `null`, which rendered as an "unknown" no-probe marker.
2. **Inactive dots read as one uniform grey.** `health-dot`'s `unknown` state no longer draws a hollow dashed ring distinct from the grey `off` / `unconfigured` bead — all three share one grey bead. So the inactive indicators are a single uniform grey rather than a grey-vs-empty mix.

## Respecting the existing design

The health-dot author deliberately kept `unknown` ("we couldn't tell") distinct from `off` ("switched off"). That distinction is **preserved where it matters**: the dot's accessible name and `title` still announce "unknown" vs "off", so screen-reader users lose nothing — only the redundant second dot *shape* is gone. The docstring is updated to record the owner's call. The **Validate** step stays `null` (pure in-process arithmetic, no component to call "online"), and now renders as the same uniform grey.

## Verification

Isolated scratch stack + Playwright, dot-class inventory + screenshot:

- **Extract audio** and **Chunk** → `ok` (green online dots).
- **Validate / Vision / Repair / Verify / Face** → uniform grey (no dashed-empty outlier).
- **0 console errors.**

## Docs

- CHANGELOG `[Unreleased] → Changed`. (No userguide/integration-guide change — the "health indicator" description is generic and still accurate.)

This completes **UI-BUNDLE-3 in full** (Models #404, Pipelines #405, Tools #406, click-model-navigate #407, dots this PR). Next: **UI-BUNDLE-2 · Schema Library UX** (item 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)