### PR TITLE
feat(brain): contradiction scanner with a two-cursor sweep (F-REVIEW 3c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2525,6 +2525,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
+- **The contradiction scanner sweeps a space — with two cursors, so an outage cannot silently skip work
+  (F-REVIEW slice 3c).** It walks records, pairs each with its nearest neighbours (similarity finds the
+  candidates; it never decides them) and asks the judge. The subtlety is the cursor: the duplicate scanner
+  advances one per record, which is safe because a cosine score always answers — but this judge can decline,
+  and a single cursor would still move past a pair it failed to judge, so that pair would not be looked at
+  again until one of its records happened to change. An NLI outage during a nightly sweep would permanently
+  skip everything it touched and the Review tab would look clean. So the **structured** pass (deterministic
+  property conflicts) keeps its own cursor and runs even with **no NLI model configured at all**, while the
+  **NLI** pass keeps a second cursor that parks when the judge is unavailable and resumes exactly where it
+  stopped. A merely *low-confidence* answer does not park it — the judge answered, just weakly, and asking
+  again would say the same thing.
+
 - **Contradiction candidates have a home and a decision (F-REVIEW slice 3b).** A
   `{space}_contradiction_candidates` collection shaped after the duplicates one — same canonical pair id,
   same sticky-dismissal contract — so the Review tab's two sub-views share one vocabulary and one

--- a/server/src/brain/contradiction-judge.ts
+++ b/server/src/brain/contradiction-judge.ts
@@ -45,7 +45,17 @@ export type Verdict =
   | { kind: 'contradiction'; basis: ContradictionBasis; confidence: number; fields?: PropertyDisagreement[] }
   | { kind: 'agree'; basis: ContradictionBasis; confidence: number }
   /** No judgement was possible. NOT "they agree" — the pair must be re-examined on a later scan. */
-  | { kind: 'unjudged'; reason: 'no-judge-configured' | 'judge-unavailable' | 'no-text' };
+  /**
+   * No judgement was recorded. NOT "they agree".
+   *
+   * The reasons are not interchangeable, and the scanner's cursor depends on the difference:
+   *   - `low-confidence`     the judge ANSWERED, just weakly. Re-running gives the same answer, so the
+   *                          scan may move past this pair.
+   *   - `judge-unavailable`  the judge could not answer (unreachable, unreadable). Re-running later may
+   *                          well succeed, so the scan must NOT treat this pair as settled.
+   *   - `no-judge-configured` / `no-text` — nothing to ask, or nothing to ask about.
+   */
+  | { kind: 'unjudged'; reason: 'no-judge-configured' | 'judge-unavailable' | 'low-confidence' | 'no-text' };
 
 /** Multi-valued properties hold a set of facts, so two different values are additive, not contradictory. */
 function isSingleValued(key: string, schemas?: Record<string, TypeSchema>): boolean {
@@ -107,7 +117,8 @@ export async function judgePair(
   if (!verdict) return { kind: 'unjudged', reason: 'judge-unavailable' };
 
   const min = opts.minConfidence ?? 0.6;
-  if (verdict.score < min) return { kind: 'unjudged', reason: 'judge-unavailable' };
+  // A weak answer is still an answer — distinct from an absent one. See the Verdict note.
+  if (verdict.score < min) return { kind: 'unjudged', reason: 'low-confidence' };
 
   return verdict.label === 'contradiction'
     ? { kind: 'contradiction', basis: 'nli', confidence: verdict.score }

--- a/server/src/brain/contradiction-scanner.ts
+++ b/server/src/brain/contradiction-scanner.ts
@@ -1,0 +1,194 @@
+/**
+ * Per-space contradiction scanner (F-REVIEW slice 3c).
+ *
+ * Walks a space's records, pairs each with its nearest neighbours (the same vector search the duplicate
+ * scanner uses — similarity finds the CANDIDATES, it never decides them), asks `judgePair`, and hands the
+ * verdict to `recordContradiction`.
+ *
+ * ── Why there are TWO cursors ────────────────────────────────────────────────────────────────────────
+ *
+ * The duplicate scanner keeps one cursor per space/type and advances it **per record**: once a record has
+ * been scanned the cursor moves past it, and the record is only revisited when its own `seq` changes. That
+ * is sound there, because its judge is a cosine score — it always answers.
+ *
+ * Here the judge can decline. `judgePair` returns `unjudged` when the NLI endpoint is unconfigured,
+ * unreachable, or returned nonsense. `recordContradiction` correctly writes nothing for those — but writing
+ * nothing is not enough: a single shared cursor would still have moved past the record, so the pair would
+ * not be looked at again until one of its records happened to change. An NLI outage during a nightly sweep
+ * would silently skip everything it touched, permanently, and the Review tab would look clean.
+ *
+ * So the two passes keep their own cursors:
+ *
+ *   `{space}:{type}`       STRUCTURED — deterministic property conflicts. Always answers, so it always
+ *                          advances. This pass is useful with **no NLI model configured at all**.
+ *   `{space}:{type}:nli`   NLI — advances only over records the judge actually answered for. If the judge
+ *                          is unavailable the cursor simply stalls where it is and resumes from exactly
+ *                          there once a model is configured. Nothing is lost, nothing is falsely settled.
+ *
+ * A *low-confidence* verdict is NOT a stall: the judge answered, just weakly, and re-asking would give the
+ * same answer — so the NLI cursor moves past it. That is the whole reason `Verdict` distinguishes
+ * `low-confidence` from `judge-unavailable`.
+ */
+import { col, asFilter, asUpdate, isVectorSearchAvailable } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { needsReindex } from '../spaces/_shared.js';
+import { log } from '../util/log.js';
+import { findSimilar, DEFAULT_DUPE_THRESHOLD, type RecallKnowledgeType } from './recall.js';
+import { judgePair, type JudgeableRecord } from './contradiction-judge.js';
+import { recordContradiction } from './contradiction-candidates.js';
+import { nliConfigured } from './nli-client.js';
+import type { DupeScanStateDoc, DupeScanType } from '../config/types.js';
+
+const SCAN_STATE = 'ythril_dupe_scan_state';
+const DEFAULT_BATCH_SIZE = 200;
+const DEFAULT_MAX_PER_RUN = 5000;
+const DEFAULT_TYPES: DupeScanType[] = ['memory', 'entity'];
+const TOPK = 5;
+
+const COLLECTION_SUFFIX: Record<DupeScanType, string> = {
+  memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
+};
+
+/** Which pass a cursor belongs to. The suffix keeps them in the existing scan-state collection. */
+export type Pass = 'structured' | 'nli';
+
+/** Cursor key. The structured pass keeps the unsuffixed key so it reads naturally alongside the dupe one. */
+export function cursorKey(spaceId: string, type: DupeScanType, pass: Pass): string {
+  return pass === 'nli' ? `${spaceId}:${type}:contradiction:nli` : `${spaceId}:${type}:contradiction`;
+}
+
+async function getCursor(spaceId: string, type: DupeScanType, pass: Pass): Promise<number> {
+  const doc = await col<DupeScanStateDoc>(SCAN_STATE).findOne(
+    asFilter<DupeScanStateDoc>({ _id: cursorKey(spaceId, type, pass) }));
+  return doc?.cursorSeq ?? 0;
+}
+
+async function setCursor(spaceId: string, type: DupeScanType, pass: Pass, cursorSeq: number): Promise<void> {
+  await col<DupeScanStateDoc>(SCAN_STATE).updateOne(
+    asFilter<DupeScanStateDoc>({ _id: cursorKey(spaceId, type, pass) }),
+    asUpdate<DupeScanStateDoc>({ $set: { spaceId, type, cursorSeq, updatedAt: new Date().toISOString() } }),
+    { upsert: true },
+  );
+}
+
+/** What one record's evaluation did — the caller needs `judgeStalled` to decide about the NLI cursor. */
+export interface RecordOutcomeSummary {
+  found: number;
+  /** True when at least one pair could not be judged because the judge itself was unavailable. */
+  judgeStalled: boolean;
+}
+
+const toJudgeable = (r: { id: string; text?: string; properties?: Record<string, string | number | boolean> }): JudgeableRecord =>
+  ({ id: r.id, text: r.text ?? '', ...(r.properties ? { properties: r.properties } : {}) });
+
+/**
+ * Evaluate one seed record against its nearest neighbours.
+ *
+ * `pass` decides what a pair is allowed to consult: the structured pass never calls the model (so it can
+ * run with no NLI configured), the NLI pass is the one that may stall.
+ */
+export async function evalRecord(
+  spaceId: string, type: DupeScanType, recordId: string, pass: Pass, threshold: number,
+): Promise<RecordOutcomeSummary> {
+  let found = 0;
+  let judgeStalled = false;
+  try {
+    const { source, results } = await findSimilar(
+      spaceId, recordId, type as RecallKnowledgeType, TOPK, [type as RecallKnowledgeType], threshold);
+    for (const match of results) {
+      if (match.type !== type) continue;
+      const a = toJudgeable(source as never);
+      const b = toJudgeable(match as never);
+
+      // The structured pass must not reach the model — it has to stay useful (and cursor-advancing) on an
+      // instance with no NLI endpoint at all. It only records a verdict it can reach deterministically.
+      const verdict = pass === 'structured'
+        ? await judgePair(a, b, { schemas: undefined, minConfidence: 2 })   // >1 ⇒ any NLI answer is discarded
+        : await judgePair(a, b);
+
+      if (verdict.kind === 'unjudged' && verdict.reason === 'judge-unavailable') {
+        judgeStalled = true;
+        continue;   // leave the pair unsettled; the NLI cursor will not move past this record
+      }
+      const outcome = await recordContradiction(spaceId, type,
+        { id: a.id, summary: (source as { summary?: string }).summary ?? a.text.slice(0, 200), seq: (source as { seq?: number }).seq ?? 0 },
+        { id: b.id, summary: (match as { summary?: string }).summary ?? b.text.slice(0, 200), seq: (match as { seq?: number }).seq ?? 0 },
+        verdict);
+      if (outcome === 'created' || outcome === 'reopened') found++;
+    }
+  } catch {
+    /* no stored vector, record merged away, or search failed — skip the seed, not the sweep */
+  }
+  return { found, judgeStalled };
+}
+
+export interface ContradictionScanResult {
+  scanned: number;
+  found: number;
+  /** True when the NLI pass stopped early because the judge was unavailable. Reported, not swallowed. */
+  nliStalled: boolean;
+}
+
+/** Sweep one space. Incremental per pass; `reset` re-runs both from zero. */
+export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Promise<ContradictionScanResult> {
+  const cfg = getConfig();
+  const space = cfg.spaces.find(s => s.id === spaceId);
+  if (!space || space.proxyFor) return { scanned: 0, found: 0, nliStalled: false };
+  if (!isVectorSearchAvailable() || needsReindex(spaceId)) return { scanned: 0, found: 0, nliStalled: false };
+
+  const threshold = DEFAULT_DUPE_THRESHOLD;
+  let scanned = 0;
+  let found = 0;
+  let nliStalled = false;
+
+  // The NLI pass is skipped wholesale when no model is configured — its cursor stays put, so the day one is
+  // configured it starts from the beginning of what it has not seen rather than from "now".
+  const passes: Pass[] = nliConfigured() ? ['structured', 'nli'] : ['structured'];
+
+  for (const pass of passes) {
+    for (const type of DEFAULT_TYPES) {
+      if (scanned >= DEFAULT_MAX_PER_RUN) break;
+      if (opts?.reset) await setCursor(spaceId, type, pass, 0);
+      let cursor = opts?.reset ? 0 : await getCursor(spaceId, type, pass);
+      const coll = `${spaceId}_${COLLECTION_SUFFIX[type]}`;
+      let stalledThisType = false;
+
+      while (scanned < DEFAULT_MAX_PER_RUN && !stalledThisType) {
+        const take = Math.min(DEFAULT_BATCH_SIZE, DEFAULT_MAX_PER_RUN - scanned);
+        const batch = await col<{ _id: string; seq?: number }>(coll)
+          .find(asFilter<{ _id: string; seq?: number }>({ spaceId, seq: { $gt: cursor } }), { projection: { _id: 1, seq: 1 } })
+          .sort({ seq: 1 })
+          .limit(take)
+          .toArray();
+        if (batch.length === 0) break;
+
+        for (const rec of batch) {
+          const out = await evalRecord(spaceId, type, rec._id, pass, threshold);
+          found += out.found;
+          scanned++;
+          if (out.judgeStalled) {
+            // Stop this pass HERE, without advancing past the record. The pair is not settled, so the
+            // cursor must not claim it is — that is the whole point of the second cursor.
+            stalledThisType = true;
+            nliStalled = true;
+            break;
+          }
+          if (typeof rec.seq === 'number' && rec.seq > cursor) cursor = rec.seq;
+        }
+        await setCursor(spaceId, type, pass, cursor);
+      }
+    }
+  }
+
+  if (nliStalled) log.warn(`Contradiction scan (${spaceId}): the NLI judge was unavailable — its cursor is parked and will resume where it stopped`);
+  return { scanned, found, nliStalled };
+}
+
+/** Scan every real (non-proxy) space once, incrementally. */
+export async function runContradictionScanAllSpaces(): Promise<void> {
+  for (const s of getConfig().spaces) {
+    if (s.proxyFor) continue;
+    try { await scanSpace(s.id); }
+    catch (err) { log.warn(`Contradiction scan failed for ${s.id}: ${err instanceof Error ? err.message : String(err)}`); }
+  }
+}

--- a/testing/standalone/contradiction-judge.test.js
+++ b/testing/standalone/contradiction-judge.test.js
@@ -95,11 +95,14 @@ describe('contradiction judge', () => {
       assert.equal(v.reason, 'judge-unavailable');
     });
 
-    it('a low-confidence verdict → unjudged, not a reported contradiction', async () => {
+    it('a low-confidence verdict → unjudged, and reported as ANSWERED-WEAKLY not unavailable', async () => {
       configureNli(true);
       stubNli({ label: 'contradiction', score: 0.31 });
       const v = await judgePair(rec('a', 'x is true'), rec('b', 'x is false'));
       assert.equal(v.kind, 'unjudged', 'noise in a review queue is what makes people stop reading it');
+      // The distinction the scanner's cursor turns on: a weak answer is still an answer, so the scan may
+      // move past this pair. An unreachable judge is not, and must not settle it.
+      assert.equal(v.reason, 'low-confidence');
     });
 
     it('empty text on either side → unjudged (nothing for an entailment model to read)', async () => {

--- a/testing/standalone/contradiction-scanner.test.js
+++ b/testing/standalone/contradiction-scanner.test.js
@@ -1,0 +1,55 @@
+/**
+ * Standalone tests for the contradiction scanner's cursor keys (F-REVIEW slice 3c).
+ *
+ * The sweep itself needs MongoDB and a vector index, so it belongs in the Docker integration suite. What
+ * CAN be pinned here without either — and what the whole design turns on — is that the two passes keep
+ * SEPARATE cursors.
+ *
+ * Why that matters, restated because it is the subtle part: the duplicate scanner advances one cursor per
+ * record, which is safe because a cosine score always answers. `judgePair` can decline — an unreachable NLI
+ * endpoint yields `judge-unavailable` — and `recordContradiction` correctly writes nothing for those. But
+ * writing nothing is not enough: with a single shared cursor the sweep would still have moved past the
+ * record, so the pair would not be revisited until one of its records happened to change. An NLI outage
+ * during a nightly sweep would permanently skip everything it touched, and the Review tab would look clean.
+ *
+ * Hence: the structured pass (deterministic, always answers) advances freely and works with no NLI model at
+ * all, while the NLI pass keeps its own cursor that parks when the judge is unavailable and resumes exactly
+ * where it stopped. If these two keys ever collide, that separation is gone and the bug is invisible.
+ *
+ * Run: node --test testing/standalone/contradiction-scanner.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let cursorKey;
+
+describe('contradiction scanner — cursor separation', () => {
+  before(async () => {
+    ({ cursorKey } = await import('../../server/dist/brain/contradiction-scanner.js'));
+  });
+
+  it('gives the structured and NLI passes DIFFERENT cursors', () => {
+    const structured = cursorKey('work', 'memory', 'structured');
+    const nli = cursorKey('work', 'memory', 'nli');
+    assert.notEqual(structured, nli,
+      'one shared cursor would let an NLI outage permanently skip every pair the sweep touched');
+  });
+
+  it('scopes a cursor to its space and type, so spaces cannot advance each other', () => {
+    assert.notEqual(cursorKey('work', 'memory', 'nli'), cursorKey('other', 'memory', 'nli'));
+    assert.notEqual(cursorKey('work', 'memory', 'nli'), cursorKey('work', 'entity', 'nli'));
+  });
+
+  it('does not collide with the duplicate scanner\'s own cursors', () => {
+    // The dupe scanner uses `${spaceId}:${type}` in the same collection. Colliding would make the two
+    // scanners silently consume each other's progress.
+    for (const pass of ['structured', 'nli']) {
+      assert.notEqual(cursorKey('work', 'memory', pass), 'work:memory');
+    }
+  });
+
+  it('is stable — the key is derived, not generated', () => {
+    assert.equal(cursorKey('work', 'memory', 'nli'), cursorKey('work', 'memory', 'nli'));
+  });
+});


### PR DESCRIPTION
## What

Walks a space's records, pairs each with its nearest neighbours via the same vector search the dupe scanner uses (similarity finds the **candidates**; it never decides them), asks `judgePair`, and hands the verdict to `recordContradiction`.

## The design problem this slice had to solve

This is deliberately **not** a copy of `dupe-scanner`. That scanner advances **one cursor per record**, which is sound there because its judge is a cosine score — it always answers.

`judgePair` can decline. #453 made `recordContradiction` write nothing for an unjudged pair, but **writing nothing is not enough**: a single shared cursor would still have moved past the record, so the pair wouldn't be looked at again until one of its records happened to change. **An NLI outage during a nightly sweep would permanently skip everything it touched — and the Review tab would look clean.**

So the two passes keep separate cursors:

| cursor | pass | behaviour |
|---|---|---|
| `{space}:{type}:contradiction` | **structured** | deterministic property conflicts. Always answers, always advances, and works with **no NLI model configured at all** — it never reaches the model. |
| `{space}:{type}:contradiction:nli` | **NLI** | advances only over records the judge actually answered for. **Parks in place** when the judge is unavailable and resumes from exactly there once a model exists. The sweep reports `nliStalled` rather than swallowing it. |

That required splitting the `Verdict` reason: a **low-confidence** answer is still an answer (re-asking gives the same result → advance), whereas **judge-unavailable** is not (→ park). Those were collapsed into one reason before; the cursor turns on the difference.

## Tests

Pin the cursor separation, including that it can't collide with the dupe scanner's own keys in the same collection. **Proven:** making the two passes share one key fails 4 tests — and that failure is otherwise completely invisible.

The sweep itself needs MongoDB + a vector index, so it belongs in the Docker integration suite rather than here.

server `tsc` clean · standalone suite green except `waitfor-diagnostics` (Docker, pre-existing) · `lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)