### PR TITLE
docs(audit): verify every documented API path resolves to a real route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -862,6 +862,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Every API path named in the docs is verified to exist in a router.** Slice 3 of the pre-release
+  audit, and the third clean result: all 182 documented endpoints resolve. A documented endpoint that
+  does not exist is the most expensive doc bug there is — someone writes an integration, gets a 404,
+  and has nothing telling them the endpoint was never real.
+
+  Resolving the routing table was the entire difficulty, and a naive extractor proposed 89 findings out
+  of 182 — half the documented API, which is a broken scanner rather than a doc crisis. Five defects
+  had to be fixed: path-less sub-router composition (the whole `/api/sync` surface is built that way,
+  so it was invisible), routes declared straight on the app, routers mounted at more than one prefix
+  (`setupRouter` serves both `/api/setup` and `/setup`), concrete example values in docs
+  (`PATCH /api/spaces/research` is an example of `/api/spaces/:id`, not a different endpoint), and
+  brace-alternation shorthand documenting four endpoints in one line. The test header lists all five,
+  so a future failure is checked against them before anyone edits a doc.
+
 - **Every key in every documented `config.json` example is now verified against the config types.**
   Slice 2 of the pre-release audit, and the happier kind of result: all 14 config examples across the
   docs check out, so nothing needed fixing. The check is kept anyway, because this is the failure that

--- a/testing/standalone/route-path-docs-coverage.test.js
+++ b/testing/standalone/route-path-docs-coverage.test.js
@@ -1,0 +1,151 @@
+/**
+ * Every API path named in the docs exists in a router.
+ *
+ * Slice 3 of the pre-release documentation audit. A documented endpoint that does not exist is the
+ * most expensive doc bug there is: someone writes an integration against it, gets a 404, and has
+ * nothing to tell them the endpoint was never real.
+ *
+ * All 182 documented endpoints check out today, so this ships as a gate rather than a correction.
+ *
+ * ── Resolving the routes is the whole difficulty ────────────────────────────────────────────────
+ *
+ * A naive extractor proposed 89 findings out of 182 — roughly half the documented API — which is a
+ * broken scanner, not a doc crisis. Five separate defects had to be fixed, each found by opening the
+ * source rather than believing the output:
+ *
+ *   1. PATH-LESS composition. The whole sync API is built as `syncRouter.use(syncDocsRouter)`, with no
+ *      path argument, so every `/api/sync/*` route was invisible.
+ *   2. Routes declared straight on the app — `app.post('/api/admin/reload-config')` — rather than on a
+ *      mounted router.
+ *   3. Routers mounted at MORE THAN ONE path. `setupRouter` serves both `/api/setup` and `/setup`;
+ *      keeping one prefix per router made every setup endpoint look missing.
+ *   4. Concrete example values in the docs. `PATCH /api/spaces/research` is an example of
+ *      `/api/spaces/:id`, not a different endpoint, so comparison has to be structural.
+ *   5. Brace alternation shorthand: `/api/brain/spaces/:id/{memories,entities,edges,chrono}` documents
+ *      four endpoints in one line.
+ *
+ * If this test ever fails, check it against that list before editing a doc — the most likely
+ * explanation for a new failure is a routing pattern the extractor has not met yet.
+ *
+ * Run: node --test testing/standalone/route-path-docs-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) { if (e !== 'node_modules' && e !== 'dist') walk(p, out); }
+    else out.push(p);
+  }
+  return out;
+}
+
+const VERBS = 'get|post|put|patch|delete';
+const norm = (p) => p.replace(/:[A-Za-z0-9_]+/g, ':P').replace(/\{[^}]+\}/g, ':P').replace(/\/+$/, '');
+
+function knownRoutes() {
+  const files = walk(join(ROOT, 'server', 'src')).filter(f => f.endsWith('.ts'));
+  const sources = new Map(files.map(f => [f, readFileSync(f, 'utf8')]));
+
+  // (1) mount prefixes — a router may have several.
+  const prefixes = new Map();
+  const addPrefix = (v, p) => {
+    if (!prefixes.has(v)) prefixes.set(v, new Set());
+    prefixes.get(v).add(p);
+  };
+  for (const m of sources.get(join(ROOT, 'server', 'src', 'app.ts')).matchAll(
+    /app\.use\(\s*'([^']+)'\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/g)) addPrefix(m[2], m[1]);
+
+  // (2) nested mounts, both prefixed and path-less, to a fixed point.
+  for (let pass = 0; pass < 5; pass++) {
+    for (const src of sources.values()) {
+      for (const m of src.matchAll(/([A-Za-z_][A-Za-z0-9_]*)\.use\(\s*'([^']+)'\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/g)) {
+        for (const p of prefixes.get(m[1]) ?? []) addPrefix(m[3], p + m[2]);
+      }
+      for (const m of src.matchAll(/([A-Za-z_][A-Za-z0-9_]*)\.use\(\s*([A-Za-z_][A-Za-z0-9_]*Router)\s*\)/g)) {
+        for (const p of prefixes.get(m[1]) ?? []) addPrefix(m[2], p);
+      }
+    }
+  }
+
+  const routes = new Set();
+  for (const src of sources.values()) {
+    for (const m of src.matchAll(new RegExp(`([A-Za-z_][A-Za-z0-9_]*)\\.(${VERBS})\\(\\s*'([^']*)'`, 'g'))) {
+      const [, v, method, path] = m;
+      for (const prefix of prefixes.get(v) ?? []) {
+        routes.add(`${method.toUpperCase()} ${norm((prefix + (path === '/' ? '' : path)) || '/')}`);
+      }
+    }
+    // (3) app-level routes
+    for (const m of src.matchAll(new RegExp(`\\bapp\\.(${VERBS})\\(\\s*'(/[^']*)'`, 'g'))) {
+      routes.add(`${m[1].toUpperCase()} ${norm(m[2])}`);
+    }
+  }
+  return routes;
+}
+
+/** Expand `{a,b,c}` alternation into one path each. */
+function expand(path) {
+  const m = path.match(/\{([^}]*,[^}]*)\}/);
+  if (!m) return [path];
+  return m[1].split(',').flatMap(opt => expand(path.replace(m[0], opt.trim())));
+}
+
+function documentedEndpoints() {
+  const out = new Map();
+  for (const f of readdirSync(join(ROOT, 'docs')).filter(n => n.endsWith('.md'))) {
+    const src = readFileSync(join(ROOT, 'docs', f), 'utf8');
+    for (const m of src.matchAll(new RegExp(`\\b(GET|POST|PUT|PATCH|DELETE)\\s+(/api/[A-Za-z0-9_\\-/:{},.]*)`, 'g'))) {
+      for (const path of expand(m[2])) {
+        const key = `${m[1]} ${norm(path)}`;
+        if (!out.has(key)) out.set(key, new Set());
+        out.get(key).add(f);
+      }
+    }
+  }
+  return out;
+}
+
+/** Structural match: a route's :P matches any single documented segment. */
+function matches(known, docKey) {
+  if (known.has(docKey)) return true;
+  const [dm, dp] = docKey.split(' ');
+  const dSegs = dp.split('/');
+  for (const k of known) {
+    const [km, kp] = k.split(' ');
+    if (km !== dm) continue;
+    const kSegs = kp.split('/');
+    if (kSegs.length === dSegs.length && kSegs.every((s, i) => s === ':P' || s === dSegs[i])) return true;
+  }
+  return false;
+}
+
+describe('documented API paths exist', () => {
+  const known = knownRoutes();
+  const documented = documentedEndpoints();
+
+  it('resolves the routing table and the docs (the check itself works)', () => {
+    // Without this, an extractor regression that finds nothing would make the assertion below pass by
+    // examining nothing — the failure mode where a gate silently stops gating.
+    assert.ok(known.size > 150, `expected to resolve the routing table, found ${known.size} routes`);
+    assert.ok(documented.size > 100, `expected documented endpoints, found ${documented.size}`);
+  });
+
+  it('every documented endpoint resolves to a real route', () => {
+    const missing = [...documented.entries()]
+      .filter(([key]) => !matches(known, key))
+      .map(([key, docs]) => `  ${key}  (in ${[...docs].join(', ')})`);
+
+    assert.equal(missing.length, 0,
+      `These endpoints are documented but no router declares them — an integration written against ` +
+      `one would 404 with nothing to explain it:\n${missing.join('\n')}\n\n` +
+      'Before editing a doc, check the header of this file: five separate extractor defects produced ' +
+      'false findings here, and a new routing pattern is the likelier cause.');
+  });
+});


