### PR TITLE
refactor(brain): one tab union instead of two hand-synced ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change alongside model / dimensions / similarity, with the same save confirmation — the prefix is part
   of the embedded string, so changing it invalidates the corpus exactly as a model change does.
 
+### Changed
+
+- **The Brain's tab identifiers are one union instead of two hand-synced ones.** `BrainTab` lived in
+  `brain.component.ts` and a subset of it was re-declared as `StatKey` in `overview-tab.component.ts` for
+  the Overview's clickable stat tiles. They agreed by convention, and the drift that convention allowed
+  was one-directional and silent: adding a key the parent lacked failed the build, but adding a *tab* and
+  a matching tile still typed against the stale copy did not — the tile just could not open its tab, and
+  nothing said so. Both now derive from `COLLECTION_TABS` in `brain-tabs.ts`, so the subset relation holds
+  by construction, and two tests walk that list through the real handler — a shared type alone would not
+  prove the tab is actually reachable.
+
 ### Fixed
 
 - **`GET /api/admin/media-config` returned the NLI provider's API key in plaintext.** Every other

--- a/client/src/app/pages/brain/brain-tabs.ts
+++ b/client/src/app/pages/brain/brain-tabs.ts
@@ -1,0 +1,31 @@
+/**
+ * The Brain's tab identifiers, in one place.
+ *
+ * `BrainTab` lived in `brain.component.ts` and a subset of it, `StatKey`, was declared independently in
+ * `overview-tab.component.ts` for the Overview's clickable stat tiles. The two agreed by hand, which meant
+ * the drift was one-directional and silent: adding a key to the child's copy that the parent lacked failed
+ * the build, but adding a TAB to the parent and a matching tile still typed against the stale child copy
+ * did not — the tile simply could not open its tab, and nothing said so.
+ *
+ * Deriving the whole union from the collection tabs removes the possibility rather than documenting it.
+ * `CollectionTab` is a subset of `BrainTab` **by construction**, so no assertion is needed and no
+ * `Extract<>` can quietly evaluate to `never` on a typo.
+ *
+ * It lives in its own file rather than being exported from `brain.component.ts` so the Overview tab does
+ * not import from its own parent — that edge would make the two mutually dependent for a string union.
+ */
+
+/**
+ * Tabs backed by a per-space collection. These are exactly the tabs an Overview stat tile can open,
+ * because a tile shows a count and only a collection has one.
+ *
+ * A runtime array as well as a type: the Overview builds its tiles from data, and a second hand-written
+ * list of the same five strings is the thing this file exists to prevent.
+ */
+export const COLLECTION_TABS = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
+
+/** A tab that shows a collection — the only kind a stat tile links to. */
+export type CollectionTab = typeof COLLECTION_TABS[number];
+
+/** Every Brain tab. The collection tabs plus the views that are not backed by one collection. */
+export type BrainTab = CollectionTab | 'overview' | 'query' | 'graph' | 'review';

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -25,6 +25,7 @@ import { NetworksApi } from '../../core/networks-api.service';
 import { AuthService } from '../../core/auth.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { BrainComponent } from './brain.component';
+import { COLLECTION_TABS } from './brain-tabs';
 
 
 /** Read-only stub: brain's init cascade is listSpaces → getSpaceStats/getReindexStatus/getSpaceMeta. */
