### PR TITLE
docs: offsite backups are pruned to 14 sets, not kept forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -862,6 +862,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **⚠️ The user guide said offsite backups are kept forever. They are pruned to the 14 most recent.**
+  The first real error the documentation audit has found, and the one class of check that cannot be
+  mechanised — a prose claim about behaviour.
+
+  `offsite.retention.keepCount` was documented as *"default: unlimited"*. The scheduler reads
+  `cfg.offsite.retention?.keepCount ?? 14` and prunes after every run, so an operator who read that
+  line, treated the offsite copy as a long-term archive and never set the value has been losing every
+  set older than the most recent fourteen — silently, with the documentation as the reason they never
+  looked.
+
+  What makes it easy to get wrong is that the two retention settings genuinely default in **opposite**
+  directions: `retention.keepLocal` is guarded by `if (cfg?.retention?.keepLocal)`, so absent really
+  does mean never pruned, while the offsite one falls back to 14. Both defaults are now stated
+  explicitly, with a note calling out the asymmetry. The integration guide already had this right,
+  which is what surfaced the contradiction.
+
 - **Every API path named in the docs is verified to exist in a router.** Slice 3 of the pre-release
   audit, and the third clean result: all 182 documented endpoints resolve. A documented endpoint that
   does not exist is the most expensive doc bug there is — someone writes an integration, gets a 404,

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -719,9 +719,11 @@ Configure automatic backups and an optional offsite destination from **Settings 
 | Field | Description |
 |---|---|
 | `schedule` | Cron expression for automatic backups (e.g. `"0 2 * * *"` = daily at 02:00). |
-| `retention.keepLocal` | Maximum number of local backups to retain. Oldest are deleted after each run. |
+| `retention.keepLocal` | Maximum number of local backups to retain. Oldest are deleted after each run. **Default: unlimited** — local backups are never pruned unless you set this. |
 | `offsite.destPath` | Absolute path **on the server's filesystem** to copy each backup to. See [Configuring the offsite path](#configuring-the-offsite-path) below. |
-| `offsite.retention.keepCount` | Maximum number of offsite backup sets to retain (default: unlimited). |
+| `offsite.retention.keepCount` | Maximum number of offsite backup sets to retain. **Default: 14** — offsite sets older than the 14 most recent are deleted after each run. Set this explicitly if you are keeping long-term archives. |
+
+> **The two retention settings default in opposite directions.** Local backups are kept forever until you set `keepLocal`; offsite sets are pruned to the 14 most recent unless you set `keepCount`. If you rely on the offsite copy as a long-term archive, set `keepCount` to the number of sets you actually want — otherwise older ones are removed on the next run.
 
 Each backup set at the offsite destination contains:
 


### PR DESCRIPTION
**The first real error the documentation audit has found** — and it's in the one class that can't be mechanised: a prose claim about behaviour. Three slices of scanning (env vars, config keys, route paths) found zero doc errors between them. Reading found one on the first pass.

## The error

`docs/userguide.md` documented `offsite.retention.keepCount` as **"default: unlimited"**.

The scheduler reads `cfg.offsite.retention?.keepCount ?? DEFAULT_KEEP_OFFSITE` where `DEFAULT_KEEP_OFFSITE = 14`, and prunes after **every run**.

So an operator who read that line, treated the offsite copy as a long-term archive, and never set the value has been losing every set older than the most recent fourteen — silently, on a schedule, **with the documentation as the reason they never went looking**. Of every doc bug this audit could have surfaced, this is close to the worst shape: it destroys data the reader believes is safe.

## Why it was easy to get wrong

The two retention settings genuinely default in **opposite** directions:

| setting | code | absent means |
|---|---|---|
| `retention.keepLocal` | `if (cfg?.retention?.keepLocal)` | **never pruned** |
| `offsite.retention.keepCount` | `?? 14` | **pruned to 14** |

Both are now stated explicitly, with a callout naming the asymmetry so the next reader doesn't have to infer it. The integration guide already had `(default: 14)` right — the contradiction between the two documents is what surfaced it.

## How it was found

Extracted every default-value claim from `docs/` (**51** — 27 concrete, 24 prose), then checked the highest-risk concrete ones against code by hand:

query `limit` 20 ✓ · `maxTimeMS` 5000 ✓ · `topK` 10 ✓ · audit `retentionDays` 90 ✓ · MCP token TTL 90 days ✓ · face `confidenceThreshold` 0.6 ✓ · sync history limit 20 / max 100 ✓ · pagination offsets 0 ✓ · **offsite `keepCount` ✗**

## What remains (tracked)

The other ~16 concrete claims, plus four prose classes — especially **"requires a restart" / "takes effect immediately"**, which has already produced one error before (an OIDC reload claim the config watcher had made untrue). That class deserves the same reading treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)