### PR TITLE
fix(media): drop the redundant On/Off pill from the Face Recognition card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Face Recognition card drops its On/Off pill.** The health dot beside the heading already says
+  whether it is running, so the pill repeated it.
+
 - **A processing file's status now updates by itself in the Files list.** The status pill and the
   processing stage bar are both drawn from the directory listing, and the list never refreshed — so a
   file's status sat at whatever it was when you opened the folder. A file could finish and still read

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1535,8 +1535,6 @@
   "mediaProcessing.pipelines.ceilingOffWarning": "Aus gilt überall — kein Bereich kann diese Klasse verarbeiten.",
   "files.progress.working": "Läuft",
   "files.progress.stalled": "Kein Fortschritt gemeldet — dieser Auftrag hängt möglicherweise",
-  "mediaProcessing.face.pillOn": "An",
-  "mediaProcessing.face.pillOff": "Aus",
   "mediaProcessing.face.confidence": "Schwelle für automatische Zuordnung",
   "mediaProcessing.face.confidenceHint": "Ähnlichkeit (0–1), ab der ein Gesicht automatisch zugeordnet wird. Darunter wird das Gesicht eingebettet, aber nicht zugeordnet.",
   "mediaProcessing.face.minSize": "Mindestgröße des Gesichts",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1535,8 +1535,6 @@
   "mediaProcessing.pipelines.ceilingOffWarning": "Off applies everywhere — no space can process this class.",
   "files.progress.working": "Working",
   "files.progress.stalled": "No progress reported — this job may be stuck",
-  "mediaProcessing.face.pillOn": "On",
-  "mediaProcessing.face.pillOff": "Off",
   "mediaProcessing.face.confidence": "Auto-label threshold",
   "mediaProcessing.face.confidenceHint": "Similarity (0–1) above which a face is labelled automatically. Below it the face is embedded but left unlabelled.",
   "mediaProcessing.face.minSize": "Minimum face size",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1535,8 +1535,6 @@
   "mediaProcessing.pipelines.ceilingOffWarning": "Wyłączenie obowiązuje wszędzie — żadna przestrzeń nie przetworzy tej klasy.",
   "files.progress.working": "W toku",
   "files.progress.stalled": "Brak zgłoszonego postępu — to zadanie mogło się zaciąć",
-  "mediaProcessing.face.pillOn": "Włączone",
-  "mediaProcessing.face.pillOff": "Wyłączone",
   "mediaProcessing.face.confidence": "Próg automatycznego oznaczania",
   "mediaProcessing.face.confidenceHint": "Podobieństwo (0–1), powyżej którego twarz jest oznaczana automatycznie. Poniżej twarz zostaje osadzona, ale bez oznaczenia.",
   "mediaProcessing.face.minSize": "Minimalny rozmiar twarzy",

--- a/client/src/app/pages/settings/media-processing/models-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.ts
@@ -349,9 +349,6 @@ import { TestTarget } from './media-processing.types';
         [purpose]="'mediaProcessing.face.purpose' | transloco"
         [health]="faceState()"
         [infra]="s.faceLocked('enabled')" envVar="FACE_RECOGNITION_ENABLED">
-        <app-status-pill pill [variant]="s.face.enabled ? 'active' : 'off'">
-          {{ (s.face.enabled ? 'mediaProcessing.face.pillOn' : 'mediaProcessing.face.pillOff') | transloco }}
-        </app-status-pill>
 
         <!-- Not wrapped in .field: that rule styles a direct child label as a small-caps field
              caption, which turned the checkbox's own label into what looked like a section header


### PR DESCRIPTION
Owner: *"remove the 'on' pill, the green diode is enough."*

The card already carries a health dot next to its heading, driven by the same state. The pill said the same thing a second time, in more space.

**The other cards keep their pills** — those report something the dot does not: external vs local provider, whether the media class is switched on, an acknowledged egress host, an env pin. Only face's was a straight duplicate.

Also removes the now-orphaned `mediaProcessing.face.pillOn` / `pillOff` strings from en/de/pl.

preflight + production AOT build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)