### PR TITLE
fix(spaces): wipe contradiction findings, index them, guard the id prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1737,6 +1737,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wiping a space left its contradiction findings behind, pointing at records that no longer exist.** The
+  wipe cleared `dupe_candidates` on both the full and per-type paths and never touched
+  `contradiction_candidates`, so after wiping a space's memories the Review tab kept listing contradictions
+  whose records were gone — and following one led nowhere. Both collections are now cleared together, on
+  both paths, using the same type mapping (extracted as a pure `candidateTypesForWipe`, so a missing entry
+  fails a test instead of silently orphaning findings).
+
+- **The contradiction-candidate collection had no indexes at all.** It was never added to
+  `SPACE_COLLECTIONS`, so it was never explicitly created or indexed — while the Review list filtered on
+  `status` and sorted by `{confidence, detectedAt}` over it, i.e. a collection scan plus an in-memory sort
+  on every load. It now gets `{status, confidence, detectedAt}` and `{type}` like its duplicate sibling.
+  (`file_tombstones` had the same omission once; that list now warns, since forgetting it is silent.)
+
+- **The `{spaceId}_` collection prefix now has a guarded invariant.** Three operations select collections by
+  that prefix with no boundary check — rename (moves data), space delete (**drops** collections), and the
+  stale-`spaceId` repair. They are correct only because a space id is validated `^[a-z0-9-]+$`, so `_`
+  cannot occur inside an id and separates unambiguously: a sibling space `work-archive` owns
+  `work-archive_memories`, which does not start with `work_`. That dependency was written down nowhere, and
+  relaxing the charset to permit `_` — a plausible thing to do for readability, or to accept an id from an
+  external system — would make deleting space `work` silently drop `work_archive`'s collections, with no
+  confirmation and no recovery outside a backup. All three sites now document it, and a test asserts the
+  pattern excludes `_` so relaxing it fails CI rather than a customer's data.
+
 - **The contradiction sweep's limits are now configurable instead of hard-coded**, and the similarity floor
   is documented on the right scale. `structuredThreshold`, `nliThreshold`, `maxJudgedPairsPerRun`,
   `batchSize` and `maxPerRun` were all fixed constants; only `dupeScanner` had equivalents.

--- a/server/src/spaces/_shared.ts
+++ b/server/src/spaces/_shared.ts
@@ -43,7 +43,15 @@ export async function syncSchemaFiles(spaceId: string, meta: SpaceMeta | undefin
   }
 }
 
-export const SPACE_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'tombstones', 'conflicts', 'files', 'dupe_candidates'] as const;
+/**
+ * Per-space collections `initSpace` creates and indexes.
+ *
+ * **Add new per-space collections here when you add them.** Omission is silent: the collection still works
+ * (Mongo creates it lazily on first insert) but is never explicitly created and never indexed.
+ * `contradiction_candidates` shipped that way — no indexes at all, while the Review list filtered and
+ * sorted over it — and `file_tombstones` had the same hole before it (see `repairStaleSpaceIds` below).
+ */
+export const SPACE_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'tombstones', 'conflicts', 'files', 'dupe_candidates', 'contradiction_candidates'] as const;
 
 // ── Embedding model mismatch tracking ──────────────────────────────────────
 const _reindexNeeded = new Set<string>();
