### PR TITLE
fix(mcp): update_chrono skipped the chrono-type allowlist that create enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`update_chrono` (MCP) let a record be moved to a chrono type the space does not allow.**
+  `create_chrono` checked the type against the space's allowlist and both REST handlers checked it too —
+  MCP update was the one write surface of four that did not, so the constraint held right up until
+  someone used the other door, and nothing reported the bypass. The check now runs on update as well,
+  with the same message, and both MCP handlers resolve the allowlist through one shared helper: two
+  copies of a validation rule is how these diverged in the first place.
+
 - **`GET /api/admin/media-config` returned the NLI provider's API key in plaintext.** Every other
   provider was masked; `nli` was added later and the mask was never extended to it, so the resolved
   block — which carries the key from `secrets.json` — was serialised as-is to any admin. Masked now,

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -66,11 +66,8 @@ export const create_chronoTool: ToolHandler = {
     if (!wt.ok) throw new Error(wt.error);
 
     // Schema validation (single pass)
-    const chronoMetaRaw = getConfig().spaces.find(s => s.id === wt.target)?.meta;
-    const chronoMeta = chronoMetaRaw ? resolveMetaRefs(chronoMetaRaw) : undefined;
-
-    // Validate type against space-specific allowlist (custom or default built-ins)
-    const allowedChronoTypes = getAllowedChronoTypes(chronoMeta);
+    // Validate type against the space-specific allowlist (custom or default built-ins).
+    const { meta: chronoMeta, allowed: allowedChronoTypes } = chronoTypeGate(wt.target);
     if (!allowedChronoTypes.has(chronoType)) {
       throw new Error(`type must be one of: ${[...allowedChronoTypes].join(', ')}`);
     }
@@ -137,6 +134,20 @@ export const create_chronoTool: ToolHandler = {
   },
 };
 
