### PR TITLE
fix(index): the readiness poll never saw READY, so every wait ran to timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -539,6 +539,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The index-readiness poll never observed READY, so every wait ran to its full timeout.** A deployment
+  measured **~67 seconds per index on an instance with almost no data** — identical to one with thirteen
+  full spaces. A build that is genuinely instant cannot take a fixed 67s; that is the 60s ceiling
+  expiring every single time, on indexes that were fine. Small deployments were hit exactly as hard as
+  large ones, because the cost was per-index and fixed, never per-byte.
+  - **One overload.** `ensureVectorIndex` lists search indexes *without* a name filter and matches by
+    name, and that call works — it is how an existing index is found for the update path. The only two
+    callers using `listSearchIndexes(indexName)` were the only two that misbehaved. Both now list
+    unfiltered and match by name, which is a strict superset of the filtered behaviour.
+  - **`pipeline-status` had the same bug with a different symptom:** `found[0]?.status` was always null,
+    and a null status becomes `missing`, so the Indexing panel declared **every index absent** on a
+    healthy instance. It also listed the `files` collection twice, once per expected index; it now lists
+    each collection once.
+  - `queryable: true` now counts as ready alongside `status: 'READY'` — it is the property recall
+    actually depends on.
+  - **The poll says what it saw.** It previously swallowed every observation and logged only "did not
+    reach READY within 60s", which is why two rounds of investigation produced the cost and never the
+    cause. It now reports the observed status periodically, and distinguishes *index not present* from
+    *index not ready* — different failures that used to read identically.
+
 - **Upgrading from 2.0.0 could look like a crash loop: boot blocked for over an hour waiting on vector
   index builds.** 2.0.0 added filter fields to the `$vectorSearch` indexes, so every upgrade reshapes the
   existing ones — and `initAllSpaces` awaited READY while doing it. That wait is **serial per index, per

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -307,14 +307,30 @@ async function indexStatus(): Promise<{ spaces: SpaceIndexStatus[]; unavailable?
 
       const collections: CollectionIndexStatus[] = [];
       let listingFailed = false;
-      await Promise.all(expected.map(async e => {
+      // List each collection ONCE, unfiltered, and match by name — the same correction made in
+      // `pollVectorIndexReady`. The name-filtered overload returned nothing on the reporting
+      // deployment, so `found[0]?.status` was always null, and `deriveLiveIndexState` turns a null
+      // status into **missing** — meaning this panel declared every index absent on an instance whose
+      // indexes were fine. Unfiltered listing is what `ensureVectorIndex` uses and it works.
+      //
+      // Once per collection rather than once per expected index: `files` carries two (embedding and
+      // faceEmbedding), and listing it twice doubled the mongot round-trips for no benefit.
+      const byCollection = new Map<string, typeof expected>();
+      for (const e of expected) {
+        const list = byCollection.get(e.collection) ?? [];
+        list.push(e);
+        byCollection.set(e.collection, list);
+      }
+      await Promise.all([...byCollection.entries()].map(async ([collection, entries]) => {
         try {
-          const found = await db.collection(`${space.id}_${e.collection}`).listSearchIndexes(e.indexName).toArray() as Array<{ status?: string }>;
-          collections.push({ ...e, status: found[0]?.status ?? null });
+          const all = await db.collection(`${space.id}_${collection}`).listSearchIndexes().toArray() as Array<{ name?: string; status?: string }>;
+          for (const e of entries) {
+            collections.push({ ...e, status: all.find(i => i.name === e.indexName)?.status ?? null });
+          }
         } catch (err) {
           listingFailed = true;
-          log.debug(`pipeline-status: could not list search indexes for ${space.id}_${e.collection}: ${err instanceof Error ? err.message : String(err)}`);
-          collections.push({ ...e, status: null });
+          log.debug(`pipeline-status: could not list search indexes for ${space.id}_${collection}: ${err instanceof Error ? err.message : String(err)}`);
+          for (const e of entries) collections.push({ ...e, status: null });
         }
       }));
 

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -271,16 +271,48 @@ export async function pollVectorIndexReady(
 ): Promise<boolean> {
   const coll = getDb().collection(`${spaceId}_${collectionSuffix}`);
   const attempts = Math.max(1, Math.round((opts.timeoutMs ?? 60_000) / 1000));
+  let lastSeen = 'nothing yet';
+
   for (let attempt = 0; attempt < attempts; attempt++) {
     await new Promise(r => setTimeout(r, 1000));
     try {
-      const current = await coll.listSearchIndexes(indexName).toArray() as Array<{ status?: string }>;
-      if (current[0]?.status === 'READY') {
-        log.debug(`Vector search index ${indexName} is READY`);
-        return true;
+      // List ALL indexes and match by name, rather than `listSearchIndexes(indexName)`.
+      //
+      // This is the fix for a poll that never succeeded. A deployment reported ~67 SECONDS PER INDEX
+      // on an instance with almost no data — the same cost as one with thirteen full spaces. A build
+      // that is genuinely instant cannot take a fixed 67s; that is the timeout expiring every single
+      // time, which means the poll was never observing READY at all.
+      //
+      // The name-filtered overload is the difference. `ensureVectorIndex` above lists WITHOUT a filter
+      // and finds by name, and that call demonstrably works — it is how an existing index is detected
+      // for the update path. Only the two callers that used the filtered form misbehaved. Listing all
+      // and matching here is a strict superset of the filtered behaviour, so it cannot be worse.
+      const all = await coll.listSearchIndexes().toArray() as Array<{ name?: string; status?: string; queryable?: boolean }>;
+      const current = all.find(i => i.name === indexName);
+
+      if (!current) {
+        lastSeen = `index not present (saw: ${all.map(i => i.name).join(', ') || 'none'})`;
+      } else {
+        lastSeen = `status=${current.status ?? 'undefined'} queryable=${current.queryable ?? 'undefined'}`;
+        // `queryable` counts as ready too: it is the property recall actually depends on, and a
+        // deployment whose mongot reports it without a READY status would otherwise poll forever.
+        if (current.status === 'READY' || current.queryable === true) {
+          log.debug(`Vector search index ${indexName} is READY (${lastSeen})`);
+          return true;
+        }
       }
-    } catch { /* ignore intermittent errors during polling */ }
+    } catch (err) {
+      lastSeen = `listSearchIndexes threw: ${err instanceof Error ? err.message : String(err)}`;
+    }
+
+    // Say what is actually being observed, periodically. The previous version swallowed everything and
+    // reported only "did not reach READY within 60s", which is why two rounds of this bug produced no
+    // evidence about WHY — the operator could see the cost and never the cause.
+    if (attempt === 4 || attempt % 30 === 29) {
+      log.warn(`Vector search index ${indexName}: still waiting after ${attempt + 1}s — ${lastSeen}`);
+    }
   }
+  log.warn(`Vector search index ${indexName}: gave up after ${attempts}s — last seen: ${lastSeen}`);
   return false;
 }
 

--- a/testing/standalone/index-ready-poll.test.js
+++ b/testing/standalone/index-ready-poll.test.js
@@ -1,0 +1,100 @@
+/**
+ * The index-readiness poll must list search indexes UNFILTERED and match by name.
+ *
+ * ## The evidence
+ *
+ * A deployment reported **~67 seconds per index on an instance with almost no data** — the same cost as
+ * one with thirteen full spaces. Five spaces in, 24 indexes, ~27 minutes. A build that is genuinely
+ * instant cannot take a fixed 67s. That is the 60s timeout expiring every single time, which means the
+ * poll never observed READY at all, on indexes that were fine.
+ *
+ * The cause is one overload. `ensureVectorIndex` lists **without** a filter and finds by name, and that
+ * call demonstrably works — it is how an existing index is detected for the update path. The two callers
+ * that used `listSearchIndexes(indexName)` are exactly the two that misbehaved:
+ *
+ *   - `pollVectorIndexReady` — never saw READY, so every wait ran to timeout.
+ *   - `pipeline-status` — `found[0]?.status` was always null, and `deriveLiveIndexState` turns a null
+ *     status into **missing**, so the Indexing panel declared every index absent on a healthy instance.
+ *
+ * Listing all and matching by name is a strict superset of the filtered behaviour, so it cannot be worse
+ * on a deployment where the filter did work.
+ *
+ * ## Why a source-level gate
+ *
+ * Reproducing it needs a live mongot that behaves this way, which CI's Atlas Local may or may not. The
+ * regression is a one-token change back to the filtered overload, and its symptom is a *slow* run rather
+ * than a failing one — the signature that let it survive two rounds of investigation.
+ *
+ * Run: node --test testing/standalone/index-ready-poll.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+
+const ROOT = 'server/src';
+
+function sources(dir = ROOT, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = `${dir}/${name}`;
+    if (statSync(p).isDirectory()) { sources(p, out); continue; }
+    if (p.endsWith('.ts') && !p.endsWith('.test.ts')) out.push(p);
+  }
+  return out;
+}
+
+/** Source with comment lines stripped — the fix is explained in comments that name the banned call. */
+function codeOf(file) {
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(l => { const t = l.trim(); return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*'); })
+    .join('\n');
+}
+
+describe('search-index listing is never name-filtered', () => {
+  it('no caller passes a name to listSearchIndexes', () => {
+    const offenders = [];
+    for (const f of sources()) {
+      const code = codeOf(f);
+      code.split('\n').forEach((line, i) => {
+        // Anything other than an empty argument list.
+        const m = /listSearchIndexes\(\s*[^)\s]/.exec(line);
+        if (m) offenders.push(`${f}:${i + 1}  ${line.trim().slice(0, 100)}`);
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'the name-filtered overload returned nothing on a real deployment, so readiness polls ran to ' +
+      'timeout every time and the index panel reported every index missing. List unfiltered and match ' +
+      'by name:\n' + offenders.join('\n'));
+  });
+
+  it('the poll matches by name and accepts queryable as ready', () => {
+    const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
+    const at = src.indexOf('export async function pollVectorIndexReady');
+    assert.ok(at > 0);
+    const body = src.slice(at, at + 3000);
+    assert.match(body, /all\.find\(i => i\.name === indexName\)/);
+    // `queryable` is the property recall actually depends on; a mongot reporting it without a READY
+    // status would otherwise poll forever.
+    assert.match(body, /current\.status === 'READY' \|\| current\.queryable === true/);
+  });
+
+  it('the poll reports WHAT it saw, not just that it gave up', () => {
+    // Two rounds of this bug produced no evidence about the cause, because the poll swallowed every
+    // observation and logged only "did not reach READY within 60s". The operator could see the cost and
+    // never the reason.
+    const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
+    assert.match(src, /lastSeen/);
+    assert.match(src, /still waiting after/);
+    assert.match(src, /gave up after/);
+    assert.match(src, /index not present/,
+      '"index missing" and "index not ready" are different failures and must not read the same');
+  });
+
+  it('pipeline-status lists each collection once, not once per expected index', () => {
+    // `files` carries two indexes (embedding + faceEmbedding); listing it per-entry doubled the mongot
+    // round-trips for no benefit.
+    const src = readFileSync(`${ROOT}/api/pipeline-status.ts`, 'utf8');
+    assert.match(src, /byCollection/);
+    assert.match(src, /all\.find\(i => i\.name === e\.indexName\)/);
+  });
+});


### PR DESCRIPTION
**The other half of the upgrade blocker.** #550 took the wait off the boot path; this is why the wait never succeeded in the first place.

## The datapoint that cracked it

> ~67s per index on a personal instance with almost no data — the same as our 13-space platform instance. Five spaces in, 24 indexes, ~27 minutes.

A build that is genuinely instant **cannot** take a fixed 67 seconds. That is the 60s ceiling expiring every single time, on indexes that were fine. The cost was per-index and constant, never per-byte — so small deployments were hit exactly as hard as large ones.

**#550 alone would have made this quieter and worse.** With the wait moved to the background, the pass would run its full ten minutes per space and then mark healthy spaces `failed`.

## One overload

`ensureVectorIndex` lists search indexes **without** a name filter and matches by name — and that call works. It is how an existing index is detected for the update path. The only two callers that passed a name were the only two that misbehaved:

| Caller | Symptom |
|---|---|
| `pollVectorIndexReady` | never saw READY, so every wait ran to timeout |
| `pipeline-status` | `found[0]?.status` always null → `deriveLiveIndexState` returns **`missing`** → the Indexing panel declared **every index absent** on a healthy instance |

Both now list unfiltered and match by name. That is a **strict superset** of the filtered behaviour, so it cannot be worse on a deployment where the filter did work.

`pipeline-status` also listed the `files` collection twice, once per expected index (embedding + faceEmbedding). It lists each collection once now.

## Two smaller corrections

- **`queryable: true` counts as ready** alongside `status: 'READY'`. It is the property recall actually depends on, and a mongot reporting it without a READY status would otherwise poll forever for no reason.
- **The poll says what it saw.** It previously swallowed every observation and logged only `did not reach READY within 60s` — which is precisely why two rounds of investigation produced the *cost* and never the *cause*. It now reports the observed status periodically and on giving up, and distinguishes **index not present** from **index not ready**, which used to read identically.

## On confidence

I cannot reproduce their mongot's behaviour locally, so I am not claiming certainty. The evidence is the asymmetry: the unfiltered call works in this same file, the filtered one does not, and only the filtered callers broke. The instrumentation is not garnish — **if this fix is wrong, the next report carries the answer in its logs** instead of costing another round.

## Verification

**Mutation-checked — five mutations, all killed:** reverting either caller to the filtered overload, dropping the `queryable` check, matching `all[0]` instead of by name, and going back to silent failure.

The gate is source-level: reproducing this needs a mongot that behaves this way, the regression is a one-token change, and its symptom is a *slow* run rather than a failing one — the signature that let it survive two rounds.

`npm run preflight` green.
