### PR TITLE
feat(spaces): If-Match makes space-meta writes conditional instead of last-write-wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -881,6 +881,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Space meta writes can now be made conditional with `If-Match`, so two admins editing one space no
+  longer silently lose an edit.** `meta.version` was already incremented on every write, with every
+  previous version kept in `previousVersions` — but nothing ever compared it. The counter *recorded*
+  collisions; it never prevented one. The second save replaced the first in full, and the only trace
+  was a history entry nobody reads.
+
+  Send the version you read as `If-Match: 7` on `PATCH /api/spaces/:id` or `PUT /api/spaces/:id/schema`
+  and a stale write is rejected with **412 Precondition Failed**, naming both versions and the recovery
+  step. The header is **optional** — omit it and behaviour is exactly as before, so no existing client
+  or script changes. Bare, quoted and weak entity-tag spellings are all accepted, as is `*`; a value
+  that is not a version is rejected with **400** rather than ignored, because silently dropping an
+  unparseable precondition hands back the false safety the header was asked for.
+
+  Note this is **412, not the 409** the internal note proposed: 409 describes a conflict the request
+  itself carries, while 412 is the defined outcome of an unmet precondition and is what HTTP clients
+  already handle. On the schema route the check runs before the schema-backup file is written — a
+  precondition evaluated after a side effect is not a precondition — and a test pins that ordering
+  rather than just the check's existence.
+
 - **Maintenance mode records which direction it was toggled.** One boolean, and the direction is the
   whole story: an entry saying only "an admin hit the maintenance route" cannot distinguish the start of
   an outage from the end of one. The route snapshots the CURRENT state before flipping it, so a no-op

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2784,6 +2784,31 @@ PATCH /api/spaces/:id
 
 Update space properties. Requires an admin token (+ TOTP if MFA is enabled). At least one of `label`, `description`, or `meta` must be provided.
 
