### PR TITLE
feat(files): per-record TTL on files (F12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -838,6 +838,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Files can now carry a per-record TTL (auto-expiry), like every other knowledge type.** Pass `ttlDays`
+  as a query param on upload — `POST /api/files/:spaceId?path=…&ttlDays=30` — or the `ttlDays` field on the
+  MCP `write_file` tool; `0`/`null` means never expire, and a space's `recordTtlDays` default applies to
+  uploads that omit it. When a file lapses, the sweep runs the **full delete cascade** (blob + embedding
+  chunks + conversion artifacts + any queued job + the record's sync tombstone) — never just the record —
+  so an expired file leaves nothing orphaned. (F12; files were previously the only type excluded from TTL.)
+
 - **The file list now shows each file's embedding status and tags inline.** Every file row carries a
   **status pill** (Embedded / Embedding / Partial / Failed / Skipped…) and its **tags**, joined from the
   file's metadata record — so you can see a space's file-processing state without leaving the file

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -740,8 +740,14 @@ instance; expiry is eventual (granularity is days), not to-the-second. A `ttlDay
 fields) is a valid write — use it to set, extend, or clear an existing record's expiry.
 
 `ttlDays` is accepted on the **MCP** write tools as well (`remember`, `update_memory`, `upsert_entity`,
-`update_entity`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`) and per item in
+`update_entity`, `upsert_edge`, `update_edge`, `create_chrono`, `update_chrono`, `write_file`) and per item in
 `bulk_write` / `POST /bulk`, with the same semantics — so agents can set an expiry directly.
