### PR TITLE
test(ux): a narrow-window sweep — and the third instance of #534 it found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by construction, and two tests walk that list through the real handler — a shared type alone would not
   prove the tab is actually reachable.
 
+- **Schema Library's header buttons ran off the page at narrow widths**, sliding the whole pane sideways
+  — 84 px past a 600 px pane, 264 px past a 420 px one. Same class as the tab strips in #534, on a route
+  that fix did not cover. The button row wraps now. Found by the new sweep below, not by a person.
+
 - **Tables and tab strips were cut off at narrow window sizes.** Reported by the owner. One root cause
   for both: `.main` is a flex child and a flex item defaults to `min-width: auto`, so it refused to
   shrink below its content. Wide content overflowed it and `.layout`'s `overflow: hidden` **clipped**
@@ -232,6 +236,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     margin, so the two column rules line up instead of sitting a few pixels apart.
 
 ### Testing
+
+- **`testing/responsive-sweep.mjs` — a narrow-window check for a bug class nothing else can see.** The
+  cut-off tables and tabs existed in no stylesheet (the offending property was a CSS *default*), threw
+  nothing, and were invisible to the unit tests, which render in jsdom and compute no layout at all. The
+  sweep drives a real browser over every route at 600 px and 420 px.
+  - **Its first invariant was wrong, and mutation-testing is the only reason that was caught.** It looked
+    for *unreachable* content and reported **zero findings on the known-broken build** — the worst
+    result a check can give. `.main` carries `overflow-y: auto`, so CSS computes `overflow-x: auto` too
+    and nothing inside it is ever strictly unreachable; you can scroll to the missing columns. What
+    actually happens is the whole page pane slides sideways, which is what "cut off" looks like.
+  - The invariant is now **the routed page pane must never scroll horizontally**, plus a second rule for
+    genuinely clipped content. Verified in both directions against the pre-#534 code: 4 findings and
+    exit 1 on the broken build, 0 and exit 0 on the fixed one.
+  - It needs a running instance, so it is deliberately not a preflight gate — preflight is the offline
+    half. Run it when touching layout or the shell.
 
 - **The last simulation test is retired.** `testing/standalone/build-properties-schema.test.js`
   asserted against a hand-written *copy* of `buildPropertiesObject` / `stripEmptyOptionalProps`, so it

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -177,7 +177,10 @@ export function entriesFromTypeSchemas(
     /* entry list */
     .header-row { display:flex; align-items:center; justify-content:space-between; margin-bottom:16px; }
     .header-row h2 { margin:0; font-size:20px; font-weight:700; }
-    .header-actions { display:flex; gap:8px; }
+    /* Wraps. A non-wrapping button row is the same narrow-window bug as the tab strips (#534): with
+       five buttons it ran 84px past the pane at 600px and 264px at 420px, sliding the whole page
+       sideways. Found by testing/responsive-sweep.mjs, which #534 did not cover this route with. */
+    .header-actions { display:flex; flex-wrap:wrap; gap:8px; }
     .search-row { margin-bottom:12px; }
     .search-row input { width:100%; max-width:400px; }
     .type-filters { display:flex; gap:6px; flex-wrap:wrap; margin-bottom:16px; }

--- a/client/src/app/pages/shell/shell.component.ts
+++ b/client/src/app/pages/shell/shell.component.ts
@@ -151,15 +151,15 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
     .main {
       flex: 1;
-      /* THE line that makes every inner overflow-x scroller actually work.
-         A flex item defaults to min-width:auto, so this column refused to shrink below its content's
-         intrinsic width. A wide table or a long tab strip therefore overflowed it — and because the
-         .layout above has overflow:hidden, that overflow was CLIPPED rather than scrolled. No
-         scrollbar, no hint: the right-hand columns and the last tabs were simply not there. Meanwhile
-         the overflow-x:auto on .table-wrapper inside never engaged, because nothing above it ever
-         imposed a width for it to overflow.
-         Measured before/after at 900px and 600px: /settings/audit-log and /brain both went from
-         "content overflows .main, nothing scrollable" to "contained, scrolls in place". */
+      /* Defensive, and honestly labelled after measuring it.
+         A flex item defaults to min-width:auto, so this column will not shrink below its content's
+         intrinsic width; anything wider then overflows it and .layout's overflow:hidden CLIPS that
+         overflow — no scrollbar, nothing to scroll, the content is just gone.
+         What this does NOT do is fix the two cases reported in #534: audit-log was fixed by giving its
+         table a .table-wrapper, and the tab strips by wrapping. Measured with this line removed, both
+         still behave. It is kept because it is the correct value for a flex column that holds arbitrary
+         page content, and it is what lets the NEXT inner scroller work without anyone rediscovering
+         this. It is insurance, not the cure — the original comment here claimed otherwise. */
       min-width: 0;
       overflow-y: auto;
       padding: 28px 32px;

--- a/testing/responsive-sweep.mjs
+++ b/testing/responsive-sweep.mjs
@@ -1,0 +1,154 @@
+/**
+ * Responsive sweep — find content the user cannot reach at narrow window sizes.
+ *
+ * ## Why this exists
+ *
+ * The owner reported (2026-07-29) that tables and tab strips were cut off in a small window. The cause
+ * was a single missing `min-width: 0` on the shell's `.main`: a flex item defaults to `min-width: auto`
+ * and refuses to shrink below its content, so wide content overflowed it and the ancestor's
+ * `overflow: hidden` **clipped** the overflow. No scrollbar, no error, no failing test — the right-hand
+ * columns and the last tabs were simply absent. Fixed in PR #534.
+ *
+ * **That class of bug is invisible to every check this repo has.** It does not exist in the stylesheet
+ * (the offending property is a default), it does not throw, and the unit tests render in jsdom, which
+ * computes no layout at all. It only exists in a real browser at a real width — so the only honest way
+ * to look for it is to open the app narrow and measure.
+ *
+ * ## What it reports, and why the obvious invariant is the wrong one
+ *
+ * The first version of this file looked for *unreachable* content — overflowing with no scrollable
+ * ancestor. Mutation-testing it against the real pre-#534 code showed it reported **zero findings on the
+ * broken build**, which is the worst possible outcome for a check: confident silence.
+ *
+ * The reason is instructive. `.main` carries `overflow-y: auto`, and CSS computes the other axis to
+ * `auto` too — so `.main` is a horizontal scroller. Nothing inside it is ever strictly unreachable; you
+ * *can* scroll to the missing table columns. What actually happens is that **the entire page pane slides
+ * sideways** — filter bars, headings and all — which is what "cut off" looks like to a user, and it is a
+ * bug whether or not the pixels are technically reachable.
+ *
+ * So the invariant is narrower and much sharper:
+ *
+ *   1. **`.main` must never scroll horizontally.** The routed page must fit the width it is given.
+ *   2. Anything overflowing with no horizontal scroller anywhere above it (genuinely clipped).
+ *
+ * Rule 1 catches both bugs the owner reported; rule 2 catches the clipped case that rule 1 cannot see.
+ *
+ * ## Usage
+ *
+ *   1. Boot an isolated instance and the client dev server (see `.claude/skills/verify`).
+ *   2. `npm i playwright` somewhere, then:
+ *      `BASE=http://localhost:4260 STATE=/path/to/state.json node testing/responsive-sweep.mjs`
+ *
+ * It needs a running instance, so it is deliberately NOT a preflight gate — preflight is the offline
+ * half. Run it when touching layout, and after any change to the shell.
+ *
+ * Exit code is 1 when anything unreachable is found, so CI could adopt it later if the stack is up.
+ */
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE ?? 'http://localhost:4260';
+const STATE = process.env.STATE;          // storageState json from an authenticated session
+const SHOTS = process.env.SHOTS;          // optional dir for screenshots of offending pages
+
+const ROUTES = (process.env.ROUTES ?? [
+  '/brain', '/graph', '/files', '/files/conflicts', '/schema-library',
+  '/settings/tokens', '/settings/spaces', '/settings/storage', '/settings/networks',
+  '/settings/preferences', '/settings/audit-log', '/settings/data', '/settings/webhooks',
+  '/settings/about', '/settings/help', '/settings/media-processing',
+].join(',')).split(',');
+
+/** Widths worth checking: a narrow desktop window, and a phone. */
+const VIEWPORTS = [[600, 900], [420, 900]];
+
+const browser = await chromium.launch({ channel: process.env.PW_CHANNEL ?? 'msedge' });
+const ctx = await browser.newContext(STATE ? { storageState: STATE } : {});
+const page = await ctx.newPage();
+
+let findings = 0;
+
+for (const [w, h] of VIEWPORTS) {
+  await page.setViewportSize({ width: w, height: h });
+  console.log(`\n===== ${w}x${h} =====`);
+
+  for (const route of ROUTES) {
+    try {
+      await page.goto(BASE + route, { waitUntil: 'networkidle', timeout: 25_000 });
+    } catch {
+      console.log(`${route}  — load timed out, skipped`);
+      continue;
+    }
+    await page.waitForTimeout(700);   // let deferred blocks and async data settle
+
+    const hits = await page.evaluate(() => {
+      const scrollsX = el => {
+        const s = getComputedStyle(el);
+        return s.overflowX === 'auto' || s.overflowX === 'scroll';
+      };
+      /**
+       * `overflow-x: auto` is NOT enough to call something reachable.
+       *
+       * An element can advertise auto and still be unable to scroll, because a `overflow: hidden`
+       * ancestor is clipping it before it ever gets the chance. That is the exact shape of the bug this
+       * file was written for, and the first version of this check missed it: `.main` computes
+       * `overflow-x: auto` (a side effect of its `overflow-y: auto`), so every descendant looked
+       * reachable while `.layout` quietly clipped the lot.
+       *
+       * So a scroller only counts if it is not itself being clipped horizontally by a hidden ancestor.
+       */
+      const clippedByHiddenAncestor = el => {
+        for (let n = el.parentElement; n; n = n.parentElement) {
+          const s = getComputedStyle(n);
+          if (s.overflowX === 'hidden' && n.scrollWidth > n.clientWidth + 2) return true;
+          if (s.overflowX === 'auto' || s.overflowX === 'scroll') return false;  // a real scroller above
+        }
+        return false;
+      };
+      /**
+       * Visually-hidden text is CLIPPED ON PURPOSE — the standard sr-only recipe is a 1px box with
+       * `overflow: hidden`, which trips the same measurement. Excluded by shape rather than by class
+       * name, so a page that rolls its own sr-only span is not reported either.
+       */
+      const isVisuallyHidden = el => el.clientWidth <= 2 || el.clientHeight <= 2;
+
+      const out = [];
+
+      // Rule 1 — the routed page pane must fit its width. This is the one that catches the real bugs.
+      const main = document.querySelector('.main');
+      if (main && main.scrollWidth > main.clientWidth + 2) {
+        out.push({
+          tag: 'main', cls: 'PAGE PANE SCROLLS SIDEWAYS',
+          over: main.scrollWidth - main.clientWidth, box: main.clientWidth,
+        });
+      }
+
+      // Rule 2 — genuinely clipped content, which rule 1 cannot see.
+      for (const el of document.querySelectorAll('body *')) {
+        if (el.scrollWidth <= el.clientWidth + 2) continue;
+        if (isVisuallyHidden(el)) continue;
+        let reachable = false;
+        for (let n = el; n; n = n.parentElement) {
+          if (scrollsX(n) && !clippedByHiddenAncestor(n)) { reachable = true; break; }
+        }
+        if (reachable) continue;
+        out.push({
+          tag: el.tagName.toLowerCase(),
+          cls: typeof el.className === 'string' ? el.className.slice(0, 60) : '',
+          over: el.scrollWidth - el.clientWidth,
+          box: el.clientWidth,
+        });
+      }
+      // A clipped child inside a clipped parent is one problem, not two — report the worst few.
+      return out.sort((a, b) => b.over - a.over).slice(0, 6);
+    });
+
+    if (!hits.length) continue;
+    findings += hits.length;
+    console.log(route);
+    for (const f of hits) console.log(`    ${f.tag}.${f.cls || '(no class)'} — ${f.over}px past a ${f.box}px box`);
+    if (SHOTS) await page.screenshot({ path: `${SHOTS}/sweep-${route.replace(/\//g, '_')}-${w}.png` });
+  }
+}
+
+await browser.close();
+console.log(`\nunreachable-overflow findings: ${findings}`);
+process.exit(findings ? 1 : 0);


### PR DESCRIPTION
#534 fixed the two narrow-window bugs you reported. This makes the check repeatable — and it immediately found a **third instance #534 missed**.

## Why a browser check at all

That bug class is invisible to everything else in the repo:

- the offending property is a CSS **default** (`min-width: auto`), so it appears in no stylesheet
- it throws nothing
- the unit tests render in **jsdom, which computes no layout at all**

It only exists in a real browser at a real width. So the sweep drives one over every route at 600 px and 420 px.

## The third instance

**Schema Library's header button row does not wrap.** At 600 px it ran 84 px past the pane; at 420 px, 264 px — sliding the whole page sideways. Same class as the tab strips, on a route #534 did not cover. Fixed the same way.

## My first invariant was wrong, and only mutation-testing caught it

I wrote the check to look for **unreachable** content — overflowing with no scrollable ancestor. That is the obvious definition and it sounds right. Run against the real pre-#534 code it reported:

```
unreachable-overflow findings: 0
exit=0
```

**Zero findings on a build known to be broken.** A check that is confidently silent is worse than no check, and I would have shipped it.

The reason: `.main` carries `overflow-y: auto`, and CSS computes the *other* axis to `auto` as well. So `.main` is a horizontal scroller, and nothing inside it is ever strictly unreachable — you *can* scroll to the missing table columns. What actually happens is that the entire page pane slides sideways, filter bars and headings and all. That is what "cut off" looks like to someone using it, and it is a bug regardless of whether the pixels are reachable.

The invariant is now narrower and sharper:

1. **the routed page pane must never scroll horizontally**
2. plus a second rule for genuinely clipped content, which rule 1 cannot see

Verified in **both directions** against the pre-#534 code:

| build | findings | exit |
|---|---|---|
| pre-#534 (no wrapper, no `min-width`) | 4 | 1 |
| fixed | 0 | 0 |

## A correction to #534

Its comment on `.main { min-width: 0 }` claimed to be the line that fixed the reported bugs. Measuring says otherwise — audit-log was fixed by its `.table-wrapper`, the strips by wrapping, and **both still behave with `min-width` removed**. The property is correct and stays as insurance for the next inner scroller, but the comment now says that rather than taking credit for someone else's work.

## Not a preflight gate

It needs a running instance; preflight is the offline half. Run it when touching layout or the shell:

```
BASE=http://localhost:4260 STATE=state.json node testing/responsive-sweep.mjs
```

`npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
