### PR TITLE
fix(brain): Graph/Files tabs must unmount when you leave them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1638,6 +1638,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Graph and Files tabs no longer linger on top of other Brain tabs.** When the two heavy tabs were
+  made lazy (`@defer`, to keep cytoscape and the file-manager renderers off the landing bundle), they were
+  gated with `@defer (when activeTab() === …)` — but a defer block's `when` is a **one-way load trigger**:
+  it renders the block when the tab is first opened and never removes it. So after visiting Graph or Files,
+  their content stayed mounted over Entities/Edges/Memories/etc. Each is now wrapped in an
+  `@if (activeTab() === …)` (which unmounts on leave, same as the record tabs) with the `@defer` inside for
+  the lazy chunk — so the tab still stays off the landing bundle, but actually goes away when you leave it.
+
 - **A dismissed duplicate pair no longer resurfaces after a routine re-embed or re-sync.** The scanner
   re-opened a dismissed pair the instant either record's `seq` changed — but `seq` advances on *any*
   re-write (an edit, a peer re-sync, a re-embed, an index rebuild), not just a content change, so

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -13,7 +13,7 @@
  * the plain `drawerEditMemory.fact`, and if the sibling signal write were ever dropped, the title
  * would render empty and this test would fail rather than the bug shipping silently.
  */
-import { TestBed } from '@angular/core/testing';
+import { TestBed, DeferBlockBehavior } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
@@ -79,6 +79,52 @@ describe('BrainComponent (OnPush)', () => {
     expect(c.collectionTabs.map(t => t.key)).toEqual(['entities', 'edges', 'memories', 'chrono']);
     c.setTab('files');
     expect(c.activeTab()).toBe('files'); // the single Files tab still activates
+  });
+
+  // ── Regression: Graph/Files must UNMOUNT when you leave their tab ────────────
+  // They are lazy-loaded with @defer to keep cytoscape + the file-manager renderers off the landing
+  // chunk. The bug: `@defer (when activeTab()==='graph')` is a ONE-WAY load trigger — it renders the
+  // block when the tab is first entered but never removes it, so Graph/Files lingered over every later
+  // tab. The fix wraps each @defer in `@if (activeTab()===…)` so leaving the tab unmounts it. This test
+  // uses Playthrough so the defer blocks resolve, and asserts graph is present on its tab and GONE after
+  // navigating to Entities. deferBlockBehavior is per-module, so this test builds its own TestBed.
+  it('unmounts the Graph tab when navigating away (defer must be @if-gated, not @defer-when)', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [BrainComponent, getTranslocoModule()],
+      deferBlockBehavior: DeferBlockBehavior.Playthrough,
+      providers: [
+        { provide: SpacesApi, useValue: makeApi() },
+        { provide: BrainApi, useValue: { ...makeApi(), listEntities: () => of({ entities: [] }) } },
+        { provide: FilesApi, useValue: makeApi() },
+        { provide: AdminApi, useValue: makeApi() },
+        { provide: NetworksApi, useValue: makeApi() },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+      ],
+    });
+    const fixture = TestBed.createComponent(BrainComponent);
+    fixture.detectChanges();                 // ngOnInit → lands on Overview
+    const c = fixture.componentInstance;
+    const el = fixture.nativeElement as HTMLElement;
+    // The graph block is present when EITHER its deferred content or its @loading placeholder renders
+    // (the `minimum 200ms` @loading holds the placeholder in a unit run — either proves the block exists).
+    const graphPresent = () => !!(el.querySelector('app-graph-view') || el.querySelector('[data-tab-defer="graph"]'));
+
+    expect(graphPresent()).toBe(false);      // not on the landing (Overview) tab
+
+    c.setTab('graph');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(graphPresent()).toBe(true);       // mounted on its own tab
+
+    c.setTab('entities');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    // The @if wrapper must have removed it — the pre-fix `@defer (when …)` left it lingering here.
+    expect(graphPresent()).toBe(false);
   });
 
   // ── Regression: the mount⇄reload request storm (app-unusable P0) ─────────────

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -243,20 +243,27 @@ interface SpaceView {
         }
 
         <!-- Graph + Files carry heavy libraries (cytoscape; the file-manager's markdown/mermaid/xlsx
-             renderers). @defer keeps them OUT of the brain chunk downloaded on landing (Overview is the
-             default tab) — the chunk loads on first visit to that tab. Trigger is the SAME activeTab()
-             gate as the record tabs, so the storm-safe "gate on activeTab() alone" rule still holds. -->
-        @defer (when activeTab() === 'graph') {
-          <app-graph-view [embeddedSpaceId]="activeSpaceId()" />
-        } @loading (minimum 200ms) {
-          <div class="loading-overlay loading-overlay--float"><span class="spinner"></span></div>
+             renderers). They must MOUNT only while their tab is active — an if-block on activeTab() does
+             that (same storm-safe "gate on activeTab() alone" rule as the record tabs), and crucially
+             UNMOUNTS them again when you leave, so they can't linger over another tab. A defer block
+             alone can't do this: its when-trigger is a one-way load and never removes what it rendered.
+             The inner defer (on immediate) still keeps these chunks OUT of the landing bundle — it fires
+             the moment the tab first renders, and the browser-cached chunk re-instantiates fast. -->
+        @if (activeTab() === 'graph') {
+          @defer (on immediate) {
+            <app-graph-view [embeddedSpaceId]="activeSpaceId()" />
+          } @loading (minimum 200ms) {
+            <div class="loading-overlay loading-overlay--float" data-tab-defer="graph"><span class="spinner"></span></div>
+          }
         }
 
         <!-- Files tab (merged: file manager + File Meta) -->
