### PR TITLE
test: cover api/brain/_shared.ts, and close the untested-modules item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- **`api/brain/_shared.ts` — the helpers every brain write route runs through — is covered.** Three
+  things in there decide something consequential and none was tested.
+  - **TTL parsing decides when records get deleted.** `ttlDaysFromBody` and `ttlDaysError` are a
+    parse/validate pair, and the test that matters asserts they can never *disagree*: anything the
+    validator rejects must not survive parsing (or an invalid TTL reaches a record), and anything it
+    accepts must not be dropped (or a valid TTL is silently ignored). `0` — "no expiry" — is a real
+    value, not a missing one, and `null` — "clear" — is distinct from absent.
+  - **`applyValidation` is where `validationMode: 'strict'` actually blocks.** The whole off / warn /
+    strict matrix is pinned; if strict stops blocking, every schema in every space quietly becomes
+    advisory.
+  - **`buildMemoryFilter` only lets strings into the filter document.** `?tag[]=a&tag[]=b` parses to an
+    array and an object-valued param is trivially forgeable; either reaching a query unchecked is how a
+    caller-supplied operator gets in.
+  - Mutation-checked: widening the TTL bound, making strict non-blocking, and dropping one `typeof`
+    guard each kill exactly one test.
+  - This closes the "production modules with no importing test" item. Two are deliberately left without
+    a standalone test, with reasons recorded: `db/mongo.ts` (the `$vectorSearch` probe needs a live
+    Mongo — it belongs in the integration suite, which already exercises it) and `util/errors.ts` (two
+    five-line `Error` subclasses with no logic; a test there is ceremony).
+
 - **Two guards that had no test now have one: the filter-key allowlist and the seq ingest ceiling.**
   Both stand between untrusted input and something expensive to get wrong, and a guard with no test is
   indistinguishable from a guard that has quietly stopped guarding.

