### PR TITLE
feat(audit): maintenance mode records its direction; the mechanical half is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -863,6 +863,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Maintenance mode records which direction it was toggled.** One boolean, and the direction is the
+  whole story: an entry saying only "an admin hit the maintenance route" cannot distinguish the start of
+  an outage from the end of one. The route snapshots the CURRENT state before flipping it, so a no-op
+  re-toggle correctly records nothing — a test pins that, because copying the requested value into both
+  sides would make every toggle look like no change at all, silently.
+
+  This completes the mechanical half of the audit old→new work. The original estimate of "~100 per-route
+  rules" turned out to be wrong: of 103 audited operations, most are **actions with no before/after
+  state** — a query, a backup, a reindex, a bulk resolve, every create and delete — for which a change
+  record is meaningless rather than missing. Every operation that does have a meaningful scalar
+  before/after now has one. What remains is two design questions rather than more of the same work:
+  whether brain RECORD edits should copy user content into a retained, admin-queryable store, and how to
+  represent SCHEMA changes given the allowlist is deliberately scalars-only.
+
 - **Two more operations record what changed: network settings and backup configuration.** Slice 3 of
   the audit old→new work. `network.update` records `label`, `syncSchedule` and `requireSignedVotes` —
   the last is why the entry earns its place, because turning signed votes off silently weakens vote

--- a/server/src/api/data.ts
+++ b/server/src/api/data.ts
@@ -174,6 +174,10 @@ dataRouter.post('/maintenance', requireAdminMfa, (req, res) => {
     res.status(400).json({ error: 'Body must be { active: boolean }' });
     return;
   }
+  // Read the current state BEFORE flipping it — the direction is the point, and a no-op re-toggle
+  // should record nothing rather than look like a state change.
+  req.auditSnapshots = { before: { active: isMaintenanceActive() }, after: { active: parsed.data.active } };
+
   setMaintenanceActive(parsed.data.active);
   res.json({ active: parsed.data.active });
 });

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -61,6 +61,10 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   // Backup schedule and retention. `offsite.destPath` is a container filesystem path (mounted volume),
   // not a URL, so it cannot carry credentials in userinfo the way a webhook target can.
   'data.backup_config.update': ['schedule', 'retention.keepLocal', 'offsite.destPath', 'offsite.retention.keepCount'],
+  // Maintenance mode blocks writes instance-wide. One boolean, and the direction is the whole story:
+  // an entry saying only "an admin hit the maintenance route" cannot distinguish starting an outage
+  // from ending one.
+  'data.maintenance.toggle': ['active'],
 };
 
 /** Scalars only — anything else is dropped rather than stringified. */

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -119,6 +119,19 @@ describe('audit changes — every allowlist is actually reachable', () => {
     }
   });
 
+  it('the maintenance toggle snapshots the CURRENT state, not the requested one twice', () => {
+    // The failure this guards is a plausible copy-paste: `before: { active: parsed.data.active }`.
+    // from === to on every request, so `auditChanges` returns [] and maintenance mode looks like it
+    // was never toggled — silent, and indistinguishable from the feature working.
+    // Must match the ASSIGNMENT, not just the expression: data.ts has a second snapshot site
+    // (backup-config), so a check for the bare pattern would pass with this one deleted, and one for
+    // `auditSnapshots` anywhere in the file would pass with it assigned to a dead variable.
+    const src = read('server/src/api/data.ts');
+    assert.ok(/req\.auditSnapshots\s*=\s*\{\s*before:\s*\{\s*active:\s*isMaintenanceActive\(\)\s*\}/.test(src),
+      'the maintenance route must assign req.auditSnapshots with isMaintenanceActive() as the before-state');
+    assert.deepEqual(AUDIT_CHANGE_FIELDS['data.maintenance.toggle'], ['active']);
+  });
+
   it('the backup-config allowlist matches the schema that validates the body', () => {
     // These are dotted paths into a nested config. A typo (retention.keepLocal -> retention.keep) reads
     // as "nothing changed" forever, so pin them against the schema that defines the shape.


### PR DESCRIPTION
Final mechanical slice of the audit old→new work (after #471, #472, #473, #476).

## The change

`data.maintenance.toggle` gains an allowlist of one boolean. **The direction is the whole story** — an entry saying only "an admin hit the maintenance route" cannot distinguish the start of an outage from the end of one, and maintenance mode blocks writes instance-wide.

The route snapshots the **current** state before flipping it, so a no-op re-toggle correctly records nothing. A test pins that specifically: the plausible copy-paste (`before: parsed.data.active`) makes `from === to` on every request, so `auditChanges` returns `[]` and the feature looks identical to working while recording nothing, forever.

## The "~100 per-route rules" estimate was wrong

I ground-truthed the remaining surface rather than assuming it. Of **103** audited operations, most are **actions with no before/after state** — `brain.query`, `data.backup`, `space.reindex`, `conflict.bulk_resolve`, and every `*.create` / `*.delete`. A change record is *meaningless* for those, not missing. They were never ~97 units of pending work.

Every operation that does have a meaningful scalar before/after now has one:

`space.update` · `space.rename` · `token.update` · `config.media.update` · `network.update` · `data.backup_config.update` · `data.maintenance.toggle`

`webhook.*`, `token.create` and `token.regenerate` remain absent **by design** — the interesting value there *is* the secret.

## What is actually left: two decisions, not more slices

Both parked in `_PARKED-DECISIONS.md` with a recommended default so they can be a quick yes/no:

1. **Should brain record edits carry old→new?** This copies user record content into a store retained for `audit.retentionDays` and readable by any admin — including for spaces their token could not otherwise read. Record writes are also the hot bulk path (imports, peer sync). *Recommended: no for content fields, yes for a small metadata subset (tags, entityIds).*
2. **How should schema changes be recorded**, given the allowlist is scalars-only by design? Allowing an object would reintroduce the forget-one-field failure through nesting. *Recommended: a summary shape (types added/removed, field-change counts), never schema bodies.*

The tracker now says this explicitly, so a later iteration doesn't try to "finish" the item by grinding out allowlists that don't exist.

## Mutation-checked

Three slips against the maintenance route — `before` copying the requested value, the snapshot dropped entirely, the snapshot assigned to a misspelled request field. All three caught, **but the second only after tightening the test**: it originally matched the bare expression, and `data.ts` has a second snapshot site (backup-config) that kept the looser check green with this one deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)