### PR TITLE
perf(mcp): halve recall response size; add includeContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP recall responses are about half the size, and `includeContent: false` makes them a fifth.**
+  Every field an MCP tool returns is multiplied by `topK` and billed as tokens to whoever called it — the
+  REST caller is a program and can afford detail, the MCP caller is a model's context window and cannot.
+  Measured on a realistic 10-result file-chunk recall: **~6 200 → ~3 150 tokens by default (−49%)**, with
+  no information removed at all, and **~900 tokens (−85%)** with `includeContent: false`.
+  - **The passage was being returned twice.** `matchedText` — the concatenated string fed to the embedder
+    — is `headingText + ' ' + content` for a file chunk and byte-identical to `content` for a media chunk.
+    It is gone from MCP responses; `content` stays, because it is a named field with a defined meaning
+    rather than a blob. (REST still returns `matchedText`.)
+  - `seq` is gone: it is the per-space counter sync orders replication by, is not an input to any tool,
+    and is read by nothing outside `sync/*`. `embeddingModel` is gone: identical for every record in a
+    space, so it was instance configuration repeated on every row. `createdAt`/`updatedAt` stay — they
+    cost the same and answer a question a caller actually asks.
+  - **No MCP tool pretty-prints its response any more** (14 sites). Indentation was billed to the caller
+    and read by nothing.
+  - **`includeContent`** (default `true`) on `recall` and `find_similar` drops the passage body, leaving
+    path, heading, chunk index, tags and properties — the right shape for a two-phase agent: recall to
+    find *where*, then read only the chunk it decided it needs.
+  - `find_similar`'s source descriptor field `matchedText` is renamed `summary`, since `matchedText` no
+    longer means anything in an MCP response.
+
 - **Hybrid retrieval: a lexical channel beside the vector one, fused by Reciprocal Rank Fusion.**
   Vector search compares *meaning*, which is exactly the wrong tool for the tokens a corpus is most
   precise about — article numbers, form ids, part codes, clause names, proper nouns. An opaque identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`npm run preflight` could report PASSED against a build from a different branch.** It compiled the
+  server only when `server/dist` was *missing*, so every gate that imports from `dist` was free to
+  validate whatever was compiled last. It now builds unconditionally. A stale pass is worse than no
+  check at all, because it is indistinguishable from a real one; `tsc` is cheap, being told the wrong
+  answer is not.
+- **Preflight now runs every standalone test that needs no running instance** (98 of 131), not the
+  curated handful of structural gates. The rest drive a live server on :3200 and stay in CI. The count
+  and the split are printed, so what was skipped is visible rather than assumed. Together these two are
+  why the MCP response-shape change above first reached CI with a test still asserting the old shape.
+
 - **Hybrid ranking and reranking were undone at the last step on almost every recall.** `recall()` orders
   each space's results by the best signal it has — cross-encoder, then RRF fusion, then vector similarity
   — but both aggregation sites (the REST recall route and the MCP `recall` tool) then re-sorted the merged

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6722,7 +6722,7 @@ Omit `space` to search across all accessible spaces. `recall` searches all knowl
 
 **Response format:**
 
