### PR TITLE
feat(brain): lay the Overview out as a uniform card grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2489,6 +2489,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Brain Overview is laid out as a uniform card grid instead of a ragged one.** The panels were
+  placed with `auto-fit` columns and `align-items: start`, so every card shrink-wrapped its own content:
+  card bottoms never lined up, the divider rule under each header sat at a different height depending on
+  whether that card's hint wrapped, and the column count re-flowed unpredictably with the viewport
+  (regularly orphaning a card on a row of its own). The board now uses a deterministic 1 / 2 / 3-column
+  grid whose cards stretch to a common row height, each header reserves two lines for its hint so the
+  dividers align across a row, and the Statistics summary spans the full width as the page's headline
+  (its six tiles sitting in one clean row) rather than competing with a five-line list for one column.
+  Long lists (peers, votes, tokens, failures) scroll within their card so one long list can no longer
+  stretch every card beside it. Verified by measuring the rendered geometry in a real browser — every
+  row now reports equal card heights and a single shared divider position.
+
 - **File deletion now runs one shared cascade across every path.** The blob-unlink + sync-tombstone +
   metadata removal + queued-job cancellation + conversion-artifact cleanup sequence was duplicated in the
   REST `DELETE /api/files/:spaceId` handler and the MCP `delete_file` tool; it is now a single

--- a/client/src/app/pages/brain/overview-tab.component.spec.ts
+++ b/client/src/app/pages/brain/overview-tab.component.spec.ts
@@ -173,6 +173,23 @@ describe('OverviewTabComponent', () => {
     expect((noVotes.fixture.nativeElement as HTMLElement).querySelector('.vote-list')).toBeNull();
   });
 