### PR DESCRIPTION
Slice 3 of the pre-release documentation audit. **All 182 documented endpoints resolve** — the third clean slice in a row, so this ships the check rather than a correction.

The bug it guards is the most expensive kind a doc can have: a documented endpoint that doesn't exist gets an integration written against it, returns 404, and offers nothing to indicate it was never real.

## Resolving the routing table was the entire difficulty

A naive extractor proposed **89 findings out of 182**. Half the documented API "missing" is a broken scanner, not a doc crisis. Five defects, each found by opening the source rather than believing the output:

| # | defect | consequence |
|---|---|---|
| 1 | **path-less composition** — `syncRouter.use(syncDocsRouter)` | the entire `/api/sync/*` surface was invisible |
| 2 | routes declared straight on the app | `reload-config`, `rotate-signing-key` looked missing |
| 3 | **routers mounted at >1 prefix** — `setupRouter` on `/api/setup` *and* `/setup` | every setup endpoint looked missing |
| 4 | concrete example values in docs | `PATCH /api/spaces/research` is an example of `/api/spaces/:id` |
| 5 | brace-alternation shorthand | `{memories,entities,edges,chrono}` documents four endpoints in one line |

**89 → 15 → 10 → 1 → 0.** Not one became a doc edit. The test header lists all five, so a future failure gets checked against them before anyone "fixes" a doc that was right.

## Drift-verified three ways

- an invented endpoint added to a doc → **caught**
- a route removed from code but left documented → **caught**
- a router remounted at a different prefix → **caught**

Plus a guard that the extractor still resolves >150 routes, so a regression can't reduce the sweep to examining nothing and passing.

## Audit progress

Three slices now ship as permanent gates: **env vars** (#486), **config keys** (#487), **route paths** (this).

Remaining: prose claims about behaviour — which needs reading rather than scanning, and can't be mechanised the way these three were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)