### PR TITLE
refactor(graph): split the 2065-line graph god file into four focused modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2800,6 +2800,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The graph page is no longer a god file: 2065 lines split into a component plus four focused
+  modules.** The traversal cache, the detail-table derivation, the cytoscape boundary and 556 lines of
+  CSS each moved to their own file, following the `pages/brain/` precedent (pure module by default, and
+  a `*.styles.ts` for the CSS). Behaviour is preserved by construction rather than by inspection: the 45
+  characterization tests from the previous release pass **unchanged**, which was the acceptance
+  condition — a test needing an edit to accommodate the split would have meant the split changed
+  something. The hand-retyped cytoscape stylesheet was additionally diffed against the original
+  structurally (8 selectors, every property, every literal value), and the page was driven in a browser
+  to confirm what no unit test reaches: the canvas renders, the side panel opens on the root, and a
+  detail row still opens its record.
+
+  One real duplication was removed rather than relocated. The template built a seven-field detail-row
+  object at four separate click handlers for a method that reads exactly two of those fields, and the
+  copies had already drifted from the component's own version — harmlessly, but only because nothing
+  read the field that differed. The handler now takes just the id and kind.
+
 - **The Schema Library's schema field showed a raw translation key instead of a label.**
   `schemaLib.field.schema` and `schemaLib.field.schemaHint` were referenced by the template but had never
   been added to any locale, so the field rendered the literal text `schemaLib.field.schema`. Both are now

--- a/client/src/app/pages/graph/graph-cytoscape.ts
+++ b/client/src/app/pages/graph/graph-cytoscape.ts
@@ -1,0 +1,322 @@
+/**
+ * The cytoscape boundary — theme, stylesheet, element model, and instance wiring.
+ *
+ * Extracted from `graph.component.ts` as part of the god-file split. Everything cytoscape-shaped lives
+ * here so the component holds no `any`-typed renderer state and no 120-line style literal.
+ *
+ * ── The line this module draws ───────────────────────────────────────────────────────────────────
+ *
+ * `buildElements` is pure and is the ONLY thing the characterization tests assert across this
+ * boundary: they pin the element model handed to cytoscape, never what cytoscape draws with it. That
+ * is deliberate — cytoscape renders to a real canvas that jsdom does not provide, so testing its
+ * output would mean testing the mock. Pinning the model instead means this renderer could be replaced
+ * wholesale and the tests would still be measuring the right thing.
+ *
+ * Everything else here — the stylesheet, the theme read, the instance creation — is configuration and
+ * wiring, verified by looking at the page rather than by assertion.
+ */
+import cytoscape from 'cytoscape';
+import type { Entity, TraverseNode, TraverseEdge } from '../../core/api.types';
+
+/** Colours read from CSS custom properties, so an enterprise theme can override the whole graph. */
+export interface GraphTheme {
+  typeColors: string[];
+  nodeBg: string;
+  nodeText: string;
+  edge: string;
+  edgeLabel: string;
+  nodeRoot: string;
+  nodeSelect: string;
+  edgeSelect: string;
+  edgeHover: string;
+  fallback: string;
+}
+
+const DEFAULT_TYPE_COLORS = [
+  '#7c6af7', '#58a6ff', '#3fb950', '#00e5ff', '#f85149',
+  '#e38625', '#9580ff', '#79c0ff', '#56d364', '#ff6eb4',
+];
+
+/**
+ * The palette before the view exists.
+ *
+ * `typeColors` is EMPTY on purpose, not pre-filled with the defaults above: `typeColor` treats an
+ * empty palette as "theme not read yet" and returns a single fixed colour. Seeding it here would make
+ * nodes render one set of colours before `readGraphTheme()` runs and another after.
+ */
+export const DEFAULT_GRAPH_THEME: GraphTheme = {
+  typeColors: [],
+  nodeBg: '#0d1117',
+  nodeText: '#c9d1d9',
+  edge: '#3d444d',
+  edgeLabel: '#6e7681',
+  nodeRoot: '#7c6af7',
+  nodeSelect: '#58a6ff',
+  edgeSelect: '#7c6af7',
+  edgeHover: '#58a6ff',
+  fallback: '#8b949e',
+};
+
+/**
+ * Read the graph palette from the document's CSS custom properties.
+ *
+ * Must run after the view exists — the values live on `:root` and are resolved by the browser, so
+ * calling this before the stylesheet applies yields the fallbacks.
+ */
+export function readGraphTheme(): GraphTheme {
+  const cs = getComputedStyle(document.documentElement);
+  const tv = (v: string, fb: string) => cs.getPropertyValue(v).trim() || fb;
+  return {
+    typeColors: DEFAULT_TYPE_COLORS.map((fb, i) => tv(`--graph-type-${i + 1}`, fb)),
+    nodeBg: tv('--graph-node-bg', '#0d1117'),
+    nodeText: tv('--graph-node-text', '#c9d1d9'),
+    edge: tv('--graph-edge', '#3d444d'),
+    edgeLabel: tv('--graph-edge-label', '#6e7681'),
+    nodeRoot: tv('--graph-node-root', '#7c6af7'),
+    nodeSelect: tv('--graph-node-select', '#58a6ff'),
+    edgeSelect: tv('--graph-edge-select', '#7c6af7'),
+    edgeHover: tv('--graph-edge-hover', '#58a6ff'),
+    fallback: tv('--graph-fallback', '#8b949e'),
+  };
+}
+
+/**
+ * A stable colour per entity type.
+ *
+ * Hashed rather than assigned, so a type keeps its colour across sessions and spaces without anything
+ * having to persist the mapping — and a type the palette has never seen still gets a colour.
+ */
+export function typeColor(theme: GraphTheme, type: string): string {
+  if (!theme.typeColors.length) return '#7c6af7';
+  let hash = 0;
+  for (let i = 0; i < type.length; i++) hash = (hash * 31 + type.charCodeAt(i)) | 0;
+  return theme.typeColors[Math.abs(hash) % theme.typeColors.length];
+}
+
+/** Radial highlight in the upper-left quadrant — gives each node its glass look. */
+function glassShineSvg(color: string): string {
+  const c = encodeURIComponent(color);
+  return `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><defs><radialGradient id='base' cx='50%25' cy='50%25' r='50%25'><stop offset='0%25' stop-color='${c}' stop-opacity='0.28'/><stop offset='100%25' stop-color='${c}' stop-opacity='0.06'/></radialGradient><radialGradient id='shine' cx='30%25' cy='22%25' r='50%25'><stop offset='0%25' stop-color='white' stop-opacity='0.55'/><stop offset='45%25' stop-color='white' stop-opacity='0.12'/><stop offset='100%25' stop-color='white' stop-opacity='0'/></radialGradient><radialGradient id='rim' cx='50%25' cy='50%25' r='50%25'><stop offset='68%25' stop-color='${c}' stop-opacity='0'/><stop offset='100%25' stop-color='${c}' stop-opacity='0.7'/></radialGradient><radialGradient id='bot' cx='58%25' cy='80%25' r='38%25'><stop offset='0%25' stop-color='${c}' stop-opacity='0.18'/><stop offset='100%25' stop-color='${c}' stop-opacity='0'/></radialGradient></defs><circle cx='50' cy='50' r='49' fill='url(%23base)'/><circle cx='50' cy='50' r='49' fill='url(%23rim)'/><circle cx='50' cy='50' r='49' fill='url(%23bot)'/><circle cx='50' cy='50' r='49' fill='url(%23shine)'/></svg>`;
+}
+
+/**
+ * The cytoscape stylesheet.
+ *
+ * Node size, opacity and shadow all taper with `depth`, so distance from the root reads visually
+ * rather than only from the layout — that is why so many values are functions of the element.
+ */
+function graphStylesheet(theme: GraphTheme): any[] {
+  const depthOf = (ele: any) => +ele.data('depth');
+  const colorOf = (ele: any) => typeColor(theme, ele.data('type') || 'default');
+  const nodeSize = (ele: any) => { const d = depthOf(ele); return d === 0 ? 68 : Math.max(36, 52 - d * 3); };
+
+  return [
+    {
+      selector: 'node',
+      style: {
+        'width': nodeSize,
+        'height': nodeSize,
+        'background-color': theme.nodeBg,
+        'background-image': (ele: any) => glassShineSvg(colorOf(ele)),
+        'background-fit': 'cover',
+        'background-clip': 'node',
+        'border-width': (ele: any) => depthOf(ele) === 0 ? 2.5 : 1.5,
+        'border-color': colorOf,
+        'border-opacity': 0.75,
+        'label': 'data(label)',
+        'font-size': (ele: any) => depthOf(ele) === 0 ? 13 : 11,
+        'font-weight': (ele: any) => depthOf(ele) === 0 ? '600' : '400',
+        'color': theme.nodeText,
+        'text-outline-color': theme.nodeBg,
+        'text-outline-width': 2,
+        'text-valign': 'bottom',
+        'text-margin-y': 8,
+        'text-max-width': '110px',
+        'text-wrap': 'ellipsis',
+        'opacity': (ele: any) => { const d = depthOf(ele); return d === 0 ? 1 : Math.max(0.55, 1 - d * 0.1); },
+        'shadow-blur': (ele: any) => depthOf(ele) === 0 ? 28 : 14,
+        'shadow-color': colorOf,
+        'shadow-opacity': (ele: any) => depthOf(ele) === 0 ? 0.6 : 0.35,
+        'shadow-offset-x': 0,
+        'shadow-offset-y': 0,
+      } as any,
+    },
+    {
+      selector: 'node.root',
+      style: { 'border-color': theme.nodeRoot, 'border-width': 3, 'border-opacity': 1 } as any,
+    },
+    {
+      selector: 'node.hovered',
+      style: { 'border-width': 2.5, 'border-opacity': 1, 'opacity': 1, 'shadow-blur': 30, 'shadow-opacity': 0.8 } as any,
+    },
+    {
+      selector: 'node:selected',
+      style: {
+        'border-color': theme.nodeSelect, 'border-width': 3, 'border-opacity': 1, 'opacity': 1,
+        'shadow-blur': 36, 'shadow-color': theme.nodeSelect, 'shadow-opacity': 0.9,
+      } as any,
+    },
+    {
+      selector: 'edge',
+      style: {
+        'width': 1.5,
+        'line-color': theme.edge,
+        'target-arrow-shape': 'triangle',
+        'target-arrow-color': theme.edge,
+        'curve-style': 'bezier',
+        'label': 'data(label)',
+        'font-size': 10,
+        'color': theme.edgeLabel,
+        'text-rotation': 'autorotate',
+        'text-margin-y': -8,
+        'text-background-color': theme.nodeBg,
+        'text-background-opacity': 0.7,
+        'text-background-padding': '2px',
+        'opacity': 0.75,
+        'shadow-blur': 0,
+      } as any,
+    },
+    {
+      selector: 'edge.hovered',
+      style: {
+        'line-color': theme.edgeHover, 'target-arrow-color': theme.edgeHover, 'opacity': 1, 'width': 2.5,
+        'shadow-blur': 12, 'shadow-color': theme.edgeHover, 'shadow-opacity': 0.6,
+        'shadow-offset-x': 0, 'shadow-offset-y': 0,
+      } as any,
+    },
+    {
+      selector: 'edge:selected',
+      style: {
+        'line-color': theme.edgeSelect, 'target-arrow-color': theme.edgeSelect, 'opacity': 1, 'width': 2.5,
+        'shadow-blur': 16, 'shadow-color': theme.edgeSelect, 'shadow-opacity': 0.7,
+        'shadow-offset-x': 0, 'shadow-offset-y': 0,
+      } as any,
+    },
+    { selector: 'edge.hide-labels', style: { 'label': '' } as any },
+  ];
+}
+
+/**
+ * The element model for one render — the pure half of this module, and the thing the characterization
+ * tests assert.
+ *
+ * The root is added here rather than coming from the traversal: a traversal returns what it reached
+ * FROM the root, never the root itself. It is emitted at depth 0 with the `root` class, and skipped in
+ * the node loop so a traversal that does echo it back cannot produce a duplicate id.
+ *
+ * `from`/`to` become `source`/`target` because that is the shape cytoscape requires — the rename is
+ * the whole reason this translation exists.
+ */
+export function buildElements(
+  root: Entity | null,
+  nodes: readonly TraverseNode[],
+  edges: readonly TraverseEdge[],
+  rootId: string,
+): any[] {
+  const elements: any[] = [];
+
+  if (root) {
+    elements.push({
+      group: 'nodes',
+      data: { id: root._id, label: root.name, type: root.type || 'default', depth: 0 },
+      classes: 'root',
+    });
+  }
+
+  for (const n of nodes) {
+    if (n._id === rootId) continue;    // already added above
+    elements.push({
+      group: 'nodes',
+      data: { id: n._id, label: n.name, type: n.type || 'default', depth: n.depth },
+    });
+  }
+
+  for (const e of edges) {
+    elements.push({ group: 'edges', data: { id: e._id, source: e.from, target: e.to, label: e.label } });
+  }
+
+  return elements;
+}
+
+/** What the component wants to know about, expressed without any cytoscape types. */
+export interface GraphHandlers {
+  onNodeTap(id: string): void;
+  onEdgeTap(id: string): void;
+  onNodeDoubleTap(id: string): void;
+  onBackgroundTap(): void;
+}
+
+/**
+ * Create the instance and wire the handlers.
+ *
+ * These callbacks fire OUTSIDE the Angular zone. That is safe here only because every one of them
+ * ends up writing a signal, and signal writes notify OnPush regardless of zone — a handler that set a
+ * plain field instead would update nothing on screen. The hover handlers stay inside this module
+ * because they only toggle cytoscape's own classes and never touch Angular state.
+ */
+export function createGraphCytoscape(
+  container: HTMLElement,
+  theme: GraphTheme,
+  handlers: GraphHandlers,
+): any {
+  const cy = cytoscape({
+    container,
+    elements: [],
+    style: graphStylesheet(theme),
+    layout: { name: 'grid' },
+    minZoom: 0.1,
+    maxZoom: 5,
+    wheelSensitivity: 0.25,
+  } as any);
+
+  cy.on('tap', 'node', (evt: any) => handlers.onNodeTap(evt.target.data('id')));
+  cy.on('tap', 'edge', (evt: any) => handlers.onEdgeTap(evt.target.data('id')));
+  cy.on('dbltap', 'node', (evt: any) => handlers.onNodeDoubleTap(evt.target.data('id')));
+
+  cy.on('mouseover', 'node', (evt: any) => { evt.target.addClass('hovered'); });
+  cy.on('mouseout',  'node', (evt: any) => { evt.target.removeClass('hovered'); });
+  cy.on('mouseover', 'edge', (evt: any) => { evt.target.addClass('hovered'); });
+  cy.on('mouseout',  'edge', (evt: any) => { evt.target.removeClass('hovered'); });
+
+  // Background tap — identified by the event target being the instance itself, not an element.
+  cy.on('tap', (evt: any) => { if (evt.target === cy) handlers.onBackgroundTap(); });
+
+  return cy;
+}
+
+/**
+ * Draw an element model, then fit.
+ *
+ * `resize()` runs twice deliberately: once before drawing, and again on `layoutstop`, because Angular
+ * may have opened or closed the side panel in between — which changes the canvas width without
+ * cytoscape knowing. Fitting against stale dimensions is what makes a graph render half off-screen.
+ */
+export function renderElements(
+  cy: any,
+  elements: any[],
+  rootId: string,
+  hideLabels: boolean,
+  onSettled: () => void,
+): void {
+  cy.resize();
+  cy.elements().remove();
+  cy.add(elements);
+
+  if (hideLabels) cy.edges().addClass('hide-labels');
+  else cy.edges().removeClass('hide-labels');
+
+  // breadthfirst keeps each node next to its direct edge-partner.
+  const layout = cy.layout({
+    name: 'breadthfirst',
+    roots: `#${rootId}`,
+    directed: false,
+    spacingFactor: 1.1,
+    padding: 40,
+    avoidOverlap: true,
+    animate: true,
+    animationDuration: 400,
+  } as any);
+
+  layout.on('layoutstop', onSettled);
+  layout.run();
+}