-The tool returns a JSON object with a `results` array and a `count`. Each result has five top-level keys — search metadata and a quick-read text field cleanly separated from the stored document:
+The tool returns a JSON object with a `results` array and a `count`. Each result has four top-level keys — search metadata cleanly separated from the stored document:
 
 ```json
 {
@@ -6731,7 +6731,6 @@ The tool returns a JSON object with a `results` array and a `count`. Each result
       "score": 0.91,
       "spaceId": "general",
       "type": "memory",
-      "matchedText": "portal-backend Traefik routing configuration uses path-prefix matchers",
       "record": {
         "_id": "a1b2c3d4-e5f6-4789-abcd-ef1234567890",
         "fact": "Traefik routing configuration uses path-prefix matchers",
@@ -6747,7 +6746,6 @@ The tool returns a JSON object with a `results` array and a `count`. Each result
       "score": 0.87,
       "spaceId": "general",
       "type": "entity",
-      "matchedText": "traefik-ingress ingress-controller portal-backend Handles HTTP routing for portal services.",
       "record": {
         "_id": "b2c3d4e5-f6a7-4890-bcde-f12345678901",
         "name": "traefik-ingress",
@@ -6769,14 +6767,20 @@ The tool returns a JSON object with a `results` array and a `count`. Each result
 | `score` | Cosine similarity score (0.0–1.0). Higher is more relevant. |
 | `spaceId` | Space this result came from. Critical for cross-space recall (no `space` arg). |
 | `type` | Knowledge type discriminator: `memory`, `entity`, `edge`, `chrono`, or `file`. |
-| `matchedText` | The full multi-field text that was fed to the embedding model for this document (e.g. for a memory: `tags + entity names + fact + description + properties`). Lets you scan results without knowing which fields to look at per type. Pre-computed at write time — not reconstructed on demand. |
-| `record` | The full stored document with all user-visible fields. `_id` is always present and can be used directly in follow-up tool calls (`update_memory`, `upsert_entity`, `delete_memory`, etc.) without a second lookup. Embedding vector excluded. |
+| `record` | The stored document with its user-visible fields. `_id` is always present and can be used directly in follow-up tool calls (`update_memory`, `upsert_entity`, `delete_memory`, etc.) without a second lookup. Embedding vector excluded. |
 
 For cross-space recall (omit `space`), `spaceId` on each result identifies which space it came from.
 
+> **The MCP response is deliberately smaller than the REST one.** Every field is multiplied by `topK` and
+> paid for in the calling model's context, so three things REST returns are dropped here:
+> `matchedText` (for a file chunk it is `headingText + ' ' + content` — the passage a second time; the
+> passage is returned once, as `content`), `embeddingModel` (identical for every record in a space) and
+> `seq` (the sync counter — not an input to any tool). The REST endpoint still returns all three.
+> To drop the passage bodies as well and get locations only, pass `includeContent: false`.
+
 **What is vector-indexed:**
 
-| Data type | Embedded? | Fields included in embedding text (`matchedText`) | Returned by `recall`? |
+| Data type | Embedded? | Fields included in the pre-embedding text (`matchedText`, REST only) | Returned by `recall`? |
 |-----------|:---------:|---------------------------------------------------|:---------------------:|
 | `memory` | ✅ | `tags` + entity names + `fact` + `description` + `properties` | ✅ |
 | `entity` | ✅ | `name` + `type` + `tags` + `description` + `properties` | ✅ |
@@ -6795,6 +6799,7 @@ For cross-space recall (omit `space`), `spaceId` on each result identifies which
 | `types` | `string[]` | — | Optional knowledge-type filter — restrict results to one or more of `memory`, `entity`, `edge`, `chrono`, `file`. Omit to search all types. |
 | `minPerType` | `object` | — | Optional minimum result count per type. Guarantees at least that many results of each specified type if available (e.g. `{"entity": 2, "edge": 1}`). Uses two-phase search: guaranteed slots filled first, remaining slots filled by score. Omit to use pure score ranking. |
 | `minScore` | `number` | — | Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded. Applies before `topK` — so `topK=10, minScore=0.7` returns at most 10 results, all with score ≥ 0.7. |
+| `includeContent` | `boolean` | — | Whether to return each file chunk's `content` — the passage body (default `true`). Set `false` for locations and metadata only (path, heading, chunk index, tags, properties), then read back only the chunk you decided you need. Passage bodies are by far the largest field in a response. |
 | `filter` | `object` | — | Property equality/comparison filter applied to the vector-search results. Same shape and allowed key prefixes as the [recall filter](#prefiltered-recall-filter-parameter) (`properties.`, `tags`, `type`, `name`, `status`, `label`) with `eq`/`ne`/`in`/`exists`/`gt`/`gte`/`lt`/`lte` operators. Records not matching **all** conditions are excluded. |
 | `traverse` | `number` | — | Graph-expansion depth (integer `0`–`5`, default `0`). When `> 0`, each semantic match is expanded along knowledge-graph edges up to this many hops; connected entities are returned alongside the seeds, annotated with `source` (`recall`/`traverse`), `hops`, and `path`. |
 

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -23,7 +23,7 @@
  * Usage:  npm run preflight
  */
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 
 /** Gates that read SOURCE only — no build required, so they run first and fail fastest. */
 const SOURCE_GATES = [
@@ -43,6 +43,7 @@ const BUILT_GATES = [
 ];
 
 const run = (cmd, opts = {}) => execSync(cmd, { stdio: 'inherit', ...opts });
+
 const failures = [];
 
 function gate(name, why, file) {
@@ -58,13 +59,36 @@ console.log('Preflight — the checks that catch failures with no error message.
 
 for (const [file, why] of SOURCE_GATES) gate(file, why, file);
 
-// Build once, only if something needs it or dist is missing.
-if (BUILT_GATES.length > 0) {
-  if (!existsSync('server/dist')) {
-    console.log('\n── building server (a gate below imports from server/dist) ──');
-    try { run('npm run build:server'); } catch { failures.push({ name: 'build:server', why: 'the server does not compile' }); }
-  }
-  for (const [file, why] of BUILT_GATES) gate(file, why, file);
+// Build UNCONDITIONALLY before anything that imports from server/dist.
+//
+// This used to build only when `server/dist` was missing, which made every gate below it a check on
+// whatever was compiled last — a different branch, a different commit, code that no longer exists. It
+// cost a red CI run: a PR changed `toRecallRecord`'s output, preflight reported PASSED, and the
+// standalone test that contradicts the change had been run against the PREVIOUS build. A stale pass is
+// worse than no check, because it is indistinguishable from a real one. A `tsc` run is cheap; being
+// told the wrong answer is not.
+console.log('\n── building server (the gates below import from server/dist) ──');
+try { run('npm run build:server'); } catch { failures.push({ name: 'build:server', why: 'the server does not compile' }); }
+
+for (const [file, why] of BUILT_GATES) gate(file, why, file);
+
+// Every standalone test that does NOT need a running instance, rather than the curated handful above.
+//
+// `npm run test:standalone` assumes the Docker stack — a third of those files drive a live server on
+// :3200. The rest are pure: they import from `server/dist` and assert on logic. Those had no reason to
+// wait for CI, and waiting for CI is exactly how a PR that changed `toRecallRecord`'s output shipped
+// with the test contradicting it still asserting the old shape.
+//
+// The split is by grep for an instance marker, and the skipped count is PRINTED. A file that reaches
+// the network without one of these markers fails here with ECONNREFUSED rather than being skipped
+// silently — loud and wrong beats quiet and wrong, and the fix is to add the marker.
+const NEEDS_INSTANCE = /fetch\(|127\.0\.0\.1|localhost:|INSTANCES|BASE_URL/;
+const allStandalone = readdirSync('testing/standalone').filter(f => f.endsWith('.test.js')).sort();
+const pure = allStandalone.filter(f => !NEEDS_INSTANCE.test(readFileSync(`testing/standalone/${f}`, 'utf8')));
+console.log(`\n── standalone tests that need no running instance (${pure.length} of ${allStandalone.length}; ` +
+  `${allStandalone.length - pure.length} drive a live server and run in CI) ──`);
+try { run(`node --test --test-concurrency=1 ${pure.map(f => `testing/standalone/${f}`).join(' ')}`); } catch {
+  failures.push({ name: 'test:standalone (offline subset)', why: 'server contracts and pure logic — no Docker needed, so no reason to learn this from CI' });
 }
 
 console.log('\n── docs lint ──');

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -128,7 +128,7 @@ export const bulk_writeTool: ToolHandler = {
     }
     const summary = `bulk_write complete — inserted: ${JSON.stringify(result.inserted)}, updated: ${JSON.stringify(result.updated)}, errors: ${result.errors.length}`;
     return {
-      content: [{ type: 'text' as const, text: summary + (result.errors.length > 0 ? '\n' + JSON.stringify(result.errors, null, 2) : '') }],
+      content: [{ type: 'text' as const, text: summary + (result.errors.length > 0 ? '\n' + JSON.stringify(result.errors) : '') }],
       isError: false,
     };
   },

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -74,7 +74,7 @@ export const create_chronoTool: ToolHandler = {
 
     const chronoSchemaViolations = chronoMeta ? validateChrono(chronoMeta, { type: chronoType, properties: chronoProps }) : [];
     if (chronoSchemaViolations.length > 0 && chronoMeta?.validationMode === 'strict') {
-      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(chronoSchemaViolations, null, 2)}` }], isError: true };
+      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(chronoSchemaViolations)}` }], isError: true };
     }
 
     const remQuota = await checkQuota('brain');

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -60,7 +60,7 @@ export const upsert_edgeTool: ToolHandler = {
     const edgeMeta = edgeMetaRaw ? resolveMetaRefs(edgeMetaRaw) : undefined;
     const edgeSchemaViolations = edgeMeta ? validateEdge(edgeMeta, { label: label.trim(), properties: edgeProps }) : [];
     if (edgeSchemaViolations.length > 0 && edgeMeta?.validationMode === 'strict') {
-      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(edgeSchemaViolations, null, 2)}` }], isError: true };
+      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(edgeSchemaViolations)}` }], isError: true };
     }
 
     const edgeTtlDays = ttlDaysFromArgs(a);
@@ -177,7 +177,7 @@ export const traverseTool: ToolHandler = {
     return {
       content: [{
         type: 'text' as const,
-        text: JSON.stringify(result, null, 2),
+        text: JSON.stringify(result),
       }],
     };
   },

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -56,7 +56,7 @@ export const upsert_entityTool: ToolHandler = {
     const entMeta = entMetaRaw ? resolveMetaRefs(entMetaRaw) : undefined;
     const entSchemaViolations = entMeta ? validateEntity(entMeta, { name: eName.trim(), type: eType.trim(), properties: props }) : [];
     if (entSchemaViolations.length > 0 && entMeta?.validationMode === 'strict') {
-      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(entSchemaViolations, null, 2)}` }], isError: true };
+      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(entSchemaViolations)}` }], isError: true };
     }
 
     // Insert-time duplicate check defaults ON for the interactive upsert tool

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -78,7 +78,7 @@ export const rememberTool: ToolHandler = {
     const remMeta = remMetaRaw ? resolveMetaRefs(remMetaRaw) : undefined;
     const remSchemaViolations = remMeta ? validateMemory(remMeta, { type: memType, properties: props }) : [];
     if (remSchemaViolations.length > 0 && remMeta?.validationMode === 'strict') {
-      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(remSchemaViolations, null, 2)}` }], isError: true };
+      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(remSchemaViolations)}` }], isError: true };
     }
 
     // Quota check — throws QuotaError (caught below) on hard limit

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -60,6 +60,11 @@ export const recallTool: ToolHandler = {
               additionalProperties: { type: 'number' },
             },
             minScore: unitScoreSchema('Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded.'),
+            includeContent: {
+              type: 'boolean',
+              default: true,
+              description: 'Whether to return each file chunk’s `content` — the passage body (default true). Set false to get locations and metadata only: path, heading, chunk index, tags, properties. Use it for a two-phase flow — recall to find WHERE something is, then read only the chunk you decided you need. Every field a result carries is multiplied by topK and paid for in tokens, and passage bodies are by far the largest of them.',
+            },
             traverse: {
               type: 'number',
               minimum: 0,
@@ -100,6 +105,7 @@ export const recallTool: ToolHandler = {
       ? (a['minPerType'] as Partial<Record<RecallKnowledgeType, number>>)
       : undefined;
     const minScore = typeof a['minScore'] === 'number' ? a['minScore'] : undefined;
+    const includeContent = a['includeContent'] !== false;
 
     // Graph-traversal expansion depth. 0 (default) = classic recall, unchanged.
     let traverse = 0;
@@ -141,12 +147,11 @@ export const recallTool: ToolHandler = {
           score: r.score,
           spaceId: r.spaceId,
           type: r.type,
-          matchedText: r.matchedText ?? formatRecallSummary(r),
-          record: toRecallRecord(r),
+          record: toRecallRecord(r, { includeContent }),
         })),
         count: seeds.length,
       };
-      return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
+      return { content: [{ type: 'text' as const, text: JSON.stringify(output) }] };
     }
 
     // Graph-augmented recall: expand seeds along edges, cap the combined output.
@@ -158,11 +163,11 @@ export const recallTool: ToolHandler = {
       Math.max(0, totalCap - seeds.length),
     );
     const results: McpRecallTraverseItem[] = [
-      ...seeds.map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, matchedText: r.matchedText ?? formatRecallSummary(r), record: toRecallRecord(r) })),
-      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity', matchedText: `${n.record.name} (${n.record.type})`, record: entityDocToRecord(n.record) })),
+      ...seeds.map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, record: toRecallRecord(r, { includeContent }) })),
+      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity', record: entityDocToRecord(n.record) })),
     ];
     const output = { results, count: results.length, traverseDepth: traverse };
-    return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(output) }] };
   },
 };
 
@@ -176,6 +181,7 @@ export const find_similarTool: ToolHandler = {
             space: s.optionalSpace,
             entryId: uuidSchema('UUID v4 of the source entry.'),
             entryType: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'], description: 'Knowledge type of the source entry.' },
+            includeContent: { type: 'boolean', default: true, description: 'Whether to return each file chunk’s `content` (default true). Same meaning as on `recall`: false returns locations and metadata only.' },
             targetTypes: {
               type: 'array',
               items: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'] },
@@ -250,6 +256,7 @@ export const find_similarTool: ToolHandler = {
     }
 
     // Graph-augmented: expand the similar seeds along edges (mirrors recall's traverse), JSON output.
+    const includeContent = a['includeContent'] !== false;
     const traverseSpaces = searchIds ?? [usedBase];
     const totalCap = topK * (traverse + 1) * 4;
     const neighbours = await traverseRecallSeeds(
@@ -259,14 +266,14 @@ export const find_similarTool: ToolHandler = {
       Math.max(0, totalCap - result.results.length),
     );
     const results: McpRecallTraverseItem[] = [
-      ...result.results.map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, matchedText: formatRecallSummary(r), record: toRecallRecord(r) })),
-      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity', matchedText: `${n.record.name} (${n.record.type})`, record: entityDocToRecord(n.record) })),
+      ...result.results.map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, record: toRecallRecord(r, { includeContent }) })),
+      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity', record: entityDocToRecord(n.record) })),
     ];
     const output = {
-      source: { type: result.source.type, id: result.source._id, matchedText: formatRecallSummary(result.source) },
+      source: { type: result.source.type, id: result.source._id, summary: formatRecallSummary(result.source) },
       results, count: results.length, traverseDepth: traverse,
     };
-    return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(output) }] };
   },
 };
 
@@ -327,7 +334,7 @@ export const queryTool: ToolHandler = {
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify(docs, null, 2),
+          text: JSON.stringify(docs),
         },
       ],
     };

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -75,12 +75,40 @@ export function formatRecallSummary(r: RecallResult): string {
   }
 }
 
-export function toRecallRecord(r: RecallResult): Record<string, unknown> {
+/**
+ * A recall result, shrunk for an MCP response.
+ *
+ * **Every field here is multiplied by `topK` and paid for in tokens by whoever called the tool.** That is
+ * the whole reason this function exists rather than returning the result object: the REST caller is a
+ * program and can afford detail, the MCP caller is a model's context window and cannot.
+ *
+ * Two things are dropped unconditionally because they carry no information a caller does not already
+ * have, not to save space at the cost of usefulness:
+ *
+ *  - `embeddingModel` — identical for every record in a space. Instance configuration, not a per-record
+ *    signal, and it was being repeated on every row.
+ *  - `seq` — the per-space monotonic counter that sync orders replication by. It is not an input to any
+ *    tool, nothing outside `sync/*` reads it, and it means nothing to a model. A caller that genuinely
+ *    needs it can read the record by `_id`.
+ *
+ * `createdAt` / `updatedAt` deliberately STAY. They cost about the same as `seq` did and, unlike it,
+ * answer a question a caller actually asks — whether what it just found is still current.
+ *  - `matchedText` — the concatenated string that was fed to the embedding model. For a file chunk it is
+ *    `headingText + ' ' + content`; for a media chunk it is byte-identical to `content`; for the other
+ *    types it is a rendering of fields the record already carries. So it was returning the passage TWICE
+ *    per result — measurably the largest single waste in the response — and the copy it duplicated is
+ *    the better one: `content` is a named field with a defined meaning, `matchedText` is a blob. Owner,
+ *    2026-07-29: *"I want the content if not flagged false. matched text does not interest me really."*
+ *    Checked before removing: audio, video and image chunks all write the transcript/caption to BOTH
+ *    `content` and `matchedText`, so nothing is only in the blob.
+ *
+ * `includeContent: false` additionally drops the passage body itself — see the tool schema.
+ */
+export function toRecallRecord(r: RecallResult, opts: { includeContent?: boolean } = {}): Record<string, unknown> {
+  const includeContent = opts.includeContent !== false;
   const common: Record<string, unknown> = { _id: r._id };
   if (r.createdAt !== undefined) common['createdAt'] = r.createdAt;
   if (r.updatedAt !== undefined) common['updatedAt'] = r.updatedAt;
-  if (r.seq !== undefined) common['seq'] = r.seq;
-  if (r.embeddingModel !== undefined) common['embeddingModel'] = r.embeddingModel;
   if (r.tags !== undefined) common['tags'] = r.tags;
   if (r.description !== undefined) common['description'] = r.description;
   if (r.properties !== undefined) common['properties'] = r.properties;
@@ -93,8 +121,11 @@ export function toRecallRecord(r: RecallResult): Record<string, unknown> {
       return { ...common, from: r.from, to: r.to, label: r.label, ...(r.weight !== undefined ? { weight: r.weight } : {}), ...(r.edgeType !== undefined ? { type: r.edgeType } : {}) };
     case 'chrono':
       return { ...common, title: r.title, type: r.chronoType, startsAt: r.startsAt, ...(r.status !== undefined ? { status: r.status } : {}), ...(r.entityIds !== undefined ? { entityIds: r.entityIds } : {}) };
-    case 'file':
-      return { ...common, path: r.path, ...(r.sizeBytes !== undefined ? { sizeBytes: r.sizeBytes } : {}), ...(r.parentFileId !== undefined ? { parentFileId: r.parentFileId } : {}), ...(r.chunkIndex !== undefined ? { chunkIndex: r.chunkIndex } : {}), ...(r.headingText !== undefined ? { headingText: r.headingText } : {}), ...(r.content !== undefined ? { content: r.content } : {}) };
+    case 'file': {
+      // `content` is the passage. It is what a caller asked for unless they said otherwise.
+      const keepContent = includeContent && r.content !== undefined;
+      return { ...common, path: r.path, ...(r.sizeBytes !== undefined ? { sizeBytes: r.sizeBytes } : {}), ...(r.parentFileId !== undefined ? { parentFileId: r.parentFileId } : {}), ...(r.chunkIndex !== undefined ? { chunkIndex: r.chunkIndex } : {}), ...(r.headingText !== undefined ? { headingText: r.headingText } : {}), ...(keepContent ? { content: r.content } : {}) };
+    }
   }
 }
 
