### PR TITLE
fix(brain): switching space lands on that space's Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1644,6 +1644,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Switching space in the Brain now lands on that space's Overview.** The active tab persisted across a
+  space switch, so picking another space while on (say) Entities just swapped the rows underneath you —
+  the page looked unchanged until you clicked a tab, and the space you had just chosen never introduced
+  itself. A switch now returns to the Overview landing view (F9). Re-clicking the chip of the space you
+  are already on is not a switch and leaves your current tab alone.
+
 - **The Graph and Files tabs no longer linger on top of other Brain tabs.** When the two heavy tabs were
   made lazy (`@defer`, to keep cytoscape and the file-manager renderers off the landing bundle), they were
   gated with `@defer (when activeTab() === …)` — but a defer block's `when` is a **one-way load trigger**:

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -73,6 +73,23 @@ describe('BrainComponent (OnPush)', () => {
     expect(create().componentInstance.activeTab()).toBe('overview');
   });
 
+  it('switching space lands on the new space Overview; re-clicking the active chip keeps your tab', () => {
+    const c = create().componentInstance; // initial load selects 'work'
+    c.setTab('entities');
+    expect(c.activeTab()).toBe('entities');
+
+    // A DIFFERENT space → its Overview (the landing view). Previously the tab persisted, so the
+    // switch silently swapped the rows under you and looked like nothing had happened.
+    c.selectSpace('other');
+    expect(c.activeTab()).toBe('overview');
+    expect(c.activeSpaceId()).toBe('other');
+
+    // Re-clicking the chip you are already on is not a switch — it must not yank you off your tab.
+    c.setTab('edges');
+    c.selectSpace('other');
+    expect(c.activeTab()).toBe('edges');
+  });
+
   it('File Meta is merged into one Files tab — no separate File Meta collection tab', () => {
     const c = create().componentInstance;
     expect(c.collectionTabs.some(t => t.key === 'filemeta' as never)).toBe(false);

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -452,6 +452,12 @@ export class BrainComponent implements OnInit, OnDestroy {
   }
 
   selectSpace(id: string): void {
+    // Switching space lands on the new space's OVERVIEW — its landing view (F9). The tab used to
+    // persist across the switch, so picking another space while on, say, Entities just swapped the
+    // rows underneath you: the page looked unchanged until you clicked a tab, and the space you had
+    // chosen never introduced itself. Re-clicking the chip of the space you are ALREADY on is not a
+    // switch, so that leaves your current tab alone.
+    if (this.activeSpaceId() !== id) this.activeTab.set('overview');
     this.activeSpaceId.set(id);
     this.picker.spaceId.set(id);
     this.drawerState.spaceId.set(id);


### PR DESCRIPTION
## The bug (owner-reported)

Switching space in the Brain kept you on whatever tab you were already on: *"it stays on the previous view until i select something."*

## Cause

`selectSpace()` reset everything **except** the tab — searches, drawer, stats, embedding queue, votes, token access all got cleared and refetched, but `activeTab` was never touched. So picking another space while on Entities just swapped the rows underneath you: the page looked unchanged until you clicked a tab, and the space you had just chosen never introduced itself.

## Fix

A space switch now lands on that space's **Overview** — its landing view (F9).

One guard: re-clicking the chip of the space you are **already** on is not a switch, so it leaves your current tab alone (otherwise clicking the active chip would yank you off whatever you were reading).

Checked before changing: brain's `selectSpace` has only two callers (the chip click and the initial load), and `brain.component.ts` reads no route params — so there is no deep link like `?tab=files` to break.

## Tests

New spec asserts both halves (switch → Overview; re-click active chip → tab preserved), and was **proven to fail without the fix** (`expected 'entities' to be 'overview'`) rather than trusted on a green run.

Brain dir **151/151**, client `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)