+**Optimistic concurrency (`If-Match`).** Meta writes are last-write-wins by default: if two clients read a space, both edit it, and both save, the second save replaces the first in full. To make your write conditional, send the `meta.version` you read as an `If-Match` header:
+
+```http
+PATCH /api/spaces/research
+If-Match: 7
+```
+
+If the space's `meta.version` is no longer 7, the request is rejected with **412 Precondition Failed** and a body naming both versions — re-read the space, re-apply your change, and retry:
+
+```json
+{
+  "error": "Space meta has changed since you read it (you expected version 7, it is now 9). Re-read the space and re-apply your change.",
+  "expectedVersion": 7,
+  "currentVersion": 9
+}
+```
+
+Notes:
+
+- **The header is optional.** Omit it and the write proceeds unconditionally, exactly as before — existing clients are unaffected.
+- `meta.version` is returned by `GET /api/spaces`. A space that has never had meta written is version `0`, so `If-Match: 0` means "only if nobody has configured this yet".
+- Bare (`7`), quoted (`"7"`) and weak (`W/"7"`) forms are all accepted, as is `*` (matches any existing space).
+- A value that is not a version — `If-Match: abc` — is rejected with **400**, never ignored. Silently ignoring an unparseable precondition would give you the false impression that your write was protected.
+- The same header is honoured by `PUT /api/spaces/:id/schema`, and is checked before that route writes its schema backup file.
+
 ```json
 {
   "label": "Research Notes (Updated)",

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -8,6 +8,7 @@ import { slugify } from '../spaces/_shared.js';
 import { createSpace, removeSpace } from '../spaces/lifecycle.js';
 import { renameSpace } from '../spaces/rename.js';
 import { updateSpace, reorderSpaces } from '../spaces/spaces.js';
+import { checkMetaPrecondition, preconditionErrorBody } from '../spaces/meta-precondition.js';
 import { ensureTtlIndex } from '../brain/ttl.js';
 import { measureUsage, dirSizeBytes } from '../quota/quota.js';
 import { col } from '../db/mongo.js';
@@ -452,6 +453,15 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
     return;
   }
 
+  // Optimistic concurrency: honour If-Match against the current meta version, if the client sent one.
+  // Runs before validation, the audit snapshot and every side effect — a rejected write must change
+  // nothing and record nothing.
+  const precondition = checkMetaPrecondition(req.get('If-Match'), space.meta?.version ?? 0);
+  if (!precondition.ok) {
+    res.status(precondition.status).json(preconditionErrorBody(precondition));
+    return;
+  }
+
   const parsed = UpdateSpaceBody.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: parsed.error.message });
@@ -606,6 +616,14 @@ spacesRouter.put('/:id/schema', globalRateLimit, requireAdminMfaScoped('id'), as
   const space = cfg.spaces.find(s => s.id === id);
   if (!space) {
     res.status(404).json({ error: `Space '${id}' not found` });
+    return;
+  }
+
+  // Optimistic concurrency: honour If-Match against the current meta version, if the client sent one.
+  // Checked BEFORE the schema backup is written — a rejected write must leave no trace on disk.
+  const schemaPrecondition = checkMetaPrecondition(req.get('If-Match'), space.meta?.version ?? 0);
+  if (!schemaPrecondition.ok) {
+    res.status(schemaPrecondition.status).json(preconditionErrorBody(schemaPrecondition));
     return;
   }
 

--- a/server/src/spaces/meta-precondition.ts
+++ b/server/src/spaces/meta-precondition.ts
@@ -1,0 +1,81 @@
+/**
+ * `If-Match` preconditions for space-meta writes.
+ *
+ * `space.meta.version` has always been incremented on every meta write, and every previous version is
+ * kept in `previousVersions` — but nothing ever COMPARED it. Two admins editing one space was
+ * last-write-wins on the whole meta object: the second save silently discarded the first, and the only
+ * trace was a history entry nobody looks at. The counter recorded the collision; it never prevented one.
+ *
+ * ── Why a precondition rather than a merge ──────────────────────────────────────────────────────
+ *
+ * Merging is what `mergeSpaceMeta` already does per type, and it cannot express every intent — a
+ * deleted type is indistinguishable from an absent one under merge semantics. Losing an edit silently
+ * is the failure worth fixing first, and a precondition fixes it without guessing what the loser meant.
+ *
+ * ── Opt-in by absence ───────────────────────────────────────────────────────────────────────────
+ *
+ * No `If-Match` header means no precondition, and the write proceeds exactly as before. That is
+ * deliberate: making the header mandatory would break every existing client and every script, to
+ * protect against a race most of them never hit. A client that wants safety asks for it.
+ *
+ * ── Status codes ────────────────────────────────────────────────────────────────────────────────
+ *
+ * A failed `If-Match` is **412 Precondition Failed** (RFC 9110 §13.1.1), not 409. The internal note
+ * proposing this feature said 409, but 409 is for a conflict the request itself describes; 412 is the
+ * defined outcome of an unmet precondition, and HTTP client libraries already understand it. A
+ * malformed header value is 400 — the client asked for a guarantee in terms the server cannot
+ * evaluate, and silently ignoring it would hand back exactly the false safety the header was for.
+ */
+
+export type PreconditionVerdict =
+  | { ok: true }
+  | { ok: false; status: 400; reason: 'malformed'; received: string }
+  | { ok: false; status: 412; reason: 'mismatch'; expected: number; actual: number };
+
+/**
+ * Evaluate an `If-Match` header against a space's current meta version.
+ *
+ * Accepts a bare integer (`If-Match: 4`), the quoted entity-tag spelling (`If-Match: "4"`), the weak
+ * form (`W/"4"`), and `*` — which per RFC 9110 means "any current representation", so it passes for
+ * any existing space.
+ *
+ * A space that has never had meta written is version 0, so `If-Match: 0` is the correct way to say
+ * "only if nobody has configured this yet".
+ */
+export function checkMetaPrecondition(header: string | undefined, currentVersion: number): PreconditionVerdict {
+  if (header === undefined) return { ok: true };      // no precondition asked for
+
+  const raw = header.trim();
+  if (raw === '') return { ok: false, status: 400, reason: 'malformed', received: header };
+  if (raw === '*') return { ok: true };               // RFC 9110: matches any existing representation
+
+  // Strip a weak-validator prefix and surrounding quotes, so all three spellings of the same version
+  // behave identically rather than one of them silently failing every write.
+  const unquoted = raw.replace(/^W\//i, '').replace(/^"(.*)"$/, '$1').trim();
+
+  // Deliberately strict: `parseInt` would accept "4-and-a-half" as 4 and let a nonsense precondition
+  // pass, which is worse than rejecting it.
+  if (!/^\d+$/.test(unquoted)) return { ok: false, status: 400, reason: 'malformed', received: header };
+
+  const expected = Number(unquoted);
+  if (expected !== currentVersion) {
+    return { ok: false, status: 412, reason: 'mismatch', expected, actual: currentVersion };
+  }
+  return { ok: true };
+}
+
+/** The message body for a failed precondition — says what to do, not just what went wrong. */
+export function preconditionErrorBody(v: Extract<PreconditionVerdict, { ok: false }>): {
+  error: string;
+  expectedVersion?: number;
+  currentVersion?: number;
+} {
+  if (v.reason === 'malformed') {
+    return { error: `Malformed If-Match header: '${v.received}'. Expected the space's meta version, e.g. If-Match: 3` };
+  }
+  return {
+    error: `Space meta has changed since you read it (you expected version ${v.expected}, it is now ${v.actual}). Re-read the space and re-apply your change.`,
+    expectedVersion: v.expected,
+    currentVersion: v.actual,
+  };
+}

