### PR TITLE
docs: correct claims this session's changes made wrong

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2502,7 +2502,16 @@ When `visionProvider: external` or `sttProvider: external`, file bytes (image fr
 
 The face recognition pipeline detects and embeds faces in uploaded images, builds a per-space face gallery, and automatically links images to person entities when a match exceeds a configurable confidence threshold. It runs **entirely in-process** on the CPU — no GPU, no sidecar, no Python — using `@vladmandic/human` (TF.js CPU backend).
 
-**Opt-in** — disabled by default. Enable it on **Settings → Media Processing → Face recognition**, via `PATCH /api/admin/media-config` with a `faceRecognition` block, or by setting `mediaEmbedding.faceRecognition.enabled: true` in `config.json`.
+**Faces are governed by the image LEVEL, not by a switch of their own.** They run only where the effective
+image level is `recognition` (or `auto`, which resolves to the most the instance allows). The instance
+default is `caption`, so **no face detection happens until someone raises a level** — on
+**Settings → Media Processing** for the instance ceiling, or per space in that space's media settings.
+
+There is no longer a face-recognition checkbox: it was redundant with the ladder, and having two controls
+meant an image level of `recognition` could still silently do nothing. `mediaEmbedding.faceRecognition.enabled`
+survives as an **infra pin only** — it defaults to `true` and exists so `FACE_RECOGNITION_ENABLED=false`
+can hard-disable the pipeline regardless of any level, for deployments where biometric processing must be
+impossible rather than merely off. Setting it to `true` does not enable anything by itself.
 
 **Turning it off stops new detection; it does not erase what was collected.** Existing face vectors and person labels stay stored and searchable until the files they came from are deleted. The admin UI states this in a confirmation before saving, because switching this off is usually a privacy decision and the two are easy to confuse.
 
@@ -2517,11 +2526,12 @@ The model files are not bundled with Ythril. Download and place them in `DATA_RO
 
 Download from `https://vladmandic.github.io/human/models/` — use the exact filenames listed above.
 
-Also create the Atlas vector index for face embeddings (per space, 128 dimensions, cosine similarity, field path `faceEmbedding`, index name `{spaceId}_files_faceEmbedding`) on the `{spaceId}_files` collection. This is done automatically when a space is initialised if face recognition is enabled.
+Also create the Atlas vector index for face embeddings (per space, 128 dimensions, cosine similarity, field path `faceEmbedding`, index name `{spaceId}_files_faceEmbedding`) on the `{spaceId}_files` collection. This is done automatically when a space is initialised.
 
 #### How It Works
 
-When a media-embedding job processes an image and `faceRecognition.enabled` is `true`:
+When a media-embedding job processes an image whose effective level permits faces (`recognition` or `auto`,
+and the infra pin not turned off):
 
 1. **Decode** — image bytes decoded to raw RGBA via `sharp`.
 2. **Detect** — `@vladmandic/human` runs BlazeFace Back detection. Faces below `minFaceSizeFraction` (default: 5% of the shorter image side) are skipped.

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -220,7 +220,7 @@ Example — find memories tagged `infra`:
 
 ### File metadata (merged into Files)
 
-There is no longer a separate **File Meta** tab. The metadata Ythril keeps for each uploaded file — the searchable side of a file (its caption/extracted text, tags, and links to entities, memories, and chrono entries) as distinct from the raw bytes — is being folded into the **[Files](#files)** tab, so files and their metadata live in one explorer-style view. Each file row already shows its **embedding status** and **tags** inline (see [Files](#files)); a docked detail view that opens the full metadata record next to the file preview follows in a subsequent update.
+There is no longer a separate **File Meta** tab. The metadata Ythril keeps for each uploaded file — the searchable side of a file (its caption/extracted text, tags, and links to entities, memories, and chrono entries) as distinct from the raw bytes — lives in the **[Files](#files)** tab, so files and their metadata are one explorer-style view. Each file row shows its **embedding status** (or a live stage bar while it is being processed) and its **tags** inline, and opening a file docks a detail pane beside the preview with the full metadata record — description, tags, entity/memory/chrono links — plus **what will run** for that file. See [Files](#files).
 
 ---
 
@@ -602,7 +602,7 @@ When both providers are set to *Local*, no file content ever leaves your instanc
 
 The **External assist model** card lets you point a bigger, hosted model at the **document repair pass** — the one used by the `repair` extraction level (and by `auto` when a repair model is configured). There is no separate "used for" tick: repair is the only thing it does, so the **extraction level is the switch**. Fill in an **Endpoint** + **Model**, then raise **Document extraction** to **Repair** (or **Auto**) to route repairs through it. At that point you are asked to **acknowledge the egress** — document content (OCR text, and page images) is sent to that host. The acknowledgement is recorded against the host and re-checked at run time, so an endpoint you have not acknowledged is never contacted: repairs fall back to the local model instead.
 
-This is the one document setting that sends content off your instance: when a task is assigned, the model receives OCR-extracted text and draft transcriptions (and, for future image tasks, rendered page images). Because of that, saving with a task assigned pops an **acknowledgment dialog** naming exactly what data goes to which host — you must confirm before it's enabled, and Ythril records that consent so content is never sent to a host you didn't acknowledge. Endpoints are checked to be public addresses, and the API key is stored in the encrypted secrets file. Leave it unconfigured (or untick every task) to keep document processing fully local.
+This is the one document setting that sends content off your instance: the model receives OCR-extracted text and draft transcriptions (and, for future image tasks, rendered page images). Because of that, configuring a host pops an **acknowledgment dialog** naming exactly what data goes where — you must confirm before it is used, and Ythril records that consent against the host and re-checks it at run time, so content is never sent somewhere you did not acknowledge. Endpoints are checked to be public addresses, and the API key is stored in the encrypted secrets file. Leave it unconfigured — or keep **Document extraction** below **Repair** — to keep document processing fully local.
 
 ---
 

--- a/docs/workstation-mode-guide.md
+++ b/docs/workstation-mode-guide.md
@@ -24,7 +24,7 @@ Recommended host minimums:
 
 > **Slimmer install:** Ythril ships with bundled image and audio/video understanding
 > services so attachments become searchable automatically. If your machine is tight
-> on memory, turn it off in **Settings → Models** — no command line needed.
+> on memory, turn it off in **Settings → Media Processing** — no command line needed.
 
 Quick checks:
 
@@ -68,7 +68,7 @@ Default stack from `docker-compose.yml`:
 - `ythril-unstructured` (document parsing for PDF/DOCX/EPUB uploads)
 - `ythril-doc-render` (PDF → page-image rendering for the VLM document-extraction path)
 
-All six containers start on `docker compose up -d` — none is behind a Compose profile. To run a lean stack, scale the ones you don't need to zero, e.g. `docker compose up --scale ollama=0 --scale whisper=0 --scale unstructured=0 --scale doc-render=0`. Setting the **images / audio / video** levels to `off` in **Settings → Models** (or `mediaEmbedding.levels` in `config.json`) stops Ythril *calling* the vision/STT sidecars, but does not stop the `unstructured`/`doc-render` document-processing containers — scale those to zero if you don't upload documents.
+All six containers start on `docker compose up -d` — none is behind a Compose profile. To run a lean stack, scale the ones you don't need to zero, e.g. `docker compose up --scale ollama=0 --scale whisper=0 --scale unstructured=0 --scale doc-render=0`. Setting the **images / audio / video** levels to `off` in **Settings → Media Processing** (or `mediaEmbedding.levels` in `config.json`) stops Ythril *calling* the vision/STT sidecars, but does not stop the `unstructured`/`doc-render` document-processing containers — scale those to zero if you don't upload documents.
 
 Option A: keep defaults (port 3200 + bundled MongoDB)
 

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -571,8 +571,16 @@ export interface MediaLevelCeilings {
  */
 export interface FaceRecognitionConfig {
   /**
-   * Master switch. When false, face detection/embedding is skipped entirely.
-   * Default: false (opt-in; requires local model files to be present).
+   * **Infra pin, not a user switch. Defaults to TRUE.**
+   *
+   * Whether faces run is decided by the image LEVEL (`recognition`, or `auto` resolving to it) — this
+   * field only lets an operator hard-disable the pipeline regardless of any level, via
+   * `FACE_RECOGNITION_ENABLED=false`, for deployments where biometric processing must be impossible
+   * rather than merely switched off. Setting it `true` enables nothing by itself.
+   *
+   * It used to be the opt-in master switch with a checkbox and a `false` default. That was removed
+   * because two controls meant an image level of `recognition` could silently do nothing; the ladder is
+   * now the single gate, and images default to `caption` so faces stay off until a level is raised.
    */
   enabled?: boolean;
   /**


### PR DESCRIPTION
Owner-requested doc-care pass: *"make sure docs/ is updated where necessary and todos are cleaned off of done/shipped items."*

Most of what it found wasn't missing documentation — it was documentation that had quietly become **wrong**.

## The one that would have cost someone real time

`faceRecognition.enabled` was documented as an **opt-in master switch defaulting to `false`**. It is neither. Since the checkbox was dropped (#444) it survives as the **infra pin only**, defaults to **`true`**, and the actual gate is the image ladder (`recognition` / `auto`).

Following the old text, you would set `enabled: true`, watch nothing happen, and have no way to work out why — the guide named a checkbox that no longer exists and a default that had inverted.

Corrected in the integration guide, in the two statements derived from it (*"when `enabled` is `true`…"*, and the vector index being created only *"if face recognition is enabled"*), and in the `FaceRecognitionConfig` doc comment, which is where the wrong claim originated.

## The rest

- **`workstation-mode-guide.md` still said "Settings → Models"** in two places — renamed to Media Processing in #446/#447. Missed because those PRs grepped only the files they were changing; nothing checks docs for names that moved.
- **The userguide promised the file detail pane "follows in a subsequent update"** — it shipped. Rewritten to describe what's actually there, including the live stage bar and the per-file "what will run" plan.
- **It told users to "untick every task"** to keep document processing local. Those per-task ticks were removed in #445; the extraction level is the control now.

## Trackers (gitignored, so not in this commit)

- `_TODO-ORDERED.md`: **231 → 95 lines**, every shipped block removed per its own rule (*"If it is done, it is gone"*). 11 open items remain.
- Across the domain trackers: **~1450 → 961 lines**, with two findings worth naming:
  - The **settings design system** was listed as seven unstarted primitives. All seven exist and are used in **4–42 files each** — verified by import count, not memory. The boxes were simply never ticked as each landed, so it read as a large block of unstarted foundation work.
  - **"What runs on upload"** was still listed as outstanding, after the owner re-scoped it into the per-file view that shipped as #460/#461.

Backed the trackers up to the scratchpad first — `todo/` is gitignored, so those deletions aren't recoverable.

**Deliberately not deleted:** QA-TODO's *"7 of 8 converted `[x]` — one left"*. Marked done but says work remains, so it's a human call rather than a script's.

Gates: server `tsc` clean · `lint:docs` clean · no code behaviour changes (the only non-docs edit is a corrected doc comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)