### PR TITLE
feat(brain): sort by edges Weight and chrono Status / Ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1652,6 +1652,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three more columns can be sorted: edges Weight, chrono Status and Ends.** They were rendered but not
+  sortable — the original sort slice covered the identity/type/date columns and closed, and nothing tracked
+  the rest. Each needed both a server whitelist entry (or the route 400s) and a client header. `properties`
+  and the `entityIds`/`memoryIds` reference arrays stay unsortable **by decision, not omission** — a JSON
+  blob has no single orderable value and an array of ids orders by nothing a reader can see; a test now
+  asserts they stay out of the whitelist so it is not "corrected" later.
+
 - **The Files tab can be sorted again — and the dead File Meta component is gone.** PR #388 gave the old
   *File Meta* tab sortable headers plus a tag filter; #421 then merged File Meta into the Files tab, and the
   surviving `file-manager` carried none of it — Name / Status / Tags / Size / Modified were all plain,

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -134,7 +134,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                       <option value="">{{ 'brain.filter.allKinds' | transloco }}</option>
                       @for (k of store.chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
                     </select>
-                  </th><th>{{ 'brain.chrono.table.status' | transloco }}</th><th app-sort-th field="startsAt" label="brain.chrono.table.starts" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.chrono.table.ends' | transloco }}</th>
+                  </th><th app-sort-th field="status" label="brain.chrono.table.status" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="startsAt" label="brain.chrono.table.starts" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="endsAt" label="brain.chrono.table.ends" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
                   <th app-sort-th label="brain.chrono.table.tags">
                     <input class="col-filter-input" type="text" [ngModel]="recordFilter().tag" (ngModelChange)="setTagFilter($event)"
                       [attr.list]="tagListId" [placeholder]="'brain.filter.tagPlaceholder' | transloco" [attr.aria-label]="'brain.filter.tagPlaceholder' | transloco" />

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -123,7 +123,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                   <th app-sort-th field="from" label="brain.edges.table.from" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="label" label="brain.edges.table.relation" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)">
                     <input class="col-filter-input" type="text" [ngModel]="search()" (ngModelChange)="setSearchFilter($event)"
                       [placeholder]="'brain.filter.searchPlaceholder' | transloco" [attr.aria-label]="'brain.filter.searchPlaceholder' | transloco" />
-                  </th><th app-sort-th field="to" label="brain.edges.table.to" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th>{{ 'brain.edges.table.weight' | transloco }}</th>
+                  </th><th app-sort-th field="to" label="brain.edges.table.to" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="weight" label="brain.edges.table.weight" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
                   <th app-sort-th label="brain.edges.table.tags">
                     <input class="col-filter-input" type="text" [ngModel]="recordFilter().tag" (ngModelChange)="setTagFilter($event)"
                       [attr.list]="tagListId" [placeholder]="'brain.filter.tagPlaceholder' | transloco" [attr.aria-label]="'brain.filter.tagPlaceholder' | transloco" />

--- a/server/src/brain/list-sort.ts
+++ b/server/src/brain/list-sort.ts
@@ -24,11 +24,15 @@ export interface SortSpec {
  * `overdue` status, which is computed from the due moment and never stored) are deliberately left
  * out — sorting by a stored `status` that disagrees with the displayed one would mislead.
  */
+// Deliberately ABSENT and not an oversight: `properties` (a free-form JSON blob — there is no single
+// value to order by) and `entityIds`/`memoryIds` (reference arrays — ordering by an array of ids sorts
+// by nothing a reader can see). Both were considered and rejected; leaving that unwritten is how they get
+// "fixed" into the list later by someone reading it as a gap.
 export const SORTABLE_FIELDS = {
   entities: new Set<string>(['createdAt', 'name', 'type']),
-  edges: new Set<string>(['createdAt', 'label', 'from', 'to', 'type']),
+  edges: new Set<string>(['createdAt', 'label', 'from', 'to', 'type', 'weight']),
   memories: new Set<string>(['createdAt', 'type']),
-  chrono: new Set<string>(['createdAt', 'title', 'startsAt', 'type']),
+  chrono: new Set<string>(['createdAt', 'title', 'startsAt', 'endsAt', 'status', 'type']),
   files: new Set<string>(['createdAt', 'updatedAt', 'path']),
 } as const;
 

--- a/testing/standalone/brain-list-sort-unit.test.js
+++ b/testing/standalone/brain-list-sort-unit.test.js
@@ -62,6 +62,24 @@ describe('parseSortParam — the 400-on-unknown-sort contract', () => {
       assert.ok(set.has('createdAt'), `${name} must allow sorting by createdAt`);
     }
   });
+
+  // Columns the tables render but could not sort by until now. Each needs BOTH the whitelist entry (or the
+  // route 400s) and a client header — the whitelist half is what this pins.
+  it('allows the late-added columns: edges weight, chrono endsAt/status', () => {
+    assert.ok(SORTABLE_FIELDS.edges.has('weight'), 'edges.weight is numeric — a natural sort');
+    assert.ok(SORTABLE_FIELDS.chrono.has('endsAt'), 'chrono renders an Ends column');
+    assert.ok(SORTABLE_FIELDS.chrono.has('status'), 'chrono renders a Status column');
+  });
+
+  // A rejected-by-design list, asserted so it is not "corrected" into the whitelist later. `properties` is
+  // a free-form JSON blob with no single orderable value; the id arrays order by nothing a reader can see.
+  it('keeps unsortable-by-nature fields OUT of every whitelist', () => {
+    for (const [name, set] of Object.entries(SORTABLE_FIELDS)) {
+      for (const field of ['properties', 'entityIds', 'memoryIds']) {
+        assert.ok(!set.has(field), `${name}.${field} must not be sortable — it has no orderable value`);
+      }
+    }
+  });
 });
 
 describe('toMongoSort — deterministic paging tiebreaker', () => {


### PR DESCRIPTION
## What

Three columns the tables rendered but couldn't sort by. The original sort slice covered the identity/type/date columns and then closed, so the remainder was never tracked — surfaced by your *"not all columns have search/sort yet"*.

- **`SORTABLE_FIELDS`**: edges `+= weight`; chrono `+= endsAt, status`. Both halves are required — without the whitelist entry the route 400s, without the header there's nothing to click.
- **`th[app-sort-th]`** on Weight (edges) and Status / Ends (chrono), using the same shared primitive and asc → desc → clear cycle as their siblings.

## The deliberate omissions

`properties` and the `entityIds` / `memoryIds` reference arrays stay **unsortable by decision, not by oversight**: a free-form JSON blob has no single orderable value, and an array of ids orders by nothing a reader can see. That's now written in a comment **and asserted by a test**, so it doesn't get "corrected" into the whitelist later by someone reading it as a gap.

Also not included: **files Size/Modified server-side.** The Files tab is a directory explorer that sorts client-side over a whole folder (justified in #443), and the paginated file-meta list that would have needed a server sort is retired. Adding whitelist entries nothing consumes would be noise.

## Verification

server + client `tsc` clean · brain dir **144/144** · list-sort unit **15/15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)