@@ -118,6 +149,5 @@ export interface McpRecallTraverseItem {
   path: { from: string; label: string; to: string }[];
   spaceId: string;
   type: string;
-  matchedText: string;
   record: Record<string, unknown>;
 }

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -42,7 +42,7 @@ export const list_spacesTool: ToolHandler = {
       counts: countsBySpaceId[s.id] ?? { memories: 0, entities: 0, edges: 0, chrono: 0 },
     }));
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
     };
   },
 };
@@ -77,7 +77,7 @@ export const get_statsTool: ToolHandler = {
     return {
       content: [{
         type: 'text' as const,
-        text: JSON.stringify({ spaceId: callSpace, memories, entities, edges, chrono, files }, null, 2),
+        text: JSON.stringify({ spaceId: callSpace, memories, entities, edges, chrono, files }),
       }],
     };
   },
@@ -132,7 +132,7 @@ export const get_space_metaTool: ToolHandler = {
     return {
       content: [{
         type: 'text' as const,
-        text: JSON.stringify(metaResult, null, 2),
+        text: JSON.stringify(metaResult),
       }],
     };
   },

--- a/server/src/mcp/tools/sync.ts
+++ b/server/src/mcp/tools/sync.ts
@@ -30,7 +30,7 @@ export const list_peersTool: ToolHandler = {
           type: 'text' as const,
           text: peers.length === 0
             ? 'No peers configured.'
-            : JSON.stringify(peers, null, 2),
+            : JSON.stringify(peers),
         },
       ],
     };

