### PR TITLE
feat(files): folders show their recursive content size in the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Folders in the file list now show their total size (the sum of everything inside), not a dash.** The
+  Size column reports a directory's recursive content size alongside files (an empty folder shows `0 B`).
+  It's computed from file metadata — a `SUM` over the file records under the folder — not a filesystem
+  walk, so it stays fast, and it reads from the raw size already stored on each file record (no schema
+  change). First step of the Files + File Meta tab merge; the merged tab reuses the same figure.
+
 - **The Brain now opens on an Overview tab (its new default landing view).** Opening a space lands on
   **Overview** — a per-space dashboard rather than the Query box. Slice one ships two panels: **Statistics**
   (record counts per collection, a total, and storage used vs. the space's quota) and **Indexing** (the

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -502,7 +502,7 @@ function previewKind(name: string): PreviewKind {
                       }
                     </td>
                     <td style="color:var(--text-muted)">
-                      {{ entry.isDirectory ? '—' : formatSize(entry.size) }}
+                      {{ formatSize(entry.size) }}
                     </td>
                     <td style="color:var(--text-muted)">{{ entry.modified | date:'dd.MM.yyyy HH:mm' }}</td>
                     <td style="display:flex; gap:6px; align-items:center;">

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -389,6 +389,14 @@ Ythril ships under the PolyForm Small Business License 1.0.0. Every contribution
 - **No proprietary service lock-in.** Features must work with self-hosted infrastructure. Cloud-managed services (Atlas, S3, etc.) may be supported as optional backends but never as the only path.
 - **NOTICE file stays accurate.** When adding or removing a dependency that requires attribution, update `NOTICE` in the same commit.
 
+### 7. Migrations & data evolution
+
+Choose a migration strategy by **whether the data syncs across networks**, because sync applies pulled records with a **whole-document `replaceOne` (last-writer-wins by `seq`)**, not a field-level merge (`server/src/sync/engine.ts`).
+
+- **Synced data → self-healing (lazy), never a one-time boot migration.** The per-space MongoDB record collections that replicate across networks — memories, entities, edges, chrono, `{space}_files`, and their fields — can be silently reverted by a **mixed-version peer**: an older-version instance that rewrites a record with a higher `seq` replaces the *whole* document and undoes any boot migration. So don't migrate these on boot — **repair or derive the field on access**, so it re-heals after any cross-version clobber. Examples: token prefixes backfilled on first use (`index.ts`); a file's raw size (`sizeFileBytes`) re-`stat`'d from disk when a record lacks it.
+- **Local, non-synced state → an idempotent boot migration is fine.** State the single instance owns and no peer overwrites — `config.json` (loader migrations), at-rest state-file encryption, index creation (`ensureIndex`/TTL) — converges once on boot and stays. Keep it idempotent (a no-op once applied) so re-running is free.
+- **A stored-field rename on a synced collection is the fragile case.** It changes the wire format, so mixed-version peers see a blank for the name they don't know until everyone upgrades. Do it only at a major release, document it as breaking, and prefer pairing it with a self-healing field for anything that must stay correct.
+
 ---
 
 ## Code Style

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -276,6 +276,8 @@ The file manager lets you upload, download, organise, and preview files within e
 
 **Navigation:** A breadcrumb bar (`root / docs / guides`) at the top lets you jump to any parent directory. The **tree sidebar** (toggle with **Show tree** / **Hide tree**) provides a full directory view.
 
+**Folder sizes:** the Size column shows a folder's **total content size** — the sum of every file inside it (recursively), not just files. An empty folder shows `0 B`.
+
 ### File preview
 
 Clicking a file name or 👁 opens an inline preview pane:

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -98,6 +98,67 @@ function enforceSizeLimit(req: Request, res: Response, next: NextFunction): void
   next();
 }
 
