### PR TITLE
docs: strictLinkage defaults to true, not false — and a new space is strict, not off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -862,6 +862,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **⚠️ The integration guide said `strictLinkage` defaults to `false`. It defaults to `true`.** The
+  second real error the documentation audit has found, and it inverted a safety property: a reader
+  concluded reference validation was off unless they turned it on, when it is on unless they turn it
+  off. Both senses of "default" contradicted the doc — an absent value resolves to `true`
+  (`strictLinkage !== false`), and new spaces are seeded `strictLinkage: true`. The code's own comment
+  is explicit that disabling it is "a deliberate per-space choice… not something you get by saying
+  nothing".
+
+  The same paragraph turned up a milder version: `validationMode` was documented as defaulting to `off`
+  without mentioning that **every space you create is seeded `strict`**. That one is technically
+  defensible — an absent value really does resolve to `off` — but it describes a state most readers
+  will never be in. Both are now stated precisely, including why `strict` does not block a brand-new
+  empty space (with no `typeSchemas` yet, everything validates).
+
+  Seeded defaults drift more easily than constants because they live in a route rather than behind a
+  name, so nothing reads as "the default" when you look at the code. Both are now gated in both
+  directions — change the seed or change the doc, either fails.
+
 - **Numbers the docs quote are now checked against the constants they quote.** Slice 4d of the
   pre-release audit. Failure-behaviour claims verified clean by reading — a peer that fails is caught
   per-member and the cycle continues, `max` mode runs exactly one repair pass, catalog fetch failures

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3091,9 +3091,15 @@ Each space can define a schema in its `meta` block that governs what data is acc
 
 | Mode | Behaviour |
 |------|-----------|
-| `off` | No validation (default). All writes accepted. |
+| `off` | No validation. All writes accepted. This is what an **absent** `validationMode` resolves to. |
 | `warn` | Violations are returned as `warnings` in the response but writes proceed. |
 | `strict` | Violations cause a `400` with `{ "error": "schema_violation", "violations": [...] }`. |
+
+> **A space you create is `strict`, not `off`.** New spaces are seeded with `validationMode: "strict"`
+> and `strictLinkage: true`. Only a space whose meta never had the field — one created before those
+> defaults, or through a path that does not seed meta — falls back to `off`. With no `typeSchemas`
+> defined yet, `strict` still accepts every type and label, so it never blocks a brand-new empty space;
+> it starts mattering the moment you define a schema.
 
 **Schema structure — `typeSchemas`:**
 
@@ -3175,7 +3181,7 @@ What the schema enforces:
 |-------|-------------|
 | `typeSchemas` | Per-type schema definitions (see above). |
 | `tagSuggestions` | **Retired.** A space-wide list of non-enforced tag hints. It is still accepted and stored (so an existing list is preserved untouched, and the change is reversible) but nothing reads it: it no longer feeds tag autocomplete in the Brain record forms, and no longer appears in the schema guidance returned to MCP clients. It was one list, editable in a single place, applied to every type and every form in the space — easy to set once and forget while quietly steering what got tagged. Autocomplete now comes from the tags actually in use, which maintains itself. Per-type `typeSchemas.<kind>.<type>.tagSuggestions` is a separate field and is unaffected. |
-| `strictLinkage` | When `true`, all reference fields (`from`/`to`, `entityIds`, `memoryIds`) must be valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. Default: `false`. |
+| `strictLinkage` | When `true`, all reference fields (`from`/`to`, `entityIds`, `memoryIds`) must be valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. **Default: `true`** — and an absent value also resolves to `true`. Turning it off is a deliberate per-space choice to accept dangling references (the case it exists for is bulk import, where targets are resolved in a later pass); you do not get that by saying nothing. |
 | `purpose` | Short description of the space (max 4000 chars). Returned by `get_space_meta`. |
 | `usageNotes` | Extended Markdown-formatted guidance for LLM clients (max 50 000 chars). Returned by `get_space_meta`. |
 

--- a/testing/standalone/doc-cited-constants.test.js
+++ b/testing/standalone/doc-cited-constants.test.js
@@ -86,6 +86,31 @@ const CITED = [
   },
 ];
 
