### PR TITLE
feat(brain): group a document's matching passages under the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Semantic search groups a document's matching passages under the document, and shows the passages
+  instead of raw JSON.** Recall over files matches *chunks*, so a paper relevant in five places returned
+  five near-identical rows that pushed everything else out of the visible list — and each row rendered as a
+  pretty-printed JSON record. A search now returns one row per document, naming the file once, badging how
+  many passages matched, and listing each passage under the heading it sits beneath with its actual text
+  (whitespace-collapsed, truncated at 400 characters).
+
+  The header states both numbers — *"1 result from 6 matching passages"* — because collapsing rows makes a
+  `topK` of 10 look like 6, and a reader who is shown fewer results than they asked for deserves to be told
+  why rather than left to wonder. A whole-file hit merges with that same file's chunk hits, so a document no
+  longer appears once as itself and again as a set of fragments that look unrelated.
+
+  Entirely presentation-side: the server has always sent `parentFileId` and an inlined `parentFile` on chunk
+  hits, and nothing had ever read them — the data crossed the wire on every recall and was discarded. So the
+  recall API is unchanged and MCP callers still receive the flat list they are built around.
+
 - **A file's detail pane now says what WILL run for it — and, when nothing will, why.** Opening a file
   shows the chain it goes through (a PDF: render → OCR evidence → vision → validate → repair; an image:
   caption → embed → faces; audio/video: transcribe → chunk → embed, with keyframe sampling for video), the

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1084,6 +1084,8 @@
   "brain.query.filterPlaceholder": "{\"tags\": {\"$in\": [\"mein-tag\"]}} oder {\"name\": {\"$regex\": \"auth\", \"$options\": \"i\"}}",
   "brain.query.projectionPlaceholder": "{\"fact\": 1, \"tags\": 1}",
   "brain.query.resultsFrom": "Ergebnis(se) aus {{ collection }}",
+  "brain.query.passages": "{{count}} Passagen",
+  "brain.query.groupedPassages": "aus {{count}} passenden Passagen",
   "graph.stats.nodesEdges": "{{ nodes }} Knoten · {{ edges }} Kanten",
   "nav.schemaLibrary": "Schema-Bibliothek",
   "schemaLib.title": "Schema-Bibliothek",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1080,6 +1080,8 @@
   "brain.query.filterPlaceholder": "{\"tags\": {\"$in\": [\"my-tag\"]}} or {\"name\": {\"$regex\": \"auth\", \"$options\": \"i\"}}",
   "brain.query.projectionPlaceholder": "{\"fact\": 1, \"tags\": 1}",
   "brain.query.resultsFrom": "result(s) from {{ collection }}",
+  "brain.query.passages": "{{count}} passages",
+  "brain.query.groupedPassages": "from {{count}} matching passages",
   "graph.stats.nodesEdges": "{{ nodes }} nodes · {{ edges }} edges",
   "settings.language": "Language",
   "settings.language.en": "English",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1080,6 +1080,8 @@
   "brain.query.filterPlaceholder": "{\"tags\": {\"$in\": [\"moj-tag\"]}} lub {\"name\": {\"$regex\": \"auth\", \"$options\": \"i\"}}",
   "brain.query.projectionPlaceholder": "{\"fact\": 1, \"tags\": 1}",
   "brain.query.resultsFrom": "wynik(i) z {{ collection }}",
+  "brain.query.passages": "{{count}} fragmentów",
+  "brain.query.groupedPassages": "z {{count}} pasujących fragmentów",
   "graph.stats.nodesEdges": "{{ nodes }} węzłów · {{ edges }} krawędzi",
   "settings.language": "Język",
   "settings.language.en": "angielski",

