### PR TITLE
fix(security): the crash handlers were printing raw errors past the redactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Crash handlers wrote the raw error to the console, bypassing redaction entirely.** `log.*` redacts;
+  `console.*` does not. Three sites — `unhandledRejection`, `uncaughtException` and the fatal-startup
+  catch — logged a redacted line to the ring buffer and then printed the **unredacted** error object to
+  stdout, immediately below it. **Stdout is what a container log collector captures**, so the copy that
+  travelled was the unsafe one.
+  - It is the highest-risk path there is for this: an unhandled `fetch` rejection quotes the endpoint it
+    failed on, and that endpoint may carry a credential in its userinfo or query string.
+  - `redactSecrets` is now exported and applied at all three, plus three more in the local-agent
+    connector — a separate process that never had a logger of its own.
+  - **A new `console-redaction-coverage` preflight gate** fails the build if any `console.*` in
+    `server/src` passes a raw error value. Static console output — the startup banner, a listening
+    address — is unaffected and stays. Mutation-checked: reinstating the old crash-handler line fails it.
+
 - **The logger now redacts credentials carried inside a URL.** `audit-changes.ts` keeps webhook routes
   out of the audit log **entirely**, and says why: *"a webhook URL can embed [a credential] in userinfo
   or a query string"*. That reasoning had been applied to the audit store and not to the application

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -37,6 +37,7 @@ const SOURCE_GATES = [
   ['doc-cited-constants', 'a number the docs quote that no longer matches the constant it quotes'],
   ['help-docs-coverage', 'a guide that ships but the in-product Help page never offers, or offers and cannot load'],
   ['help-anchor-coverage', 'a help link whose anchor matches no heading — it opens the guide and scrolls nowhere'],
+  ['console-redaction-coverage', 'an error written straight to the console, bypassing the redaction log.* applies'],
 ];
 
 /** Gates that import from server/dist and therefore need a build. */

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,7 +8,7 @@ import { stopSyncScheduler } from './sync/engine.js';
 import { stopBackupScheduler } from './db/backup-scheduler.js';
 import { stopDupeScanner } from './brain/dupe-scanner.js';
 import { cleanupStaleChunks } from './files/chunks.js';
-import { log } from './util/log.js';
+import { log, redactSecrets } from './util/log.js';
 
 // Enable debug logging when --debug flag is passed or DEBUG env is already set.
 if (process.argv.includes('--debug')) {
@@ -216,18 +216,21 @@ async function main(): Promise<void> {
 
   // Crash handlers — catch unhandled rejections/exceptions so they are logged
   // instead of silently killing the process.
+  // Both write to the console as well as the ring buffer on purpose: a dying process may never have
+  // its buffer read. Both go through redactSecrets first — an unhandled fetch rejection quotes the
+  // endpoint it failed on, and that endpoint may carry a credential in its userinfo or query string.
   process.on('unhandledRejection', (reason, promise) => {
     log.error(`Unhandled rejection at: ${promise}, reason: ${reason}`);
-    console.error('UNHANDLED REJECTION:', reason);
+    console.error(redactSecrets(`UNHANDLED REJECTION: ${String(reason)}`));
   });
   process.on('uncaughtException', (err) => {
     log.error(`Uncaught exception: ${err.stack ?? err}`);
-    console.error('UNCAUGHT EXCEPTION:', err);
+    console.error(redactSecrets(`UNCAUGHT EXCEPTION: ${err.stack ?? String(err)}`));
     process.exit(1);
   });
 }
 
 main().catch(err => {
-  console.error('Fatal startup error:', err);
+  console.error(redactSecrets(`Fatal startup error: ${err?.stack ?? String(err)}`));
   process.exit(1);
 });

--- a/server/src/local-agent-connector/index.ts
+++ b/server/src/local-agent-connector/index.ts
@@ -3,6 +3,9 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+// This process writes only to the console. `redactSecrets` is the same rule `log.*` applies on the
+// server side; `util/log.ts` has no imports of its own, so borrowing it costs nothing.
+import { redactSecrets } from '../util/log.js';
 import { spawn } from 'node:child_process';
 import { z } from 'zod';
 
@@ -31,7 +34,7 @@ function loadOrCreateToken(): string {
       if (fileToken) return fileToken;
     }
   } catch (err) {
-    console.error(`FATAL: unable to read connector token file '${TOKEN_FILE}': ${err}`);
+    console.error(redactSecrets(`FATAL: unable to read connector token file '${TOKEN_FILE}': ${err}`));
     process.exit(1);
   }
 
