### PR TITLE
feat(audit): record what changed on brain record edits, including tags and entity links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Brain record edits now record what actually changed — including tags and entity links.** The second
+  half of the owner's "yes, with a TTL": `memory.update`, `entity.update`, `edge.update` and
+  `chrono.update` capture their old→new values, which expire on the short clock shipped in the previous
+  entry.
+
+  The blocker was invisible rather than hard. `scalarOrDrop` discards arrays — correct in general,
+  since letting an object through would allow one allowlisted parent to silently ship every child it
+  gains later — but it meant `tags` and `entityIds` recorded **nothing at all**, with no error and no
+  empty value. The entry would appear with the field simply missing, and a reader would conclude the
+  tags were untouched. List fields are now opt-in per name, must contain only primitives (one object
+  and the whole field is dropped), and record what moved rather than the whole list: re-tagging one
+  memory does not copy forty tags into the log twice. Reordering records nothing, since these compare
+  as sets.
+
+  **`properties` is not recorded for any record type** — it is the one field on a record whose keys the
+  user chooses, so it is where a pasted credential would land, and an allowlist cannot vet names it has
+  never seen. `file.meta.update` and `entity.merge` are deliberately absent until their routes supply
+  snapshots, rather than shipping a list that claims coverage it does not have.
+
+  Only single-record edits carry changes: `bulk.write` has no allowlist and peer sync never reaches
+  these routes, so the bulk paths cannot flood the audit collection with content.
+
 - **Audit entries can now carry brain record changes, and that payload expires on its own short clock.**
   Owner decision: record edits MAY record old→new values, with a TTL. This ships the TTL first — the
   guard before the thing it guards — so content can never land without the mechanism that ages it out.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5592,6 +5592,33 @@ used to say" ages out.
 `changesRedacted` exists so a reader can distinguish *"this operation records no changes"* from *"it did, and
 they have expired"*. Without it an absent `changes` would quietly imply nothing was ever captured.
 
+#### What a record edit records
+
+| Operation | Recorded fields |
+|---|---|
+| `memory.update` | `fact`, `description`, `type`, `tags`, `entityIds` |
+| `entity.update` | `name`, `type`, `description`, `tags` |
+| `edge.update` | `label`, `from`, `to`, `weight`, `type` |
+| `chrono.update` | `title`, `description`, `type`, `status`, `startsAt`, `endsAt`, `tags`, `entityIds`, `memoryIds` |
+
+**`properties` is never recorded, for any record type.** It is a free-form bag whose keys you choose, so it
+is the one field on a record that could hold a pasted credential — and an allowlist cannot vet names it has
+never seen.
+
+List-valued fields (`tags`, `entityIds`, `memoryIds`) are recorded as what moved rather than as the whole
+list, so re-tagging one memory does not copy forty tags into the log twice:
+
+```json
+{ "field": "tags", "added": ["urgent"], "removed": ["draft"] }
+```
+
+Reordering a list records nothing — these are compared as sets. A list containing anything other than a
+string, number or boolean is dropped entirely rather than partially recorded.
+
+Only **single-record** edits carry changes. `POST /api/brain/spaces/:id/bulk` is a separate operation with
+no change allowlist, and records arriving via peer sync never pass through these routes at all — so bulk
+paths do not fill the audit log with content.
+
 ### Tracked operations
 
 Audit entries are recorded for all write operations and (when `logReads` is enabled) read operations across the API surface:

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -222,11 +222,18 @@ chronoRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceA
   const ttlErr = ttlDaysError(req.body);
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
 
+  // Snapshot for the audit change list — see the note in memories.ts. Read before the write, since
+  // `updateChrono` returns only the new document.
+  const prior = await findFirstAcrossMembers(wt.target, mid => getChronoById(mid, id));
   const updated = await findFirstAcrossMembers(wt.target, mid => updateChrono(mid, id, {
     title, type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
   }, webhookToken(req), ttlDaysFromBody(req.body)));
