### PR TITLE
docs(audit): verify every documented config.json key against the config types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -862,6 +862,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Every key in every documented `config.json` example is now verified against the config types.**
+  Slice 2 of the pre-release audit, and the happier kind of result: all 14 config examples across the
+  docs check out, so nothing needed fixing. The check is kept anyway, because this is the failure that
+  gives an operator the least to work with — unknown config keys are *ignored*, so a wrong key means
+  editing config.json, restarting, and watching the setting do nothing, with no error to search for.
+
+  Getting the check to be trustworthy took three attempts, which is the part worth recording. Scanning
+  every dotted `a.b` in backticks proposed 69 findings, almost all audit *operation* names and
+  hostnames. Parsing any JSON block containing a config-ish key proposed 36, mostly API *response*
+  fields. The rule that actually works: a block is a config example only when **every** top-level key
+  is a declared field of the `Config` interface — a response body fails that on its first key. A fourth
+  correction was needed on the other side, matching field names anywhere rather than at line start,
+  because inline literals like `total?: { softLimitGiB: number; hardLimitGiB: number }` declare fields
+  on one line.
+
 - **Seven local-connector settings existed only in the source; they are documented now, and a test
   keeps it that way.** The pre-release doc audit's first slice compared every environment variable the
   code reads against every one the docs name. The connector's token, port, bind host, tunnel name,

