### PR TITLE
feat(brain): merge the Files and File Meta tabs into one Files tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2403,6 +2403,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain's separate "Files" and "File Meta" tabs are merged into one "Files" tab.** The per-space
+  Brain used to carry both a **Files** tab (the file manager) and a distinct **File Meta** tab (the
+  metadata records), which forced you to jump between the raw bytes and their searchable side. They are
+  now a single **Files** tab, in the slot where **File Meta** was — one explorer-style view of files
+  with their embedding status and tags inline (shipped in the two prior slices). Deep-link handoffs
+  between the two old tabs are gone (there is nowhere left to hand off to), and the file preview's
+  now-obsolete "Metadata" button is removed. A docked detail view that opens the full metadata
+  record next to the file preview follows in a subsequent update.
+
 - **⚠️ BREAKING: the media-embedding master switch is removed. Media embedding is now always on,
   controlled per class by the `images` / `audio` / `video` levels.** The `MEDIA_EMBEDDING_ENABLED`
   environment variable and the `mediaEmbedding.enabled` config flag no longer exist, and the "Enable

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -503,8 +503,6 @@
   "files.downloadFailed": "Download fehlgeschlagen.",
   "files.renameEntryAriaLabel": "Eintrag umbenennen",
   "files.deleteEntryAriaLabel": "Eintrag löschen",
-  "files.viewMetadata": "Metadaten",
-  "files.viewMetadataTitle": "Brain-Metadaten für diese Datei anzeigen",
   "files.closePreviewAriaLabel": "Vorschau schließen",
   "files.emptyFolder.title": "Leerer Ordner",
   "files.emptyFolder.body": "Laden Sie Dateien hoch oder erstellen Sie einen Ordner.",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -503,8 +503,6 @@
   "files.downloadFailed": "Download failed.",
   "files.renameEntryAriaLabel": "Rename entry",
   "files.deleteEntryAriaLabel": "Delete entry",
-  "files.viewMetadata": "Metadata",
-  "files.viewMetadataTitle": "View Brain metadata for this file",
   "files.closePreviewAriaLabel": "Close preview",
   "files.emptyFolder.title": "Empty folder",
   "files.emptyFolder.body": "Upload files or create a folder.",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -503,8 +503,6 @@
   "files.downloadFailed": "Pobieranie nie powiodło się.",
   "files.renameEntryAriaLabel": "Zmień nazwę wpisu",
   "files.deleteEntryAriaLabel": "Usuń wpis",
-  "files.viewMetadata": "Metadane",
-  "files.viewMetadataTitle": "Wyświetl metadane Brain dla tego pliku",
   "files.closePreviewAriaLabel": "Zamknij podgląd",
   "files.emptyFolder.title": "Pusty folder",
   "files.emptyFolder.body": "Prześlij pliki lub utwórz folder.",

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -65,6 +65,14 @@ describe('BrainComponent (OnPush)', () => {
     expect(create().componentInstance.activeTab()).toBe('overview');
   });
 
+  it('File Meta is merged into one Files tab — no separate File Meta collection tab', () => {
+    const c = create().componentInstance;
+    expect(c.collectionTabs.some(t => t.key === 'filemeta' as never)).toBe(false);
+    expect(c.collectionTabs.map(t => t.key)).toEqual(['entities', 'edges', 'memories', 'chrono']);
+    c.setTab('files');
+    expect(c.activeTab()).toBe('files'); // the single Files tab still activates
+  });
+
   // ── Regression: the mount⇄reload request storm (app-unusable P0) ─────────────
   // The five record tabs each WRITE `recordList.loading` during their own `load()`. They used to be
   // mounted inside the `@else` of `@if (recordList.loading())`, so a tab set loading=true on load,

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -10,7 +10,6 @@ import { MemoriesTabComponent } from './memories-tab.component';
 import { EntitiesTabComponent } from './entities-tab.component';
 import { EdgesTabComponent } from './edges-tab.component';
 import { ChronoTabComponent } from './chrono-tab.component';
-import { FilemetaTabComponent } from './filemeta-tab.component';
 import { OverviewTabComponent } from './overview-tab.component';
 import { FormsModule } from '@angular/forms';
 import { Space, SpaceStats } from '../../core/api.types';
