### PR TITLE
feat(ux): a scroll control above the table, and the pipelines batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Wide tables carry a visible scroll control above them, not an invisible one below.** #548 bounded the
+  wrapper so its scrollbar was not a page-length away; that added a second nested vertical scrollbar and
+  still did not put the control where the eye is, because a scroll container's bar is at the bottom of
+  its box and the box moves with the page. Height was never the problem — position was.
+  - The control is now **drawn** (a track and a proportional thumb, dragged or clicked), sitting
+    immediately above the table. A mirrored *native* scroller was tried first and was invisible: this
+    platform uses overlay scrollbars that paint only while scrolling and occupy no layout space
+    (`offsetHeight - clientHeight === 0`, confirmed by screenshot). Styling `::-webkit-scrollbar` did not
+    bring it back.
+  - The table keeps its own `overflow-x: auto`, so wheel, trackpad, touch and keyboard scrolling are
+    untouched — this adds a handle for them rather than replacing the mechanism. The nested vertical
+    scrollbar is gone; the page has one again.
+  - `ResizeObserver` is feature-detected. Constructing it unguarded threw in jsdom and took down twelve
+    unrelated component specs — a decorative scrollbar breaking the test suite for tables it merely
+    happened to be attached to.
+
+- **Media Processing opens on Pipelines, and each pipeline saves itself.**
+  - **Pipelines is first and the landing tab.** It answers the question an operator arrives with — what
+    happens to a file I upload — where Models answers the follow-up. Clicking a step already jumps to the
+    model that implements it, so the tab order now matches the direction people already move in.
+  - **Text first, then Documents, then Images, Audio, Video** — poor to rich *medium*. Documents sits
+    second despite being much the hardest pipeline to implement, because sorting by implementation
+    difficulty produces an order that is incoherent to anyone who has not read the code.
+  - **All four media pipelines now show what they actually run**, not merely what is available. Only the
+    document pipeline ever dimmed its unused steps; the others rendered green dots and no indication of
+    which steps the configured rung executes — so "the traffic light says the model is up" and "this step
+    runs" looked like the same statement.
+  - **A pipeline whose first step is unavailable offers only `off` and `auto`.** Everything downstream
+    consumes step one's output, so a rung promising captioning or transcription is a promise the instance
+    cannot keep. `auto` stays because it is not a promise — with step one down it resolves to nothing
+    running — and removing it would strand an operator whose stored value *is* `auto` with no valid
+    option. The greyed-out rungs say why, since a disabled control with no explanation reads as a bug.
+  - **A Save per pipeline**, replacing the one bar at the bottom. Safe because the server already merges
+    both affected blocks per key: `levels` through `mergeLevelCeilings`, `documentProcessing` through the
+    one-level deep merge the assist card relies on. The old code justified the bar by saying pipeline
+    knobs "are not grouped into per-provider boxes" — true of the layout, not of the data.
+
+- **Brain's Overview tiles follow the tab strip: Entities · Edges · Memories · Chrono · Files.** The tiles
+  are shortcuts into those tabs and used to lead with Memories, so the two disagreed about what comes next
+  and every click became a small search.
+
+- **The four record tabs finally show icons — and finally translate.** Overview, Query, Graph, Review and
+  Files each carried an icon; Entities, Edges, Memories and Chrono did not, leaving a strip where some
+  tabs have one and some do not. Their labels were also hard-coded English literals while the
+  translations existed unused, so the strip read half-German in a German UI and nothing flagged it.
+
 - **The media env vars are named after what they configure, not after what once implemented them.**
   `OLLAMA_URL` → **`VISION_BASE_URL`**, `WHISPER_URL` → **`STT_BASE_URL`**, `WHISPER_MODEL` →
   **`STT_MODEL`**.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1598,6 +1598,7 @@
   "mediaProcessing.class.text": "Text",
   "mediaProcessing.pipelines.ceilingHint": "Jede Pipeline unten hat eine Instanz-Obergrenze — das Maximum, das ein Space mit dieser Klasse tun darf. Ein Space kann weniger wählen, nie mehr: Wird eine Obergrenze gesenkt, werden alle bereits höher eingestellten Spaces begrenzt; ihre eigene Wahl bleibt erhalten, wenn du sie wieder anhebst.",
   "mediaProcessing.pipelines.ceilingOffWarning": "Aus gilt überall — kein Bereich kann diese Klasse verarbeiten.",
+  "mediaProcessing.pipelines.firstStepDown": "Der erste Schritt dieser Pipeline ist nicht verfügbar, daher sind nur „Aus\" und „Auto\" wählbar. Konfiguriere ihn im Tab „Modelle\".",
   "files.progress.working": "Läuft",
   "files.progress.stalled": "Kein Fortschritt gemeldet — dieser Auftrag hängt möglicherweise",
   "mediaProcessing.face.confidence": "Schwelle für automatische Zuordnung",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1598,6 +1598,7 @@
   "mediaProcessing.class.text": "Text",
   "mediaProcessing.pipelines.ceilingHint": "Each pipeline below carries an instance ceiling — the most any space may do with that class. A space can choose less, never more: lowering a ceiling caps every space already above it, and those spaces keep their own choice if you raise it again.",
   "mediaProcessing.pipelines.ceilingOffWarning": "Off applies everywhere — no space can process this class.",
+  "mediaProcessing.pipelines.firstStepDown": "The first step of this pipeline is unavailable, so only Off and Auto can be selected. Configure it on the Models tab.",
   "files.progress.working": "Working",
   "files.progress.stalled": "No progress reported — this job may be stuck",
   "mediaProcessing.face.confidence": "Auto-label threshold",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1598,6 +1598,7 @@
   "mediaProcessing.class.text": "Tekst",
   "mediaProcessing.pipelines.ceilingHint": "Każdy potok poniżej ma limit instancji — maksimum, jakie przestrzeń może zrobić z daną klasą. Przestrzeń może wybrać mniej, nigdy więcej: obniżenie limitu ogranicza każdą przestrzeń już powyżej niego, a te przestrzenie zachowują swój wybór, gdy limit zostanie ponownie podniesiony.",
   "mediaProcessing.pipelines.ceilingOffWarning": "Wyłączenie obowiązuje wszędzie — żadna przestrzeń nie przetworzy tej klasy.",
