### PR TITLE
fix(invite): build the generate response from fresh config, not the entry snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1894,6 +1894,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An invite could advertise a `publicUrl` and space list that were already out of date when it was
+  printed.** `POST /api/invite/generate` snapshots config on entry, then generates an RSA-4096 key pair
+  and bcrypt-hashes the handshake id — both deliberately slow — before building its response from that
+  snapshot. An admin correcting `publicUrl`, or a space being added to the network, inside that window
+  was silently ignored: no lost write, but a wrong answer that looks authoritative, handed to the one
+  party who has no way to check it. Both fields now come from a read taken after the awaits.
+
+  A network deleted during the same window now invalidates the handshake session it created, instead of
+  leaving a live invite pointing at nothing — which would have been accepted right up until apply and
+  then failed with nothing to explain it.
+
 - **Review findings whose records were deleted are now cleaned up.** Neither candidate collection had any
   retention: deleting a record individually stranded every finding about it forever, so the Review tab
   could list a pair where clicking through leads nowhere. A background prune (every 6h, always on) now

--- a/server/src/api/invite.ts
+++ b/server/src/api/invite.ts
@@ -222,16 +222,32 @@ inviteRouter.post('/generate', globalRateLimit, requireAdmin, async (req, res) =
     reparentInstanceId ? ` [reparent target: ${reparentInstanceId}]` : ''
   }`);
 
+  // Re-read config AFTER the awaits above rather than reusing the snapshot taken at the top of the
+  // handler. `bcrypt.hash` is deliberately slow (BCRYPT_ROUNDS) and RSA-4096 generation is not fast
+  // either, so that snapshot can be hundreds of milliseconds old by the time the response is built.
+  // An admin correcting `publicUrl`, or a space being added to the network, inside that window would
+  // otherwise be silently ignored — and the invite would hand the joining instance a URL and a space
+  // list that were already wrong when it was printed.
+  const fresh = getConfig();
+  const freshNet = fresh.networks.find(n => n.id === networkId);
+  if (!freshNet) {
+    // The network was deleted while this handshake was being prepared. The session is now useless —
+    // drop it rather than leaving a live invite pointing at nothing.
+    _sessions.delete(sessionKey);
+    res.status(404).json({ error: 'Network not found' });
+    return;
+  }
+
   // Use the operator-configured publicUrl when available to prevent Host header
   // injection (a crafted Host header could point the inviteUrl at an attacker's server).
-  const baseUrl = (cfg.publicUrl ?? `${req.protocol}://${req.get('host')}`).replace(/\/$/, '');
+  const baseUrl = (fresh.publicUrl ?? `${req.protocol}://${req.get('host')}`).replace(/\/$/, '');
   res.status(201).json({
     handshakeId,
     networkId,
     inviteUrl: `${baseUrl}/api/invite/apply`,
     rsaPublicKeyPem: publicKey,
     expiresAt: new Date(expiresAt).toISOString(),
-    spaces: net.spaces,
+    spaces: freshNet.spaces,
   });
 });
 

--- a/testing/standalone/config-detached-refs.test.js
+++ b/testing/standalone/config-detached-refs.test.js
@@ -171,3 +171,43 @@ describe('a reload detaches nested references', () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// The response side of the same mechanism
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('invite generate — the RESPONSE is built from fresh config, not the entry snapshot', () => {
+  const src = fs.readFileSync(new URL('../../server/src/api/invite.ts', import.meta.url), 'utf8');
+  const generateAt = src.indexOf("inviteRouter.post('/generate'");
+  const applyAt = src.indexOf("inviteRouter.post('/apply'");
+  const handler = src.slice(generateAt, applyAt);
+
+  it('re-reads config after the slow awaits rather than reusing the entry snapshot', () => {
+    // This handler generates an RSA-4096 key pair and bcrypt-hashes the handshake id before it
+    // responds — both deliberately slow. The config snapshot taken on entry can be hundreds of
+    // milliseconds stale by the time the response is assembled, so an admin correcting `publicUrl`
+    // in that window would have the invite hand out the OLD url anyway. No lost write, but a wrong
+    // answer that looks authoritative.
+    const hashAt = handler.indexOf('bcrypt.hash(');
+    const refreshAt = handler.indexOf('const fresh = getConfig();');
+    assert.ok(hashAt > 0, 'expected the bcrypt hash to still be in this handler');
+    assert.ok(refreshAt > hashAt, 'config must be re-read AFTER the slow awaits, not before');
+  });
+
+  it('builds both stale-able response fields from the fresh read', () => {
+    // `publicUrl` and the network's `spaces` are the two fields the joining instance acts on.
+    const responseAt = handler.indexOf('res.status(201)');
+    const response = handler.slice(responseAt);
+    assert.match(handler.slice(0, responseAt), /const baseUrl = \(fresh\.publicUrl/,
+      'the invite URL must come from the fresh config');
+    assert.match(response, /spaces: freshNet\.spaces/,
+      'the advertised space list must come from the freshly re-found network');
+  });
+
+  it('drops the session when the network vanished during the window', () => {
+    // A live invite pointing at a network that no longer exists is worse than no invite: the
+    // handshake would be accepted right up until apply, then fail with nothing to explain it.
+    assert.match(handler, /_sessions\.delete\(sessionKey\)/,
+      'a network deleted mid-handshake must invalidate the session it created');
+  });
+});


### PR DESCRIPTION
The last of the two detached-reference sites. One fixed, one verified as an accepted tradeoff.

## (a) The invite response — fixed

`POST /api/invite/generate` snapshots config on entry, then generates an **RSA-4096 key pair** and **bcrypt-hashes** the handshake id — both deliberately slow — before assembling its response from that snapshot. `publicUrl` and the network's `spaces` could be hundreds of milliseconds stale by the time they were handed out.

No write is lost, which is why this sat as low severity. But the failure it produces is **a wrong answer that looks authoritative, given to the party who cannot check it**: an admin corrects `publicUrl`, immediately generates an invite, and the invite carries the old URL. The joining instance has no way to know.

Both fields now come from a read taken after the awaits. And a network deleted during the same window now **invalidates the session it created** — previously the handshake stayed live pointing at nothing, accepted right up until apply, then failing with nothing to explain it.

**Mutation-proven 4/4:** response reverting to the entry snapshot · `spaces` reverting to the stale network ref · no fresh read at all · deleted network no longer dropping its session.

## (b) The config-watcher window — accepted tradeoff, not an open bug

`loader.ts` already argues this case in its own comments, and the argument holds:

- The watcher uses `fs.watchFile` (stat polling) rather than `fs.watch` **deliberately** — `config.json` normally sits on a Docker Desktop bind mount where inotify events are unreliable and can be missed entirely. That's a correctness reason, not a lazy one, and it's what creates the window.
- `mutateConfig` (re-read → apply → save) exists and closes it for a single writer, but the source is explicit that it *"cannot fix the 67 call sites that save a config they already hold, and converting them all would still leave the next one someone writes exposed."*

Converting 67 sites to narrow a two-second window on manual file edits is a poor trade against that. The tracker now records the reasoning and names the real lever if it's ever revisited: **a shorter poll interval, not a call-site sweep.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)