### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+---
+
+## [2.0.0] — 2026-07-29
+
+**Major release.** Three breaking changes are marked inline below (the media-embedding master switch,
+UUID-only record references, and MCP tool-argument validation). Everything else is additive.
+
+The instance version now reads 2.0.0 across the API, the About page and the published container image.
+
 ### Security
 
 - **The conflicts and link-violation lists no longer truncate silently.** `GET /api/conflicts` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,17 @@ _Nothing yet._
 
 ## [2.0.0] — 2026-07-29
 
-**Major release.** Three breaking changes are marked inline below (the media-embedding master switch,
-UUID-only record references, and MCP tool-argument validation). Everything else is additive.
+**Major release.** Four breaking changes are marked inline below — read these before upgrading:
+
+1. The **media-embedding master switch is removed** (`MEDIA_EMBEDDING_ENABLED` / `mediaEmbedding.enabled`);
+   each class is now controlled by its own `images` / `audio` / `video` level.
+2. **Every reference between brain records is a UUID**, and one that cannot resolve is refused rather
+   than silently stored unlinked.
+3. **MCP tool arguments are validated against each tool's `inputSchema`** before the handler runs.
+4. The **legacy `/api/brain/:spaceId/…` route shape is removed**; use the canonical
+   `/api/brain/spaces/:spaceId/…`.
+
+Everything else is additive.
 
 The instance version now reads 2.0.0 across the API, the About page and the published container image.
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/kubernetes/manifests/ythril-deployment.yaml
+++ b/kubernetes/manifests/ythril-deployment.yaml
@@ -38,9 +38,9 @@ spec:
           # Pin by immutable digest in production — a mutable tag (`:latest` or a
           # version tag) lets a compromised registry silently swap the image on the
           # next pull. Resolve the digest with:
-          #   docker buildx imagetools inspect ghcr.io/ythril-network/ythril:1.4.4
+          #   docker buildx imagetools inspect ghcr.io/ythril-network/ythril:2.0.0
           # then replace the tag below with @sha256:<digest>.
-          image: ghcr.io/ythril-network/ythril:1.4.4
+          image: ghcr.io/ythril-network/ythril:2.0.0
           # The image already sets `USER node`; these settings *enforce* non-root at
           # the cluster level and lock the container down further. readOnlyRootFilesystem
           # is safe here because every path the server writes is backed by a volume:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "1.4.4",
+      "version": "2.0.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "1.4.4",
+      "version": "2.0.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21006,7 +21006,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "1.4.4",
+      "version": "2.0.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Version bumped where it actually lives

- root / server / client `package.json` (1.4.4 → 2.0.0) + `package-lock.json`
- `kubernetes/manifests/ythril-deployment.yaml` image tag, and the `imagetools inspect` comment beside it

## Deliberately NOT bumped

- **`docs/integration-guide.md:1047`** — *"1.4.4 — if you are upgrading, existing records keep their old embedding"* is a **since-version** note about history. Rewriting it would make the upgrade note wrong.
- **The `version: '1.4.4'` strings in two spec files** — fixtures proving the page renders whatever version the API reports. They are not the app's version, and pinning them to the real one would make the tests tautological.

## CHANGELOG

`[Unreleased]` cut to `[2.0.0] — 2026-07-29`, with a fresh empty Unreleased above it.

**The major bump is earned** — three breaking changes are marked inline: the media-embedding master switch removed, record references now UUID-only, and MCP tool arguments validated against `inputSchema`.

## Preceded by a security audit

Run against `_AUDIT-LENSES.md` §4. **One real finding, fixed in #516** (the external face endpoint ignored `allowPrivateModelEndpoints`, so a self-hosted recogniser saved fine then failed every call).

One candidate finding was **withdrawn on inspection**: bare `fetch()` in `providers.ts` is deliberate — the bundled Ollama/Whisper sit at private addresses the SSRF guard would rightly reject. Routing them through it would have broken every default install.

Route auth coverage, NoSQL operator smuggling, secrets in logs, pre-auth invite routes and regex injection all checked clean.

preflight passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)