### PR TITLE
fix(files): refresh the list on the shell's live tick so status stops going stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A processing file's status now updates by itself in the Files list.** The status pill and the
+  processing stage bar are both drawn from the directory listing, and the list never refreshed — so a
+  file's status sat at whatever it was when you opened the folder. A file could finish and still read
+  "Embedding" until you navigated away and back. The shell was already broadcasting the change (it is how
+  every record tab stays current); the file list simply was not listening.
+
 - **Each model card on Media Processing has its own Save button, shown only when that card changed.**
   There was one Save at the bottom of the page for every card at once. Now the button appears in the box
   you edited and saves only that box — and only its own confirmation runs, so saving a speech-to-text

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -17,6 +17,7 @@ import { type FileEntry, type UploadProgress } from '../../core/api.types';
 import { FilesApi } from '../../core/files-api.service';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { AuthService } from '../../core/auth.service';
+import { BrainStore } from '../brain/brain-store.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { FileManagerComponent } from './file-manager.component';
 
@@ -438,5 +439,64 @@ describe('FileManagerComponent — preview/download auth', () => {
     // #134 scoped the ?token= fallback to SSE only — the token must NOT ride in the URL.
     expect(String(calls[0].url)).not.toContain('token=');
     expect(calls[0].opts.headers.Authorization).toBe('Bearer T');
+  });
+});
+
+/**
+ * Live refresh while a file is processing.
+ *
+ * The shell opens an SSE stream and bumps `BrainStore.liveRefreshTick` on a `file.*` event — that is how
+ * every record tab stays current. This list never read it. Status pill and processing stage bar are both
+ * built from the DIRECTORY LISTING, so with no reload they sat at whatever they were when the folder was
+ * opened: a file could finish and still read "Embedding" until you navigated away and back.
+ *
+ * Nothing errored, which is exactly why it presented as a slow pipeline rather than a stale view — so the
+ * test asserts the RELOAD happens, not that a particular pill is drawn.
+ */
+describe('FileManagerComponent — live refresh on the shell tick', () => {
+  function create(entries: FileEntry[]) {
+    const api = makeApi(entries);
+    const listFiles = vi.fn().mockReturnValue(of({ entries }));
+    api.listFiles = listFiles;
+    const store = new BrainStore();
+    TestBed.configureTestingModule({
+      imports: [FileManagerComponent, getTranslocoModule()],
+      providers: [
+        { provide: FilesApi, useValue: api },
+        { provide: SpacesApi, useValue: api },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: BrainStore, useValue: store },
+      ],
+    });
+    const fixture = TestBed.createComponent(FileManagerComponent);
+    fixture.componentRef.setInput('embeddedSpaceId', 'work');
+    fixture.detectChanges();
+    return { fixture, store, listFiles };
+  }
+
+  const PROCESSING: FileEntry[] = [
+    { name: 'big.pdf', size: 10, isFile: true, isDirectory: false, modified: '2026-01-01', embeddingStatus: 'processing' } as FileEntry,
+  ];
+
+  it('re-lists the directory when the shell signals a change', () => {
+    const { fixture, store, listFiles } = create(PROCESSING);
+    const before = listFiles.mock.calls.length;
+
+    store.liveRefreshTick.update(t => t + 1);
+    fixture.detectChanges();
+
+    expect(listFiles.mock.calls.length, 'a tick must re-list the directory').toBeGreaterThan(before);
+  });
+
+  it('lists the directory exactly ONCE on open — the effect must not double-load', () => {
+    // The effect skips its own first run, because creating the component already listed the folder.
+    // Without that guard every folder open costs two identical requests. Asserting the absolute count is
+    // what catches it: measuring "no further calls AFTER creation" is blind, since the duplicate already
+    // happened by then.
+    // Two, not one: opening a folder lists the folder AND the tree root. Three would mean the effect
+    // ran on its own first tick and re-listed on top of the initial load.
+    const { listFiles } = create(PROCESSING);
+    expect(listFiles.mock.calls.length, 'folder + tree root, and nothing more').toBe(2);
   });
 });

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, OnDestroy, HostListener, ElementRef, viewChild, Input, Output, EventEmitter } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal, computed, effect, untracked, OnInit, OnDestroy, HostListener, ElementRef, viewChild, Input, Output, EventEmitter } from '@angular/core';
 import { SortableHeaderComponent } from '../brain/sortable-header.component';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -26,6 +26,7 @@ import { EntityRefFieldComponent } from '../brain/entity-ref-field.component';
 import { MemoryRefFieldComponent } from '../brain/memory-ref-field.component';
 import { ChronoRefFieldComponent } from '../brain/chrono-ref-field.component';
 import { EntityRefPicker } from '../brain/entity-ref-picker.service';
