### PR TITLE
fix(reliability): jitter the retry backoff in both retry queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by construction, and two tests walk that list through the real handler — a shared type alone would not
   prove the tab is actually reachable.
 
+- **Retries had backoff but no jitter, so simultaneous failures retried in lockstep.** Both retry queues
+  — media jobs and webhook delivery — already backed off exponentially, which is the half everyone
+  remembers. But the delay was *identical* for every job, so failures that happen together retry
+  together. Upload twenty files while the document sidecar is restarting: all twenty fail within a
+  second, all wait exactly 30 000 ms, and all hit the sidecar again on the same tick — a synchronised
+  burst aimed at something that has just come back and is at its most fragile. If that knocks it over,
+  they fail together again and re-synchronise on the next step.
+  - Backoff spaces retries out over *time*; jitter spaces them across *clients*. Neither substitutes for
+    the other, and the second was missing.
+  - **Equal jitter**, not full: the delay lands in `[delay/2, delay]`, so half the nominal wait is still
+    guaranteed. Full jitter (`0..delay`) spreads better but lets a job retry almost immediately, which
+    throws away the reason 30 s was chosen.
+  - The exponential schedules are unchanged, and a test pins that they stay exponential — jitter on a
+    flat schedule would spread the herd while still hammering a dependency that needs time.
+
 - **A draining instance kept advertising itself as ready, so new work kept arriving.** The other half of
   the shutdown fix below. `server.close()` refuses new *connections*, but a load balancer holding an
   established keep-alive connection keeps using it — and kept getting `200` from `/ready`, because the

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -11,6 +11,7 @@ import { escapeRegex } from '../../util/redos.js';
 import type { StepProgress } from '../converters/types.js';
 import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
+import { withJitter } from '../../util/backoff.js';
 
 const MAX_ATTEMPTS = 3;
 
