### PR TITLE
feat(audit): wire the three allowlists that were never reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Three more operations record what changed: space rename, token rename, and media/extraction
+  levels.** The first slice allowlisted four operations and wired one, so three of those allowlists could
+  never fire — silent, which is the safe direction, but the list claimed coverage the code did not deliver.
+  One of them could not have worked at all: the media route emits `config.media.update` while the
+  allowlist said `media-config.update`, a key that matches no operation and would have stayed silent
+  forever. A test now cross-checks every allowlist key against the operation names in the audit middleware,
+  and another asserts each allowlisted route actually supplies snapshots.
+
 - **The audit log shows what changed.** The entry detail gains a **What changed** table — field, from, to —
   for the operations that record it. Two readings are kept distinct because conflating them is how an audit
   log misleads: a field that **was not set** before renders as *not set* rather than a dash, so "this field

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -154,6 +154,18 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
 
   const activeCfg = getMediaEmbeddingConfig();
 
+  // Levels and extraction mode only — these decide what gets processed and what leaves the instance, which
+  // is exactly what an operator needs explained after the fact. The SAME payload carries provider API
+  // keys; handing the whole thing over is safe because `audit-changes.ts` reads only the allowlisted
+  // paths, but the snapshot is narrowed here as well so the intent is visible at the call site.
+  req.auditSnapshots = {
+    before: { levels: { ...(activeCfg.levels ?? {}) }, documentProcessing: { mode: activeCfg.documentProcessing?.mode } },
+    after: {
+      levels: { ...(activeCfg.levels ?? {}), ...(parsed.data.levels ?? {}) },
+      documentProcessing: { mode: parsed.data.documentProcessing?.mode ?? activeCfg.documentProcessing?.mode },
+    },
+  };
+
   // F11 — whole-config infra lock (like YTHRIL_MONGO_INFRA_MANAGED for the database). When the media/model
   // configuration is managed by infrastructure, the admin API refuses all edits — change config.json / env.
   if (activeCfg.infraManaged) {

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -252,6 +252,10 @@ spacesRouter.patch('/:id/rename', globalRateLimit, requireAdminMfaScoped('id'), 
     return;
   }
 
+  // The rename IS the change, so the snapshot is just the two ids. Set before the attempt and only read
+  // by the audit middleware on a <400 response, so a failed rename records nothing.
+  req.auditSnapshots = { before: { id: oldId }, after: { id: parsed.data.newId } };
+
   try {
     const space = await renameSpace(oldId, parsed.data.newId);
     res.json({ space });

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -87,6 +87,12 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
     return;
   }
   const id = req.params['id'] as string;
+  // Only the name. The record also holds `hash` and `prefix`; handing the whole thing over would be safe
+  // (the allowlist reads `name` and nothing else), but naming the two fields keeps the intent legible at
+  // the call site rather than resting entirely on a list in another file.
+  const previous = listTokens().find(t => t.id === id);
+  req.auditSnapshots = { before: { name: previous?.name }, after: { name: parsed.data.name.trim() } };
+
   const ok = renameToken(id, parsed.data.name.trim());
   if (!ok) {
     res.status(404).json({ error: 'Token not found' });

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -45,12 +45,13 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   // Space settings a reader would actually want explained after the fact.
   'space.update': ['label', 'purpose', 'validationMode', 'strictLinkage', 'dupeRulesOnInsert', 'dupeMergeSurvivor'],
   'space.rename': ['id'],
-  // Token metadata ONLY. Never the token, its hash, or its prefix — `token.create` and `token.regenerate`
-  // are absent entirely, because the interesting value there IS the secret.
-  'token.update': ['label', 'level', 'expiresAt'],
+  // Token metadata ONLY, and only what this route can actually change: `PATCH /api/tokens/:id` renames.
+  // Never `hash` or `prefix`; `token.create` and `token.regenerate` are absent entirely, because the
+  // interesting value there IS the secret.
+  'token.update': ['name'],
   // Media levels and extraction mode: the settings that decide what gets processed and what leaves the
   // instance. The provider blocks in the same payload carry API keys and are NOT listed.
-  'media-config.update': ['levels.images', 'levels.audio', 'levels.video', 'levels.text', 'documentProcessing.mode'],
+  'config.media.update': ['levels.images', 'levels.audio', 'levels.video', 'levels.text', 'documentProcessing.mode'],
 };
 
 /** Scalars only — anything else is dropped rather than stringified. */

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -17,6 +17,7 @@
  */
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 let auditChanges, AUDIT_CHANGE_FIELDS;
 
@@ -66,6 +67,48 @@ describe('audit changes — nothing is recorded unless it was named', () => {
   });
 });
 
