### PR TITLE
feat(files): formatted Markdown preview + full-screen button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2403,6 +2403,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Files preview now renders Markdown formatted and can go full-screen.** `.md` / `.markdown` files
+  render as formatted Markdown (headings, lists, links, code blocks, tables) instead of highlighted source,
+  and the preview gains a **full-screen** button that expands it to a full-window overlay (Escape or the close
+  button collapses it back to the docked pane, which stays open). The generated HTML is bound through Angular's
+  DOM sanitizer, so scripts/handlers in file content are stripped. (Mermaid diagrams and an .xlsx table preview
+  follow in later updates.)
+
 - **The Brain's Files tab gains a docked detail pane — preview + description, toggled to the full file-meta
   record.** Clicking a file now opens a right-hand column beside the list (the list runs full width until
   then, and reclaims it on close) instead of a full-screen modal drawer. Its header is a lean

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@phosphor-icons/core": "^2.1.1",
     "cytoscape": "^3.33.2",
     "highlight.js": "^11.11.1",
+    "marked": "^18.0.7",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "uqr": "^0.1.3"

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -509,6 +509,8 @@
   "files.preview.failed": "Vorschau konnte nicht geladen werden.",
   "files.preview.size": "Größe",
   "files.preview.modified": "Geändert",
+  "files.preview.fullscreen": "Vollbild",
+  "files.preview.exitFullscreen": "Vollbild beenden",
   "files.detail.tabsAriaLabel": "Detailansicht",
   "files.detail.previewTab": "Vorschau & Beschreibung",
   "files.detail.metaTab": "Datei-Metadaten",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -509,6 +509,8 @@
   "files.preview.failed": "Couldn’t load preview.",
   "files.preview.size": "Size",
   "files.preview.modified": "Modified",
+  "files.preview.fullscreen": "Full screen",
+  "files.preview.exitFullscreen": "Exit full screen",
   "files.detail.tabsAriaLabel": "Detail view",
   "files.detail.previewTab": "Preview & description",
   "files.detail.metaTab": "File meta",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -509,6 +509,8 @@
   "files.preview.failed": "Nie udało się wczytać podglądu.",
   "files.preview.size": "Rozmiar",
   "files.preview.modified": "Zmodyfikowany",
+  "files.preview.fullscreen": "Pełny ekran",
+  "files.preview.exitFullscreen": "Zamknij pełny ekran",
   "files.detail.tabsAriaLabel": "Widok szczegółów",
   "files.detail.previewTab": "Podgląd i opis",
   "files.detail.metaTab": "Metadane pliku",

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -115,6 +115,37 @@ describe('FileManagerComponent (OnPush)', () => {
     expect(fixture.nativeElement.querySelector('.seg-toggle')).toBeNull();
   });
 
