### PR TITLE
fix(spaces): If-Match now covers every meta-writing route, not the two it shipped with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -881,6 +881,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`If-Match` now covers every route that writes space meta, not the two it shipped with.** The
+  previous entry guarded `PATCH /api/spaces/:id` and `PUT /api/spaces/:id/schema` — but the single-type
+  upsert and delete routes (`PUT`/`DELETE /api/spaces/:id/meta/typeSchemas/:kt/:type`) write meta too,
+  and were left unguarded. A caller could hold a precondition on one route and still lose an edit
+  through another, which is worse than no precondition because it looks like protection.
+
+  Both now check it, and the coverage test no longer counts call sites — it **derives** them: every
+  `updateSpace(…, { meta })` in the router must sit in a handler that evaluated the precondition first.
+  A count would have passed the moment it was written and rotted the moment a fifth route appeared;
+  the derived version fails on exactly the gap that shipped, which is how it was verified.
+
 - **Space meta writes can now be made conditional with `If-Match`, so two admins editing one space no
   longer silently lose an edit.** `meta.version` was already incremented on every write, with every
   previous version kept in `previousVersions` — but nothing ever compared it. The counter *recorded*

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2807,7 +2807,9 @@ Notes:
 - `meta.version` is returned by `GET /api/spaces`. A space that has never had meta written is version `0`, so `If-Match: 0` means "only if nobody has configured this yet".
 - Bare (`7`), quoted (`"7"`) and weak (`W/"7"`) forms are all accepted, as is `*` (matches any existing space).
 - A value that is not a version — `If-Match: abc` — is rejected with **400**, never ignored. Silently ignoring an unparseable precondition would give you the false impression that your write was protected.