--- a/client/src/app/pages/graph/graph-details.ts
+++ b/client/src/app/pages/graph/graph-details.ts
@@ -1,0 +1,145 @@
+/**
+ * The graph side panel's detail table — deriving, filtering and sorting the rows.
+ *
+ * Extracted from `graph.component.ts` (2065 lines) as part of the god-file split. Pure by design: no
+ * Angular, no HTTP, no DOM. Everything here is pinned by `graph.component.characterization.spec.ts`,
+ * which was written and mutation-validated against the ORIGINAL component before this file existed —
+ * so behaviour is preserved by construction, not by inspection.
+ *
+ * Follows the `pages/brain/recall-grouping.ts` precedent: a plain module beside the component rather
+ * than an injectable, because nothing here needs DI or holds state. The component's `computed()`
+ * signals call straight into these functions.
+ *
+ * Two behaviours below look like oversights and are deliberately preserved — the split is not the
+ * place to change them, and each is characterized so changing it later is a visible decision:
+ *
+ *   - Memory and chrono rows read DIFFERENT primary fields (`fact` / `title`) with a shared fallback
+ *     to `description`, which is why the two mappers are not collapsed into one.
+ *   - Chrono rows always carry an EMPTY properties bag, even though chrono records can hold
+ *     schema-defined properties (#397). Surfacing them is a feature decision.
+ */
+
+/** One row of the side panel's detail table. */
+export interface DetailRow {
+  id: string;
+  kind: 'memory' | 'chrono';
+  description: string;
+  tags: string[];
+  properties: Record<string, unknown>;
+  createdAt: string;
+  raw: Record<string, unknown>;
+}
+
+/**
+ * What opening a detail popup actually needs.
+ *
+ * The template used to build four full `DetailRow` literals — seven fields each — at the click
+ * handlers, of which the handler reads exactly two. The copies had already drifted (they passed a bare
+ * `{}` for `properties` where the table's rows pass the record's own), harmlessly only because nothing
+ * read the field. Narrowing the parameter deletes the duplication instead of relocating it; a full
+ * `DetailRow` still satisfies this shape, so the table's own rows pass through unchanged.
+ */
+export interface DetailRef {
+  id: string;
+  kind: 'memory' | 'chrono';
+}
+
+/** How the table is currently filtered and ordered. */
+export interface DetailView {
+  type: 'all' | 'memory' | 'chrono';
+  text: string;
+  field: 'description' | 'createdAt';
+  asc: boolean;
+}
+
+/** Records as they arrive from the API — only the fields this table reads are required. */
+interface MemoryLike {
+  _id: string;
+  fact?: string;
+  description?: string;
+  tags?: string[];
+  properties?: Record<string, unknown>;
+  createdAt: string;
+}
+interface ChronoLike {
+  _id: string;
+  title?: string;
+  description?: string;
+  tags: string[];
+  createdAt: string;
+}
+
+/** A memory's display text: its fact, falling back to its description. */
+export function memoryText(m: MemoryLike): string {
+  return m.fact || m.description || '';
+}
+
+/** A chrono entry's display text: its title, falling back to its description. */
+export function chronoText(c: ChronoLike): string {
+  return c.title || c.description || '';
+}
+
+/**
+ * All rows for the selected node, memories first.
+ *
+ * Order matters: it is the tie-break whenever two records share a sort key, so it is the difference
+ * between a stable table and one that reshuffles on re-render.
+ */
+export function buildDetailRows(memories: readonly MemoryLike[], chrono: readonly ChronoLike[]): DetailRow[] {
+  return [
+    ...memories.map((m): DetailRow => ({
+      id: m._id,
+      kind: 'memory',
+      description: memoryText(m),
+      tags: m.tags ?? [],
+      properties: m.properties ?? {},
+      createdAt: m.createdAt,
+      raw: m as unknown as Record<string, unknown>,
+    })),
+    ...chrono.map((c): DetailRow => ({
+      id: c._id,
+      kind: 'chrono',
+      description: chronoText(c),
+      tags: c.tags,
+      properties: {},          // see the header note — deliberately not read from the record
+      createdAt: c.createdAt,
+      raw: c as unknown as Record<string, unknown>,
+    })),
+  ];
+}
+
+/**
+ * Narrow by kind, then by a case-insensitive substring of the description, then order.
+ *
+ * The three compose rather than override — the text filter applies within the chosen kind, and the
+ * sort applies to whatever survived. Sorts a copy: the caller's array is derived state and mutating it
+ * in place would mean a signal's value changing without a write, which OnPush would never see.
+ */
+export function filterAndSortDetails(rows: readonly DetailRow[], view: DetailView): DetailRow[] {
+  let out = rows as readonly DetailRow[];
+  if (view.type !== 'all') out = out.filter(r => r.kind === view.type);
+
+  const needle = view.text.toLowerCase();
+  if (needle) out = out.filter(r => r.description.toLowerCase().includes(needle));
+
+  return [...out].sort((a, b) => {
+    const va = view.field === 'description' ? a.description.toLowerCase() : a.createdAt;
+    const vb = view.field === 'description' ? b.description.toLowerCase() : b.createdAt;
+    return view.asc ? (va < vb ? -1 : va > vb ? 1 : 0)
+                    : (va > vb ? -1 : va < vb ? 1 : 0);
+  });
+}
+
+/**
+ * What clicking a column header does.
+ *
+ * The asymmetry is the whole behaviour: re-clicking the ACTIVE column reverses it, but clicking a NEW
+ * column always starts ascending rather than inheriting the previous column's direction. Inheriting
+ * would mean the same click producing different orders depending on history.
+ */
+export function nextSort(
+  current: { field: 'description' | 'createdAt'; asc: boolean },
+  field: 'description' | 'createdAt',
+): { field: 'description' | 'createdAt'; asc: boolean } {
+  return current.field === field ? { field, asc: !current.asc } : { field, asc: true };
+}