@@ -26,7 +27,9 @@ const RETRY_BACKOFF_MS: Record<number, number> = {
 
 function nextClaimableAfter(nextAttempt: number): string {
   const delay = RETRY_BACKOFF_MS[nextAttempt] ?? 300_000;
-  return new Date(Date.now() + delay).toISOString();
+  // Jittered: twenty files failing together while a sidecar restarts would otherwise all become
+  // claimable on the same tick and hit it again in one burst, at the moment it is least able to cope.
+  return new Date(Date.now() + withJitter(delay)).toISOString();
 }
 
 

--- a/server/src/util/backoff.ts
+++ b/server/src/util/backoff.ts
@@ -1,0 +1,36 @@
+/**
+ * Jitter for retry backoff — the part that stops a recovering dependency being knocked straight back
+ * over by the clients that were waiting for it.
+ *
+ * ## The failure this prevents
+ *
+ * Both retry queues here already back off exponentially, which is the half everyone remembers. But the
+ * delay was *exactly* the same for every job, so failures that happen together retry together. Upload
+ * twenty files while the document sidecar is restarting and all twenty fail within the same second, all
+ * wait exactly 30 000 ms, and all hit the sidecar again on the same tick — a synchronised herd, aimed at
+ * something that has just come back up and is at its most fragile. If that knocks it over, the twenty
+ * fail together again and re-synchronise on the next step of the schedule.
+ *
+ * Backoff spaces retries out *over time*. Jitter spaces them out *across clients*. Neither substitutes
+ * for the other, and the second one is the one that was missing.
+ *
+ * ## Equal jitter, not full jitter
+ *
+ * Full jitter (`random(0, delay)`) spreads best but throws away the floor: a job can retry almost
+ * immediately after failing, which defeats the point of having chosen 30 s. Equal jitter keeps half the
+ * delay as a guaranteed minimum and randomises the rest, so the schedule still means what it says while
+ * the herd still breaks up. For a queue measured in tens of jobs rather than thousands, that is the
+ * better trade.
+ */
+
+/**
+ * `delayMs` scattered to somewhere in `[delayMs/2, delayMs)`.
+ *
+ * Returns 0 for a non-positive delay, so "retry immediately" stays immediate rather than becoming a
+ * random tiny wait.
+ */
+export function withJitter(delayMs: number): number {
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return 0;
+  const half = delayMs / 2;
+  return Math.round(half + Math.random() * half);
+}

--- a/server/src/webhooks/dispatcher.ts
+++ b/server/src/webhooks/dispatcher.ts
@@ -18,6 +18,7 @@ import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
 import { publishBrainChange } from '../brain/brain-events.js';
 import type { WebhookEventType, WebhookEventPayload, WebhookDelivery, WebhookSubscription } from './types.js';
+import { withJitter } from '../util/backoff.js';
 
 /** Retry schedule in milliseconds: 10s, 30s, 1m, 5m, 30m, 1h */
 const RETRY_DELAYS_MS = [10_000, 30_000, 60_000, 300_000, 1_800_000, 3_600_000];
@@ -102,7 +103,10 @@ async function enqueueRetry(
   deliveryId: string,
   attempt: number,
 ): Promise<void> {
-  const delayMs = RETRY_DELAYS_MS[attempt - 2] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!;
+  // Jittered: one webhook target going down fails every event queued against it at once, and without
+  // jitter they would all come back at the same instant — a burst aimed at an endpoint that is, by
+  // definition, already having a bad time. See `util/backoff.ts`.
+  const delayMs = withJitter(RETRY_DELAYS_MS[attempt - 2] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!);
   const job: RetryJob = {
     _id: uuidv4(),
     webhookId,

--- a/testing/standalone/retry-jitter.test.js
+++ b/testing/standalone/retry-jitter.test.js
@@ -1,0 +1,86 @@
+/**
+ * Retry delays are jittered, so a herd of simultaneous failures does not retry in lockstep.
+ *
+ * Both retry queues already backed off exponentially — the half everyone remembers. But the delay was
+ * identical for every job, so failures that happen together retry together. Upload twenty files while
+ * the document sidecar is restarting: all twenty fail inside a second, all wait exactly 30 000 ms, all
+ * hit the sidecar again on the same tick, at the moment it is least able to cope. If that knocks it
+ * over they fail together again and re-synchronise on the next step of the schedule.
+ *
+ * Backoff spaces retries out over TIME. Jitter spaces them out across CLIENTS. The second one was
+ * missing, and it is the one that breaks the herd.
+ *
+ * Run: node --test testing/standalone/retry-jitter.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let withJitter;
+before(async () => { ({ withJitter } = await import('../../server/dist/util/backoff.js')); });
+
+describe('withJitter', () => {
+  it('stays within [delay/2, delay] — the floor is the point of equal jitter', () => {
+    // Full jitter (0..delay) would let a job retry almost immediately, throwing away the reason 30 s
+    // was chosen. Half the nominal delay is guaranteed.
+    for (const delay of [1_000, 30_000, 120_000, 3_600_000]) {
+      for (let i = 0; i < 2_000; i++) {
+        const v = withJitter(delay);
+        assert.ok(v >= delay / 2, `${v} below the floor for ${delay}`);
+        assert.ok(v <= delay, `${v} above the nominal delay ${delay}`);
+      }
+    }
+  });
+
+  it('actually scatters — this is the assertion the whole change exists for', () => {
+    // A stub returning the delay unchanged passes the range check above. It must not pass this one.
+    const seen = new Set();
+    for (let i = 0; i < 500; i++) seen.add(withJitter(30_000));
+    assert.ok(seen.size > 100,
+      `expected a spread of retry times, got ${seen.size} distinct values — the herd would still be synchronised`);
+  });
+
+  it('spreads across the whole window, not just one end of it', () => {
+    const vals = Array.from({ length: 2_000 }, () => withJitter(10_000));
+    const lower = vals.filter(v => v < 7_500).length;
+    const upper = vals.filter(v => v >= 7_500).length;
+    assert.ok(lower > 200 && upper > 200, `lopsided distribution: ${lower} low / ${upper} high`);
+  });
+
+  it('a non-positive delay stays immediate rather than becoming a random small wait', () => {
+    assert.equal(withJitter(0), 0);
+    assert.equal(withJitter(-5), 0);
+    assert.equal(withJitter(NaN), 0);
+  });
+});
+
+describe('both retry queues use it', () => {
+  it('the media job queue jitters its backoff', () => {
+    const src = readFileSync('server/src/files/media/job-queue.ts', 'utf8');
+    assert.match(src, /withJitter\(/, 'media retries must be jittered');
+    // Pin it to the scheduling function specifically — importing the helper and not using it here
+    // would leave the herd intact.
+    const fn = src.slice(src.indexOf('function nextClaimableAfter'), src.indexOf('function nextClaimableAfter') + 400);
+    assert.match(fn, /withJitter\(delay\)/);
+  });
+
+  it('the webhook dispatcher jitters its backoff', () => {
+    const src = readFileSync('server/src/webhooks/dispatcher.ts', 'utf8');
+    assert.match(src, /withJitter\(RETRY_DELAYS_MS\[/,
+      'the scheduled retry time must be jittered, not the raw table value');
+  });
+
+  it('the backoff schedules themselves are still exponential', () => {
+    // Jitter is added ON TOP of backoff, not instead of it — a flat schedule with jitter would spread
+    // the herd and still hammer a dependency that needs time.
+    const media = readFileSync('server/src/files/media/job-queue.ts', 'utf8');
+    assert.match(media, /1: 30_000/);
+    assert.match(media, /2: 120_000/);
+    const hook = readFileSync('server/src/webhooks/dispatcher.ts', 'utf8');
+    const delays = /RETRY_DELAYS_MS = \[([^\]]+)\]/.exec(hook)[1].split(',').map(x => Number(x.trim().replace(/_/g, '')));
+    for (let i = 1; i < delays.length; i++) {
+      assert.ok(delays[i] > delays[i - 1], `webhook delays must increase: ${delays.join(', ')}`);
+    }
+  });
+});


### PR DESCRIPTION
Reliability lens, continued.

## Backoff without jitter is half a fix

Media jobs and webhook delivery both back off exponentially already — the half everyone remembers. But the delay was **identical for every job**, so failures that happen together retry together.

Upload twenty files while the document sidecar is restarting: all twenty fail inside a second, all wait exactly `30_000` ms, and all hit the sidecar again **on the same tick** — at the moment it is least able to cope. If that knocks it over, they fail together again and re-synchronise on the next step of the schedule.

Same shape for webhooks: one endpoint going down fails every event queued against it at once, and they all come back in a single burst aimed at something already having a bad time.

> Backoff spaces retries out over **time**. Jitter spaces them out across **clients**. They are not substitutes, and only the first was there.

## Equal jitter, not full

The delay lands in `[delay/2, delay]`, so **half the nominal wait is still guaranteed**. Full jitter (`0..delay`) spreads better but lets a job retry almost immediately, which throws away the reason 30 s was picked. For queues measured in tens of jobs rather than thousands, that is the better trade.

One helper used by both queues, so the rule lives in one place. The exponential schedules are untouched — and a test pins that they **stay** exponential, because jitter layered on a flat schedule would spread the herd while still hammering a dependency that needs time.

## The test that carries the weight

A stub returning the delay unchanged satisfies every range assertion you would naturally write. So there is an explicit one for *"these values actually differ"*:

```js
const seen = new Set();
for (let i = 0; i < 500; i++) seen.add(withJitter(30_000));
assert.ok(seen.size > 100, '…the herd would still be synchronised');
```

**Mutation-checked:** that stub fails it, and the distribution check with it.

`npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
