### PR TITLE
feat(brain): the real Contradictions sub-view (F-REVIEW 4, client half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2525,6 +2525,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
+- **The Review tab's Contradictions sub-view is real (F-REVIEW slice 4, client half).** It replaces the
+  placeholder with the actual candidate list, reusing the Duplicates card so the two halves of the queue read
+  as one thing. The card keeps the two bases apart rather than flattening them into a single percentage: a
+  **Field conflict** names the property and shows *both* values, while a **Model verdict** shows the
+  entailment model's confidence — "these disagree on `port`" is a fact and "a model thinks these disagree"
+  is an opinion, and a reviewer has to be able to act on the difference. Actions match what a contradiction
+  actually permits: dismiss (sticky), resolved-by-edit, or link the two as a contradiction. There is no
+  merge, because both records are real. A failed load surfaces an error instead of rendering the empty
+  state, which would otherwise read as "nothing to review".
+
 - **A contradiction review API (F-REVIEW slice 4, server half).** `/api/contradictions` mirrors the
   duplicates API — same space scoping, same content-gated sticky dismissal — because the Review tab shows
   both under one vocabulary and the two should not drift. What it keeps distinct is the **basis**: a

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1539,5 +1539,12 @@
   "review.sub.contradictions": "Widersprüche",
   "review.contradictions.intro": "Datensätze in diesem Space, die sich widersprechen — gleiches Thema, gegenteilige Aussagen.",
   "review.contradictions.pendingTitle": "Die Widerspruchserkennung läuft noch nicht",
-  "review.contradictions.pendingBody": "Sie benötigt ein NLI-Modell (Entailment). Konfiguriere eines unter Einstellungen → Medienverarbeitung; danach füllt sich diese Liste, sobald der Scanner läuft."
+  "review.contradictions.pendingBody": "Sie benötigt ein NLI-Modell (Entailment). Konfiguriere eines unter Einstellungen → Medienverarbeitung; danach füllt sich diese Liste, sobald der Scanner läuft.",
+  "review.contradictions.basis.structured": "Feldkonflikt",
+  "review.contradictions.basis.nli": "Modell-Urteil",
+  "review.contradictions.confidence": "Modell-Konfidenz",
+  "review.contradictions.versus": "vs.",
+  "review.contradictions.action.edited": "Durch Bearbeitung gelöst",
+  "review.contradictions.action.linked": "Als Widerspruch verknüpfen",
+  "review.contradictions.loadError": "Widersprüche konnten nicht geladen werden."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1539,5 +1539,12 @@
   "review.sub.contradictions": "Contradictions",
   "review.contradictions.intro": "Records in this space that disagree with each other — same subject, opposite claims.",
   "review.contradictions.pendingTitle": "Contradiction detection is not running yet",
-  "review.contradictions.pendingBody": "It needs an NLI (entailment) model. Configure one under Settings → Media Processing, then this list fills as the scanner runs."
+  "review.contradictions.pendingBody": "It needs an NLI (entailment) model. Configure one under Settings → Media Processing, then this list fills as the scanner runs.",
+  "review.contradictions.basis.structured": "Field conflict",
+  "review.contradictions.basis.nli": "Model verdict",
+  "review.contradictions.confidence": "Model confidence",
+  "review.contradictions.versus": "vs",
+  "review.contradictions.action.edited": "Resolved by edit",
+  "review.contradictions.action.linked": "Link as contradiction",
+  "review.contradictions.loadError": "Could not load contradictions."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1539,5 +1539,12 @@
   "review.sub.contradictions": "Sprzeczności",
   "review.contradictions.intro": "Rekordy w tej przestrzeni, które są ze sobą sprzeczne — ten sam temat, przeciwne twierdzenia.",
   "review.contradictions.pendingTitle": "Wykrywanie sprzeczności jeszcze nie działa",
-  "review.contradictions.pendingBody": "Wymaga modelu NLI (entailment). Skonfiguruj go w Ustawienia → Przetwarzanie mediów, a ta lista wypełni się po uruchomieniu skanera."
+  "review.contradictions.pendingBody": "Wymaga modelu NLI (entailment). Skonfiguruj go w Ustawienia → Przetwarzanie mediów, a ta lista wypełni się po uruchomieniu skanera.",
+  "review.contradictions.basis.structured": "Konflikt pola",
+  "review.contradictions.basis.nli": "Werdykt modelu",
+  "review.contradictions.confidence": "Pewność modelu",
+  "review.contradictions.versus": "vs",
+  "review.contradictions.action.edited": "Rozwiązane przez edycję",
+  "review.contradictions.action.linked": "Połącz jako sprzeczność",
+  "review.contradictions.loadError": "Nie udało się wczytać sprzeczności."
 }

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -412,6 +412,32 @@ export interface DupeActionRule {
   webhookUrl?: string;
 }
 