@@ -21,7 +20,7 @@ import { FileManagerComponent } from '../files/file-manager.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
-type BrainTab = 'overview' | 'query' | 'graph' | 'files' | 'entities' | 'edges' | 'memories' | 'chrono' | 'filemeta';
+type BrainTab = 'overview' | 'query' | 'graph' | 'files' | 'entities' | 'edges' | 'memories' | 'chrono';
 
 interface SpaceView {
   space: Space;
@@ -40,7 +39,7 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, FilemetaTabComponent, OverviewTabComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [`
     .space-tabs {
@@ -207,12 +206,6 @@ interface SpaceView {
         <button class="tab" [class.active]="activeTab() === 'graph'" (click)="setTab('graph')">
           <ph-icon name="binoculars" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.graph' | transloco }}
         </button>
-        <button class="tab" [class.active]="activeTab() === 'files'" (click)="setTab('files')">
-          <ph-icon name="folder" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.files' | transloco }}
-          @if (activeStats(); as s) {
-            <span class="tab-count">{{ s.files }}</span>
-          }
-        </button>
         <span class="tab-spacer"></span>
         @for (tab of collectionTabs; track tab.key) {
           <button class="tab" [class.active]="activeTab() === tab.key" (click)="setTab(tab.key)">
@@ -224,6 +217,14 @@ interface SpaceView {
             }
           </button>
         }
+        <!-- Files (the former File Meta slot) — the file manager and File Meta merged into one tab: the
+             explorer now shows each file's status, tags and folder sizes inline. -->
+        <button class="tab" [class.active]="activeTab() === 'files'" (click)="setTab('files')">
+          <ph-icon name="folder" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.files' | transloco }}
+          @if (activeStats(); as s) {
+            <span class="tab-count">{{ s.files }}</span>
+          }
+        </button>
       </div>
 
       <!-- Content. Tabs are gated by activeTab() ONLY — NEVER wrapped in @else of
@@ -242,9 +243,9 @@ interface SpaceView {
           <app-graph-view [embeddedSpaceId]="activeSpaceId()" />
         }
 
-        <!-- Files tab -->
+        <!-- Files tab (merged: file manager + File Meta) -->
         @if (activeTab() === 'files') {
-          <app-file-manager [embeddedSpaceId]="activeSpaceId()" [navigatePath]="fileManagerNavPath()" (viewFileMeta)="openFileMetaEntry($event)" (filesChanged)="loadStats(activeSpaceId())" />
+          <app-file-manager [embeddedSpaceId]="activeSpaceId()" (filesChanged)="loadStats(activeSpaceId())" />
         }
 
         <!-- Memories -->
@@ -258,9 +259,6 @@ interface SpaceView {
 
         <!-- Chrono -->
         @if (activeTab() === 'chrono') { <app-chrono-tab [spaceId]="activeSpaceId()" /> }
-
-        <!-- File Meta -->
-        @if (activeTab() === 'filemeta') { <app-filemeta-tab [spaceId]="activeSpaceId()" (mutated)="loadStats(activeSpaceId())" (openInManager)="openFileInManager($event)" /> }
 
         <!-- Query -->
         @if (activeTab() === 'overview') {
@@ -286,12 +284,12 @@ export class BrainComponent implements OnInit, OnDestroy {
   private brainApi = inject(BrainApi);
   private transloco = inject(TranslocoService);
 
+  // File Meta merged into the Files tab (rendered separately, after these, in the same group).
   collectionTabs: { key: BrainTab; label: string; statsKey?: keyof SpaceStats }[] = [
     { key: 'entities', label: 'Entities', statsKey: 'entities' },
     { key: 'edges', label: 'Edges', statsKey: 'edges' },
     { key: 'memories', label: 'Memories', statsKey: 'memories' },
     { key: 'chrono', label: 'Chrono', statsKey: 'chrono' },
-    { key: 'filemeta', label: 'File Meta', statsKey: 'files' },
   ];
 
   readonly pageSize = 20;
@@ -300,8 +298,6 @@ export class BrainComponent implements OnInit, OnDestroy {
   activeSpaceId = signal('');
   activeTab = signal<BrainTab>('overview');
   loadingSpaces = signal(true);
-
-  fileManagerNavPath = signal('');
 
   // Reindex
   needsReindex = signal(false);
@@ -359,7 +355,7 @@ export class BrainComponent implements OnInit, OnDestroy {
   private liveReconnectTimer?: ReturnType<typeof setTimeout>;
   private static readonly LIVE_RECONNECT_MS = 3000;
   private static readonly TAB_FOR_COLLECTION: Record<string, BrainTab> = {
-    memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'filemeta',
+    memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
   };
 
   /** (Re)open the live-change SSE stream for a space. EventSource can't send an Authorization header, and
@@ -462,21 +458,6 @@ export class BrainComponent implements OnInit, OnDestroy {
 
   requestDelete(id: string): void { this.recordList.confirmDeleteId.set(id); }
   cancelDelete(): void { this.recordList.confirmDeleteId.set(''); }
-
-  // ── File Meta inline edit ─────────────────────────────────────────────────
-
-  /** Called from Files tab file preview: switch to Filemeta tab filtered by path. */
-  openFileMetaEntry(path: string): void {
-    this.store.fileMetaSearch.set(path.replace(/^\/+/, ''));
-    this.activeTab.set('filemeta');
-  }
-
-  /** Called from Filemeta tab: switch to Files tab and navigate to the file's directory. */
-  openFileInManager(path: string): void {
-    const dir = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) || '/' : '/';
-    this.fileManagerNavPath.set(dir === '/' ? '' : dir);
-    this.setTab('files');
-  }
 
   runReindex(): void {
     this.reindexing.set(true);

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -600,9 +600,6 @@ function previewKind(name: string): PreviewKind {
           <div class="preview-header">
             <span class="file-title" [title]="pf.name">{{ pf.name }}</span>
             <button type="button" class="btn-secondary btn btn-sm" (click)="downloadFile(pf)" style="display:inline-flex;align-items:center;gap:4px"><ph-icon name="download-simple" [size]="14"/> {{ 'files.download' | transloco }}</button>
-            @if (embeddedSpaceId) {
-              <button class="btn btn-sm btn-secondary" [attr.title]="'files.viewMetadataTitle' | transloco" (click)="viewFileMeta.emit(previewFilePath(pf))" style="display:inline-flex;align-items:center;gap:4px"><ph-icon name="tag" [size]="14"/> {{ 'files.viewMetadata' | transloco }}</button>
-            }
             <button class="icon-btn" (click)="closePreview()" [attr.aria-label]="'files.closePreviewAriaLabel' | transloco"><ph-icon name="x" [size]="16"/></button>
           </div>
           <div class="preview-body">
@@ -650,17 +647,8 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   /** When set (embedded in brain), skip space loading and use this space. */
   @Input() embeddedSpaceId = '';
 
-  /** Emits the file path when user clicks "View Brain Metadata" in the preview pane. */
-  @Output() viewFileMeta = new EventEmitter<string>();
   /** Fires whenever the file set in this space changes (delete or upload complete) so the host can refresh counts. */
   @Output() filesChanged = new EventEmitter<void>();
-
-  /** Navigate to the given directory when changed from parent (used by Brain filemeta→Files link). */
-  @Input() set navigatePath(p: string) {
-    if (p && this.activeSpaceId()) {
-      this.navigate(p);
-    }
-  }
 
   spaces = signal<Space[]>([]);
   activeSpaceId = signal('');
@@ -983,11 +971,6 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     } catch (e) {
       this.toast.error(`${this.transloco.translate('files.downloadFailed')} ${httpErrorReason(e)}`.trim());
     }
-  }
-
-  /** Returns the space-relative path for a preview entry (used for brain metadata links). */
-  previewFilePath(entry: FileEntry): string {
-    return this.join(this.currentPath(), entry.name);
   }
 
   formatSize(bytes: number): string {

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -12,13 +12,12 @@ For setting up a workstation quickly see [workstation-mode-guide.md](workstation
 1. [Logging in](#logging-in)
 2. [Navigation](#navigation)
 3. [Spaces — what they are](#spaces--what-they-are)
-4. [Brain](#brain) — tabs: Overview (default landing), [Query](#query), [Graph](#graph), [Files](#files), Entities, Edges, Memories, Chrono, [File Meta](#file-meta)
+4. [Brain](#brain) — tabs: Overview (default landing), [Query](#query), [Graph](#graph), [Files](#files), Entities, Edges, Memories, Chrono
    - [Memories](#memories)
    - [Entities](#entities)
    - [Edges](#edges)
    - [Chrono](#chrono)
    - [Query](#query)
-   - [File Meta](#file-meta)
 5. [Graph](#graph)
 6. [Files](#files)
 7. [Conflict resolution](#conflict-resolution)
@@ -84,7 +83,7 @@ The `general` space is created automatically on first run. Admins can create add
 
 ## Brain
 
-The Brain is where all your knowledge lives. It has nine tabs: **Overview**, **Query**, **Graph**, **Files**, **Entities**, **Edges**, **Memories**, **Chrono**, and **File Meta**.
+The Brain is where all your knowledge lives. It has eight tabs: **Overview**, **Query**, **Graph**, **Files**, **Entities**, **Edges**, **Memories**, and **Chrono**.
 
 **Overview** is the **default landing tab** — opening a space lands here first. It is a per-space dashboard assembled from what the Brain already knows: a **Statistics** panel (record counts per collection, a total, and storage used against the space's quota) and an **Indexing** panel (the vector index's state, plus a **Reindex** button — behind a confirmation — when embeddings have gone stale). More panels (embedding queue, networks, health) arrive in later updates.
 
@@ -211,13 +210,9 @@ Example — find memories tagged `infra`:
 
 ---
 
-### File Meta
+### File metadata (merged into Files)
 
-The **File Meta** tab lists the metadata records Ythril keeps for uploaded files — the searchable side of a file (its caption/extracted text, tags, and links) as distinct from the raw bytes you manage on the Files tab.
-
-Each row can be opened inline to edit its links: you can attach **entities**, **memories**, and **chrono** entries to a file so it surfaces alongside related knowledge. Opening a file from the Files tab's metadata action jumps you straight to its File Meta entry.
-
-Sort by clicking the **Path** or **Updated** column headers (server-side, across the whole list). Narrow the list with the filter boxes docked under the headers — a **freetext box under Path** (case-insensitive substring over path + description, matched server-side across the whole list) and a **tag box under Tags** — the same header controls the other Brain list tabs use. (Semantic file search in a top bar is coming in a later slice.)
+There is no longer a separate **File Meta** tab. The metadata Ythril keeps for each uploaded file — the searchable side of a file (its caption/extracted text, tags, and links to entities, memories, and chrono entries) as distinct from the raw bytes — is being folded into the **[Files](#files)** tab, so files and their metadata live in one explorer-style view. Each file row already shows its **embedding status** and **tags** inline (see [Files](#files)); a docked detail view that opens the full metadata record next to the file preview follows in a subsequent update.
 
 ---
 


### PR DESCRIPTION
## What & why

The per-space Brain carried **two** file-related tabs — a left-group **Files** tab (the file manager) and a separate **File Meta** collection tab — forcing you to jump between a file's raw bytes and its searchable metadata. This collapses them into **one Files tab**, in the slot where **File Meta** was (collection group, count badge = `stats.files`), rendering the enhanced `app-file-manager` that already surfaces each file's embedding status, tags and folder sizes inline (shipped in #419/#420).

This is the **tab-restructure** slice of the owner-approved Files-tab merge (mockup approved). The docked detail pane (preview + description ⇄ full meta record) is the next slice; `filemeta-tab.component` is kept for it.

## Changes

- `BrainTab` union drops `'filemeta'`; `collectionTabs` no longer lists it; the single **Files** tab renders after the collection `@for` in the same group.
- `TAB_FOR_COLLECTION` maps `file → 'files'` (was `'filemeta'`) so a live file-change still selects the right tab.
- Removes the now-moot cross-handoff wiring: `openFileMetaEntry`, `openFileInManager`, `fileManagerNavPath`.
- **file-manager:** drops the now-inert preview **"Metadata"** button (it only showed when embedded and jumped to the old File Meta tab) plus the orphaned `viewFileMeta` output, `navigatePath` input and `previewFilePath` method, and the `files.viewMetadata*` i18n keys (en/de/pl).

## Tests & docs

- `brain.component.spec` pins the single-tab structure (no File Meta collection tab, no left-group Files tab, `setTab('files')` activates). 142 brain + 10 file-manager tests green; client `tsc` clean; icon-registry green.
- Docs: userguide now says **eight** Brain tabs and the File-Meta section is rewritten to point at the merged Files tab. CHANGELOG `[Unreleased]` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)