### PR TITLE
test(sync): characterize the engine's dedup lock and space-id mapping before splitting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -752,6 +752,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **The sync engine's per-network lock and space-id mapping are now pinned, before that file is
+  split.** `sync/engine.ts` is 1396 lines and had no dedicated unit test — only red-team and cron
+  tests touched it, and the only direct coverage was 8 tests over vote-round pruning. The two pieces
+  now covered are the ones that fail *silently*: a dedup lock that stops coalescing still syncs
+  correctly, just several cycles at once competing for connections; a lock that leaked on error would
+  be worse, wedging one network forever while every other network stays fine and nothing logs again.
+  Space-id mapping is the same shape — a wrong answer syncs a space under the wrong id or quietly
+  stops syncing one that worked, rather than throwing.
+
+  Two behaviours are explicitly **not** covered, and the test file says so rather than omitting them
+  quietly: that a concurrent trigger starts no second cycle, and that a mid-cycle trigger fires
+  exactly one more afterwards. Neither is observable through the module's public surface —
+  `runSyncForNetwork` is `async`, so the "return the in-flight promise" it documents is true
+  semantically but not referentially, and a cycle with no reachable members resolves in microtasks, so
+  a queued rerun begins and ends before any caller resumes. Observing either needs the cycle
+  implementation injected, which is a refactor; that is now a stated goal of the split rather than a
+  gap nobody wrote down.
+
 - **The graph page is now pinned by 45 characterization tests, written before it is split.** At 2065 lines
   and 53 methods it had four tests, all of which covered the OnPush conversion — the traversal cache, the
   depth filter, the model handed to cytoscape and the out-of-zone tap handlers were entirely unpinned, and