+/**
+ * One contradiction candidate. Mirrors DuplicateRecord, except that where a duplicate has a similarity
+ * `score`, a contradiction has a `basis` — and the two bases are not equally strong, so the UI must not
+ * flatten them into one number.
+ */
+export interface ContradictionRecord {
+  id: string;
+  spaceId: string;
+  type: string;
+  aId: string;
+  aSummary: string;
+  bId: string;
+  bSummary: string;
+  /** `structured-field` = deterministic (the records set one single-valued property to two values, listed
+   *  in `fields`). `nli` = an entailment model's verdict, and `confidence` is its score. */
+  basis: 'structured-field' | 'nli';
+  confidence: number;
+  /** The disagreeing properties — present only for a `structured-field` basis. */
+  fields?: { key: string; aValue: string | number | boolean; bValue: string | number | boolean }[];
+  status: 'open' | 'dismissed' | 'resolved';
+  /** `edited` = a record was corrected; `linked` = a contradicts/supersedes edge was drawn instead. */
+  resolution?: 'edited' | 'linked';
+  detectedAt: string;
+  updatedAt: string;
+}
+
 export interface DuplicateRecord {
   id: string;
   spaceId: string;

--- a/client/src/app/core/contradictions-api.service.ts
+++ b/client/src/app/core/contradictions-api.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import type { ContradictionRecord } from './api.types';
+
+/** Contradiction candidates: list, dismiss, re-open, resolve, and rescan. Mirrors DuplicatesApi. */
+@Injectable({ providedIn: 'root' })
+export class ContradictionsApi {
+  private http = inject(HttpClient);
+
+  listContradictions(status: 'open' | 'dismissed' | 'resolved' | 'all' = 'open', space?: string): Observable<{ contradictions: ContradictionRecord[] }> {
+    const params = new URLSearchParams({ status });
+    if (space) params.set('space', space);
+    return this.http.get<{ contradictions: ContradictionRecord[] }>(`/api/contradictions?${params.toString()}`);
+  }
+
+  dismissContradiction(id: string): Observable<{ status: string }> {
+    return this.http.post<{ status: string }>(`/api/contradictions/${encodeURIComponent(id)}/dismiss`, {});
+  }
+
+  reopenContradiction(id: string): Observable<{ status: string }> {
+    return this.http.post<{ status: string }>(`/api/contradictions/${encodeURIComponent(id)}/reopen`, {});
+  }
+
+  /** Contradictions are never merged — this records HOW a human settled it. */
+  resolveContradiction(id: string, resolution: 'edited' | 'linked'): Observable<{ status: string; resolution: string }> {
+    return this.http.post<{ status: string; resolution: string }>(`/api/contradictions/${encodeURIComponent(id)}/resolve`, { resolution });
+  }
+
+  scanContradictions(space?: string): Observable<{ scannedSpaces: number; scanned: number; found: number; nliStalled: boolean }> {
+    return this.http.post<{ scannedSpaces: number; scanned: number; found: number; nliStalled: boolean }>(
+      `/api/contradictions/scan${space ? `?space=${encodeURIComponent(space)}` : ''}`, {});
+  }
+}

--- a/client/src/app/pages/brain/review-tab.component.spec.ts
+++ b/client/src/app/pages/brain/review-tab.component.spec.ts
@@ -12,6 +12,7 @@ import { of, throwError } from 'rxjs';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { ReviewTabComponent } from './review-tab.component';
 import { DuplicatesApi } from '../../core/duplicates-api.service';
+import { ContradictionsApi } from '../../core/contradictions-api.service';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import type { DuplicateRecord } from '../../core/api.types';
@@ -21,7 +22,7 @@ const rec = (over: Partial<DuplicateRecord> = {}): DuplicateRecord => ({
   score: 0.9, status: 'open', detectedAt: '2026-01-01', updatedAt: '2026-01-01', ...over,
 });
 
-function setup(api: Partial<Record<string, unknown>> = {}, confirmResult = true) {
+function setup(api: Partial<Record<string, unknown>> = {}, confirmResult = true, conApi: Partial<Record<string, unknown>> = {}) {
   const toastErrors: string[] = [];
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
@@ -33,6 +34,13 @@ function setup(api: Partial<Record<string, unknown>> = {}, confirmResult = true)
         dismissDuplicate: () => of({ status: 'ok' }),
         mergeDuplicate: () => of({ status: 'ok' }),
         ...api,
+      } },
+      { provide: ContradictionsApi, useValue: {
+        listContradictions: () => of({ contradictions: [] }),
+        dismissContradiction: () => of({ status: 'ok' }),
+        reopenContradiction: () => of({ status: 'ok' }),
+        resolveContradiction: () => of({ status: 'resolved', resolution: 'edited' }),
+        ...conApi,
       } },
       { provide: ToastService, useValue: { error: (m: string) => toastErrors.push(m), success: () => {}, show: () => {} } },
       { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(confirmResult) } },