-- The same header is honoured by `PUT /api/spaces/:id/schema`, and is checked before that route writes its schema backup file.
+- The same header is honoured by **every route that writes space meta**: `PUT /api/spaces/:id/schema` (checked before that route writes its schema backup file), and the single-type `PUT` and `DELETE` on `/api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName`.
+
+**Removing a type schema.** `PATCH` deep-merges, so omitting a type does not delete it — a merge that could delete would make every PATCH potentially destructive, and a client that round-trips a space would silently drop schemas whenever its serialiser emitted `null` for an unset field. Deletion is explicit instead: `DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` for one type (404 if it does not exist), or `PUT /api/spaces/:id/schema` to replace the whole map.
 
 ```json
 {

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -787,6 +787,13 @@ spacesRouter.put('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLim
     return;
   }
 
+  // Same optimistic-concurrency contract as PATCH /:id — this writes meta too.
+  const upsertPrecondition = checkMetaPrecondition(req.get('If-Match'), space.meta?.version ?? 0);
+  if (!upsertPrecondition.ok) {
+    res.status(upsertPrecondition.status).json(preconditionErrorBody(upsertPrecondition));
+    return;
+  }
+
   const kt = knowledgeType as 'entity' | 'memory' | 'edge' | 'chrono';
   const existingMeta: SpaceMeta = space.meta ?? {};
   const existingKtMap: Record<string, import('../config/types.js').TypeSchema> = { ...(existingMeta.typeSchemas?.[kt] ?? {}) };
@@ -833,6 +840,13 @@ spacesRouter.delete('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRate
   const space = cfg.spaces.find(s => s.id === id);
   if (!space) {
     res.status(404).json({ error: `Space '${id}' not found` });
+    return;
+  }
+
+  // Same optimistic-concurrency contract as PATCH /:id — removing a type is a meta write.
+  const deletePrecondition = checkMetaPrecondition(req.get('If-Match'), space.meta?.version ?? 0);
+  if (!deletePrecondition.ok) {
+    res.status(deletePrecondition.status).json(preconditionErrorBody(deletePrecondition));
     return;
   }
 

--- a/testing/standalone/meta-precondition.test.js
+++ b/testing/standalone/meta-precondition.test.js
@@ -117,10 +117,34 @@ describe('If-Match — both meta-writing routes check it, and check it FIRST', (
     assert.match(src, /checkMetaPrecondition\(req\.get\('If-Match'\)/);
   });
 
-  it('both meta-writing routes consult it — not just the one that was easy', () => {
-    const checks = src.match(/checkMetaPrecondition\(/g) ?? [];
-    assert.ok(checks.length >= 2,
-      `expected PATCH /:id and PUT /:id/schema to both check, found ${checks.length}`);
+  it('EVERY route that writes meta consults it — derived, not counted', () => {
+    // This is the check that was missing when the feature first shipped, and the gap it would have
+    // caught is the one that actually happened: `If-Match` went onto PATCH /:id and PUT /:id/schema,
+    // and the single-type upsert and delete routes — which write meta just as much — were left
+    // unguarded. A caller could hold a precondition on one route and lose an edit through another.
+    //
+    // Asserting a COUNT would rot the moment a fifth route appeared. So derive the set: every
+    // `updateSpace(..., { meta })` call is a meta write, and each must sit in a handler that checked
+    // the precondition first.
+    const writeSites = [...src.matchAll(/updateSpace\([^)]*\{\s*[^}]*\bmeta\b/g)].map(m => m.index);
+    assert.ok(writeSites.length >= 4,
+      `expected at least 4 meta-write sites, found ${writeSites.length} — has the shape changed?`);
+
+    const checkSites = [...src.matchAll(/checkMetaPrecondition\(/g)].map(m => m.index);
+
+    for (const write of writeSites) {
+      // The handler containing this write starts at the nearest preceding `spacesRouter.<verb>(`.
+      const handlerStart = Math.max(
+        ...[...src.matchAll(/spacesRouter\.(get|post|put|patch|delete)\(/g)]
+          .map(m => m.index)
+          .filter(i => i < write),
+      );
+      const guarded = checkSites.some(c => c > handlerStart && c < write);
+      assert.ok(guarded,
+        `a meta write at index ${write} is in a handler that never calls checkMetaPrecondition — ` +
+        `that route can silently discard a concurrent edit. Handler starts at ${handlerStart}: ` +
+        JSON.stringify(src.slice(handlerStart, handlerStart + 90)));
+    }
   });
 
   it('the schema route checks BEFORE writing its backup file', () => {


### PR DESCRIPTION
#480 added the precondition to `PATCH /:id` and `PUT /:id/schema`. There are **four** routes that write space meta — the single-type upsert and delete on `/:id/meta/typeSchemas/:kt/:typeName` write it too, and were left unguarded.

That's worse than no precondition: a caller could hold one on `PATCH` and still lose an edit through `DELETE`, while believing the space was protected.

**Found while ground-truthing the next tracker item, not by a test.** That's the real lesson, and it's why the test changed shape.

## The coverage test now derives the route set instead of counting it

The old assertion was "`checkMetaPrecondition` appears at least twice". It passed the moment it was written, **would have passed with this gap present**, and would have rotted the moment a fifth route appeared. It asserted the number I happened to have implemented.

It now derives: every `updateSpace(…, { meta })` in the router must sit in a handler that evaluated the precondition *before* it. Verified the only way that counts — by removing each new guard in turn and confirming failure. Both killed.

## The next tracker item was a mis-framing — corrected, not built

"`mergeSpaceMeta` cannot express 'remove this type'" reads as a gap. It's the design. Removal already works two ways: `DELETE` on the single-type path, and `PUT /:id/schema` for a full replace.

What merge can't do is delete via `PATCH`, and it **shouldn't**. The obvious way to add that is a `null` sentinel (RFC 7386 JSON Merge Patch semantics), which makes every `PATCH` potentially destructive. Plenty of JSON serialisers emit `null` for an unset field — so a client that round-trips a space and PATCHes it back would silently drop type schemas it never touched. That's the same silent-data-loss shape `If-Match` exists to prevent, reintroduced through the merge path.

Merge stays non-destructive, deletion stays explicit, and the tracker now records the reasoning instead of an open item nobody should act on.

## Docs

`integration-guide.md` now states that all four routes honour the header, and explains how to remove a type schema — so the next reader doesn't rediscover the merge behaviour as a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)