### PR TITLE
fix(audit): schema changes were invisible; record them as a summary of names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Schema changes were invisible in the audit log; they are now summarised.** `space.schema.update` and
+  `schema_library.update` change nested objects, and the audit layer records allowlisted scalars and
+  drops objects outright — so replacing a space's entire schema recorded **nothing**. The entry said an
+  admin hit the route and could not say whether they added a type or deleted eleven, for the one setting
+  that decides what the space will accept from then on.
+  - Recorded as name-set deltas — `typeSchemas.entity` added/removed, and per-type
+    `propertySchemas` key changes — reusing the existing `added`/`removed` shape, so no reader, retention
+    sweep or API contract needs a new case.
+  - **Names only, never values.** A property's `default`, `enum` or `namingPattern` can be example data
+    lifted from real records; its key is the declared vocabulary an admin chose. `scalarOrDrop` was not
+    relaxed to achieve this. A test feeds a schema full of recognisable secrets and scans the serialised
+    output for every one of them, so a future field that starts leaking is caught even though the test
+    has never heard of it.
+  - A type added or removed outright is not *also* itemised property-by-property, and the key list is
+    capped at 25 per field so one enormous paste cannot flood a retained store.
+  - The three routes involved now capture before/after snapshots at all — including the granular
+    single-type `PUT`/`DELETE` that the Schema tab actually uses, which was the silent half of an
+    already-silent pair. Deleting a type is the change most worth having: it silently widens what the
+    space accepts, and the definition it removed is not recoverable from the entry.
+
 - **Preflight now runs the production build**, which type-checks Angular *templates* (AOT) and compiles
   under the app's own tsconfig — neither of which the unit-test run does. It immediately caught a
   `[...NodeList]` spread that all 785 tests passed straight over. ~7 seconds, and it is where an unknown

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5993,6 +5993,46 @@ All query params are optional:
 | `status` | `number` | HTTP status code of the response |
 | `entryId` | `string \| null` | Entry ID when the operation targets a specific document |
 | `durationMs` | `number` | Request duration in milliseconds |
+| `changes` | `AuditChange[]` | What actually changed — see below. Present only on a successful mutating request that has a recording rule; absent otherwise |
+
+### What `changes` records, and what it deliberately does not
+
+`changes` answers the question the rest of the entry cannot: *"an admin patched the space at 14:02"* does
+not say whether they renamed it or turned strict linkage off.
+
+Each element is one of two shapes:
+
+```jsonc
+{ "field": "validationMode", "from": "warn", "to": "strict" }   // scalar
+{ "field": "tags", "added": ["auth"], "removed": ["draft"] }    // set
+```
+
+**It is an allowlist, never a redaction denylist.** Several audited routes handle secrets directly —
+token create/regenerate, webhook create/update (target URLs and signing secrets), the media-config
+routes (vision / STT / NLI / assist API keys) — and audit entries are queryable by any admin and retained
+for `retentionDays`. Diffing a whole body and stripping known-secret names fails in the worst direction:
+forget one field and a live key sits in a queryable store until retention expires, with nothing to report
+it. Naming the fields that *may* be recorded fails the other way — forget one and the entry simply lacks
+it, which is visible and harmless. **An operation with no rule records nothing.** Token, webhook and
+provider-config routes are deliberately absent, and a record's free-form `properties` bag is excluded
+from every rule because its keys are user-chosen and could hold a pasted credential.
+
+Recorded values are **scalars or primitive lists only**. An allowlisted object would silently ship every
+child it later gained.
+
+**Schema changes are summarised, as names.** `space.schema.update` and `schema_library.update` change
+nested objects, so the scalars-only rule dropped them entirely and no amount of adding field names could
+have recorded them. They are recorded as name-set deltas instead:
+
+```jsonc
+{ "field": "typeSchemas.entity", "added": ["adr"], "removed": ["runbook"] }
+{ "field": "typeSchemas.entity.service.propertySchemas", "added": ["sla"], "removed": ["tier"] }
+```
+
+Type names and property **keys** only — never a property's schema, default, enum or naming pattern, any
+of which can be example data lifted from real records. A type that was added or removed outright is not
+also itemised property-by-property, and the key list is capped at 25 per field. A schema replacement that
+recorded nothing was the gap this closes: the schema decides what the space accepts from then on.
 
 ### Data retention
 

