### PR TITLE
feat(metrics): count the recalls that answered with a weaker pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ythril_recall_degraded_total` — a counter for the answers that are quietly worse.** Every other
+  metric measures work done or work failed. This one measures the gap: recall answered, HTTP 200, and a
+  weaker pipeline than the instance is configured for. A reranker unreachable for a week produces no
+  failed requests, no error rate and no latency change worth noticing — every recall simply comes back in
+  vector order and nobody is told.
+  - Two reasons: `rerank_unavailable` (configured but it did not answer) and `rerank_skipped_budget`
+    (not attempted; `RECALL_BUDGET_MS` was already spent upstream). Both already logged a warning — a log
+    line explains one occurrence and is the wrong place to notice a *pattern*.
+  - Both series report `0` from process start: absent and zero render identically on a graph and mean
+    opposite things.
+  - **A missing lexical channel is deliberately not counted.** `applyLexicalFusion` cannot yet tell "this
+    space has no text index" from "the query matched nothing", so a counter there would fire on ordinary
+    queries and report degradation where there is none. A metric an operator learns to ignore will not be
+    read on the day it matters. The omission is recorded in code and pinned by a test.
+
 - **MCP recall responses are about half the size, and `includeContent: false` makes them a fifth.**
   Every field an MCP tool returns is multiplied by `topK` and billed as tokens to whoever called it — the
   REST caller is a program and can afford detail, the MCP caller is a model's context window and cannot.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -5129,6 +5129,7 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_sync_items_pulled_total` | counter | Items received by type |
 | `ythril_sync_items_pushed_total` | counter | Items sent by type |
 | `ythril_sync_duration_seconds` | histogram | Time per sync cycle |
+| `ythril_recall_degraded_total` | counter | Recalls answered with a **weaker pipeline than configured**, by `reason`. `rerank_unavailable` = the cross-encoder is configured but did not answer; `rerank_skipped_budget` = it was not attempted because the end-to-end `RECALL_BUDGET_MS` was already spent upstream. **This is the one to alert on**: these paths return HTTP 200 with a worse ranking, so they raise no error rate and barely move latency — a reranker down for a week is otherwise invisible. Both series report `0` from process start, so absent-vs-zero is never ambiguous. |
 
 Default Node.js process metrics (`nodejs_*`, `process_*`) are also included via [prom-client](https://github.com/siimon/prom-client)'s `collectDefaultMetrics()`.
 

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -17,6 +17,7 @@ import { rerank, rerankConfigured, candidateMultiplier, MAX_CANDIDATES } from '.
 import { lexicalSearch, rrfFuse, hybridSearchEnabled, LEXICAL_LIMIT_MULTIPLIER } from './lexical-search.js';
 import type { ChronoStatus } from '../config/types.js';
 import { log } from '../util/log.js';
+import { recallDegradedTotal } from '../metrics/registry.js';
 
 /**
  * End-to-end budget for one recall call.
@@ -222,6 +223,7 @@ export async function recall(
   // order — slightly worse ranking, delivered. Degrading beats being right too late.
   const remaining = RECALL_BUDGET_MS - (Date.now() - startedAt);
   if (reranking && remaining < RERANK_MIN_BUDGET_MS) {
+    recallDegradedTotal.labels({ reason: 'rerank_skipped_budget' }).inc();
     log.warn(`Recall: ${remaining}ms of the ${RECALL_BUDGET_MS}ms budget left — skipping the reranker and returning the fused order`);
   } else if (reranking) {
     await applyRerank(query, guaranteed, allResults, remaining);
@@ -408,7 +410,12 @@ async function applyRerank(
 
   const passages = ids.map(id => rerankTextOf(byId.get(id)![0]));
   const scores = await rerank(query, passages, budgetMs);
-  if (!scores) return; // no opinion — vector order stands
+  if (!scores) {
+    // Configured but it did not answer. `rerank()` already logged why; this is what makes a reranker
+    // that has been down for a week visible without anyone reading a week of logs.
+    recallDegradedTotal.labels({ reason: 'rerank_unavailable' }).inc();
+    return; // no opinion — vector order stands
+  }
 
   for (const { index, score } of scores) {
     const id = ids[index];

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -354,3 +354,41 @@ export const mediaJobsFailed = new Gauge({
     } catch { /* ignore */ }
   },
 });