-        @defer (when activeTab() === 'files') {
-          <app-file-manager [embeddedSpaceId]="activeSpaceId()" (filesChanged)="loadStats(activeSpaceId())" />
-        } @loading (minimum 200ms) {
-          <div class="loading-overlay loading-overlay--float"><span class="spinner"></span></div>
+        @if (activeTab() === 'files') {
+          @defer (on immediate) {
+            <app-file-manager [embeddedSpaceId]="activeSpaceId()" (filesChanged)="loadStats(activeSpaceId())" />
+          } @loading (minimum 200ms) {
+            <div class="loading-overlay loading-overlay--float" data-tab-defer="files"><span class="spinner"></span></div>
+          }
         }
 
         <!-- Memories -->


### PR DESCRIPTION
## The bug (owner-reported)

Navigating away from **Graph** or **Files** in Brain left their content **lingering on top of the tab you moved to** (Entities, Edges, Memories, …).

## Cause — a regression from #426

The two heavy tabs were made lazy with `@defer` (to keep cytoscape + the file-manager renderers off the landing bundle), gated as:

```
@defer (when activeTab() === 'graph') { <app-graph-view/> }
```

A defer block's `when` is a **one-way load trigger** — it renders the block when the condition first becomes true and **never removes it** when the condition goes false again. `@defer` is not a conditional; it can't gate a tab. So once Graph/Files mounted, they stayed.

## Fix

Wrap each `@defer` in an `@if (activeTab() === …)` — the `@if` unmounts on leave (exactly how the record tabs already work), with the `@defer (on immediate)` **inside** so the chunk still stays off the landing bundle and loads on first entry.

```
@if (activeTab() === 'graph') {
  @defer (on immediate) { <app-graph-view/> } @loading (minimum 200ms) { … }
}
```

## Tests

- New Playthrough regression test in `brain.component.spec`: graph is **absent** on Overview, **present** on its own tab, and **gone again** after switching to Entities (the pre-fix `@defer-when` left it in the DOM). Distinct `data-tab-defer` markers on the two loading overlays make it deterministic.
- Brain dir **150/150**; client `tsc` clean.

Also honours the repo rule the hard way — the first attempt put backticks in the inline-template comment and broke the template string; the comment is now backtick-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)