### PR TITLE
fix(ux): tables and tab strips no longer cut off at narrow window sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by construction, and two tests walk that list through the real handler — a shared type alone would not
   prove the tab is actually reachable.
 
+- **Tables and tab strips were cut off at narrow window sizes.** Reported by the owner. One root cause
+  for both: `.main` is a flex child and a flex item defaults to `min-width: auto`, so it refused to
+  shrink below its content. Wide content overflowed it and `.layout`'s `overflow: hidden` **clipped**
+  that overflow — no scrollbar, no hint, the right-hand columns and the last tabs simply were not there.
+  The `overflow-x: auto` already sitting on `.table-wrapper` never engaged, because nothing above it
+  imposed a width to overflow.
+  - `min-width: 0` on `.main` is the fix, and it activates every scroller that was already in place.
+  - **Tab strips now wrap rather than scroll.** Scrolling was the first attempt and it is worse than it
+    sounds: a scrolled strip looks *identical* to a clipped one, so nothing tells you there is more to
+    reach. Measured at 600 px, the Brain showed five of its ten tabs either way; wrapping shows all ten
+    over three rows. Applies to the global strip, the space-settings dialog tabs and Media Processing.
+  - The two page tables that had no scroll container at all — Audit Log and Data — are now wrapped in
+    the same `.table-wrapper` the other twelve use.
+  - Verified in a booted instance at 900 px and 600 px, before and after: `/settings/audit-log` and
+    `/brain` went from "content overflows `.main`, nothing scrollable" to contained, with the page itself
+    never scrolling sideways.
+
 - **A destructive icon button now looks destructive at rest, not on hover.** `.icon-btn.danger` coloured
   only on `:hover`, so delete and revoke sat in a row looking exactly like the harmless icon beside them
   — you learned which was which by pointing at it, which is backwards for the one action you cannot undo

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -291,6 +291,7 @@ import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-st
     } @else if (entries().length === 0) {
       <div class="empty">{{ 'auditLog.empty' | transloco }}</div>
     } @else {
+      <div class="table-wrapper">
       <table class="audit-table">
         <thead>
           <tr>
@@ -319,6 +320,7 @@ import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-st
           }
         </tbody>
       </table>
+      </div>
 
       <div class="pagination">
         <span>{{ 'auditLog.pagination.total' | transloco: { count: total() } }}</span>

--- a/client/src/app/pages/settings/data.component.ts
+++ b/client/src/app/pages/settings/data.component.ts
@@ -87,6 +87,7 @@ interface BackupConfig {
         } @else if (!backups().length) {
           <p class="muted">{{ 'data.backup.empty' | transloco }}</p>
         } @else {
+          <div class="table-wrapper">
           <table class="table" style="font-size:13px;">
             <thead><tr>
               <th>{{ 'data.backup.colDate' | transloco }}</th>
@@ -110,6 +111,7 @@ interface BackupConfig {
               }
             </tbody>
           </table>
+          </div>
         }
       </app-settings-card>
 

--- a/client/src/app/pages/settings/media-processing/media-processing-page.component.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-page.component.ts
@@ -49,7 +49,9 @@ type Tab = 'models' | 'pipelines' | 'tools';
        nav and tab strip already say where you are, and the old title/subtitle were redundant. */
 
     /* Tabs sized to content, at the top of the panel — not a full-width strip. */
-    .tabs { display: flex; gap: 2px; border-bottom: 1px solid var(--border); margin-bottom: 18px; }
+    .tabs { display: flex; flex-wrap: wrap; row-gap: 2px; gap: 2px;
+      border-bottom: 1px solid var(--border); margin-bottom: 18px; }
+    .tabs > * { flex: none; white-space: nowrap; }
     .tab { background: none; border: none; border-bottom: 2px solid transparent; padding: 9px 16px;
       cursor: pointer; font-size: 13px; font-family: var(--font); color: var(--text-muted);
       display: flex; align-items: center; gap: 7px; }