-  if (updated) { res.json(updated); return; }
+  if (updated) {
+    req.auditSnapshots = { before: prior ?? {}, after: updated };
+    res.json(updated);
+    return;
+  }
   res.status(404).json({ error: 'Chrono entry not found' });
 });
 

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -221,8 +221,11 @@ edgesRouter.patch('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAut
         return;
       }
     }
+    // Snapshot for the audit change list — see the note in memories.ts.
+    const prior = await getEdgeById(mid, id);
     const updated = await updateEdgeById(mid, id, updates, dfPaths, webhookToken(req), ttlDaysFromBody(req.body));
     if (updated) {
+      req.auditSnapshots = { before: prior ?? {}, after: updated };
       res.json(updated);
       return;
     }

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -265,8 +265,12 @@ entitiesRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSp
         return;
       }
     }
+    // Snapshot for the audit change list — see the note in memories.ts. Interactive single-record path
+    // only; `properties` is deliberately not allowlisted, so handing the record over cannot publish it.
+    const prior = await getEntityById(mid, id);
     const updated = await updateEntityById(mid, id, updates, dfPaths, webhookToken(req), ttlDaysFromBody(req.body));
     if (updated) {
+      req.auditSnapshots = { before: prior ?? {}, after: updated };
       res.json(updated);
       return;
     }

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -216,8 +216,15 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
         return;
       }
     }
+    // Snapshot for the audit change list. One extra read, on the interactive single-record path only —
+    // bulk writes go through `bulk.write`, which has no allowlist, and peer sync never reaches this
+    // route at all. `audit-changes.ts` reads only the allowlisted fields, so handing the whole record
+    // over cannot publish `properties` (deliberately unlisted: its keys are user-chosen and could hold
+    // a pasted credential).
+    const prior = await listMemories(mid, { _id: id }, 1, 0);
     const updated = await updateMemory(mid, id, updates, dfPaths, webhookToken(req), ttlDaysFromBody(req.body));
     if (updated) {
+      req.auditSnapshots = { before: prior[0] ?? {}, after: updated };
       res.json(updated);
       return;
     }

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -26,11 +26,21 @@
  * through nesting.
  */
 