+describe('audit changes — every allowlist is actually reachable', () => {
+  before(async () => {
+    ({ AUDIT_CHANGE_FIELDS } = await import('../../server/dist/audit/audit-changes.js'));
+  });
+
+  const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8');
+  const ROUTE_SOURCES = [
+    'server/src/api/spaces.ts', 'server/src/api/tokens.ts', 'server/src/api/media-config.ts',
+  ];
+
+  it('every allowlisted key is a REAL operation name from the middleware', () => {
+    // The failure this catches, found end-to-end rather than by any unit test: the media route's
+    // operation is `config.media.update`, and the allowlist said `media-config.update`. A key that
+    // matches no operation is silent forever — the entry is written, `changes` never appears, and
+    // nothing anywhere reports the mismatch.
+    const middleware = read('server/src/audit/middleware.ts');
+    const known = new Set([...middleware.matchAll(/operation:\s*'([^']+)'/g)].map(m => m[1]));
+    assert.ok(known.size > 50, `expected the middleware operation table, parsed ${known.size}`);
+    for (const key of Object.keys(AUDIT_CHANGE_FIELDS)) {
+      assert.ok(known.has(key), `"${key}" is not an operation name in middleware.ts — it can never match`);
+    }
+  });
+
+  it('every allowlisted operation has a route that supplies snapshots', () => {
+    // An allowlist with no route behind it records nothing while claiming coverage — which is how the
+    // FIRST slice shipped: four operations listed, one wired. Harmless (silence is the safe direction)
+    // but misleading to anyone reading the list to find out what is audited.
+    const wiredFiles = ROUTE_SOURCES.filter(f => read(f).includes('auditSnapshots'));
+    assert.equal(wiredFiles.length, ROUTE_SOURCES.length,
+      `these route files should set auditSnapshots but do not: ${ROUTE_SOURCES.filter(f => !wiredFiles.includes(f))}`);
+  });
+
+  it('allowlists the field names the routes can actually change', () => {
+    // The second half of the same mistake: `token.update` was allowlisted as label/level/expiresAt when
+    // the record field is `name` and the route changes nothing else. Entries that can never match are
+    // silent forever, so nothing would have reported it.
+    assert.deepEqual(AUDIT_CHANGE_FIELDS['token.update'], ['name']);
+    assert.ok(read('server/src/api/tokens.ts').includes('name: parsed.data.name.trim()'),
+      'the token route should snapshot the same field the allowlist names');
+  });
+});
+
 describe('audit changes — scalars only', () => {
   before(async () => {
     ({ auditChanges } = await import('../../server/dist/audit/audit-changes.js'));
@@ -100,7 +143,7 @@ describe('audit changes — scalars only', () => {
   });
 
   it('reads dotted paths without touching their siblings', () => {
-    const changes = auditChanges('media-config.update',
+    const changes = auditChanges('config.media.update',
       { levels: { images: 'caption', audio: 'off' }, vision: { apiKey: 'sk-AAA' } },
       { levels: { images: 'recognition', audio: 'off' }, vision: { apiKey: 'sk-BBB' } });
     assert.deepEqual(changes, [{ field: 'levels.images', from: 'caption', to: 'recognition' }]);


### PR DESCRIPTION
Slice 2. The first slice allowlisted **four** operations and wired **one** — so `space.rename`, `token.update` and `config.media.update` recorded nothing while `AUDIT_CHANGE_FIELDS` claimed they were covered. Silent, which is the safe direction, but misleading to anyone reading the list to find out what is audited.

Two of the three were also wrong in ways **no unit test could see**, because the tests only ever exercised the differ with keys I supplied myself:

- **`token.update` was allowlisted as `label` / `level` / `expiresAt`.** The record field is `name`, and `PATCH /api/tokens/:id` changes nothing else — so all three entries could never match anything.
- **The media route's operation is `config.media.update`; the allowlist said `media-config.update`.** A key that matches no operation name is silent *forever*: the entry is written, `changes` never appears, and nothing anywhere reports the mismatch. Found end-to-end, not by any test.

That is the same shape as the rest of this session — configuration that looks right, errors nowhere, and does nothing.

## The tests now check the allowlist against reality

- **Every key must be an operation name parsed out of `audit/middleware.ts`.** This is the one that would have caught the `config.media.update` typo.
- **Every route file listed must actually set `auditSnapshots`.** This is the one that would have caught three allowlists with no route behind them.

## Verification

Scratch instance, all three now recording:

| Operation | Recorded |
|---|---|
| `space.rename` | `id: scratch-a → scratch-b` |
| `config.media.update` | `levels.audio: auto → off` |
| `token.update` | `name: Admin → Renamed Admin Token` |

With an `apiKey: sk-live-…` sent in the **same** media-config payload and absent from the log, and a 400 rename recording no changes at all — the differ reported only `levels.audio` because `images` was already at its new value, which is the correct behaviour rather than a miss.

Gates: server `tsc` clean · 17/17 on the affected standalone suites (+4) · `lint:docs` clean · audit-route-coverage passes (no routes added; three existing handlers gained snapshots) · no client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)