### PR TITLE
test(networks): render test for per-peer sync-health member rows (#431 backfill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -752,6 +752,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **Backfilled the one overnight gap: the networks per-peer sync-health row (#431) now has a render
+  test.** That display shipped template-only (no method to characterize), so it had no assertion. A
+  focused render test in `networks.component.spec` expands a network and asserts a member on a failing
+  streak shows the "Failing(N)" badge while a never-synced member shows the never-synced label rather
+  than a date — so the sync-health markup can't silently regress.
+
 - **The brain list sort is proven against a real MongoDB across a page boundary — the one thing a
   client-only sort could never do.** `brain-list-sort-db.test.js` seeds records in a deliberately
   scrambled order, then walks every page of a sorted list and asserts the concatenation is one

--- a/client/src/app/pages/settings/networks.component.spec.ts
+++ b/client/src/app/pages/settings/networks.component.spec.ts
@@ -288,4 +288,29 @@ describe('NetworksComponent (characterization)', () => {
     expect(c.joinMyUrl).toBe('https://brain.example.com');
     expect(c.needsNetworkEnable()).toBe(false);
   });
+
+  // Per-peer sync health on the member rows (#431) is TEMPLATE-ONLY (no method to drive), so unlike the
+  // logic-only characterization above this one render test expands a network and asserts the markup:
+  // a member with a failing streak shows the "Failing(N)" badge and a member never synced shows the
+  // never-synced label rather than a date.
+  it('member rows show per-peer sync health: a failing badge on a streak, never-synced when unsynced', () => {
+    make(); // configures the TestBed (providers) and resets it; we build our own fixture below
+    const members = [
+      { instanceId: 'aaaaaaaa1111', label: 'Peer A', endpoint: 'https://a.example', consecutiveFailures: 3, lastSyncAt: '2026-07-20T10:00:00Z' },
+      { instanceId: 'bbbbbbbb2222', label: 'Peer B', endpoint: 'https://b.example', consecutiveFailures: 0, lastSyncAt: null },
+    ];
+    api.listNetworks.mockReturnValue(of({ networks: [net({ id: 'n1', members: members as never })] }));
+    const fixture = TestBed.createComponent(NetworksComponent);
+    const inst = fixture.componentInstance;
+    inst.load();          // populate networks from the mocked API
+    inst.expanded.set('n1'); // expand so the member rows render
+    fixture.detectChanges();
+    const rows = [...(fixture.nativeElement as HTMLElement).querySelectorAll('.member-row')];
+    expect(rows.length).toBe(2);
+    // Peer A (3 failures) shows the failing badge; Peer B (0) does not.
+    expect(rows[0].querySelector('.member-failing')).toBeTruthy();
+    expect(rows[1].querySelector('.member-failing')).toBeNull();
+    // Peer B never synced → the never-synced label (test transloco emits the raw key), not a date.
+    expect(rows[1].querySelector('.member-sync')?.textContent).toContain('networks.member.neverSynced');
+  });
 });


### PR DESCRIPTION
## Why

While auditing overnight coverage (does every merged PR have CHANGELOG + docs + tests?), I found **one gap**: the per-peer sync-health display shipped in #431 was template-only markup, and the networks spec is deliberately logic-only (it never renders the template), so nothing asserted that display. CHANGELOG and docs were complete across all 27 overnight PRs; this closes the single test gap.

## What

A focused render test in `networks.component.spec` — the one place it renders — that:
- expands a network with two members,
- asserts a member on a failing streak shows the **Failing(N)** badge (and one with `consecutiveFailures: 0` does not),
- asserts a member with `lastSyncAt: null` shows the **never-synced** label rather than a date.

## Verification

- `vitest run src/app/pages/settings/` → **278/278** (was 277 + this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)