### PR TITLE
refactor(graph): one linked-records list for both side panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The graph's node and edge panels now share one linked-records list instead of two copies of it.**
+  Both panels rendered the "linked memories + chrono entries" lists from blocks that were byte-identical
+  apart from their two empty-state messages, and **nothing tested either of them** — the 45 graph
+  characterization tests set the underlying data and assert on it, never on a rendered row. So the two
+  copies could have drifted apart, or one could have been dropped, without a single test noticing.
+
+  They are now one `app-graph-linked-records` component used twice, with the empty-state wording kept
+  as an input (a node with no memories and an edge whose endpoints share none are different
+  sentences). No behaviour changes; the 45 characterization tests pass untouched, and the list
+  rendering has real coverage for the first time.
+
 - **The Graph tab now uses the same record drawer as the rest of Brain, instead of its own copy.**
   Editing a memory or chrono entry from the graph's detail panel opened a drawer that had been forked
   from Brain's and then left behind: no schema-defined property fields, no `confidence` on chrono

--- a/client/src/app/pages/graph/graph-linked-records.component.spec.ts
+++ b/client/src/app/pages/graph/graph-linked-records.component.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * GraphLinkedRecordsComponent — the memory/chrono lists under a node or edge side panel.
+ *
+ * This block was rendered TWICE in `graph.component.ts`, byte-identical apart from its two
+ * empty-state translation keys, and **nothing tested it**. The 45 graph characterization tests set
+ * `nodeMemories`/`nodeChrono` and assert on the SIGNALS; not one asserts a row ever reached the DOM.
+ * So the copies could have diverged — or the extraction could have dropped a list — with a fully
+ * green suite. These tests close that hole.
+ *
+ * The empty-state key is deliberately an INPUT: a node with no memories and an edge whose endpoints
+ * share none are different sentences. The test below asserts the INPUT is used rather than a
+ * hard-coded key, because collapsing the two copies is exactly when that distinction gets lost.
+ * (`getTranslocoModule()` ships an empty dictionary, so a key renders as itself — which is what makes
+ * "which key did it use?" observable at all.)
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component, signal } from '@angular/core';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { GraphLinkedRecordsComponent } from './graph-linked-records.component';
+import { DetailRef } from './graph-details';
+
+@Component({
+  standalone: true,
+  imports: [GraphLinkedRecordsComponent],
+  template: `
+    <app-graph-linked-records
+      [memories]="mems()"
+      [chrono]="chrono()"
+      [emptyMemoriesKey]="'graph.panel.noMemories'"
+      [emptyChronoKey]="'graph.panel.noChronoEntries'"
+      (open)="opened.push($event)" />
+  `,
+})
+class Host {
+  mems = signal<any[]>([]);
+  chrono = signal<any[]>([]);
+  opened: DetailRef[] = [];
+}
+
+describe('GraphLinkedRecordsComponent', () => {
+  function create() {
+    TestBed.configureTestingModule({ imports: [Host, getTranslocoModule()] });
+    const fixture = TestBed.createComponent(Host);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('is compiled as OnPush', () => {
+    expect(GraphLinkedRecordsComponent.ɵcmp?.onPush).toBe(true);
+  });
+
+  it('renders one row per memory AND one per chrono entry', () => {
+    const fixture = create();
+    fixture.componentInstance.mems.set([
+      { _id: 'm1', fact: 'first fact', createdAt: '2026-01-01' },
+      { _id: 'm2', fact: 'second fact', createdAt: '2026-01-02' },
+    ]);
+    fixture.componentInstance.chrono.set([{ _id: 'c1', title: 'a milestone', startsAt: '2026-02-01' }]);
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('.list-row');
+    // 3, not 2: a splice that dropped one of the two sections would still render rows.
+    expect(rows.length, 'both sections must render').toBe(3);
+    expect(fixture.nativeElement.textContent).toContain('first fact');
+    expect(fixture.nativeElement.textContent).toContain('a milestone');
+  });
+
+  it('falls back to the description when a memory has no fact', () => {
+    const fixture = create();
+    fixture.componentInstance.mems.set([{ _id: 'm1', description: 'only a description', createdAt: '2026-01-01' }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.list-row-text').textContent).toContain('only a description');
+  });
+
+  it('emits the clicked row as a DetailRef, tagged with the right kind', () => {
+    const fixture = create();
+    const host = fixture.componentInstance;
+    host.mems.set([{ _id: 'm1', fact: 'f', createdAt: '2026-01-01' }]);
+    host.chrono.set([{ _id: 'c1', title: 't', startsAt: '2026-01-01' }]);
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('.list-row');
+    rows[0].click();
+    rows[1].click();
+
+    // The kind decides which endpoint the parent fetches; swapping them would open the wrong record.
+    expect(host.opened).toEqual([{ id: 'm1', kind: 'memory' }, { id: 'c1', kind: 'chrono' }]);
+  });
+
+  it('shows the empty state from its INPUT key, per list', () => {
+    const fixture = create();
+    const empties = [...fixture.nativeElement.querySelectorAll('.list-empty')].map((e: any) => e.textContent.trim());
+    // Both lists empty → both keys, in order. A hard-coded key would show the same text twice.
+    expect(empties).toEqual(['graph.panel.noMemories', 'graph.panel.noChronoEntries']);
+  });
+
+  it('counts each list independently in its header chip', () => {
+    const fixture = create();
+    fixture.componentInstance.mems.set([{ _id: 'm1', fact: 'f', createdAt: '2026-01-01' }]);
+    fixture.componentInstance.chrono.set([
+      { _id: 'c1', title: 't', startsAt: '2026-01-01' },
+      { _id: 'c2', title: 'u', startsAt: '2026-01-02' },
+    ]);
+    fixture.detectChanges();
+
+    const chips = [...fixture.nativeElement.querySelectorAll('.count-chip')].map((e: any) => e.textContent.trim());
+    // 1 then 2 — a chip reading the other list's length would still be a plausible-looking number.
+    expect(chips).toEqual(['1', '2']);
+  });
+});

--- a/client/src/app/pages/graph/graph-linked-records.component.ts
+++ b/client/src/app/pages/graph/graph-linked-records.component.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { Memory, ChronoEntry } from '../../core/api.types';
+import { DetailRef } from './graph-details';
+import { GRAPH_LINKED_RECORDS_STYLES } from './graph.styles';
+
+/**
+ * The "linked memories + chrono entries" lists shown beneath a selected node or edge.
+ *
+ * Extracted because the graph page rendered this block TWICE — once in the node side panel, once in
+ * the edge side panel — byte-identical apart from the two empty-state translation keys. Two copies of
+ * one list is the same mechanism that let the record drawer drift out of date before #503: a change
+ * made to one copy silently misses the other, and the result presents as a list that looks fine but
+ * behaves differently, never as an error.
+ *
+ * The empty-state keys stay INPUTS rather than being unified — "no memories" (a node has none) and
+ * "no linked memories" (nothing links these two endpoints) are deliberately different sentences.
+ *
+ * The `.lists-pane` rules apply to `:host` here. That is load-bearing: the parent's styles are scoped
+ * to the parent's own template, so markup moved into a child renders UNSTYLED unless its rules move
+ * with it — a full-bleed, borderless list that no unit test can see.
+ */
+@Component({
+  selector: 'app-graph-linked-records',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, TranslocoPipe],
+  styles: [GRAPH_LINKED_RECORDS_STYLES],
+  template: `
+    <div class="list-section">
+      <div class="list-section-header">
+        {{ 'graph.panel.memories' | transloco }} <span class="count-chip">{{ memories().length }}</span>
+      </div>
+      <div class="list-body">
+        @for (m of memories(); track m._id) {
+          <div class="list-row" (click)="open.emit({ id: m._id, kind: 'memory' })">
+            <span class="list-row-text" [title]="m.fact || m.description">{{ m.fact || m.description || '—' }}</span>
+            <span class="list-row-date">{{ m.createdAt | date:'dd.MM.yy' }}</span>
+          </div>
+        } @empty {
+          <div class="list-empty">{{ emptyMemoriesKey() | transloco }}</div>
+        }
+      </div>
+    </div>
+    <div class="list-section">
+      <div class="list-section-header">
+        {{ 'graph.panel.chrono' | transloco }} <span class="count-chip">{{ chrono().length }}</span>
+      </div>
+      <div class="list-body">
+        @for (c of chrono(); track c._id) {
+          <div class="list-row" (click)="open.emit({ id: c._id, kind: 'chrono' })">
+            <span class="list-row-text" [title]="c.title || c.description">{{ c.title || c.description || '—' }}</span>
+            <span class="list-row-date">{{ c.startsAt | date:'dd.MM.yy' }}</span>
+          </div>
+        } @empty {
+          <div class="list-empty">{{ emptyChronoKey() | transloco }}</div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class GraphLinkedRecordsComponent {
+  memories = input.required<Memory[]>();
+  chrono = input.required<ChronoEntry[]>();
+
+  /** Translation key for "this node/edge has no memories". Differs per panel, on purpose. */
+  emptyMemoriesKey = input.required<string>();
+  /** Translation key for "this node/edge has no chrono entries". Differs per panel, on purpose. */
+  emptyChronoKey = input.required<string>();
+
+  /** A row was clicked. The parent fetches the full record and opens the shared drawer. */
+  readonly open = output<DetailRef>();
+}

--- a/client/src/app/pages/graph/graph.component.spec.ts
+++ b/client/src/app/pages/graph/graph.component.spec.ts
@@ -87,6 +87,27 @@ describe('GraphComponent (OnPush)', () => {
     expect(fixture.nativeElement.querySelector('.side-panel')).toBeNull();
   });
 
+  it('renders the linked-records lists in BOTH the node panel and the edge panel', () => {
+    // The two panels used to carry byte-identical copies of this block. Now they share one component,
+    // so a mis-wire affects one call site and not the other — and nothing else in the suite would
+    // notice: the 45 characterization tests set `nodeMemories`/`nodeChrono` and assert on the signals,
+    // never on a rendered row. Asserting BOTH panels is the whole point of this test.
+    const fixture = create();
+    const c = fixture.componentInstance;
+    c.nodeMemories.set([{ _id: 'm1', fact: 'linked fact', createdAt: '2026-01-01' } as any]);
+
+    c.selectedNode.set({ _id: 'n1', name: 'Node', type: 'x', depth: 1 } as any);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('app-graph-linked-records'), 'node panel').toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('linked fact');
+
+    c.selectedNode.set(null);
+    c.selectedEdge.set({ _id: 'e1', label: 'knows', from: 'a', to: 'b' } as any);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('app-graph-linked-records'), 'edge panel').toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('linked fact');
+  });
+
   it('opens the SHARED record drawer, whose plain form model renders under this page\'s OnPush', () => {
     // The page no longer forks the drawer — `openBrainDrawer` delegates to `RecordDrawerState.open()`.
     // The coupling under test is unchanged and still load-bearing: `open()` writes the `drawerRecord`

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -36,6 +36,7 @@ import { AuthApi } from '../../core/auth-api.service';
 import { EntryPopupComponent } from '../../shared/entry-popup.component';
 import { EntitySearchComponent } from '../../shared/entity-search.component';
 import { PropertiesViewComponent } from '../../shared/properties-view.component';
+import { GraphLinkedRecordsComponent } from './graph-linked-records.component';
 import { TranslocoPipe } from '@jsverse/transloco';
 // The record drawer and its state are shared with the Brain page rather than forked here: this page
 // used to carry a copy that had drifted behind (no schema-driven properties, no confidence field, no
@@ -69,7 +70,7 @@ import { GRAPH_STYLES } from './graph.styles';
   // `openBrainDrawer` alongside the `drawerRecord` signal that guards the drawer's `@if`, the same
   // load-bearing coupling pinned by the brain spec.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, RecordDrawerComponent],
+  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, RecordDrawerComponent, GraphLinkedRecordsComponent],
   // Its own drawer collaborators, so the standalone `/graph` route works with nothing above it. When
   // this page is embedded as Brain's Graph tab these SHADOW Brain's instances, which is deliberate:
   // the drawer then patches this page's per-node lists, exactly as the forked drawer did. The cost is
@@ -224,38 +225,12 @@ import { GRAPH_STYLES } from './graph.styles';
             </div>
 
             <!-- Lists pane: memories + chrono -->
-            <div class="lists-pane">
-              <div class="list-section">
-                <div class="list-section-header">
-                  {{ 'graph.panel.memories' | transloco }} <span class="count-chip">{{ nodeMemories().length }}</span>
-                </div>
-                <div class="list-body">
-                  @for (m of nodeMemories(); track m._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: m._id, kind: 'memory' })">
-                      <span class="list-row-text" [title]="m.fact || m.description">{{ m.fact || m.description || 'â€”' }}</span>
-                      <span class="list-row-date">{{ m.createdAt | date:'dd.MM.yy' }}</span>
-                    </div>
-                  } @empty {
-                    <div class="list-empty">{{ 'graph.panel.noMemories' | transloco }}</div>
-                  }
-                </div>
-              </div>
-              <div class="list-section">
-                <div class="list-section-header">
-                  {{ 'graph.panel.chrono' | transloco }} <span class="count-chip">{{ nodeChrono().length }}</span>
-                </div>
-                <div class="list-body">
-                  @for (c of nodeChrono(); track c._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: c._id, kind: 'chrono' })">
-                      <span class="list-row-text" [title]="c.title || c.description">{{ c.title || c.description || 'â€”' }}</span>
-                      <span class="list-row-date">{{ c.startsAt | date:'dd.MM.yy' }}</span>
-                    </div>
-                  } @empty {
-                    <div class="list-empty">{{ 'graph.panel.noChronoEntries' | transloco }}</div>
-                  }
-                </div>
-              </div>
-            </div>
+            <app-graph-linked-records
+              [memories]="nodeMemories()"
+              [chrono]="nodeChrono()"
+              [emptyMemoriesKey]="'graph.panel.noMemories'"
+              [emptyChronoKey]="'graph.panel.noChronoEntries'"
+              (open)="openDetailPopup($event)" />
 
           </div>
         </div>
@@ -339,38 +314,12 @@ import { GRAPH_STYLES } from './graph.styles';
             </div>
 
             <!-- Lists pane: memories + chrono for both endpoints -->
-            <div class="lists-pane">
-              <div class="list-section">
-                <div class="list-section-header">
-                  {{ 'graph.panel.memories' | transloco }} <span class="count-chip">{{ nodeMemories().length }}</span>
-                </div>
-                <div class="list-body">
-                  @for (m of nodeMemories(); track m._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: m._id, kind: 'memory' })">
-                      <span class="list-row-text" [title]="m.fact || m.description">{{ m.fact || m.description || 'â€”' }}</span>
-                      <span class="list-row-date">{{ m.createdAt | date:'dd.MM.yy' }}</span>
-                    </div>
-                  } @empty {
-                    <div class="list-empty">{{ 'graph.panel.noLinkedMemories' | transloco }}</div>
-                  }
-                </div>
-              </div>
-              <div class="list-section">
-                <div class="list-section-header">
-                  {{ 'graph.panel.chrono' | transloco }} <span class="count-chip">{{ nodeChrono().length }}</span>
-                </div>
-                <div class="list-body">
-                  @for (c of nodeChrono(); track c._id) {
-                    <div class="list-row" (click)="openDetailPopup({ id: c._id, kind: 'chrono' })">
-                      <span class="list-row-text" [title]="c.title || c.description">{{ c.title || c.description || 'â€”' }}</span>
-                      <span class="list-row-date">{{ c.startsAt | date:'dd.MM.yy' }}</span>
-                    </div>
-                  } @empty {
-                    <div class="list-empty">{{ 'graph.panel.noLinkedChrono' | transloco }}</div>
-                  }
-                </div>
-              </div>
-            </div>
+            <app-graph-linked-records
+              [memories]="nodeMemories()"
+              [chrono]="nodeChrono()"
+              [emptyMemoriesKey]="'graph.panel.noLinkedMemories'"
+              [emptyChronoKey]="'graph.panel.noLinkedChrono'"
+              (open)="openDetailPopup($event)" />
 
           </div>
         </div>

--- a/client/src/app/pages/graph/graph.styles.ts
+++ b/client/src/app/pages/graph/graph.styles.ts
@@ -399,82 +399,6 @@ export const GRAPH_STYLES = `
       margin: 2px 3px 2px 0;
     }
 
-    /* Right column: memory + chrono lists */
-    .lists-pane {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      min-height: 0;
-      overflow: hidden;
-    }
-    .list-section {
-      display: flex;
-      flex-direction: column;
-      flex: 1;
-      min-height: 0;
-      overflow: hidden;
-      border-bottom: 1px solid var(--border);
-    }
-    .list-section:last-child { border-bottom: none; }
-    .list-section-header {
-      font-size: 10px;
-      font-weight: 600;
-      color: var(--text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      padding: 8px 12px 6px;
-      border-bottom: 1px solid var(--border);
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-    .list-section-header .count-chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 16px;
-      height: 16px;
-      padding: 0 4px;
-      background: var(--bg-overlay);
-      border-radius: 8px;
-      font-size: 10px;
-      color: var(--text-muted);
-    }
-    .list-body { overflow-y: auto; flex: 1; }
-    .list-row {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 7px 12px;
-      border-bottom: 1px solid var(--border);
-      cursor: pointer;
-      transition: background var(--transition);
-    }
-    .list-row:last-child { border-bottom: none; }
-    .list-row:hover { background: var(--bg-elevated); }
-    .list-row-text {
-      flex: 1;
-      font-size: 12px;
-      color: var(--text-primary);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    .list-row-date {
-      font-size: 10px;
-      color: var(--text-muted);
-      font-family: var(--font-mono);
-      white-space: nowrap;
-      flex-shrink: 0;
-    }
-    .list-empty {
-      font-size: 12px;
-      color: var(--text-muted);
-      font-style: italic;
-      text-align: center;
-      padding: 16px 12px;
-    }
 
     /* â”€â”€ Shared badge, button helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
     .tag {
@@ -495,4 +419,91 @@ export const GRAPH_STYLES = `
       background: var(--accent-dim); border: 1px solid var(--accent);
       font-size: 11px; color: var(--text-primary);
     }
+`;
+
+
+/**
+ * Styles for `GraphLinkedRecordsComponent` — the memory/chrono lists under a node or edge panel.
+ *
+ * These left `GRAPH_STYLES` when the markup did. A parent component's styles do not reach a child's
+ * template, so leaving them behind would have rendered the lists unstyled: still present, still
+ * clickable, just visually wrong — which no unit test can see.
+ */
+export const GRAPH_LINKED_RECORDS_STYLES = `
+  /* The pane itself — this component IS the right column of a side panel. */
+  :host {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .list-section {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    border-bottom: 1px solid var(--border);
+  }
+  .list-section:last-child { border-bottom: none; }
+  .list-section-header {
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 8px 12px 6px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .list-section-header .count-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    background: var(--bg-overlay);
+    border-radius: 8px;
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+  .list-body { overflow-y: auto; flex: 1; }
+  .list-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 12px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    transition: background var(--transition);
+  }
+  .list-row:last-child { border-bottom: none; }
+  .list-row:hover { background: var(--bg-elevated); }
+  .list-row-text {
+    flex: 1;
+    font-size: 12px;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .list-row-date {
+    font-size: 10px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .list-empty {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+    padding: 16px 12px;
+  }
 `;


### PR DESCRIPTION
## What

The node panel and the edge panel each rendered the "linked memories + chrono entries" lists from their own block. The two were **byte-identical** apart from the two empty-state translation keys — 32 duplicated lines, bound to the same signals, calling the same handler.

More to the point: **nothing tested either copy.** The 45 characterization tests set `nodeMemories`/`nodeChrono` and assert on the *signals*; not one asserts a row ever reached the DOM. The two copies could have drifted apart, or one could have been deleted outright, with a fully green suite.

That is the same mechanism that let the record drawer rot into the fork removed in #503 — a second copy nobody was watching.

Now one `app-graph-linked-records` used at both sites. **968 → 916 lines.**

## Two decisions worth calling out

**The empty-state keys stay inputs.** "No memories" (this node has none) and "no linked memories" (nothing links these two endpoints) are deliberately different sentences. Collapsing two copies is exactly when that kind of distinction gets quietly lost, so a test asserts the *input* key is used rather than a hard-coded one.

**The list styles moved with the markup**, with `.lists-pane` rewritten as `:host`. This is the load-bearing part: a parent's styles do not reach a child's template, so leaving them behind renders the lists present, clickable, and completely unstyled — which no unit test can see.

## Verification

- **All 45 characterization tests pass with assertions unchanged** — and this time no spec needed editing at all.
- **Mutation-proven 6/6.** Dropping the chrono section, crossing the count chips, hard-coding one empty key over the other, mis-tagging a chrono row as a memory, losing the description fallback, and un-wiring the **edge** call site all fail the suite.
- **New coverage where there was none:** 6 tests on the component itself, plus a parent test asserting *both* panels render it.
- `npm run preflight` (73 files / 701 tests) + production AOT build.
- **Browser-checked against a live server, asserting computed layout rather than presence:** `:host` resolves to `flex`/`column`/`hidden`, two bordered sections, pointer rows, correct count chips — in the node panel *and* the edge panel.

## Follow-up

The tracker's "split the graph template into sub-components" item is now effectively done. What remains of the side panels is per-kind header/field markup that genuinely differs between node and edge — extracting that would be a shuffle, not a dedup. Noted in the tracker as recommended-to-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
