### PR TITLE
feat(files): show the live processing stage per file, and fix the root metadata join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The Files list now shows which processing stage a file is actually in, instead of "embedding" and a
+  spinner.** An in-flight file's row draws a segmented bar for **that file's own route** — a PDF might run
+  render → VLM → repair, an image caption → embed — with the active stage filling as its pages land, a
+  `12 / 40` unit count where the stage is countable, and a **stalled** state when the worker has not
+  reported for longer than the stall timeout. Previously every in-flight file said the same generic thing
+  for the whole job and looked identical whether it was working or wedged.
+
+  Both halves of this already existed and had never been connected: the worker has been reporting steps to
+  the job record for a while, and `app-step-progress-bar` was built, unit-tested and imported by **nothing**.
+  What is new is the join — `GET /api/files/:spaceId` now decorates in-flight entries with their job's
+  `progress`/`progressAt`. Finished files cost **no** extra query at all (a listing of completed files is
+  the common case and must not pay for the rare one), the lookup is grouped **per member space** so a proxy
+  space's listing makes one query per member rather than one per file, and it is best-effort throughout: a
+  failed lookup leaves the row on its plain status pill rather than failing the listing. A job that has been
+  claimed but has not yet reported a step keeps the pill too — "not known yet" must not render as an empty
+  bar, which reads as zero progress.
+
 - **Chrono entries are now covered by duplicate and contradiction detection — both on insert and in the
   nightly sweep.** They previously had neither: `create_chrono` ran no near-duplicate check, and
   `dupeScanner.types` defaulted to `["memory", "entity"]` — which the new contradiction scanner inherited —
@@ -1671,6 +1688,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of a third-party signed cast, tampered cast rejected).
 
 ### Fixed
+
+- **The Files list showed no status, no tags and no folder sizes at the root — which is most listings.**
+  The directory listing joins each row to its file-metadata record over an indexed path-prefix range, but
+  the prefix was derived by comparing the **raw** request path against `'.'`. The client asks for the root
+  as `/`, and `toDocId('/')` is `''`, so the expression produced the prefix `'/'` — and file records store
+  their paths with no leading slash, so the range `['/', '/￿')` matched **nothing**. Every file still
+  listed (the filesystem walk is separate), they just arrived stripped of their metadata, which reads as
+  "nothing has been processed yet" rather than as a bug. The prefix is now normalised **before** the
+  root check, so every spelling of the root (`/`, `.`, `//`, `./`) means the same thing, and a leading
+  slash on a sub-folder path no longer produces a prefix that can match no record. Found while wiring the
+  per-file stage bar, which could not appear for the same reason.
 
 - **The contradiction sweep recorded every finding in a space under one row, and its model pass never ran
   at all.** The scanner mapped a vector-search hit onto the judge's input with a cast that silenced the type

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -314,6 +314,10 @@ export interface FileEntry {
   // ── Joined from the file's metadata record (files only) — for the merged Files list ──
   embeddingStatus?: 'pending' | 'processing' | 'complete' | 'partial' | 'failed' | 'skipped' | 'disabled';
   tags?: string[];
+  /** Live stage of this file's media job — present only while it is in flight and has reported a step. */
+  progress?: { step: string; steps: string[]; done?: number; total?: number };
+  /** ISO8601 of the job's last report, so a wedged job does not look like a working one. */
+  progressAt?: string | null;
 }
 
 export interface FileMeta {

--- a/client/src/app/core/files-api.service.ts
+++ b/client/src/app/core/files-api.service.ts
@@ -24,6 +24,9 @@ export class FilesApi {
           modified: e.modifiedAt ?? '',
           embeddingStatus: e.embeddingStatus,
           tags: e.tags,
+          // Present only for files still in flight; absent leaves the row on its plain status pill.
+          progress: e.progress,
+          progressAt: e.progressAt,
         } as FileEntry)),
       })),
     );

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -65,6 +65,35 @@ describe('FileManagerComponent (OnPush)', () => {
     expect(FileManagerComponent.ɵcmp?.onPush).toBe(true);
   });
 
