### PR TITLE
fix(about): match the Components card header to its siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,6 +897,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now "all of them, it takes seconds". Verified by reintroducing the blank-icon regression and
   confirming preflight fails on it and says why.
 
+- **The Components card header now matches its siblings.** Browser-verified after shipping: the card
+  purpose wrapped to four lines where Instance and System use a single short phrase, leaving the icon
+  and pill visibly misaligned and the card taller than its neighbours. Shortened to match. Also
+  confirmed in the DOM what no unit test can see — the card icon resolves to a real 18x18 glyph rather
+  than the empty string an unregistered name produces, which is the defect that turned CI red earlier
+  in this release.
+
 - **The About page now shows that component liveness, closing the loop on the endpoint above.** A
   Components card lists each optional service with its state, and — only when something is actually
   down — what breaks while it is. Printing the consequence beside a healthy component turns the panel

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -562,7 +562,7 @@
   "about.disk.critical": "Kritisch",
   "about.error.load": "Instanzinformationen konnten nicht geladen werden",
   "about.card.components": "Komponenten",
-  "about.card.componentsDesc": "Optionale Dienste, die diese Instanz nutzt. Nur zur Anzeige — keiner beeinflusst die Bereitschaft.",
+  "about.card.componentsDesc": "Optionale Dienste und ihr Status.",
   "about.health.ok": "Alle erreichbar",
   "about.health.degraded": "Beeinträchtigt",
   "about.health.unknown": "Unbekannt",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -562,7 +562,7 @@
   "about.disk.critical": "Critical",
   "about.error.load": "Couldn't load instance info",
   "about.card.components": "Components",
-  "about.card.componentsDesc": "Optional services this instance delegates to. Reporting only — none of these affect readiness.",
+  "about.card.componentsDesc": "Optional services and their status.",
   "about.health.ok": "All reachable",
   "about.health.degraded": "Degraded",
   "about.health.unknown": "Unknown",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -562,7 +562,7 @@
   "about.disk.critical": "Krytyczny",
   "about.error.load": "Nie udało się wczytać informacji o instancji",
   "about.card.components": "Komponenty",
-  "about.card.componentsDesc": "Opcjonalne usługi, z których korzysta ta instancja. Tylko informacyjnie — żadna nie wpływa na gotowość.",
+  "about.card.componentsDesc": "Opcjonalne usługi i ich stan.",
   "about.health.ok": "Wszystkie dostępne",
   "about.health.degraded": "Ograniczona sprawność",
   "about.health.unknown": "Nieznany",


### PR DESCRIPTION
Found by **looking at the page after shipping it** — the only way this class of defect surfaces.

The card's purpose text wrapped to **four lines** where Instance and System use a single short phrase, leaving the icon and status pill visibly misaligned and the card taller than its neighbours. Every test passed; nothing about it is a functional failure.

Shortened to *"Optional services and their status."* — matches the sibling style, header settles to two lines, card heights align.

## Where the nuance went

The "reporting only, never gates readiness" point moves out of the card and stays where it belongs: the integration guide, and the pill wording itself. **"Degraded" already says this isn't an outage**, and the impact line under a failing component says what it costs. Four lines of reassurance in a card header was paying for that twice.

## What else the browser check confirmed

- **The card icon resolves to a real 18×18 SVG with a path** — not the empty string an unregistered name produces. That's the exact defect that turned CI red earlier in this release (#499), now checked by looking rather than assumed.
- All three states render distinctly: `Reachable` / `Unreachable` / `Not configured`
- The impact line appears on the failing component **and only that one**
- No untranslated keys leak through in any locale
- Console clean

`npm run preflight` green — run unconditionally, which is the point of having added it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)