--- a/client/src/app/pages/graph/graph-modules.spec.ts
+++ b/client/src/app/pages/graph/graph-modules.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Direct tests for the pure modules extracted from `graph.component.ts`.
+ *
+ * These are NOT a re-run of `graph.component.characterization.spec.ts`, which drives the same logic
+ * through the component and is what proves the split preserved behaviour. What these add is the part
+ * that was impractical to reach from outside: the traversal cache's full decision table, including the
+ * combinations a user cannot produce by clicking (a cache that is truncated AND shallower, a request
+ * against an empty cache), plus the boundaries — the exact depth cut, an empty result, a root with no
+ * edges. No TestBed, so they run in milliseconds.
+ *
+ * That is the point of extracting them: this file could not have been written against the original.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildDetailRows, filterAndSortDetails, nextSort, memoryText, chronoText,
+} from './graph-details';
+import {
+  emptyCache, decideFetch, applyResult, filterToDepth, type TraversalCache,
+} from './graph-traversal-cache';
+import { buildElements, typeColor, DEFAULT_GRAPH_THEME } from './graph-cytoscape';
+import type { TraverseNode, TraverseEdge, Entity } from '../../core/api.types';
+
+const node = (id: string, depth: number): TraverseNode => ({ _id: id, name: id.toUpperCase(), type: 'thing', depth });
+const edge = (id: string, from: string, to: string): TraverseEdge => ({ _id: id, from, to, label: 'rel' });
+
+function cacheOf(nodes: TraverseNode[], edges: TraverseEdge[], over: Partial<TraversalCache> = {}): TraversalCache {
+  return { startId: 'root', direction: 'both', maxDepth: 2, nodes, edges, truncated: false, ...over };
+}
+
+describe('graph-traversal-cache — the decision table', () => {
+  const req = { startId: 'root', maxDepth: 2, direction: 'both' as const };
+
+  it('has nothing to serve from an empty cache', () => {
+    expect(decideFetch(emptyCache(), req)).toBe('replace');
+  });
+
+  it('serves the same depth from cache, not just a shallower one', () => {
+    // The boundary is `<=`, not `<`. Off by one here means every re-render of an unchanged view
+    // re-fetches — correct on screen, invisible in testing, and obvious only in request logs.
+    expect(decideFetch(cacheOf([], []), { ...req, maxDepth: 2 })).toBe('from-cache');
+    expect(decideFetch(cacheOf([], []), { ...req, maxDepth: 1 })).toBe('from-cache');
+    expect(decideFetch(cacheOf([], []), { ...req, maxDepth: 3 })).toBe('incremental');
+  });
+
+  it('replaces rather than merges whenever the cache is truncated — at ANY depth', () => {
+    // Reachable by clicking only in one direction, but the rule is unconditional: a truncated result
+    // is not a prefix of a deeper one, so merging would keep nodes the server has since dropped.
+    const t = cacheOf([], [], { truncated: true });
+    expect(decideFetch(t, { ...req, maxDepth: 3 })).toBe('replace');
+    expect(decideFetch(t, { ...req, maxDepth: 2 })).toBe('from-cache');  // still a subset — safe
+  });
+
+  it('treats direction as identity, not as a filter', () => {
+    const c = cacheOf([], []);
+    expect(decideFetch(c, { ...req, direction: 'inbound' })).toBe('replace');
+    expect(decideFetch(c, { ...req, direction: 'outbound', maxDepth: 1 })).toBe('replace');
+  });
+
+  it('treats a different root as a different cache', () => {
+    expect(decideFetch(cacheOf([], []), { ...req, startId: 'other', maxDepth: 1 })).toBe('replace');
+  });
+
+  it('merges without duplicating what it already holds', () => {
+    const before = cacheOf([node('a', 1)], [edge('e1', 'root', 'a')]);
+    const after = applyResult(before, 'incremental', { ...req, maxDepth: 3 }, {
+      nodes: [node('a', 1), node('b', 3)],           // 'a' repeated by the deeper traversal
+      edges: [edge('e1', 'root', 'a'), edge('e2', 'a', 'b')],
+      truncated: false,
+    });
+    expect(after.nodes.map(n => n._id)).toEqual(['a', 'b']);
+    expect(after.edges.map(e => e._id)).toEqual(['e1', 'e2']);
+    expect(after.maxDepth).toBe(3);
+  });
+
+  it('does not mutate the cache it was given', () => {
+    // The component holds this in a field read during rendering; growing it in place would make
+    // "what is cached" depend on when it was observed.
+    const before = cacheOf([node('a', 1)], []);
+    applyResult(before, 'incremental', { ...req, maxDepth: 3 }, { nodes: [node('b', 3)], edges: [], truncated: false });
+    expect(before.nodes.map(n => n._id)).toEqual(['a']);
+  });
+
+  it('a replace drops what the previous root had', () => {
+    const before = cacheOf([node('stale', 1)], [edge('old', 'root', 'stale')]);
+    const after = applyResult(before, 'replace', { ...req, startId: 'other' }, {
+      nodes: [node('fresh', 1)], edges: [], truncated: true,
+    });
+    expect(after.nodes.map(n => n._id)).toEqual(['fresh']);
+    expect(after.edges).toEqual([]);
+    expect([after.startId, after.truncated]).toEqual(['other', true]);
+  });
+
+  it('cuts at the depth boundary inclusively', () => {
+    const c = cacheOf([node('a', 1), node('b', 2), node('c', 3)], []);
+    expect(filterToDepth(c, 'root', 2).nodes.map(n => n._id)).toEqual(['a', 'b']);
+    expect(filterToDepth(c, 'root', 0).nodes).toEqual([]);
+  });
+
+  it('keeps an edge only when both endpoints survive, counting the root as present', () => {
+    const c = cacheOf(
+      [node('a', 1), node('deep', 3)],
+      [edge('fromRoot', 'root', 'a'), edge('toRoot', 'a', 'root'), edge('dangling', 'a', 'deep')],
+    );
+    // The root is never in the node list — it is the thing being traversed FROM — so without forcing
+    // it into the visible set, every edge touching it would be dropped as dangling.
+    expect(filterToDepth(c, 'root', 2).edges.map(e => e._id)).toEqual(['fromRoot', 'toRoot']);
+  });
+});
+
+describe('graph-cytoscape — the element model', () => {
+  const root = { _id: 'root', name: 'Ada', type: 'person' } as Entity;
+
+  it('emits nothing at all for an empty graph with no root', () => {
+    expect(buildElements(null, [], [], 'root')).toEqual([]);
+  });
+
+  it('emits a lone root when the traversal found nothing', () => {
+    const els = buildElements(root, [], [], 'root');
+    expect(els).toHaveLength(1);
+    expect(els[0]).toMatchObject({ group: 'nodes', classes: 'root', data: { depth: 0 } });
+  });
+
+  it('never emits a duplicate id when the traversal echoes the root back', () => {
+    // cytoscape rejects a repeated id outright, so this guard is the difference between a graph and
+    // an exception.
+    const els = buildElements(root, [node('root', 0), node('a', 1)], [], 'root');
+    expect(els.filter(e => e.data.id === 'root')).toHaveLength(1);
+  });
+
+  it('skips the root by id, not by identity — a renamed root node is still the root', () => {
+    const els = buildElements(root, [{ ...node('root', 0), name: 'Different' }], [], 'root');
+    expect(els.map(e => e.data.label)).toEqual(['Ada']);
+  });
+
+  it('renames from/to to source/target', () => {
+    const els = buildElements(root, [node('a', 1)], [edge('e1', 'root', 'a')], 'root');
+    expect(els.at(-1)).toEqual({ group: 'edges', data: { id: 'e1', source: 'root', target: 'a', label: 'rel' } });
+  });
+
+  it('substitutes a "default" type rather than emitting undefined', () => {
+    const els = buildElements({ ...root, type: '' } as Entity, [{ ...node('a', 1), type: '' }], [], 'root');
+    expect(els.map(e => e.data.type)).toEqual(['default', 'default']);
+  });
+});
+
+describe('graph-cytoscape — type colours', () => {
+  it('returns one fixed colour before the theme has been read', () => {
+    // An empty palette means "not read yet", which is why DEFAULT_GRAPH_THEME does not pre-fill it.
+    expect(DEFAULT_GRAPH_THEME.typeColors).toEqual([]);
+    expect(typeColor(DEFAULT_GRAPH_THEME, 'person')).toBe(typeColor(DEFAULT_GRAPH_THEME, 'place'));
+  });
+
+  it('is stable per type, so a type keeps its colour with nothing persisted', () => {
+    const theme = { ...DEFAULT_GRAPH_THEME, typeColors: ['#a', '#b', '#c'] };
+    expect(typeColor(theme, 'person')).toBe(typeColor(theme, 'person'));
+    expect(theme.typeColors).toContain(typeColor(theme, 'a-type-never-seen-before'));
+  });
+});
+
+describe('graph-details — derivation boundaries', () => {
+  it('falls back only when the primary field is empty, not merely absent', () => {
+    expect(memoryText({ _id: 'm', fact: '', description: 'fallback', createdAt: '' })).toBe('fallback');
+    expect(memoryText({ _id: 'm', description: 'fallback', createdAt: '' })).toBe('fallback');
+    expect(memoryText({ _id: 'm', fact: 'primary', description: 'fallback', createdAt: '' })).toBe('primary');
+    expect(memoryText({ _id: 'm', createdAt: '' })).toBe('');
+    expect(chronoText({ _id: 'c', title: '', description: 'fallback', tags: [], createdAt: '' })).toBe('fallback');
+  });
+
+  it('puts memories before chrono — the tie-break that keeps the table stable', () => {
+    const rows = buildDetailRows(
+      [{ _id: 'm1', fact: 'x', createdAt: 'same' }],
+      [{ _id: 'c1', title: 'y', tags: [], createdAt: 'same' }],
+    );
+    expect(rows.map(r => r.id)).toEqual(['m1', 'c1']);
+  });
+
+  it('never returns the array it was given, so a signal cannot change without a write', () => {
+    const rows = buildDetailRows([{ _id: 'm1', fact: 'x', createdAt: 'a' }], []);
+    const sorted = filterAndSortDetails(rows, { type: 'all', text: '', field: 'createdAt', asc: false });
+    expect(sorted).not.toBe(rows);
+  });
+
+  it('an empty text filter matches everything rather than nothing', () => {
+    const rows = buildDetailRows([{ _id: 'm1', fact: '', createdAt: 'a' }], []);
+    expect(filterAndSortDetails(rows, { type: 'all', text: '', field: 'createdAt', asc: false })).toHaveLength(1);
+  });
+
+  it('starts a new column ascending from either previous direction', () => {
+    expect(nextSort({ field: 'createdAt', asc: false }, 'description')).toEqual({ field: 'description', asc: true });
+    expect(nextSort({ field: 'createdAt', asc: true }, 'description')).toEqual({ field: 'description', asc: true });
+    expect(nextSort({ field: 'createdAt', asc: true }, 'createdAt')).toEqual({ field: 'createdAt', asc: false });
+  });
+});

--- a/client/src/app/pages/graph/graph-traversal-cache.ts
+++ b/client/src/app/pages/graph/graph-traversal-cache.ts
@@ -1,0 +1,125 @@
+/**
+ * The graph's traversal cache — deciding what reaches the network, and what the canvas shows.
+ *
+ * Extracted from `graph.component.ts` as part of the god-file split. Pure by design: no Angular, no
+ * HTTP. Pinned by `graph.component.characterization.spec.ts`, written against the ORIGINAL component
+ * before this file existed.
+ *
+ * ── Why this is worth its own module ─────────────────────────────────────────────────────────────
+ *
+ * This cache is the reason dragging the depth slider DOWN is instant: a shallower view is always a
+ * subset of what was already fetched, so it needs no request at all. Every failure mode here is
+ * silent — a broken cache still draws a completely correct graph, just at several times the request
+ * volume, and nothing in the UI reports it. That makes it exactly the kind of logic that should be a
+ * pure decision function with tests, rather than three conditions buried in a subscribe callback.
+ *
+ * The decision has three outcomes and they are not interchangeable:
+ *
+ *   from-cache   same root and direction, and no deeper than what is cached → filter locally.
+ *   incremental  same root and direction, deeper, and the cache is COMPLETE → fetch and merge.
+ *   replace      anything else → fetch and overwrite.
+ *
+ * `truncated` is what separates the last two. A truncated result is not a prefix of the deeper one —
+ * the server dropped nodes to fit a limit, and which nodes it dropped may change. Merging into it
+ * would keep entries the server has since discarded, so a truncated cache must always be replaced.
+ */
+import type { TraverseNode, TraverseEdge, TraverseResult } from '../../core/api.types';
+
+export type Direction = 'outbound' | 'inbound' | 'both';
+
+/** What a traversal is being asked for. */
+export interface TraverseRequest {
+  startId: string;
+  maxDepth: number;
+  direction: Direction;
+}
+
+/** Everything fetched so far for one root, at the deepest depth requested. */
+export interface TraversalCache {
+  startId: string | null;
+  direction: Direction | null;
+  maxDepth: number;
+  nodes: TraverseNode[];
+  edges: TraverseEdge[];
+  truncated: boolean;
+}
+
+/** How the request should be satisfied. */
+export type FetchPlan = 'from-cache' | 'incremental' | 'replace';
+
+/** A cache holding nothing — also what a graph reset returns to. */
+export function emptyCache(): TraversalCache {
+  return { startId: null, direction: null, maxDepth: 0, nodes: [], edges: [], truncated: false };
+}
+
+/**
+ * Whether this request needs the network, and if so whether it may be merged.
+ *
+ * Direction is part of the identity check, not a filter: an inbound traversal is a different set of
+ * edges, not a subset of a both-direction one, so changing it invalidates the cache even at the same
+ * depth.
+ */
+export function decideFetch(cache: TraversalCache, req: TraverseRequest): FetchPlan {
+  const sameRoot = cache.startId === req.startId && cache.direction === req.direction;
+  if (!sameRoot) return 'replace';
+  if (req.maxDepth <= cache.maxDepth) return 'from-cache';
+  return cache.truncated ? 'replace' : 'incremental';
+}
+
+/**
+ * Fold a fetched result into the cache according to the plan.
+ *
+ * Merging dedupes by `_id` because a deeper traversal re-returns everything shallower — without this
+ * the cache would grow a duplicate of every existing node on each depth increase, and cytoscape would
+ * reject the repeated ids.
+ *
+ * Returns a new cache rather than mutating: the caller holds this in a field read during rendering,
+ * and in-place growth would make "what is cached" depend on when it was observed.
+ */
+export function applyResult(
+  cache: TraversalCache,
+  plan: FetchPlan,
+  req: TraverseRequest,
+  result: TraverseResult,
+): TraversalCache {
+  let nodes: TraverseNode[];
+  let edges: TraverseEdge[];
+
+  if (plan === 'incremental') {
+    const knownNodes = new Set(cache.nodes.map(n => n._id));
+    const knownEdges = new Set(cache.edges.map(e => e._id));
+    nodes = [...cache.nodes, ...result.nodes.filter(n => !knownNodes.has(n._id))];
+    edges = [...cache.edges, ...result.edges.filter(e => !knownEdges.has(e._id))];
+  } else {
+    nodes = result.nodes;
+    edges = result.edges;
+  }
+
+  return {
+    startId: req.startId,
+    direction: req.direction,
+    maxDepth: req.maxDepth,
+    nodes,
+    edges,
+    truncated: result.truncated,
+  };
+}
+
+/**
+ * The slice of the cache the canvas should show at this depth.
+ *
+ * An edge survives only when BOTH endpoints do. This is load-bearing, not cosmetic: handing cytoscape
+ * an edge pointing at a node that was never added throws inside the renderer. The root is forced into
+ * the visible set because it is never part of a traversal result — it is the thing being traversed
+ * FROM — so without it every edge leaving the root would be dropped as dangling.
+ */
+export function filterToDepth(
+  cache: TraversalCache,
+  startId: string,
+  maxDepth: number,
+): { nodes: TraverseNode[]; edges: TraverseEdge[] } {
+  const nodes = cache.nodes.filter(n => n.depth <= maxDepth);
+  const visible = new Set<string>(nodes.map(n => n._id));
+  visible.add(startId);
+  return { nodes, edges: cache.edges.filter(e => visible.has(e.from) && visible.has(e.to)) };
+}

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -16,7 +16,6 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription, forkJoin, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import cytoscape from 'cytoscape';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { ModalDirective } from '../../shared/modal.directive';
@@ -42,18 +41,17 @@ import { PropertiesViewComponent } from '../../shared/properties-view.component'
 import { TagInputComponent } from '../../shared/tag-input.component';
 import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
 import { TranslocoPipe } from '@jsverse/transloco';
