### PR TITLE
feat(files): read long documents in windows instead of cutting them at maxPages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Long documents are now read in full instead of being cut at 50 pages.** A document longer than
+  `maxPages` became its first `maxPages` pages, permanently — a 400-page report was indexed as its first
+  fifty, and recall then answered confidently from an eighth of it. The page sidecars accept a `startPage`,
+  so a document is walked in windows rather than truncated.
+
+  **`maxPages` keeps its real job and loses the one it should never have had.** It bounds a single render
+  call — that call's memory and latency — which is a genuine constraint. It was never meant to be the limit
+  on how much of a document gets read; it just was, because nothing looped.
+
+  The whole-job limit is now its own setting, `documentProcessing.maxTotalPages` (default **200**, four
+  times the old effective limit). It is deliberately separate and deliberately not unlimited: every page is
+  a VLM call, so an unbounded walk over a 600-page scan is 600 model calls and — with an external endpoint —
+  600 pages of content leaving the instance, triggered by an upload nobody is watching. A document beyond
+  the budget still stops, and still says so loudly in the log and in the stored markdown. The bug being
+  fixed is the silence and the tiny cap, not the existence of a cap.
+
+  The `max`-mode consensus pass is **skipped for a segmented document**, and says so. It re-transcribes
+  every page with a second model, so on a walked document it would double the page cost the budget exists
+  to bound and require every window's images alive at once. Not a regression: before this change a long
+  document was truncated to one window, so consensus never saw more than that anyway.
+
 - **The Chrono tab now has a Created column, and it sorts.** Entities, edges and memories all showed one;
   chrono did not, even though the API has accepted `sort=createdAt` for chrono all along — the column simply
   was never added, so the capability existed and could not be reached.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2270,7 +2270,14 @@ They are never queued, so they do not sit at `pending` waiting for work that wil
 | `verifyModel` | `""` | Engages on the **`repair`** level, and on **`auto`** when a repair model is set (F11-d consensus). A *second* document VLM. When set, the repair level runs it as an independent second transcription of each page, reconciles it with the primary draft against the OCR text, and keeps the highest-coverage result — **never worse** than the primary. Empty ⇒ no consensus pass. Best set to a *different* model than `vlmModel`. Env override: `DOC_VERIFY_MODEL`. |
 | `verifyBaseUrl` | `""` | Endpoint for the verify model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_VERIFY_URL`. |
 | `renderDpi` | `150` | Page rasterization DPI for the render sidecar (VLM modes only). |
-| `maxPages` | `50` | Cap on pages rendered/transcribed per document (VLM modes only). |
+| `maxPages` | `50` | Pages rendered per **render call** — one sidecar round trip's memory/latency bound. Not how much of a document is read: longer documents are walked in windows of this size. |
+| `maxTotalPages` | `200` | Pages read from **one document** in total, across windows. Beyond this the extraction stops and says so, in the log and in the stored markdown. |
+
+> **Why two numbers.** They bound different things. `maxPages` is one round trip; `maxTotalPages` is the
+> job's cost ceiling — every page is a VLM call, so an unbounded walk over a 600-page scan means 600 model
+> calls and, with an external endpoint, 600 pages of content leaving the instance, on an upload nobody is
+> watching. Raise `maxTotalPages` deliberately. In `max` mode the consensus pass is skipped for a document
+> that had to be walked, since it re-transcribes every page with a second model.
 | `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
 | `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
 | `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `repair`). Env override: `DOC_OCR_TIMEOUT_MS`. |

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -899,6 +899,9 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   mode: 'vlm',
   renderDpi: 150,
   maxPages: 50,
+  // Pages read from one document in total, across render windows. Separate from `maxPages`, which bounds
+  // ONE render call: this is the job's cost ceiling, and every page beyond it is another VLM call.
+  maxTotalPages: 200,
   pageTimeoutMs: 60_000,
   concurrency: 2,
   ocrTimeoutMs: 120_000, // 2 min — the historical hardcoded OCR-sidecar ceiling, now tunable
@@ -931,6 +934,7 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     mode: normalizeDocExtractionMode(base.mode) ?? d.mode,
     renderDpi: base.renderDpi ?? d.renderDpi,
     maxPages: base.maxPages ?? d.maxPages,