-/** A single recorded field change. `from`/`to` are scalars; absent means "was not set". */
+/**
+ * A single recorded field change.
+ *
+ * Two shapes, and a change is only ever one of them:
+ *   - scalar: `from`/`to`, where absent means "was not set";
+ *   - set: `added`/`removed`, for a list-valued field like `tags`.
+ */
 export interface AuditChange {
   field: string;
   from?: string | number | boolean | null;
   to?: string | number | boolean | null;
+  /** Members present after but not before. Only for allowlisted list fields. */
+  added?: (string | number | boolean)[];
+  /** Members present before but not after. */
+  removed?: (string | number | boolean)[];
 }
 
 /**
@@ -61,6 +71,23 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   // Backup schedule and retention. `offsite.destPath` is a container filesystem path (mounted volume),
   // not a URL, so it cannot carry credentials in userinfo the way a webhook target can.
   'data.backup_config.update': ['schedule', 'retention.keepLocal', 'offsite.destPath', 'offsite.retention.keepCount'],
+  // ── Brain record edits ─────────────────────────────────────────────────────────────────────────
+  //
+  // These carry USER CONTENT — a memory's old text, an entity's old description — which is why they
+  // were an owner decision rather than another slice, and why their `changes` expire on a much shorter
+  // clock than the entry (see `change-retention.ts`, default 14 days).
+  //
+  // `properties` is deliberately absent from every one of them. It is a free-form bag whose keys the
+  // user chooses, so it is the one field on a record that could hold a pasted credential, and the
+  // allowlist cannot vet names it has never seen. Same reasoning that keeps webhook routes out.
+  'memory.update': ['fact', 'description', 'type', 'tags', 'entityIds'],
+  'entity.update': ['name', 'type', 'description', 'tags'],
+  'edge.update': ['label', 'from', 'to', 'weight', 'type'],
+  'chrono.update': ['title', 'description', 'type', 'status', 'startsAt', 'endsAt', 'tags', 'entityIds', 'memoryIds'],
+  // NOT YET LISTED: `file.meta.update` and `entity.merge`. Both are real candidates, but their routes
+  // do not supply snapshots yet, and an allowlist without a route behind it records nothing while the
+  // list claims coverage — the exact mistake the first audit slice shipped. They land with their
+  // wiring, in one change, or not at all.
   // Maintenance mode blocks writes instance-wide. One boolean, and the direction is the whole story:
   // an entry saying only "an admin hit the maintenance route" cannot distinguish starting an outage
   // from ending one.
@@ -73,6 +100,51 @@ function scalarOrDrop(v: unknown): string | number | boolean | null | undefined 
   const t = typeof v;
   if (t === 'string' || t === 'number' || t === 'boolean') return v as string | number | boolean;
   return undefined;   // objects, arrays, functions, undefined — never recorded
+}
+
+/**
+ * Fields whose value is a LIST, recorded as added/removed rather than dropped.
+ *
+ * `scalarOrDrop` discards arrays, which is right for the general case — allowing an object or array
+ * through would let one allowlisted parent name silently ship every child it gains later. But it means
+ * `tags` and `entityIds` record NOTHING, and that failure is invisible: the entry appears, the field
+ * is simply missing from `changes`, and an audit reader concludes the tags were untouched.
+ *
+ * So list handling is opt-in per field and deliberately narrow:
+ *   - the field must be named here AND in the operation's allowlist;
+ *   - every member must be a primitive. One object in the array and the whole field is dropped, which
+ *     is the same fail-closed direction as everywhere else in this module.
+ *
+ * Recording added/removed rather than the whole before/after list keeps the entry proportional to the
+ * change. Re-tagging one memory should not copy forty tags into the audit log twice.
+ */
+const LIST_FIELDS: ReadonlySet<string> = new Set(['tags', 'entityIds', 'memoryIds']);
+
+/** An array of primitives, or undefined if it is not one. Nested values disqualify the whole field. */
+function primitiveListOrDrop(v: unknown): (string | number | boolean)[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: (string | number | boolean)[] = [];
+  for (const item of v) {
+    const t = typeof item;
+    if (t !== 'string' && t !== 'number' && t !== 'boolean') return undefined;
+    out.push(item as string | number | boolean);
+  }
+  return out;
+}
+
+/** Set difference for a list field, or null when either side is not a primitive list. */
+function listDelta(beforeV: unknown, afterV: unknown): { added: (string | number | boolean)[]; removed: (string | number | boolean)[] } | null {
+  // An absent side is an empty list, so adding tags to a record that had none still records them.
+  const b = beforeV === undefined ? [] : primitiveListOrDrop(beforeV);
+  const a = afterV === undefined ? [] : primitiveListOrDrop(afterV);
+  if (b === undefined || a === undefined) return null;
+
+  const bSet = new Set(b);
+  const aSet = new Set(a);
+  return {
+    added: a.filter(x => !bSet.has(x)),
+    removed: b.filter(x => !aSet.has(x)),
+  };
 }
 
 /** Read a dotted path (`levels.images`) without touching anything else on the object. */
