### PR TITLE
refactor(config): name the media env vars after what they configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **"Diagnosing a Misconfiguration" — the deployment guide now answers the question operators were
+  answering by trial and error.** Prompted by a 2.0.0 Kubernetes report in which a correct configuration
+  was refused and the only evidence was a string in a dialog. Most problems here are *config that looks
+  right and is declined*, not crashes, and nothing told an operator which of the three status endpoints
+  answered which question.
+  - **Which endpoint answers what**, in order: `/api/about/security` (is the config coherent?),
+    `/api/about/health` (are components reachable?), `/ready` (should this pod take traffic?) — with what
+    each one deliberately does *not* answer, so `/ready` ignoring optional sidecars reads as design rather
+    than an omission.
+  - **A symptom → cause table** covering the refusals that produce identical-looking failures for very
+    different reasons: private address vs crown-jewel address vs DNS returning nothing.
+  - **How to read the posture block**, including the one phrase that inverts if misread: *"not resolved
+    here"* is the absence of a verdict, while *"nothing is using the permission; unset it"* is a verdict.
+  - **Why one private endpoint works and another does not** — render sidecars use a plain fetch, model
+    endpoints go through the egress guard. A green sidecar beside a refused model endpoint proves DNS and
+    reachability are fine and the difference is policy. That is precisely the observation that located
+    the probe bug above, so it is now written down instead of rediscovered.
+  - **First-boot duration** — an expected 30–90 s range, what drives it, and the warning that sizing
+    `startupProbe` to the warm-boot time turns a normal first boot into a crashloop.
+
+- **Version annotations, so a reader can tell what applies to their instance.** The guide tracks the
+  latest release; anything added after 2.0.0 now carries `*New in <version>.*` under its heading, with a
+  "Which version does this describe?" summary of the 2.1 changes at the top. Requested by a reader working
+  from current docs against a 2.0.0 deployment with no way to tell the two apart.
+
 - **`ythril_recall_degraded_total` — a counter for the answers that are quietly worse.** Every other
   metric measures work done or work failed. This one measures the gap: recall answered, HTTP 200, and a
   weaker pipeline than the instance is configured for. A reranker unreachable for a week produces no
@@ -193,6 +218,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the embedded string, so changing it invalidates the corpus exactly as a model change does.
 
 ### Changed
+
+- **The media env vars are named after what they configure, not after what once implemented them.**
+  `OLLAMA_URL` → **`VISION_BASE_URL`**, `WHISPER_URL` → **`STT_BASE_URL`**, `WHISPER_MODEL` →
+  **`STT_MODEL`**.
+  - `OLLAMA_URL` is the sharpest case: it sets `vision.baseUrl`, which is used **even when
+    `visionProvider` is `external`**. An operator running vLLM or llama.cpp had to set a variable named
+    after a product they were not running — assuming they found it at all. `WHISPER_URL` / `WHISPER_MODEL`
+    did the same to anyone whose STT backend is not Whisper; reported by a deployment running Qwen3-ASR.
+  - This is the distinction the provider switch already gets right and states in its own documentation:
+    **the setting names a wire protocol, not a product.** These three names contradicted it.
+  - **The old names keep working, indefinitely.** Breaking a documented env var to improve its spelling is
+    not a worthwhile trade, and an operator upgrading for a security fix should not also be handed an
+    outage. Each legacy name logs one `warn` at startup naming its replacement — a silent alias is one
+    nobody migrates off, and the deprecation never ends.
+  - **If both spellings are set, the new one wins and the log says so.** A value that is visibly present
+    in your own manifest and silently absent in effect is among the most expensive things to debug.
+  - `lockedByInfra` tracks whichever spelling was used, so the Settings UI renders the field read-only
+    either way. Keying it off the new name alone would have left the control editable while the legacy
+    env var overrode every save — the same "looks configured, isn't" shape as the probe bug above.
+  - The default vision **label** now follows the resolved provider too: an `external` provider is no
+    longer labelled `(Ollama-compatible)`, a protocol it does not speak.
 
 - **The Brain's tab identifiers are one union instead of two hand-synced ones.** `BrainTab` lived in
   `brain.component.ts` and a subset of it was re-declared as `StatKey` in `overview-tab.component.ts` for

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6,6 +6,27 @@ Audience: integrators building clients, automation, or multi-instance deployment
 
 If you are here for web UI usage, read [User Guide](userguide.md). If you are contributing to source code, read [Contribution Guide](contribution-guide.md).
 
