### PR TITLE
fix(startup): boot no longer waits an hour for vector index builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,6 +493,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrading from 2.0.0 could look like a crash loop: boot blocked for over an hour waiting on vector
+  index builds.** 2.0.0 added filter fields to the `$vectorSearch` indexes, so every upgrade reshapes the
+  existing ones — and `initAllSpaces` awaited READY while doing it. That wait is **serial per index, per
+  space**, with a 60-second ceiling each:
+
+  ```text
+  13 spaces × ~5 indexes × 60s  ≈  65 minutes of blocking startup
+  ```
+
+  Reported from a Kubernetes deployment where it exceeded a 60-minute `startupProbe` budget. The
+  container was killed mid-migration and a completely healthy upgrade presented as a failure to start.
+  - **The wait was buying nothing.** Every poll in that report timed out, logged a warning, and continued
+    regardless — so the delay was certain and the guarantee was absent. A wait whose failure path is
+    "carry on anyway" is not a guarantee.
+  - Boot now uses the path `createSpace` has used since B1: create or update the indexes (still awaited —
+    that part is fast and must precede traffic), mark the space `building`, and let a background pass
+    flip it to `ready`/`failed`. **No new machinery** — the old code already relied on `initAllSpaces` to
+    recover spaces left `building` by a crash; it now recovers them the same way they were created.
+  - **The background ceiling is 10 minutes, not 60 seconds** (`INDEX_READY_TIMEOUT_MS`). The old ceiling
+    was short *because* boot was blocked on it, and being short is precisely why it expired on a real
+    migration and reported `failed` for indexes that were building perfectly well. Off the boot path
+    nothing waits on it but a status label, so it can afford to be long enough to be true.
+  - Confirmation runs **three spaces at a time**. One task per space, each polling every collection once
+    a second, would be ~65 pollers hammering `listSearchIndexes` — swapping a startup stall for a load
+    spike on the database doing the building.
+  - Recall against a still-building index returns empty rather than failing, which is pre-existing
+    behaviour and is why deferring is safe: the ceiling never protected correctness.
+
 - **A wide table's horizontal scrollbar was ~2800px below the fold, so "scrollable" and "reachable" were
   not the same thing.** #534 gave `.table-wrapper` `overflow-x: auto`, and it worked: measured on Brain →
   Entities at a 900px viewport, the wrapper had 614px of width and 822px of content — real, scrollable

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -405,6 +405,20 @@ Size `startupProbe.failureThreshold × periodSeconds` to cover that, and let `li
 after the startup probe succeeds. A startup budget tuned to the warm-boot time turns a normal first boot
 into a crashloop, which then looks like a failure to start rather than a probe that was too impatient.
 
+> **Upgrading to 2.1 from 2.0.x fixes a much worse version of this.** 2.0.0 reshaped existing vector
+> indexes on startup and *waited* for each one to report READY — serially, with a 60-second ceiling per
+> index. On an instance with a dozen spaces that was **over an hour of blocking startup**, enough to blow
+> a 60-minute `startupProbe` budget and have a perfectly healthy upgrade killed mid-migration.
+>
+> From 2.1, index builds are confirmed **in the background**: boot completes in seconds, affected spaces
+> report `indexStatus: "building"`, and each flips to `ready` when its build finishes. Semantic recall on
+> a space that is still building returns no results until it completes — the same behaviour a
+> newly-created space has always had. `INDEX_READY_TIMEOUT_MS` (default 10 minutes) bounds how long the
+> background check waits before marking a space `failed`; raise it for very large collections.
+>
+> **If you are upgrading a 2.0.x instance with many spaces, upgrade straight to 2.1** rather than
+> restarting 2.0.x, and there is no need to raise the startup budget for it.
+
 Note also that a newly created space returns immediately with `indexStatus: "building"` — it is writable
 at once, but semantic recall stays empty until the index finishes. That is expected, not a fault.
 

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -147,29 +147,101 @@ export async function initSpace(
   }
 }
 
-/** Initialise all spaces defined in config */
+/**
+ * How long the background pass waits for one space's indexes, in ms.
+ *
+ * Ten minutes, not the 60 seconds the boot path used. The old ceiling existed because boot was blocked
+ * on it, so it had to be short — and being short is exactly why it always expired on a real migration
+ * and reported `failed` for indexes that were building perfectly well. Off the boot path nothing is
+ * waiting on this but a status label, so it can afford to be long enough to be TRUE.
+ */
+const STARTUP_INDEX_READY_TIMEOUT_MS = Number(process.env['INDEX_READY_TIMEOUT_MS'] ?? 10 * 60_000);
+
+/** How many spaces confirm their index builds at once, once boot has already finished. */
+const FINALIZE_CONCURRENCY = 3;
+
+/**
+ * Initialise all spaces defined in config.
+ *
+ * ## Boot does not wait for index builds any more
+ *
+ * It used to. `initSpace` defaulted to `waitForVectorReady: true`, which polls each index for READY with
+ * a 60-second ceiling — **serially, per index, per space**. An upgrade that reshapes existing indexes
+ * (2.0.0 added filter fields to them) therefore paid that ceiling on every index it touched:
+ *
+ *     13 spaces x ~5 indexes x 60s  ≈  65 minutes of blocking startup
+ *
+ * Reported from a real deployment, where it exceeded a 60-minute Kubernetes `startupProbe` budget. The
+ * container was killed mid-migration and a completely healthy upgrade presented as a crash loop.
+ *
+ * The wait was also buying nothing. Every poll in that report timed out — logged a warning and continued
+ * regardless — so the cost was certain and the guarantee was not. A wait whose failure path is "carry on
+ * anyway" is not a guarantee, it is a delay.
+ *
+ * ## What replaces it
+ *
+ * Exactly the path `createSpace` has used since B1: create or update the indexes, mark the space
+ * `building`, return, and let a background task flip it to `ready`/`failed` when the builds actually
+ * finish. Nothing here is new machinery — the previous code even said so, in the comment explaining that
+ * `initAllSpaces` is what recovers a space left `building` by a crash. It now recovers it the same way
+ * it was created.
+ *
+ * Recall on a still-building index returns empty rather than failing, which is the pre-existing
+ * behaviour and is why deferring is safe: the ceiling was never protecting correctness, only tidiness.
+ */
 export async function initAllSpaces(): Promise<void> {
-  // Collect ids, not space objects: `initSpace` waits for index readiness, so this loop holds its
-  // references across many seconds of awaits. A config reload in that window replaces cfg.spaces and
-  // every held object becomes an orphan — the status flips below would then be written to detached
-  // records and lost, leaving spaces stuck reporting 'building' forever with nothing to explain it.
-  const readyAgain: string[] = [];
-  for (const spaceId of getConfig().spaces.map(s => s.id)) {
+  // Collect ids, not space objects: a config reload during these awaits replaces cfg.spaces and every
+  // held object becomes an orphan — status flips would then be written to detached records and lost,
+  // leaving spaces stuck reporting 'building' forever with nothing to explain it.
+  const spaceIds = getConfig().spaces.map(s => s.id);
+
+  for (const spaceId of spaceIds) {
     log.debug(`Initialising space: ${spaceId}`);
-    await initSpace(spaceId);
-    // initSpace waited for READY here, so a space left mid-build by a crash during
-    // createSpace's async finalize (B1) is now ready — clear the stale marker.
-    const current = getConfig().spaces.find(s => s.id === spaceId);
-    if (current?.indexStatus === 'building' || current?.indexStatus === 'failed') readyAgain.push(spaceId);
+    // Collections, regular indexes and the vector-index create/update all still happen here and are
+    // still awaited. Only the READY *poll* is deferred — the schema work must be done before the
+    // instance serves traffic, and it is fast.
+    await initSpace(spaceId, { waitForVectorReady: false });
   }
-  if (readyAgain.length > 0) {
-    mutateConfig(fresh => {
-      for (const spaceId of readyAgain) {
-        const live = fresh.spaces.find(s => s.id === spaceId);
-        if (live) live.indexStatus = 'ready';
+
+  // Every space is now either genuinely ready or building; say so, and let the background pass settle it.
+  mutateConfig(fresh => {
+    for (const spaceId of spaceIds) {
+      const live = fresh.spaces.find(s => s.id === spaceId);
+      if (live) live.indexStatus = 'building';
+    }
+  });
+
+  log.info(`Initialised ${spaceIds.length} space(s); confirming vector index readiness in the background.`);
+  void confirmSpaceIndexesInBackground(spaceIds);
+}
+
+/**
+ * Confirm index readiness after boot, a few spaces at a time.
+ *
+ * Bounded because the alternative is unbounded: one `finalizeSpaceIndexReady` per space, each polling
+ * every collection's index once a second. Thirteen spaces would be ~65 pollers hitting
+ * `listSearchIndexes` every second for as long as the builds take — replacing a startup stall with a
+ * self-inflicted load spike on the database that is doing the building.
+ *
+ * Deliberately not awaited by the caller, and deliberately never throwing: nothing downstream of boot
+ * depends on the outcome, and an unhandled rejection here would take down a process whose only pending
+ * work is a status label.
+ */
+async function confirmSpaceIndexesInBackground(spaceIds: readonly string[]): Promise<void> {
+  const queue = [...spaceIds];
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const spaceId = queue.shift();
+      if (!spaceId) return;
+      try {
+        await finalizeSpaceIndexReady(spaceId, { timeoutMs: STARTUP_INDEX_READY_TIMEOUT_MS });
+      } catch (err) {
+        log.warn(`Space '${spaceId}': index readiness check failed: ${err instanceof Error ? err.message : String(err)}`);
       }
-    });
-  }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(FINALIZE_CONCURRENCY, queue.length) }, worker));
+  log.info('Vector index readiness confirmed for all spaces.');
 }
 
 /** Ensure the built-in 'general' space exists in config and MongoDB */

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -267,9 +267,11 @@ export async function pollVectorIndexReady(
   spaceId: string,
   collectionSuffix: VectorIndexedCollection,
   indexName: string,
+  opts: { timeoutMs?: number } = {},
 ): Promise<boolean> {
   const coll = getDb().collection(`${spaceId}_${collectionSuffix}`);
-  for (let attempt = 0; attempt < 60; attempt++) {
+  const attempts = Math.max(1, Math.round((opts.timeoutMs ?? 60_000) / 1000));
+  for (let attempt = 0; attempt < attempts; attempt++) {
     await new Promise(r => setTimeout(r, 1000));
     try {
       const current = await coll.listSearchIndexes(indexName).toArray() as Array<{ status?: string }>;
@@ -308,16 +310,19 @@ export async function buildSpaceVectorIndexes(
 
 /** Poll all of a space's vector-search indexes until READY. Returns true only if every
  *  expected index reached READY within the window. */
-export async function waitForSpaceIndexesReady(spaceId: string): Promise<boolean> {
+export async function waitForSpaceIndexesReady(
+  spaceId: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<boolean> {
   // Poll CONCURRENTLY. These builds run independently inside the database, so waiting on them one after
   // another only adds up their timeouts: five collections at a 60s ceiling each meant a space could sit
   // at indexStatus='building' for five minutes when every index was in fact ready in seconds. That was
   // masked for as long as only `memories` was ever indexed — fixing that made the serial wait visible.
   const polls = VECTOR_INDEXED_COLLECTIONS.map(suffix =>
-    pollVectorIndexReady(spaceId, suffix, `${spaceId}_${suffix}_embedding`),
+    pollVectorIndexReady(spaceId, suffix, `${spaceId}_${suffix}_embedding`, opts),
   );
   if (getFaceRecognitionConfig().enabled) {
-    polls.push(pollVectorIndexReady(spaceId, 'files', `${spaceId}_files_faceEmbedding`));
+    polls.push(pollVectorIndexReady(spaceId, 'files', `${spaceId}_files_faceEmbedding`, opts));
   }
   const results = await Promise.all(polls);
   return results.every(Boolean);
@@ -326,10 +331,13 @@ export async function waitForSpaceIndexesReady(spaceId: string): Promise<boolean
 /** Background step kicked off by createSpace: wait for the deferred vector-index
  *  builds to reach READY, then flip the space's indexStatus to 'ready' (or 'failed').
  *  A crash before this completes is recovered on the next boot by initAllSpaces. */
-export async function finalizeSpaceIndexReady(spaceId: string): Promise<void> {
+export async function finalizeSpaceIndexReady(
+  spaceId: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<void> {
   let ok = false;
   try {
-    ok = await waitForSpaceIndexesReady(spaceId);
+    ok = await waitForSpaceIndexesReady(spaceId, opts);
   } catch (err) {
     log.warn(`Space '${spaceId}': error awaiting vector index readiness: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/testing/standalone/startup-index-wait.test.js
