### PR TITLE
fix(data): build the summary strip only once translations have loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2164,6 +2164,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Data page built its summary labels before translations had loaded.** `summaryItems` is a
+  `computed` that calls `transloco.translate()` imperatively — and a computed memoises on its SIGNAL
+  dependencies, which "the language file finished loading" is not. So it evaluated during the first
+  render, got raw keys back, logged three `Missing translation key` errors, and never re-ran to
+  correct itself.
+
+  It looked fine only by luck: `backups()` and `backupConfig()` land after their HTTP calls, which
+  happens to be after translations load, forcing a re-evaluation. Reorder or remove those loads and the
+  strip would read `data.summary.backups` permanently. Readiness is now a real dependency, and it asks
+  whether the active language has been LOADED rather than whether it has content — an empty-but-loaded
+  dictionary is legitimate, and the first attempt at this fix blanked the strip on exactly that.
+
+  Found by a pre-release sweep of 16 routes looking for defects that pass every test. Verified in a
+  browser: three console errors before, zero after, on both a direct navigation and a re-navigation.
+  The unit tests deliberately do NOT claim to cover it — TestBed preloads translations synchronously so
+  the timing defect cannot occur there, and mutation confirms that deleting the fix leaves them green.
+  What they do guard is the blank-strip regression.
+
+- **The client test suite could fail at random.** Two different specs were measured at 5063ms and
+  5729ms against Vitest's 5000ms default — each passing alone, failing intermittently in a full run,
+  and never the same test twice. These are Angular TestBed specs running across 71 parallel forks: the
+  ceiling was wrong, not the tests. Raised to 20s, after which three consecutive full runs were clean.
+  It matters more now that `npm run preflight` asks every push to run this suite — a gate that fails at
+  random is one people stop trusting, and then stop running.
+
 - **An invite could advertise a `publicUrl` and space list that were already out of date when it was
   printed.** `POST /api/invite/generate` snapshots config on entry, then generates an RSA-4096 key pair
   and bcrypt-hashes the handshake id — both deliberately slow — before building its response from that

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -228,6 +228,9 @@ describe('FileManagerComponent (OnPush)', () => {
     expect(table.rows[1]).toEqual(['Bob', '25']);
     expect(table.note).toBeNull(); // small sheet → not truncated
   });