+## Which version does this describe?
+
+This guide tracks the **latest release**, so a section may document something your instance does not have
+yet. Anything added after 2.0.0 is marked `*New in <version>.*` directly under its heading — an unmarked
+section has been there since 2.0.0 or earlier. `GET /api/about` reports the version you are running.
+
+**New in 2.1**, in rough order of how likely you are to notice it:
+
+| Area | What changed |
+|---|---|
+| Retrieval | Hybrid search — a lexical channel fused into `recall` by RRF; optional cross-encoder reranking |
+| Diagnosis | [Diagnosing a Misconfiguration](#diagnosing-a-misconfiguration); every egress refusal is now logged with the setting that would permit it |
+| Config | `OLLAMA_URL` → `VISION_BASE_URL`, `WHISPER_URL` → `STT_BASE_URL`, `WHISPER_MODEL` → `STT_MODEL` (old names still work, and warn) |
+| Lifecycle | Graceful shutdown actually drains; `/ready` fails first (`SHUTDOWN_DRAIN_MS`, `SHUTDOWN_READY_GRACE_MS`) |
+| Recall | An end-to-end budget (`RECALL_BUDGET_MS`, `RERANK_MIN_BUDGET_MS`) and a `ythril_recall_degraded_total` metric |
+| Brain | Space completeness scoring; Review → Suggestions |
+| MCP | Roughly half-size recall responses; `includeContent: false` for a fifth |
+| Posture | `mcp.publicUrl`; endpoint classes no longer imply a DNS resolution that did not happen |
+
+Full detail in [CHANGELOG.md](https://github.com/ythril-network/Ythril/blob/main/CHANGELOG.md).
+
 ---
 
 ## Table of Contents
@@ -294,6 +315,98 @@ Levels are `pass` / `warn` / `fail` (`fail` = actively broken, e.g. `requireEncr
 `trustProxy`, so requests would 403). Set **`security.strict`** (config) or **`YTHRIL_SECURITY_STRICT=true`**
 to make any `fail` finding abort boot — the aggregate "don't start if misconfigured" switch, on top of the
 individual `require*` flags.
+
+### Diagnosing a Misconfiguration
+
+*New in 2.1.*
+
+Most deployment problems here are **configuration that looks correct and is refused**, not crashes. The
+instance is designed so you never have to guess which: three endpoints answer three different questions,
+and every refusal names the setting that would permit it.
+
+#### Start here, in this order
+
+| Ask | Endpoint | Answers | Does **not** answer |
+|---|---|---|---|
+| 1. Is my config coherent? | `GET /api/about/security` | Which settings conflict, which are unused, which would break something | Whether anything is reachable |
+| 2. Are my components reachable? | `GET /api/about/health` | Per-component `configured` / `reachable` / `impact` | Whether the instance should serve traffic |
+| 3. Should this pod take traffic? | `GET /ready` | MongoDB + vector search only | Anything about sidecars or models — **by design** |
+
+`/ready` deliberately ignores optional components. Folding a dead render sidecar into it would let a
+degraded feature pull a healthy instance out of the load balancer.
+
+#### The single most useful habit: read the posture block
+
+It prints at boot and is live at `GET /api/about/security`. Every line is written to be actionable — a
+`warn` or `fail` names the setting, the observed value, and what changes if you act. Two conventions
+worth knowing, because they are easy to misread:
+
+- **"nothing is using the permission; unset it"** means exactly that: the flag is on and provably
+  unnecessary. Acting on it is safe.
+- **"not resolved here"** means the opposite of a verdict. The posture check is synchronous and does
+  **not** resolve DNS — resolving at boot would hang the block on a slow resolver. An endpoint written as
+  a hostname is reported as `(hostname, not resolved here)`, and on a cluster where everything is a
+  `*.svc.cluster.local` name, *none* of them will be counted as private. **That is not evidence the
+  permission is unused.** Only endpoints written as IP literals can be classified from config alone.
+
+#### Symptom → where to look
+
+| Symptom | First check | Usual cause |
+|---|---|---|
+| A model endpoint is refused with `Blocked SSRF target` | the `warn` line the guard logged | private address without `allowPrivateModelEndpoints` |
+| Endpoint refused, and the address it names is `169.254.*` / loopback | same | a crown-jewel address — **no** flag permits these |
+| Endpoint refused with `DNS returned no records` | cluster DNS | not a policy decision at all; the name did not resolve |
+| Nobody can sign in after enabling OIDC | `oidc.issuer` in the posture block | private issuer without `oidc.allowPrivateIssuer` |
+| MCP works with a bearer token, browser connectors will not authorize | `mcp.publicUrl` in the posture block | `publicUrl` unset → loopback issuer |
+| A setting in the UI is read-only | `lockedByInfra` in `GET /api/admin/media-config` | an env var is pinning it |
+| A value in your manifest has no effect | startup log | you set a legacy env var alias *and* its replacement |
+| Every API call 403s behind a proxy | `transport.trustProxy` in the posture block | `requireEncryptedTransport` on without `trustProxy` |
+
+#### Every egress refusal is logged
+
+An SSRF refusal writes one `warn` line naming the target, the address it resolved to, and the setting
+that would permit it — so a blocked endpoint is diagnosable from `kubectl logs`, not only from whatever
+a dialog happened to show:
+
+```text
+WARN  Blocked SSRF target (llm.llm.svc.cluster.local resolves to blocked address 10.43.90.115)
+      — if this address is meant to be reachable, set allowPrivateModelEndpoints
+      (YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true) for a self-hosted model endpoint, or
+      allowPrivatePeers for a sync peer
+```
+
+The line is redacted like any other, so a key in a query string is not echoed into your log collector.
+
+Grep for `Blocked SSRF target` to see every refusal at once. If your endpoint fails and **nothing** is
+logged, the failure is not the egress guard — look at `GET /api/about/health` instead.
+
+#### Why one endpoint works and another on the same subnet does not
+
+Two private addresses in the same cluster can behave differently, and that is not a bug in your network:
+
+- **Render/conversion sidecars** (`CONVERSION_SIDECAR_URL`, doc-render) are reached with a plain `fetch`.
+  They are declared infrastructure, expected to be private, and are not subject to the egress guard.
+- **Model provider endpoints** (vision, STT, embedding, rerank, NLI, document assist) go through the
+  SSRF-guarded fetch, because those URLs are admin-settable and become egress targets.
+
+So a green sidecar next to a refused model endpoint tells you cluster DNS and reachability are fine, and
+the difference is policy. That is the point at which `allowPrivateModelEndpoints` is the answer.
+
+#### First boot takes longer than you expect
+
+A cold start does work that no later start repeats: creating vector and lexical search indexes for each
+space, and — on the bundled configuration — loading the in-process embedding model.
+
+- **Subsequent boots:** a few seconds to ready.
+- **First boot:** commonly **30–90 s**, and legitimately several minutes on a slow disk, a cold image
+  pull, or a MongoDB that is itself still starting.
+
+Size `startupProbe.failureThreshold × periodSeconds` to cover that, and let `livenessProbe` start only
+after the startup probe succeeds. A startup budget tuned to the warm-boot time turns a normal first boot
+into a crashloop, which then looks like a failure to start rather than a probe that was too impatient.
+
+Note also that a newly created space returns immediately with `indexStatus: "building"` — it is writable
+at once, but semantic recall stays empty until the index finishes. That is expected, not a fault.
 
 ### Running Multiple Brains on One Host
 
@@ -2689,12 +2802,29 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `levels.{images,audio,video,text}` | — | `auto` | Per-class instance ceiling; set a class to `off` to take it offline. **This is the media on/off control** (the `enabled` / `MEDIA_EMBEDDING_ENABLED` master switch was removed). |
 | `visionProvider` | `VISION_PROVIDER` | `local` | Wire protocol, not trust level: `local` (Ollama `/api/chat`) or `external` (OpenAI `/chat/completions`). A self-hosted OpenAI-compatible server needs `external` — see `allowPrivateModelEndpoints` for one on a private address. |
 | `sttProvider` | `STT_PROVIDER` | `local` | Wire protocol, not trust level: `local` (bundled Whisper) or `external` (OpenAI-compatible). Both speak `/v1/audio/transcriptions`. |
-| `vision.baseUrl` | `OLLAMA_URL` | `http://ollama:11434` | Vision service endpoint (short name resolves in both Docker Compose and the K8s `ythril` namespace) |
+| `vision.baseUrl` | `VISION_BASE_URL` | `http://ollama:11434` | Vision service endpoint, **whatever the provider** (short name resolves in both Docker Compose and the K8s `ythril` namespace). Legacy alias: `OLLAMA_URL`. |
 | `vision.model` | `VISION_MODEL` | `moondream` | Vision model name |
 | `vision.apiKey` | `VISION_API_KEY` | — | API key for external vision provider (stored in `secrets.json`, never in `config.json`) |
-| `stt.baseUrl` | `WHISPER_URL` | `http://whisper:8000` | STT service endpoint |
-| `stt.model` | `WHISPER_MODEL` | `base` | Whisper model size/name |
+| `stt.baseUrl` | `STT_BASE_URL` | `http://whisper:8000` | STT service endpoint, **whatever the backend**. Legacy alias: `WHISPER_URL`. |
+| `stt.model` | `STT_MODEL` | `base` | STT model name — passed through to the backend, so it is not restricted to Whisper size names. Legacy alias: `WHISPER_MODEL`. |
 | `stt.apiKey` | `STT_API_KEY` | — | API key for external STT provider (stored in `secrets.json`) |
+
+> **Renamed in 2.1: `OLLAMA_URL` → `VISION_BASE_URL`, `WHISPER_URL` → `STT_BASE_URL`, `WHISPER_MODEL` → `STT_MODEL`.**
+>
+> The old names described the implementation that happened to be first, not the field they configure.
+> `OLLAMA_URL` is the sharpest case: it sets `vision.baseUrl`, which is used **even when
+> `visionProvider` is `external`** — so an operator running vLLM or llama.cpp had to set a variable named
+> after a product they were not running, assuming they found it at all. This is the same distinction the
+> provider switch already gets right: **the setting names a wire protocol, not a product.**
+>
+> **The old names keep working.** They are not deprecated-then-removed on a timer — breaking a documented
+> env var to improve its spelling is not a worthwhile trade, and an upgrade should never become an outage.
+> Each one logs a single `warn` at startup naming its replacement. If both spellings are set, the new one
+> wins **and the log says so** — a silently-ignored value that is visibly present in your own manifest is
+> among the most expensive things to debug.
+>
+> `lockedByInfra` tracks whichever spelling you used, so the Settings UI renders the field read-only
+> either way.
 | `embedding.provider` | `EMBEDDING_PROVIDER` | `local` | Text-embedding endpoint trust: `local` (bundled ONNX or an internal HTTP endpoint, plain fetch) or `external` (public endpoint, reached through the SSRF-guarded fetch). Config lives at top-level `config.embedding` but is edited on **Settings → Media Processing**. |
 | `embedding.baseUrl` | `EMBEDDING_URL` | — | Embedding HTTP endpoint (OpenAI-compatible `/v1/embeddings`). Blank = the bundled in-process ONNX model. |
 | `embedding.model` | `EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5` | Embedding model. **Changing the model / `dimensions` / `similarity` / `prefixScheme` re-indexes every vector** (the UI requires an explicit confirmation; `POST /api/brain/spaces/:id/reindex` runs it). |
@@ -3126,6 +3256,8 @@ Returns the full schema definition for a space along with derived stats.
 ---
 
 ### Get Space Completeness
+
+*New in 2.1.*
 
 ```http
 GET /api/spaces/:id/completeness

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -615,6 +615,26 @@ By default, Ythril ships with a bundled vision service (Ollama running `moondrea
 
 Fields shown with an **env** badge cannot be changed from the UI — they are pinned by an environment variable set by your infrastructure administrator. This is normal in managed deployments where credentials are injected by Kubernetes secrets or similar.
 
+### When a provider won't connect
+
+*New in 2.1.*
+
+**Test connection** reports what the server actually gets back, and the failure text names the reason
+rather than just saying it failed. Two cases account for almost all of them:
+
+- **"Blocked SSRF target … resolves to blocked address 10.x / 192.168.x / 172.16-31.x"** — the endpoint
+  is on a private network address. Ythril refuses those by default, because an admin-settable URL that
+  the server will call is the classic way to make a server fetch things it should not. If the endpoint is
+  a model server you run yourself, that refusal is wrong for your case and an administrator can permit it
+  with `allowPrivateModelEndpoints` — see
+  [Diagnosing a Misconfiguration](integration-guide.md#diagnosing-a-misconfiguration). It cannot be
+  enabled from this page, on purpose.
+- **"Blocked SSRF target … 169.254.x" or a loopback address** — these stay blocked whatever the setting.
+  Point the endpoint at a real service address.
+
+Every refusal is also written to the server log with the same detail, so an administrator can find it
+without you having to reproduce the click.
+
 ### Privacy note
 
 When both providers are set to *Local*, no file content ever leaves your instance. Switching to *External* sends image frames or audio segments to the configured endpoint — review your data residency policy before doing so.

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -754,6 +754,59 @@ function normalizeVisionModel(model: string): string {
   return model === 'moondream2' ? 'moondream' : model;
 }
 
+/**
+ * Env vars renamed because their names described the implementation that happened to be first, not the
+ * field they configure.
+ *
+ * `OLLAMA_URL` is the clearest case: it sets `vision.baseUrl`, which is used **even when
+ * `visionProvider` is `external`**. An operator running vLLM or llama.cpp either sets a variable named
+ * after a product they are not using, or never finds it at all. Same mistake in `WHISPER_URL` /
+ * `WHISPER_MODEL`, which configure STT regardless of backend — reported by a deployment running
+ * Qwen3-ASR.
+ *
+ * This is the same distinction the `local` / `external` provider switch already gets right, and says so
+ * in its own documentation: **the setting names a wire protocol, not a product.**
+ */
+const RENAMED_ENV_VARS: ReadonlyArray<{ current: string; legacy: string; configures: string }> = [
+  { current: 'VISION_BASE_URL', legacy: 'OLLAMA_URL', configures: 'vision.baseUrl' },
+  { current: 'STT_BASE_URL', legacy: 'WHISPER_URL', configures: 'stt.baseUrl' },
+  { current: 'STT_MODEL', legacy: 'WHISPER_MODEL', configures: 'stt.model' },
+];
+
+/** One warning per legacy name per process — this resolver runs on every config read. */
+const legacyEnvWarned = new Set<string>();
+
+/** Test seam: the warning is once-per-process by design, which would make the second test vacuous. */
+export function resetLegacyEnvWarningsForTests(): void {
+  legacyEnvWarned.clear();
+}
+
+/**
+ * Read a renamed env var, preferring the current name.
+ *
+ * The legacy name keeps working indefinitely — breaking a documented env var to improve its spelling is
+ * not a trade worth making, and an operator upgrading for a security fix should not also be handed an
+ * outage. But it is deliberately **not silent**: an alias nobody is told about is one nobody migrates
+ * off, and the deprecation never ends.
+ */
+function envRenamed(current: string): string | undefined {
+  const entry = RENAMED_ENV_VARS.find(e => e.current === current);
+  if (!entry) return process.env[current];
+  const currentVal = process.env[current];
+  const legacyVal = process.env[entry.legacy];
+
+  if (legacyVal !== undefined && !legacyEnvWarned.has(entry.legacy)) {
+    legacyEnvWarned.add(entry.legacy);
+    log.warn(currentVal !== undefined
+      // Both set: say which one won. Silently preferring one of two conflicting values is how an
+      // operator ends up debugging a value they can see in their own manifest and cannot find in effect.
+      ? `${entry.legacy} is deprecated and ${entry.current} is also set — using ${entry.current}. Remove ${entry.legacy}.`
+      : `${entry.legacy} is deprecated: rename it to ${entry.current}. It configures ${entry.configures} `
+        + 'for every backend, not just the product it is named after, and it still works unchanged.');
+  }
+  return currentVal ?? legacyVal;
+}
+
 export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   const cfg = getConfig();
   const base = cfg.mediaEmbedding ?? {};
@@ -779,7 +832,10 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   const sttProvider = pick('STT_PROVIDER', 'sttProvider', base.sttProvider, MEDIA_EMBEDDING_DEFAULTS.sttProvider) as 'local' | 'external';
 
   // Vision provider block — each sub-field has its own env var
-  const visionBaseUrlEnv = process.env['OLLAMA_URL'];
+  // `lockedByInfra` keys off the RESOLVED value below, so it stays correct whichever spelling was used.
+  // Keying it off the current name alone would leave the UI field editable while the legacy env var
+  // silently won — the same "looks configured, isn't" class of bug as the probe fix in #546.
+  const visionBaseUrlEnv = envRenamed('VISION_BASE_URL');
   const visionModelEnv = process.env['VISION_MODEL'];
   const visionApiKeyEnv = process.env['VISION_API_KEY'];
   // API keys: env var > secrets.json > legacy config.json (deprecated)
@@ -801,15 +857,19 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
       visionModelEnv ?? base.vision?.model ?? base.visionModel ?? 'moondream',
     ),
     apiKey: visionApiKeyEnv ?? mediaSecrets.visionApiKey ?? base.vision?.apiKey,
-    label: base.vision?.label ?? 'Vision provider (Ollama-compatible)',
+    // The default label follows the resolved provider. A fixed "(Ollama-compatible)" was wrong exactly
+    // when it mattered — an operator on vLLM saw their OpenAI-compatible endpoint labelled with a
+    // protocol it does not speak, which is the same misdirection as the `OLLAMA_URL` name itself.
+    label: base.vision?.label
+      ?? `Vision provider (${visionProvider === 'external' ? 'OpenAI' : 'Ollama'}-compatible)`,
   };
   if (visionBaseUrlEnv) locked.push('vision.baseUrl');
   if (visionModelEnv) locked.push('vision.model');
   if (visionApiKeyEnv) locked.push('vision.apiKey');
 
   // STT provider block
-  const sttBaseUrlEnv = process.env['WHISPER_URL'];
-  const sttModelEnv = process.env['WHISPER_MODEL'];
+  const sttBaseUrlEnv = envRenamed('STT_BASE_URL');
+  const sttModelEnv = envRenamed('STT_MODEL');
   const sttApiKeyEnv = process.env['STT_API_KEY'];
   const stt: MediaProviderConfig = {
     baseUrl: sttBaseUrlEnv

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -331,8 +331,11 @@ export interface MediaProviderConfig {
  *
  * ── Resolution order (high → low precedence) ────────────────────────────────
  * `getMediaEmbeddingConfig()` in the loader applies:
- *   1. Env vars (`VISION_PROVIDER`, `OLLAMA_URL`, `VISION_MODEL`, `VISION_API_KEY`,
- *      `STT_PROVIDER`, `WHISPER_URL`, `WHISPER_MODEL`, `STT_API_KEY`, …)
+ *   1. Env vars (`VISION_PROVIDER`, `VISION_BASE_URL`, `VISION_MODEL`, `VISION_API_KEY`,
+ *      `STT_PROVIDER`, `STT_BASE_URL`, `STT_MODEL`, `STT_API_KEY`, …)
+ *      Legacy aliases `OLLAMA_URL`, `WHISPER_URL` and `WHISPER_MODEL` still work and warn once at
+ *      startup — they named the product that happened to be first, not the field they configure, and
+ *      `OLLAMA_URL` applies even when the provider is `external`.
  *   2. `config.json` `mediaEmbedding.*` (writable from the UI)
  *   3. Built-in defaults
  *

--- a/testing/standalone/renamed-media-env-vars.test.js
+++ b/testing/standalone/renamed-media-env-vars.test.js
@@ -1,0 +1,185 @@
+/**
+ * Renamed media env vars: the current name wins, the legacy name still works, and the swap is announced.
+ *
+ * `OLLAMA_URL` sets `vision.baseUrl` — and `vision.baseUrl` is used **even when `visionProvider` is
+ * `external`**. So an operator running vLLM, llama.cpp or LocalAI must set a variable named after a
+ * product they are not running, if they find it at all. `WHISPER_URL` / `WHISPER_MODEL` do the same to
+ * anyone whose STT backend is not Whisper (reported by a deployment running Qwen3-ASR).
+ *
+ * The instance already gets this distinction right one layer up and documents it: `local` / `external`
+ * names a **wire protocol, not a product**. These three names contradict that.
+ *
+ * Two failure modes this pins, in opposite directions:
+ *
+ *   1. **Breaking the legacy name.** Someone upgrading for a security fix should not also get an outage
+ *      because a variable was renamed. The aliases work indefinitely.
+ *   2. **A silent alias.** An operator never told the name changed never migrates, and the deprecation
+ *      never ends. Exactly one warning per legacy name per process.
+ *
+ * And the one that is easy to get wrong: `lockedByInfra` must reflect **whichever** spelling was used.
+ * If it only tracked the new name, the Settings UI would render the field editable while the legacy env
+ * var silently overrode every save — the same "looks configured, isn't" shape as the #546 probe bug.
+ *
+ * Run: node --test testing/standalone/renamed-media-env-vars.test.js
+ */
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// CONFIG_PATH is read when the loader module is first evaluated, so it must be set before the dynamic
+// import below — a static import would run too early.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-env-rename-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let getMediaEmbeddingConfig;
+let resetLegacyEnvWarningsForTests;
+let getLogLines;
+
+const KEYS = [
+  'VISION_BASE_URL', 'OLLAMA_URL',
+  'STT_BASE_URL', 'WHISPER_URL',
+  'STT_MODEL', 'WHISPER_MODEL',
+  'VISION_PROVIDER', 'STT_PROVIDER',
+];
+
+const clear = () => { for (const k of KEYS) delete process.env[k]; };
+
+/**
+ * Lines emitted *during* `fn`, filtered to those mentioning `needle`.
+ *
+ * The log ring buffer is process-wide and append-only, so reading its tail after the fact also picks up
+ * warnings from earlier cases in this same file — which made "warns exactly once" and "stays quiet" pass
+ * or fail on test ORDER rather than on behaviour. Snapshot, act, diff.
+ */
+function capture(fn, needle) {
+  const before = getLogLines(500).length;
+  fn();
+  return getLogLines(500).slice(before).filter(l => l.includes(needle));
+}
+
+describe('renamed media env vars', () => {
+  before(async () => {
+    const loader = await import('../../server/dist/config/loader.js');
+    ({ getMediaEmbeddingConfig, resetLegacyEnvWarningsForTests } = loader);
+    ({ getLogLines } = await import('../../server/dist/util/log.js'));
+    // A minimal config with no `mediaEmbedding` block at all: every value under test then comes from the
+    // env layer or the built-in default, which is exactly the resolution path being exercised.
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      instanceId: 'env-rename-test', instanceLabel: 'test', tokens: [], networks: [],
+      spaces: [{ id: 'general', label: 'General', builtIn: true, folders: [] }],
+    }, null, 2), { mode: 0o600 });
+    loader.loadConfig();
+  });
+
+  beforeEach(() => { clear(); resetLegacyEnvWarningsForTests(); });
+  afterEach(clear);
+
+  describe('resolution', () => {
+    it('the current name is used', () => {
+      process.env.VISION_BASE_URL = 'http://vllm.llm.svc.cluster.local:8000';
+      assert.equal(getMediaEmbeddingConfig().vision.baseUrl, 'http://vllm.llm.svc.cluster.local:8000');
+    });
+
+    it('the legacy name still works — an upgrade must not become an outage', () => {
+      process.env.OLLAMA_URL = 'http://legacy:11434';
+      assert.equal(getMediaEmbeddingConfig().vision.baseUrl, 'http://legacy:11434');
+    });
+
+    it('with both set, the current name wins', () => {
+      process.env.VISION_BASE_URL = 'http://new:8000';
+      process.env.OLLAMA_URL = 'http://old:11434';
+      assert.equal(getMediaEmbeddingConfig().vision.baseUrl, 'http://new:8000');
+    });
+
+    it('covers STT_BASE_URL / WHISPER_URL', () => {
+      process.env.WHISPER_URL = 'http://asr:9000';
+      assert.equal(getMediaEmbeddingConfig().stt.baseUrl, 'http://asr:9000');
+      clear(); resetLegacyEnvWarningsForTests();
+      process.env.STT_BASE_URL = 'http://qwen-asr.media.svc.cluster.local:9000';
+      assert.equal(getMediaEmbeddingConfig().stt.baseUrl, 'http://qwen-asr.media.svc.cluster.local:9000');
+    });
+
+    it('covers STT_MODEL / WHISPER_MODEL', () => {
+      process.env.WHISPER_MODEL = 'large-v3';
+      assert.equal(getMediaEmbeddingConfig().stt.model, 'large-v3');
+      clear(); resetLegacyEnvWarningsForTests();
+      process.env.STT_MODEL = 'qwen3-asr';
+      assert.equal(getMediaEmbeddingConfig().stt.model, 'qwen3-asr');
+    });
+  });
+
+  describe('the deprecation is announced', () => {
+    it('a legacy name warns and names its replacement', () => {
+      process.env.OLLAMA_URL = 'http://legacy:11434';
+      const warned = capture(() => getMediaEmbeddingConfig(), 'OLLAMA_URL');
+      assert.ok(warned.length > 0, 'expected a deprecation warning');
+      assert.match(warned.join('\n'), /VISION_BASE_URL/, 'must name the replacement, not just complain');
+    });
+
+    it('says which value won when both are set — the worst thing to leave silent', () => {
+      // An operator can see OLLAMA_URL in their own manifest. Preferring the other one without saying so
+      // sends them looking for a value that is present in config and absent in effect.
+      process.env.VISION_BASE_URL = 'http://new:8000';
+      process.env.OLLAMA_URL = 'http://old:11434';
+      const warned = capture(() => getMediaEmbeddingConfig(), 'OLLAMA_URL');
+      assert.match(warned.join('\n'), /using VISION_BASE_URL/);
+    });
+
+    it('warns once per process, not once per config read', () => {
+      // getMediaEmbeddingConfig() is a resolver called on essentially every request path.
+      process.env.WHISPER_URL = 'http://asr:9000';
+      const warned = capture(() => { for (let i = 0; i < 5; i++) getMediaEmbeddingConfig(); },
+        'WHISPER_URL is deprecated');
+      assert.equal(warned.length, 1);
+    });
+
+    it('stays quiet when only the current name is used', () => {
+      process.env.VISION_BASE_URL = 'http://vllm:8000';
+      assert.deepEqual(capture(() => getMediaEmbeddingConfig(), 'deprecated'), []);
+    });
+  });
+
+  describe('lockedByInfra follows whichever spelling was used', () => {
+    // The regression that would be invisible: the UI renders the field editable, every save appears to
+    // work, and the env var overrides it on the next read.
+    it('locks vision.baseUrl via the current name', () => {
+      process.env.VISION_BASE_URL = 'http://vllm:8000';
+      assert.ok(getMediaEmbeddingConfig().lockedByInfra.includes('vision.baseUrl'));
+    });
+
+    it('locks vision.baseUrl via the LEGACY name too', () => {
+      process.env.OLLAMA_URL = 'http://legacy:11434';
+      assert.ok(getMediaEmbeddingConfig().lockedByInfra.includes('vision.baseUrl'));
+    });
+
+    it('locks stt.baseUrl and stt.model via either name', () => {
+      process.env.WHISPER_URL = 'http://asr:9000';
+      process.env.STT_MODEL = 'qwen3-asr';
+      const locked = getMediaEmbeddingConfig().lockedByInfra;
+      assert.ok(locked.includes('stt.baseUrl'), 'legacy spelling must still lock');
+      assert.ok(locked.includes('stt.model'), 'current spelling must lock');
+    });
+
+    it('locks nothing when no env var is set', () => {
+      const locked = getMediaEmbeddingConfig().lockedByInfra;
+      for (const f of ['vision.baseUrl', 'stt.baseUrl', 'stt.model']) {
+        assert.ok(!locked.includes(f), `${f} must be editable when infra has not pinned it`);
+      }
+    });
+  });
+
+  describe('the default label follows the provider, not the historical product', () => {
+    it('an external vision provider is not labelled Ollama-compatible', () => {
+      process.env.VISION_PROVIDER = 'external';
+      assert.match(getMediaEmbeddingConfig().vision.label, /OpenAI-compatible/);
+    });
+
+    it('a local vision provider still says Ollama-compatible', () => {
+      process.env.VISION_PROVIDER = 'local';
+      assert.match(getMediaEmbeddingConfig().vision.label, /Ollama-compatible/);
+    });
+  });
+});


### PR DESCRIPTION
Sections 6 and 8 of the 2.0.0 Kubernetes deployment report, plus the documentation gap that let §1 cost a day instead of a minute.

## §6 — the names describe the wrong thing

| today | configures | problem |
|---|---|---|
| `OLLAMA_URL` | `vision.baseUrl` | **used even when `visionProvider: external`** — an operator running vLLM sets a variable named after a product they aren't running, or never finds it |
| `WHISPER_URL` | `stt.baseUrl` | misdescribes any non-Whisper backend; the reporter runs Qwen3-ASR |
| `WHISPER_MODEL` | `stt.model` | same |

→ **`VISION_BASE_URL`**, **`STT_BASE_URL`**, **`STT_MODEL`**.

This is the distinction the provider switch already gets right and states in its own docs: **the setting names a wire protocol, not a product.** These three names contradicted it.

### The old names keep working — indefinitely

Not a transition period nobody has scheduled the end of. Breaking a documented env var to improve its spelling is not a worthwhile trade, and an operator upgrading *for a security fix* should not also be handed an outage.

But not silent either — **one `warn` per legacy name per process**, naming the replacement. An alias nobody is told about is one nobody migrates off.

**With both set, the new one wins and the log says so.** A value that is visibly present in your own manifest and silently absent in effect is among the most expensive things to debug — and it is the exact shape of bug this PR series is about.

### The part that would have been invisible

`lockedByInfra` keys off the **resolved** value, so it is correct whichever spelling was used. Keying it off the new name alone would leave the Settings control editable while the legacy env var overrode every save — the same "looks configured, isn't" failure as #546's probe.

The default vision **label** now follows the resolved provider too. A fixed `(Ollama-compatible)` was wrong exactly when it mattered: an operator on vLLM saw their OpenAI-compatible endpoint labelled with a protocol it does not speak.

## Documentation is the larger half

The report's real cost was not the bug. It was that a correct configuration was refused and the only evidence anywhere was a string in a dialog.

**New: "Diagnosing a Misconfiguration"**

- **Which of the three status endpoints answers which question** — `/api/about/security` (is the config coherent?), `/api/about/health` (is it reachable?), `/ready` (should this pod take traffic?) — *and what each deliberately does not answer*, so `/ready` ignoring optional sidecars reads as design rather than omission.
- **A symptom → cause table** for the refusals that look identical and are not: private address vs crown-jewel address vs DNS returning nothing.
- **How to read the posture block**, including the one phrase that inverts if misread: *"not resolved here"* is the **absence** of a verdict; *"nothing is using the permission; unset it"* **is** one.
- **Why a render sidecar on a private address works while a model endpoint on the same subnet is refused.** This is the observation that actually located #546 — now written down instead of rediscovered.
- **First-boot duration**: 30–90 s typical, legitimately minutes. Sizing `startupProbe` to the warm-boot time turns a normal first boot into a crashloop that reads as a failure to start.

## §8 — version annotations

The guide tracks the latest release, so anything added after 2.0.0 carries `*New in <version>.*` under its heading, with a "Which version does this describe?" summary table at the top. The reporter was reading current docs against a 2.0.0 deployment with no way to tell which parts applied.

> **Convention note for future annotations:** the marker must end in a period. markdownlint MD036 flags an emphasis-only line that does not end in punctuation, so `*(new in 2.1)*` fails the build and `*New in 2.1.*` does not.

The userguide gets the same material in user terms on the **Models & Media** page — where the failure is actually seen — including why `allowPrivateModelEndpoints` deliberately cannot be set from that page.

## Verification

20 new tests. **Mutation-checked** — each fails its tests:

| Mutation | Result |
|---|---|
| read only the legacy name (pre-rename behaviour) | killed |
| warn on every config read instead of once | killed |
| `lockedByInfra` keys off the current name only | killed |
| pin the label to `Ollama-compatible` | killed |
| drop the legacy fallback entirely (the breaking change refused above) | killed |

`npm run preflight` and `npm run lint:docs` green.

## Not in this PR

Two UI defects the owner found while walking the visual check — the Entities table clipping at narrow widths, and long space names overflowing their chip. Being measured in a booted browser now; they are client layout and unrelated to config naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
