### PR TITLE
refactor(graph): reuse Brain's record drawer instead of a drifted fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Graph tab now uses the same record drawer as the rest of Brain, instead of its own copy.**
+  Editing a memory or chrono entry from the graph's detail panel opened a drawer that had been forked
+  from Brain's and then left behind: no schema-defined property fields, no `confidence` on chrono
+  entries, no tag suggestions (it passed an empty list), no memory picker, and its own copy of the
+  entity-picker flyout that was retired everywhere else. Nothing about it looked broken — it simply
+  offered less than the identical-looking drawer one tab over, and every improvement made to the real
+  one since the fork had silently skipped it.
+
+  The forked drawer is gone: **300 lines** out of `graph.component.ts` (1231 → 931, of which ~175 were
+  inline template) and **70 lines** of now-unreachable styles. The page renders `<app-record-drawer />`
+  and provides the same collaborators Brain does, so it gains all of the above and cannot drift again.
+  It also now *looks* the same: editing from the graph opens the familiar right-side drawer rather
+  than the fork's centred modal.
+
+  One addition made the reuse possible: `RecordDrawerState` now announces a successful save on a
+  `lastSaved` signal. Saving already patched the shared record lists, which is all Brain needs — but
+  the Graph tab renders its own per-node arrays, so without the announcement a save would succeed and
+  leave the pre-save row on screen. All 45 graph characterization tests pass with their assertions
+  untouched.
+
 - **File-conflict handling in sync is now a tested unit, including the peer-controlled filename.**
   Slice 2b of the sync/engine split — which had been written off as thin returns, wrongly. Two pure
   decisions came out of `syncFiles`, and both had a quiet failure mode.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -490,8 +490,6 @@
   "graph.panel.noLinkedMemories": "Keine verknüpften Erinnerungen",
   "graph.panel.noLinkedChrono": "Kein verknüpfter Chrono",
   "graph.panel.loading": "Laden…",
-  "graph.drawer.badge.memory": "Erinnerung",
-  "graph.drawer.badge.chrono": "Chrono",
   "graph.drawer.badge.edge": "Rand",
   "files.newFolder": "+ Neuer Ordner",
   "files.newFolderPlaceholder": "Ordnername",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -490,8 +490,6 @@
   "graph.panel.noLinkedMemories": "No linked memories",
   "graph.panel.noLinkedChrono": "No linked chrono",
   "graph.panel.loading": "Loading…",
-  "graph.drawer.badge.memory": "memory",
-  "graph.drawer.badge.chrono": "chrono",
   "graph.drawer.badge.edge": "edge",
   "files.newFolder": "+ New folder",
   "files.newFolderPlaceholder": "Folder name",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -490,8 +490,6 @@
   "graph.panel.noLinkedMemories": "Żadnych powiązanych wspomnień",
   "graph.panel.noLinkedChrono": "Brak połączonego chronometrażu",
   "graph.panel.loading": "Załadunek…",
-  "graph.drawer.badge.memory": "pamięć",
-  "graph.drawer.badge.chrono": "chrono",
   "graph.drawer.badge.edge": "krawędź",
   "files.newFolder": "+ Nowy folder",
   "files.newFolderPlaceholder": "Nazwa folderu",

