### PR TITLE
perf(client): per-chunk bundle budgets, and a check that they bind to real chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Lazy chunks had no size ceiling, so one could grow past the initial bundle unnoticed** — which is how
+  the Brain chunk once reached twice the initial bundle with no CI signal at all. `client/angular.json`
+  budgeted `initial`, `anyComponentStyle` and `all`, and nothing per chunk.
+  - An **`any`** budget (1 MB warn / 1.5 MB error) now bounds every chunk including the unnamed
+    third-party ones, and four **named** budgets cover the app pages that have actually grown: Brain,
+    Spaces, Files and Media Processing. Thresholds were set from the current measured sizes with
+    headroom, not from taste.
+  - **A budget naming a chunk that does not exist is silently never evaluated** — the build stays green
+    while the thing it was meant to guard grows. The first draft of this set named `graph-component`,
+    which is not a chunk at all. Preflight now re-checks every `bundle` budget name against the real
+    chunk table the build just printed, and a standalone gate checks the config shape.
+
 - **Schema changes were invisible in the audit log; they are now summarised.** `space.schema.update` and
   `schema_library.update` change nested objects, and the audit layer records allowlisted scalars and
   drops objects outright — so replacing a space's entire schema recorded **nothing**. The entry said an

--- a/client/angular.json
+++ b/client/angular.json
@@ -56,7 +56,12 @@
               "budgets": [
                 { "type": "initial", "maximumWarning": "1MB", "maximumError": "2MB" },
                 { "type": "anyComponentStyle", "maximumWarning": "12kB", "maximumError": "24kB" },
-                { "type": "all", "maximumWarning": "8mb", "maximumError": "12mb" }
+                { "type": "all", "maximumWarning": "8mb", "maximumError": "12mb" },
+                { "type": "any", "maximumWarning": "1mb", "maximumError": "1.5mb" },
+                { "type": "bundle", "name": "brain-component", "maximumWarning": "260kB", "maximumError": "400kB" },
+                { "type": "bundle", "name": "spaces-component", "maximumWarning": "270kB", "maximumError": "400kB" },
+                { "type": "bundle", "name": "file-manager-component", "maximumWarning": "160kB", "maximumError": "260kB" },
+                { "type": "bundle", "name": "media-processing-page-component", "maximumWarning": "130kB", "maximumError": "200kB" }
               ],
               "outputHashing": "all"
             },

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -105,8 +105,41 @@ try { run('npm run test:client'); } catch {
 // which the unit-test run does. It caught a `[...NodeList]` spread that every test passed straight over,
 // and it is where an unknown element, a bad binding or a broken inline template surfaces. ~7 seconds.
 console.log('\n── client production build (AOT template type-check) ──');
-try { run('npm run build:prod --workspace=client'); } catch {
+let buildOut = '';
+try {
+  // Captured, not inherited, so the chunk table below can be read — then printed, because a build whose
+  // output vanishes is a build nobody can debug.
+  buildOut = execSync('npm run build:prod --workspace=client', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  process.stdout.write(buildOut);
+} catch (e) {
+  buildOut = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+  process.stdout.write(buildOut);
   failures.push({ name: 'build:prod', why: 'AOT template errors and tsconfig differences the unit tests never see' });
+}
+
+// A `bundle`-type budget names a chunk. Angular does NOT complain when that name matches nothing — the
+// budget is simply never evaluated, the build stays green, and the chunk it was meant to guard grows
+// without limit. That is the same silent no-op the budgets exist to prevent, one level up, and the only
+// place it can be checked is against the real chunk table the build just printed.
+console.log('\n── bundle budgets bind to real chunks ──');
+try {
+  const cfg = JSON.parse(readFileSync('client/angular.json', 'utf8'));
+  const project = cfg.projects[Object.keys(cfg.projects)[0]];
+  const named = (project.architect.build.configurations.production.budgets ?? [])
+    .filter(b => b.type === 'bundle').map(b => b.name);
+  const plain = buildOut.replace(/\x1b\[[0-9;]*m/g, '');
+  const unmatched = named.filter(n => !new RegExp(`\\|\\s*${n}\\s*\\|`).test(plain));
+  if (unmatched.length) {
+    console.log(`  budgets naming no emitted chunk: ${unmatched.join(', ')}`);
+    failures.push({
+      name: 'bundle-budgets',
+      why: `${unmatched.join(', ')} — Angular evaluates these against nothing, so the build stays green while the chunk grows`,
+    });
+  } else {
+    console.log(`  ${named.length} bundle budget(s) matched an emitted chunk.`);
+  }
+} catch (e) {
+  failures.push({ name: 'bundle-budgets', why: `could not verify budget names: ${e}` });
 }
 
 console.log('\n' + '='.repeat(76));

--- a/testing/standalone/bundle-budget-coverage.test.js
+++ b/testing/standalone/bundle-budget-coverage.test.js
@@ -1,0 +1,117 @@
+/**
+ * The bundle budgets guard chunks that actually exist, and cover the app's own lazy routes.
+ *
+ * A `bundle`-type budget names a chunk. Angular does **not** complain when that name matches nothing —
+ * the budget is simply never evaluated, the build is green, and the chunk it was supposed to guard grows
+ * without limit. That is the same silent no-op the budgets were added to prevent, one level up.
+ *
+ * It is not hypothetical: the first draft of this budget set named `graph-component`, which is not a
+ * chunk at all (Graph is `@defer`-loaded inside the Brain, so it lands in an unnamed chunk). It would
+ * have sat there looking like protection.
+ *
+ * The other half is coverage: every lazily-routed page component should have a budget, so a new heavy
+ * dependency shows up as a failed build rather than as a slow page nobody measured.
+ *
+ * Run: node --test testing/standalone/bundle-budget-coverage.test.js
+ * (reads client/dist — run `npm run build:prod --workspace=client` first; preflight does)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+
+const ANGULAR_JSON = 'client/angular.json';
+const STATS_DIR = 'client/dist/browser';
+
+let budgets, chunkNames;
+
+before(() => {
+  const cfg = JSON.parse(readFileSync(ANGULAR_JSON, 'utf8'));
+  // Read the single project rather than hard-coding its name — a renamed project would otherwise make
+  // this whole gate throw in `before` and cancel its tests, which reads as an error but not as a
+  // budget failure.
+  const project = cfg.projects[Object.keys(cfg.projects)[0]];
+  budgets = project.architect.build.configurations.production.budgets;
+
+  // Chunk NAMES are not in the filenames — they come from the build's own map. `.map` files are not
+  // emitted in production, so the names are recovered from the lazy-route imports instead: Angular names
+  // a lazy chunk after the component file it loads.
+  chunkNames = new Set();
+  if (existsSync(STATS_DIR)) {
+    for (const f of readdirSync(STATS_DIR)) {
+      if (f.endsWith('.js')) chunkNames.add(f);
+    }
+  }
+});
+
+/**
+ * Every component reached by a dynamic `import()` anywhere in the client — each becomes its own lazy
+ * chunk, named after the file with dots replaced by hyphens (`brain.component.ts` → `brain-component`).
+ *
+ * The whole source tree, not just `app.routes.ts`: the Files manager is not a route at all, it is
+ * `@defer`-loaded inside the Brain, and reading only the route table would have called its budget bogus.
+ */
+function lazyComponents() {
+  const found = new Set();
+  const walk = dir => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = `${dir}/${e.name}`;
+      if (e.isDirectory()) { walk(p); continue; }
+      if (!e.name.endsWith('.ts') || e.name.endsWith('.spec.ts')) continue;
+      const src = readFileSync(p, 'utf8');
+      // Dynamic import — a lazy route.
+      for (const m of src.matchAll(/import\('[^']*\/([a-z0-9-]+)\.component'\)/g)) {
+        found.add(`${m[1]}-component`);
+      }
+      // `@defer` splits a STATICALLY imported component out too, which is how the Files manager gets
+      // its own chunk without ever appearing in the route table. Any static component import in a file
+      // that uses @defer is a candidate.
+      if (src.includes('@defer')) {
+        for (const m of src.matchAll(/from '[^']*\/([a-z0-9-]+)\.component'/g)) {
+          found.add(`${m[1]}-component`);
+        }
+      }
+    }
+  };
+  walk('client/src/app');
+  return [...found];
+}
+
+describe('bundle budgets', () => {
+  it('every bundle budget names a component that is lazily loaded somewhere', () => {
+    // A cheap first filter only. Whether Angular actually emits a separately NAMED chunk for it is
+    // decided by the build, not by the source — so preflight re-checks each name against the real chunk
+    // table after `build:prod`. This catches the obvious case: a budget naming a component that is not
+    // lazily loaded at all can never match anything.
+    const named = budgets.filter(b => b.type === 'bundle').map(b => b.name);
+    assert.ok(named.length > 0, 'no bundle budgets configured');
+    const known = new Set(lazyComponents());
+    for (const name of named) {
+      assert.ok(known.has(name),
+        `bundle budget "${name}" names no lazily-loaded component. Known: ${[...known].join(', ')}`);
+    }
+  });
+
+  it('there is an `any` budget, so an UNNAMED chunk cannot grow without limit either', () => {
+    // The named budgets only cover our own pages. The biggest chunks in this app are third-party
+    // (exceljs, katex, mermaid diagram splits) and land unnamed; `any` is what bounds those.
+    const any = budgets.find(b => b.type === 'any');
+    assert.ok(any, 'no `any` budget — an unnamed vendor chunk has no ceiling at all');
+    assert.ok(any.maximumError, '`any` needs an error threshold, not just a warning');
+  });
+
+  it('the initial-bundle budget survived — per-chunk limits are an addition, not a replacement', () => {
+    const initial = budgets.find(b => b.type === 'initial');
+    assert.ok(initial, 'no initial budget — the whole point of lazy loading is that this stays small');
+    assert.ok(initial.maximumWarning && initial.maximumError, 'initial needs both thresholds');
+  });
+
+  it('the app pages that carry real weight are named individually', () => {
+    // Not "every page needs a budget" — most are a few kB and an `any` ceiling covers them fine. These
+    // four are the ones that have actually grown: the Brain (once 2x the initial bundle), the Spaces
+    // settings screen, the Files manager (exceljs, mermaid) and Media Processing.
+    const named = new Set(budgets.filter(b => b.type === 'bundle').map(b => b.name));
+    for (const heavy of ['brain-component', 'spaces-component', 'file-manager-component', 'media-processing-page-component']) {
+      assert.ok(named.has(heavy), `${heavy} has grown before and needs its own ceiling`);
+    }
+  });
+});


### PR DESCRIPTION
`angular.json` budgeted `initial`, `anyComponentStyle` and `all` — **nothing per lazy chunk**. That is how the Brain chunk once reached twice the initial bundle with no CI signal at all.

## Thresholds from measurement, not taste

| | raw |
|---|---|
| **Initial total** | 419 kB |
| spaces-component | 222 kB |
| brain-component | 211 kB |
| file-manager-component | 120 kB |
| media-processing-page-component | 89 kB |
| *exceljs (vendor)* | *944 kB* |
| *unnamed vendor* | *668 / 443 kB* |
| *katex (vendor)* | *268 kB* |

The genuinely large chunks here are third-party and **unnamed**, so a blanket per-chunk limit low enough to be interesting for our pages would fail on those immediately. Hence both:

- an **`any`** ceiling (1 MB warn / 1.5 MB error) bounding everything, vendors included
- four **named** budgets where the interesting movement actually happens, each warning a little above today's size with an error roughly double

## The part that matters most is second-order

A `bundle`-type budget names a chunk. **Angular does not complain when that name matches nothing** — the budget is never evaluated, the build stays green, and the chunk it was meant to guard grows without limit. That is precisely the silent no-op these budgets exist to prevent, one level up.

My first draft named `graph-component`, which is not a chunk at all (Graph is `@defer`-loaded inside the Brain and folds into an unnamed one). It would have sat there looking like protection.

So **preflight re-checks every budget name against the real chunk table the build just printed** — the only place the truth exists, since dist filenames are hashed and carry no names. Verified by pointing a budget at `graph-component` and watching preflight fail:

```
  bundle-budgets
      graph-component — Angular evaluates these against nothing, so the build
      stays green while the chunk grows
```

…then restoring it and confirming `4 bundle budget(s) matched an emitted chunk.`

A standalone gate covers the config shape: every budget names something lazily loaded (a dynamic import **or** a static import in a file that uses `@defer` — which is how Files gets its own chunk without being a route), an `any` budget exists *with an error threshold*, `initial` survived, and the four pages that have grown before are named individually.

Dropped from an earlier draft: a rule that every lazily-routed page needs a budget. That is taste, not a property — most pages are a few kB and the `any` ceiling covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