@@ -230,6 +238,51 @@ describe('ReviewTabComponent', () => {
       const tabs = [...(f.nativeElement as HTMLElement).querySelectorAll('nav.tabs button[role="tab"]')];
       expect(tabs[0].getAttribute('aria-controls')).toBe('review-panel-duplicates');
       expect(tabs[1].getAttribute('aria-controls')).toBe('review-panel-contradictions');
+    });
+  });
+
+  // The card must keep the two bases distinct. A deterministic field conflict and a model's opinion are
+  // different kinds of claim — flattening both into one percentage would tell a reviewer that "these
+  // disagree on `port`" and "a model thinks these disagree" are the same statement. They are not.
+  describe('contradictions sub-view', () => {
+    const con = (over: Record<string, unknown> = {}) => ({
+      id: 'a:b', spaceId: 'work', type: 'memory',
+      aId: 'a', aSummary: 'runs on 8080', bId: 'b', bSummary: 'does not run on 8080',
+      basis: 'structured-field', confidence: 1,
+      fields: [{ key: 'port', aValue: 8080, bValue: 9090 }],
+      status: 'open', detectedAt: '2026-07-27T00:00:00Z', updatedAt: '2026-07-27T00:00:00Z',
+      ...over,
+    });
+
+    it('names the disagreeing field for a structured verdict, with BOTH values', () => {
+      const { f, c } = setup({}, true, { listContradictions: () => of({ contradictions: [con()] }) });
+      c.sub.set('contradictions');
+      f.detectChanges();
+      const el = f.nativeElement as HTMLElement;
+      const field = el.querySelector('.con-fields li');
+      expect(field).toBeTruthy();
+      expect(field!.textContent).toContain('port');
+      expect(field!.textContent).toContain('8080');
+      expect(field!.textContent).toContain('9090');
+      // A deterministic conflict must NOT be dressed up as a confidence percentage.
+      expect(el.querySelector('#review-panel-contradictions .conf-pct')).toBeNull();
+    });
+
+    it('shows the model confidence for an NLI verdict, and no field list', () => {
+      const nli = con({ basis: 'nli', confidence: 0.91, fields: undefined });
+      const { f, c } = setup({}, true, { listContradictions: () => of({ contradictions: [nli] }) });
+      c.sub.set('contradictions');
+      f.detectChanges();
+      const el = f.nativeElement as HTMLElement;
+      expect(el.querySelector('.con-fields')).toBeNull('a model verdict has no field to name');
+      expect(el.querySelector('#review-panel-contradictions .conf-pct')?.textContent).toContain('91');
+    });
+
+    it('a load failure surfaces an error instead of rendering "nothing to review"', () => {
+      const { f, c, toastErrors } = setup({}, true, { listContradictions: () => throwError(() => ({})) });
+      c.sub.set('contradictions');
+      f.detectChanges();
+      expect(toastErrors.length).toBeGreaterThan(0);
     });
   });
 });

--- a/client/src/app/pages/brain/review-tab.component.ts
+++ b/client/src/app/pages/brain/review-tab.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject, signal, computed, OnInit, OnChanges, SimpleChanges, Input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { DuplicateRecord } from '../../core/api.types';
+import { DuplicateRecord, ContradictionRecord } from '../../core/api.types';
 import { DuplicatesApi } from '../../core/duplicates-api.service';