+  // ^ One of the two specs that exposed the suite-wide timeout ceiling: it imports `exceljs` twice
+  // (here for the fixture workbook, and again inside `renderXlsx`), so it runs long under a full
+  // parallel run. No per-test override needed — `testTimeout` in vitest.config.ts covers the class.
 
   it('toggles the full-screen preview overlay; Escape collapses it before closing the pane', () => {
     const fixture = create([fileEntry('doc.md')]);

--- a/client/src/app/pages/settings/data.component.spec.ts
+++ b/client/src/app/pages/settings/data.component.spec.ts
@@ -260,3 +260,85 @@ describe('DataComponent — API flows and error fallbacks', () => {
     expect(startMigration).not.toHaveBeenCalled();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+// Summary strip vs translation loading
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('DataComponent — the summary strip waits for translations', () => {
+  /**
+   * `summaryItems` is a computed that translates IMPERATIVELY. A computed memoises on its signal
+   * dependencies, and `transloco.translate()` is not one — so without care it evaluates during the
+   * first render, before the language file resolves, logs "Missing translation key" and bakes the raw
+   * key into the label, then never re-runs to correct it.
+   *
+   * On the real page that was invisible: `backups()` and `backupConfig()` land after their HTTP calls,
+   * which happens to be after translations load, so the strip re-evaluated and looked right. It was
+   * correct by luck, and three console errors said so.
+   *
+   * ── What these tests do and do NOT cover ──────────────────────────────────────────────────────
+   *
+   * They do NOT reproduce the timing defect. `TranslocoTestingModule` preloads synchronously
+   * (`preloadLangs: true`), so `translate()` works on the first evaluation and the bug cannot occur
+   * here. Mutation confirms it: deleting the readiness guard entirely leaves every test below green.
+   *
+   * The fix is verified in a BROWSER — three `Missing translation key` console errors before, zero
+   * after, on both a direct navigation and a re-navigation.
+   *
+   * What these tests DO guard is the regression the fix could introduce: gating on readiness must not
+   * blank the strip. The first attempt required a non-empty dictionary and did exactly that, and the
+   * mutation for it is caught below. That is worth having — it is just not coverage of the defect.
+   */
+  it('produces items at all — the loop below is worthless on an empty array', () => {
+    // Asserted separately and FIRST because the original version of the next test iterated the labels
+    // and passed vacuously while the strip was empty. A per-item assertion over zero items proves
+    // nothing, which is the same shape as a green test over deleted code.
+    const { c, fixture } = make();
+    fixture.detectChanges();
+    expect(c.summaryItems().length).toBeGreaterThan(0);
+  });
+
+  it('renders resolved labels when a dictionary is present', () => {
+    // The default harness deliberately ships an EMPTY `en` and echoes unknown keys, so a raw key there
+    // is correct behaviour rather than the defect — asserting against it would fail for the wrong
+    // reason. Give it a real dictionary and the assertion becomes meaningful.
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [DataComponent, getTranslocoModule({
+        translation: { en: { 'data.summary.database': 'Database', 'data.summary.backups': 'Backups' } },
+      })],
+      providers: [
+        { provide: AdminApi, useValue: makeAdmin() },
+        { provide: ConfirmDialogService, useValue: { confirm: vi.fn().mockResolvedValue(true) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(DataComponent);
+    fixture.detectChanges();
+
+    const labels = fixture.componentInstance.summaryItems().map(i => String(i.label));
+    expect(labels.length).toBeGreaterThan(0);
+    // Only the keys supplied above can resolve — the harness echoes the rest, correctly. Asserting
+    // "no raw keys at all" would mean mirroring the whole dictionary here, which rots on every copy
+    // edit and would fail for a reason that has nothing to do with this defect.
+    expect(labels).toContain('Backups');
+    expect(labels).toContain('Database');
+  });
+
+  it('still renders when translations were ALREADY loaded before the component mounted', () => {
+    // The regression the first attempt at this fix would have caused. `events$` does not replay, so a
+    // check that waited only for the load EVENT would leave a component mounted after that event with
+    // an empty strip forever — worse than the bug being fixed. The synchronous `getTranslation()` half
+    // is what covers it, and in TestBed translations are already present, which is exactly this case.
+    const { c, fixture } = make();
+    fixture.detectChanges();
+    expect(c.summaryItems().length, 'the strip must not be empty when translations pre-exist').toBeGreaterThan(0);
+  });
+
+  it('reports the backup count from the loaded backups', () => {
+    // Guards that gating on translations did not also gate away the data.
+    const { c, fixture } = make();
+    fixture.detectChanges();
+    const backupItem = c.summaryItems().find(i => String(i.label).toLowerCase().includes('backup'));
+    expect(backupItem, 'a backups item should be present').toBeTruthy();
+  });
+});

--- a/client/src/app/pages/settings/data.component.ts
+++ b/client/src/app/pages/settings/data.component.ts
@@ -1,4 +1,6 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { AdminApi } from '../../core/admin-api.service';
@@ -291,8 +293,47 @@ export class DataComponent implements OnInit {
   /** The most-recent backup id, for the "Latest" marker (backups come newest-first from the API). */
   latestBackupId = computed(() => this.backups()[0]?.id ?? null);
 
+  /**
+   * Flips whenever a translation file finishes loading.
+   *
+   * `computed` memoises on its SIGNAL dependencies, and `transloco.translate()` is not one — it is a
+   * plain method call. So a computed that translates imperatively evaluates once during the first
+   * render, BEFORE the language file has resolved, gets the raw key back (Transloco logs
+   * "Missing translation key"), and then never re-runs to pick up the real string.
+   *
+   * That was not visible here only by luck: `backups()` and `backupConfig()` land after their HTTP
+   * calls, which happens to be after translations load, so the strip re-evaluated and looked correct.
+   * Remove or reorder those loads and the labels would read `data.summary.backups` permanently.
+   *
+   * Reading this signal inside the computed makes "translations arrived" a real dependency.
+   */
+  private translationLoad = toSignal(
+    this.transloco.events$.pipe(filter(e => e.type === 'translationLoadSuccess')),
+    { initialValue: null },
+  );
+
+  /**
+   * Are translations actually available to `translate()` right now?
+   *
+   * Both halves are needed. `events$` does NOT replay, so a component mounted after the language file
+   * already loaded would never see the event and — if that were the only check — would render an empty
+   * strip forever, which is a worse bug than the one being fixed. `getTranslation()` is synchronous and
+   * covers exactly that case; the signal covers the first-load case and supplies the reactivity.
+   */
+  private translationsReady = computed<boolean>(() => {
+    this.translationLoad();   // dependency, not a value
+    // Ask whether the active language has been LOADED, not whether it has content. An empty-but-loaded
+    // dictionary is a legitimate state — the spec harness uses exactly that, and so would a minimal
+    // locale — and treating it as "not ready" would blank the strip permanently.
+    return this.transloco.getTranslation().has(this.transloco.getActiveLang());
+  });
+
   /** Operator overview strip: DB source, maintenance state, backup count, and the saved schedule. */
   summaryItems = computed<SummaryItem[]>(() => {
+    // Render nothing rather than translate too early. Calling `translate()` before the language file
+    // resolves logs "Missing translation key" and bakes the raw key into the label; an empty strip for
+    // one frame is honest, since the data behind it has not loaded either.
+    if (!this.translationsReady()) return [];
     const t = (k: string) => this.transloco.translate(k);
     const items: SummaryItem[] = [];
     const src = this.uriSource();

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -16,6 +16,20 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['src/test-setup.ts'],
     include: ['src/**/*.spec.ts'],
+    // Vitest's 5s default is tuned for plain unit tests. These are Angular TestBed specs: creating a
+    // component compiles it, builds an injector and renders into jsdom, and 71 spec files run in
+    // parallel forks contending for CPU. Individual tests were measured at 5063ms and 5729ms against
+    // that 5000ms ceiling — passing alone, failing at random in a full run, and never the same test
+    // twice.
+    //
+    // Raised rather than chased test-by-test: two different specs tipped over on consecutive runs, so
+    // it is the ceiling that is wrong, not the tests. This matters more since `npm run preflight`
+    // asks every push to run this suite — a gate that fails at random is one people stop trusting,
+    // and then stop running.
+    //
+    // The cost is that a genuinely hung test now takes 20s to report instead of 5s. The suite
+    // completes in ~9s when healthy, so that is a rare price for a stable signal.
+    testTimeout: 20_000,
     // Default per-file isolation (each spec file in its own fork) — so each file gets a fresh
     // Angular test platform and TestBed. A shared/single fork instead leaked TestBed state
     // between files (a component created by one file broke the next) and double-created the


### PR DESCRIPTION
Found by a **pre-release sweep of 16 routes** looking for the class of defect that passes every test.

`summaryItems` is a `computed` calling `transloco.translate()` imperatively. A computed memoises on its **signal** dependencies — and "the language file finished loading" isn't one. So it evaluated during the first render, got raw keys back, logged three `Missing translation key` errors, and never re-ran to correct itself.

**It looked fine only by luck.** `backups()` and `backupConfig()` land after their HTTP calls, which happens to be after translations load, forcing a re-evaluation. Reorder or remove those loads and the strip reads `data.summary.backups` permanently.

## The first attempt at this fix was worse than the bug

Gating on the `translationLoadSuccess` **event alone** looked right and was wrong: `events$` doesn't replay, so a component mounted after that event never sees it — **empty strip forever**.

Readiness now asks whether the active language has been *loaded*, via the synchronous `getTranslation()` map, with the event supplying reactivity for first load.

A second wrong turn worth recording: the check first required a **non-empty** dictionary. An empty-but-loaded dictionary is legitimate — the spec harness ships exactly that — and requiring content blanked the strip. *"Loaded"* and *"has content"* are different questions.

## What the tests do and don't cover

**They do not cover the timing defect, and they say so.** `TranslocoTestingModule` preloads synchronously, so the bug can't occur in TestBed — mutation confirms it: deleting the readiness guard leaves every test green.

The fix is **browser-verified**: three console errors before, zero after, on both a direct navigation and a re-navigation. What the tests *do* guard is the blank-strip regression above, which mutation does kill.

## Plus the flakiness that would have undermined the new gate

Chasing this surfaced that the client suite **fails at random**: two different specs at **5063ms** and **5729ms** against Vitest's 5000ms default — each passing alone, failing intermittently in a full run, never the same test twice. Angular TestBed specs across 71 parallel forks; the ceiling is wrong, not the tests. Raised to 20s, three consecutive clean runs.

Not a tangent: #500 asks every push to run this suite via `npm run preflight`. **A gate that fails at random is one people stop trusting, and then stop running.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)