### PR TITLE
ci: build the client for production as its own step, before the Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,22 @@ jobs:
         # build: OnPush's failure mode is a silently-stale view, invisible to `ng build`.
         run: npm run test:client
 
+      - name: Build client (production)
+        # The production build already runs in CI — the Dockerfile's client-builder stage does
+        # `npm run build:prod --workspace=client`, so the image build below would fail on it. What this
+        # step changes is WHEN and HOW LEGIBLY: there it fails ~10 minutes in, inside a buildx log
+        # interleaved with layer caching. Here it fails in about ten seconds. Same reasoning as the
+        # unit-test step above.
+        #
+        # It is not redundant with `test:client`. Measured by injecting a template reference to a
+        # non-existent member:
+        #   - in a component that HAS a render spec, Vitest catches it (the render throws);
+        #   - in a component that has NO spec, Vitest passes 680/680 green and only the AOT build
+        #     reports it (TS2339 from the angular-compiler plugin).
+        # 19 of this repo's 67 components have no spec, so that second case is the common one.
+        # Bundle budgets (`all`: warn 8mb / error 12mb in angular.json) are likewise enforced only here.
+        run: npm run build:client
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -752,6 +752,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **CI builds the client for production as its own step, so an AOT-only failure surfaces in seconds
+  rather than ten minutes into a Docker build.** The tracker recorded this as "the client prod build
+  isn't in CI"; it already was, via the Dockerfile's client-builder stage, which the image build runs.
+  What was missing was a fast, legible failure — it surfaced inside a buildx log interleaved with layer
+  caching, for what is usually a one-line template error.
+
+  It is not redundant with the unit suite, and that was measured rather than assumed. Injecting a
+  template reference to a non-existent member: in a component that **has** a render spec, Vitest catches
+  it; in a component that has **no** spec, Vitest passes 680/680 green and only the AOT build reports it.
+  19 of this repo's 67 components have no spec, so the second case is the common one. Bundle budgets are
+  likewise enforced only by this build.
+
 - **The MCP OAuth suite now says why it failed, and survives about twice as many consecutive runs.**
   Re-running it without `npm run test:up` degraded badly, and the cause on record — registered
   `oauthClients` accumulating in config — was wrong. The real one: `POST /register` is rate-limited to


### PR DESCRIPTION
**The tracker item was mis-framed.** It read "the client prod build isn't in CI" — it already was, via the Dockerfile's client-builder stage (`npm run build:prod --workspace=client`), which the image build runs. A broken client already failed the job.

What was actually missing is a **fast, legible failure**. It surfaced ~10 minutes in, inside a buildx log interleaved with layer caching, for what is typically a one-line template error. As its own step it fails in ~8 seconds, and the guarantee becomes explicit rather than incidental to the Docker build — the same reasoning the existing unit-test step already documents.

## Not redundant with `test:client` — measured, not assumed

My first draft of this step claimed Vitest "never type-checks a template". **That was wrong**, and testing it said so: injecting a template reference to a non-existent member into a component that *has* a render spec fails 48 Vitest tests, because the render throws.

The real gap is narrower and worth stating precisely. The same injection into a component with **no spec**:

| | result |
|---|---|
| `npm run test:client` | 71 files, **680 tests, all green** |
| `npm run build:client` | `TS2339: Property 'thisMemberDoesNotExist' does not exist on type 'MfaPromptComponent'` |

**19 of this repo's 67 components have no spec**, so that's the common case, not the exotic one. Bundle budgets (`all`: warn 8mb / error 12mb) are enforced only by this build as well.

## Cost

8.4s locally, against a ~15 minute CI run. YAML validated; the step sits at position 7, between the unit tests and the buildx setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)