### PR TITLE
test: cover the two untested guards — filter-key allowlist and seq ingest ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **Two guards that had no test now have one: the filter-key allowlist and the seq ingest ceiling.**
+  Both stand between untrusted input and something expensive to get wrong, and a guard with no test is
+  indistinguishable from a guard that has quietly stopped guarding.
+  - `brain/filter.ts` decides which record fields a caller may filter on — the allowlist between a
+    user-supplied filter expression and a MongoDB query document. Covered: every allowed key, top-level
+    operator injection (`$where`, `$or`, `$expr`, …), prototype-pollution shapes, and the near-misses
+    (`typeface`, `namely`, `tagsSecret`) that a `startsWith` without the segment boundary would admit.
+  - `buildMongoFilter`'s falsy handling: `exists: false`, `eq: 0`, `eq: false`, `eq: ''` all survive. A
+    truthiness check there would silently turn "this field must be absent" into no constraint at all —
+    widening results rather than narrowing them.
+  - `util/seq.ts`'s `isSeqImplausible` — the guard that stops one peer document near the protocol ceiling
+    from dragging a space's counter up so far that every subsequent *local* write is rejected by every
+    peer. Silent, unrecoverable write loss.
+  - **Mutation-checked, three mutants, one test killed by each:** widening the allowlist to a bare
+    `startsWith`, swapping `!== undefined` for truthiness, and making the seq guard relative instead of
+    absolute.
+
 - **`testing/responsive-sweep.mjs` — a narrow-window check for a bug class nothing else can see.** The
   cut-off tables and tabs existed in no stylesheet (the offending property was a CSS *default*), threw
   nothing, and were invisible to the unit tests, which render in jsdom and compute no layout at all. The