+
+// ── Silent degradation ───────────────────────────────────────────────────────
+/**
+ * Recall answered, but with a weaker pipeline than the instance is configured for.
+ *
+ * Every other counter here measures work done or work failed. This one measures the gap between them:
+ * the paths where nothing errors, the caller gets a 200, and the answer is quietly worse than it should
+ * be. A reranker that has been unreachable for a week produces no failed requests, no error rate, no
+ * change in latency worth noticing — every recall simply comes back in vector order and nobody is told.
+ * The same is true of a space whose lexical index is missing, and of a rerank skipped because the
+ * end-to-end budget had already been spent upstream.
+ *
+ * These already log a warning each. A log line is the right place to explain ONE occurrence and the
+ * wrong place to notice a pattern — nobody greps a week of logs to discover that recall quality has been
+ * degraded the whole time. A counter turns "is my reranker actually being used?" into a question the
+ * operator can answer, and alert on.
+ *
+ * `reason` is a closed set, deliberately: an unbounded label is a cardinality bomb.
+ *  - `rerank_unavailable`    — configured, but it did not answer (unreachable, non-2xx, unreadable body)
+ *  - `rerank_skipped_budget` — not attempted; the end-to-end budget was already spent (see RECALL_BUDGET_MS)
+ *
+ * **A missing lexical channel is deliberately NOT counted here.** `applyLexicalFusion` cannot currently
+ * tell "this space has no text index" from "the query matched nothing lexically" — both surface as an
+ * empty result. Counting that would fire on ordinary queries and report degradation where there is none,
+ * which is worse than not measuring it: a metric an operator learns to ignore is a metric that will not
+ * be read on the day it matters. Wire it only once `lexicalSearch` distinguishes the two.
+ */
+export const recallDegradedTotal = new Counter({
+  name: 'ythril_recall_degraded_total',
+  help: 'Recalls answered with a weaker pipeline than configured, by reason',
+  labelNames: ['reason'] as const,
+  registers: [register],
+});
+// Pre-declare every series so a scrape before the first degradation reports 0 rather than nothing at
+// all — "absent" and "zero" look identical in a graph and mean opposite things.
+for (const reason of ['rerank_unavailable', 'rerank_skipped_budget']) {
+  recallDegradedTotal.labels({ reason }).inc(0);
+}

