### PR TITLE
perf(brain): @defer the Graph and Files tabs off the landing chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2403,6 +2403,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain landing page is much lighter.** The Graph and Files tabs (which carry cytoscape and the
+  file-manager's markdown / mermaid / xlsx renderers) are now `@defer`-loaded on first visit instead of
+  being downloaded with the Brain page. Opening a space (which lands on Overview) no longer pulls those
+  libraries — the Brain route chunk drops from ~828 kB to ~183 kB raw (~186 kB → ~25 kB transfer); Graph
+  and Files each load their own chunk the first time you open the tab. A build-size budget was added so
+  bundle growth is caught. No behavioural change to either tab.
+
 - **Spreadsheets (`.xlsx` / `.xlsm`) now preview as a table.** Opening a spreadsheet in the Files tab renders
   its first sheet as a grid (first row as a header band, formula cells shown as their computed result). The
   parser (exceljs) is **lazy-loaded** — only fetched when a spreadsheet is opened, out of the initial bundle.

--- a/client/angular.json
+++ b/client/angular.json
@@ -53,7 +53,8 @@
             "production": {
               "budgets": [
                 { "type": "initial", "maximumWarning": "1MB", "maximumError": "2MB" },
-                { "type": "anyComponentStyle", "maximumWarning": "12kB", "maximumError": "24kB" }
+                { "type": "anyComponentStyle", "maximumWarning": "12kB", "maximumError": "24kB" },
+                { "type": "all", "maximumWarning": "8mb", "maximumError": "12mb" }
               ],
               "outputHashing": "all"
             },

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -238,14 +238,21 @@ interface SpaceView {
           <div class="loading-overlay loading-overlay--float"><span class="spinner"></span></div>
         }
 
-        <!-- Graph tab -->
-        @if (activeTab() === 'graph') {
+        <!-- Graph + Files carry heavy libraries (cytoscape; the file-manager's markdown/mermaid/xlsx
+             renderers). @defer keeps them OUT of the brain chunk downloaded on landing (Overview is the
+             default tab) — the chunk loads on first visit to that tab. Trigger is the SAME activeTab()
+             gate as the record tabs, so the storm-safe "gate on activeTab() alone" rule still holds. -->
+        @defer (when activeTab() === 'graph') {
           <app-graph-view [embeddedSpaceId]="activeSpaceId()" />
+        } @loading (minimum 200ms) {
+          <div class="loading-overlay loading-overlay--float"><span class="spinner"></span></div>
         }
 
         <!-- Files tab (merged: file manager + File Meta) -->
-        @if (activeTab() === 'files') {
+        @defer (when activeTab() === 'files') {
           <app-file-manager [embeddedSpaceId]="activeSpaceId()" (filesChanged)="loadStats(activeSpaceId())" />
+        } @loading (minimum 200ms) {
+          <div class="loading-overlay loading-overlay--float"><span class="spinner"></span></div>
         }
 
         <!-- Memories -->


### PR DESCRIPTION
## What & why

Opening a space lands on **Overview**, but the Brain route chunk downloaded on landing statically pulled `GraphComponent` (cytoscape) and `FileManagerComponent` (the markdown / mermaid / xlsx preview renderers) even though neither renders until you click its tab. They're now `@defer` blocks, so those libraries leave the landing chunk.

## How

- `@defer (when activeTab() === 'graph')` / `@defer (when activeTab() === 'files')` — triggered by the **same `activeTab()` gate** the record tabs use, so the storm-safe "gate on `activeTab()` alone, never in an `@else` of loading" invariant still holds. A short `@loading (minimum 200ms)` spinner covers the first-visit chunk fetch.

## Result (production build)

- Brain route chunk: **~828 kB → ~183 kB raw (~186 kB → ~25 kB transfer)**.
- New on-demand chunks: `graph-component` ~75 kB, `file-manager-component` ~153 kB — fetched the first time you open that tab.
- Initial app bundle unaffected.

## Guard

Added an `all`-type production build budget (`warn 8 mb / error 12 mb`) so overall bundle growth gets a signal. **Caveat:** `ng build` isn't run in CI today (CI runs client vitest + server build + Docker), so this is a **local / release-build** signal; wiring the client prod build into CI is a sensible follow-up (it'd also catch AOT errors the JIT unit tests can't).

## Tests

`brain.component.spec` stays **7/7** under `@defer` (TestBed leaves defer blocks in their placeholder; no test asserts Graph/Files rendered content). Client `tsc` clean; production build clean (no budget trip, no CJS warnings). No behavioural change to either tab, so no docs change; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)