### PR TITLE
fix(conflicts): bound the conflict + link-violation lists (no silent truncation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The conflicts and link-violation lists no longer truncate silently.** `GET /api/conflicts` and
+  `GET /api/conflicts/link-violations` capped each space's results at 500 with no pagination and concatenated
+  every accessible space in memory (up to 500·N docs for an N-space token), returning a silently-capped array
+  a client couldn't tell was incomplete. Both now cap per space **and** bound the cross-space total, and
+  return `returned` + `truncated` so the caller knows whether it saw everything. The Conflicts page shows a
+  note when the list is truncated.
+
 - **The chrono `?search=` filter no longer passes the raw query to a MongoDB `$regex`.** The value was
   handed to the engine un-escaped, so a crafted input (e.g. `(a+)+$`) was a regex-injection / ReDoS
   vector against the list endpoint. It is now escaped and matched as a literal substring, the same as

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -605,6 +605,7 @@
   "conflicts.action.keepBoth": "Beide behalten",
   "conflicts.action.saveToSpace": "In Bereich speichern…",
   "conflicts.unresolvedCount": "{{ count }} ungelöste Konflikte.",
+  "conflicts.truncated": "Es werden die ersten {{ count }} Konflikte angezeigt — es gibt mehr, als auf einmal aufgelistet werden können. Lösen Sie einige, um die übrigen zu sehen.",
   "conflicts.resolveSelected": "{{ count }} ausgewählte Konflikte lösen",
   "conflicts.resolving": "Löse auf…",
   "conflicts.resolveButton": "Lösen",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -605,6 +605,7 @@
   "conflicts.action.keepBoth": "Keep both",
   "conflicts.action.saveToSpace": "Save to space…",
   "conflicts.unresolvedCount": "Unresolved conflicts: {{ count }}.",
+  "conflicts.truncated": "Showing the first {{ count }} conflicts — there are more than can be listed at once. Resolve some to see the rest.",
   "conflicts.resolveSelected": "Resolve {{ count }} selected",
   "conflicts.resolving": "Resolving…",
   "conflicts.resolveButton": "Resolve",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -605,6 +605,7 @@
   "conflicts.action.keepBoth": "Zachowaj oba",
   "conflicts.action.saveToSpace": "Zapisz do przestrzeni…",
   "conflicts.unresolvedCount": "Nierozwiązane konflikty: {{ count }}.",
+  "conflicts.truncated": "Wyświetlono pierwsze {{ count }} konfliktów — jest ich więcej, niż można wyświetlić naraz. Rozwiąż część, aby zobaczyć resztę.",
   "conflicts.resolveSelected": "Rozwiąż zaznaczone: {{ count }}",
   "conflicts.resolving": "Rozwiązywanie…",
   "conflicts.resolveButton": "Rozwiąż",

--- a/client/src/app/core/files-api.service.ts
+++ b/client/src/app/core/files-api.service.ts
@@ -185,7 +185,7 @@ export class FilesApi {
 
   // ── File conflicts ────────────────────────────────────────────────────────
 
-  listConflicts(): Observable<{ conflicts: ConflictRecord[] }> {
+  listConflicts(): Observable<{ conflicts: ConflictRecord[]; truncated?: boolean; returned?: number }> {
     return this.http.get<any>('/api/conflicts');
   }
 

--- a/client/src/app/pages/files/conflicts.component.spec.ts
+++ b/client/src/app/pages/files/conflicts.component.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * ConflictsComponent — the cross-space conflict list.
+ *
+ * The server caps this list (per-space + a total bound) and returns a `truncated` flag so the client can
+ * say the operator is NOT seeing every conflict. This pins that the flag surfaces a visible note — a
+ * silently-capped list with no signal is exactly the "no silent caps" defect the server change fixes.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of } from 'rxjs';
+import { provideRouter } from '@angular/router';
+import { FilesApi } from '../../core/files-api.service';
+import { SpacesApi } from '../../core/spaces-api.service';
+import { ToastService } from '../../core/toast.service';
+import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { ConflictsComponent } from './conflicts.component';
+
+function conflict(id: string) {
+  return { id, spaceId: 's', originalPath: `a/${id}.txt`, conflictPath: `a/${id}.conflict.txt`, peerInstanceId: 'p', peerInstanceLabel: 'Peer', detectedAt: '2026-07-27T00:00:00.000Z' };
+}
+
+describe('ConflictsComponent', () => {
+  function create(resp: { conflicts: ReturnType<typeof conflict>[]; truncated?: boolean }) {
+    TestBed.configureTestingModule({
+      imports: [ConflictsComponent, getTranslocoModule()],
+      providers: [
+        provideRouter([]),
+        { provide: FilesApi, useValue: { listConflicts: () => of(resp) } },
+        { provide: SpacesApi, useValue: { listSpaces: () => of({ spaces: [] }) } },
+        { provide: ToastService, useValue: { success: () => {}, error: () => {} } },
+        { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(true) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(ConflictsComponent);
+    fixture.detectChanges(); // ngOnInit → load() resolves synchronously via of()
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('shows the truncation note when the server reports truncated:true', () => {
+    const fixture = create({ conflicts: [conflict('a'), conflict('b')], truncated: true });
+    expect(fixture.componentInstance.truncated()).toBe(true);
+    const note = fixture.nativeElement.querySelector('.alert-info');
+    expect(note).toBeTruthy();
+    // Test transloco renders raw keys, so assert the note binds the truncation message key.
+    expect((note as HTMLElement).textContent).toContain('conflicts.truncated');
+  });
+
+  it('shows NO truncation note when the list is complete (truncated falsy)', () => {
+    const fixture = create({ conflicts: [conflict('a')] });
+    expect(fixture.componentInstance.truncated()).toBe(false);
+    expect(fixture.nativeElement.querySelector('.alert-info')).toBeNull();
+  });
+});

--- a/client/src/app/pages/files/conflicts.component.ts
+++ b/client/src/app/pages/files/conflicts.component.ts
@@ -33,6 +33,11 @@ type ResolveAction = 'keep-local' | 'keep-incoming' | 'keep-both' | 'save-to-spa
       <div class="alert alert-warning" style="margin-bottom:16px;">
         {{ 'conflicts.unresolvedCount' | transloco: { count: conflicts().length } }}
       </div>
+      @if (truncated()) {
+        <div class="alert alert-info" style="margin-bottom:16px;">
+          {{ 'conflicts.truncated' | transloco: { count: conflicts().length } }}
+        </div>
+      }
 
       <!-- Bulk action bar -->
       @if (conflicts().length > 1) {
@@ -135,6 +140,8 @@ export class ConflictsComponent implements OnInit {
 
   loading = signal(true);
   conflicts = signal<ConflictRecord[]>([]);
+  /** True when the server capped the list — the user is NOT seeing every conflict (resolve some to see more). */
+  truncated = signal(false);
   resolving = signal<string | null>(null);
   bulkResolving = signal(false);
   selectedIds = signal<string[]>([]);
@@ -173,8 +180,9 @@ export class ConflictsComponent implements OnInit {
   private load(): void {
     this.loading.set(true);
     this.filesApi.listConflicts().subscribe({
-      next: ({ conflicts }) => {
+      next: ({ conflicts, truncated }) => {
         this.conflicts.set(conflicts);
+        this.truncated.set(truncated === true);
         for (const c of conflicts) {
           if (!this.conflictActions[c.id]) this.conflictActions[c.id] = 'keep-local';
         }

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -4484,6 +4484,11 @@ Base path: `/api/conflicts`
 GET /api/conflicts?spaceId=general
 ```
 
+Returns `{ conflicts: [...], returned: <n>, truncated: <bool> }`. The list is bounded — capped per space
+and to a total across all accessible spaces — so a token spanning many spaces cannot force an unbounded
+response. When `truncated` is `true` the caller has **not** seen every conflict (resolve some and re-list to
+see the rest); `returned` is how many were included. The `link-violations` list is bounded the same way.
+
 ---
 
 ### Get Conflict

--- a/server/src/api/conflicts.ts
+++ b/server/src/api/conflicts.ts
@@ -93,20 +93,31 @@ async function executeResolve(
     .deleteOne(asFilter<ConflictDoc>({ _id: doc._id }));
 }
 
+// Bounds for the cross-space list endpoints below. Without these the fan-in was up to 500·N docs
+// materialised in memory for an N-space token, and the client got a silently-capped array with no way
+// to tell it was incomplete. We cap per space (fetch cap+1 to DETECT overflow) and bound the total,
+// and always report `truncated` + `returned` so the caller knows whether it saw everything.
+const PER_SPACE_CAP = 500;
+const MAX_TOTAL = 2000;
+
 // GET /api/conflicts — list unresolved conflicts for all accessible spaces
 conflictsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
   try {
     const spaces = accessibleSpaces(req.authToken?.spaces);
     const results: ConflictDoc[] = [];
+    let truncated = false;
     for (const spaceId of spaces) {
       const docs = await col<ConflictDoc>(`${spaceId}_conflicts`)
         .find({})
         .sort({ detectedAt: -1 })
-        .limit(500)
+        .limit(PER_SPACE_CAP + 1)
         .toArray() as ConflictDoc[];
+      if (docs.length > PER_SPACE_CAP) { truncated = true; docs.length = PER_SPACE_CAP; }
       results.push(...docs);
+      if (results.length >= MAX_TOTAL) { truncated = true; break; } // bound cross-space memory
     }
     results.sort((a, b) => b.detectedAt.localeCompare(a.detectedAt));
+    if (results.length > MAX_TOTAL) { results.length = MAX_TOTAL; truncated = true; }
     res.json({
       conflicts: results.map(c => ({
         id: c._id,
@@ -117,6 +128,8 @@ conflictsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
         peerInstanceLabel: c.peerInstanceLabel,
         detectedAt: c.detectedAt,
       })),
+      returned: results.length,
+      truncated,
     });
   } catch (err) {
     log.error(`GET /api/conflicts: ${err}`);
@@ -133,16 +146,20 @@ conflictsRouter.get('/link-violations', globalRateLimit, requireAuth, async (_re
   try {
     const spaces = accessibleSpaces(_req.authToken?.spaces);
     const results: LinkViolationDoc[] = [];
+    let truncated = false;
     for (const spaceId of spaces) {
       const docs = await col<LinkViolationDoc>(`${spaceId}_link_violations`)
         .find({})
         .sort({ detectedAt: -1 })
-        .limit(500)
+        .limit(PER_SPACE_CAP + 1)
         .toArray() as LinkViolationDoc[];
+      if (docs.length > PER_SPACE_CAP) { truncated = true; docs.length = PER_SPACE_CAP; }
       results.push(...docs);
+      if (results.length >= MAX_TOTAL) { truncated = true; break; }
     }
     results.sort((a, b) => b.detectedAt.localeCompare(a.detectedAt));
-    res.json({ violations: results });
+    if (results.length > MAX_TOTAL) { results.length = MAX_TOTAL; truncated = true; }
+    res.json({ violations: results, returned: results.length, truncated });
   } catch (err) {
     log.error(`GET /api/conflicts/link-violations: ${err}`);
     res.status(500).json({ error: 'Internal error' });


### PR DESCRIPTION
## What & why

`GET /api/conflicts` and `GET /api/conflicts/link-violations` capped each space's results at `.limit(500)` with **no pagination and no truncation signal**, then concatenated every accessible space in memory — up to **500·N docs** for an N-space admin token. The client got a silently-capped array it couldn't tell was incomplete: exactly the "no silent caps" gap `_AUDIT-LENSES.md` calls out.

## Fix

- Fetch **`cap+1` per space** to *detect* overflow (cap = 500), and **bound the cross-space total** (`MAX_TOTAL = 2000`) so the fan-in can't grow unboundedly with the number of spaces.
- Both endpoints now return **`returned`** (count included) and **`truncated`** (bool).
- The **Conflicts page** reads `truncated` and shows a note: *"showing the first N — resolve some to see the rest."* (i18n en/de/pl).

## Tests & gates

- New `conflicts.component.spec` pins the note **shows** on `truncated: true` and is **absent** otherwise.
- Server + client `tsc` clean; **audit-route-coverage green** (both are GET / read-only — no new mutating verb, so no new audit rule needed); `lint:docs` clean.

## Docs

- integration-guide "List Conflicts" now documents the `{ conflicts, returned, truncated }` shape and the bounding; CHANGELOG `[Unreleased]` (Security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)