### PR TITLE
docs(audit): gate the documented mutating/read-only split of MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -862,6 +862,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **The documented split of MCP tools into mutating and read-only is now checked against what the code
+  actually blocks.** Slice 4c of the pre-release audit — the security-posture class — and a clean
+  result: all 31 tools are classified correctly, 18 mutating and 12 read-only, with `list_peers`
+  covered by its own admin-gated sentence.
+
+  It is worth a gate because the guide and the enforcement are two independent statements of the same
+  fact, and one direction of drift is genuinely dangerous. A tool missing from the doc's mutating list
+  only misleads an integrator; a tool *listed* as mutating that carries no `mutating: true` flag tells
+  someone a write is blocked for read-only tokens when nothing blocks it. The test covers both, plus
+  the read-only list, plus the two-part enforcement itself — `router.ts` filters mutating tools out of
+  `tools/list` **and** rejects them if called, and only the second is a control, since a client can
+  call a tool it was never shown. Verified by deleting the call-time rejection while leaving the list
+  filter intact: caught.
+
 - **⚠️ The user guide said offsite backups are kept forever. They are pruned to the 14 most recent.**
   The first real error the documentation audit has found, and the one class of check that cannot be
   mechanised — a prose claim about behaviour.

--- a/testing/standalone/mcp-tool-docs-coverage.test.js
+++ b/testing/standalone/mcp-tool-docs-coverage.test.js
@@ -1,0 +1,106 @@
+/**
+ * The documented split of MCP tools into mutating / read-only matches what the code enforces.
+ *
+ * Slice 4c of the pre-release documentation audit — the security-posture class. The doc tells an
+ * integrator exactly which tools a `readOnly` token loses, and the enforcement reads a `mutating` flag
+ * on each tool definition. Those are two independent lists of the same fact, which is the shape that
+ * drifts.
+ *
+ * Both directions are a real problem, and one is much worse than the other:
+ *
+ *   - a tool flagged `mutating` in code but missing from the doc's list — the doc under-states what a
+ *     read-only token loses, so an integrator plans around a tool that will not be there;
+ *   - a tool listed as READ-ONLY that the code flags mutating — the doc says a call works when it is
+ *     actually blocked;
+ *   - a tool listed as mutating that is NOT flagged — the worst of the three: the doc claims a write
+ *     is blocked for read-only tokens when nothing blocks it. Someone hands out a read-only token
+ *     believing it cannot write.
+ *
+ * The enforcement itself is belt-and-braces and pins here too: `router.ts` both filters the tool out
+ * of `tools/list` and rejects it if called directly. Only the second is a security control; the first
+ * is discoverability.
+ *
+ * Run: node --test testing/standalone/mcp-tool-docs-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+const TOOLS_DIR = join(ROOT, 'server', 'src', 'mcp', 'tools');
+
+function fromCode() {
+  const all = new Set();
+  const mutating = new Set();
+  for (const f of readdirSync(TOOLS_DIR).filter(n => n.endsWith('.ts'))) {
+    const src = readFileSync(join(TOOLS_DIR, f), 'utf8');
+    // Walk name/mutating markers in order and attach each `mutating: true` to the nearest preceding
+    // tool name — tool definitions are object literals, so order is the association.
+    let current = null;
+    for (const m of src.matchAll(/name:\s*'([a-z_0-9]+)'|mutating:\s*true/g)) {
+      if (m[1]) { current = m[1]; all.add(current); }
+      else if (current) mutating.add(current);
+    }
+  }
+  return { all, mutating };
+}
+
+function fromDocs() {
+  const guide = readFileSync(join(ROOT, 'docs', 'integration-guide.md'), 'utf8');
+  const line = guide.split(/\r?\n/).find(l => l.includes('mutating tools (') && l.includes('readOnly'));
+  assert.ok(line, 'expected the integration guide to describe what a readOnly token loses');
+
+  // Both lists live on the SAME line ("mutating tools (…) … Read-only tools (…) work normally"), so
+  // each must be read from its own parenthetical. Taking every backticked name off the line captures
+  // all 31 tools and reports the read-only ones as errors.
+  const clause = (marker) => {
+    const i = line.indexOf(marker);
+    if (i < 0) return new Set();
+    return new Set([...line.slice(i).split(')')[0].matchAll(/`([a-z_0-9]+)`/g)].map(m => m[1]));
+  };
+  return { mutating: clause('mutating tools ('), readOnly: clause('Read-only tools (') };
+}
+
+describe('MCP tool read-only classification matches the docs', () => {
+  const code = fromCode();
+  const docs = fromDocs();
+
+  it('parses both sides (the check itself works)', () => {
+    assert.ok(code.all.size >= 25, `expected to find the MCP tools, found ${code.all.size}`);
+    assert.ok(code.mutating.size >= 10, `expected mutating tools, found ${code.mutating.size}`);
+    assert.ok(docs.mutating.size >= 10, `expected a documented mutating list, found ${docs.mutating.size}`);
+  });
+
+  it('every tool the code blocks for read-only tokens is documented as mutating', () => {
+    const missing = [...code.mutating].filter(t => !docs.mutating.has(t)).sort();
+    assert.deepEqual(missing, [],
+      'These tools are blocked for readOnly tokens but the integration guide does not list them, so ' +
+      'an integrator would plan around a tool that will not be there.');
+  });
+
+  it('every tool documented as mutating is actually flagged mutating', () => {
+    // The dangerous direction: the doc promises a write is blocked when nothing blocks it.
+    const overstated = [...docs.mutating].filter(t => !code.mutating.has(t)).sort();
+    assert.deepEqual(overstated, [],
+      'The guide lists these as blocked for readOnly tokens, but no `mutating: true` flag backs that ' +
+      'up — a read-only token could call them.');
+  });
+
+  it('no tool documented as read-only is actually blocked', () => {
+    const wrong = [...docs.readOnly].filter(t => code.mutating.has(t)).sort();
+    assert.deepEqual(wrong, [],
+      'The guide says these work normally with a readOnly token, but the code flags them mutating.');
+  });
+
+  it('the enforcement both hides AND rejects — only the second is the control', () => {
+    // Filtering `tools/list` is discoverability; a client can still call a tool it was not shown, so
+    // the call-time rejection is what actually enforces read-only.
+    const router = readFileSync(join(ROOT, 'server', 'src', 'mcp', 'router.ts'), 'utf8');
+    assert.match(router, /ALL_TOOLS\.filter\([^)]*readOnly && \w+\.mutating/,
+      'expected tools/list to filter mutating tools for readOnly tokens');
+    assert.match(router, /if \(readOnly && \w+\?\.mutating\)/,
+      'expected a call-time rejection for mutating tools — filtering the list alone is not a control');
+  });
+});


### PR DESCRIPTION
Slice 4c of the pre-release documentation audit — the **security-posture** class, where a wrong claim means someone trusts a control that isn't doing what they think.

**Clean result:** all 31 MCP tools classified correctly — 18 mutating, 12 read-only, `list_peers` covered by its own admin-gated sentence.

Also verified by hand: the audit-log router (1 route, `requireAdmin`), the mfa router (4 routes, all `requireAdmin`/`requireAdminMfa`), and that a `schemaLibrary` token is forced to `readOnly` regardless of what the create call asks for.

## Why gate a list that's currently correct

The guide and the enforcement are two independent statements of the same fact — one a prose list, the other a flag on each tool definition. That's the shape that drifts, and the two directions aren't equally bad:

| drift | consequence |
|---|---|
| flagged mutating, **missing** from the doc | an integrator plans around a tool that won't be there — annoying |
| **listed** as mutating, no `mutating: true` behind it | the doc says a write is blocked for read-only tokens **when nothing blocks it** |

The second is a false security claim: someone hands out a read-only token believing it cannot write. The test covers both directions plus the read-only list.

## The enforcement is two parts, and only one is a control

`router.ts` both filters mutating tools out of `tools/list` **and** rejects them if called directly. The filter is discoverability — a client can call a tool it was never shown — so **the call-time rejection is the actual control**.

The test pins them separately, and I verified it by deleting the rejection while leaving the filter intact: **caught**. That's the mutation that would look completely healthy from the outside.

## One scanner correction

Both tool lists live on the **same line** of the guide, so reading every backticked name off it captured all 31 and reported the 12 read-only tools as doc errors. Each list is now read from its own parenthetical.

Fourth doc-audit gate: env vars (#486), config keys (#487), route paths (#488), MCP tool classification (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)