### PR TITLE
feat(audit): network settings and backup config record what changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -863,6 +863,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Two more operations record what changed: network settings and backup configuration.** Slice 3 of
+  the audit old→new work. `network.update` records `label`, `syncSchedule` and `requireSignedVotes` —
+  the last is why the entry earns its place, because turning signed votes off silently weakens vote
+  verification for the entire network, and "an admin patched the network at 14:02" does not tell you
+  that is what happened. `data.backup_config.update` records the schedule, both retention counts and
+  the offsite destination path.
+
+  Neither can leak a credential by construction: the network record also holds `inviteKeyHash` and
+  every member's `tokenHash`, and the allowlist reads three named fields rather than diffing the
+  record. Two new cross-checks extend the ones added in slice 2 — one asserts every field named for
+  `network.update` is actually assigned by that PATCH route, the other that each dotted backup-config
+  path exists in the schema validating the body. Both failure modes are silent: a field the route
+  never writes, or a mistyped nested path, records nothing forever while the list claims coverage.
+  Verified by mutation — five plausible slips, including a route that forgets to snapshot at all,
+  were each caught.
+
 - **Three more operations record what changed: space rename, token rename, and media/extraction
   levels.** The first slice allowlisted four operations and wired one, so three of those allowlists could
   never fire — silent, which is the safe direction, but the list claimed coverage the code did not deliver.