--- a/testing/standalone/brain-shared-guards.test.js
+++ b/testing/standalone/brain-shared-guards.test.js
@@ -1,0 +1,140 @@
+/**
+ * `api/brain/_shared.ts` — the helpers every brain write route runs through.
+ *
+ * Last of the QA tracker's "modules with no importing test" that is worth testing standalone. Three
+ * things in here decide something consequential, and none of them was covered:
+ *
+ *  1. **TTL parsing decides when records get deleted.** `ttlDays` drives the F10 auto-expiry sweep. A
+ *     value accepted that should not be, or a bound off by one, is silent data loss on a timer.
+ *  2. **`applyValidation` is where `validationMode: 'strict'` actually blocks.** If strict stops
+ *     blocking, every schema in every space becomes advisory and nothing says so.
+ *  3. **`buildMemoryFilter` turns query params into a Mongo filter.** Query strings are not necessarily
+ *     strings — `?tag[]=a&tag[]=b` parses to an array — and the `typeof === 'string'` guards are what
+ *     keep a caller-shaped object out of the filter document.
+ *
+ * Run: node --test testing/standalone/brain-shared-guards.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let ttlDaysFromBody, ttlDaysError, applyValidation, buildMemoryFilter;
+
+before(async () => {
+  ({ ttlDaysFromBody, ttlDaysError, applyValidation, buildMemoryFilter } =
+    await import('../../server/dist/api/brain/_shared.js'));
+});
+
+describe('ttlDays — parse and validate must agree', () => {
+  it('accepts the documented range, including both ends', () => {
+    for (const v of [0, 1, 365, 36_500]) {
+      assert.equal(ttlDaysError({ ttlDays: v }), null, `${v} should be valid`);
+      assert.equal(ttlDaysFromBody({ ttlDays: v }), v);
+    }
+  });
+
+  it('0 is a real value, not a missing one', () => {
+    // `Absent/0 = no expiry` per the Space type. A truthiness check would collapse 0 into "not supplied",
+    // which reads the same but is a different instruction.
+    assert.equal(ttlDaysFromBody({ ttlDays: 0 }), 0);
+    assert.notEqual(ttlDaysFromBody({ ttlDays: 0 }), undefined);
+  });
+
+  it('null means CLEAR and is distinct from absent', () => {
+    assert.equal(ttlDaysFromBody({ ttlDays: null }), null);
+    assert.equal(ttlDaysFromBody({}), undefined);
+    assert.equal(ttlDaysError({ ttlDays: null }), null);
+    assert.equal(ttlDaysError({}), null);
+  });
+
+  it('rejects out-of-range, fractional and non-numeric values', () => {
+    for (const v of [-1, 36_501, 1.5, '30', NaN, Infinity, true, [], {}]) {
+      assert.match(ttlDaysError({ ttlDays: v }) ?? '', /must be an integer/, `${JSON.stringify(v)} should error`);
+    }
+  });
+
+  it('the two functions never disagree — anything the validator rejects, the parser drops', () => {
+    // The pair is the contract: a route calls the validator, then the parser. If the parser accepted a
+    // value the validator rejected, an invalid TTL would reach a record. If it dropped one the validator
+    // accepted, a valid TTL would be silently ignored. Neither may happen.
+    const values = [undefined, null, 0, 1, 36_500, -1, 36_501, 1.5, '30', NaN, Infinity, true, [], {}];
+    for (const v of values) {
+      const absent = v === undefined;
+      const body = absent ? {} : { ttlDays: v };
+      const rejected = ttlDaysError(body) !== null;
+      const parsed = ttlDaysFromBody(body);
+
+      if (rejected) {
+        // Rejected → must not survive parsing, or an invalid TTL reaches a record.
+        assert.equal(parsed, undefined, `${JSON.stringify(v)}: rejected by the validator but parsed to ${String(parsed)}`);
+      } else if (absent) {
+        assert.equal(parsed, undefined, 'absent must parse to undefined (leave the TTL alone)');
+      } else {
+        // Accepted and present → must survive, or a valid TTL is silently ignored. `null` (clear) and
+        // `0` (no expiry) are both legitimate here, so the check is "not dropped", not "truthy".
+        assert.notEqual(parsed, undefined, `${JSON.stringify(v)}: accepted by the validator but dropped by the parser`);
+      }
+    }
+  });
+
+  it('a non-object body does not throw', () => {
+    for (const b of [null, undefined, 'x', 7]) {
+      assert.equal(ttlDaysError(b), null);
+      assert.equal(ttlDaysFromBody(b), undefined);
+    }
+  });
+});
+
+describe('applyValidation — strict must actually block', () => {
+  const violation = [{ field: 'type', value: 'x', reason: 'nope' }];
+
+  it('strict blocks and reports', () => {
+    const r = applyValidation({ validationMode: 'strict' }, violation);
+    assert.equal(r.blocked, true);
+    assert.deepEqual(r.warnings, violation);
+  });
+
+  it('warn lets the write through but surfaces the violations', () => {
+    const r = applyValidation({ validationMode: 'warn' }, violation);
+    assert.equal(r.blocked, false);
+    assert.deepEqual(r.warnings, violation);
+  });
+
+  it('off blocks nothing and reports nothing', () => {
+    const r = applyValidation({ validationMode: 'off' }, violation);
+    assert.equal(r.blocked, false);
+    assert.deepEqual(r.warnings, []);
+  });
+
+  it('no meta, no mode, or no violations all mean "nothing to do"', () => {
+    for (const meta of [undefined, {}, { validationMode: undefined }]) {
+      assert.deepEqual(applyValidation(meta, violation), { blocked: false, warnings: [] });
+    }
+    assert.deepEqual(applyValidation({ validationMode: 'strict' }, []), { blocked: false, warnings: [] });
+  });
+});
+
+describe('buildMemoryFilter — only strings reach the filter document', () => {
+  it('maps the simple equality params', () => {
+    const f = buildMemoryFilter({ entity: 'e1', type: 'decision' });
+    assert.equal(f['entityIds'], 'e1');
+    assert.equal(f['type'], 'decision');
+  });
+
+  it('ignores a non-string param instead of putting it in the query', () => {
+    // `?tag[]=a&tag[]=b` parses to an array, and an object-valued param is trivially forgeable. Either
+    // reaching the filter document unchecked is how a caller-supplied operator gets into a query.
+    for (const bad of [['a', 'b'], { $ne: null }, 7, true, null]) {
+      const f = buildMemoryFilter({ tag: bad, entity: bad, type: bad, search: bad, description: bad, properties: bad });
+      assert.deepEqual(f, {}, `a ${typeof bad} param must be ignored, got ${JSON.stringify(f)}`);
+    }
+  });
+
+  it('an empty query produces an empty filter, not a match-nothing one', () => {
+    assert.deepEqual(buildMemoryFilter({}), {});
+  });
+
+  it('an empty-string param is treated as absent', () => {
+    assert.deepEqual(buildMemoryFilter({ tag: '', entity: '', type: '', search: '' }), {});
+  });
+});


### PR DESCRIPTION
Last of the QA tracker's *"modules with no importing test"* worth testing standalone. Three things in `api/brain/_shared.ts` decide something consequential and none was covered.

## TTL parsing decides when records get deleted

`ttlDaysFromBody` and `ttlDaysError` are a **parse/validate pair**, and the test that carries the weight asserts they can never *disagree*:

- anything the validator **rejects** must not survive parsing — or an invalid TTL reaches a record
- anything it **accepts** must not be dropped — or a valid TTL is silently ignored

Both directions matter and neither is obvious from reading either function alone.

`0` — "no expiry" — is a real value, not a missing one. `null` — "clear" — is distinct from absent. A truthiness check anywhere in that path collapses two different instructions into one.

## `applyValidation` is where `strict` actually blocks

The full off / warn / strict matrix is pinned. If strict stops blocking, **every schema in every space quietly becomes advisory** and nothing anywhere says so.

## `buildMemoryFilter` only lets strings into the filter document

`?tag[]=a&tag[]=b` parses to an array, and an object-valued param is trivially forgeable. Either reaching a Mongo query unchecked is how a caller-supplied operator gets in. The `typeof` guards are the protection, so they are what the test pins.

## Mutation-checked

| mutant | test killed |
|---|---|
| TTL upper bound widened | the agreement test |
| `strict` made non-blocking | strict blocks and reports |
| one `typeof` guard dropped | non-string param ignored |

## One note on the test itself

I rewrote the agreement assertion before committing. The first version was a one-liner with a nested ternary and a `Symbol` sentinel that I could not read back a minute later — which means I could not tell whether it was vacuous. It is now three explicit branches.

## This closes the item

Two modules are deliberately left without a standalone test, with the reasons **recorded in the tracker** rather than left as a silent gap:

- `db/mongo.ts` — the `$vectorSearch` probe needs a live Mongo and is already exercised by the integration suite. Mocking the driver would assert only that the mock behaves like the mock.
- `util/errors.ts` — two five-line `Error` subclasses with no logic. This tracker's own rule is that counting tests is not counting coverage.

`_TODO-ORDERED.md` §1 now holds only the two UX rows, both of which say "pick up alongside other work" in their own text.

`npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
