### PR TITLE
docs(audit): document 7 hidden local-connector settings, and gate env-var drift both ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -862,6 +862,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Seven local-connector settings existed only in the source; they are documented now, and a test
+  keeps it that way.** The pre-release doc audit's first slice compared every environment variable the
+  code reads against every one the docs name. The connector's token, port, bind host, tunnel name,
+  cloudflared path and service-install toggle — plus the two Ythril-side token variables — were all
+  configurable and all undiscoverable. An undocumented setting is not a missing feature; it is one
+  nobody can find, and nothing reports it.
+
+  The check is now a permanent gate rather than a one-off sweep, in both directions: a variable the
+  code reads but no doc mentions fails, and so does one the docs name but nothing reads — the nastier
+  case, because a reader copies it into `.env`, it does nothing, and no error explains why. Verified by
+  introducing each kind of drift and confirming all three are caught.
+
+  Worth recording that the scan produced three classes of false finding before it was trustworthy: it
+  missed reads routed through an `envTrue(...)` helper, it did not count `docker-compose.yml` as a place
+  a variable can be used (`YTHRIL_PORT` lives only there), and its compose-interpolation pattern matched
+  ordinary `${CONSTANT}` template literals in TypeScript. Every finding was opened in the source before
+  being believed, which is the only reason none of those became a doc change.
+
 - **Documentation staleness sweep — one statement was wrong, not merely out of date.** The integration
   guide told operators that *"any change to the `oidc` block requires `POST /api/admin/reload-config`
   or a container restart to take effect"*. Since the config watcher landed, an OIDC edit is picked up

--- a/docs/workstation-mode-guide.md
+++ b/docs/workstation-mode-guide.md
@@ -400,6 +400,28 @@ Keep this terminal open (or set it up as a startup item) — the connector must 
 
 Why: the wizard communicates with a small HTTP helper process (`local-agent-connector`) that runs on Windows and executes cloudflared on your behalf. This process cannot be started from inside the Docker container.
 
+#### Local connector environment variables
+
+Every one is optional — the defaults are what the wizard expects, so change these only if your setup differs.
+
+| Variable | Default | What it does |
+|---|---|---|
+| `YTHRIL_CONNECTOR_PORT` | `38123` | Port the connector listens on. The Ythril container reaches it at this port via host-gateway, so changing it means changing the local-agent URL to match. |
+| `YTHRIL_CONNECTOR_BIND_HOST` | `0.0.0.0` | Bind address. `0.0.0.0` is deliberate so the container can reach it; see the security note below before narrowing it. |
+| `YTHRIL_CONNECTOR_TOKEN` | *(none)* | Bearer token the connector requires. Ythril injects this automatically when it spawns the connector; set it by hand only when running the connector standalone. |
+| `YTHRIL_CONNECTOR_TOKEN_FILE` | `~/.ythril-local-connector/token` | Where the token is read from when it is not supplied via the environment. |
+| `YTHRIL_CONNECTOR_TUNNEL_NAME` | `ythril-local` | Name of the cloudflared tunnel the connector creates or reuses. |
+| `YTHRIL_CONNECTOR_CLOUDFLARED_BIN` | `cloudflared` (from `PATH`) | Full path to the cloudflared executable. Set this when installation succeeded but the binary is not yet on `PATH` in the current session. |
+| `YTHRIL_CONNECTOR_ALLOW_SERVICE_INSTALL` | `true` on Windows, `false` elsewhere | Whether cloudflared may be installed as a service so the tunnel survives reboots. See "Service install" below. |
+
+The Ythril side of the same link:
+
+| Variable | Default | What it does |
+|---|---|---|
+| `YTHRIL_LOCAL_AGENT_URL` | loopback default | Where Ythril reaches the connector. |
+| `YTHRIL_LOCAL_AGENT_TOKEN` | *(none)* | Bearer token Ythril presents to the connector. Normally generated at spawn time. |
+| `YTHRIL_LOCAL_AGENT_TOKEN_FILE` | connector's token file | Read when the token is not supplied via the environment. |
+
 ### Run the wizard
 
 Once the connector is running:

--- a/testing/standalone/env-var-docs-coverage.test.js
+++ b/testing/standalone/env-var-docs-coverage.test.js
@@ -1,0 +1,135 @@
+/**
+ * Every environment variable the code reads is documented, and every one the docs name exists.
+ *
+ * Written during the pre-release doc audit, and kept as a gate rather than thrown away: the audit
+ * found seven user-facing local-connector settings (token, port, tunnel name, cloudflared path…) that
+ * existed only in the source. An undocumented setting is not a missing feature — it is a feature
+ * nobody can find, and nothing anywhere reports it.
+ *
+ * The reverse direction matters as much. A variable named in the docs but absent from the code is
+ * worse than an omission: a reader copies it into their compose file or `.env`, it does nothing, and
+ * there is no error to explain why. Renames are the usual cause.
+ *
+ * ── Two false-positive classes this scanner had to learn ────────────────────────────────────────
+ *
+ * The first version reported three variables as absent from the code that are read on every request,
+ * because it only matched `process.env[...]` and missed reads routed through an `envTrue(...)` helper.
+ * The second reported `YTHRIL_PORT` as absent because it only looked at `server/src` — that one is a
+ * docker-compose variable (`"${YTHRIL_PORT:-3200}:3200"`), never read by the server at all.
+ *
+ * Both are why compose files count as "code" here and why helper calls are matched. A scanner that
+ * under-detects usage manufactures findings, and findings that turn out to be noise are how a check
+ * like this gets ignored and then deleted.
+ *
+ * Run: node --test testing/standalone/env-var-docs-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      if (entry !== 'node_modules' && entry !== 'dist') walk(p, out);
+    } else out.push(p);
+  }
+  return out;
+}
+
+/** Only this project's own namespaces — NODE_ENV, PATH and friends are not ours to document. */
+const OURS = /^(YTHRIL_|MONGO_|MCP_|OIDC_)/;
+
+const NAME = '([A-Z][A-Z0-9_]{2,})';
+const READ_PATTERNS = [
+  new RegExp(`process\\.env\\[['"]${NAME}['"]\\]`, 'g'),
+  new RegExp(`process\\.env\\.${NAME}`, 'g'),
+  new RegExp(`os\\.environ\\.get\\(\\s*['"]${NAME}['"]`, 'g'),
+  new RegExp(`os\\.getenv\\(\\s*['"]${NAME}['"]`, 'g'),
+  // Reads via helpers. Omitting these made the first run of this scan produce three false findings.
+  new RegExp(`\\b(?:envTrue|envFalse|envInt|envNum|envStr|envList|readEnv|getEnv)\\(\\s*['"]${NAME}['"]`, 'g'),
+];
+
+/** Where a variable can legitimately be "used": source, plus compose/Dockerfile interpolation. */
+function collectUsage() {
+  const files = [
+    ...walk(join(ROOT, 'server', 'src')).filter(f => f.endsWith('.ts')),
+    ...walk(join(ROOT, 'sidecars')).filter(f => f.endsWith('.py')),
+    ...['docker-compose.yml', 'Dockerfile'].map(f => join(ROOT, f)).filter(existsSync),
+  ];
+
+  const used = new Map();
+  const add = (name, file) => {
+    if (!used.has(name)) used.set(name, new Set());
+    used.get(name).add(file.replace(ROOT, '').replace(/\\/g, '/').replace(/^[/\\]/, ''));
+  };
+
+  for (const f of files) {
+    const src = readFileSync(f, 'utf8');
+    for (const re of READ_PATTERNS) for (const m of src.matchAll(re)) add(m[1], f);
+
+    // Compose / Dockerfile interpolation: ${VAR} and ${VAR:-default}.
+    //
+    // ONLY for those files. Applying it to TypeScript matches ordinary template-literal
+    // interpolation of SCREAMING_CASE constants — it reported `OIDC_HTTP_TIMEOUT_MS` and
+    // `OIDC_PRIVATE_ISSUER_HINT` as undocumented settings when both are `export const` values that
+    // happen to be interpolated into an error message.
+    if (/(docker-compose\.ya?ml|Dockerfile)$/i.test(f)) {
+      for (const m of src.matchAll(/\$\{([A-Z][A-Z0-9_]{2,})(?::-[^}]*)?\}/g)) add(m[1], f);
+    }
+  }
+  return used;
+}
+
+function collectDocumented() {
+  const docs = new Map();
+  for (const f of readdirSync(join(ROOT, 'docs')).filter(n => n.endsWith('.md'))) {
+    const src = readFileSync(join(ROOT, 'docs', f), 'utf8');
+    for (const m of src.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/g)) {
+      if (!OURS.test(m[1])) continue;
+      if (!docs.has(m[1])) docs.set(m[1], new Set());
+      docs.get(m[1]).add(f);
+    }
+  }
+  return docs;
+}
+
+describe('env vars — docs and code agree', () => {
+  const used = collectUsage();
+  const documented = collectDocumented();
+
+  it('finds a meaningful number of variables (the scan itself still works)', () => {
+    // Guards against a refactor silently breaking the patterns and turning both checks green by
+    // finding nothing — the failure mode where a gate quietly stops gating.
+    const ours = [...used.keys()].filter(n => OURS.test(n));
+    assert.ok(ours.length >= 25, `expected the scan to find our env vars, found ${ours.length}`);
+    assert.ok(documented.size >= 15, `expected docs to name our env vars, found ${documented.size}`);
+  });
+
+  it('every variable the code reads is documented', () => {
+    const missing = [...used.entries()]
+      .filter(([name]) => OURS.test(name) && !documented.has(name))
+      .map(([name, files]) => `  ${name}  (read in ${[...files].slice(0, 2).join(', ')})`);
+
+    assert.equal(missing.length, 0,
+      `These settings exist but no doc mentions them, so nobody can find them:\n${missing.join('\n')}\n` +
+      'Document them (docs/workstation-mode-guide.md or integration-guide.md), or rename them out of ' +
+      'our namespaces if they are genuinely internal.');
+  });
+
+  it('every variable the docs name actually exists', () => {
+    // The nastier direction: a reader copies it into .env, it does nothing, and nothing explains why.
+    const phantom = [...documented.entries()]
+      .filter(([name]) => !used.has(name))
+      .map(([name, docs]) => `  ${name}  (documented in ${[...docs].join(', ')})`);
+
+    assert.equal(phantom.length, 0,
+      `These are documented but read nowhere — a reader would set them and see no effect:\n${phantom.join('\n')}\n` +
+      'Fix the doc, or restore the variable if it was renamed.');
+  });
+});