@@ -108,6 +116,8 @@ export async function repairStaleSpaceIds(spaceId: string): Promise<number> {
   // list was itself the bug.
   let collections: string[];
   try {
+    // Prefix match with no boundary check — safe only because a space id cannot contain an underscore
+    // (validated `^[a-z0-9-]+$`), so `_` separates unambiguously. See space-id-prefix-safety.test.js.
     collections = (await db.listCollections().toArray())
       .map(c => c.name)
       .filter(n => n.startsWith(prefix));

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -57,13 +57,15 @@ export async function initSpace(
   const tombstonesColl = db.collection(`${spaceId}_tombstones`);
   const conflictsColl = db.collection(`${spaceId}_conflicts`);
   const dupeColl = db.collection(`${spaceId}_dupe_candidates`);
+  const contraColl = db.collection(`${spaceId}_contradiction_candidates`);
   const filesColl = db.collection(`${spaceId}_files`);
 
   await Promise.all([
     dropLegacyPrefixedIndexes(memoriesColl), dropLegacyPrefixedIndexes(entitiesColl),
     dropLegacyPrefixedIndexes(edgesColl), dropLegacyPrefixedIndexes(chronoColl),
     dropLegacyPrefixedIndexes(tombstonesColl), dropLegacyPrefixedIndexes(conflictsColl),
-    dropLegacyPrefixedIndexes(dupeColl), dropLegacyPrefixedIndexes(filesColl),
+    dropLegacyPrefixedIndexes(dupeColl), dropLegacyPrefixedIndexes(contraColl),
+    dropLegacyPrefixedIndexes(filesColl),
   ]);
 
   await memoriesColl.createIndex({ seq: 1 });
@@ -83,6 +85,12 @@ export async function initSpace(
   // Serves the list query: equality on `status` (now the leading field) + sort by (score desc,
   // detectedAt desc).
   await dupeColl.createIndex({ status: 1, score: -1, detectedAt: -1 });
+  // Mirrors the Review list's query exactly: filter on status, then sort by confidence and recency
+  // (`api/contradictions.ts` — `.sort({ confidence: -1, detectedAt: -1 })`). Without it that endpoint was a
+  // collection scan plus an in-memory sort on every load, because this collection had no indexes at all.
+  await contraColl.createIndex({ status: 1, confidence: -1, detectedAt: -1 });
+  // The type filter in the Review tab narrows on this, and the per-type wipe below deletes by it.
+  await contraColl.createIndex({ type: 1 });
   await filesColl.createIndex({ tags: 1 });
   await filesColl.createIndex({ updatedAt: -1 });
 
@@ -224,7 +232,15 @@ export async function dropSpaceData(spaceId: string): Promise<string[]> {
     }
   }
 
-  // 2. Drop all MongoDB collections associated with this space
+  // 2. Drop all MongoDB collections associated with this space.
+  //
+  // **This is a prefix match with no boundary check, and it DROPS.** It is safe only because a space id is
+  // validated `^[a-z0-9-]+$` everywhere one is accepted (`api/spaces.ts` create + rename,
+  // `api/networks/join.ts`), so `_` can never appear inside an id and is therefore an unambiguous
+  // separator: a sibling space `work-archive` owns `work-archive_memories`, which does not start with
+  // `work_`. Relax that charset to permit `_` and deleting `work` would silently drop `work_archive`'s
+  // collections — another space's data, with no confirmation and no recovery outside a backup.
+  // `space-id-prefix-safety.test.js` pins the pattern for exactly this reason.
   const prefix = `${spaceId}_`;
   const existingColls = await db.listCollections().toArray();
   for (const coll of existingColls.filter(c => c.name.startsWith(prefix))) {
@@ -317,6 +333,24 @@ export type WipeCollectionType = 'memories' | 'entities' | 'edges' | 'chrono' | 
 
 export const WIPE_COLLECTION_TYPES: readonly WipeCollectionType[] = ['memories', 'entities', 'edges', 'chrono', 'files'];
 
+/**
+ * Which review-finding `type` values a partial wipe should clear.
+ *
+ * A finding is a claim about two records; once those records are wiped the claim is not just stale, it is
+ * unopenable — the Review tab lists it and following it leads nowhere. Both `dupe_candidates` and
+ * `contradiction_candidates` key their rows by the same singular vocabulary, so one map serves both.
+ *
+ * Pure, and exported, because it is the part with a decision in it: the collection-name plural
+ * (`memories`) and the finding `type` (`memory`) are different vocabularies, and a missing entry here
+ * silently orphans findings rather than failing.
+ */
+export function candidateTypesForWipe(targets: ReadonlySet<WipeCollectionType>): string[] {
+  const MAP: Partial<Record<WipeCollectionType, string>> = {
+    memories: 'memory', entities: 'entity', edges: 'edge', chrono: 'chrono', files: 'file',
+  };
+  return Array.from(targets).map(t => MAP[t]).filter((t): t is string => t !== undefined);
+}
+
 export interface WipeResult {
   memories: number;
   entities: number;
@@ -386,16 +420,22 @@ export async function wipeSpace(spaceId: string, types?: WipeCollectionType[]): 
       await col(`${spaceId}_tombstones`).deleteMany({ type: { $in: tombstoneTypes } });
     }
   }
-  // Clear duplicate-scanner candidates that reference the wiped types.
+  // Clear review findings that reference the wiped types — BOTH candidate collections. See
+  // `candidateTypesForWipe` for the mapping.
+  //
+  // A finding is a claim about two records. Once those records are gone the claim is not merely stale, it
+  // is unopenable: the Review tab lists it, and following it leads nowhere. Contradictions were missed here
+  // when the collection was added, so wiping a space's memories left its contradiction queue intact and
+  // pointing at nothing.
   if (isFullWipe) {
     await col(`${spaceId}_dupe_candidates`).deleteMany({});
+    await col(`${spaceId}_contradiction_candidates`).deleteMany({});
   } else {
-    const DUPE_TYPE_MAP: Partial<Record<WipeCollectionType, string>> = {
-      memories: 'memory', entities: 'entity', edges: 'edge', chrono: 'chrono', files: 'file',
-    };
-    const dupeTypes = Array.from(targets).map(t => DUPE_TYPE_MAP[t]).filter((t): t is string => t !== undefined);
+    const dupeTypes = candidateTypesForWipe(targets);
     if (dupeTypes.length > 0) {
+      // Both collections key their rows by the same `type` vocabulary, so one map serves both.
       await col(`${spaceId}_dupe_candidates`).deleteMany({ type: { $in: dupeTypes } });
+      await col(`${spaceId}_contradiction_candidates`).deleteMany({ type: { $in: dupeTypes } });
     }
   }
 

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -23,6 +23,11 @@ export async function moveSpaceData(oldId: string, newId: string): Promise<strin
 
   // 1. Rename MongoDB collections ({oldId}_* → {newId}_*). Only collections still
   //    under the old prefix remain after a partial run, so this is idempotent.
+  //
+  //    Prefix match with no boundary check — safe only because a space id is validated `^[a-z0-9-]+$`,
+  //    so `_` cannot occur inside an id and separates cleanly (`work-archive_memories` does not start with
+  //    `work_`). See the fuller note on the drop path in `lifecycle.ts`, which has the same dependency with
+  //    worse consequences. Pinned by `space-id-prefix-safety.test.js`.
   const existingColls = await db.listCollections().toArray();
   const prefix = `${oldId}_`;
   for (const coll of existingColls.filter(c => c.name.startsWith(prefix))) {

--- a/testing/standalone/space-id-prefix-safety.test.js
+++ b/testing/standalone/space-id-prefix-safety.test.js
@@ -1,0 +1,119 @@
+/**
+ * The space-id charset is load-bearing for three prefix operations, one of which drops collections.
+ *
+ * Per-space collections are named `{spaceId}_{suffix}`, and three places select them with a bare
+ * `name.startsWith(`${spaceId}_`)` — no boundary check:
+ *
+ *   spaces/rename.ts    renames every match          (moves data)
+ *   spaces/lifecycle.ts DROPS every match            (destroys data)
+ *   spaces/_shared.ts   lists them to repair spaceId  (rewrites a field)
+ *
+ * They are correct today for one reason: a space id is validated `^[a-z0-9-]+$`, so `_` cannot appear
+ * inside an id and is an unambiguous separator. A sibling space `work-archive` owns
+ * `work-archive_memories`, which does not start with `work_`.
+ *
+ * Nothing states that dependency at the validation site, and it is the kind of rule that gets relaxed for
+ * a good-sounding reason — readability, or accepting an id from an external system. If `_` were ever
+ * permitted, deleting space `work` would silently drop `work_archive`'s collections: another space's data,
+ * no confirmation, recoverable only from a backup. This test is the tripwire.
+ *
+ * It reads the pattern out of the SOURCE rather than re-declaring it, so relaxing the real rule fails here
+ * instead of quietly diverging from a copy.
+ *
+ * Run: node --test testing/standalone/space-id-prefix-safety.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8');
+
+/** Every place a caller-supplied space id is validated. */
+const VALIDATION_SITES = [
+  { file: 'server/src/api/spaces.ts', what: 'create + rename' },
+  { file: 'server/src/api/networks/join.ts', what: 'peer space map' },
+  { file: 'server/src/spaces/lifecycle.ts', what: 'wipe guard' },
+];
+
+/** The prefix operations that depend on the charset. */
+const PREFIX_SITES = [
+  { file: 'server/src/spaces/rename.ts', why: 'renames every matching collection' },
+  { file: 'server/src/spaces/lifecycle.ts', why: 'DROPS every matching collection' },
+  { file: 'server/src/spaces/_shared.ts', why: 'walks them to repair stale spaceId fields' },
+];
+
+/** Pull every space-id character class actually written in a file, e.g. `[a-z0-9-]`. */
+function charClassesIn(src) {
+  return [...src.matchAll(/\/\^\[([^\]]+)\]\+\$\//g)].map(m => m[1]);
+}
+
+describe('space id charset — the prefix operations depend on it', () => {
+  it('never permits an underscore at any validation site', () => {
+    for (const { file, what } of VALIDATION_SITES) {
+      const classes = charClassesIn(read(file));
+      assert.ok(classes.length > 0, `${file} (${what}) should validate the space id with an anchored pattern`);
+      for (const cls of classes) {
+        assert.ok(!cls.includes('_'),
+          `${file} (${what}) allows "_" in a space id — that makes the "{id}_" prefix ambiguous, and ` +
+          `deleting space "work" would drop "work_archive"'s collections`);
+      }
+    }
+  });
+
+  it('keeps every prefix site pointing at this test, so the dependency is discoverable', () => {
+    // A future reader relaxing the charset needs a way to find out why they must not. Each prefix site
+    // names this file; if one loses the reference, the tripwire is invisible from the dangerous code.
+    for (const { file, why } of PREFIX_SITES) {
+      assert.match(read(file), /space-id-prefix-safety/,
+        `${file} (${why}) should reference this test so the charset dependency is not silently inherited`);
+    }
+  });
+});
+
+describe('wipe → review findings', () => {
+  let candidateTypesForWipe, WIPE_COLLECTION_TYPES;
+  before(async () => {
+    ({ candidateTypesForWipe, WIPE_COLLECTION_TYPES } = await import('../../server/dist/spaces/lifecycle.js'));
+  });
+
+  it('maps every wipeable collection to a finding type — a gap here orphans findings silently', () => {
+    // The collection plural ("memories") and the finding type ("memory") are different vocabularies. A
+    // missing entry does not fail; it just leaves findings pointing at records that no longer exist.
+    const mapped = candidateTypesForWipe(new Set(WIPE_COLLECTION_TYPES));
+    assert.equal(mapped.length, WIPE_COLLECTION_TYPES.length,
+      `every wipeable type needs a finding-type mapping; got ${JSON.stringify(mapped)}`);
+  });
+
+  it('clears only the wiped type', () => {
+    assert.deepEqual(candidateTypesForWipe(new Set(['memories'])), ['memory']);
+    assert.deepEqual(candidateTypesForWipe(new Set(['entities', 'chrono'])).sort(), ['chrono', 'entity']);
+  });
+
+  it('asks for nothing when nothing is targeted, rather than deleting everything', () => {
+    // An empty `$in` would be a no-op, but the caller skips the query entirely on an empty list — and a
+    // truthy-but-empty result here would be the kind of mistake that wipes an unrelated type.
+    assert.deepEqual(candidateTypesForWipe(new Set()), []);
+  });
+});
+
+describe('space id charset — the collision it prevents', () => {
+  // Demonstrates the actual failure, so the rule is not an article of faith.
+  const startsWithPrefix = (collection, spaceId) => collection.startsWith(`${spaceId}_`);
+
+  it('does not let a sibling space be caught by another space\'s prefix', () => {
+    // Legal sibling ids under the current charset. Hyphen, not underscore, is what keeps them apart.
+    assert.equal(startsWithPrefix('work-archive_memories', 'work'), false);
+    assert.equal(startsWithPrefix('work2_memories', 'work'), false);
+    assert.equal(startsWithPrefix('workspace_memories', 'work'), false);
+  });
+
+  it('still matches the space\'s own collections', () => {
+    assert.equal(startsWithPrefix('work_memories', 'work'), true);
+    assert.equal(startsWithPrefix('work_contradiction_candidates', 'work'), true);
+  });
+
+  it('WOULD collide if underscores were ever allowed — the thing being guarded', () => {
+    // If `work_archive` were a legal id, this is what dropping `work` would take with it.
+    assert.equal(startsWithPrefix('work_archive_memories', 'work'), true);
+  });
+});


### PR DESCRIPTION
Three gaps around `{space}_contradiction_candidates`, which was added as a collection without the surrounding machinery learning about it. The third came out of an owner question — *"what operations are done by prefix?"* — and is the one I'd want reviewed most.

## 1. A space wipe left contradiction findings behind

The wipe cleared `dupe_candidates` on both the full and per-type paths and never touched the contradiction collection. Wipe a space's memories and the Review tab kept listing contradictions whose records were gone; following one led nowhere.

Both are cleared together now, on both paths. The type mapping is extracted as a pure `candidateTypesForWipe` because that's the part with a decision in it: the collection plural (`memories`) and the finding type (`memory`) are different vocabularies, and a missing entry orphans findings **silently** rather than failing.

## 2. The collection had no indexes at all

It was never in `SPACE_COLLECTIONS`, so it was never explicitly created or indexed — while the Review list filters on `status` and sorts by `{confidence, detectedAt}` over it. That's a collection scan plus an in-memory sort on every load. It now gets `{status, confidence, detectedAt}` and `{type}`, matching its duplicate sibling.

`SPACE_COLLECTIONS` now states that omitting a collection is silent, because this has happened before — `file_tombstones` had the same hole, and the comment in `repairStaleSpaceIds` still describes the fallout.

## 3. The `{spaceId}_` prefix invariant is now guarded

Three operations select collections by prefix with **no boundary check**:

| Site | Operation |
|---|---|
| `spaces/rename.ts:28` | renames every match — moves data |
| `spaces/lifecycle.ts:229` | **`.drop()`s every match — destroys data** |
| `spaces/_shared.ts:111` | lists them to repair stale `spaceId` fields |

They are correct today for exactly one reason: a space id is validated `^[a-z0-9-]+$` at every site that accepts one, so `_` cannot appear inside an id and separates unambiguously — a sibling space `work-archive` owns `work-archive_memories`, which does not start with `work_`.

**That dependency was written down nowhere.** Relaxing the charset to permit `_` is a plausible thing to do — for readability, or to accept an id from an external system — and it would make deleting space `work` silently drop `work_archive`'s collections. Another space's data, no confirmation, recoverable only from a backup.

All three sites now document it, and `space-id-prefix-safety.test.js` reads the pattern **out of the source** (rather than re-declaring it, which would just diverge) and fails if `_` is ever permitted. It also asserts each prefix site still references the test, so the tripwire stays discoverable from the dangerous code — and demonstrates the collision directly, so the rule isn't an article of faith.

Proven by relaxing the charset (1 fail) and restoring it (8/8).

## Verification

Scratch instance:

| Check | Result |
|---|---|
| Indexes on `contradiction_candidates` | `{status,confidence,detectedAt}` + `{type}` — previously none |
| Per-type wipe (`memories`) | memory findings gone from **both** collections; chrono findings intact in both |
| Full wipe | both collections empty |

Gates: server `tsc` clean · 44/44 on the affected standalone suites · `lint:docs` clean · audit-route-coverage + route-guard-coverage pass (no route changes) · no client changes.

One note on process: I initially made the `_shared.ts` edit with a `node -e` one-liner and the shell mangled the `$` in the regex, duplicating the file. Restored from git and redone with the editor — the repo's own notes warn about exactly this and I ignored them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)