### PR TITLE
feat(models): the two models the Models screen never listed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The Models screen now lists every model the pipeline actually calls.** Two were missing, both
+  configurable since the day they shipped and neither reachable from the admin surface — so the one page
+  that claims to enumerate the pipeline's models was quietly incomplete.
+  - **Contradiction judge (NLI).** Settable by `NLI_URL` / `NLI_MODEL` / `NLI_API_KEY` and `config.json`
+    from the first release, absent from `PATCH /api/admin/media-config`, from the pipeline probe, and
+    from the UI. It is the one model whose absence produces a view that looks *finished*: an unreachable
+    reranker gives worse ordering, an unreachable judge gives an **empty Contradictions list**, which is
+    indistinguishable from "nothing contradicts". It is now patchable, probed, and shown with a health
+    dot — and the guard rails came in the same commit, because wiring it up creates a real egress path:
+    the judge is sent **pairs of record texts**, which is heavier than a search query. SSRF-checked with
+    the flag named in the rejection, key routed to `secrets.json` and masked on read, `403` when pinned
+    by env, and `baseUrl`/`model` nullable so clearing them is how the judge is turned back off — a
+    field that could only ever be *set* would be a one-way door.
+  - **Office renderer** (`RENDER_OFFICE_SIDECAR_URL`) — probed by the server and reported on About, but
+    absent from this tab, so its status was visible everywhere except the screen about models.
+
 - **"Diagnosing a Misconfiguration" — the deployment guide now answers the question operators were
   answering by trial and error.** Prompted by a 2.0.0 Kubernetes report in which a correct configuration
   was refused and the only evidence was a string in a dialog. Most problems here are *config that looks
@@ -504,6 +520,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its neighbour. Chips now cap at 200px and ellipsise, with the full name and id in the tooltip. The
   `min-width: 0` on the chip's children is load-bearing: a flex item defaults to `min-width: auto` and
   refuses to shrink below its content, so `text-overflow` would never have engaged.
+
+- **About → Components appeared out of nowhere seconds after the page settled.** The card rendered only
+  once its probe answered, for a stated reason that was half right: an empty card filling in a moment
+  later reads as "nothing configured", which is a genuinely different claim. True — but the remedy was
+  wrong, because rendering *nothing* still makes a whole card materialise on a page the reader has
+  already finished scanning. It now renders immediately in a **pending** state, which claims neither.
 
 - **"Test connection" refused every self-hosted model endpoint on a private address, even with
   `allowPrivateModelEndpoints` on.** `probeModelEndpoint` called `ssrfSafeFetch(url, init)` without the

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1466,6 +1466,13 @@
   "mediaProcessing.rerank.multiplierLabel": "Kandidaten pro Treffer",
   "mediaProcessing.rerank.multiplierHint": "Wie viele Kandidaten die Vektorsuche pro angefordertem Treffer holt. Ein Reranker kann nur umsortieren, was bereits gefunden wurde — dieser Vorrat ist also das, woraus er schöpfen kann. 2–10, Standard 4.",
   "mediaProcessing.rerank.egressWarning": "Dieser Endpunkt ist <b>nicht lokal</b>. Ein Reranker erhält die Suchanfrage <b>und</b> die Passagen, die Ihre eigenen Daten dafür geliefert haben — die aufschlussreichste Kombination im System. Betreiben Sie ihn selbst (z. B. <b>bge-reranker-v2-m3</b>), damit beides auf dieser Instanz bleibt.",
+  "mediaProcessing.nli.title": "Widerspruchsprüfer",
+  "mediaProcessing.nli.purpose": "Entscheidet, ob zwei ähnliche Einträge übereinstimmen oder sich widersprechen. Ähnlichkeit allein reicht nicht — zwei gegensätzliche Aussagen zum selben Thema sind meist ÄHNLICHER, nicht unähnlicher.",
+  "mediaProcessing.nli.pillOn": "Aktiv",
+  "mediaProcessing.nli.pillOff": "Nicht konfiguriert",
+  "mediaProcessing.nli.endpointPlaceholder": "https://nli.internal/v1",
+  "mediaProcessing.nli.endpointHint": "Leer lässt die Widerspruchserkennung ohne Prüfer, die Ansicht „Widersprüche“ bleibt dann leer. Kein Sidecar bringt einen mit — gemeint ist ein Encoder-Klassifikator der roberta/deberta-MNLI-Familie.",
+  "mediaProcessing.nli.egressWarning": "Dieser Endpunkt ist <b>extern</b>: Paare von Eintragstexten verlassen diese Instanz zur Prüfung. Bitte vorher die Datenschutzvorgaben prüfen.",
   "mediaProcessing.vision.title": "Bildverstehen",
   "mediaProcessing.vision.purpose": "Beschreibt hochgeladene Bilder und indiziert Gesichter für die Suche.",
   "mediaProcessing.vision.pillLocal": "Lokal · Ollama",
@@ -1485,6 +1492,8 @@
   "mediaProcessing.assist.egressPending": "Sie bestätigen den Datenabfluss an {{host}} beim Speichern.",
   "mediaProcessing.render.title": "Seiten-Renderer",
   "mediaProcessing.render.purpose": "Rendert Dokumentseiten zu Bildern, damit das Bildmodell sie lesen kann.",
+  "mediaProcessing.office.title": "Office-Renderer",
+  "mediaProcessing.office.purpose": "Rendert Word-, Excel- und PowerPoint-Seiten zu Bildern. Getrennt vom Seiten-Renderer, weil Office-Formate eine andere Engine benötigen.",
   "mediaProcessing.converter.title": "Dokumentkonverter",
   "mediaProcessing.converter.purpose": "Extrahiert Text und Tabellen aus PDFs, Word-Dokumenten und EPUBs.",
   "mediaProcessing.face.title": "Gesichtserkennung",
@@ -1656,5 +1665,6 @@
   "review.typeFilter.all": "Alle Typen",
   "review.typeFilter.capped": "Es werden die ersten 500 Funde angezeigt — Filter gelten nur für diese.",
   "review.typeFilter.noneOfType": "Keine Funde dieses Typs",
-  "review.typeFilter.noneOfTypeBody": "In dieser Liste gibt es Funde, aber keine des gewählten Datensatztyps. Wähle „Alle Typen“, um sie zu sehen."
+  "review.typeFilter.noneOfTypeBody": "In dieser Liste gibt es Funde, aber keine des gewählten Datensatztyps. Wähle „Alle Typen“, um sie zu sehen.",
+  "about.components.pending": "Komponenten werden geprüft…"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1466,6 +1466,13 @@
   "mediaProcessing.rerank.multiplierLabel": "Candidates per result",
   "mediaProcessing.rerank.multiplierHint": "How many candidates the vector search fetches per requested result. A reranker can only re-order what was already found, so this over-fetch is what gives it something to rescue. 2–10, default 4.",
   "mediaProcessing.rerank.egressWarning": "This endpoint is <b>not local</b>. A reranker receives the search query <b>and</b> the passages your own data returned for it — the most revealing pairing in the system. Self-host it (for example <b>bge-reranker-v2-m3</b>) to keep both on this instance.",