+    maxTotalPages: base.maxTotalPages ?? d.maxTotalPages,
     pageTimeoutMs: base.pageTimeoutMs ?? d.pageTimeoutMs,
     concurrency: base.concurrency ?? d.concurrency,
     ocrTimeoutMs: process.env['DOC_OCR_TIMEOUT_MS'] ? Number(process.env['DOC_OCR_TIMEOUT_MS']) : (base.ocrTimeoutMs ?? d.ocrTimeoutMs),

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -424,8 +424,24 @@ export interface DocumentProcessingConfig {
   mode?: DocExtractionMode;
   /** F11 — DPI for page rasterization in VLM modes. Default 150. */
   renderDpi?: number;
-  /** F11 — max pages rasterized + sent to the VLM per document (cost/latency bound). Default 50. */
+  /**
+   * F11 — max pages rasterized per RENDER CALL (memory/latency bound on one sidecar round trip).
+   * Default 50.
+   *
+   * This is no longer how much of a document gets read: long documents are walked in windows of this size
+   * via the sidecars' `startPage`. Use `maxTotalPages` to bound the whole job.
+   */
   maxPages?: number;
+  /**
+   * F11 — max pages read from ONE document across all windows. Default 200. Beyond this the extraction
+   * stops and says so, in the log and in the stored markdown.
+   *
+   * Deliberately separate from `maxPages`, because they bound different things: `maxPages` is one round
+   * trip's memory, this is the job's total cost. Every page is a VLM call, so an unbounded walk over a
+   * 600-page scan means 600 model calls and — with an external endpoint — 600 pages of content leaving the
+   * instance, on an upload nobody is watching. Raise it deliberately.
+   */
+  maxTotalPages?: number;
   /** F11 — per-page model-call timeout in ms (VLM/repair). Default 60000. */
   pageTimeoutMs?: number;
   /** F11 — max concurrent per-page model calls within one document. Default 2. */

--- a/server/src/files/converters/renderer.ts
+++ b/server/src/files/converters/renderer.ts
@@ -68,10 +68,12 @@ export function _resetRenderHealthCache(): void { _renderHealth = null; _officeH
 /** Rendered document pages (PNG bytes per page). */
 export interface RenderedPages {
   pages: Buffer[];
-  /** Total pages in the document (may exceed `pages.length` when the maxPages cap was hit). */
+  /** Total pages in the document (may exceed `pages.length` when only a window was rendered). */
   total: number;
-  /** True when `total > pages.length` — the render was capped. */
+  /** True when there are pages AFTER this window — i.e. keep going, or stop and say you truncated. */
   truncated: boolean;
+  /** First page index of the returned window. Echoed by the sidecar; 0 for a from-the-start render. */
+  startPage: number;
 }
 
 /**
@@ -82,10 +84,11 @@ export interface RenderedPages {
  */
 export async function renderDocumentPages(
   bytes: Buffer,
-  opts: { fileName: string; dpi?: number; maxPages?: number; timeoutMs?: number },
+  opts: { fileName: string; dpi?: number; maxPages?: number; timeoutMs?: number; startPage?: number },
 ): Promise<RenderedPages> {
   const dpi = opts.dpi ?? 150;
   const maxPages = opts.maxPages ?? 50;
+  const startPage = Math.max(0, Math.trunc(opts.startPage ?? 0));
   const office = isOfficeDocument(opts.fileName);
   const base = office ? OFFICE_URL : RENDER_URL;
 
@@ -94,7 +97,7 @@ export async function renderDocumentPages(
   // treated as PDF); the PDF sidecar ignores it.
   form.append('file', new Blob([new Uint8Array(bytes)]), opts.fileName || (office ? 'document' : 'document.pdf'));
 
-  const url = `${base}/render?dpi=${dpi}&maxPages=${maxPages}`;
+  const url = `${base}/render?dpi=${dpi}&maxPages=${maxPages}&startPage=${startPage}`;
   const which = office ? 'doc-office' : 'doc-render';
   let res: Response;
   try {
@@ -107,8 +110,15 @@ export async function renderDocumentPages(
     throw new Error(`${which} sidecar error ${res.status}: ${detail.slice(0, 200)}`);
   }
 
-  const body = await res.json() as { pages?: string[]; total?: number; truncated?: boolean };
+  const body = await res.json() as { pages?: string[]; total?: number; truncated?: boolean; startPage?: number };
   const pages = (body.pages ?? []).map(b64 => Buffer.from(b64, 'base64'));
-  if (body.truncated) log.debug(`render: document truncated to ${pages.length}/${body.total} pages`);
-  return { pages, total: body.total ?? pages.length, truncated: body.truncated ?? false };
+  if (body.truncated) log.debug(`render: pages ${startPage}–${startPage + pages.length} of ${body.total}; more follow`);
+  // `startPage` falls back to what we asked for: an older sidecar that does not echo it still windows
+  // correctly, it just cannot confirm the offset.
+  return {
+    pages,
+    total: body.total ?? pages.length,
+    truncated: body.truncated ?? false,
+    startPage: body.startPage ?? startPage,
+  };
 }

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -21,6 +21,15 @@ import { transcribePageImage, repairMarkdown, repairMarkdownExternal, reconcileC
 import type { StepProgress } from './types.js';
 import { decideRoute, validateExtraction, bestByEvidence } from './extraction-policy.js';
 
+/**
+ * Pages read from one document across all render windows, when unconfigured.
+ *
+ * 200 rather than "no limit": every page is a VLM call, so the budget is the cost ceiling for a single
+ * upload. Four times the old effective limit of 50, which was never a budget at all — it was one render
+ * call's memory bound doing double duty as the document's reading limit.
+ */
+const DEFAULT_MAX_TOTAL_PAGES = 200;
+
 const TRANSCRIBE_PROMPT =
   'Transcribe this document page to GitHub-Flavored Markdown, verbatim. Preserve headings, lists, and ' +
   'tables (use Markdown tables; use minimal HTML only if a table is too complex for Markdown). Do NOT ' +
@@ -66,36 +75,79 @@ export async function vlmExtractDocument(
   // ── VLM path ────────────────────────────────────────────────────────────────
   const baseUrl = cfg.vlmBaseUrl || getMediaEmbeddingConfig().vision?.baseUrl || 'http://ollama:11434';
   try {
-    const { pages, truncated, total: totalPages } = await renderDocumentPages(fileBytes, {
-      fileName,
-      dpi: cfg.renderDpi,
-      maxPages: cfg.maxPages,
-      timeoutMs: cfg.pageTimeoutMs * Math.min(cfg.maxPages, 20),
-    });
-    if (pages.length === 0) throw new Error('render produced no pages');
-    onProgress?.({ step: 'render', steps, done: pages.length, total: pages.length });
+    // ── Segmented render + transcribe ─────────────────────────────────────────────────────────────
+    //
+    // A long document used to become its first `maxPages` pages, full stop. `maxPages` bounds ONE render
+    // call — memory and latency per call — which is a real constraint and is kept; what it should never
+    // have been is the limit on how much of the document is read. The sidecars now take a `startPage`, so
+    // the work is walked in windows of `maxPages` instead.
+    //
+    // `maxTotalPages` is the separate, deliberate limit on the whole job, and it is not the same knob:
+    // every extra page is a VLM call, so an unbounded loop over a 600-page scan is 600 model calls and —
+    // on an external endpoint — 600 pages of content leaving the instance, triggered by an upload with
+    // nobody watching. When a document exceeds the budget we do exactly what today's code does, but
+    // honestly: extract what the budget allows and say plainly that the rest was skipped.
+    const pageBudget = Math.max(1, cfg.maxTotalPages ?? DEFAULT_MAX_TOTAL_PAGES);
+    const windowSize = Math.max(1, cfg.maxPages);
+    const parts: string[] = [];
+    let pagesRead = 0;
+    let totalPages = 0;
+    let moreAfterBudget = false;
     let pagesDone = 0;
+    let segmented = false;
+    // Kept ONLY for the single-window case, so the consensus pass below can re-read the same images.
+    // Holding every window's buffers would defeat the per-call memory bound that `maxPages` exists for.
+    let firstWindowPages: Buffer[] = [];
 
-    const parts = await mapLimit(pages, cfg.concurrency, async (img) => {
-      const t = await transcribePageImage(img, {
-        baseUrl, model: cfg.vlmModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
+    for (let startPage = 0; pagesRead < pageBudget; startPage += windowSize) {
+      const take = Math.min(windowSize, pageBudget - pagesRead);
+      const window = await renderDocumentPages(fileBytes, {
+        fileName,
+        dpi: cfg.renderDpi,
+        maxPages: take,
+        startPage,
+        timeoutMs: cfg.pageTimeoutMs * Math.min(take, 20),
       });
-      // A finished page is the smallest honest unit of progress on this path — it is what makes a
-      // long document slow rather than wedged. Counting completions rather than using the map index
-      // keeps the number monotonic: pages run concurrently, so index order is not completion order
-      // and a bar driven by it would jump backwards.
-      onProgress?.({ step: 'vlm', steps, done: ++pagesDone, total: pages.length });
-      return t.text.trim();
-    });
+      totalPages = window.total;
+      if (window.pages.length === 0) {
+        // Only an error on the FIRST window: a later empty window just means we reached the end, which
+        // `truncated: false` would normally have told us already.
+        if (startPage === 0) throw new Error('render produced no pages');
+        break;
+      }
+      if (startPage === 0) firstWindowPages = window.pages; else { segmented = true; firstWindowPages = []; }
+      pagesRead += window.pages.length;
+      onProgress?.({ step: 'render', steps, done: pagesRead, total: Math.min(totalPages, pageBudget) });
+
+      const windowParts = await mapLimit(window.pages, cfg.concurrency, async (img) => {
+        const t = await transcribePageImage(img, {
+          baseUrl, model: cfg.vlmModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
+        });
+        // A finished page is the smallest honest unit of progress on this path — it is what makes a
+        // long document slow rather than wedged. Counting completions rather than using the map index
+        // keeps the number monotonic: pages run concurrently, so index order is not completion order
+        // and a bar driven by it would jump backwards. Across windows the count keeps rising, so the
+        // bar does not restart at each segment.
+        onProgress?.({ step: 'vlm', steps, done: ++pagesDone, total: Math.min(totalPages, pageBudget) });
+        return t.text.trim();
+      });
+      parts.push(...windowParts);
+
+      if (!window.truncated) break;          // no pages after this window — done
+      if (pagesRead >= pageBudget) { moreAfterBudget = true; break; }
+    }
+
     let markdown = parts.filter(Boolean).join('\n\n---\n\n').trim();
-    if (truncated) {
+    if (moreAfterBudget) {
       // Truncation used to leave ONLY this HTML comment buried in the converted markdown: not
       // logged, not stored, and the file still reported success. A 400-page document silently
-      // became its first 50 pages, and recall then answered confidently from a tenth of it.
-      markdown += `\n\n<!-- document truncated to ${pages.length} of ${totalPages} pages -->`;
+      // became its first 50 pages, and recall then answered confidently from a tenth of it. It is now
+      // reached far less often — the cap is the whole-job budget, not one render — but when it IS hit it
+      // must still be loud.
+      markdown += `\n\n<!-- document truncated to ${pagesRead} of ${totalPages} pages -->`;
       log.warn(
-        `VLM extract: '${fileName}' truncated — read ${pages.length} of ${totalPages} pages ` +
-        `(documentProcessing.maxPages = ${cfg.maxPages}). The rest was NOT indexed.`,
+        `VLM extract: '${fileName}' truncated — read ${pagesRead} of ${totalPages} pages ` +
+        `(documentProcessing.maxTotalPages = ${pageBudget}). The rest was NOT indexed.`,
       );
     }
 
@@ -107,8 +159,15 @@ export async function vlmExtractDocument(
       // ── F11-d max-mode consensus: an independent second-VLM pass + reconcile, kept only if it covers the
       // OCR evidence at least as well as the primary (never worse). Precision step on an ALREADY-accepted
       // draft; failure-gated to `max` (route has the verify stage) and to a configured verify model.
-      if (route.stages.includes('verify') && cfg.verifyModel && evidence.trim()) {
-        const consensus = await runConsensus(pages, markdown, evidence, cfg, baseUrl).catch(err => {
+      // Skipped for a SEGMENTED document, deliberately. `runConsensus` re-transcribes every page with a
+      // second model, so on a walked document it would double the page cost the budget exists to bound and
+      // require every window's buffers alive at once. Not a regression either: before segmentation a long
+      // document was truncated to one window, so consensus never saw more than this anyway.
+      if (segmented && route.stages.includes('verify') && cfg.verifyModel) {
+        log.info(`VLM extract: '${fileName}' was read in segments — skipping the consensus pass (it would re-transcribe all ${pagesRead} pages).`);
+      }
+      if (!segmented && route.stages.includes('verify') && cfg.verifyModel && evidence.trim()) {
+        const consensus = await runConsensus(firstWindowPages, markdown, evidence, cfg, baseUrl).catch(err => {
           log.warn(`VLM extract: consensus pass errored (${err instanceof Error ? err.message : err}) — keeping primary`);
           return null;
         });
@@ -117,7 +176,7 @@ export async function vlmExtractDocument(
           return { markdown: consensus.text, extractedImages: ocr?.extractedImages ?? [], extractionPath: `${ranLabel}+verify` };
         }
       }
-      log.debug(`VLM extract: accepted ${ranLabel} (${pages.length} pages, coverage ${(v.coverage * 100).toFixed(0)}%)`);
+      log.debug(`VLM extract: accepted ${ranLabel} (${pagesRead} pages, coverage ${(v.coverage * 100).toFixed(0)}%)`);
       return { markdown, extractedImages: ocr?.extractedImages ?? [], extractionPath: ranLabel };
     }
 

--- a/sidecars/doc-office/app.py
+++ b/sidecars/doc-office/app.py
@@ -19,7 +19,10 @@ See LICENSES.md.
 Endpoints:
   GET  /health                      -> {"status": "ok"}
   POST /render  (multipart 'file')  -> {"pages": [<base64 png>...], "count", "total", "truncated", "dpi"}
-    query: dpi (72..600), maxPages (1..RENDER_MAX_PAGES)
+    query: dpi (72..600), maxPages (1..RENDER_MAX_PAGES), startPage (>=0)
+
+`startPage` mirrors doc-render so a caller can walk either sidecar the same way, taking one window of pages
+at a time instead of losing everything past `maxPages`.
 """
 import base64
 import io
@@ -77,6 +80,7 @@ async def render(
     file: UploadFile = File(...),
     dpi: int = Query(150, ge=72, le=600),
     maxPages: int = Query(50, ge=1, le=MAX_PAGES_HARD),
+    startPage: int = Query(0, ge=0),
 ) -> dict:
     data = await file.read()
     if not data:
@@ -94,11 +98,14 @@ async def render(
 
         try:
             total = len(pdf)
-            n = min(total, maxPages)
+            # Window [start, end) — see doc-render for the rationale; kept identical so a caller can walk
+            # either sidecar the same way. A startPage past the end renders nothing rather than erroring.
+            start = min(startPage, total)
+            end = min(total, start + maxPages)
             scale = dpi / 72.0  # pypdfium2 render scale is relative to 72 DPI
             pages = []
             # Render page-by-page and release each bitmap/page promptly — bound memory to ~one page.
-            for i in range(n):
+            for i in range(start, end):
                 page = pdf[i]
                 bitmap = page.render(scale=scale)
                 pil = bitmap.to_pil()
@@ -114,6 +121,8 @@ async def render(
         "pages": pages,
         "count": len(pages),
         "total": total,
-        "truncated": total > n,
+        # "there are pages after this window" — lets a caller loop without knowing `total` up front.
+        "truncated": end < total,
+        "startPage": start,
         "dpi": dpi,
     }

--- a/sidecars/doc-render/app.py
+++ b/sidecars/doc-render/app.py
@@ -12,8 +12,14 @@ copyleft. (We deliberately do NOT use PyMuPDF, which is AGPL-3.0.) See LICENSES.
 
 Endpoints:
   GET  /health                      -> {"status": "ok"}
-  POST /render  (multipart 'file')  -> {"pages": [<base64 png>...], "count", "total", "truncated", "dpi"}
-    query: dpi (72..600), maxPages (1..RENDER_MAX_PAGES)
+  POST /render  (multipart 'file')  -> {"pages": [<base64 png>...], "count", "total", "truncated",
+                                        "startPage", "dpi"}
+    query: dpi (72..600), maxPages (1..RENDER_MAX_PAGES), startPage (>=0)
+
+`startPage` lets the caller walk a long document in windows instead of losing everything past `maxPages`.
+Memory is unchanged by it: one page is rendered at a time and at most `maxPages` are held encoded, whichever
+window is being asked for. `truncated` means "there are pages after this window", so a caller can loop until
+it is false without knowing `total` up front.
 """
 import base64
 import io
@@ -39,6 +45,7 @@ async def render(
     file: UploadFile = File(...),
     dpi: int = Query(150, ge=72, le=600),
     maxPages: int = Query(50, ge=1, le=MAX_PAGES_HARD),
+    startPage: int = Query(0, ge=0),
 ) -> dict:
     data = await file.read()
     if not data:
@@ -53,11 +60,16 @@ async def render(
 
     try:
         total = len(pdf)
-        n = min(total, maxPages)
+        # The window is [startPage, end). A startPage at or past the end renders nothing rather than
+        # erroring: a caller walking to the end should get an empty, non-truncated result and stop, not a
+        # 4xx it has to special-case on the last iteration.
+        start = min(startPage, total)
+        end = min(total, start + maxPages)
         scale = dpi / 72.0  # pypdfium2 render scale is relative to 72 DPI
         pages = []
         # Render page-by-page and release each bitmap/page promptly — bound memory to ~one page in flight.
-        for i in range(n):
+        # Unchanged by windowing: at most `maxPages` are ever held encoded, whichever window is requested.
+        for i in range(start, end):
             page = pdf[i]
             bitmap = page.render(scale=scale)
             pil = bitmap.to_pil()
@@ -73,6 +85,8 @@ async def render(
         "pages": pages,
         "count": len(pages),
         "total": total,
-        "truncated": total > n,
+        # "there are pages after this window" — so a caller can loop until false without knowing `total`.
+        "truncated": end < total,
+        "startPage": start,
         "dpi": dpi,
     }

--- a/testing/standalone/render-client.test.js
+++ b/testing/standalone/render-client.test.js
@@ -19,6 +19,7 @@ function mockSidecar(state) {
       return;
     }
     if (url.startsWith('/render') && req.method === 'POST') {
+      state.lastUrl = url;   // so a test can assert the window that was actually requested
       req.on('data', () => {}); // drain the multipart body
       req.on('end', () => {
         res.writeHead(state.status, { 'content-type': 'application/json' });
@@ -80,6 +81,53 @@ describe('render client — availability probes', () => {
     R._resetRenderHealthCache();
     assert.equal(await R.isRenderAvailableFor('report.docx'), false); // office sidecar down
     officeState.health = 200;
+  });
+});
+
+describe('render client — page windows', () => {
+  // A long document used to become its first `maxPages` pages, permanently. The sidecars now take a
+  // `startPage` so the caller can walk the document in windows; these pin the request the client builds,
+  // because a dropped or mis-typed parameter degrades silently back to "always page 0" — the exact bug
+  // being fixed, and one where every page still renders and nothing errors.
+  it('asks for page 0 by default, so an un-windowed call is unchanged', async () => {
+    renderState.lastUrl = '';
+    await R.renderDocumentPages(Buffer.from('%PDF'), { fileName: 'x.pdf', maxPages: 2 });
+    assert.match(renderState.lastUrl, /startPage=0/);
+  });
+
+  it('passes the requested window through to the sidecar', async () => {
+    renderState.lastUrl = '';
+    await R.renderDocumentPages(Buffer.from('%PDF'), { fileName: 'x.pdf', maxPages: 50, startPage: 150 });
+    assert.match(renderState.lastUrl, /maxPages=50/);
+    assert.match(renderState.lastUrl, /startPage=150/);
+  });
+
+  it('never sends a negative or fractional startPage', async () => {
+    // These would be a 422 from the sidecar's `ge=0` int query, turning a caller bug into a failed
+    // extraction rather than a clamped one.
+    renderState.lastUrl = '';
+    await R.renderDocumentPages(Buffer.from('%PDF'), { fileName: 'x.pdf', startPage: -5 });
+    assert.match(renderState.lastUrl, /startPage=0/);
+    renderState.lastUrl = '';
+    await R.renderDocumentPages(Buffer.from('%PDF'), { fileName: 'x.pdf', startPage: 12.7 });
+    assert.match(renderState.lastUrl, /startPage=12(&|$)/);
+  });
+
+  it('reports the window offset back, falling back to what was asked', async () => {
+    // An older sidecar that does not echo `startPage` still windows correctly; the client must not then
+    // report 0 and make a caller think it was handed the start of the document.
+    renderState.body = JSON.stringify({ pages: [], count: 0, total: 300, truncated: true, dpi: 150 });
+    const r = await R.renderDocumentPages(Buffer.from('%PDF'), { fileName: 'x.pdf', startPage: 100 });
+    assert.equal(r.startPage, 100);
+    renderState.body = null;
+  });
+
+  it('windows office documents too, not just PDFs', async () => {
+    // Segmenting only PDFs would leave long .docx/.odt silently truncated — the same bug, half-fixed.
+    officeState.lastUrl = '';
+    await R.renderDocumentPages(Buffer.from('PK'), { fileName: 'report.docx', maxPages: 25, startPage: 25 });
+    assert.match(officeState.lastUrl, /startPage=25/);
+    assert.match(officeState.lastUrl, /maxPages=25/);
   });
 });
 


### PR DESCRIPTION
A document longer than `maxPages` became its **first `maxPages` pages, permanently**. A 400-page report was indexed as its first fifty, and recall then answered confidently from an eighth of it. Both page sidecars now accept a `startPage`, so the document is walked in windows.

## `maxPages` keeps its real job and loses the one it never should have had

It bounds **one render call** — that call's memory and latency — which is a genuine constraint worth keeping. It was the limit on *how much of a document gets read* only because nothing looped.

The whole-job limit is now its own setting: **`documentProcessing.maxTotalPages`, default 200** (four times the old effective cap).

**Deliberately separate, and deliberately not unlimited.** Every page is a VLM call, so an unbounded walk over a 600-page scan is 600 model calls and — with an external endpoint — 600 pages of content leaving the instance, triggered by an upload nobody is watching. A document past the budget still stops and still says so, in the log *and* in the stored markdown. The bug being fixed is the **silence and the tiny cap**, not the existence of a cap.

Flagging this as the judgement call most worth disagreeing with: I chose a bounded default over "segment everything and let operators cap it".

## Two things the change forced a decision on

**The consensus pass is skipped for a segmented document**, and says so in the log. `runConsensus` re-transcribes *every page* with a second model, so on a walked document it would double the page cost the budget exists to bound and require every window's images alive at once — defeating the per-call memory bound. Not a regression: before this change a long document was truncated to one window, so consensus never saw more than that anyway.

**Both sidecars changed, not just the PDF one.** `doc-office` had the identical cap; segmenting only PDFs would have left long `.docx`/`.odt` silently truncated — the same bug, half-fixed.

## Verification

Against a **real rebuilt sidecar** and a generated 12-page PDF (each page carrying its own number, so an off-by-one cannot hide):

| Check | Result |
|---|---|
| `window(5,4)` vs whole-document pages 5–8 | identical by image hash |
| `window(9,4)` vs whole-document pages 9–11 | identical by image hash |
| Walk in windows of 5 | reconstructs the document **byte-identically, in order** |
| All 12 pages distinct | yes — so the above comparisons mean something |
| `startPage` past the end | HTTP 200, 0 pages, `truncated: false` — not an error on a caller's last iteration |

Client-side windowing is unit-tested and **proven**: dropping `startPage` from the request URL fails four tests.

Gates: server `tsc` clean · 93/93 on the affected standalone suites (+5) · `lint:docs` clean · no client changes. The `config-loader` suite fails locally with `ECONNREFUSED 127.0.0.1:3200` — it needs the running stack, and I baselined it against `main` earlier in this session with identical failures.

Docker hygiene: the sidecar rebuild was cached (no measurable disk cost), the test container and image were removed, `docker:reclaim` run before and after, and the user's own stack was untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)