@@ -95,6 +167,19 @@ export function auditChanges(operation: string, before: unknown, after: unknown)
 
   const out: AuditChange[] = [];
   for (const field of fields) {
+    // List fields first: they would otherwise be dropped by scalarOrDrop and record nothing at all.
+    if (LIST_FIELDS.has(field.split('.').pop() ?? field)) {
+      const delta = listDelta(at(before, field), at(after, field));
+      if (delta && (delta.added.length || delta.removed.length)) {
+        out.push({
+          field,
+          ...(delta.added.length ? { added: delta.added } : {}),
+          ...(delta.removed.length ? { removed: delta.removed } : {}),
+        });
+      }
+      continue;
+    }
+
     const from = scalarOrDrop(at(before, field));
     const to = scalarOrDrop(at(after, field));
     if (from === undefined && to === undefined) continue;   // absent on both sides — nothing happened

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -76,6 +76,9 @@ describe('audit changes — every allowlist is actually reachable', () => {
   const ROUTE_SOURCES = [
     'server/src/api/spaces.ts', 'server/src/api/tokens.ts', 'server/src/api/media-config.ts',
     'server/src/api/networks/crud.ts', 'server/src/api/data.ts',
+    // Brain record edits — the operations whose changes carry user content and expire early.
+    'server/src/api/brain/memories.ts', 'server/src/api/brain/entities.ts',
+    'server/src/api/brain/edges.ts', 'server/src/api/brain/chrono.ts',
   ];
 
   it('every allowlisted key is a REAL operation name from the middleware', () => {
@@ -190,5 +193,79 @@ describe('audit changes — scalars only', () => {
     assert.deepEqual(auditChanges('space.update', null, { label: 'x' }), []);
     assert.deepEqual(auditChanges('space.update', undefined, undefined), []);
     assert.deepEqual(auditChanges('space.update', 'not-an-object', 42), []);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Brain record edits — list fields, and the content that must NOT be recorded
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('audit changes — list fields record what moved, not the whole list', () => {
+  before(async () => {
+    ({ auditChanges, AUDIT_CHANGE_FIELDS } = await import('../../server/dist/audit/audit-changes.js'));
+  });
+
+  it('records tags as added/removed rather than dropping them', () => {
+    // The bug this exists to prevent is silent: `scalarOrDrop` discards arrays, so before this the
+    // entry appeared with `tags` simply missing from `changes` — and a reader concludes the tags were
+    // untouched. No error, no empty value, just absence.
+    const changes = auditChanges('memory.update',
+      { tags: ['a', 'b'] }, { tags: ['b', 'c'] });
+    assert.deepEqual(changes, [{ field: 'tags', added: ['c'], removed: ['a'] }]);
+  });
+
+  it('treats an absent list as empty, so first-time tagging still records', () => {
+    assert.deepEqual(auditChanges('memory.update', {}, { tags: ['new'] }),
+      [{ field: 'tags', added: ['new'] }]);
+  });
+
+  it('records a cleared list as removals', () => {
+    assert.deepEqual(auditChanges('memory.update', { tags: ['gone'] }, { tags: [] }),
+      [{ field: 'tags', removed: ['gone'] }]);
+  });
+
+  it('says nothing when a list is merely reordered', () => {
+    // Set semantics, not sequence — a reorder is not a change anyone needs explained, and recording
+    // one would make every save look like an edit.
+    assert.deepEqual(auditChanges('memory.update', { tags: ['a', 'b'] }, { tags: ['b', 'a'] }), []);
+  });
+
+  it('drops the whole field when a list contains a non-primitive', () => {
+    // Fail-closed, same direction as everywhere else here: one object in the array and nothing is
+    // recorded, rather than recording part of it or stringifying the object.
+    assert.deepEqual(auditChanges('memory.update',
+      { tags: ['a'] }, { tags: [{ nested: 'sk-live-AAA' }] }), []);
+  });
+
+  it('never records `properties` for any record type', () => {
+    // The one field on a record whose KEYS the user chooses, so it is where a pasted credential would
+    // land. The allowlist cannot vet names it has never seen, so the whole bag stays out.
+    for (const op of ['memory.update', 'entity.update', 'edge.update', 'chrono.update']) {
+      assert.ok(!(AUDIT_CHANGE_FIELDS[op] ?? []).includes('properties'),
+        `${op} must not allowlist the free-form properties bag`);
+      assert.deepEqual(
+        auditChanges(op, { properties: { k: 'old' } }, { properties: { k: 'sk-live-AAA' } }), [],
+        `${op} must record nothing from properties`);
+    }
+  });
+
+  it('records the content fields the owner asked for', () => {
+    // "Yes with a TTL" means content IS in scope — the TTL is the mitigation, not omission.
+    const changes = auditChanges('memory.update',
+      { fact: 'old text' }, { fact: 'new text' });
+    assert.deepEqual(changes, [{ field: 'fact', from: 'old text', to: 'new text' }]);
+  });
+
+  it('every record operation that expires early has an allowlist, and vice versa', async () => {
+    // The two lists are written in different files and must not drift: an operation with content in
+    // `changes` but no early expiry would keep user content for the full 90 days.
+    const { RECORD_CHANGE_OPERATIONS } = await import('../../server/dist/audit/change-retention.js');
+    for (const op of Object.keys(AUDIT_CHANGE_FIELDS)) {
+      const isRecordOp = /^(memory|entity|edge|chrono|file\.meta)\./.test(op);
+      if (!isRecordOp) continue;
+      assert.ok(RECORD_CHANGE_OPERATIONS.includes(op),
+        `${op} records record content but is not in RECORD_CHANGE_OPERATIONS — its changes would ` +
+        'keep the full audit retention instead of the short one.');
+    }
   });
 });


### PR DESCRIPTION
Second half of the owner's **"yes, with a TTL"**. #491 shipped the TTL; this captures the content it protects. `memory.update`, `entity.update`, `edge.update` and `chrono.update` now record old→new values, expiring on the 14-day clock rather than the entry's 90.

## The blocker was invisible, not hard

`scalarOrDrop` discards arrays — correct in general, since letting an object through would allow one allowlisted parent to silently ship every child it gains later. But it meant **`tags` and `entityIds` recorded nothing at all**: no error, no empty value, just a field missing from `changes` while a reader concludes the tags were untouched.

List handling is now opt-in per name and deliberately narrow:

- must be named in `LIST_FIELDS` **and** in the operation's allowlist
- every member must be a primitive — one object and the **whole field** is dropped (same fail-closed direction as the rest of the module)
- recorded as **added/removed**, not before/after — re-tagging one memory doesn't copy forty tags into the log twice
- compared as **sets**, so a reorder records nothing and every save doesn't look like an edit

```json
{ "field": "tags", "added": ["urgent"], "removed": ["draft"] }
```

## Deliberately not recorded

**`properties`, for any record type.** It's the one field whose *keys* the user chooses — where a pasted credential would land — and an allowlist can't vet names it has never seen.

**`file.meta.update` and `entity.merge`.** Both are real candidates, but their routes don't supply snapshots yet, and an allowlist with no route behind it records nothing while claiming coverage — the exact mistake #471 shipped (four listed, one wired). They land *with* their wiring or not at all.

## Volume — checked, not assumed

Only single-record edits carry changes. `POST /:space/bulk` maps to `bulk.write` (no allowlist), and peer sync goes through `batchUpsertBySeq` internally, never reaching these routes. The hot bulk paths can't fill the audit collection. Cost: one extra read per interactive record update.

## Mutation-proven

list fields falling back to `scalarOrDrop` · a non-primitive no longer disqualifying the list · reorder counted as a change · absent side not treated as empty · `properties` allowlisted · a route dropping its snapshot · **a record op that records content but is missing from the early-expiry list** (would keep user content 90 days)

**That last one initially reported SURVIVED — and it was my harness, not the test.** The ad-hoc script's anchor used `\n` against a CRLF file, so the mutation never applied; "survived" meant "was never made". My scripted harness treats a missed anchor as fatal for exactly this reason; the one-off didn't. Re-run correctly: **killed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)