-
-// â”€â”€ Helper types â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-
-interface DetailRow {
-  id: string;
-  kind: 'memory' | 'chrono';
-  description: string;
-  tags: string[];
-  properties: Record<string, unknown>;
-  createdAt: string;
-  raw: Record<string, unknown>;
-}
+import {
+  DetailRow, DetailRef, buildDetailRows, filterAndSortDetails, nextSort,
+} from './graph-details';
+import {
+  TraversalCache, emptyCache, decideFetch, applyResult, filterToDepth,
+} from './graph-traversal-cache';
+import {
+  GraphTheme, DEFAULT_GRAPH_THEME, readGraphTheme, typeColor,
+  buildElements, createGraphCytoscape, renderElements,
+} from './graph-cytoscape';
+import { GRAPH_STYLES } from './graph.styles';
 
 @Component({
   selector: 'app-graph-view',
@@ -70,564 +68,7 @@ interface DetailRow {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, TagInputComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, ModalDirective],
   host: { '[class.embedded]': 'isEmbedded()' },
-  styles: [`
-    :host {
-      display: flex;
-      flex-direction: column;
-      height: calc(100vh - 56px - 56px);
-      min-height: 0;
-      gap: 8px;
-    }
-    :host.embedded {
-      height: 70vh;
-      min-height: 400px;
-    }
-
-    /* â”€â”€ Space chips (matches brain style) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-    .space-tabs {
-      display: flex;
-      gap: 8px;
-      margin-bottom: 8px;
-      overflow-x: auto;
-      padding-bottom: 2px;
-      flex-shrink: 0;
-    }
-    .space-chip {
-      padding: 5px 12px;
-      border-radius: 4px;
-      font-size: 12px;
-      font-weight: 500;
-      border: 1px solid var(--border);
-      background: var(--bg-surface);
-      color: var(--text-secondary);
-      cursor: pointer;
-      transition: all var(--transition);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 1px;
-      min-width: 90px;
-      white-space: nowrap;
-    }
-    .space-chip:hover { border-color: var(--accent); color: var(--text-primary); }
-    .space-chip.active {
-      background: var(--accent-dim);
-      border-color: var(--accent);
-      color: var(--accent);
-    }
-    .space-chip-label { font-size: 12px; font-weight: 500; }
-    .space-chip-id { font-size: 10px; color: var(--text-muted); }
-    .space-chip.active .space-chip-id { color: var(--accent); opacity: 0.7; }
-
-    /* â”€â”€ Toolbar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-
-    .graph-toolbar {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      background: var(--bg-surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      margin-bottom: 8px;
-      flex-shrink: 0;
-    }
-
-    .graph-toolbar select,
-    .graph-toolbar input[type="search"],
-    .graph-toolbar input[type="text"] {
-      background: var(--bg-elevated);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
-      color: var(--text-primary);
-      font-family: var(--font);
-      font-size: 13px;
-      padding: 6px 10px;
-      outline: none;
-      transition: border-color var(--transition);
-    }
-    .graph-toolbar select:focus,
-    .graph-toolbar input:focus {
-      border-color: var(--accent);
-    }
-
-    .graph-toolbar select { min-width: 140px; }
-
-    .search-wrapper {
-      position: relative;
-      flex: 1;
-      min-width: 200px;
-      max-width: 360px;
-    }
-
-    .toolbar-divider {
-      width: 1px;
-      height: 22px;
-      background: var(--border);
-      flex-shrink: 0;
-    }
-    .toolbar-spacer { flex: 1; }
-    .toolbar-label {
-      font-size: 12px;
-      color: var(--text-muted);
-      white-space: nowrap;
-    }
-
-    .depth-control {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-    .depth-control input[type="range"] {
-      accent-color: var(--accent);
-      width: 80px;
-      cursor: pointer;
-    }
-    .depth-value {
-      font-family: var(--font-mono);
-      font-size: 12px;
-      color: var(--text-primary);
-      min-width: 14px;
-      text-align: center;
-    }
-
-    .pill-group {
-      display: flex;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
-      overflow: hidden;
-      flex-shrink: 0;
-    }
-    .pill-group button {
-      padding: 5px 12px;
-      font-size: 12px;
-      background: var(--bg-elevated);
-      color: var(--text-secondary);
-      border: none;
-      cursor: pointer;
-      transition: background var(--transition), color var(--transition);
-      white-space: nowrap;
-    }
-    .pill-group button + button { border-left: 1px solid var(--border); }
-    .pill-group button.active {
-      background: var(--accent-dim);
-      color: var(--accent);
-    }
-    .pill-group button:hover:not(.active) {
-      background: var(--bg-overlay);
-      color: var(--text-primary);
-    }
-
-    .toolbar-toggle {
-      display: flex;
-      align-items: center;
-      gap: 5px;
-      color: var(--text-secondary);
-      font-size: 12px;
-      cursor: pointer;
-      white-space: nowrap;
-    }
-    .toolbar-toggle input[type="checkbox"] { accent-color: var(--accent); }
-
-    .toolbar-btn {
-      padding: 5px 10px;
-      background: var(--bg-elevated);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
-      color: var(--text-secondary);
-      font-size: 14px;
-      cursor: pointer;
-      line-height: 1;
-      transition: border-color var(--transition), color var(--transition), background var(--transition);
-    }
-    .toolbar-btn:hover {
-      border-color: var(--accent);
-      color: var(--text-primary);
-      background: var(--accent-dim);
-    }
-    .graph-stats {
-      font-size: 12px;
-      color: var(--text-muted);
-      white-space: nowrap;
-      font-family: var(--font-mono);
-    }
-
-    /* â”€â”€ Canvas zone â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-
-    .canvas-row {
-      display: flex;
-      flex: 1;
-      min-height: 0;
-      gap: 8px;
-    }
-
-    .canvas-zone {
-      position: relative;
-      flex: 1;
-      min-height: 0;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      background: var(--bg-primary);
-      overflow: hidden;
-    }
-
-    .cy-container {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      inset: 0;
-    }
-
-    .truncation-banner {
-      position: absolute;
-      top: 12px;
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 20;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      padding: 8px 16px;
-      background: var(--error-dim);
-      border: 1px solid var(--error);
-      border-radius: var(--radius-sm);
-      color: var(--warning);
-      font-size: 13px;
-      white-space: nowrap;
-    }
-    .truncation-banner button {
-      background: transparent;
-      border: none;
-      color: var(--text-secondary);
-      font-size: 14px;
-      cursor: pointer;
-      padding: 0 2px;
-    }
-
-    .canvas-empty {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      pointer-events: none;
-      gap: 8px;
-    }
-    .empty-icon {
-      font-size: 52px;
-      line-height: 1;
-      opacity: 0.2;
-    }
-    .canvas-empty h3 {
-      color: var(--text-muted);
-      font-weight: 500;
-      font-size: 15px;
-      margin: 0;
-    }
-    .canvas-empty p {
-      color: var(--text-muted);
-      font-size: 13px;
-      margin: 0;
-      opacity: 0.7;
-    }
-
-    /* Loading overlay */
-    .loading-overlay {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: color-mix(in srgb, var(--bg-primary) 60%, transparent);
-      z-index: 30;
-      backdrop-filter: blur(2px);
-    }
-    .loading-spinner {
-      width: 36px;
-      height: 36px;
-      border: 3px solid color-mix(in srgb, var(--accent) 25%, transparent);
-      border-top-color: var(--accent);
-      border-radius: 50%;
-      animation: graph-spin 0.75s linear infinite;
-    }
-    @keyframes graph-spin { to { transform: rotate(360deg); } }
-
-    /* â”€â”€ Side panel (shown when node or edge selected) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-
-    .side-panel {
-      width: 560px;
-      flex-shrink: 0;
-      display: flex;
-      flex-direction: column;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      background: var(--bg-surface);
-      overflow: hidden;
-      min-height: 0;
-    }
-
-    .side-panel-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 10px 14px;
-      border-bottom: 1px solid var(--border);
-      flex-shrink: 0;
-      gap: 8px;
-    }
-    .side-panel-title {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      min-width: 0;
-    }
-    .side-dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
-    .side-panel-title h3 {
-      margin: 0;
-      font-size: 14px;
-      font-weight: 600;
-      color: var(--text-primary);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    .side-panel-header-actions {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      flex-shrink: 0;
-    }
-
-    /* Side panel body: two columns */
-    .side-panel-body {
-      display: flex;
-      flex: 1;
-      min-height: 0;
-      overflow: hidden;
-    }
-
-    /* Left column: record card */
-    .record-card {
-      flex: 0 0 50%;
-      border-right: 1px solid var(--border);
-      overflow-y: auto;
-      padding: 12px 14px;
-    }
-
-    /* Drawer fields (same pattern as brain component) */
-    .drawer-field { margin-bottom: 14px; }
-    .drawer-label {
-      font-size: 10px;
-      font-weight: 600;
-      color: var(--text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 4px;
-    }
-    .drawer-value {
-      font-size: 12px;
-      color: var(--text-primary);
-      white-space: pre-wrap;
-      word-break: break-word;
-      line-height: 1.5;
-    }
-    .drawer-muted { color: var(--text-muted); }
-    .drawer-hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
-    .drawer-readonly-value {
-      font-size: 12px;
-      color: var(--text-muted);
-      padding: 4px 8px;
-      border: 1px solid var(--border-muted, var(--border));
-      border-radius: var(--radius-sm);
-      background: var(--bg-elevated);
-      word-break: break-all;
-      line-height: 1.4;
-    }
-    .drawer-tag {
-      display: inline-block;
-      padding: 1px 7px;
-      border-radius: 10px;
-      font-size: 11px;
-      background: var(--bg-elevated);
-      color: var(--text-secondary);
-      border: 1px solid var(--border);
-      margin: 2px 3px 2px 0;
-    }
-
-    /* Right column: memory + chrono lists */
-    .lists-pane {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      min-height: 0;
-      overflow: hidden;
-    }
-    .list-section {
-      display: flex;
-      flex-direction: column;
-      flex: 1;
-      min-height: 0;
-      overflow: hidden;
-      border-bottom: 1px solid var(--border);
-    }
-    .list-section:last-child { border-bottom: none; }
-    .list-section-header {
-      font-size: 10px;
-      font-weight: 600;
-      color: var(--text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      padding: 8px 12px 6px;
-      border-bottom: 1px solid var(--border);
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-    .list-section-header .count-chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 16px;
-      height: 16px;
-      padding: 0 4px;
-      background: var(--bg-overlay);
-      border-radius: 8px;
-      font-size: 10px;
-      color: var(--text-muted);
-    }
-    .list-body { overflow-y: auto; flex: 1; }
-    .list-row {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 7px 12px;
-      border-bottom: 1px solid var(--border);
-      cursor: pointer;
-      transition: background var(--transition);
-    }
-    .list-row:last-child { border-bottom: none; }
-    .list-row:hover { background: var(--bg-elevated); }
-    .list-row-text {
-      flex: 1;
-      font-size: 12px;
-      color: var(--text-primary);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    .list-row-date {
-      font-size: 10px;
-      color: var(--text-muted);
-      font-family: var(--font-mono);
-      white-space: nowrap;
-      flex-shrink: 0;
-    }
-    .list-empty {
-      font-size: 12px;
-      color: var(--text-muted);
-      font-style: italic;
-      text-align: center;
-      padding: 16px 12px;
-    }
-
-    /* â”€â”€ Shared badge, button helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-    .tag {
-      display: inline-block;
-      padding: 1px 7px;
-      border-radius: 10px;
-      font-size: 11px;
-      background: var(--bg-elevated);
-      color: var(--text-secondary);
-      border: 1px solid var(--border);
-      margin-right: 3px;
-    }
-
-    /* â”€â”€ Brain-style record drawer modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-    .bdrawer-overlay {
-      position: fixed; inset: 0;
-      background: var(--bg-scrim);
-      display: flex; align-items: center; justify-content: center;
-      z-index: 1100;
-    }
-    .bdrawer-modal {
-      background: var(--bg-surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      width: 100%; max-width: 640px;
-      max-height: 88vh; overflow: hidden;
-      display: flex; flex-direction: column;
-    }
-    .bdrawer-header {
-      display: flex; align-items: flex-start; justify-content: space-between;
-      padding: 16px 20px; border-bottom: 1px solid var(--border); gap: 12px; flex-shrink: 0;
-    }
-    .bdrawer-title { font-size: 15px; font-weight: 600; color: var(--text-primary); word-break: break-word; }
-    .bdrawer-body { overflow-y: auto; flex: 1; padding: 20px; }
-    .bdrawer-footer {
-      display: flex; align-items: center; justify-content: flex-end;
-      gap: 8px; padding: 12px 20px; border-top: 1px solid var(--border); flex-shrink: 0;
-    }
-    .bdrawer-field { margin-bottom: 16px; }
-    .bdrawer-label {
-      font-size: 10px; font-weight: 600; color: var(--text-muted);
-      text-transform: uppercase; letter-spacing: .05em; margin-bottom: 4px;
-    }
-    .bdrawer-readonly {
-      font-size: 12px; color: var(--text-muted); padding: 5px 8px;
-      border: 1px solid var(--border-muted, var(--border)); border-radius: var(--radius-sm);
-      background: var(--bg-elevated); word-break: break-all; line-height: 1.4;
-      font-family: var(--font-mono);
-    }
-    .bdrawer-muted { color: var(--text-muted); font-size: 11px; }
-    .bdrawer-hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
-    .bdrawer-modal input[type=text], .bdrawer-modal input[type=number],
-    .bdrawer-modal input[type=datetime-local], .bdrawer-modal textarea, .bdrawer-modal select {
-      width: 100%; padding: 6px 9px;
-      border: 1px solid var(--border); border-radius: var(--radius-sm);
-      font-size: 13px; background: var(--bg-primary); color: var(--text-primary);
-      box-sizing: border-box; font-family: var(--font);
-    }
-    .bdrawer-modal textarea { resize: vertical; }
-    .bdrawer-modal input:focus, .bdrawer-modal select:focus, .bdrawer-modal textarea:focus {
-      outline: none; border-color: var(--accent);
-    }
-    /* entity chips */
-    .entity-multi {
-      display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
-      padding: 4px 6px; border: 1px solid var(--border); border-radius: var(--radius-sm);
-      background: var(--bg-primary); min-height: 34px;
-    }
-    .chip {
-      display: inline-flex; align-items: center; gap: 3px;
-      padding: 2px 8px; border-radius: 10px;
-      background: var(--accent-dim); border: 1px solid var(--accent);
-      font-size: 11px; color: var(--text-primary);
-    }
-    .chip-name { max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .chip-remove {
-      background: none; border: none; color: var(--text-muted); cursor: pointer;
-      padding: 0 1px; font-size: 12px; line-height: 1;
-    }
-    .chip-add {
-      background: none; border: none; color: var(--accent); cursor: pointer;
-      font-size: 12px; padding: 2px 4px;
-    }
-    .flyout-wrap { position: relative; }
-    .flyout-panel {
-      position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
-      background: var(--bg-surface); border: 1px solid var(--border);
-      border-radius: var(--radius-md); padding: 10px; margin-top: 4px;
-      box-shadow: var(--shadow-lg);
-    }
-  `],
+  styles: [GRAPH_STYLES],
   template: `
     <!-- â•â•â• Space selector â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
     @if (!isEmbedded() && spaces().length > 0) {
@@ -782,7 +223,7 @@ interface DetailRow {
                 </div>
                 <div class="list-body">
                   @for (m of nodeMemories(); track m._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: m._id, kind: 'memory', description: m.fact || m.description || '', tags: m.tags ?? [], properties: {}, createdAt: m.createdAt, raw: asRecord(m) })">
+                    <div class="list-row" (click)="openDetailPopup({ id: m._id, kind: 'memory' })">
                       <span class="list-row-text" [title]="m.fact || m.description">{{ m.fact || m.description || 'â€”' }}</span>
                       <span class="list-row-date">{{ m.createdAt | date:'dd.MM.yy' }}</span>
                     </div>
@@ -797,7 +238,7 @@ interface DetailRow {
                 </div>
                 <div class="list-body">
                   @for (c of nodeChrono(); track c._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: c._id, kind: 'chrono', description: c.title || c.description || '', tags: c.tags, properties: {}, createdAt: c.createdAt, raw: asRecord(c) })">
+                    <div class="list-row" (click)="openDetailPopup({ id: c._id, kind: 'chrono' })">
                       <span class="list-row-text" [title]="c.title || c.description">{{ c.title || c.description || 'â€”' }}</span>
                       <span class="list-row-date">{{ c.startsAt | date:'dd.MM.yy' }}</span>
                     </div>
@@ -897,7 +338,7 @@ interface DetailRow {
                 </div>
                 <div class="list-body">
                   @for (m of nodeMemories(); track m._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: m._id, kind: 'memory', description: m.fact || m.description || '', tags: m.tags ?? [], properties: {}, createdAt: m.createdAt, raw: asRecord(m) })">
+                    <div class="list-row" (click)="openDetailPopup({ id: m._id, kind: 'memory' })">
                       <span class="list-row-text" [title]="m.fact || m.description">{{ m.fact || m.description || 'â€”' }}</span>
                       <span class="list-row-date">{{ m.createdAt | date:'dd.MM.yy' }}</span>
                     </div>
@@ -912,7 +353,7 @@ interface DetailRow {
                 </div>
                 <div class="list-body">
                   @for (c of nodeChrono(); track c._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: c._id, kind: 'chrono', description: c.title || c.description || '', tags: c.tags, properties: {}, createdAt: c.createdAt, raw: asRecord(c) })">
+                    <div class="list-row" (click)="openDetailPopup({ id: c._id, kind: 'chrono' })">
                       <span class="list-row-text" [title]="c.title || c.description">{{ c.title || c.description || 'â€”' }}</span>
                       <span class="list-row-date">{{ c.startsAt | date:'dd.MM.yy' }}</span>
                     </div>
@@ -1190,48 +631,18 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   private lastTraverse: { startId: string; maxDepth: number; direction: 'outbound' | 'inbound' | 'both' } | null = null;
 
   // â”€â”€ Computed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-  allDetails = computed<DetailRow[]>(() => {
-    const mems: DetailRow[] = this.nodeMemories().map(m => ({
-      id: m._id,
-      kind: 'memory' as const,
-      description: m.fact || m.description || '',
-      tags: m.tags ?? [],
-      properties: (m.properties ?? {}) as Record<string, unknown>,
-      createdAt: m.createdAt,
-      raw: m as unknown as Record<string, unknown>,
-    }));
-    const chrs: DetailRow[] = this.nodeChrono().map(c => ({
-      id: c._id,
-      kind: 'chrono' as const,
-      description: c.title || c.description || '',
-      tags: c.tags,
-      properties: {} as Record<string, unknown>,
-      createdAt: c.createdAt,
-      raw: c as unknown as Record<string, unknown>,
-    }));
-    return [...mems, ...chrs];
-  });
+  allDetails = computed<DetailRow[]>(() => buildDetailRows(this.nodeMemories(), this.nodeChrono()));
 
-  filteredDetails = computed<DetailRow[]>(() => {
-    let rows = this.allDetails();
-    const tf = this.detailTypeFilter();
-    if (tf !== 'all') rows = rows.filter(r => r.kind === tf);
-    const df = this.detailDescFilter().toLowerCase();
-    if (df) rows = rows.filter(r => r.description.toLowerCase().includes(df));
-    const field = this.sortField();
-    const asc = this.sortAsc();
-    rows = [...rows].sort((a, b) => {
-      const va = field === 'description' ? a.description.toLowerCase() : a.createdAt;
-      const vb = field === 'description' ? b.description.toLowerCase() : b.createdAt;
-      return asc ? (va < vb ? -1 : va > vb ? 1 : 0)
-                 : (va > vb ? -1 : va < vb ? 1 : 0);
-    });
-    return rows;
-  });
+  filteredDetails = computed<DetailRow[]>(() => filterAndSortDetails(this.allDetails(), {
+    type: this.detailTypeFilter(),
+    text: this.detailDescFilter(),
+    field: this.sortField(),
+    asc: this.sortAsc(),
+  }));
 
   nodeColor = computed(() => {
     const n = this.selectedNode();
-    return n ? this.typeColor(n.type || 'default') : this.graphFallback;
+    return n ? this.typeColor(n.type || 'default') : this.theme.fallback;
   });
 
   panelTitle = computed(() => {
@@ -1247,61 +658,26 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     if (n) return this.typeColor(n.type || 'default');
     const e = this.selectedEdgeRecord();
     if (e) return this.typeColor(e.label || 'edge');
-    return this.graphFallback;
+    return this.theme.fallback;
   });
 
   // â”€â”€ Private state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   private cy: any = null;
   private subs = new Subscription();
 
-  // â”€â”€ Graph theme (read from CSS vars at init â€” allows enterprise overrides) â”€â”€â”€
-  private graphTypeColors: string[] = [];
-  private graphNodeBg    = '#0d1117';
-  private graphNodeText  = '#c9d1d9';
-  private graphEdge      = '#3d444d';
-  private graphEdgeLabel = '#6e7681';
-  private graphNodeRoot  = '#7c6af7';
-  private graphNodeSelect = '#58a6ff';
-  private graphEdgeSelect = '#7c6af7';
-  private graphEdgeHover  = '#58a6ff';
-  private graphFallback   = '#8b949e';
-
-  private readGraphTheme(): void {
-    const cs = getComputedStyle(document.documentElement);
-    const tv = (v: string, fb: string) => cs.getPropertyValue(v).trim() || fb;
-    const DEFAULT_COLORS = ['#7c6af7','#58a6ff','#3fb950','#00e5ff','#f85149','#e38625','#9580ff','#79c0ff','#56d364','#ff6eb4'];
-    this.graphTypeColors = Array.from({ length: 10 }, (_, i) =>
-      tv(`--graph-type-${i + 1}`, DEFAULT_COLORS[i])
-    );
-    this.graphNodeBg     = tv('--graph-node-bg',     '#0d1117');
-    this.graphNodeText   = tv('--graph-node-text',   '#c9d1d9');
-    this.graphEdge       = tv('--graph-edge',        '#3d444d');
-    this.graphEdgeLabel  = tv('--graph-edge-label',  '#6e7681');
-    this.graphNodeRoot   = tv('--graph-node-root',   '#7c6af7');
-    this.graphNodeSelect = tv('--graph-node-select', '#58a6ff');
-    this.graphEdgeSelect = tv('--graph-edge-select', '#7c6af7');
-    this.graphEdgeHover  = tv('--graph-edge-hover',  '#58a6ff');
-    this.graphFallback   = tv('--graph-fallback',    '#8b949e');
-  }
+  /** Palette read from CSS vars once the view exists; the default until then. */
+  private theme: GraphTheme = DEFAULT_GRAPH_THEME;
 
   private typeColor(type: string): string {
-    if (!this.graphTypeColors.length) return '#7c6af7';
-    let hash = 0;
-    for (let i = 0; i < type.length; i++) hash = (hash * 31 + type.charCodeAt(i)) | 0;
-    return this.graphTypeColors[Math.abs(hash) % this.graphTypeColors.length];
+    return typeColor(this.theme, type);
   }
 
   // Currently rendered (depth-filtered) view
   private graphNodes: TraverseNode[] = [];
   private graphEdges: TraverseEdge[] = [];
 
-  // Full-depth traversal cache â€” avoids re-fetching shallower depths
-  private cacheStartId: string | null = null;
-  private cacheDirection: 'outbound' | 'inbound' | 'both' | null = null;
-  private cacheMaxDepth = 0;
-  private cacheNodes: TraverseNode[] = [];
-  private cacheEdges: TraverseEdge[] = [];
-  private cacheTruncated = false;
+  /** Full-depth traversal cache — what makes a shallower depth free. See `graph-traversal-cache.ts`. */
+  private cache: TraversalCache = emptyCache();
 
   // â”€â”€ Lifecycle â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
@@ -1331,7 +707,7 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.readGraphTheme();
+    this.theme = readGraphTheme();   // CSS vars resolve only once the view exists
     this.initCytoscape();
 
     // Watch direction / depth / hideLabels changes via effect
@@ -1353,196 +729,57 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   private initCytoscape(): void {
     const container = this.cyContainer()?.nativeElement;
     if (!container) return;
-
-    // Glass shine SVG â€” radial highlight in upper-left quadrant
-    const glassShineSvg = (color: string) => {
-      const c = encodeURIComponent(color);
-      return `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><defs><radialGradient id='base' cx='50%25' cy='50%25' r='50%25'><stop offset='0%25' stop-color='${c}' stop-opacity='0.28'/><stop offset='100%25' stop-color='${c}' stop-opacity='0.06'/></radialGradient><radialGradient id='shine' cx='30%25' cy='22%25' r='50%25'><stop offset='0%25' stop-color='white' stop-opacity='0.55'/><stop offset='45%25' stop-color='white' stop-opacity='0.12'/><stop offset='100%25' stop-color='white' stop-opacity='0'/></radialGradient><radialGradient id='rim' cx='50%25' cy='50%25' r='50%25'><stop offset='68%25' stop-color='${c}' stop-opacity='0'/><stop offset='100%25' stop-color='${c}' stop-opacity='0.7'/></radialGradient><radialGradient id='bot' cx='58%25' cy='80%25' r='38%25'><stop offset='0%25' stop-color='${c}' stop-opacity='0.18'/><stop offset='100%25' stop-color='${c}' stop-opacity='0'/></radialGradient></defs><circle cx='50' cy='50' r='49' fill='url(%23base)'/><circle cx='50' cy='50' r='49' fill='url(%23rim)'/><circle cx='50' cy='50' r='49' fill='url(%23bot)'/><circle cx='50' cy='50' r='49' fill='url(%23shine)'/></svg>`;
-    };
-
-    this.cy = cytoscape({
-      container,
-      elements: [],
-      style: [
-        {
-          selector: 'node',
-          style: {
-            'width': (ele: any) => { const d = +ele.data('depth'); return d === 0 ? 68 : Math.max(36, 52 - d * 3); },
-            'height': (ele: any) => { const d = +ele.data('depth'); return d === 0 ? 68 : Math.max(36, 52 - d * 3); },
-            'background-color': this.graphNodeBg,
-            'background-image': (ele: any) => glassShineSvg(this.typeColor(ele.data('type') || 'default')),
-            'background-fit': 'cover',
-            'background-clip': 'node',
-            'border-width': (ele: any) => +ele.data('depth') === 0 ? 2.5 : 1.5,
-            'border-color': (ele: any) => this.typeColor(ele.data('type') || 'default'),
-            'border-opacity': 0.75,
-            'label': 'data(label)',
-            'font-size': (ele: any) => +ele.data('depth') === 0 ? 13 : 11,
-            'font-weight': (ele: any) => +ele.data('depth') === 0 ? '600' : '400',
-            'color': this.graphNodeText,
-            'text-outline-color': this.graphNodeBg,
-            'text-outline-width': 2,
-            'text-valign': 'bottom',
-            'text-margin-y': 8,
-            'text-max-width': '110px',
-            'text-wrap': 'ellipsis',
-            'opacity': (ele: any) => { const d = +ele.data('depth'); return d === 0 ? 1 : Math.max(0.55, 1 - d * 0.1); },
-            'shadow-blur': (ele: any) => +ele.data('depth') === 0 ? 28 : 14,
-            'shadow-color': (ele: any) => this.typeColor(ele.data('type') || 'default'),
-            'shadow-opacity': (ele: any) => +ele.data('depth') === 0 ? 0.6 : 0.35,
-            'shadow-offset-x': 0,
-            'shadow-offset-y': 0,
-          } as any,
-        },
-        {
-          selector: 'node.root',
-          style: {
-            'border-color': this.graphNodeRoot,
-            'border-width': 3,
-            'border-opacity': 1,
-          } as any,
-        },
-        {
-          selector: 'node.hovered',
-          style: {
-            'border-width': 2.5,
-            'border-opacity': 1,
-            'opacity': 1,
-            'shadow-blur': 30,
-            'shadow-opacity': 0.8,
-          } as any,
-        },
-        {
-          selector: 'node:selected',
-          style: {
-            'border-color': this.graphNodeSelect,
-            'border-width': 3,
-            'border-opacity': 1,
-            'opacity': 1,
-            'shadow-blur': 36,
-            'shadow-color': this.graphNodeSelect,
-            'shadow-opacity': 0.9,
-          } as any,
-        },
-        {
-          selector: 'edge',
-          style: {
-            'width': 1.5,
-            'line-color': this.graphEdge,
-            'target-arrow-shape': 'triangle',
-            'target-arrow-color': this.graphEdge,
-            'curve-style': 'bezier',
-            'label': 'data(label)',
-            'font-size': 10,
-            'color': this.graphEdgeLabel,
-            'text-rotation': 'autorotate',
-            'text-margin-y': -8,
-            'text-background-color': this.graphNodeBg,
-            'text-background-opacity': 0.7,
-            'text-background-padding': '2px',
-            'opacity': 0.75,
-            'shadow-blur': 0,
-          } as any,
-        },
-        {
-          selector: 'edge.hovered',
-          style: {
-            'line-color': this.graphEdgeHover,
-            'target-arrow-color': this.graphEdgeHover,
-            'opacity': 1,
-            'width': 2.5,
-            'shadow-blur': 12,
-            'shadow-color': this.graphEdgeHover,
-            'shadow-opacity': 0.6,
-            'shadow-offset-x': 0,
-            'shadow-offset-y': 0,
-          } as any,
-        },
-        {
-          selector: 'edge:selected',
-          style: {
-            'line-color': this.graphEdgeSelect,
-            'target-arrow-color': this.graphEdgeSelect,
-            'opacity': 1,
-            'width': 2.5,
-            'shadow-blur': 16,
-            'shadow-color': this.graphEdgeSelect,
-            'shadow-opacity': 0.7,
-            'shadow-offset-x': 0,
-            'shadow-offset-y': 0,
-          } as any,
-        },
-        {
-          selector: 'edge.hide-labels',
-          style: {
-            'label': '',
-          } as any,
-        },
-      ],
-      layout: { name: 'grid' },
-      minZoom: 0.1,
-      maxZoom: 5,
-      wheelSensitivity: 0.25,
+    this.cy = createGraphCytoscape(container, this.theme, {
+      onNodeTap: (id) => this.onNodeTap(id),
+      onEdgeTap: (id) => this.onEdgeTap(id),
+      onNodeDoubleTap: (id) => this.onNodeDoubleTap(id),
+      onBackgroundTap: () => this.onBackgroundTap(),
     });
+  }
 
-    // Node tap â†’ select + show detail panel
-    this.cy.on('tap', 'node', (evt: any) => {
-      const node = evt.target;
-      const id = node.data('id');
-      // graphNodes does NOT include the root node (added separately in renderGraph)
-      let tn = this.graphNodes.find(n => n._id === id);
-      if (!tn) {
-        const root = this.rootEntity();
-        if (root && root._id === id) {
-          tn = { _id: root._id, name: root.name, type: root.type || 'default', depth: 0, description: root.description, tags: root.tags };
-        }
+  // â”€â”€ Canvas interactions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  //
+  // These run OUTSIDE the Angular zone (cytoscape's own event system). Safe under OnPush only because
+  // each writes a SIGNAL — a plain field would update nothing on screen.
+
+  private onNodeTap(id: string): void {
+    // graphNodes does NOT include the root (it is added to the canvas separately), so a tap on the
+    // root — the most-clicked node in any graph — has to be reconstructed from rootEntity.
+    let tn = this.graphNodes.find(n => n._id === id);
+    if (!tn) {
+      const root = this.rootEntity();
+      if (root && root._id === id) {
+        tn = { _id: root._id, name: root.name, type: root.type || 'default', depth: 0, description: root.description, tags: root.tags };
       }
-      if (tn) {
-        this.selectedEdge.set(null);
-        this.selectedEdgeRecord.set(null);
-        this.selectedEntityRecord.set(null);
-        this.selectedNode.set(tn);
-        this.loadNodeDetails(id);
-      }
-    });
+    }
+    if (!tn) return;
+    this.selectedEdge.set(null);
+    this.selectedEdgeRecord.set(null);
+    this.selectedEntityRecord.set(null);
+    this.selectedNode.set(tn);
+    this.loadNodeDetails(id);
+  }
 
-    // Edge tap â†’ show edge side panel
-    this.cy.on('tap', 'edge', (evt: any) => {
-      const edgeId = evt.target.data('id');
-      const te = this.graphEdges.find(e => e._id === edgeId);
-      if (te) {
-        this.selectedNode.set(null);
-        this.selectedEdge.set(te);
-        this.loadEdgeDetails(te);
-      }
-    });
+  private onEdgeTap(id: string): void {
+    const te = this.graphEdges.find(e => e._id === id);
+    if (!te) return;
+    this.selectedNode.set(null);
+    this.selectedEdge.set(te);
+    this.loadEdgeDetails(te);
+  }
 
-    // Double-tap node â†’ re-root
-    this.cy.on('dbltap', 'node', (evt: any) => {
-      const id = evt.target.data('id');
-      const spaceId = this.activeSpaceId();
-      if (!spaceId) return;
-      this.brainApi.getEntity(spaceId, id).pipe(
-        catchError(() => of(null)),
-      ).subscribe(ent => {
-        if (ent) this.selectRoot(ent, true);
-      });
-    });
+  private onNodeDoubleTap(id: string): void {
+    const spaceId = this.activeSpaceId();
+    if (!spaceId) return;
+    this.brainApi.getEntity(spaceId, id).pipe(
+      catchError(() => of(null)),
+    ).subscribe(ent => { if (ent) this.selectRoot(ent, true); });
+  }
 
-    // Hover effects
-    this.cy.on('mouseover', 'node', (evt: any) => { evt.target.addClass('hovered'); });
-    this.cy.on('mouseout',  'node', (evt: any) => { evt.target.removeClass('hovered'); });
-    this.cy.on('mouseover', 'edge', (evt: any) => { evt.target.addClass('hovered'); });
-    this.cy.on('mouseout',  'edge', (evt: any) => { evt.target.removeClass('hovered'); });
-
-    // Background tap â†’ deselect
-    this.cy.on('tap', (evt: any) => {
-      if (evt.target === this.cy) {
-        this.selectedNode.set(null);
-        this.selectedEdge.set(null);
-        this.selectedEdgeRecord.set(null);
-      }
-    });
+  private onBackgroundTap(): void {
+    this.selectedNode.set(null);
+    this.selectedEdge.set(null);
+    this.selectedEdgeRecord.set(null);
   }
 
   // â”€â”€ Toolbar handlers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -1614,12 +851,7 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     this.truncated.set(false);
     this.graphNodes = [];
     this.graphEdges = [];
-    this.cacheStartId = null;
-    this.cacheDirection = null;
-    this.cacheMaxDepth = 0;
-    this.cacheNodes = [];
-    this.cacheEdges = [];
-    this.cacheTruncated = false;
+    this.cache = emptyCache();
     if (this.cy) {
       this.cy.elements().remove();
     }
@@ -1636,43 +868,25 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     this.selectedEdge.set(null);
     this.selectedEdgeRecord.set(null);
 
-    const sameRoot = this.cacheStartId === startId && this.cacheDirection === direction;
+    const req = { startId, maxDepth, direction };
+    const plan = decideFetch(this.cache, req);
 
-    // Depth decrease (or same depth): serve from cache â€” no network request needed
-    if (sameRoot && maxDepth <= this.cacheMaxDepth) {
+    // A shallower view is always a subset of what was already fetched — no request needed.
+    if (plan === 'from-cache') {
       this.applyDepthFilter(startId, maxDepth);
       return;
     }
 
-    // Depth increase into an un-truncated cache: fetch only the new frontier and merge
-    const incremental = sameRoot && maxDepth > this.cacheMaxDepth && !this.cacheTruncated;
-
     this.loading.set(true);
     this.loadError.set(null);
-    this.lastTraverse = { startId, maxDepth, direction };
+    this.lastTraverse = req;
     this.brainApi.traverseGraph(spaceId, { startId, direction, maxDepth, limit: 200 }).subscribe({
       error: (e) => { this.loading.set(false); this.loadError.set(httpErrorReason(e)); },
       next: (result) => {
-      this.loading.set(false);
-
-      if (incremental) {
-        // Merge only the new nodes/edges into the existing cache
-        const knownNodes = new Set(this.cacheNodes.map(n => n._id));
-        const knownEdges = new Set(this.cacheEdges.map(e => e._id));
-        for (const n of result.nodes) if (!knownNodes.has(n._id)) this.cacheNodes.push(n);
-        for (const e of result.edges) if (!knownEdges.has(e._id)) this.cacheEdges.push(e);
-      } else {
-        this.cacheNodes = result.nodes;
-        this.cacheEdges = result.edges;
-      }
-
-      this.cacheStartId = startId;
-      this.cacheDirection = direction;
-      this.cacheMaxDepth = maxDepth;
-      this.cacheTruncated = result.truncated;
-
-      this.truncated.set(result.truncated);
-      this.applyDepthFilter(startId, maxDepth);
+        this.loading.set(false);
+        this.cache = applyResult(this.cache, plan, req, result);
+        this.truncated.set(result.truncated);
+        this.applyDepthFilter(startId, maxDepth);
       },
     });
   }
@@ -1687,93 +901,45 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // Filter the full cache down to the requested depth and re-render
   private applyDepthFilter(startId: string, maxDepth: number): void {
-    this.graphNodes = this.cacheNodes.filter(n => n.depth <= maxDepth);
-    const visibleIds = new Set<string>(this.graphNodes.map(n => n._id));
-    visibleIds.add(startId);  // root node always included
-    this.graphEdges = this.cacheEdges.filter(e => visibleIds.has(e.from) && visibleIds.has(e.to));
+    const view = filterToDepth(this.cache, startId, maxDepth);
+    this.graphNodes = view.nodes;
+    this.graphEdges = view.edges;
     this.renderGraph(startId);
   }
 
   private renderGraph(rootId: string): void {
     if (!this.cy) return;
 
-    this.cy.resize();  // ensure canvas matches current container dimensions
-    this.cy.elements().remove();
+    const elements = buildElements(this.rootEntity(), this.graphNodes, this.graphEdges, rootId);
 
-    const elements: any[] = [];
+    // Count what was actually handed over, not what is cached — the badges must track the canvas, or
+    // they keep reporting depth-5 nodes after the slider went back to 2.
+    this.nodeCount.set(elements.filter(e => e.group === 'nodes').length);
+    this.edgeCount.set(elements.filter(e => e.group === 'edges').length);
 
-    // Add the root node (not included in traverse result)
+    renderElements(this.cy, elements, rootId, this.hideLabels(), () => this.onLayoutSettled());
+  }
+
+  /** Fit the finished layout, and open the root's panel if the user has not chosen something else. */
+  private onLayoutSettled(): void {
+    if (!this.cy) return;
+    // Resize first: Angular may have opened or closed the side panel since renderGraph() ran, which
+    // changes the canvas width without cytoscape knowing.
+    this.cy.resize();
+    this.cy.fit(undefined, 40);
+
     const root = this.rootEntity();
-    if (root) {
-      elements.push({
-        group: 'nodes',
-        data: { id: root._id, label: root.name, type: root.type || 'default', depth: 0 },
-        classes: 'root',
-      });
-    }
+    if (!root || this.selectedNode() || this.selectedEdge()) return;
 
-    for (const n of this.graphNodes) {
-      // Skip if root was already added
-      if (n._id === rootId) continue;
-      elements.push({
-        group: 'nodes',
-        data: { id: n._id, label: n.name, type: n.type || 'default', depth: n.depth },
-      });
-    }
-
-    for (const e of this.graphEdges) {
-      elements.push({
-        group: 'edges',
-        data: { id: e._id, source: e.from, target: e.to, label: e.label },
-      });
-    }
-
-    this.cy.add(elements);
-    this.nodeCount.set(elements.filter((e: any) => e.group === 'nodes').length);
-    this.edgeCount.set(elements.filter((e: any) => e.group === 'edges').length);
-
-    // Apply hide-labels class to edges
-    if (this.hideLabels()) {
-      this.cy.edges().addClass('hide-labels');
-    } else {
-      this.cy.edges().removeClass('hide-labels');
-    }
-
-    // Run layout â€” breadthfirst keeps each node next to its direct edge-partner
-    const layout = this.cy.layout({
-      name: 'breadthfirst',
-      roots: `#${rootId}`,
-      directed: false,
-      spacingFactor: 1.1,
-      padding: 40,
-      avoidOverlap: true,
-      animate: true,
-      animationDuration: 400,
-    } as any);
-
-    layout.on('layoutstop', () => {
-      if (!this.cy) return;
-      // resize first so Cytoscape knows the current canvas dimensions
-      // (Angular may have closed the side panel since renderGraph() was called)
-      this.cy.resize();
-      this.cy.fit(undefined, 40);
-
-      // Auto-select root node on first render
-      const root = this.rootEntity();
-      if (root && !this.selectedNode() && !this.selectedEdge()) {
-        const rootTn: TraverseNode = { _id: root._id, name: root.name, type: root.type || 'default', depth: 0, description: root.description, tags: root.tags };
-        this.selectedNode.set(rootTn);
-        this.loadNodeDetails(root._id);
-        // After the side panel opens (DOM update), refit to the narrower canvas
-        setTimeout(() => {
-          if (this.cy) {
-            this.cy.resize();
-            this.cy.fit(undefined, 40);
-          }
-        }, 50);
+    this.selectedNode.set({ _id: root._id, name: root.name, type: root.type || 'default', depth: 0, description: root.description, tags: root.tags });
+    this.loadNodeDetails(root._id);
+    // Opening the panel narrows the canvas — refit once the DOM has caught up.
+    setTimeout(() => {
+      if (this.cy) {
+        this.cy.resize();
+        this.cy.fit(undefined, 40);
       }
-    });
-    layout.run();
+    }, 50);
   }
 
   // â”€â”€ Detail panel helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -1805,12 +971,9 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   toggleSort(field: 'description' | 'createdAt'): void {
