### PR TITLE
feat(brain): contradiction warning at insert time (memories + entities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2525,6 +2525,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
+- **`remember` and `upsert_entity` can warn about CONTRADICTING records at write time, not just duplicates.**
+  The write already searches for near-neighbours before inserting (that is how the duplicate check works), so
+  the candidate pairs are already in hand — judging whether one of them *disagrees* costs a single lookup of
+  their properties, no second vector search. When a neighbour sets the same single-valued property to a
+  different value, the response names the property and **both** values, so an agent can tell whether it is
+  correcting an outdated fact or is itself mistaken. Three deliberate limits: it is **its own flag**
+  (`checkContradictions`, default off — "is this redundant?" and "does this conflict?" are different
+  questions); it is **deterministic only**, because putting the entailment model on the write path would add
+  latency and egress to every insert while the nightly scanner already covers the same pairs; and it **never
+  blocks the write**, since an agent correcting a fact should be able to contradict the record it supersedes.
+  Memories and entities only — edge writes are the bulk path (imports, peer sync) where a per-insert search
+  would be felt most, and a file record "disagreeing" with another is not a meaningful claim.
+
 - **The Review tab's Contradictions sub-view is real (F-REVIEW slice 4, client half).** It replaces the
   placeholder with the actual candidate list, reusing the Duplicates card so the two halves of the queue read
   as one thing. The card keeps the two bases apart rather than flattening them into a single percentage: a

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6209,6 +6209,32 @@ Stored memory (seq 1284, ID 7f3c…).
 ⚠️ Possible duplicate — 1 existing memory is highly similar: "The Vault service stores secrets and rotates auth tokens" (ID 9a1b…, 0.97). This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.
 ```
 
+#### Contradiction warning on insert
+
+`checkContradictions` (default **off**) asks a different question of the same neighbours: not *"is this
+redundant?"* but *"does this conflict with what we already believe?"*. When a near-neighbour sets the same
+single-valued property to a different value, the response names the property and **both** values:
+
+```text
+Stored memory (seq 1290, ID 4c2e…).
+⚠️ Contradiction — 1 existing memory disagrees with this one: "Vault runs in the eu-west cluster" (ID 9a1b…: region eu-west vs us-east). This memory was still stored. If you are correcting an outdated fact, update or supersede the record above instead of leaving both.
+```
+
+Three deliberate limits:
+
+- **It is its own flag**, not a rider on `checkDuplicates` — a caller may well want the conflict check
+  without the redundancy check. One neighbour search serves both when both are on.
+- **Deterministic only.** The entailment (NLI) judge is a model call *per pair*; on the write path that
+  would add latency to every insert and, with an external endpoint, send record text off the instance on
+  every insert. The nightly scanner runs the NLI pass over the same pairs, so nothing is lost — this is a
+  fast-path courtesy, not the safety net.
+- **It never blocks the write.** An agent correcting an outdated fact *should* be able to contradict the
+  record it supersedes; the point is to tell it, not to stop it.
+
+Available on `remember` and `upsert_entity`. **Not** on edges or files: edge writes are the bulk path
+(imports, peer sync, subgraph building) where a per-insert vector search would be felt most, and a file
+record "disagreeing" with another is not a meaningful claim.
+
 - **The write always succeeds** — the check is advisory, never blocking. It also never fails an insert: if vector search is unavailable or the space needs reindexing, the check is silently skipped.
 - **Default on** for both tools. Pass `checkDuplicates: false` to skip it, or `dupeThreshold` (0–1, default ~0.92) to tune sensitivity — lower flags looser matches.
 - For `upsert_entity` the check fires only on a **new insert** (no `id`, or an `id` that does not yet exist), not on updates.

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { authorRef } from '../config/author.js';
+import { findInsertContradictions, type ContradictionWarning } from './insert-contradictions.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
@@ -65,6 +66,9 @@ export interface UpsertResult {
   warning?: string;
   /** Near-duplicate entities surfaced by an opt-in insert-time similarity check. */
   similar?: SimilarMatch[];
+  /** Near-neighbours that structurally CONTRADICT this entity (same single-valued property, different
+   *  value). Advisory — the entity is stored regardless. */
+  contradicts?: ContradictionWarning[];
 }
 
 
@@ -143,12 +147,17 @@ export async function upsertEntity(
     }
   }
 
-  // Opt-in insert-time duplicate check, using the freshly computed vector
-  // BEFORE insert so it can never self-match.
+  // Opt-in insert-time duplicate / contradiction checks, using the freshly computed vector BEFORE insert
+  // so it can never self-match. ONE neighbour search serves both flags.
   let similar: SimilarMatch[] | undefined;
-  if (opts?.checkDuplicates && embeddingFields.embedding) {
+  let contradicts: ContradictionWarning[] | undefined;
+  if ((opts?.checkDuplicates || opts?.checkContradictions) && embeddingFields.embedding) {
     const hits = await checkDuplicates(spaceId, 'entity', embeddingFields.embedding, opts.dupeThreshold, opts.dupeTopK);
-    if (hits.length > 0) similar = hits;
+    if (opts.checkDuplicates && hits.length > 0) similar = hits;
+    if (opts.checkContradictions && hits.length > 0) {
+      const found = await findInsertContradictions(spaceId, 'entity', { properties }, hits);
+      if (found.length > 0) contradicts = found;
+    }
   }
 
   const doc: EntityDoc = {
@@ -173,7 +182,8 @@ export async function upsertEntity(
     import('./dupe-scanner.js').then(m => m.evaluateRecordForDuplicates(spaceId, 'entity', doc._id)).catch(() => { /* best-effort */ });
   }
   if (actor) emitWebhookEvent({ event: 'entity.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
-  return { entity: doc, warning, similar };
+  // Advisory only — the entity is stored either way.
+  return { entity: doc, warning, similar, contradicts };
 }
 
 /**

--- a/server/src/brain/insert-contradictions.ts
+++ b/server/src/brain/insert-contradictions.ts
@@ -1,0 +1,77 @@
+/**
+ * Insert-time contradiction warning.
+ *
+ * A write already runs a near-duplicate check (opt-in per call): it embeds the incoming record, searches
+ * for similar ones BEFORE inserting — so it cannot self-match — and returns them as `similar`, which lets a
+ * caller update an existing record instead of adding a redundant one.
+ *
+ * **The candidate pairs are therefore already in hand**, which is what makes this cheap. Judging whether a
+ * near-neighbour actually DISAGREES with the incoming record needs no extra vector search: only the
+ * neighbours' properties, a single `$in` over at most a handful of ids.
+ *
+ * Only the **structured** judge runs here, and that is deliberate. It is pure, deterministic and free —
+ * both records set the same single-valued property to different values, full stop. The NLI judge is a model
+ * call per pair; putting it on the write path would make every insert slower and, with an external
+ * endpoint, would egress record text on every write. The nightly scanner already runs the NLI pass, so
+ * nothing is lost by leaving it out of the fast path: this is a courtesy warning, not the safety net.
+ *
+ * The warning never blocks the write. An agent correcting an outdated fact *should* be able to contradict
+ * the record it is superseding — the point is to tell it, not to stop it.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { findPropertyDisagreements, type PropertyDisagreement } from './contradiction-judge.js';
+import type { SimilarMatch } from './recall.js';
+
+/** A near-neighbour that disagrees with the record being written. */
+export interface ContradictionWarning {
+  id: string;
+  summary: string;
+  /** The single-valued properties they disagree on, with both values. */
+  fields: PropertyDisagreement[];
+}
+
+const COLLECTION_SUFFIX: Record<string, string> = {
+  memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
+};
+
+/**
+ * Which of `hits` structurally contradict the record being written.
+ *
+ * Returns [] rather than throwing: a warning is a courtesy on the write path and must never be the reason
+ * a write fails.
+ */
+export async function findInsertContradictions(
+  spaceId: string,
+  type: string,
+  incoming: { properties?: Record<string, string | number | boolean> },
+  hits: SimilarMatch[],
+): Promise<ContradictionWarning[]> {
+  // Nothing to disagree about: the incoming record makes no property claims.
+  if (!incoming.properties || Object.keys(incoming.properties).length === 0) return [];
+  if (hits.length === 0) return [];
+
+  const suffix = COLLECTION_SUFFIX[type];
+  if (!suffix) return [];
+
+  try {
+    const ids = hits.map(h => h._id);
+    const docs = await col<{ _id: string; properties?: Record<string, string | number | boolean> }>(`${spaceId}_${suffix}`)
+      .find(asFilter<{ _id: string }>({ _id: { $in: ids } }), { projection: { _id: 1, properties: 1 } })
+      .toArray() as Array<{ _id: string; properties?: Record<string, string | number | boolean> }>;
+
+    const byId = new Map(docs.map(d => [d._id, d.properties]));
+    const out: ContradictionWarning[] = [];
+    for (const hit of hits) {
+      const props = byId.get(hit._id);
+      if (!props) continue;
+      const fields = findPropertyDisagreements(
+        { id: 'incoming', text: '', properties: incoming.properties },
+        { id: hit._id, text: '', properties: props },
+      );
+      if (fields.length > 0) out.push({ id: hit._id, summary: hit.summary, fields });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -7,6 +7,7 @@
  */
 import { v4 as uuidv4 } from 'uuid';
 import { authorRef } from '../config/author.js';
+import { findInsertContradictions, type ContradictionWarning } from './insert-contradictions.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
@@ -42,17 +43,23 @@ export async function remember(
   opts?: DupeCheckOpts,
   actor?: WebhookActor,
   ttlDays?: number | null,
-): Promise<MemoryDoc & { similar?: SimilarMatch[] }> {
+): Promise<MemoryDoc & { similar?: SimilarMatch[]; contradicts?: ContradictionWarning[] }> {
   const names = entityNames ?? await resolveEntityNames(spaceId, entityIds);
   const embedText = memoryEmbedText(fact, tags, names, description, properties);
   const embResult = await embed(embedText);
 
-  // Opt-in insert-time duplicate check, using the freshly computed vector
-  // BEFORE insert so it can never self-match.
+  // Opt-in insert-time duplicate / contradiction checks, using the freshly computed vector BEFORE insert
+  // so it can never self-match. ONE neighbour search serves both flags — the second question is free once
+  // the first has paid for the vector search.
   let similar: SimilarMatch[] | undefined;
-  if (opts?.checkDuplicates) {
+  let contradicts: ContradictionWarning[] | undefined;
+  if (opts?.checkDuplicates || opts?.checkContradictions) {
     const hits = await checkDuplicates(spaceId, 'memory', embResult.vector, opts.dupeThreshold, opts.dupeTopK);
-    if (hits.length > 0) similar = hits;
+    if (opts.checkDuplicates && hits.length > 0) similar = hits;
+    if (opts.checkContradictions && hits.length > 0) {
+      const found = await findInsertContradictions(spaceId, 'memory', { properties }, hits);
+      if (found.length > 0) contradicts = found;
+    }
   }
 
   const seq = await nextSeq(spaceId);
@@ -82,7 +89,8 @@ export async function remember(
     import('./dupe-scanner.js').then(m => m.evaluateRecordForDuplicates(spaceId, 'memory', doc._id)).catch(() => { /* best-effort */ });
   }
   if (actor) emitWebhookEvent({ event: 'memory.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
-  return similar ? { ...doc, similar } : doc;
+  // Advisory only — the record is stored either way.
+  return (similar || contradicts) ? { ...doc, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) } : doc;
 }
 
 /** Update an existing memory's fact, tags, entityIds, description, or properties. Re-embeds when content fields change. */

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -214,6 +214,17 @@ const DEFAULT_DUPE_TOPK = 3;
 /** Options controlling the optional insert-time duplicate check on remember/upsertEntity. */
 export interface DupeCheckOpts {
   checkDuplicates?: boolean;
+  /**
+   * Also report near-neighbours that structurally CONTRADICT the incoming record (same single-valued
+   * property, different value). Its own flag rather than a rider on `checkDuplicates`: "is this redundant?"
+   * and "does this conflict with what we already believe?" are different questions, and a caller may well
+   * want the second without the first.
+   *
+   * Only the deterministic judge runs on the write path — no model call, so no added latency or egress per
+   * insert. The nightly scanner still runs the NLI pass. The warning NEVER blocks the write: an agent
+   * correcting an outdated fact should be able to contradict the record it supersedes.
+   */
+  checkContradictions?: boolean;
   dupeThreshold?: number;
   dupeTopK?: number;
 }

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -27,6 +27,7 @@ export const upsert_entityTool: ToolHandler = {
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+            checkContradictions: { type: 'boolean', default: false, description: 'Also flag existing entities that CONTRADICT this one — a near-neighbour setting the same single-valued property to a different value. Deterministic only (no model call). The entity is still stored regardless.' },
             checkDuplicates: { type: 'boolean', default: true, description: 'On a NEW entity insert (no id / unknown id), run a semantic near-duplicate check first (default true). Flags highly similar existing entities (id + summary + score) so you can merge or update instead of creating a duplicate. Does not fire on updates. Set false to skip.' },
             dupeThreshold: unitScoreSchema('Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.'),
             ttlDays: TTL_DAYS_SCHEMA,
@@ -61,13 +62,20 @@ export const upsert_entityTool: ToolHandler = {
     // Insert-time duplicate check defaults ON for the interactive upsert tool
     // (only fires on inserts, not updates — see upsertEntity).
     const entDupeCheck = a['checkDuplicates'] !== false;
+    const entContraCheck = a['checkContradictions'] === true;
     const entDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
     const entTtlDays = ttlDaysFromArgs(a);
-    const { entity, warning, similar } = await upsertEntity(wt.target, eName, eType, tags, props, description, rawId,
-      { checkDuplicates: entDupeCheck, dupeThreshold: entDupeThreshold }, ctx.actor, entTtlDays);
+    const { entity, warning, similar, contradicts } = await upsertEntity(wt.target, eName, eType, tags, props, description, rawId,
+      { checkDuplicates: entDupeCheck, checkContradictions: entContraCheck, dupeThreshold: entDupeThreshold }, ctx.actor, entTtlDays);
     let msg = `Entity '${entity.name}' (${entity.type}) upserted (ID ${entity._id}).${warning ? `\n⚠️ ${warning}` : ''}`;
     if (similar && similar.length > 0) {
       msg += `\n⚠️ Possible duplicate — ${similar.length} existing entit${similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. Pass checkDuplicates:false to skip, or provide the existing id to update it instead.`;
+    }
+    if (contradicts && contradicts.length > 0) {
+      const detail = contradicts.map(c =>
+        `"${c.summary}" (ID ${c.id}: ${c.fields.map(f => `${f.key} ${f.aValue} vs ${f.bValue}`).join(', ')})`).join('; ');
+      msg += `
+⚠️ Contradiction — ${contradicts.length} existing entit${contradicts.length === 1 ? 'y disagrees' : 'ies disagree'} with this one: ${detail}. The entity was still stored. If you are correcting an outdated fact, update the record above instead of leaving both.`;
     }
     // Schema warnings (reuse violations from pre-write check)
     if (entMeta?.validationMode === 'warn') {

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -45,6 +45,7 @@ export const rememberTool: ToolHandler = {
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             checkDuplicates: { type: 'boolean', default: true, description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar memory already exists, the response flags it (id + summary + score) so you can update it instead of creating a redundant one. The memory is still stored regardless. Set false to skip the check.' },
+            checkContradictions: { type: 'boolean', default: false, description: 'Also flag existing memories that CONTRADICT this one — a near-neighbour that sets the same single-valued property to a different value (e.g. status="active" vs status="retired"). Different question from checkDuplicates: "is this redundant?" vs "does this conflict with what we already believe?". Deterministic only (no model call, no added latency). The memory is still stored regardless — if you are correcting an outdated fact, that is expected; consider updating or superseding the record named in the warning.' },
             dupeThreshold: unitScoreSchema('Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.'),
             ttlDays: TTL_DAYS_SCHEMA,
           },
@@ -96,13 +97,21 @@ export const rememberTool: ToolHandler = {
     const resolvedNames = (await findEntitiesByIds(ts, entityIds)).map(e => e.name);
     // Insert-time duplicate check defaults ON for the interactive remember tool.
     const remDupeCheck = a['checkDuplicates'] !== false;
+    const remContraCheck = a['checkContradictions'] === true;
     const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
     const remTtlDays = ttlDaysFromArgs(a);
     const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames, memType,
-      { checkDuplicates: remDupeCheck, dupeThreshold: remDupeThreshold }, ctx.actor, remTtlDays);
+      { checkDuplicates: remDupeCheck, checkContradictions: remContraCheck, dupeThreshold: remDupeThreshold }, ctx.actor, remTtlDays);
     const warnings: string[] = [];
     if (mem.similar && mem.similar.length > 0) {
       warnings.push(`⚠️ Possible duplicate — ${mem.similar.length} existing memor${mem.similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${mem.similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.`);
+    }
+    if (mem.contradicts && mem.contradicts.length > 0) {
+      // Named field + both values: the agent should be able to see WHAT disagrees, not just that
+      // something does — otherwise it cannot decide whether it is correcting or mistaken.
+      const detail = mem.contradicts.map(c =>
+        `"${c.summary}" (ID ${c.id}: ${c.fields.map(f => `${f.key} ${f.aValue} vs ${f.bValue}`).join(', ')})`).join('; ');
+      warnings.push(`⚠️ Contradiction — ${mem.contradicts.length} existing memor${mem.contradicts.length === 1 ? 'y disagrees' : 'ies disagree'} with this one: ${detail}. This memory was still stored. If you are correcting an outdated fact, update or supersede the record above instead of leaving both.`);
     }
     // (An unresolved or ambiguous reference is now a hard error above, not a warning on a write
     // that already happened.)

--- a/testing/standalone/insert-contradictions.test.js
+++ b/testing/standalone/insert-contradictions.test.js
@@ -1,0 +1,60 @@
+/**
+ * Standalone tests for the insert-time contradiction warning.
+ *
+ * `findInsertContradictions` needs the database (it fetches the neighbours' properties), so what is pinned
+ * here is the pure judging rule it delegates to — `findPropertyDisagreements` — for exactly the shapes the
+ * write path hands it, plus the guard conditions that decide whether it does any work at all.
+ *
+ * Why this warning is structured-only, restated because it is a deliberate limit rather than an omission:
+ * the NLI judge is a model call per candidate pair. On the write path that is latency on every insert and,
+ * with an external endpoint, record text leaving the instance on every insert. The nightly scanner already
+ * runs the NLI pass over the same pairs, so nothing is lost by keeping the fast path deterministic — this
+ * is a courtesy warning, not the safety net.
+ *
+ * Run: node --test testing/standalone/insert-contradictions.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let findPropertyDisagreements;
+const rec = (properties) => ({ id: 'x', text: '', ...(properties ? { properties } : {}) });
+
+describe('insert-time contradiction warning', () => {
+  before(async () => {
+    ({ findPropertyDisagreements } = await import('../../server/dist/brain/contradiction-judge.js'));
+  });
+
+  it('flags the same property set to a different value — the case the warning exists for', () => {
+    const d = findPropertyDisagreements(rec({ status: 'active' }), rec({ status: 'retired' }));
+    assert.equal(d.length, 1);
+    assert.deepEqual(d[0], { key: 'status', aValue: 'active', bValue: 'retired' });
+  });
+
+  it('reports BOTH values, so the caller can tell whether it is correcting or mistaken', () => {
+    const [d] = findPropertyDisagreements(rec({ port: 8080 }), rec({ port: 9090 }));
+    assert.equal(d.aValue, 8080, 'the incoming value');
+    assert.equal(d.bValue, 9090, 'the value already stored');
+  });
+
+  it('says nothing when the incoming record makes no property claims', () => {
+    // The common case for a plain text memory — it must not cost a lookup or produce noise.
+    assert.deepEqual(findPropertyDisagreements(rec(), rec({ status: 'active' })), []);
+  });
+
+  it('says nothing when only one side claims a property', () => {
+    // Additive information is not a disagreement; flagging it would train people to ignore the warning.
+    assert.deepEqual(findPropertyDisagreements(rec({ owner: 'ana' }), rec({ status: 'active' })), []);
+  });
+
+  it('says nothing when they agree', () => {
+    assert.deepEqual(findPropertyDisagreements(rec({ status: 'active' }), rec({ status: 'active' })), []);
+  });
+
+  it('flags every disagreeing property, not just the first', () => {
+    const d = findPropertyDisagreements(
+      rec({ status: 'active', port: 8080, owner: 'ana' }),
+      rec({ status: 'retired', port: 9090, owner: 'ana' }));
+    assert.deepEqual(d.map(x => x.key).sort(), ['port', 'status'], 'owner agrees and is not reported');
+  });
+});


### PR DESCRIPTION
## What

Your question — *"on insert we have the return similar right? can we also return contradicting?"* — and yes, it's nearly free. The write **already** searches for near-neighbours before inserting (that's what powers the duplicate check), so the candidate pairs are in hand. Judging whether one *disagrees* needs only their properties: a single `$in` over a handful of ids, **no second vector search**.

The warning names the property and **both values**, not just "these conflict" — an agent can't decide whether it's correcting an outdated fact or is itself mistaken without seeing what disagrees.

```text
⚠️ Contradiction — 1 existing memory disagrees with this one: "Vault runs in the eu-west cluster"
   (ID 9a1b…: region eu-west vs us-east). This memory was still stored.
```

## Three deliberate limits

- **Its own flag** (`checkContradictions`, default off), per your call. *"Is this redundant?"* and *"does this conflict with what we already believe?"* are different questions, and a caller may want the second without the first. One neighbour search serves both when both are on.
- **Deterministic only.** The NLI judge is a model call *per pair* — on the write path that's latency on every insert and, with an external endpoint, record text leaving the instance on every insert. The nightly scanner already runs the NLI pass over the same pairs, so the fast path loses nothing.
- **Never blocks the write**, per your call. An agent correcting an outdated fact *should* be able to contradict the record it supersedes.

## Scope

**Memories and entities only.** Edges and files are excluded deliberately: edge writes are the hot bulk path (imports, peer sync, subgraph building) where a per-insert vector search would be felt most, and a file record "disagreeing" with another isn't a meaningful claim. Both recorded in the tracker with reasoning rather than left as gaps.

server `tsc` clean · **6** new tests · standalone suite green except `waitfor-diagnostics` (Docker, pre-existing) · `lint:docs` clean · integration-guide documents the flag and its limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)