### PR TITLE
fix(media): the external face endpoint must honour allowPrivateModelEndpoints

### DIFF
--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -1,5 +1,6 @@
 import { ssrfSafeFetch } from '../../util/ssrf.js';
 import { getConfig, getSecrets } from '../../config/loader.js';
+import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
 import { log } from '../../util/log.js';
 
 /** One detected face, in exactly the shape the in-process recogniser produces. */
@@ -71,6 +72,12 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
         image: imageBytes.toString('base64'),
       }),
       signal: AbortSignal.timeout(TIMEOUT_MS),
+    }, {
+      // Matches the assist model: a self-hosted recogniser may live on a private cluster address. The
+      // guard stays on — DNS-resolve, IP-pin and redirect re-validation all still apply; only the
+      // private-address rejection lifts. Without this the WRITE check accepts such an endpoint and every
+      // call then fails, which is a configurable feature that silently does not work.
+      allowPrivate: allowPrivateModelEndpoints(),
     });
     if (!res.ok) {
       log.warn(`External face model: HTTP ${res.status} — falling back to in-process recognition`);

--- a/testing/standalone/face-external.test.js
+++ b/testing/standalone/face-external.test.js
@@ -100,3 +100,22 @@ describe('the embedder falls back instead of dropping faces', () => {
     assert.equal((src.match(/Process each detected face/g) ?? []).length, 1);
   });
 });
+
+describe('the external face endpoint honours the egress policy', () => {
+  const src = readFileSync(new URL('../../server/src/files/media/face-external.ts', import.meta.url), 'utf8');
+
+  it('passes allowPrivateModelEndpoints to the guard', () => {
+    // Without it the guard rejects a self-hosted recogniser on a cluster address at RUNTIME, even though
+    // the write path accepted it — a configurable feature that silently does not work. That was the one
+    // real finding of the 2026-07-29 audit, and it was in this file.
+    assert.ok(src.includes('allowPrivate: allowPrivateModelEndpoints()'),
+      'the operator private-endpoint policy must reach the fetch');
+  });
+
+  it('is an EXTERNAL provider, so it is guarded rather than plain-fetched', () => {
+    // Unlike the bundled Ollama/Whisper (local, private addresses, deliberately plain `fetch`), there is
+    // no bundled face sidecar — this endpoint is operator-supplied by definition.
+    assert.ok(src.includes('ssrfSafeFetch('));
+    assert.ok(!/await fetch\(/.test(src));
+  });
+});


### PR DESCRIPTION
Found by the pre-2.0.0 security audit — in code added earlier the same night.

## The finding

`ssrfSafeFetch` defaults `allowPrivate` to **false**. `face-external.ts` called it without the options object, so an operator who set `allowPrivateModelEndpoints: true` and pointed at a self-hosted recogniser on a cluster address passed the **write** check and then had every call rejected at **runtime**.

Configurable, documented, non-functional — the shape this whole run has been removing. Now matches the external assist model, which was always correct: the guard stays on (DNS-resolve, IP-pin, redirect re-validation) and only the private-address rejection follows the operator's policy.

## A finding I withdrew

A grep for bare `fetch()` flagged `providers.ts` and the local VLM path. Reading them showed a deliberate split:

```
egressFetch(external) → external ? ssrfSafeFetch-with-allowPrivate : fetch
```

External endpoints are already guarded; **local** providers (bundled Ollama / Whisper) deliberately use plain `fetch` because their addresses are private and the guard would rightly reject them.

`OllamaVisionProvider` is a *local* provider. Routing it through the guard — which I briefly did — would have rejected the bundled Ollama on every default install unless the operator opted into private endpoints. **Reverted before it left the branch.**

The lesson is recorded in the audit file: *"bare `fetch()` is a pointer, not a verdict. The question is whether the URL is attacker-influenceable, and a bundled sidecar at a fixed private address is not."*

## Audit result

**One real finding, fixed.** Route auth coverage (gate passes), NoSQL operator smuggling (`sanitizeFilter` allowlist), secrets in logs, pre-auth invite routes, and regex injection all checked clean. `nli-client.ts` was already correct.

preflight + server build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)