+/**
+ * Recursive size of each immediate sub-folder of `dirPath`, as a Map of folder name → total bytes.
+ *
+ * A folder's size is the sum of the RAW sizes of the files beneath it — computed from metadata, not a
+ * filesystem walk: the file-level FileMeta record (`_id`/`path`, no `parentFileId`) already carries the
+ * raw upload size in `sizeBytes` (chunk/derived records have a `parentFileId` and are excluded). One
+ * indexed prefix query per member space; the immediate-child grouping is done in JS (unicode-safe,
+ * unlike Mongo `$substr` byte offsets). Soft-deleted records are excluded.
+ */
+/**
+ * Pure grouping: given file-level records and the listing's path prefix (`''` at root, else
+ * `dir/`), sum each file's `sizeBytes` into the IMMEDIATE sub-folder it lives under. A file sitting
+ * loose in the listed directory (no further `/`) belongs to no sub-folder and is skipped — its own
+ * size shows on its own row. Exported for unit testing. Accumulates into `into` so callers can merge
+ * across member spaces.
+ */
+export function groupFolderSizes(
+  docs: { path: string; sizeBytes?: number }[], prefix: string, into = new Map<string, number>(),
+): Map<string, number> {
+  for (const d of docs) {
+    const rel = prefix ? d.path.slice(prefix.length) : d.path;
+    const slash = rel.indexOf('/');
+    if (slash <= 0) continue; // loose file directly in the listed dir — not a sub-folder's content
+    const child = rel.slice(0, slash);
+    into.set(child, (into.get(child) ?? 0) + (d.sizeBytes ?? 0));
+  }
+  return into;
+}
+
+async function folderSizes(memberIds: string[], dirPath: string): Promise<Map<string, number>> {
+  const prefix = dirPath === '.' ? '' : toDocId(dirPath) + '/';
+  const sizes = new Map<string, number>();
+  for (const mid of memberIds) {
+    try {
+      const docs = await col<FileMetaDoc>(`${mid}_files`).find(
+        asFilter<FileMetaDoc>({
+          parentFileId: { $exists: false },
+          deletedAt: { $exists: false },
+          // Indexed prefix range over `path` — files under this directory only (all files when root).
+          // '￿' is the highest BMP code unit, so `[prefix, prefix+￿)` covers every path with
+          // this prefix without a regex.
+          ...(prefix ? { path: { $gte: prefix, $lt: prefix + '￿' } } : {}),
+        }),
+        { projection: { path: 1, sizeBytes: 1 } },
+      ).toArray() as { path: string; sizeBytes?: number }[];
+      groupFolderSizes(docs, prefix, sizes);
+    } catch { /* member has no files collection — skip */ }
+  }
+  return sizes;
+}
+
+/** Fill in each `dir` entry's `size` with its recursive content size (files stay as listed). */
+async function withFolderSizes(
+  memberIds: string[], dirPath: string, entries: { name: string; type: 'file' | 'dir'; size?: number }[],
+): Promise<typeof entries> {
+  if (!entries.some(e => e.type === 'dir')) return entries;
+  const sizes = await folderSizes(memberIds, dirPath);
+  for (const e of entries) if (e.type === 'dir') e.size = sizes.get(e.name) ?? 0;
+  return entries;
+}
+
 // ── GET /api/files/:spaceId ───────────────────────────────────────────────────
 // Stat the path: directory → JSON list, file → stream bytes.
 fileStoreRouter.get('/:spaceId', globalRateLimit, requireSpaceAuth, async (req, res) => {
@@ -144,7 +205,7 @@ fileStoreRouter.get('/:spaceId', globalRateLimit, requireSpaceAuth, async (req, 
           }
         } catch { /* member may have no files dir */ }
       }
-      res.json({ path: normalised, type: 'dir', entries: allEntries });
+      res.json({ path: normalised, type: 'dir', entries: await withFolderSizes(memberIds, normalised, allEntries) });
       return;
     }
     res.status(404).json({ error: 'Path not found' });
@@ -163,7 +224,7 @@ fileStoreRouter.get('/:spaceId', globalRateLimit, requireSpaceAuth, async (req, 
         }
       } catch { /* dir may not exist in this member */ }
     }
-    res.json({ path: normalised, type: 'dir', entries: allEntries });
+    res.json({ path: normalised, type: 'dir', entries: await withFolderSizes(memberIds, normalised, allEntries) });
     return;
   }
 

--- a/testing/integration/files.test.js
+++ b/testing/integration/files.test.js
@@ -136,6 +136,18 @@ describe('Directory listing', () => {
     assert.equal(body.type, 'dir');
   });
 