### PR DESCRIPTION
First slice of the **pre-release documentation audit**: every environment variable the code reads, compared against every one the docs name — in both directions.

## The finding

**Seven user-facing settings existed only in the source**: the local connector's token, port, bind host, tunnel name, cloudflared binary path and service-install toggle, plus the two Ythril-side token variables. All configurable, none discoverable.

An undocumented setting isn't a missing feature — it's a feature nobody can find, and nothing reports it. They're now a table in the workstation guide.

## Kept as a gate, not a sweep

Both directions rot silently:

- a variable the code reads that **no doc mentions** → undiscoverable
- a variable the docs name that **nothing reads** → worse: a reader copies it into `.env`, it does nothing, and no error explains why (renames are the usual cause)

Verified by introducing each kind of drift: a new undocumented var, a phantom documented var, and an existing var quietly renamed out of the docs. **All three caught.**

## Three classes of false finding — and why that's the important part

The scan was wrong three times before it was trustworthy. Each was caught by opening the source rather than believing the output:

1. **Missed helper-routed reads.** It only matched `process.env[...]`, so three variables read on *every request* via `envTrue(...)` looked absent from the code.
2. **Missed compose-only vars.** It only scanned `server/src`, so `YTHRIL_PORT` looked undefined — it's a docker-compose variable (`"${YTHRIL_PORT:-3200}:3200"`) the server never reads.
3. **Matched template literals.** Its compose-interpolation pattern was applied to TypeScript, where `${CONSTANT}` matched — reporting `OIDC_HTTP_TIMEOUT_MS` and `OIDC_PRIVATE_ISSUER_HINT` as undocumented settings when both are `export const` values.

**Not one became a doc change.** A gate whose findings turn out to be noise is a gate that gets ignored and then deleted, so the test carries the same caveat in its header for whoever extends it.

## Remaining slices (tracked)

config keys · route paths · prose claims about behaviour — the expensive one, which needs reading rather than scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)