### PR TITLE
feat(brain): move duplicate review into a per-space Review tab (F-REVIEW 1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2518,7 +2518,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
-- **Settings → Models is now Settings → Media Processing.** The page long ago stopped being about model
+- **Duplicate review moved out of global Settings into a per-space Brain "Review" tab (F-REVIEW slice 1).**
+  A duplicate pair only ever means something *inside* one space, so reviewing them from an instance-wide
+  page meant reading a mixed list and checking a space badge on every row. The Review tab shows one space's
+  pairs, and **Scan now** scans that space instead of every space you can see. The old `/settings/duplicates`
+  path redirects to the Brain — it was a sidebar entry, so it is in muscle memory as well as bookmarks. The
+  per-space *duplicate rules* stay where they are, on the space's own Duplicates settings tab. The page long ago stopped being about model
   endpoints — it governs the whole media and document pipeline: per-class analysis ladders, extraction
   rungs, face recognition, the external assist model. The **route moved too**
   (`/settings/models` → `/settings/media-processing`), because renaming only the label leaves the URL, the

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1209,7 +1209,6 @@
   "spaces.schema.libRef.unlinkTitle": "Das Bibliotheksschema inline kopieren, um es für diesen Space anzupassen (löst die Verknüpfung)",
   "spaces.schema.libRef.noProps": "Dieses Bibliotheksschema definiert keine Eigenschaften.",
   "spaces.schema.libRef.unlinkFailed": "Verknüpfung konnte nicht gelöst werden — der Bibliothekseintrag konnte nicht geladen werden.",
-  "nav.duplicates": "Duplikate",
   "spaces.popup.tab.duplicates": "Duplikate",
   "spaces.dupe.intro": "Legen Sie fest, wie dieser Raum mit semantischen Duplikaten umgeht, die der Hintergrund-Scanner findet. Regeln werden nach höchstem Score zuerst ausgewertet; die erste Übereinstimmung bestimmt die Aktion.",
   "spaces.dupe.survivor": "Beibehaltener Datensatz beim Zusammenführen",
@@ -1533,5 +1532,6 @@
   "mediaProcessing.face.gatedByPipeline": "Die Gesichtserkennung folgt der Bilder-Pipeline: Stelle sie auf \"Beschreibung + Gesichtserkennung\", um Gesichter zu erkennen und einzubetten. Setzt voraus, dass die lokalen Modelldateien vorhanden sind.",
   "mediaProcessing.assist.gatedByPipeline": "Wird für den Dokumenten-Reparaturlauf verwendet. Stelle die Dokumentenextraktion auf \"Reparatur\" (oder Auto), um Reparaturen darüber zu leiten; die Datenübermittlung muss dabei bestätigt werden.",
   "schemaLib.field.schema": "Schema (JSON)",
-  "schemaLib.field.schemaHint": "Die Eigenschaftsdefinitionen für diesen Typ als JSON-Objekt. Ungültiges JSON wird beim Speichern abgelehnt."
+  "schemaLib.field.schemaHint": "Die Eigenschaftsdefinitionen für diesen Typ als JSON-Objekt. Ungültiges JSON wird beim Speichern abgelehnt.",
+  "brain.tab.review": "Prüfung"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1209,7 +1209,6 @@
   "spaces.schema.libRef.unlinkTitle": "Copy the library schema inline so you can customise it for this space (breaks the link)",
   "spaces.schema.libRef.noProps": "This library schema defines no properties.",
   "spaces.schema.libRef.unlinkFailed": "Couldn't unlink — the library entry could not be loaded.",
-  "nav.duplicates": "Duplicates",
   "spaces.popup.tab.duplicates": "Duplicates",
   "spaces.dupe.intro": "Configure how this space handles semantic duplicates found by the background scanner. Rules are evaluated highest-score-first; the first match decides the action.",
   "spaces.dupe.survivor": "Merge survivor",
@@ -1533,5 +1532,6 @@
   "mediaProcessing.face.gatedByPipeline": "Face recognition follows the Images pipeline: raise it to \"Caption + face recognition\" to detect and embed faces. Requires the local model files to be present.",
   "mediaProcessing.assist.gatedByPipeline": "Used for the document repair pass. Raise Document extraction to \"Repair\" (or Auto) to route repairs through it; you will be asked to acknowledge the egress.",
   "schemaLib.field.schema": "Schema (JSON)",
-  "schemaLib.field.schemaHint": "The property definitions for this type, as a JSON object. Invalid JSON is rejected on save."
+  "schemaLib.field.schemaHint": "The property definitions for this type, as a JSON object. Invalid JSON is rejected on save.",
+  "brain.tab.review": "Review"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1209,7 +1209,6 @@
   "spaces.schema.libRef.unlinkTitle": "Skopiuj schemat biblioteki bezpośrednio, aby dostosować go do tej przestrzeni (zrywa połączenie)",
   "spaces.schema.libRef.noProps": "Ten schemat biblioteki nie definiuje żadnych właściwości.",
   "spaces.schema.libRef.unlinkFailed": "Nie udało się odłączyć — nie można załadować wpisu biblioteki.",
-  "nav.duplicates": "Duplikaty",
   "spaces.popup.tab.duplicates": "Duplikaty",
   "spaces.dupe.intro": "Skonfiguruj, jak ta przestrzeń obsługuje semantyczne duplikaty znalezione przez skaner w tle. Reguły są oceniane od najwyższego wyniku; pierwsze dopasowanie decyduje o akcji.",
   "spaces.dupe.survivor": "Rekord zachowywany przy scalaniu",
@@ -1533,5 +1532,6 @@
   "mediaProcessing.face.gatedByPipeline": "Rozpoznawanie twarzy podąża za potokiem Obrazy: ustaw go na \"Opis + rozpoznawanie twarzy\", aby wykrywać i osadzać twarze. Wymaga obecności lokalnych plików modelu.",
   "mediaProcessing.assist.gatedByPipeline": "Używany do przebiegu naprawy dokumentów. Ustaw ekstrakcję dokumentów na \"Naprawa\" (lub Auto), aby kierować naprawy przez ten model; konieczne będzie potwierdzenie transferu danych.",
   "schemaLib.field.schema": "Schemat (JSON)",
-  "schemaLib.field.schemaHint": "Definicje właściwości dla tego typu jako obiekt JSON. Nieprawidłowy JSON zostanie odrzucony przy zapisie."
+  "schemaLib.field.schemaHint": "Definicje właściwości dla tego typu jako obiekt JSON. Nieprawidłowy JSON zostanie odrzucony przy zapisie.",
+  "brain.tab.review": "Przegląd"
 }

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -124,12 +124,10 @@ export const routes: Routes = [
           // The page was called "Models" until it grew to cover the whole media/document pipeline. Keep the
           // old path working: it is in bookmarks, in older docs, and in links people have already shared.
           { path: 'models', redirectTo: 'media-processing', pathMatch: 'full' },
-          {
-            path: 'duplicates',
-            title: 'nav.duplicates',
-            loadComponent: () =>
-              import('./pages/settings/duplicates.component').then(m => m.DuplicatesComponent),
-          },
+          // Duplicate review moved out of global Settings and into the per-space Brain "Review" tab
+          // (F-REVIEW): a duplicate pair only ever means something inside one space. The old path stays
+          // as a redirect — it was a sidebar entry, so it is in muscle memory and in bookmarks.
+          { path: 'duplicates', redirectTo: '/brain', pathMatch: 'full' },
         ],
       },
     ],

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -11,6 +11,7 @@ import { EntitiesTabComponent } from './entities-tab.component';
 import { EdgesTabComponent } from './edges-tab.component';
 import { ChronoTabComponent } from './chrono-tab.component';
 import { OverviewTabComponent } from './overview-tab.component';
