### PR TITLE
fix(retrieval): recall aggregation discarded the fused/rerank order + document the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hybrid retrieval and reranking shipped undocumented outside the config table — and left one doc
+  actively wrong.** The integration guide still said recall results were *"ranked by vector similarity"*,
+  which stopped being true; the MCP retrieval guide still told callers to route exact criteria away from
+  `recall`, which is now the opposite of the advice; and the `recall` tool description still said
+  "semantically search". A guide that is confidently wrong is worse than one that is silent. All four
+  surfaces now describe the three ranking stages, the `lexicalScore` / `fusedScore` / `rerankScore`
+  fields, and — the sharpest point — that **`minScore` filters on the vector score only**, so a threshold
+  set once keeps meaning the same thing. Pinned by tests, so the next ranking change cannot quietly
+  un-document itself.
+
 - **`update_chrono` (MCP) let a record be moved to a chrono type the space does not allow.**
   `create_chrono` checked the type against the space's allowlist and both REST handlers checked it too —
   MCP update was the one write surface of four that did not, so the constraint held right up until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hybrid ranking and reranking were undone at the last step on almost every recall.** `recall()` orders
+  each space's results by the best signal it has — cross-encoder, then RRF fusion, then vector similarity
+  — but both aggregation sites (the REST recall route and the MCP `recall` tool) then re-sorted the merged
+  list by raw `score`, throwing both away. It was not a proxy-space edge case: a single-space REST recall
+  still passes through the member merge with one member, so the only path where #519 and #521 actually
+  took effect was MCP recall with no `space`. Nothing errored — results were simply ordered as if neither
+  feature had shipped. Both sites now use the shared `rankOf`, which is exported for that reason, and a
+  test counts the raw-score sorts left in the retrieval path so a new one fails rather than silently
+  reverting the feature.
+
 - **Hybrid retrieval and reranking shipped undocumented outside the config table — and left one doc
   actively wrong.** The integration guide still said recall results were *"ranked by vector similarity"*,
   which stopped being true; the MCP retrieval guide still told callers to route exact criteria away from

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -981,6 +981,10 @@ did:
 `lexicalScore` is absent when the record did not match lexically; `fusedScore` when hybrid is off;
 `rerankScore` when no reranker is configured or it did not answer.
 