+  // ── Live processing stage (replaces the generic "embedding" + spinner) ───────────────────────
+  // The bar component and the server-side stage data both already existed; nothing joined them, so
+  // every in-flight file said "embedding" for the whole job and looked the same working or wedged.
+  describe('live processing stage', () => {
+    const withProgress = (name: string, progress: FileEntry['progress'], status: FileEntry['embeddingStatus'] = 'processing') =>
+      ({ ...fileEntry(name), embeddingStatus: status, progress, progressAt: new Date().toISOString() }) as FileEntry;
+
+    it('draws the stage bar for a file whose job has reported a step', () => {
+      const fixture = create([withProgress('scan.pdf', { step: 'vlm', steps: ['render', 'vlm'], done: 2, total: 9 })]);
+      const row = fixture.nativeElement.querySelector('table tbody tr') as HTMLElement;
+      expect(row.querySelector('app-step-progress-bar')).toBeTruthy();
+      // The pill is REPLACED, not accompanied — two status indicators on one row is worse than either.
+      expect(row.querySelector('.emb-pill')).toBeNull();
+    });
+
+    it('keeps the plain status pill when there is no stage to show', () => {
+      // A finished file, and a claimed job that has not reported yet, both fall back here. Drawing an
+      // empty bar for the latter would read as "zero progress" rather than "not known yet".
+      const fixture = create([
+        { ...fileEntry('done.pdf'), embeddingStatus: 'complete' } as FileEntry,
+        { ...fileEntry('queued.pdf'), embeddingStatus: 'pending' } as FileEntry,
+      ]);
+      const rows = fixture.nativeElement.querySelectorAll('table tbody tr');
+      expect(rows.length).toBe(2);
+      expect(fixture.nativeElement.querySelectorAll('app-step-progress-bar').length).toBe(0);
+      expect(fixture.nativeElement.querySelectorAll('.emb-pill').length).toBe(2);
+    });
+  });
+
   it('renders a row per file entry after load (signal-driven view updates under OnPush)', () => {
     const fixture = create([fileEntry('readme.md'), fileEntry('notes.txt'), fileEntry('sub', true)]);
     const names = Array.from(fixture.nativeElement.querySelectorAll('table tbody .file-name-btn')).map(

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -14,6 +14,7 @@ import { Subscription } from 'rxjs';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import { ErrorStateComponent } from '../../shared/error-state.component';
+import { StepProgressBarComponent } from '../../shared/step-progress-bar.component';
 import { httpErrorReason } from '../../core/http-error';
 import { Marked } from 'marked';
 import DOMPurify from 'dompurify';
@@ -140,7 +141,7 @@ function xlsxCellText(v: unknown): string {
   // regardless of zone. Text fields (`newFolderName`, `renameValue`) are ngModel two-way bindings
   // whose input events mark the view dirty. So OnPush re-checks exactly when state changes.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent],
   styles: [`
     .toolbar {
       display: flex;
@@ -612,7 +613,15 @@ function xlsxCellText(v: unknown): string {
                       }
                     </td>
                     <td>
-                      @if (entry.isFile && entry.embeddingStatus) {
+                      @if (entry.isFile && entry.progress) {
+                        <!-- In flight AND the worker has reported a stage: show WHICH stage of this
+                             file's own route is running, rather than a generic "embedding" + spinner
+                             that looks identical whether the job is working or wedged. Falls back to
+                             the pill below the moment the job finishes or before it reports. -->
+                        <app-step-progress-bar
+                          [progress]="entry.progress"
+                          [progressAt]="entry.progressAt" />
+                      } @else if (entry.isFile && entry.embeddingStatus) {
                         <span class="emb-pill" [class]="'emb-' + entry.embeddingStatus">
                           <span class="emb-dot"></span>{{ 'files.embStatus.' + entry.embeddingStatus | transloco }}
                         </span>

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1916,12 +1916,34 @@ GET /api/files/:spaceId?path=reports/
   "path": "reports/",
   "type": "dir",
   "entries": [
-    { "name": "q1.pdf", "type": "file", "size": 204800 },
-    { "name": "q1-data.xlsx", "type": "file", "size": 51200 },
-    { "name": "charts", "type": "dir" }
+    { "name": "q1.pdf", "type": "file", "size": 204800, "embeddingStatus": "complete", "tags": ["finance"] },
+    {
+      "name": "q1-data.xlsx", "type": "file", "size": 51200, "embeddingStatus": "processing",
+      "progress": { "step": "vlm", "steps": ["render", "vlm", "repair"], "done": 12, "total": 40 },
+      "progressAt": "2026-07-27T15:04:11.204Z"
+    },
+    { "name": "charts", "type": "dir", "size": 819200 }
   ]
 }
 ```
+
+A directory's `size` is the recursive sum of everything beneath it. Files carry their `embeddingStatus` and
+`tags` from the file's metadata record.
+
+**`progress` / `progressAt` are present only while a file is in flight** (`pending`/`processing`) *and* its
+worker has reported at least one step:
+
+- `steps` is the route **this** file is taking, not a fixed list — it differs per file type and per the
+  space's effective extraction level, so a client can render exactly the stages that will really run.
+- `step` is the one running now; `done`/`total` are units within it (pages, usually) and are **absent for
+  stages that are not divisible** — render those as indeterminate rather than inventing a fraction.
+- `progressAt` is the last sign of life. Treat a file whose `progressAt` is older than the stall timeout as
+  **stalled**, not working — that distinction is the whole point of the field.
+
+Absence means "not known yet", **not** "no work to do": a job claimed a moment ago has no `progress` until
+its first report. Fall back to `embeddingStatus` rather than rendering an empty progress indicator. The
+lookup is best-effort server-side, so these fields may also be absent if the job store was briefly
+unreachable — the listing itself never fails over them.
 
 ---
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -275,6 +275,13 @@ The file manager lets you upload, download, organise, and preview files within e
 
 **Status & tags:** each file row also shows its **embedding status** (a pill: *Embedded*, *Embedding*, *Partial*, *Failed*, *Skipped*…) and its **tags**, pulled from the file's metadata — so a space's file-processing state is visible right in the list. (This is the file manager and the *File Meta* tab coming together into one view.)
 
+**While a file is being processed**, the Status column shows a **stage bar** instead of the pill: a segment
+per stage of *that file's own route* — a PDF might run render → VLM → repair, an image caption → embed — with
+the current stage filling as its pages land and a `12 / 40` count where the work is countable. It replaces a
+generic "Embedding" that looked the same for every file and every stage. If the worker stops reporting for
+longer than the stall timeout the bar turns amber and says **stalled**, so a wedged job no longer looks like
+a working one. The moment the file finishes, the row goes back to its status pill.
+
 **Sorting:** click the **Name**, **Status**, **Size** or **Modified** header to sort the current folder. Clicking cycles ascending → descending → back to the folder's own order. **Folders always stay at the top** — a file explorer where directories interleave with files by size or date is hard to navigate. Sorting applies to the folder you are looking at, which is the whole set the view holds.
 
 ### Detail pane (preview + description ⇄ file meta)

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -35,6 +35,7 @@ import {
   listFilesRecursive,
   type FileEntry,
 } from '../files/files.js';
+import { fetchJobProgress } from '../files/media/job-queue.js';
 import {
   parseContentRange,
   storeChunk,
@@ -119,7 +120,24 @@ function enforceSizeLimit(req: Request, res: Response, next: NextFunction): void
 
 /** A file-level FileMeta row projected for the merged listing: path, raw size, and the bits the UI
  *  shows per file (embedding status, tags). */
-interface FileMetaRow { path: string; sizeBytes?: number; embeddingStatus?: FileEntry['embeddingStatus']; tags?: string[] }
+interface FileMetaRow { _id?: string; path: string; sizeBytes?: number; embeddingStatus?: FileEntry['embeddingStatus']; tags?: string[] }
+
+/**
+ * What the roll-up records per file sitting directly in the listed directory.
+ *
+ * `id` and `memberId` are carried so the live-stage lookup can find the file's job afterwards: a media
+ * job's `_id` IS the file record's `_id`, and jobs live in the MEMBER space's collection — a proxy
+ * space's listing merges several members, so the id alone would not say which collection to ask.
+ */
+interface DirFileMeta {
+  embeddingStatus?: FileEntry['embeddingStatus'];
+  tags?: string[];
+  id?: string;
+  memberId?: string;
+}
+
+/** Statuses worth a progress lookup. Anything else is finished and has nothing left to draw. */
+const IN_FLIGHT = new Set(['pending', 'processing']);
 
 /**
  * Pure roll-up over the file-level records under a directory: sums each file's `sizeBytes` into the
@@ -131,8 +149,9 @@ interface FileMetaRow { path: string; sizeBytes?: number; embeddingStatus?: File
 export function rollUpDirRows(
   rows: FileMetaRow[], prefix: string,
   folderSizes = new Map<string, number>(),
-  fileMeta = new Map<string, { embeddingStatus?: FileEntry['embeddingStatus']; tags?: string[] }>(),
-): { folderSizes: Map<string, number>; fileMeta: Map<string, { embeddingStatus?: FileEntry['embeddingStatus']; tags?: string[] }> } {
+  fileMeta = new Map<string, DirFileMeta>(),
+  memberId?: string,
+): { folderSizes: Map<string, number>; fileMeta: Map<string, DirFileMeta> } {
   for (const r of rows) {
     const rel = prefix ? r.path.slice(prefix.length) : r.path;
     const slash = rel.indexOf('/');
@@ -142,16 +161,39 @@ export function rollUpDirRows(
       folderSizes.set(child, (folderSizes.get(child) ?? 0) + (r.sizeBytes ?? 0));
     } else if (slash === -1 && rel) {
       // A file sitting directly in the listed directory → carry its metadata onto the row.
-      if (!fileMeta.has(rel)) fileMeta.set(rel, { embeddingStatus: r.embeddingStatus, tags: r.tags });
+      if (!fileMeta.has(rel)) {
+        fileMeta.set(rel, {
+          embeddingStatus: r.embeddingStatus, tags: r.tags,
+          ...(r._id ? { id: r._id } : {}), ...(memberId ? { memberId } : {}),
+        });
+      }
     }
   }
   return { folderSizes, fileMeta };
 }
 
+/**
+ * The stored-path prefix for a directory listing — `''` for the root, `reports/` for a sub-folder.
+ *
+ * Pure and exported because getting it wrong fails SILENTLY and completely: file records store their path
+ * with no leading slash (`notes.txt`), so a prefix of `/` makes the indexed range `['/', '/￿')` match
+ * nothing at all. The listing still returns every file — the filesystem walk is a separate thing — they
+ * just arrive with no status, no tags and no folder sizes, which reads as "nothing has been processed yet"
+ * rather than as a bug.
+ *
+ * That is exactly what happened: the caller compared the RAW path against `'.'`, but the client asks for
+ * the root as `/`. `toDocId('/')` is `''`, so the old expression produced `'' + '/'` — the broken prefix —
+ * for every root listing, which is most listings. Normalise FIRST, then decide if it is the root.
+ */
+export function dirPrefix(dirPath: string): string {
+  const docPath = toDocId(dirPath).replace(/\/+$/, '');
+  return docPath === '' || docPath === '.' ? '' : docPath + '/';
+}
+
 async function dirAggregates(memberIds: string[], dirPath: string): Promise<ReturnType<typeof rollUpDirRows>> {
-  const prefix = dirPath === '.' ? '' : toDocId(dirPath) + '/';
+  const prefix = dirPrefix(dirPath);
   const folderSizes = new Map<string, number>();
-  const fileMeta = new Map<string, { embeddingStatus?: FileEntry['embeddingStatus']; tags?: string[] }>();
+  const fileMeta = new Map<string, DirFileMeta>();
   for (const mid of memberIds) {
     try {
       const rows = await col<FileMetaDoc>(`${mid}_files`).find(
@@ -163,18 +205,67 @@ async function dirAggregates(memberIds: string[], dirPath: string): Promise<Retu
           // this prefix without a regex.
           ...(prefix ? { path: { $gte: prefix, $lt: prefix + '￿' } } : {}),
         }),
-        { projection: { path: 1, sizeBytes: 1, embeddingStatus: 1, tags: 1 } },
+        { projection: { _id: 1, path: 1, sizeBytes: 1, embeddingStatus: 1, tags: 1 } },
       ).toArray() as FileMetaRow[];
-      rollUpDirRows(rows, prefix, folderSizes, fileMeta);
+      rollUpDirRows(rows, prefix, folderSizes, fileMeta, mid);
     } catch { /* member has no files collection — skip */ }
   }
   return { folderSizes, fileMeta };
 }
 
 /**
+ * Attach the live stage to the files that HAVE one.
+ *
+ * Only in-flight files are looked up, and only the member spaces that actually contain one are queried:
+ * a listing of finished files — which is most listings — issues no query at all, and a proxy space with
+ * five members does not pay five round trips to decorate two files. The lookup is grouped by member
+ * because a media job lives in its own space's collection and its `_id` is the file record's `_id`.
+ *
+ * Best-effort, like the heartbeat that writes the data: a failed lookup simply leaves the rows
+ * undecorated and the UI falls back to the status pill. A progress bar is not worth failing a listing over.
+ *
+ * `lookup` is injectable so a test can observe WHICH members were queried with WHICH ids — asserting on
+ * the decorated rows alone cannot tell "skipped the query" from "queried and got nothing back", and
+ * skipping it for finished files is the whole point.
+ */
+export async function attachLiveStage(
+  entries: FileEntry[],
+  fileMeta: Map<string, DirFileMeta>,
+  lookup: typeof fetchJobProgress = fetchJobProgress,
+): Promise<void> {
+  const byMember = new Map<string, Array<{ entry: FileEntry; id: string }>>();
+  for (const e of entries) {
+    if (e.type === 'dir' || !IN_FLIGHT.has(String(e.embeddingStatus ?? ''))) continue;
+    const m = fileMeta.get(e.name);
+    if (!m?.id || !m.memberId) continue;
+    const list = byMember.get(m.memberId) ?? [];
+    list.push({ entry: e, id: m.id });
+    byMember.set(m.memberId, list);
+  }
+  if (byMember.size === 0) return;
+
+  await Promise.all([...byMember].map(async ([mid, items]) => {
+    try {
+      const progressById = await lookup(mid, items.map(i => i.id));
+      for (const { entry, id } of items) {
+        const view = progressById.get(id);
+        // A claimed job that has not reported its first step yet adds nothing — leaving the field absent
+        // keeps "we do not know yet" distinct from "the route has no steps".
+        if (!view?.progress) continue;
+        entry.progress = view.progress;
+        entry.progressAt = view.progressAt;
+      }
+    } catch {
+      // One member's jobs collection being unreachable must not lose the OTHER members' rows, and must
+      // never fail the listing. `fetchJobProgress` already swallows its own errors; this covers the rest.
+    }
+  }));
+}
+
+/**
  * Enrich a directory listing from the FileMeta records in one query per member: directories get their
  * recursive content `size`, files get their `embeddingStatus` + `tags` — the merged filesystem +
- * metadata rows the Files list renders.
+ * metadata rows the Files list renders — plus the live processing stage for anything still in flight.
  */
 async function enrichEntries(memberIds: string[], dirPath: string, entries: FileEntry[]): Promise<FileEntry[]> {
   if (entries.length === 0) return entries;
@@ -187,6 +278,7 @@ async function enrichEntries(memberIds: string[], dirPath: string, entries: File
       if (m) { e.embeddingStatus = m.embeddingStatus; e.tags = m.tags; }
     }
   }
+  await attachLiveStage(entries, fileMeta);
   return entries;
 }
 

--- a/server/src/files/files.ts
+++ b/server/src/files/files.ts
@@ -14,6 +14,14 @@ export interface FileEntry {
   embeddingStatus?: 'pending' | 'processing' | 'complete' | 'partial' | 'failed' | 'skipped' | 'disabled';
   /** Tags on the file's metadata record. */
   tags?: string[];
+  /**
+   * Live stage of the file's media job — which step of THIS file's route is running, and how far in.
+   * Present only while the file is in flight (`pending`/`processing`) and only once the worker has
+   * reported a step; absent means "not known yet", which the UI must keep distinct from "no steps".
+   */
+  progress?: { step: string; steps: string[]; done?: number; total?: number };
+  /** ISO8601 of the job's last sign of life, so the UI can tell "working" from "wedged". */
+  progressAt?: string | null;
 }
 
 /** Ensure the space files directory exists */

--- a/testing/standalone/file-live-stage.test.js
+++ b/testing/standalone/file-live-stage.test.js
@@ -1,0 +1,156 @@
+/**
+ * The live processing stage attached to a Files listing.
+ *
+ * The Files list used to say "embedding" with a spinner for the whole of a job, which looks identical
+ * whether the job is working or wedged and says nothing about which of a document's stages is running.
+ * The stage data and the bar that draws it both already existed — on a different endpoint and in an
+ * unused component respectively — so what is new here is the join, and the join has two ways to be wrong
+ * that a rendered row cannot distinguish:
+ *
+ *  1. **Querying for files that are finished.** Most listings are entirely finished files. Asserting on
+ *     the returned rows cannot tell "did not query" from "queried and got nothing", so the lookup is
+ *     injected and the calls themselves are asserted.
+ *  2. **Asking the wrong space.** A media job lives in its OWN space's collection and its `_id` is the
+ *     file record's `_id`. A proxy space's listing merges several members, so a lookup that ignored which
+ *     member a file came from would silently find nothing for every file but the first member's.
+ *
+ * Run: node --test testing/standalone/file-live-stage.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let attachLiveStage, dirPrefix;
+
+const file = (name, embeddingStatus) => ({ name, type: 'file', embeddingStatus });
+const meta = (pairs) => new Map(pairs.map(([name, id, memberId]) => [name, { id, memberId }]));
+
+/** A lookup that records every call and answers with a step for any id it is asked about. */
+function spyLookup(answer = { step: 'vlm', steps: ['render', 'vlm'], done: 2, total: 9 }) {
+  const calls = [];
+  const fn = async (spaceId, ids) => {
+    calls.push({ spaceId, ids: [...ids] });
+    return new Map(ids.map(id => [id, { progress: answer, progressAt: '2026-07-27T12:00:00Z' }]));
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/**
+ * The prefix bug this feature tripped over.
+ *
+ * The client asks for the root as `path=/`, but the prefix was derived by comparing the RAW path against
+ * `'.'` — so only the literal `.` was treated as the root, and `/` produced the prefix `'/'`. File records
+ * store paths with NO leading slash, so the indexed range `['/', '/￿')` matched nothing: every root listing
+ * came back with no status, no tags and no folder sizes. Nothing errored, the files were all still listed,
+ * and an empty Status column just reads as "nothing has been processed yet". It had been that way the whole
+ * time, which is exactly why a live-stage bar could not appear either.
+ */
+describe('directory prefix — the root has many spellings', () => {
+  before(async () => {
+    ({ dirPrefix } = await import('../../server/dist/api/files.js'));
+  });
+
+  it('treats every spelling of the root as the empty prefix', () => {
+    for (const root of ['/', '.', '', '//', './', '/./']) {
+      assert.equal(dirPrefix(root), '', `'${root}' must mean the root, not a folder literally named that`);
+    }
+  });
+
+  it('still builds a real prefix for a sub-folder, with or without a trailing slash', () => {
+    assert.equal(dirPrefix('reports'), 'reports/');
+    assert.equal(dirPrefix('reports/'), 'reports/');
+    assert.equal(dirPrefix('/reports'), 'reports/', 'a leading slash is how the client spells paths');
+    assert.equal(dirPrefix('reports/q1'), 'reports/q1/');
+    assert.equal(dirPrefix('reports\\q1'), 'reports/q1/', 'windows separators normalise too');
+  });
+
+  it('never emits a leading slash — stored paths do not have one', () => {
+    for (const p of ['/', '/reports', '//reports//', '/a/b']) {
+      assert.ok(!dirPrefix(p).startsWith('/'), `'${p}' produced a prefix that can match no stored record`);
+    }
+  });
+});
+
+describe('live stage — only in-flight files cost a query', () => {
+  before(async () => {
+    ({ attachLiveStage } = await import('../../server/dist/api/files.js'));
+  });
+
+  it('issues NO lookup at all for a listing of finished files', async () => {
+    const entries = [file('a.pdf', 'complete'), file('b.pdf', 'failed'), file('c.pdf', 'skipped')];
+    const lookup = spyLookup();
+    await attachLiveStage(entries, meta([['a.pdf', 'id-a', 's1'], ['b.pdf', 'id-b', 's1'], ['c.pdf', 'id-c', 's1']]), lookup);
+    assert.equal(lookup.calls.length, 0, 'the common case — a page of finished files — must not pay for the rare one');
+    assert.ok(entries.every(e => e.progress === undefined));
+  });
+
+  it('asks only about the files that are actually in flight', async () => {
+    const entries = [file('done.pdf', 'complete'), file('busy.pdf', 'processing'), file('queued.pdf', 'pending')];
+    const lookup = spyLookup();
+    await attachLiveStage(entries, meta([['done.pdf', 'id-done', 's1'], ['busy.pdf', 'id-busy', 's1'], ['queued.pdf', 'id-q', 's1']]), lookup);
+    assert.equal(lookup.calls.length, 1);
+    assert.deepEqual(lookup.calls[0].ids.sort(), ['id-busy', 'id-q'], 'the finished file must not be in the query');
+  });
+
+  it('never queries a directory row', async () => {
+    const entries = [{ name: 'folder', type: 'dir' }];
+    const lookup = spyLookup();
+    await attachLiveStage(entries, meta([['folder', 'id-f', 's1']]), lookup);
+    assert.equal(lookup.calls.length, 0);
+  });
+});
+
+describe('live stage — a proxy listing asks each member for its own jobs', () => {
+  before(async () => {
+    ({ attachLiveStage } = await import('../../server/dist/api/files.js'));
+  });
+
+  it('groups the lookup by the member space the file came from', async () => {
+    // A job lives in its own space's collection; asking space A about space B's file finds nothing.
+    const entries = [file('x.pdf', 'processing'), file('y.pdf', 'processing')];
+    const lookup = spyLookup();
+    await attachLiveStage(entries, meta([['x.pdf', 'id-x', 'alpha'], ['y.pdf', 'id-y', 'beta']]), lookup);
+    const bySpace = Object.fromEntries(lookup.calls.map(c => [c.spaceId, c.ids]));
+    assert.deepEqual(bySpace, { alpha: ['id-x'], beta: ['id-y'] });
+    assert.ok(entries.every(e => e.progress?.step === 'vlm'), 'both rows decorated, each from its own member');
+  });
+
+  it('makes one call per member, not one per file', async () => {
+    const entries = [file('x.pdf', 'processing'), file('y.pdf', 'processing'), file('z.pdf', 'pending')];
+    const lookup = spyLookup();
+    await attachLiveStage(entries, meta([['x.pdf', 'id-x', 'alpha'], ['y.pdf', 'id-y', 'alpha'], ['z.pdf', 'id-z', 'alpha']]), lookup);
+    assert.equal(lookup.calls.length, 1, 'an N+1 walk over a directory would be a query per file');
+    assert.equal(lookup.calls[0].ids.length, 3);
+  });
+});
+
+describe('live stage — absence is preserved, not invented', () => {
+  before(async () => {
+    ({ attachLiveStage } = await import('../../server/dist/api/files.js'));
+  });
+
+  it('leaves the row undecorated when the job has not reported a step yet', async () => {
+    // Claimed but silent so far. "We do not know yet" must stay distinct from "the route has no steps",
+    // or the bar would draw an empty track that reads as zero progress.
+    const entries = [file('new.pdf', 'processing')];
+    const lookup = async () => new Map([['id-n', { progressAt: '2026-07-27T12:00:00Z' }]]);
+    await attachLiveStage(entries, meta([['new.pdf', 'id-n', 's1']]), lookup);
+    assert.equal(entries[0].progress, undefined);
+  });
+
+  it('survives a failing lookup — a listing must not fail over a progress bar', async () => {
+    const entries = [file('busy.pdf', 'processing')];
+    const boom = async () => { throw new Error('mongo is having a day'); };
+    await assert.doesNotReject(() => attachLiveStage(entries, meta([['busy.pdf', 'id-b', 's1']]), boom));
+    assert.equal(entries[0].progress, undefined);
+  });
+
+  it('skips a file whose metadata record was not found in the roll-up', async () => {
+    // On disk but with no FileMeta row yet (just uploaded): there is no id to ask about.
+    const entries = [file('orphan.pdf', 'processing')];
+    const lookup = spyLookup();
+    await attachLiveStage(entries, new Map(), lookup);
+    assert.equal(lookup.calls.length, 0);
+  });
+});


### PR DESCRIPTION
Owner-scoped: *"what happens to THIS file"* — and *"it also was about progress so we can see at what stage the file currently is instead of the generic 'embedding' with a spinner."*

This is **slice A: where it is now.** Slice B (*what will run* for a file that hasn't started, from its type narrowed by the space's effective rungs) follows separately — it needs the effective-rung computation, which this doesn't.

## The work was wiring, not building

Ground-truthing found both halves already existed and had never been connected:

- the worker has been reporting steps into the job record for a while (`StepProgress`, `touchJobProgress`, `fetchJobProgress`);
- `app-step-progress-bar` was built, unit-tested, and **imported by nothing**;
- `attachJobProgress` decorated a *different* endpoint — the paginated file-meta list, which is retired.

So: `GET /api/files/:spaceId` now decorates in-flight entries with `progress`/`progressAt`, and the Files row renders the existing bar.

Deliberate properties, each with a test:

- **Finished files cost no query.** A page of completed files is the common case and must not pay for the rare one. Asserting on returned rows can't tell "skipped the query" from "queried and got nothing", so the lookup is injected and the *calls* are asserted.
- **Grouped per member space.** A media job lives in its own space's collection and its `_id` is the file record's `_id`; a proxy listing merges several members, so an ungrouped lookup would silently find nothing for every member but the first. One call per member, not per file.
- **Absence is preserved, not invented.** A claimed-but-silent job keeps the plain pill — an empty bar reads as *zero progress*, not *not known yet*.
- **Best-effort.** A failing lookup leaves rows undecorated rather than failing the listing. Writing that test exposed that my own doc comment claimed best-effort with no `catch`; added.

## Fix found on the way: the root listing joined no metadata at all

The verification looked wrong at first — no bar, but also **no status pills**, which predate this change. Not a rendering bug:

The listing joins rows to their metadata over an indexed path-prefix range, but the prefix compared the **raw** path against `'.'`. The client asks for the root as `/`, and `toDocId('/')` is `''` — so the prefix became `'/'`, and since file records store paths with no leading slash, the range matched **nothing**. Every file still listed (the filesystem walk is separate); they just arrived stripped of status, tags and folder sizes, which reads as *"nothing has been processed yet"* rather than as a bug. That's why it went unnoticed, and it's why the stage bar couldn't appear either.

`dirPrefix` now normalises **before** the root check, is exported, and is unit-tested across every spelling of the root (`/`, `.`, `//`, `./`) plus leading-slash sub-folder paths.

## Verification

Browser, scratch instance, seeded mid-flight PDF:

| Check | Result |
|---|---|
| Stage bar / pills | 1 bar, 2 pills (the pills had been missing from every root listing) |
| Segments | 3 — render done, vision filling, repair pending |
| Accessible name | `aria-valuenow=32`, `aria-valuetext="Vision 12 / 40 — 32%"` — translated, not a raw key |
| Fits its cell | bar 156px in a 184px cell; no horizontal overflow |
| Row stability | 1px height spread — the bar doesn't make rows jump |
| Console | no errors |

Gates: server `tsc` clean · client `tsconfig.app.json` clean · **577/577** client tests (+2) · 33/33 on the affected standalone suites · i18n — no new keys, and all 13 the bar renders confirmed present in en/de/pl (parity 1548×3; it had never been rendered, so a missing key would have shown raw) · `lint:docs` clean · audit-route-coverage + route-guard-coverage pass (no new routes; the changed one is a read-only GET) · no new icons.

Both fixes proven to fail without them: disabling the template branch fails the bar test; mis-grouping the lookup fails the member test.

Docs: userguide (stage bar, stalled state) and integration-guide (List Directory response now documents `progress`/`progressAt`, including that absence means "not known yet" and that indivisible stages have no `done`/`total`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)