### PR TITLE
refactor(sync): extract the last-writer-wins upsert decision from batchUpsertBySeq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2919,6 +2919,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Sync's last-writer-wins decision is now a tested unit, not four lines inside a Mongo helper.**
+  `batchUpsertBySeq` decided which pulled documents to write, and that decision *is* the conflict
+  resolution — sync applies a record as a whole-document replace, so `seq` alone picks the winner. It
+  had no direct test, and each way it can be wrong is silent: loosening `>` to `>=` makes every cycle
+  rewrite every document it has ever seen (correct data, write volume scaling with the size of the
+  space instead of with what changed), while dropping the lower-seq guard lets a peer restored from a
+  backup roll newer local records *backwards*, with reverting records as the only evidence.
+
+  Both, plus the space re-tagging that keeps synced documents visible to `listEntities` and
+  `findEntityByName`, moved to a pure module with 15 tests, mutation-proven 7/7. The engine keeps the
+  IO; only the decisions moved.
+
 - **The sync engine's per-network lock is now a separate, testable unit — which is the entire point of
   the change.** `runSyncForNetwork` guarded sync cycles with a Map and a Set inlined in the engine, and
   two of its three behaviours could not be verified from outside: that a concurrent trigger starts no

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -31,6 +31,7 @@ import { schedule as cronSchedule, type ScheduledTask } from 'node-cron';
 import { resolveSyncCron } from './schedule.js';
 import { createCoalescingRunner } from './coalescing-runner.js';
 import { remoteToLocal, localToRemote } from './space-map.js';
