### PR TITLE
feat(brain): filter From / To / Entities columns by entity name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3184,6 +3184,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The From, To and Entities columns filter by entity name.** Those columns show names while the
+  records store ids, so the name is resolved to ids on the server — meaning the filter applies to the
+  whole collection, not just the rows already on screen. A name that matches no entity returns no rows,
+  rather than quietly showing everything.
+
 - **The Properties columns filter by property VALUE.** Typing `engineer` finds records whose property
   bag holds that value anywhere; property *names* are not matched. Values are stringified first, so `12`
   finds a numeric `12` rather than nothing. Because property names are yours to choose, this query

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -418,6 +418,7 @@
   "brain.filter.tagPlaceholder": "Tag…",
   "brain.filter.descriptionPlaceholder": "Beschreibung filtern…",
   "brain.filter.propertiesPlaceholder": "Nach Eigenschaftswert filtern…",
+  "brain.filter.entityNamePlaceholder": "Nach Entitätsnamen filtern…",
   "brain.filter.allStatuses": "Alle Status",
   "brain.filter.statusLabel": "Nach Status filtern",
   "brain.filter.searchPlaceholder": "suchen…",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -418,6 +418,7 @@
   "brain.filter.tagPlaceholder": "tag…",
   "brain.filter.descriptionPlaceholder": "Filter description…",
   "brain.filter.propertiesPlaceholder": "Filter by property value…",
+  "brain.filter.entityNamePlaceholder": "Filter by entity name…",
   "brain.filter.allStatuses": "All statuses",
   "brain.filter.statusLabel": "Filter by status",
   "brain.filter.searchPlaceholder": "search…",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -418,6 +418,7 @@
   "brain.filter.tagPlaceholder": "tag…",
   "brain.filter.descriptionPlaceholder": "Filtruj opis…",
   "brain.filter.propertiesPlaceholder": "Filtruj wedlug wartosci wlasciwosci…",
+  "brain.filter.entityNamePlaceholder": "Filtruj wedlug nazwy encji…",
   "brain.filter.allStatuses": "Wszystkie statusy",
   "brain.filter.statusLabel": "Filtruj wedlug statusu",
   "brain.filter.searchPlaceholder": "szukaj…",