--- a/testing/standalone/meta-precondition.test.js
+++ b/testing/standalone/meta-precondition.test.js
@@ -1,0 +1,147 @@
+/**
+ * `If-Match` preconditions on space-meta writes.
+ *
+ * `space.meta.version` was incremented on every write and every previous version kept in
+ * `previousVersions` — but nothing ever compared it. Two admins editing one space was last-write-wins
+ * on the whole meta object: the second save silently discarded the first, and the only trace was a
+ * history entry nobody reads. The counter RECORDED collisions; it never prevented one.
+ *
+ * These tests pin the decision function and, structurally, that both meta-writing routes consult it
+ * before doing anything. The second half matters as much as the first: a precondition evaluated after
+ * a side effect is not a precondition. `PUT /:id/schema` writes a timestamped backup file, so a check
+ * placed below it would reject the write and still litter the space with a backup of a change that
+ * never happened.
+ *
+ * Run: node --test testing/standalone/meta-precondition.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let checkMetaPrecondition, preconditionErrorBody;
+
+before(async () => {
+  ({ checkMetaPrecondition, preconditionErrorBody } =
+    await import('../../server/dist/spaces/meta-precondition.js'));
+});
+
+describe('If-Match — absent means no precondition', () => {
+  it('allows a write when no header was sent', () => {
+    // Opt-in by absence. Making the header mandatory would break every existing client and script to
+    // protect against a race most never hit; a client that wants the guarantee asks for it.
+    assert.deepEqual(checkMetaPrecondition(undefined, 7), { ok: true });
+  });
+
+  it('allows a write for `*` on any version', () => {
+    // RFC 9110: `*` matches any current representation. It asserts the space EXISTS, which the route
+    // has already established by this point.
+    assert.deepEqual(checkMetaPrecondition('*', 0), { ok: true });
+    assert.deepEqual(checkMetaPrecondition('*', 99), { ok: true });
+  });
+});
+
+describe('If-Match — version comparison', () => {
+  it('allows the write when the version matches', () => {
+    assert.deepEqual(checkMetaPrecondition('4', 4), { ok: true });
+  });
+
+  it('accepts all three spellings of the same version', () => {
+    // Bare, quoted entity-tag, and weak. A client library that quotes automatically must not have
+    // every write rejected, and one that does not quote must not either.
+    for (const spelling of ['4', '"4"', 'W/"4"', ' 4 ']) {
+      assert.deepEqual(checkMetaPrecondition(spelling, 4), { ok: true }, `spelling: ${spelling}`);
+    }
+  });
+
+  it('REJECTS with 412 when the space moved on', () => {
+    // The whole point: this is the edit that used to be silently discarded.
+    const v = checkMetaPrecondition('3', 5);
+    assert.equal(v.ok, false);
+    assert.equal(v.status, 412, 'a failed If-Match is 412 Precondition Failed, not 409');
+    assert.equal(v.reason, 'mismatch');
+    assert.deepEqual([v.expected, v.actual], [3, 5]);
+  });
+
+  it('rejects a STALE-in-either-direction version, not just an older one', () => {
+    // A client that somehow reports a future version is equally out of sync; matching is equality,
+    // not "at least".
+    assert.equal(checkMetaPrecondition('9', 5).ok, false);
+    assert.equal(checkMetaPrecondition('1', 5).ok, false);
+  });
+
+  it('treats a space that has never had meta as version 0', () => {
+    // `If-Match: 0` is how a caller says "only if nobody has configured this yet".
+    assert.deepEqual(checkMetaPrecondition('0', 0), { ok: true });
+    assert.equal(checkMetaPrecondition('0', 1).ok, false);
+  });
+});
+
+describe('If-Match — malformed values are refused, never ignored', () => {
+  it('rejects a non-numeric value with 400', () => {
+    // Ignoring an unparseable precondition would hand back exactly the false safety the header was
+    // asked for — the client believes it is protected and is not.
+    for (const bad of ['abc', '"abc"', '', '   ', '4.5', '-1', 'null', 'undefined']) {
+      const v = checkMetaPrecondition(bad, 4);
+      assert.equal(v.ok, false, `should reject: ${JSON.stringify(bad)}`);
+      assert.equal(v.status, 400, `should be 400: ${JSON.stringify(bad)}`);
+    }
+  });
+
+  it('does not accept a numeric PREFIX as the version', () => {
+    // The `parseInt` trap: it reads "4-and-a-half" as 4 and lets a nonsense precondition pass.
+    const v = checkMetaPrecondition('4-and-a-half', 4);
+    assert.equal(v.ok, false);
+    assert.equal(v.status, 400);
+  });
+});
+
+describe('If-Match — the error tells the caller what to do', () => {
+  it('names both versions and the recovery step on a mismatch', () => {
+    const body = preconditionErrorBody(checkMetaPrecondition('3', 5));
+    assert.match(body.error, /re-read/i, 'should say how to recover, not just that it failed');
+    assert.equal(body.expectedVersion, 3);
+    assert.equal(body.currentVersion, 5);
+  });
+
+  it('shows the offending value on a malformed header', () => {
+    const body = preconditionErrorBody(checkMetaPrecondition('bogus', 5));
+    assert.match(body.error, /bogus/);
+  });
+});
+
+describe('If-Match — both meta-writing routes check it, and check it FIRST', () => {
+  const src = readFileSync(new URL('../../server/src/api/spaces.ts', import.meta.url), 'utf8');
+
+  it('PATCH /:id consults the precondition', () => {
+    assert.match(src, /checkMetaPrecondition\(req\.get\('If-Match'\)/);
+  });
+
+  it('both meta-writing routes consult it — not just the one that was easy', () => {
+    const checks = src.match(/checkMetaPrecondition\(/g) ?? [];
+    assert.ok(checks.length >= 2,
+      `expected PATCH /:id and PUT /:id/schema to both check, found ${checks.length}`);
+  });
+
+  it('the schema route checks BEFORE writing its backup file', () => {
+    // A precondition evaluated after a side effect is not a precondition. This route writes a
+    // timestamped schema backup into the space; checking below it would reject the write and still
+    // leave a backup of a change that never happened.
+    const checkAt = src.indexOf("checkMetaPrecondition(req.get('If-Match'), space.meta?.version ?? 0)",
+      src.indexOf("spacesRouter.put('/:id/schema'"));
+    const backupAt = src.indexOf('backup of the previous schema', src.indexOf("spacesRouter.put('/:id/schema'"));
+    assert.ok(checkAt > 0, 'the schema route should check the precondition');
+    assert.ok(backupAt > 0, 'expected the schema-backup step to still exist');
+    assert.ok(checkAt < backupAt, 'the precondition must be evaluated before the backup is written');
+  });
+
+  it('PATCH checks before taking the audit snapshot', () => {
+    // The audit middleware records on any <400 response. A precondition checked after the snapshot
+    // would still be correct, but this keeps the ordering explicit: rejected writes record nothing.
+    const patchAt = src.indexOf("spacesRouter.patch('/:id'");
+    const checkAt = src.indexOf('checkMetaPrecondition(', patchAt);
+    const snapshotAt = src.indexOf('req.auditSnapshots', patchAt);
+    assert.ok(checkAt > 0 && snapshotAt > 0);
+    assert.ok(checkAt < snapshotAt, 'the precondition must be evaluated before the audit snapshot');
+  });
+});


### PR DESCRIPTION
`space.meta.version` was incremented on every meta write, with every previous version kept in `previousVersions` — but **nothing ever compared it**. Two admins editing one space was last-write-wins on the whole meta object: the second save replaced the first in full, and the only trace was a history entry nobody reads. The counter *recorded* collisions; it never prevented one.

`PATCH /api/spaces/:id` and `PUT /api/spaces/:id/schema` now honour `If-Match` against the current `meta.version`.

```http
PATCH /api/spaces/research
If-Match: 7
```

```json
{
  "error": "Space meta has changed since you read it (you expected version 7, it is now 9). Re-read the space and re-apply your change.",
  "expectedVersion": 7,
  "currentVersion": 9
}
```

## Opt-in by absence

No header means no precondition — the write proceeds exactly as before. Making it mandatory would break every existing client and script to protect against a race most never hit; a caller that wants the guarantee asks for it. `meta.version` is already in `GET /api/spaces`, so there's nothing new to plumb. A space that has never had meta written is version `0`, so `If-Match: 0` means "only if nobody has configured this yet".

## 412, not the 409 the tracker proposed

Flagging this rather than silently following or silently deviating. **409** describes a conflict the request itself carries; **412 Precondition Failed** is the defined outcome of an unmet precondition (RFC 9110 §13.1.1) and is what HTTP client libraries already handle.

A malformed value is **400, never ignored** — silently dropping an unparseable precondition hands back exactly the false safety the header was asked for. The check is `/^\d+$/` rather than `parseInt` for the same reason: `parseInt` reads `"4-and-a-half"` as `4` and lets nonsense through. Bare, quoted and weak spellings all work, so a client that quotes automatically isn't rejected on every write.

## Ordering is part of the feature

On the schema route the check runs **before the timestamped schema-backup file is written**; on PATCH, before the audit snapshot. A precondition evaluated after a side effect is not a precondition — a check below the backup would reject the write and still leave a backup of a change that never happened. **Tests pin the ordering**, not merely that the check exists.

## Mutation-proven 9/9

The original bug restored (mismatch allowed through) · 409 instead of 412 · malformed header ignored · `parseInt` semantics · quoted tags no longer unwrapped · `*` no longer matching · absent header blocking writes · **each route quietly dropping its check**.

## Docs

`integration-guide.md` gains the request/response shape, every accepted spelling, and the note that omitting the header preserves existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)