### PR TITLE
feat(audit): record file-metadata edits and entity merges, completing the owner decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **File-metadata edits and entity merges complete the record-change coverage.** The two operations
+  held back from the previous entry — because their routes did not supply snapshots yet, and an
+  allowlist with no route behind it records nothing while claiming coverage — now ship with their
+  wiring.
+
+  A file carries **three** reference lists (`entityIds`, `chronoIds`, `memoryIds`); missing one would
+  leave a link nobody could account for, and the symptom is a traversal coming back empty rather than
+  an error. A merge is a deletion wearing an edit's clothes: the entry already has the survivor's id
+  and the path has the absorbed one, but an id means nothing once its record is gone — so the absorbed
+  entity's **name** is recorded as it disappears.
+
+  A mutation found a real gap in the tests while verifying this, worth noting because it is the same
+  shape as an earlier fix: `entities.ts` now has two snapshot sites, and a file-level "does it mention
+  `auditSnapshots`" check passes when either one is deleted. Deleting the PATCH snapshot left every
+  test green. The check is now per-site.
+
 - **Brain record edits now record what actually changed — including tags and entity links.** The second
   half of the owner's "yes, with a TTL": `memory.update`, `entity.update`, `edge.update` and
   `chrono.update` capture their old→new values, which expire on the short clock shipped in the previous

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5600,6 +5600,12 @@ they have expired"*. Without it an absent `changes` would quietly imply nothing 
 | `entity.update` | `name`, `type`, `description`, `tags` |
 | `edge.update` | `label`, `from`, `to`, `weight`, `type` |
 | `chrono.update` | `title`, `description`, `type`, `status`, `startsAt`, `endsAt`, `tags`, `entityIds`, `memoryIds` |
+| `file.meta.update` | `description`, `tags`, `entityIds`, `chronoIds`, `memoryIds` |
+| `entity.merge` | `absorbedName` (recorded as name → `null`) |
+
+A merge is a deletion wearing an edit's clothes. The entry already carries the survivor's id, and the request
+path carries the absorbed one — but an id means nothing once the record it pointed at is gone, so the
+absorbed entity's **name** is recorded as it disappears.
 
 **`properties` is never recorded, for any record type.** It is a free-form bag whose keys you choose, so it
 is the one field on a record that could hold a pasted credential — and an allowlist cannot vet names it has

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -359,6 +359,15 @@ entitiesRouter.post('/spaces/:spaceId/entities/:survivorId/merge/:absorbedId', g
     plan.absorbedOnlyProperties,
   );
 
+  // Snapshot for the audit change list. A merge is a deletion wearing an edit's clothes: the entry
+  // already carries the survivor's id and the path carries the absorbed one, but an id means nothing
+  // once the record it pointed at is gone. The absorbed NAME is the only fact that becomes
+  // unrecoverable, so it is recorded as name → null.
+  req.auditSnapshots = {
+    before: { absorbedName: absorbed.name },
+    after: { absorbedName: null },
+  };
+
   const mergeResult = await executeMerge(spaceId, survivor, absorbed, mergedProperties, webhookToken(req));
   const mergedEntity = mergeResult.entity;
 

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -14,7 +14,7 @@ import { toDocId } from '../../util/paths.js';
 import { requireSpaceAuth, denyReadOnly, requireAdmin } from '../../auth/middleware.js';
 import { listTokens } from '../../auth/tokens.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
-import { updateFileMeta, deleteFileMeta } from '../../files/file-meta.js';
+import { updateFileMeta, deleteFileMeta, getFileMeta } from '../../files/file-meta.js';
 import { assertRefsResolve } from '../../brain/entity-refs.js';
 import { fileExists } from '../../files/files.js';
 import { getConfig } from '../../config/loader.js';
@@ -270,8 +270,15 @@ fileMetaRouter.patch('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth
     }
   }
 
+  // Snapshot for the audit change list — see the note in memories.ts. `properties` is not allowlisted,
+  // so handing the record over cannot publish it.
+  const prior = await findFirstAcrossMembers(wt.target, mid => getFileMeta(mid, path));
   const updated = await findFirstAcrossMembers(wt.target,
     mid => updateFileMeta(mid, path, { description, tags, entityIds, chronoIds, memoryIds, properties }));