+**The MCP `recall` tool returns `score` only.** Every field it returns is multiplied by `topK` and paid
+for in tokens by whoever called it, so the per-stage scores are deliberately omitted there and kept here,
+where the caller is a program and the response is not a model's context window.
+
 #### A request using every capability
 
 Nothing here is required — this is one call exercising all eight parameters at once, to show how they

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -912,7 +912,173 @@ Available as both:
 }
 ```
 
-Searches **all knowledge types** (memories, entities, edges, chrono entries, and files) using the built-in embedding model and MongoDB Atlas `$vectorSearch`. Results are ranked by vector similarity across all types and include a `type` discriminator field. No extra configuration needed.
+Searches **all knowledge types** (memories, entities, edges, chrono entries, and files) and includes a
+`type` discriminator field on every result. No configuration needed — the defaults below are what a
+fresh instance does.
+
+#### How a result is ranked
+
+Recall runs up to three stages. Each is independent, each degrades to the previous one if it is
+unavailable, and **none of them can fail a search** — a stage that cannot answer simply has no opinion.
+
+1. **Vector search** (always). The query is embedded with the same model and the same task prefix used at
+   index time, and MongoDB `$vectorSearch` returns the nearest records per type. This produces `score`.
+
+2. **Lexical search + rank fusion** (automatic). In parallel, a MongoDB `$text` (BM25-family) query ranks
+   the same records lexically, producing `lexicalScore`; the two rankings are combined by **Reciprocal
+   Rank Fusion** into `fusedScore`.
+
+   This exists because vector search compares *meaning*, which is the wrong tool for the tokens a corpus
+   is most precise about — article numbers, form ids, part codes, clause names, proper nouns. An opaque
+   identifier has no useful semantic neighbourhood, so the right record could rank below plausible prose
+   and fall outside `topK`. Nothing errored; the answer was just built from the wrong passages.
+
+   Fusion uses **rank, never raw score**: `textScore` is unbounded and grows with term rarity, cosine is
+   bounded, and any normalisation between them would need a calibration that drifts as a space grows. A
+   record ranked well by *both* channels outranks one that wins a single channel — agreement between an
+   exact-token match and a semantic match is the strongest signal either gives.
+
+   It **reorders** the candidate set; it does not introduce records the vector search did not return.
+   Set `YTHRIL_HYBRID_SEARCH=off` to disable it.
+
+3. **Cross-encoder reranking** (only when configured). If `mediaEmbedding.rerank` names an endpoint and a
+   model, a cross-encoder reads the query and each candidate passage *together* and scores the actual
+   match, producing `rerankScore`. A bi-encoder can only compare two independently-computed summaries of
+   meaning; a cross-encoder reads the pair. That is what lifts precision in the top few results.
+
+   It has no index, so it can only re-order what stages 1–2 found — hence `candidateMultiplier`, which
+   widens the pool it gets to choose from. Unreachable or unconfigured means no opinion, and the fused
+   order stands. See the `mediaEmbedding.rerank.*` rows in [Configuration](#configuration) below.
+
+**Ordering precedence is `rerankScore` → `fusedScore` → `score`** — the order of how much each signal
+actually knows.
+
+#### `minScore` always filters on `score`
+
+This is deliberate and worth being explicit about: `minScore` is a **vector-similarity** floor and stays
+one. The three scores are on unrelated scales, so reinterpreting a caller's fixed threshold against a
+fused rank or a cross-encoder logit would change what that threshold returns without anyone touching it.
+Ordering may use the better signal; filtering does not.
+
+The extra scores are returned when they were produced, so a caller can see why a result placed where it
+did:
+
+```json
+{
+  "results": [
+    {
+      "_id": "...", "type": "file", "path": "specs/NMK-240C.md",
+      "score": 0.71,
+      "lexicalScore": 4.83,
+      "fusedScore": 0.0325,
+      "rerankScore": 0.94
+    }
+  ],
+  "count": 1
+}
+```
+
+`lexicalScore` is absent when the record did not match lexically; `fusedScore` when hybrid is off;
+`rerankScore` when no reranker is configured or it did not answer.
+
+#### A request using every capability
+
+Nothing here is required — this is one call exercising all eight parameters at once, to show how they
+compose.
+
+```json
+POST /api/brain/spaces/dev-apps/recall
+{
+  "query": "PKCE failures on form NMK-SI-11 during the auth rewrite",
+  "topK": 20,
+  "types": ["memory", "entity", "chrono", "file"],
+  "tags": ["auth", "postmortem"],
+  "minPerType": { "entity": 2, "chrono": 1 },
+  "minScore": 0.55,
+  "traverse": 1,
+  "filter": {
+    "properties.severity": { "in": ["high", "critical"] },
+    "properties.reviewCount": { "gte": 2 },
+    "properties.supersededBy": { "exists": false },
+    "status": { "ne": "cancelled" }
+  }
+}
+```
+
+Read in the order the server applies them:
+
+| Parameter | What it does here |
+|---|---|
+| `query` | Ranked semantically **and** lexically. `NMK-SI-11` is the reason the lexical channel matters — its embedding carries almost no meaning. |
+| `types` | Restricts which collections are searched at all. Edges are excluded. |
+| `tags` | Hard filter, **AND** semantics — a record must carry *both* `auth` and `postmortem`. |
+| `filter` | Hard filter. Keys must start with `properties.`, `tags`, `type`, `name`, `status` or `label`; any other key is rejected. Operators: `eq`, `ne`, `in`, `exists`, `gt`, `gte`, `lt`, `lte`. All conditions must match. |
+| `minPerType` | Guarantees a floor per type *if that many exist*, so a flood of file passages cannot crowd out every entity. Each value is clamped to `topK`. |
+| `minScore` | Applied **last**, on the vector score, and it can drop a `minPerType`-guaranteed result — a floor is a request for coverage, not a licence to return matches you called too weak. |
+| `topK` | The final cut. |
+| `traverse` | After the cut, follows knowledge-graph edges outward from every match (both directions) and returns the connected entities alongside them. |
+
+**`traverse > 0` changes the response shape** — this is the one thing worth knowing before using it. Each
+item becomes a wrapper around the record:
+
+```json
+{
+  "results": [
+    {
+      "source": "recall",
+      "hops": 0,
+      "path": [],
+      "spaceId": "dev-apps",
+      "type": "file",
+      "score": 0.71,
+      "record": {
+        "_id": "…", "type": "file", "path": "runbooks/NMK-SI-11.md",
+        "score": 0.71, "lexicalScore": 4.83, "fusedScore": 0.0325, "rerankScore": 0.94,
+        "matchedText": "Form NMK-SI-11 must be filed within 6 hours…"
+      }
+    },
+    {
+      "source": "traverse",
+      "hops": 1,
+      "path": [{ "from": "runbooks/NMK-SI-11.md", "label": "owned-by", "to": "security-team" }],
+      "spaceId": "dev-apps",
+      "type": "entity",
+      "score": null,
+      "record": { "_id": "…", "type": "entity", "name": "security-team" }
+    }
+  ],
+  "count": 2
+}
+```
+
+`score` is `null` on a traversed neighbour on purpose: it was reached **structurally**, not matched. It
+has no similarity to the query and inventing one would let `minScore` act on a number nobody measured.
+
+The MCP `recall` tool takes the same parameters, plus `space` (omit it to search every accessible space):
+
+```json
+{
+  "space": "dev-apps",
+  "query": "PKCE failures on form NMK-SI-11 during the auth rewrite",
+  "topK": 20,
+  "types": ["memory", "entity", "chrono", "file"],
+  "tags": ["auth", "postmortem"],
+  "minPerType": { "entity": 2, "chrono": 1 },
+  "minScore": 0.55,
+  "traverse": 1,
+  "filter": {
+    "properties.severity": { "in": ["high", "critical"] },
+    "properties.reviewCount": { "gte": 2 },
+    "properties.supersededBy": { "exists": false },
+    "status": { "ne": "cancelled" }
+  }
+}
+```
+
+**Performance note.** `tags`, `type`, `name`, `status`, `label` — and, on spaces whose schema declares
+them, `properties.<key>` — are pushed into the vector index as native pre-filters. Undeclared
+`properties.*` and `exists` are still correct but scan exhaustively, so prefer declared fields on large
+spaces. `traverse` above 2 on a dense graph is slow; narrow the seed set with `tags`/`filter` first.
 
 #### Graph-Augmented Recall (`traverse` parameter)
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -181,10 +181,23 @@ The Query tab has two modes, switched with the buttons at the top: **Semantic Se
 
 #### Semantic Search
 
-Type a natural-language query and press Enter (or click **Search**) to find the most relevant records by meaning across the space. Two options sit next to the query box:
+Type a natural-language query and press Enter (or click **Search**) to find the most relevant records
+across the space.
+
+**It matches meaning *and* exact wording.** Two rankings run and are combined: one by meaning (so
+"how do we handle a data breach" finds a passage titled "incident reporting"), and one by the words
+themselves (so a part number, form id or clause name is found even though such a string carries almost no
+meaning for a language model). A record that scores on both ranks highest. If your administrator has
+configured a reranking model, the top candidates are then re-scored by a model that reads your question
+and each passage together.
+
+None of that needs setting up, and none of it can make a search fail — a stage that is unavailable is
+simply skipped.
+
+Two options sit next to the query box:
 
 - **topK** — how many results to return (1–100).
-- **minScore** — drop results below this similarity score (0–1).
+- **minScore** — drop results below this similarity score (0–1). This is always the **meaning** score, even when word-matching or reranking has changed the order — so a threshold you set once keeps meaning the same thing.
 
 Click **Show advanced** for more control:
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -9,7 +9,7 @@ import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
 import { queryBrain } from '../../brain/query.js';
-import { findSimilar, recall, type RecallKnowledgeType } from '../../brain/recall.js';
+import { findSimilar, recall, rankOf, type RecallKnowledgeType } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
 import { traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE, resolveEdgeEntityNames } from '../../brain/edges.js';
 import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from '../../brain/embed-text.js';
@@ -229,7 +229,12 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     const all = (await Promise.all(
       memberIds.map(mid => recall(mid, query.trim(), safeTopK, safeTags, safeTypes, safeMinPerType, safeMinScore, safeFilter)),
     )).flat();
-    all.sort((x, y) => (y.score ?? 0) - (x.score ?? 0));
+    // rankOf, NOT `.score`. `recall()` has already ordered each space's results by the best signal it
+    // has — cross-encoder, then RRF fusion, then vector similarity. Re-sorting the merged list by raw
+    // vector score here silently threw both away, so hybrid ranking and reranking were undone at the
+    // last step on every REST recall — including a single-space one, which still passes through this
+    // merge with one member.
+    all.sort((x, y) => rankOf(y) - rankOf(x));
     const seeds = all.slice(0, safeTopK);
 
     if (safeTraverse === 0) {

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -249,7 +249,7 @@ export function mergeRecallResults(
  * and the vector score saw one. `??` rather than branches so a partial signal — some records reranked,
  * some not — still orders sensibly instead of collapsing the unscored ones to the bottom.
  */
-function rankOf(r: RecallResult): number {
+export function rankOf(r: RecallResult): number {
   return r.rerankScore ?? r.fusedScore ?? r.score ?? 0;
 }
 

--- a/server/src/mcp/tools/help.ts
+++ b/server/src/mcp/tools/help.ts
@@ -46,11 +46,17 @@ Three retrieval modes exist and they are easy to confuse:
    type, a property value, a date range — and want all matches.
    Example: query(space, collection: "entities", filter: { "type": "person" }).
 
-2. **recall** — semantic nearest-neighbour search. Use for "find things ABOUT X"
-   where wording varies. IMPORTANT: the free-text query only RANKS results by
-   meaning — it does NOT hard-filter. "confidential files about the merger" as
-   free text returns things semantically near that phrase, not things tagged
-   "confidential"; to restrict, pass tags/filter (mode 3).
+2. **recall** — HYBRID search: semantic nearest-neighbour ranking fused with a
+   lexical (BM25) ranking. Use for "find things ABOUT X" where wording varies,
+   AND for exact tokens — an article number, form id, part code or clause name
+   ranks on the lexical side even though its embedding is near-arbitrary.
+   IMPORTANT: the free-text query only RANKS results — it does NOT hard-filter.
+   "confidential files about the merger" as free text returns things ranked near
+   that phrase, not things tagged "confidential"; to restrict, pass tags/filter
+   (mode 3). Ranking may be refined further by a cross-encoder when the operator
+   has configured one; results carry score (vector), and lexicalScore /
+   fusedScore / rerankScore when those stages ran. minScore always filters on
+   the VECTOR score, never on the fused or rerank score.
 
 3. **recall with tags/types/filter** — semantic ranking WITHIN a structured
    subset. tags requires ALL listed tags; types restricts knowledge types; filter
@@ -61,8 +67,10 @@ Three retrieval modes exist and they are easy to confuse:
    Other filters (undeclared properties.*, exists) are still correct but scan
    exhaustively, so prefer declared fields on large spaces.
 
-Rule of thumb: exact criteria → query; fuzzy meaning → recall; both → recall +
-tags/filter. find_similar finds records semantically near an EXISTING record;
+Rule of thumb: exact criteria you can name as a FIELD → query; meaning, or an
+exact TOKEN you can only find inside the text → recall; both → recall +
+tags/filter. (Before hybrid ranking, recall was a poor choice for exact tokens
+and this guide said so; it no longer holds.) find_similar finds records semantically near an EXISTING record;
 traverse walks the entity graph structurally (no semantics).`;
 
 const SCHEMA_GUIDE = `## Schemas

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -41,7 +41,7 @@ export function resolveFindSimilarScope(
 
 export const recallTool: ToolHandler = {
   name: 'recall',
-  description: 'Semantically search all knowledge types (memories, entities, edges, chrono entries, files). Searches the specified space if provided, otherwise searches across all accessible spaces.',
+  description: 'Search all knowledge types (memories, entities, edges, chrono entries, files) by MEANING and by exact tokens: a semantic vector ranking is fused with a lexical (BM25) ranking, so identifiers such as article numbers or form ids rank even though their embeddings carry little meaning. A cross-encoder refines the top candidates when the operator has configured one. Searches the specified space if provided, otherwise across all accessible spaces. Results carry `score` (vector similarity) plus `lexicalScore`/`fusedScore`/`rerankScore` for whichever stages ran; `minScore` filters on `score` only.',
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -41,7 +41,7 @@ export function resolveFindSimilarScope(
 
 export const recallTool: ToolHandler = {
   name: 'recall',
-  description: 'Search all knowledge types (memories, entities, edges, chrono entries, files) by MEANING and by exact tokens: a semantic vector ranking is fused with a lexical (BM25) ranking, so identifiers such as article numbers or form ids rank even though their embeddings carry little meaning. A cross-encoder refines the top candidates when the operator has configured one. Searches the specified space if provided, otherwise across all accessible spaces. Results carry `score` (vector similarity) plus `lexicalScore`/`fusedScore`/`rerankScore` for whichever stages ran; `minScore` filters on `score` only.',
+  description: 'Search all knowledge types (memories, entities, edges, chrono entries, files) by MEANING and by exact tokens: a semantic vector ranking is fused with a lexical (BM25) ranking, so identifiers such as article numbers or form ids rank even though their embeddings carry little meaning. A cross-encoder refines the top candidates when the operator has configured one. Searches the specified space if provided, otherwise across all accessible spaces. Results carry `score` (vector similarity); `minScore` filters on that score only, never on the fused or rerank ordering. The per-stage scores are deliberately omitted here to keep responses small — the REST endpoint returns them for debugging.',
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -12,7 +12,7 @@ import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, uui
 import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
 import { queryBrain } from '../../brain/query.js';
-import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
+import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal, rankOf } from '../../brain/recall.js';
 import { resolveMemberSpaces, collectAcrossMembers } from '../../spaces/proxy.js';
 import { NotFoundError } from '../../util/errors.js';
 
@@ -126,7 +126,8 @@ export const recallTool: ToolHandler = {
     if (callSpace) {
       const memberIds = resolveMemberSpaces(callSpace);
       const all = (await Promise.all(memberIds.map(mid => recall(mid, query, topK, tags, types, minPerType, minScore, filter)))).flat();
-      all.sort((x, y) => (y.score ?? 0) - (x.score ?? 0));
+      // Same rule as everywhere else: rankOf, not `.score`. See the note on the REST recall route.
+      all.sort((x, y) => rankOf(y) - rankOf(x));
       seeds = all.slice(0, topK);
       traverseSpaces = memberIds;
     } else {

--- a/testing/standalone/hybrid-retrieval.test.js
+++ b/testing/standalone/hybrid-retrieval.test.js
@@ -174,3 +174,41 @@ describe('the source keeps its contracts', () => {
     assert.ok(life.includes('lexical_text'), 'the index needs a stable name so it can be replaced later');
   });
 });
+
+describe('the behaviour change is documented where callers actually look', () => {
+  // Shipping a ranking change without updating the docs that describe ranking leaves a guide that is
+  // confidently wrong — worse than one that is silent. `minScore` is the sharpest case: it now means
+  // something narrower than "the score", and a caller who does not know that will misread their results.
+  const guide = readFileSync(new URL('../../docs/integration-guide.md', import.meta.url), 'utf8');
+  const userguide = readFileSync(new URL('../../docs/userguide.md', import.meta.url), 'utf8');
+  const help = readFileSync(new URL('../../server/src/mcp/tools/help.ts', import.meta.url), 'utf8');
+  const search = readFileSync(new URL('../../server/src/mcp/tools/search.ts', import.meta.url), 'utf8');
+
+  it('the integration guide no longer claims results are ranked by vector similarity alone', () => {
+    assert.ok(!/ranked by vector similarity across all types/.test(guide),
+      'that sentence was true before hybrid ranking and is now wrong');
+    assert.ok(/Reciprocal\s+Rank\s+Fusion/.test(guide), 'the fusion stage must be explained');
+    assert.ok(guide.includes('lexicalScore') && guide.includes('fusedScore'),
+      'the new response fields must be documented');
+  });
+
+  it('the integration guide states which score minScore filters on', () => {
+    assert.ok(/`minScore` always filters on `score`/.test(guide));
+  });
+
+  it('the MCP retrieval guide no longer routes exact tokens away from recall', () => {
+    assert.ok(!/Rule of thumb: exact criteria → query; fuzzy meaning → recall; both/.test(help),
+      'the old rule of thumb predates hybrid ranking and now misroutes callers');
+    assert.ok(/HYBRID search/.test(help), 'recall must be described as hybrid');
+  });
+
+  it('the recall tool description says it matches exact tokens too', () => {
+    assert.ok(!/description: 'Semantically search all knowledge types/.test(search),
+      'the description must not still claim purely semantic matching');
+    assert.ok(/lexical \(BM25\) ranking/.test(search));
+  });
+
+  it('the user guide explains it without jargon', () => {
+    assert.ok(/matches meaning \*and\* exact wording/.test(userguide));
+  });
+});

--- a/testing/standalone/hybrid-retrieval.test.js
+++ b/testing/standalone/hybrid-retrieval.test.js
@@ -212,3 +212,45 @@ describe('the behaviour change is documented where callers actually look', () =>
     assert.ok(/matches meaning \*and\* exact wording/.test(userguide));
   });
 });
+
+describe('every aggregation site orders by rankOf, not by raw score', () => {
+  // The bug this pins: `recall()` orders each space's results by the best signal it has, and BOTH
+  // aggregation sites then re-sorted the merged list by raw `.score` — throwing the fused and reranked
+  // ordering away at the last step. It was not a proxy-space edge case: a single-space REST recall still
+  // passes through the member merge with one member, so hybrid ranking and reranking were undone on
+  // effectively every request that was not the MCP global path. Nothing errored; results were just
+  // ordered as if neither feature had shipped.
+  const rest = readFileSync(new URL('../../server/src/api/brain/search.ts', import.meta.url), 'utf8');
+  const mcp = readFileSync(new URL('../../server/src/mcp/tools/search.ts', import.meta.url), 'utf8');
+  const recall = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8');
+
+  const sortsByRawScore = src =>
+    (src.match(/\.sort\(\([^)]*\)\s*=>\s*\(?[a-z]\.score\s*\?\?\s*0\)?\s*-/g) ?? []).length;
+
+  it('the REST recall route merges member spaces with rankOf', () => {
+    assert.ok(/all\.sort\(\(x, y\) => rankOf\(y\) - rankOf\(x\)\)/.test(rest));
+    assert.equal(sortsByRawScore(rest), 0, 'no recall path in this file may sort by raw score');
+  });
+
+  it('the MCP recall tool merges member spaces with rankOf', () => {
+    assert.ok(/all\.sort\(\(x, y\) => rankOf\(y\) - rankOf\(x\)\)/.test(mcp));
+    assert.equal(sortsByRawScore(mcp), 0, 'no recall path in this file may sort by raw score');
+  });
+
+  it('rankOf is exported, so there is one ordering rule rather than three', () => {
+    assert.ok(/export function rankOf\(/.test(recall),
+      'a private rankOf is what let two callers invent their own ordering');
+  });
+
+  it('the raw-score sorts left in recall.ts are the ones that MUST be raw', () => {
+    // Three survive on purpose, and none of them is an output ordering:
+    //   1. the pre-fusion sort, which ESTABLISHES the vector ranking fusion consumes;
+    //   2. the vector channel handed to RRF, which must be the vector order by definition;
+    //   3. `findSimilar`, which starts from a stored vector with no query text — there is no lexical
+    //      or cross-encoder signal to prefer, so raw similarity is the only signal there is.
+    // A fourth raw-score sort exists in `applyRerank` (choosing which candidates survive the cap) but
+    // reads through a Map, so it does not match this pattern. Counted rather than listed so a NEW raw
+    // sort appearing anywhere in this file fails here.
+    assert.equal(sortsByRawScore(recall), 3);
+  });
+});

--- a/testing/standalone/hybrid-retrieval.test.js
+++ b/testing/standalone/hybrid-retrieval.test.js
@@ -206,6 +206,10 @@ describe('the behaviour change is documented where callers actually look', () =>
     assert.ok(!/description: 'Semantically search all knowledge types/.test(search),
       'the description must not still claim purely semantic matching');
     assert.ok(/lexical \(BM25\) ranking/.test(search));
+    // …and must not promise per-stage scores the MCP response does not carry. It returns `score` only,
+    // on purpose: every field is multiplied by topK and paid for in tokens by whoever called the tool.
+    assert.ok(!/plus `lexicalScore`\/`fusedScore`\/`rerankScore`/.test(search),
+      'the MCP description must not advertise fields the MCP response omits');
   });
 
   it('the user guide explains it without jargon', () => {


### PR DESCRIPTION
Two commits. The first documents hybrid ranking and reranking; the second fixes a bug the owner's question about multi-space search exposed — which turned out to be the more important half.

## The bug: two features shipped and, on most traffic, changed nothing

`recall()` orders each space's results by the best signal it has — cross-encoder → RRF fusion → vector similarity. **Both** callers that merge across member spaces then re-sorted the merged list by raw `.score`, throwing both away:

- `api/brain/search.ts` — the REST recall route
- `mcp/tools/search.ts` — the MCP `recall` tool, when `space` is given

**This was not a proxy-space edge case.** `resolveMemberSpaces(spaceId)` returns `[spaceId]` for an ordinary space, so a single-space REST recall passes through the same merge with one member and got re-sorted too.

The only path where #519 and #521 actually took effect was MCP `recall` with **no** `space`, which goes via `recallGlobal` — already fixed when the reranker landed.

So: two features, both green, both mutation-tested, and on most requests neither changed a single result. Nothing errored. Ordering was simply what it would have been if neither had been built.

**It was found because the owner asked how multi-space search works.** No test caught it: every test covered `recall()` in isolation, and none covered what its callers did with the answer.

### Fix

`rankOf` is exported and used at both sites, so there is **one** ordering rule rather than three. Guarded by tests that assert neither file sorts by raw score, and that **count** the raw-score sorts remaining in `recall.ts` — currently 3, each a vector-ranking *input* rather than an output ordering:

1. the pre-fusion sort, which establishes the vector ranking fusion consumes;
2. the vector channel handed to RRF, which must be the vector order by definition;
3. `findSimilar`, which starts from a stored vector with no query text — no lexical or cross-encoder signal exists to prefer.

A new raw sort anywhere in that file now fails rather than silently reverting the feature. Mutation-tested: reverting either site kills a test.

## The docs half

#519 and #521 shipped with documentation only in the config table, leaving one doc **actively wrong** rather than merely silent:

| doc | said | now |
|---|---|---|
| integration guide | *"ranked by vector similarity across all types"* | the three stages, and which score `minScore` uses |
| MCP retrieval guide | *"exact criteria → query; fuzzy meaning → recall"* | that rule existed **because** recall could not find exact tokens; it can now |
| `recall` tool description | *"Semantically search…"* | hybrid, with the score fields named |
| user guide | nothing | plain-language, no BM25 jargon |

Plus a **full-capability request example** — all eight parameters at once, the order the server applies them in, and the response-shape change `traverse > 0` causes (results wrap into `{source, hops, path, record}` and traversed neighbours carry `score: null`, because they were reached structurally and never matched).

Six doc tests, two of them **negative** assertions on the sentences that were wrong, so the next ranking change cannot quietly un-document itself.

Preflight green. `lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)