--- a/client/src/app/pages/brain/record-drawer-state.service.spec.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * RecordDrawerState — the `lastSaved` announcement.
+ *
+ * `save()` patches the `BrainStore` lists, which is everything the Brain page needs. The Graph page
+ * embeds the same drawer but renders its OWN per-node arrays, which the store never sees, so it
+ * reads `lastSaved` to patch them. That makes the announcement load-bearing for a consumer in a
+ * different folder — exactly the kind of cross-page contract that rots silently: delete the
+ * `lastSaved.set` line and the Brain page is entirely unaffected, while the Graph page starts
+ * leaving the pre-save row on screen after a successful save, with no error anywhere.
+ *
+ * Mutation-checked: removing either `lastSaved.set` call below fails this spec.
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { of } from 'rxjs';
+import { BrainApi } from '../../core/brain-api.service';
+import { BrainStore } from './brain-store.service';
+import { EntityRefPicker } from './entity-ref-picker.service';
+import { RecordDrawerState } from './record-drawer-state.service';
+
+function makeApi() {
+  return {
+    getEntitiesByIds: () => of({ entities: [] }),
+    getMemory: () => of({}),
+    updateMemory: (_s: string, id: string, body: any) => of({ _id: id, ...body, updatedAt: 'saved' }),
+    updateChrono: (_s: string, id: string, body: any) => of({ _id: id, ...body, updatedAt: 'saved' }),
+  } as any;
+}
+
+describe('RecordDrawerState — lastSaved', () => {
+  function create(): RecordDrawerState {
+    TestBed.configureTestingModule({
+      providers: [RecordDrawerState, BrainStore, EntityRefPicker, { provide: BrainApi, useValue: makeApi() }],
+    });
+    const state = TestBed.inject(RecordDrawerState);
+    state.spaceId.set('work');
+    return state;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('starts with nothing announced', () => {
+    expect(create().lastSaved()).toBeNull();
+  });
+
+  it('announces the SERVER copy of a saved memory, not the local edit model', () => {
+    const state = create();
+    state.open('memory', { _id: 'm1', fact: 'before', tags: [], entityIds: [], properties: {} });
+    state.drawerEditMemory.fact = 'after';
+
+    state.save();
+
+    const saved = state.lastSaved();
+    expect(saved?.kind).toBe('memory');
+    expect(saved?.record._id).toBe('m1');
+    expect(saved?.record.fact).toBe('after');
+    // The announced record is what the API returned — a consumer patching its own list with the edit
+    // model instead would drop every server-assigned field.
+    expect(saved?.record.updatedAt, 'the announced record must be the response, not the edit model').toBe('saved');
+  });
+
+  it('announces a saved chrono under its own kind', () => {
+    const state = create();
+    state.open('chrono', { _id: 'c1', title: 'before', type: 'event', status: 'upcoming', tags: [], entityIds: [], memoryIds: [], properties: {} });
+    state.drawerEditChrono.title = 'after';
+
+    state.save();
+
+    expect(state.lastSaved()?.kind).toBe('chrono');
+    expect(state.lastSaved()?.record.title).toBe('after');
+  });
+
+  it('announces nothing when the save fails', () => {
+    const state = create();
+    state.open('memory', { _id: 'm1', fact: 'before', tags: [], entityIds: [], properties: {} });
+    // A failing save must not announce: a consumer would otherwise patch its list with a record the
+    // server rejected, showing the edit as persisted.
+    (TestBed.inject(BrainApi) as any).updateMemory = () => ({
+      subscribe: (h: any) => h.error({ error: { error: 'nope' } }),
+    });
+
+    state.save();
+
+    expect(state.lastSaved()).toBeNull();
+    expect(state.drawerError()).toBeTruthy();
+  });
+});

--- a/client/src/app/pages/brain/record-drawer-state.service.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.ts
@@ -34,6 +34,17 @@ export class RecordDrawerState {
   drawerSaving = signal(false);
   drawerError = signal('');
 
+  /**
+   * The last record a `save()` persisted, for hosts that keep their OWN copies of records.
+   *
+   * `save()` already patches the `BrainStore` lists, which is all the brain page needs. The graph
+   * page holds per-node `nodeMemories`/`nodeChrono` arrays the store never sees, so without this it
+   * would save successfully and still show the stale row underneath — the silent-staleness shape.
+   * Deliberately a signal rather than a callback so a host reacts declaratively and one host cannot
+   * overwrite another's handler.
+   */
+  readonly lastSaved = signal<{ kind: 'memory' | 'entity' | 'edge' | 'chrono'; record: any } | null>(null);
+
   drawerEditMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEdge = { label: '', type: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
@@ -130,6 +141,7 @@ export class RecordDrawerState {
           this.drawerSaving.set(false);
           this.drawerRecord.set({ kind: 'memory', record: updated });
           this.store.memories.update(list => list.map(m => m._id === id ? updated : m));
+          this.lastSaved.set({ kind: 'memory', record: updated });
         },
         error: (err) => { this.drawerSaving.set(false); this.drawerError.set(fmtApiError(err, 'Failed to save')); },
       });
@@ -146,6 +158,7 @@ export class RecordDrawerState {
           this.drawerSaving.set(false);
           this.drawerRecord.set({ kind: 'entity', record: updated });
           this.store.entities.update(list => list.map(e => e._id === id ? updated : e));
+          this.lastSaved.set({ kind: 'entity', record: updated });
         },
         error: (err) => { this.drawerSaving.set(false); this.drawerError.set(fmtApiError(err, 'Failed to save')); },
       });
@@ -163,6 +176,7 @@ export class RecordDrawerState {
           this.drawerSaving.set(false);
           this.drawerRecord.set({ kind: 'edge', record: updated });
           this.store.edges.update(list => list.map(e => e._id === id ? updated : e));
+          this.lastSaved.set({ kind: 'edge', record: updated });
         },
         error: (err) => { this.drawerSaving.set(false); this.drawerError.set(fmtApiError(err, 'Failed to save')); },
       });
@@ -188,6 +202,7 @@ export class RecordDrawerState {
           this.drawerSaving.set(false);
           this.drawerRecord.set({ kind: 'chrono', record: updated });
           this.store.chrono.update(list => list.map(c => c._id === id ? updated : c));
+          this.lastSaved.set({ kind: 'chrono', record: updated });
         },
         error: (err) => { this.drawerSaving.set(false); this.drawerError.set(fmtApiError(err, 'Failed to save')); },
       });