-    if (this.sortField() === field) {
-      this.sortAsc.set(!this.sortAsc());
-    } else {
-      this.sortField.set(field);
-      this.sortAsc.set(true);
-    }
+    const next = nextSort({ field: this.sortField(), asc: this.sortAsc() }, field);
+    this.sortField.set(next.field);
+    this.sortAsc.set(next.asc);
   }
 
   sortArrow(field: 'description' | 'createdAt'): string {
@@ -1868,7 +1031,9 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
-  openDetailPopup(row: DetailRow): void {
+  // Takes only what it reads. The template used to build seven-field DetailRow literals at four call
+  // sites for these two fields; the table's own rows still satisfy this shape.
+  openDetailPopup(row: DetailRef): void {
     const spaceId = this.activeSpaceId();
     if (!spaceId) return;
     if (row.kind === 'memory') {

--- a/client/src/app/pages/graph/graph.styles.ts
+++ b/client/src/app/pages/graph/graph.styles.ts
@@ -1,0 +1,568 @@
+/**
+ * Styles for the graph page — the canvas shell, toolbar, side panel, detail table and record drawer.
+ *
+ * Extracted verbatim from `graph.component.ts` during the god-file split, following the
+ * `pages/brain/*.styles.ts` precedent: 558 lines of CSS in the middle of a component file pushes the
+ * TypeScript that a reader came for past the point where anyone scrolls. Not one declaration changed.
+ *
+ * NB: never put a backtick in a comment in here — it terminates the template literal, and the error
+ * points at the component's `@Component` decorator rather than at this file.
+ */
+export const GRAPH_STYLES = `
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: calc(100vh - 56px - 56px);
+      min-height: 0;
+      gap: 8px;
+    }
+    :host.embedded {
+      height: 70vh;
+      min-height: 400px;
+    }
+
+    /* â”€â”€ Space chips (matches brain style) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    .space-tabs {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 8px;
+      overflow-x: auto;
+      padding-bottom: 2px;
+      flex-shrink: 0;
+    }
+    .space-chip {
+      padding: 5px 12px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: 500;
+      border: 1px solid var(--border);
+      background: var(--bg-surface);
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: all var(--transition);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1px;
+      min-width: 90px;
+      white-space: nowrap;
+    }
+    .space-chip:hover { border-color: var(--accent); color: var(--text-primary); }
+    .space-chip.active {
+      background: var(--accent-dim);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+    .space-chip-label { font-size: 12px; font-weight: 500; }
+    .space-chip-id { font-size: 10px; color: var(--text-muted); }
+    .space-chip.active .space-chip-id { color: var(--accent); opacity: 0.7; }
+
+    /* â”€â”€ Toolbar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+
+    .graph-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 16px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      margin-bottom: 8px;
+      flex-shrink: 0;
+    }
+
+    .graph-toolbar select,
+    .graph-toolbar input[type="search"],
+    .graph-toolbar input[type="text"] {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      color: var(--text-primary);
+      font-family: var(--font);
+      font-size: 13px;
+      padding: 6px 10px;
+      outline: none;
+      transition: border-color var(--transition);
+    }
+    .graph-toolbar select:focus,
+    .graph-toolbar input:focus {
+      border-color: var(--accent);
+    }
+
+    .graph-toolbar select { min-width: 140px; }
+
+    .search-wrapper {
+      position: relative;
+      flex: 1;
+      min-width: 200px;
+      max-width: 360px;
+    }
+
+    .toolbar-divider {
+      width: 1px;
+      height: 22px;
+      background: var(--border);
+      flex-shrink: 0;
+    }
+    .toolbar-spacer { flex: 1; }
+    .toolbar-label {
+      font-size: 12px;
+      color: var(--text-muted);
+      white-space: nowrap;
+    }
+
+    .depth-control {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .depth-control input[type="range"] {
+      accent-color: var(--accent);
+      width: 80px;
+      cursor: pointer;
+    }
+    .depth-value {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-primary);
+      min-width: 14px;
+      text-align: center;
+    }
+
+    .pill-group {
+      display: flex;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      overflow: hidden;
+      flex-shrink: 0;
+    }
+    .pill-group button {
+      padding: 5px 12px;
+      font-size: 12px;
+      background: var(--bg-elevated);
+      color: var(--text-secondary);
+      border: none;
+      cursor: pointer;
+      transition: background var(--transition), color var(--transition);
+      white-space: nowrap;
+    }
+    .pill-group button + button { border-left: 1px solid var(--border); }
+    .pill-group button.active {
+      background: var(--accent-dim);
+      color: var(--accent);
+    }
+    .pill-group button:hover:not(.active) {
+      background: var(--bg-overlay);
+      color: var(--text-primary);
+    }
+
+    .toolbar-toggle {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      color: var(--text-secondary);
+      font-size: 12px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .toolbar-toggle input[type="checkbox"] { accent-color: var(--accent); }
+
+    .toolbar-btn {
+      padding: 5px 10px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      color: var(--text-secondary);
+      font-size: 14px;
+      cursor: pointer;
+      line-height: 1;
+      transition: border-color var(--transition), color var(--transition), background var(--transition);
+    }
+    .toolbar-btn:hover {
+      border-color: var(--accent);
+      color: var(--text-primary);
+      background: var(--accent-dim);
+    }
+    .graph-stats {
+      font-size: 12px;
+      color: var(--text-muted);
+      white-space: nowrap;
+      font-family: var(--font-mono);
+    }
+
+    /* â”€â”€ Canvas zone â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+
+    .canvas-row {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+      gap: 8px;
+    }
+
+    .canvas-zone {
+      position: relative;
+      flex: 1;
+      min-height: 0;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      background: var(--bg-primary);
+      overflow: hidden;
+    }
+
+    .cy-container {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      inset: 0;
+    }
+
+    .truncation-banner {
+      position: absolute;
+      top: 12px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 20;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 16px;
+      background: var(--error-dim);
+      border: 1px solid var(--error);
+      border-radius: var(--radius-sm);
+      color: var(--warning);
+      font-size: 13px;
+      white-space: nowrap;
+    }
+    .truncation-banner button {
+      background: transparent;
+      border: none;
+      color: var(--text-secondary);
+      font-size: 14px;
+      cursor: pointer;
+      padding: 0 2px;
+    }
+
+    .canvas-empty {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+      gap: 8px;
+    }
+    .empty-icon {
+      font-size: 52px;
+      line-height: 1;
+      opacity: 0.2;
+    }
+    .canvas-empty h3 {
+      color: var(--text-muted);
+      font-weight: 500;
+      font-size: 15px;
+      margin: 0;
+    }
+    .canvas-empty p {
+      color: var(--text-muted);
+      font-size: 13px;
+      margin: 0;
+      opacity: 0.7;
+    }
+
+    /* Loading overlay */
+    .loading-overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: color-mix(in srgb, var(--bg-primary) 60%, transparent);
+      z-index: 30;
+      backdrop-filter: blur(2px);
+    }
+    .loading-spinner {
+      width: 36px;
+      height: 36px;
+      border: 3px solid color-mix(in srgb, var(--accent) 25%, transparent);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: graph-spin 0.75s linear infinite;
+    }
+    @keyframes graph-spin { to { transform: rotate(360deg); } }
+
+    /* â”€â”€ Side panel (shown when node or edge selected) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+
+    .side-panel {
+      width: 560px;
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      background: var(--bg-surface);
+      overflow: hidden;
+      min-height: 0;
+    }
+
+    .side-panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+      gap: 8px;
+    }
+    .side-panel-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+    .side-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .side-panel-title h3 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .side-panel-header-actions {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+
+    /* Side panel body: two columns */
+    .side-panel-body {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    /* Left column: record card */
+    .record-card {
+      flex: 0 0 50%;
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+      padding: 12px 14px;
+    }
+
+    /* Drawer fields (same pattern as brain component) */
+    .drawer-field { margin-bottom: 14px; }
+    .drawer-label {
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 4px;
+    }
+    .drawer-value {
+      font-size: 12px;
+      color: var(--text-primary);
+      white-space: pre-wrap;
+      word-break: break-word;
+      line-height: 1.5;
+    }
+    .drawer-muted { color: var(--text-muted); }
+    .drawer-hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
+    .drawer-readonly-value {
+      font-size: 12px;
+      color: var(--text-muted);
+      padding: 4px 8px;
+      border: 1px solid var(--border-muted, var(--border));
+      border-radius: var(--radius-sm);
+      background: var(--bg-elevated);
+      word-break: break-all;
+      line-height: 1.4;
+    }
+    .drawer-tag {
+      display: inline-block;
+      padding: 1px 7px;
+      border-radius: 10px;
+      font-size: 11px;
+      background: var(--bg-elevated);
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+      margin: 2px 3px 2px 0;
+    }
+
+    /* Right column: memory + chrono lists */
+    .lists-pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+    }
+    .list-section {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+      border-bottom: 1px solid var(--border);
+    }
+    .list-section:last-child { border-bottom: none; }
+    .list-section-header {
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 8px 12px 6px;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .list-section-header .count-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 4px;
+      background: var(--bg-overlay);
+      border-radius: 8px;
+      font-size: 10px;
+      color: var(--text-muted);
+    }
+    .list-body { overflow-y: auto; flex: 1; }
+    .list-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 12px;
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+      transition: background var(--transition);
+    }
+    .list-row:last-child { border-bottom: none; }
+    .list-row:hover { background: var(--bg-elevated); }
+    .list-row-text {
+      flex: 1;
+      font-size: 12px;
+      color: var(--text-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .list-row-date {
+      font-size: 10px;
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .list-empty {
+      font-size: 12px;
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 16px 12px;
+    }
+
+    /* â”€â”€ Shared badge, button helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    .tag {
+      display: inline-block;
+      padding: 1px 7px;
+      border-radius: 10px;
+      font-size: 11px;
+      background: var(--bg-elevated);
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+      margin-right: 3px;
+    }
+
+    /* â”€â”€ Brain-style record drawer modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    .bdrawer-overlay {
+      position: fixed; inset: 0;
+      background: var(--bg-scrim);
+      display: flex; align-items: center; justify-content: center;
+      z-index: 1100;
+    }
+    .bdrawer-modal {
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      width: 100%; max-width: 640px;
+      max-height: 88vh; overflow: hidden;
+      display: flex; flex-direction: column;
+    }
+    .bdrawer-header {
+      display: flex; align-items: flex-start; justify-content: space-between;
+      padding: 16px 20px; border-bottom: 1px solid var(--border); gap: 12px; flex-shrink: 0;
+    }
+    .bdrawer-title { font-size: 15px; font-weight: 600; color: var(--text-primary); word-break: break-word; }
+    .bdrawer-body { overflow-y: auto; flex: 1; padding: 20px; }
+    .bdrawer-footer {
+      display: flex; align-items: center; justify-content: flex-end;
+      gap: 8px; padding: 12px 20px; border-top: 1px solid var(--border); flex-shrink: 0;
+    }
+    .bdrawer-field { margin-bottom: 16px; }
+    .bdrawer-label {
+      font-size: 10px; font-weight: 600; color: var(--text-muted);
+      text-transform: uppercase; letter-spacing: .05em; margin-bottom: 4px;
+    }
+    .bdrawer-readonly {
+      font-size: 12px; color: var(--text-muted); padding: 5px 8px;
+      border: 1px solid var(--border-muted, var(--border)); border-radius: var(--radius-sm);
+      background: var(--bg-elevated); word-break: break-all; line-height: 1.4;
+      font-family: var(--font-mono);
+    }
+    .bdrawer-muted { color: var(--text-muted); font-size: 11px; }
+    .bdrawer-hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+    .bdrawer-modal input[type=text], .bdrawer-modal input[type=number],
+    .bdrawer-modal input[type=datetime-local], .bdrawer-modal textarea, .bdrawer-modal select {
+      width: 100%; padding: 6px 9px;
+      border: 1px solid var(--border); border-radius: var(--radius-sm);
+      font-size: 13px; background: var(--bg-primary); color: var(--text-primary);
+      box-sizing: border-box; font-family: var(--font);
+    }
+    .bdrawer-modal textarea { resize: vertical; }
+    .bdrawer-modal input:focus, .bdrawer-modal select:focus, .bdrawer-modal textarea:focus {
+      outline: none; border-color: var(--accent);
+    }
+    /* entity chips */
+    .entity-multi {
+      display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
+      padding: 4px 6px; border: 1px solid var(--border); border-radius: var(--radius-sm);
+      background: var(--bg-primary); min-height: 34px;
+    }
+    .chip {
+      display: inline-flex; align-items: center; gap: 3px;
+      padding: 2px 8px; border-radius: 10px;
+      background: var(--accent-dim); border: 1px solid var(--accent);
+      font-size: 11px; color: var(--text-primary);
+    }
+    .chip-name { max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .chip-remove {
+      background: none; border: none; color: var(--text-muted); cursor: pointer;
+      padding: 0 1px; font-size: 12px; line-height: 1;
+    }
+    .chip-add {
+      background: none; border: none; color: var(--accent); cursor: pointer;
+      font-size: 12px; padding: 2px 4px;
+    }
+    .flyout-wrap { position: relative; }
+    .flyout-panel {
+      position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
+      background: var(--bg-surface); border: 1px solid var(--border);
+      border-radius: var(--radius-md); padding: 10px; margin-top: 4px;
+      box-shadow: var(--shadow-lg);
+    }
+`;


### PR DESCRIPTION
Step 2 of 2. #474 put the safety net on main; this moves what it pinned.

## The split

| file | lines | |
|---|---|---|
| `graph.component.ts` | **2065 → 1230** | the view (~490 of the remainder is the inline template) |
| `graph-details.ts` | 145 | detail-row derivation, filtering, sorting — **pure** |
| `graph-traversal-cache.ts` | 125 | the three-way fetch decision + depth cut — **pure** |
| `graph-cytoscape.ts` | 340 | theme, stylesheet, element model, instance wiring |
| `graph.styles.ts` | 568 | CSS, moved verbatim |

Structure follows `pages/brain/`, which went through this same treatment: a plain module by default, an injectable only when something must hold state or inject an API, and a `*.styles.ts` for the CSS. Nothing here needs DI, so nothing here is a service.

## The acceptance condition

**All 45 characterization tests pass unchanged.** That was the rule set in #474 — a test needing an edit to accommodate the split would mean the split changed behaviour. `git diff` on that spec is empty.

## One duplication deleted, not relocated

The template built a seven-field `DetailRow` literal at **four** click handlers for a method that reads exactly two of those fields — and the copies had already drifted from the component's own version (a bare `{}` for `properties` against the record's own), harmlessly only because nothing read the field that differed. The handler now takes a `DetailRef` (`id` + `kind`); the table's own rows still satisfy the shape structurally.

## What unit tests could not have caught, checked directly

- **The cytoscape stylesheet was retyped by hand** and nothing tests it — it renders to a canvas jsdom does not provide. Diffed structurally against the original from git: **8 selectors, every property under each, every literal value** match.
- **The page was driven in a browser** against a seeded 7-entity graph. Canvas renders with type colours and edge labels, side panel opens on the auto-selected root with its memory and chrono lists, a detail row opens its record through the narrowed handler, console clean.

  One apparent discrepancy — a cross-edge between two visible nodes never appearing at any depth — was traced to the **server's** traversal returning tree edges only. Identical before and after; not introduced here.

## New tests

23 direct tests for the pure modules, covering what was impractical to reach through the component: the cache combinations a user cannot produce by clicking (truncated **and** shallower, an empty cache, a same-depth re-request), and the exact depth boundary. They run in **7ms** against 601ms for the equivalents driven through the component — that is the point of extracting them.

Client suite: **71 files, 680 tests** green. Production AOT build passes.

## Deliberately unchanged

The two asymmetries characterized in #474 — the edge panel's memory/chrono filter mismatch, and chrono rows' hard-coded empty properties bag. Changing either belongs in its own PR with its own CHANGELOG line, not hidden inside a refactor diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)