+  "mediaProcessing.pipelines.firstStepDown": "Pierwszy krok tego potoku jest niedostępny, więc można wybrać tylko „Wył.\" i „Auto\". Skonfiguruj go w zakładce „Modele\".",
   "files.progress.working": "W toku",
   "files.progress.stalled": "Brak zgłoszonego postępu — to zadanie mogło się zaciąć",
   "mediaProcessing.face.confidence": "Próg automatycznego oznaczania",

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -231,7 +231,7 @@ interface SpaceView {
         <span class="tab-spacer"></span>
         @for (tab of collectionTabs; track tab.key) {
           <button class="tab" [class.active]="activeTab() === tab.key" (click)="setTab(tab.key)">
-            {{ tab.label }}
+            <ph-icon [name]="tab.icon" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ tab.label | transloco }}
             @if (activeStats(); as s) {
               @if (tab.statsKey) {
                 <span class="tab-count">{{ s[tab.statsKey] }}</span>
@@ -330,11 +330,24 @@ export class BrainComponent implements OnInit, OnDestroy {
   private transloco = inject(TranslocoService);
 
   // File Meta merged into the Files tab (rendered separately, after these, in the same group).
-  collectionTabs: { key: BrainTab; label: string; statsKey?: keyof SpaceStats }[] = [
-    { key: 'entities', label: 'Entities', statsKey: 'entities' },
-    { key: 'edges', label: 'Edges', statsKey: 'edges' },
-    { key: 'memories', label: 'Memories', statsKey: 'memories' },
-    { key: 'chrono', label: 'Chrono', statsKey: 'chrono' },
+  /**
+   * The record-collection tabs.
+   *
+   * `label` is an i18n KEY now, not a literal. These four were the only tabs in the strip rendering a
+   * hard-coded English string — the translations existed the whole time and were simply never used, so
+   * the strip read half-German in a German UI and nothing flagged it.
+   *
+   * `icon` likewise: Overview, Query, Graph, Review and Files each carried one and these four did not,
+   * leaving a strip where some tabs have an icon and some do not. The icons match the Overview tiles
+   * that link here, because the tiles and the tabs are the same five things.
+   */
+  collectionTabs: { key: BrainTab; label: string; icon: string; statsKey?: keyof SpaceStats }[] = [
+    { key: 'entities', label: 'brain.tab.entities', icon: 'stack', statsKey: 'entities' },
+    // `link` and not `graph`: the Graph tab already owns that glyph, and two different tabs wearing the
+    // same icon in one strip is worse than a slightly less literal one.
+    { key: 'edges', label: 'brain.tab.edges', icon: 'link', statsKey: 'edges' },
+    { key: 'memories', label: 'brain.tab.memories', icon: 'brain', statsKey: 'memories' },
+    { key: 'chrono', label: 'brain.tab.chrono', icon: 'timer', statsKey: 'chrono' },
   ];
 
   readonly pageSize = 20;

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -19,6 +19,7 @@ import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError, toLocalDatetime } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 /**
  * The Chrono record tab, extracted from BrainComponent (A17.9b-6g) following the memories/edges pattern.
@@ -35,7 +36,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -122,7 +123,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <div class="alert alert-error" style="margin-bottom:12px;">{{ createChronoError() }}</div>
           }
 
-          <div class="table-wrapper">
+          <div class="table-wrapper" hscrollTop>
             <table>
               <thead>
                 <tr>

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -19,6 +19,7 @@ import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 /**
  * The Edges record tab, extracted from BrainComponent (A17.9b-6f) following the memories pattern.
@@ -33,7 +34,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-edges-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -116,7 +117,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
           @if (createEdgeError()) {
             <div class="alert alert-error" style="margin-bottom:12px;">{{ createEdgeError() }}</div>
           }
-          <div class="table-wrapper">
+          <div class="table-wrapper" hscrollTop>
             <table>
               <thead>
                 <tr>

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -17,6 +17,7 @@ import { RecordTabBase } from './record-tab-base';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 /**
  * The Entities record tab, extracted from BrainComponent (A17.9b-6e) following the memories pattern.
@@ -34,7 +35,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-entities-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, SortableHeaderComponent, HscrollTopDirective],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -105,7 +106,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             <div class="alert alert-error" style="margin-bottom:12px;">{{ createEntityError() }}</div>
           }
 
-          <div class="table-wrapper">
+          <div class="table-wrapper" hscrollTop>
             <table>
               <thead>
                 <tr>

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -19,6 +19,7 @@ import { RecordSearchBarComponent } from './record-search-bar.component';
 import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 /**
  * The Memories record tab, extracted from BrainComponent (A17.9b-6d) — the first of the five record
@@ -40,7 +41,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
   selector: 'app-memories-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -103,7 +104,7 @@ import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
             </div>
           }
 
-          <div class="table-wrapper">
+          <div class="table-wrapper" hscrollTop>
             <table>
               <thead>
                 <tr>

--- a/client/src/app/pages/brain/overview-tab.component.spec.ts
+++ b/client/src/app/pages/brain/overview-tab.component.spec.ts
@@ -39,8 +39,11 @@ describe('OverviewTabComponent', () => {
   it('total sums every collection; statCards carries the five counts', () => {
     const { c } = setup({ stats: STATS });
     expect(c.total()).toBe(5 + 12 + 30 + 3 + 7);
+    // Order matters and is asserted deliberately: these tiles are shortcuts INTO the tab strip, so they
+    // follow it exactly (Entities · Edges · Memories · Chrono · Files). They used to lead with Memories,
+    // which meant the two disagreed about what comes next and every click became a small search.
     expect(c.statCards().map(s => [s.key, s.value])).toEqual([
-      ['memories', 5], ['entities', 12], ['edges', 30], ['chrono', 3], ['files', 7],
+      ['entities', 12], ['edges', 30], ['memories', 5], ['chrono', 3], ['files', 7],
     ]);
   });
 

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -448,9 +448,12 @@ export class OverviewTabComponent {
     const s = this.stats();
     if (!s) return [];
     return [
-      { key: 'memories', icon: 'brain', label: 'brain.overview.rec.memories', value: s.memories },
+      // Same order as the tab strip above: Entities · Edges · Memories · Chrono · Files. These tiles are
+      // clickable shortcuts INTO those tabs, so a different order made the two disagree about what comes
+      // next and turned every click into a small search.
       { key: 'entities', icon: 'stack', label: 'brain.overview.rec.entities', value: s.entities },
-      { key: 'edges', icon: 'graph', label: 'brain.overview.rec.edges', value: s.edges },
+      { key: 'edges', icon: 'link', label: 'brain.overview.rec.edges', value: s.edges },
+      { key: 'memories', icon: 'brain', label: 'brain.overview.rec.memories', value: s.memories },
       { key: 'chrono', icon: 'timer', label: 'brain.overview.rec.chrono', value: s.chrono },
       { key: 'files', icon: 'folder', label: 'brain.overview.rec.files', value: s.files },
     ];

--- a/client/src/app/pages/files/conflicts.component.ts
+++ b/client/src/app/pages/files/conflicts.component.ts
@@ -9,13 +9,14 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 type ResolveAction = 'keep-local' | 'keep-incoming' | 'keep-both' | 'save-to-space';
 
 @Component({
   selector: 'app-conflicts',
   standalone: true,
-  imports: [DatePipe, SlicePipe, RouterLink, FormsModule, PhIconComponent, TranslocoPipe],
+  imports: [DatePipe, SlicePipe, RouterLink, FormsModule, PhIconComponent, TranslocoPipe, HscrollTopDirective],
   template: `
     <div style="display:flex; justify-content:flex-end; margin-bottom:12px;">
       <a routerLink="/files" class="btn-secondary btn btn-sm"><ph-icon name="arrow-left" [size]="14"/> {{ 'conflicts.backToFiles' | transloco }}</a>
@@ -61,7 +62,7 @@ type ResolveAction = 'keep-local' | 'keep-incoming' | 'keep-both' | 'save-to-spa
         </div>
       }
 
-      <div class="table-wrapper">
+      <div class="table-wrapper" hscrollTop>
         <table>
           <thead>
             <tr>

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -37,6 +37,7 @@ import markdown from 'highlight.js/lib/languages/markdown';
 import python from 'highlight.js/lib/languages/python';
 import bash from 'highlight.js/lib/languages/bash';
 import plaintext from 'highlight.js/lib/languages/plaintext';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('typescript', typescript);
@@ -141,7 +142,7 @@ function xlsxCellText(v: unknown): string {
   // regardless of zone. Text fields (`newFolderName`, `renameValue`) are ngModel two-way bindings
   // whose input events mark the view dirty. So OnPush re-checks exactly when state changes.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent],
+  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent, HscrollTopDirective],
   styles: [`
     .toolbar {
       display: flex;
@@ -581,7 +582,7 @@ function xlsxCellText(v: unknown): string {
             @if (loading()) {
               <div class="loading-overlay"><span class="spinner"></span></div>
             } @else {
-          <div class="table-wrapper">
+          <div class="table-wrapper" hscrollTop>
             <table>
               <thead>
                 <tr>

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -9,6 +9,7 @@ import { StatusPillComponent, type StatusVariant } from '../../shared/status-pil
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 @Component({
   selector: 'app-audit-log',
@@ -19,7 +20,7 @@ import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-st
   // when state changes and skips the whole-tree sweep otherwise — this page renders up to a
   // 100-row table plus a live-streaming server log, both in the CD hot path.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, StatusPillComponent, RelativeTimeComponent, SummaryStripComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, StatusPillComponent, RelativeTimeComponent, SummaryStripComponent, ModalDirective, HscrollTopDirective],
   styles: [`
     .audit-toolbar {
       display: flex;
@@ -291,7 +292,7 @@ import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-st
     } @else if (entries().length === 0) {
       <div class="empty">{{ 'auditLog.empty' | transloco }}</div>
     } @else {
-      <div class="table-wrapper">
+      <div class="table-wrapper" hscrollTop>
       <table class="audit-table">
         <thead>
           <tr>

--- a/client/src/app/pages/settings/data.component.ts
+++ b/client/src/app/pages/settings/data.component.ts
@@ -11,6 +11,7 @@ import { StatusPillComponent, type StatusVariant } from '../../shared/status-pil
 import { SummaryStripComponent, type SummaryItem } from '../../shared/summary-strip.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { PhIconComponent } from '../../shared/ph-icon.component';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 type UriSource = 'env' | 'config' | 'default';
 type Frequency = 'never' | 'hourly' | 'daily' | 'weekly' | 'monthly';
@@ -29,8 +30,7 @@ interface BackupConfig {
   standalone: true,
   imports: [
     CommonModule, FormsModule, TranslocoPipe,
-    SettingsCardComponent, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, PhIconComponent,
-  ],
+    SettingsCardComponent, StatusPillComponent, SummaryStripComponent, RelativeTimeComponent, PhIconComponent, HscrollTopDirective],
   styles: [`
     .data-page { display: flex; flex-direction: column; gap: 16px; max-width: 860px; }
     .freq-opt, .day-opt { display: flex; align-items: center; gap: 6px; cursor: pointer; border-radius: var(--radius-sm);
@@ -87,7 +87,7 @@ interface BackupConfig {
         } @else if (!backups().length) {
           <p class="muted">{{ 'data.backup.empty' | transloco }}</p>
         } @else {
-          <div class="table-wrapper">
+          <div class="table-wrapper" hscrollTop>
           <table class="table" style="font-size:13px;">
             <thead><tr>
               <th>{{ 'data.backup.colDate' | transloco }}</th>

--- a/client/src/app/pages/settings/media-processing/media-processing-page.component.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-page.component.ts
@@ -127,8 +127,16 @@ export class MediaProcessingPageComponent implements OnInit {
   private readonly confirmDialog = inject(ConfirmDialogService);
   private readonly transloco = inject(TranslocoService);
 
-  readonly TABS: Tab[] = ['models', 'pipelines', 'tools'];
-  readonly tab = signal<Tab>('models');
+  /**
+   * Pipelines first, and the landing tab.
+   *
+   * Owner, 2026-07-30. It is the right default because it answers the question an operator actually
+   * arrives with — *what happens to a file I upload* — whereas Models answers *what is configured*, which
+   * is the follow-up. Clicking a step in a pipeline already jumps to the model that implements it, so
+   * the natural direction is pipeline → model, and the tab order now matches it.
+   */
+  readonly TABS: Tab[] = ['pipelines', 'models', 'tools'];
+  readonly tab = signal<Tab>('pipelines');
 
   /**
    * Tools is read-only, so it never needs the save bar — and Models no longer does either: each of its
@@ -139,7 +147,17 @@ export class MediaProcessingPageComponent implements OnInit {
    * Pipelines keeps the bar. Its knobs are not grouped into per-provider boxes, so there is no "the box
    * that changed" to put a button in.
    */
-  readonly showsSave = computed(() => this.tab() === 'pipelines');
+  /**
+   * No page-level Save anywhere any more.
+   *
+   * Models lost it first (owner, 2026-07-28) and Pipelines keeps it no longer: every pipeline card now
+   * carries its own Save, shown only when that pipeline changed. The comment above used to justify the
+   * bar by saying pipeline knobs "are not grouped into per-provider boxes, so there is no box that
+   * changed to put a button in" — that was true of the layout, not of the data. Each pipeline owns
+   * exactly one class ceiling (or, for Documents, the extraction block), and the server merges both
+   * per key, so the boxes were always there.
+   */
+  readonly showsSave = computed(() => false);
 
   /**
    * A pipeline step actor was clicked (see `focusCard`): jump to the Models tab and reveal the card

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
@@ -30,9 +30,30 @@ import {
 export type ModelCardId = 'embedding' | 'rerank' | 'nli' | 'vision' | 'stt' | 'assist' | 'face';
 export const MODEL_CARDS: readonly ModelCardId[] = ['embedding', 'rerank', 'nli', 'vision', 'stt', 'assist', 'face'];
 
-/** A card, or everything the cards do not own (the Pipelines knobs, ceilings and limits). */
-export type CfgSection = ModelCardId | 'rest';
-export const ALL_SECTIONS: readonly CfgSection[] = [...MODEL_CARDS, 'rest'];
+/**
+ * One pipeline on the Pipelines tab.
+ *
+ * These used to be pooled into a single `rest` section saved by one bar at the bottom of the page —
+ * the same shape the Models tab had before per-card saves, and wrong for the same reason: a Save whose
+ * scope is "everything on this tab" makes an operator who changed one ceiling wonder what else is going
+ * out with it. Owner, 2026-07-30: "save button per pipe like on models, not one at the bottom."
+ *
+ * Splitting is safe because the server merges both of these PER KEY: `levels` through
+ * `mergeLevelCeilings` (which exists precisely so one class can be patched alone) and
+ * `documentProcessing` through the one-level deep merge the assist card already relies on.
+ */
+export type PipeId = 'pipe-text' | 'pipe-images' | 'pipe-audio' | 'pipe-video' | 'pipe-documents';
+export const PIPE_SECTIONS: readonly PipeId[] =
+  ['pipe-text', 'pipe-images', 'pipe-audio', 'pipe-video', 'pipe-documents'];
+
+/** The media class each pipeline owns. `pipe-documents` owns `documentProcessing` instead. */
+export const PIPE_CLASS: Record<Exclude<PipeId, 'pipe-documents'>, MediaClass> = {
+  'pipe-text': 'text', 'pipe-images': 'images', 'pipe-audio': 'audio', 'pipe-video': 'video',
+};
+
+/** A card, a pipeline, or the leftovers neither owns. */
+export type CfgSection = ModelCardId | PipeId | 'rest';
+export const ALL_SECTIONS: readonly CfgSection[] = [...MODEL_CARDS, ...PIPE_SECTIONS, 'rest'];
 
 @Injectable()
 export class MediaProcessingStateService {
@@ -295,8 +316,58 @@ export class MediaProcessingStateService {
       maxFileSizeBytes: b.maxFileSizeBytes, workerConcurrency: b.workerConcurrency };
   }
 
+  /**
+   * The PATCH block one pipeline owns.
+   *
+   * A media pipeline sends ONLY its own class inside `levels`. The server merges class by class, so a
+   * patch naming `images` cannot disturb `audio` — which is the property that makes a per-pipeline
+   * Save honest rather than a relabelled Save-everything.
+   */
+  private pipeBlock(id: PipeId): Record<string, unknown> {
+    if (id === 'pipe-documents') {
+      const dp = { ...this.payload().documentProcessing };
+      // The assist model belongs to its own card on the Models tab; sending it from here would let the
+      // Documents pipeline's Save quietly rewrite a credentialled endpoint it does not own.
+      delete (dp as Record<string, unknown>)['assistModel'];
+      return { documentProcessing: dp };
+    }
+    const cls = PIPE_CLASS[id];
+    return { levels: { [cls]: (this.form.levels ?? {})[cls] ?? 'auto' } };
+  }
+
   private sectionSnapshot(section: CfgSection): string {
-    return JSON.stringify(section === 'rest' ? this.restBlock() : this.cardBlock(section));
+    if (section === 'rest') return JSON.stringify(this.restBlock());
+    if ((PIPE_SECTIONS as readonly string[]).includes(section)) {
+      return JSON.stringify(this.pipeBlock(section as PipeId));
+    }
+    return JSON.stringify(this.cardBlock(section as ModelCardId));
+  }
+
+  /** Whether this pipeline alone has an unsaved change — what its own Save button keys off. */
+  pipeDirty(id: PipeId): boolean {
+    if (this.loading() || this.managed) return false;
+    return this.touched() && this.sectionSnapshot(id) !== (this.savedSnapshots[id] ?? '');
+  }
+
+  /** Save one pipeline's block, leaving every other pipeline and card untouched. */
+  savePipe(id: PipeId): void {
+    if (this.managed || this.saving()) return;
+    this.saving.set(true);
+    this.saveOk.set('');
+    this.saveError.set('');
+    const body = JSON.parse(JSON.stringify(this.pipeBlock(id)));
+    this.http.patch<{ ok: boolean; config: MediaCfg }>('/api/admin/media-config', body).subscribe({
+      next: () => {
+        this.saveOk.set(this.transloco.translate('mediaProcessing.saved'));
+        this.rebaseline([id]);
+        this.saving.set(false);
+        setTimeout(() => this.saveOk.set(''), 3000);
+      },
+      error: err => {
+        this.saveError.set(err?.error?.error ?? err?.message ?? 'Save failed');
+        this.saving.set(false);
+      },
+    });
   }
 
   private rebaseline(sections: readonly CfgSection[]): void {

--- a/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
@@ -18,12 +18,13 @@
  *     takes the class offline everywhere — so both facts are stated at the control, not in a doc.
  */
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { PhIconComponent } from '../../../shared/ph-icon.component';
 import { StatusPillComponent } from '../../../shared/status-pill.component';
 import { HealthDotComponent } from './health-dot.component';
-import { MediaProcessingStateService } from './media-processing-state.service';
+import { MediaProcessingStateService, PipeId } from './media-processing-state.service';
 import { PipelineStatusService } from './pipeline-status.service';
 import { HealthState, MODE_STAGES, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, MediaClass } from './media-processing.types';
 
@@ -44,7 +45,7 @@ interface Step {
   selector: 'app-pipelines-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent],
+  imports: [NgTemplateOutlet, FormsModule, TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent],
   styles: [`
     :host { display: block; }
     .pipe-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px;
@@ -112,6 +113,9 @@ interface Step {
       width: auto; min-width: 190px; max-width: 260px; }
     .ceiling select:disabled { opacity: .6; cursor: not-allowed; }
     .ceiling-hint { font-size: 12px; color: var(--text-muted); margin: 0 0 11px; max-width: 70ch; }
+    /* Each pipeline's own Save, appearing only when that pipeline changed — same contract as the
+       Models cards. Right-aligned inside the knobs block so it reads as belonging to it. */
+    .pipe-save { display: flex; justify-content: flex-end; margin-top: 12px; }
     /* Hoisted to the top of the tab: needs the breathing room a knobs block used to give it. */
     .tab-hint { margin: 0 0 16px; }
     /* Not a warning box: choosing "off" is legitimate. It states the blast radius, which is easy to
@@ -143,6 +147,11 @@ interface Step {
          under every pipeline's ceiling control — five copies of the same paragraph is noise a reader
          learns to skip, which defeats the point of explaining it at all. -->
     <p class="ceiling-hint tab-hint">{{ 'mediaProcessing.pipelines.ceilingHint' | transloco }}</p>
+
+    <!-- ── Text (first: the poorest medium) ───────────────────────────── -->
+    @for (p of textPipeline(); track p.id) {
+      <ng-container [ngTemplateOutlet]="pipeCard" [ngTemplateOutletContext]="{ $implicit: p }"/>
+    }
 
     <!-- ── Documents ──────────────────────────────────────────────────── -->
     <section class="pipe-card">
@@ -210,11 +219,22 @@ interface Step {
             <input id="dp-ocrtimeout" type="number" min="10000" max="1800000" [(ngModel)]="s.form.documentProcessing!.ocrTimeoutMs" [disabled]="s.managed" />
           </div>
         </div>
+        @if (s.pipeDirty('pipe-documents')) {
+          <div class="pipe-save">
+            <button class="btn btn-sm btn-primary" type="button"
+              [disabled]="s.saving()" (click)="s.savePipe('pipe-documents')">
+              {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+            </button>
+          </div>
+        }
       </div>
     </section>
 
     <!-- ── Images / Audio / Video / Text ──────────────────────────────── -->
-    @for (p of mediaPipelines(); track p.id) {
+    <!-- One card definition, instantiated twice: Text renders ABOVE the document pipeline and the rest
+         below it, so the page reads poor → rich media. Documents cannot join the list because its
+         control is an extraction mode rather than a class ceiling. -->
+    <ng-template #pipeCard let-p>
       <section class="pipe-card">
         <header class="pipe-h">
           <span class="ic"><ph-icon [name]="p.icon" [size]="17"/></span>
@@ -226,7 +246,11 @@ interface Step {
 
         <div class="chain">
           @for (st of p.steps; track st.key) {
-            <div class="step" [class.cond]="st.conditional">
+            <!-- dim/active, same as the document pipeline. Without these the four media pipelines showed
+                 availability only: green dots everywhere and no indication of which steps the chosen
+                 rung actually executes. -->
+            <div class="step" [class.cond]="st.conditional"
+                 [class.dim]="mediaStepDim(p.id, st.key)" [class.active]="mediaStepActive(p.id, st.key)">
               <div class="box">
                 <div class="nm">{{ st.name | transloco }}<app-health-dot [state]="st.health" [subject]="st.name | transloco"/></div>
                 <div class="actor">
@@ -252,12 +276,17 @@ interface Step {
               <div class="modeseg" role="group" [attr.aria-label]="'mediaProcessing.class.' + c.cls | transloco">
                 @for (rung of c.ladder; track rung) {
                   <button type="button" [class.on]="ceilingOf(c.cls) === rung" (click)="setCeiling(c.cls, rung)"
-                    [disabled]="s.isLocked('levels.' + c.cls) || s.managed">
+                    [disabled]="rungDisabled(c.cls, rung, p.steps)">
                     {{ 'mediaProcessing.level.' + rung | transloco }}
                   </button>
                 }
               </div>
               @if (s.isLocked('levels.' + c.cls)) { <app-status-pill variant="env">{{ 'mediaProcessing.pill.env' | transloco }}</app-status-pill> }
+              @if (firstStepUnavailable(p.steps)) {
+                <!-- Say WHY the rungs are greyed out. A disabled control with no explanation is read as
+                     a bug, and the operator's next move is on the Models tab, not here. -->
+                <span class="ceiling-warn">{{ 'mediaProcessing.pipelines.firstStepDown' | transloco }}</span>
+              }
               @if (ceilingOf(c.cls) === 'off') {
                 <!-- "off" is a floor as well as a ceiling: it takes the class offline for every space,
                      whatever that space asked for. Worth saying where it is chosen, not in a doc. -->
@@ -265,8 +294,22 @@ interface Step {
               }
             </div>
           }
+          <!-- This pipeline's own Save, shown only when this pipeline changed. -->
+          @if (s.pipeDirty(pipeIdOf(p.id))) {
+            <div class="pipe-save">
+              <button class="btn btn-sm btn-primary" type="button"
+                [disabled]="s.saving()" (click)="s.savePipe(pipeIdOf(p.id))">
+                {{ (s.saving() ? 'common.saving' : 'common.save') | transloco }}
+              </button>
+            </div>
+          }
         </div>
       </section>
+    </ng-template>
+
+    <!-- The rest of the media pipelines, after Documents. -->
+    @for (p of otherPipelines(); track p.id) {
+      <ng-container [ngTemplateOutlet]="pipeCard" [ngTemplateOutletContext]="{ $implicit: p }"/>
     }
   `,
 })
@@ -300,12 +343,104 @@ export class PipelinesTabComponent {
     return this.s.docMode() !== 'off' && !this.stepDim(key);
   }
 
+  // ── What the MEDIA pipelines actually run ───────────────────────────────────
+  //
+  // The document pipeline has had dim/active markings since it shipped. The other four never did: their
+  // steps rendered with `cond` alone, so nothing was ever highlighted and the traffic lights reported
+  // only what was *available*, never what the configured level would actually execute. Owner, 2026-07-30:
+  // "i can see with the traffic light what is available but not what is actually used in the pipeline."
+  //
+  // The rung governs it, and the mapping is per class rather than generic because the ladders mean
+  // genuinely different things — `audio` on the video ladder is "run the audio pipeline and skip the
+  // vision model", which no shared rule would guess.
+
+  /** Steps a class runs at a given rung. `auto` resolves to the class's fullest rung. */
+  private static readonly RUNS: Record<string, Record<string, readonly string[]>> = {
+    images: {
+      off: [],
+      caption: ['caption', 'img-embed'],
+      recognition: ['caption', 'img-embed', 'faces'],
+    },
+    audio: {
+      off: [],
+      on: ['transcribe', 'aud-embed'],
+    },
+    video: {
+      off: [],
+      // "audio" means take the audio track only — ffmpeg splits, STT transcribes, and the vision model
+      // is not called at all.
+      audio: ['vid-split', 'vid-transcribe', 'vid-embed'],
+      full: ['vid-split', 'vid-transcribe', 'vid-keyframe', 'vid-embed'],
+    },
+    text: {
+      off: [],
+      // `embed` produces one vector for the whole document; only `chunk` splits it first.
+      embed: ['txt-embed'],
+      chunk: ['chunk', 'txt-embed'],
+    },
+  };
+
+  /** The rung `auto` resolves to — the fullest one, since auto means "no ceiling of my own". */
+  private static readonly AUTO_RUNG: Record<string, string> = {
+    images: 'recognition', audio: 'on', video: 'full', text: 'chunk',
+  };
+
+  private runsAt(cls: string): readonly string[] {
+    const rung = this.ceilingOf(cls as MediaClass);
+    const resolved = rung === 'auto' ? PipelinesTabComponent.AUTO_RUNG[cls] ?? 'off' : rung;
+    return PipelinesTabComponent.RUNS[cls]?.[resolved] ?? [];
+  }
+
+  /** True when this class runs nothing at all — the whole card reads as inert. */
+  mediaOff(cls: string): boolean { return this.runsAt(cls).length === 0; }
+
+  /** Drawn as not-running: the class is off, or this rung skips the step. */
+  mediaStepDim(cls: string, key: string): boolean { return !this.runsAt(cls).includes(key); }
+
+  /** On the path the current rung executes — mirrors `stepActive` on the document pipeline. */
+  mediaStepActive(cls: string, key: string): boolean { return this.runsAt(cls).includes(key); }
+
+  // ── Gating a pipeline whose first step cannot run ───────────────────────────
+
+  /** Health states that mean the step cannot do its job right now. */
+  private static readonly UNAVAILABLE = new Set(['down', 'blocked', 'unconfigured']);
+
+  /**
+   * Whether a pipeline's FIRST step is unavailable.
+   *
+   * Everything downstream consumes its output, so if step one cannot run the rest cannot either, and
+   * offering rungs that promise captioning or transcription is a promise the instance cannot keep.
+   * Owner, 2026-07-30: "if step one of a pipeline is not available only allow state off and auto (=off)
+   * on toggles."
+   */
+  firstStepUnavailable(steps: readonly Step[]): boolean {
+    const first = steps[0];
+    if (!first || first.health == null) return false;   // no endpoint to be down (in-process step)
+    return PipelinesTabComponent.UNAVAILABLE.has(first.health);
+  }
+
+  /**
+   * Which rungs stay selectable when step one is down: only `off` and `auto`.
+   *
+   * `auto` is kept because it is not a promise — it means "no ceiling of my own", and with the first
+   * step unavailable it resolves to nothing running, exactly like `off`. Removing it too would strand an
+   * operator whose stored value IS `auto` on a control with no valid option.
+   */
+  rungDisabled(cls: MediaClass, rung: string, steps: readonly Step[]): boolean {
+    if (this.s.isLocked('levels.' + cls) || this.s.managed) return true;
+    if (!this.firstStepUnavailable(steps)) return false;
+    return rung !== 'off' && rung !== 'auto';
+  }
+
   private notSet = '—';
 
   /** Cards rendered as infra (env-owned, read-only) on the Models tab — their actor links get the
    *  dotted underline that marks "you can see it here but change it in the environment". */
   private readonly infraCards = new Set(['doc-render', 'unstructured']);
   isInfra(cardId: string): boolean { return this.infraCards.has(cardId); }
+
+  /** Map a pipeline card's id to its config section, so each card can own its own Save. */
+  pipeIdOf(id: string): PipeId { return `pipe-${id}` as PipeId; }
 
   /** The stored ceiling for a class, defaulting to `auto` (no policy limit of its own). */
   ceilingOf(cls: MediaClass): string { return (this.s.form.levels ?? {})[cls] ?? 'auto'; }
@@ -335,6 +470,20 @@ export class PipelinesTabComponent {
       { key: 'embed', name: 'mediaProcessing.step.embed', actor: this.s.embedding.model || this.notSet, health: ps.modelState('embedding'), conditional: false, cardId: 'embedding' },
     ];
   });
+
+  /**
+   * Ordered poor → rich media, from the reader's point of view: Text, Documents, Images, Audio, Video.
+   *
+   * Owner, 2026-07-30. Documents sits second even though it is by far the most complicated pipeline —
+   * the ordering principle is how rich the *medium* is, not how hard it is to process, and a document is
+   * text with structure. Sorting by implementation difficulty would put Documents last and make the list
+   * incoherent to anyone who has not read the code.
+   *
+   * Documents renders between `textPipeline` and `otherPipelines` in the template because its control is
+   * an extraction MODE rather than a class ceiling, so it does not fit this list's shape.
+   */
+  textPipeline = computed(() => this.mediaPipelines().filter(p => p.id === 'text'));
+  otherPipelines = computed(() => this.mediaPipelines().filter(p => p.id !== 'text'));
 
   mediaPipelines = computed(() => {
     const ps = this.pipeline;

--- a/client/src/app/pages/settings/network-create-dialog.component.ts
+++ b/client/src/app/pages/settings/network-create-dialog.component.ts
@@ -6,6 +6,7 @@ import { NetworksApi } from '../../core/networks-api.service';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ModalDirective } from '../../shared/modal.directive';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 /**
  * Create-network dialog, extracted from the (large) NetworksComponent as the first slice of taming that
@@ -21,7 +22,7 @@ import { ModalDirective } from '../../shared/modal.directive';
 @Component({
   selector: 'app-network-create-dialog',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, HscrollTopDirective],
   styles: [`
     .dialog-backdrop {
       position: fixed;
@@ -82,7 +83,7 @@ import { ModalDirective } from '../../shared/modal.directive';
             } @else if (availableSpaces().length === 0) {
               <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'networks.dialog.create.loadingSpaces' | transloco }}</div>
             } @else {
-              <div class="table-wrapper" style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
+              <div class="table-wrapper" hscrollTop style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
                 <table style="margin:0;">
                   <thead>
                     <tr>

--- a/client/src/app/pages/settings/space-create-dialog.component.ts
+++ b/client/src/app/pages/settings/space-create-dialog.component.ts
@@ -16,11 +16,12 @@ import { SPACE_DIALOG_STYLES } from './space-dialog.styles';
 import { SpacesStore } from './spaces-store.service';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { SpaceMeta, ValidationMode } from '../../core/api.types';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 @Component({
   selector: 'app-space-create-dialog',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, HscrollTopDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [SPACE_DIALOG_STYLES],
   template: `
@@ -52,7 +53,7 @@ import { SpaceMeta, ValidationMode } from '../../core/api.types';
         <div class="field" style="flex:1;margin-bottom:0;display:flex;flex-direction:column;">
           <label>{{ 'spaces.create.proxyFor' | transloco }}</label>
           @if (store.spaces().length > 0) {
-            <div class="table-wrapper" style="flex:1;min-height:160px;max-height:240px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius-sm);">
+            <div class="table-wrapper" hscrollTop style="flex:1;min-height:160px;max-height:240px;overflow-y:auto;border:1px solid var(--border);border-radius:var(--radius-sm);">
               <table style="margin:0;">
                 <thead><tr><th style="width:40px;"></th><th>{{ 'spaces.table.column.label' | transloco }}</th><th>{{ 'spaces.table.column.id' | transloco }}</th></tr></thead>
                 <tbody>

--- a/client/src/app/pages/settings/space-schema-tab.component.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.ts
@@ -25,6 +25,7 @@ import { SpaceSettingsState, type TypeSchemaState } from './space-settings-state
 import { SchemaApi } from '../../core/schema-api.service';
 import { ToastService } from '../../core/toast.service';
 import { KnowledgeType, PropertySchema, SchemaLibraryEntry, TypeSchema } from '../../core/api.types';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 const SCHEMA_MD_STYLES = `
 /* A floor, so this row cannot collapse and drag the master/detail grid up with it. The row's height is
@@ -108,7 +109,7 @@ const SCHEMA_MD_STYLES = `
 @Component({
   selector: 'app-space-schema-tab',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, HscrollTopDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [SPACE_DIALOG_STYLES, SCHEMA_MD_STYLES],
   template: `
@@ -321,7 +322,7 @@ const SCHEMA_MD_STYLES = `
                which is a whole panel away at the top of the tab. -->
           <div class="sch-section-label">{{ 'spaces.schema.propertySchemas' | transloco }}
             <span class="sch-hint">{{ 'spaces.schema.propertySchemasHint' | transloco }}</span></div>
-          <div class="table-wrapper" style="margin-bottom:0;">
+          <div class="table-wrapper" hscrollTop style="margin-bottom:0;">
             <table class="prop-table" style="margin-bottom:0;">
               <thead>
                 <tr>

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -26,13 +26,14 @@ import { SpaceDangerTabComponent } from './space-danger-tab.component';
 import { SpaceSchemaTabComponent } from './space-schema-tab.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { SpaceCreateDialogComponent } from './space-create-dialog.component';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 @Component({
   selector: 'app-spaces',
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, DragDropModule, PhIconComponent, SummaryStripComponent,
     SpaceSettingsTabComponent, SpaceDuplicatesTabComponent, SpaceDangerTabComponent, SpaceSchemaTabComponent,
-    SpaceCreateDialogComponent, ModalDirective],
+    SpaceCreateDialogComponent, ModalDirective, HscrollTopDirective],
   // Provided here (not root) so each mount gets its own settings state, with a lifetime tied to
   // this component rather than the app.
   providers: [SpacesStore, SpaceSettingsState],
@@ -133,7 +134,7 @@ import { SpaceCreateDialogComponent } from './space-create-dialog.component';
           <button class="btn btn-secondary btn-sm" (click)="store.load()">{{ 'spaces.table.refreshButton' | transloco }}</button>
         </div>
       } @else {
-        <div class="table-wrapper">
+        <div class="table-wrapper" hscrollTop>
           <table>
             <thead>
               <tr><th style="width:32px;"></th><th>{{ 'spaces.table.column.label' | transloco }}</th><th>{{ 'spaces.table.column.id' | transloco }}</th><th>{{ 'spaces.table.column.storage' | transloco }}</th><th>{{ 'spaces.table.column.networks' | transloco }}</th><th>{{ 'spaces.table.column.proxy' | transloco }}</th><th></th></tr>

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -14,12 +14,13 @@ import { ModalDirective } from '../../shared/modal.directive';
 import { SummaryStripComponent, SummaryItem } from '../../shared/summary-strip.component';
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 
 @Component({
   selector: 'app-tokens',
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
-            SummaryStripComponent, StatusPillComponent, RelativeTimeComponent],
+            SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective],
   styles: [`
     .new-token-banner {
       background: var(--success-dim);
@@ -285,7 +286,7 @@ import { RelativeTimeComponent } from '../../shared/relative-time.component';
               } @else if (availableSpaces().length === 0) {
                 <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'tokens.create.loadingSpaces' | transloco }}</div>
               } @else {
-                <div class="table-wrapper" style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
+                <div class="table-wrapper" hscrollTop style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
                   <table style="margin:0;">
                     <thead>
                       <tr>
@@ -367,7 +368,7 @@ import { RelativeTimeComponent } from '../../shared/relative-time.component';
       @if (loading()) {
         <div class="loading-overlay"><span class="spinner"></span></div>
       } @else {
-        <div class="table-wrapper">
+        <div class="table-wrapper" hscrollTop>
           <table>
             <thead>
               <tr>

--- a/client/src/app/pages/settings/webhooks.component.ts
+++ b/client/src/app/pages/settings/webhooks.component.ts
@@ -12,6 +12,7 @@ import { ErrorStateComponent } from '../../shared/error-state.component';
 import { SummaryStripComponent, SummaryItem } from '../../shared/summary-strip.component';
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
+import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 import {
   Space, WebhookSubscription, WebhookDelivery, WebhookEventType, WEBHOOK_EVENT_GROUPS,
 } from '../../core/api.types';
@@ -32,7 +33,7 @@ interface WebhookForm {
   selector: 'app-webhooks',
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, ErrorStateComponent,
-            SummaryStripComponent, StatusPillComponent, RelativeTimeComponent],
+            SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     .dialog-backdrop { position:fixed; inset:0; background:var(--bg-scrim); display:flex; align-items:center; justify-content:center; z-index:100; }
@@ -138,7 +139,7 @@ interface WebhookForm {
           } @else if (deliveries().length === 0) {
             <p class="muted" style="font-size:13px;">{{ 'webhooks.deliveries.empty' | transloco }}</p>
           } @else {
-            <div class="table-wrapper">
+            <div class="table-wrapper" hscrollTop>
               <table>
                 <thead><tr>
                   <th>{{ 'webhooks.deliveries.event' | transloco }}</th>
@@ -184,7 +185,7 @@ interface WebhookForm {
         <div class="empty-state" style="padding:32px;"><h3>{{ 'webhooks.empty.title' | transloco }}</h3><p>{{ 'webhooks.empty.body' | transloco }}</p></div>
       } @else {
         <app-summary-strip [heading]="'webhooks.title' | transloco" [items]="summary()" style="display:block;margin:0 0 16px;"/>
-        <div class="table-wrapper">
+        <div class="table-wrapper" hscrollTop>
           <table>
             <thead><tr>
               <th>{{ 'webhooks.col.url' | transloco }}</th>

--- a/client/src/app/shared/hscroll-top.directive.ts
+++ b/client/src/app/shared/hscroll-top.directive.ts
@@ -1,0 +1,161 @@
+import { Directive, ElementRef, OnDestroy, AfterViewInit, inject, NgZone } from '@angular/core';
+
+/**
+ * Draw a horizontal scroll control ABOVE the element it scrolls.
+ *
+ * ## Why this exists
+ *
+ * A scroll container puts its horizontal scrollbar at the bottom of its own box. For a data table that
+ * is the worst possible place: the table is the tallest thing on the page, so the only hint that there
+ * is more to the right sits below everything, and the box moves as the page scrolls. Measured on
+ * Brain → Entities at a 900px viewport, the bar was roughly **2800px** below the fold — the table was
+ * scrollable the whole time and nobody could tell.
+ *
+ * Three approaches were tried before this one. Recording them because each looked correct:
+ *
+ *  1. **A blanket `min-width` on `table`.** Stopped the column collapse, and forced a horizontal
+ *     scrollbar onto every narrow three-column settings table that previously fit.
+ *  2. **Bounding the wrapper's height** so the bar could not be far away. It shortened the distance,
+ *     added a second vertical scrollbar nested in a page that already scrolls — rejected on sight — and
+ *     the bar still moved with the page, because height was never the problem. *Position* was.
+ *  3. **A mirrored native scroller above the table.** Right position, invisible: this platform uses
+ *     OVERLAY scrollbars, which paint only while scrolling and occupy no layout space. Measured
+ *     `offsetHeight - clientHeight === 0`, and a screenshot showed nothing at all. An affordance you
+ *     cannot see until you have already used it is not an affordance.
+ *
+ * So the control is **drawn**, not borrowed: a track and a proportional thumb, always visible while the
+ * host overflows, positioned immediately above it. The host keeps its own `overflow-x: auto`, so wheel,
+ * trackpad, touch and keyboard scrolling all still work untouched — this adds a visible, draggable
+ * handle for them rather than replacing the mechanism.
+ */
+@Directive({
+  selector: '[hscrollTop]',
+  standalone: true,
+})
+export class HscrollTopDirective implements AfterViewInit, OnDestroy {
+  private readonly host = inject(ElementRef<HTMLElement>).nativeElement as HTMLElement;
+  private readonly zone = inject(NgZone);
+
+  private track?: HTMLDivElement;
+  private thumb?: HTMLDivElement;
+  private ro?: ResizeObserver;
+  private mo?: MutationObserver;
+
+  /** Pointer id + geometry captured at drag start, so a drag survives the pointer leaving the thumb. */
+  private drag: { pointerId: number; startX: number; startScroll: number } | null = null;
+
+  ngAfterViewInit(): void {
+    if (!this.host.parentElement) return;
+
+    const track = document.createElement('div');
+    track.className = 'hscroll-top';
+    // Decorative twin of a control the host already exposes to assistive tech and the keyboard.
+    track.setAttribute('aria-hidden', 'true');
+    const thumb = document.createElement('div');
+    thumb.className = 'hscroll-top-thumb';
+    track.appendChild(thumb);
+    this.host.parentElement.insertBefore(track, this.host);
+    this.track = track;
+    this.thumb = thumb;
+
+    // Outside Angular: scrolling and dragging fire continuously and change no state the framework
+    // needs to hear about.
+    this.zone.runOutsideAngular(() => {
+      this.host.addEventListener('scroll', this.render, { passive: true });
+      thumb.addEventListener('pointerdown', this.onPointerDown);
+      window.addEventListener('pointermove', this.onPointerMove, { passive: true });
+      window.addEventListener('pointerup', this.onPointerUp, { passive: true });
+      track.addEventListener('pointerdown', this.onTrackClick);
+
+      // The table's width changes without the host resizing — a column filter narrows the data, a row
+      // expands. Observe both the box and the subtree, or the thumb goes stale and lies about the range.
+      //
+      // Feature-detected, not assumed: jsdom has MutationObserver and no ResizeObserver, so
+      // constructing one unguarded threw inside `runOutsideAngular` and took down every spec that
+      // rendered a table — a decorative scrollbar breaking twelve unrelated tests.
+      if (typeof ResizeObserver !== 'undefined') {
+        this.ro = new ResizeObserver(this.render);
+        this.ro.observe(this.host);
+        const table = this.host.querySelector('table');
+        if (table) this.ro.observe(table);
+      }
+      if (typeof MutationObserver !== 'undefined') {
+        this.mo = new MutationObserver(this.render);
+        this.mo.observe(this.host, { childList: true, subtree: true });
+      }
+    });
+
+    this.render();
+  }
+
+  ngOnDestroy(): void {
+    this.host.removeEventListener('scroll', this.render);
+    this.thumb?.removeEventListener('pointerdown', this.onPointerDown);
+    window.removeEventListener('pointermove', this.onPointerMove);
+    window.removeEventListener('pointerup', this.onPointerUp);
+    this.track?.removeEventListener('pointerdown', this.onTrackClick);
+    this.ro?.disconnect();
+    this.mo?.disconnect();
+    this.track?.remove();
+  }
+
+  /** How far the host can scroll. Zero means it fits, and the control hides itself. */
+  private get range(): number { return this.host.scrollWidth - this.host.clientWidth; }
+
+  /** Size and place the thumb from the host's current geometry. */
+  private render = (): void => {
+    const track = this.track, thumb = this.thumb;
+    if (!track || !thumb) return;
+
+    if (this.range <= 1 || this.host.clientWidth === 0) {
+      track.style.display = 'none';
+      return;
+    }
+    track.style.display = '';
+
+    const trackW = track.clientWidth;
+    const ratio = this.host.clientWidth / this.host.scrollWidth;
+    // A floor, or a very wide table produces a thumb too small to aim at.
+    const thumbW = Math.max(28, Math.round(trackW * ratio));
+    const maxLeft = trackW - thumbW;
+    const left = Math.round((this.host.scrollLeft / this.range) * maxLeft);
+
+    thumb.style.width = `${thumbW}px`;
+    thumb.style.transform = `translateX(${left}px)`;
+  };
+
+  private onPointerDown = (e: PointerEvent): void => {
+    if (!this.thumb) return;
+    e.preventDefault();
+    e.stopPropagation();   // do not also fire the track's jump-to-position
+    this.drag = { pointerId: e.pointerId, startX: e.clientX, startScroll: this.host.scrollLeft };
+    this.thumb.classList.add('is-dragging');
+  };
+
+  private onPointerMove = (e: PointerEvent): void => {
+    const drag = this.drag, track = this.track, thumb = this.thumb;
+    if (!drag || drag.pointerId !== e.pointerId || !track || !thumb) return;
+    const maxLeft = track.clientWidth - thumb.clientWidth;
+    if (maxLeft <= 0) return;
+    // Convert thumb travel back into host travel: the thumb crosses `maxLeft` px while the host
+    // crosses its whole range, so the two are related by that ratio and nothing else.
+    this.host.scrollLeft = drag.startScroll + ((e.clientX - drag.startX) / maxLeft) * this.range;
+  };
+
+  private onPointerUp = (): void => {
+    if (!this.drag) return;
+    this.drag = null;
+    this.thumb?.classList.remove('is-dragging');
+  };
+
+  /** Click anywhere on the track: centre the thumb there. */
+  private onTrackClick = (e: PointerEvent): void => {
+    const track = this.track, thumb = this.thumb;
+    if (!track || !thumb || this.range <= 1) return;
+    const rect = track.getBoundingClientRect();
+    const maxLeft = track.clientWidth - thumb.clientWidth;
+    if (maxLeft <= 0) return;
+    const target = e.clientX - rect.left - thumb.clientWidth / 2;
+    this.host.scrollLeft = (Math.min(Math.max(target, 0), maxLeft) / maxLeft) * this.range;
+  };
+}

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -321,17 +321,58 @@ button:disabled, .btn:disabled {
  * scrollbar is on screen instead of a page-length away. The header sticks, because a horizontally
  * scrolled table with the column names gone is its own small usability problem.
  */
+/*
+ * A wide table needs its horizontal scrollbar where the eye already is.
+ *
+ * #548 bounded the wrapper so the bar was not 2800px down the page. That helped and was still wrong: a
+ * scroll container's horizontal bar sits at the BOTTOM of its box, the box moves with the page, and on a
+ * real window you were still scrolling to find it. Bounding the height cannot fix a position problem.
+ *
+ * A bounded wrapper with its own vertical scroll was the second attempt, and the owner rejected it on
+ * sight: two nested vertical scrollbars on one page, and it STILL did not put the horizontal bar where
+ * you were looking.
+ *
+ * So the page keeps exactly one vertical scrollbar, and the horizontal bar is mirrored ABOVE the table
+ * (`hscrollTop`), where it is visible the moment the table's top edge is.
+ */
 .table-wrapper {
-  overflow: auto;
-  /* Tall tables scroll inside the box; short ones are unaffected, since max-height only ever clamps.
-     60vh rather than a larger share on purpose: the box has to END above the fold, or its horizontal
-     scrollbar is off screen again and we are back to the reported bug in a milder form. Measured on
-     Brain → Entities at 900x900, where the wrapper starts at y=354 — 70vh put its bottom edge at 984,
-     60vh puts it at 894. */
-  max-height: min(60vh, 720px);
+  overflow-x: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
 }
+
+/*
+ * The drawn scroll control, not a native scrollbar.
+ *
+ * A mirrored native scroller was tried here first and was invisible: this platform uses OVERLAY
+ * scrollbars, which paint only while scrolling and take no layout space (measured
+ * `offsetHeight - clientHeight === 0`, and a screenshot showed nothing). Styling `::-webkit-scrollbar`
+ * did not bring it back. So the track and thumb are ordinary elements the directive positions — always
+ * visible while the table overflows, and themable like everything else.
+ */
+.hscroll-top {
+  position: relative;
+  height: 10px;
+  margin-bottom: 4px;
+  border-radius: 5px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-muted);
+  cursor: pointer;
+}
+
+.hscroll-top-thumb {
+  position: absolute;
+  top: 1px;
+  left: 0;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--text-muted);
+  /* No transition on transform: it lags a drag and makes the thumb feel detached from the pointer. */
+  transition: background var(--transition);
+}
+
+.hscroll-top:hover .hscroll-top-thumb,
+.hscroll-top-thumb.is-dragging { background: var(--accent); }
 
 table {
   width: 100%;


### PR DESCRIPTION
Seven owner findings from one session. All measured in a booted browser rather than reasoned about — every plausible explanation I started with was wrong.

## 1. A scroll control above the table

**Third attempt at "the Entities table is cut off at Tags and there is no way to scroll right", and the first one that is right.** The two rejected attempts are worth recording, because each looked correct:

| Attempt | Why it failed |
|---|---|
| blanket `min-width` on `table` | fixed Entities, forced a scrollbar onto every narrow settings table that fit fine |
| bound the wrapper's height (#548) | added a **second nested vertical scrollbar** — rejected on sight — and the bar still moved with the page |
| mirror a **native** scroller above | right position, **invisible**: overlay scrollbars paint only while scrolling and occupy no layout space |

That third one is the instructive one. Measured `offsetHeight - clientHeight === 0`, and a screenshot showed nothing at all. Styling `::-webkit-scrollbar` did not bring it back. **An affordance you cannot see until you have already used it is not an affordance.**

So it is **drawn**: a track and a proportional thumb, draggable, click-to-jump, sitting immediately above the table and visible whenever the table overflows. The host keeps its own `overflow-x: auto`, so wheel, trackpad, touch and keyboard scrolling are untouched — this adds a handle for them rather than replacing the mechanism.

Verified in the browser: thumb 449px of a 616px track for a 614/839 viewport ratio, scrolling the table 200px moves the thumb 147px, both directions sync, and `wrapperHasVerticalScroll: false`.

> `ResizeObserver` is feature-detected. Constructing it unguarded threw in jsdom and took down **twelve unrelated component specs** — a decorative scrollbar breaking the suite for tables it merely happened to be attached to.

## 2. Pipelines

- **Opens on Pipelines**, left of Models. It answers the question an operator arrives with — *what happens to a file I upload* — where Models answers the follow-up. Clicking a step already jumps to the model that implements it, so the tab order now matches the direction people move in.
- **Text → Documents → Images → Audio → Video**: poor to rich *medium*. Documents sits second despite being much the hardest pipeline to implement, because ordering by implementation difficulty produces a list that is incoherent to anyone who has not read the code.
- **All four media pipelines now show what they RUN.** Only the document pipeline ever dimmed its unused steps; the others rendered green dots and nothing else, so *"the model is up"* and *"this step runs"* looked like the same statement. The mapping is per class, not generic — `audio` on the video ladder means "run the audio pipeline and skip the vision model", which no shared rule would guess.
- **First step unavailable → only `off` and `auto`.** Everything downstream consumes step one's output. `auto` stays because it is not a promise (with step one down it resolves to nothing running), and removing it would strand an operator whose stored value *is* `auto` on a control with no valid option. The greyed rungs say why — a disabled control with no explanation reads as a bug.
- **Save per pipeline.** Safe because the server already merges both affected blocks per key: `levels` via `mergeLevelCeilings`, `documentProcessing` via the one-level deep merge the assist card relies on. The old comment justified the bar by saying pipeline knobs "are not grouped into per-provider boxes" — true of the layout, not of the data. Documents' block deliberately strips `assistModel`, which belongs to its own card, so this Save cannot rewrite a credentialled endpoint it does not own.

## 3. Brain

- **Overview tiles follow the tab strip** (Entities · Edges · Memories · Chrono · Files). They are shortcuts *into* those tabs and used to lead with Memories, so the two disagreed about what came next and every click became a small search. The spec asserted the old order, so fixing it had to change the test.
- **The four record tabs finally show icons — and finally translate.** Entities/Edges/Memories/Chrono were the only tabs rendering a hard-coded English literal while their translations sat unused, so the strip read half-German in a German UI and nothing flagged it. Edges uses `link` rather than `graph` on both the tab and its Overview tile, because the Graph tab already owns that glyph.

## Verification

`npm run preflight` green. Verified in a booted instance seeded to reproduce the reported conditions, with screenshots read rather than only measurements taken — which is how the invisible-scrollbar attempt was caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