--- a/testing/standalone/filter-and-seq-guards.test.js
+++ b/testing/standalone/filter-and-seq-guards.test.js
@@ -1,0 +1,130 @@
+/**
+ * Two untested modules, both of them guards.
+ *
+ * From the QA tracker's "production modules with no importing test" list. Not a sweep — these two are
+ * here because both are *guards*, and a guard with no test is indistinguishable from a guard that has
+ * quietly stopped guarding.
+ *
+ *  - `brain/filter.ts` decides which record fields a caller may filter on. It is the allowlist standing
+ *    between a user-supplied filter expression and a MongoDB query document.
+ *  - `util/seq.ts` decides which `seq` values may be ingested from a peer. It exists to stop one hostile
+ *    or broken document from stranding a space's counter near the protocol ceiling, after which every
+ *    local write is rejected by every peer — silent, unrecoverable write loss.
+ *
+ * Run: node --test testing/standalone/filter-and-seq-guards.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let validateFilterExpression, buildMongoFilter;
+let isSeqImplausible, MAX_INGEST_SEQ, MAX_SYNC_SEQ, SEQ_CEILING_RESERVE;
+
+before(async () => {
+  ({ validateFilterExpression, buildMongoFilter } = await import('../../server/dist/brain/filter.js'));
+  ({ isSeqImplausible, MAX_INGEST_SEQ, MAX_SYNC_SEQ, SEQ_CEILING_RESERVE } =
+    await import('../../server/dist/util/seq.js'));
+});
+
+const ok = f => assert.equal(validateFilterExpression(f), null);
+const rejected = f => assert.match(validateFilterExpression(f) ?? '', /not allowed/);
+
+describe('filter key allowlist — what a caller may filter on', () => {
+  it('accepts each allowed key, bare and dotted', () => {
+    for (const k of ['tags', 'type', 'name', 'status', 'label']) ok({ [k]: { eq: 'x' } });
+    ok({ 'properties.owner': { eq: 'x' } });
+    ok({ 'properties.a.b.c': { eq: 'x' } });
+    ok({ 'tags.0': { eq: 'x' } });
+  });
+
+  it('rejects Mongo operators at the top level — the injection this exists to stop', () => {
+    for (const k of ['$where', '$or', '$and', '$expr', '$function', '$nor']) {
+      rejected({ [k]: { eq: 1 } });
+    }
+  });
+
+  it('rejects prototype-pollution shaped keys', () => {
+    for (const k of ['__proto__', 'constructor', 'prototype']) rejected({ [k]: { eq: 1 } });
+  });
+
+  it('rejects near-misses — a prefix must end at a segment boundary', () => {
+    // The bug this guards: a `startsWith` without the dot would let `typeface`, `namely` and
+    // `tagsSecret` through, and with them any field whose name happens to begin with an allowed word.
+    for (const k of ['typeface', 'namely', 'tagsSecret', 'labelled', 'statusy', 'embedding']) {
+      rejected({ [k]: { eq: 1 } });
+    }
+  });
+
+  it('rejects bare `properties` — only its sub-keys are filterable', () => {
+    rejected({ properties: { eq: 1 } });
+  });
+
+  it('rejects the whole expression if ANY key is disallowed', () => {
+    rejected({ tags: { eq: 'a' }, $where: { eq: 'b' } });
+  });
+
+  it('an empty expression is valid and constrains nothing', () => {
+    ok({});
+    assert.deepEqual(buildMongoFilter({}), {});
+  });
+});
+
+describe('buildMongoFilter — falsy values are values', () => {
+  it('maps every supported operator', () => {
+    assert.deepEqual(
+      buildMongoFilter({ 'properties.n': { gt: 1, gte: 2, lt: 3, lte: 4, ne: 5 } }),
+      { 'properties.n': { $gt: 1, $gte: 2, $lt: 3, $lte: 4, $ne: 5 } },
+    );
+    assert.deepEqual(buildMongoFilter({ tags: { in: ['a', 'b'] } }), { tags: { $in: ['a', 'b'] } });
+  });
+
+  it('keeps `exists: false`', () => {
+    // The classic bug: a truthiness check here silently turns "this field must be ABSENT" into no
+    // constraint at all, which widens the result set instead of narrowing it. Same for eq below.
+    assert.deepEqual(buildMongoFilter({ 'properties.x': { exists: false } }),
+      { 'properties.x': { $exists: false } });
+  });
+
+  it('keeps `eq: 0`, `eq: false` and `eq: ""`', () => {
+    assert.deepEqual(buildMongoFilter({ 'properties.n': { eq: 0 } }), { 'properties.n': { $eq: 0 } });
+    assert.deepEqual(buildMongoFilter({ 'properties.b': { eq: false } }), { 'properties.b': { $eq: false } });
+    assert.deepEqual(buildMongoFilter({ 'properties.s': { eq: '' } }), { 'properties.s': { $eq: '' } });
+  });
+
+  it('drops a key whose operator object is empty rather than emitting a match-anything clause', () => {
+    assert.deepEqual(buildMongoFilter({ tags: {} }), {});
+  });
+
+  it('never emits a key the caller did not supply', () => {
+    const out = buildMongoFilter({ tags: { eq: 'a' } });
+    assert.deepEqual(Object.keys(out), ['tags']);
+  });
+});
+
+describe('seq ingest guard — the sync-poisoning ceiling', () => {
+  it('the reserve leaves real headroom below the protocol ceiling', () => {
+    assert.equal(MAX_INGEST_SEQ, MAX_SYNC_SEQ - SEQ_CEILING_RESERVE);
+    assert.ok(SEQ_CEILING_RESERVE > 0 && SEQ_CEILING_RESERVE < MAX_SYNC_SEQ);
+  });
+
+  it('accepts ordinary counter values', () => {
+    for (const s of [0, 1, 42, 1_000_000, MAX_INGEST_SEQ]) {
+      assert.equal(isSeqImplausible(s), false, `${s} should be ingestible`);
+    }
+  });
+
+  it('rejects a value near the ceiling — the poisoning case', () => {
+    // One document carrying this drags the space counter up via bumpSeq, and every subsequent LOCAL
+    // write then exceeds what peers accept. The loss is silent and unrecoverable, which is why the
+    // guard is absolute rather than relative to the current counter.
+    assert.equal(isSeqImplausible(MAX_INGEST_SEQ + 1), true);
+    assert.equal(isSeqImplausible(MAX_SYNC_SEQ), true);
+    assert.equal(isSeqImplausible(MAX_SYNC_SEQ * 2), true);
+  });
+
+  it('rejects negatives and non-finite values', () => {
+    for (const s of [-1, -0.5, NaN, Infinity, -Infinity]) {
+      assert.equal(isSeqImplausible(s), true, `${s} should be refused`);
+    }
+  });
+});


### PR DESCRIPTION
From the QA tracker's *"production modules with no importing test"*. **Not a sweep** — these two are here because both are **guards**, and a guard with no test is indistinguishable from a guard that has quietly stopped guarding.

## `brain/filter.ts` — the allowlist between user input and a Mongo query

Covered:

- every allowed key, bare and dotted
- top-level operator injection: `$where`, `$or`, `$and`, `$expr`, `$function`, `$nor`
- prototype-pollution shapes: `__proto__`, `constructor`, `prototype`
- **near-misses**: `typeface`, `namely`, `tagsSecret`, `labelled`, `statusy` — the ones a `startsWith` without the segment boundary would let through, taking any field beginning with an allowed word with them
- bare `properties` rejected; only its sub-keys are filterable
- one bad key rejects the whole expression

## The subtler half: falsy values are values

`exists: false`, `eq: 0`, `eq: false`, `eq: ''` all have to survive `buildMongoFilter`.

A truthiness check there silently turns *"this field must be **absent**"* into **no constraint at all** — which **widens** the result set instead of narrowing it. That is a wrong answer that looks exactly like a working query.

## `util/seq.ts` — the sync-poisoning ceiling

`isSeqImplausible` stops one peer document carrying a `seq` near the protocol ceiling from dragging the space counter up behind it, after which every subsequent **local** write exceeds what peers accept: silent, unrecoverable write loss.

The test pins that the guard is **absolute** rather than relative to the current counter — the property its own docstring argues for, and the one a "smarter" max-jump heuristic would quietly replace.

## Mutation-checked

Three mutants, **one test killed by each**:

| mutant | test killed |
|---|---|
| allowlist widened to a bare `startsWith` | near-misses |
| `!== undefined` → truthiness | `exists: false` |
| seq guard made relative | value near the ceiling |

## Tracker re-measured

The list had gone stale: eight of the twelve modules picked up importing tests through other work, two more are covered here, and one of the remaining three (`db/mongo.ts`, the `$vectorSearch` probe) needs a live Mongo so it belongs in the integration suite, not standalone. **Three left**, and the entry now says which and why instead of carrying names that are no longer true.

`npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