+import { retagToLocalSpace, planSeqUpserts } from './upsert-plan.js';
 import {
   syncCyclesTotal,
   syncItemsPulledTotal,
@@ -1279,18 +1280,8 @@ async function batchUpsertBySeq<T extends { _id: string; seq: number }>(
 ): Promise<void> {
   if (docs.length === 0) return;
 
-  // Re-tag incoming documents to the LOCAL space.
-  //
-  // A peer's document carries ITS space id, and with `spaceMap` aliasing that is not our
-  // space id — but we store it in OUR collection. The read paths filter on this field
-  // (listEntities, findEntityByName, the edge-dedup lookup, cascade deletes), so leaving
-  // the remote id in place would make every synced document invisible to list and lookup
-  // while still being counted: the data looks lost, and `findEntityByName` stops matching,
-  // so `remember` starts creating duplicates. The collection name is the only real scope,
-  // so a document we write into `{localSpaceId}_*` belongs to `localSpaceId` by definition.
-  for (const doc of docs) {
-    (doc as unknown as { spaceId?: string }).spaceId = localSpaceId;
-  }
+  // See ./upsert-plan.ts for why re-tagging is load-bearing and why the seq comparison is strict.
+  retagToLocalSpace(docs, localSpaceId);
 
   const collection = col<T>(collName);
   const ids = docs.map(d => d._id);
@@ -1299,15 +1290,11 @@ async function batchUpsertBySeq<T extends { _id: string; seq: number }>(
     .toArray() as Array<{ _id: string; seq: number }>;
   const existingSeq = new Map(existing.map(e => [e._id, e.seq]));
 
-  const ops = [];
-  for (const doc of docs) {
-    const prev = existingSeq.get(doc._id);
-    if (prev === undefined || doc.seq > prev) {
-      ops.push({ replaceOne: { filter: { _id: doc._id }, replacement: doc, upsert: true } });
-    }
-  }
-  if (ops.length > 0) {
-    await collection.bulkWrite(asBulk<T>(ops));
+  const toWrite = planSeqUpserts(docs, existingSeq);
+  if (toWrite.length > 0) {
+    await collection.bulkWrite(asBulk<T>(
+      toWrite.map(doc => ({ replaceOne: { filter: { _id: doc._id }, replacement: doc, upsert: true } })),
+    ));
   }
 }
 

--- a/server/src/sync/upsert-plan.ts
+++ b/server/src/sync/upsert-plan.ts
@@ -1,0 +1,69 @@
+/**
+ * Deciding which pulled documents actually get written, and re-tagging them to the local space.
+ *
+ * Extracted from `sync/engine.ts` as slice 2 of the god-file split. Pure: no Mongo, no network. The
+ * engine keeps the IO (the `find` for existing seqs, the `bulkWrite`); everything that decides is here,
+ * because every mistake in this decision is silent and expensive.
+ *
+ * ── Last-writer-wins by `seq`, and why the comparison is strict ─────────────────────────────────
+ *
+ * Sync applies a pulled record as a whole-document replace. Which of two versions wins is decided by
+ * `seq` alone, so this comparison IS the conflict resolution:
+ *
+ *   - **absent locally** → write it. This is the ordinary new-record path.
+ *   - **incoming seq is HIGHER** → write it. The peer has a newer version.
+ *   - **incoming seq is EQUAL** → do NOT write. Both sides already agree, and a re-sync must be a
+ *     no-op. Loosening this to `>=` would make every cycle rewrite every document it has ever seen:
+ *     the data would stay correct, so nothing would fail, while write volume grew with the size of
+ *     the space rather than with what changed.
+ *   - **incoming seq is LOWER** → do NOT write. A peer that is behind — restored from a backup, or
+ *     offline through several local edits — must not roll newer local records backwards. This is the
+ *     clause that makes the rule a data-loss guard rather than a bandwidth optimisation.
+ *
+ * ── Re-tagging is not cosmetic ──────────────────────────────────────────────────────────────────
+ *
+ * A peer's document carries ITS space id, and under `spaceMap` aliasing that is not ours — yet we
+ * store it in OUR collection. Every read path filters on `spaceId` (`listEntities`,
+ * `findEntityByName`, the edge-dedup lookup, cascade deletes), so leaving the remote id in place makes
+ * a synced document invisible to list and lookup while still being counted. The data reads as lost,
+ * and because `findEntityByName` stops matching, `remember` starts creating duplicates instead of
+ * updating. The collection name is the only real scope: a document written into `{localSpaceId}_*`
+ * belongs to `localSpaceId` by definition.
+ */
+
+/** The minimum shape this module needs: everything sync replicates carries an id and a seq. */
+export interface Replicable {
+  _id: string;
+  seq: number;
+}
+
+/**
+ * Stamp every document with the local space id, in place.
+ *
+ * In place because the caller writes these same objects straight to Mongo — copying would mean the
+ * copy is tagged and the written original is not, which is the exact bug this prevents.
+ */
+export function retagToLocalSpace(docs: readonly unknown[], localSpaceId: string): void {
+  for (const doc of docs) {
+    (doc as { spaceId?: string }).spaceId = localSpaceId;
+  }
+}
+
+/**
+ * Which of `docs` should be written, given the seq each id currently has locally.
+ *
+ * An id missing from `existingSeq` means the document does not exist locally yet. Returns the subset
+ * to replace, preserving input order; an empty result means the caller should skip the write entirely
+ * rather than issue an empty bulkWrite.
+ */
+export function planSeqUpserts<T extends Replicable>(
+  docs: readonly T[],
+  existingSeq: ReadonlyMap<string, number>,
+): T[] {
+  const out: T[] = [];
+  for (const doc of docs) {
+    const prev = existingSeq.get(doc._id);
+    if (prev === undefined || doc.seq > prev) out.push(doc);
+  }
+  return out;
+}

--- a/testing/standalone/sync-upsert-plan.test.js
+++ b/testing/standalone/sync-upsert-plan.test.js
@@ -1,0 +1,126 @@
+/**
+ * Which pulled documents sync actually writes, and how they are scoped.
+ *
+ * Extracted from `batchUpsertBySeq` in `sync/engine.ts` (god-file split, slice 2). The engine keeps the
+ * Mongo IO; the decisions live in `upsert-plan.ts` and are tested here with no database at all.
+ *
+ * Every mistake in this decision is silent:
+ *
+ *   - loosen `>` to `>=` and every sync cycle rewrites every document it has ever seen. Nothing fails,
+ *     the data stays correct, and write volume starts scaling with the size of the space instead of
+ *     with what changed;
+ *   - drop the lower-seq guard and a peer that is behind — restored from a backup, or offline across
+ *     several local edits — silently rolls newer local records backwards. That one is data loss, and
+ *     the only evidence is records reverting;
+ *   - drop the re-tag and synced documents land with the PEER's space id in our collection. Every read
+ *     path filters on `spaceId`, so they are invisible to list and lookup while still being counted:
+ *     the data reads as lost, and `findEntityByName` no longer matches, so `remember` starts creating
+ *     duplicates instead of updating.
+ *
+ * Run: node --test testing/standalone/sync-upsert-plan.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let planSeqUpserts, retagToLocalSpace;
+
+before(async () => {
+  ({ planSeqUpserts, retagToLocalSpace } = await import('../../server/dist/sync/upsert-plan.js'));
+});
+
+const doc = (id, seq, extra = {}) => ({ _id: id, seq, ...extra });
+const ids = (list) => list.map(d => d._id);
+
+describe('planSeqUpserts — last-writer-wins by seq', () => {
+  it('writes a document that does not exist locally', () => {
+    assert.deepEqual(ids(planSeqUpserts([doc('a', 1)], new Map())), ['a']);
+  });
+
+  it('writes a document whose incoming seq is HIGHER', () => {
+    assert.deepEqual(ids(planSeqUpserts([doc('a', 5)], new Map([['a', 4]]))), ['a']);
+  });
+
+  it('does NOT rewrite when the seqs are EQUAL — a re-sync must be a no-op', () => {
+    // The `>=` trap. Both sides already agree, so rewriting changes nothing and costs a full
+    // replaceOne per document, every cycle, forever — invisible except in write volume.
+    assert.deepEqual(planSeqUpserts([doc('a', 7)], new Map([['a', 7]])), []);
+  });
+
+  it('does NOT write when the incoming seq is LOWER — the data-loss guard', () => {
+    // A peer restored from a backup, or offline across several local edits, arrives with stale
+    // versions. Without this the older document replaces the newer one and the only symptom is
+    // records silently reverting.
+    assert.deepEqual(planSeqUpserts([doc('a', 2)], new Map([['a', 9]])), []);
+  });
+
+  it('decides per document, not per batch', () => {
+    // One stale document in a batch must not suppress its fresh neighbours, and one fresh document
+    // must not drag stale ones in with it.
+    const batch = [doc('new', 1), doc('higher', 9), doc('equal', 3), doc('lower', 1)];
+    const existing = new Map([['higher', 8], ['equal', 3], ['lower', 5]]);
+    assert.deepEqual(ids(planSeqUpserts(batch, existing)), ['new', 'higher']);
+  });
+
+  it('preserves input order', () => {
+    const batch = [doc('c', 1), doc('a', 1), doc('b', 1)];
+    assert.deepEqual(ids(planSeqUpserts(batch, new Map())), ['c', 'a', 'b']);
+  });
+
+  it('returns an empty array for an empty batch, so the caller can skip the write', () => {
+    assert.deepEqual(planSeqUpserts([], new Map()), []);
+  });
+
+  it('treats seq 0 as a real value, not as absent', () => {
+    // `prev === undefined` is the existence check precisely so that a legitimate seq of 0 is not
+    // mistaken for "not present" by a falsy test.
+    assert.deepEqual(planSeqUpserts([doc('a', 0)], new Map([['a', 0]])), [], 'equal at zero: no write');
+    assert.deepEqual(ids(planSeqUpserts([doc('a', 1)], new Map([['a', 0]]))), ['a'], 'zero is beatable');
+    assert.deepEqual(planSeqUpserts([doc('a', 0)], new Map([['a', 1]])), [], 'zero cannot clobber');
+  });
+
+  it('returns the caller\'s own objects, not copies', () => {
+    // The caller writes these straight to Mongo. Returning copies would mean the re-tag applied to
+    // one object and the write carrying another.
+    const d = doc('a', 1);
+    assert.equal(planSeqUpserts([d], new Map())[0], d);
+  });
+
+  it('does not mutate the batch it was given', () => {
+    const batch = [doc('a', 1), doc('b', 2)];
+    planSeqUpserts(batch, new Map([['a', 5]]));
+    assert.deepEqual(ids(batch), ['a', 'b']);
+  });
+});
+
+describe('retagToLocalSpace — synced documents belong to the local space', () => {
+  it('overwrites the peer\'s space id on every document', () => {
+    const docs = [doc('a', 1, { spaceId: 'their-research' }), doc('b', 1, { spaceId: 'their-ops' })];
+    retagToLocalSpace(docs, 'our-space');
+    assert.deepEqual(docs.map(d => d.spaceId), ['our-space', 'our-space']);
+  });
+
+  it('adds the field when the peer omitted it', () => {
+    const docs = [doc('a', 1)];
+    retagToLocalSpace(docs, 'our-space');
+    assert.equal(docs[0].spaceId, 'our-space');
+  });
+
+  it('mutates in place rather than returning copies', () => {
+    // Load-bearing: the caller writes these same objects. A copied-and-tagged result with an
+    // untagged original is exactly the bug the re-tag exists to prevent.
+    const original = doc('a', 1, { spaceId: 'theirs' });
+    retagToLocalSpace([original], 'ours');
+    assert.equal(original.spaceId, 'ours');
+  });
+
+  it('touches nothing else on the document', () => {
+    const d = doc('a', 3, { spaceId: 'theirs', fact: 'keep me', tags: ['x'] });
+    retagToLocalSpace([d], 'ours');
+    assert.deepEqual(d, { _id: 'a', seq: 3, spaceId: 'ours', fact: 'keep me', tags: ['x'] });
+  });
+
+  it('is a no-op on an empty batch', () => {
+    assert.doesNotThrow(() => retagToLocalSpace([], 'ours'));
+  });
+});


### PR DESCRIPTION
Slice 2a of the sync/engine split.

`batchUpsertBySeq` decided which pulled documents get written — and **that decision *is* the conflict resolution**. Sync applies a record as a whole-document replace, so `seq` alone picks the winner. It sat as four lines inside a Mongo helper with no direct test.

## Every way it can be wrong is silent

| mutation | consequence |
|---|---|
| `>` → `>=` | every cycle rewrites every document it has ever seen — data stays correct, write volume scales with the size of the space instead of with what changed |
| lower-seq guard dropped | a peer restored from a backup rolls newer local records **backwards** — data loss, evidenced only by records reverting |
| re-tag dropped | synced docs keep the *peer's* space id; every read path filters on `spaceId`, so they're invisible to list/lookup while still counted — and `findEntityByName` stops matching, so `remember` creates duplicates instead of updating |

None of those throw. None fail a test that existed before this PR.

## The split

`upsert-plan.ts` holds `planSeqUpserts` and `retagToLocalSpace`, both pure. The engine keeps the IO — the `find` for existing seqs and the `bulkWrite` — so **only the decisions moved**.

## 15 tests, mutation-proven 7/7

Including the two subtle ones:

- **seq 0 must be a real value, not falsy-absent.** `prev === undefined` is the existence check for exactly this reason; `!prev` would treat a legitimate seq of 0 as "not present".
- **the planner returns the caller's own objects, not copies.** The caller writes those same objects to Mongo after re-tagging — returning copies would mean the tag applied to one object and the write carrying another.

All 53 tests across the four sync suites pass. The characterization tests from #478 are unchanged.

## Scope

Slice 2b (`pullFromPeer`, `pushToPeer`, `syncFiles`, `gossipWithPeer`, `propagateVotesWithPeer`, `checkMerkleWithPeer`) is tracked separately, with a note that those are mostly IO orchestration — the extractable-decision pattern that worked for the lock and this plan applies less cleanly there, so expect thinner returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)