--- a/server/src/api/schema-library.ts
+++ b/server/src/api/schema-library.ts
@@ -498,6 +498,10 @@ schemaLibraryRouter.put('/:name', globalRateLimit, requireAdminMfa, (req, res) =
     const updatedLibrary = [...library];
     updatedLibrary[existingIdx] = updatedEntry;
     saveSchemaLibrary(updatedLibrary);
+    // A library entry is referenced by `$ref` from any number of spaces, so editing one changes what all
+    // of them validate against. The audit layer records the scalar metadata plus the property-key names
+    // that changed — never the property schemas, which can carry example values.
+    req.auditSnapshots = { before: existing, after: updatedEntry };
     res.json({ entry: updatedEntry });
   }
 });

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -675,6 +675,13 @@ spacesRouter.put('/:id/schema', globalRateLimit, requireAdminMfaScoped('id'), as
     res.status(404).json({ error: `Space '${id}' not found` });
     return;
   }
+  // Full-replace: `previousTypeSchemas` was read before the write, so this is a true before/after. The
+  // audit layer summarises it as type and property-key NAMES — a schema replacement that recorded
+  // nothing was the whole gap here.
+  req.auditSnapshots = {
+    before: { typeSchemas: previousTypeSchemas ?? {} },
+    after: { typeSchemas: newMeta.typeSchemas ?? {} },
+  };
   res.json({ space: updated });
 });
 
@@ -841,6 +848,14 @@ spacesRouter.put('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLim
     return;
   }
 
+  // A single-type upsert is audited under the same `space.schema.update` operation as the full replace,
+  // so it needs the same snapshot shape. Without it the granular route — the one the Schema tab actually
+  // uses — was the silent half of an already-silent pair.
+  req.auditSnapshots = {
+    before: { typeSchemas: existingMeta.typeSchemas ?? {} },
+    after: { typeSchemas: updatedMeta.typeSchemas ?? {} },
+  };
+
   res.json({ knowledgeType: kt, typeName, schema: parsed.data });
 });
 
@@ -894,6 +909,13 @@ spacesRouter.delete('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRate
     res.status(404).json({ error: `Space '${id}' not found` });
     return;
   }
+
+  // Deleting a type is the change most worth having in the log: it silently widens what the space
+  // accepts from then on, and the definition it removed is not recoverable from the entry alone.
+  req.auditSnapshots = {
+    before: { typeSchemas: existingMeta.typeSchemas ?? {} },
+    after: { typeSchemas: updatedTypeSchemas },
+  };
 
   res.status(204).end();
 });

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -26,6 +26,8 @@
  * through nesting.
  */
 
