### PR TITLE
feat(about): report which optional components are alive, without gating readiness on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -880,6 +880,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name, so nothing reads as "the default" when you look at the code. Both are now gated in both
   directions — change the seed or change the doc, either fails.
 
+- **The Instance panel can now tell you which optional components are actually alive.**
+  `GET /api/about/health` (admin) reports the render sidecars and the NLI judge with, for each, whether
+  it is configured, whether it is reachable, and what breaks when it is not. Until now "documents
+  stopped being extracted" and "the renderer container died" were the same screen.
+
+  **It reports; it does not gate.** `/ready` is the orchestration probe — a 503 there takes the
+  instance out of service — and it still depends on MongoDB and vector search alone. Everything in the
+  new endpoint is optional: the render sidecars are opt-in, the NLI judge ships with no endpoint and
+  its scanner is off by default. Folding any of them into readiness would let a dead render container
+  pull a healthy instance out of the load balancer, turning a degraded feature into an outage. A test
+  asserts `ready.ts` never references them, because that is a change someone would make in good faith.
+
+  Two smaller distinctions the summary keeps: a component nobody configured is not a fault (otherwise
+  the panel is permanently yellow, and a warning that is always on is one nobody reads), and a probe
+  that could not run reports `unknown` rather than `degraded` — "we could not check" and "it is broken"
+  want different responses. Mutation-proven 7/7.
+
 - **The pre-release documentation audit is complete.** Seven classes swept: environment variables,
   config keys, route paths, the MCP tool split, default values, restart/reload semantics, and
   failure-behaviour claims. Three real errors found — offsite backup retention (silently deleting

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -271,6 +271,21 @@ GET /api/about/security      # admin token
 → { "checks": [ { "id": "transport.tls", "level": "warn", "message": "…" }, … ], "worst": "warn", "strict": false }
 ```
 
+**Component liveness** is a separate, admin-only endpoint:
+
+```http
+GET /api/about/health        # admin token
+→ { "level": "degraded", "down": ["doc-render"], "components": [ { "id": "doc-render", "configured": true, "reachable": false, "impact": "…" }, … ] }
+```
+
+`level` is `ok`, `degraded`, or `unknown`, and it is **reporting, never gating**:
+
+- Everything probed here is **optional** — the render sidecars are opt-in, and the NLI judge ships with no endpoint at all. A component the operator never configured reports `configured: false` and does **not** count as a fault; otherwise the panel would be permanently yellow.
+- A configured component that is unreachable is `degraded`, never "down". It degrades a feature, it does not stop the instance serving.
+- `reachable: null` means the probe could not run, which is reported as `unknown` rather than folded into `degraded` — "we could not check" and "it is broken" want different responses.
+
+**This is not `/ready`.** `/ready` is the orchestration probe and gates on MongoDB and vector search only. Adding an optional sidecar to it would let a dead render container pull a healthy instance out of the load balancer — turning a degraded feature into an outage.
+
 Levels are `pass` / `warn` / `fail` (`fail` = actively broken, e.g. `requireEncryptedTransport` on without
 `trustProxy`, so requests would 403). Set **`security.strict`** (config) or **`YTHRIL_SECURITY_STRICT=true`**
 to make any `fail` finding abort boot — the aggregate "don't start if misconfigured" switch, on top of the

--- a/server/src/api/about.ts
+++ b/server/src/api/about.ts
@@ -5,7 +5,9 @@ import path from 'node:path';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { requireAuth, requireAdmin } from '../auth/middleware.js';
 import { mintSseTicket } from '../auth/sse-ticket.js';
-import { getConfig } from '../config/loader.js';
+import { getConfig, getDocumentProcessingConfig, getMediaEmbeddingConfig } from '../config/loader.js';
+import { isRenderAvailable, isOfficeRenderAvailable } from '../files/converters/renderer.js';
+import { summariseHealth } from './health-summary.js';
 import { getMongo } from '../db/mongo.js';
 import { getLogLines, subscribeLogLines } from '../util/log.js';
 import { computeSecurityPosture, securityStrict } from '../config/security-posture.js';
@@ -93,6 +95,52 @@ aboutRouter.get('/', async (_req, res) => {
 aboutRouter.get('/logs', requireAdmin, (_req, res) => {
   const lines = Math.min(Math.max(1, Number(_req.query['lines']) || 200), 1000);
   res.json({ lines: getLogLines(lines) });
+});
+
+// Component liveness for the Instance panel (F9 follow-up). Admin-only: it names which optional
+// services an instance is wired to, which is deployment shape.
+//
+// NOT part of `/ready`, deliberately — see health-summary.ts. Everything probed here is optional, and
+// a dead render sidecar must degrade a feature, not pull a healthy instance out of the load balancer.
+aboutRouter.get('/health', requireAdmin, async (_req, res) => {
+  const docCfg = getDocumentProcessingConfig();
+  // The NLI judge is a media-embedding PROVIDER (same shape as vision/stt), not a field on the
+  // contradiction-scanner block — the scanner consumes it but does not own it.
+  const nli = getMediaEmbeddingConfig().nli;
+
+  // Each probe is already cached and timeout-bounded at its source, so this route cannot hang on a
+  // sidecar that accepts connections and never answers.
+  const [render, office] = await Promise.all([
+    isRenderAvailable().catch(() => false),
+    isOfficeRenderAvailable().catch(() => false),
+  ]);
+
+  const renderWanted = docCfg.mode !== 'off';
+  const components = [
+    {
+      id: 'doc-render',
+      label: 'Document renderer',
+      configured: renderWanted,
+      reachable: renderWanted ? render : null,
+      impact: 'PDFs fall back to plain text extraction — no page images, so no VLM or OCR route.',
+    },
+    {
+      id: 'doc-office',
+      label: 'Office renderer',
+      configured: renderWanted,
+      reachable: renderWanted ? office : null,
+      impact: 'Office formats (docx, pptx, xlsx…) cannot be rasterised; they fall back to text.',
+    },
+    {
+      id: 'nli',
+      label: 'Contradiction judge (NLI)',
+      configured: !!nli?.baseUrl,
+      reachable: null,   // no cheap liveness probe — the endpoint shape varies by provider
+      impact: 'Contradiction findings stay at the structured pass; the NLI cursor parks.',
+    },
+  ];
+
+  res.json(summariseHealth(components));
 });
 
 // Security posture report (PR-S3). Admin-only — reveals the instance's security configuration.

--- a/server/src/api/health-summary.ts
+++ b/server/src/api/health-summary.ts
@@ -1,0 +1,71 @@
+/**
+ * Component liveness for the Instance panel — reported, never gating.
+ *
+ * F9 follow-up: the Overview showed that an instance was up, but not whether the pieces it delegates
+ * to are. "Documents stopped being extracted" and "the renderer container died" were the same screen.
+ *
+ * ── Why this is separate from /ready, and must stay separate ────────────────────────────────────
+ *
+ * `/ready` is an ORCHESTRATION probe. A 503 there tells Kubernetes or Docker to take the instance out
+ * of service, so only things that make the instance genuinely unable to serve belong in it — MongoDB,
+ * and the vector index the brain depends on.
+ *
+ * Every component below is OPTIONAL. The render sidecars are opt-in; the NLI judge ships with no
+ * endpoint at all and the contradiction scanner is off by default. An instance without any of them
+ * works perfectly for everything else it does. Folding them into `/ready` would mean a dead
+ * doc-render container pulling a healthy instance out of the load balancer — turning a degraded
+ * feature into an outage, which is a far worse failure than the one it reports.
+ *
+ * So this answers a different question: not "should traffic reach this instance" but "which parts are
+ * currently working". The two must not be conflated, and the summary below is the shape of that
+ * distinction rather than a rollup of booleans.
+ */
+
+/** One probed component. `configured: false` means the operator never asked for it. */
+export interface ComponentHealth {
+  /** Stable id the UI keys off. */
+  id: string;
+  /** Human label for the panel. */
+  label: string;
+  /** Whether this instance is set up to use it at all. */
+  configured: boolean;
+  /** Reachability. `null` when not configured — absence of a probe, not a failed one. */
+  reachable: boolean | null;
+  /** Why it matters, shown when it is down. */
+  impact: string;
+}
+
+export type HealthLevel = 'ok' | 'degraded' | 'unknown';
+
+export interface HealthSummary {
+  level: HealthLevel;
+  components: ComponentHealth[];
+  /** Ids of configured components that are not reachable. Empty when level is 'ok'. */
+  down: string[];
+}
+
+/**
+ * Roll component probes into one level.
+ *
+ * The rules, and each exists because the naive version is misleading:
+ *
+ *   - a component the operator never configured is NOT a problem. Reporting "degraded" because an
+ *     optional sidecar nobody wanted is absent would make the panel permanently yellow, and a warning
+ *     that is always on is one nobody reads.
+ *   - a configured component that is unreachable IS degraded — never "down". Nothing here can take the
+ *     instance out of service, and saying "down" invites someone to treat it as an outage.
+ *   - no components configured at all is `ok`, not `unknown`: a plain instance with no sidecars is a
+ *     supported, healthy configuration, not an unknown one.
+ */
+export function summariseHealth(components: readonly ComponentHealth[]): HealthSummary {
+  const down = components
+    .filter(c => c.configured && c.reachable === false)
+    .map(c => c.id);
+
+  // `unknown` is reserved for a configured component whose probe could not run at all — distinct from
+  // one that ran and failed, because "we could not check" and "it is broken" want different responses.
+  const unprobed = components.some(c => c.configured && c.reachable === null);
+
+  const level: HealthLevel = down.length > 0 ? 'degraded' : unprobed ? 'unknown' : 'ok';
+  return { level, components: [...components], down };
+}

--- a/testing/standalone/health-summary.test.js
+++ b/testing/standalone/health-summary.test.js
@@ -1,0 +1,129 @@
+/**
+ * Component liveness reporting — and the line between "report" and "gate".
+ *
+ * F9 follow-up. The Overview could tell you an instance was up but not whether the pieces it delegates
+ * to were, so "documents stopped being extracted" and "the renderer container died" looked identical.
+ *
+ * ── The distinction these tests exist to protect ────────────────────────────────────────────────
+ *
+ * `/ready` is an ORCHESTRATION probe: a 503 there takes the instance out of service. Every component
+ * reported here is OPTIONAL — the render sidecars are opt-in, the NLI judge ships with no endpoint at
+ * all and its scanner is off by default. Folding any of them into readiness would mean a dead
+ * doc-render container pulling a healthy instance out of the load balancer, turning a degraded feature
+ * into an outage.
+ *
+ * So the summary must never produce a level that reads as "take this instance down", and an
+ * unconfigured component must never read as a fault. A warning that is always on is one nobody reads.
+ *
+ * Run: node --test testing/standalone/health-summary.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let summariseHealth;
+before(async () => {
+  ({ summariseHealth } = await import('../../server/dist/api/health-summary.js'));
+});
+
+const comp = (over = {}) => ({
+  id: 'doc-render', label: 'Document renderer',
+  configured: true, reachable: true, impact: 'x', ...over,
+});
+
+describe('rolling component probes into a level', () => {
+  it('is ok when everything configured is reachable', () => {
+    const s = summariseHealth([comp(), comp({ id: 'doc-office' })]);
+    assert.equal(s.level, 'ok');
+    assert.deepEqual(s.down, []);
+  });
+
+  it('is ok — not degraded — when nothing is configured at all', () => {
+    // A plain instance with no sidecars is a SUPPORTED configuration, not a broken one. Reporting
+    // degraded here would make the panel permanently yellow, and a warning that is always on is one
+    // nobody reads.
+    const s = summariseHealth([
+      comp({ configured: false, reachable: null }),
+      comp({ id: 'nli', configured: false, reachable: null }),
+    ]);
+    assert.equal(s.level, 'ok');
+  });
+
+  it('is degraded — never "down" — when a configured component is unreachable', () => {
+    // Nothing here can take the instance out of service. Calling it "down" invites someone to treat a
+    // degraded feature as an outage.
+    const s = summariseHealth([comp({ reachable: false })]);
+    assert.equal(s.level, 'degraded');
+    assert.notEqual(s.level, 'down');
+    assert.deepEqual(s.down, ['doc-render']);
+  });
+
+  it('names every component that is down, not just the first', () => {
+    const s = summariseHealth([
+      comp({ id: 'doc-render', reachable: false }),
+      comp({ id: 'doc-office', reachable: false }),
+      comp({ id: 'nli', reachable: true }),
+    ]);
+    assert.deepEqual(s.down.sort(), ['doc-office', 'doc-render']);
+  });
+
+  it('ignores an UNCONFIGURED component even when its probe says false', () => {
+    // The probe result is meaningless for something the operator never asked for; `configured` is what
+    // decides whether the answer matters.
+    const s = summariseHealth([comp({ configured: false, reachable: false })]);
+    assert.equal(s.level, 'ok');
+    assert.deepEqual(s.down, []);
+  });
+
+  it('distinguishes "could not check" from "checked and failed"', () => {
+    // Configured but unprobed is `unknown` — those want different responses, and collapsing them would
+    // either hide a real failure or invent one.
+    const s = summariseHealth([comp({ reachable: null })]);
+    assert.equal(s.level, 'unknown');
+    assert.deepEqual(s.down, [], 'an unprobed component is not a failure');
+  });
+
+  it('a real failure outranks an unprobed one', () => {
+    const s = summariseHealth([comp({ reachable: null }), comp({ id: 'doc-office', reachable: false })]);
+    assert.equal(s.level, 'degraded');
+  });
+
+  it('handles an empty component list', () => {
+    assert.deepEqual(summariseHealth([]), { level: 'ok', components: [], down: [] });
+  });
+
+  it('does not alias the caller\'s array', () => {
+    const input = [comp()];
+    const s = summariseHealth(input);
+    assert.notEqual(s.components, input);
+  });
+});
+
+describe('the reporting/gating boundary', () => {
+  const ready = readFileSync(new URL('../../server/src/ready.ts', import.meta.url), 'utf8');
+  const about = readFileSync(new URL('../../server/src/api/about.ts', import.meta.url), 'utf8');
+
+  it('readiness still gates on mongodb and vectorSearch ONLY', () => {
+    // The regression this guards: someone adds a sidecar to `ready` because it seems more complete,
+    // and a dead optional container starts pulling healthy instances out of the load balancer.
+    assert.match(ready, /ready:\s*mongodb\.status === 'ok' && vectorSearch\.status === 'ok'/,
+      'readiness must not depend on any optional component');
+    for (const optional of ['isRenderAvailable', 'isOfficeRenderAvailable', 'summariseHealth']) {
+      assert.equal(ready.includes(optional), false,
+        `ready.ts must not reference ${optional} — optional components report, they do not gate`);
+    }
+  });
+
+  it('the health route is admin-only', () => {
+    // It names which optional services an instance is wired to, which is deployment shape.
+    assert.match(about, /aboutRouter\.get\('\/health', requireAdmin/);
+  });
+
+  it('sidecar probes cannot hang the route', () => {
+    // Both probes are cached and timeout-bounded at source; the route additionally swallows a rejection
+    // so one failing probe cannot 500 the panel.
+    assert.match(about, /isRenderAvailable\(\)\.catch\(\(\) => false\)/);
+    assert.match(about, /isOfficeRenderAvailable\(\)\.catch\(\(\) => false\)/);
+  });
+});


### PR DESCRIPTION
F9 follow-up. The Overview could tell you an instance was up, but not whether the pieces it delegates to were — so *"documents stopped being extracted"* and *"the renderer container died"* looked identical from the panel.

`GET /api/about/health` (admin) reports the render sidecars and the NLI judge with, for each: **configured**, **reachable**, and **what breaks** when it isn't.

## It reports. It does not gate.

`/ready` is the **orchestration** probe — a 503 there tells Kubernetes or Docker to pull the instance out of service. It still depends on MongoDB and vector search alone, deliberately.

Everything in the new endpoint is **optional**: render sidecars are opt-in, the NLI judge ships with no endpoint and its scanner is off by default. An instance without any of them works fine for everything else. Folding one into `/ready` would mean **a dead doc-render container pulling a healthy instance out of the load balancer** — turning a degraded feature into an outage, a far worse failure than the one it reports.

A test asserts `ready.ts` never references the optional probes, because adding one is a change someone would make in good faith while tidying. Mutating exactly that is one of the seven kills.

## Two distinctions that keep the panel worth reading

- **A component nobody configured is not a fault.** Reporting `degraded` for an optional sidecar the operator never wanted makes the panel permanently yellow — and a warning that's always on is one nobody reads.
- **A probe that couldn't run reports `unknown`, not `degraded`.** "We couldn't check" and "it's broken" want different responses; collapsing them either hides a real failure or invents one.

Sidecar probes are already cached and timeout-bounded at source, and the route swallows a rejection, so one failing probe can't hang or 500 the panel.

## Mutation-proven 7/7

unconfigured counted as down · `degraded` renamed to `down` · unprobed collapsed into degraded · summary aliasing the caller's array · **a sidecar folded into readiness** · health route losing its admin guard · a failing probe able to 500 the panel

## Scope

**Server + docs only — the UI panel is not wired yet**, and it's tracked as such. The endpoint is the hard part (that boundary); the panel is presentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)