--- a/client/src/app/pages/graph/graph.component.characterization.spec.ts
+++ b/client/src/app/pages/graph/graph.component.characterization.spec.ts
@@ -125,7 +125,9 @@ function create(brain: any = makeBrain()) {
   TestBed.configureTestingModule({
     imports: [GraphComponent, getTranslocoModule()],
     providers: [
-      { provide: SpacesApi, useValue: { listSpaces: () => of({ spaces: [] }) } },
+      // `getSpaceMeta` feeds the shared record drawer's property schema. Added to the stub, not to any
+      // assertion: every behaviour characterized below is unchanged by the drawer swap.
+      { provide: SpacesApi, useValue: { listSpaces: () => of({ spaces: [] }), getSpaceMeta: () => of({ typeSchemas: {} }) } },
       { provide: BrainApi, useValue: brain },
       { provide: AuthApi, useValue: { getMe: () => of({ readOnly: false }) } },
       { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } },

--- a/client/src/app/pages/graph/graph.component.spec.ts
+++ b/client/src/app/pages/graph/graph.component.spec.ts
@@ -26,12 +26,15 @@ import { SpacesApi } from '../../core/spaces-api.service';
 import { BrainApi } from '../../core/brain-api.service';
 import { AuthApi } from '../../core/auth-api.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
+import { RecordDrawerState } from '../brain/record-drawer-state.service';
 import { GraphComponent } from './graph.component';
 
 function makeApi() {
   return {
     getMe: () => of({ readOnly: false }),
     listSpaces: () => of({ spaces: [] }),
+    // The page feeds `BrainStore.spaceMeta` so the shared drawer's property editors get their schema.
+    getSpaceMeta: () => of({ typeSchemas: {} }),
   } as any;
 }
 
@@ -84,10 +87,14 @@ describe('GraphComponent (OnPush)', () => {
     expect(fixture.nativeElement.querySelector('.side-panel')).toBeNull();
   });
 
-  it('opens the brain drawer and renders its plain (non-signal) form model', () => {
-    // Same load-bearing coupling as brain: openBrainDrawer writes the drawerRecord SIGNAL (guards the
-    // drawer @if) and the plain drawerEditMemory field in the same turn. The title binds the plain
-    // field, so if the sibling signal write were dropped this would render empty rather than ship stale.
+  it('opens the SHARED record drawer, whose plain form model renders under this page\'s OnPush', () => {
+    // The page no longer forks the drawer — `openBrainDrawer` delegates to `RecordDrawerState.open()`.
+    // The coupling under test is unchanged and still load-bearing: `open()` writes the `drawerRecord`
+    // SIGNAL (which guards the drawer's @if) and the plain `drawerEditMemory` field in the same turn,
+    // and the title binds the PLAIN field. Drop the sibling signal write and this renders empty.
+    //
+    // Asserting through the shared drawer's own markup (`.drawer`/`.drawer-title`) is the point: it is
+    // what proves the reuse is real rather than a renamed copy.
     const fixture = create();
     const c = fixture.componentInstance;
     expect(fixture.nativeElement.querySelector('.drawer')).toBeNull();
@@ -95,9 +102,25 @@ describe('GraphComponent (OnPush)', () => {
     c.openBrainDrawer('memory', { _id: 'm1', fact: 'a graph-drawer fact', tags: [], entityIds: [], properties: {} });
     fixture.detectChanges();
 
-    const drawer = fixture.nativeElement.querySelector('.bdrawer-modal');
+    const drawer = fixture.nativeElement.querySelector('.drawer');
     expect(drawer, 'the drawer should be open').toBeTruthy();
-    expect((fixture.nativeElement.querySelector('.bdrawer-title') as HTMLElement).textContent)
+    expect((fixture.nativeElement.querySelector('.drawer-title') as HTMLElement).textContent)
       .toContain('a graph-drawer fact');
+  });
+
+  it('patches the node panel list when the shared drawer saves (the store it patches is not this page\'s)', () => {
+    // The drawer updates `BrainStore.memories`, which this page never renders — it keeps its own
+    // per-node arrays. Without the `lastSaved` bridge a save would succeed and leave the pre-save row
+    // on screen: a silent staleness that no error and no drawer-side test can see.
+    const fixture = create();
+    const c = fixture.componentInstance;
+    c.nodeMemories.set([{ _id: 'm1', fact: 'before' } as any]);
+
+    // From the COMPONENT's injector, not TestBed's — the page provides its own drawer collaborators.
+    const drawerState = fixture.debugElement.injector.get(RecordDrawerState);
+    drawerState.lastSaved.set({ kind: 'memory', record: { _id: 'm1', fact: 'after' } });
+    fixture.detectChanges();
+
+    expect(c.nodeMemories()[0].fact).toBe('after');
   });
 });

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -8,6 +8,7 @@
   inject,
   signal,
   computed,
+  effect,
   viewChild,
   ElementRef,
 } from '@angular/core';
@@ -18,15 +19,12 @@ import { Subscription, forkJoin, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
-import { ModalDirective } from '../../shared/modal.directive';
 import { httpErrorReason } from '../../core/http-error';
 import {
   Space,
   Entity,
   Memory,
   ChronoEntry,
-  ChronoType,
-  ChronoStatus,
   Edge,
   TraverseNode,
   TraverseEdge,
@@ -38,9 +36,14 @@ import { AuthApi } from '../../core/auth-api.service';
 import { EntryPopupComponent } from '../../shared/entry-popup.component';
 import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PropertiesViewComponent } from '../../shared/properties-view.component';
-import { TagInputComponent } from '../../shared/tag-input.component';
-import { PropertiesEditorComponent } from '../../shared/properties-editor.component';
 import { TranslocoPipe } from '@jsverse/transloco';
+// The record drawer and its state are shared with the Brain page rather than forked here: this page
+// used to carry a copy that had drifted behind (no schema-driven properties, no confidence field, no
+// tag suggestions, and its own retired entity-picker flyout).
+import { RecordDrawerComponent } from '../brain/record-drawer.component';
+import { RecordDrawerState } from '../brain/record-drawer-state.service';
+import { BrainStore } from '../brain/brain-store.service';
+import { EntityRefPicker } from '../brain/entity-ref-picker.service';
 import {
   DetailRow, DetailRef, buildDetailRows, filterAndSortDetails, nextSort,
 } from './graph-details';
@@ -66,7 +69,12 @@ import { GRAPH_STYLES } from './graph.styles';
   // `openBrainDrawer` alongside the `drawerRecord` signal that guards the drawer's `@if`, the same
   // load-bearing coupling pinned by the brain spec.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, TagInputComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, ModalDirective],
+  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, RecordDrawerComponent],
+  // Its own drawer collaborators, so the standalone `/graph` route works with nothing above it. When
+  // this page is embedded as Brain's Graph tab these SHADOW Brain's instances, which is deliberate:
+  // the drawer then patches this page's per-node lists, exactly as the forked drawer did. The cost is
+  // one extra space-meta fetch while embedded.
+  providers: [BrainStore, EntityRefPicker, RecordDrawerState],
   host: { '[class.embedded]': 'isEmbedded()' },
   styles: [GRAPH_STYLES],
   template: `
@@ -382,181 +390,8 @@ import { GRAPH_STYLES } from './graph.styles';
       />
     }
 
-    <!-- â•â•â• Brain-style drawer modal (memory / chrono) â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
-    @if (drawerRecord(); as dr) {
-      <div class="bdrawer-overlay">
-        <div class="bdrawer-modal" [appModal]="'brain.drawer.recordDetailsAriaLabel' | transloco" (dismiss)="closeBrainDrawer()" (click)="$event.stopPropagation()">
-          <div class="bdrawer-header">
-            <div style="flex:1; min-width:0;">
-              @if (dr.kind === 'memory') { <span class="badge badge-blue" style="margin-bottom:6px; display:inline-block;">{{ 'graph.drawer.badge.memory' | transloco }}</span> }
-              @if (dr.kind === 'chrono') { <span class="badge" style="margin-bottom:6px; display:inline-block;">{{ 'graph.drawer.badge.chrono' | transloco }}</span> }
-              <div class="bdrawer-title">
-                @if (dr.kind === 'memory') { {{ drawerEditMemory.fact.length > 80 ? (drawerEditMemory.fact | slice:0:80) + 'â€¦' : drawerEditMemory.fact }} }
-                @if (dr.kind === 'chrono') { {{ drawerEditChrono.title || dr.record.title }} }
-              </div>
-            </div>
-            <div style="display:flex; gap:8px; flex-shrink:0; align-items:flex-start; padding-top:2px;">
-              <button class="btn btn-sm btn-primary" [disabled]="drawerSaving()" (click)="saveBrainDrawer()">
-                @if (drawerSaving()) { <span class="spinner" style="width:11px;height:11px;border-width:2px;"></span> } {{ 'common.save' | transloco }}
-              </button>
-              <button class="icon-btn" [attr.title]="'common.close' | transloco" (click)="closeBrainDrawer()"><ph-icon name="x" [size]="16"/></button>
-            </div>
-          </div>
-
-          <div class="bdrawer-body">
-            @if (drawerError()) {
-              <div class="alert alert-error" style="margin-bottom:16px; font-size:13px;">{{ drawerError() }}</div>
-            }
-            <form>
-
-              <!-- â”€â”€ MEMORY â”€â”€ -->
-              @if (dr.kind === 'memory') {
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.fact' | transloco }} <span style="color:var(--error)">*</span></div>
-                  <textarea [(ngModel)]="drawerEditMemory.fact" name="drwMemFact" rows="4"></textarea>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.description' | transloco }}</div>
-                  <textarea [(ngModel)]="drawerEditMemory.description" name="drwMemDesc" rows="3" style="resize:vertical;"></textarea>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.tags' | transloco }}</div>
-                  <app-tag-input [(value)]="drawerEditMemory.tags" [suggestions]="[]" inputName="drwMemTags" />
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.entityIds' | transloco }}</div>
-                  <div class="flyout-wrap">
-                    <div class="entity-multi">
-                      @for (chip of entityChips(drawerEditMemory.entityIds); track chip.id) {
-                        <span class="chip" [title]="chip.id">
-                          <span class="chip-name">{{ chip.name }}</span>
-                          <button type="button" class="chip-remove" (mousedown)="removeEntityId(drawerEditMemory, chip.id)"><ph-icon name="x" [size]="12"/></button>
-                        </span>
-                      }
-                      <button type="button" class="chip-add" (click)="openFlyout('drawer-memory-entityIds')">{{ 'common.addMore' | transloco }}</button>
-                    </div>
-                    @if (flyoutField() === 'drawer-memory-entityIds') {
-                      <div class="flyout-panel">
-                        <app-entity-search mode="picker" [spaceId]="activeSpaceId()" placeholder="common.searchEntitiesPlaceholder"
-                          (selected)="pickDrawerEntity($event, 'drawer-memory-entityIds')" />
-                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                          <button type="button" class="btn btn-sm btn-secondary" (click)="closeFlyout()">{{ 'common.done' | transloco }}</button>
-                        </div>
-                      </div>
-                    }
-                  </div>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.properties' | transloco }}</div>
-                  <app-properties-editor [(value)]="drawerEditMemory.properties" />
-                </div>
-                <hr class="bdrawer-hr">
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">_id</div>
-                  <div class="bdrawer-readonly">{{ dr.record._id }}</div>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.seq' | transloco }}</div>
-                  <div class="bdrawer-readonly">{{ dr.record.seq }}</div>
-                </div>
-                <div class="bdrawer-field" style="margin-bottom:0;">
-                  <div class="bdrawer-label">{{ 'common.createdAt' | transloco }}</div>
-                  <div class="bdrawer-readonly">{{ dr.record.createdAt | date:'yyyy-MM-dd HH:mm:ss' }}</div>
-                </div>
-              }
-
-              <!-- â”€â”€ CHRONO â”€â”€ -->
-              @if (dr.kind === 'chrono') {
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.title' | transloco }} <span style="color:var(--error)">*</span></div>
-                  <input type="text" [(ngModel)]="drawerEditChrono.title" name="drwChronoTitle" />
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.kind' | transloco }} <span style="color:var(--error)">*</span></div>
-                  @if (drawerEditChrono.kind !== '__custom__') {
-                    <select [(ngModel)]="drawerEditChrono.kind" name="drwChronoKind">
-                      @for (k of chronoKinds; track k) { <option [value]="k">{{ k }}</option> }
-                      <option value="__custom__">{{ 'brain.chrono.form.customKind' | transloco }}</option>
-                    </select>
-                  } @else {
-                    <div style="display:flex; gap:4px;">
-                      <input type="text" [(ngModel)]="drawerEditChrono.customKind" name="drwChronoCustomKind" style="flex:1;" />
-                      <button type="button" class="btn btn-sm btn-secondary" style="padding:4px 8px;" (click)="drawerEditChrono.kind = 'event'; drawerEditChrono.customKind = ''"><ph-icon name="x" [size]="14"/></button>
-                    </div>
-                  }
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'brain.chrono.table.status' | transloco }}</div>
-                  <select [(ngModel)]="drawerEditChrono.status" name="drwChronoStatus">
-                    @for (s of chronoStatusOptions; track s) { <option [value]="s">{{ s }}</option> }
-                  </select>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.startsAt' | transloco }} <span style="color:var(--error)">*</span></div>
-                  <input type="datetime-local" [(ngModel)]="drawerEditChrono.startsAt" name="drwChronoStarts" />
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.endsAt' | transloco }}</div>
-                  <input type="datetime-local" [(ngModel)]="drawerEditChrono.endsAt" name="drwChronoEnds" />
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.description' | transloco }}</div>
-                  <textarea [(ngModel)]="drawerEditChrono.description" name="drwChronoDesc" rows="3"></textarea>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.form.tags' | transloco }}</div>
-                  <app-tag-input [(value)]="drawerEditChrono.tags" [suggestions]="[]" inputName="drwChronoTags" />
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.entityIds' | transloco }}</div>
-                  <div class="flyout-wrap">
-                    <div class="entity-multi">
-                      @for (chip of entityChips(drawerEditChrono.entityIds); track chip.id) {
-                        <span class="chip" [title]="chip.id">
-                          <span class="chip-name">{{ chip.name }}</span>
-                          <button type="button" class="chip-remove" (mousedown)="removeEntityId(drawerEditChrono, chip.id)"><ph-icon name="x" [size]="12"/></button>
-                        </span>
-                      }
-                      <button type="button" class="chip-add" (click)="openFlyout('drawer-chrono-entityIds')">{{ 'common.addMore' | transloco }}</button>
-                    </div>
-                    @if (flyoutField() === 'drawer-chrono-entityIds') {
-                      <div class="flyout-panel">
-                        <app-entity-search mode="picker" [spaceId]="activeSpaceId()" placeholder="common.searchEntitiesPlaceholder"
-                          (selected)="pickDrawerEntity($event, 'drawer-chrono-entityIds')" />
-                        <div style="display:flex; justify-content:flex-end; margin-top:8px;">
-                          <button type="button" class="btn btn-sm btn-secondary" (click)="closeFlyout()">{{ 'common.done' | transloco }}</button>
-                        </div>
-                      </div>
-                    }
-                  </div>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.memoryIds' | transloco }} <span class="bdrawer-muted">{{ 'common.commaSeparatedIds' | transloco }}</span></div>
-                  <textarea [(ngModel)]="drawerEditChrono.memoryIds" name="drwChronoMemIds" rows="2" style="font-family:var(--font-mono,monospace); font-size:11px;"></textarea>
-                </div>
-                <hr class="bdrawer-hr">
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">_id</div>
-                  <div class="bdrawer-readonly">{{ dr.record._id }}</div>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.seq' | transloco }}</div>
-                  <div class="bdrawer-readonly">{{ dr.record.seq }}</div>
-                </div>
-                <div class="bdrawer-field">
-                  <div class="bdrawer-label">{{ 'common.createdAt' | transloco }}</div>
-                  <div class="bdrawer-readonly">{{ dr.record.createdAt | date:'yyyy-MM-dd HH:mm:ss' }}</div>
-                </div>
-                <div class="bdrawer-field" style="margin-bottom:0;">
-                  <div class="bdrawer-label">{{ 'common.updatedAt' | transloco }}</div>
-                  <div class="bdrawer-readonly">{{ dr.record.updatedAt | date:'yyyy-MM-dd HH:mm:ss' }}</div>
-                </div>
-              }
-            </form>
-          </div>
-        </div>
-      </div>
-    }
+    <!-- Record drawer (memory / chrono) - the shared brain drawer, not a copy -->
+    <app-record-drawer />
   `,
 })
 export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
@@ -566,6 +401,35 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   private authApi = inject(AuthApi);
   private location = inject(Location);
   private route = inject(ActivatedRoute);
+  private store = inject(BrainStore);
+  private picker = inject(EntityRefPicker);
+  protected drawerState = inject(RecordDrawerState);
+
+  constructor() {
+    // One propagation point for the three places `activeSpaceId` is written (the embedded @Input
+    // setter, the initial route read, and the space picker). An effect rather than three call sites
+    // so a fourth writer added later cannot forget to feed the drawer — that failure mode is silent:
+    // the drawer opens and saves into the empty space id.
+    effect(() => {
+      const id = this.activeSpaceId();
+      this.drawerState.spaceId.set(id);
+      this.picker.spaceId.set(id);
+      this.loadSpaceMeta(id);
+    });
+
+    // The drawer patches the `BrainStore` lists, which this page does not render. Its per-node arrays
+    // are its own, so without this a save would succeed and leave the stale row on screen underneath.
+    effect(() => {
+      const saved = this.drawerState.lastSaved();
+      if (!saved) return;
+      const rec = saved.record;
+      if (saved.kind === 'memory') {
+        this.nodeMemories.update(list => list.map(m => m._id === rec._id ? rec : m));
+      } else if (saved.kind === 'chrono') {
+        this.nodeChrono.update(list => list.map(c => c._id === rec._id ? rec : c));
+      }
+    });
+  }
 
   // â”€â”€ Element refs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   cyContainer = viewChild<ElementRef<HTMLDivElement>>('cyContainer');
@@ -612,16 +476,9 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   popupType = signal<'entity' | 'edge' | 'memory' | 'chrono'>('entity');
   canEdit = signal(false);
 
-  // â”€â”€ Brain-style drawer for memory / chrono â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-  drawerRecord = signal<{ kind: 'memory' | 'chrono'; record: any } | null>(null);
-  drawerSaving = signal(false);
-  drawerError = signal('');
-  drawerEditMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
-  drawerEditChrono = { title: '', kind: 'event' as string, customKind: '', status: 'upcoming' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', memoryIds: '' };
-  entityNameCache = signal<Record<string, string>>({});
-  flyoutField = signal('');
-  readonly chronoKinds: ChronoType[] = ['event', 'deadline', 'plan', 'prediction', 'milestone'];
-  readonly chronoStatusOptions: ChronoStatus[] = ['upcoming', 'active', 'completed', 'overdue', 'cancelled'];
+  // -- Record drawer (memory / chrono) ----------------------------------------
+  // Drawer state lives in the shared `RecordDrawerState` provided above. This page only opens it
+  // and reacts to `lastSaved`; it holds no edit models of its own.
 
   loading = signal(false);
   /** Failure reason for the last traversal; null when it succeeded (U3). A
@@ -1047,148 +904,28 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
+  /**
+   * Open the shared record drawer on a graph node's memory or chrono record.
+   *
+   * Kept as a method rather than calling `drawerState.open()` from each of the three call sites,
+   * so this page keeps one seam for the open path.
+   */
   openBrainDrawer(kind: 'memory' | 'chrono', record: any): void {
-    this.drawerError.set('');
-    this.drawerSaving.set(false);
-    this.flyoutField.set('');
-    const ids: string[] = record.entityIds ?? [];
-    if (ids.length) this.resolveEntityNamesById(ids);
-    if (kind === 'memory') {
-      this.drawerEditMemory = {
-        fact: record.fact ?? '',
-        tags: [...(record.tags ?? [])],
-        entityIds: (record.entityIds ?? []).join(', '),
-        description: record.description ?? '',
-        properties: { ...(record.properties ?? {}) },
-      };
-    } else {
-      const isPredefined = this.chronoKinds.includes(record.type as ChronoType);
-      this.drawerEditChrono = {
-        title: record.title ?? '',
-        kind: isPredefined ? record.type : '__custom__',
-        customKind: isPredefined ? '' : (record.type ?? ''),
-        status: record.status ?? 'upcoming',
-        startsAt: record.startsAt ? this.toLocalDatetime(record.startsAt) : '',
-        endsAt: record.endsAt ? this.toLocalDatetime(record.endsAt) : '',
-        description: record.description ?? '',
-        tags: [...(record.tags ?? [])],
-        entityIds: (record.entityIds ?? []).join(', '),
-        memoryIds: (record.memoryIds ?? []).join(', '),
-      };
-    }
-    this.drawerRecord.set({ kind, record });
+    this.drawerState.open(kind, record);
   }
 
-  closeBrainDrawer(): void {
-    this.drawerRecord.set(null);
-    this.drawerError.set('');
-    this.flyoutField.set('');
-  }
-
-  saveBrainDrawer(): void {
-    const dr = this.drawerRecord();
-    if (!dr) return;
-    const spaceId = this.activeSpaceId();
-    const id = dr.record._id;
-    this.drawerSaving.set(true);
-    this.drawerError.set('');
-    if (dr.kind === 'memory') {
-      const props = this.drawerEditMemory.properties;
-      this.brainApi.updateMemory(spaceId, id, {
-        fact: this.drawerEditMemory.fact.trim(),
-        tags: this.drawerEditMemory.tags,
-        entityIds: this.drawerEditMemory.entityIds.split(',').map(s => s.trim()).filter(Boolean),
-        description: this.drawerEditMemory.description.trim(),
-        ...(Object.keys(props).length ? { properties: props } : {}),
-      }).subscribe({
-        next: (updated) => {
-          this.drawerSaving.set(false);
-          this.drawerRecord.set({ kind: 'memory', record: updated });
-          this.nodeMemories.update(list => list.map(m => m._id === id ? updated : m));
-        },
-        error: (err) => { this.drawerSaving.set(false); this.drawerError.set(err?.error?.error ?? err?.message ?? 'Save failed'); },
-      });
-    } else {
-      const resolvedKind = this.drawerEditChrono.kind === '__custom__'
-        ? (this.drawerEditChrono.customKind.trim() as ChronoType)
-        : this.drawerEditChrono.kind as ChronoType;
-      this.brainApi.updateChrono(spaceId, id, {
-        title: this.drawerEditChrono.title.trim(),
-        type: resolvedKind,
-        status: this.drawerEditChrono.status as ChronoStatus,
-        ...(this.drawerEditChrono.startsAt ? { startsAt: new Date(this.drawerEditChrono.startsAt).toISOString() } : {}),
-        ...(this.drawerEditChrono.endsAt ? { endsAt: new Date(this.drawerEditChrono.endsAt).toISOString() } : {}),
-        description: this.drawerEditChrono.description.trim(),
-        tags: this.drawerEditChrono.tags,
-        entityIds: this.drawerEditChrono.entityIds.split(',').map(s => s.trim()).filter(Boolean),
-        ...(this.drawerEditChrono.memoryIds.trim() ? { memoryIds: this.drawerEditChrono.memoryIds.split(',').map(s => s.trim()).filter(Boolean) } : {}),
-      }).subscribe({
-        next: (updated) => {
-          this.drawerSaving.set(false);
-          this.drawerRecord.set({ kind: 'chrono', record: updated });
-          this.nodeChrono.update(list => list.map(c => c._id === id ? updated : c));
-        },
-        error: (err) => { this.drawerSaving.set(false); this.drawerError.set(err?.error?.error ?? err?.message ?? 'Save failed'); },
-      });
-    }
-  }
-
-  entityChips(ids: string): Array<{ id: string; name: string }> {
-    const cache = this.entityNameCache();
-    return ids.split(',').map(s => s.trim()).filter(Boolean).map(id => ({ id, name: cache[id] ?? id }));
-  }
-
-  removeEntityId(target: { entityIds: string }, id: string): void {
-    target.entityIds = target.entityIds.split(',').map(s => s.trim()).filter(s => s && s !== id).join(', ');
-  }
-
-  openFlyout(key: string): void {
-    this.flyoutField.set(key);
-    let ids = '';
-    if (key === 'drawer-memory-entityIds') ids = this.drawerEditMemory.entityIds;
-    if (key === 'drawer-chrono-entityIds') ids = this.drawerEditChrono.entityIds;
-    const spaceId = this.activeSpaceId();
-    if (spaceId && ids) {
-      const unknown = ids.split(',').map(s => s.trim()).filter(s => s && !this.entityNameCache()[s]);
-      if (unknown.length) this.resolveEntityNamesById(unknown);
-    }
-  }
-
-  closeFlyout(): void { this.flyoutField.set(''); }
-
-  pickDrawerEntity(ent: Entity, field: string): void {
-    this.entityNameCache.update(c => ({ ...c, [ent._id]: ent.name }));
-    if (field === 'drawer-memory-entityIds') {
-      const parts = this.drawerEditMemory.entityIds.split(',').map(s => s.trim()).filter(Boolean);
-      if (!parts.includes(ent._id)) parts.push(ent._id);
-      this.drawerEditMemory.entityIds = parts.join(', ');
-    } else if (field === 'drawer-chrono-entityIds') {
-      const parts = this.drawerEditChrono.entityIds.split(',').map(s => s.trim()).filter(Boolean);
-      if (!parts.includes(ent._id)) parts.push(ent._id);
-      this.drawerEditChrono.entityIds = parts.join(', ');
-    }
-  }
-
-  private resolveEntityNamesById(ids: string[]): void {
-    const spaceId = this.activeSpaceId();
-    if (!spaceId || !ids.length) return;
-    const unknown = ids.filter(id => !this.entityNameCache()[id]);
-    if (!unknown.length) return;
-    this.brainApi.getEntitiesByIds(spaceId, unknown).subscribe({
-      next: ({ entities }) => {
-        const patch: Record<string, string> = {};
-        for (const e of entities) patch[e._id] = e.name;
-        this.entityNameCache.update(c => ({ ...c, ...patch }));
-      },
-      error: () => {},
+  /**
+   * Feed the schema the drawer's property editors and tag suggestions read.
+   *
+   * A space with no typeSchemas is not an error: `buildPropertiesObject` returns the record's own
+   * properties untouched, which is exactly what the forked drawer used to do for every space.
+   */
+  private loadSpaceMeta(spaceId: string): void {
+    if (!spaceId) { this.store.spaceMeta.set(null); return; }
+    this.spacesApi.getSpaceMeta(spaceId).subscribe({
+      next: (meta) => this.store.spaceMeta.set(meta),
+      error: () => this.store.spaceMeta.set(null),
     });
-  }
-
-  private toLocalDatetime(iso: string): string {
-    const d = new Date(iso);
-    if (isNaN(d.getTime())) return '';
-    const pad = (n: number) => n.toString().padStart(2, '0');
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   }
 
   asRecord(obj: unknown): Record<string, unknown> {

--- a/client/src/app/pages/graph/graph.styles.ts
+++ b/client/src/app/pages/graph/graph.styles.ts
@@ -488,81 +488,11 @@ export const GRAPH_STYLES = `
       margin-right: 3px;
     }
 
-    /* â”€â”€ Brain-style record drawer modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-    .bdrawer-overlay {
-      position: fixed; inset: 0;
-      background: var(--bg-scrim);
-      display: flex; align-items: center; justify-content: center;
-      z-index: 1100;
-    }
-    .bdrawer-modal {
-      background: var(--bg-surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-lg);
-      width: 100%; max-width: 640px;
-      max-height: 88vh; overflow: hidden;
-      display: flex; flex-direction: column;
-    }
-    .bdrawer-header {
-      display: flex; align-items: flex-start; justify-content: space-between;
-      padding: 16px 20px; border-bottom: 1px solid var(--border); gap: 12px; flex-shrink: 0;
-    }
-    .bdrawer-title { font-size: 15px; font-weight: 600; color: var(--text-primary); word-break: break-word; }
-    .bdrawer-body { overflow-y: auto; flex: 1; padding: 20px; }
-    .bdrawer-footer {
-      display: flex; align-items: center; justify-content: flex-end;
-      gap: 8px; padding: 12px 20px; border-top: 1px solid var(--border); flex-shrink: 0;
-    }
-    .bdrawer-field { margin-bottom: 16px; }
-    .bdrawer-label {
-      font-size: 10px; font-weight: 600; color: var(--text-muted);
-      text-transform: uppercase; letter-spacing: .05em; margin-bottom: 4px;
-    }
-    .bdrawer-readonly {
-      font-size: 12px; color: var(--text-muted); padding: 5px 8px;
-      border: 1px solid var(--border-muted, var(--border)); border-radius: var(--radius-sm);
-      background: var(--bg-elevated); word-break: break-all; line-height: 1.4;
-      font-family: var(--font-mono);
-    }
-    .bdrawer-muted { color: var(--text-muted); font-size: 11px; }
-    .bdrawer-hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
-    .bdrawer-modal input[type=text], .bdrawer-modal input[type=number],
-    .bdrawer-modal input[type=datetime-local], .bdrawer-modal textarea, .bdrawer-modal select {
-      width: 100%; padding: 6px 9px;
-      border: 1px solid var(--border); border-radius: var(--radius-sm);
-      font-size: 13px; background: var(--bg-primary); color: var(--text-primary);
-      box-sizing: border-box; font-family: var(--font);
-    }
-    .bdrawer-modal textarea { resize: vertical; }
-    .bdrawer-modal input:focus, .bdrawer-modal select:focus, .bdrawer-modal textarea:focus {
-      outline: none; border-color: var(--accent);
-    }
     /* entity chips */
-    .entity-multi {
-      display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
-      padding: 4px 6px; border: 1px solid var(--border); border-radius: var(--radius-sm);
-      background: var(--bg-primary); min-height: 34px;
-    }
     .chip {
       display: inline-flex; align-items: center; gap: 3px;
       padding: 2px 8px; border-radius: 10px;
       background: var(--accent-dim); border: 1px solid var(--accent);
       font-size: 11px; color: var(--text-primary);
-    }
-    .chip-name { max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .chip-remove {
-      background: none; border: none; color: var(--text-muted); cursor: pointer;
-      padding: 0 1px; font-size: 12px; line-height: 1;
-    }
-    .chip-add {
-      background: none; border: none; color: var(--accent); cursor: pointer;
-      font-size: 12px; padding: 2px 4px;
-    }
-    .flyout-wrap { position: relative; }
-    .flyout-panel {
-      position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
-      background: var(--bg-surface); border: 1px solid var(--border);
-      border-radius: var(--radius-md); padding: 10px; margin-top: 4px;
-      box-shadow: var(--shadow-lg);
     }
 `;

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -256,6 +256,8 @@ The Graph view lets you explore how entities relate to each other visually.
 
 The detail panel below the canvas shows all memories and chrono entries linked to the selected entity. Use the type filter and description filter to narrow what you see.
 
+**Editing from the graph:** click any memory or chrono row in that panel to open the same editable detail drawer used on the Brain tabs — including tag suggestions, the entity and memory pickers, and the property fields defined by the record type's schema. Saving updates the row in the panel behind it.
+
 ---
 
 ## Files


### PR DESCRIPTION
## What

The Graph tab's detail panel opened an editable drawer that was forked from Brain's and then left behind. Every improvement made to the real drawer since the fork had silently skipped it:

| | forked drawer | shared drawer |
|---|---|---|
| Property fields | none (no schema passed) | schema-defined, per record type |
| Chrono `confidence` | absent | present |
| Tag suggestions | `[suggestions]="[]"` | schema + existing values |
| Memory picker | comma-separated id string | searchable picker with chips |
| Entity picker | its own copy of the retired flyout | shared inline ref-field |

Nothing about it looked broken — it just offered less than the identical-looking drawer one tab over. **The failure mode is absence, and absence renders fine.**

## Why delete rather than extract

`_TODO-ORDERED.md` framed this as "split `graph.component.ts`'s ~490-line inline template into sub-components". Extracting the drawer as its own component would have needed ~12 inputs/outputs and merely *relocated* the duplication. Reusing the real drawer removes it:

```
graph.component.ts   1231 → 931 lines   (~175 of them inline template)
graph.styles.ts       −70 lines         (unreachable .bdrawer-* / chip / flyout CSS)
```

The drawer turned out to be a fully self-contained island — every member it touched (`drawerEdit*`, `entityChips`, `openFlyout`, `pickDrawerEntity`, `entityNameCache`, `toLocalDatetime`, …) was referenced only from inside it.

## The one addition

`RecordDrawerState.save()` patches the `BrainStore` lists, which is all Brain needs. The graph page renders its **own** per-node arrays the store never sees, so it now reads a new `lastSaved` signal. Without that bridge a save would succeed and leave the pre-save row on screen — silent staleness, no error.

## Verification

- **All 45 graph characterization tests pass with assertions untouched.** Only the API stubs gained `getSpaceMeta`; no pinned behaviour moved.
- **Mutation-checked, 4/4 killed** — dropping the bridge effect, dropping either `lastSaved.set`, and announcing on a *failed* save all fail the suite. The first run left one survivor, exposing that the producing side was untested; that gap is why `record-drawer-state.service.spec.ts` is new.
- `npm run preflight` (72 files / 694 tests) + production AOT build.
- **Driven in a browser against a live server**: the drawer renders styled (480px side panel, not a full-bleed unstyled block), shows the tag input / entity ref-field / properties editor, resolves entity chips by name, and a real save round-trips into the panel row behind it. No blank icons, raw keys, or console errors.

Visible change: editing from the graph now opens the familiar right-side drawer rather than the fork's centred modal.

## Docs

The graph drawer was **never documented**. `docs/userguide.md` now states that clicking a memory or chrono row in the detail panel opens it. The two orphaned `graph.drawer.badge.*` keys are removed from en/de/pl — `.edge` stays, still used by the details panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