+  "mediaProcessing.nli.title": "Contradiction judge",
+  "mediaProcessing.nli.purpose": "Decides whether two similar records agree or contradict. Similarity alone cannot tell them apart — two opposite claims about the same subject are usually MORE alike, not less.",
+  "mediaProcessing.nli.pillOn": "Active",
+  "mediaProcessing.nli.pillOff": "Not configured",
+  "mediaProcessing.nli.endpointPlaceholder": "https://nli.internal/v1",
+  "mediaProcessing.nli.endpointHint": "Blank leaves contradiction detection without a judge, so the Contradictions view stays empty. No sidecar ships with one — this is an encoder classifier of the roberta/deberta-MNLI family.",
+  "mediaProcessing.nli.egressWarning": "This endpoint is <b>external</b>: pairs of record texts leave this instance to be judged. Review your data-residency policy first.",
   "mediaProcessing.vision.title": "Vision",
   "mediaProcessing.vision.purpose": "Describes uploaded images and indexes faces for search.",
   "mediaProcessing.vision.pillLocal": "Local · Ollama",
@@ -1485,6 +1492,8 @@
   "mediaProcessing.assist.egressPending": "You will confirm egress to {{host}} when you save.",
   "mediaProcessing.render.title": "Page renderer",
   "mediaProcessing.render.purpose": "Renders document pages to images for the vision model to read.",
+  "mediaProcessing.office.title": "Office renderer",
+  "mediaProcessing.office.purpose": "Renders Word, Excel and PowerPoint pages to images. Separate from the page renderer because office formats need a different engine.",
   "mediaProcessing.converter.title": "Document converter",
   "mediaProcessing.converter.purpose": "Extracts text and tables from PDFs, Word documents and EPUBs.",
   "mediaProcessing.face.title": "Face recognition",
@@ -1656,5 +1665,6 @@
   "review.typeFilter.all": "All types",
   "review.typeFilter.capped": "Showing the first 500 findings — filters apply to those only.",
   "review.typeFilter.noneOfType": "No findings of this type",
-  "review.typeFilter.noneOfTypeBody": "There are findings in this queue, but none of the selected record type. Choose All types to see them."
+  "review.typeFilter.noneOfTypeBody": "There are findings in this queue, but none of the selected record type. Choose All types to see them.",
+  "about.components.pending": "Checking components…"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1466,6 +1466,13 @@
   "mediaProcessing.rerank.multiplierLabel": "Kandydaci na wynik",
   "mediaProcessing.rerank.multiplierHint": "Ilu kandydatów wyszukiwanie wektorowe pobiera na każdy żądany wynik. Reranker może jedynie przestawić to, co już znaleziono — ten zapas daje mu z czego wybierać. 2–10, domyślnie 4.",
   "mediaProcessing.rerank.egressWarning": "Ten punkt końcowy <b>nie jest lokalny</b>. Reranker otrzymuje zapytanie <b>oraz</b> fragmenty, które zwróciły na nie Twoje dane — najbardziej ujawniające połączenie w systemie. Uruchom go u siebie (np. <b>bge-reranker-v2-m3</b>), aby oba zostały na tej instancji.",
+  "mediaProcessing.nli.title": "Sędzia sprzeczności",
+  "mediaProcessing.nli.purpose": "Ocenia, czy dwa podobne wpisy są zgodne, czy sprzeczne. Samo podobieństwo nie wystarczy — dwa przeciwstawne twierdzenia na ten sam temat są zwykle BARDZIEJ podobne, nie mniej.",
+  "mediaProcessing.nli.pillOn": "Aktywny",
+  "mediaProcessing.nli.pillOff": "Nieskonfigurowany",
+  "mediaProcessing.nli.endpointPlaceholder": "https://nli.internal/v1",
+  "mediaProcessing.nli.endpointHint": "Puste pole zostawia wykrywanie sprzeczności bez sędziego, więc widok „Sprzeczności” pozostaje pusty. Żaden sidecar go nie dostarcza — chodzi o klasyfikator enkoderowy z rodziny roberta/deberta-MNLI.",
+  "mediaProcessing.nli.egressWarning": "Ten punkt końcowy jest <b>zewnętrzny</b>: pary tekstów wpisów opuszczają tę instancję w celu oceny. Najpierw sprawdź zasady przechowywania danych.",
   "mediaProcessing.vision.title": "Rozpoznawanie obrazu",
   "mediaProcessing.vision.purpose": "Opisuje przesłane obrazy i indeksuje twarze na potrzeby wyszukiwania.",
   "mediaProcessing.vision.pillLocal": "Lokalny · Ollama",
@@ -1485,6 +1492,8 @@
   "mediaProcessing.assist.egressPending": "Potwierdzisz wysyłkę do {{host}} przy zapisie.",
   "mediaProcessing.render.title": "Renderer stron",
   "mediaProcessing.render.purpose": "Renderuje strony dokumentów do obrazów, aby model wizyjny mógł je odczytać.",
+  "mediaProcessing.office.title": "Renderer Office",
+  "mediaProcessing.office.purpose": "Renderuje strony Worda, Excela i PowerPointa do obrazów. Oddzielny od renderera stron, ponieważ formaty Office wymagają innego silnika.",
   "mediaProcessing.converter.title": "Konwerter dokumentów",
   "mediaProcessing.converter.purpose": "Wydobywa tekst i tabele z plików PDF, dokumentów Word i EPUB.",
   "mediaProcessing.face.title": "Rozpoznawanie twarzy",
@@ -1656,5 +1665,6 @@
   "review.typeFilter.all": "Wszystkie typy",
   "review.typeFilter.capped": "Pokazano pierwsze 500 wyników — filtry dotyczą tylko ich.",
   "review.typeFilter.noneOfType": "Brak wyników tego typu",
-  "review.typeFilter.noneOfTypeBody": "W tej kolejce są wyniki, ale żaden nie jest wybranego typu rekordu. Wybierz „Wszystkie typy”, aby je zobaczyć."
+  "review.typeFilter.noneOfTypeBody": "W tej kolejce są wyniki, ale żaden nie jest wybranego typu rekordu. Wybierz „Wszystkie typy”, aby je zobaczyć.",
+  "about.components.pending": "Sprawdzanie komponentów…"
 }