@@ -42,7 +45,7 @@ function loadOrCreateToken(): string {
     fs.writeFileSync(TOKEN_FILE, generated + '\n', { encoding: 'utf8', mode: 0o600 });
     return generated;
   } catch (err) {
-    console.error(`FATAL: unable to create connector token file '${TOKEN_FILE}': ${err}`);
+    console.error(redactSecrets(`FATAL: unable to create connector token file '${TOKEN_FILE}': ${err}`));
     process.exit(1);
   }
 }
@@ -420,7 +423,7 @@ app.listen(PORT, HOST, () => {
           return ensureUserModeTunnelRunning(DEFAULT_TUNNEL_NAME);
         })
         .then(msg => { if (msg) console.log(`[ythril-local-connector] auto-resume: ${msg}`); })
-        .catch(err => { console.error(`[ythril-local-connector] auto-resume error: ${err}`); });
+        .catch(err => { console.error(redactSecrets(`[ythril-local-connector] auto-resume error: ${err}`)); });
     }
   }
 });

--- a/server/src/util/log.ts
+++ b/server/src/util/log.ts
@@ -36,6 +36,16 @@ const SECRET_QUERY_PARAMS = /([?&](?:token|api[-_]?key|access[-_]?token|auth|sec
  */
 const URL_USERINFO = /([a-z][a-z0-9+.\-]*:\/\/)[^\s/@]+@/gi;
 
+/**
+ * Exported so the few places that legitimately write straight to the console — the crash handlers,
+ * which must still say something when the process is dying and the ring buffer may never be read — can
+ * apply the same rules. A `console.error(err)` beside a redacted `log.error` is not belt and braces; it
+ * is the braces quietly undoing the belt, because stdout is what a container log collector captures.
+ */
+export function redactSecrets(msg: string): string {
+  return redact(msg);
+}
+
 function redact(msg: string): string {
   return msg
     .replace(/Bearer\s+[A-Za-z0-9_.\-]+/gi, REDACTED)

--- a/testing/standalone/console-redaction-coverage.test.js
+++ b/testing/standalone/console-redaction-coverage.test.js
@@ -1,0 +1,84 @@
+/**
+ * Nothing writes an error object straight to the console, bypassing redaction.
+ *
+ * `log.*` redacts — Bearer tokens, URL userinfo, credential-bearing query params. `console.*` does not.
+ * So a `console.error('...', err)` sitting beside a redacted `log.error` is not belt and braces; it is
+ * the braces quietly undoing the belt, and it is the copy that matters: **stdout is what a container log
+ * collector captures**, while the ring buffer is read by whoever thinks to open the logs page.
+ *
+ * That is exactly what the crash handlers did — the one path most likely to be holding a URL, because an
+ * unhandled fetch rejection quotes the endpoint it failed on.
+ *
+ * Static console output (a startup banner, a listening address) is fine and stays. What must never
+ * happen again is an *error value* reaching the console unredacted.
+ *
+ * Run: node --test testing/standalone/console-redaction-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+
+const ROOT = 'server/src';
+
+/** Every .ts file under server/src, excluding tests. */
+function sources(dir = ROOT, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = `${dir}/${name}`;
+    if (statSync(p).isDirectory()) { sources(p, out); continue; }
+    if (p.endsWith('.ts') && !p.endsWith('.test.ts')) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * A console call is suspicious when it passes a bare error-ish identifier.
+ *
+ * Deliberately narrow: `console.log('listening on ...')` is not a problem and never was. The risk is an
+ * `Error`, a rejection reason, or a caught exception — the values that carry a stack, a URL and, if you
+ * are unlucky, a credential inside it.
+ */
+const SUSPICIOUS = /console\.(?:error|warn|log|info|debug)\([^)]*(?<![\w.$])(?:err|error|reason|e|ex|exception)(?![\w$])/;
+
+describe('console output cannot bypass the redactor', () => {
+  const files = sources();
+
+  it('finds the source tree', () => {
+    assert.ok(files.length > 50, `expected a populated source tree, got ${files.length} files`);
+  });
+
+  it('no console call passes a raw error value', () => {
+    const offenders = [];
+    for (const f of files) {
+      const lines = readFileSync(f, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        // Comments talk ABOUT console calls — including the ones explaining this very rule.
+        const t = line.trim();
+        if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return;
+        if (!SUSPICIOUS.test(line)) return;
+        // Redacted is fine — that is the whole point.
+        if (line.includes('redactSecrets(')) return;
+        offenders.push(`${f}:${i + 1}  ${line.trim().slice(0, 100)}`);
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'these write an error value to the console without redaction — stdout is what the log collector ' +
+      'captures, so this defeats the redaction that log.* applies:\n' + offenders.join('\n'));
+  });
+
+  it('the crash handlers specifically go through redactSecrets', () => {
+    // Named explicitly because they are the highest-risk path (an unhandled fetch rejection quotes the
+    // endpoint) and because a future refactor is most likely to "simplify" them back.
+    const src = readFileSync(`${ROOT}/index.ts`, 'utf8');
+    for (const handler of ['unhandledRejection', 'uncaughtException']) {
+      const at = src.indexOf(handler);
+      assert.ok(at > 0, `${handler} handler should exist`);
+      const block = src.slice(at, at + 400);
+      assert.ok(block.includes('redactSecrets('), `${handler} must redact before writing to the console`);
+    }
+  });
+
+  it('the redactor is actually exported for them to use', () => {
+    const logSrc = readFileSync(`${ROOT}/util/log.ts`, 'utf8');
+    assert.match(logSrc, /export function redactSecrets/);
+  });
+});


### PR DESCRIPTION
#544 made the logger redact credentials inside a URL. **This is the hole immediately next to it.**

## The redaction was decoration on the path that mattered

`log.*` redacts. `console.*` does not. The crash handlers did **both**:

```ts
log.error(`Unhandled rejection at: ${promise}, reason: ${reason}`);  // redacted → ring buffer
console.error('UNHANDLED REJECTION:', reason);                       // RAW → stdout
```

**Stdout is what a container log collector captures.** The ring buffer is what someone reads if they think to open the logs page. So the copy that actually travelled off the box was the unsafe one.

It is also the worst possible path for this: an unhandled `fetch` rejection quotes the endpoint it failed on — exactly the kind of URL that carries a credential in its userinfo or query string, which is the case #544 exists for.

## Fixed

`redactSecrets` is exported and applied at all three sites (`unhandledRejection`, `uncaughtException`, fatal-startup catch), plus three more in the **local-agent connector** — a separate process that never had a logger of its own. `util/log.ts` has no imports, so borrowing the function there costs nothing.

## The durable part is the gate

`console-redaction-coverage` fails the build if any `console.*` under `server/src` passes a raw error-ish value. The redaction is now **unbypassable rather than merely present**.

Static console output — the startup banner, the listening address — is untouched and stays. The rule is about error *values*, which are the things carrying stacks and URLs.

## Writing the gate found things I hadn't looked at

- **three real offenders** in the local-agent connector
- **one false positive**: my own doc comment in `log.ts`, which mentions `console.error(err)` while explaining why not to write it

Comment lines are now skipped. That is the right fix — a gate that trips on prose about itself teaches people to weaken the gate.

**Mutation-checked:** reinstating the old crash-handler line fails it.

`npm run preflight` green, with the new gate registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