+import { AUDIT_SCHEMA_SUMMARY } from './audit-schema-summary.js';
+
 /**
  * A single recorded field change.
  *
@@ -92,6 +94,10 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   // becomes UNRECOVERABLE is the absorbed entity's name — an id alone means nothing once the record it
   // pointed at is gone. Recorded as name → null, which reads as "this entity no longer exists".
   'entity.merge': ['absorbedName'],
+  // A library entry is `$ref`-ed by any number of spaces, so what it declares is what all of them
+  // validate against. Scalars only here — the `schema` object itself is summarised as property-key
+  // NAMES by `audit-schema-summary.ts`, because a property's schema can carry example values.
+  'schema_library.update': ['knowledgeType', 'typeName', 'published', 'schemaGroup'],
   // Maintenance mode blocks writes instance-wide. One boolean, and the direction is the whole story:
   // an entry saying only "an admin hit the maintenance route" cannot distinguish starting an outage
   // from ending one.
@@ -166,10 +172,18 @@ function at(obj: unknown, path: string): unknown {
  * accident even if it sits alongside one that is listed. Returns [] for an unknown operation.
  */
 export function auditChanges(operation: string, before: unknown, after: unknown): AuditChange[] {
-  const fields = AUDIT_CHANGE_FIELDS[operation];
-  if (!fields || before == null || after == null) return [];
+  if (before == null || after == null) return [];
 
-  const out: AuditChange[] = [];
+  // Nested-object changes — a space's typeSchemas, a library entry's schema — that the scalars-only rule
+  // above drops entirely, and that no amount of adding names to the allowlist could ever record. They
+  // are summarised as NAME sets (which types, which property keys) and never values. See
+  // `audit-schema-summary.ts` for why names are the line and values are not.
+  const summary = AUDIT_SCHEMA_SUMMARY[operation]?.(before, after) ?? [];
+
+  const fields = AUDIT_CHANGE_FIELDS[operation];
+  if (!fields) return summary;
+
+  const out: AuditChange[] = [...summary];
   for (const field of fields) {
     // List fields first: they would otherwise be dropped by scalarOrDrop and record nothing at all.
     if (LIST_FIELDS.has(field.split('.').pop() ?? field)) {

--- a/server/src/audit/audit-schema-summary.ts
+++ b/server/src/audit/audit-schema-summary.ts
@@ -1,0 +1,122 @@
+/**
+ * Schema changes, recorded as a SUMMARY of names — never as values.
+ *
+ * `audit-changes.ts` records scalars from an allowlist of field names, and drops objects and arrays
+ * outright so that one allowlisted parent cannot silently ship every child it later gains. That is the
+ * right default and it is not relaxed here. But it left a real hole: `space.schema.update` and
+ * `schema_library.update` change **nested objects**, so every one of them recorded nothing at all. The
+ * audit log said "an admin replaced the schema" and could not say whether they added a type or deleted
+ * eleven — which is precisely the question an audit log exists to answer, and the schema is the thing
+ * that decides what the whole space will accept from then on.
+ *
+ * ── What is recorded, and why that is safe ───────────────────────────────────────────────────────────
+ *
+ * **Names only.** Type names and property KEYS; never a property's schema, never a default, never an
+ * enum member, never a naming pattern. A default or an enum can be example data pulled from real
+ * records; a key is the declared vocabulary an admin chose. This is the same line the record-edit
+ * allowlist draws when it records `tags` but refuses `properties`.
+ *
+ * The output reuses `AuditChange`'s existing `added`/`removed` set shape rather than inventing one.
+ * That is not just convenience: it means the reader, the retention sweep and the API contract need no
+ * new case, and there is no second value-carrying shape for a future field to leak through.
+ *
+ * ── Fail closed ──────────────────────────────────────────────────────────────────────────────────────
+ *
+ * Anything that is not a plain object where an object is expected yields no entry for that level. A
+ * malformed snapshot records nothing rather than guessing, exactly as `scalarOrDrop` does.
+ */
+import type { AuditChange } from './audit-changes.js';
+import type { KnowledgeType } from '../config/types.js';
+
+/** The four knowledge collections a space's `typeSchemas` can describe. */
+const KNOWLEDGE_TYPES: readonly KnowledgeType[] = ['entity', 'memory', 'edge', 'chrono'];
+
+/** Property keys reported per type before the list is truncated. Keeps one paste-of-a-huge-schema from
+ *  writing thousands of names into a retained store; the count still tells the reader it happened. */
+export const MAX_KEYS_PER_FIELD = 25;
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' && !Array.isArray(v) ? v as Record<string, unknown> : null;
+}
+
+/** Set difference over object keys, capped. Returns null when nothing changed. */
+function keyDelta(before: unknown, after: unknown): { added: string[]; removed: string[] } | null {
+  const b = asRecord(before) ?? {};
+  const a = asRecord(after) ?? {};
+  const bKeys = new Set(Object.keys(b));
+  const aKeys = new Set(Object.keys(a));
+  const added = [...aKeys].filter(k => !bKeys.has(k));
+  const removed = [...bKeys].filter(k => !aKeys.has(k));
+  if (!added.length && !removed.length) return null;
+  return { added: added.slice(0, MAX_KEYS_PER_FIELD), removed: removed.slice(0, MAX_KEYS_PER_FIELD) };
+}
+
+function push(out: AuditChange[], field: string, delta: { added: string[]; removed: string[] } | null): void {
+  if (!delta) return;
+  out.push({
+    field,
+    ...(delta.added.length ? { added: delta.added } : {}),
+    ...(delta.removed.length ? { removed: delta.removed } : {}),
+  });
+}
+
+/**
+ * Summarise a change to one `typeSchemas` map (the shape under `meta.typeSchemas`).
+ *
+ * Two levels, both name-only:
+ *   - `typeSchemas.<kind>` — which type names appeared or disappeared;
+ *   - `typeSchemas.<kind>.<type>.propertySchemas` — which property keys appeared or disappeared, for a
+ *     type that exists on **both** sides. A type that was just added or removed is not also reported
+ *     property-by-property: the first line already said the whole type arrived or left, and repeating
+ *     its fields would bury the change that matters under the change that is implied by it.
+ */
+export function summariseTypeSchemas(before: unknown, after: unknown): AuditChange[] {
+  const out: AuditChange[] = [];
+  const b = asRecord(before) ?? {};
+  const a = asRecord(after) ?? {};
+
+  for (const kind of KNOWLEDGE_TYPES) {
+    const bKind = asRecord(b[kind]);
+    const aKind = asRecord(a[kind]);
+    if (!bKind && !aKind) continue;
+
+    push(out, `typeSchemas.${kind}`, keyDelta(bKind, aKind));
+
+    // Property-key changes, only for types present on both sides.
+    for (const typeName of Object.keys(aKind ?? {})) {
+      if (!bKind || !(typeName in bKind)) continue;
+      const bProps = asRecord(bKind[typeName])?.['propertySchemas'];
+      const aProps = asRecord((aKind ?? {})[typeName])?.['propertySchemas'];
+      push(out, `typeSchemas.${kind}.${typeName}.propertySchemas`, keyDelta(bProps, aProps));
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Summarise a change to one schema-library entry.
+ *
+ * The library entry holds a single `schema` (a `TypeSchema`), so the interesting delta is its property
+ * keys plus the scalar metadata the ordinary allowlist can already carry. Only the keys are produced
+ * here; `knowledgeType`/`typeName`/`published` go through `AUDIT_CHANGE_FIELDS` as normal scalars.
+ */
+export function summariseLibraryEntry(before: unknown, after: unknown): AuditChange[] {
+  const out: AuditChange[] = [];
+  const bProps = asRecord(asRecord(before)?.['schema'])?.['propertySchemas'];
+  const aProps = asRecord(asRecord(after)?.['schema'])?.['propertySchemas'];
+  push(out, 'schema.propertySchemas', keyDelta(bProps, aProps));
+  return out;
+}
+
+/**
+ * Which operations get a summary, and how to derive it.
+ *
+ * An operation absent here summarises nothing — the same silent-by-default rule the field allowlist
+ * follows, for the same reason: a route added later must not start recording structure nobody vetted.
+ */
+export const AUDIT_SCHEMA_SUMMARY: Readonly<Record<string, (before: unknown, after: unknown) => AuditChange[]>> = {
+  'space.schema.update': (before, after) =>
+    summariseTypeSchemas(asRecord(before)?.['typeSchemas'], asRecord(after)?.['typeSchemas']),
+  'schema_library.update': summariseLibraryEntry,
+};

--- a/testing/standalone/audit-schema-summary.test.js
+++ b/testing/standalone/audit-schema-summary.test.js
@@ -1,0 +1,144 @@
+/**
+ * Schema changes are recorded — as names, and only as names.
+ *
+ * `space.schema.update` and `schema_library.update` change nested objects, and the audit layer records
+ * scalars from an allowlist and drops objects outright. The result was that replacing a space's entire
+ * schema recorded **nothing**: the log said an admin hit the route and could not say whether they added
+ * a type or deleted eleven. The schema decides what the space will accept from then on, so that is the
+ * one change least affordable to lose.
+ *
+ * The fix is a summary, and the whole safety of it rests on one line: **names, never values.** A
+ * property's `default` or `enum` can be example data lifted from real records; its KEY is the declared
+ * vocabulary an admin chose. The last test here is the one that matters — it feeds a schema whose values
+ * are recognisable secrets and asserts none of them appear anywhere in the output, by scanning the
+ * serialised result rather than the fields the test happens to think of.
+ *
+ * Run: node --test testing/standalone/audit-schema-summary.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let auditChanges, summariseTypeSchemas, MAX_KEYS_PER_FIELD;
+
+before(async () => {
+  ({ auditChanges } = await import('../../server/dist/audit/audit-changes.js'));
+  ({ summariseTypeSchemas, MAX_KEYS_PER_FIELD } = await import('../../server/dist/audit/audit-schema-summary.js'));
+});
+
+const ts = (entity = {}) => ({ typeSchemas: { entity } });
+const find = (changes, field) => changes.find(c => c.field === field);
+
+describe('space schema changes are no longer invisible', () => {
+  it('records which type names were added and removed', () => {
+    const changes = auditChanges('space.schema.update',
+      ts({ service: {}, runbook: {} }),
+      ts({ service: {}, adr: {} }));
+    const c = find(changes, 'typeSchemas.entity');
+    assert.deepEqual(c.added, ['adr']);
+    assert.deepEqual(c.removed, ['runbook']);
+  });
+
+  it('records property KEY changes for a type that exists on both sides', () => {
+    const changes = auditChanges('space.schema.update',
+      ts({ service: { propertySchemas: { owner: {}, tier: {} } } }),
+      ts({ service: { propertySchemas: { owner: {}, sla: {} } } }));
+    const c = find(changes, 'typeSchemas.entity.service.propertySchemas');
+    assert.deepEqual(c.added, ['sla']);
+    assert.deepEqual(c.removed, ['tier']);
+  });
+
+  it('does not also itemise the properties of a type that was just added or removed', () => {
+    // The line saying the whole type arrived already covers them; repeating each field buries the
+    // change that matters under the change implied by it.
+    const changes = auditChanges('space.schema.update',
+      ts({}),
+      ts({ service: { propertySchemas: { owner: {}, tier: {} } } }));
+    assert.deepEqual(find(changes, 'typeSchemas.entity').added, ['service']);
+    assert.equal(find(changes, 'typeSchemas.entity.service.propertySchemas'), undefined);
+  });
+
+  it('reports each knowledge kind separately — an edge label is not an entity type', () => {
+    const changes = auditChanges('space.schema.update',
+      { typeSchemas: { entity: { service: {} }, edge: { runs_on: {} } } },
+      { typeSchemas: { entity: { service: {} }, edge: { runs_on: {}, owns: {} } } });
+    assert.equal(find(changes, 'typeSchemas.entity'), undefined, 'the entity side did not change');
+    assert.deepEqual(find(changes, 'typeSchemas.edge').added, ['owns']);
+  });
+
+  it('an unchanged schema records nothing at all', () => {
+    const same = ts({ service: { propertySchemas: { owner: {} } } });
+    assert.deepEqual(auditChanges('space.schema.update', same, structuredClone(same)), []);
+  });
+
+  it('caps the key list so one enormous paste cannot flood a retained store', () => {
+    const many = {};
+    for (let i = 0; i < MAX_KEYS_PER_FIELD + 10; i++) many[`p${i}`] = {};
+    const changes = summariseTypeSchemas(
+      { entity: { service: { propertySchemas: {} } } },
+      { entity: { service: { propertySchemas: many } } });
+    assert.equal(find(changes, 'typeSchemas.entity.service.propertySchemas').added.length, MAX_KEYS_PER_FIELD);
+  });
+
+  it('a malformed snapshot records nothing rather than guessing', () => {
+    assert.deepEqual(auditChanges('space.schema.update', { typeSchemas: 'nope' }, { typeSchemas: 42 }), []);
+    assert.deepEqual(auditChanges('space.schema.update', {}, {}), []);
+  });
+
+  it('an operation with no summary rule is unaffected', () => {
+    // Silent by default stays the rule: a route added later must not start recording structure nobody
+    // vetted, exactly as it does not start recording fields nobody allowlisted.
+    assert.deepEqual(auditChanges('token.create', ts({ a: {} }), ts({ b: {} })), []);
+  });
+});
+
+describe('schema library entries', () => {
+  it('records scalar metadata AND the property-key delta together', () => {
+    const before = { knowledgeType: 'entity', typeName: 'service', published: false, schema: { propertySchemas: { owner: {} } } };
+    const after = { knowledgeType: 'entity', typeName: 'service', published: true, schema: { propertySchemas: { owner: {}, sla: {} } } };
+    const changes = auditChanges('schema_library.update', before, after);
+    assert.equal(find(changes, 'published').to, true);
+    assert.deepEqual(find(changes, 'schema.propertySchemas').added, ['sla']);
+  });
+});
+
+describe('values never reach the audit log — the property the whole design rests on', () => {
+  it('no schema VALUE appears anywhere in the recorded output', () => {
+    // Everything below is a value, not a name. A `default` or an `enum` member can be example data
+    // copied from a real record, which is exactly what must not land in a retained, admin-queryable
+    // store. Asserted by scanning the serialised output, so a future field that starts leaking is
+    // caught even though this test never heard of it.
+    const secrets = ['sk-live-DEADBEEF', 'hunter2', 'https://user:pw@example.invalid/hook', '^secret-[0-9]+$'];
+    const before = ts({ service: { propertySchemas: { owner: {} } } });
+    const after = ts({
+      service: {
+        namingPattern: secrets[3],
+        tagSuggestions: [secrets[1]],
+        propertySchemas: {
+          owner: {},
+          apiKey: { type: 'string', default: secrets[0], enum: [secrets[0], secrets[1]] },
+          hook: { type: 'string', default: secrets[2] },
+        },
+      },
+      newType: { propertySchemas: { x: { default: secrets[1] } } },
+    });
+
+    const serialised = JSON.stringify(auditChanges('space.schema.update', before, after));
+    for (const s of secrets) {
+      assert.ok(!serialised.includes(s), `a schema value reached the audit entry: ${s}`);
+    }
+    // …while still recording the change itself, so this is not passing by recording nothing.
+    assert.ok(serialised.includes('apiKey'), 'the property KEY is the point — it must still be recorded');
+    assert.ok(serialised.includes('newType'));
+  });
+
+  it('the same holds for a library entry', () => {
+    const secret = 'sk-live-CAFEBABE';
+    const changes = auditChanges('schema_library.update',
+      { schema: { propertySchemas: {} } },
+      { schema: { propertySchemas: { apiKey: { default: secret } } } });
+    const serialised = JSON.stringify(changes);
+    assert.ok(!serialised.includes(secret));
+    assert.ok(serialised.includes('apiKey'));
+  });
+});


### PR DESCRIPTION
Replacing a space's entire schema recorded **nothing**.

The audit layer records allowlisted scalars and drops objects outright — right as a default, and **not relaxed here**. But `space.schema.update` and `schema_library.update` change nested objects, so they fell through it completely, and no amount of adding field names to `AUDIT_CHANGE_FIELDS` could ever have caught them. The entry said an admin hit the route. It could not say whether they added a type or deleted eleven — for the one setting that decides what the space will accept from then on.

## The summary

Name-set deltas, reusing `AuditChange`'s existing `added`/`removed` shape:

```jsonc
{ "field": "typeSchemas.entity", "added": ["adr"], "removed": ["runbook"] }
{ "field": "typeSchemas.entity.service.propertySchemas", "added": ["sla"], "removed": ["tier"] }
```

Reusing the shape is not convenience: a second value-carrying shape is a second thing a future field can leak through, and the reader, the retention sweep and the API contract all need no new case.

## Names only, never values

A property's `default`, `enum` or `namingPattern` can be example data lifted from real records; its **key** is the declared vocabulary an admin chose. Same line the record-edit allowlist draws when it records `tags` and refuses `properties`.

The test that matters feeds a schema whose values are recognisable secrets and scans the **serialised** output for each of them — so a future field that starts leaking is caught even though the test never heard of it — and also asserts the keys still come through, so it cannot pass by recording nothing:

```js
const secrets = ['sk-live-DEADBEEF', 'hunter2', 'https://user:pw@example.invalid/hook', '^secret-[0-9]+$'];
// …namingPattern, tagSuggestions, default, enum all set to those…
for (const s of secrets) assert.ok(!serialised.includes(s));
assert.ok(serialised.includes('apiKey'));   // the KEY is the point
```

## Proportionality

- A type added or removed outright is **not also** itemised property-by-property. The line saying the whole type arrived already covers them; repeating each field buries the change that matters under the one implied by it.
- Key lists capped at 25 per field, so one enormous paste cannot flood a retained, admin-queryable store.
- A malformed snapshot records nothing rather than guessing — same fail-closed direction as `scalarOrDrop`.
- An operation with no summary rule is unaffected: silent by default stays the rule.

## Three routes had to start capturing snapshots at all

Including the granular single-type `PUT` and `DELETE` that the Schema tab actually uses — the silent half of an already-silent pair. **Deleting a type is the change most worth having in the log**: it silently widens what the space accepts from then on, and the definition it removed is not recoverable from the entry.

## Also

The audit-log API reference never documented the `changes` field at all. It now does, including why it is an allowlist rather than a redaction denylist, and what is deliberately excluded (token, webhook and provider-config routes; a record's free-form `properties`).

11 new tests; `npm run preflight` green; `audit-route-coverage` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