--- a/server/src/api/data.ts
+++ b/server/src/api/data.ts
@@ -319,6 +319,10 @@ dataRouter.put('/backup-config', requireAdminMfa, (req, res) => {
     return;
   }
 
+  // Snapshot before the write. This is a whole-document PUT, so the previous file IS the before-state;
+  // the allowlist decides which of its fields may be recorded.
+  req.auditSnapshots = { before: loadBackupConfig(), after: cfg };
+
   try {
     fs.mkdirSync(path.dirname(BACKUP_CONFIG_PATH), { recursive: true });
     fs.writeFileSync(BACKUP_CONFIG_PATH, JSON.stringify(cfg, null, 2), 'utf8');

--- a/server/src/api/networks/crud.ts
+++ b/server/src/api/networks/crud.ts
@@ -213,6 +213,18 @@ crudRouter.patch('/:id', globalRateLimit, requireAdmin, (req, res) => {
   const net = cfg.networks.find(n => n.id === req.params['id']);
   if (!net) { res.status(404).json({ error: 'Network not found' }); return; }
 
+  // Snapshot before mutating. Only the three fields this route can change — the record also holds
+  // `inviteKeyHash` and members' `tokenHash`, and handing the whole thing over would rest entirely on
+  // the allowlist in audit-changes.ts rather than being obvious here.
+  req.auditSnapshots = {
+    before: { label: net.label, syncSchedule: net.syncSchedule, requireSignedVotes: net.requireSignedVotes },
+    after: {
+      label: parsed.data.label ?? net.label,
+      syncSchedule: parsed.data.syncSchedule !== undefined ? (parsed.data.syncSchedule || undefined) : net.syncSchedule,
+      requireSignedVotes: parsed.data.requireSignedVotes ?? net.requireSignedVotes,
+    },
+  };
+
   if (parsed.data.syncSchedule !== undefined) {
     net.syncSchedule = parsed.data.syncSchedule || undefined;
     // Re-register cron timer for this network with the new schedule

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -52,6 +52,15 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   // Media levels and extraction mode: the settings that decide what gets processed and what leaves the
   // instance. The provider blocks in the same payload carry API keys and are NOT listed.
   'config.media.update': ['levels.images', 'levels.audio', 'levels.video', 'levels.text', 'documentProcessing.mode'],
+  // Network settings a `PATCH /api/networks/:id` can actually change — and only those three. The network
+  // record also holds `inviteKeyHash` and each member's `tokenHash`; naming fields rather than diffing the
+  // record is what keeps them out. `requireSignedVotes` is the reason this entry is worth having: turning
+  // it off silently weakens vote verification for the whole network, and "an admin patched the network"
+  // does not tell you that happened.
+  'network.update': ['label', 'syncSchedule', 'requireSignedVotes'],
+  // Backup schedule and retention. `offsite.destPath` is a container filesystem path (mounted volume),
+  // not a URL, so it cannot carry credentials in userinfo the way a webhook target can.
+  'data.backup_config.update': ['schedule', 'retention.keepLocal', 'offsite.destPath', 'offsite.retention.keepCount'],
 };
 
 /** Scalars only — anything else is dropped rather than stringified. */

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -75,6 +75,7 @@ describe('audit changes — every allowlist is actually reachable', () => {
   const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8');
   const ROUTE_SOURCES = [
     'server/src/api/spaces.ts', 'server/src/api/tokens.ts', 'server/src/api/media-config.ts',
+    'server/src/api/networks/crud.ts', 'server/src/api/data.ts',
   ];
 
   it('every allowlisted key is a REAL operation name from the middleware', () => {
@@ -106,6 +107,27 @@ describe('audit changes — every allowlist is actually reachable', () => {
     assert.deepEqual(AUDIT_CHANGE_FIELDS['token.update'], ['name']);
     assert.ok(read('server/src/api/tokens.ts').includes('name: parsed.data.name.trim()'),
       'the token route should snapshot the same field the allowlist names');
+  });
+
+  it('network.update names exactly the three fields its PATCH can change', () => {
+    // Same check for slice 3. The route assigns `label`, `syncSchedule` and `requireSignedVotes` and
+    // nothing else; an allowlist naming a fourth would be silent forever rather than wrong-and-loud.
+    const src = read('server/src/api/networks/crud.ts');
+    for (const f of AUDIT_CHANGE_FIELDS['network.update']) {
+      assert.ok(src.includes(`net.${f} =`) || src.includes(`net.${f},`),
+        `network.update allowlists "${f}", which the PATCH route never assigns`);
+    }
+  });
+
+  it('the backup-config allowlist matches the schema that validates the body', () => {
+    // These are dotted paths into a nested config. A typo (retention.keepLocal -> retention.keep) reads
+    // as "nothing changed" forever, so pin them against the schema that defines the shape.
+    const schema = read('server/src/db/backup-config.ts');
+    for (const path of AUDIT_CHANGE_FIELDS['data.backup_config.update']) {
+      const leaf = path.split('.').pop();
+      assert.ok(new RegExp(`\\b${leaf}\\s*:`).test(schema),
+        `backup-config allowlists "${path}" but the schema defines no "${leaf}"`);
+    }
   });
 });
 


### PR DESCRIPTION
Slice 3 of the audit old→new work (after #471, #472, #473).

## What now records its changes

| operation | fields |
|---|---|
| `network.update` | `label`, `syncSchedule`, `requireSignedVotes` |
| `data.backup_config.update` | `schedule`, `retention.keepLocal`, `offsite.destPath`, `offsite.retention.keepCount` |

**`requireSignedVotes` is why the first entry earns its place.** Turning it off silently weakens vote verification for an entire network — and "an admin patched the network at 14:02" is precisely the entry an audit log exists to improve on.

## Neither can leak a credential by construction

The network record also holds `inviteKeyHash` and every member's `tokenHash`. The route snapshots **three named fields** rather than handing the record over, so the allowlist is a second line of defence rather than the only one.

`offsite.destPath` is a container filesystem path, not a URL — unlike a webhook target it cannot carry credentials in userinfo or a query string.

## Two new cross-checks, both guarding silent failure

Slice 2 shipped four allowlists of which one was wired and two named fields that did not exist. Those bugs record *nothing, forever*, while the list claims coverage — no error, no failing test, nothing to notice. So each slice now adds the check that would have caught its own likely mistake:

- every field named for `network.update` must actually be **assigned by that PATCH route**
- every dotted backup-config path must exist in the **zod schema that validates the body** (a typo like `retention.keepLocal` → `retention.keep` is otherwise permanently silent)

## Verified by mutation, not by passing

All 15 tests were green on the first run, which proves nothing. Five plausible slips were applied one at a time — an allowlisted field the route never assigns, a plausible-but-absent field, a dotted-path typo, an operation key matching no middleware operation, and a route that forgets to snapshot at all. **5/5 caught.**

## Note on local test results

75 standalone tests fail on my machine without the Docker stack running (metrics, theme, SPA fallback, quota — all need a live instance). I confirmed these fail identically on a clean stash of `main`, so they are environmental rather than introduced; CI runs them after `test:up`. `audit-changes` (15/15) and `audit-route-coverage` (4/4) pass.

## Remaining

~97 operations still have no change allowlist. The brain record updates (`entity.update`, `memory.update`, …) are a different question from admin config and want their own decision — auditing every record edit's before/after duplicates record content into a retained store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)