--- a/client/src/app/core/brain-api.service.ts
+++ b/client/src/app/core/brain-api.service.ts
@@ -82,12 +82,13 @@ export class BrainApi {
 
   // ── Brain — memories ──────────────────────────────────────────────────────
 
-  listMemories(spaceId: string, limit = 20, skip = 0, filters?: { tag?: string; entity?: string; type?: string; description?: string; properties?: string }, sort?: ListSort, search?: string): Observable<{ memories: Memory[]; limit: number; skip: number }> {
+  listMemories(spaceId: string, limit = 20, skip = 0, filters?: { tag?: string; entity?: string; type?: string; description?: string; properties?: string; entityName?: string }, sort?: ListSort, search?: string): Observable<{ memories: Memory[]; limit: number; skip: number }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.tag) params = params.set('tag', filters.tag);
     if (filters?.entity) params = params.set('entity', filters.entity);
     if (filters?.type) params = params.set('type', filters.type);
     if (filters?.description) params = params.set('description', filters.description);
+    if (filters?.entityName) params = params.set('entityName', filters.entityName);
     if (filters?.properties) params = params.set('properties', filters.properties);
     if (search) params = params.set('search', search);
     params = this.withSort(params, sort);
@@ -142,11 +143,13 @@ export class BrainApi {
 
   // ── Brain — edges ─────────────────────────────────────────────────────────
 
-  listEdges(spaceId: string, limit = 50, skip = 0, filters?: { type?: string; tag?: string; description?: string; properties?: string }, sort?: ListSort, search?: string): Observable<{ edges: Edge[] }> {
+  listEdges(spaceId: string, limit = 50, skip = 0, filters?: { type?: string; tag?: string; description?: string; properties?: string; fromName?: string; toName?: string }, sort?: ListSort, search?: string): Observable<{ edges: Edge[] }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.type) params = params.set('type', filters.type);
     if (filters?.tag) params = params.set('tag', filters.tag);
     if (filters?.description) params = params.set('description', filters.description);
+    if (filters?.fromName) params = params.set('fromName', filters.fromName);
+    if (filters?.toName) params = params.set('toName', filters.toName);
     if (filters?.properties) params = params.set('properties', filters.properties);
     if (search) params = params.set('search', search);
     params = this.withSort(params, sort);
@@ -200,12 +203,13 @@ export class BrainApi {
 
   // ── Brain — chrono ──────────────────────────────────────────────────────
 
-  listChrono(spaceId: string, limit = 50, skip = 0, filters?: { tags?: string; tagsAny?: string; tag?: string; type?: string; status?: string; after?: string; before?: string; search?: string; description?: string }, sort?: ListSort): Observable<{ chrono: ChronoEntry[] }> {
+  listChrono(spaceId: string, limit = 50, skip = 0, filters?: { tags?: string; tagsAny?: string; tag?: string; type?: string; status?: string; after?: string; before?: string; search?: string; description?: string; entityName?: string }, sort?: ListSort): Observable<{ chrono: ChronoEntry[] }> {
     let params = new HttpParams().set('limit', limit).set('skip', skip);
     if (filters?.tags) params = params.set('tags', filters.tags);
     if (filters?.tagsAny) params = params.set('tagsAny', filters.tagsAny);
     if (filters?.tag) params = params.set('tag', filters.tag);
     if (filters?.description) params = params.set('description', filters.description);
+    if (filters?.entityName) params = params.set('entityName', filters.entityName);
     // The chrono record "kind" (event/deadline/…) is filtered via the `type` query
     // param server-side; the old `kind` param was silently ignored.
     if (filters?.type) params = params.set('type', filters.type);

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -147,7 +147,10 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                     <input class="col-filter-input" type="text" [ngModel]="recordFilter().tag" (ngModelChange)="setTagFilter($event)"
                       [attr.list]="tagListId" [placeholder]="'brain.filter.tagPlaceholder' | transloco" [attr.aria-label]="'brain.filter.tagPlaceholder' | transloco" />
                     <datalist [id]="tagListId">@for (s of store.chronoTagSuggestions(); track s) { <option [value]="s"></option> }</datalist>
-                  </th><th>{{ 'brain.chrono.table.entities' | transloco }}</th><th app-sort-th field="createdAt" label="brain.chrono.table.created" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th></th>
+                  </th><th app-sort-th label="brain.chrono.table.entities">
+                    <input class="col-filter-input" type="text" [ngModel]="recordFilter().entityName" (ngModelChange)="setNameFilter('entityName', $event)"
+                      [placeholder]="'brain.filter.entityNamePlaceholder' | transloco" [attr.aria-label]="'brain.filter.entityNamePlaceholder' | transloco" />
+                  </th><th app-sort-th field="createdAt" label="brain.chrono.table.created" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th></th>
                 </tr>
               </thead>
               <tbody>
@@ -297,7 +300,7 @@ export class ChronoTabComponent extends RecordTabBase {
   }
 
   protected override resetOnSpaceChange(): void {
-    this.recordFilter.set({ type: '', tag: '', description: '', properties: '' });
+    this.recordFilter.set({ type: '', tag: '', description: '', properties: '', fromName: '', toName: '', entityName: '' });
     this.statusFilter.set('');
   }
 
@@ -306,13 +309,14 @@ export class ChronoTabComponent extends RecordTabBase {
     if (!spaceId) return;
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
-    const cf: { search?: string; type?: string; tag?: string; description?: string; status?: string } = {};
+    const cf: { search?: string; type?: string; tag?: string; description?: string; status?: string; entityName?: string } = {};
     // Docked Title column freetext filter → server-side substring (2b-iii-c), matching memories/edges.
     // The top bar is semantic-only now and never feeds this.
     if (this.searchParam()) cf.search = this.searchParam();
     if (this.recordFilter().type) cf.type = this.recordFilter().type;
     if (this.recordFilter().tag) cf.tag = this.recordFilter().tag;
     if (this.recordFilter().description) cf.description = this.recordFilter().description;
+    if (this.recordFilter().entityName) cf.entityName = this.recordFilter().entityName;
     if (this.statusFilter()) cf.status = this.statusFilter();
     this.brainApi.listChrono(spaceId, this.pageSize, this.skip(), cf, this.sortParam()).subscribe({
       next: ({ chrono }) => {

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -120,10 +120,16 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <table>
               <thead>
                 <tr>
-                  <th app-sort-th field="from" label="brain.edges.table.from" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="label" label="brain.edges.table.relation" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)">
+                  <th app-sort-th field="from" label="brain.edges.table.from" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)">
+                    <input class="col-filter-input" type="text" [ngModel]="recordFilter().fromName" (ngModelChange)="setNameFilter('fromName', $event)"
+                      [placeholder]="'brain.filter.entityNamePlaceholder' | transloco" [attr.aria-label]="'brain.filter.entityNamePlaceholder' | transloco" />
+                  </th><th app-sort-th field="label" label="brain.edges.table.relation" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)">
                     <input class="col-filter-input" type="text" [ngModel]="search()" (ngModelChange)="setSearchFilter($event)"
                       [placeholder]="'brain.filter.searchPlaceholder' | transloco" [attr.aria-label]="'brain.filter.searchPlaceholder' | transloco" />
-                  </th><th app-sort-th field="to" label="brain.edges.table.to" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th app-sort-th field="weight" label="brain.edges.table.weight" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
+                  </th><th app-sort-th field="to" label="brain.edges.table.to" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)">
+                    <input class="col-filter-input" type="text" [ngModel]="recordFilter().toName" (ngModelChange)="setNameFilter('toName', $event)"
+                      [placeholder]="'brain.filter.entityNamePlaceholder' | transloco" [attr.aria-label]="'brain.filter.entityNamePlaceholder' | transloco" />
+                  </th><th app-sort-th field="weight" label="brain.edges.table.weight" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th>
                   <th app-sort-th label="brain.edges.table.tags">
                     <input class="col-filter-input" type="text" [ngModel]="recordFilter().tag" (ngModelChange)="setTagFilter($event)"
                       [attr.list]="tagListId" [placeholder]="'brain.filter.tagPlaceholder' | transloco" [attr.aria-label]="'brain.filter.tagPlaceholder' | transloco" />
@@ -266,7 +272,7 @@ export class EdgesTabComponent extends RecordTabBase {
   private _edgeSemTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected override resetOnSpaceChange(): void {
-    this.recordFilter.set({ type: '', tag: '', description: '', properties: '' });
+    this.recordFilter.set({ type: '', tag: '', description: '', properties: '', fromName: '', toName: '', entityName: '' });
   }
 
   protected override load(): void {
@@ -274,11 +280,13 @@ export class EdgesTabComponent extends RecordTabBase {
     if (!spaceId) return;
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
-    const gf: { type?: string; tag?: string; description?: string; properties?: string } = {};
+    const gf: { type?: string; tag?: string; description?: string; properties?: string; fromName?: string; toName?: string } = {};
     if (this.recordFilter().type) gf.type = this.recordFilter().type;
     if (this.recordFilter().tag) gf.tag = this.recordFilter().tag;
     if (this.recordFilter().description) gf.description = this.recordFilter().description;
     if (this.recordFilter().properties) gf.properties = this.recordFilter().properties;
+    if (this.recordFilter().fromName) gf.fromName = this.recordFilter().fromName;
+    if (this.recordFilter().toName) gf.toName = this.recordFilter().toName;
     this.brainApi.listEdges(spaceId, this.pageSize, this.skip(), gf, this.sortParam(), this.searchParam()).subscribe({
       next: ({ edges }) => { this.store.edges.set(edges); this.recordList.loading.set(false); },
       error: (e) => { this.recordList.loadError.set(httpErrorReason(e)); this.recordList.loading.set(false); },

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -248,7 +248,7 @@ export class EntitiesTabComponent extends RecordTabBase {
   editEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
 
   protected override resetOnSpaceChange(): void {
-    this.recordFilter.set({ type: '', tag: '', description: '', properties: '' });
+    this.recordFilter.set({ type: '', tag: '', description: '', properties: '', fromName: '', toName: '', entityName: '' });
   }
 
   protected override load(): void {

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -118,7 +118,10 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
                       [attr.list]="tagListId" [placeholder]="'brain.filter.tagPlaceholder' | transloco" [attr.aria-label]="'brain.filter.tagPlaceholder' | transloco" />
                     <datalist [id]="tagListId">@for (s of store.memoryTagSuggestions(); track s) { <option [value]="s"></option> }</datalist>
                   </th>
-                  <th>{{ 'brain.memories.table.entities' | transloco }}</th><th app-sort-th label="brain.memories.table.properties">
+                  <th app-sort-th label="brain.memories.table.entities">
+                    <input class="col-filter-input" type="text" [ngModel]="recordFilter().entityName" (ngModelChange)="setNameFilter('entityName', $event)"
+                      [placeholder]="'brain.filter.entityNamePlaceholder' | transloco" [attr.aria-label]="'brain.filter.entityNamePlaceholder' | transloco" />
+                  </th><th app-sort-th label="brain.memories.table.properties">
                     <input class="col-filter-input" type="text" [ngModel]="recordFilter().properties" (ngModelChange)="setPropertiesFilter($event)"
                       [placeholder]="'brain.filter.propertiesPlaceholder' | transloco" [attr.aria-label]="'brain.filter.propertiesPlaceholder' | transloco" />
                   </th><th app-sort-th field="createdAt" label="brain.memories.table.created" [activeField]="sortField()" [dir]="sortDir()" (sort)="setSort($event)"></th><th></th>
@@ -247,7 +250,7 @@ export class MemoriesTabComponent extends RecordTabBase {
   private _memSemTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected override resetOnSpaceChange(): void {
-    this.recordFilter.set({ type: '', tag: '', description: '', properties: '' });
+    this.recordFilter.set({ type: '', tag: '', description: '', properties: '', fromName: '', toName: '', entityName: '' });
     this.filterEntity.set('');
   }
 
@@ -256,11 +259,12 @@ export class MemoriesTabComponent extends RecordTabBase {
     if (!spaceId) return;
     this.recordList.loading.set(true);
     this.recordList.loadError.set(null);
-    const filters: { tag?: string; entity?: string; type?: string; description?: string; properties?: string } = {};
+    const filters: { tag?: string; entity?: string; type?: string; description?: string; properties?: string; entityName?: string } = {};
     if (this.recordFilter().tag) filters.tag = this.recordFilter().tag;
     if (this.filterEntity()) filters.entity = this.filterEntity();
     if (this.recordFilter().type) filters.type = this.recordFilter().type;
     if (this.recordFilter().description) filters.description = this.recordFilter().description;
+    if (this.recordFilter().entityName) filters.entityName = this.recordFilter().entityName;
     if (this.recordFilter().properties) filters.properties = this.recordFilter().properties;
     this.brainApi.listMemories(spaceId, this.pageSize, this.skip(), filters, this.sortParam(), this.searchParam()).subscribe({
       next: ({ memories }) => {

--- a/client/src/app/pages/brain/record-tab-base.ts
+++ b/client/src/app/pages/brain/record-tab-base.ts
@@ -22,6 +22,10 @@ export interface RecordFilter {
    * is debounced like the other typed filters and the query carries its own deadline.
    */
   properties: string;
+  /** Entity-NAME filters. The columns show names; the records store ids, so the server translates. */
+  fromName: string;
+  toName: string;
+  entityName: string;
 }
 
 /**
@@ -66,7 +70,7 @@ export abstract class RecordTabBase {
    * memories tab's tag-badge click writes it — so pushing a value in still reflects into the header
    * control, the round-trip the old filter bar's `[value]` gave. Each tab's `load()` reads it.
    */
-  recordFilter = signal<RecordFilter>({ type: '', tag: '', description: '', properties: '' });
+  recordFilter = signal<RecordFilter>({ type: '', tag: '', description: '', properties: '', fromName: '', toName: '', entityName: '' });
 
   /** Unique datalist id for a tab's docked tag-filter suggestions (multiple tables on one shell). */
   readonly tagListId = `brain-tag-filter-${RecordTabBase._tagSeq++}`;
@@ -185,6 +189,19 @@ export abstract class RecordTabBase {
     this._propsTimer = setTimeout(() => this.load(), 250);
   }
   private _propsTimer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * Docked entity-NAME header filter (From / To / Entities).
+   *
+   * `key` picks which column, so one debounced setter serves all three rather than three near-copies.
+   */
+  setNameFilter(key: 'fromName' | 'toName' | 'entityName', value: string): void {
+    this.recordFilter.update(f => ({ ...f, [key]: value }));
+    this.skip.set(0);
+    if (this._nameTimer) clearTimeout(this._nameTimer);
+    this._nameTimer = setTimeout(() => this.load(), 250);
+  }
+  private _nameTimer?: ReturnType<typeof setTimeout>;
 
   /**
    * Docked freetext header filter changed. Updates the value immediately (so the input stays

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -789,6 +789,8 @@ Optional filters:
 | `tag` | Filter by tag — case-insensitive **substring** match, so `arch` finds `architecture` |
 | `description` | Filter by description — case-insensitive **substring**, this field ALONE (unlike `search`, which also spans the name/fact/title field) |
 | `properties` | Filter by property **value** (not key) — case-insensitive substring across every value in the bag. Values are stringified first, so `12` finds a numeric `12`. **Cannot use an index** (the keys are user-defined), so it is a bounded collection scan |
+| `entityName` | *(memories, chrono)* Filter by LINKED ENTITY name — case-insensitive substring. Resolved to ids server-side; a name matching nothing returns nothing |
+| `fromName` / `toName` | *(edges)* Filter the From/To endpoint by entity name, same resolution |
 | `entity` | Filter by linked entity ID |
 | `limit` | Results per page (default 100, max 500) |
 | `skip` | Offset for pagination |

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -14,6 +14,7 @@ import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembe
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
 import type { ChronoStatus } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const chronoRouter = Router();
 
@@ -290,7 +291,15 @@ chronoRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, a
   if (typeof req.query['before'] === 'string') filter.before = req.query['before'];
   if (typeof req.query['search'] === 'string') filter.search = req.query['search'];
 
-  const all = await collectAcrossMembers(spaceId, mid => listChrono(mid, filter, limit, skip, sortParse.sort));
+  // The Entities column shows entity NAMES; records store ids. Resolved per member for the same reason
+  // as edges: an id belongs to the member that owns it. An empty resolution filters to nothing, which is
+  // correct — "no entity by that name" must not fall back to showing everything.
+  const entityName = typeof req.query['entityName'] === 'string' ? req.query['entityName'] : undefined;
+  const all = await collectAcrossMembers(spaceId, async mid => {
+    const perMember: Record<string, unknown> = { ...filter };
+    if (entityName) perMember['entityIds'] = { $in: await resolveEntityIdsByName(mid, entityName) };
+    return listChrono(mid, perMember, limit, skip, sortParse.sort);
+  });
   res.json({ chrono: capPage(all, limit, sortParse.sort), limit, skip });
 });
 

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -16,6 +16,7 @@ import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEdge } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const edgesRouter = Router();
 
@@ -113,7 +114,7 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     res.status(400).json({ error: sortParse.error });
     return;
   }
-  const filter: { from?: string; to?: string; label?: string; type?: string; tag?: string; search?: string; description?: string; properties?: string } = {};
+  const filter: { from?: string; to?: string; label?: string; type?: string; tag?: string; search?: string; description?: string; properties?: string; fromIds?: string[]; toIds?: string[] } = {};
   if (typeof req.query['from'] === 'string') filter.from = req.query['from'];
   if (typeof req.query['to'] === 'string') filter.to = req.query['to'];
   if (typeof req.query['label'] === 'string') filter.label = req.query['label'];
@@ -122,7 +123,16 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
   if (typeof req.query['search'] === 'string') filter.search = req.query['search'];
   if (typeof req.query['description'] === 'string') filter.description = req.query['description'];
   if (typeof req.query['properties'] === 'string') filter.properties = req.query['properties'];
-  const all = await collectAcrossMembers(spaceId, mid => listEdges(mid, filter, limit, skip, sortParse.sort));
+  // The From/To columns show entity NAMES; edges store ids. Resolve per member — an id belongs to the
+  // member that owns it, so resolving against another's entities would match nothing while looking fine.
+  const fromName = typeof req.query['fromName'] === 'string' ? req.query['fromName'] : undefined;
+  const toName = typeof req.query['toName'] === 'string' ? req.query['toName'] : undefined;
+  const all = await collectAcrossMembers(spaceId, async mid => {
+    const perMember = { ...filter };
+    if (fromName) perMember.fromIds = await resolveEntityIdsByName(mid, fromName);
+    if (toName) perMember.toIds = await resolveEntityIdsByName(mid, toName);
+    return listEdges(mid, perMember, limit, skip, sortParse.sort);
+  });
   // Batch-resolve entity names for from/to so the client can display names instead of raw UUIDs
   const allEntityIds = [...new Set(all.flatMap(e => [e.from, e.to]))];
   const nameMap = new Map<string, string>();

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -18,6 +18,7 @@ import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage,
 import { validateMemory } from '../../spaces/schema-validation.js';
 import type { MemoryDoc } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, buildMemoryFilter, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const memoriesRouter = Router();
 
@@ -137,7 +138,15 @@ memoriesRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAut
     return;
   }
   const filter = buildMemoryFilter(req.query as Record<string, unknown>);
-  const all = await collectAcrossMembers(spaceId, mid => listMemories(mid, filter, limit, skip, sortParse.sort));
+  // The Entities column shows entity NAMES; records store ids. Resolved per member for the same reason
+  // as edges: an id belongs to the member that owns it. An empty resolution filters to nothing, which is
+  // correct — "no entity by that name" must not fall back to showing everything.
+  const entityName = typeof req.query['entityName'] === 'string' ? req.query['entityName'] : undefined;
+  const all = await collectAcrossMembers(spaceId, async mid => {
+    const perMember: Record<string, unknown> = { ...filter };
+    if (entityName) perMember['entityIds'] = { $in: await resolveEntityIdsByName(mid, entityName) };
+    return listMemories(mid, perMember, limit, skip, sortParse.sort);
+  });
   res.json({ memories: capPage(all, limit, sortParse.sort), limit, skip });
 });
 

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -148,7 +148,7 @@ export async function upsertEdge(
 /** List edges for a space, optionally filtering by from/to entity */
 export async function listEdges(
   spaceId: string,
-  filter: { from?: string; to?: string; label?: string; type?: string; tag?: string; search?: string; description?: string; properties?: string } = {},
+  filter: { from?: string; to?: string; label?: string; type?: string; tag?: string; search?: string; description?: string; properties?: string; fromIds?: string[]; toIds?: string[] } = {},
   limit = 50,
   skip = 0,
   sort?: SortSpec,
@@ -163,6 +163,10 @@ export async function listEdges(
   // Per-column description filter. `search` below also spans `label`, so a column control needs its own.
   if (filter.description) q['description'] = textContains(filter.description);
   if (filter.properties) Object.assign(q, propertiesValueContains(filter.properties));
+  // Name filters arrive already resolved to ids (per member). An EMPTY list means "no entity by that
+  // name", so it must filter to nothing — not be skipped, which would silently show everything.
+  if (filter.fromIds) q['from'] = { $in: filter.fromIds };
+  if (filter.toIds) q['to'] = { $in: filter.toIds };
   // Freetext substring over the edge's text fields (2b-iii-a).
   const search = textSearchOr(filter.search, SEARCHABLE_FIELDS.edges);
   if (search) Object.assign(q, search);

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -14,7 +14,7 @@ import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './recall
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import { log } from '../util/log.js';
 import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc, FileMetaDoc } from '../config/types.js';
-import { PROPERTIES_SCAN_MAX_MS } from './tag-filter.js';
+import { PROPERTIES_SCAN_MAX_MS, textContains } from './tag-filter.js';
 
 /** A backlink entry describing an item that references a given entity. */
 export interface BacklinkEntry {
@@ -456,4 +456,30 @@ export async function findEntityBacklinks(spaceId: string, entityId: string): Pr
   for (const f of faces) backlinks.push({ type: 'face', _id: f._id });
 
   return backlinks;
+}
+
+/** Cap on how many entity ids a name filter may expand to, bounding the `$in` it produces. */
+export const NAME_FILTER_ID_CAP = 500;
+
+/**
+ * Entity ids whose NAME contains `needle` (case-insensitive substring), within one member space.
+ *
+ * The From/To and Entities columns display entity NAMES while the records store ids, so a column filter
+ * has to translate before it can query. Doing it here — rather than post-filtering the page in the
+ * client — means the filter applies to the whole collection, not just the rows that happened to load.
+ *
+ * Called per MEMBER (inside `collectAcrossMembers`): ids belong to the member that owns them, and
+ * resolving against another member's entities would match nothing while looking like it worked.
+ *
+ * Returns at most `NAME_FILTER_ID_CAP` ids. An empty result is meaningful — it means "no entity by that
+ * name", so the caller filters to nothing rather than falling back to unfiltered.
+ */
+export async function resolveEntityIdsByName(spaceId: string, needle: string): Promise<string[]> {
+  const trimmed = needle.trim();
+  if (!trimmed) return [];
+  const docs = await col<EntityDoc>(`${spaceId}_entities`)
+    .find(asFilter<EntityDoc>({ name: textContains(trimmed) }), { projection: { _id: 1 } })
+    .limit(NAME_FILTER_ID_CAP)
+    .toArray();
+  return docs.map(d => String(d._id));
 }

--- a/testing/standalone/column-filters.test.js
+++ b/testing/standalone/column-filters.test.js
@@ -130,3 +130,41 @@ describe('propertiesValueContains — filters on VALUE, not key', () => {
     }
   });
 });
+
+describe('entity-NAME column filters (From / To / Entities)', () => {
+  it('an unmatched name filters to NOTHING, never to everything', () => {
+    // The dangerous shape: resolve a name to zero ids, then skip the filter because the list is empty.
+    // The column would show every row while claiming to be filtered. All three sites must apply the
+    // `$in` unconditionally once a name was given.
+    const edges = readFileSync(new URL('../../server/src/brain/edges.ts', import.meta.url), 'utf8');
+    assert.match(edges, /if \(filter\.fromIds\) q\['from'\] = \{ \$in: filter\.fromIds \}/);
+    assert.match(edges, /if \(filter\.toIds\) q\['to'\] = \{ \$in: filter\.toIds \}/);
+
+    for (const f of ['memories.ts', 'chrono.ts']) {
+      const src = readFileSync(new URL(`../../server/src/api/brain/${f}`, import.meta.url), 'utf8');
+      assert.match(src, /entityIds'\] = \{ \$in: await resolveEntityIdsByName/,
+        `${f} must apply the resolved ids even when empty`);
+    }
+  });
+
+  it('resolves per MEMBER, not once for the whole proxy space', () => {
+    // Ids belong to the member that owns them; resolving against another member's entities would match
+    // nothing while looking like it worked.
+    for (const f of ['edges.ts', 'memories.ts', 'chrono.ts']) {
+      const src = readFileSync(new URL(`../../server/src/api/brain/${f}`, import.meta.url), 'utf8');
+      assert.match(src, /collectAcrossMembers\(spaceId, async mid =>/, `${f} must resolve inside the member loop`);
+      assert.match(src, /resolveEntityIdsByName\(mid,/, `${f} must resolve against the MEMBER id`);
+    }
+  });
+
+  it('caps how many ids one name can expand to', () => {
+    const src = readFileSync(new URL('../../server/src/brain/entities.ts', import.meta.url), 'utf8');
+    assert.ok(src.includes('NAME_FILTER_ID_CAP'), 'an unbounded $in is a denial-of-service shape');
+    assert.match(src, /\.limit\(NAME_FILTER_ID_CAP\)/, 'the cap must be applied to the query');
+  });
+
+  it('matches names by escaped substring, like every other text filter', () => {
+    const src = readFileSync(new URL('../../server/src/brain/entities.ts', import.meta.url), 'utf8');
+    assert.match(src, /name: textContains\(trimmed\)/);
+  });
+});


### PR DESCRIPTION
Last of the four column tiers from the owner's report. These columns display entity **names** while the records store **ids**, so a filter has to translate before it can query.

Resolved on the **server**, not by post-filtering the loaded page — filtering rows already on screen would silently mean *"filter this page"* rather than *"filter this collection"*, which is the sort of half-working control this run has been removing.

## Two properties the tests pin, because both fail quietly

- **An unmatched name filters to NOTHING.** The tempting shape is to skip the `$in` when resolution returns an empty list — which shows *every* row while the control claims to be filtering. The `$in` is applied unconditionally once a name is given.
- **Resolution happens per MEMBER**, inside `collectAcrossMembers`. Ids belong to the member that owns them, so resolving against the parent space would match nothing while looking like it worked.

The expansion is capped (`NAME_FILTER_ID_CAP`) — an unbounded `$in` built from user input is a denial-of-service shape.

## Verification

**Mutation-proven 5/5:** empty-resolution fallback (both edges *and* memories), resolving against the parent space, an uncapped expansion, and exact-instead-of-substring matching all fail the suite.

Checked live: `?fromName=Ada` → 3 of 7 edges, case-insensitive, `?fromName=nobody` → **0** (not 7), `?entityName=Ada` → 2 memories.

preflight + production AOT build.

**This completes the owner's column-filter report** — every text column across the four record tabs now filters from its own header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)