+/**
+ * Defaults a NEW SPACE is seeded with, which the docs state separately from the absent-value default.
+ *
+ * These are the second and third real findings of the audit, and they are the same shape as the first:
+ * a documented default that contradicts what the code actually does. `strictLinkage` was documented as
+ * `false` when an absent value resolves to `true` AND new spaces are seeded `true` — inverting a
+ * safety property, so a reader believes reference validation is off when it is on. `validationMode`
+ * was documented as defaulting to `off` without mentioning that every space you create is `strict`.
+ *
+ * Seeded defaults drift more easily than constants because they live in a route rather than in a
+ * named constant, so nothing looks like "the default" when you read the code.
+ */
+const SEEDED_SPACE_DEFAULTS = [
+  {
+    what: 'a new space is seeded strictLinkage: true',
+    code: /strictLinkage: true/,
+    doc: /\*\*Default: `true`\*\* — and an absent value also resolves to `true`/,
+  },
+  {
+    what: 'a new space is seeded validationMode: strict',
+    code: /validationMode: 'strict'/,
+    doc: /A space you create is `strict`, not `off`/,
+  },
+];
+
 describe('numbers quoted in the docs match the constants they quote', () => {
   it('every cited constant still exists in its source', () => {
     // Guards the check itself: a renamed constant would otherwise make the pair silently untestable.
@@ -106,6 +131,22 @@ describe('numbers quoted in the docs match the constants they quote', () => {
         `${row.source} says ${raw}${row.scale ? ` (${value}s)` : ''}, but ${row.doc} does not state ` +
         'that value. A quoted number that no longer matches is read as authoritative and planned ' +
         'around — update the doc, or the constant.');
+    });
+  }
+});
+
+describe('the defaults a new space is seeded with are documented as such', () => {
+  const spacesSrc = read('server/src/api/spaces.ts');
+  const guide = read('docs/integration-guide.md');
+
+  for (const row of SEEDED_SPACE_DEFAULTS) {
+    it(row.what, () => {
+      assert.match(spacesSrc, row.code,
+        'the seeded default changed in api/spaces.ts — update the doc and this pairing together');
+      assert.match(guide, row.doc,
+        'the integration guide no longer states this seeded default. A space-creation default that ' +
+        'contradicts the docs is how strictLinkage came to be documented as `false` while both an ' +
+        'absent value and a new space resolved to `true`.');
     });
   }
 });


### PR DESCRIPTION
**The second real error the documentation audit has found — and it inverted a safety property.**

The integration guide documented `meta.strictLinkage` as **"Default: `false`"**. It is `true`, in both senses:

| | |
|---|---|
| absent value | `isStrictLinkage` returns `meta?.strictLinkage !== false` → **true** |
| new space | `spaces.ts` seeds `strictLinkage: true` |

So a reader concluded reference validation was **off unless enabled**, when it's **on unless disabled**. The code's own comment says the opposite of the doc in as many words: disabling it is *"a deliberate, per-space choice to accept dangling references — not something you get by saying nothing."*

## A milder third finding in the same paragraph

`validationMode` was documented as defaulting to `off`, with no mention that **every space you create is seeded `strict`**. Technically defensible — an absent value really does resolve to `off` — but it describes a state most readers will never be in.

Now stated precisely, including why `strict` doesn't block a brand-new empty space: with no `typeSchemas` defined, there's nothing to violate.

## Why this class drifted when constants didn't

**Seeded defaults live in a route, not behind a name.** Nothing reads as "the default" when you look at `spaces.ts` — it's one object literal inside a create handler. A named `DEFAULT_X` constant at least advertises itself.

Both are now gated **in both directions**, alongside the cited-constants pairs: flip the seed in code, or revert the sentence in the doc — either fails. Verified by doing all four.

## Rest of the 4a worklist

Verified correct and unchanged: moondream/base vision models, `caption` for images (with `auto` → `recognition`), the face-recognition infra pin, `enforceForBrowser: false`, OIDC public-only issuer policy, pagination/sort defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)