### PR TITLE
feat(brain): make the contradiction sweep's limits configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1737,6 +1737,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The contradiction sweep's limits are now configurable instead of hard-coded**, and the similarity floor
+  is documented on the right scale. `structuredThreshold`, `nliThreshold`, `maxJudgedPairsPerRun`,
+  `batchSize` and `maxPerRun` were all fixed constants; only `dupeScanner` had equivalents.
+
+  **The thresholds are not raw cosine** — `$vectorSearch` normalises cosine to `(1 + cos) / 2`, so 0.92
+  means cosine ≈ 0.84, and a plausible-looking 0.70 would mean cosine 0.40, where a great deal of
+  barely-related text sits. Reading them as cosine sets them roughly twice as loose as intended, so the
+  docs and the code now say so explicitly.
+
+  **The defaults are unchanged.** Lowering the floor is attractive in principle — 0.92 asks "are these the
+  same record?" rather than "do these disagree?" — but two deliberately-constructed contradicting pairs
+  still scored 0.9479 and 0.9259, because records sharing a subject embed close together even when their
+  descriptions diverge. With no reproducible miss, changing behaviour for every instance was not warranted;
+  the knob is.
+
+  The model pass gets its own floor, and its defaults key on **where the judge runs** rather than on the
+  fact that it is a model at all. The judge is an MNLI *encoder* — one forward pass, three labels, no
+  generation — so a loopback sidecar is not expensive and now gets the same wide floor as the free
+  deterministic pass, with no pair cap. A **remote** endpoint keeps the strict floor and a per-run budget
+  (2000 judged pairs), because every remote judgement is record text leaving the instance and that cost
+  does not shrink with faster hardware. All of it is configurable — `structuredThreshold`, `nliThreshold`,
+  `maxJudgedPairsPerRun`, `batchSize`, `maxPerRun` — where previously all five were hard-coded constants.
+  The defaults are reasoned, not benchmarked: no NLI sidecar ships with the stack, so there was nothing to
+  time against, which is exactly why they are all overridable.
+
+  Hitting the pair budget is an **orderly** stop, deliberately unlike a stall: the pairs it judged are
+  settled and the cursor advances past them, so the next run resumes rather than re-judging (and re-paying
+  for) the same work. Only an unavailable judge parks the cursor. `POST /api/contradictions/scan` now
+  reports `judgedPairs` and distinguishes `budgetExhausted` from `nliStalled`, since one means "settled as
+  far as it got" and the other means "settled nothing".
+
 - **The contradiction sweep was never scheduled — it only ever ran if an admin triggered it by hand.**
   `runContradictionScanAllSpaces` was written, exported and tested, and **nothing called it**: the boot
   sequence started the duplicate scanner, the backup scheduler and the TTL sweep, with no contradiction

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5703,10 +5703,41 @@ external endpoint, sends record text off the instance:
 {
   "contradictionScanner": {
     "enabled": true,
-    "schedule": "30 3 * * *"   // cron — 03:30 daily (default), half an hour after the dupe sweep
+    "schedule": "30 3 * * *",       // cron — 03:30 daily (default), half an hour after the dupe sweep
+    "structuredThreshold": 0.92,    // similarity floor for the free deterministic pass (default)
+    "nliThreshold": 0.92,           // floor for the model pass (default)
+    "maxJudgedPairsPerRun": 0,      // 0 = unlimited (the local default); 2000 for a remote judge
+    "batchSize": 200,
+    "maxPerRun": 5000
   }
 }
 ```
+
+> **These thresholds are not raw cosine.** `$vectorSearch` normalises cosine similarity to `(1 + cos) / 2`,
+> and that is the number compared here. So **0.92 ⇒ cosine 0.84**, **0.85 ⇒ cosine 0.70**, and a
+> reasonable-looking **0.70 ⇒ cosine 0.40** — where a lot of barely-related text sits. Read these as cosine
+> and you will set them roughly twice as loose as you intended.
+
+**Should you lower it?** In principle 0.92 asks *"are these the same record?"* rather than *"do these
+disagree?"*, so a lower floor should surface contradictions between records that are related but not
+near-identical. In practice that was hard to reproduce: two deliberately-constructed contradicting pairs
+still scored 0.9479 and 0.9259, because records sharing a subject embed close together even when their
+descriptions diverge sharply. The default is therefore left at 0.92 — but if you see real contradictions
+being missed in your data, this is the knob, and lowering it costs nothing on the structured pass.
+
+**Why the model-pass defaults depend on where the judge runs.** The judge is an MNLI *encoder* — one
+forward pass returning three labels, not a generative model — so it is not slow. What differs is that every
+pair judged by a **remote** endpoint is record text leaving the instance, and that cost does not shrink with
+a faster model or a bigger GPU. So a loopback sidecar gets the same wide floor as the free pass and no pair
+cap, while a remote endpoint defaults to the strict floor plus a per-run budget. Override any of it.
+
+> These defaults are **reasoned, not benchmarked** — no NLI sidecar ships with the stack, so there was
+> nothing to time against. That is precisely why they are all configurable.
+
+`POST /scan` reports `judgedPairs` (what a remote judge was actually asked) plus two *distinct* incomplete
+endings: `nliStalled` means the judge was unreachable and **nothing** was settled (the cursor is parked),
+while `budgetExhausted` means the pairs it judged **are** settled and the next run continues from there.
+Neither should be read as a clean result.
 
 Until it is enabled, contradictions are found **only** when an admin runs `POST /api/contradictions/scan`
 by hand — so the Review tab's Contradictions view stays empty on an instance nobody has scanned manually.

--- a/server/src/api/contradictions.ts
+++ b/server/src/api/contradictions.ts
@@ -164,14 +164,18 @@ contradictionsRouter.post('/scan', globalRateLimit, requireAdminMfa, denyReadOnl
   try {
     const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
     const spaces = accessibleSpaces(req.authToken?.spaces).filter(id => !spaceFilter || id === spaceFilter);
-    let scanned = 0, found = 0, nliStalled = false;
+    let scanned = 0, found = 0, nliStalled = false, judgedPairs = 0, budgetExhausted = false;
     for (const spaceId of spaces) {
       const r = await scanSpace(spaceId);
-      scanned += r.scanned; found += r.found; nliStalled = nliStalled || r.nliStalled;
+      scanned += r.scanned; found += r.found; judgedPairs += r.judgedPairs;
+      nliStalled = nliStalled || r.nliStalled;
+      budgetExhausted = budgetExhausted || r.budgetExhausted;
     }
-    // `nliStalled` is surfaced, not swallowed: a sweep that stopped because the judge was unavailable has
-    // NOT cleared the space, and the caller should be able to tell that from a genuinely clean result.
-    res.json({ scannedSpaces: spaces.length, scanned, found, nliStalled });
+    // Three different reasons the list may be incomplete, and they are NOT interchangeable:
+    //   nliStalled       the judge was unreachable — nothing was settled, the cursor is parked.
+    //   budgetExhausted  the pair budget ran out — what was judged IS settled; the next run continues.
+    // Neither may read as a clean result. `judgedPairs` is what a remote endpoint actually spent.
+    res.json({ scannedSpaces: spaces.length, scanned, found, judgedPairs, nliStalled, budgetExhausted });
   } catch (err) {
     log.error(`POST /api/contradictions/scan: ${err}`);
     res.status(500).json({ error: 'Internal error' });

--- a/server/src/brain/contradiction-scanner.ts
+++ b/server/src/brain/contradiction-scanner.ts
@@ -38,12 +38,43 @@ import { findSimilar, summariseRecall, DEFAULT_DUPE_THRESHOLD, type RecallKnowle
 import { judgePair, type JudgeableRecord } from './contradiction-judge.js';
 import { extraClaimFields, fetchStructuredClaims, type ClaimMap } from './structured-claims.js';
 import { recordContradiction } from './contradiction-candidates.js';
-import { nliConfigured } from './nli-client.js';
-import type { DupeScanStateDoc, DupeScanType } from '../config/types.js';
+import { nliConfigured, nliIsLocal } from './nli-client.js';
+import type { ContradictionScannerConfig, DupeScanStateDoc, DupeScanType } from '../config/types.js';
 
 const SCAN_STATE = 'ythril_dupe_scan_state';
 const DEFAULT_BATCH_SIZE = 200;
 const DEFAULT_MAX_PER_RUN = 5000;
+/**
+ * Similarity floor for candidate pairs.
+ *
+ * ── READ THIS BEFORE CHANGING THE NUMBER ────────────────────────────────────────────────────────────────
+ *
+ * These thresholds are **not raw cosine**. `$vectorSearch` with cosine returns a score NORMALISED to
+ * [0, 1] as `(1 + cosine) / 2`, and that is what `findSimilar` compares against. So:
+ *
+ *      score 0.92  ⇒  cosine 0.84        score 0.85  ⇒  cosine 0.70        score 0.70  ⇒  cosine 0.40
+ *
+ * Measured, not assumed: a chrono pair with raw cosine 0.8957 came back from the search as 0.9479.
+ * Reading these as cosine makes every one of them sound ~2× stricter than it is, and picking "0.7 because
+ * the records should at least be related" would actually mean cosine 0.4 — where a great deal of loosely
+ * related text lands, which would bury the queue in noise.
+ *
+ * ── Why the DEFAULT is unchanged at 0.92 ────────────────────────────────────────────────────────────────
+ *
+ * It is tempting to loosen this on the argument that 0.92 asks "are these the same record?" rather than
+ * "do these disagree?". That argument is sound in principle, but two attempts to build a pair that
+ * genuinely contradicts and falls BELOW 0.92 both failed — they scored 0.9479 and 0.9259. Records that
+ * share a subject embed close together even when their descriptions diverge sharply, because the subject
+ * dominates the embedded text.
+ *
+ * So: no demonstrated case where a lower default changes the outcome, and therefore no default change.
+ * What was genuinely missing is the ability to TUNE it, which is now here. Shipping a behaviour change to
+ * every instance on an argument that could not be reproduced would be a worse trade than leaving the
+ * number alone and letting operators who see real misses lower it themselves.
+ */
+const DEFAULT_STRUCTURED_THRESHOLD = DEFAULT_DUPE_THRESHOLD;
+/** Pairs a REMOTE judge may be asked per run by default. Bounds egress, not time. */
+const DEFAULT_REMOTE_PAIR_BUDGET = 2000;
 // Chrono is swept alongside memories and entities: a calendar is exactly where the same thing gets logged
 // twice with conflicting states, and its `status` is a single-valued claim the structured pass can settle
 // without a model. See structured-claims.ts for why its dates are deliberately not part of that.
@@ -81,6 +112,8 @@ export interface RecordOutcomeSummary {
   found: number;
   /** True when at least one pair could not be judged because the judge itself was unavailable. */
   judgeStalled: boolean;
+  /** Pairs the judge actually answered for — what a remote endpoint's budget is spent on. */
+  judged: number;
 }
 
 /**
@@ -117,6 +150,7 @@ export async function evalRecord(
 ): Promise<RecordOutcomeSummary> {
   let found = 0;
   let judgeStalled = false;
+  let judged = 0;
   try {
     const { source, results } = await findSimilar(
       spaceId, recordId, type as RecallKnowledgeType, TOPK, [type as RecallKnowledgeType], threshold);
@@ -146,6 +180,9 @@ export async function evalRecord(
         judgeStalled = true;
         continue;   // leave the pair unsettled; the NLI cursor will not move past this record
       }
+      // Count only what the MODEL was actually asked. The structured pass reaches no endpoint, and an
+      // unavailable judge answered nothing — neither spends the budget the budget exists to bound.
+      if (pass === 'nli' && verdict.kind !== 'unjudged') judged++;
       const outcome = await recordContradiction(spaceId, type,
         { id: a.id, summary: summariseRecall(source), seq: source.seq ?? 0 },
         { id: b.id, summary: summariseRecall(match), seq: match.seq ?? 0 },
@@ -155,7 +192,7 @@ export async function evalRecord(
   } catch {
     /* no stored vector, record merged away, or search failed — skip the seed, not the sweep */
   }
-  return { found, judgeStalled };
+  return { found, judgeStalled, judged };
 }
 
 export interface ContradictionScanResult {
@@ -163,34 +200,71 @@ export interface ContradictionScanResult {
   found: number;
   /** True when the NLI pass stopped early because the judge was unavailable. Reported, not swallowed. */
   nliStalled: boolean;
+  /** Pairs the NLI judge actually answered for. The number an operator pays for on a remote endpoint. */
+  judgedPairs: number;
+  /** True when the NLI pass stopped because its per-run budget was spent. An ORDERLY stop, not a stall. */
+  budgetExhausted: boolean;
+}
+
+/**
+ * Effective knobs for a sweep.
+ *
+ * The NLI defaults key on **where the judge runs**, not on the pass alone. An MNLI encoder is one forward
+ * pass whether it is loopback or across the internet — what differs is that every remote judgement is
+ * record text leaving the instance, a cost no hardware makes cheaper. So a local sidecar gets the same wide
+ * net as the free structured pass, and a remote endpoint stays at the strict duplicate-grade threshold with
+ * a pair budget on top.
+ *
+ * NOTE: these defaults are reasoned, not measured — no NLI sidecar ships with the stack, so there was
+ * nothing to time against. They are all configurable for exactly that reason.
+ */
+export function scanTuning(cfg: ContradictionScannerConfig | undefined, judgeIsLocal: boolean): {
+  structuredThreshold: number; nliThreshold: number; maxJudgedPairs: number; batchSize: number; maxPerRun: number;
+} {
+  const clamp01 = (n: number) => Math.min(Math.max(n, 0), 1);
+  return {
+    structuredThreshold: typeof cfg?.structuredThreshold === 'number' ? clamp01(cfg.structuredThreshold) : DEFAULT_STRUCTURED_THRESHOLD,
+    nliThreshold: typeof cfg?.nliThreshold === 'number' ? clamp01(cfg.nliThreshold)
+      : (judgeIsLocal ? DEFAULT_STRUCTURED_THRESHOLD : DEFAULT_DUPE_THRESHOLD),
+    // 0 means unlimited, and that is the local default: a forward pass that leaves the box is free to run.
+    maxJudgedPairs: typeof cfg?.maxJudgedPairsPerRun === 'number' && cfg.maxJudgedPairsPerRun >= 0
+      ? cfg.maxJudgedPairsPerRun
+      : (judgeIsLocal ? 0 : DEFAULT_REMOTE_PAIR_BUDGET),
+    batchSize: Math.min(Math.max(cfg?.batchSize ?? DEFAULT_BATCH_SIZE, 1), 1000),
+    maxPerRun: Math.min(Math.max(cfg?.maxPerRun ?? DEFAULT_MAX_PER_RUN, 1), 1_000_000),
+  };
 }
 
 /** Sweep one space. Incremental per pass; `reset` re-runs both from zero. */
 export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Promise<ContradictionScanResult> {
   const cfg = getConfig();
+  const empty: ContradictionScanResult = { scanned: 0, found: 0, nliStalled: false, judgedPairs: 0, budgetExhausted: false };
   const space = cfg.spaces.find(s => s.id === spaceId);
-  if (!space || space.proxyFor) return { scanned: 0, found: 0, nliStalled: false };
-  if (!isVectorSearchAvailable() || needsReindex(spaceId)) return { scanned: 0, found: 0, nliStalled: false };
+  if (!space || space.proxyFor) return empty;
+  if (!isVectorSearchAvailable() || needsReindex(spaceId)) return empty;
 
-  const threshold = DEFAULT_DUPE_THRESHOLD;
+  const tune = scanTuning(cfg.contradictionScanner, nliIsLocal());
   let scanned = 0;
   let found = 0;
   let nliStalled = false;
+  let judgedPairs = 0;
+  let budgetExhausted = false;
 
   // The NLI pass is skipped wholesale when no model is configured — its cursor stays put, so the day one is
   // configured it starts from the beginning of what it has not seen rather than from "now".
   const passes: Pass[] = nliConfigured() ? ['structured', 'nli'] : ['structured'];
 
   for (const pass of passes) {
+    const threshold = pass === 'nli' ? tune.nliThreshold : tune.structuredThreshold;
     for (const type of DEFAULT_TYPES) {
-      if (scanned >= DEFAULT_MAX_PER_RUN) break;
+      if (scanned >= tune.maxPerRun || budgetExhausted) break;
       if (opts?.reset) await setCursor(spaceId, type, pass, 0);
       let cursor = opts?.reset ? 0 : await getCursor(spaceId, type, pass);
       const coll = `${spaceId}_${COLLECTION_SUFFIX[type]}`;
-      let stalledThisType = false;
+      let stopThisType = false;
 
-      while (scanned < DEFAULT_MAX_PER_RUN && !stalledThisType) {
-        const take = Math.min(DEFAULT_BATCH_SIZE, DEFAULT_MAX_PER_RUN - scanned);
+      while (scanned < tune.maxPerRun && !stopThisType) {
+        const take = Math.min(tune.batchSize, tune.maxPerRun - scanned);
         const batch = await col<{ _id: string; seq?: number }>(coll)
           .find(asFilter<{ _id: string; seq?: number }>({ spaceId, seq: { $gt: cursor } }), { projection: { _id: 1, seq: 1 } })
           .sort({ seq: 1 })
@@ -201,15 +275,25 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
         for (const rec of batch) {
           const out = await evalRecord(spaceId, type, rec._id, pass, threshold);
           found += out.found;
+          judgedPairs += out.judged;
           scanned++;
           if (out.judgeStalled) {
             // Stop this pass HERE, without advancing past the record. The pair is not settled, so the
             // cursor must not claim it is — that is the whole point of the second cursor.
-            stalledThisType = true;
+            stopThisType = true;
             nliStalled = true;
             break;
           }
+          // The record itself IS settled, so the cursor advances before any budget check below.
           if (typeof rec.seq === 'number' && rec.seq > cursor) cursor = rec.seq;
+          // Budget spent: an ORDERLY stop. Everything judged so far is settled and the cursor has moved
+          // past it, so the next run resumes here rather than re-judging (and re-paying for) the same
+          // pairs. This is exactly why it is checked AFTER the cursor advance, unlike a stall.
+          if (pass === 'nli' && tune.maxJudgedPairs > 0 && judgedPairs >= tune.maxJudgedPairs) {
+            stopThisType = true;
+            budgetExhausted = true;
+            break;
+          }
         }
         await setCursor(spaceId, type, pass, cursor);
       }
@@ -217,7 +301,8 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
   }
 
   if (nliStalled) log.warn(`Contradiction scan (${spaceId}): the NLI judge was unavailable — its cursor is parked and will resume where it stopped`);
-  return { scanned, found, nliStalled };
+  if (budgetExhausted) log.info(`Contradiction scan (${spaceId}): judged ${judgedPairs} pairs and stopped at its per-run budget; the next run resumes from there`);
+  return { scanned, found, nliStalled, judgedPairs, budgetExhausted };
 }
 
 /**
@@ -231,16 +316,22 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
 export async function runContradictionScanAllSpaces(): Promise<void> {
   let scanned = 0;
   let found = 0;
+  let judgedPairs = 0;
   let stalled = false;
+  let budgetOut = false;
   for (const s of getConfig().spaces) {
     if (s.proxyFor) continue;
     try {
       const r = await scanSpace(s.id);
-      scanned += r.scanned; found += r.found; stalled ||= r.nliStalled;
+      scanned += r.scanned; found += r.found; judgedPairs += r.judgedPairs;
+      stalled ||= r.nliStalled; budgetOut ||= r.budgetExhausted;
     } catch (err) { log.warn(`Contradiction scan failed for ${s.id}: ${err instanceof Error ? err.message : String(err)}`); }
   }
-  if (scanned > 0) log.info(`Contradiction scan: scanned ${scanned}, found ${found}`);
+  if (scanned > 0) log.info(`Contradiction scan: scanned ${scanned}, judged ${judgedPairs} pairs, found ${found}`);
+  // Two different incomplete endings, logged differently on purpose: one means nothing was settled, the
+  // other means everything judged WAS settled and the next run picks up from there.
   if (stalled) log.warn('Contradiction scan: the NLI judge was unavailable — its cursor is parked and will resume where it stopped. This sweep did NOT clear the queue.');
+  if (budgetOut) log.info('Contradiction scan: stopped at the per-run judged-pair budget. What it judged is settled; the next run continues from there.');
 }
 
 // ── Scheduler (node-cron, mirrors the duplicate scanner) ─────────────────────

--- a/server/src/brain/nli-client.ts
+++ b/server/src/brain/nli-client.ts
@@ -34,6 +34,20 @@ export function nliConfigured(): boolean {
   return !!nli?.baseUrl?.trim() && !!nli?.model?.trim();
 }
 
+/**
+ * True when the configured judge runs locally — i.e. judging a pair costs CPU but sends nothing anywhere.
+ *
+ * Callers use this to decide how *freely* they may judge. The distinction is not speed: an MNLI encoder is
+ * a single forward pass either way. It is that every judged pair on a remote endpoint is document content
+ * leaving the instance, and that cost does not shrink with a faster model or a bigger machine.
+ *
+ * Unconfigured counts as NOT local: there is nothing to call, so nothing may be assumed cheap.
+ */
+export function nliIsLocal(): boolean {
+  const url = getMediaEmbeddingConfig().nli?.baseUrl?.trim();
+  return !!url && isLocalEndpoint(url);
+}
+
 /** Loopback/private hosts are the bundled sidecar; anything else is egress and gets the SSRF guard. */
 function isLocalEndpoint(rawUrl: string): boolean {
   try {

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -844,6 +844,42 @@ export interface ContradictionScannerConfig {
   enabled?: boolean;
   /** Cron schedule for the sweep. Default: '30 3 * * *' (03:30 daily). */
   schedule?: string;
+  /**
+   * Similarity floor for the STRUCTURED pass. Default: 0.85.
+   *
+   * **NOT raw cosine.** `$vectorSearch` normalises cosine to `(1 + cos) / 2`, so 0.85 here means cosine
+   * ≈ 0.70, and the previous 0.92 meant cosine ≈ 0.84. Reading these as cosine makes them sound roughly
+   * twice as strict as they are — and setting 0.7 "so the records are at least related" would really mean
+   * cosine 0.4, where plenty of unrelated text lands.
+   *
+   * Loosened from the inherited duplicate threshold because 0.92 asks "are these the same record?", which
+   * is the right question for de-duplication and the wrong one here: two records can contradict without
+   * being near-identical. The structured judge is deterministic and free per pair, so a somewhat wider net
+   * costs nothing but review attention.
+   */
+  structuredThreshold?: number;
+  /**
+   * Similarity floor for the NLI pass. Default: **0.85 when the judge is local, 0.92 when it is remote**.
+   *
+   * Same normalised scale as `structuredThreshold`. The gap is not about speed — an MNLI encoder is one
+   * forward pass either way — but about egress: every pair judged remotely is record text leaving the
+   * instance, and no amount of hardware makes that cheaper. A local sidecar can afford the same net as the
+   * free pass.
+   */
+  nliThreshold?: number;
+  /**
+   * Cap on how many pairs the NLI pass may judge in one run. Default: **unlimited when local, 2000 when
+   * remote**. 0 means unlimited.
+   *
+   * Hitting the cap is an ORDERLY stop, not a stall: the pairs it did judge are settled and the cursor
+   * advances past them, so the next run resumes where it left off. Only an unavailable judge parks the
+   * cursor. Conflating the two would either re-judge the same pairs forever or silently skip them.
+   */
+  maxJudgedPairsPerRun?: number;
+  /** Records fetched per DB batch during a sweep. Default: 200. */
+  batchSize?: number;
+  /** Max records scanned per space per run. Default: 5000. */
+  maxPerRun?: number;
 }
 
 /**

--- a/testing/standalone/contradiction-tuning.test.js
+++ b/testing/standalone/contradiction-tuning.test.js
@@ -1,0 +1,105 @@
+/**
+ * How hard the contradiction sweep is allowed to look, and how much it may spend doing it.
+ *
+ * Two decisions are pinned here, both of which were wrong in the shipped version:
+ *
+ *  1. **The similarity floor was inherited from duplicate detection (0.92).** That answers "are these the
+ *     same record?", which is not this question — records can contradict without being near-identical.
+ *
+ *     Mind the SCALE when tuning it. These are not raw cosine: `$vectorSearch` normalises cosine to
+ *     `(1 + cos) / 2`, measured directly here — a chrono pair with raw cosine 0.8957 came back from the
+ *     search as 0.9479. So 0.92 ⇒ cosine 0.84 and 0.85 ⇒ cosine 0.70, while an innocent-looking 0.70 would
+ *     mean cosine 0.40 and drag in a great deal of barely-related text.
+ *
+ *  2. **The NLI pass was treated as expensive because it calls a model.** It is an MNLI encoder: one
+ *     forward pass, three labels, no generation. On a loopback sidecar that is not expensive. What is
+ *     genuinely costly is a REMOTE judge — every judged pair is record text leaving the instance, and that
+ *     cost does not shrink with a faster model. So the conservative defaults key on WHERE the judge runs,
+ *     not on which pass is running.
+ *
+ * The numbers themselves are reasoned rather than measured — no NLI sidecar ships with the stack, so there
+ * was nothing to time against. That is exactly why every one of them is configurable, and why these tests
+ * pin the RELATIONSHIPS (local ≤ remote, explicit beats default) rather than blessing specific constants.
+ *
+ * Run: node --test testing/standalone/contradiction-tuning.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let scanTuning;
+
+describe('scan tuning — the similarity floor is not the duplicate threshold', () => {
+  before(async () => {
+    ({ scanTuning } = await import('../../server/dist/brain/contradiction-scanner.js'));
+  });
+
+  it('leaves the default floor alone, because loosening it could not be justified empirically', () => {
+    // These are NOT raw cosine: $vectorSearch normalises to (1 + cos) / 2. Measured — a pair with raw
+    // cosine 0.8957 came back as 0.9479. So 0.92 ⇒ cosine 0.84 and a plausible-looking 0.70 ⇒ cosine 0.40.
+    //
+    // Two attempts to construct a genuinely-contradicting pair BELOW 0.92 both failed (0.9479, 0.9259):
+    // records sharing a subject embed close together even when their descriptions diverge sharply. With no
+    // reproducible miss, changing the default for every instance is not warranted — tuning it is.
+    assert.equal(scanTuning(undefined, true).structuredThreshold, 0.92);
+  });
+
+  it('costs nothing extra to widen the structured net, so it does not depend on the judge', () => {
+    // The structured pass reaches no endpoint at all — its floor has no reason to care where NLI lives.
+    assert.equal(scanTuning(undefined, true).structuredThreshold, scanTuning(undefined, false).structuredThreshold);
+  });
+});
+
+describe('scan tuning — the conservative defaults key on WHERE the judge runs', () => {
+  before(async () => {
+    ({ scanTuning } = await import('../../server/dist/brain/contradiction-scanner.js'));
+  });
+
+  it('bounds a remote judge by pair count, and leaves a local one unbounded', () => {
+    // This is the part of the local/remote split that IS justified: a loopback forward pass sends nothing
+    // anywhere, while every remote judgement is record text leaving the instance — a cost no faster model
+    // reduces. Unlike the similarity floor, this needs no empirical case; it follows from what egress is.
+    assert.equal(scanTuning(undefined, true).maxJudgedPairs, 0, '0 means unlimited');
+    assert.ok(scanTuning(undefined, false).maxJudgedPairs > 0);
+  });
+
+  it('never lets the remote floor be looser than the local one', () => {
+    const local = scanTuning(undefined, true);
+    const remote = scanTuning(undefined, false);
+    assert.ok(remote.nliThreshold >= local.nliThreshold);
+  });
+});
+
+describe('scan tuning — explicit config always wins', () => {
+  before(async () => {
+    ({ scanTuning } = await import('../../server/dist/brain/contradiction-scanner.js'));
+  });
+
+  it('honours operator thresholds over either default', () => {
+    const t = scanTuning({ structuredThreshold: 0.55, nliThreshold: 0.8 }, false);
+    assert.equal(t.structuredThreshold, 0.55);
+    assert.equal(t.nliThreshold, 0.8);
+  });
+
+  it('lets an operator lift the remote budget, including to unlimited', () => {
+    assert.equal(scanTuning({ maxJudgedPairsPerRun: 0 }, false).maxJudgedPairs, 0);
+    assert.equal(scanTuning({ maxJudgedPairsPerRun: 50 }, false).maxJudgedPairs, 50);
+  });
+
+  it('clamps thresholds into [0,1] rather than trusting a typo', () => {
+    // A cosine floor of 92 (meaning 0.92) would silently match nothing at all, forever.
+    assert.equal(scanTuning({ structuredThreshold: 92 }, true).structuredThreshold, 1);
+    assert.equal(scanTuning({ nliThreshold: -3 }, true).nliThreshold, 0);
+  });
+
+  it('clamps batch and per-run sizes to sane bounds', () => {
+    assert.equal(scanTuning({ batchSize: 0 }, true).batchSize, 1);
+    assert.equal(scanTuning({ batchSize: 99999 }, true).batchSize, 1000);
+    assert.equal(scanTuning({ maxPerRun: 0 }, true).maxPerRun, 1);
+  });
+
+  it('ignores a negative budget rather than treating it as unlimited', () => {
+    // -1 must not read as "no cap" on a remote endpoint, which is the expensive direction to get wrong.
+    assert.ok(scanTuning({ maxJudgedPairsPerRun: -1 }, false).maxJudgedPairs > 0);
+  });
+});


### PR DESCRIPTION
F-REVIEW slice 5. `structuredThreshold`, `nliThreshold`, `maxJudgedPairsPerRun`, `batchSize` and `maxPerRun` were hard-coded constants — only `dupeScanner` had equivalents. They're tunable now, with a per-run budget for remote judges and honest counters on the result.

**Prompted by an owner question** — *"do we need to scan all records? we could use at least 0.7 similarity so it at least has to do something with the other record"* — the answer to which is that a floor already existed at 0.92. Chasing that produced two corrections to my own reasoning, both caught by checking rather than arguing.

## What changed

- **A pair budget for a remote judge** (2000/run; local unlimited). This is the part of the local/remote split that needs no empirical case: a loopback forward pass sends nothing anywhere, while every remote judgement is record text leaving the instance — a cost no faster model reduces. The judge is an MNLI *encoder* (one forward pass, three labels, no generation), so "it calls a model" is not by itself grounds for restraint.
- **Hitting the budget is an orderly stop**, deliberately unlike a stall: the pairs it judged are settled and the cursor advances past them, so the next run continues rather than re-judging — and re-paying for — the same work. Only an unavailable judge parks the cursor.
- **`POST /scan` now reports `judgedPairs`** and distinguishes `budgetExhausted` from `nliStalled`. One means "settled as far as it got"; the other means "settled nothing". Neither may read as a clean result.

## Two corrections, both from measuring

**The thresholds are not raw cosine.** `$vectorSearch` normalises cosine to `(1 + cos) / 2`. Measured directly: a pair with raw cosine **0.8957** came back from the search as **0.9479**. So 0.92 means cosine ≈ 0.84, and the "0.7" that sounds like a sensible relatedness floor would actually mean **cosine 0.40** — where a great deal of barely-related text sits. I had reasoned about these as cosine and would have set them roughly twice as loose as intended. Now stated in the config docs, the code, and the tests, because it's a trap for anyone tuning them.

**The defaults are unchanged, and that is the finding.** I argued that 0.92 asks *"are these the same record?"* rather than *"do these disagree?"*, and initially lowered it. But two deliberately-constructed contradicting pairs — same subject, sharply opposed descriptions and statuses — scored **0.9479** and **0.9259**, both clearing 0.92. Records sharing a subject embed close together even when their prose diverges, because the subject dominates the embedded text.

So I could not reproduce the miss the change was meant to fix. Shipping a behaviour change to every instance on an argument that didn't survive contact with data would be the wrong trade; the knob is the deliverable, not a new default. If real data shows misses, `structuredThreshold` is free to lower — the structured pass costs nothing per pair.

## Verification

Scratch instance on an Atlas-local stack: scan reports the new counters (`judgedPairs: 0` with no NLI configured, correctly), the config knob demonstrably drives the floor (pinning 0.92 vs default behaves identically, as it must now), and the cosine/score relationship was measured directly against stored embeddings rather than assumed.

Gates: server `tsc` clean · 27/27 on the affected standalone suites · `lint:docs` clean · audit-route-coverage + route-guard-coverage pass (no new routes; an existing admin+MFA POST gained response fields) · no client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)