### PR TITLE
fix(media-processing): state the ceiling rule once, not under every pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2525,6 +2525,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now
   present in en/de/pl. Found by the new i18n key-coverage test below — it had been broken on main.
 
+- **The instance-ceiling explanation is stated once at the top of the Pipelines tab, not under every
+  pipeline.** The same paragraph was repeated beneath all five ceiling controls — five copies of one rule is
+  noise a reader learns to skip, which defeats the point of explaining it. It now sits once above the cards,
+  reworded for that position: it used to say "the most any space may do with **this** class", which only
+  parsed while it sat under one specific pipeline. The per-pipeline **Instance ceiling** control labels stay
+  where they are — those name the control, they do not repeat the rule.
+
 - **`remember` and `upsert_entity` can warn about CONTRADICTING records at write time, not just duplicates.**
   The write already searches for near-neighbours before inserting (that is how the duplicate check works), so
   the candidate pairs are already in hand — judging whether one of them *disagrees* costs a single lookup of

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1511,7 +1511,7 @@
   "mediaProcessing.class.audio": "Audio",
   "mediaProcessing.class.video": "Video",
   "mediaProcessing.class.text": "Text",
-  "mediaProcessing.pipelines.ceilingHint": "Das Maximum, das ein Bereich mit dieser Klasse tun darf. Ein Bereich kann weniger wählen, nie mehr — wenn Sie das hier senken, werden alle Bereiche darüber gekappt, und sie behalten ihre eigene Wahl, falls Sie es wieder anheben.",
+  "mediaProcessing.pipelines.ceilingHint": "Jede Pipeline unten hat eine Instanz-Obergrenze — das Maximum, das ein Space mit dieser Klasse tun darf. Ein Space kann weniger wählen, nie mehr: Wird eine Obergrenze gesenkt, werden alle bereits höher eingestellten Spaces begrenzt; ihre eigene Wahl bleibt erhalten, wenn du sie wieder anhebst.",
   "mediaProcessing.pipelines.ceilingOffWarning": "Aus gilt überall — kein Bereich kann diese Klasse verarbeiten.",
   "files.progress.working": "Läuft",
   "files.progress.stalled": "Kein Fortschritt gemeldet — dieser Auftrag hängt möglicherweise",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1511,7 +1511,7 @@
   "mediaProcessing.class.audio": "Audio",
   "mediaProcessing.class.video": "Video",
   "mediaProcessing.class.text": "Text",
-  "mediaProcessing.pipelines.ceilingHint": "The most any space may do with this class. A space can choose less, never more — lowering this caps every space already above it, and those spaces keep their own choice if you raise it again.",
+  "mediaProcessing.pipelines.ceilingHint": "Each pipeline below carries an instance ceiling — the most any space may do with that class. A space can choose less, never more: lowering a ceiling caps every space already above it, and those spaces keep their own choice if you raise it again.",
   "mediaProcessing.pipelines.ceilingOffWarning": "Off applies everywhere — no space can process this class.",
   "files.progress.working": "Working",
   "files.progress.stalled": "No progress reported — this job may be stuck",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1511,7 +1511,7 @@
   "mediaProcessing.class.audio": "Audio",
   "mediaProcessing.class.video": "Wideo",
   "mediaProcessing.class.text": "Tekst",
-  "mediaProcessing.pipelines.ceilingHint": "Najwięcej, co przestrzeń może zrobić z tą klasą. Przestrzeń może wybrać mniej, nigdy więcej — obniżenie tego limitu ogranicza każdą przestrzeń powyżej, a te zachowują swój wybór, jeśli limit znów podniesiesz.",
+  "mediaProcessing.pipelines.ceilingHint": "Każdy potok poniżej ma limit instancji — maksimum, jakie przestrzeń może zrobić z daną klasą. Przestrzeń może wybrać mniej, nigdy więcej: obniżenie limitu ogranicza każdą przestrzeń już powyżej niego, a te przestrzenie zachowują swój wybór, gdy limit zostanie ponownie podniesiony.",
   "mediaProcessing.pipelines.ceilingOffWarning": "Wyłączenie obowiązuje wszędzie — żadna przestrzeń nie przetworzy tej klasy.",
   "files.progress.working": "W toku",
   "files.progress.stalled": "Brak zgłoszonego postępu — to zadanie mogło się zaciąć",

--- a/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
@@ -105,6 +105,8 @@ interface Step {
       width: auto; min-width: 190px; max-width: 260px; }
     .ceiling select:disabled { opacity: .6; cursor: not-allowed; }
     .ceiling-hint { font-size: 12px; color: var(--text-muted); margin: 0 0 11px; max-width: 70ch; }
+    /* Hoisted to the top of the tab: needs the breathing room a knobs block used to give it. */
+    .tab-hint { margin: 0 0 16px; }
     /* Not a warning box: choosing "off" is legitimate. It states the blast radius, which is easy to
        miss when the control sits next to three that only affect thoroughness. */
     .ceiling-warn { color: var(--warning); font-size: 11.5px; }
@@ -129,6 +131,11 @@ interface Step {
         <span>{{ 'mediaProcessing.pipelines.statusUnavailable' | transloco: { detail: e } }}</span>
       </div>
     }
+
+    <!-- The ceiling rule is one rule for the whole tab, so it is stated once here rather than repeated
+         under every pipeline's ceiling control — five copies of the same paragraph is noise a reader
+         learns to skip, which defeats the point of explaining it at all. -->
+    <p class="ceiling-hint tab-hint">{{ 'mediaProcessing.pipelines.ceilingHint' | transloco }}</p>
 
     <!-- ── Documents ──────────────────────────────────────────────────── -->
     <section class="pipe-card">
@@ -230,7 +237,6 @@ interface Step {
 
         <div class="knobs">
           <div class="knobs-h">{{ 'mediaProcessing.pipelines.ceiling' | transloco }}</div>
-          <p class="ceiling-hint">{{ 'mediaProcessing.pipelines.ceilingHint' | transloco }}</p>
           @for (c of p.ceilings; track c.cls) {
             <div class="ceiling">
               <label>{{ 'mediaProcessing.class.' + c.cls | transloco }}</label>


### PR DESCRIPTION
## What

The same explanatory paragraph rendered beneath **all five** ceiling controls. Five copies of one rule is noise a reader learns to skip — which defeats the point of explaining it at all. It now sits once above the cards.

## The copy fix the visual check caught

Hoisting it broke the sentence. It read *"the most any space may do with **this** class"*, which only parsed while it sat under one specific pipeline; at the top of the tab, "this class" dangles with no referent. Reworded for its new position in en/de/pl:

> "Each pipeline below carries an instance ceiling — the most any space may do with that class. A space can choose less, never more: lowering a ceiling caps every space already above it, and those spaces keep their own choice if you raise it again."

The per-pipeline **Instance ceiling** control labels stay put — those *name the control*, they don't repeat the rule.

## Verification

You asked me to make sure the layout fits, so I checked it in a real browser rather than reasoning about the markup:

- exactly **one** `.ceiling-hint` renders (was 5),
- it sits above all five pipeline cards,
- **no horizontal overflow** at 1440px.

Client **575/575** · `tsc` clean · i18n parity **1548×3** · `lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)