### PR TITLE
feat(brain): prune review findings that can never resurface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1737,6 +1737,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Review findings whose records were deleted are now cleaned up.** Neither candidate collection had any
+  retention: deleting a record individually stranded every finding about it forever, so the Review tab
+  could list a pair where clicking through leads nowhere. A background prune (every 6h, always on) now
+  removes findings that **can never resurface** — orphans, and duplicate pairs resolved by `merged`, where
+  the absorbed record is gone by construction.
+
+  **It is deliberately not a time policy.** "Delete settled findings older than N days" would forget
+  *dismissals* and let the scanner re-flag the pair — precisely what the sticky-dismissal machinery exists
+  to prevent — and would equally forget resolutions whose records still exist and still look conflicting.
+  Dismissals and those resolutions are kept indefinitely; a few hundred bytes each is a better trade than
+  silently re-asking a question somebody already answered.
+
+  It runs on its own timer rather than off the duplicate or contradiction scanner, because both are off by
+  default and orphans accumulate regardless of whether anyone enabled scanning. It is also **fail-closed**:
+  any error, or any record type it cannot resolve, leaves that collection entirely alone — the dangerous
+  failure here is not a missed prune but a lookup that comes back empty for an unrelated reason and makes
+  every finding look orphaned.
+
 - **Wiping a space left its contradiction findings behind, pointing at records that no longer exist.** The
   wipe cleared `dupe_candidates` on both the full and per-type paths and never touched
   `contradiction_candidates`, so after wiping a space's memories the Review tab kept listing contradictions

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5744,6 +5744,13 @@ by hand — so the Review tab's Contradictions view stays empty on an instance n
 An invalid cron expression is refused at boot with a warning rather than silently ignored, and a scheduled
 run that parks because the judge was unreachable logs that it did **not** clear the queue.
 