+
+**Files** carry TTL too: pass `ttlDays` as a **query parameter** on the upload — `POST /api/files/:spaceId?path=…&ttlDays=30`
+(a query param so it works for raw-binary bodies) — or the `ttlDays` field on the MCP `write_file` tool. The
+expiry is stamped on the file's metadata record; when it lapses, the sweep runs the **full file delete**
+(the blob, its embedding chunks, conversion artifacts and any queued job — not just the record), the same as
+`DELETE /api/files/:spaceId`. The space-wide `recordTtlDays` default applies to uploads that omit `ttlDays`.
 
 ---
 

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -71,6 +71,18 @@ function webhookToken(req: Request): { tokenId?: string; tokenLabel?: string } {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Parse an optional `?ttlDays=` upload query param (per-record file TTL, F12). Must be a query param,
+ * not a body field, so it works for raw-binary uploads too. A non-negative number wins; `0` means
+ * "never expire" (explicit); anything invalid/absent → undefined (fall back to the space default).
+ */
+function parseTtlDaysQuery(req: Request): number | undefined {
+  const raw = req.query['ttlDays'];
+  if (raw == null || raw === '') return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
 /** Validate and return the `path` query param; 404 if missing. */
 function requireQueryPath(req: Request, res: Response): string | null {
   const p = req.query['path'];
@@ -410,7 +422,7 @@ fileStoreRouter.post(
           const absTarget = resolveSafePath(targetSpace, filePath);
           await assertNoSymlinkEscape(targetSpace, absTarget);
           const sha256 = await assembleChunks(targetSpace, filePath, range.total, absTarget);
-          await upsertFileMeta(targetSpace, filePath, range.total).catch(err => {
+          await upsertFileMeta(targetSpace, filePath, range.total, { ttlDays: parseTtlDaysQuery(req) }).catch(err => {
             log.warn(`upsertFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
           });
 
@@ -485,12 +497,14 @@ fileStoreRouter.post(
       }
 
       // Persist file metadata to MongoDB
-      const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> } = {};
+      const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number } = {};
       if (typeof req.body?.description === 'string') metaOpts.description = req.body.description;
       if (Array.isArray(req.body?.tags)) metaOpts.tags = req.body.tags as string[];
       if (req.body?.properties != null && typeof req.body.properties === 'object' && !Array.isArray(req.body.properties)) {
         metaOpts.properties = req.body.properties as Record<string, string | number | boolean>;
       }
+      const ttlDaysQ = parseTtlDaysQuery(req);
+      if (ttlDaysQ !== undefined) metaOpts.ttlDays = ttlDaysQ;
       await upsertFileMeta(targetSpace, filePath, incomingBytes, metaOpts).catch(err => {
         log.warn(`upsertFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
       });

--- a/server/src/brain/ttl-sweep.ts
+++ b/server/src/brain/ttl-sweep.ts
@@ -16,6 +16,7 @@ import { deleteMemory } from './memory.js';
 import { deleteEntity } from './entities.js';
 import { deleteEdge } from './edges.js';
 import { deleteChrono } from './chrono.js';
+import { deleteFileCascade } from '../files/delete-cascade.js';
 
 const SWEEP_INTERVAL_MS = 5 * 60_000; // 5 min
 const SWEEP_BATCH = 500;              // max deletions per collection per cycle
@@ -28,6 +29,14 @@ const DELETERS: Record<(typeof TTL_COLLECTIONS)[number], (spaceId: string, id: s
   entities: deleteEntity,
   edges: deleteEdge,
   chrono: deleteChrono,
+  // A file record's `_id` is its path (toDocId); the full cascade removes blob + chunks + meta + jobs.
+  files: (spaceId, id, actor) => deleteFileCascade(spaceId, id, actor).then(() => true),
+};
+
+/** Extra filter for the sweep query, per collection. Files: only the file-level records (chunk/face
+ *  records carry `parentFileId` and never an `_expireAt`) and not already soft-deleted. */
+const SWEEP_FILTER: Partial<Record<(typeof TTL_COLLECTIONS)[number], Record<string, unknown>>> = {
+  files: { parentFileId: { $exists: false }, deletedAt: { $exists: false } },
 };
 
 /** Delete all records past their `_expireAt`, across every space. Returns the number deleted. */
@@ -41,7 +50,7 @@ export async function sweepExpired(now: Date = new Date()): Promise<number> {
       let expired;
       try {
         expired = await col(`${space.id}_${c}`)
-          .find(asFilter({ _expireAt: { $lte: now } }), { projection: { _id: 1 } })
+          .find(asFilter({ _expireAt: { $lte: now }, ...(SWEEP_FILTER[c] ?? {}) }), { projection: { _id: 1 } })
           .limit(SWEEP_BATCH)
           .toArray() as unknown as Array<{ _id: string }>;
       } catch { continue; } // collection may not exist yet

--- a/server/src/brain/ttl.ts
+++ b/server/src/brain/ttl.ts
@@ -13,8 +13,9 @@ import { log } from '../util/log.js';
 
 const DAY_MS = 86_400_000;
 
-/** Collections that carry per-record TTL. */
-export const TTL_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono'] as const;
+/** Collections that carry per-record TTL. (`files` = the file-level FileMeta records; the sweep's
+ *  deleter runs the full file cascade, and only file-level records ever carry `_expireAt`.) */
+export const TTL_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
 
 function spaceRecordTtlDays(spaceId: string): number | undefined {
   try { return getConfig().spaces.find(s => s.id === spaceId)?.recordTtlDays; } catch { return undefined; }

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -18,6 +18,7 @@ import { escapeRegex } from '../util/redos.js';
 import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { embed } from '../brain/embedding.js';
+import { expiryForCreate } from '../brain/ttl.js';
 import { fileEmbedText } from '../brain/embed-text.js';
 import { getConfig } from '../config/loader.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../config/types.js';
@@ -45,7 +46,7 @@ export async function upsertFileMeta(
   spaceId: string,
   filePath: string,
   sizeBytes: number,
-  opts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> } = {},
+  opts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number | null } = {},
 ): Promise<void> {
   const normalised = toDocId(filePath);
   const now = new Date().toISOString();
@@ -73,11 +74,20 @@ export async function upsertFileMeta(
     if (opts.tags !== undefined) $set['tags'] = opts.tags;
     if (opts.properties !== undefined) $set['properties'] = opts.properties;
     // A write to a soft-deleted path means the file is live again — clear the flag.
+    const $unset: Record<string, unknown> = { deletedAt: '' };
+    // Only an EXPLICIT ttlDays on a re-upload touches expiry: >0 (re)stamps, 0/null clears it. A plain
+    // overwrite (ttlDays omitted) leaves any existing TTL untouched — it must not silently reset.
+    if (opts.ttlDays !== undefined) {
+      const expireAt = expiryForCreate(spaceId, opts.ttlDays);
+      if (expireAt) $set['_expireAt'] = expireAt; else $unset['_expireAt'] = '';
+    }
     await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
       asFilter<FileMetaDoc>({ _id: normalised }),
-      asUpdate<FileMetaDoc>({ $set, $unset: { deletedAt: '' } }),
+      asUpdate<FileMetaDoc>({ $set, $unset }),
     );
   } else {
+    // A per-record ttlDays wins; otherwise the space's recordTtlDays default applies (expiryForCreate).
+    const expireAt = expiryForCreate(spaceId, opts.ttlDays);
     const doc: FileMetaDoc = {
       _id: normalised,
       spaceId,
@@ -89,6 +99,7 @@ export async function upsertFileMeta(
       updatedAt: now,
       sizeBytes,
       author: authorRef(),
+      ...(expireAt ? { _expireAt: expireAt } : {}),
       ...embeddingFields,
     };
     await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(doc));

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -1,5 +1,6 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { recall } from '../../brain/recall.js';
+import { TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
 import { type InputFormat } from '../../files/converters/pipeline.js';
 import { renameFileMeta, renameFileMetaByPrefix, upsertFileMeta } from '../../files/file-meta.js';
 import { createDir, listDir, listFilesRecursive, moveFile, readFile, writeFile } from '../../files/files.js';
@@ -57,6 +58,7 @@ export const write_fileTool: ToolHandler = {
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+            ttlDays: TTL_DAYS_SCHEMA,
             inputFormat: {
               type: 'string',
               enum: ['pdf', 'docx', 'epub', 'html', 'md', 'txt', 'text', 'auto'],
@@ -79,12 +81,13 @@ export const write_fileTool: ToolHandler = {
     const sizeBytes = Buffer.byteLength(content, 'utf8');
     const wfQuota = await checkQuota('files', sizeBytes);
     const { sha256 } = await writeFile(wt.target, filePath, content);
-    const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> } = {};
+    const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number | null } = {};
     if (typeof a['description'] === 'string') metaOpts.description = a['description'];
     if (Array.isArray(a['tags'])) metaOpts.tags = a['tags'] as string[];
     if (a['properties'] != null && typeof a['properties'] === 'object' && !Array.isArray(a['properties'])) {
       metaOpts.properties = a['properties'] as Record<string, string | number | boolean>;
     }
+    metaOpts.ttlDays = ttlDaysFromArgs(a);
     await upsertFileMeta(wt.target, filePath, sizeBytes, metaOpts);
     // Resolve format, record media state, and enqueue the async embedding job — one shared policy
     // with the REST upload path. Documents are converted by the background worker (not inline), so

--- a/testing/integration/record-ttl.test.js
+++ b/testing/integration/record-ttl.test.js
@@ -90,6 +90,40 @@ describe('record TTL (F10)', () => {
     await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/memories/${w.body._id}`).catch(() => {});
   });
 
+  // ── files (F12): per-record TTL on uploads, stamped on the file-level FileMeta record ────────────
+  // Upload carries ttlDays as a QUERY param (works for raw-binary bodies); _expireAt surfaces on the
+  // filemeta read. The sweep's files-deleter runs the full cascade — same enforcement path as F10.
+
+  async function uploadWithTtl(pathName, ttlDays) {
+    const q = ttlDays === undefined ? '' : `&ttlDays=${ttlDays}`;
+    return fetch(`${INSTANCES.a}/api/files/general?path=${encodeURIComponent(pathName)}${q}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${tokenA}`, 'Content-Type': 'application/octet-stream' },
+      body: `ttl file body ${RUN}`,
+    });
+  }
+  async function fileMeta(pathName) {
+    return get(INSTANCES.a, tokenA, `/api/brain/spaces/general/files?path=${encodeURIComponent(pathName)}`);
+  }
+
+  it('file upload with ttlDays > 0 stamps _expireAt on the file record', async () => {
+    const p = `ttl-file-${RUN}.txt`;
+    const up = await uploadWithTtl(p, 10);
+    assert.ok([200, 201, 202].includes(up.status), `upload status ${up.status}`);
+    const g = await fileMeta(p);
+    assertAboutDaysFromNow(g.body.files?.[0]?._expireAt, 10);
+    await del(INSTANCES.a, tokenA, `/api/files/general?path=${encodeURIComponent(p)}`).catch(() => {});
+  });
+
+  it('file upload with ttlDays = 0 gets no _expireAt', async () => {
+    const p = `ttl-file-zero-${RUN}.txt`;
+    const up = await uploadWithTtl(p, 0);
+    assert.ok([200, 201, 202].includes(up.status), `upload status ${up.status}`);
+    const g = await fileMeta(p);
+    assert.equal(g.body.files?.[0]?._expireAt, undefined);
+    await del(INSTANCES.a, tokenA, `/api/files/general?path=${encodeURIComponent(p)}`).catch(() => {});
+  });
+
   // ── space-wide recordTtlDays auto-TTL ─────────────────────────────────────
 
   it('space recordTtlDays applies to writes that omit ttlDays; per-record overrides; 0 opts out', async () => {

--- a/testing/standalone/ttl-expiry.test.js
+++ b/testing/standalone/ttl-expiry.test.js
@@ -107,7 +107,7 @@ describe('applyExpiryToUpdate — $set/$unset precedence', () => {
 });
 
 describe('TTL_COLLECTIONS', () => {
-  it('covers exactly the four record collections', () => {
-    assert.deepEqual([...TTL_COLLECTIONS].sort(), ['chrono', 'edges', 'entities', 'memories']);
+  it('covers the five TTL-bearing collections (F12 added files)', () => {
+    assert.deepEqual([...TTL_COLLECTIONS].sort(), ['chrono', 'edges', 'entities', 'files', 'memories']);
   });
 });


### PR DESCRIPTION
## What & why

Files were the only knowledge type without auto-expiry — `TTL_COLLECTIONS` was memories/entities/edges/chrono, and an uploaded file had no way to be given a lifespan. This closes F12.

## How

- **Stamp on write:** `upsertFileMeta` sets `_expireAt` on the file-level record — a per-record `ttlDays` wins, else the space's `recordTtlDays` default (via the existing `expiryForCreate`). On a re-upload an explicit `ttlDays` re-stamps (`>0`) or clears (`0`/`null`); a plain overwrite leaves any existing TTL untouched.
- **Set it:** `ttlDays` as a REST upload **query param** (`POST /api/files/:spaceId?path=…&ttlDays=N` — a query param so it works for raw-binary bodies) and as a field on the MCP `write_file` tool (reuses `TTL_DAYS_SCHEMA` / `ttlDaysFromArgs`).
- **Enforce it:** the TTL sweep gains a `files` deleter that runs the full **`deleteFileCascade`** (blob + embedding chunks + conversion artifacts + queued job + sync tombstone — extracted in #428), plus a per-collection sweep filter so only file-level records (no `parentFileId`, not soft-deleted) are swept. Only file-level records are ever stamped, so an expired file cleans up completely and never orphans bytes, jobs or artifacts — the reason files were held back from TTL until the cascade was extracted.

## Tests & verification

- `record-ttl.test.js` gains file cases (upload `ttlDays>0` stamps `_expireAt`, `ttlDays=0` doesn't — same black-box pattern as the memory/entity cases; run in CI).
- Server `tsc` clean; scratch server **boots clean** on this branch (the new `file-meta → ttl` and `ttl-sweep → delete-cascade → file-meta` import graph resolves — no circular-init). `lint:docs` clean.
- Docs: integration-guide TTL section (files carry TTL via the upload query param / `write_file`; lapse runs the full delete). CHANGELOG `[Unreleased]` (Added).

Builds on #428 (the shared `deleteFileCascade`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)