+  it('the Statistics summary is the one full-width card; every other panel is a normal grid cell', () => {
+    // Uniform card sizing is CSS (jsdom computes no layout, so heights are verified by the E2E
+    // geometry check, not here). What IS pinnable is the structure that layout relies on: exactly one
+    // .span-all card, and it is the Statistics summary.
+    const { fixture } = setup({ stats: STATS });
+    fixture.componentRef.setInput('about', {
+      instanceId: 'i', instanceLabel: 'L', version: '1', uptime: '0m', mongoVersion: '8',
+      diskInfo: { total: 0, used: 0, available: 0, dataUsed: 0 },
+    });
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const spanning = [...el.querySelectorAll('.panel.span-all')];
+    expect(spanning.length).toBe(1);
+    expect(spanning[0].querySelector('h3')?.textContent).toContain('brain.overview.statsTitle');
+    expect(el.querySelectorAll('.panel').length).toBeGreaterThan(1); // other panels are normal cells
+  });
+
   it('Token-access panel is admin-only: hidden when null, lists tokens with level badges when provided', () => {
     // null (non-admin / endpoint 403) → panel hidden.
     const hidden = setup();

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -29,16 +29,44 @@ interface StatCard { key: string; icon: string; label: string; value: number }
   imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, RouterLink, DatePipe],
   styles: [`
     :host { display: block; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; align-items: start; }
-    .panel { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
-    .panel-h { display: flex; align-items: center; gap: 9px; padding: 13px 16px; border-bottom: 1px solid var(--border-muted); }
+
+    /* Deterministic column count instead of auto-fit: auto-fit re-flowed at every viewport width and
+       regularly orphaned a card on a row of its own, which is what made the board look arbitrary.
+       Cards STRETCH to their row height (no align-items:start), so every card in a row ends level. */
+    .grid { display: grid; grid-template-columns: 1fr; gap: 16px; }
+    @media (min-width: 820px)  { .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    @media (min-width: 1280px) { .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+
+    /* The summary spans the full row — it is the heaviest card (six tiles + the storage bar) and
+       reads as the page's headline rather than one tile among equals. */
+    .panel.span-all { grid-column: 1 / -1; }
+
+    /* A card is a column: header, then a body that FILLS the stretched height. Without the filling
+       body a short card's content floats against a tall border box. */
+    .panel { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden;
+      display: flex; flex-direction: column; }
+    .panel-h { display: flex; align-items: center; gap: 9px; padding: 13px 16px;
+      border-bottom: 1px solid var(--border-muted); }
     .panel-h .ic { width: 30px; height: 30px; border-radius: 8px; display: grid; place-items: center; flex: none;
       background: var(--bg-elevated); border: 1px solid var(--border); color: var(--accent); }
     .panel-h h3 { margin: 0; font-size: 14px; font-weight: 620; }
-    .panel-h p { margin: 1px 0 0; font-size: 12px; color: var(--text-secondary); }
-    .panel-b { padding: 14px 16px; }
+    /* Every hint RESERVES two lines and clamps to two, so a card whose hint wraps and one whose hint
+       fits on a single line still put their divider rule at the same height. Reserving (rather than
+       truncating to one line) keeps the full hint readable — the alignment costs a little whitespace,
+       not information. em-based, so it survives a font-size change; no magic total-height number. */
+    .panel-h p { margin: 1px 0 0; font-size: 12px; color: var(--text-secondary); line-height: 1.35;
+      min-height: calc(2 * 1.35em);
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+    .panel-b { padding: 14px 16px; flex: 1; }
 
-    .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(92px, 1fr)); gap: 10px; }
+    /* Default tile grid: the embedding-queue card's three counters, in a normal-width card. NOTE the
+       breakpoints below are VIEWPORT-based, so they must not be allowed to reach this card — six
+       columns inside a one-third-width card squeezes the labels to nothing. Hence the .span-all scope. */
+    .stat-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+    /* The summary's six tiles (five collections + total) across the full-width card. */
+    .span-all .stat-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    @media (min-width: 560px)  { .span-all .stat-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+    @media (min-width: 1000px) { .span-all .stat-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); } }
     .stat { background: var(--bg-elevated); border: 1px solid var(--border-muted); border-radius: 8px; padding: 11px 12px; }
     .stat .v { font-size: 22px; font-weight: 700; font-family: var(--font-mono, monospace); font-variant-numeric: tabular-nums; line-height: 1.1; }
     .stat .l { display: flex; align-items: center; gap: 5px; margin-top: 4px; font-size: 11.5px; color: var(--text-secondary); }
@@ -93,13 +121,17 @@ interface StatCard { key: string; icon: string; label: string; value: number }
     .tok-list .tx { font-size: 11px; color: var(--text-muted); white-space: nowrap; }
     .lvl { font-size: 10.5px; font-weight: 620; padding: 1px 7px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.03em; flex: none; }
     .lvl.admin { background: color-mix(in srgb, var(--error) 16%, transparent); color: var(--error); }
+
+    /* Rows are as tall as their tallest card, so an unbounded list (many tokens, many peers) used to
+       stretch every sibling with it. Cap the lists and let the long ones scroll in place. */
+    .net-list, .vote-list, .tok-list, .fail-list { max-height: 216px; overflow-y: auto; }
     .lvl.full { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent); }
     .lvl.readOnly { background: color-mix(in srgb, var(--text-muted) 18%, transparent); color: var(--text-secondary); }
   `],
   template: `
     <div class="grid">
-      <!-- ── Statistics ─────────────────────────────────────────────── -->
-      <section class="panel">
+      <!-- ── Statistics (full-width summary strip) ──────────────────── -->
+      <section class="panel span-all">
         <header class="panel-h">
           <span class="ic"><ph-icon name="chart-bar" [size]="16"/></span>
           <div><h3>{{ 'brain.overview.statsTitle' | transloco }}</h3>


### PR DESCRIPTION
## Why

Owner feedback on the running instance: *"the overview looks too random. should be cleaner (for example same sized cards)"* — fair. Four things made it read as arbitrary:

1. **`align-items: start`** — every card shrink-wrapped its own content, so bottoms never lined up.
2. **`auto-fit minmax(300px, 1fr)`** — the column count re-flowed at every viewport width and regularly orphaned a card on a row of its own.
3. **Statistics** (six tiles + storage bar) competed for a single `1fr` column with a five-line key/value list.
4. **Header hints wrapped to different line counts**, so even the divider rule under each header sat at a different height across a row.

## What changed

- **Deterministic grid** — 1 / 2 / 3 columns at explicit breakpoints; cards **stretch to a common row height** (`.panel` is a flex column, `.panel-b` is `flex: 1` so a short card fills its box instead of floating in it).
- **Aligned dividers** — every header hint *reserves* two lines (em-based, clamped to two). Reserving rather than truncating keeps the full hint readable; the alignment costs a little whitespace, not information.
- **Statistics spans the full width** as the headline summary, its six tiles in one clean row.
- **Long lists scroll in-card** (peers / votes / tokens / failures, capped at 216px) so one long list can't stretch every sibling in its row.

## Verification — measured, not eyeballed

Booted the scratch stack and drove it with Playwright, reading back the **rendered geometry** of every card:

```
row y=237: 1 card  [Statistics]                            heights=227 dividers=321 UNIFORM
row y=481: 3 cards [Indexing, Embedding queue, Networks]   heights=227 dividers=565 UNIFORM
row y=724: 2 cards [Instance, Token access]                heights=237 dividers=808 UNIFORM
ALL ROWS UNIFORM: true
```

Checked at 1440px and 900px. **That measurement earned its keep twice:**
- the first run still showed `dividers=768/787` on the last row (the `min-height` approach didn't cover a wrapping hint) — hence the reserve-two-lines fix;
- the screenshot then caught a regression *this change introduced* — the six-column tile rule is viewport-scoped, so it also hit the embedding-queue card and squeezed its label to "Processi". The six-up is now scoped to `.span-all`.

Unit side: spec pins the structural invariant (exactly one `.span-all` card, and it's Statistics — jsdom computes no layout, so heights belong to the E2E check). Brain dir **151/151**, client `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)