--- a/testing/standalone/recall-degraded-metric.test.js
+++ b/testing/standalone/recall-degraded-metric.test.js
@@ -1,0 +1,68 @@
+/**
+ * Silent degradation is counted, and only where it can be counted honestly.
+ *
+ * Every other counter in the registry measures work done or work failed. This one measures the gap
+ * between them: recall answered, 200, and the answer was quietly worse than the instance is configured
+ * to produce. A reranker unreachable for a week generates no failed requests, no error rate and no
+ * latency change worth noticing — every recall simply comes back in vector order and nobody is told.
+ *
+ * The tests worth having here are about **trustworthiness of the metric**, not the plumbing:
+ *
+ *  1. Both series exist from process start. "Absent" and "zero" render identically on a graph and mean
+ *     opposite things — a scrape before the first degradation must say 0, not nothing.
+ *  2. The label set is CLOSED. An unbounded `reason` is a cardinality bomb.
+ *  3. Every declared reason is actually incremented somewhere. A label that can only ever read 0 is
+ *     worse than no label: an operator reads it as "this never happens".
+ *
+ * Run: node --test testing/standalone/recall-degraded-metric.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let register, recallDegradedTotal;
+
+before(async () => {
+  ({ register, recallDegradedTotal } = await import('../../server/dist/metrics/registry.js'));
+});
+
+const REASONS = ['rerank_unavailable', 'rerank_skipped_budget'];
+
+describe('ythril_recall_degraded_total', () => {
+  it('exposes every reason at zero before anything has degraded', async () => {
+    const metrics = await register.metrics();
+    for (const reason of REASONS) {
+      assert.match(metrics, new RegExp(`ythril_recall_degraded_total\\{reason="${reason}"\\} 0`),
+        `${reason} must be pre-declared — an absent series and a zero series look the same on a graph`);
+    }
+  });
+
+  it('counts up when a degradation is recorded', async () => {
+    recallDegradedTotal.labels({ reason: 'rerank_unavailable' }).inc();
+    const metrics = await register.metrics();
+    assert.match(metrics, /ythril_recall_degraded_total\{reason="rerank_unavailable"\} 1/);
+    // …and does not disturb its sibling.
+    assert.match(metrics, /ythril_recall_degraded_total\{reason="rerank_skipped_budget"\} 0/);
+  });
+
+  it('every declared reason is incremented somewhere in the source', () => {
+    // A label that can only ever read 0 tells an operator "this never happens", which is a stronger and
+    // more misleading claim than saying nothing at all.
+    const recall = readFileSync('server/src/brain/recall.ts', 'utf8');
+    for (const reason of REASONS) {
+      assert.ok(recall.includes(`reason: '${reason}'`), `${reason} is declared but never incremented`);
+    }
+  });
+
+  it('the lexical channel is deliberately NOT counted, and the reason is recorded', () => {
+    // `applyLexicalFusion` cannot tell "no text index" from "nothing matched" — both are an empty
+    // result. Counting it would fire on ordinary queries and report degradation where there is none.
+    // A metric an operator learns to ignore will not be read on the day it matters.
+    const registrySrc = readFileSync('server/src/metrics/registry.ts', 'utf8');
+    assert.ok(!registrySrc.includes("'lexical_unavailable'"),
+      'the lexical reason must not be declared until it can be distinguished from a normal empty result');
+    assert.match(registrySrc, /deliberately NOT counted/,
+      'the omission must be explained, or someone will "fix" it by adding a misleading counter');
+  });
+});

--- a/testing/standalone/rerank.test.js
+++ b/testing/standalone/rerank.test.js
@@ -185,7 +185,16 @@ describe('recall wiring', () => {
   });
 
   it('a null from the reranker leaves every result untouched', () => {
+    // Asserted as a PROPERTY, not as literal source. This used to match `if (!scores) return;`
+    // character-for-character and broke when a metrics counter was added inside the same branch —
+    // the behaviour was identical and the test failed anyway. What must hold is that a falsy `scores`
+    // returns before anything is assigned to `rerankScore`.
     const fn = src.slice(src.indexOf('async function applyRerank('));
-    assert.ok(/if \(!scores\) return;/.test(fn), 'no opinion must mean the vector order stands');
+    const guard = fn.indexOf('if (!scores)');
+    const assigns = fn.indexOf('rerankScore =');
+    assert.ok(guard > 0, 'a falsy rerank result must be guarded');
+    assert.ok(assigns > guard, 'the guard must come before any score is applied');
+    const branch = fn.slice(guard, assigns);
+    assert.ok(/\breturn\b/.test(branch), 'no opinion must mean the vector order stands — return early');
   });
 });


### PR DESCRIPTION
Observability lens.

## The gap

Every other counter in the registry measures **work done** or **work failed**. Nothing measured the gap between them: recall answered, HTTP **200**, and the answer quietly worse than the instance is configured to produce.

A reranker unreachable for a week generates no failed requests, no error rate, and no latency change worth noticing. Every recall simply comes back in vector order and nobody is told. Same for a rerank skipped because the end-to-end budget was already spent upstream — a path **this session added**, so the gap is partly mine.

Both already log a warning. A log line is the right place to explain **one occurrence** and the wrong place to notice a **pattern**: nobody greps a week of logs to discover that search quality has been degraded the whole time.

## `ythril_recall_degraded_total{reason}`

| reason | meaning |
|---|---|
| `rerank_unavailable` | configured, but it did not answer — unreachable, non-2xx, unreadable body |
| `rerank_skipped_budget` | not attempted; `RECALL_BUDGET_MS` was already spent upstream |

Both series pre-declared at `0`. An absent series and a zero series render identically on a graph and mean opposite things.

## The part worth arguing with

**A missing lexical channel is deliberately NOT counted**, even though it is the obvious third reason.

`applyLexicalFusion` cannot currently tell *"this space has no text index"* from *"the query matched nothing lexically"* — both surface as an empty result. A counter there would fire on ordinary queries and report degradation where there is none, and **a metric an operator learns to ignore will not be read on the day it matters**.

Two reasons that can be trusted beat three where one is noise. The omission is explained in the code, and a test pins both the absence *and* the explanation — so the next person to spot the gap finds the reasoning rather than "fixing" it.

## Also

De-brittled an existing assertion in `rerank.test.js`. It matched the literal source `if (!scores) return;` character-for-character and broke the moment the counter went into that branch — identical behaviour, failing test. **Preflight caught it**, which is what preflight is for. It now asserts the property: the guard exists, precedes any score assignment, and returns.

Documented in the metrics table with a note that this is the one to alert on.

`npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
