### PR TITLE
feat(brain): filter the Review queue by record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The Review tab can be filtered by record type.** Now that chrono entries are swept alongside memories
+  and entities, a space's queue genuinely mixes kinds, and "show me only the chrono findings" was not
+  expressible. A single control under the sub-tabs filters **both** of them — the sub-tabs stay *kinds of
+  finding* (Duplicates / Contradictions) and the type is a separate axis, because making it a third and
+  fourth tab would produce a matrix (duplicates×memory, contradictions×chrono, …) that grows badly.
+
+  It offers only the types actually present in the loaded queue, so no choice can return nothing, and it
+  hides itself entirely when everything is one type. When a filter empties the list, the empty state says
+  *"no findings of this type"* rather than "nothing to review" — the queue is not empty, the filter is. It
+  composes with the existing duplicates search box rather than replacing it.
+
+  **The 500-row server cap is now stated** rather than left implicit: both list endpoints return at most 500
+  findings per space with no pagination, so a filter over them can only ever mean "…among the first 500".
+  When the cap is reached the control says so. Filtering a silently truncated list would have looked
+  authoritative while under-reporting.
+
 - **Semantic search groups a document's matching passages under the document, and shows the passages
   instead of raw JSON.** Recall over files matches *chunks*, so a paper relevant in five places returned
   five near-identical rows that pushed everything else out of the visible list — and each row rendered as a

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1555,5 +1555,10 @@
   "review.contradictions.versus": "vs.",
   "review.contradictions.action.edited": "Durch Bearbeitung gelöst",
   "review.contradictions.action.linked": "Als Widerspruch verknüpfen",
-  "review.contradictions.loadError": "Widersprüche konnten nicht geladen werden."
+  "review.contradictions.loadError": "Widersprüche konnten nicht geladen werden.",
+  "review.typeFilter.label": "Datensatztyp",
+  "review.typeFilter.all": "Alle Typen",
+  "review.typeFilter.capped": "Es werden die ersten 500 Funde angezeigt — Filter gelten nur für diese.",
+  "review.typeFilter.noneOfType": "Keine Funde dieses Typs",
+  "review.typeFilter.noneOfTypeBody": "In dieser Liste gibt es Funde, aber keine des gewählten Datensatztyps. Wähle „Alle Typen“, um sie zu sehen."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1555,5 +1555,10 @@
   "review.contradictions.versus": "vs",
   "review.contradictions.action.edited": "Resolved by edit",
   "review.contradictions.action.linked": "Link as contradiction",
-  "review.contradictions.loadError": "Could not load contradictions."
+  "review.contradictions.loadError": "Could not load contradictions.",
+  "review.typeFilter.label": "Record type",
+  "review.typeFilter.all": "All types",
+  "review.typeFilter.capped": "Showing the first 500 findings — filters apply to those only.",
+  "review.typeFilter.noneOfType": "No findings of this type",
+  "review.typeFilter.noneOfTypeBody": "There are findings in this queue, but none of the selected record type. Choose All types to see them."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1555,5 +1555,10 @@
   "review.contradictions.versus": "vs",
   "review.contradictions.action.edited": "Rozwiązane przez edycję",
   "review.contradictions.action.linked": "Połącz jako sprzeczność",
-  "review.contradictions.loadError": "Nie udało się wczytać sprzeczności."
+  "review.contradictions.loadError": "Nie udało się wczytać sprzeczności.",
+  "review.typeFilter.label": "Typ rekordu",
+  "review.typeFilter.all": "Wszystkie typy",
+  "review.typeFilter.capped": "Pokazano pierwsze 500 wyników — filtry dotyczą tylko ich.",
+  "review.typeFilter.noneOfType": "Brak wyników tego typu",
+  "review.typeFilter.noneOfTypeBody": "W tej kolejce są wyniki, ale żaden nie jest wybranego typu rekordu. Wybierz „Wszystkie typy”, aby je zobaczyć."
 }