--- a/testing/integration/mcp-tools.test.js
+++ b/testing/integration/mcp-tools.test.js
@@ -287,11 +287,18 @@ describe('MCP brain tools — remember / recall / query', () => {
       assert.ok('score' in item, 'each result must have score');
       assert.ok('spaceId' in item, 'each result must have spaceId');
       assert.ok('type' in item, 'each result must have type');
-      assert.ok('matchedText' in item, 'each result must have matchedText');
+      // `matchedText` was the pre-embedding source string, and for a file chunk it is
+      // `headingText + ' ' + content` — i.e. the passage a second time. Dropped from MCP
+      // responses so the passage is paid for once, under its named field. REST still has it.
+      assert.ok(!('matchedText' in item), 'MCP recall must not duplicate the passage as matchedText');
       assert.ok('record' in item, 'each result must have record');
       assert.ok(typeof item.record === 'object' && item.record !== null, 'record must be an object');
       assert.ok('_id' in item.record, 'record must have _id');
       assert.ok(!('embedding' in item.record), 'record must not expose embedding vector');
+      // Per-row cost with no per-row information: `embeddingModel` is identical for every record in a
+      // space, `seq` is the sync counter and is not an input to any tool.
+      assert.ok(!('embeddingModel' in item.record), 'record must not repeat embeddingModel per row');
+      assert.ok(!('seq' in item.record), 'record must not carry the sync seq counter');
     }
   });
 