+import { ContradictionsApi } from '../../core/contradictions-api.service';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
 import { StatusPillComponent } from '../../shared/status-pill.component';
@@ -43,6 +44,12 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
     .dup-rec.b .dup-rec-txt { color: var(--text-secondary); }
     .dup-vs { display: flex; align-items: center; color: var(--text-muted); font-size: 11px; font-style: italic; }
 
+    .con-fields { list-style: none; margin: 0 0 8px; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+    .con-fields li { display: flex; align-items: baseline; gap: 7px; font-size: 12px; flex-wrap: wrap; }
+    .con-key { font-family: var(--font-mono, monospace); font-size: 11px; color: var(--text-muted); }
+    .con-a, .con-b { font-weight: 600; color: var(--text-primary); }
+    .con-sep { color: var(--text-muted); font-style: italic; font-size: 11px; }
+
     .dup-actions { display: flex; gap: 8px; justify-content: flex-end; align-items: center; }
     .dup-resolved { font-size: 12px; color: var(--success); text-align: right; }
   `],
@@ -66,11 +73,84 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
     @if (sub() === 'contradictions') {
       <section role="tabpanel" id="review-panel-contradictions" aria-labelledby="review-tab-contradictions">
         <p class="intro">{{ 'review.contradictions.intro' | transloco }}</p>
-        <div class="empty-state">
-          <div class="empty-state-icon"><ph-icon name="warning" [size]="48"/></div>
-          <h3>{{ 'review.contradictions.pendingTitle' | transloco }}</h3>
-          <p>{{ 'review.contradictions.pendingBody' | transloco }}</p>
-        </div>
+        @if (conLoading()) {
+          <div class="loading-overlay"><span class="spinner"></span></div>
+        } @else if (conRows().length === 0) {
+          <div class="empty-state">
+            <div class="empty-state-icon"><ph-icon name="warning" [size]="48"/></div>
+            <h3>{{ 'review.contradictions.pendingTitle' | transloco }}</h3>
+            <p>{{ 'review.contradictions.pendingBody' | transloco }}</p>
+          </div>
+        } @else {
+          <div class="dup-grid">
+            @for (c of conRows(); track c.id) {
+              <div class="dup-card">
+                <div class="dup-card-h">
+                  <span class="dup-type">{{ c.type }}</span>
+                  <!-- The basis, never a bare number: a deterministic field conflict and a model's opinion
+                       are different kinds of claim, and a reviewer needs to tell them apart at a glance. -->
+                  @if (c.basis === 'structured-field') {
+                    <app-status-pill variant="warn">{{ 'review.contradictions.basis.structured' | transloco }}</app-status-pill>
+                  } @else {
+                    <app-status-pill variant="off">{{ 'review.contradictions.basis.nli' | transloco }}</app-status-pill>
+                    <span class="conf" [attr.title]="'review.contradictions.confidence' | transloco">
+                      <span class="conf-track"><span class="conf-fill" [class]="scoreVariant(c.confidence)" [style.width.%]="scorePct(c.confidence)"></span></span>
+                      <span class="conf-pct">{{ scorePct(c.confidence) }}%</span>
+                    </span>
+                  }
+                  @if (c.status !== 'open') {
+                    <app-status-pill [variant]="c.status === 'resolved' ? 'ok' : 'off'">{{ ('duplicates.status.' + c.status) | transloco }}</app-status-pill>
+                  }
+                  <span class="dup-when"><app-relative-time [value]="c.detectedAt"/></span>
+                </div>
+
+                <!-- A structured verdict can NAME the disagreement; say what it is rather than asserting one. -->
+                @if (c.fields?.length) {
+                  <ul class="con-fields">
+                    @for (f of c.fields; track f.key) {
+                      <li><span class="con-key">{{ f.key }}</span>
+                        <span class="con-a">{{ f.aValue }}</span>
+                        <span class="con-sep">{{ 'review.contradictions.versus' | transloco }}</span>
+                        <span class="con-b">{{ f.bValue }}</span></li>
+                    }
+                  </ul>
+                }
+
+                <div class="dup-ab">
+                  <div class="dup-rec">
+                    <div class="dup-rec-l">{{ 'duplicates.table.recordA' | transloco }}</div>
+                    <div class="dup-rec-txt">{{ c.aSummary }}</div>
+                  </div>
+                  <div class="dup-vs">{{ 'review.contradictions.versus' | transloco }}</div>
+                  <div class="dup-rec b">
+                    <div class="dup-rec-l">{{ 'duplicates.table.recordB' | transloco }}</div>
+                    <div class="dup-rec-txt">{{ c.bSummary }}</div>
+                  </div>
+                </div>
+
+                <div class="dup-actions">
+                  @if (c.status === 'dismissed') {
+                    <button class="btn btn-sm btn-secondary" type="button" [disabled]="conBusy() === c.id" (click)="reopenContradiction(c)">
+                      {{ 'duplicates.reRate' | transloco }}
+                    </button>
+                  } @else if (c.status === 'open') {
+                    <button class="btn btn-sm btn-secondary" type="button" [disabled]="conBusy() === c.id" (click)="dismissContradiction(c)">
+                      {{ 'duplicates.dismiss' | transloco }}
+                    </button>
+                    <!-- Contradictions are never merged: both records are real and which is wrong is a
+                         judgement call, so the reviewer records HOW they settled it. -->
+                    <button class="btn btn-sm btn-secondary" type="button" [disabled]="conBusy() === c.id" (click)="resolveContradiction(c, 'edited')">
+                      {{ 'review.contradictions.action.edited' | transloco }}
+                    </button>
+                    <button class="btn btn-sm btn-secondary" type="button" [disabled]="conBusy() === c.id" (click)="resolveContradiction(c, 'linked')">
+                      {{ 'review.contradictions.action.linked' | transloco }}
+                    </button>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+        }
       </section>
     } @else {
     <section role="tabpanel" id="review-panel-duplicates" aria-labelledby="review-tab-duplicates">
@@ -170,6 +250,46 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
   `,
 })
 export class ReviewTabComponent implements OnInit, OnChanges {
+  private contradictionsApi = inject(ContradictionsApi);
+  readonly conRows = signal<ContradictionRecord[]>([]);
+  readonly conLoading = signal(false);
+  readonly conBusy = signal<string | null>(null);
+
+  /** Load this space's contradictions. Called on init, on space switch, and after every action. */
+  loadContradictions(): void {
+    this.conLoading.set(true);
+    this.contradictionsApi.listContradictions('open', this.spaceId).subscribe({
+      next: r => { this.conRows.set(r.contradictions); this.conLoading.set(false); },
+      // A load failure must not read as "no contradictions" — the empty state would be a lie. Surface it
+      // and leave whatever was already on screen.
+      error: () => { this.conLoading.set(false); this.toast.error(this.transloco.translate('review.contradictions.loadError')); },
+    });
+  }
+
+  dismissContradiction(c: ContradictionRecord): void {
+    this.conBusy.set(c.id);
+    this.contradictionsApi.dismissContradiction(c.id).subscribe({
+      next: () => { this.conBusy.set(null); this.loadContradictions(); },
+      error: () => { this.conBusy.set(null); this.toast.error(this.transloco.translate('duplicates.dismissError')); },
+    });
+  }
+
+  reopenContradiction(c: ContradictionRecord): void {
+    this.conBusy.set(c.id);
+    this.contradictionsApi.reopenContradiction(c.id).subscribe({
+      next: () => { this.conBusy.set(null); this.loadContradictions(); },
+      error: () => { this.conBusy.set(null); this.toast.error(this.transloco.translate('duplicates.dismissError')); },
+    });
+  }
+
+  resolveContradiction(c: ContradictionRecord, resolution: 'edited' | 'linked'): void {
+    this.conBusy.set(c.id);
+    this.contradictionsApi.resolveContradiction(c.id, resolution).subscribe({
+      next: () => { this.conBusy.set(null); this.loadContradictions(); },
+      error: () => { this.conBusy.set(null); this.toast.error(this.transloco.translate('duplicates.dismissError')); },
+    });
+  }
+
   /** Sub-views of the space's record-QA queue. Ordered as a reviewer meets them. */
   readonly SUBTABS = ['duplicates', 'contradictions'] as const;
   readonly sub = signal<'duplicates' | 'contradictions'>('duplicates');
@@ -216,9 +336,9 @@ export class ReviewTabComponent implements OnInit, OnChanges {
   scorePct(s: number): number { return Math.round(Math.min(Math.max(s, 0), 1) * 100); }
   scoreVariant(s: number): 'high' | 'mid' | 'low' { return s >= 0.95 ? 'high' : s >= 0.85 ? 'mid' : 'low'; }
 
-  ngOnInit(): void { this.load(); }
+  ngOnInit(): void { this.load(); this.loadContradictions(); }
   /** Switching space in the Brain re-points this tab rather than leaving another space's pairs on screen. */
-  ngOnChanges(ch: SimpleChanges): void { if (ch['spaceId'] && !ch['spaceId'].firstChange) this.load(); }
+  ngOnChanges(ch: SimpleChanges): void { if (ch['spaceId'] && !ch['spaceId'].firstChange) { this.load(); this.loadContradictions(); } }
 
   load(): void {
     this.loading.set(true);

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -820,6 +820,14 @@ The **Review** tab inside a space's Brain is that space's record-QA queue, split
 **Duplicates** and **Contradictions**. (Contradictions needs an NLI model configured under
 **Settings → Media Processing**; until the scanner has run, the tab explains what it needs.)
 
+**Contradictions** lists records in this space that *disagree*. Each card says **why**: a **Field conflict**
+names the property and shows both values (deterministic — the two records simply set the same single-valued
+property differently), while a **Model verdict** shows an entailment model's judgement and its confidence.
+That distinction is the point — "these disagree on `port`" is a fact, "a model thinks these disagree" is an
+opinion. Contradictions are never merged: both records are real and which one is wrong is your call, so you
+either **dismiss** it (sticky, like a duplicate dismissal), mark it **resolved by edit** after correcting a
+record, or **link** the two as a contradiction instead.
+
 **Duplicates** surfaces near-duplicate records found by the background semantic-duplicate scanner, **for that space**. It used to be a global page at Settings → Duplicates; a duplicate pair only ever means something *inside* one space, so it now lives beside that space's data. (The old `/settings/duplicates` link still works — it redirects to the Brain.)
 
 A summary row at the top shows how many pairs are **open**, the **average match confidence**, and how many are **shown**, alongside a **search box**, a status filter (**open / dismissed / all**) and a **Scan now** button. The search box narrows the list by record summary, type, or space — handy once a **dismissed** pile has grown. Each duplicate pair is a **comparison card**: the space and record type, a **confidence meter** (the similarity as a coloured percentage), when it was detected, and record **A** shown side-by-side with record **B**. For an entity pair you can **Merge** the two records (the older one is kept); any open pair can be **Dismiss**ed — dismissing asks for confirmation first, since it removes the pair from the open list.


### PR DESCRIPTION
## What

Replaces the placeholder panel with the actual candidate list, reusing the Duplicates card so both halves of the review queue read as one thing.

## The card keeps the two bases apart

Rather than flattening them into a single percentage:

- **`structured-field`** → a *Field conflict* pill plus the property name and **both values**, so the card *says what the disagreement is* instead of asserting one. Deliberately **no confidence bar** — a deterministic conflict is not a probability.
- **`nli`** → a *Model verdict* pill plus the model's confidence.

*"These disagree on `port`"* is a fact; *"a model thinks these disagree"* is an opinion, and a reviewer has to act on the difference. **Proven:** collapsing the two branches fails the test.

## Actions match what a contradiction actually permits

Dismiss (sticky), resolved-by-edit, or link the pair as a contradiction. **No merge** — both records are real, and which one is wrong is a judgement call.

A failed load surfaces an error rather than falling through to the empty state, which would otherwise read as *"nothing to review"* — the same class of lie as an outage looking like a clean queue.

## A note on the i18n gate

I reused the **existing** duplicates keys instead of inventing parallel ones — and the key-coverage gate from #447 caught that I'd referenced two keys (`duplicates.action.*`) that don't exist, before they could ship as raw key text in the UI. That's the second real bug that gate has caught.

Client **575/575** · `tsc` clean · i18n parity **1548×3** · `lint:docs` clean · userguide documents the sub-view.

Remaining in F-REVIEW: perf/abuse limits (NLI batching, per-scan caps, retention) and wiring the scheduled sweep alongside the dupe scanner's cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)