### PR TITLE
docs(audit): close the pre-release documentation audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -880,6 +880,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name, so nothing reads as "the default" when you look at the code. Both are now gated in both
   directions — change the seed or change the doc, either fails.
 
+- **The pre-release documentation audit is complete.** Seven classes swept: environment variables,
+  config keys, route paths, the MCP tool split, default values, restart/reload semantics, and
+  failure-behaviour claims. Three real errors found — offsite backup retention (silently deleting
+  archives someone believed were kept), `strictLinkage` documented as `false` when it is `true` in both
+  senses (inverting a safety property), and `validationMode` not mentioning that every space you create
+  is seeded `strict`. Seven undocumented local-connector settings were also brought into the guide.
+
+  The distribution of those findings is the useful result. **The four mechanical classes — env vars,
+  config keys, 182 route paths, the MCP tool split — contained zero errors between them**, while the
+  scanners written to check them produced around thirteen classes of *false* finding, each needing to
+  be chased down and none reaching a doc. Every real error was in prose about defaults or behaviour,
+  and two of the three misrepresented how safe the system is. Scan to build a worklist, then read: the
+  scanner is wrong far more often than the documentation is.
+
+  Six gates now run in CI so these classes cannot drift again, including the last three cited constants
+  added here — the SSRF redirect limit, the minimum detectable face size, and the contradiction
+  similarity threshold.
+
 - **Numbers the docs quote are now checked against the constants they quote.** Slice 4d of the
   pre-release audit. Failure-behaviour claims verified clean by reading — a peer that fails is caught
   per-member and the cycle continues, `max` mode runs exactly one repair pass, catalog fetch failures

--- a/testing/standalone/doc-cited-constants.test.js
+++ b/testing/standalone/doc-cited-constants.test.js
@@ -84,6 +84,28 @@ const CITED = [
     doc: 'docs/userguide.md',
     text: (v) => new RegExp(`Default: ${v}\\*\\*`),
   },
+  {
+    what: 'SSRF redirect hop limit',
+    source: 'server/src/util/ssrf.ts',
+    code: /const maxRedirects = opts\.maxRedirects \?\? ([0-9_]+);/,
+    doc: 'docs/integration-guide.md',
+    text: (v) => new RegExp(`defaults to ${v} and is configurable via \`webhookMaxRedirects\``),
+  },
+  {
+    what: 'minimum detectable face size, as a fraction of the shorter image side',
+    source: 'server/src/config/loader.ts',
+    code: /minFaceSizeFraction: (0\.[0-9]+),/,
+    scale: 0.01,   // fraction in code, percent in prose
+    doc: 'docs/integration-guide.md',
+    text: (v) => new RegExp(`default: ${v}% of the shorter image side`),
+  },
+  {
+    what: 'contradiction-scanner similarity threshold',
+    source: 'server/src/config/types.ts',
+    code: /Default: (0\.[0-9]+)\./,
+    doc: 'docs/integration-guide.md',
+    text: (v) => new RegExp(`default is therefore left at ${v}`),
+  },
 ];
 
 /**


### PR DESCRIPTION
Final slice (**4e, prose defaults**): verified clean. Twelve prose defaults, not the twenty-four first counted — that tally double-counted concrete ones. Every checkable value correct: `minFaceSizeFraction` 5%, SSRF redirect limit 3, contradiction threshold 0.92. All three added to the cited-constants gate and drift-verified.

## What the audit found

Seven classes swept. **Three real errors, all in prose:**

| error | consequence |
|---|---|
| offsite backup retention documented as unlimited, prunes to 14 | **silently deleting archives** someone believed were kept |
| `strictLinkage` documented `false`, is `true` in both senses | **inverted a safety property** — reader thinks validation is off when it's on |
| `validationMode` documented `off`, new spaces seeded `strict` | describes a state most readers are never in |

Two of the three misrepresented how safe the system is. Seven undocumented local-connector settings were also brought into the guide.

## The distribution is the actual result

**The four mechanical classes — env vars, config keys, 182 route paths, MCP tool split — contained zero errors between them.** The scanners written to check them produced ~13 classes of *false* finding:

helper-routed env reads · compose-only variables · `${CONST}` template literals · audit operation names read as config paths · API responses read as config examples · path-less sub-router composition · app-level routes · multi-mounted routers · concrete example values · brace-alternation shorthand · two lists sharing one line

**Not one reached a doc**, because every finding was opened in the source before being believed. Had any run been trusted, accurate documentation would have been "corrected" into wrong documentation — worse than leaving it alone, because it looks like diligence.

> **Scan to build a worklist, then read. The scanner is wrong far more often than the docs are.**

## Six gates now in CI

env vars (#486) · config keys (#487) · route paths (#488) · MCP tool classification (#490) · cited constants (#494) · seeded space defaults (#495)

🤖 Generated with [Claude Code](https://claude.com/claude-code)