-  if (updated) { res.json(updated); return; }
+  if (updated) {
+    req.auditSnapshots = { before: prior ?? {}, after: updated };
+    res.json(updated);
+    return;
+  }
   res.status(404).json({ error: 'File metadata record not found' });
 });

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -84,10 +84,14 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   'entity.update': ['name', 'type', 'description', 'tags'],
   'edge.update': ['label', 'from', 'to', 'weight', 'type'],
   'chrono.update': ['title', 'description', 'type', 'status', 'startsAt', 'endsAt', 'tags', 'entityIds', 'memoryIds'],
-  // NOT YET LISTED: `file.meta.update` and `entity.merge`. Both are real candidates, but their routes
-  // do not supply snapshots yet, and an allowlist without a route behind it records nothing while the
-  // list claims coverage — the exact mistake the first audit slice shipped. They land with their
-  // wiring, in one change, or not at all.
+  // A file's metadata carries THREE reference lists, and losing track of what a file was linked to is
+  // exactly the kind of change nobody notices until a traversal comes back empty.
+  'file.meta.update': ['description', 'tags', 'entityIds', 'chronoIds', 'memoryIds'],
+  // A merge is a deletion wearing an edit's clothes: the absorbed entity ceases to exist. The entry
+  // already carries the survivor's id and the path carries the absorbed one, so the only fact that
+  // becomes UNRECOVERABLE is the absorbed entity's name — an id alone means nothing once the record it
+  // pointed at is gone. Recorded as name → null, which reads as "this entity no longer exists".
+  'entity.merge': ['absorbedName'],
   // Maintenance mode blocks writes instance-wide. One boolean, and the direction is the whole story:
   // an entry saying only "an admin hit the maintenance route" cannot distinguish starting an outage
   // from ending one.
@@ -118,7 +122,7 @@ function scalarOrDrop(v: unknown): string | number | boolean | null | undefined 
  * Recording added/removed rather than the whole before/after list keeps the entry proportional to the
  * change. Re-tagging one memory should not copy forty tags into the audit log twice.
  */
-const LIST_FIELDS: ReadonlySet<string> = new Set(['tags', 'entityIds', 'memoryIds']);
+const LIST_FIELDS: ReadonlySet<string> = new Set(['tags', 'entityIds', 'memoryIds', 'chronoIds']);
 
 /** An array of primitives, or undefined if it is not one. Nested values disqualify the whole field. */
 function primitiveListOrDrop(v: unknown): (string | number | boolean)[] | undefined {

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -112,6 +112,18 @@ export async function upsertFileMeta(
  * every successful update.  Returns the updated document, or null if the
  * record does not exist.
  */
+/**
+ * Read one file-metadata record by path, or null.
+ *
+ * Exists for the audit before-snapshot: `updateFileMeta` reads the same document internally but returns
+ * only the new one, and the audit change list needs the prior state. Kept as a plain getter rather than
+ * changing that signature, so nothing else has to care.
+ */
+export async function getFileMeta(spaceId: string, filePath: string): Promise<FileMetaDoc | null> {
+  return await col<FileMetaDoc>(`${spaceId}_files`)
+    .findOne(asFilter<FileMetaDoc>({ _id: toDocId(filePath) })) as FileMetaDoc | null;
+}
+
 export async function updateFileMeta(
   spaceId: string,
   filePath: string,

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -269,3 +269,73 @@ describe('audit changes — list fields record what moved, not the whole list', 
     }
   });
 });
