### PR TITLE
test(graph): characterize the 2065-line graph component before splitting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -752,6 +752,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **The graph page is now pinned by 45 characterization tests, written before it is split.** At 2065 lines
+  and 53 methods it had four tests, all of which covered the OnPush conversion — the traversal cache, the
+  depth filter, the model handed to cytoscape and the out-of-zone tap handlers were entirely unpinned, and
+  every one of them fails *silently* when broken: a lost cache still draws a correct graph at N× the request
+  volume, and a dropped root fallback just makes the most-clicked node in the graph stop responding. The
+  suite records what the component does **today**, including two asymmetries it does not endorse (an edge
+  panel filters memories on one endpoint but chrono on both; chrono rows hard-code an empty properties bag),
+  so changing either is a visible decision rather than an accident. It was validated by mutation: 24
+  plausible refactor slips were applied to the original component one at a time, and all 24 were caught —
+  three of them only after the tests that missed them were strengthened.
+
 - **Translation keys are now verified against the source, so a missing one can't ship silently.** A missing
   key fails invisibly: Transloco renders the key itself, the build succeeds, and the unit tests pass — the
   test harness deliberately echoes raw keys — so the only detector is a human looking at that exact screen.

--- a/client/src/app/pages/graph/graph.component.characterization.spec.ts
+++ b/client/src/app/pages/graph/graph.component.characterization.spec.ts
@@ -1,0 +1,603 @@
+/**
+ * GraphComponent — characterization tests, written against the ORIGINAL 2065-line component.
+ *
+ * These exist to make a later split safe, and they were deliberately written BEFORE any refactor:
+ * a characterization test written against already-restructured code pins the new behaviour, which is
+ * worth nothing. Everything asserted here is what the component does TODAY — including the parts that
+ * look like oversights (see `loadEdgeDetails`, below). Where behaviour is surprising, the comment says
+ * so rather than "fixing" it silently; changing any of it is a separate, deliberate decision that
+ * should make one of these tests fail loudly.
+ *
+ * Four concern clusters are covered, in the order a split would move them:
+ *
+ *   1. Derivation      — `allDetails` / `filteredDetails` / `toggleSort`: pure, and the easiest thing
+ *                        to break silently when it moves to a service.
+ *   2. Traversal cache — which interactions hit the network and which do not. Invisible when wrong:
+ *                        a broken cache still shows a correct graph, just with N× the requests.
+ *   3. Render boundary — cytoscape itself is NOT tested. What IS pinned is the MODEL handed to it, so
+ *                        the renderer can be swapped or moved without changing what it is asked to draw.
+ *   4. Selection       — what the (out-of-zone) cytoscape handlers write, and teardown.
+ *
+ * The cytoscape fake records rather than renders: jsdom has no canvas, and the behaviour under test is
+ * entirely on the Angular side of that boundary. `layout().run()` does NOT fire `layoutstop` on its
+ * own — tests trigger it explicitly, so the auto-select-root path is observed rather than raced.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError, Subject } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+
+/** Records what the component asks cytoscape to do. Hoisted so `vi.mock`'s factory can reach it. */
+const cy = vi.hoisted(() => {
+  const state: any = {
+    instance: null as any,
+    handlers: [] as Array<{ ev: string; sel?: string; cb: (e: any) => void }>,
+    added: [] as any[][],      // one entry per cy.add() call
+    layoutOpts: [] as any[],
+    layoutStop: null as null | (() => void),
+    edgeClasses: new Set<string>(),
+    removeCalls: 0,
+    destroyed: 0,
+    fits: 0,
+  };
+
+  state.reset = () => {
+    state.handlers = []; state.added = []; state.layoutOpts = []; state.layoutStop = null;
+    state.edgeClasses = new Set<string>();
+    state.removeCalls = 0; state.destroyed = 0; state.fits = 0;
+  };
+
+  /** The last element batch handed over, split by group. */
+  state.lastModel = () => {
+    const els = state.added[state.added.length - 1] ?? [];
+    return {
+      nodes: els.filter((e: any) => e.group === 'nodes'),
+      edges: els.filter((e: any) => e.group === 'edges'),
+    };
+  };
+
+  /** Fire a registered handler, as a real user tap would. */
+  state.fire = (ev: string, sel: string | undefined, evt: any) => {
+    for (const h of state.handlers) if (h.ev === ev && h.sel === sel) h.cb(evt);
+  };
+
+  state.make = () => {
+    const inst: any = {
+      on: (ev: string, a: any, b?: any) =>
+        state.handlers.push(typeof a === 'function' ? { ev, cb: a } : { ev, sel: a, cb: b }),
+      add: (els: any[]) => state.added.push(els),
+      elements: () => ({ remove: () => { state.removeCalls++; } }),
+      edges: () => ({
+        addClass: (c: string) => state.edgeClasses.add(c),
+        removeClass: (c: string) => state.edgeClasses.delete(c),
+      }),
+      resize: () => {},
+      fit: () => { state.fits++; },
+      destroy: () => { state.destroyed++; },
+      layout: (opts: any) => {
+        state.layoutOpts.push(opts);
+        return { on: (_ev: string, cb: () => void) => { state.layoutStop = cb; }, run: () => {} };
+      },
+    };
+    state.instance = inst;
+    return inst;
+  };
+
+  return state;
+});
+
+vi.mock('cytoscape', () => ({ default: (opts: any) => { cy.initOpts = opts; return cy.make(); } }));
+
+import { SpacesApi } from '../../core/spaces-api.service';
+import { BrainApi } from '../../core/brain-api.service';
+import { AuthApi } from '../../core/auth-api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { GraphComponent } from './graph.component';
+
+const ROOT = { _id: 'root', name: 'Ada', type: 'person', description: 'root desc', tags: ['t'] } as any;
+
+/** A traversal result whose nodes sit at the given depths. */
+function traverseResult(nodes: Array<[string, number]>, edges: Array<[string, string, string]>, truncated = false) {
+  return {
+    nodes: nodes.map(([id, depth]) => ({ _id: id, name: id.toUpperCase(), type: 'thing', depth })),
+    edges: edges.map(([id, from, to]) => ({ _id: id, from, to, label: 'rel' })),
+    truncated,
+  };
+}
+
+/** BrainApi double: counts traversals so cache behaviour is observable, and never touches HTTP. */
+function makeBrain(overrides: Record<string, any> = {}) {
+  const calls: any[] = [];
+  return {
+    calls,
+    traverseGraph: vi.fn((_s: string, body: any) => { calls.push(body); return of(traverseResult([], [])); }),
+    getEntity: vi.fn(() => of(null as any)),
+    getEdge: vi.fn(() => of(null as any)),
+    getMemory: vi.fn(() => of(null as any)),
+    getChrono: vi.fn(() => of(null as any)),
+    listMemories: vi.fn(() => of({ memories: [] })),
+    queryBrain: vi.fn(() => of({ results: [], collection: 'chrono', count: 0 })),
+    ...overrides,
+  } as any;
+}
+
+function create(brain: any = makeBrain()) {
+  TestBed.configureTestingModule({
+    imports: [GraphComponent, getTranslocoModule()],
+    providers: [
+      { provide: SpacesApi, useValue: { listSpaces: () => of({ spaces: [] }) } },
+      { provide: BrainApi, useValue: brain },
+      { provide: AuthApi, useValue: { getMe: () => of({ readOnly: false }) } },
+      { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } },
+    ],
+  });
+  const fixture = TestBed.createComponent(GraphComponent);
+  fixture.componentRef.setInput('embeddedSpaceId', 'work');  // embedded: no listSpaces, no URL writes
+  fixture.detectChanges();                                   // ngOnInit + ngAfterViewInit
+  return { fixture, c: fixture.componentInstance as any, brain };
+}
+
+beforeEach(() => { TestBed.resetTestingModule(); cy.reset(); vi.clearAllMocks(); });
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// 1. Derivation — the detail table under the side panel
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('GraphComponent — detail rows are derived, not stored', () => {
+  const MEMS = [
+    { _id: 'm1', fact: 'Ada wrote the first program', tags: ['history'], properties: { x: 1 }, createdAt: '2026-01-02', entityIds: ['root'] },
+    { _id: 'm2', fact: '', description: 'falls back to description', tags: [], createdAt: '2026-01-03' },
+  ] as any[];
+  const CHRONO = [
+    { _id: 'c1', title: 'Analytical Engine note', tags: ['note'], createdAt: '2026-01-01', entityIds: ['root'] },
+    { _id: 'c2', title: '', description: 'chrono description fallback', tags: [], createdAt: '2026-01-04' },
+  ] as any[];
+
+  function withRows() {
+    const { c } = create();
+    c.nodeMemories.set(MEMS);
+    c.nodeChrono.set(CHRONO);
+    return c;
+  }
+
+  it('reads a memory as fact-then-description and a chrono as title-then-description', () => {
+    // Two different field names collapsing into one `description` column. A split that mapped both
+    // through the same helper would silently blank one of the four cases.
+    const rows = withRows().allDetails();
+    expect(rows.map((r: any) => r.description)).toEqual([
+      'Ada wrote the first program',
+      'falls back to description',
+      'Analytical Engine note',
+      'chrono description fallback',
+    ]);
+    expect(rows.map((r: any) => r.kind)).toEqual(['memory', 'memory', 'chrono', 'chrono']);
+  });
+
+  it('gives chrono rows an empty properties bag even when the record has properties', () => {
+    // Chrono records CAN carry schema-defined properties, but this table does not read them — it hard-codes
+    // `{}`. Pinned as-is: surfacing them is a feature decision, not a refactor.
+    const c = create().c;
+    c.nodeChrono.set([{ _id: 'c9', title: 't', tags: [], createdAt: '2026-01-01', properties: { real: 'value' } }]);
+    expect(c.allDetails()[0].properties).toEqual({});
+  });
+
+  it('defaults to newest-first by createdAt', () => {
+    expect(withRows().filteredDetails().map((r: any) => r.id)).toEqual(['c2', 'm2', 'm1', 'c1']);
+  });
+
+  it('filters by kind', () => {
+    const c = withRows();
+    c.detailTypeFilter.set('chrono');
+    expect(c.filteredDetails().map((r: any) => r.id)).toEqual(['c2', 'c1']);
+    c.detailTypeFilter.set('memory');
+    expect(c.filteredDetails().map((r: any) => r.id)).toEqual(['m2', 'm1']);
+  });
+
+  it('matches the description filter case-insensitively, as a substring', () => {
+    const c = withRows();
+    c.detailDescFilter.set('ENGINE');
+    expect(c.filteredDetails().map((r: any) => r.id)).toEqual(['c1']);
+  });
+
+  it('composes kind + text + sort rather than letting one win', () => {
+    const c = withRows();
+    c.detailTypeFilter.set('memory');
+    c.detailDescFilter.set('a');            // matches both memories
+    c.sortField.set('description');
+    c.sortAsc.set(true);
+    expect(c.filteredDetails().map((r: any) => r.id)).toEqual(['m1', 'm2']);
+  });
+
+  it('sorts description case-insensitively', () => {
+    const c = create().c;
+    c.nodeMemories.set([
+      { _id: 'a', fact: 'beta', tags: [], createdAt: '2026-01-01' },
+      { _id: 'b', fact: 'Alpha', tags: [], createdAt: '2026-01-02' },
+    ]);
+    c.sortField.set('description');
+    c.sortAsc.set(true);
+    expect(c.filteredDetails().map((r: any) => r.id)).toEqual(['b', 'a']);
+  });
+
+  it('toggleSort flips the SAME field but starts a NEW field ascending', () => {
+    // The asymmetry is the whole behaviour: re-clicking reverses, first-clicking does not inherit the
+    // previous column's direction.
+    const c = create().c;
+    expect([c.sortField(), c.sortAsc()]).toEqual(['createdAt', false]);
+
+    // Switching column while the current direction is DESC: the new column starts ASC regardless.
+    // (Asserting the switch from an already-ASC state would pass even if the reset were dropped.)
+    c.toggleSort('description');
+    expect([c.sortField(), c.sortAsc()]).toEqual(['description', true]);
+
+    c.toggleSort('description');
+    expect(c.sortAsc()).toBe(false);            // same column reverses
+    c.toggleSort('description');
+    expect(c.sortAsc()).toBe(true);
+
+    // And back the other way: ASC on the old column must not carry into the new one.
+    c.toggleSort('createdAt');
+    expect([c.sortField(), c.sortAsc()]).toEqual(['createdAt', true]);
+  });
+
+  it('sortArrow marks only the active column', () => {
+    const c = create().c;
+    expect(c.sortArrow('description')).toBe('');
+    expect(c.sortArrow('createdAt')).not.toBe('');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// 2. Traversal cache — which gestures reach the network
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('GraphComponent — the traversal cache decides what hits the network', () => {
+  it('fetches once for a new root', () => {
+    const { c, brain } = create();
+    c.selectRoot(ROOT);
+    expect(brain.traverseGraph).toHaveBeenCalledTimes(1);
+    expect(brain.calls[0]).toEqual({ startId: 'root', direction: 'both', maxDepth: 2, limit: 200 });
+  });
+
+  it('serves a SHALLOWER depth from cache without a second request', () => {
+    // The cache is the reason dragging the depth slider down is instant. Losing it is invisible in the
+    // UI and only shows up as request volume.
+    const brain = makeBrain({
+      traverseGraph: vi.fn((_s: string, b: any) => { brain.calls.push(b); return of(traverseResult([['a', 1], ['b', 2]], [])); }),
+    });
+    const { c } = create(brain);
+    c.selectRoot(ROOT);
+    c.onDepthChange(1);
+    expect(brain.traverseGraph).toHaveBeenCalledTimes(1);
+    expect(cy.lastModel().nodes.map((n: any) => n.data.id).sort()).toEqual(['a', 'root']);
+  });
+
+  it('fetches once more for a DEEPER depth and merges without duplicating', () => {
+    let call = 0;
+    const brain: any = makeBrain();
+    brain.traverseGraph = vi.fn((_s: string, b: any) => {
+      brain.calls.push(b);
+      return of(call++ === 0
+        ? traverseResult([['a', 1]], [['e1', 'root', 'a']])
+        : traverseResult([['a', 1], ['b', 3]], [['e1', 'root', 'a'], ['e2', 'a', 'b']]));  // repeats a/e1
+    });
+    const { c } = create(brain);
+    c.selectRoot(ROOT);
+    c.onDepthChange(3);
+    expect(brain.traverseGraph).toHaveBeenCalledTimes(2);
+    const model = cy.lastModel();
+    expect(model.nodes.map((n: any) => n.data.id).sort()).toEqual(['a', 'b', 'root']);
+    expect(model.edges.map((e: any) => e.data.id).sort()).toEqual(['e1', 'e2']);
+  });
+
+  it('REPLACES rather than merges when the cached result was truncated', () => {
+    // A truncated result is not a prefix of the deeper one, so merging would keep nodes the server has
+    // since dropped. The flag is what makes the deeper fetch authoritative.
+    let call = 0;
+    const brain: any = makeBrain();
+    brain.traverseGraph = vi.fn((_s: string, b: any) => {
+      brain.calls.push(b);
+      return of(call++ === 0
+        ? traverseResult([['stale', 1]], [], true)
+        : traverseResult([['fresh', 1]], [], false));
+    });
+    const { c } = create(brain);
+    c.selectRoot(ROOT);
+    expect(c.truncated()).toBe(true);
+    c.onDepthChange(3);
+    expect(cy.lastModel().nodes.map((n: any) => n.data.id).sort()).toEqual(['fresh', 'root']);
+    expect(c.truncated()).toBe(false);
+  });
+
+  it('refetches when only the DIRECTION changes, even at the same depth', () => {
+    const { c, brain } = create();
+    c.selectRoot(ROOT);
+    c.setDirection('outbound');
+    expect(brain.traverseGraph).toHaveBeenCalledTimes(2);
+    expect(brain.calls[1].direction).toBe('outbound');
+  });
+
+  it('resetGraph drops the cache so the next selection refetches', () => {
+    const { c, brain } = create();
+    c.selectRoot(ROOT);
+    c.resetGraph();
+    expect([c.rootEntity(), c.searchQuery(), c.truncated()]).toEqual([null, '', false]);
+    c.selectRoot(ROOT);
+    expect(brain.traverseGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not traverse at all without an active space', () => {
+    const { c, brain } = create();
+    c.activeSpaceId.set('');
+    c.selectRoot(ROOT);
+    expect(brain.traverseGraph).not.toHaveBeenCalled();
+  });
+
+  it('records the failure reason instead of rendering an empty graph', () => {
+    // U3: a failed traversal that cleared the canvas would read as "this entity has no connections".
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => throwError(() => ({ status: 500 }))) });
+    const { c } = create(brain);
+    c.selectRoot(ROOT);
+    expect(c.loading()).toBe(false);
+    expect(c.loadError()).toBeTruthy();
+    expect(cy.added.length).toBe(0);        // nothing was handed to the renderer
+  });
+
+  it('retryTraverse replays the exact parameters that failed', () => {
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => throwError(() => ({ status: 500 }))) });
+    const { c } = create(brain);
+    c.depth.set(4);
+    c.setDirection('inbound');
+    c.selectRoot(ROOT);
+    const failed = brain.traverseGraph.mock.calls.at(-1)[1];
+    c.retryTraverse();
+    expect(brain.traverseGraph.mock.calls.at(-1)[1]).toEqual(failed);
+  });
+
+  it('retryTraverse is a no-op before any traversal has been attempted', () => {
+    const { c, brain } = create();
+    c.retryTraverse();
+    expect(brain.traverseGraph).not.toHaveBeenCalled();
+  });
+
+  it('clears the loading flag and stale selection when a traversal starts', () => {
+    const gate = new Subject<any>();
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => gate) });
+    const { c } = create(brain);
+    c.selectedNode.set({ _id: 'old', name: 'stale', type: 'x', depth: 1 });
+    c.selectRoot(ROOT);
+    expect(c.loading()).toBe(true);
+    expect(c.selectedNode()).toBeNull();     // stale panel must not survive the new traversal
+    gate.next(traverseResult([], []));
+    expect(c.loading()).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// 3. Render boundary — the model handed to cytoscape (cytoscape itself is NOT under test)
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('GraphComponent — what it asks the renderer to draw', () => {
+  function render(nodes: Array<[string, number]>, edges: Array<[string, string, string]>, depth = 2) {
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => of(traverseResult(nodes, edges))) });
+    const { c } = create(brain);
+    c.depth.set(depth);
+    c.selectRoot(ROOT);
+    return c;
+  }
+
+  it('adds the root itself — the traversal result never contains it', () => {
+    render([['a', 1]], [['e1', 'root', 'a']]);
+    const root = cy.lastModel().nodes.find((n: any) => n.data.id === 'root');
+    expect(root).toMatchObject({ classes: 'root', data: { label: 'Ada', type: 'person', depth: 0 } });
+  });
+
+  it('does not duplicate the root when the traversal also returns it', () => {
+    render([['root', 0], ['a', 1]], []);
+    expect(cy.lastModel().nodes.filter((n: any) => n.data.id === 'root')).toHaveLength(1);
+  });
+
+  it('falls back to a "default" node type rather than emitting undefined', () => {
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => of({ nodes: [{ _id: 'a', name: 'A', type: '', depth: 1 }], edges: [], truncated: false })) });
+    const { c } = create(brain);
+    c.selectRoot({ ...ROOT, type: '' });
+    for (const n of cy.lastModel().nodes) expect(n.data.type).toBe('default');
+  });
+
+  it('renames from/to to source/target — the shape cytoscape requires', () => {
+    render([['a', 1]], [['e1', 'root', 'a']]);
+    expect(cy.lastModel().edges[0]).toMatchObject({ group: 'edges', data: { id: 'e1', source: 'root', target: 'a', label: 'rel' } });
+  });
+
+  it('drops nodes past the requested depth', () => {
+    render([['a', 1], ['b', 2], ['deep', 3]], [], 2);
+    expect(cy.lastModel().nodes.map((n: any) => n.data.id).sort()).toEqual(['a', 'b', 'root']);
+  });
+
+  it('keeps an edge only when BOTH endpoints survived the depth cut', () => {
+    // The dangling-edge guard. Handing cytoscape an edge to a node that was not added throws there, so
+    // this filter is load-bearing, not cosmetic.
+    render([['a', 1], ['deep', 3]], [['keep', 'root', 'a'], ['dangling', 'a', 'deep']], 2);
+    expect(cy.lastModel().edges.map((e: any) => e.data.id)).toEqual(['keep']);
+  });
+
+  it('treats the root as visible for edge survival even though it is not in the node list', () => {
+    render([['a', 1]], [['e1', 'root', 'a']], 1);
+    expect(cy.lastModel().edges.map((e: any) => e.data.id)).toEqual(['e1']);
+  });
+
+  it('counts what it handed over, not what the server returned', () => {
+    // The badge must track the canvas. Counting the cache instead would keep showing depth-5 nodes
+    // after the user dragged the slider back to 2 — the numbers and the picture disagreeing with no
+    // error anywhere. Three cached nodes, two drawn: the counts must differ from the cache size.
+    const c = render([['a', 1], ['deep', 5], ['deeper', 6]], [['e1', 'root', 'a'], ['far', 'deep', 'deeper']], 2);
+    expect([c.nodeCount(), c.edgeCount()]).toEqual([2, 1]);   // root + a, and the one surviving edge
+  });
+
+  it('clears the previous drawing before each render', () => {
+    render([['a', 1]], []);
+    expect(cy.removeCalls).toBeGreaterThan(0);
+  });
+
+  it('roots the layout at the entity the user selected', () => {
+    render([['a', 1]], []);
+    expect(cy.layoutOpts.at(-1)).toMatchObject({ name: 'breadthfirst', roots: '#root' });
+  });
+
+  it('applies the hide-labels state on every render, not only on toggle', () => {
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => of(traverseResult([['a', 1]], []))) });
+    const { c } = create(brain);
+    c.onHideLabelsChange(true);
+    c.selectRoot(ROOT);
+    expect(cy.edgeClasses.has('hide-labels')).toBe(true);   // a re-render must not lose the setting
+    c.onHideLabelsChange(false);
+    expect(cy.edgeClasses.has('hide-labels')).toBe(false);
+  });
+
+  it('auto-selects the root once the layout settles, and not before', () => {
+    const c = render([['a', 1]], []);
+    expect(c.selectedNode()).toBeNull();      // layout still running
+    cy.layoutStop();
+    expect(c.selectedNode()).toMatchObject({ _id: 'root', name: 'Ada', depth: 0, description: 'root desc' });
+  });
+
+  it('does not steal a selection the user already made', () => {
+    const c = render([['a', 1]], []);
+    c.selectedNode.set({ _id: 'a', name: 'A', type: 'thing', depth: 1 });
+    cy.layoutStop();
+    expect(c.selectedNode()._id).toBe('a');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// 4. Selection — what the out-of-zone cytoscape handlers write, and teardown
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('GraphComponent — selection written from cytoscape handlers', () => {
+  function withGraph(brain?: any) {
+    const b = brain ?? makeBrain({ traverseGraph: vi.fn(() => of(traverseResult([['a', 1]], [['e1', 'root', 'a']]))) });
+    const { c } = create(b);
+    c.selectRoot(ROOT);
+    return { c, brain: b };
+  }
+  const tapTarget = (id: string) => ({ target: { data: () => id, addClass: () => {}, removeClass: () => {} } });
+
+  it('selects a traversed node on tap and loads its details', () => {
+    const { c, brain } = withGraph();
+    cy.fire('tap', 'node', tapTarget('a'));
+    expect(c.selectedNode()).toMatchObject({ _id: 'a', depth: 1 });
+    expect(brain.listMemories).toHaveBeenCalled();
+  });
+
+  it('reconstructs the ROOT node on tap — it is absent from the traversal list', () => {
+    // The root is added to the canvas separately, so a tap on it finds nothing in `graphNodes`. Without
+    // this fallback the most-clicked node in the graph would be the one that does not respond.
+    const { c } = withGraph();
+    cy.fire('tap', 'node', tapTarget('root'));
+    expect(c.selectedNode()).toMatchObject({ _id: 'root', name: 'Ada', depth: 0 });
+  });
+
+  it('ignores a tap on an id it does not know', () => {
+    const { c } = withGraph();
+    cy.fire('tap', 'node', tapTarget('ghost'));
+    expect(c.selectedNode()).toBeNull();
+  });
+
+  it('an edge tap replaces a node selection rather than showing both panels', () => {
+    const { c } = withGraph();
+    cy.fire('tap', 'node', tapTarget('a'));
+    cy.fire('tap', 'edge', tapTarget('e1'));
+    expect(c.selectedNode()).toBeNull();
+    expect(c.selectedEdge()).toMatchObject({ _id: 'e1', from: 'root', to: 'a' });
+  });
+
+  it('a node tap clears a previous edge selection, including its fetched record', () => {
+    const { c } = withGraph();
+    cy.fire('tap', 'edge', tapTarget('e1'));
+    c.selectedEdgeRecord.set({ _id: 'e1' } as any);
+    cy.fire('tap', 'node', tapTarget('a'));
+    expect([c.selectedEdge(), c.selectedEdgeRecord()]).toEqual([null, null]);
+  });
+
+  it('a background tap clears everything the panels bind to', () => {
+    const { c } = withGraph();
+    cy.fire('tap', 'node', tapTarget('a'));
+    cy.fire('tap', undefined, { target: cy.instance });   // background === the cy instance itself
+    expect([c.selectedNode(), c.selectedEdge(), c.selectedEdgeRecord()]).toEqual([null, null, null]);
+  });
+
+  it('a tap on an element is not mistaken for a background tap', () => {
+    const { c } = withGraph();
+    cy.fire('tap', 'node', tapTarget('a'));
+    cy.fire('tap', undefined, tapTarget('a'));
+    expect(c.selectedNode()).not.toBeNull();
+  });
+
+  it('a double-tap re-roots the graph on the tapped entity', () => {
+    const NEW = { _id: 'a', name: 'A', type: 'thing' } as any;
+    const brain: any = makeBrain({
+      traverseGraph: vi.fn(() => of(traverseResult([['a', 1]], [['e1', 'root', 'a']]))),
+      getEntity: vi.fn(() => of(NEW)),
+    });
+    const { c } = withGraph(brain);
+    cy.fire('dbltap', 'node', tapTarget('a'));
+    expect(c.rootEntity()).toBe(NEW);
+    expect(c.searchQuery()).toBe('A');       // the search box follows the root
+  });
+
+  it('selectRoot clears every panel signal from the previous root', () => {
+    const { c } = withGraph();
+    c.selectedNode.set({ _id: 'a' } as any);
+    c.selectedEntityRecord.set({ _id: 'a' } as any);
+    c.selectedEdge.set({ _id: 'e1' } as any);
+    c.selectedEdgeRecord.set({ _id: 'e1' } as any);
+    c.nodeMemories.set([{ _id: 'm1' } as any]);
+    c.nodeChrono.set([{ _id: 'c1' } as any]);
+    c.selectRoot(ROOT);
+    expect([c.selectedNode(), c.selectedEntityRecord(), c.selectedEdge(), c.selectedEdgeRecord()])
+      .toEqual([null, null, null, null]);
+    expect([c.nodeMemories(), c.nodeChrono()]).toEqual([[], []]);
+  });
+
+  it('an edge panel lists only records referencing BOTH endpoints — asymmetrically', () => {
+    // Characterizing an asymmetry rather than endorsing it: memories are fetched for `from` and then
+    // filtered on `to` only, while chrono is filtered on `from` AND `to`. A chrono row that omits `from`
+    // is therefore dropped where the equivalent memory row is kept. Pinned so a "tidy-up" of these two
+    // filters into one helper is a visible decision, not an accident.
+    const brain: any = makeBrain({
+      traverseGraph: vi.fn(() => of(traverseResult([['a', 1]], [['e1', 'root', 'a']]))),
+      listMemories: vi.fn(() => of({ memories: [
+        { _id: 'both', entityIds: ['root', 'a'] },
+        { _id: 'to-only', entityIds: ['a'] },        // kept: only `to` is checked
+        { _id: 'from-only', entityIds: ['root'] },   // dropped
+      ] })),
+      queryBrain: vi.fn(() => of({ results: [
+        { _id: 'c-both', entityIds: ['root', 'a'] },
+        { _id: 'c-to-only', entityIds: ['a'] },      // dropped: chrono requires both
+      ], collection: 'chrono', count: 0 })),
+    });
+    const { c } = withGraph(brain);
+    cy.fire('tap', 'edge', tapTarget('e1'));
+    expect(c.nodeMemories().map((m: any) => m._id)).toEqual(['both', 'to-only']);
+    expect(c.nodeChrono().map((x: any) => x._id)).toEqual(['c-both']);
+  });
+});
+
+describe('GraphComponent — teardown', () => {
+  it('destroys the cytoscape instance and drops the subscription bag', () => {
+    // A leaked cy instance keeps its canvas, its listeners and the whole element graph alive; nothing
+    // in the UI reports it.
+    const { fixture, c } = create();
+    const unsub = vi.spyOn((c as any).subs, 'unsubscribe');
+    fixture.destroy();
+    expect(cy.destroyed).toBe(1);
+    expect(unsub).toHaveBeenCalled();
+  });
+
+  it('survives a second teardown without touching a destroyed instance', () => {
+    const { fixture, c } = create();
+    fixture.destroy();
+    c.ngOnDestroy();
+    expect(cy.destroyed).toBe(1);
+  });
+});

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -146,6 +146,17 @@ npm run test:client          # → vitest run
 
 Runs the Angular component/service specs under `client/` in a jsdom environment. This suite runs in CI as the dedicated **"Client unit tests"** step (`.github/workflows/ci.yml`).
 
+#### Characterization tests before a refactor
+
+Before splitting or restructuring a large component, add a `*.characterization.spec.ts` next to it and prove it against the **original** file, in its own commit or PR. A characterization test written against already-restructured code pins the new behaviour, which tells you nothing about whether the restructure preserved anything.
+
+Two conventions make these worth the effort:
+
+- **Record what the code does today, not what it should do.** Where behaviour is surprising, say so in the comment and pin it anyway — that turns a later "tidy-up" into a visible decision instead of a silent change. `graph.component.characterization.spec.ts` is the worked example.
+- **Validate the suite by mutation.** A test that passes both before and after a change is worth nothing. Apply plausible refactor slips to the original one at a time (drop a cache guard, loosen an `&&` to `||`, remove a fallback) and confirm each one fails the suite. Anything that survives is a gap in the tests, not a harmless mutation.
+
+At the rendering boundary, pin the **model** handed to the library rather than the library's output — e.g. the element list given to cytoscape, not what it draws. That lets the renderer move without the tests moving with it.
+
 ### Standalone tests (no Docker required)
 
 ```bash


### PR DESCRIPTION
## Why this is tests-only

`client/src/app/pages/graph/graph.component.ts` is **2065 lines, 53 methods, 4 tests** — and all four cover the OnPush conversion. Everything a split would actually move was unpinned.

These are written against the **original** file, in their own PR. A characterization test written against already-restructured code pins the new behaviour, which proves nothing about whether the restructure preserved anything. The split is the next PR.

## What is now pinned (45 tests)

| cluster | why it matters | failure mode if broken |
|---|---|---|
| **Derivation** — `allDetails` / `filteredDetails` / `toggleSort` | pure, and the first thing to move to a service | wrong rows, quietly |
| **Traversal cache** — which gestures reach the network | dragging the depth slider down is instant *because of* the cache | correct graph, N× the requests — invisible |
| **Render boundary** — the element model handed to cytoscape | lets the renderer move without the tests moving | dangling edge → cytoscape throws |
| **Selection** — what the out-of-zone tap handlers write | the root is added separately, so a root tap finds nothing in `graphNodes` | the most-clicked node stops responding |

## Two asymmetries pinned, not endorsed

Recorded as-is with comments saying so, precisely so that changing them is a visible decision rather than a tidy-up:

- `loadEdgeDetails` filters **memories** on one endpoint (`to`) but **chrono** on both (`from` *and* `to`) — so a chrono row omitting `from` is dropped where the equivalent memory row is kept.
- Chrono detail rows hard-code `properties: {}` even though chrono records can carry schema-defined properties (#397).

## Validated by mutation, not by passing

All 45 passed on the first run, which on its own means nothing. 24 plausible refactor slips were applied to the original component one at a time — drop the cache early-return, loosen the both-endpoints edge filter to `||`, merge into a truncated cache, take the counts from the cache instead of the drawn elements, remove the root-tap fallback, let a new sort column inherit the previous direction, leak the cy instance on destroy.

**24/24 caught.** Three only after the tests that missed them were strengthened. One apparent survivor turned out to be a mutation landing in the *template* rather than the class — which is how the **4× duplicated** `DetailRow` construction in the template surfaced. That is recorded in the tracker as *consolidate, don't move* for the split.

## Scope

- `graph.component.ts` is **not modified** — `git status` shows only the new spec (the mutation harness restored it byte-for-byte).
- Docs: contribution guide gains the convention (characterize before refactoring; validate by mutation; pin the model, not the renderer).
- CHANGELOG under Testing.
- Full client suite green: **70 files, 657 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)