--- a/testing/standalone/config-key-docs-coverage.test.js
+++ b/testing/standalone/config-key-docs-coverage.test.js
@@ -1,0 +1,119 @@
+/**
+ * Every key in a documented `config.json` example is a real config field.
+ *
+ * Slice 2 of the pre-release documentation audit, kept as a gate. Config examples are the single most
+ * copy-pasted thing in the docs, and a wrong key there fails in the worst possible way: unknown keys
+ * are ignored, so an operator edits config.json, restarts, and the setting simply does nothing. No
+ * error, no warning, nothing to search for.
+ *
+ * ── Identifying a config example precisely ──────────────────────────────────────────────────────
+ *
+ * This check is only worth having if its findings are trustworthy, and getting there took three
+ * attempts:
+ *
+ *   1. Scanning every dotted `a.b` in backticks produced 69 proposals, overwhelmingly audit OPERATION
+ *      names (`space.update`, `webhook.delete`) and hostnames.
+ *   2. Parsing json blocks that contained any config-ish marker produced 36, mostly API RESPONSE
+ *      fields — a response listing `spaces` looked like a config example.
+ *   3. The rule that works: a block is a config example only when EVERY top-level key is a declared
+ *      field of the `Config` interface. A response body fails that on its first key.
+ *
+ * Free-form maps (`typeSchemas`, `properties`, `spaceMap`, …) have user-chosen keys and are skipped
+ * below that point — otherwise every example type name would read as an unknown field.
+ *
+ * A fourth correction was needed on the other side: field names must be matched anywhere, not only at
+ * line start, because inline literals like `total?: { softLimitGiB: number; hardLimitGiB: number }`
+ * declare fields on one line. A line-anchored pattern reported both as undeclared when both are used
+ * throughout `files.ts`.
+ *
+ * Run: node --test testing/standalone/config-key-docs-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+const TYPES = join(ROOT, 'server', 'src', 'config', 'types.ts');
+
+/** Maps whose keys the USER chooses — not config fields. */
+const FREE_FORM = new Set([
+  'typeSchemas', 'properties', 'propertySchemas', 'spaceMap', 'headers', 'meta',
+  'entity', 'memory', 'edge', 'chrono',
+]);
+
+function declaredFields() {
+  const out = new Set();
+  const sources = [TYPES, join(ROOT, 'server', 'src', 'db', 'backup-config.ts')].filter(existsSync);
+  for (const f of sources) {
+    const src = readFileSync(f, 'utf8');
+    // Anywhere, not line-anchored — see the header note on inline object literals.
+    for (const m of src.matchAll(/([a-zA-Z_][a-zA-Z0-9_]*)\??\s*:/g)) out.add(m[1]);
+    for (const m of src.matchAll(/['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]\s*:/g)) out.add(m[1]);
+  }
+  return out;
+}
+
+function topLevelConfigFields() {
+  const src = readFileSync(TYPES, 'utf8');
+  const i = src.indexOf('export interface Config ');
+  assert.ok(i >= 0, 'expected an `export interface Config` in config/types.ts');
+  let depth = 0, start = src.indexOf('{', i), j = start;
+  do { if (src[j] === '{') depth++; else if (src[j] === '}') depth--; j++; } while (depth > 0 && j < src.length);
+  return new Set([...src.slice(start, j).matchAll(/^\s{2}([a-zA-Z_][a-zA-Z0-9_]*)\??\s*:/gm)].map(m => m[1]));
+}
+
+function collectKeys(value, out, skipping = false) {
+  if (Array.isArray(value)) { for (const v of value) collectKeys(v, out, skipping); return out; }
+  if (!value || typeof value !== 'object') return out;
+  for (const [k, v] of Object.entries(value)) {
+    if (!skipping) out.add(k);
+    collectKeys(v, out, skipping || FREE_FORM.has(k));
+  }
+  return out;
+}
+
+/** Every fenced json block in docs/ whose top-level keys are all real Config fields. */
+function configExamples() {
+  const topLevel = topLevelConfigFields();
+  const found = [];
+  for (const f of readdirSync(join(ROOT, 'docs')).filter(n => n.endsWith('.md'))) {
+    const src = readFileSync(join(ROOT, 'docs', f), 'utf8');
+    for (const m of src.matchAll(/```json\s*\n([\s\S]*?)```/g)) {
+      let parsed;
+      try { parsed = JSON.parse(m[1]); } catch { continue; }   // samples with ellipses etc.
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+      const roots = Object.keys(parsed);
+      if (!roots.length || !roots.every(k => topLevel.has(k))) continue;
+      found.push({ doc: f, parsed });
+    }
+  }
+  return found;
+}
+
+describe('config.json examples in the docs name real fields', () => {
+  it('still finds the config examples (the check itself works)', () => {
+    // Without this, a change to the doc format or the Config interface would silently reduce the
+    // sweep to zero blocks and the assertion below would pass by examining nothing.
+    const examples = configExamples();
+    assert.ok(examples.length >= 8,
+      `expected to find config.json examples in docs/, found ${examples.length}`);
+    assert.ok(declaredFields().size > 200, 'expected the config types to parse');
+  });
+
+  it('every key in every example is a declared config field', () => {
+    const declared = declaredFields();
+    const bad = [];
+    for (const { doc, parsed } of configExamples()) {
+      for (const k of collectKeys(parsed, new Set())) {
+        if (!declared.has(k)) bad.push(`  ${k}  (in ${doc})`);
+      }
+    }
+    assert.equal(bad.length, 0,
+      'These keys appear in a documented config.json example but are declared nowhere in the config ' +
+      'types. Unknown keys are IGNORED, so a reader would set them and see no effect:\n' +
+      `${[...new Set(bad)].join('\n')}\n` +
+      'Fix the doc, or add the field if it was meant to exist.');
+  });
+});


### PR DESCRIPTION
Slice 2 of the pre-release documentation audit. **All 14 config examples across the docs check out — zero doc fixes needed**, so this ships the check rather than a correction.

## Why keep a check that found nothing

This is the failure that leaves an operator with the least to work with. Unknown keys in `config.json` are **ignored** — so a wrong key means editing the file, restarting, and watching the setting do nothing. No error, no warning, nothing to search for. Config examples are also the most copy-pasted thing in the docs.

## Three attempts to get an instrument worth trusting

| attempt | proposals | why they were noise |
|---|---|---|
| every dotted `a.b` in backticks | **69** | overwhelmingly audit *operation* names (`space.update`, `webhook.delete`) and hostnames |
| JSON blocks containing a config-ish key | **36** | mostly API *response* fields — a response listing `spaces` looked like a config example |
| **every top-level key must be a declared `Config` field** | **0** | a response body fails on its first key |

A fourth correction was needed on the other side: field names must be matched **anywhere**, not only at line start, because inline literals declare fields on one line — `total?: { softLimitGiB: number; hardLimitGiB: number }`. The line-anchored version reported both inner fields as undeclared when both are used throughout `files.ts`.

## Drift-verified, not assumed

- a typo introduced into a documented example → **caught**
- a field renamed in the code but not in the docs → **caught**

Plus a guard that the sweep still finds ≥8 examples, so a format change can't silently reduce it to examining nothing and passing.

## Audit progress

Two slices now shipped as permanent gates: **env vars** (#486), **config keys** (this). Remaining: route paths, and the expensive one — prose claims about behaviour, which needs reading rather than scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)