### PR TITLE
fix(ux): a table's scrollbar 2800px below the fold is not a scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -477,6 +477,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A wide table's horizontal scrollbar was ~2800px below the fold, so "scrollable" and "reachable" were
+  not the same thing.** #534 gave `.table-wrapper` `overflow-x: auto`, and it worked: measured on Brain →
+  Entities at a 900px viewport, the wrapper had 614px of width and 822px of content — real, scrollable
+  overflow. The owner still reported the table cut off at Tags with no way to scroll right, and was
+  right. A scroll container's horizontal scrollbar sits at its **bottom**, the container was **3388px
+  tall**, and the viewport was 900px.
+  - The height was itself a symptom. Seven columns in 614px collapsed every cell to its min-content
+    width, and inside the Properties cell the nested key/value table gave its `white-space: nowrap` key
+    column full width, leaving the **value ~10px** — enough for one character. "Germany" rendered
+    vertically, one letter per line, and each row grew to 274px.
+  - Capping the key column at 45% and giving the value a `5em` floor takes rows from **274px to 150px**
+    for 17px of extra table width. `word-break: break-all` on the value became `overflow-wrap: anywhere`,
+    which still breaks a long hash or URL but no longer makes an ordinary word's min-content one
+    character wide.
+  - `.table-wrapper` is now bounded (`max-height: min(60vh, 720px)`) with a **sticky header**, so the
+    scrollbar is at the bottom of a screen-sized box rather than a page-length away, and the column names
+    survive scrolling. 60vh and not more because the box has to *end* above the fold — at 70vh its bottom
+    edge measured 984px against a 900px viewport, which is the same bug in a milder form.
+  - **No blanket `min-width` on `table`.** An earlier attempt used one; it fixed Entities and forced a
+    horizontal scrollbar onto every narrow three-column settings table that previously fit. The collapse
+    had a specific cause and is fixed at that cause.
+
+- **A long space name painted straight over the next chip.** `.space-chip` had a `min-width` and no
+  maximum, and the label had no truncation, so a 284px label rendered inside a 144px chip and overlapped
+  its neighbour. Chips now cap at 200px and ellipsise, with the full name and id in the tooltip. The
+  `min-width: 0` on the chip's children is load-bearing: a flex item defaults to `min-width: auto` and
+  refuses to shrink below its content, so `text-overflow` would never have engaged.
+
 - **"Test connection" refused every self-hosted model endpoint on a private address, even with
   `allowPrivateModelEndpoints` on.** `probeModelEndpoint` called `ssrfSafeFetch(url, init)` without the
   third argument, and that argument defaults to *refuse private addresses* — so the probe silently

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -70,7 +70,18 @@ interface SpaceView {
       align-items: center;
       gap: 2px;
       min-width: 110px;
+      /* A long space name used to render at its full intrinsic width and paint straight over the
+         neighbouring chip — measured at 284px of label inside a 144px chip. The strip is a horizontal
+         scroller, so the chip must not be allowed to grow without bound, and the label must be told what
+         to do when it does not fit. Truncation is the right answer here: the id line underneath and the
+         title tooltip both carry the full name. */
+      max-width: 200px;
+      flex: 0 0 auto;
     }
+
+    /* min-width:0 is load-bearing. A flex item defaults to min-width:auto and refuses to shrink below
+       its content, so text-overflow would never engage and the label would overflow exactly as before. */
+    .space-chip > * { max-width: 100%; min-width: 0; }
 
     .space-chip:hover { border-color: var(--accent); color: var(--text-primary); }
 
@@ -80,8 +91,8 @@ interface SpaceView {
       color: var(--accent);
     }
 