+/**
+ * The space's resolved meta, and the chrono types it allows.
+ *
+ * Extracted because create and update MUST agree: `update_chrono` shipped without the allowlist check
+ * `create_chrono` has, so a record could be moved to a disallowed type through the door that did not
+ * check. One helper, called by both, is what stops that recurring — two copies of a validation rule is
+ * how they diverged in the first place.
+ */
+function chronoTypeGate(spaceId: string): { meta: ReturnType<typeof resolveMetaRefs> | undefined; allowed: Set<string> } {
+  const raw = getConfig().spaces.find(s => s.id === spaceId)?.meta;
+  const meta = raw ? resolveMetaRefs(raw) : undefined;
+  return { meta, allowed: getAllowedChronoTypes(meta) };
+}
+
 export const update_chronoTool: ToolHandler = {
   name: 'update_chrono',
   description: 'Update an existing chronological entry.',
@@ -188,7 +199,17 @@ export const update_chronoTool: ToolHandler = {
 
     const updates: Record<string, unknown> = {};
     if (typeof a['title'] === 'string') updates['title'] = a['title'];
-    if (typeof a['type'] === 'string') updates['type'] = a['type'];
+    if (typeof a['type'] === 'string') {
+      // Same allowlist check `create_chrono` runs, and the same one the REST PATCH already runs.
+      // Without it this was the ONE surface of four that let a record be moved to a type the space
+      // does not allow — and an asymmetry between two write paths is worse than either rule alone,
+      // because the constraint looks enforced right up until someone uses the other door.
+      const { allowed } = chronoTypeGate(wt.target);
+      if (!allowed.has(a['type'] as string)) {
+        throw new Error(`type must be one of: ${[...allowed].join(', ')}`);
+      }
+      updates['type'] = a['type'];
+    }
     if (typeof a['startsAt'] === 'string') updates['startsAt'] = a['startsAt'];
     if (typeof a['endsAt'] === 'string') updates['endsAt'] = a['endsAt'];
     if (typeof a['status'] === 'string') updates['status'] = a['status'];

--- a/testing/standalone/chrono-type-allowlist.test.js
+++ b/testing/standalone/chrono-type-allowlist.test.js
@@ -1,0 +1,95 @@
+/**
+ * The chrono type allowlist must be enforced by EVERY write surface.
+ *
+ * `create_chrono` rejected a type outside the space's allowed set; `update_chrono` did not — so a record
+ * could be moved to a disallowed type through the door that skipped the check. Both REST handlers
+ * enforced it, which made MCP update the one surface of four that did not.
+ *
+ * That asymmetry is worse than either rule alone: the constraint looks enforced right up until someone
+ * uses the other door, and nothing anywhere reports that it was bypassed.
+ *
+ * **These are behavioural, not source greps.** A grep-based first version of this file SURVIVED a
+ * mutation that moved the guard into an `else if (false)` branch — the strings were still inside the
+ * region being matched, so the test could not tell live code from dead code. The rejection happens
+ * before any database call, so the handler can be driven directly with nothing but a config file.
+ *
+ * Run: node --test testing/standalone/chrono-type-allowlist.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-chrono-allowlist-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH; // read at module load — must be set before importing
+
+/** A space whose schema declares its OWN chrono types, so the built-in defaults are not the allowlist. */
+const SPACE = {
+  id: 'ops',
+  label: 'Ops',
+  meta: { typeSchemas: { chrono: { incident: {}, maintenance: {} } } },
+};
+
+let create_chronoTool, update_chronoTool;
+
+before(async () => {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify({ spaces: [SPACE], networks: [], tokens: [] }, null, 2));
+  const loader = await import('../../server/dist/config/loader.js');
+  loader.loadConfig();
+  ({ create_chronoTool, update_chronoTool } = await import('../../server/dist/mcp/tools/chrono.js'));
+});
+
+after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+const ctx = args => ({ args: { space: 'ops', ...args }, callSpace: 'ops', actor: undefined });
+
+/** The allowlist rejection, told apart from any later failure (database, quota, …). */
+const isAllowlistRejection = err => /type must be one of/.test(String(err?.message ?? err));
+
+describe('update_chrono — the gap this closes', () => {
+  it('REJECTS a type outside the space allowlist', async () => {
+    await assert.rejects(
+      () => update_chronoTool.handle(ctx({ id: 'c1', type: 'event' })),
+      isAllowlistRejection,
+      'the space declares incident/maintenance, so the built-in "event" must be refused',
+    );
+  });
+
+  it('names the allowed types, so the caller can correct itself', async () => {
+    const err = await update_chronoTool.handle(ctx({ id: 'c1', type: 'nonsense' })).catch(e => e);
+    assert.match(String(err.message), /incident/);
+    assert.match(String(err.message), /maintenance/);
+  });
+
+  it('does NOT reject an allowed type — the guard gates the bad value, not the field', async () => {
+    // This one gets past the allowlist and fails later (no database in a standalone run). Telling the
+    // two apart is the point: a guard that rejected everything would pass the test above and be useless.
+    const err = await update_chronoTool.handle(ctx({ id: 'c1', type: 'incident' })).catch(e => e);
+    assert.ok(err, 'no database here, so it must fail somewhere');
+    assert.ok(!isAllowlistRejection(err), `expected a later failure, got the allowlist rejection: ${err.message}`);
+  });
+
+  it('an update that does not touch `type` is not gated on it', async () => {
+    const err = await update_chronoTool.handle(ctx({ id: 'c1', title: 'renamed' })).catch(e => e);
+    assert.ok(!isAllowlistRejection(err), 'renaming an entry must not require a valid type argument');
+  });
+});
+
+describe('create_chrono still enforces the same rule', () => {
+  it('REJECTS a type outside the space allowlist', async () => {
+    await assert.rejects(
+      () => create_chronoTool.handle(ctx({ title: 'x', type: 'event', startsAt: '2026-01-01T00:00:00Z' })),
+      isAllowlistRejection,
+    );
+  });
+
+  it('and both surfaces reject with the SAME message', async () => {
+    // Two rules that agree in effect but differ in wording still read as two rules to whoever hits them.
+    const a = await create_chronoTool.handle(ctx({ title: 'x', type: 'nope', startsAt: '2026-01-01T00:00:00Z' })).catch(e => e);
+    const b = await update_chronoTool.handle(ctx({ id: 'c1', type: 'nope' })).catch(e => e);
+    assert.equal(a.message, b.message);
+  });
+});


### PR DESCRIPTION
Queue item 2, from `ARCHITECTURE-TODO.md`.

## The hole

Four write surfaces set a chrono entry's `type`. **Three** checked it against the space's allowed set:

| surface | checked? |
|---|---|
| `create_chrono` (MCP) | ✅ |
| `POST /api/brain/spaces/:id/chrono` | ✅ |
| `PATCH …/chrono/:id` | ✅ |
| **`update_chrono` (MCP)** | ❌ |

So a record could be moved to a type the space does not allow, through the one door that skipped the check.

The asymmetry is the real problem. A constraint enforced on three of four paths reads as enforced — right up until someone uses the fourth — and nothing anywhere reports that it was bypassed.

## The fix

The check runs on update too, with the **same message**, so a caller that hits it gets one rule rather than two that happen to agree.

Both MCP handlers now resolve the allowlist through one `chronoTypeGate` helper. Two copies of a validation rule is exactly how these diverged; one call site is what stops it recurring.

## The tests are behavioural, and that was not my first instinct

I wrote source greps first. They **survived** a mutation that moved the guard into an `else if (false)` branch — the strings were still inside the region being matched, so the test could not tell live code from dead code.

Rewritten to drive the handler directly. The rejection lands before any database call, so a config file is the only fixture needed. The same mutation now kills **three** tests.

They also pin the half a one-sided guard would pass:

- an **allowed** type must NOT be rejected (a guard that refuses everything passes the rejection test and is useless);
- an update that does not touch `type` must not be gated on it;
- create and update must produce the **identical** error message.

Preflight green. `audit-route-coverage` green.

## Not in scope, and worth naming

Neither surface runs the **property schema** validation on update — `validateChrono` is create-only on both MCP and REST. So `validationMode: 'strict'` can be sidestepped by writing properties through an update. That is the same family of hole but a genuinely two-sided design question (validate the delta, or the merged record — the latter can block an unrelated edit to a record that a later schema change made non-compliant), so it is filed rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)