### PR TITLE
feat(media): a Save button per model card, shown only when that card changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Each model card on Media Processing has its own Save button, shown only when that card changed.**
+  There was one Save at the bottom of the page for every card at once. Now the button appears in the box
+  you edited and saves only that box — and only its own confirmation runs, so saving a speech-to-text
+  endpoint no longer asks whether to re-embed every vector in every space. The two cards that report
+  env-only infrastructure get no button, because there is nothing there to save. Pipelines keeps its page
+  bar: its knobs are not grouped into per-provider boxes, so there is no "the box that changed" to put a
+  button in.
+
 - **Tag search matches part of a word.** Typing `arch` now finds a record tagged `architecture`. It used
   to require the whole tag, which reads as "no results" rather than "keep typing" — a tag was effectively
   unfindable unless you already knew it exactly. The five record types had also drifted into five

--- a/client/src/app/pages/settings/media-processing/media-processing-page.component.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-page.component.ts
@@ -128,8 +128,16 @@ export class MediaProcessingPageComponent implements OnInit {
   readonly TABS: Tab[] = ['models', 'pipelines', 'tools'];
   readonly tab = signal<Tab>('models');
 
-  /** Tools is read-only, so it never needs the save bar. */
-  readonly showsSave = computed(() => this.tab() !== 'tools');
+  /**
+   * Tools is read-only, so it never needs the save bar — and Models no longer does either: each of its
+   * cards carries its own Save, shown only when that card has an unsaved change. Owner, 2026-07-28:
+   * "save button on model page should appear only after change in the changed models box and not one
+   * global on the bottom of the page."
+   *
+   * Pipelines keeps the bar. Its knobs are not grouped into per-provider boxes, so there is no "the box
+   * that changed" to put a button in.
+   */
+  readonly showsSave = computed(() => this.tab() === 'pipelines');
 
   /**
    * A pipeline step actor was clicked (see `focusCard`): jump to the Models tab and reveal the card

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.spec.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.spec.ts
@@ -532,3 +532,137 @@ describe('MediaProcessingStateService — assist "in use" reflects real configur
     expect(c.assistInUse()).toBe(false);
   });
 });
+
+/**
+ * Per-card saving (owner, 2026-07-28: the Save button belongs in the box that changed).
+ *
+ * The failure this guards against is not a broken button — it is a button that lies about its scope.
+ * With one global `save()` behind a per-card button, saving card A silently writes card B's pending
+ * edits too, and nobody finds out until an edit they never confirmed is live. So these assert on the
+ * PATCH BODY, not on the click.
+ */
+describe('MediaProcessingStateService — per-card save', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('reports only the edited card as dirty', () => {
+    const { c } = make();
+    c.form.stt!.model = 'large-v3';
+    c.touched.set(true);
+
+    expect(c.cardDirty('stt'), 'the edited card').toBe(true);
+    for (const other of ['embedding', 'vision', 'assist', 'face'] as const) {
+      expect(c.cardDirty(other), `${other} must stay clean`).toBe(false);
+    }
+  });
+
+  it('sends ONLY the edited card\'s block — a sibling\'s pending edit is not swept in', () => {
+    const { c, patch } = make();
+    c.form.stt!.model = 'large-v3';
+    c.embedding.model = 'some-other-embedder';   // pending, NOT confirmed by the operator
+    c.touched.set(true);
+
+    c.saveCard('stt');
+
+    const body = sent(patch);
+    expect(body['stt']).toMatchObject({ model: 'large-v3' });
+    expect(body['embedding'], 'the untouched card must not be in the body at all').toBeUndefined();
+    expect(body['faceRecognition']).toBeUndefined();
+  });
+
+  it('sends each card\'s block WHOLE, because the server replaces a key it receives', () => {
+    // media-config.ts shallow-merges top level: `{...existing, ...patch}`. A block that omits a field
+    // ERASES it rather than leaving it alone — so this checks EVERY card, not a representative one. The
+    // single-card version of this test passed while the vision block was silently dropping `baseUrl`.
+    const EXPECTED: Record<string, Record<string, unknown>> = {
+      stt: { baseUrl: 'http://whisper:9000', model: 'base' },
+      vision: { baseUrl: 'http://ollama:11434', model: 'llava' },
+      embedding: { provider: 'local', baseUrl: null, model: 'nomic-embed-text-v1.5', dimensions: 768, similarity: 'cosine' },
+    };
+    for (const [card, block] of Object.entries(EXPECTED)) {
+      const { c, patch } = make();
+      c.touched.set(true);
+      c.saveCard(card as 'stt');
+      expect(sent(patch)[card], `${card} must be sent complete`).toEqual(block);
+    }
+  });
+
+  it('keeps the OTHER cards dirty after one card is saved', async () => {
+    const { c } = make();
+    c.form.stt!.model = 'large-v3';
+    c.embedding.model = 'other';
+    c.touched.set(true);
+
+    await c.saveCard('stt');
+
+    expect(c.cardDirty('stt'), 'saved card is clean').toBe(false);
+    expect(c.cardDirty('embedding'), 'the unsaved card must still warn').toBe(true);
+    expect(c.isDirty(), 'and the tab-switch guard must still fire').toBe(true);
+  });
+
+  it('runs only the gate that belongs to the card', async () => {
+    // Each confirmation in the global save belongs to exactly ONE card. Saving speech-to-text must not
+    // ask whether to re-embed every vector in every space.
+    const { c, confirm } = make();
+    c.form.stt!.model = 'large-v3';
+    c.touched.set(true);
+
+    await c.saveCard('stt');
+
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it('still asks before re-indexing when the EMBEDDING card is saved', async () => {
+    const { c, confirm, patch } = make();
+    c.embedding.model = 'a-different-model';
+    c.touched.set(true);
+
+    await c.saveCard('embedding');
+
+    expect(confirm).toHaveBeenCalled();
+    expect(patch).toHaveBeenCalled();
+  });
+
+  it('aborts the card save when its confirmation is declined', async () => {
+    const { c, patch } = make(cfgFixture(), false);
+    c.embedding.model = 'a-different-model';
+    c.touched.set(true);
+
+    await c.saveCard('embedding');
+
+    expect(patch, 'declining must send nothing').not.toHaveBeenCalled();
+  });
+
+  it('grafts a typed API key onto its own card only, and clears only that box', async () => {
+    const { c, patch } = make();
+    c.sttApiKeyInput = 'sk-typed';
+    c.visionApiKeyInput = 'sk-other-card';
+
+    expect(c.cardDirty('stt')).toBe(true);
+    await c.saveCard('stt');
+
+    expect((sent(patch)['stt'] as Record<string, unknown>)['apiKey']).toBe('sk-typed');
+    expect(c.sttApiKeyInput, 'saved card cleared').toBe('');
+    expect(c.visionApiKeyInput, 'the other card keeps its unsaved key').toBe('sk-other-card');
+  });
+
+  it('sends the assist card under documentProcessing, which the server deep-merges', () => {
+    // Nested, unlike every other card. The handler merges documentProcessing one level deep precisely so
+    // a patch naming only assistModel keeps mode/renderDpi — without that this card could not be saved
+    // on its own at all.
+    const { c, patch } = make();
+    c.assist.model = 'gpt-4o-mini';
+    c.touched.set(true);
+    c.saveCard('assist');
+
+    const dp = sent(patch)['documentProcessing'] as Record<string, unknown>;
+    expect(dp['assistModel']).toMatchObject({ model: 'gpt-4o-mini' });
+    expect(dp['mode'], 'the knobs are NOT resent — the deep merge preserves them').toBeUndefined();
+  });
+
+  it('is never dirty while infra-managed', () => {
+    const { c } = make(cfgFixture({ infraManaged: true }));
+    c.form.stt!.model = 'x';
+    c.touched.set(true);
+    expect(c.cardDirty('stt')).toBe(false);
+  });
+});

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
@@ -21,6 +21,19 @@ import {
   TestResult, TestTarget, FaceRecognitionCfg, MODE_STAGES,
 } from './media-processing.types';
 
+/**
+ * The Models tab's cards that own editable config and therefore get their own Save button.
+ *
+ * `doc-render` and `unstructured` are deliberately absent: neither has a single `ngModel` — they report
+ * env-only infrastructure, so a Save button on them would be a control that cannot do anything.
+ */
+export type ModelCardId = 'embedding' | 'vision' | 'stt' | 'assist' | 'face';
+export const MODEL_CARDS: readonly ModelCardId[] = ['embedding', 'vision', 'stt', 'assist', 'face'];
+
+/** A card, or everything the cards do not own (the Pipelines knobs, ceilings and limits). */
+export type CfgSection = ModelCardId | 'rest';
+export const ALL_SECTIONS: readonly CfgSection[] = [...MODEL_CARDS, 'rest'];
+
 @Injectable()
 export class MediaProcessingStateService {
   private readonly http = inject(HttpClient);
@@ -45,8 +58,15 @@ export class MediaProcessingStateService {
 
   /** Serialized model|dimensions|similarity at load — changing any of these re-indexes every vector. */
   private embeddingReindexBaseline = '';
-  /** The saved payload as it stood at load, for the unsaved-changes guard. */
-  private savedSnapshot = '';
+  /**
+   * The saved payload PER SECTION, as it stood at the last save of that section.
+   *
+   * One snapshot for the whole config used to be enough, because one button saved everything. With
+   * per-card saves it is actively wrong: saving the vision card would re-baseline the entire config and
+   * mark an edited embedding card clean, so the operator's unsaved change would stop warning them and
+   * then be lost on navigate. Each section re-baselines only itself.
+   */
+  private savedSnapshots: Partial<Record<CfgSection, string>> = {};
   /** Flipped by a delegated input/change listener on the page. See `isDirty`. */
   touched = signal(false);
 
@@ -144,9 +164,9 @@ export class MediaProcessingStateService {
         this.embeddingApiKeyInput = '';
         this.docCfgSig.set(dp);
         this.docMode.set(dp.mode ?? 'ocr');
-        this.savedSnapshot = this.snapshot();
+        this.loading.set(false);   // before rebaseline: sectionSnapshot is inert while loading
+        this.rebaseline(ALL_SECTIONS);
         this.touched.set(false);
-        this.loading.set(false);
       },
       error: err => { this.loadError.set(`Failed to load configuration: ${err?.message ?? 'Unknown error'}`); this.loading.set(false); },
     });
@@ -156,6 +176,73 @@ export class MediaProcessingStateService {
   get managed(): boolean { return !!this.form.infraManaged; }
   // When infra-managed, EVERY field is locked (the API refuses edits) — so isLocked() short-circuits.
   isLocked(field: string): boolean { return this.managed || this.lockedByInfra.includes(field); }
+
+  // ── per-card sections ──
+
+  /**
+   * The complete PATCH block a single card owns.
+   *
+   * Each block is sent WHOLE. `media-config.ts` shallow-merges top-level keys, so omitting a key leaves
+   * it untouched (which is what makes a per-card save safe) but a key that IS sent replaces its previous
+   * value outright — send `vision: { model }` without `baseUrl` and the base URL is erased.
+   *
+   * `assist` is the exception that proves it: it lives under `documentProcessing`, which the handler
+   * DEEP-merges one level precisely so a patch naming only `assistModel` keeps `mode`/`renderDpi`/the
+   * rest. That is why the assist card can be saved on its own at all.
+   */
+  private cardBlock(card: ModelCardId): MediaCfg {
+    const base = this.payload();
+    switch (card) {
+      case 'embedding': return { embedding: base.embedding };
+      case 'vision': return { visionProvider: this.form.visionProvider, vision: base.vision };
+      case 'stt': return { sttProvider: this.form.sttProvider, stt: base.stt };
+      case 'face': return { faceRecognition: base.faceRecognition };
+      case 'assist': {
+        const a = this.assist;
+        return { documentProcessing: { assistModel: {
+          baseUrl: a.baseUrl || undefined, model: a.model || undefined, acknowledgedHost: a.acknowledgedHost,
+        } } };
+      }
+    }
+  }
+
+  /** Everything the cards do NOT own — the Pipelines knobs, ceilings and limits. Saved by the page bar. */
+  private restBlock(): Record<string, unknown> {
+    const b = this.payload();
+    const dp = { ...b.documentProcessing };
+    return { levels: b.levels, documentProcessing: dp, fallbackToExternal: b.fallbackToExternal,
+      maxFileSizeBytes: b.maxFileSizeBytes, workerConcurrency: b.workerConcurrency };
+  }
+
+  private sectionSnapshot(section: CfgSection): string {
+    return JSON.stringify(section === 'rest' ? this.restBlock() : this.cardBlock(section));
+  }
+
+  private rebaseline(sections: readonly CfgSection[]): void {
+    for (const sec of sections) this.savedSnapshots[sec] = this.sectionSnapshot(sec);
+  }
+
+  /** The typed-but-unsaved API key belonging to this card, if it has one. */
+  private cardKeyInput(card: ModelCardId): string {
+    return card === 'vision' ? this.visionApiKeyInput
+      : card === 'stt' ? this.sttApiKeyInput
+      : card === 'assist' ? this.assistApiKeyInput
+      : card === 'embedding' ? this.embeddingApiKeyInput
+      : '';
+  }
+
+  /**
+   * True when THIS card has something a save would change — what its own Save button keys off.
+   *
+   * Same two-part rule as the global guard: a typed API key counts even though it is absent from the
+   * snapshot (it is deliberately not in `payload()`), and otherwise it is a real diff, not merely a
+   * keystroke that was undone.
+   */
+  cardDirty(card: ModelCardId): boolean {
+    if (this.managed || this.loading()) return false;
+    if (this.cardKeyInput(card)) return true;
+    return this.touched() && this.sectionSnapshot(card) !== (this.savedSnapshots[card] ?? '');
+  }
 
   // ── unsaved-changes guard ──
 
@@ -172,7 +259,10 @@ export class MediaProcessingStateService {
   isDirty(): boolean {
     if (this.managed || this.loading()) return false;
     if (this.visionApiKeyInput || this.sttApiKeyInput || this.assistApiKeyInput || this.embeddingApiKeyInput) return true;
-    return this.touched() && this.snapshot() !== this.savedSnapshot;
+    if (!this.touched()) return false;
+    // Derived from the sections rather than one whole-config snapshot, so that saving one card leaves the
+    // guard still warning about the others. A single snapshot would have gone clean for all of them.
+    return ALL_SECTIONS.some(sec => this.sectionSnapshot(sec) !== (this.savedSnapshots[sec] ?? ''));
   }
 
   // ── document extraction helpers ──
@@ -258,6 +348,87 @@ export class MediaProcessingStateService {
     };
   }
 
+  /**
+   * Save ONE card.
+   *
+   * Only that card's block is sent, and only its confirmation gate runs. Both halves matter: each gate in
+   * the global `save()` belongs to exactly one card (egress consent to assist, the face-off warning to
+   * face, the re-embed warning to embedding), so running all three from a card would ask about re-indexing
+   * every vector because someone edited a speech-to-text URL.
+   *
+   * On success only this card is re-baselined and only its API-key box is cleared — an edit sitting in
+   * another card must keep reporting itself as unsaved.
+   */
+  async saveCard(card: ModelCardId): Promise<void> {
+    if (this.managed || this.saving()) return;
+
+    if (card === 'assist' && !this.assistLocked() && this.assistNeedsAck()) {
+      const host = this.assistHost();
+      const ok = await this.confirmDialog.confirm({
+        title: this.transloco.translate('mediaProcessing.confirm.egressTitle'),
+        message: this.transloco.translate('mediaProcessing.confirm.egressMessage', { host }),
+        confirmLabel: this.transloco.translate('mediaProcessing.confirm.egressConfirm'),
+        cancelLabel: this.transloco.translate('common.cancel'),
+        danger: true,
+      });
+      if (!ok) return;
+      this.assist.acknowledgedHost = host;
+    }
+    if (card === 'face' && this.faceBeingDisabled()) {
+      const ok = await this.confirmDialog.confirm({
+        title: this.transloco.translate('mediaProcessing.confirm.faceOffTitle'),
+        message: this.transloco.translate('mediaProcessing.confirm.faceOffMessage'),
+        confirmLabel: this.transloco.translate('mediaProcessing.confirm.faceOffConfirm'),
+        cancelLabel: this.transloco.translate('common.cancel'),
+        danger: true,
+      });
+      if (!ok) return;
+    }
+    if (card === 'embedding' && this.embeddingNeedsReindex()) {
+      const ok = await this.confirmDialog.confirm({
+        title: this.transloco.translate('mediaProcessing.confirm.reindexTitle'),
+        message: this.transloco.translate('mediaProcessing.confirm.reindexMessage'),
+        confirmLabel: this.transloco.translate('mediaProcessing.confirm.reindexConfirm'),
+        cancelLabel: this.transloco.translate('common.cancel'),
+        danger: true,
+      });
+      if (!ok) return;
+    }
+
+    this.saving.set(true);
+    this.saveError.set('');
+    this.saveOk.set('');
+
+    // The typed key is grafted on here for the same reason the global save does it: `payload()` holds the
+    // server's MASK, and echoing a mask back would overwrite a real credential with asterisks.
+    const key = this.cardKeyInput(card);
+    const block = this.cardBlock(card);
+    if (key) {
+      if (card === 'vision') block.vision = { ...block.vision, apiKey: key };
+      else if (card === 'stt') block.stt = { ...block.stt, apiKey: key };
+      else if (card === 'embedding') block.embedding = { ...block.embedding, apiKey: key };
+      else if (card === 'assist') {
+        block.documentProcessing = { assistModel: { ...block.documentProcessing?.assistModel, apiKey: key } };
+      }
+    }
+
+    const body = JSON.parse(JSON.stringify(block)) as MediaCfg;
+    this.http.patch<{ ok: boolean; config: MediaCfg }>('/api/admin/media-config', body).subscribe({
+      next: () => {
+        this.saveOk.set(this.transloco.translate('mediaProcessing.saved'));
+        if (card === 'vision') this.visionApiKeyInput = '';
+        else if (card === 'stt') this.sttApiKeyInput = '';
+        else if (card === 'assist') this.assistApiKeyInput = '';
+        else if (card === 'embedding') { this.embeddingApiKeyInput = ''; this.embeddingReindexBaseline = this.reindexKey(); }
+        if (card === 'face') this.faceEnabledBaseline = this.face.enabled === true;
+        this.rebaseline([card]);
+        this.saving.set(false);
+        setTimeout(() => this.saveOk.set(''), 3000);
+      },
+      error: err => { this.saveError.set(`Save failed: ${err?.error?.error ?? err?.message ?? 'Unknown error'}`); this.saving.set(false); },
+    });
+  }
+
   async save(): Promise<void> {
     if (this.managed) return; // infra-managed: the API would reject it anyway
     const dp = this.form.documentProcessing ?? {};
@@ -334,7 +505,7 @@ export class MediaProcessingStateService {
         this.assistApiKeyInput = '';
         this.embeddingApiKeyInput = '';
         this.embeddingReindexBaseline = this.reindexKey(); // re-baseline so a second save won't re-prompt
-        this.savedSnapshot = this.snapshot();
+        this.rebaseline(ALL_SECTIONS);
         this.faceEnabledBaseline = this.face.enabled === true;
         this.touched.set(false);
         this.saving.set(false);

--- a/client/src/app/pages/settings/media-processing/models-tab.component.spec.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.spec.ts
@@ -13,6 +13,8 @@ import { ModelsTabComponent } from './models-tab.component';
 import { MediaProcessingStateService } from './media-processing-state.service';
 import { PipelineStatusService } from './pipeline-status.service';
 import { SchemaApi } from '../../../core/schema-api.service';
+import { HttpClient } from '@angular/common/http';
+import { ConfirmDialogService } from '../../../core/confirm-dialog.service';
 
 function setup(libEntries: { knowledgeType: string; typeName: string }[] = [], initialTypes?: string[]) {
   const touched = vi.fn();
@@ -79,5 +81,94 @@ describe('ModelsTabComponent — person-types picker', () => {
     expect(c.availablePersonTypes()).toEqual(['person']);   // library options don't include the stored 'legacy'
     c.removePersonType('legacy');
     expect(state.face.personEntityTypes).toEqual([]);
+  });
+});
+
+/**
+ * The per-card Save button, asserted in the DOM.
+ *
+ * The service tests drive `cardDirty`/`saveCard` directly, which is exactly the blind spot that let the
+ * graph panel's filters ship documented-but-unreachable: logic that works, wired to no control. A
+ * mutation that stopped rendering these buttons entirely survived the service suite. So this renders the
+ * real template against the real service and asserts the button is THERE, in the right card and no other.
+ */
+describe('ModelsTabComponent — per-card Save button', () => {
+  function render(cfg: Record<string, unknown>) {
+    TestBed.resetTestingModule();
+    const patch = vi.fn().mockReturnValue(of({ ok: true, config: cfg }));
+    const http = { get: vi.fn().mockReturnValue(of(cfg)), patch, post: vi.fn().mockReturnValue(of({})) };
+    TestBed.configureTestingModule({
+      imports: [ModelsTabComponent, getTranslocoModule()],
+      providers: [
+        MediaProcessingStateService,
+        { provide: HttpClient, useValue: http },
+        { provide: ConfirmDialogService, useValue: { confirm: vi.fn().mockResolvedValue(true) } },
+        // The rendered template asks for more of this service than the logic-only tests do.
+        { provide: PipelineStatusService, useValue: {
+          status: () => null, bySidecarKey: () => new Map(),
+          modelState: () => null, sidecarState: () => null,
+        } },
+        { provide: SchemaApi, useValue: { listSchemaLibrary: () => of({ entries: [] }) } },
+      ],
+    });
+    const state = TestBed.inject(MediaProcessingStateService);
+    state.load();
+    const fixture = TestBed.createComponent(ModelsTabComponent);
+    fixture.detectChanges();
+    return { fixture, state };
+  }
+
+  const CFG = {
+    visionProvider: 'local', sttProvider: 'local',
+    vision: { baseUrl: 'http://ollama:11434', model: 'llava' },
+    stt: { baseUrl: 'http://whisper:9000', model: 'base' },
+    embedding: { provider: 'local', model: 'nomic', dimensions: 768, similarity: 'cosine' },
+    documentProcessing: { mode: 'ocr', assistModel: {} },
+    faceRecognition: { enabled: false },
+    lockedByInfra: [],
+  };
+
+  const saveIn = (fixture: { nativeElement: HTMLElement }, card: string) =>
+    fixture.nativeElement.querySelector(`#model-card-${card} .card-save`);
+
+  it('shows no Save button until something changes', () => {
+    const { fixture } = render(CFG);
+    expect(fixture.nativeElement.querySelectorAll('.card-save').length).toBe(0);
+  });
+
+  it('shows Save in the edited card and in NO other', () => {
+    const { fixture, state } = render(CFG);
+    state.form.stt!.model = 'large-v3';
+    state.touched.set(true);
+    fixture.detectChanges();
+
+    expect(saveIn(fixture, 'stt'), 'the edited card').toBeTruthy();
+    for (const other of ['embedding', 'vision', 'assist', 'face']) {
+      expect(saveIn(fixture, other), `${other} must not offer a save`).toBeNull();
+    }
+  });
+
+  it('never offers Save on the env-only cards', () => {
+    // doc-render and unstructured report infrastructure and have no editable field; a button there
+    // would be a control that cannot do anything.
+    const { fixture, state } = render(CFG);
+    state.form.stt!.model = 'large-v3';
+    state.touched.set(true);
+    fixture.detectChanges();
+
+    expect(saveIn(fixture, 'doc-render')).toBeNull();
+    expect(saveIn(fixture, 'unstructured')).toBeNull();
+  });
+
+  it('clicking it saves that card', () => {
+    const { fixture, state } = render(CFG);
+    const spy = vi.spyOn(state, 'saveCard');
+    state.form.vision!.model = 'moondream';
+    state.touched.set(true);
+    fixture.detectChanges();
+
+    (saveIn(fixture, 'vision') as HTMLButtonElement).click();
+
+    expect(spy).toHaveBeenCalledWith('vision');
   });
 });

--- a/client/src/app/pages/settings/media-processing/models-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.ts
@@ -79,6 +79,9 @@ import { TestTarget } from './media-processing.types';
     .testrow { display: flex; gap: 10px; align-items: center; flex-wrap: nowrap; min-height: 34px; }
     .testrow > :not(.hint) { flex: none; }
     .testrow .hint { margin: 0; min-width: 0; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    /* Save belongs to the card it sits in and appears only when that card has an unsaved change, so it
+       is pushed to the far end of the row rather than sitting beside Test as a peer action. */
+    .testrow .card-save { margin-left: auto; }
   `],
   template: `
     <div class="cards">
@@ -145,6 +148,12 @@ import { TestTarget } from './media-processing.types';
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
             <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
           }
+          @if (s.cardDirty('embedding')) {
+            <button class="btn btn-sm btn-primary card-save" type="button"
+              [disabled]="s.saving()" (click)="s.saveCard('embedding')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
+          }
         </div>
       </app-model-provider-card>
 
@@ -187,6 +196,12 @@ import { TestTarget } from './media-processing.types';
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
             <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
           }
+          @if (s.cardDirty('vision')) {
+            <button class="btn btn-sm btn-primary card-save" type="button"
+              [disabled]="s.saving()" (click)="s.saveCard('vision')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
+          }
         </div>
       </app-model-provider-card>
 
@@ -228,6 +243,12 @@ import { TestTarget } from './media-processing.types';
           @if (s.testOf('stt')?.res; as r) {
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
             <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+          }
+          @if (s.cardDirty('stt')) {
+            <button class="btn btn-sm btn-primary card-save" type="button"
+              [disabled]="s.saving()" (click)="s.saveCard('stt')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
           }
         </div>
       </app-model-provider-card>
@@ -279,6 +300,12 @@ import { TestTarget } from './media-processing.types';
           @if (s.testOf('assist')?.res; as r) {
             <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
             <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+          }
+          @if (s.cardDirty('assist')) {
+            <button class="btn btn-sm btn-primary card-save" type="button"
+              [disabled]="s.saving()" (click)="s.saveCard('assist')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
           }
         </div>
       </app-model-provider-card>
@@ -379,6 +406,14 @@ import { TestTarget } from './media-processing.types';
         <div class="field" style="margin-bottom:0;">
           <label>{{ 'mediaProcessing.face.actorLabel' | transloco }}</label>
           <div class="ro">BlazeFace + FaceRes</div>
+        </div>
+        <div footer class="testrow">
+          @if (s.cardDirty('face')) {
+            <button class="btn btn-sm btn-primary card-save" type="button"
+              [disabled]="s.saving()" (click)="s.saveCard('face')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
+          }
         </div>
       </app-model-provider-card>
     </div>


### PR DESCRIPTION
Owner: *"save button on model page should appear only after change in the changed models box and not one global on the bottom of the page."*

The page had one Save at the bottom that wrote every card at once.

## The risk this had to avoid

A button that **lies about its scope**. Keep the global `save()` behind a per-card button and saving card A silently writes card B's pending edits too — worse than the honest global bar, and invisible until someone loses an edit they never confirmed. So the save is genuinely partial.

## What made that safe

Verified against `server/src/api/media-config.ts` *before* writing any of it:

- The PATCH handler shallow-merges top-level keys (`{...existing, ...patch}`). **Omitting** a key leaves it untouched — so a per-card body is safe.
- But a key that **is** sent replaces its previous value outright, so each card sends its block **whole**. A `vision` block missing `baseUrl` would erase the base URL.
- `documentProcessing` is deep-merged one level — the only reason the nested assist card can be saved on its own.

## Per-section snapshots

One snapshot for the whole config was fine when one button saved everything. With per-card saves it's actively wrong: saving vision would re-baseline the entire config and mark an edited embedding card clean, so the unsaved change would stop warning and then be lost on navigate. Each section re-baselines only itself, and the cross-tab guard derives from the sections.

## Each gate belongs to one card

Egress consent → assist, face-off warning → face, re-embed warning → embedding. Running all three from a card would ask about re-indexing every vector because someone edited a speech-to-text URL.

`doc-render` and `unstructured` get no button — neither has a single `ngModel`, so a Save there would be a control that can't do anything. Pipelines keeps the page bar: its knobs aren't grouped into per-provider boxes, so there's no "box that changed" to put a button in.

## Verification

**Mutation-proven 9/9 — and the first run left two survivors, both real:**

1. The vision block could drop `baseUrl`, because the "sends the block whole" test only covered one card. It now checks every card.
2. The Save buttons could stop rendering **entirely** and nothing failed, because every test drove the service directly. That's the same blind spot that let the graph filters ship documented-but-unreachable — so the models tab now renders the real template against the real service and asserts the button is there, in the right card and no other.

All 46 pre-existing state-service tests pass with assertions unchanged. preflight (73 files / 715 tests) + production AOT build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)