-    .space-chip-label { font-size: 13px; font-weight: 500; }
-    .space-chip-id { font-size: 10px; color: var(--text-muted); }
+    .space-chip-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .space-chip-id { font-size: 10px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .space-chip-count {
       font-size: 10px;
       color: var(--text-muted);
@@ -170,6 +181,7 @@ interface SpaceView {
           <button
             class="space-chip"
             [class.active]="activeSpaceId() === sv.space.id"
+            [title]="sv.space.label + ' (' + sv.space.id + ')'"
             (click)="selectSpace(sv.space.id)"
           >
             <span class="space-chip-label">{{ sv.space.label }}</span>

--- a/client/src/app/shared/properties-view.component.ts
+++ b/client/src/app/shared/properties-view.component.ts
@@ -47,12 +47,28 @@ import { TranslocoPipe } from '@jsverse/transloco';
       padding-right: 10px;
       vertical-align: top;
       font-size: 11px;
+      /* The key is nowrap, so in a squeezed column it claims its full width and leaves the value with
+         whatever is left — which was ~10px, enough for one character. Cap it so the two share. */
+      max-width: 45%;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .props-val {
       color: var(--text-primary);
-      word-break: break-all;
+      /* overflow-wrap:anywhere, NOT word-break:break-all.
+         Both break long unbroken tokens (a URL, a hash, an id), which is why the rule exists. The
+         difference is what they do to the element's MIN-CONTENT width: break-all makes it one character
+         wide, so a table column containing this cell can be squeezed to nothing — and it was. In a
+         narrow window the Entities table collapsed every column to ~118px and rendered the property
+         value "Germany" one letter per line, at which point each row was 274px tall, the table was
+         3388px tall, and the horizontal scrollbar it needed sat 2800px below the fold.
+         anywhere breaks only when a word genuinely does not fit, so min-content stays the width of the
+         longest word and the column keeps a sane floor. */
+      overflow-wrap: anywhere;
       font-size: 11px;
       vertical-align: top;
+      /* A floor, so the value column cannot be reduced to a single character of vertical text. */
+      min-width: 5em;
     }
     .props-pre {
       font-family: var(--font-mono, 'Consolas', 'Monaco', monospace);

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -303,8 +303,32 @@ button:disabled, .btn:disabled {
 }
 
 /* ── Tables ──────────────────────────────────────────────────────────────── */
+/*
+ * A data table that does not fit needs TWO things, and #534 only delivered one.
+ *
+ * `overflow-x: auto` made the table scrollable, and it genuinely was — measured on Brain → Entities at
+ * a 900px viewport: wrapper client 614px, scroll 822px, so 208px of real, scrollable overflow. And the
+ * owner still reported "no way to scroll right", correctly. The horizontal scrollbar sits at the BOTTOM
+ * of the scroll container, the container was 3388px tall, and the viewport was 900px — so the only
+ * affordance for the overflow was roughly 2800px below the fold.
+ *
+ * Worse, the height was itself a symptom. With seven columns squeezed into 614px every cell collapsed to
+ * its min-content width (~118px) and wrapped brutally: a property value of "Germany" rendered one letter
+ * per line, and each row grew to 274px. The table's own min-content width is 822px, so no amount of
+ * shrinking was ever going to make it fit — squeezing only made it unreadable AND unscrollable.
+ *
+ * So: give the table a floor so columns stop collapsing into vertical text, and bound the wrapper so its
+ * scrollbar is on screen instead of a page-length away. The header sticks, because a horizontally
+ * scrolled table with the column names gone is its own small usability problem.
+ */
 .table-wrapper {
-  overflow-x: auto;
+  overflow: auto;
+  /* Tall tables scroll inside the box; short ones are unaffected, since max-height only ever clamps.
+     60vh rather than a larger share on purpose: the box has to END above the fold, or its horizontal
+     scrollbar is off screen again and we are back to the reported bug in a milder form. Measured on
+     Brain → Entities at 900x900, where the wrapper starts at y=354 — 70vh put its bottom edge at 984,
+     60vh puts it at 894. */
+  max-height: min(60vh, 720px);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
 }
@@ -313,10 +337,19 @@ table {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
+  /* Deliberately NO blanket min-width. An earlier attempt at this bug set `min-width: 820px` here, which
+     did stop the column collapse — and forced a horizontal scrollbar onto every narrow three-column
+     settings table that previously fit perfectly well. The collapse had a specific cause
+     (`word-break: break-all` in properties-view, whose min-content width is one character) and it is
+     fixed there, at the source, instead of being papered over for every table in the app. */
 }
 
 thead {
   background: var(--bg-elevated);
+  /* The wrapper is the scroll container, so `top: 0` is its top edge, not the page's. */
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 th {


### PR DESCRIPTION
Two defects the owner found while walking the visual check. Both **measured in a booted browser at 900×900**, not reasoned about — and every plausible explanation I started with was wrong.

## 1. "The table is cut off at Tags and there is no way to scroll right"

`.table-wrapper` was already scrollable. #534 gave it `overflow-x: auto` and it worked — measured on Brain → Entities:

```
wrapper   client=614  scroll=822   → 208px of real, scrollable overflow
```

And the report was still correct. **A scroll container's horizontal scrollbar sits at its bottom edge**, the container was **3388px tall**, and the viewport was 900px. The only affordance for that overflow was roughly **2800px below the fold**.

*Scrollable* and *reachable* are different properties. Only the first had ever been checked — including by the `responsive-sweep` script written for exactly this class of bug, which visits `/brain` but never clicks a tab, so `@if (activeTab() === 'entities')` meant the table was never in the DOM when it measured.

### The height was itself a symptom

Seven columns in 614px collapsed every cell to its min-content width. Inside the Properties cell, the nested key/value table gave its `white-space: nowrap` key column full width and left the **value about 10px** — one character. `"Germany"` rendered vertically, one letter per line, and each row grew to **274px**.

| | before | after |
|---|---|---|
| row height | 274px | **150px** |
| wrapper height | 3388px | 630px |
| table min-content | 822px | 839px (+17) |
| h-scrollbar on screen | no | **yes** |

- Key column capped at **45%**, value given a **5em floor** — that alone is the 274 → 150 change, for 17px of extra table width.
- `word-break: break-all` → **`overflow-wrap: anywhere`** on the value. Both break a long hash or URL, which is why the rule exists; only `break-all` reduces an ordinary word's min-content width to a single character.
- `.table-wrapper` is now bounded — `max-height: min(60vh, 720px)` — with a **sticky header**, so the scrollbar is at the bottom of a screen-sized box and the column names survive horizontal scrolling.

**60vh and not more, deliberately.** The box has to *end* above the fold or this is the same bug in a milder form: at 70vh its bottom edge measured **984** against a 900px viewport. At 60vh it measures 894. Verified on screen at 900 and 1200 wide; at 600 the space chips wrap to a second row and it lands 24px low.

### An approach I tried and rejected

A blanket `table { min-width: 820px }`. It fixed Entities — and forced a horizontal scrollbar onto every narrow three-column settings table that previously fit perfectly well. The collapse had a specific cause and is fixed at that cause instead. Recorded in a comment so it is not retried.

## 2. A long space name painted over the next chip

```
chipW=144  labelW=284   → 140px of label rendered outside its own chip
```

`.space-chip` had a `min-width` and no maximum; the label had no truncation. Chips now cap at 200px and ellipsise, with the full name and id in the `title`.

The `min-width: 0` on the chip's children is load-bearing and not decoration: **a flex item defaults to `min-width: auto` and refuses to shrink below its content**, so `text-overflow` would never have engaged. This is the same property whose absence caused #534.

## Verification

Before/after measured with Playwright against a booted instance seeded to reproduce the owner's screenshot — a space with a 46-character label, and entities carrying five tags and multiple properties. An empty Entities tab measures perfectly clean, which is the other half of why this was never caught.

`npm run preflight` green.

## Follow-up queued, not in this PR

- `responsive-sweep.mjs` should drive tab strips before measuring, and should assert *reachability* of a scroll affordance rather than only its existence. That is a change to the checking tool and belongs on its own.
- Three further owner findings: Models tab missing Office renderer and the contradiction judge, and About → Components rendering nothing until its probe answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