--- a/client/src/app/pages/brain/review-tab.component.spec.ts
+++ b/client/src/app/pages/brain/review-tab.component.spec.ts
@@ -208,6 +208,95 @@ describe('ReviewTabComponent', () => {
   // Sub-tabs, not a compact toggle: the owner's call was explicitly "not a small toggle that noone finds".
   // The Review tab is the space's record-QA queue and will grow past two views, so it uses the same tab
   // affordance as the rest of the app.
+  // Owner's call: the sub-tabs stay KINDS OF FINDING; record type is a filter INSIDE them. Splitting by
+  // type as well would produce a duplicates×type / contradictions×type matrix that grows badly.
+  describe('record-type filter', () => {
+    const mixed = [rec({ id: 'd1', type: 'entity' }), rec({ id: 'd2', type: 'memory' }), rec({ id: 'd3', type: 'chrono' })];
+
+    it('offers only the types actually present, so no choice can yield nothing', () => {
+      const { c } = setup({ listDuplicates: () => of({ duplicates: mixed }) });
+      expect(c.availableTypes()).toEqual(['chrono', 'entity', 'memory']);
+    });
+
+    it('hides the control entirely when everything is one type', () => {
+      // A filter with a single real option is noise on a queue that is already one kind of thing.
+      const { f, c } = setup({ listDuplicates: () => of({ duplicates: [rec({ type: 'entity' }), rec({ id: 'd2', type: 'entity' })] }) });
+      expect(c.availableTypes().length).toBe(1);
+      expect((f.nativeElement as HTMLElement).querySelector('#review-type-filter')).toBeNull();
+    });
+
+    it('keeps the control visible whenever a filter is applied, even where the type is absent', () => {
+      // The signal is shared across sub-tabs. Filtering Duplicates to `memory` and switching to a
+      // Contradictions queue with no memory findings must not hide the control while it is still
+      // constraining the list — that leaves an empty view with no way to clear it.
+      const { f, c } = setup({ listDuplicates: () => of({ duplicates: [rec({ type: 'entity' })] }) });
+      expect((f.nativeElement as HTMLElement).querySelector('#review-type-filter')).toBeNull();
+      c.typeFilter.set('memory');
+      f.detectChanges();
+      expect(c.showTypeFilter()).toBe(true);
+      expect((f.nativeElement as HTMLElement).querySelector('#review-type-filter')).not.toBeNull();
+    });
+
+    it('offers the active filter as an option even when this tab has none of that type', () => {
+      // Otherwise the <select> holds a value with no matching <option> and renders blank — looking unset
+      // while still filtering.
+      const { c } = setup({ listDuplicates: () => of({ duplicates: [rec({ type: 'entity' })] }) });
+      c.typeFilter.set('memory');
+      expect(c.typeOptions()).toContain('memory');
+    });
+
+    it('narrows the duplicate list to the chosen type', () => {
+      const { c } = setup({ listDuplicates: () => of({ duplicates: mixed }) });
+      expect(c.filteredRows().length).toBe(3);
+      c.typeFilter.set('memory');
+      expect(c.filteredRows().map(r => r.id)).toEqual(['d2']);
+    });
+
+    it('applies to contradictions too, from the same control', () => {
+      // One shared signal: "I am looking at chrono findings" should survive a tab switch rather than
+      // meaning something different on each side.
+      const { c } = setup({}, true, { listContradictions: () => of({ contradictions: [
+        { id: 'c1', type: 'memory' }, { id: 'c2', type: 'chrono' },
+      ] }) });
+      c.typeFilter.set('chrono');
+      expect(c.conFilteredRows().map((r: { id: string }) => r.id)).toEqual(['c2']);
+    });
+
+    it('combines with the search box rather than replacing it', () => {
+      const { c } = setup({ listDuplicates: () => of({ duplicates: [
+        rec({ id: 'd1', type: 'memory', aSummary: 'kafka broker' }),
+        rec({ id: 'd2', type: 'memory', aSummary: 'postgres tuning' }),
+        rec({ id: 'd3', type: 'entity', aSummary: 'kafka broker' }),
+      ] }) });
+      c.typeFilter.set('memory');
+      c.query.set('kafka');
+      expect(c.filteredRows().map(r => r.id)).toEqual(['d1']);
+    });
+
+    it('says the queue is not empty when only the FILTER is', () => {
+      // "Nothing to review" would be a lie — there are findings, just not of this type.
+      const { f, c } = setup({ listDuplicates: () => of({ duplicates: mixed }) });
+      c.typeFilter.set('memory');
+      c.query.set('nothing-matches-this');
+      f.detectChanges();
+      expect(c.filteredRows().length).toBe(0);
+      expect(c.rows().length).toBeGreaterThan(0);
+    });
+
+    it('warns that filters only cover the first 500 when the server cap was hit', () => {
+      // Both list endpoints cap at 500 per space with no pagination. A filter over a truncated set would
+      // imply completeness it cannot have.
+      const many = Array.from({ length: 500 }, (_, i) => rec({ id: `d${i}`, type: i % 2 ? 'memory' : 'entity' }));
+      const { c } = setup({ listDuplicates: () => of({ duplicates: many }) });
+      expect(c.listCapped()).toBe(true);
+    });
+
+    it('does not warn when the list is comfortably under the cap', () => {
+      const { c } = setup({ listDuplicates: () => of({ duplicates: mixed }) });
+      expect(c.listCapped()).toBe(false);
+    });
+  });
+
   describe('sub-tabs', () => {
     it('offers Duplicates and Contradictions as real tabs, Duplicates first', () => {
       const { f } = setup();

--- a/client/src/app/pages/brain/review-tab.component.ts
+++ b/client/src/app/pages/brain/review-tab.component.ts
@@ -52,6 +52,14 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 
     .dup-actions { display: flex; gap: 8px; justify-content: flex-end; align-items: center; }
     .dup-resolved { font-size: 12px; color: var(--success); text-align: right; }
+
+    /* Record-type filter — sits under the sub-tabs because it applies to whichever one is open. */
+    .type-filter { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 12px 0 0; font-size: 13px; }
+    .type-filter label { color: var(--text-muted); font-size: 12px; }
+    /* width/flex are explicit: a global full-width rule on select otherwise stretches this across the
+       whole page and pushes the label onto its own line. */
+    .type-filter select { font-size: 13px; padding: 4px 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-primary); color: var(--text-primary); width: auto; min-width: 140px; flex: 0 0 auto; }
+    .cap-note { font-size: 11px; color: var(--warning); }
   `],
   template: `
     <h2 class="page-title">{{ 'review.title' | transloco }}</h2>
@@ -70,20 +78,48 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
       }
     </nav>
 
+    <!-- Record-TYPE filter, shared by both sub-tabs. The tabs are kinds of finding; this is the record
+         type. Keeping them as separate axes is what avoids a duplicates×type / contradictions×type matrix.
+         Only shown when the loaded rows actually span more than one type — a control with one real choice
+         is noise. -->
+    @if (showTypeFilter()) {
+      <div class="type-filter">
+        <label [attr.for]="'review-type-filter'">{{ 'review.typeFilter.label' | transloco }}</label>
+        <select id="review-type-filter" [ngModel]="typeFilter()" (ngModelChange)="typeFilter.set($event)"
+          [attr.aria-label]="'review.typeFilter.label' | transloco">
+          <option value="all">{{ 'review.typeFilter.all' | transloco }}</option>
+          @for (t of typeOptions(); track t) {
+            <option [value]="t">{{ t }}</option>
+          }
+        </select>
+        <!-- The lists are capped server-side with no pagination, so a filter over them can only ever mean
+             "…among the first 500". Saying so beats letting the filter imply completeness. -->
+        @if (listCapped()) {
+          <span class="cap-note">{{ 'review.typeFilter.capped' | transloco }}</span>
+        }
+      </div>
+    }
+
     @if (sub() === 'contradictions') {
       <section role="tabpanel" id="review-panel-contradictions" aria-labelledby="review-tab-contradictions">
         <p class="intro">{{ 'review.contradictions.intro' | transloco }}</p>
         @if (conLoading()) {
           <div class="loading-overlay"><span class="spinner"></span></div>
-        } @else if (conRows().length === 0) {
+        } @else if (conFilteredRows().length === 0) {
           <div class="empty-state">
             <div class="empty-state-icon"><ph-icon name="warning" [size]="48"/></div>
-            <h3>{{ 'review.contradictions.pendingTitle' | transloco }}</h3>
-            <p>{{ 'review.contradictions.pendingBody' | transloco }}</p>
+            @if (typeFilter() !== 'all' && conRows().length) {
+              <!-- Distinct from "nothing to review": the queue is not empty, this filter is. -->
+              <h3>{{ 'review.typeFilter.noneOfType' | transloco }}</h3>
+              <p>{{ 'review.typeFilter.noneOfTypeBody' | transloco }}</p>
+            } @else {
+              <h3>{{ 'review.contradictions.pendingTitle' | transloco }}</h3>
+              <p>{{ 'review.contradictions.pendingBody' | transloco }}</p>
+            }
           </div>
         } @else {
           <div class="dup-grid">
-            @for (c of conRows(); track c.id) {
+            @for (c of conFilteredRows(); track c.id) {
               <div class="dup-card">
                 <div class="dup-card-h">
                   <span class="dup-type">{{ c.type }}</span>
@@ -186,6 +222,10 @@ import { ConfirmDialogService } from '../../core/confirm-dialog.service';
         @if (query().trim() && rows().length) {
           <h3>{{ 'duplicates.noMatches.title' | transloco }}</h3>
           <p>{{ 'duplicates.noMatches.body' | transloco }}</p>
+        } @else if (typeFilter() !== 'all' && rows().length) {
+          <!-- The queue is not empty, this filter is — a distinction "nothing to review" would hide. -->
+          <h3>{{ 'review.typeFilter.noneOfType' | transloco }}</h3>
+          <p>{{ 'review.typeFilter.noneOfTypeBody' | transloco }}</p>
         } @else {
           <h3>{{ 'duplicates.empty.title' | transloco }}</h3>
           <p>{{ 'duplicates.empty.body' | transloco }}</p>
@@ -311,14 +351,79 @@ export class ReviewTabComponent implements OnInit, OnChanges {
   /** Free-text filter over the loaded list — a dismissed pile can grow large, so it is searchable. */
   query = signal('');
 
+  /**
+   * Record-type filter, shared by BOTH sub-tabs.
+   *
+   * The sub-tabs are kinds of FINDING (duplicates vs contradictions); this is the record TYPE. They are
+   * orthogonal, which is exactly why type is not a third and fourth tab — that would produce a matrix
+   * (duplicates×memory, contradictions×chrono, …) that grows badly. Sharing one signal across both panels
+   * means "I am looking at chrono findings" survives a tab switch, rather than the filter silently meaning
+   * something different on each side.
+   */
+  typeFilter = signal<string>('all');
+
+  /**
+   * The types actually present in the current sub-tab's loaded rows, so the control never offers a choice
+   * that can only ever yield nothing. Derived from the UNFILTERED rows — deriving from the filtered list
+   * would make every other option vanish the moment one was picked.
+   */
+  availableTypes = computed<string[]>(() => {
+    const list: Array<{ type: string }> = this.sub() === 'contradictions' ? this.conRows() : this.rows();
+    return [...new Set(list.map(r => r.type))].sort();
+  });
+
+  /**
+   * Whether to render the control.
+   *
+   * Normally hidden when the queue is all one type — a filter with a single real choice is noise. But it
+   * MUST stay visible whenever a filter is actually applied, even if this tab has one type or none: the
+   * signal is shared across both sub-tabs, so filtering Duplicates to `memory` and switching to
+   * Contradictions would otherwise hide the control while it was still constraining the list, leaving an
+   * empty view and no way to clear it. Never hide a control that is currently narrowing what is on screen.
+   */
+  showTypeFilter = computed(() => this.availableTypes().length > 1 || this.typeFilter() !== 'all');
+
+  /**
+   * The options to render: the types present here, plus the active filter if this tab has none of them.
+   *
+   * Without that union the `<select>` would hold a value with no matching `<option>` after a tab switch and
+   * render blank — the control would look unset while still filtering the list.
+   */
+  typeOptions = computed<string[]>(() => {
+    const types = this.availableTypes();
+    const active = this.typeFilter();
+    return active !== 'all' && !types.includes(active) ? [...types, active].sort() : types;
+  });
+
   /** The list actually shown: the loaded rows narrowed by the search box (summaries, type, space). */
   filteredRows = computed<DuplicateRecord[]>(() => {
     const q = this.query().trim().toLowerCase();
-    const list = this.rows();
+    const type = this.typeFilter();
+    let list = this.rows();
+    if (type !== 'all') list = list.filter(r => r.type === type);
     if (!q) return list;
     return list.filter(r =>
       `${r.aSummary} ${r.bSummary} ${r.type} ${r.spaceId}`.toLowerCase().includes(q));
   });
+
+  /** Contradictions narrowed by the same type filter. No search box on this side yet. */
+  conFilteredRows = computed<ContradictionRecord[]>(() => {
+    const type = this.typeFilter();
+    const list = this.conRows();
+    return type === 'all' ? list : list.filter(r => r.type === type);
+  });
+
+  /**
+   * True when the server's per-space cap was reached, so the list on screen is not the whole story.
+   *
+   * Both list endpoints return a capped set (500 per space) with no pagination. Filtering a truncated set
+   * client-side would quietly under-report while looking authoritative — the filter would imply "these are
+   * all the chrono findings" when it can only mean "these are the chrono findings among the first 500".
+   * Say so rather than adding pagination as a side quest.
+   */
+  private static readonly SERVER_CAP = 500;
+  listCapped = computed(() =>
+    (this.sub() === 'contradictions' ? this.conRows() : this.rows()).length >= ReviewTabComponent.SERVER_CAP);
 
   /** Operator-first rollup atop the list: how many still need attention + how strong the matches are. */
   summaryItems = computed<SummaryItem[]>(() => {

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -861,6 +861,15 @@ disagreement worth your attention. The **dates** are deliberately left out: two 
 repeating event ("Team sync", every Monday) would otherwise be reported as contradicting each other every
 single week, which is the fastest way to make a review queue not worth reading.
 
+**Filtering by record type:** a **Record type** dropdown under the sub-tabs narrows *both* views to one kind
+of record — handy once a space's queue mixes memories, entities and chrono entries. It lists only the types
+actually present, and disappears when everything is the same type. If a filter empties the list, the page
+says *no findings of this type* rather than pretending the queue is clear.
+
+Both lists return at most **500 findings per space**. When that cap is reached the filter says so, because a
+filter applied to a capped list can only mean "among the first 500" — clear the filter or resolve some
+findings to see the rest.
+
 **Duplicates** surfaces near-duplicate records found by the background semantic-duplicate scanner, **for that space**. It used to be a global page at Settings → Duplicates; a duplicate pair only ever means something *inside* one space, so it now lives beside that space's data. (The old `/settings/duplicates` link still works — it redirects to the Brain.)
 
 A summary row at the top shows how many pairs are **open**, the **average match confidence**, and how many are **shown**, alongside a **search box**, a status filter (**open / dismissed / all**) and a **Scan now** button. The search box narrows the list by record summary, type, or space — handy once a **dismissed** pile has grown. Each duplicate pair is a **comparison card**: the space and record type, a **confidence meter** (the similarity as a coloured percentage), when it was detected, and record **A** shown side-by-side with record **B**. For an entity pair you can **Merge** the two records (the older one is kept); any open pair can be **Dismiss**ed — dismissing asks for confirmation first, since it removes the pair from the open list.


### PR DESCRIPTION
`_TODO-ORDERED.md` §2 (f). Chrono entries are swept alongside memories and entities now (#459), so a space's review queue genuinely mixes kinds — and *"show me only the chrono findings"* wasn't expressible.

**Owner's call, honoured:** the sub-tabs stay **kinds of finding** (Duplicates / Contradictions); record type is a filter **inside** them. Type as a third and fourth tab would produce a matrix — duplicates×memory, contradictions×chrono, … — that grows badly. One control under the tabs filters both, because finding-kind and record-type are orthogonal axes and *"I'm looking at chrono findings"* should survive a tab switch.

## Behaviour, each with a test

- Offers **only the types actually present**, so no choice can return nothing.
- **Hides when the queue is all one type** — a filter with one real option is noise.
- **…but stays visible whenever a filter is applied**, even where this tab has none of that type. The signal is shared, so hiding it after a tab switch would leave an empty list constrained by a control no longer on screen, with no way to clear it. The active value is also injected into the options, or the `<select>` renders blank while still filtering.
- When a filter empties the list, the empty state says **"no findings of this type"**, not "nothing to review" — the queue isn't empty, the filter is.
- **Composes with** the existing duplicates search box rather than replacing it.

## The cap is now stated

Both list endpoints return at most **500 findings per space with no pagination** — they're capped full sets, not pages. A filter over that can only mean *"among the first 500"*, so the control says so when the cap is hit. Filtering a silently truncated list would have looked authoritative while under-reporting — the same shape as the empty Status column (#460) and the contradiction queue that had never actually judged anything (#459).

That capped-set property is also why filtering is **client-side**: the candidates already carry `type`, and filtering a complete set is honest, whereas filtering one page of a paginated list would misrepresent the rest. Same reasoning as the Files tab sorting client-side in #443. **No API change.**

## Verification

Browser, scratch instance, seeded queue of 4 findings across 3 types:

| Step | Result |
|---|---|
| Options offered | All types / chrono / entity / memory |
| Unfiltered | 4 cards |
| → chrono | 2 cards, only `chrono` rendered |
| → memory | 1 card |
| Switch to Contradictions | filter still shown and clearable |
| Raw i18n keys / console | none / none |

**The browser check caught two things the unit tests didn't:** the hidden-while-active trap above, and a global full-width `select` rule stretching the control across the entire page and pushing its label onto its own line.

It also caught a third, on me: I put backticks inside a CSS comment, which terminates the Angular inline-styles template string. The error points at `@Component`, never at the comment — a trap this repo has hit before. Reworded.

Gates: client `tsconfig.app.json` clean · **606/606** client tests (+9) · i18n +5 keys × 3 locales, parity **1562×3**, inserted in place · `lint:docs` clean · icon-registry passes · no server changes, so no route/audit surface.

Both filter paths proven to fail without the fix: disabling the type narrowing fails "narrows the duplicate list" and "combines with the search box".

Docs: userguide — the filter, that it lists only present types, the "no findings of this type" state, and the 500-per-space cap with what to do about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)