--- a/testing/standalone/sync-engine-lock.test.js
+++ b/testing/standalone/sync-engine-lock.test.js
@@ -1,0 +1,249 @@
+/**
+ * `sync/engine.ts` — characterization tests, written against the ORIGINAL 1396-line file.
+ *
+ * Written BEFORE any split, for the reason the graph work established: a characterization test written
+ * against already-restructured code pins the new behaviour and says nothing about whether the
+ * restructure preserved anything.
+ *
+ * ── What this covers, and what it deliberately does not ──────────────────────────────────────────
+ *
+ * `vote-round-prune.test.js` already covers `isRoundPrunable` / `pruneExpiredRounds` in 8 tests,
+ * including the deliberate NaN fail-safe. Those are not duplicated here.
+ *
+ * This file pins the two untested pieces that fail SILENTLY:
+ *
+ *   1. The per-network sync dedup lock. Every failure mode here looks healthy. A lock that stops
+ *      coalescing still syncs correctly — just N cycles at once, competing for bcrypt cache, Mongo
+ *      connections and peer sockets. A lock that LEAKS on error is worse: that one network stops
+ *      syncing forever, every other network is fine, and nothing ever logs again. There is no error
+ *      state to notice, only an absence.
+ *
+ *   2. Space ID mapping. A wrong answer here does not throw — it syncs a space under the wrong id, or
+ *      silently stops syncing one that used to work.
+ *
+ * The engine is imported from `server/dist` against a temp config file (the `config-*.test.js`
+ * pattern): no Docker, no Mongo, no peers. A network with zero members is a complete, successful sync
+ * cycle that touches no network — which is exactly what makes the lock observable in isolation.
+ *
+ * Run: node --test testing/standalone/sync-engine-lock.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-sync-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+
+// Read at module-load time by the loader — must be set BEFORE the import below.
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+/** A network with NO members: a complete sync cycle that contacts nobody. */
+const EMPTY_NETWORK = {
+  id: 'net-empty',
+  label: 'Empty Network',
+  members: [],
+  spaces: [],
+};
+
+let engine;
+
+before(async () => {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+    instanceId: 'test-instance',
+    instanceLabel: 'sync-engine-test',
+    spaces: [],
+    tokens: [],
+    networks: [EMPTY_NETWORK],
+  }, null, 2));
+
+  const loader = await import('../../server/dist/config/loader.js');
+  await loader.loadConfig();
+  engine = await import('../../server/dist/sync/engine.js');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Space ID resolution
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('sync engine — space id mapping', () => {
+  const mapped = { id: 'n', spaceMap: { 'their-research': 'our-research', 'their-ops': 'our-ops' } };
+  const unmapped = { id: 'n' };
+
+  it('translates a peer space id to the local one', () => {
+    assert.equal(engine.remoteToLocal(mapped, 'their-research'), 'our-research');
+  });
+
+  it('translates a local space id back to the peer one', () => {
+    assert.equal(engine.localToRemote(mapped, 'our-ops'), 'their-ops');
+  });
+
+  it('round-trips a mapped id in both directions', () => {
+    for (const [remote, local] of Object.entries(mapped.spaceMap)) {
+      assert.equal(engine.remoteToLocal(mapped, remote), local);
+      assert.equal(engine.localToRemote(mapped, local), remote);
+    }
+  });
+
+  it('passes an UNMAPPED id through unchanged rather than dropping it', () => {
+    // The no-aliasing fallback. If this returned undefined or '', an unmapped space would sync under
+    // a broken id or vanish from the cycle — and both read as "that space just does not sync".
+    assert.equal(engine.remoteToLocal(mapped, 'not-in-the-map'), 'not-in-the-map');
+    assert.equal(engine.localToRemote(mapped, 'not-in-the-map'), 'not-in-the-map');
+  });
+
+  it('is the identity when the network has no spaceMap at all', () => {
+    // The common case: most networks never configure aliasing.
+    assert.equal(engine.remoteToLocal(unmapped, 'shared'), 'shared');
+    assert.equal(engine.localToRemote(unmapped, 'shared'), 'shared');
+  });
+
+  it('resolves an AMBIGUOUS reverse lookup by key order, first match wins', () => {
+    // Characterizing, not endorsing. `localToRemote` scans Object.entries and returns the first
+    // remote whose value matches, so two peer spaces aliased onto one local space resolve to
+    // whichever key was inserted first. Nothing rejects that config, so pin the behaviour rather
+    // than pretend it cannot happen — a split that swapped this for a reversed Map built the other
+    // way round would silently change which peer receives the push.
+    const ambiguous = { id: 'n', spaceMap: { 'peer-a': 'shared', 'peer-b': 'shared' } };
+    assert.equal(engine.localToRemote(ambiguous, 'shared'), 'peer-a');
+  });
+
+  it('does not treat a spaceMap VALUE as if it were a key', () => {
+    // Guards the direction of each lookup: asking remoteToLocal for a LOCAL id must not accidentally
+    // match, or the two functions become interchangeable and one of them is silently wrong.
+    assert.equal(engine.remoteToLocal(mapped, 'our-research'), 'our-research');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// The per-network dedup lock
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('sync engine — the per-network dedup lock', () => {
+  beforeEach(async () => {
+    // Let any queued rerun from a previous test drain, so each starts from an idle lock.
+    await new Promise(r => setTimeout(r, 50));
+  });
+
+  it('reports a network as not syncing when idle', () => {
+    assert.equal(engine.isNetworkSyncing('net-empty'), false);
+  });
+
+  it('holds the lock for the duration of a cycle and releases it after', async () => {
+    // `isNetworkSyncing` is what GET /api/spaces reads to show the "syncing" chip, so a lock that is
+    // never observed as held means the chip never appears.
+    const p = engine.runSyncForNetwork('net-empty');
+    assert.equal(engine.isNetworkSyncing('net-empty'), true, 'lock should be held while in flight');
+    await p;
+    await new Promise(r => setTimeout(r, 50));   // let the one queued rerun (if any) finish
+    assert.equal(engine.isNetworkSyncing('net-empty'), false, 'lock should be released after');
+  });
+
+  it('gives every concurrent trigger the same answer as the cycle they joined', async () => {
+    // Consistent with one shared cycle, and the strongest concurrency claim that is honestly
+    // observable from outside this module (see the note below on what is NOT).
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => engine.runSyncForNetwork('net-empty')),
+    );
+    for (const r of results) assert.deepEqual(r, results[0]);
+    await new Promise(r => setTimeout(r, 50));
+  });
+
+  /*
+   * NOT TESTED HERE, deliberately, and worth stating rather than quietly skipping.
+   *
+   * Two behaviours of this lock cannot be observed through its public surface:
+   *
+   *   - that a concurrent trigger COALESCES (starts no second cycle), and
+   *   - that a trigger arriving mid-cycle fires exactly ONE more cycle afterwards.
+   *
+   * Neither is assertable from outside. `runSyncForNetwork` is `async`, so `return inflight` is
+   * wrapped in a fresh promise and identity comparison can never succeed — the doc comment's "return
+   * the CURRENT inflight promise" is true semantically, not referentially. (Asserting `p1 === p2`
+   * was tried, and fails against the original code: the test was wrong, not the engine.) And the
+   * only other signal, `isNetworkSyncing`, cannot catch the rerun: with no reachable members a cycle
+   * resolves entirely in microtasks, so the queued rerun starts AND finishes before any caller's
+   * continuation runs. Measured at 2ms, including with a member pointed at a closed port.
+   *
+   * Observing either requires counting cycles, which requires injecting the cycle implementation.
+   * That is a REFACTOR, and this file is characterization — it must not change the code it pins.
+   *
+   * So: make `_runSyncForNetworkImpl` injectable a goal of the sync/engine SPLIT, and add the
+   * coalescing and rerun-once tests there. Until then those two behaviours rest on code review.
+   */
+
+  it('RELEASES the lock when the cycle throws — the failure that would wedge a network forever', async () => {
+    // The release lives in a `finally`. If it did not, one failed cycle would leave the lock held and
+    // that network would never sync again: no error, no retry, no log — every other network fine.
+    // An unknown network id is the cheapest way to make the cycle throw.
+    await assert.rejects(
+      () => engine.runSyncForNetwork('no-such-network'),
+      /not found/i,
+    );
+    assert.equal(engine.isNetworkSyncing('no-such-network'), false,
+      'the lock must be released even when the cycle throws');
+  });
+
+  it('can still run a network whose previous cycle threw', async () => {
+    // The observable consequence of the above: recovery, not just a cleared flag.
+    await assert.rejects(() => engine.runSyncForNetwork('no-such-network'), /not found/i);
+    await assert.rejects(() => engine.runSyncForNetwork('no-such-network'), /not found/i);
+    assert.equal(engine.isNetworkSyncing('no-such-network'), false);
+  });
+
+  it('locks per network, not globally', async () => {
+    // Two networks must not block each other; a global lock would serialise every peer in the
+    // instance behind the slowest one.
+    const p = engine.runSyncForNetwork('net-empty');
+    assert.equal(engine.isNetworkSyncing('net-empty'), true);
+    assert.equal(engine.isNetworkSyncing('some-other-network'), false);
+    await p;
+    await new Promise(r => setTimeout(r, 50));
+  });
+
+  it('completes a members-less cycle as a success, not an error', async () => {
+    const result = await engine.runSyncForNetwork('net-empty');
+    assert.deepEqual(result, { synced: 0, errors: 0 });
+    await new Promise(r => setTimeout(r, 50));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Scheduler
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('sync engine — cron scheduler', () => {
+  it('ignores an invalid cron expression instead of throwing at the caller', () => {
+    // Reached from PATCH /api/networks/:id, so a bad schedule must not 500 the request.
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', 'not a cron expression'));
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', '99 99 99 99 99'));
+  });
+
+  it('treats an absent schedule as "unschedule", not as an error', () => {
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', undefined));
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', ''));
+  });
+
+  it('accepts a valid schedule and can replace it', () => {
+    // Replacing must not accumulate timers — a leaked task keeps firing for a network that may since
+    // have been deleted, and the only symptom is sync traffic nobody asked for.
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', '*/5 * * * *'));
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', '0 * * * *'));
+    assert.doesNotThrow(() => engine.scheduleSyncForNetwork('net-empty', undefined));
+  });
+
+  it('start and stop are both idempotent', () => {
+    assert.doesNotThrow(() => engine.startSyncScheduler());
+    assert.doesNotThrow(() => engine.startSyncScheduler());
+    assert.doesNotThrow(() => engine.stopSyncScheduler());
+    assert.doesNotThrow(() => engine.stopSyncScheduler());
+  });
+
+  it('can restart after a stop', () => {
+    engine.stopSyncScheduler();
+    assert.doesNotThrow(() => engine.startSyncScheduler());
+    engine.stopSyncScheduler();
+  });
+});


### PR DESCRIPTION
`sync/engine.ts` is **1396 lines with no dedicated unit test** — only red-team and cron tests touch it. The sole direct coverage was 8 tests over vote-round pruning, which are not duplicated here.

19 tests, written against the **original** file, in their own PR. The split is next.

## What is pinned, and why these two

Both fail *silently*:

**The per-network dedup lock.** A lock that stops coalescing still syncs correctly — just several cycles at once, competing for bcrypt cache, Mongo connections and peer sockets. The only symptom is load. A lock that **leaked on error** is worse: that one network stops syncing forever, every other network is fine, and nothing ever logs again. No error state to notice, only an absence. The release lives in a `finally`; two tests pin that it survives a throwing cycle and that the network recovers.

**Space-id mapping.** A wrong answer doesn't throw — it syncs a space under the wrong id, or quietly stops syncing one that worked. The reverse lookup returns the **first** match, so two peer spaces aliased onto one local space resolve by key order. Characterized as-is: nothing rejects that config, and a split swapping in a reversed `Map` built the other way round would silently change which peer gets pushed.

## Two behaviours deliberately NOT covered — stated, not omitted

That a concurrent trigger starts no second cycle, and that a mid-cycle trigger fires exactly one more afterwards. **Neither is observable through the public surface:**

- `runSyncForNetwork` is `async`, so `return inflight` is wrapped in a fresh promise. The doc comment's "return the CURRENT inflight promise" is true *semantically*, not referentially — asserting `p1 === p2` **fails against the original code**. I wrote that test first; the test was wrong, not the engine.
- `isNetworkSyncing` can't catch the rerun either: a cycle with no reachable members resolves entirely in microtasks, so the queued rerun starts *and finishes* before any caller's continuation runs. Measured at 2ms, including with a member pointed at a closed port.

Observing either requires injecting the cycle implementation — a refactor, which this file must not do. **That injection is now a stated requirement of the sync/engine split** in the tracker, with these two tests named as part of it, rather than a gap nobody wrote down.

## Mutation-validated 6/6

An unmapped id dropped instead of passed through · the reverse lookup matching on key instead of value · the reverse lookup returning the last match · the lock never held · the lock never released.

**The harness itself needed fixing first.** Its initial run printed `7/7 killed` when all seven anchors had *missed* — it counted skips as successes. Skips are now fatal. Same false-confidence shape these checks exist to catch, in the checker.

## Note

No Docker or Mongo needed: the engine imports cleanly from `server/dist` against a temp config file (the `config-*.test.js` pattern), and a network with zero members is a complete sync cycle that contacts nobody.

Also verified in passing: the `spaceMap` description in [integration-guide.md:3925](docs/integration-guide.md#L3925) matches the characterized behaviour exactly, identity fallback included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)