### PR TITLE
feat(brain): contradiction candidate store + decision (F-REVIEW 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2525,6 +2525,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
+- **Contradiction candidates have a home and a decision (F-REVIEW slice 3b).** A
+  `{space}_contradiction_candidates` collection shaped after the duplicates one — same canonical pair id,
+  same sticky-dismissal contract — so the Review tab's two sub-views share one vocabulary and one
+  `decideDismissed`, rather than growing a second copy of a rule that was hard to get right once. What a
+  duplicate expresses as a *score*, a contradiction expresses as a **basis**: `structured-field` (the
+  records literally set the same single-valued property to different values — deterministic) or `nli`
+  (a model's opinion, carrying its confidence), so a reviewer can tell "these disagree on `port`" from
+  "a model thinks these disagree". An **unjudged** pair writes nothing at all — not an unjudged row, not a
+  clean one — because every status query filters on open/dismissed/resolved, so any row would make an
+  outage look like a completed review.
+
 - **The contradiction judge decides whether a candidate pair actually disagrees (F-REVIEW slice 3a).** Pure
   logic, so it is testable without a database or a model; finding and storing the pairs is the scanner slice
   that follows. Two judges, cheapest first: a **deterministic** pass (both records set the same single-valued

--- a/server/src/brain/contradiction-candidates.ts
+++ b/server/src/brain/contradiction-candidates.ts
@@ -1,0 +1,154 @@
+/**
+ * Persistence for contradiction candidates (F-REVIEW slice 3b).
+ *
+ * The scan loop that finds pairs is separate; this owns what happens to a pair once the judge has spoken.
+ * It reuses the duplicate machinery deliberately rather than growing a parallel one:
+ *
+ *   - the same canonical pair id (`aId:bId`, lexicographically ordered) so one pair is one row however it
+ *     was encountered;
+ *   - `pairContentHash` for the dismissal fingerprint;
+ *   - **`decideDismissed`** — the sticky-dismissal policy from the #415 fix — unchanged. A dismissed
+ *     contradiction must survive a re-embed or a peer re-sync (seq bumps that change no content) and must
+ *     re-open when the text materially changes. That rule was hard to get right once; deriving a second
+ *     copy for contradictions is how the two would drift apart.
+ *
+ * **An `unjudged` verdict writes nothing.** Not an "unjudged" row, not a "clean" row — nothing. The pair
+ * simply stays unsettled and is re-examined on a later scan. Persisting it in any form would make an
+ * outage look like a review: every status query filters on `open`/`dismissed`/`resolved`, so a row that is
+ * none of those either hides the pair forever or, worse, reads as reviewed-and-fine.
+ */
+import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
+import { pairContentHash, decideDismissed } from './dupe-scanner.js';
+import type { ContradictionCandidateDoc, DupeScanType } from '../config/types.js';
+import type { Verdict } from './contradiction-judge.js';
+
+const collectionFor = (spaceId: string) => col<ContradictionCandidateDoc>(`${spaceId}_contradiction_candidates`);
+
+/** Canonical pair id — order-independent, so A-vs-B and B-vs-A are the same candidate. */
+export function contradictionPairId(aId: string, bId: string): string {
+  return aId < bId ? `${aId}:${bId}` : `${bId}:${aId}`;
+}
+
+export interface PairSide {
+  id: string;
+  summary: string;
+  seq: number;
+}
+
+export type RecordOutcome = 'created' | 'updated' | 'kept-dismissed' | 'reopened' | 'skipped-unjudged';
+
+/** What a judged pair should do to the store. Separated from the writing so it is exhaustively
+ *  unit-testable with no database — the same reason `decideDismissed` is pure. */
+export type CandidateAction =
+  | { do: 'nothing'; outcome: 'skipped-unjudged' }
+  | { do: 'delete'; outcome: 'updated' }
+  | { do: 'insert'; outcome: 'created' }
+  | { do: 'refresh-dismissed'; outcome: 'kept-dismissed' }
+  | { do: 'keep'; outcome: 'kept-dismissed' }
+  | { do: 'reopen'; outcome: 'reopened' }
+  | { do: 'update'; outcome: 'updated' };
+
+/**
+ * Decide what a verdict means for the stored candidate. Pure.
+ *
+ * `dismissalDecision` is `decideDismissed`'s answer for this pair, or null when the stored row is not
+ * dismissed — passed in rather than computed here so this stays free of the content-hash lookup.
+ */
+export function decideCandidateAction(
+  existing: Pick<ContradictionCandidateDoc, 'status'> | null,
+  verdict: Verdict,
+  dismissalDecision: 'keep' | 'refresh' | 'reopen' | null,
+): CandidateAction {
+  // The judge could not answer: write nothing, settle nothing, look again later.
+  if (verdict.kind === 'unjudged') return { do: 'nothing', outcome: 'skipped-unjudged' };
+
+  // They agree. Any OPEN finding is stale and must leave the reviewer's list; a dismissed or resolved row
+  // is a human decision about this pair and is left alone.
+  if (verdict.kind === 'agree') {
+    return existing?.status === 'open'
+      ? { do: 'delete', outcome: 'updated' }
+      : { do: 'nothing', outcome: 'skipped-unjudged' };
+  }
+
+  if (!existing) return { do: 'insert', outcome: 'created' };
+
+  if (existing.status === 'dismissed') {
+    if (dismissalDecision === 'keep') return { do: 'keep', outcome: 'kept-dismissed' };
+    if (dismissalDecision === 'reopen') return { do: 'reopen', outcome: 'reopened' };
+    return { do: 'refresh-dismissed', outcome: 'kept-dismissed' };
+  }
+
+  // Open or resolved: refresh the evidence, but never silently re-open what a human resolved.
+  return { do: 'update', outcome: 'updated' };
+}
+
+/**
+ * Record (or update) a judged pair.
+ *
+ * Returns what it did, so a scan can report honestly rather than counting every pair it looked at as a
+ * finding.
+ */
+export async function recordContradiction(
+  spaceId: string,
+  type: DupeScanType,
+  a: PairSide,
+  b: PairSide,
+  verdict: Verdict,
+): Promise<RecordOutcome> {
+  if (verdict.kind === 'unjudged') return 'skipped-unjudged';   // see the module note
+
+  const [lo, hi] = a.id < b.id ? [a, b] : [b, a];
+  const _id = contradictionPairId(a.id, b.id);
+  const coll = collectionFor(spaceId);
+  const existing = await coll.findOne(asFilter<ContradictionCandidateDoc>({ _id })) as ContradictionCandidateDoc | null;
+  const now = new Date().toISOString();
+
+  // The dismissal policy needs the content fingerprint, so it is resolved only for a dismissed row.
+  let hash: string | undefined;
+  let dismissal: 'keep' | 'refresh' | 'reopen' | null = null;
+  if (existing?.status === 'dismissed') {
+    hash = await pairContentHash(spaceId, type, lo.id, hi.id);
+    dismissal = decideDismissed(existing, lo.seq, hi.seq, hash);
+  }
+
+  // ONE source of truth for what a verdict means — the pure decision, exhaustively unit-tested.
+  const action = decideCandidateAction(existing, verdict, dismissal);
+
+  const base = {
+    spaceId, type,
+    aId: lo.id, aSummary: lo.summary, aSeq: lo.seq,
+    bId: hi.id, bSummary: hi.summary, bSeq: hi.seq,
+    ...(verdict.kind === 'contradiction'
+      ? {
+          basis: verdict.basis,
+          confidence: verdict.confidence,
+          ...(verdict.basis === 'structured-field' && verdict.fields ? { fields: verdict.fields } : {}),
+        }
+      : {}),
+    updatedAt: now,
+  };
+
+  switch (action.do) {
+    case 'nothing':
+    case 'keep':
+      break;
+    case 'delete':
+      await coll.deleteOne(asFilter<ContradictionCandidateDoc>({ _id }));
+      break;
+    case 'insert':
+      await coll.insertOne(asDoc<ContradictionCandidateDoc>({ _id, ...base, status: 'open', detectedAt: now } as ContradictionCandidateDoc));
+      break;
+    case 'refresh-dismissed':
+      await coll.updateOne(asFilter<ContradictionCandidateDoc>({ _id }),
+        asUpdate<ContradictionCandidateDoc>({ $set: { ...base, dismissedContentHash: hash } }));
+      break;
+    case 'reopen':
+      await coll.updateOne(asFilter<ContradictionCandidateDoc>({ _id }),
+        asUpdate<ContradictionCandidateDoc>({ $set: { ...base, status: 'open' }, $unset: { dismissedContentHash: '' } }));
+      break;
+    case 'update':
+      await coll.updateOne(asFilter<ContradictionCandidateDoc>({ _id }), asUpdate<ContradictionCandidateDoc>({ $set: base }));
+      break;
+  }
+  return action.outcome;
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1321,6 +1321,50 @@ export interface SpaceCounterDoc {
  * `${spaceId}_dupe_candidates`. The `_id` is a canonical pair key so the same
  * pair is only ever recorded once regardless of which member is scanned first.
  */
+/**
+ * One contradiction candidate — a pair of records in a space that appear to DISAGREE (F-REVIEW).
+ *
+ * Shaped after `DupeCandidateDoc` on purpose: same identity scheme, same sticky-dismissal contract, so the
+ * Review tab's two sub-views share one vocabulary and `decideDismissed` serves both.
+ *
+ * The difference that matters is `basis`. A duplicate has a similarity SCORE; a contradiction has a REASON,
+ * and the two reasons are not equally strong. `structured-field` is deterministic — the records literally
+ * set the same single-valued property to different values. `nli` is a model's opinion, so it carries a
+ * confidence and deserves to be labelled as such in the UI: a reviewer should be able to tell "these two
+ * disagree on `port`" from "a model thinks these disagree".
+ *
+ * There is deliberately NO record for an *unjudged* pair. When the judge cannot answer (no endpoint,
+ * outage, low confidence), nothing is written and the scan cursor does not treat the pair as settled — so
+ * it is re-examined later. Writing an "unjudged" row would be worse than useless: it would look like a
+ * reviewed-and-clean pair to every query that filters on status.
+ */
+export interface ContradictionCandidateDoc {
+  _id: string;            // canonical `${aId}:${bId}` with aId < bId
+  spaceId: string;
+  /** Which collection the pair lives in — contradictions are judged within one kind of record. */
+  type: DupeScanType;
+  aId: string;
+  aSummary: string;
+  aSeq: number;
+  bId: string;
+  bSummary: string;
+  bSeq: number;
+  /** How the disagreement was established. */
+  basis: 'structured-field' | 'nli';
+  /** 1 for a deterministic structured conflict; the model's confidence for an `nli` verdict. */
+  confidence: number;
+  /** The disagreeing single-valued properties — present only when `basis` is `structured-field`. */
+  fields?: { key: string; aValue: string | number | boolean; bValue: string | number | boolean }[];
+  status: 'open' | 'dismissed' | 'resolved';
+  /** How a resolved candidate was actioned. `edited` = a record was corrected; `linked` = a
+   *  contradicts/supersedes edge was drawn instead of changing either record. */
+  resolution?: 'edited' | 'linked';
+  /** Same sticky-dismissal contract as duplicates — see `decideDismissed`. */
+  dismissedContentHash?: string;
+  detectedAt: string;
+  updatedAt: string;
+}
+
 export interface DupeCandidateDoc {
   _id: string;            // canonical `${type}:${aId}:${bId}` with aId < bId
   spaceId: string;

--- a/testing/standalone/contradiction-candidates.test.js
+++ b/testing/standalone/contradiction-candidates.test.js
@@ -1,0 +1,102 @@
+/**
+ * Standalone tests for the contradiction-candidate decision (F-REVIEW slice 3b).
+ *
+ * `decideCandidateAction` is pure — what a verdict MEANS for the stored row, with no database in the way.
+ * That split follows the precedent `decideDismissed` set in the dupe scanner ("Pure (no DB) so it is
+ * exhaustively unit-testable"), and it is why these cases can be enumerated rather than sampled.
+ *
+ * The properties worth pinning are the ones that decide whether a review queue can be trusted:
+ *
+ *  1. **An `unjudged` verdict writes NOTHING.** Not a row marked unjudged, not a clean row. Every status
+ *     query filters on open/dismissed/resolved, so a row that is none of those either hides the pair
+ *     forever or reads as reviewed-and-fine. The pair must stay unsettled and be re-examined later. This
+ *     is the difference between "the judge was down" and "there is nothing wrong here".
+ *  2. **`agree` retracts a stale OPEN finding** — a disagreement since fixed must leave the reviewer's
+ *     list — but never touches a dismissed or resolved row, which are human decisions.
+ *  3. **A dismissed pair follows the duplicates policy**, via the same `decideDismissed`, not a copy.
+ *  4. **A human `resolved` is never silently re-opened** by a later scan.
+ *
+ * Run: node --test testing/standalone/contradiction-candidates.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let decideCandidateAction, contradictionPairId;
+
+const CONTRA = { kind: 'contradiction', basis: 'structured-field', confidence: 1, fields: [{ key: 'port', aValue: 1, bValue: 2 }] };
+const NLI = { kind: 'contradiction', basis: 'nli', confidence: 0.91 };
+const AGREE = { kind: 'agree', basis: 'nli', confidence: 0.9 };
+const UNJUDGED = { kind: 'unjudged', reason: 'judge-unavailable' };
+const row = (status) => ({ status });
+
+describe('contradiction candidates — the decision', () => {
+  before(async () => {
+    ({ decideCandidateAction, contradictionPairId } =
+      await import('../../server/dist/brain/contradiction-candidates.js'));
+  });
+
+  it('gives a pair one identity regardless of argument order', () => {
+    assert.equal(contradictionPairId('b', 'a'), contradictionPairId('a', 'b'));
+    assert.equal(contradictionPairId('a', 'b'), 'a:b', 'lexicographically ordered');
+  });
+
+  describe('unjudged is not a finding and not a clearance', () => {
+    it('writes nothing, whatever the stored row is', () => {
+      for (const existing of [null, row('open'), row('dismissed'), row('resolved')]) {
+        const a = decideCandidateAction(existing, UNJUDGED, null);
+        assert.equal(a.do, 'nothing', 'an outage must never be persisted as a review');
+        assert.equal(a.outcome, 'skipped-unjudged');
+      }
+    });
+  });
+
+  describe('agree', () => {
+    it('retracts a stale OPEN finding', () => {
+      assert.equal(decideCandidateAction(row('open'), AGREE, null).do, 'delete');
+    });
+
+    it('leaves a dismissed or resolved row alone — those are human decisions', () => {
+      assert.equal(decideCandidateAction(row('dismissed'), AGREE, 'keep').do, 'nothing');
+      assert.equal(decideCandidateAction(row('resolved'), AGREE, null).do, 'nothing');
+    });
+
+    it('writes nothing when there was no row to begin with', () => {
+      assert.equal(decideCandidateAction(null, AGREE, null).do, 'nothing');
+    });
+  });
+
+  describe('contradiction', () => {
+    it('inserts when the pair is new', () => {
+      const a = decideCandidateAction(null, CONTRA, null);
+      assert.equal(a.do, 'insert');
+      assert.equal(a.outcome, 'created');
+    });
+
+    it('refreshes the evidence on an already-open pair', () => {
+      assert.equal(decideCandidateAction(row('open'), NLI, null).do, 'update');
+    });
+
+    it('never silently re-opens what a human resolved', () => {
+      const a = decideCandidateAction(row('resolved'), CONTRA, null);
+      assert.equal(a.do, 'update', 'evidence may refresh…');
+      assert.notEqual(a.do, 'reopen', '…but a resolution is a decision, not a suggestion');
+    });
+
+    describe('a dismissed pair follows the duplicates sticky policy', () => {
+      it('keep → stays dismissed, no write', () => {
+        assert.equal(decideCandidateAction(row('dismissed'), CONTRA, 'keep').do, 'keep');
+      });
+      it('refresh → stays dismissed, fingerprint back-filled', () => {
+        const a = decideCandidateAction(row('dismissed'), CONTRA, 'refresh');
+        assert.equal(a.do, 'refresh-dismissed');
+        assert.equal(a.outcome, 'kept-dismissed', 'a refresh is not a new finding');
+      });
+      it('reopen → back onto the review list', () => {
+        const a = decideCandidateAction(row('dismissed'), CONTRA, 'reopen');
+        assert.equal(a.do, 'reopen');
+        assert.equal(a.outcome, 'reopened');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

The scan loop that *finds* pairs is the next slice; this is what happens to a pair once the judge has spoken.

- **`ContradictionCandidateDoc`**, shaped after `DupeCandidateDoc`: same canonical pair id (`aId:bId`, lexicographically ordered, so one pair is one row however it was encountered) and the same sticky-dismissal contract.
- **Reuses `decideDismissed`** — the #415 sticky-dismissal policy — rather than deriving a second copy. A dismissed contradiction must survive a re-embed or a peer re-sync and re-open on real content change; that rule was hard to get right once, and two copies drift.
- Where a duplicate has a **score**, a contradiction has a **basis**: `structured-field` (deterministic — same single-valued property, different values) or `nli` (a model's opinion, with confidence). A reviewer should be able to tell *"these disagree on `port`"* from *"a model thinks these disagree"*.

## One source of truth

`decideCandidateAction` is **pure** and exhaustively unit-tested, following the precedent `decideDismissed` set in the dupe scanner (*"Pure (no DB) so it is exhaustively unit-testable"*). `recordContradiction` is thin glue over it — I initially wrote the logic twice and collapsed it, since duplicated policy is exactly the drift this PR is otherwise trying to avoid.

## The property that matters

**An `unjudged` verdict writes nothing.** Not an unjudged row, not a clean one. Every status query filters on `open`/`dismissed`/`resolved`, so any row would either hide the pair forever or read as reviewed-and-fine — **an outage would look like a completed review**. **Proven:** letting `unjudged` clear an open finding fails 5 tests.

`agree` retracts a stale **open** finding (a disagreement since fixed must leave the queue) but never touches a dismissed or resolved row — those are human decisions — and a resolution is never silently re-opened.

## Verification

server `tsc` clean · **11** decision tests · standalone suite green except `waitfor-diagnostics` (needs the Docker stack, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)