@@ -1552,9 +1559,13 @@ describe('MCP brain tools � recall and recall_global with minPerType', () => {
     });
     assert.ok(!result?.isError, `recall with minPerType error: ${JSON.stringify(result)}`);
     const text = result?.content?.[0]?.text ?? '';
-    // Response is formatted text � verify entity name appears somewhere in the output
-    // (embedded entity should match the exact name we seeded)
-    assert.ok(text.includes(entityName) || text.toLowerCase().includes('[entity]') || text.includes('"type": "entity"'), `Expected entity in recall output: ${text}`);
+    // Parse rather than substring-match: the response is compact JSON, so a literal
+    // `"type": "entity"` (pretty-printed spacing) silently stopped matching.
+    const parsed = JSON.parse(text);
+    assert.ok(
+      Array.isArray(parsed.results) && parsed.results.some(r => r.type === 'entity'),
+      `Expected an entity result with minPerType={entity:1}: ${text}`,
+    );
   });
 
   it('recall_global with minPerType does not return isError', async (t) => {

--- a/testing/standalone/mcp-recall-payload.test.js
+++ b/testing/standalone/mcp-recall-payload.test.js
@@ -1,0 +1,137 @@
+/**
+ * MCP recall response size — what the caller pays for.
+ *
+ * An MCP result is read by a language model, so **every field is multiplied by `topK` and billed as
+ * tokens to whoever called the tool**. The REST caller is a program and can afford detail; the MCP caller
+ * cannot. That asymmetry is the whole reason `toRecallRecord` exists rather than returning the result.
+ *
+ * These assert the SIZE, not the absence of particular fields. The claim being made is about cost, so a
+ * test that only checked "field X is gone" would pass while something else grew back into its place.
+ *
+ * Run: node --test testing/standalone/mcp-recall-payload.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let toRecallRecord;
+before(async () => { ({ toRecallRecord } = await import('../../server/dist/mcp/tools/shared.js')); });
+
+const CHUNK = 'Form NMK-SI-11 must be filed within 6 hours of discovering a data breach. '.repeat(12).trim();
+const HEADING = 'Incident reporting';
+
+/** A file-chunk result as recall produces it — the expensive and most common shape. */
+const fileHit = i => ({
+  _id: `f${i}#chunk3`, spaceId: 'dev-apps', type: 'file', score: 0.7 - i * 0.01,
+  createdAt: '2026-07-01T10:00:00.000Z', updatedAt: '2026-07-02T11:00:00.000Z',
+  seq: 100 + i, embeddingModel: 'nomic-ai/nomic-embed-text-v1.5',
+  tags: ['auth', 'postmortem'], description: 'Runbook section', properties: { severity: 'high' },
+  path: 'runbooks/NMK-SI-11.md', parentFileId: `f${i}`, chunkIndex: 3,
+  headingText: HEADING, content: CHUNK, matchedText: `${HEADING} ${CHUNK}`,
+});
+
+const wrap = (r, includeContent) => ({
+  score: r.score, spaceId: r.spaceId, type: r.type, record: toRecallRecord(r, { includeContent }),
+});
+const respond = includeContent =>
+  JSON.stringify({ results: Array.from({ length: 10 }, (_, i) => wrap(fileHit(i), includeContent)), count: 10 });
+
+/** The payload as it stood before this change: pretty-printed, with the passage returned twice. */
+const BASELINE = JSON.stringify({
+  results: Array.from({ length: 10 }, (_, i) => {
+    const r = fileHit(i);
+    return {
+      score: r.score, spaceId: r.spaceId, type: r.type, matchedText: r.matchedText,
+      record: {
+        _id: r._id, createdAt: r.createdAt, updatedAt: r.updatedAt, seq: r.seq,
+        embeddingModel: r.embeddingModel, tags: r.tags, description: r.description,
+        properties: r.properties, path: r.path, parentFileId: r.parentFileId,
+        chunkIndex: r.chunkIndex, headingText: r.headingText, content: r.content,
+      },
+    };
+  }),
+  count: 10,
+}, null, 2);
+
+describe('the default response is much smaller, and loses nothing', () => {
+  it('is at least 40% smaller than the old shape', () => {
+    const saved = 1 - respond(true).length / BASELINE.length;
+    assert.ok(saved >= 0.4, `expected ≥40% smaller, got ${(saved * 100).toFixed(0)}%`);
+  });
+
+  it('still carries the passage — `content` is the field a caller asked for', () => {
+    // The owner's call, 2026-07-29: "I want the content if not flagged false. matched text does not
+    // interest me really." `content` is a named field with a defined meaning; `matchedText` was the
+    // concatenated blob fed to the embedder, and for a file chunk it CONTAINED content — so the passage
+    // was going back twice and the copy being kept was the worse one.
+    const rec = toRecallRecord(fileHit(0), {});
+    assert.equal(rec.content, CHUNK);
+  });
+
+  it('drops the blob, not the field', () => {
+    const body = respond(true);
+    assert.ok(!body.includes('"matchedText"'), 'matchedText must not appear in an MCP recall response');
+    assert.ok(body.includes('"content"'), 'the passage must still be there');
+    // The whole passage appears exactly once per result rather than twice. Counted on the full chunk,
+    // not a phrase inside it — the fixture repeats its sentence, so a phrase count measures the fixture.
+    const occurrences = body.split(JSON.stringify(CHUNK).slice(1, -1)).length - 1;
+    assert.equal(occurrences, 10, 'the passage must be returned once per result, not twice');
+  });
+
+  it('drops `seq` and `embeddingModel`, which tell a model nothing', () => {
+    // seq is the per-space counter sync orders replication by — never an input to any tool, read only by
+    // sync/*. embeddingModel is identical for every record in a space: instance config, not a signal.
+    const rec = toRecallRecord(fileHit(0), {});
+    assert.equal(rec.seq, undefined);
+    assert.equal(rec.embeddingModel, undefined);
+  });
+
+  it('keeps createdAt/updatedAt — they cost the same as seq and answer a real question', () => {
+    const rec = toRecallRecord(fileHit(0), {});
+    assert.equal(rec.createdAt, '2026-07-01T10:00:00.000Z');
+    assert.equal(rec.updatedAt, '2026-07-02T11:00:00.000Z');
+  });
+});
+
+describe('includeContent: false returns locations, not passages', () => {
+  it('is at least 80% smaller than the old shape', () => {
+    const saved = 1 - respond(false).length / BASELINE.length;
+    assert.ok(saved >= 0.8, `expected ≥80% smaller, got ${(saved * 100).toFixed(0)}%`);
+  });
+
+  it('actually removes the passage — the parameter must not be decorative', () => {
+    // It nearly shipped as a no-op: the first version dropped `record.content` while the passage was
+    // still going back inside `matchedText` on the wrapper. Measuring the payload is what caught it;
+    // asserting "content is undefined" would have passed.
+    const body = respond(false);
+    assert.ok(!body.includes('Form NMK-SI-11 must be filed'), 'no passage text may survive');
+  });
+
+  it('still identifies every hit, so the caller can fetch what it wants', () => {
+    const rec = toRecallRecord(fileHit(0), { includeContent: false });
+    assert.equal(rec._id, 'f0#chunk3');
+    assert.equal(rec.path, 'runbooks/NMK-SI-11.md');
+    assert.equal(rec.headingText, HEADING);
+    assert.equal(rec.chunkIndex, 3);
+    assert.deepEqual(rec.tags, ['auth', 'postmortem']);
+  });
+
+  it('does not strip a record whose text IS the record', () => {
+    // A memory's `fact` is not a passage — removing it would leave a result that says nothing. The
+    // parameter governs file chunk bodies, which is what the tool description promises.
+    const mem = { _id: 'm1', spaceId: 's', type: 'memory', score: 0.9, fact: 'PKCE is required for all public clients.' };
+    assert.equal(toRecallRecord(mem, { includeContent: false }).fact, 'PKCE is required for all public clients.');
+  });
+});
+
+describe('no MCP tool pretty-prints its response', () => {
+  it('indentation is billed to the caller and read by nothing', () => {
+    const files = ['bulk', 'chrono', 'edge', 'entity', 'memory', 'search', 'spaces', 'sync'];
+    for (const f of files) {
+      const src = readFileSync(new URL(`../../server/src/mcp/tools/${f}.ts`, import.meta.url), 'utf8');
+      assert.ok(!/JSON\.stringify\([^)]*,\s*null,\s*2\)/.test(src),
+        `${f}.ts still pretty-prints an MCP response`);
+    }
+  });
+});

--- a/testing/standalone/multi-type-recall.test.js
+++ b/testing/standalone/multi-type-recall.test.js
@@ -77,17 +77,29 @@ describe('toRecallRecord — common fields appear only when present', () => {
   it('omits absent optional fields rather than emitting undefined', () => {
     // An explicit `"tags": undefined` in an MCP payload is noise an agent has to reason about.
     const rec = toRecallRecord(memory());
-    for (const k of ['createdAt', 'updatedAt', 'seq', 'embeddingModel', 'tags', 'description', 'properties']) {
+    // `seq`/`embeddingModel` are not in this list: they are dropped unconditionally now, present or
+    // not, which the next test pins.
+    for (const k of ['createdAt', 'updatedAt', 'tags', 'description', 'properties']) {
       assert.ok(!(k in rec), `${k} should be absent, got ${JSON.stringify(rec)}`);
     }
   });
 
   it('includes them when they are present', () => {
-    const rec = toRecallRecord(memory({ tags: ['t'], description: 'd', properties: { a: 1 }, seq: 3 }));
+    const rec = toRecallRecord(memory({ tags: ['t'], description: 'd', properties: { a: 1 }, createdAt: '2026-01-01T00:00:00Z' }));
     assert.deepEqual(rec.tags, ['t']);
     assert.equal(rec.description, 'd');
     assert.deepEqual(rec.properties, { a: 1 });
-    assert.equal(rec.seq, 3);
+    assert.equal(rec.createdAt, '2026-01-01T00:00:00Z');
+  });
+
+  it('drops seq and embeddingModel even when the source record carries them', () => {
+    // Cost with no per-row information: `embeddingModel` is identical for every record in a space, and
+    // `seq` is the counter sync orders replication by — not an input to any tool. `createdAt`/
+    // `updatedAt` cost the same and stay, because they answer whether a hit is still current.
+    const rec = toRecallRecord(memory({ seq: 3, embeddingModel: 'nomic-v1.5', updatedAt: '2026-01-02T00:00:00Z' }));
+    assert.ok(!('seq' in rec), `seq must not reach an MCP response: ${JSON.stringify(rec)}`);
+    assert.ok(!('embeddingModel' in rec), `embeddingModel must not be repeated per row: ${JSON.stringify(rec)}`);
+    assert.equal(rec.updatedAt, '2026-01-02T00:00:00Z');
   });
 });
 


### PR DESCRIPTION
Owner, 2026-07-29: *"mcp is usually for llm usage and the results will consume tokens. returning everything is costing money."*

Correct, and measurable. On a realistic 10-result file-chunk recall:

| | tokens | |
|---|---|---|
| before | ~6 215 | |
| **after, default** | **~3 157** | **−49%**, nothing removed |
| **`includeContent: false`** | **~907** | **−85%** |

## The default change removes no information

- **The passage was going back twice.** `matchedText` is the concatenated string fed to the embedder — `headingText + ' ' + content` for a file chunk, and byte-identical to `content` for audio/video/image chunks (checked, not assumed: all three write both fields). Owner's call on which copy survives: *"I want the content if not flagged false. matched text does not interest me really."* Right — `content` is a named field with a defined meaning; `matchedText` is a blob. **REST keeps returning both.**
- **`seq` is gone.** It is the per-space counter sync orders replication by: never an input to any tool, read by nothing outside `sync/*`, meaningless to a model. Owner: *"in 99% of cases seq is not interesting to a caller."* A caller that needs it can read the record by `_id`.
- **`embeddingModel` is gone.** Identical for every record in a space — instance configuration repeated on every row.
- **No MCP tool pretty-prints any more** (14 sites). That indentation was billed to the caller and read by nothing.

`createdAt`/`updatedAt` deliberately **stay**: same cost as `seq`, and unlike it they answer a question a caller actually asks — is this still current.

## `includeContent` (default `true`)

On `recall` and `find_similar`. `false` drops the passage body, leaving path, heading, chunk index, tags and properties — the right shape for a two-phase agent: recall to find *where*, then read only the chunk it decided it needs.

Named `include*` rather than `return*` because it describes what the **response contains**, which is what the caller is choosing, and it matches the existing parameter shape (`checkDuplicates`, `checkContradictions`, `crossSpace`). `maxContentChars` was offered as a strictly more capable alternative and declined — boolean only.

A record whose text *is* the record (a memory's `fact`, an entity's `name`) is never stripped; the flag governs file chunk bodies, which is what the description promises.

## It nearly shipped as a no-op

The first version dropped `record.content` while the passage was still going back inside `matchedText` on the wrapper — so the flag would have changed nothing. **Measuring the payload caught it; a test asserting "content is undefined" would have passed.**

So the tests assert **size against a baseline of the old shape**, not the absence of named fields — the claim is about cost, and a field growing back into the gap has to fail. Mutation-tested: ignoring `includeContent`, re-adding `seq`, and restoring pretty-printing each kill a test.

Preflight green. `audit-route-coverage` green. `lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)