--- a/client/src/app/pages/brain/query-tab.component.ts
+++ b/client/src/app/pages/brain/query-tab.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
+import { groupRecallResults, chunkLabel, passageText } from './recall-grouping';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
@@ -207,17 +208,56 @@ import { BrainStore } from './brain-store.service';
 
               @if (recallResults().length) {
                 <div class="query-results-header" style="margin-top:12px;">
-                  <strong>{{ recallResults().length }}</strong> {{ 'brain.query.resultsCount' | transloco: { count: recallResults().length } }}
+                  <strong>{{ recallGroups().length }}</strong> {{ 'brain.query.resultsCount' | transloco: { count: recallGroups().length } }}
+                  <!-- Grouping makes a topK of 10 look like 6, so the passage count is stated rather than
+                       left for the reader to wonder about. Only shown when grouping actually happened. -->
+                  @if (recallResults().length !== recallGroups().length) {
+                    <span style="font-size:11px; color:var(--text-muted); margin-left:6px;">{{ 'brain.query.groupedPassages' | transloco: { count: recallResults().length } }}</span>
+                  }
                 </div>
-                @for (r of recallResults(); track $index) {
+                @for (g of recallGroups(); track $index) {
                   <div class="query-result-card" style="margin-top:6px;">
-                    <div style="display:flex; gap:8px; margin-bottom:4px; align-items:center;">
-                      <span class="badge badge-purple" style="font-size:10px;">{{ r.type }}</span>
-                      @if (r.score != null) {
-                        <span style="font-size:11px; color:var(--text-muted);">{{ 'common.score' | transloco }}: {{ r.score.toFixed(3) }}</span>
+                    @if (g.file; as f) {
+                      <!-- A grouped document: name the FILE once, then say where inside it matched. -->
+                      <div style="display:flex; gap:8px; margin-bottom:4px; align-items:center; flex-wrap:wrap;">
+                        <span class="badge badge-purple" style="font-size:10px;">file</span>
+                        <strong style="font-size:12px; word-break:break-all;">{{ f.path }}</strong>
+                        @if (g.score != null) {
+                          <span style="font-size:11px; color:var(--text-muted);">{{ 'common.score' | transloco }}: {{ g.score.toFixed(3) }}</span>
+                        }
+                        @if (g.hitCount > 1) {
+                          <span class="badge" style="font-size:10px;">{{ 'brain.query.passages' | transloco: { count: g.hitCount } }}</span>
+                        }
+                      </div>
+                      @if (f.description) {
+                        <div style="font-size:11px; color:var(--text-muted); margin-bottom:4px;">{{ f.description }}</div>
                       }
-                    </div>
-                    <div style="white-space:pre-wrap; word-break:break-all;">{{ formatQueryDoc(r) }}</div>
+                      <ul style="margin:0; padding-left:16px;">
+                        @for (h of g.hits; track $index) {
+                          <li style="margin:2px 0;">
+                            @if (chunkHeading(h); as heading) {
+                              <span style="font-size:11px; color:var(--text-secondary); font-weight:550;">{{ heading }}</span>
+                            }
+                            <!-- The passage's own text, not the raw record: a JSON dump per passage is
+                                 unreadable stacked six deep, and the text is what actually matched.
+                                 Falls back to the record only when a hit carries no text at all. -->
+                            @if (passageOf(h); as text) {
+                              <div style="white-space:pre-wrap; word-break:break-word; font-size:12px;">{{ text }}</div>
+                            } @else {
+                              <div style="white-space:pre-wrap; word-break:break-all;">{{ formatQueryDoc(h) }}</div>
+                            }
+                          </li>
+                        }
+                      </ul>
+                    } @else {
+                      <div style="display:flex; gap:8px; margin-bottom:4px; align-items:center;">
+                        <span class="badge badge-purple" style="font-size:10px;">{{ g.hits[0].type }}</span>
+                        @if (g.score != null) {
+                          <span style="font-size:11px; color:var(--text-muted);">{{ 'common.score' | transloco }}: {{ g.score.toFixed(3) }}</span>
+                        }
+                      </div>
+                      <div style="white-space:pre-wrap; word-break:break-all;">{{ formatQueryDoc(g.hits[0]) }}</div>
+                    }
                   </div>
                 }
               }
@@ -342,6 +382,26 @@ export class QueryTabComponent {
   recallRunning = signal(false);
   recallResults = signal<RecallResult[]>([]);
   recallError = signal('');
+
+  /**
+   * Recall hits with each document's chunk matches collapsed under it (4c-ii).
+   *
+   * A long paper relevant in five places used to return five near-identical rows, pushing everything else
+   * out of view. The server has always sent `parentFileId` + an inlined `parentFile` on chunk hits; nothing
+   * read them until now, so this is presentation only — no API change, and MCP callers still get the flat
+   * list they are built around.
+   */
+  recallGroups = computed(() => groupRecallResults(this.recallResults()));
+
+  /** The heading a passage sits under, when the chunker recorded one. */
+  chunkHeading(r: RecallResult): string | undefined {
+    return chunkLabel(r);
+  }
+
+  /** The passage's own text for display, or undefined when the hit carries none. */
+  passageOf(r: RecallResult): string | undefined {
+    return passageText(r);
+  }
 
   runQuery(): void {
     this.queryFilterError.set('');

--- a/client/src/app/pages/brain/recall-grouping.spec.ts
+++ b/client/src/app/pages/brain/recall-grouping.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Grouping chunk hits under their parent document (4c-ii).
+ *
+ * The arithmetic is small; the judgement is not. What is pinned here is that grouping does not quietly
+ * change what the reader is told: it must not re-rank results the server already ranked, must not lose
+ * hits, and must not present six documents as though six passages matched.
+ */
+import { describe, it, expect } from 'vitest';
+import { groupRecallResults, fileGroupKey, chunkLabel, passageText } from './recall-grouping';
+import type { RecallResult } from '../../core/api.types';
+
+const chunk = (parent: string, id: string, score: number, heading?: string, path = 'papers/study.pdf'): RecallResult =>
+  ({ type: 'file', _id: id, score, parentFileId: parent, parentFile: { path }, ...(heading ? { headingText: heading } : {}) }) as unknown as RecallResult;
+const memory = (id: string, score: number): RecallResult =>
+  ({ type: 'memory', _id: id, score, fact: 'a fact' }) as unknown as RecallResult;
+const wholeFile = (id: string, score: number, path: string): RecallResult =>
+  ({ type: 'file', _id: id, score, path }) as unknown as RecallResult;
+
+describe('recall grouping — chunk hits collapse to their document', () => {
+  it('turns five passages of one paper into one row that says five', () => {
+    const results = [
+      chunk('paper-1', 'c1', 0.94, 'Method'),
+      chunk('paper-1', 'c2', 0.91, 'Results'),
+      chunk('paper-1', 'c3', 0.88),
+      chunk('paper-1', 'c4', 0.86),
+      chunk('paper-1', 'c5', 0.85),
+    ];
+    const groups = groupRecallResults(results);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.hitCount).toBe(5);
+    expect(groups[0]!.file?.path).toBe('papers/study.pdf');
+    expect(groups[0]!.hits).toHaveLength(5);
+  });
+
+  it('keeps unrelated documents apart', () => {
+    const groups = groupRecallResults([chunk('a', 'c1', 0.9), chunk('b', 'c2', 0.8), chunk('a', 'c3', 0.7)]);
+    expect(groups).toHaveLength(2);
+    expect(groups.map(g => g.hitCount)).toEqual([2, 1]);
+  });
+
+  it('leaves non-file results exactly as they were, one group each', () => {
+    // Grouping is a file concern. A memory must not acquire a document header or a passage count.
+    const groups = groupRecallResults([memory('m1', 0.9), memory('m2', 0.8)]);
+    expect(groups).toHaveLength(2);
+    expect(groups.every(g => g.file === undefined && g.hitCount === 1)).toBe(true);
+  });
+
+  it('merges a whole-file hit with that same file\'s chunk hits', () => {
+    // Otherwise the document appears once as itself and again as a set of fragments that look unrelated.
+    const groups = groupRecallResults([
+      wholeFile('paper-1', 0.95, 'papers/study.pdf'),
+      chunk('paper-1', 'c1', 0.9, 'Method'),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.hitCount).toBe(2);
+    expect(groups[0]!.file?.path).toBe('papers/study.pdf');
+  });
+});
+
+describe('recall grouping — it must not change the answer', () => {
+  it('preserves the server ordering rather than re-ranking', () => {
+    // The server has already ranked these. Re-sorting here would make the UI disagree with every other
+    // consumer of the same endpoint, for no reason the reader could see.
+    const groups = groupRecallResults([memory('m1', 0.99), chunk('p', 'c1', 0.5), memory('m2', 0.98)]);
+    expect(groups.map(g => g.hits[0]!['_id'])).toEqual(['m1', 'c1', 'm2']);
+  });
+
+  it('orders a group by its first (best) hit, not its last', () => {
+    const groups = groupRecallResults([memory('m1', 0.9), chunk('p', 'c1', 0.8), chunk('p', 'c2', 0.1)]);
+    expect(groups[1]!.score).toBe(0.8);
+  });
+
+  it('loses nothing — every input hit is still present', () => {
+    const input = [memory('m1', 0.9), chunk('p', 'c1', 0.8), chunk('p', 'c2', 0.7), memory('m2', 0.6)];
+    const flat = groupRecallResults(input).flatMap(g => g.hits);
+    expect(flat).toHaveLength(input.length);
+    expect(flat.map(h => h['_id']).sort()).toEqual(['c1', 'c2', 'm1', 'm2']);
+  });
+
+  it('names the document even when the first hit of a group did not carry the parent', () => {
+    const a = { type: 'file', _id: 'c1', score: 0.9, parentFileId: 'p' } as unknown as RecallResult;
+    const b = chunk('p', 'c2', 0.8, 'Results', 'papers/late.pdf');
+    expect(groupRecallResults([a, b])[0]!.file?.path).toBe('papers/late.pdf');
+  });
+
+  it('falls back to the key rather than rendering an empty document name', () => {
+    const orphan = { type: 'file', _id: 'c1', score: 0.9, parentFileId: 'ghost' } as unknown as RecallResult;
+    expect(groupRecallResults([orphan])[0]!.file?.path).toBe('ghost');
+  });
+});
+
+describe('recall grouping — helpers', () => {
+  it('groups a chunk under its parent and a whole file under itself', () => {
+    expect(fileGroupKey(chunk('paper-1', 'c1', 0.9))).toBe('paper-1');
+    expect(fileGroupKey(wholeFile('f1', 0.9, 'a.pdf'))).toBe('f1');
+  });
+
+  it('does not group anything that is not a file', () => {
+    expect(fileGroupKey(memory('m1', 0.9))).toBeNull();
+  });
+
+  it('surfaces the heading a passage sits under, and nothing when there is none', () => {
+    expect(chunkLabel(chunk('p', 'c1', 0.9, 'Method'))).toBe('Method');
+    expect(chunkLabel(chunk('p', 'c2', 0.9))).toBeUndefined();
+  });
+});
+
+describe('recall grouping — passage text', () => {
+  const hit = (fields: Record<string, unknown>) => ({ type: 'file', _id: 'c1', ...fields }) as unknown as RecallResult;
+
+  it('prefers the chunk content', () => {
+    expect(passageText(hit({ content: 'Mean shoreline retreat was 1.4 metres per year.' })))
+      .toBe('Mean shoreline retreat was 1.4 metres per year.');
+  });
+
+  it('falls back to the embedded text, which is what actually matched', () => {
+    expect(passageText(hit({ matchedText: 'Results Mean shoreline retreat…' }))).toBe('Results Mean shoreline retreat…');
+  });
+
+  it('returns undefined when there is no text, so the caller can fall back instead of rendering nothing', () => {
+    expect(passageText(hit({}))).toBeUndefined();
+    expect(passageText(hit({ content: '   ' }))).toBeUndefined();
+  });
+
+  it('collapses whitespace so a passage does not render as a ragged column', () => {
+    expect(passageText(hit({ content: 'one\n\n  two\t\tthree' }))).toBe('one two three');
+  });
+
+  it('truncates a long passage with an ellipsis rather than flooding the card', () => {
+    const out = passageText(hit({ content: 'x'.repeat(900) }))!;
+    expect(out.length).toBe(400);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});

--- a/client/src/app/pages/brain/recall-grouping.ts
+++ b/client/src/app/pages/brain/recall-grouping.ts
@@ -1,0 +1,150 @@
+/**
+ * Group chunk-level file hits under the document they came from (brain-ux-epic 4c-ii).
+ *
+ * Semantic recall over files matches CHUNKS, not documents — a long paper that is relevant in five places
+ * returns five near-identical rows, which pushes everything else out of the visible list and tells the
+ * reader five times over what they already knew after the first. Grouping restores the thing they are
+ * actually looking for: *which document*, and *where in it*.
+ *
+ * ── Why this lives in the client ────────────────────────────────────────────────────────────────────────
+ *
+ * The server already does the expensive half: every chunk hit arrives carrying `parentFileId` and an
+ * inlined `parentFile {path, description, tags}`, batch-fetched in one query. Nothing in the client had
+ * ever read those fields — the data crossed the wire on every recall and was thrown away. So this is a
+ * presentation concern, and doing it here changes no API shape and does not ripple to MCP callers, who
+ * receive the flat list they are built around.
+ *
+ * ── The count question, answered honestly ───────────────────────────────────────────────────────────────
+ *
+ * Collapsing five rows into one makes a `topK` of ten look like six. The alternative — over-fetching and
+ * collapsing server-side — would change the recall contract for every consumer to fix a display problem.
+ * Instead the group carries `hitCount`, and the UI reports both numbers. A reader who asked for ten and
+ * sees six documents is not being short-changed as long as the six say how many passages they matched;
+ * silently showing six with no explanation is what would mislead.
+ */
+import type { RecallResult } from '../../core/api.types';
+
+/** The file-specific fields the server sends on a recall hit. `RecallResult` is index-signature typed, so
+ *  these are narrowed here rather than being assumed at every use site. */
+interface FileHitFields {
+  _id?: unknown;
+  parentFileId?: unknown;
+  parentFile?: { path?: unknown; description?: unknown; tags?: unknown };
+  headingText?: unknown;
+  path?: unknown;
+}
+
+/** A parent document, when a group represents one. */
+export interface RecallGroupFile {
+  id: string;
+  path: string;
+  description?: string;
+  tags?: string[];
+}
+
+export interface RecallGroup {
+  /** Best score in the group — what the list orders by, so grouping never reorders relative to other hits. */
+  score?: number;
+  /** Set only for a grouped file. Absent for memories, entities, edges, chrono and ungroupable file rows. */
+  file?: RecallGroupFile;
+  /** The underlying hits, best first. Exactly one for a non-file group. */
+  hits: RecallResult[];
+  /** How many passages matched. 1 for everything that is not a grouped document. */
+  hitCount: number;
+}
+
+const str = (v: unknown): string | undefined => (typeof v === 'string' && v.trim() ? v : undefined);
+
+/**
+ * The key a file hit groups under: its parent document when it is a chunk, otherwise itself.
+ *
+ * Returning the file's own id for a NON-chunk hit is deliberate — it means a whole-file match and the
+ * chunk matches from that same file collapse into one group instead of appearing as a document plus some
+ * unrelated-looking fragments.
+ */
+export function fileGroupKey(r: RecallResult): string | null {
+  if (r.type !== 'file') return null;
+  const f = r as unknown as FileHitFields;
+  return str(f.parentFileId) ?? str(f._id) ?? null;
+}
+
+/** The parent document description for a group, from whichever hit carries it. */
+function fileOf(hits: RecallResult[], key: string): RecallGroupFile {
+  for (const h of hits) {
+    const f = h as unknown as FileHitFields;
+    const p = str(f.parentFile?.path);
+    if (p) {
+      return {
+        id: key, path: p,
+        ...(str(f.parentFile?.description) ? { description: str(f.parentFile?.description)! } : {}),
+        ...(Array.isArray(f.parentFile?.tags) ? { tags: f.parentFile?.tags as string[] } : {}),
+      };
+    }
+  }
+  // A non-chunk file hit has no `parentFile` — it IS the file, so its own path is the document's path.
+  for (const h of hits) {
+    const p = str((h as unknown as FileHitFields).path);
+    if (p) return { id: key, path: p };
+  }
+  return { id: key, path: key };
+}
+
+/**
+ * Collapse chunk hits under their parent document, preserving the incoming order.
+ *
+ * Order is by each group's FIRST occurrence, not by re-sorting on score: the server has already ranked the
+ * results, and re-ranking here would quietly disagree with the ordering every other consumer sees.
+ */
+export function groupRecallResults(results: readonly RecallResult[]): RecallGroup[] {
+  const groups: RecallGroup[] = [];
+  const byKey = new Map<string, RecallGroup>();
+
+  for (const r of results) {
+    const key = fileGroupKey(r);
+    if (key === null) {
+      groups.push({ hits: [r], hitCount: 1, ...(r.score != null ? { score: r.score } : {}) });
+      continue;
+    }
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.hits.push(r);
+      existing.hitCount++;
+      continue;
+    }
+    const group: RecallGroup = { hits: [r], hitCount: 1, ...(r.score != null ? { score: r.score } : {}) };
+    byKey.set(key, group);
+    groups.push(group);
+  }
+
+  // The parent is resolved after collection so a group whose FIRST hit lacked `parentFile` can still be
+  // named from a later one.
+  for (const [key, g] of byKey) g.file = fileOf(g.hits, key);
+  return groups;
+}
+
+/** A short label for where in the document a chunk matched — its heading, when the chunker recorded one. */
+export function chunkLabel(r: RecallResult): string | undefined {
+  return str((r as unknown as FileHitFields).headingText);
+}
+
+/** Longest passage rendered inline before it is cut. Long enough to judge relevance, short enough that six
+ *  of them under one document stay scannable. */
+const PASSAGE_MAX = 400;
+
+/**
+ * The matching passage's own text, for display.
+ *
+ * Recall results otherwise render as pretty-printed JSON, which is defensible for a record you are
+ * inspecting and useless for a passage you are reading — and grouping makes it worse, stacking six JSON
+ * blobs under one document. `content` is the chunk's text; `matchedText` is the exact string that was
+ * embedded, which is what actually matched, so it is the better fallback than the raw record.
+ *
+ * Returns undefined when there is no text, so the caller can fall back rather than render an empty block.
+ */
+export function passageText(r: RecallResult): string | undefined {
+  const f = r as unknown as FileHitFields & { content?: unknown; matchedText?: unknown };
+  const text = str(f.content) ?? str(f.matchedText);
+  if (!text) return undefined;
+  const clean = text.replace(/\s+/g, ' ').trim();
+  return clean.length > PASSAGE_MAX ? `${clean.slice(0, PASSAGE_MAX - 1)}…` : clean;
+}

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -192,6 +192,14 @@ Click **Show advanced** for more control:
 - **Tags** — a tag filter applied to results.
 - **Filter** — a JSON object of extra field constraints, validated before the search runs. The recall filter accepts fields such as `status` and `label`, which are applied as native `$vectorSearch` pre-filters (they narrow the candidate set inside the vector index rather than filtering afterwards).
 
+**File results are grouped by document.** Searching over files matches *passages*, not whole documents, so a
+long paper that is relevant in five places would otherwise fill the list with five near-identical rows. Each
+document instead appears once — named, with a badge saying how many passages matched, and each passage listed
+under the heading it sits beneath with its text.
+
+Because several rows collapse into one, the header states both counts: *"1 result from 6 matching passages"*.
+So a **topK** of 10 can legitimately show fewer than ten rows — the passage count tells you nothing was lost.
+
 #### Advanced Query
 
 Runs a structured MongoDB-style query against one collection. Select a collection (`memories`, `entities`, `edges`, `chrono`, or `files`), optionally set a **limit** and **max time (ms)**, enter a filter as JSON, and click **Run**. Results appear below.


### PR DESCRIPTION
brain-ux-epic **4c-ii**, owner-decided 2026-07-25.

Semantic recall over files matches **chunks**, not documents. A paper relevant in five places returned five near-identical rows that pushed everything else out of the visible list — and each row rendered as a pretty-printed **JSON record**, which is defensible for a record you're inspecting and useless for a passage you're reading.

A search now returns **one row per document**: the file named once, a badge for how many passages matched, and each passage under the heading it sits beneath with its actual text.

## Ground truth changed the plan

The tracker warned this might be partly superseded, and suggested the grouping might belong in `recall()`. It doesn't:

- The server **already** sends `parentFileId` and an inlined `parentFile {path, description, tags}` on every chunk hit, batch-fetched in one query.
- A grep of the whole client for `parentFile` / `parentFileId` / `chunkIndex` returned **nothing** — that data has been crossing the wire on every recall and getting discarded.

So this is presentation-side only. **No API change, no MCP ripple** — agents keep the flat list they're built around.

## Decisions worth reviewing

**The count is disclosed, not hidden.** Collapsing rows makes a `topK` of 10 look like 6. The header says *"1 result from 6 matching passages"*. The alternative — over-fetching and collapsing server-side — would change the recall contract for every consumer to fix a display problem.

**A whole-file hit merges with its own chunks** (group key is `parentFileId ?? _id`), so a document doesn't appear once as itself and again as a set of fragments that look unrelated. This came up for real: the test document produced exactly that pair.

**Order is preserved by first occurrence, not re-ranked.** The server has already ranked these; re-sorting here would quietly disagree with every other consumer of the same endpoint, for no reason a reader could see.

**Passage text replaces the JSON dump** for grouped file hits — `content`, falling back to `matchedText` (the string that actually matched), whitespace-collapsed and cut at 400 chars. Other result types keep their existing rendering; this wasn't a licence to redesign the whole results list.

I only noticed the JSON problem *because* of the browser check: grouping alone turned six JSON blobs in six cards into six JSON blobs in one card, which is not obviously an improvement. The screenshot made that plain in a way the passing unit tests did not.

## Verification

Atlas-local stack, a five-section document, query *"shoreline retreat rate along the coast"*:

| | Result |
|---|---|
| Raw hits from the server | **6** — 5 chunks + the whole file, all one document (the exact pathology) |
| Cards rendered | **1** |
| Header | "1 result(s) from 6 matching passages" |
| Card | `study.md` · score 0.935 · **6 passages** |
| Passages | Discussion / Results / Limitations / Method, each as readable text |
| Raw i18n keys | none |
| Layout / console | no overflow, no errors |

Gates: client `tsconfig.app.json` clean · **596/596** client tests (+17: 12 grouping, 5 passage-text) · i18n +2 keys × 3 locales, parity **1557×3**, inserted in place · `lint:docs` clean · no server changes, so no route/audit surface · no new icons.

Docs: userguide — how file results are grouped, and explicitly that a topK of 10 can legitimately show fewer rows, with the passage count as the reassurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)