+import { BrainStore } from '../brain/brain-store.service';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 import typescript from 'highlight.js/lib/languages/typescript';
@@ -827,6 +828,29 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   // Brain-provided (only present when embedded in the Brain). Optional so the standalone /files route,
   // where the Brain injector isn't in the tree, still constructs — there the meta edit mode is hidden.
   private picker = inject(EntityRefPicker, { optional: true });
+  /** Optional for the same reason as `picker`: this component also runs outside the Brain shell. */
+  private store = inject(BrainStore, { optional: true });
+
+  constructor() {
+    /**
+     * Live refresh while a file is processing.
+     *
+     * The shell already opens an SSE stream and bumps `liveRefreshTick` on a `file.*` event — that is how
+     * every record tab stays current. This list never read it. The status pill and the processing stage
+     * bar are both built from the DIRECTORY LISTING, so with no reload they sat at whatever they were
+     * when the folder was first opened: a file could finish and still read "Embedding" until you clicked
+     * away and back. Nothing errored, which is why it looked like a slow pipeline rather than a stale view.
+     *
+     * `untracked` around the reload so the effect depends on the tick ALONE — `loadDir` reads
+     * `currentPath()`, and tracking that would reload the directory on every navigation as well.
+     */
+    let firstTick = true;
+    effect(() => {
+      this.store?.liveRefreshTick();
+      if (firstTick) { firstTick = false; return; }
+      untracked(() => this.reloadDir());
+    });
+  }
 
   /** When set (embedded in brain), skip space loading and use this space. */
   @Input() embeddedSpaceId = '';


### PR DESCRIPTION
Owner: *"in the files tab when the file is processing, status is not live updated."*

**It never was.** The status pill and the processing stage bar are both built from the **directory listing**, and nothing re-listed — so a file's status sat at whatever it was when you opened the folder. It could finish and still read "Embedding" until you navigated away and back.

## The plumbing already existed

The shell opens an SSE stream per space and bumps `BrainStore.liveRefreshTick` on a `file.*` event — `TAB_FOR_COLLECTION` even maps `file → files`. Every record tab picks that up via `record-tab-base`.

The file manager doesn't extend that base and **never read the tick**, so the signal arrived and was dropped on the floor. Classic absence-that-looks-healthy: no error, no failing test, just a view that quietly stopped agreeing with reality.

`BrainStore` is injected `{ optional: true }`, matching how this component already takes `EntityRefPicker` — it also runs outside the Brain shell, where there's no store and the effect simply never fires.

## Two load-bearing details

- **`untracked` around the reload**, so the effect depends on the tick *alone*. `loadDir` reads `currentPath()`, and tracking that would re-list the directory on every navigation too.
- **The effect skips its own first run**, because creating the component already listed the folder. Without that guard every folder open costs a duplicate request.

## Verification

**Mutation-proven 3/3** — restoring the original bug (never reading the tick), dropping the reload, and dropping the first-run guard all fail the suite.

The third one needed the test rewritten: my first version checked "no further calls *after* creation" and was blind to the duplicate, because it had already happened by the time it measured. It now asserts an **absolute** call count (folder + tree root = 2; a third means the effect double-loaded).

preflight (73 files / 717 tests) + production AOT build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)