--- a/client/src/app/pages/settings/about.component.spec.ts
+++ b/client/src/app/pages/settings/about.component.spec.ts
@@ -113,10 +113,33 @@ describe('AboutComponent', () => {
 
   it('renders the grouped cards + shared usage bar', () => {
     const f = make(() => of({ ...INFO }));
-    // Instance, System, and the Documentation card that points at the bundled guides.
-    expect(el(f).querySelectorAll('app-settings-card').length).toBe(3);
+    // Instance, System, the Documentation card that points at the bundled guides — and Components,
+    // which is present from the first paint in a pending state (see the test below).
+    expect(el(f).querySelectorAll('app-settings-card').length).toBe(4);
     expect(el(f).querySelector('app-usage-bar')).toBeTruthy();
-    expect(el(f).querySelectorAll('app-status-pill').length).toBe(2);
+    expect(el(f).querySelectorAll('app-status-pill').length).toBe(3);
+  });
+
+  it('the Components card is present while its probe is still running, not conjured afterwards', () => {
+    // The card used to render only once the probe answered. The stated reason was half right — an empty
+    // card reads as "nothing configured", a different claim — but the remedy was wrong: rendering
+    // nothing makes a whole card materialise on a page the reader has already finished scanning, which
+    // is what the owner reported. A pending state claims neither.
+    const f = make(() => of({ ...INFO }));   // default stub: the health probe never resolves successfully
+    const text = el(f).textContent ?? '';
+    expect(text).toContain('about.card.components');
+    expect(text).toContain('about.components.pending');
+  });
+
+  it('once the probe answers, the pending card is replaced rather than duplicated', () => {
+    const f = make(
+      () => of({ ...INFO }),
+      () => of({ level: 'ok', down: [], components: [{ id: 'doc-render', label: 'Page renderer', configured: true, reachable: true, impact: '' }] }),
+    );
+    const text = el(f).textContent ?? '';
+    expect(text).not.toContain('about.components.pending');
+    // Still four cards: the resolved Components card takes the pending one's place.
+    expect(el(f).querySelectorAll('app-settings-card').length).toBe(4);
   });
 
   it('a load failure renders the shared error-state (with the reason), and Retry re-loads', () => {

--- a/client/src/app/pages/settings/about.component.ts
+++ b/client/src/app/pages/settings/about.component.ts
@@ -99,8 +99,19 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
           </div>
         </app-settings-card>
 
-        <!-- Optional components. Rendered only once the probe has answered: an empty card that fills in
-             a moment later reads as "nothing configured", which is a different claim entirely. -->
+        <!-- Optional components.
+             This used to render nothing at all until the probe answered, for a stated reason that was
+             half right: an empty card filling in a moment later reads as "nothing configured", which is
+             a different claim entirely. True — but the remedy was wrong. Rendering NOTHING makes the
+             card appear out of nowhere seconds after the page settles, and the owner reported exactly
+             that. A pending state claims neither: the card is there, and it says it is still looking. -->
+        @if (!health()) {
+          <app-settings-card icon="broadcast"
+                             [heading]="'about.card.components' | transloco"
+                             [purpose]="'about.card.componentsDesc' | transloco">
+            <app-status-pill pill variant="warn" [dot]="true">{{ 'about.components.pending' | transloco }}</app-status-pill>
+          </app-settings-card>
+        }
         @if (health(); as h) {
           <app-settings-card icon="broadcast"
                              [heading]="'about.card.components' | transloco"

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
@@ -18,7 +18,7 @@ import { ConfirmDialogService } from '../../../core/confirm-dialog.service';
 import { StatusVariant } from '../../../shared/status-pill.component';
 import {
   MediaCfg, MediaClass, DocProcCfg, DocAssistCfg, DocMode, EmbeddingCfg,
-  TestResult, TestTarget, FaceRecognitionCfg, MODE_STAGES, FaceExternalCfg, RerankCfg,
+  TestResult, TestTarget, FaceRecognitionCfg, MODE_STAGES, FaceExternalCfg, RerankCfg, NliCfg,
 } from './media-processing.types';
 
 /**
@@ -27,8 +27,8 @@ import {
  * `doc-render` and `unstructured` are deliberately absent: neither has a single `ngModel` — they report
  * env-only infrastructure, so a Save button on them would be a control that cannot do anything.
  */
-export type ModelCardId = 'embedding' | 'rerank' | 'vision' | 'stt' | 'assist' | 'face';
-export const MODEL_CARDS: readonly ModelCardId[] = ['embedding', 'rerank', 'vision', 'stt', 'assist', 'face'];
+export type ModelCardId = 'embedding' | 'rerank' | 'nli' | 'vision' | 'stt' | 'assist' | 'face';
+export const MODEL_CARDS: readonly ModelCardId[] = ['embedding', 'rerank', 'nli', 'vision', 'stt', 'assist', 'face'];
 
 /** A card, or everything the cards do not own (the Pipelines knobs, ceilings and limits). */
 export type CfgSection = ModelCardId | 'rest';
@@ -132,6 +132,25 @@ export class MediaProcessingStateService {
    * the warning is the point, so an approximation that is wrong in the safe direction is not acceptable
    * — a hostname with a dot is treated as remote.
    */
+  /** Live handle to the editable NLI block, lazily created so the template can bind its fields. */
+  get nli(): NliCfg { return (this.form.nli ??= {}); }
+  nliLocked(field: string): boolean { return this.isLocked(`nli.${field}`); }
+  nliApiKeyInput = '';
+  /** Configured = on, exactly as for the reranker: no master toggle, so clearing the endpoint is off. */
+  nliConfigured(): boolean { return !!this.nli.baseUrl?.trim() && !!this.nli.model?.trim(); }
+  /** Same loopback test as the reranker, and it matters more here: the judge is sent PAIRS OF RECORD
+   *  TEXTS, not a query. Wrong in the safe direction — a hostname with a dot counts as remote. */
+  nliIsExternal(): boolean {
+    const raw = this.nli.baseUrl?.trim();
+    if (!raw) return false;
+    try {
+      const h = new URL(raw).hostname;
+      return !(h === 'localhost' || h === '127.0.0.1' || h === '::1' || !h.includes('.'));
+    } catch {
+      return false;
+    }
+  }
+
   rerankIsExternal(): boolean {
     const raw = this.rerank.baseUrl?.trim();
     if (!raw) return false;
@@ -207,6 +226,7 @@ export class MediaProcessingStateService {
         this.form.stt = { ...cfg.stt, apiKey: undefined };
         this.form.embedding = { provider: 'local', ...cfg.embedding };
         this.form.rerank = { ...cfg.rerank, apiKey: undefined };
+        this.form.nli = { ...cfg.nli, apiKey: undefined };
         // Strip the masked key on the way in, like vision/stt: a mask sitting in `form` is one edit away
         // from being echoed back and overwriting a real credential with asterisks.
         this.form.faceRecognition = {
@@ -220,6 +240,7 @@ export class MediaProcessingStateService {
         this.assistApiKeyInput = '';
         this.embeddingApiKeyInput = '';
         this.rerankApiKeyInput = '';
+        this.nliApiKeyInput = '';
         this.docCfgSig.set(dp);
         this.docMode.set(dp.mode ?? 'ocr');
         this.loading.set(false);   // before rebaseline: sectionSnapshot is inert while loading
@@ -253,6 +274,7 @@ export class MediaProcessingStateService {
     switch (card) {
       case 'embedding': return { embedding: base.embedding };
       case 'rerank': return { rerank: base.rerank };
+      case 'nli': return { nli: base.nli };
       case 'vision': return { visionProvider: this.form.visionProvider, vision: base.vision };
       case 'stt': return { sttProvider: this.form.sttProvider, stt: base.stt };
       case 'face': return { faceRecognition: base.faceRecognition };
@@ -289,6 +311,7 @@ export class MediaProcessingStateService {
       : card === 'embedding' ? this.embeddingApiKeyInput
       : card === 'face' ? this.faceApiKeyInput
       : card === 'rerank' ? this.rerankApiKeyInput
+      : card === 'nli' ? this.nliApiKeyInput
       : '';
   }
 
@@ -400,6 +423,12 @@ export class MediaProcessingStateService {
         model: this.rerank.model || null,
         candidateMultiplier: this.rerank.candidateMultiplier,
       },
+      // NLI, same rule: `|| null` so CLEARING reaches the server as an explicit delete rather than a
+      // configured-but-blank endpoint, which is how the judge gets switched back off.
+      nli: {
+        baseUrl: this.nli.baseUrl || null,
+        model: this.nli.model || null,
+      },
       // Only the PATCH-writable doc fields (vlmModel/repairModel/URLs are env-only, never sent).
       documentProcessing: {
         mode: dp.mode, renderDpi: dp.renderDpi, maxPages: dp.maxPages, pageTimeoutMs: dp.pageTimeoutMs,
@@ -497,6 +526,7 @@ export class MediaProcessingStateService {
       else if (card === 'stt') block.stt = { ...block.stt, apiKey: key };
       else if (card === 'embedding') block.embedding = { ...block.embedding, apiKey: key };
       else if (card === 'rerank') block.rerank = { ...block.rerank, apiKey: key };
+      else if (card === 'nli') block.nli = { ...block.nli, apiKey: key };
       else if (card === 'assist') {
         block.documentProcessing = { assistModel: { ...block.documentProcessing?.assistModel, apiKey: key } };
       }
@@ -514,6 +544,7 @@ export class MediaProcessingStateService {
         else if (card === 'assist') this.assistApiKeyInput = '';
         else if (card === 'embedding') { this.embeddingApiKeyInput = ''; this.embeddingReindexBaseline = this.reindexKey(); }
         else if (card === 'rerank') { this.rerankApiKeyInput = ''; }
+        else if (card === 'nli') { this.nliApiKeyInput = ''; }
         if (card === 'face') { this.faceEnabledBaseline = this.face.enabled === true; this.faceApiKeyInput = ''; }
         this.rebaseline([card]);
         this.saving.set(false);
@@ -601,6 +632,7 @@ export class MediaProcessingStateService {
       stt: { ...base.stt, ...(this.sttApiKeyInput ? { apiKey: this.sttApiKeyInput } : {}) },
       embedding: { ...base.embedding, ...(this.embeddingApiKeyInput ? { apiKey: this.embeddingApiKeyInput } : {}) },
       rerank: { ...base.rerank, ...(this.rerankApiKeyInput ? { apiKey: this.rerankApiKeyInput } : {}) },
+      nli: { ...base.nli, ...(this.nliApiKeyInput ? { apiKey: this.nliApiKeyInput } : {}) },
       documentProcessing: { ...base.documentProcessing, ...(assistPayload ? { assistModel: assistPayload } : {}) },
     };
     const body = JSON.parse(JSON.stringify(payload)) as MediaCfg;

--- a/client/src/app/pages/settings/media-processing/media-processing.types.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing.types.ts
@@ -14,7 +14,7 @@ export interface TestResult {
   modelPresent?: boolean; detail?: string; latencyMs: number;
 }
 
-export type TestTarget = 'vision' | 'stt' | 'assist' | 'embedding' | 'rerank';
+export type TestTarget = 'vision' | 'stt' | 'assist' | 'embedding' | 'rerank' | 'nli';
 
 /** Text-embedding config (top-level `config.embedding`, surfaced on this page). Changing
  *  model/dimensions/similarity/prefixScheme re-indexes every vector — the save gates those behind a
@@ -35,6 +35,12 @@ export interface RerankCfg {
   baseUrl?: string | null; model?: string | null; apiKey?: string;
   /** Candidates fetched per requested result before reranking, as a multiple of topK. 2..10. */
   candidateMultiplier?: number;
+}
+
+/** NLI — the contradiction judge. Same shape and same "configured = on" rule as the reranker: there is
+ *  no master toggle, so clearing the endpoint is how it is switched off. */
+export interface NliCfg {
+  baseUrl?: string | null; model?: string | null; apiKey?: string;
 }
 
 export type DocMode = 'off' | 'ocr' | 'vlm' | 'repair' | 'auto';
@@ -115,6 +121,7 @@ export interface MediaCfg {
   stt?: ProviderCfg;
   embedding?: EmbeddingCfg;
   rerank?: RerankCfg;
+  nli?: NliCfg;
   documentProcessing?: DocProcCfg;
   workerConcurrency?: number;
   fallbackToExternal?: boolean;

--- a/client/src/app/pages/settings/media-processing/models-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.ts
@@ -225,6 +225,60 @@ import { TestTarget } from './media-processing.types';
         </div>
       </app-model-provider-card>
 
+      <!-- ── Contradiction judge (NLI) ──────────────────────────────────── -->
+      <!-- Configurable by env and config.json since F-REVIEW shipped, and never reachable from the admin
+           API or this screen — so the one page that claims to list what the pipeline calls was missing
+           it, and an operator had no way to discover why the Contradictions view stayed empty. -->
+      <app-model-provider-card id="nli" icon="check-circle"
+        [heading]="'mediaProcessing.nli.title' | transloco"
+        [purpose]="'mediaProcessing.nli.purpose' | transloco"
+        [health]="pipeline.modelState('nli')">
+        <app-status-pill pill [variant]="s.nliConfigured() ? 'active' : 'off'">
+          {{ (s.nliConfigured() ? 'mediaProcessing.nli.pillOn' : 'mediaProcessing.nli.pillOff') | transloco }}
+        </app-status-pill>
+        @if (s.nliLocked('baseUrl')) { <app-status-pill pill variant="env">{{ 'mediaProcessing.pill.env' | transloco }}</app-status-pill> }
+
+        <div class="field">
+          <label for="nli-endpoint">{{ 'mediaProcessing.field.endpoint' | transloco }}</label>
+          <input id="nli-endpoint" data-mono type="url" [(ngModel)]="s.nli.baseUrl"
+            [disabled]="s.nliLocked('baseUrl')" [placeholder]="'mediaProcessing.nli.endpointPlaceholder' | transloco" />
+          <div class="hint">{{ 'mediaProcessing.nli.endpointHint' | transloco }}</div>
+        </div>
+        <div class="field">
+          <label for="nli-model">{{ 'mediaProcessing.field.model' | transloco }}</label>
+          <input id="nli-model" data-mono [(ngModel)]="s.nli.model" [disabled]="s.nliLocked('model')"
+            placeholder="MoritzLaurer/deberta-v3-base-zeroshot-v2.0" />
+        </div>
+        <div class="field">
+          <label for="nli-key">{{ 'mediaProcessing.field.apiKeyExternal' | transloco }}</label>
+          <input id="nli-key" type="password" [(ngModel)]="s.nliApiKeyInput" [disabled]="s.nliLocked('apiKey')"
+            [placeholder]="(s.nli.apiKey ? 'mediaProcessing.field.apiKeyKeep' : 'mediaProcessing.field.apiKeyOptional') | transloco" />
+        </div>
+        @if (s.nliIsExternal()) {
+          <div class="warnline">
+            <ph-icon name="warning" [size]="15"/>
+            <span [innerHTML]="'mediaProcessing.nli.egressWarning' | transloco"></span>
+          </div>
+        }
+
+        <div footer class="testrow">
+          <button class="btn btn-sm btn-secondary" type="button" (click)="s.testConnection('nli')"
+            [disabled]="s.testOf('nli')?.loading || !s.nli.baseUrl">
+            {{ (s.testOf('nli')?.loading ? 'mediaProcessing.action.testing' : 'mediaProcessing.action.test') | transloco }}
+          </button>
+          @if (s.testOf('nli')?.res; as r) {
+            <app-status-pill [variant]="s.testPillVariant(r)" [dot]="true">{{ s.testPillLabelKey(r) | transloco }}</app-status-pill>
+            <span class="hint" [attr.title]="r.reachable ? null : (r.detail || null)">{{ r.reachable ? (r.latencyMs + ' ms') : (r.detail || '') }}</span>
+          }
+          @if (s.cardDirty('nli')) {
+            <button class="btn btn-sm btn-primary card-save" type="button"
+              [disabled]="s.saving()" (click)="s.saveCard('nli')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
+          }
+        </div>
+      </app-model-provider-card>
+
       <!-- ── Vision ─────────────────────────────────────────────────────── -->
       <app-model-provider-card id="vision" icon="image"
         [heading]="'mediaProcessing.vision.title' | transloco"
@@ -389,6 +443,26 @@ import { TestTarget } from './media-processing.types';
           <div class="ro">{{ sidecarUrl('doc-render') }}</div>
         </div>
         @if (sidecarDetail('doc-render'); as d) {
+          <div class="field"><label>{{ 'mediaProcessing.field.lastProbe' | transloco }}</label><div class="ro">{{ d }}</div></div>
+        }
+      </app-model-provider-card>
+
+      <!-- ── Office renderer (infra) ────────────────────────────────────── -->
+      <!-- Probed by the server and reported on the About page, but absent from this tab, so the one
+           screen that claims to list the pipeline's models was quietly missing one of them. -->
+      <!-- "stack" and not a Word/Office glyph: the registry has none, and an unregistered ph-icon name
+           renders as nothing at all, with no error. A layered stack reads well enough for multi-sheet
+           and multi-slide formats. -->
+      <app-model-provider-card id="doc-office" icon="stack"
+        [heading]="'mediaProcessing.office.title' | transloco"
+        [purpose]="'mediaProcessing.office.purpose' | transloco"
+        [health]="pipeline.sidecarState('doc-office')"
+        [infra]="true" envVar="RENDER_OFFICE_SIDECAR_URL">
+        <div class="field">
+          <label>{{ 'mediaProcessing.field.endpoint' | transloco }}</label>
+          <div class="ro">{{ sidecarUrl('doc-office') }}</div>
+        </div>
+        @if (sidecarDetail('doc-office'); as d) {
           <div class="field"><label>{{ 'mediaProcessing.field.lastProbe' | transloco }}</label><div class="ro">{{ d }}</div></div>
         }
       </app-model-provider-card>

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -106,6 +106,20 @@ const RerankPatchSchema = z.object({
 }).strict();
 
 /**
+ * NLI — the contradiction judge (F-REVIEW). Same shape and the same nullable-to-clear rule as the
+ * reranker, and for the same reason: there is no master toggle, so clearing the URL is how it is turned
+ * off, and a field that can only ever be SET would be a one-way door.
+ *
+ * It was configurable by env and `config.json` from the start but never reachable from the admin API, so
+ * the Models screen — the one page that claims to list what the pipeline calls — was silently missing it.
+ */
+const NliPatchSchema = z.object({
+  baseUrl: z.string().url().optional().nullable(),
+  model: z.string().max(128).optional().nullable(),
+  apiKey: z.string().max(512).optional().nullable(),
+}).strict();
+
+/**
  * Instance CEILINGS per media class — the most any space is allowed to do, not a default it inherits.
  *
  * Built from the same `*_LEVELS` constants the lattice in `files/converters/media-level.ts` uses, so
@@ -160,6 +174,7 @@ const MediaConfigPatchSchema = z.object({
   stt: ProviderPatchSchema.optional(),
   embedding: EmbeddingPatchSchema.optional(),
   rerank: RerankPatchSchema.optional(),
+  nli: NliPatchSchema.optional(),
   documentProcessing: DocumentProcessingPatchSchema.optional(),
   workerConcurrency: z.number().int().min(1).max(16).optional(),
   workerPollIntervalMs: z.number().int().min(100).max(60_000).optional(),
@@ -251,6 +266,19 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
   if (rerankPatch?.baseUrl && !isLocalModelEndpoint(rerankPatch.baseUrl)
       && !isSsrfSafeUrl(rerankPatch.baseUrl, allowPrivate)) {
     res.status(400).json({ error: 'rerank.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
+    return;
+  }
+
+  // NLI (contradiction judge) — identical enforcement to the reranker. It sees PAIRS OF RECORD TEXTS,
+  // so it is an egress path of the same weight as vision or STT, not an infrastructure detail.
+  const nliPatch = parsed.data.nli;
+  if (nliPatch !== undefined && (locked.has('nli.baseUrl') || locked.has('nli.model') || locked.has('nli.apiKey'))) {
+    res.status(403).json({ error: 'The contradiction judge is locked by infrastructure env vars and cannot be changed via the UI' });
+    return;
+  }
+  if (nliPatch?.baseUrl && !isLocalModelEndpoint(nliPatch.baseUrl)
+      && !isSsrfSafeUrl(nliPatch.baseUrl, allowPrivate)) {
+    res.status(400).json({ error: 'nli.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
     return;
   }
 
@@ -356,8 +384,12 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     const rerankApiKeyChange = (rerankPatch && 'apiKey' in rerankPatch)
       ? rerankPatch.apiKey ?? null
       : undefined;
+    // NLI key → secrets.mediaEmbedding.nliApiKey (the loader already reads it from there).
+    const nliApiKeyChange = (nliPatch && 'apiKey' in nliPatch)
+      ? nliPatch.apiKey ?? null
+      : undefined;
 
-    if (visionApiKeyChange !== undefined || sttApiKeyChange !== undefined || assistApiKeyChange !== undefined || embApiKeyChange !== undefined || faceApiKeyChange !== undefined || rerankApiKeyChange !== undefined) {
+    if (visionApiKeyChange !== undefined || sttApiKeyChange !== undefined || assistApiKeyChange !== undefined || embApiKeyChange !== undefined || faceApiKeyChange !== undefined || rerankApiKeyChange !== undefined || nliApiKeyChange !== undefined) {
       const secrets = getSecrets();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sAny = secrets as any;
@@ -377,6 +409,10 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
       if (faceApiKeyChange !== undefined) {
         if (faceApiKeyChange === null || faceApiKeyChange === '') delete sAny.mediaEmbedding.faceApiKey;
         else sAny.mediaEmbedding.faceApiKey = faceApiKeyChange;
+      }
+      if (nliApiKeyChange !== undefined) {
+        if (nliApiKeyChange === null || nliApiKeyChange === '') delete sAny.mediaEmbedding.nliApiKey;
+        else sAny.mediaEmbedding.nliApiKey = nliApiKeyChange;
       }
       if (rerankApiKeyChange !== undefined) {
         if (rerankApiKeyChange === null || rerankApiKeyChange === '') delete sAny.mediaEmbedding.rerankApiKey;
@@ -419,6 +455,15 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
         if (rerankPatch[k] === null || rerankPatch[k] === '') delete r[k];
       }
       merged['rerank'] = r;
+    }
+    // NLI: same per-field merge and same null-deletes-the-field rule as the reranker above.
+    if (nliPatch) {
+      const n: Record<string, unknown> = { ...(existing.nli as Record<string, unknown> ?? {}), ...nliPatch };
+      delete n['apiKey']; // never in config.json
+      for (const k of ['baseUrl', 'model'] as const) {
+        if (nliPatch[k] === null || nliPatch[k] === '') delete n[k];
+      }
+      merged['nli'] = n;
     }
     if (parsed.data.levels) merged['levels'] = mergeLevelCeilings(existing.levels, parsed.data.levels);
     // Face recognition: merge per field for the same reason as the ceilings, and additionally because

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -25,7 +25,7 @@
  */
 
 import { Router } from 'express';
-import { getConfig, getMediaEmbeddingConfig, getEmbeddingConfig, getEmbeddingApiKey, getDocumentProcessingConfig, getDocAssistApiKey, getFaceRecognitionConfig, getRerankApiKey } from '../config/loader.js';
+import { getConfig, getMediaEmbeddingConfig, getEmbeddingConfig, getEmbeddingApiKey, getDocumentProcessingConfig, getDocAssistApiKey, getFaceRecognitionConfig, getRerankApiKey, getNliApiKey } from '../config/loader.js';
 import { requireAdmin } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl } from '../util/ssrf.js';
@@ -167,6 +167,12 @@ function modelStages(): StageSpec[] {
     // model-backed, optional, and when it is unreachable searches quietly get worse rather than fail —
     // which is precisely the condition this endpoint exists to make visible.
     { key: 'rerank', label: 'Reranker', model: media.rerank?.model, baseUrl: media.rerank?.baseUrl, apiKey: getRerankApiKey(), external: !!media.rerank?.baseUrl && !isLocalModelEndpoint(media.rerank.baseUrl) },
+    // The contradiction judge, on the board for exactly the reranker's reason and one more: it is the
+    // only model here whose absence produces a view that looks FINISHED. An unreachable reranker gives
+    // worse ordering; an unreachable judge gives an empty Contradictions list, which is indistinguishable
+    // from "nothing contradicts". It was configurable from the first release and never probed, so there
+    // was no way to tell those two apart from inside the app.
+    { key: 'nli', label: 'Contradiction judge', model: media.nli?.model, baseUrl: media.nli?.baseUrl, apiKey: getNliApiKey(), external: !!media.nli?.baseUrl && !isLocalModelEndpoint(media.nli.baseUrl) },
   ];
 }
 

--- a/testing/standalone/nli-config-surface.test.js
+++ b/testing/standalone/nli-config-surface.test.js
@@ -1,0 +1,167 @@
+/**
+ * The contradiction judge is now reachable from the admin surface — and reachable on the same terms as
+ * every other model endpoint, not looser ones.
+ *
+ * Why this needed a test rather than "it mirrors the reranker":
+ *
+ * NLI was configurable by env and `config.json` from the first release and was never in the PATCH
+ * schema, never probed by pipeline-status, and never on the Models screen. So it was the one model whose
+ * absence produced a view that looks *finished*: an unreachable reranker gives worse ordering, an
+ * unreachable judge gives an EMPTY Contradictions list, which is indistinguishable from "nothing
+ * contradicts". Wiring it up means wiring up a genuine egress path — the judge is sent pairs of record
+ * texts — so the guard rails have to come with it in the same commit, not after someone notices.
+ *
+ * Run: node --test testing/standalone/nli-config-surface.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const MEDIA_CONFIG = readFileSync('server/src/api/media-config.ts', 'utf8');
+const PIPELINE = readFileSync('server/src/api/pipeline-status.ts', 'utf8');
+const MODELS_TAB = readFileSync('client/src/app/pages/settings/media-processing/models-tab.component.ts', 'utf8');
+const STATE_SVC = readFileSync('client/src/app/pages/settings/media-processing/media-processing-state.service.ts', 'utf8');
+
+describe('NLI is a first-class model surface', () => {
+  describe('the PATCH route accepts it, on the same terms as the reranker', () => {
+    it('is in the patch schema', () => {
+      assert.match(MEDIA_CONFIG, /nli:\s*NliPatchSchema\.optional\(\)/);
+    });
+
+    it('baseUrl and model are NULLABLE, so the judge can be switched back off', () => {
+      // There is no master toggle — clearing the endpoint is the off switch. A field that can only ever
+      // be set would be a one-way door: configure it once and it can never be undone from the UI.
+      const schema = MEDIA_CONFIG.slice(MEDIA_CONFIG.indexOf('const NliPatchSchema'));
+      const body = schema.slice(0, schema.indexOf('}).strict()'));
+      for (const f of ['baseUrl', 'model']) {
+        assert.match(body, new RegExp(`${f}:[^\\n]*\\.nullable\\(\\)`), `${f} must be nullable`);
+      }
+    });
+
+    it('refuses an env-locked block with 403 rather than silently ignoring the write', () => {
+      assert.match(MEDIA_CONFIG, /locked\.has\('nli\.baseUrl'\)/);
+      assert.match(MEDIA_CONFIG, /The contradiction judge is locked by infrastructure env vars/);
+    });
+
+    it('SSRF-checks the endpoint, and names the flag that would permit a private address', () => {
+      // The same rule as every other model endpoint: a non-local URL is egress and must pass the guard.
+      assert.match(MEDIA_CONFIG, /nliPatch\?\.baseUrl && !isLocalModelEndpoint\(nliPatch\.baseUrl\)/);
+      assert.match(MEDIA_CONFIG, /nli\.baseUrl rejected/);
+      assert.match(MEDIA_CONFIG, /nli\.baseUrl rejected[^\n]*allowPrivateModelEndpoints/);
+    });
+
+    it('routes the key to secrets.json and never lets it reach config.json', () => {
+      assert.match(MEDIA_CONFIG, /sAny\.mediaEmbedding\.nliApiKey = nliApiKeyChange/);
+      const merge = MEDIA_CONFIG.slice(MEDIA_CONFIG.indexOf('if (nliPatch) {'));
+      assert.match(merge.slice(0, 400), /delete n\['apiKey'\]/,
+        'the key must be stripped before the block is written to config.json');
+    });
+
+    it('masks the key on the way back out', () => {
+      assert.match(MEDIA_CONFIG, /nli: cfg\.nli \? \{ \.\.\.cfg\.nli, apiKey: mask\(cfg\.nli\.apiKey\) \}/);
+    });
+  });
+
+  describe('it is probed, so the card can show a real state', () => {
+    it('is a model stage', () => {
+      assert.match(PIPELINE, /key: 'nli', label: 'Contradiction judge'/);
+    });
+
+    it('its external flag is derived from the endpoint, not assumed', () => {
+      // Assuming `external: false` would skip the SSRF-guarded fetch for a genuinely remote endpoint.
+      assert.match(PIPELINE, /key: 'nli'[^\n]*external: !!media\.nli\?\.baseUrl && !isLocalModelEndpoint\(media\.nli\.baseUrl\)/);
+    });
+  });
+
+  describe('the client wires every touchpoint, not most of them', () => {
+    // A half-wired card renders, accepts edits, and quietly fails to save or to clear its key — which
+    // looks like a working feature until someone checks whether the value stuck.
+    const REQUIRED = [
+      ["ModelCardId includes nli", /ModelCardId =[^;]*'nli'/],
+      ["MODEL_CARDS includes nli", /MODEL_CARDS[^;]*'nli'/],
+      ['a live nli handle', /get nli\(\): NliCfg/],
+      ['lock lookup', /nliLocked\(field: string\)/],
+      ['configured-means-on', /nliConfigured\(\)/],
+      ['egress predicate', /nliIsExternal\(\)/],
+      ['masked key stripped on load', /this\.form\.nli = \{ \.\.\.cfg\.nli, apiKey: undefined \}/],
+      ['per-card save block', /case 'nli': return \{ nli: base\.nli \}/],
+      ['pending key resolution', /card === 'nli' \? this\.nliApiKeyInput/],
+      ['key attached on save', /card === 'nli'\) block\.nli =/],
+      ['key input cleared after save', /card === 'nli'\) \{ this\.nliApiKeyInput = ''/],
+    ];
+    for (const [what, re] of REQUIRED) {
+      it(what, () => assert.match(STATE_SVC, re));
+    }
+
+    it('clearing the endpoint sends null, not an empty string', () => {
+      // An empty string would be stored as a configured-but-blank endpoint — on, and broken.
+      const block = STATE_SVC.slice(STATE_SVC.indexOf('nli: {'));
+      assert.match(block.slice(0, 200), /baseUrl: this\.nli\.baseUrl \|\| null/);
+      assert.match(block.slice(0, 200), /model: this\.nli\.model \|\| null/);
+    });
+  });
+
+  describe('the card is on the Models screen', () => {
+    it('exists, with a health dot', () => {
+      assert.match(MODELS_TAB, /id="nli"/);
+      assert.match(MODELS_TAB, /pipeline\.modelState\('nli'\)/);
+    });
+
+    it('warns before record text leaves the instance', () => {
+      // The judge receives PAIRS OF RECORD TEXTS. That is a heavier egress than a search query, and the
+      // warning is the only place a reader learns it.
+      assert.match(MODELS_TAB, /s\.nliIsExternal\(\)/);
+      assert.match(MODELS_TAB, /mediaProcessing\.nli\.egressWarning/);
+    });
+
+    it('uses a registered icon', () => {
+      // An unregistered ph-icon name renders as nothing, with no error anywhere.
+      const registry = readFileSync('client/src/app/shared/ph-icon.component.ts', 'utf8');
+      const icon = /id="nli" icon="([a-z0-9-]+)"/.exec(MODELS_TAB)?.[1];
+      assert.ok(icon, 'the nli card should declare an icon');
+      assert.ok(registry.includes(`'${icon}'`) || registry.includes(`${icon}:`),
+        `icon "${icon}" is not in the registry and would render blank`);
+    });
+  });
+
+  describe('the office renderer card, missing for the same reason', () => {
+    it('is on the Models screen with its env var named', () => {
+      assert.match(MODELS_TAB, /id="doc-office"/);
+      assert.match(MODELS_TAB, /envVar="RENDER_OFFICE_SIDECAR_URL"/);
+    });
+
+    it('uses a registered icon', () => {
+      const registry = readFileSync('client/src/app/shared/ph-icon.component.ts', 'utf8');
+      const icon = /id="doc-office" icon="([a-z0-9-]+)"/.exec(MODELS_TAB)?.[1];
+      assert.ok(icon, 'the office card should declare an icon');
+      assert.ok(registry.includes(`'${icon}'`) || registry.includes(`${icon}:`),
+        `icon "${icon}" is not in the registry and would render blank`);
+    });
+  });
+
+  describe('translations exist in every locale', () => {
+    // A missing key renders as the key path itself, which is worse than English in a German UI.
+    const LOCALES = ['en', 'de', 'pl'];
+    const NEEDED = [
+      'mediaProcessing.nli.title', 'mediaProcessing.nli.purpose', 'mediaProcessing.nli.pillOn',
+      'mediaProcessing.nli.pillOff', 'mediaProcessing.nli.endpointHint', 'mediaProcessing.nli.egressWarning',
+      'mediaProcessing.office.title', 'mediaProcessing.office.purpose',
+      'about.components.pending',
+    ];
+    for (const loc of LOCALES) {
+      it(loc, () => {
+        const j = JSON.parse(readFileSync(`client/public/assets/i18n/${loc}.json`, 'utf8'));
+        const missing = NEEDED.filter(k => !j[k]);
+        assert.deepEqual(missing, [], `missing in ${loc}`);
+      });
+    }
+  });
+
+  describe('About renders its components card immediately', () => {
+    it('has a pending branch, so the card does not appear out of nowhere', () => {
+      const about = readFileSync('client/src/app/pages/settings/about.component.ts', 'utf8');
+      assert.match(about, /@if \(!health\(\)\) \{/);
+      assert.match(about, /about\.components\.pending/);
+    });
+  });
+});

--- a/testing/standalone/source-text-hygiene.test.js
+++ b/testing/standalone/source-text-hygiene.test.js
@@ -88,6 +88,28 @@ describe('source text carries no raw control bytes', () => {
       'escape sequence instead (\\u0000, \\b): identical value, reviewable file.\n' + offenders.join('\n'));
   });
 
+  it('no tracked file carries an unresolved conflict marker', () => {
+    // Committed in this very PR, and nothing caught it. A rebase left markers in CHANGELOG.md; the
+    // script meant to strip them searched for "<<<<<<< HEAD\n" against a CRLF file, matched nothing,
+    // and printed success anyway. `git rebase --continue` does not re-check, no linter reads the
+    // CHANGELOG, and the markers went in.
+    //
+    // Cheap to check and impossible to argue with: these three tokens at the start of a line are never
+    // legitimate content in this repo. Anchored to line start so prose about them (like this comment)
+    // does not trip it.
+    const MARKERS = [/^<{7} /, /^={7}$/, /^>{7} /];
+    const offenders = [];
+    for (const f of files) {
+      const lines = readFileSync(f, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        const t = line.replace(/\r$/, '');
+        if (MARKERS.some(m => m.test(t))) offenders.push(`${f}:${i + 1}  ${t.slice(0, 60)}`);
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'unresolved merge/rebase conflict markers are committed here:\n' + offenders.join('\n'));
+  });
+
   it('the hash separator that started this is still a real NUL at runtime', () => {
     // The point was never to remove the separator — only to stop writing it as a raw byte. If a future
     // cleanup "fixes" the escape away, distinct entity pairs start colliding in the dupe scanner's


### PR DESCRIPTION
Two models the Models screen never listed — both configurable since the day they shipped, neither reachable from the admin surface. So the one page that claims to enumerate the pipeline's models was quietly incomplete.

## Contradiction judge (NLI)

Settable by `NLI_URL` / `NLI_MODEL` / `NLI_API_KEY` and `config.json` from the first release. Absent from `PATCH /api/admin/media-config`, absent from the pipeline probe, absent from the UI.

**It is the one model here whose absence produces a view that looks *finished*.** An unreachable reranker gives worse ordering — visibly worse. An unreachable judge gives an **empty Contradictions list**, which is indistinguishable from "nothing contradicts". From inside the app there was no way to tell those two apart.

Now patchable, probed, and shown with a health dot that means something.

### The guard rails ship in the same commit, not after someone notices

Wiring this up creates a genuine egress path, and a heavier one than it looks: the judge is sent **pairs of record texts**, not a search query. The card says so when the endpoint is remote.

| | |
|---|---|
| SSRF | checked, with the permitting flag named in the rejection |
| API key | routed to `secrets.json`, masked on read, never written to `config.json` |
| env-pinned | `403` rather than a silently ignored write |
| `baseUrl` / `model` | **nullable** |

That last row is the one worth stating plainly. There is no master toggle — clearing the endpoint *is* the off switch — so a field that could only ever be **set** would be a one-way door: configure the judge once and never be able to undo it from the UI.

## Office renderer

`RENDER_OFFICE_SIDECAR_URL` was probed by the server and reported on About, but missing from this tab — visible everywhere except the screen about models. Read-only infra card, matching the page renderer and document converter beside it.

## Also: About → Components appeared out of nowhere

The card rendered only once its probe answered, for a reason the code stated and that was **half right**:

> an empty card that fills in a moment later reads as "nothing configured", which is a different claim entirely

True. But the remedy was wrong — rendering *nothing* still makes a whole card materialise on a page the reader has already finished scanning, which is what was reported. It now renders immediately in a **pending** state, which claims neither.

The existing spec asserted the old card count, so fixing the behaviour had to change the test. It now pins both the pending state and that the resolved card *replaces* rather than duplicates it.

## Verification

**Mutation-checked — nine mutations, all killed:**

| Mutation | |
|---|---|
| drop the SSRF check on `nli.baseUrl` | killed |
| drop the env-locked `403` | killed |
| let the API key reach `config.json` | killed |
| make `baseUrl` non-nullable (the one-way door) | killed |
| assume the stage is never external | killed |
| forget to clear the key input after save | killed |
| send `''` instead of `null` on clear | killed |
| use an unregistered icon (renders blank, no error) | killed |
| drop the egress warning | killed |

**Two of the nine initially failed to *apply*** and were re-anchored. A mutation that misses its target reads exactly like one that was caught — which is the second time that has bitten in this series, so it is checked explicitly now.

`npm run preflight` green.

## One more gate, earned the hard way

A rebase in this PR left **conflict markers in `CHANGELOG.md` and they got committed**. The script meant to strip them searched for `"<<<<<<< HEAD\n"` against a CRLF file, matched nothing, and reported success anyway. `git rebase --continue` does not re-check, and no linter reads the CHANGELOG.

`source-text-hygiene` now fails on any tracked file carrying a conflict marker at line start. Cheap, unarguable, and mutation-checked.

## Queued behind the 2.1.0 tag

Owner has asked for these after the release, as UX-only: Pipelines tab ordering and default, per-pipeline save buttons, showing what a pipeline actually *runs* rather than only what is available, gating toggles when step one is unavailable, Overview statistics ordering, and tab icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