+import { ReviewTabComponent } from './review-tab.component';
 import { FormsModule } from '@angular/forms';
 import { Space, SpaceStats, AboutInfo, EmbeddingQueue, VoteRound, TokenAccessEntry } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
@@ -24,7 +25,7 @@ import { FileManagerComponent } from '../files/file-manager.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
-type BrainTab = 'overview' | 'query' | 'graph' | 'files' | 'entities' | 'edges' | 'memories' | 'chrono';
+type BrainTab = 'overview' | 'query' | 'graph' | 'files' | 'entities' | 'edges' | 'memories' | 'chrono' | 'review';
 
 interface SpaceView {
   space: Space;
@@ -43,7 +44,7 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, TranslocoPipe],
+  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, ReviewTabComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [`
     .space-tabs {
@@ -229,6 +230,10 @@ interface SpaceView {
             <span class="tab-count">{{ s.files }}</span>
           }
         </button>
+        <!-- Review (F-REVIEW): duplicate pairs awaiting a decision in this space. -->
+        <button class="tab" [class.active]="activeTab() === 'review'" (click)="setTab('review')">
+          <ph-icon name="copy" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.review' | transloco }}
+        </button>
       </div>
 
       <!-- Content. Tabs are gated by activeTab() ONLY — NEVER wrapped in @else of
@@ -287,6 +292,10 @@ interface SpaceView {
           }
         }
         @if (activeTab() === 'query') { <app-query-tab [spaceId]="activeSpaceId()" /> }
+
+        <!-- Review (F-REVIEW): duplicate pairs for THIS space. Was a global Settings page; a duplicate
+             pair only ever means something inside one space, so it belongs beside the space's data. -->
+        @if (activeTab() === 'review') { <app-review-tab [spaceId]="activeSpaceId()" /> }
       </div>
 
       <!-- Detail Drawer -->

--- a/client/src/app/pages/brain/review-tab.component.spec.ts
+++ b/client/src/app/pages/brain/review-tab.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * DuplicatesComponent characterization tests.
+ * ReviewTabComponent characterization tests.
  *
  * Written BEFORE the PR-U8 UX rework (comparison cards, confidence meter, guarded Dismiss, SummaryStrip)
  * and proven green against the ORIGINAL component. Pins the load/scan/dismiss/merge behaviour that must
@@ -10,7 +10,7 @@ import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of, throwError } from 'rxjs';
 import { getTranslocoModule } from '../../testing/transloco-testing';
-import { DuplicatesComponent } from './duplicates.component';
+import { ReviewTabComponent } from './review-tab.component';
 import { DuplicatesApi } from '../../core/duplicates-api.service';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
@@ -25,7 +25,7 @@ function setup(api: Partial<Record<string, unknown>> = {}, confirmResult = true)
   const toastErrors: string[] = [];
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
-    imports: [DuplicatesComponent, getTranslocoModule()],
+    imports: [ReviewTabComponent, getTranslocoModule()],
     providers: [
       { provide: DuplicatesApi, useValue: {
         listDuplicates: () => of({ duplicates: [] }),
@@ -38,12 +38,13 @@ function setup(api: Partial<Record<string, unknown>> = {}, confirmResult = true)
       { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(confirmResult) } },
     ],
   });
-  const f = TestBed.createComponent(DuplicatesComponent);
+  const f = TestBed.createComponent(ReviewTabComponent);
+  f.componentInstance.spaceId = 'work';   // per-space now: the tab always reviews one space
   f.detectChanges(); // ngOnInit → load()
   return { f, c: f.componentInstance, toastErrors };
 }
 
-describe('DuplicatesComponent', () => {
+describe('ReviewTabComponent', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
   it('load populates rows and clears loading', () => {
@@ -175,5 +176,24 @@ describe('DuplicatesComponent', () => {
     expect(btn).not.toBeNull();
     btn!.click();
     expect(reopen).toHaveBeenCalledWith('d1');
+  });
+
+  it('scopes every query to its space, and reloads when the space changes', async () => {
+    // The move out of global Settings is only real if the space reaches the API — otherwise the tab would
+    // quietly show every space's pairs inside one space's Brain.
+    const listDuplicates = vi.fn(() => of({ duplicates: [] }));
+    const scanDuplicates = vi.fn(() => of({ scannedSpaces: 1, scanned: 0, pairs: 0 }));
+    const { f, c } = setup({ listDuplicates, scanDuplicates });
+    expect(listDuplicates).toHaveBeenCalledWith('open', 'work');
+
+    c.scan();
+    expect(scanDuplicates).toHaveBeenCalledWith('work');
+
+    // Switching space in the Brain must re-point the tab, not leave the previous space's pairs on screen.
+    listDuplicates.mockClear();
+    c.spaceId = 'other';
+    f.componentRef.setInput?.('spaceId', 'other');
+    c.ngOnChanges({ spaceId: { currentValue: 'other', previousValue: 'work', firstChange: false, isFirstChange: () => false } });
+    expect(listDuplicates).toHaveBeenCalledWith('open', 'other');
   });
 });

--- a/client/src/app/pages/brain/review-tab.component.ts
+++ b/client/src/app/pages/brain/review-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, OnInit } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, OnChanges, SimpleChanges, Input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DuplicateRecord } from '../../core/api.types';
 import { DuplicatesApi } from '../../core/duplicates-api.service';
@@ -11,7 +11,7 @@ import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 
 @Component({
-  selector: 'app-duplicates',
+  selector: 'app-review-tab',
   standalone: true,
   imports: [FormsModule, PhIconComponent, TranslocoPipe, SummaryStripComponent, StatusPillComponent, RelativeTimeComponent],
   styles: [`
@@ -90,7 +90,6 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
         @for (d of filteredRows(); track d.id) {
           <div class="dup-card">
             <div class="dup-card-h">
-              <span class="badge badge-blue mono">{{ d.spaceId }}</span>
               <span class="dup-type">{{ d.type }}</span>
               <span class="conf" [attr.title]="'duplicates.confidence' | transloco">
                 <span class="conf-track"><span class="conf-fill" [class]="scoreVariant(d.score)" [style.width.%]="scorePct(d.score)"></span></span>
@@ -142,7 +141,10 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
     }
   `,
 })
-export class DuplicatesComponent implements OnInit {
+export class ReviewTabComponent implements OnInit, OnChanges {
+  /** The space being reviewed. Required: this view is per-space now, never instance-wide. */
+  @Input({ required: true }) spaceId = '';
+
   private duplicatesApi = inject(DuplicatesApi);
   private transloco = inject(TranslocoService);
   private toast = inject(ToastService);
@@ -183,11 +185,13 @@ export class DuplicatesComponent implements OnInit {
   scoreVariant(s: number): 'high' | 'mid' | 'low' { return s >= 0.95 ? 'high' : s >= 0.85 ? 'mid' : 'low'; }
 
   ngOnInit(): void { this.load(); }
+  /** Switching space in the Brain re-points this tab rather than leaving another space's pairs on screen. */
+  ngOnChanges(ch: SimpleChanges): void { if (ch['spaceId'] && !ch['spaceId'].firstChange) this.load(); }
 
   load(): void {
     this.loading.set(true);
     this.error.set(false);
-    this.duplicatesApi.listDuplicates(this.statusFilter).subscribe({
+    this.duplicatesApi.listDuplicates(this.statusFilter, this.spaceId).subscribe({
       next: ({ duplicates }) => { this.rows.set(duplicates); this.loading.set(false); },
       error: () => { this.error.set(true); this.loading.set(false); },
     });
@@ -195,7 +199,7 @@ export class DuplicatesComponent implements OnInit {
 
   scan(): void {
     this.scanning.set(true);
-    this.duplicatesApi.scanDuplicates().subscribe({
+    this.duplicatesApi.scanDuplicates(this.spaceId).subscribe({
       next: () => { this.scanning.set(false); this.load(); },
       error: (e) => {
         this.scanning.set(false);

--- a/client/src/app/pages/shell/shell.component.ts
+++ b/client/src/app/pages/shell/shell.component.ts
@@ -271,9 +271,6 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
         <a class="nav-link" routerLink="/settings/media-processing" routerLinkActive="active">
           <span class="nav-icon"><ph-icon name="brain" [size]="16"/></span>{{ 'nav.models' | transloco }}
         </a>
-        <a class="nav-link" routerLink="/settings/duplicates" routerLinkActive="active">
-          <span class="nav-icon"><ph-icon name="copy" [size]="16"/></span>{{ 'nav.duplicates' | transloco }}
-        </a>
         <a class="nav-link" routerLink="/settings/about" routerLinkActive="active">
           <span class="nav-icon"><ph-icon name="info" [size]="16"/></span>{{ 'nav.about' | transloco }}
         </a>

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5610,7 +5610,7 @@ Base path: `/api/duplicates`.
 | `POST` | `/api/duplicates/:id/merge` | non-read-only | Merge an entity candidate losslessly. `409` with the merge plan if there is a value conflict. |
 | `POST` | `/api/duplicates/scan?space=<id>` | admin + MFA | Trigger an on-demand full re-scan (all accessible spaces, or one). Requires `X-TOTP-Code` when MFA is enabled. |
 
-A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, score, status, resolution?, detectedAt, updatedAt }`. The web UI (**Settings → Duplicates**) lists candidates with dismiss / merge / re-rate actions, a **search box** (handy for a large dismissed pile), and a "Scan now" button.
+A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, score, status, resolution?, detectedAt, updatedAt }`. The web UI (a space's **Brain → Review** tab) lists that space's candidates with dismiss / merge / re-rate actions, a **search box** (handy for a large dismissed pile), and a "Scan now" button.
 
 > **Cost note:** the initial full scan of a large existing space is O(N) vector searches — inherently the expensive part. It is bounded per run (`maxPerRun`) and runs off-hours; steady-state runs only touch new or edited records. Keep `notify` rules and automation idempotent, since an edited record re-fires its pair's action.
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -32,7 +32,7 @@ For setting up a workstation quickly see [workstation-mode-guide.md](workstation
 14. [Settings — Storage](#settings--storage)
 15. [Settings — Data](#settings--data)
 16. [Settings — Audit Log](#settings--audit-log)
-17. [Settings — Duplicates](#settings--duplicates)
+17. [Brain — Review tab (duplicates)](#brain--review-tab-duplicates)
 18. [Settings — Webhooks](#settings--webhooks)
 19. [Settings — About](#settings--about)
 20. [Connecting an AI assistant (MCP)](#connecting-an-ai-assistant-mcp)
@@ -814,9 +814,9 @@ Migration is a one-way operation. Keep your old database available until you hav
 
 ---
 
-## Settings — Duplicates
+## Brain — Review tab (duplicates)
 
-**Settings → Duplicates** (admin only) surfaces near-duplicate records found by the background semantic-duplicate scanner.
+The **Review** tab inside a space's Brain surfaces near-duplicate records found by the background semantic-duplicate scanner, **for that space**. It used to be a global page at Settings → Duplicates; a duplicate pair only ever means something *inside* one space, so it now lives beside that space's data. (The old `/settings/duplicates` link still works — it redirects to the Brain.)
 
 A summary row at the top shows how many pairs are **open**, the **average match confidence**, and how many are **shown**, alongside a **search box**, a status filter (**open / dismissed / all**) and a **Scan now** button. The search box narrows the list by record summary, type, or space — handy once a **dismissed** pile has grown. Each duplicate pair is a **comparison card**: the space and record type, a **confidence meter** (the similarity as a coloured percentage), when it was detected, and record **A** shown side-by-side with record **B**. For an entity pair you can **Merge** the two records (the older one is kept); any open pair can be **Dismiss**ed — dismissing asks for confirmation first, since it removes the pair from the open list.
 


### PR DESCRIPTION
## What

F-REVIEW slice 1a, per your green-light. The global **Settings → Duplicates** page becomes a per-space **Brain → Review** tab — which is also the tab slice 1b (contradiction detection) will hang off.

**Per-space is the point, not the move.** A duplicate pair only ever means something *inside* one space. The instance-wide page made you read a mixed list and check a space badge on every row, and *Scan now* scanned every space your token could see.

## Changes

- `duplicates.component` → `pages/brain/review-tab.component` (`git mv`, so history follows), with a required `spaceId` input threaded into `listDuplicates` / `scanDuplicates`. **No API change needed** — the server already supported `?space=` on both.
- `ngOnChanges` reloads on space switch, so the tab re-points instead of leaving the previous space's pairs on screen.
- Dropped the per-row space badge — every row is the same space now.
- Brain gains the Review tab; the Settings nav entry is gone and `/settings/duplicates` **redirects to `/brain`** (it was a sidebar item, so it's in muscle memory as well as bookmarks).
- Space-level duplicate **rules** stay put on the space's own Duplicates settings tab — those are configuration, not review.

## Tests

New spec asserts the space actually reaches the API and that switching space re-queries. **Proven to fail** when the space argument is dropped — without it the tab would quietly show *every* space's pairs inside one space's Brain, which looks plausible and is wrong.

Client **569/569** · `tsc` clean · `lint:docs` clean · userguide section + TOC and the integration-guide reference rewritten · dead `nav.duplicates` / `titles.duplicates` keys removed from all three locales.

## Next

Slice 1b — contradiction detection (structured checks + a small NLI judge), once this is in and you've seen the tab in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)