### PR TITLE
fix(spaces): re-baseline the unsaved-changes guard on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Saving a space's settings no longer leaves it looking unsaved.** The unsaved-changes snapshot was
+  only taken when a space was opened, so after a save the editor still compared against the pre-save
+  values — closing it could then warn you about discarding changes that were already persisted.
+
 - **The Face Recognition card drops its On/Off pill.** The health dot beside the heading already says
   whether it is running, so the pill repeated it.
 

--- a/client/src/app/pages/settings/spaces.component.spec.ts
+++ b/client/src/app/pages/settings/spaces.component.spec.ts
@@ -45,6 +45,7 @@ function makeApi(spaces: Space[] = []) {
     listNetworks: () => of({ networks: [] }),
     getSpaceStats: () => of(STATS),
     listSchemaLibrary: () => of({ entries: [] }),
+    updateSpace: (_id: string, _body: unknown) => of({ space: space() }),
   } as any;
 }
 
@@ -257,5 +258,32 @@ describe('SpacesComponent — settings dialog rendering', () => {
     c.showCreateDialog.set(true);
     fixture.detectChanges();
     expect(c.showCreateDialog()).toBe(true);
+  });
+});
+
+/**
+ * The dirty snapshot must be re-baselined by a successful save.
+ *
+ * It was only ever taken when a space was OPENED, so after saving, the editor still compared against the
+ * pre-save values and reported unsaved changes for edits it had just persisted. Closing the dialog on
+ * success hid it in the common path, but any flow that kept the editor open produced a discard prompt
+ * for nothing — and a discard prompt that fires after a save is worse than none, because it trains
+ * people to click through discard prompts.
+ */
+describe('SpacesComponent — save re-baselines the unsaved-changes guard', () => {
+  it('is not dirty after a successful save', () => {
+    const fixture = create([space()]);
+    const c = fixture.componentInstance as any;
+
+    c.state.settingsSpace.set(space());
+    c.state.markPristine();
+    c.state.stForm.label = 'Renamed';
+    expect(c.state.isDirty(), 'an edit must be dirty').toBe(true);
+
+    c.saveSettings();
+
+    // Asserted on the STATE, not on whether the dialog closed: closing is what used to mask this.
+    c.state.settingsSpace.set(space());
+    expect(c.state.isDirty(), 'a saved edit must not still count as unsaved').toBe(false);
   });
 });

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -278,6 +278,12 @@ export class SpacesComponent implements OnInit {
       next: ({ space }) => {
         this.state.settingsSaving.set(false);
         this.store.applySpace(space);
+        // Re-baseline BEFORE closing. The dirty snapshot was only ever taken when a space was opened, so
+        // a successful save left it stale: the editor still compared against the pre-save values and
+        // reported unsaved changes for edits that were already persisted. Closing here happened to hide
+        // it, but any path that keeps the dialog open (or reopens it without a full load) nagged — and a
+        // discard prompt after a save teaches people to click through discard prompts.
+        this.state.markPristine();
         this.state.closeSettings();
       },
       error: (err) => { this.state.settingsSaving.set(false); this.state.settingsError.set(err.error?.error ?? this.transloco.translate('spaces.error.saveFailed')); },


### PR DESCRIPTION
Owner: wiped a space's data, added a schema from the library, pressed **Save**, then hit **x** — and got the discard-unsaved-changes prompt for edits that had just been saved.

## Cause

`markPristine()` was called when a space was **opened**, and after the duplicates tab's own save — but never after the main settings/schema save. So the snapshot the guard compares against stayed at the pre-save values, and `isDirty()` kept returning true for work already persisted.

Closing the dialog on success hid it in the common path (`settingsSpace()` goes null and `isDirty()` short-circuits), which is why it survived this long. Any flow that keeps the editor open — or reopens it without a full load — gets the prompt.

**A discard prompt that fires after a save is worse than no prompt at all**: it teaches people to click through discard prompts, and the next one will be real.

## Verification

Mutation-checked — removing the re-baseline fails the new test. The test asserts on the **state**, not on whether the dialog closed, since closing is exactly what masked the bug.

preflight (73 files / 719 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)