### PR TITLE
feat(audit): give brain record changes their own short retention, before capturing any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Audit entries can now carry brain record changes, and that payload expires on its own short clock.**
+  Owner decision: record edits MAY record old→new values, with a TTL. This ships the TTL first — the
+  guard before the thing it guards — so content can never land without the mechanism that ages it out.
+
+  The obvious implementation would be a nearer `_expireAt`, letting MongoDB's TTL index handle it. That
+  is wrong: a TTL index deletes the whole **document**, so it would take who / when / route with it and
+  shorten the audit TRAIL for exactly the operations the feature exists to make auditable. The trail is
+  the durable part, the content is the sensitive part, and they need different lifetimes. A sweep unsets
+  `changes` in place instead; the entry keeps its full `audit.retentionDays`.
+
+  New `audit.recordChangeRetentionDays` (default **14**). Only the six brain record operations expire
+  early — admin and config changes keep the full retention, because a label or a boolean an operator set
+  is not user content and is the log's core value. Redaction is recorded as `changesRedacted: true`
+  rather than silent, so a reader can tell "this operation records no changes" from "it did, and they
+  have aged out".
+
 - **`If-Match` now covers every route that writes space meta, not the two it shipped with.** The
   previous entry guarded `PATCH /api/spaces/:id` and `PUT /api/spaces/:id/schema` — but the single-type
   upsert and delete routes (`PUT`/`DELETE /api/spaces/:id/meta/typeSchemas/:kt/:type`) write meta too,

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5560,7 +5560,8 @@ Add an `audit` block to `config.json`:
 {
   "audit": {
     "logReads": false,
-    "retentionDays": 90
+    "retentionDays": 90,
+    "recordChangeRetentionDays": 14
   }
 }
 ```
@@ -5569,6 +5570,27 @@ Add an `audit` block to `config.json`:
 |-------|------|---------|-------------|
 | `logReads` | `boolean` | `false` | When `true`, read operations (recall, query, list, traverse, stats) are also logged. By default only write operations and auth failures are recorded. |
 | `retentionDays` | `number` | `90` | Number of days before audit entries are automatically purged by MongoDB's TTL daemon. |
+| `recordChangeRetentionDays` | `number` | `14` | Days a **brain record edit's** `changes` payload survives before being redacted. See below. |
+
+#### Why record changes expire sooner than the entries that carry them
+
+An audit entry answers *who changed what, when, and through which route*. For admin and configuration
+operations the `changes` payload is part of that answer — a label, a cron schedule, a `requireSignedVotes`
+boolean — and it keeps the full `retentionDays`.
+
+For **brain record edits** (`memory.update`, `entity.update`, `edge.update`, `chrono.update`,
+`file.meta.update`, `entity.merge`) the payload is different in kind: it contains user content, the old text
+of a memory or the previous description of an entity. That is a copy of your data in a second store with
+different access rules — any admin can read the audit log, including for spaces their token could not
+otherwise reach.
+
+So the payload alone expires early. A background sweep unsets `changes` on those entries once they pass
+`recordChangeRetentionDays` and marks them `changesRedacted: true`. **The entry itself is never shortened** —
+who edited that memory and when remains answerable for the full retention period. Only "and here is what it
+used to say" ages out.
+
+`changesRedacted` exists so a reader can distinguish *"this operation records no changes"* from *"it did, and
+they have expired"*. Without it an absent `changes` would quietly imply nothing was ever captured.
 
 ### Tracked operations
 

--- a/server/src/audit/audit.ts
+++ b/server/src/audit/audit.ts
@@ -96,6 +96,13 @@ export interface AuditEntryInput {
   durationMs: number;
   /** Allowlisted field changes — see `audit-changes.ts`. Omitted when the operation has no allowlist. */
   changes?: AuditChange[];
+  /**
+   * Set once a record-edit entry's `changes` have aged out and been unset (see `change-retention.ts`).
+   *
+   * Distinguishes "this operation records no changes" from "it did, and they have expired" — without
+   * it, an absent `changes` quietly implies nothing was ever captured.
+   */
+  changesRedacted?: boolean;
 }
 
 /** Insert an audit log entry. Fire-and-forget — never throws. */

--- a/server/src/audit/change-retention.ts
+++ b/server/src/audit/change-retention.ts
@@ -1,0 +1,132 @@
+/**
+ * A shorter life for the `changes` payload than for the audit entry that carries it.
+ *
+ * Owner decision, 2026-07-28: brain RECORD edits (memories, entities, edges, chrono, file meta) may
+ * record old→new values, **with a TTL**. That TTL is the mitigation for what made the feature a
+ * decision rather than a slice — recording record edits copies user content into a second store with
+ * different access rules, and record writes are the hot bulk path.
+ *
+ * ── Why the TTL cannot be the entry's TTL ────────────────────────────────────────────────────────
+ *
+ * The obvious implementation is a shorter `_expireAt` on those entries, letting the existing Mongo TTL
+ * index handle it. That would be wrong. A TTL index deletes the whole **document**, so it would take
+ * who / when / route / status with it — shortening the audit TRAIL for exactly the operations the
+ * feature exists to make auditable. The trail is the durable part; the content is the sensitive part,
+ * and they want different lifetimes.
+ *
+ * So this sweep unsets `changes` in place. The entry survives its full `audit.retentionDays` and still
+ * answers "who edited that memory, and when". Only "and here is what it used to say" expires early.
+ *
+ * ── Redaction is recorded, not silent ───────────────────────────────────────────────────────────
+ *
+ * A swept entry gets `changesRedacted: true` rather than simply losing a field. An audit reader who
+ * finds no `changes` must be able to tell "this operation records no changes" from "it did, and they
+ * have aged out" — otherwise the log quietly implies nothing was captured, which is its own small lie.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+
+const COLLECTION = '_audit_log';
+
+/** Days a `changes` payload survives when the operation is a brain record edit. */
+export const DEFAULT_RECORD_CHANGE_RETENTION_DAYS = 14;
+
+/**
+ * Operations whose `changes` carry user record content and therefore expire early.
+ *
+ * Admin/config operations are deliberately absent: `space.update`, `network.update` and friends record
+ * a label or a boolean an operator set, which is not user content and is the audit log's core value.
+ * Those keep the full retention.
+ */
+export const RECORD_CHANGE_OPERATIONS: readonly string[] = [
+  'memory.update',
+  'entity.update',
+  'edge.update',
+  'chrono.update',
+  'file.meta.update',
+  'entity.merge',
+];
+
+/** Resolved retention in days; falls back to the default outside a loaded config. */
+export function recordChangeRetentionDays(): number {
+  try {
+    const v = getConfig().audit?.recordChangeRetentionDays;
+    return typeof v === 'number' && v > 0 ? v : DEFAULT_RECORD_CHANGE_RETENTION_DAYS;
+  } catch {
+    return DEFAULT_RECORD_CHANGE_RETENTION_DAYS;   // pre-setup
+  }
+}
+
+/**
+ * The cutoff before which a record-edit entry's `changes` should no longer exist.
+ *
+ * Exported and pure so the policy is testable without a database — the sweep itself is a one-line
+ * `updateMany` around it.
+ */
+export function changesCutoff(now: number = Date.now(), retentionDays = DEFAULT_RECORD_CHANGE_RETENTION_DAYS): Date {
+  return new Date(now - retentionDays * 86_400_000);
+}
+
+/**
+ * Should this entry's changes be redacted now?
+ *
+ * Pure decision, kept separate from the query so the rule can be tested directly:
+ *   - only record-content operations expire early;
+ *   - only entries that still HAVE changes (re-sweeping a redacted entry is a no-op, not an update);
+ *   - only entries older than the cutoff.
+ */
+export function shouldRedact(
+  entry: { operation?: string; timestamp?: string; changes?: unknown; changesRedacted?: boolean },
+  cutoff: Date,
+): boolean {
+  if (!entry.operation || !RECORD_CHANGE_OPERATIONS.includes(entry.operation)) return false;
+  if (entry.changesRedacted) return false;
+  if (entry.changes === undefined || entry.changes === null) return false;
+  if (!entry.timestamp) return false;
+  return new Date(entry.timestamp).getTime() < cutoff.getTime();
+}
+
+/**
+ * Unset `changes` on record-edit entries past the retention window.
+ *
+ * Returns the number redacted. Never throws — this is housekeeping, and a failed sweep must not take
+ * anything else down with it.
+ */
+export async function redactExpiredChanges(now: number = Date.now()): Promise<number> {
+  const cutoff = changesCutoff(now, recordChangeRetentionDays());
+  try {
+    const res = await col(COLLECTION).updateMany(
+      asFilter({
+        operation: { $in: RECORD_CHANGE_OPERATIONS },
+        timestamp: { $lt: cutoff.toISOString() },
+        changes: { $exists: true },
+      }),
+      { $unset: { changes: '' }, $set: { changesRedacted: true } },
+    );
+    const n = res.modifiedCount ?? 0;
+    if (n > 0) log.info(`Audit: redacted changes on ${n} record-edit entr${n === 1 ? 'y' : 'ies'} older than ${cutoff.toISOString()}`);
+    return n;
+  } catch (err) {
+    log.warn(`Audit change-retention sweep: ${err}`);
+    return 0;
+  }
+}
+
+const SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;   // 6h — the same cadence as the other housekeeping sweeps
+let _timer: NodeJS.Timeout | null = null;
+
+/**
+ * Start the sweep. Always on: it only removes content that policy says should already be gone, and an
+ * instance that never records record changes simply matches nothing.
+ */
+export function startAuditChangeRetention(): void {
+  if (_timer) return;
+  _timer = setInterval(() => { void redactExpiredChanges(); }, SWEEP_INTERVAL_MS);
+  _timer.unref();   // housekeeping must never hold the process open
+  log.debug('Audit change-retention sweep started');
+}
+
+export function stopAuditChangeRetention(): void {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+}

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -70,6 +70,10 @@ export async function startConfiguredInstanceServices(): Promise<void> {
   // that never enabled them.
   const { startCandidatePrune } = await import('./brain/candidate-prune.js');
   startCandidatePrune();
+  // Redacts the `changes` payload on brain record-edit audit entries past their shorter retention.
+  // The entry itself keeps `audit.retentionDays` — only the user content inside it expires early.
+  const { startAuditChangeRetention } = await import('./audit/change-retention.js');
+  startAuditChangeRetention();
 
   const { cleanupStaleChunks } = await import('./files/chunks.js');
   cleanupStaleChunks().catch(err => log.error(`Stale chunk cleanup failed: ${err}`));

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -823,6 +823,18 @@ export interface AuditConfig {
   logReads?: boolean;
   /** Number of days to retain audit entries (TTL). Default: 90. */
   retentionDays?: number;
+  /**
+   * Days a brain record edit's `changes` payload survives before being redacted. Default: 14.
+   *
+   * Separate from `retentionDays` on purpose. Record-edit changes carry USER CONTENT — a memory's old
+   * text, an entity's old description — so they get a short life, while the entry itself (who, when,
+   * which route) keeps the full retention. A sweep unsets the payload and marks `changesRedacted`;
+   * the audit trail is never shortened, only the content inside it.
+   *
+   * Admin/config changes (`space.update`, `network.update`, …) are unaffected — a label or a boolean
+   * an operator set is not user content, and is the audit log's core value.
+   */
+  recordChangeRetentionDays?: number;
 }
 
 /** Knowledge types the background duplicate scanner can sweep (same values as RecallKnowledgeType). */

--- a/testing/standalone/audit-change-retention.test.js
+++ b/testing/standalone/audit-change-retention.test.js
@@ -1,0 +1,136 @@
+/**
+ * A brain record edit's `changes` outlive nothing but their own short window; the entry outlives them.
+ *
+ * Owner decision, 2026-07-28: record edits MAY carry old→new values, **with a TTL**. This is that TTL,
+ * and the shape of it is the whole point.
+ *
+ * ── Why this is not just a shorter `_expireAt` ──────────────────────────────────────────────────
+ *
+ * The obvious implementation — give these entries a nearer expiry and let Mongo's TTL index handle it
+ * — deletes the whole DOCUMENT. That takes who / when / route / status with it, shortening the audit
+ * TRAIL for exactly the operations the feature exists to make auditable. The trail is the durable
+ * part; the content is the sensitive part. They need different lifetimes, so the payload is unset in
+ * place and the entry is left alone.
+ *
+ * The tests below pin that separation, the operation scoping (admin/config changes must NOT expire
+ * early — a label an operator set is not user content and is the log's core value), and the fact that
+ * redaction is RECORDED rather than silent.
+ *
+ * Run: node --test testing/standalone/audit-change-retention.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mod;
+before(async () => { mod = await import('../../server/dist/audit/change-retention.js'); });
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 6, 28, 12, 0, 0);
+const at = (daysAgo) => new Date(NOW - daysAgo * DAY).toISOString();
+
+const entry = (over = {}) => ({
+  operation: 'memory.update',
+  timestamp: at(30),
+  changes: [{ field: 'fact', from: 'old', to: 'new' }],
+  ...over,
+});
+
+describe('which operations expire early', () => {
+  it('covers every brain record edit', () => {
+    // If a record type is missing here its content silently keeps the FULL 90-day retention — the
+    // exact exposure the TTL was granted to prevent, and nothing would report it.
+    for (const op of ['memory.update', 'entity.update', 'edge.update', 'chrono.update',
+      'file.meta.update', 'entity.merge']) {
+      assert.ok(mod.RECORD_CHANGE_OPERATIONS.includes(op), `${op} must expire early`);
+    }
+  });
+
+  it('leaves admin and config changes alone', () => {
+    // A label, a cron schedule or a `requireSignedVotes` boolean is what an operator set, not user
+    // content. Expiring those early would degrade the audit log's core value to fix a problem they
+    // do not have.
+    for (const op of ['space.update', 'space.rename', 'token.update', 'network.update',
+      'config.media.update', 'data.backup_config.update', 'data.maintenance.toggle']) {
+      assert.equal(mod.RECORD_CHANGE_OPERATIONS.includes(op), false,
+        `${op} must keep the full audit retention`);
+    }
+  });
+});
+
+describe('the redaction decision', () => {
+  const cutoff = mod0 => mod0.changesCutoff(NOW, 14);
+
+  it('redacts a record edit older than the window', () => {
+    assert.equal(mod.shouldRedact(entry({ timestamp: at(30) }), cutoff(mod)), true);
+  });
+
+  it('leaves a record edit inside the window', () => {
+    assert.equal(mod.shouldRedact(entry({ timestamp: at(3) }), cutoff(mod)), false);
+  });
+
+  it('never redacts an admin change, however old', () => {
+    assert.equal(
+      mod.shouldRedact(entry({ operation: 'space.update', timestamp: at(3650) }), cutoff(mod)),
+      false, 'admin changes keep the full retention regardless of age');
+  });
+
+  it('is a no-op on an entry that was already redacted', () => {
+    // Re-sweeping must not keep reporting work it is not doing.
+    //
+    // NOTE the fixture keeps `changes` PRESENT. The first version omitted it, so the later
+    // "no changes to redact" guard returned false regardless and the test passed with the
+    // already-redacted check deleted — it asserted nothing about the flag it was named for.
+    assert.equal(
+      mod.shouldRedact(entry({ timestamp: at(30), changesRedacted: true }), cutoff(mod)),
+      false, 'the changesRedacted flag alone must stop a re-sweep');
+  });
+
+  it('is a no-op on an entry that never had changes', () => {
+    assert.equal(mod.shouldRedact({ operation: 'memory.update', timestamp: at(30) }, cutoff(mod)), false);
+  });
+
+  it('does not redact on a missing timestamp rather than treating it as ancient', () => {
+    // Fail-closed the safe way round: an entry with no timestamp is a data problem, and silently
+    // stripping its content would destroy the evidence of that problem.
+    assert.equal(mod.shouldRedact(entry({ timestamp: undefined }), cutoff(mod)), false);
+  });
+
+  it('treats an unknown operation as not-a-record-edit', () => {
+    assert.equal(mod.shouldRedact(entry({ operation: 'something.new' }), cutoff(mod)), false);
+  });
+});
+
+describe('the retention window', () => {
+  it('defaults to 14 days', () => {
+    assert.equal(mod.DEFAULT_RECORD_CHANGE_RETENTION_DAYS, 14);
+    assert.equal(mod.recordChangeRetentionDays(), 14, 'falls back to the default outside a loaded config');
+  });
+
+  it('computes the cutoff from the window, not from a fixed constant', () => {
+    assert.equal(mod.changesCutoff(NOW, 14).getTime(), NOW - 14 * DAY);
+    assert.equal(mod.changesCutoff(NOW, 1).getTime(), NOW - 1 * DAY);
+    assert.equal(mod.changesCutoff(NOW, 90).getTime(), NOW - 90 * DAY);
+  });
+
+  it('the boundary is strict — exactly at the cutoff is kept', () => {
+    const c = mod.changesCutoff(NOW, 14);
+    assert.equal(mod.shouldRedact(entry({ timestamp: c.toISOString() }), c), false);
+    assert.equal(mod.shouldRedact(entry({ timestamp: new Date(c.getTime() - 1).toISOString() }), c), true);
+  });
+});
+
+describe('the scheduler', () => {
+  it('start and stop are idempotent', () => {
+    assert.doesNotThrow(() => { mod.startAuditChangeRetention(); mod.startAuditChangeRetention(); });
+    assert.doesNotThrow(() => { mod.stopAuditChangeRetention(); mod.stopAuditChangeRetention(); });
+  });
+
+  it('is started by bootstrap — a sweep nobody calls is the failure this repo keeps hitting', async () => {
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync(new URL('../../server/src/bootstrap.ts', import.meta.url), 'utf8')
+      .split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+    assert.match(src, /startAuditChangeRetention\(\)/,
+      'bootstrap must start the sweep; an unstarted sweep leaves record content for the full 90 days');
+  });
+});


### PR DESCRIPTION
Owner decision: brain record edits **may** carry old→new values, **with a TTL**.

This ships **the TTL first** — the guard before the thing it guards — so record content can never land in the audit log without the mechanism that ages it out already running.

## The TTL cannot be the entry's TTL

The obvious implementation is a nearer `_expireAt`, letting MongoDB's existing TTL index do the work. That's wrong, and quietly so: **a TTL index deletes the whole document.** It would take who / when / route / status with it — shortening the audit *trail* for exactly the operations this feature exists to make auditable.

The trail is the durable part; the content is the sensitive part. They need different lifetimes. So a sweep unsets `changes` **in place**, and the entry keeps its full `audit.retentionDays`.

| | |
|---|---|
| `audit/change-retention.ts` | the policy (pure decisions) + a 6h sweep |
| `audit.recordChangeRetentionDays` | new config, default **14** days |
| `changesRedacted: true` | set on sweep — redaction is recorded, never silent |

**Only the six brain record operations expire early.** Admin and config changes keep the full retention: a label, a cron schedule or a `requireSignedVotes` boolean is what an operator *set*, not user content, and it's the audit log's core value.

`changesRedacted` exists so a reader can tell *"this operation records no changes"* from *"it did, and they've aged out"* — without it, an absent `changes` quietly implies nothing was captured.

## Mutation-proven 9/9

a record type dropped from the early-expiry list · admin changes swept up with record edits · age comparison inverted · boundary loosened to `<=` · missing timestamp treated as ancient · already-redacted entries re-swept · cutoff ignoring the configured window · default lengthened to 90 · **bootstrap never starting the sweep**

That last one matters here specifically: an unstarted sweep leaves record content sitting for the full 90 days *while every test of the policy still passes*. Same absence-shaped failure this repo keeps hitting, so it's asserted structurally against `bootstrap.ts`.

**One test was fixed after surviving its own mutation** — the already-redacted fixture omitted `changes`, so a later guard returned false regardless and the check passed with the flag it was named for deleted.

## Next

Slice 2 (capturing the changes) is tracked, with the blocker written down: `scalarOrDrop` silently drops arrays, so `tags` / `entityIds` / `memoryIds` would record **nothing** without a bounded extension for arrays of primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)