### PR TITLE
fix(ux): destructive icons read as destructive at rest; MFA success note self-dismisses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by construction, and two tests walk that list through the real handler — a shared type alone would not
   prove the tab is actually reachable.
 
+- **A destructive icon button now looks destructive at rest, not on hover.** `.icon-btn.danger` coloured
+  only on `:hover`, so delete and revoke sat in a row looking exactly like the harmless icon beside them
+  — you learned which was which by pointing at it, which is backwards for the one action you cannot undo
+  and is *invisible on touch*, where there is no hover at all. Affects the 10 destructive icon actions
+  across Brain, Files, Tokens and the schema screens. Muted at rest so a row of them is not alarming;
+  hover still escalates to full `--error`.
+- **The MFA success note retires itself after six seconds.** It persisted until the next action, so
+  "MFA enabled" was still on screen the next time the page was opened — reading as a live status rather
+  than the receipt for something done a while ago. The pending dismissal is cancelled on destroy, and
+  both properties are tested (the timer is mutation-checked; a timer that silently stops working
+  restores exactly the old behaviour and reports nothing).
+
 - **Schema tab: the add control stops moving, and four near-identical hints become one.** Owner,
   2026-07-21: *"Schema menu still is a bit messy with guidance text and different fontstyles."*
   - The per-collection guidance was four strings that differed only in the field they named

--- a/client/src/app/pages/settings/mfa.component.spec.ts
+++ b/client/src/app/pages/settings/mfa.component.spec.ts
@@ -9,7 +9,7 @@
  * image" — not the implementation. Proven green against the original `qrcode` impl before the swap.
  */
 import { TestBed } from '@angular/core/testing';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { of } from 'rxjs';
 import { AuthApi } from '../../core/auth-api.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
@@ -48,5 +48,47 @@ describe('MfaComponent — enrolment QR (characterization)', () => {
     const url = cmp.qrUrl();
     expect(url.startsWith('data:image/')).toBe(true);
     expect(url.length).toBeGreaterThan(100);
+  });
+});
+
+/**
+ * The success note retires itself.
+ *
+ * It used to persist until the next action, so "MFA enabled" was still on screen the next time the page
+ * was opened — reading as a live status rather than the receipt for something done a while ago. A timer
+ * that silently stops working leaves exactly the old behaviour and no error, so it is worth pinning.
+ */
+describe('MfaComponent — the success note auto-dismisses', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [MfaComponent, getTranslocoModule()],
+      providers: [{ provide: AuthApi, useValue: {
+        getMfaStatus: () => of({ enabled: true }),
+        setupMfa: () => of({ secret: 's', otpauth: 'otpauth://totp/x' }),
+        disableMfa: () => of({ ok: true }),
+      } as never }],
+    });
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('shows the note, then clears it on its own', () => {
+    const cmp = TestBed.createComponent(MfaComponent).componentInstance;
+    cmp.confirmDisable();
+    expect(cmp.successMsg()).not.toBe('');
+    vi.advanceTimersByTime(5_000);
+    expect(cmp.successMsg()).not.toBe('');   // still readable a few seconds in
+    vi.advanceTimersByTime(2_000);
+    expect(cmp.successMsg()).toBe('');
+  });
+
+  it('a pending dismissal cannot fire into a destroyed component', () => {
+    const fixture = TestBed.createComponent(MfaComponent);
+    fixture.componentInstance.confirmDisable();
+    fixture.destroy();
+    // The assertion is that advancing past the deadline throws nothing — a timer left armed against a
+    // torn-down component is the classic version of this bug.
+    expect(() => vi.advanceTimersByTime(10_000)).not.toThrow();
   });
 });

