### PR TITLE
feat(api): contradiction review endpoints (F-REVIEW 4, server half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2525,6 +2525,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
+- **A contradiction review API (F-REVIEW slice 4, server half).** `/api/contradictions` mirrors the
+  duplicates API — same space scoping, same content-gated sticky dismissal — because the Review tab shows
+  both under one vocabulary and the two should not drift. What it keeps distinct is the **basis**: a
+  `structured-field` finding is deterministic and names the offending property and both values, while an
+  `nli` finding is a model's opinion with its confidence. A reviewer needs to tell "these disagree on
+  `port`" from "a model thinks these disagree", so the list preserves that instead of flattening both into
+  one number. **Contradictions are never merged** — two records that disagree are both real and which is
+  wrong is a judgement call, so `resolve` records how a human settled it (`edited` or `linked` via a
+  contradicts/supersedes edge) and leaves the records to the normal edit paths. All four mutating routes are
+  audited. The scan endpoint reports `nliStalled` rather than swallowing it, so a sweep that stopped because
+  the judge was unreachable is distinguishable from a genuinely clean space.
+
 - **The contradiction scanner sweeps a space — with two cursors, so an outage cannot silently skip work
   (F-REVIEW slice 3c).** It walks records, pairs each with its nearest neighbours (similarity finds the
   candidates; it never decides them) and asks the judge. The subtlety is the cursor: the duplicate scanner

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5612,6 +5612,35 @@ Base path: `/api/duplicates`.
 
 A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, score, status, resolution?, detectedAt, updatedAt }`. The web UI (a space's **Brain → Review** tab) lists that space's candidates with dismiss / merge / re-rate actions, a **search box** (handy for a large dismissed pile), and a "Scan now" button.
 
+### Contradictions API
+
+Base path: `/api/contradictions`. Mirrors the duplicates API — same space scoping, same content-gated
+sticky dismissal — because the Review tab presents both under one vocabulary.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/contradictions?status=open&space=<id>` | any token (space-scoped) | List candidates. `status` = `open` (default), `dismissed`, `resolved`, or `all`. |
+| `POST` | `/api/contradictions/:id/dismiss` | non-read-only | Reviewed / not a real disagreement. Content-gated exactly like a duplicate dismissal. |
+| `POST` | `/api/contradictions/:id/reopen` | non-read-only | Bring a **dismissed** pair back onto the open list. `404` if it is not currently dismissed. |
+| `POST` | `/api/contradictions/:id/resolve` | non-read-only | Body `{ "resolution": "edited" \| "linked" }`. Records HOW a human settled it. |
+| `POST` | `/api/contradictions/scan?space=<id>` | admin + MFA | Run the sweep now. Returns `nliStalled: true` if it stopped because the judge was unavailable. |
+
+A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, basis, confidence, fields?, status,
+resolution?, detectedAt, updatedAt }`.
+
+**`basis` is the important field.** `structured-field` means the two records set the same single-valued
+property to different values — deterministic, `confidence` is 1, and `fields` names the offending keys and
+both values. `nli` means an entailment model judged the free text, and `confidence` is its score. A reviewer
+must be able to tell *"these disagree on `port`"* from *"a model thinks these disagree"*, so do not flatten
+the two into one number.
+
+**Contradictions are never merged.** Two records that disagree are both real, and which one is wrong is a
+judgement call — so `resolve` records the outcome (`edited`: a record was corrected; `linked`: a
+`contradicts`/`supersedes` edge was drawn instead) and leaves the records to the normal edit paths.
+
+**`nliStalled`** is surfaced rather than swallowed: a sweep that stopped because the NLI judge was
+unreachable has *not* cleared the space, and that must be distinguishable from a genuinely clean result.
+
 > **Cost note:** the initial full scan of a large existing space is O(N) vector searches — inherently the expensive part. It is bounded per run (`maxPerRun`) and runs off-hours; steady-state runs only touch new or edited records. Keep `notify` rules and automation idempotent, since an edited record re-fires its pair's action.
 
 ---

--- a/server/src/api/contradictions.ts
+++ b/server/src/api/contradictions.ts
@@ -1,0 +1,179 @@
+/**
+ * Contradiction review API (F-REVIEW slice 4) — the Review tab's Contradictions sub-view.
+ *
+ * Mirrors `api/duplicates.ts` deliberately: same space-scoping, same sticky-dismissal contract, same
+ * shapes. The Review tab shows both under one vocabulary, so the two APIs should not drift.
+ *
+ * Where it differs is what a candidate MEANS. A duplicate carries a similarity `score`; a contradiction
+ * carries a **basis** — `structured-field` (deterministic: the records set the same single-valued property
+ * to different values, and the offending fields are listed) or `nli` (a model's opinion, with its
+ * confidence). The list preserves that distinction rather than flattening both into one number, because a
+ * reviewer needs to tell "these disagree on `port`" from "a model thinks these disagree".
+ *
+ * Resolution is also different. Duplicates merge; contradictions do not — two records that disagree are
+ * both real, and which one is wrong is a judgement call. So `resolve` records HOW it was settled
+ * (`edited` — someone corrected a record; `linked` — a contradicts/supersedes edge was drawn instead) and
+ * leaves the records themselves to the normal edit paths.
+ */
+import { Router } from 'express';
+import { requireAuth, requireAdminMfa, denyReadOnly } from '../auth/middleware.js';
+import { globalRateLimit } from '../rate-limit/middleware.js';
+import { col, asFilter, asUpdate } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+import { pairContentHash } from '../brain/dupe-scanner.js';
+import { scanSpace } from '../brain/contradiction-scanner.js';
+import type { ContradictionCandidateDoc } from '../config/types.js';
+
+export const contradictionsRouter = Router();
+
+const collectionFor = (spaceId: string) => col<ContradictionCandidateDoc>(`${spaceId}_contradiction_candidates`);
+
+/** Space IDs the authenticated token may access (empty/absent allow-list = all spaces). */
+function accessibleSpaces(tokenSpaces?: string[]): string[] {
+  const all = getConfig().spaces.map(s => s.id);
+  if (!tokenSpaces || tokenSpaces.length === 0) return all;
+  return all.filter(id => tokenSpaces.includes(id));
+}
+
+function toRecord(c: ContradictionCandidateDoc) {
+  return {
+    id: c._id,
+    spaceId: c.spaceId,
+    type: c.type,
+    aId: c.aId,
+    aSummary: c.aSummary,
+    bId: c.bId,
+    bSummary: c.bSummary,
+    basis: c.basis,
+    confidence: c.confidence,
+    // Present only for a structured verdict — this is what lets the UI name the disagreement instead of
+    // just asserting one.
+    ...(c.fields ? { fields: c.fields } : {}),
+    status: c.status,
+    ...(c.resolution ? { resolution: c.resolution } : {}),
+    detectedAt: c.detectedAt,
+    updatedAt: c.updatedAt,
+  };
+}
+
+// GET /api/contradictions?status=open&space=<id>
+contradictionsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
+  try {
+    const statusRaw = req.query['status'];
+    const status = statusRaw === 'dismissed' || statusRaw === 'resolved' || statusRaw === 'all' ? statusRaw : 'open';
+    const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
+
+    let spaces = accessibleSpaces(req.authToken?.spaces);
+    if (spaceFilter) spaces = spaces.filter(id => id === spaceFilter);
+
+    const results: ContradictionCandidateDoc[] = [];
+    for (const spaceId of spaces) {
+      const q = status === 'all' ? { spaceId } : { spaceId, status };
+      const docs = await collectionFor(spaceId)
+        .find(asFilter<ContradictionCandidateDoc>(q))
+        // Deterministic findings first (confidence 1), then the model's most confident. Within a tie the
+        // newest, so a reviewer meets fresh disagreements rather than re-reading the same old ones.
+        .sort({ confidence: -1, detectedAt: -1 })
+        .limit(500)
+        .toArray() as ContradictionCandidateDoc[];
+      results.push(...docs);
+    }
+    results.sort((a, b) => (b.confidence - a.confidence) || b.detectedAt.localeCompare(a.detectedAt));
+    // Cap the merged cross-space result, as duplicates does — a many-space token must not materialise
+    // 500 x spaces rows.
+    res.json({ contradictions: results.slice(0, 500).map(toRecord) });
+  } catch (err) {
+    log.error(`GET /api/contradictions: ${err}`);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// POST /api/contradictions/:id/dismiss — reviewed, not a real disagreement.
+// Captures the pair's content fingerprint so a later re-embed / re-sync / index rebuild (which bump seq
+// without changing content) will NOT resurface it, while a real edit to either record will.
+contradictionsRouter.post('/:id/dismiss', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
+  try {
+    const id = req.params['id'] as string;
+    for (const spaceId of accessibleSpaces(req.authToken?.spaces)) {
+      const coll = collectionFor(spaceId);
+      const doc = await coll.findOne(asFilter<ContradictionCandidateDoc>({ _id: id })) as ContradictionCandidateDoc | null;
+      if (!doc) continue;
+      const dismissedContentHash = await pairContentHash(spaceId, doc.type, doc.aId, doc.bId);
+      await coll.updateOne(
+        asFilter<ContradictionCandidateDoc>({ _id: id }),
+        asUpdate<ContradictionCandidateDoc>({ $set: { status: 'dismissed', dismissedContentHash, updatedAt: new Date().toISOString() } }),
+      );
+      res.json({ status: 'dismissed' });
+      return;
+    }
+    res.status(404).json({ error: 'Contradiction candidate not found' });
+  } catch (err) {
+    log.error(`POST /api/contradictions/:id/dismiss: ${err}`);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// POST /api/contradictions/:id/reopen — bring a dismissed pair back onto the review list.
+// Only matches a currently-dismissed pair: reopening an open or resolved one is a 404, not a silent no-op.
+contradictionsRouter.post('/:id/reopen', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
+  try {
+    const id = req.params['id'] as string;
+    for (const spaceId of accessibleSpaces(req.authToken?.spaces)) {
+      const r = await collectionFor(spaceId).updateOne(
+        asFilter<ContradictionCandidateDoc>({ _id: id, status: 'dismissed' }),
+        asUpdate<ContradictionCandidateDoc>({ $set: { status: 'open', updatedAt: new Date().toISOString() }, $unset: { dismissedContentHash: '' } }),
+      );
+      if (r.matchedCount > 0) { res.json({ status: 'open' }); return; }
+    }
+    res.status(404).json({ error: 'Dismissed contradiction candidate not found' });
+  } catch (err) {
+    log.error(`POST /api/contradictions/:id/reopen: ${err}`);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// POST /api/contradictions/:id/resolve  { resolution: 'edited' | 'linked' }
+// Contradictions are NOT merged. Two records that disagree are both real and which one is wrong is a
+// judgement call, so this records HOW a human settled it and leaves the records to the normal edit paths.
+contradictionsRouter.post('/:id/resolve', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
+  try {
+    const id = req.params['id'] as string;
+    const resolution = (req.body as { resolution?: unknown } | undefined)?.resolution;
+    if (resolution !== 'edited' && resolution !== 'linked') {
+      res.status(400).json({ error: "resolution must be 'edited' or 'linked'" });
+      return;
+    }
+    for (const spaceId of accessibleSpaces(req.authToken?.spaces)) {
+      const r = await collectionFor(spaceId).updateOne(
+        asFilter<ContradictionCandidateDoc>({ _id: id }),
+        asUpdate<ContradictionCandidateDoc>({ $set: { status: 'resolved', resolution, updatedAt: new Date().toISOString() } }),
+      );
+      if (r.matchedCount > 0) { res.json({ status: 'resolved', resolution }); return; }
+    }
+    res.status(404).json({ error: 'Contradiction candidate not found' });
+  } catch (err) {
+    log.error(`POST /api/contradictions/:id/resolve: ${err}`);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// POST /api/contradictions/scan?space=<id> — run the sweep now instead of waiting for the schedule.
+// Admin + MFA, like the duplicate scan: it is a model-spending operation over a whole space.
+contradictionsRouter.post('/scan', globalRateLimit, requireAdminMfa, denyReadOnly, async (req, res) => {
+  try {
+    const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
+    const spaces = accessibleSpaces(req.authToken?.spaces).filter(id => !spaceFilter || id === spaceFilter);
+    let scanned = 0, found = 0, nliStalled = false;
+    for (const spaceId of spaces) {
+      const r = await scanSpace(spaceId);
+      scanned += r.scanned; found += r.found; nliStalled = nliStalled || r.nliStalled;
+    }
+    // `nliStalled` is surfaced, not swallowed: a sweep that stopped because the judge was unavailable has
+    // NOT cleared the space, and the caller should be able to tell that from a genuinely clean result.
+    res.json({ scannedSpaces: spaces.length, scanned, found, nliStalled });
+  } catch (err) {
+    log.error(`POST /api/contradictions/scan: ${err}`);
+    res.status(500).json({ error: 'Internal error' });
+  }
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,6 +9,7 @@ import { spacesRouter } from './api/spaces.js';
 import { fileStoreRouter } from './api/files.js';
 import { conflictsRouter } from './api/conflicts.js';
 import { duplicatesRouter } from './api/duplicates.js';
+import { contradictionsRouter } from './api/contradictions.js';
 import { syncRouter } from './api/sync/index.js';
 import { networksRouter } from './api/networks/index.js';
 import { notifyRouter } from './api/notify.js';
@@ -235,6 +236,7 @@ export function createApp() {
   app.use('/api/files', fileStoreRouter);
   app.use('/api/conflicts', conflictsRouter);
   app.use('/api/duplicates', duplicatesRouter);
+  app.use('/api/contradictions', contradictionsRouter);
   app.use('/api/sync', syncRouter);
   app.use('/api/networks', networksRouter);
   app.use('/api/notify', notifyRouter);

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -147,6 +147,13 @@ const ROUTE_RULES: RouteRule[] = [
   { method: 'POST',   pattern: /^\/api\/duplicates\/([^/]+)\/merge$/,               operation: 'duplicate.merge' },
   { method: 'POST',   pattern: /^\/api\/duplicates\/([^/]+)\/dismiss$/,             operation: 'duplicate.dismiss' },
   { method: 'POST',   pattern: /^\/api\/duplicates\/([^/]+)\/reopen$/,              operation: 'duplicate.reopen' },
+  // Contradiction review (F-REVIEW). Same shape as duplicates: reviewing a record-QA finding is a
+  // decision about the knowledge base, so it belongs in the trail alongside the merge/dismiss actions.
+  { method: 'POST',   pattern: /^\/api\/contradictions\/scan$/,                     operation: 'contradiction.scan' },
+  { method: 'POST',   pattern: /^\/api\/contradictions\/([^/]+)\/dismiss$/,         operation: 'contradiction.dismiss' },
+  { method: 'POST',   pattern: /^\/api\/contradictions\/([^/]+)\/reopen$/,          operation: 'contradiction.reopen' },
+  { method: 'POST',   pattern: /^\/api\/contradictions\/([^/]+)\/resolve$/,         operation: 'contradiction.resolve' },
+
 
   // ── Schema library ───────────────────────────────────────────────────────
   { method: 'POST',   pattern: /^\/api\/schema-library$/,                           operation: 'schema_library.create' },


### PR DESCRIPTION
## What

`/api/contradictions` — mirrors `api/duplicates.ts` deliberately (same space scoping, same content-gated sticky dismissal), because the Review tab presents both under one vocabulary and the two APIs must not drift. The client sub-view is the next half.

## Where it differs from duplicates

**The `basis` field.** A duplicate has a similarity *score*; a contradiction has a *reason*, and the two reasons aren't equally strong:

- `structured-field` — deterministic (`confidence: 1`), and carries `fields` naming the property and both values.
- `nli` — a model's opinion, with its confidence.

A reviewer has to be able to tell *"these disagree on `port`"* from *"a model thinks these disagree"*, so the list preserves that rather than flattening both into one number.

**Contradictions are never merged.** Two records that disagree are both real, and which one is wrong is a judgement call. So `/resolve` records *how* a human settled it — `edited` (a record was corrected) or `linked` (a `contradicts`/`supersedes` edge drawn instead) — and leaves the records to the normal edit paths. An unknown resolution is a `400`, not a silently stored string.

**`/scan` returns `nliStalled`** — surfaced, not swallowed. A sweep that stopped because the judge was unreachable has *not* cleared the space, and that must be distinguishable from a genuinely clean result.

## Audit

All four mutating routes have rules. I verified the gate actually **sees** them rather than trusting a green run: removing the `/resolve` rule fails `audit-route-coverage`, so the 4/4 pass is real and not a test that never discovered the new file.

## Verification

**E2E on scratch:** seeded a structured contradiction → listed with its `fields` → resolved `linked` → gone from `?status=open` → `contradiction.resolve` in the audit log. Bad resolution `400`; unknown id `404`.

server `tsc` clean · standalone suite green except `waitfor-diagnostics` (Docker, pre-existing) · `lint:docs` clean · integration-guide documents the endpoints and the `basis` distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)