+  it('renders markdown FORMATTED (not as highlighted source) in the preview face', () => {
+    const fixture = create([fileEntry('doc.md')]);
+    fixture.componentInstance.previewFile.set(fileEntry('doc.md'));
+    fixture.componentInstance.previewKind.set('markdown');
+    fixture.componentInstance.previewHtml.set('<h1>Hello</h1><p>world</p>');
+    fixture.detectChanges();
+    const md = fixture.nativeElement.querySelector('.md-rendered') as HTMLElement | null;
+    expect(md).toBeTruthy();
+    expect(md!.querySelector('h1')?.textContent).toContain('Hello');
+    // A .md must NOT fall through to the source-code (<pre class="preview-code">) branch.
+    expect(fixture.nativeElement.querySelector('.preview-code')).toBeNull();
+  });
+
+  it('toggles the full-screen preview overlay; Escape collapses it before closing the pane', () => {
+    const fixture = create([fileEntry('doc.md')]);
+    fixture.componentInstance.previewFile.set(fileEntry('doc.md'));
+    fixture.componentInstance.previewKind.set('markdown');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.preview-fs-overlay')).toBeNull();
+
+    fixture.componentInstance.previewFullscreen.set(true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.preview-fs-overlay')).toBeTruthy();
+
+    // First Escape collapses full-screen but leaves the docked pane open.
+    fixture.componentInstance.onPreviewKey(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.previewFullscreen()).toBe(false);
+    expect(fixture.componentInstance.previewFile()).toBeTruthy();
+  });
+
   it('re-renders the listing when the entries signal is replaced (not just on first load)', () => {
     const fixture = create([fileEntry('first.md')]);
     const body = () => (fixture.nativeElement.querySelector('table tbody') as HTMLElement).textContent ?? '';

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -14,6 +14,7 @@ import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
+import { marked } from 'marked';
 // The docked detail pane reuses the Brain's file-metadata edit fields. These are dumb, shared
 // ref-field widgets; they resolve chip labels via EntityRefPicker, which the Brain provides — so the
 // "File meta" edit mode is available only when embedded in the Brain (embeddedSpaceId set).
@@ -55,7 +56,7 @@ interface TreeNode {
   children: TreeNode[] | null;  // null = not yet loaded
 }
 
-type PreviewKind = 'text' | 'image' | 'pdf' | 'unknown';
+type PreviewKind = 'text' | 'markdown' | 'image' | 'pdf' | 'unknown';
 
 type UploadStatus = 'queued' | 'uploading' | 'done' | 'failed';
 
@@ -70,9 +71,11 @@ interface UploadItem {
 }
 
 const TEXT_EXTS = new Set([
-  '.txt', '.md', '.json', '.yaml', '.yml', '.ts', '.js', '.py', '.sh',
+  '.txt', '.json', '.yaml', '.yml', '.ts', '.js', '.py', '.sh',
   '.csv', '.xml', '.html', '.css', '.log', '.env', '.toml',
 ]);
+// Markdown renders formatted (via marked) rather than as highlighted source.
+const MARKDOWN_EXTS = new Set(['.md', '.markdown']);
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp']);
 const PDF_EXTS = new Set(['.pdf']);
 
@@ -90,6 +93,7 @@ function extOf(name: string): string {
 
 function previewKind(name: string): PreviewKind {
   const ext = extOf(name);
+  if (MARKDOWN_EXTS.has(ext)) return 'markdown';
   if (TEXT_EXTS.has(ext)) return 'text';
   if (IMAGE_EXTS.has(ext)) return 'image';
   if (PDF_EXTS.has(ext)) return 'pdf';
@@ -304,6 +308,35 @@ function previewKind(name: string): PreviewKind {
     .detail-meta-form label { display: block; margin-bottom: 4px; font-size: 0.8em; color: var(--text-muted); }
     .detail-meta-form textarea { width: 100%; resize: vertical; }
     .detail-meta-actions { display: flex; gap: 8px; align-items: center; margin-top: 6px; }
+    /* Full-screen toggle floats at the top-right of the preview body. */
+    .preview-body { position: relative; }
+    .preview-fs-btn { position: absolute; top: 4px; right: 4px; z-index: 1; opacity: 0.75; }
+    .preview-fs-btn:hover { opacity: 1; }
+    /* Formatted markdown */
+    .md-rendered { line-height: 1.6; word-break: break-word; }
+    .md-rendered h1, .md-rendered h2, .md-rendered h3 { margin: 0.8em 0 0.4em; line-height: 1.25; }
+    .md-rendered h1 { font-size: 1.5em; } .md-rendered h2 { font-size: 1.3em; } .md-rendered h3 { font-size: 1.12em; }
+    .md-rendered p { margin: 0.5em 0; }
+    .md-rendered ul, .md-rendered ol { margin: 0.5em 0; padding-left: 1.5em; }
+    .md-rendered code { background: var(--bg-muted); padding: 0.1em 0.35em; border-radius: 4px; font-family: var(--font-mono, monospace); font-size: 0.9em; }
+    .md-rendered pre { background: var(--bg-muted); padding: 12px; border-radius: 6px; overflow: auto; margin: 0.6em 0; }
+    .md-rendered pre code { background: none; padding: 0; }
+    .md-rendered a { color: var(--accent, #6ea8fe); }
+    .md-rendered blockquote { margin: 0.5em 0; padding-left: 12px; border-left: 3px solid var(--border); color: var(--text-muted); }
+    .md-rendered table { border-collapse: collapse; margin: 0.5em 0; }
+    .md-rendered th, .md-rendered td { border: 1px solid var(--border); padding: 4px 8px; }
+    .md-rendered img { max-width: 100%; }
+    /* Full-screen preview overlay */
+    .preview-fs-overlay {
+      position: fixed; inset: 0; z-index: 1200;
+      background: var(--bg-surface); display: flex; flex-direction: column;
+    }
+    .preview-fs-bar {
+      display: flex; align-items: center; gap: 10px;
+      padding: 12px 16px; border-bottom: 1px solid var(--border); flex-shrink: 0;
+    }
+    .preview-fs-bar .file-title { flex: 1; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .preview-fs-body { flex: 1; overflow: auto; padding: 20px; max-width: 1100px; width: 100%; margin: 0 auto; }
     .preview-body {
       flex: 1;
       overflow: auto;
@@ -590,7 +623,7 @@ function previewKind(name: string): PreviewKind {
           <!-- Docked detail pane: preview + description ⇄ file-meta record (the merged File Meta view).
                The list runs full width until a file is opened; opening one adds this column. -->
           @if (previewFile(); as pf) {
-            <div class="fm-detail" tabindex="0" (keydown)="onPreviewKey($event)" #detailPane>
+            <div class="fm-detail" tabindex="0" #detailPane>
               <div class="detail-header">
                 @if (embeddedSpaceId) {
                   <div class="seg-toggle" role="tablist" [attr.aria-label]="'files.detail.tabsAriaLabel' | transloco">
@@ -606,24 +639,11 @@ function previewKind(name: string): PreviewKind {
               <div class="detail-body">
                 @if (detailMode() === 'preview' || !embeddedSpaceId) {
                   <div class="preview-body">
-                    @if (previewLoading()) {
-                      <div class="loading-overlay"><span class="spinner"></span></div>
-                    } @else if (previewError() !== null) {
-                      <div class="alert alert-error" role="alert">{{ 'files.preview.failed' | transloco }} {{ previewError() }}</div>
-                    } @else {
-                      @switch (previewKind()) {
-                        @case ('text') { <pre class="preview-code"><code [innerHTML]="previewHtml()"></code></pre> }
-                        @case ('image') { <img [src]="previewMediaUrl()" [alt]="pf.name" /> }
-                        @case ('pdf') { <iframe [src]="previewSafeUrl()"></iframe> }
-                        @default {
-                          <dl class="preview-meta">
-                            <dt>{{ 'files.preview.name' | transloco }}</dt><dd>{{ pf.name }}</dd>
-                            <dt>{{ 'files.preview.size' | transloco }}</dt><dd>{{ formatSize(pf.size) }}</dd>
-                            <dt>{{ 'files.preview.modified' | transloco }}</dt><dd>{{ pf.modified | date:'dd.MM.yyyy HH:mm' }}</dd>
-                          </dl>
-                        }
-                      }
+                    <!-- Full-screen toggle: shown once there's rendered content (not while loading / on error). -->
+                    @if (!previewLoading() && previewError() === null && previewKind() !== 'unknown') {
+                      <button class="btn-ghost btn btn-sm preview-fs-btn" type="button" (click)="previewFullscreen.set(true)" [attr.title]="'files.preview.fullscreen' | transloco" [attr.aria-label]="'files.preview.fullscreen' | transloco"><ph-icon name="corners-out" [size]="16"/></button>
                     }
+                    <ng-container [ngTemplateOutlet]="previewContent" [ngTemplateOutletContext]="{ $implicit: pf }"></ng-container>
                   </div>
                   @if (selectedMeta()?.description) {
                     <div class="detail-desc">
@@ -690,6 +710,42 @@ function previewKind(name: string): PreviewKind {
         }
       }
     </ng-template>
+
+    <!-- Preview content, shared by the docked pane and the full-screen overlay. -->
+    <ng-template #previewContent let-pf>
+      @if (previewLoading()) {
+        <div class="loading-overlay"><span class="spinner"></span></div>
+      } @else if (previewError() !== null) {
+        <div class="alert alert-error" role="alert">{{ 'files.preview.failed' | transloco }} {{ previewError() }}</div>
+      } @else {
+        @switch (previewKind()) {
+          @case ('markdown') { <div class="md-rendered" [innerHTML]="previewHtml()"></div> }
+          @case ('text') { <pre class="preview-code"><code [innerHTML]="previewHtml()"></code></pre> }
+          @case ('image') { <img [src]="previewMediaUrl()" [alt]="pf.name" /> }
+          @case ('pdf') { <iframe [src]="previewSafeUrl()"></iframe> }
+          @default {
+            <dl class="preview-meta">
+              <dt>{{ 'files.preview.name' | transloco }}</dt><dd>{{ pf.name }}</dd>
+              <dt>{{ 'files.preview.size' | transloco }}</dt><dd>{{ formatSize(pf.size) }}</dd>
+              <dt>{{ 'files.preview.modified' | transloco }}</dt><dd>{{ pf.modified | date:'dd.MM.yyyy HH:mm' }}</dd>
+            </dl>
+          }
+        }
+      }
+    </ng-template>
+
+    <!-- Full-screen preview overlay (the one intentional fixed overlay — for the full-screen button). -->
+    @if (previewFullscreen() && previewFile(); as pf) {
+      <div class="preview-fs-overlay" tabindex="0" #fsOverlay>
+        <div class="preview-fs-bar">
+          <span class="file-title" [title]="pf.name">{{ pf.name }}</span>
+          <button class="icon-btn" (click)="previewFullscreen.set(false)" [attr.aria-label]="'files.preview.exitFullscreen' | transloco"><ph-icon name="x" [size]="18"/></button>
+        </div>
+        <div class="preview-fs-body preview-body">
+          <ng-container [ngTemplateOutlet]="previewContent" [ngTemplateOutletContext]="{ $implicit: pf }"></ng-container>
+        </div>
+      </div>
+    }
   `,
 })
 export class FileManagerComponent implements OnInit, OnDestroy {
@@ -753,6 +809,8 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   previewError = signal<string | null>(null);
   /** Blob object URL backing the current image/PDF preview; revoked on close/next. */
   private _previewObjectUrl: string | null = null;
+  /** True while the preview is expanded to a full-screen overlay (Escape collapses it first). */
+  previewFullscreen = signal(false);
 
   // ── Docked detail-pane state (preview+description ⇄ file-meta record) ──────
   /** Which face of the detail pane is showing. Meta editing is only reachable when embedded. */
@@ -1142,6 +1200,7 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     // Selecting a file always shows the preview face first; the meta record loads alongside so the
     // description shows here and the (embedded-only) edit form is ready when the toggle is used.
     this.detailMode.set('preview');
+    this.previewFullscreen.set(false);
     this.loadSelectedMeta(entry);
 
     // Every preview fetch must carry the auth header — the file endpoint requires it,
@@ -1152,14 +1211,20 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     const token = this.auth.token();
     const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {};
 
-    if (kind === 'text') {
+    if (kind === 'text' || kind === 'markdown') {
       this.previewLoading.set(true);
       fetch(url, { headers })
         .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); })
         .then(text => {
-          const ext = extOf(entry.name);
-          const lang = EXT_LANG[ext] ?? 'plaintext';
-          this.previewHtml.set(hljs.highlight(text, { language: lang }).value);
+          if (kind === 'markdown') {
+            // marked → HTML string. Bound via [innerHTML] WITHOUT bypassSecurityTrust, so Angular's
+            // built-in DOM sanitizer strips scripts/handlers from the (untrusted) file content.
+            this.previewHtml.set(marked.parse(text, { async: false }) as string);
+          } else {
+            const ext = extOf(entry.name);
+            const lang = EXT_LANG[ext] ?? 'plaintext';
+            this.previewHtml.set(hljs.highlight(text, { language: lang }).value);
+          }
           this.previewLoading.set(false);
         })
         .catch((e) => { this.previewError.set(httpErrorReason(e)); this.previewLoading.set(false); });
@@ -1278,6 +1343,8 @@ export class FileManagerComponent implements OnInit, OnDestroy {
 
   onPreviewKey(e: KeyboardEvent): void {
     if (e.key === 'Escape') {
+      // Full-screen collapses back to the docked pane first; a second Escape closes the pane.
+      if (this.previewFullscreen()) { this.previewFullscreen.set(false); return; }
       this.closePreview();
       return;
     }

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -283,16 +283,19 @@ Clicking a file opens a **docked detail pane** to the right of the list (the lis
 
   | Type | How it renders |
   |------|---------------|
-  | Text, code, Markdown, JSON, YAML… | Syntax-highlighted |
+  | Markdown (.md, .markdown) | **Formatted** — headings, lists, links, code blocks, tables |
+  | Text, code, JSON, YAML… | Syntax-highlighted source |
   | Images (.png, .jpg, .gif, .webp, .svg…) | Inline image |
   | PDF | Embedded viewer |
   | Everything else | File info + download button |
+
+  A **full-screen** button (top-right of the preview) expands the preview to fill the window; **Escape** or its close button collapses it back to the docked pane.
 
 - **File meta** *(in the Brain)* — the editable metadata record: **description**, **tags**, and links to **entities**, **memories** and **chrono** entries, plus a **Retry** action to re-queue embedding for a failed or partial file. This is where the former *File Meta* tab's editing now lives. (On the standalone Files page, outside the Brain, the pane shows preview + description only.)
 
 Press **Escape** or the close button to dismiss the pane. Use arrow keys to move to the previous or next file in the directory.
 
-> Formatted Markdown and Mermaid rendering, an .xlsx table preview, and a full-screen preview button are coming in a later update.
+> Mermaid diagram rendering and an .xlsx table preview are coming in a later update.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@phosphor-icons/core": "^2.1.1",
         "cytoscape": "^3.33.2",
         "highlight.js": "^11.11.1",
+        "marked": "^18.0.7",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "uqr": "^0.1.3"
@@ -13427,6 +13428,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {


### PR DESCRIPTION
## What & why

Third slice of the merged Files tab's preview work (first of the mockup's final "formatted previews" group).

- **Markdown renders formatted.** `.md` / `.markdown` files now render as formatted Markdown (headings, lists, links, code blocks, tables) via `marked`, instead of being highlighted as raw source.
- **Full-screen preview.** A button (top-right of the preview) expands it to a full-window overlay; **Escape** or the close button collapses it back to the docked pane (which stays open).

## Security

The Markdown HTML is bound via `[innerHTML]` **without** `bypassSecurityTrust`, so Angular's built-in DOM sanitizer strips `<script>`/event handlers from the (untrusted) file content. No extra sanitizer dependency.

## Notable

- New `markdown` `PreviewKind`; `.md`/`.markdown` split out of `TEXT_EXTS`.
- Preview content extracted into a shared `#previewContent` ng-template, reused by the docked pane and the full-screen overlay (no duplication).
- **Escape double-fire fix:** the pane/overlay carried element `(keydown)` handlers *and* a document keydown listener, so one Escape ran `onPreviewKey` twice (collapse full-screen, then close the pane). Dropped the element handlers — the document listener is now the sole handler. **This was caught by the scratch E2E**; a unit test calling the method directly could not have surfaced it.
- i18n en/de/pl (`files.preview.fullscreen` / `exitFullscreen`).

## Tests & verification

- `file-manager.component.spec`: pins that `.md` renders `.md-rendered` (not the source `.preview-code` branch) and that the full-screen overlay toggles + Escape collapses it while keeping the pane open. **13 file-manager + 155 brain/files tests green**; client `tsc` clean; **production build OK** (`marked` lands in the lazy Files/Brain chunk, no budget errors); icon-registry green (`corners-out` already registered); `lint:docs` clean.
- **E2E against a scratch stack:** upload a rich `readme.md` → Brain → Files → open it → renders **h1 / list / code block formatted, zero source-fallback** → full-screen button opens the overlay (markdown re-rendered) → **Escape collapses it and the docked pane stays open**. Verdict PASS.

## Docs

- userguide preview table (Markdown → formatted; note the full-screen button); CHANGELOG `[Unreleased]`.

Mermaid diagram rendering and an `.xlsx` table preview follow in later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)