+
+describe('audit changes — file meta and entity merge (the two held back from slice 2)', () => {
+  before(async () => {
+    ({ auditChanges, AUDIT_CHANGE_FIELDS } = await import('../../server/dist/audit/audit-changes.js'));
+  });
+
+  const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8');
+
+  it('file meta records all THREE reference lists, not just entityIds', () => {
+    // A file links to entities, chrono entries AND memories. Missing one means a link nobody can
+    // account for later — and the symptom is a traversal that comes back empty, not an error.
+    const changes = auditChanges('file.meta.update',
+      { entityIds: ['e1'], chronoIds: ['c1'], memoryIds: ['m1'] },
+      { entityIds: ['e1', 'e2'], chronoIds: [], memoryIds: ['m1'] });
+    assert.deepEqual(changes, [
+      { field: 'entityIds', added: ['e2'] },
+      { field: 'chronoIds', removed: ['c1'] },
+    ]);
+  });
+
+  it('file meta never records properties', () => {
+    assert.ok(!AUDIT_CHANGE_FIELDS['file.meta.update'].includes('properties'));
+    assert.deepEqual(
+      auditChanges('file.meta.update', { properties: { k: 'a' } }, { properties: { k: 'sk-live-X' } }), []);
+  });
+
+  it('a merge records the absorbed name going to null', () => {
+    // The id is in the path and the survivor is the entry id; the NAME is the only thing that stops
+    // being resolvable once the record is gone.
+    assert.deepEqual(
+      auditChanges('entity.merge', { absorbedName: 'Acme Corp' }, { absorbedName: null }),
+      [{ field: 'absorbedName', from: 'Acme Corp', to: null }]);
+  });
+
+  it('both routes actually supply snapshots — checked per SITE, not per file', () => {
+    // The #471 rule: an allowlist with no route behind it records nothing while claiming coverage.
+    //
+    // Per-site matters because entities.ts now has TWO snapshot sites (the PATCH and the merge). A
+    // file-level "does it mention auditSnapshots" check passes when either one is deleted — mutation
+    // proved it, by removing the PATCH snapshot while every test stayed green.
+    const entities = read('server/src/api/brain/entities.ts');
+    assert.match(entities, /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/,
+      'entity.update must snapshot around its PATCH');
+    assert.match(entities, /before: \{ absorbedName: absorbed\.name \}/,
+      'entity.merge must snapshot the absorbed name');
+
+    assert.match(read('server/src/api/brain/file-meta.ts'),
+      /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/);
+  });
+
+  it('every record route that was wired still has its snapshot', () => {
+    // Derived rather than enumerated, same lesson as the If-Match coverage fix: a per-file check rots
+    // the moment a file gains a second site.
+    const WIRED = {
+      'server/src/api/brain/memories.ts': /req\.auditSnapshots = \{ before: prior\[0\] \?\? \{\}, after: updated \}/,
+      'server/src/api/brain/edges.ts': /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/,
+      'server/src/api/brain/chrono.ts': /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/,
+    };
+    for (const [file, pattern] of Object.entries(WIRED)) {
+      assert.match(read(file), pattern, `${file} lost its audit snapshot`);
+    }
+  });
+
+  it('the merge snapshot reads the absorbed entity, not the survivor', () => {
+    // Recording `survivor.name` here would look correct and be useless — the survivor still exists.
+    const src = read('server/src/api/brain/entities.ts');
+    assert.match(src, /before: \{ absorbedName: absorbed\.name \}/,
+      'the before-snapshot must come from the ABSORBED entity');
+  });
+});


### PR DESCRIPTION
The two operations held back from #492, now shipping **with their route wiring**. They were withheld because an allowlist with no route behind it records nothing while the list claims coverage — the mistake #471 shipped (four listed, one wired).

| operation | recorded |
|---|---|
| `file.meta.update` | `description`, `tags`, `entityIds`, `chronoIds`, `memoryIds` |
| `entity.merge` | `absorbedName`, as name → `null` |

**A file carries three reference lists.** Missing one leaves a link nobody can account for afterwards, and the symptom is a traversal coming back empty rather than anything resembling an error. `chronoIds` had to be added to `LIST_FIELDS` for that reason.

**A merge is a deletion wearing an edit's clothes.** The entry already carries the survivor's id and the path carries the absorbed one — but an id means nothing once the record it pointed at is gone. The absorbed entity's *name* is the only fact that becomes unrecoverable, so that's what's recorded. Snapshotting `survivor.name` would look correct and say nothing; that's one of the mutations below.

`getFileMeta` is a new export rather than a change to `updateFileMeta`'s signature — the update already reads the same document internally but returns only the new one.

## A real test gap, found by mutation

**6/6 killed — but only after fixing a check that was passing for the wrong reason.**

`entities.ts` now has **two** snapshot sites (the PATCH and the merge), and the coverage assertion was per-*file* — "does it mention `auditSnapshots`". Deleting the PATCH snapshot left every test green.

That's the same weakness fixed for the If-Match coverage check in #481, reappearing in a different file: **a per-file check rots the moment a file gains a second site.** It's now per-site, for every wired record route.

Mutations killed: `chronoIds` no longer a list · file meta dropping a reference list · `properties` allowlisted · merge recording the survivor's name · merge losing its snapshot · file meta losing its snapshot.

## Decision complete

All six record operations record their changes, all expire on the 14-day clock from #491, and `properties` is never recorded for any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)