--- a/client/src/app/pages/settings/mfa.component.ts
+++ b/client/src/app/pages/settings/mfa.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { AuthApi } from '../../core/auth-api.service';
@@ -105,7 +105,7 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
     </app-settings-card>
   `,
 })
-export class MfaComponent implements OnInit {
+export class MfaComponent implements OnInit, OnDestroy {
   private authApi = inject(AuthApi);
   private transloco = inject(TranslocoService);
 
@@ -121,8 +121,25 @@ export class MfaComponent implements OnInit {
 
   disabling = signal(false);
   successMsg = signal('');
+  /** Cleared on destroy so a pending dismissal cannot fire into a torn-down component. */
+  private successTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnInit(): void { this.refresh(); }
+
+  ngOnDestroy(): void { if (this.successTimer !== null) clearTimeout(this.successTimer); }
+
+  /**
+   * Show a success note and retire it on its own.
+   *
+   * It used to persist until the next action, so "MFA enabled" stayed on screen indefinitely and was
+   * still there the next time you opened the page — reading as a live status rather than the receipt for
+   * something you did a while ago. Six seconds is long enough to read twice.
+   */
+  private flashSuccess(message: string): void {
+    if (this.successTimer !== null) clearTimeout(this.successTimer);
+    this.successMsg.set(message);
+    this.successTimer = setTimeout(() => { this.successMsg.set(''); this.successTimer = null; }, 6000);
+  }
 
   refresh(): void {
     this.loading.set(true);
@@ -160,7 +177,7 @@ export class MfaComponent implements OnInit {
         if (valid) {
           this.enabled.set(true);
           this.state.set('idle');
-          this.successMsg.set(this.transloco.translate('mfa.success.enabled'));
+          this.flashSuccess(this.transloco.translate('mfa.success.enabled'));
         } else {
           this.enrollError.set(this.transloco.translate('mfa.error.invalidCode'));
         }
@@ -184,7 +201,7 @@ export class MfaComponent implements OnInit {
         this.disabling.set(false);
         this.enabled.set(false);
         this.state.set('idle');
-        this.successMsg.set(this.transloco.translate('mfa.success.disabled'));
+        this.flashSuccess(this.transloco.translate('mfa.success.disabled'));
       },
       error: () => this.disabling.set(false),
     });

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -677,6 +677,12 @@ hr, .divider {
   align-items: center;
 }
 .icon-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
+/* A destructive action reads as destructive AT REST, not on hover.
+   This used to colour only on `:hover`, so delete and revoke sat in a row looking exactly like the
+   non-destructive icon beside them and you learned which was which by pointing at it — backwards for
+   the one action you cannot undo, and invisible on touch, where there is no hover at all. Muted rather
+   than full `--error` so a row of them is not alarming; hover still escalates. */
+.icon-btn.danger { color: color-mix(in srgb, var(--error) 78%, var(--text-secondary)); }
 .icon-btn.danger:hover { color: var(--error); background: var(--error-dim); }
 
 /* ── Reduced motion ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## The tokens item was almost entirely shipped already

Checked each of the five before building anything. Already in `tokens.component.ts` today:

- ✅ `SummaryStrip` — "active · expiring ≤7d · expired", warn/error variants only when > 0
- ✅ amber **Expiring soon** pill with a dot
- ✅ `RelativeTime` on created / last-used / expires
- ✅ labelled icon actions (`title` + `aria-label` on both)
- ✅ real empty state with a "create your first token" CTA

So the item is closed, not implemented. **One thing on it was genuinely missing — and it isn't a tokens problem.**

## A destructive icon that only looks destructive when you point at it

"Visually distinguish the destructive one" was implemented as:

```scss
.icon-btn.danger:hover { color: var(--error); background: var(--error-dim); }
```

Hover only. So revoke sat beside rotate looking **identical** until you pointed at it — backwards for the one action you cannot undo — and on a touch screen there is no hover at all, so it never distinguished itself from the harmless icon next to it.

Fixed **globally** rather than in the tokens template: the same class marks the destructive icon in Brain (memories, entities, edges, chrono), Files, the schema tab, the schema library and the property-schema table. All **10** had the same problem, and a tokens-only override would have left nine of them wrong and introduced an inconsistency.

Muted at rest rather than full `--error`, so a list with a delete on every row isn't a wall of red; hover still escalates.

## MFA success note self-dismisses

The substantive half of the mfa item. The note persisted until the next action, so *"MFA enabled"* was still on screen the next time the page opened — reading as a live status rather than the receipt for something done a while ago.

Six seconds, and the pending timer is cancelled on destroy so it cannot fire into a torn-down component. Both properties tested; the dismissal is **mutation-checked** — removing the `setTimeout` fails the test, which matters because a timer that quietly stops firing restores precisely the old behaviour and reports nothing.

## Deliberately not done

Lifting mfa's ten inline styles into classes. The tracker marks that page *"optional polish only, do NOT restructure"* — moving declarations around a page I cannot see buys nothing and risks something. Left open in `UX-TODO.md` rather than silently dropped.

## Verification

`npm run preflight` green. As with #532, the resting colour is a visual change I have not seen rendered — the claim that it *changes* is certain, the exact shade is worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
