### PR TITLE
fix(brain): actually schedule the contradiction sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1737,6 +1737,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The contradiction sweep was never scheduled — it only ever ran if an admin triggered it by hand.**
+  `runContradictionScanAllSpaces` was written, exported and tested, and **nothing called it**: the boot
+  sequence started the duplicate scanner, the backup scheduler and the TTL sweep, with no contradiction
+  equivalent. So on any instance where nobody had manually hit `POST /api/contradictions/scan`, the Review
+  tab's Contradictions view was permanently empty — indistinguishable from a space with nothing to review.
+  It now has its own scheduler (`contradictionScanner: { enabled, schedule }`, **off by default**, 03:30
+  daily when switched on), deliberately separate from `dupeScanner` so that enabling duplicate detection
+  does not silently start paying for NLI inference and egressing record text. An invalid cron is refused at
+  boot with a warning, and a scheduled run that parks because the judge was unreachable now says it did
+  **not** clear the queue — the two-cursor design exists precisely so an outage cannot look like a clean
+  review list.
+
+  A new `scheduler-wiring` test asserts every background scheduler's `start*` export is actually **called**
+  in the boot sequence (and paired with a `stop*`), because nothing else can detect a function that is
+  simply never reached: the code compiles, its own unit tests pass, and the resulting empty queue looks
+  exactly like a healthy one.
+
 - **A `faces` processing stage displayed as a generic "working" despite being translated in all three
   locales.** The progress bar maps a stage to its `mediaProcessing.step.*` label only if the stage is in its
   known-stages set, and falls back to "working" otherwise — correct for a genuinely unknown stage, but

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5695,6 +5695,24 @@ judgement call — so `resolve` records the outcome (`edited`: a record was corr
 **`nliStalled`** is surfaced rather than swallowed: a sweep that stopped because the NLI judge was
 unreachable has *not* cleared the space, and that must be distinguishable from a genuinely clean result.
 
+**Scheduling the sweep.** Off by default, and **its own switch** — enabling the duplicate scanner must not
+silently start paying for model inference, since the NLI pass is a call per candidate pair and, with an
+external endpoint, sends record text off the instance:
+
+```jsonc
+{
+  "contradictionScanner": {
+    "enabled": true,
+    "schedule": "30 3 * * *"   // cron — 03:30 daily (default), half an hour after the dupe sweep
+  }
+}
+```
+
+Until it is enabled, contradictions are found **only** when an admin runs `POST /api/contradictions/scan`
+by hand — so the Review tab's Contradictions view stays empty on an instance nobody has scanned manually.
+An invalid cron expression is refused at boot with a warning rather than silently ignored, and a scheduled
+run that parks because the judge was unreachable logs that it did **not** clear the queue.
+
 **What the sweep covers.** Memories, entities and **chrono** entries. For a chrono pair the structured pass
 compares the stored `status` as well as `properties` — the dates are deliberately not compared, for the
 reason given under [Duplicate Detection on Insert](#what-counts-as-a-claim). Edges are excluded until edge

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -57,6 +57,12 @@ export async function startConfiguredInstanceServices(): Promise<void> {
   startBackupScheduler();
   const { startDupeScanner } = await import('./brain/dupe-scanner.js');
   startDupeScanner();
+  // Its own scheduler, not a rider on the dupe sweep: the contradiction pass may call an NLI model per
+  // pair, so it has to be opted into separately. Without this the sweep only ever ran when an admin hit
+  // POST /api/contradictions/scan by hand, which left the Review tab's Contradictions view permanently
+  // empty on any instance nobody had poked manually.
+  const { startContradictionScanner } = await import('./brain/contradiction-scanner.js');
+  startContradictionScanner();
   const { startTtlSweep } = await import('./brain/ttl-sweep.js');
   startTtlSweep();
 

--- a/server/src/brain/contradiction-scanner.ts
+++ b/server/src/brain/contradiction-scanner.ts
@@ -29,6 +29,7 @@
  * same answer — so the NLI cursor moves past it. That is the whole reason `Verdict` distinguishes
  * `low-confidence` from `judge-unavailable`.
  */
+import { schedule, validate, type ScheduledTask } from 'node-cron';
 import { col, asFilter, asUpdate, isVectorSearchAvailable } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
@@ -219,11 +220,55 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
   return { scanned, found, nliStalled };
 }
 
-/** Scan every real (non-proxy) space once, incrementally. */
+/**
+ * Scan every real (non-proxy) space once, incrementally.
+ *
+ * Reports what it did rather than running silently: a sweep that parked because the judge was unreachable
+ * has NOT cleared anything, and that has to be distinguishable in the logs from a sweep that found nothing.
+ * The whole two-cursor design exists to stop an outage looking like a clean queue; swallowing it here would
+ * put the blind spot straight back.
+ */
 export async function runContradictionScanAllSpaces(): Promise<void> {
+  let scanned = 0;
+  let found = 0;
+  let stalled = false;
   for (const s of getConfig().spaces) {
     if (s.proxyFor) continue;
-    try { await scanSpace(s.id); }
-    catch (err) { log.warn(`Contradiction scan failed for ${s.id}: ${err instanceof Error ? err.message : String(err)}`); }
+    try {
+      const r = await scanSpace(s.id);
+      scanned += r.scanned; found += r.found; stalled ||= r.nliStalled;
+    } catch (err) { log.warn(`Contradiction scan failed for ${s.id}: ${err instanceof Error ? err.message : String(err)}`); }
   }
+  if (scanned > 0) log.info(`Contradiction scan: scanned ${scanned}, found ${found}`);
+  if (stalled) log.warn('Contradiction scan: the NLI judge was unavailable — its cursor is parked and will resume where it stopped. This sweep did NOT clear the queue.');
+}
+
+// ── Scheduler (node-cron, mirrors the duplicate scanner) ─────────────────────
+//
+// Off by default and deliberately its own switch: the NLI pass is a model call per candidate pair and,
+// with an external endpoint, egresses record text. Enabling duplicate detection must not silently start
+// paying for inference. The default time sits half an hour after the dupe sweep so the two do not contend
+// for the same vector-search capacity on a small instance.
+
+const DEFAULT_SCHEDULE = '30 3 * * *';
+let _task: ScheduledTask | null = null;
+
+export function startContradictionScanner(): void {
+  stopContradictionScanner();
+  const cs = getConfig().contradictionScanner;
+  if (!cs?.enabled) return;
+  const cron = cs.schedule ?? DEFAULT_SCHEDULE;
+  if (!validate(cron)) {
+    log.warn(`Invalid contradictionScanner.schedule '${cron}' — contradiction scanner not started`);
+    return;
+  }
+  _task = schedule(cron, () => {
+    runContradictionScanAllSpaces().catch(err => log.error(`Scheduled contradiction scan error: ${err}`));
+  });
+  log.info(`Contradiction scanner scheduled (${cron})`);
+}
+
+export function stopContradictionScanner(): void {
+  _task?.stop();
+  _task = null;
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -823,8 +823,27 @@ export interface DupeScannerConfig {
   batchSize?: number;
   /** Max records scanned per space per run (bounds resource use; the rest is picked up next run). Default: 5000. */
   maxPerRun?: number;
-  /** Knowledge types to scan. Default: ['memory', 'entity']. */
+  /** Knowledge types to scan. Default: ['memory', 'entity', 'chrono']. */
   types?: DupeScanType[];
+}
+
+/**
+ * Background contradiction scanner (F-REVIEW).
+ *
+ * Separate from `dupeScanner` rather than a flag on it, because the two answer different questions and
+ * cost differently: a duplicate is a cosine score that always answers and costs nothing, while a
+ * contradiction may need an entailment (NLI) model — a call per candidate pair, and with an external
+ * endpoint that means record text leaving the instance. Sharing one switch would make enabling duplicate
+ * detection silently start paying for model inference.
+ *
+ * **Off by default**, like the duplicate scanner. Until it is enabled, contradictions are only found when
+ * an admin runs `POST /api/contradictions/scan` by hand.
+ */
+export interface ContradictionScannerConfig {
+  /** Master switch. Default: false. */
+  enabled?: boolean;
+  /** Cron schedule for the sweep. Default: '30 3 * * *' (03:30 daily). */
+  schedule?: string;
 }
 
 /**
@@ -973,6 +992,8 @@ export interface Config {
   audit?: AuditConfig;
   /** Optional background semantic-duplicate scanner. Off by default. */
   dupeScanner?: DupeScannerConfig;
+  /** Optional background contradiction scanner. Off by default. */
+  contradictionScanner?: ContradictionScannerConfig;
   /**
    * Allow sync peers to live on private/reserved addresses (RFC-1918, CGNAT,
    * IPv6 ULA) — for same-host or LAN deployments. Default false (public peers

--- a/testing/standalone/scheduler-wiring.test.js
+++ b/testing/standalone/scheduler-wiring.test.js
@@ -1,0 +1,69 @@
+/**
+ * Every background scheduler is actually started.
+ *
+ * This exists because one was not. `runContradictionScanAllSpaces` was written, exported, tested and
+ * shipped — and nothing ever called it. `bootstrap.ts` started the duplicate scanner, the backup scheduler
+ * and the TTL sweep, with no contradiction equivalent, so contradictions were only ever found when an admin
+ * hit `POST /api/contradictions/scan` by hand. On any instance nobody had poked manually, the Review tab's
+ * Contradictions view was permanently empty and the whole feature was inert.
+ *
+ * Nothing catches that. The code compiles, the unit tests pass, the endpoint works when called, and the
+ * empty queue is indistinguishable from a clean one — which is the same failure shape as the sweep that
+ * wrote every finding to `"undefined:undefined"` and the file listing that silently joined no metadata.
+ *
+ * So the check is structural: for each module that owns a scheduler, assert its `start*` export is named in
+ * `bootstrap.ts`. Source-scanning rather than behavioural on purpose — the bug is *absence of a call*, and
+ * no amount of testing the function itself can detect that the function is never reached.
+ *
+ * Run: node --test testing/standalone/scheduler-wiring.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+/** Modules that own a background scheduler, and the export bootstrap must call. */
+const SCHEDULERS = [
+  { module: 'server/src/brain/dupe-scanner.ts', start: 'startDupeScanner' },
+  { module: 'server/src/brain/contradiction-scanner.ts', start: 'startContradictionScanner' },
+  { module: 'server/src/brain/ttl-sweep.ts', start: 'startTtlSweep' },
+  { module: 'server/src/db/backup-scheduler.ts', start: 'startBackupScheduler' },
+];
+
+const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8');
+
+/**
+ * Source with comments removed.
+ *
+ * Required, not tidiness: a commented-out `// startContradictionScanner();` matches a naive search for the
+ * call just as well as a real one, so the guard would pass on precisely the change it exists to catch.
+ * (Found by trying it.)
+ */
+const code = (rel) => read(rel).replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('scheduler wiring — a scheduler nobody starts is dead code that looks alive', () => {
+  let bootstrap;
+  before(() => { bootstrap = code('server/src/bootstrap.ts'); });
+
+  for (const { module, start } of SCHEDULERS) {
+    it(`${start} is exported by its module`, () => {
+      assert.match(read(module), new RegExp(`export function ${start}\\b`),
+        `${module} should export ${start}`);
+    });
+
+    it(`${start} is CALLED in bootstrap`, () => {
+      // The import alone is not enough — an unused import is exactly as dead as no import.
+      assert.match(bootstrap, new RegExp(`${start}\\s*\\(`),
+        `bootstrap.ts imports-but-never-calls or omits ${start}; the sweep would never run`);
+    });
+  }
+
+  it('pairs every start with a stop, so a config reload can restart it cleanly', () => {
+    // Each scheduler holds a module-level task handle. Without a stop, a reload leaks the old cron task and
+    // the sweep quietly runs twice per tick.
+    for (const { module, start } of SCHEDULERS) {
+      const stop = start.replace(/^start/, 'stop');
+      assert.match(read(module), new RegExp(`export function ${stop}\\b`),
+        `${module} should export ${stop} alongside ${start}`);
+    }
+  });
+});


### PR DESCRIPTION
**`runContradictionScanAllSpaces` was written, exported, tested and shipped — and nothing ever called it.**

The boot sequence started the duplicate scanner, the backup scheduler and the TTL sweep. There was no contradiction equivalent. So contradictions were found *only* when an admin hit `POST /api/contradictions/scan` by hand, and on any instance nobody had poked manually the Review tab's Contradictions view was permanently empty — **indistinguishable from a space with nothing to review.** The entire F-REVIEW stack built across #449–#459 was inert by default.

Nothing catches this. The code compiles, its unit tests pass, the endpoint works when called, and an empty queue looks exactly like a clean one. It's the same failure shape as two other bugs found this session: the sweep writing every finding to `"undefined:undefined"` (#459) and the file listing silently joining no metadata (#460). All three looked fine and quietly did nothing.

## What ships

- **`contradictionScanner: { enabled, schedule }`** — off by default, 03:30 daily when enabled (half an hour after the dupe sweep, so the two don't contend for vector-search capacity on a small instance).
- **Its own switch, not a flag on `dupeScanner`.** The NLI pass is a model call per candidate pair and, with an external endpoint, egresses record text. Enabling duplicate detection must not silently start paying for inference — so the two stay separately opt-in.
- **Invalid cron refused at boot** with a warning, mirroring the dupe scanner, rather than silently not running.
- **The sweep now reports what it did**, and says explicitly when a run parked because the judge was unreachable: that run did **not** clear the queue. Swallowing it would reintroduce the exact blind spot the NLI pass keeps a separate cursor to prevent.

## The test that would have caught it

New `scheduler-wiring` test: for every module owning a scheduler, assert its `start*` export is actually **called** in bootstrap, and paired with a `stop*`.

It's source-scanning on purpose. The bug is the *absence of a call* — no amount of testing the function can detect that the function is never reached.

Writing it caught a flaw in itself: a naive search matches a **commented-out** call just as well as a real one, so the guard would have passed on precisely the change it exists to catch. It strips comments first now. Proven by commenting the call out (8 pass / 1 fail) and restoring it (9/9).

## Verification

Real boot, three paths:

| Config | Log |
|---|---|
| unconfigured | *(silent — off by default)* |
| `{enabled: true, schedule: "15 4 * * *"}` | `Contradiction scanner scheduled (15 4 * * *)` |
| `{enabled: true, schedule: "not a cron"}` | `Invalid contradictionScanner.schedule 'not a cron' — contradiction scanner not started` |

Gates: server `tsc` clean · 37/37 on the affected standalone suites · `lint:docs` clean · no route changes, so no audit/route-guard surface · no client changes.

The `config-loader` suite fails locally with `ECONNREFUSED 127.0.0.1:3200` — it needs the running stack, and I baselined it against `main` earlier in this session with identical failures.

Also fixed a stale doc comment: `dupeScanner.types` has defaulted to `['memory','entity','chrono']` since #459.

Docs: integration-guide — the config block, that contradictions are otherwise manual-only, and the parked-run behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)