+++ b/testing/standalone/startup-index-wait.test.js
@@ -1,0 +1,123 @@
+/**
+ * Boot must not block on vector-index READY polling.
+ *
+ * ## The failure this prevents
+ *
+ * 2.0.0 added filter fields to the $vectorSearch indexes, so upgrading reshapes every existing one.
+ * `initAllSpaces` awaited readiness while doing it, and that wait is **serial per index, per space**,
+ * with a 60-second ceiling each:
+ *
+ *     13 spaces x ~5 indexes x 60s  ≈  65 minutes of blocking startup
+ *
+ * Reported from a real Kubernetes deployment where it exceeded a 60-minute `startupProbe` budget: the
+ * container was killed mid-migration, and a completely healthy upgrade presented as a crash loop. The
+ * cost was also being paid for nothing — every poll in that report timed out, warned, and continued, so
+ * the guarantee was absent while the delay was certain.
+ *
+ * ## Why a source-level gate
+ *
+ * The regression is a single default reverting: `initSpace(spaceId)` instead of
+ * `initSpace(spaceId, { waitForVectorReady: false })`. It needs a live MongoDB with Atlas Search to
+ * observe behaviourally, so CI would catch it only in the Docker suite, and only as a slow run rather
+ * than a failure — the exact signature that let it ship. Pinning the call shape catches it offline, in
+ * the second it takes to run.
+ *
+ * Run: node --test testing/standalone/startup-index-wait.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const LIFECYCLE = readFileSync('server/src/spaces/lifecycle.ts', 'utf8');
+const VECTOR = readFileSync('server/src/spaces/vector-index.ts', 'utf8');
+
+/**
+ * The body of `initAllSpaces` ONLY — up to its own closing brace at column 0.
+ *
+ * Not "up to the next export": the background helper below it is not exported, so a looser slice
+ * swallowed it, and its `await finalizeSpaceIndexReady(...)` — which is correct, being inside the
+ * background worker — failed the very assertion that exists to keep that await OFF the boot path.
+ */
+function initAllSpacesBody() {
+  const lines = LIFECYCLE.split('\n');
+  const start = lines.findIndex(l => l.startsWith('export async function initAllSpaces'));
+  assert.ok(start >= 0, 'initAllSpaces should exist');
+  const end = lines.findIndex((l, i) => i > start && l.replace(/\r$/, '') === '}');
+  assert.ok(end > start, 'initAllSpaces should be closed at column 0');
+  return lines.slice(start, end + 1).join('\n');
+}
+
+describe('startup does not block on index readiness', () => {
+  const body = initAllSpacesBody();
+
+  it('initAllSpaces defers the READY poll', () => {
+    assert.match(body, /initSpace\(spaceId,\s*\{\s*waitForVectorReady:\s*false\s*\}\)/,
+      'initAllSpaces must call initSpace with waitForVectorReady:false — the default is true, and the ' +
+      'default is a ~65 minute startup on a 13-space upgrade');
+  });
+
+  it('and never awaits readiness inline', () => {
+    // The two functions that block. Either one on this path re-creates the stall.
+    assert.doesNotMatch(body, /await\s+waitForSpaceIndexesReady/);
+    assert.doesNotMatch(body, /await\s+finalizeSpaceIndexReady/);
+    assert.doesNotMatch(body, /await\s+pollVectorIndexReady/);
+  });
+
+  it('hands readiness to a background pass', () => {
+    assert.match(body, /void confirmSpaceIndexesInBackground\(/,
+      'readiness must still be confirmed — deferred, not dropped');
+    assert.match(LIFECYCLE, /finalizeSpaceIndexReady\(spaceId, \{ timeoutMs: STARTUP_INDEX_READY_TIMEOUT_MS \}\)/);
+  });
+
+  it('marks spaces building so the deferred state is visible, not invented', () => {
+    // Without this a space whose indexes are still building reports 'ready' and its empty recall results
+    // look like data loss rather than a build in progress.
+    assert.match(body, /indexStatus = 'building'/);
+  });
+
+  it('bounds how many spaces are confirmed at once', () => {
+    // One finalize per space, each polling every collection once a second, is ~65 pollers hammering
+    // listSearchIndexes — swapping a startup stall for a load spike on the database doing the building.
+    assert.match(LIFECYCLE, /FINALIZE_CONCURRENCY\s*=\s*\d+/);
+    const conc = Number(/FINALIZE_CONCURRENCY\s*=\s*(\d+)/.exec(LIFECYCLE)?.[1]);
+    assert.ok(conc >= 1 && conc <= 8, `concurrency should be a small bound, got ${conc}`);
+    assert.match(LIFECYCLE, /Math\.min\(FINALIZE_CONCURRENCY, queue\.length\)/,
+      'never spawn more workers than there are spaces');
+  });
+
+  it('the background pass cannot take the process down', () => {
+    // It is fire-and-forget; an unhandled rejection in a status-label task must not kill a healthy server.
+    const at = LIFECYCLE.indexOf('async function confirmSpaceIndexesInBackground');
+    assert.ok(at > 0);
+    const fn = LIFECYCLE.slice(at, at + 1200);
+    assert.match(fn, /try \{[\s\S]*?\} catch \(err\) \{/, 'each space must be individually guarded');
+  });
+});
+
+describe('the readiness timeout is a parameter, and generous off the boot path', () => {
+  it('pollVectorIndexReady accepts a timeout instead of hard-coding 60 attempts', () => {
+    assert.match(VECTOR, /opts:\s*\{\s*timeoutMs\?:\s*number\s*\}\s*=\s*\{\s*\}/);
+    assert.match(VECTOR, /const attempts = Math\.max\(1, Math\.round\(\(opts\.timeoutMs \?\? 60_000\) \/ 1000\)\)/,
+      'the default must stay 60s so existing callers are unchanged');
+    assert.doesNotMatch(VECTOR, /attempt < 60;/, 'the hard-coded ceiling should be gone');
+  });
+
+  it('waitForSpaceIndexesReady and finalizeSpaceIndexReady thread it through', () => {
+    // A timeout accepted at the top and dropped halfway down is the worst kind of knob: it looks
+    // configurable and is not.
+    assert.match(VECTOR, /pollVectorIndexReady\(spaceId, suffix, `\$\{spaceId\}_\$\{suffix\}_embedding`, opts\)/);
+    assert.match(VECTOR, /pollVectorIndexReady\(spaceId, 'files', `\$\{spaceId\}_files_faceEmbedding`, opts\)/);
+    assert.match(VECTOR, /waitForSpaceIndexesReady\(spaceId, opts\)/);
+  });
+
+  it('startup waits far longer than 60s, because nothing is blocked on it', () => {
+    // The old ceiling was short BECAUSE boot was blocked on it — and being short is exactly why it
+    // always expired on a real migration and reported `failed` for indexes that were building fine.
+    const m = /STARTUP_INDEX_READY_TIMEOUT_MS = Number\(process\.env\['INDEX_READY_TIMEOUT_MS'\] \?\? ([^)]+)\)/
+      .exec(LIFECYCLE);
+    assert.ok(m, 'startup timeout should be defined and env-overridable');
+    // eslint-disable-next-line no-eval
+    const ms = eval(m[1].replaceAll('_', ''));
+    assert.ok(ms >= 5 * 60_000, `expected a multi-minute ceiling, got ${ms}ms`);
+  });
+});


### PR DESCRIPTION
**Upgrade-blocking.** Reported against 2.0.0 from a Kubernetes deployment.

## What happens

2.0.0 added filter fields to the `$vectorSearch` indexes, so every upgrade reshapes the existing ones — and `initAllSpaces` awaited READY while doing it. That wait is **serial per index, per space**, with a 60-second ceiling each:

```text
13 spaces × ~5 indexes × 60s  ≈  65 minutes of blocking startup
```

That exceeds a 60-minute `startupProbe` budget. The container is killed mid-migration, and a completely healthy upgrade presents as a crash loop.

**The wait was buying nothing.** Every poll in the report timed out (`did not reach READY within 60s after update`), logged a warning, and continued regardless. The delay was certain; the guarantee was absent. A wait whose failure path is "carry on anyway" is a delay, not a guarantee.

## The fix is their suggestion, and it is our own existing pattern

Boot now uses the path `createSpace` has used since B1:

1. Create or update the indexes — **still awaited**; that part is fast and must precede traffic.
2. Mark the space `indexStatus: "building"`.
3. A background pass flips it to `ready`/`failed` when the builds actually finish.

No new machinery. The old code already depended on `initAllSpaces` to recover a space left `building` by a crash during `createSpace`'s async finalize — it now recovers it the same way it was created.

## Three things the naive version gets wrong

| | |
|---|---|
| **The 60s ceiling was short *because* boot was blocked on it.** Kept as-is off the boot path, it would mark thirteen healthy spaces `failed` on a real migration. | Ten minutes, env-overridable (`INDEX_READY_TIMEOUT_MS`), and threaded all the way down — a timeout accepted at the top and dropped halfway is a knob that looks configurable and is not. |
| **One finalize per space, each polling every collection once a second, is ~65 pollers** hitting `listSearchIndexes` every second — a startup stall traded for a load spike on the database doing the building. | Bounded to three spaces at a time. |
| **The background pass is fire-and-forget.** An unhandled rejection in a task whose only product is a status label must not kill a server that is otherwise serving fine. | Every space individually guarded. |

## Why spaces are marked `building` rather than left alone

Recall against a still-building index returns empty. Empty results under a `ready` label read as data loss; empty under `building` reads as what it is. That behaviour is unchanged from newly-created spaces — and it is why deferring is safe at all: **the ceiling was never protecting correctness.**

## Verification

**Mutation-checked — eight mutations, all killed:**

| Mutation | |
|---|---|
| revert to the blocking wait (the reported bug) | killed |
| await the background pass on the boot path | killed |
| stop marking spaces `building` | killed |
| unbounded finalize concurrency | killed |
| drop the per-space guard | killed |
| shorten the ceiling back to 60s | killed |
| re-hard-code the 60-attempt poll | killed |
| drop the timeout one level down | killed |

One of the eight first failed to *apply* — a `\n` anchor against a CRLF file — and was re-anchored. That is the second time today; a mutation that misses its target reads exactly like one that was caught.

**The gate is source-level on purpose.** The regression is a single default reverting (`initSpace(spaceId)` instead of passing `waitForVectorReady: false`). Observing it behaviourally needs a live Atlas Search, and in CI it would surface as a *slow Docker run* rather than a failure — which is precisely the signature that let it ship in the first place.

`npm run preflight` and `npm run lint:docs` green.

## Docs

The integration guide's first-boot section now carries an upgrade note: what 2.0.x did, what 2.1 does instead, that `indexStatus: "building"` is expected and recall is empty until it clears, and that there is no need to raise the startup budget for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