+  it('a folder entry reports its recursive content size (sum of files beneath it)', async () => {
+    const dir = `sizedir-${Date.now()}`;
+    // 'hello' = 5 bytes at the top of the folder; 'worldwide!!' = 11 bytes nested → both roll up.
+    await uploadFile(tokenA, 'general', `${dir}/a.txt`, 'hello');
+    await uploadFile(tokenA, 'general', `${dir}/sub/b.txt`, 'worldwide!!');
+    const r = await fetch(`${INSTANCES.a}/api/files/general?path=.`, { headers: { 'Authorization': `Bearer ${tokenA}` } });
+    const body = await r.json();
+    const folder = body.entries.find(e => e.name === dir && e.type === 'dir');
+    assert.ok(folder, `folder ${dir} is listed`);
+    assert.equal(folder.size, 16, 'folder size sums every file beneath it (5 + 11), recursively');
+  });
+
   it('Listing non-existent dir returns 404', async () => {
     const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent('no-such-dir/')}`;
     const r = await fetch(url, { headers: { 'Authorization': `Bearer ${tokenA}` } });

--- a/testing/standalone/folder-sizes.test.js
+++ b/testing/standalone/folder-sizes.test.js
@@ -1,0 +1,55 @@
+/**
+ * Standalone tests for `groupFolderSizes` — the folder-size roll-up in the file listing.
+ *
+ * A folder's size in the file list is the sum of the raw sizes of the files beneath it, computed from
+ * the file-level FileMeta records (chunk/derived records are excluded by the DB query, not here). This
+ * pins the pure grouping: nested files roll up into the top-level sub-folder, loose files in the listed
+ * directory belong to no folder, and the path prefix (root vs a sub-directory) is handled correctly.
+ *
+ * Run: node --test testing/standalone/folder-sizes.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { groupFolderSizes } from '../../server/dist/api/files.js';
+
+const f = (path, sizeBytes) => ({ path, sizeBytes });
+
+describe('groupFolderSizes', () => {
+  it('at root: groups by the top-level folder, nested files roll up', () => {
+    const docs = [
+      f('docs/a.txt', 100),
+      f('docs/sub/b.txt', 250),      // nested → still rolls into `docs`
+      f('docs/sub/deep/c.txt', 50),
+      f('images/x.png', 400),
+      f('readme.md', 999),           // loose file at root → no folder
+    ];
+    const m = groupFolderSizes(docs, '');
+    assert.equal(m.get('docs'), 400);
+    assert.equal(m.get('images'), 400);
+    assert.equal(m.has('readme.md'), false); // loose file is not a folder
+  });
+
+  it('under a sub-directory: prefix stripped, groups by the IMMEDIATE child only', () => {
+    const docs = [
+      f('docs/sub/b.txt', 250),
+      f('docs/sub/deep/c.txt', 50),  // immediate child of docs/ is `sub`, not `deep`
+      f('docs/loose.txt', 10),       // loose in the listed dir → no folder
+    ];
+    const m = groupFolderSizes(docs, 'docs/');
+    assert.equal(m.get('sub'), 300);   // 250 + 50 both roll into `sub`
+    assert.equal(m.has('deep'), false); // deep is nested under sub, not directly under docs/
+    assert.equal(m.size, 1);            // only `sub` (loose.txt skipped)
+  });
+
+  it('sizes accumulate across calls (merging member spaces) and tolerate missing sizeBytes', () => {
+    const acc = new Map();
+    groupFolderSizes([f('a/one.txt', 100)], '', acc);
+    groupFolderSizes([f('a/two.txt', 50), f('a/no-size.txt')], '', acc); // missing size → 0
+    assert.equal(acc.get('a'), 150);
+  });
+
+  it('an empty input yields an empty map (folders render as 0 B)', () => {
+    assert.equal(groupFolderSizes([], '').size, 0);
+  });
+});


### PR DESCRIPTION
## What

The file list's Size column showed a dash (`—`) for folders. It now shows a folder's **total content size** — the sum of every file beneath it, recursively — alongside files. An empty folder shows `0 B`.

Also includes the **"Migrations & data evolution"** principle in `docs/contribution-guide.md` (self-healing for synced data, idempotent boot for local state) — the reasoning that shaped this design.

## How (the interesting part)

It's a **calculation over metadata, not a filesystem walk** — and needs **no schema change**:

- The file-level `FileMeta` record already stores each file's **raw** size in `sizeBytes` (set at upload / MCP write / sync). The pipeline's derived sizes (converted markdown, captions, transcripts, chunks) live on **separate** records carrying a `parentFileId`, which the query excludes.
- So a folder size is one **indexed prefix query** per member space (`path` range `[dir/, dir/￿)`) plus a JS roll-up into the immediate sub-folder (`groupFolderSizes`) — unicode-safe, no Mongo `$substr` byte-offset pitfalls, no disk crawl.
- Handles proxy / multi-member spaces (sums across members) and soft-deleted records (excluded).

This route (metadata calc) came out of the design discussion: a filesystem recursive walk was prototyped and **measured** (~200ms per 5k entries, several× slower on Docker bind mounts) but rejected for the perf cliff; and a schema rename (`sizeBytes → sizeMetaBytes`) was planned until ground-truth showed the file-record `sizeBytes` is *already* the raw size — so the rename, migration, and MCP-contract change all evaporated.

## Tests

- **`testing/standalone/folder-sizes.test.js`** (4) — the pure roll-up: nested files fold into the top sub-folder, loose files belong to no folder, prefix handling (root vs sub-dir), and accumulation across member spaces.
- **`testing/integration/files.test.js`** — end-to-end: upload files into a sub-folder, list the parent, assert the folder's listed size sums them (runs against real Mongo/files in CI).
- Gates: server + client `tsc`, `audit-route-coverage` (listing is a GET — no new route), file-manager client tests, `lint:docs` — all green.

## Docs / changelog

- `docs/userguide.md` (Files — folder sizes) + `docs/contribution-guide.md` (migration principle).
- `CHANGELOG.md` — Added.

First step of the **Files + File Meta tab merge**; the merged tab reuses this figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)