+**Retention.** A background prune (every 6 hours, always on, no configuration) removes review findings that
+can never resurface: those whose records have been deleted, and duplicate pairs resolved by **merge** — the
+absorbed record is gone, so the pair cannot be detected again. Everything else is kept indefinitely, on
+purpose: deleting a **dismissed** finding would forget the dismissal and let the next sweep re-flag the same
+pair, and deleting a resolution whose records still exist invites the same. Findings are small; re-asking a
+settled question is expensive.
+
 **What the sweep covers.** Memories, entities and **chrono** entries. For a chrono pair the structured pass
 compares the stored `status` as well as `properties` — the dates are deliberately not compared, for the
 reason given under [Duplicate Detection on Insert](#what-counts-as-a-claim). Edges are excluded until edge

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -65,6 +65,11 @@ export async function startConfiguredInstanceServices(): Promise<void> {
   startContradictionScanner();
   const { startTtlSweep } = await import('./brain/ttl-sweep.js');
   startTtlSweep();
+  // Housekeeping for review findings whose records are gone. Deliberately NOT hung off the duplicate or
+  // contradiction scanner: both are off by default, so orphans would accumulate on exactly the instances
+  // that never enabled them.
+  const { startCandidatePrune } = await import('./brain/candidate-prune.js');
+  startCandidatePrune();
 
   const { cleanupStaleChunks } = await import('./files/chunks.js');
   cleanupStaleChunks().catch(err => log.error(`Stale chunk cleanup failed: ${err}`));

--- a/server/src/brain/candidate-prune.ts
+++ b/server/src/brain/candidate-prune.ts
@@ -1,0 +1,177 @@
+/**
+ * Prune review findings that can never resurface.
+ *
+ * `{space}_dupe_candidates` and `{space}_contradiction_candidates` had no retention at all: the only
+ * deletes anywhere were the space wipe and space delete. A finding outlives the records it is about, so
+ * deleting a record individually stranded its findings forever — the Review tab listing a pair where
+ * clicking through leads nowhere.
+ *
+ * ── Why this is NOT "delete settled findings older than N days" ──────────────────────────────────────────
+ *
+ * The obvious retention policy would undo human decisions:
+ *
+ *   open                     the queue. Obviously kept.
+ *   dismissed                deleting it FORGETS the dismissal, and the next sweep re-flags the pair. That
+ *                            is precisely what the sticky-dismissal machinery (`decideDismissed`,
+ *                            `dismissedContentHash`) exists to prevent — a time-based prune would silently
+ *                            re-open every dismissal that aged out.
+ *   resolved edited/linked   the two records still exist and still look contradictory on the surface;
+ *                            forgetting how it was settled invites a re-flag.
+ *   resolved merged          SAFE — the absorbed record is gone, so the pair can never be detected again.
+ *
+ * So the rule is not age, it is **can this ever come back?** Dismissals are a few hundred bytes each and
+ * encode a decision somebody made; unbounded growth of those is a better trade than re-asking a settled
+ * question. What actually grows without bound — and loses nothing when removed — is findings whose records
+ * are gone.
+ *
+ * ── Why it runs on its own timer ─────────────────────────────────────────────────────────────────────────
+ *
+ * Not hung off the duplicate or contradiction scanner: both are **off by default**, so pruning would never
+ * run on most instances while the orphans accumulated anyway. Not folded into the TTL sweep either — that
+ * deletes through the normal record paths, which emit tombstones and webhooks. These are internal review
+ * state and were never user records; publishing `*.deleted` events for them would be wrong.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+import type { DupeScanType } from '../config/types.js';
+
+/** Both collections key their rows by the same singular vocabulary. */
+const COLLECTION_SUFFIX: Record<string, string> = {
+  memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
+};
+
+const CANDIDATE_COLLECTIONS = ['dupe_candidates', 'contradiction_candidates'] as const;
+
+/** How often to sweep. Orphans are not urgent — this is housekeeping, not correctness. */
+const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;   // 6h
+
+/** The subset of a candidate row this decision needs. */
+export interface PrunableCandidate {
+  status?: string;
+  resolution?: string;
+  aId?: string;
+  bId?: string;
+}
+
+export type PruneVerdict = 'keep' | 'prune-merged' | 'prune-orphan';
+
+/**
+ * Whether a finding can be dropped. Pure, so every branch is checkable without a database — and this is
+ * the branch that matters, because getting it wrong deletes a human decision rather than erroring.
+ *
+ * `aExists` / `bExists` must be the caller's POSITIVE knowledge that each record was found. A caller that
+ * could not check must not call this (see `pruneSpaceCandidates`, which keeps everything on a failed
+ * lookup): "I did not find it" and "I could not look" are the same value here and only one of them is safe.
+ */
+export function decideCandidatePrune(
+  row: PrunableCandidate, aExists: boolean, bExists: boolean,
+): PruneVerdict {
+  // A merged pair is unresurfacable by construction: one of the two records no longer exists, so the
+  // similarity search can never pair them again.
+  if (row.status === 'resolved' && row.resolution === 'merged') return 'prune-merged';
+
+  // Either record gone ⇒ the finding is unopenable. True for open, dismissed and resolved alike: a
+  // dismissal of a pair that no longer exists protects nothing, because the pair cannot be re-detected.
+  if (!aExists || !bExists) return 'prune-orphan';
+
+  return 'keep';
+}
+
+export interface PruneResult { merged: number; orphaned: number }
+
+/**
+ * Prune one space's findings across both candidate collections.
+ *
+ * Best-effort and **fail-closed**: any error, or any inability to confirm which records exist, leaves the
+ * rows alone. The dangerous failure here is not missing a prune — it is a lookup that comes back empty for
+ * an unrelated reason and makes every finding look orphaned.
+ */
+export async function pruneSpaceCandidates(spaceId: string): Promise<PruneResult> {
+  const result: PruneResult = { merged: 0, orphaned: 0 };
+
+  for (const suffix of CANDIDATE_COLLECTIONS) {
+    try {
+      const coll = col<PrunableCandidate & { _id: string; type?: string }>(`${spaceId}_${suffix}`);
+      const rows = await coll.find({}, { projection: { _id: 1, type: 1, status: 1, resolution: 1, aId: 1, bId: 1 } })
+        .toArray() as Array<PrunableCandidate & { _id: string; type?: string }>;
+      if (rows.length === 0) continue;
+
+      // Resolve existence per record type, one query each rather than one per finding.
+      const idsByType = new Map<string, Set<string>>();
+      for (const r of rows) {
+        if (!r.type) continue;
+        const set = idsByType.get(r.type) ?? new Set<string>();
+        if (r.aId) set.add(r.aId);
+        if (r.bId) set.add(r.bId);
+        idsByType.set(r.type, set);
+      }
+
+      const existing = new Map<string, Set<string>>();
+      let lookupFailed = false;
+      for (const [type, ids] of idsByType) {
+        const recSuffix = COLLECTION_SUFFIX[type as DupeScanType];
+        if (!recSuffix) { lookupFailed = true; break; }   // unknown type ⇒ cannot judge ⇒ keep everything
+        try {
+          const found = await col<{ _id: string }>(`${spaceId}_${recSuffix}`)
+            .find(asFilter<{ _id: string }>({ _id: { $in: [...ids] } }), { projection: { _id: 1 } })
+            .toArray() as Array<{ _id: string }>;
+          existing.set(type, new Set(found.map(d => d._id)));
+        } catch {
+          lookupFailed = true;
+          break;
+        }
+      }
+      if (lookupFailed) continue;   // fail closed: keep everything rather than mass-delete on a bad read
+
+      const toDelete: string[] = [];
+      for (const r of rows) {
+        const present = r.type ? existing.get(r.type) : undefined;
+        if (!present) continue;     // no knowledge for this type ⇒ keep
+        const verdict = decideCandidatePrune(r, !!r.aId && present.has(r.aId), !!r.bId && present.has(r.bId));
+        if (verdict === 'keep') continue;
+        toDelete.push(r._id);
+        if (verdict === 'prune-merged') result.merged++; else result.orphaned++;
+      }
+
+      if (toDelete.length > 0) {
+        await coll.deleteMany(asFilter<{ _id: string }>({ _id: { $in: toDelete } }));
+      }
+    } catch (err) {
+      log.warn(`Candidate prune (${spaceId}/${suffix}): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return result;
+}
+
+/** Prune every real (non-proxy) space. */
+export async function pruneAllSpaces(): Promise<void> {
+  let cfg;
+  try { cfg = getConfig(); } catch { return; }   // pre-setup
+  let merged = 0, orphaned = 0;
+  for (const s of cfg.spaces) {
+    if (s.proxyFor) continue;
+    const r = await pruneSpaceCandidates(s.id);
+    merged += r.merged; orphaned += r.orphaned;
+  }
+  if (merged + orphaned > 0) {
+    log.info(`Candidate prune: removed ${orphaned} finding(s) whose records are gone and ${merged} merged pair(s)`);
+  }
+}
+
+let _timer: NodeJS.Timeout | null = null;
+
+/**
+ * Start the background prune. Always on — unlike the scanners it has no cost worth gating and no behaviour
+ * an operator would want to opt out of: it only removes findings that cannot be acted on.
+ */
+export function startCandidatePrune(): void {
+  if (_timer) return;
+  _timer = setInterval(() => { void pruneAllSpaces().catch(err => log.error(`Candidate prune cycle: ${err}`)); }, PRUNE_INTERVAL_MS);
+  _timer.unref();   // never keep the process alive for housekeeping
+  log.debug('Candidate prune worker started');
+}
+
+export function stopCandidatePrune(): void {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+}

--- a/testing/standalone/candidate-prune.test.js
+++ b/testing/standalone/candidate-prune.test.js
@@ -1,0 +1,82 @@
+/**
+ * Which review findings may be deleted — the decision, isolated from the plumbing.
+ *
+ * This is the branch worth testing exhaustively, because getting it wrong does not error: it silently
+ * deletes a decision a person made. A finding is a claim about two records, and the naive retention policy
+ * ("delete settled findings older than N days") would forget dismissals — the exact thing the sticky-
+ * dismissal machinery exists to preserve. Age is the wrong axis; **can this ever resurface** is the right
+ * one.
+ *
+ * Run: node --test testing/standalone/candidate-prune.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let decideCandidatePrune;
+const row = (over = {}) => ({ status: 'open', aId: 'a', bId: 'b', ...over });
+
+describe('candidate prune — a human decision is never deleted', () => {
+  before(async () => {
+    ({ decideCandidatePrune } = await import('../../server/dist/brain/candidate-prune.js'));
+  });
+
+  it('keeps a dismissal while both records still exist', () => {
+    // The whole point of sticky dismissal: forgetting this re-flags the pair on the next sweep, which is
+    // how a queue teaches people to stop reading it.
+    assert.equal(decideCandidatePrune(row({ status: 'dismissed' }), true, true), 'keep');
+  });
+
+  it('keeps a resolution that could still be re-detected', () => {
+    // The records still exist and still look contradictory on the surface — only the stored resolution
+    // says otherwise.
+    assert.equal(decideCandidatePrune(row({ status: 'resolved', resolution: 'edited' }), true, true), 'keep');
+    assert.equal(decideCandidatePrune(row({ status: 'resolved', resolution: 'linked' }), true, true), 'keep');
+    assert.equal(decideCandidatePrune(row({ status: 'resolved', resolution: 'notified' }), true, true), 'keep');
+  });
+
+  it('keeps an open finding — that is the queue', () => {
+    assert.equal(decideCandidatePrune(row(), true, true), 'keep');
+  });
+});
+
+describe('candidate prune — what can never come back', () => {
+  before(async () => {
+    ({ decideCandidatePrune } = await import('../../server/dist/brain/candidate-prune.js'));
+  });
+
+  it('prunes a merged pair — the absorbed record is gone, so it cannot re-detect', () => {
+    assert.equal(decideCandidatePrune(row({ status: 'resolved', resolution: 'merged' }), true, true), 'prune-merged');
+  });
+
+  it('prunes a finding whose record was deleted, whatever its status', () => {
+    // Unopenable: the Review tab lists it and clicking through leads nowhere.
+    for (const status of ['open', 'dismissed', 'resolved']) {
+      assert.equal(decideCandidatePrune(row({ status }), false, true), 'prune-orphan', `${status} / A gone`);
+      assert.equal(decideCandidatePrune(row({ status }), true, false), 'prune-orphan', `${status} / B gone`);
+    }
+  });
+
+  it('drops a dismissal only once its pair can no longer be re-detected', () => {
+    // Not a contradiction of the rule above: a dismissal protects against re-flagging, and a pair whose
+    // record is gone can never be flagged again. Nothing is lost.
+    assert.equal(decideCandidatePrune(row({ status: 'dismissed' }), true, true), 'keep');
+    assert.equal(decideCandidatePrune(row({ status: 'dismissed' }), false, false), 'prune-orphan');
+  });
+
+  it('treats a row with no record ids as an orphan rather than keeping it forever', () => {
+    assert.equal(decideCandidatePrune({ status: 'open' }, false, false), 'prune-orphan');
+  });
+});
+
+describe('candidate prune — merged wins over orphaned, and both are reported', () => {
+  before(async () => {
+    ({ decideCandidatePrune } = await import('../../server/dist/brain/candidate-prune.js'));
+  });
+
+  it('reports a merged pair as merged even though its record is also gone', () => {
+    // A merge deletes the absorbed record, so every merged row is ALSO an orphan. The more specific reason
+    // is the useful one in the log line.
+    assert.equal(decideCandidatePrune(row({ status: 'resolved', resolution: 'merged' }), true, false), 'prune-merged');
+  });
+});

--- a/testing/standalone/scheduler-wiring.test.js
+++ b/testing/standalone/scheduler-wiring.test.js
@@ -26,6 +26,7 @@ const SCHEDULERS = [
   { module: 'server/src/brain/dupe-scanner.ts', start: 'startDupeScanner' },
   { module: 'server/src/brain/contradiction-scanner.ts', start: 'startContradictionScanner' },
   { module: 'server/src/brain/ttl-sweep.ts', start: 'startTtlSweep' },
+  { module: 'server/src/brain/candidate-prune.ts', start: 'startCandidatePrune' },
   { module: 'server/src/db/backup-scheduler.ts', start: 'startBackupScheduler' },
 ];
 


### PR DESCRIPTION
Neither `{space}_dupe_candidates` nor `{space}_contradiction_candidates` had any retention. The only deletes anywhere were the space wipe and space delete, so **deleting a record individually stranded every finding about it forever** — the Review tab listing a pair where clicking through leads nowhere.

## The tracker said "retention"; grounding it inverted the design

The obvious policy — *delete settled findings older than N days* — would have **undone human decisions**:

| Row | Delete it and… |
|---|---|
| `open` | it's the queue. Obviously kept. |
| `dismissed` | **the dismissal is forgotten and the next sweep re-flags the pair** — exactly what `decideDismissed` / `dismissedContentHash` exist to prevent. Every dismissal that aged out would silently re-open. |
| `resolved: edited` / `linked` | the pair still exists and still looks conflicting on the surface; forgetting how it was settled invites a re-flag. |
| `resolved: merged` | **safe** — the absorbed record is gone, so the pair can never be detected again. |

So the axis isn't age, it's **can this ever come back?** Only orphans and merged pairs are pruned. Dismissals and live resolutions are kept indefinitely — a few hundred bytes each is a better trade than re-asking a question somebody already answered.

Worth noting the one case that looks like an exception but isn't: a **dismissed** finding whose records are gone *is* pruned. A dismissal protects against re-flagging, and a pair that can no longer be detected can no longer be flagged. Nothing is lost.

## Two placement decisions

**Its own timer, not the scanners'.** Both the duplicate and contradiction scanners are off by default, so hanging pruning off them would mean it never runs on exactly the instances where orphans still accumulate — the same "absence looks healthy" shape as the sweep that was never scheduled (#464).

**Not folded into the TTL sweep.** That deletes through the normal record paths, which emit tombstones and webhooks. These are internal review state and were never user records; publishing `*.deleted` events for them would be wrong.

## Fail-closed

Any error, or any record type it cannot resolve, leaves that collection **entirely alone**. The dangerous failure here isn't a missed prune — it's a lookup returning empty for an unrelated reason and making every finding look orphaned. `decideCandidatePrune` takes *positive* knowledge that each record was found, and a caller that couldn't check must not call it.

## Verification

Scratch instance, five seeded findings:

| Finding | Outcome |
|---|---|
| live `open` (both records exist) | **kept** |
| live `dismissed` (both records exist) | **kept** — the decision survives |
| `resolved: merged` | pruned |
| orphan `open` | pruned |
| orphan `dismissed` | pruned |

→ `{merged: 1, orphaned: 2}`, leaving exactly the two live rows.

Then the guard: adding **one** row with an unresolvable record type stopped the whole collection being pruned, leaving a would-be orphan in place → `{merged: 0, orphaned: 0}`.

Gates: server `tsc` clean · 40/40 on the affected standalone suites (19 new) · `lint:docs` clean · no route changes · no client changes. The new scheduler is picked up automatically by the `scheduler-wiring` test from #464, which asserts every `start*` is actually called in bootstrap and paired with a `stop*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)