--- a/client/src/app/pages/settings/space-dialog.styles.ts
+++ b/client/src/app/pages/settings/space-dialog.styles.ts
@@ -52,7 +52,12 @@ export const SPACE_DIALOG_STYLES = `
 .sp-backdrop { position:fixed; inset:0; background:var(--bg-scrim); z-index:200; display:flex; align-items:center; justify-content:center; }
 .sp-panel { width:92vw; height:92vh; max-width:1200px; background:var(--bg-primary); border:1px solid var(--border); border-radius:var(--radius-lg); display:flex; flex-direction:column; overflow:hidden; }
 .sp-header { display:flex; align-items:center; gap:12px; padding:14px 20px; border-bottom:1px solid var(--border); flex-shrink:0; }
-.sp-tabs { display:flex; border-bottom:1px solid var(--border); flex-shrink:0; background:var(--bg-surface); }
+/* Wraps rather than clips: Danger Zone is the last tab and was the first to vanish in a narrow dialog,
+   which is a poor thing to make unreachable. Wrapping over a scroller for the same reason as the global
+   .tabs — a scrolled strip looks exactly like a clipped one, so nothing signals the missing tabs. */
+.sp-tabs { display:flex; flex-wrap:wrap; border-bottom:1px solid var(--border); flex-shrink:0;
+  background:var(--bg-surface); }
+.sp-tabs > .sp-tab { flex:none; white-space:nowrap; }
 .sp-tab { background:none; border:none; border-bottom:2px solid transparent; padding:10px 20px; cursor:pointer; font-size:13px; font-family:var(--font); color:var(--text-muted); transition:color .15s; }
 .sp-tab:hover { color:var(--text-primary); }
 .sp-tab.active { color:var(--text-primary); border-bottom-color:var(--accent); font-weight:500; }

--- a/client/src/app/pages/shell/shell.component.ts
+++ b/client/src/app/pages/shell/shell.component.ts
@@ -151,6 +151,16 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
     .main {
       flex: 1;
+      /* THE line that makes every inner overflow-x scroller actually work.
+         A flex item defaults to min-width:auto, so this column refused to shrink below its content's
+         intrinsic width. A wide table or a long tab strip therefore overflowed it — and because the
+         .layout above has overflow:hidden, that overflow was CLIPPED rather than scrolled. No
+         scrollbar, no hint: the right-hand columns and the last tabs were simply not there. Meanwhile
+         the overflow-x:auto on .table-wrapper inside never engaged, because nothing above it ever
+         imposed a width for it to overflow.
+         Measured before/after at 900px and 600px: /settings/audit-log and /brain both went from
+         "content overflows .main, nothing scrollable" to "contained, scrolls in place". */
+      min-width: 0;
       overflow-y: auto;
       padding: 28px 32px;
     }

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -601,7 +601,19 @@ hr, .divider {
   gap: 4px;
   border-bottom: 1px solid var(--border);
   margin-bottom: 24px;
+  /* WRAP, don't scroll. A tab strip running off the edge does not merely look wrong — the tabs past
+     the edge are unreachable, so part of the app silently disappears at narrow widths.
+     Scrolling was the first attempt and it is worse than it sounds: the strip looks identical to the
+     clipped version, so nothing tells you there is more to reach. A screenshot at 600px showed five of
+     the Brain's ten tabs and no hint of the other five. Wrapping shows all of them, and the container's
+     single bottom rule still sits under the whole block. */
+  flex-wrap: wrap;
+  row-gap: 2px;
 }
+
+/* Labels stay whole. Without this the flex children shrink to fit and you get a strip reading
+   "Mem…", "Ent…", "Edg…" instead of a second row. */
+.tabs > * { flex: none; white-space: nowrap; }
 
 .tab {
   padding: 8px 16px;


### PR DESCRIPTION
Both reported bugs — cut-off tables and cut-off tab strips — are **one root cause**.

`.main` is a flex child, and a flex item defaults to `min-width: auto`: it refuses to shrink below its content's intrinsic width. So a wide table or a long tab strip overflowed it, and because `.layout` has `overflow: hidden`, that overflow was **clipped rather than scrolled** — no scrollbar, no hint, the right-hand columns and the last tabs simply were not there. Meanwhile the `overflow-x: auto` already sitting on `.table-wrapper` never engaged, because nothing above it ever imposed a width for it to overflow.

`min-width: 0` on `.main` is the fix, and it switches on every scroller that was already in place.

## Verified in a booted instance, fix stashed vs applied

Measured `documentElement`, `.main` and every scroll container at 900 px and 600 px:

| | before | after |
|---|---|---|
| `/settings/audit-log` | `main` overflows, **0 scroll containers** | contained, 1 scroller, scrolls in place |
| `/brain` | `main` overflows, `.tabs` overflowing and **not scrollable** | contained, `.tabs` overflow **0** |

The page body never scrolled sideways in either state — an ancestor clips it, which is exactly *why* the symptom is "cut off". **That corrected my diagnosis**: I had assumed sideways page overflow and written a comment saying so. The comment now says the true thing.

## The screenshot overruled the measurement

Scrolling was my first fix for the tabs, and the numbers said it worked — every overflowing strip was scrollable. The screenshot said otherwise:

**Before / scroll-only** — five of ten tabs, nothing indicating the rest exist:
> Overview · Query · Graph · Review · Entities ⁸ ▊

**After (wrap)** — all ten, three rows:
> Overview · Query · Graph · Review
> Entities ⁸ · Edges ⁷ · Memories ² · Chrono ¹
> Files ⁰

A scrolled strip looks *identical* to a clipped one. The measurement was satisfied and you would not have been. Wrapping applies to the global strip, the space-settings dialog tabs (Danger Zone was the first to vanish) and Media Processing.

## Also

The two page tables with no scroll container at all — Audit Log and Data — are now wrapped in the same `.table-wrapper` the other twelve use.

**Not touched:** the three small key/value tables in shared components (`properties-view`, `prop-schema-table`, `entry-popup`). Two-column, inside containers that already scroll, and nothing reported them — left alone rather than churned blind.

`npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