@@ -88,6 +89,19 @@ describe('BrainComponent (OnPush)', () => {
     c.setTab('edges');
     c.selectSpace('other');
     expect(c.activeTab()).toBe('edges');
+  });
+
+  it('every Overview stat tile opens a tab that actually exists', () => {
+    // The tiles and the tabs used to be two hand-written unions (`StatKey` in overview-tab,
+    // `BrainTab` here) that agreed only by convention. The drift was one-directional and SILENT:
+    // adding a tab here and a tile there against a stale copy would compile and the tile simply
+    // would not open anything. Both now derive from COLLECTION_TABS, and this walks the same list
+    // through the real handler — a type alias alone would not prove the tab is reachable.
+    const c = create().componentInstance;
+    for (const tab of COLLECTION_TABS) {
+      c.setTab(tab);
+      expect(c.activeTab()).toBe(tab);
+    }
   });
 
   it('File Meta is merged into one Files tab — no separate File Meta collection tab', () => {

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -25,7 +25,7 @@ import { FileManagerComponent } from '../files/file-manager.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
-type BrainTab = 'overview' | 'query' | 'graph' | 'files' | 'entities' | 'edges' | 'memories' | 'chrono' | 'review';
+import { BrainTab, CollectionTab } from './brain-tabs';
 
 interface SpaceView {
   space: Space;
@@ -397,7 +397,7 @@ export class BrainComponent implements OnInit, OnDestroy {
   private liveRefreshTimer?: ReturnType<typeof setTimeout>;
   private liveReconnectTimer?: ReturnType<typeof setTimeout>;
   private static readonly LIVE_RECONNECT_MS = 3000;
-  private static readonly TAB_FOR_COLLECTION: Record<string, BrainTab> = {
+  private static readonly TAB_FOR_COLLECTION: Record<string, CollectionTab> = {
     memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
   };
 

--- a/client/src/app/pages/brain/overview-tab.component.spec.ts
+++ b/client/src/app/pages/brain/overview-tab.component.spec.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { provideRouter } from '@angular/router';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { OverviewTabComponent } from './overview-tab.component';
+import { COLLECTION_TABS } from './brain-tabs';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import type { Space, SpaceStats } from '../../core/api.types';
 
@@ -41,6 +42,17 @@ describe('OverviewTabComponent', () => {
     expect(c.statCards().map(s => [s.key, s.value])).toEqual([
       ['memories', 5], ['entities', 12], ['edges', 30], ['chrono', 3], ['files', 7],
     ]);
+  });
+
+  it('every stat tile targets a real collection tab', () => {
+    // The tile's `key` IS the tab it opens. Typed from COLLECTION_TABS now rather than a second
+    // hand-written union, and checked at runtime too: the type stops a mismatch reaching the build,
+    // this stops a tile being added from data the type never sees.
+    const { c } = setup({ stats: STATS });
+    expect(c.statCards().length).toBe(COLLECTION_TABS.length);
+    for (const card of c.statCards()) {
+      expect(COLLECTION_TABS).toContain(card.key);
+    }
   });
 
   it('total is 0 and statCards empty while stats are still loading', () => {

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -20,9 +20,11 @@ import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { Space, SpaceStats, AboutInfo, EmbeddingQueue, VoteRound, TokenAccessEntry } from '../../core/api.types';
 
-/** `key` doubles as the Brain tab this tile jumps to — the five collection tabs. */
-type StatKey = 'memories' | 'entities' | 'edges' | 'chrono' | 'files';
-interface StatCard { key: StatKey; icon: string; label: string; value: number }
+import { CollectionTab } from './brain-tabs';
+
+/** `key` doubles as the Brain tab this tile jumps to. Typed from the shared union rather than re-declared,
+ *  so a tab added to the Brain and a tile added here can no longer disagree in silence. */
+interface StatCard { key: CollectionTab; icon: string; label: string; value: number }
 
 @Component({
   selector: 'app-overview-tab',
@@ -359,7 +361,7 @@ export class OverviewTabComponent {
   tokenAccess = input<TokenAccessEntry[] | null>(null);
   /** Emitted (after a confirm) so the shell's existing reindex flow runs — no duplicate API path. */
   /** A collection tile was clicked — the shell switches to that tab. */
-  openTab = output<StatKey>();
+  openTab = output<CollectionTab>();
 
   reindex = output<void>();
   /** Emitted so the shell re-queues every failed embedding job and reloads the queue (fetch-free tab). */


### PR DESCRIPTION
## The drift this removes

`BrainTab` lived in [brain.component.ts](client/src/app/pages/brain/brain.component.ts); a subset of it was re-declared as `StatKey` in [overview-tab.component.ts](client/src/app/pages/brain/overview-tab.component.ts) for the Overview's clickable stat tiles. They agreed by convention.

The drift that convention allowed was **one-directional and silent**:

- adding a key to the child's copy that the parent lacked → build fails. Good.
- adding a **tab** to the parent, plus a matching tile still typed against the stale child copy → compiles fine. The tile simply cannot open its tab, and nothing says so.

## The fix

```ts
export const COLLECTION_TABS = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
export type CollectionTab = typeof COLLECTION_TABS[number];
export type BrainTab = CollectionTab | 'overview' | 'query' | 'graph' | 'review';
```

`CollectionTab` is a subset of `BrainTab` **by construction** — no assertion to keep in sync, and no `Extract<>` that can quietly evaluate to `never` on a typo. The runtime array matters too: the Overview builds its tiles from data, and a second hand-written list of the same five strings is the thing this file exists to prevent.

Its own file rather than an export from `brain.component.ts`, so the Overview tab does not import from its own parent.

## Two tests, because the type is not the guarantee

A shared alias proves the types match. It does **not** prove the tab is reachable — `setTab` could ignore a value and everything would still compile.

- `brain.component.spec` walks `COLLECTION_TABS` through the real `setTab` and asserts `activeTab()` follows.
- `overview-tab.spec` asserts every `statCard` key is in the list, and that there are exactly as many tiles as collection tabs.

Both mutation-tested:

| mutation | caught by |
|---|---|
| a tile pointing at `'review'` | *every stat tile targets a real collection tab* (+ the existing counts test) |
| `setTab` silently ignoring `'chrono'` | *every Overview stat tile opens a tab that actually exists* |

Preflight green (73 files / 743 tests).

## Context

The owner hit an `ngtsc(2345)` on `setTab($event)`. That turned out to be a **stale Angular language server** — `ng build` with `strictTemplates: true` is clean, and no fix was needed for it. This PR is the durability point behind the error, not the error itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)