### PR TITLE
feat(storage): env-pinnable quotas, and the quota UI that never rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Storage quotas are env-pinnable** — `STORAGE_{TOTAL,FILES,BRAIN}_{SOFT,HARD}_GIB`, on the same
+  env → `config.json` → unset precedence as the model settings, with pinned fields reported in
+  `lockedByInfra` and rendered read-only in Settings.
+  - For multi-tenant hosting. On a host running several brains the disk ceiling is the host operator's
+    call, and this was the only infra-shaped setting with no way to bind it from the Deployment;
+    `allowPrivateModelEndpoints`, `modelPath` and the model endpoints have been pinnable for exactly this
+    reason. *(The reporter believed a tenant could raise it from Settings — they could not, since no route
+    writes `cfg.storage` and none is added here. But they own their config volume, so config-only still
+    meant unpinnable: the same gap by a longer path.)*
+  - All six are independent, so `total` can be pinned while per-area limits stay editable. `0` is a real
+    limit, not an absent one. A malformed value is **refused with a warning** rather than coerced — `NaN`
+    compares false against every usage figure, so it would look configured and enforce nothing.
+  - The resolver is wired into all four consumers (quota check, file-upload check, metrics, the spaces
+    API) and a test asserts none of them reads `cfg.storage` directly, because a pin that resolves in the
+    loader and binds nowhere is exactly the class of bug this release keeps finding.
+
 - **The Models screen now lists every model the pipeline actually calls.** Two were missing, both
   configurable since the day they shipped and neither reachable from the admin surface — so the one page
   that claims to enumerate the pipeline's models was quietly incomplete.
@@ -558,6 +574,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     reach READY within 60s", which is why two rounds of investigation produced the cost and never the
     cause. It now reports the observed status periodically, and distinguishes *index not present* from
     *index not ready* — different failures that used to read identically.
+
+- **Settings → Storage showed no quota at all on an instance that had one configured.** The client's
+  `StorageLimits` type was `{ totalLimitGiB, warnAtPercent }` — a shape the server has **never** sent. The
+  real payload is `{ total: { softLimitGiB, hardLimitGiB }, files: {…}, brain: {…} }`, so
+  `limits.totalLimitGiB` was permanently `undefined`, every `@if` guarding the quota UI was permanently
+  false, and the page rendered no limit, no usage bar and no health pill. It read exactly like "no quota
+  set". Nothing ever failed, because reading a missing field is not an error.
+  - Found while adding the env pins above, and worse than the thing that was reported.
+  - The page now shows **every configured area** with its soft and hard limit, not a single total that
+    was never displayed. The warn threshold is **derived from the soft limit** as a share of the hard one
+    rather than read from `warnAtPercent`, another field the server does not send — that one silently fell
+    through to a hard-coded 80% unrelated to the operator's actual soft limit.
+  - The usage bar is drawn against the **hard** total (falling back to soft), because hard is what
+    actually refuses a write.
 
 - **Upgrading from 2.0.0 could look like a crash loop: boot blocked for over an hour waiting on vector
   index builds.** 2.0.0 added filter fields to the `$vectorSearch` indexes, so every upgrade reshapes the

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -946,6 +946,7 @@
   "metrics.empty": "Noch keine Speichernutzung vorhanden.",
   "metrics.stat.totalUsed": "Insgesamt verwendet",
   "metrics.stat.brain": "Gehirn (MongoDB)",
+  "metrics.stat.total": "Gesamt",
   "metrics.stat.files": "Dateien",
   "metrics.stat.limit": "Limit",
   "metrics.stat.unit": "GiB",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -946,6 +946,7 @@
   "metrics.empty": "No storage usage to report yet.",
   "metrics.stat.totalUsed": "Total used",
   "metrics.stat.brain": "Brain (MongoDB)",
+  "metrics.stat.total": "Total",
   "metrics.stat.files": "Files",
   "metrics.stat.limit": "Limit",
   "metrics.stat.unit": "GiB",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -946,6 +946,7 @@
   "metrics.empty": "Brak danych o użyciu pamięci.",
   "metrics.stat.totalUsed": "Łącznie wykorzystano",
   "metrics.stat.brain": "Mózg (MongoDB)",
+  "metrics.stat.total": "Łącznie",
   "metrics.stat.files": "Akta",
   "metrics.stat.limit": "Limit",
   "metrics.stat.unit": "GiB",

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -140,9 +140,26 @@ export interface SpacesResponse {
   };
 }
 
+/**
+ * Instance storage quotas, as the server actually sends them.
+ *
+ * The previous shape — `{ totalLimitGiB, warnAtPercent }` — was **fiction**. The server has always sent
+ * `{ total: { softLimitGiB, hardLimitGiB }, files: {...}, brain: {...} }`, so `limits.totalLimitGiB` was
+ * permanently `undefined`, every `@if` guarding the quota UI was permanently false, and Settings →
+ * Storage showed *no limit, no usage bar and no health pill* on an instance that had quotas configured.
+ * It read exactly like "no quota set". Nothing failed, because reading a missing field is not an error.
+ */
+export interface StorageAreaLimit {
+  softLimitGiB?: number;
+  hardLimitGiB?: number;
+}
+
 export interface StorageLimits {
-  totalLimitGiB?: number;
-  warnAtPercent?: number;
+  total?: StorageAreaLimit;
+  files?: StorageAreaLimit;
+  brain?: StorageAreaLimit;
+  /** Dotted paths pinned by an env var (`total.hardLimitGiB`), rendered read-only. */
+  lockedByInfra?: string[];
 }
 
 export interface TokenRecord {

--- a/client/src/app/pages/settings/storage.component.spec.ts
+++ b/client/src/app/pages/settings/storage.component.spec.ts
@@ -36,21 +36,62 @@ describe('StorageComponent', () => {
     expect(el(f).querySelector('.alert-error')).toBeTruthy();
   });
 
+  // Every fixture below sends the shape the SERVER sends. The previous ones seeded
+  // `{ totalLimitGiB, warnAtPercent }` — a shape the server has never produced — and silenced the type
+  // error with `as never`. That is why the dead quota UI survived: the spec agreed with the client's
+  // wrong type instead of with the payload, so both were consistently wrong and nothing failed.
+  const limits = (soft?: number, hard?: number) => ({ total: { softLimitGiB: soft, hardLimitGiB: hard } });
+
   it('renders the shared usage bar + a health pill when a limit is configured', () => {
-    const f = make(() => of({ storage: { usageGiB: { files: 1, brain: 1, total: 2 }, limits: { totalLimitGiB: 10, warnAtPercent: 80 } } }));
+    const f = make(() => of({ storage: { usageGiB: { files: 1, brain: 1, total: 2 }, limits: limits(8, 10) } }));
     expect(el(f).querySelector('app-usage-bar')).toBeTruthy();
     expect(el(f).querySelector('app-status-pill')).toBeTruthy();
   });
 
+  it('lists every configured area, and badges the ones the host pinned', () => {
+    const f = make(() => of({ storage: {
+      usageGiB: { files: 1, brain: 1, total: 2 },
+      limits: {
+        total: { softLimitGiB: 8, hardLimitGiB: 10 },
+        files: { hardLimitGiB: 5 },
+        lockedByInfra: ['files.hardLimitGiB'],
+      },
+    } }));
+    const c = f.componentInstance;
+    expect(c.limitRows().map((r: { area: string; pinned: boolean }) => [r.area, r.pinned]))
+      .toEqual([['total', false], ['files', true]]);
+    expect(el(f).textContent).toContain('mediaProcessing.pill.env');
+  });
+
+  it('the warn threshold comes from the soft limit, not a hard-coded 80', () => {
+    // soft 5 of hard 10 means the bar should turn amber at 50%, not at whatever 80 happens to mean.
+    const c = make(() => of({ storage: null })).componentInstance;
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 0 }, limits: limits(5, 10) });
+    expect(c.warnAtPercent()).toBe(50);
+    // With no soft limit there is nothing to derive from, so it falls back.
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 0 }, limits: limits(undefined, 10) });
+    expect(c.warnAtPercent()).toBe(80);
+  });
+
+  it('the bar is drawn against the HARD limit, falling back to soft', () => {
+    // Hard is what actually refuses a write. Falling back matters because an operator may set a warning
+    // threshold and no hard cap, and drawing no bar at all is how this page looked unconfigured.
+    const c = make(() => of({ storage: null })).componentInstance;
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 0 }, limits: limits(8, 10) });
+    expect(c.totalHard()).toBe(10);
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 0 }, limits: limits(8, undefined) });
+    expect(c.totalHard()).toBe(8);
+  });
+
   it('healthPill reflects the usage level (ok / warn / full), and is null with no limit', () => {
     const c = make(() => of({ storage: null })).componentInstance;
-    c.data.set({ usageGiB: { files: 0, brain: 0, total: 5 }, limits: { totalLimitGiB: 10, warnAtPercent: 80 } } as never);
-    expect(c.healthPill()?.variant).toBe('ok'); // 50%
-    c.data.set({ usageGiB: { files: 0, brain: 0, total: 9 }, limits: { totalLimitGiB: 10, warnAtPercent: 80 } } as never);
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 4 }, limits: limits(8, 10) });
+    expect(c.healthPill()?.variant).toBe('ok'); // 40%, under the 80% soft share
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 9 }, limits: limits(8, 10) });
     expect(c.healthPill()?.variant).toBe('warn'); // 90%
-    c.data.set({ usageGiB: { files: 0, brain: 0, total: 10 }, limits: { totalLimitGiB: 10 } } as never);
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 10 }, limits: limits(undefined, 10) });
     expect(c.healthPill()?.variant).toBe('error'); // 100%
-    c.data.set({ usageGiB: { files: 0, brain: 0, total: 5 } } as never); // no limit
+    c.data.set({ usageGiB: { files: 0, brain: 0, total: 5 } }); // no limit
     expect(c.healthPill()).toBeNull();
   });
 });

--- a/client/src/app/pages/settings/storage.component.ts
+++ b/client/src/app/pages/settings/storage.component.ts
@@ -4,10 +4,11 @@ import { SpacesApi } from '../../core/spaces-api.service';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { UsageBarComponent, usageLevel } from '../../shared/usage-bar.component';
 import { StatusPillComponent, type StatusVariant } from '../../shared/status-pill.component';
+import type { StorageLimits } from '../../core/api.types';
 
 interface StorageData {
   usageGiB: { files: number; brain: number; total: number };
-  limits?: { totalLimitGiB?: number; warnAtPercent?: number };
+  limits?: StorageLimits;
 }
 
 @Component({
@@ -63,16 +64,16 @@ interface StorageData {
           <div class="stat-value">{{ fmt(data()!.usageGiB.files) }}</div>
           <div class="stat-sub">{{ 'metrics.stat.unit' | transloco }}</div>
         </div>
-        @if (data()!.limits?.totalLimitGiB) {
+        @if (totalHard(); as limit) {
           <div class="stat-card">
             <div class="stat-label">{{ 'metrics.stat.limit' | transloco }}</div>
-            <div class="stat-value">{{ data()!.limits!.totalLimitGiB }}</div>
+            <div class="stat-value">{{ limit }}</div>
             <div class="stat-sub">{{ 'metrics.stat.unit' | transloco }}</div>
           </div>
         }
       </div>
 
-      @if (data()!.limits?.totalLimitGiB) {
+      @if (totalHard(); as limit) {
         <div class="card" style="margin-bottom:20px;">
           <div class="row">
             <span class="label" style="display:inline-flex; align-items:center; gap:8px;">
@@ -83,22 +84,41 @@ interface StorageData {
           </div>
           <app-usage-bar
             [used]="data()!.usageGiB.total"
-            [total]="data()!.limits!.totalLimitGiB!"
-            [warnAtPercent]="data()!.limits?.warnAtPercent ?? 80"
+            [total]="limit"
+            [warnAtPercent]="warnAtPercent()"
             style="display:block; margin:8px 0 6px;"
           />
           <div style="font-size:11px; color:var(--text-muted);">
-            {{ fmt(data()!.usageGiB.total) }} of {{ data()!.limits!.totalLimitGiB }} GiB
+            {{ fmt(data()!.usageGiB.total) }} of {{ limit }} GiB
           </div>
         </div>
       }
 
-      @if (data()!.limits?.totalLimitGiB) {
+      <!-- Every configured limit, per area, with a pill on the ones the host has pinned. Previously
+           only a single "total" number was even attempted, and it was read from a field that does not
+           exist — so files/brain limits were invisible whether pinned or not. -->
+      @if (limitRows().length > 0) {
+        <div class="card" style="margin-bottom:20px;">
+          @for (r of limitRows(); track r.area) {
+            <div class="row">
+              <span class="label" style="display:inline-flex; align-items:center; gap:8px;">
+                {{ 'metrics.stat.' + r.area | transloco }}
+                @if (r.pinned) {
+                  <app-status-pill variant="env">{{ 'mediaProcessing.pill.env' | transloco }}</app-status-pill>
+                }
+              </span>
+              <span class="value">{{ r.text }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      @if (totalHard()) {
         @if (pct >= 95) {
           <div class="alert alert-error">
             {{ 'metrics.alert.full' | transloco }}
           </div>
-        } @else if (pct >= (data()!.limits?.warnAtPercent ?? 80)) {
+        } @else if (pct >= warnAtPercent()) {
           <div class="alert alert-warning">
             {{ 'metrics.alert.warning' | transloco }}
           </div>
@@ -116,18 +136,64 @@ export class StorageComponent implements OnInit {
   /** Distinct from `!data()`: a load *failure*, so a successful-but-empty response isn't shown as an error. */
   error = signal(false);
 
+  /**
+   * The ceiling the usage bar is drawn against: the HARD total limit, falling back to the soft one.
+   *
+   * Hard is what actually refuses a write, so it is the honest denominator. Falling back to soft matters
+   * because an operator may set a warning threshold and no hard cap, and drawing no bar at all in that
+   * case is how this page ended up looking unconfigured in the first place.
+   */
+  totalHard = computed<number | undefined>(() => {
+    const t = this.data()?.limits?.total;
+    return t?.hardLimitGiB ?? t?.softLimitGiB;
+  });
+
+  /**
+   * Where the bar turns amber: the soft limit expressed as a percentage of the hard one.
+   *
+   * Derived rather than configured. The old code read `limits.warnAtPercent`, which the server has never
+   * sent — so it always fell through to a hard-coded 80% that had nothing to do with the operator's
+   * actual soft limit. If soft is 80 GiB of a 100 GiB hard cap, the warning belongs at 80%, not at
+   * whatever 80 happens to mean.
+   */
+  warnAtPercent = computed<number>(() => {
+    const t = this.data()?.limits?.total;
+    if (!t?.softLimitGiB || !t?.hardLimitGiB || t.hardLimitGiB <= 0) return 80;
+    return Math.min(100, (t.softLimitGiB / t.hardLimitGiB) * 100);
+  });
+
+  /** One row per configured area, with whether the host pinned it from the environment. */
+  limitRows = computed<{ area: string; text: string; pinned: boolean }[]>(() => {
+    const lim = this.data()?.limits;
+    if (!lim) return [];
+    const locked = new Set(lim.lockedByInfra ?? []);
+    const rows: { area: string; text: string; pinned: boolean }[] = [];
+    for (const area of ['total', 'files', 'brain'] as const) {
+      const v = lim[area];
+      if (!v || (v.softLimitGiB === undefined && v.hardLimitGiB === undefined)) continue;
+      const parts: string[] = [];
+      if (v.softLimitGiB !== undefined) parts.push(`${v.softLimitGiB} GiB soft`);
+      if (v.hardLimitGiB !== undefined) parts.push(`${v.hardLimitGiB} GiB hard`);
+      rows.push({
+        area,
+        text: parts.join(' · '),
+        pinned: locked.has(`${area}.softLimitGiB`) || locked.has(`${area}.hardLimitGiB`),
+      });
+    }
+    return rows;
+  });
+
   /** Derived from `data()` so it can never render a stale percentage against a prior/absent load. */
   usagePct = computed(() => {
+    const limit = this.totalHard();
     const d = this.data();
-    const limit = d?.limits?.totalLimitGiB;
-    return limit ? (d!.usageGiB.total / limit) * 100 : 0;
+    return limit && d ? (d.usageGiB.total / limit) * 100 : 0;
   });
 
   /** Storage health as a status pill — only meaningful when a limit is configured. */
   healthPill = computed<{ variant: StatusVariant; key: string } | null>(() => {
-    const d = this.data();
-    if (!d?.limits?.totalLimitGiB) return null;
-    const level = usageLevel(this.usagePct(), d.limits.warnAtPercent ?? 80);
+    if (!this.totalHard()) return null;
+    const level = usageLevel(this.usagePct(), this.warnAtPercent());
     return {
       ok:     { variant: 'ok' as StatusVariant,    key: 'metrics.health.ok' },
       warn:   { variant: 'warn' as StatusVariant,  key: 'metrics.health.warn' },

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -7249,6 +7249,33 @@ Configured in `config.json` under `storage`:
 | Above soft limit | Write succeeds, response includes `storageWarning: true` |
 | Above hard limit | Write rejected with `507` and `storageExceeded: true` |
 
+### Pinning the limits from the environment
+
+*New in 2.1.*
+
+Every limit can also be set by an environment variable, on the same **env → `config.json` → unset**
+precedence as the model settings:
+
+| Field | Env var |
+|---|---|
+| `storage.total.softLimitGiB` | `STORAGE_TOTAL_SOFT_GIB` |
+| `storage.total.hardLimitGiB` | `STORAGE_TOTAL_HARD_GIB` |
+| `storage.files.softLimitGiB` | `STORAGE_FILES_SOFT_GIB` |
+| `storage.files.hardLimitGiB` | `STORAGE_FILES_HARD_GIB` |
+| `storage.brain.softLimitGiB` | `STORAGE_BRAIN_SOFT_GIB` |
+| `storage.brain.hardLimitGiB` | `STORAGE_BRAIN_HARD_GIB` |
+
+**This is for multi-tenant hosting.** On a host running several brains, the disk ceiling is the host
+operator's call, and it was the only infra-shaped setting with no way to bind it from the Deployment —
+`allowPrivateModelEndpoints`, `modelPath` and the model endpoints have all been env-pinnable for exactly
+this reason. A pinned field is reported in `lockedByInfra` on `GET /api/spaces` and rendered read-only
+with an **env** badge on **Settings → Storage**.
+
+Each of the six is independent, so `total` can be pinned while the per-area limits stay editable, or the
+reverse. A value of `0` is a real limit (refuse everything), not an absent one. A malformed value is
+ignored with a warning and the `config.json` value is used — a limit that parsed to `NaN` would compare
+false against every usage figure and enforce nothing while looking configured.
+
 ---
 
 ## Pagination

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import path from 'path';
 import { requireAuth, requireAdmin, requireAdminMfa, requireAdminMfaScoped } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
-import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig } from '../config/loader.js';
+import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
 import { slugify } from '../spaces/_shared.js';
 import { createSpace, removeSpace } from '../spaces/lifecycle.js';
@@ -364,11 +364,17 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     ...(includeCounts && countsBySpaceId[id] ? { counts: countsBySpaceId[id] } : {}),
   }));
   // Include storage usage summary when quota is configured
-  let storage: { usageGiB?: { files: number; brain: number; total: number }; limits?: typeof cfg.storage } | undefined;
-  if (cfg.storage) {
+  // Resolved, not raw: `getStorageConfig()` applies the env pins, and `lockedByInfra` is what lets the
+  // Settings page render a host-imposed limit read-only instead of as something the tenant may edit.
+  const resolvedStorage = getStorageConfig();
+  let storage: {
+    usageGiB?: { files: number; brain: number; total: number };
+    limits?: ReturnType<typeof getStorageConfig>;
+  } | undefined;
+  if (resolvedStorage) {
     try {
       const usage = await measureUsage();
-      storage = { usageGiB: usage, limits: cfg.storage };
+      storage = { usageGiB: usage, limits: resolvedStorage };
     } catch {
       // Non-fatal: storage summary omitted on measurement error
     }

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -641,6 +641,76 @@ export function saveSchemaCatalogs(catalogs: SchemaCatalog[]): void {
 
 // ── Defaults ───────────────────────────────────────────────────────────────
 
+/**
+ * Storage quotas, resolved env → config.json → unset, with the env-pinned fields reported.
+ *
+ * ## Why these needed an env layer
+ *
+ * Every other infra-shaped field — `allowPrivateModelEndpoints`, `modelPath`, the model endpoints —
+ * is env-pinnable and lands in `lockedByInfra` precisely so the instance's own admin cannot widen it.
+ * Storage limits were the exception: config.json only. On a host running several brains, the disk
+ * ceiling is the host operator's call, not the tenant's, and it was the one setting the operator had no
+ * way to bound from the Deployment.
+ *
+ * (The tenant could not raise it from Settings — no route writes `cfg.storage`, and none is added here.
+ * But they own their config volume, so config-only meant unpinnable, which is the same gap by a
+ * slightly longer path.)
+ *
+ * All six are separately pinnable. Six env vars is more surface than one, and the alternative — pinning
+ * `total` alone — leaves the per-area limits widenable, which is the same hole in a smaller room.
+ */
+export interface ResolvedStorageConfig {
+  total?: { softLimitGiB?: number; hardLimitGiB?: number };
+  files?: { softLimitGiB?: number; hardLimitGiB?: number };
+  brain?: { softLimitGiB?: number; hardLimitGiB?: number };
+  /** Dotted paths pinned by an env var, e.g. `total.hardLimitGiB`. Rendered read-only by the UI. */
+  lockedByInfra: string[];
+}
+
+const STORAGE_AREAS = ['total', 'files', 'brain'] as const;
+const STORAGE_TIERS = [['soft', 'softLimitGiB'], ['hard', 'hardLimitGiB']] as const;
+
+/** `STORAGE_TOTAL_HARD_GIB` etc. Spelled out rather than derived, so the names are greppable. */
+function storageEnvName(area: string, tier: string): string {
+  return `STORAGE_${area.toUpperCase()}_${tier.toUpperCase()}_GIB`;
+}
+
+export function getStorageConfig(): ResolvedStorageConfig | undefined {
+  let base: Record<string, { softLimitGiB?: number; hardLimitGiB?: number } | undefined> = {};
+  try { base = (getConfig().storage ?? {}) as typeof base; } catch { /* pre-setup */ }
+
+  const out: ResolvedStorageConfig = { lockedByInfra: [] };
+  let any = false;
+
+  for (const area of STORAGE_AREAS) {
+    const resolved: { softLimitGiB?: number; hardLimitGiB?: number } = {};
+    for (const [tier, field] of STORAGE_TIERS) {
+      const raw = process.env[storageEnvName(area, tier)];
+      if (raw !== undefined && raw.trim() !== '') {
+        const n = Number(raw);
+        // A malformed pin is IGNORED, loudly, rather than silently becoming NaN — a NaN limit compares
+        // false against every usage figure, so the quota would read as configured and enforce nothing.
+        if (Number.isFinite(n) && n >= 0) {
+          resolved[field] = n;
+          out.lockedByInfra.push(`${area}.${field}`);
+          continue;
+        }
+        log.warn(`${storageEnvName(area, tier)}="${raw}" is not a non-negative number — ignoring it and falling back to config.json.`);
+      }
+      const fromConfig = base[area]?.[field];
+      if (fromConfig !== undefined) resolved[field] = fromConfig;
+    }
+    if (resolved.softLimitGiB !== undefined || resolved.hardLimitGiB !== undefined) {
+      out[area] = resolved;
+      any = true;
+    }
+  }
+
+  // Undefined, not an empty object: every caller treats "no storage config" as "quota disabled", and an
+  // object with only `lockedByInfra` in it is truthy.
+  return any ? out : undefined;
+}
+
 export function getEmbeddingConfig() {
   const cfg = getConfig();
   // No baseUrl in the default = use the bundled local ONNX model.

--- a/server/src/files/files.ts
+++ b/server/src/files/files.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { createHash } from 'crypto';
 import { resolveSafePathChecked, spaceRoot } from './sandbox.js';
-import { getConfig, getDataRoot } from '../config/loader.js';
+import { getConfig, getDataRoot, getStorageConfig } from '../config/loader.js';
 
 export interface FileEntry {
   name: string;
@@ -196,8 +196,7 @@ export interface QuotaCheckResult {
  * @param incomingBytes estimated size of the incoming write (0 for a safe check with no addend)
  */
 export async function checkFilesQuota(incomingBytes: number): Promise<QuotaCheckResult> {
-  const cfg = getConfig();
-  const fileLimits = cfg.storage?.files;
+  const fileLimits = getStorageConfig()?.files;
   if (!fileLimits) return { allowed: true, softWarning: false };
 
   const filesRoot = path.join(getDataRoot(), 'files');

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -17,7 +17,7 @@ import {
   Gauge,
 } from 'prom-client';
 import { col } from '../db/mongo.js';
-import { getConfig } from '../config/loader.js';
+import { getConfig, getStorageConfig } from '../config/loader.js';
 import { measureUsage } from '../quota/quota.js';
 
 export const register = new Registry();
@@ -182,9 +182,8 @@ export const storageLimitBytes = new Gauge({
   registers: [register],
   collect() {
     try {
-      const cfg = getConfig();
       const GiB = 1024 ** 3;
-      const storage = cfg.storage;
+      const storage = getStorageConfig();
       if (!storage) return;
       if (storage.total?.softLimitGiB != null) this.set({ area: 'total', tier: 'soft' }, storage.total.softLimitGiB * GiB);
       if (storage.total?.hardLimitGiB != null) this.set({ area: 'total', tier: 'hard' }, storage.total.hardLimitGiB * GiB);

--- a/server/src/quota/quota.ts
+++ b/server/src/quota/quota.ts
@@ -17,7 +17,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { getConfig, getDataRoot } from '../config/loader.js';
+import { getDataRoot, getStorageConfig } from '../config/loader.js';
 import { getDb } from '../db/mongo.js';
 
 const GiB = 1024 ** 3;
@@ -171,8 +171,8 @@ export async function checkQuota(
   incomingBytes = 0,
   opts: { maxAgeMs?: number } = {},
 ): Promise<QuotaCheckResult> {
-  const cfg = getConfig();
-  const storage = cfg.storage;
+  // getStorageConfig(), not cfg.storage: an env pin must actually bind here or it is decoration.
+  const storage = getStorageConfig();
 
   // No storage config → quota disabled, always allow.
   if (!storage) {

--- a/testing/standalone/storage-quota-env-pins.test.js
+++ b/testing/standalone/storage-quota-env-pins.test.js
@@ -1,0 +1,186 @@
+/**
+ * Storage quotas are env-pinnable, and the pins actually bind.
+ *
+ * ## Two problems, one of them worse than the reported one
+ *
+ * **Reported:** storage limits were `config.json`-only, so on a host running several brains the disk
+ * ceiling — the host operator's call, not the tenant's — was the one infra-shaped setting with no env
+ * pin. Every other one (`allowPrivateModelEndpoints`, `modelPath`, the model endpoints) is pinnable and
+ * lands in `lockedByInfra` precisely so it cannot be widened from inside the instance.
+ *
+ * *(The reporter believed the tenant could raise it from Settings. They could not — no route writes
+ * `cfg.storage`, and none is added here. But they own the config volume, so config-only still meant
+ * unpinnable: the same gap by a longer path.)*
+ *
+ * **Found while fixing it, and worse:** the client's `StorageLimits` type was
+ * `{ totalLimitGiB, warnAtPercent }` — a shape the server has NEVER sent. The real payload is
+ * `{ total: { softLimitGiB, hardLimitGiB }, … }`. So `limits.totalLimitGiB` was permanently undefined,
+ * every `@if` guarding the quota UI was permanently false, and Settings → Storage showed no limit, no
+ * usage bar and no health pill on an instance that had quotas configured. It read as "no quota set".
+ * Reading a missing field is not an error, so nothing ever complained.
+ *
+ * Run: node --test testing/standalone/storage-quota-env-pins.test.js
+ */
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-storage-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let getStorageConfig;
+let loader;
+
+const ENV_KEYS = [
+  'STORAGE_TOTAL_SOFT_GIB', 'STORAGE_TOTAL_HARD_GIB',
+  'STORAGE_FILES_SOFT_GIB', 'STORAGE_FILES_HARD_GIB',
+  'STORAGE_BRAIN_SOFT_GIB', 'STORAGE_BRAIN_HARD_GIB',
+];
+const clear = () => { for (const k of ENV_KEYS) delete process.env[k]; };
+
+function seed(storage) {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+    instanceId: 'storage-test', instanceLabel: 'test', tokens: [], networks: [],
+    spaces: [{ id: 'general', label: 'General', builtIn: true, folders: [] }],
+    ...(storage ? { storage } : {}),
+  }, null, 2), { mode: 0o600 });
+  loader.loadConfig();
+}
+
+describe('storage quota env pins', () => {
+  before(async () => {
+    loader = await import('../../server/dist/config/loader.js');
+    ({ getStorageConfig } = loader);
+  });
+  beforeEach(clear);
+  afterEach(clear);
+
+  describe('resolution', () => {
+    it('is undefined when nothing is configured — quota disabled, not "limit 0"', () => {
+      // Every caller treats a falsy result as "no quota". Returning an object with only lockedByInfra
+      // in it would be truthy and would switch enforcement on with no limits in it.
+      seed(null);
+      assert.equal(getStorageConfig(), undefined);
+    });
+
+    it('reads config.json when no env var is set', () => {
+      seed({ total: { softLimitGiB: 80, hardLimitGiB: 100 } });
+      const r = getStorageConfig();
+      assert.deepEqual(r.total, { softLimitGiB: 80, hardLimitGiB: 100 });
+      assert.deepEqual(r.lockedByInfra, []);
+    });
+
+    it('an env pin overrides config.json and is reported as locked', () => {
+      seed({ total: { softLimitGiB: 80, hardLimitGiB: 100 } });
+      process.env.STORAGE_TOTAL_HARD_GIB = '50';
+      const r = getStorageConfig();
+      assert.equal(r.total.hardLimitGiB, 50, 'the pin must win');
+      assert.equal(r.total.softLimitGiB, 80, 'the unpinned tier still comes from config');
+      assert.deepEqual(r.lockedByInfra, ['total.hardLimitGiB']);
+    });
+
+    it('pins an area that config.json never mentioned', () => {
+      seed(null);
+      process.env.STORAGE_FILES_HARD_GIB = '25';
+      const r = getStorageConfig();
+      assert.equal(r.files.hardLimitGiB, 25);
+      assert.ok(r.lockedByInfra.includes('files.hardLimitGiB'));
+    });
+
+    it('all six are separately pinnable', () => {
+      seed(null);
+      process.env.STORAGE_TOTAL_SOFT_GIB = '1';
+      process.env.STORAGE_TOTAL_HARD_GIB = '2';
+      process.env.STORAGE_FILES_SOFT_GIB = '3';
+      process.env.STORAGE_FILES_HARD_GIB = '4';
+      process.env.STORAGE_BRAIN_SOFT_GIB = '5';
+      process.env.STORAGE_BRAIN_HARD_GIB = '6';
+      const r = getStorageConfig();
+      assert.deepEqual(r.total, { softLimitGiB: 1, hardLimitGiB: 2 });
+      assert.deepEqual(r.files, { softLimitGiB: 3, hardLimitGiB: 4 });
+      assert.deepEqual(r.brain, { softLimitGiB: 5, hardLimitGiB: 6 });
+      assert.equal(r.lockedByInfra.length, 6);
+    });
+
+    it('0 is a real pin, not an absent one', () => {
+      // "No writes at all" is a legitimate ceiling, and `if (!value)` would silently discard it.
+      seed(null);
+      process.env.STORAGE_FILES_HARD_GIB = '0';
+      assert.equal(getStorageConfig().files.hardLimitGiB, 0);
+    });
+  });
+
+  describe('a malformed pin is refused, not turned into NaN', () => {
+    // NaN compares false against every usage figure, so a NaN limit reads as configured and enforces
+    // nothing — a quota that silently does not exist is worse than no quota at all.
+    for (const bad of ['abc', '', '  ', '-5']) {
+      it(`ignores ${JSON.stringify(bad)} and falls back to config.json`, () => {
+        seed({ files: { hardLimitGiB: 10 } });
+        process.env.STORAGE_FILES_HARD_GIB = bad;
+        const r = getStorageConfig();
+        assert.equal(r.files.hardLimitGiB, 10);
+        assert.ok(!r.lockedByInfra.includes('files.hardLimitGiB'),
+          'a rejected pin must not claim to have locked the field');
+      });
+    }
+  });
+
+  /**
+   * Source with comment lines removed.
+   *
+   * Third time this has bitten in one session: an assertion that forbids a string trips on the comment
+   * *explaining why the string is forbidden*. A gate that fails on its own justification teaches people
+   * to delete the justification.
+   */
+  function codeOf(file) {
+    return fs.readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(l => { const t = l.trim(); return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*'); })
+      .join('\n');
+  }
+
+  describe('the pins actually bind', () => {
+    // A resolver nothing calls is decoration. Each of these read `cfg.storage` directly before.
+    const CONSUMERS = [
+      ['server/src/quota/quota.ts', /const storage = getStorageConfig\(\)/],
+      ['server/src/files/files.ts', /const fileLimits = getStorageConfig\(\)\?\.files/],
+      ['server/src/metrics/registry.ts', /const storage = getStorageConfig\(\)/],
+      ['server/src/api/spaces.ts', /const resolvedStorage = getStorageConfig\(\)/],
+    ];
+    for (const [file, re] of CONSUMERS) {
+      it(file, () => {
+        const code = codeOf(file);
+        assert.match(code, re);
+        assert.doesNotMatch(code, /cfg\.storage/, 'must not read the raw config, which skips the env layer');
+      });
+    }
+  });
+
+  describe('the client reads the shape the server sends', () => {
+    it('StorageLimits is the per-area shape, not the invented flat one', () => {
+      const types = codeOf('client/src/app/core/api.types.ts');
+      assert.match(types, /export interface StorageLimits \{[\s\S]*?total\?: StorageAreaLimit/);
+      assert.doesNotMatch(types, /totalLimitGiB/,
+        'the flat shape was never sent by the server; reintroducing it re-hides the whole quota UI');
+    });
+
+    it('the Storage page no longer reads the field that does not exist', () => {
+      const ui = codeOf('client/src/app/pages/settings/storage.component.ts');
+      assert.doesNotMatch(ui, /totalLimitGiB/);
+      assert.doesNotMatch(ui, /warnAtPercent \?\? 80/,
+        'the warn threshold is derived from the soft limit now, not a hard-coded fallback for a field ' +
+        'the server never sent');
+      assert.match(ui, /totalHard = computed/);
+      assert.match(ui, /limitRows = computed/);
+    });
+
+    it('an env-pinned limit is rendered read-only', () => {
+      const ui = codeOf('client/src/app/pages/settings/storage.component.ts');
+      assert.match(ui, /lockedByInfra/);
+      assert.match(ui, /mediaProcessing\.pill\.env/);
+    });
+  });
+});


### PR DESCRIPTION
Reported: storage limits were `config.json`-only, so on a host running several brains the disk ceiling — the host operator's call, not the tenant's — was the one infra-shaped setting with no env pin. `allowPrivateModelEndpoints`, `modelPath` and the model endpoints are all pinnable and land in `lockedByInfra` precisely so they cannot be widened from inside the instance.

> **One correction to the report:** the tenant could **not** raise it from Settings. No route writes `cfg.storage`, and none is added here. But they own their config volume, so config-only still meant unpinnable — the same gap by a longer path, and the same fix either way.

## The pins

`STORAGE_{TOTAL,FILES,BRAIN}_{SOFT,HARD}_GIB`, resolved **env → `config.json` → unset**.

- **All six are independent**, so `total` can be pinned while per-area limits stay editable. Pinning `total` alone — the reduced scope offered in the report — would leave the per-area limits widenable, which is the same hole in a smaller room.
- **`0` is a real limit** (refuse everything), not an absent one.
- **A malformed value is refused with a warning**, not coerced. `NaN` compares false against every usage figure, so a `NaN` limit reads as configured and enforces nothing — worse than no quota at all.
- Pinned fields appear in `lockedByInfra` on `GET /api/spaces` and render read-only with an **env** badge.

The resolver is wired into **all four** consumers (quota check, upload check, metrics, spaces API), and a test asserts none of them still reads `cfg.storage`. A pin that resolves in the loader and binds nowhere is a knob that looks configurable and is not — the exact class of bug this release keeps finding.

## Found while fixing it, and worse

**Settings → Storage showed no quota at all on an instance that had one configured.**

The client's `StorageLimits` type was `{ totalLimitGiB, warnAtPercent }` — a shape the server has **never** sent. The real payload is `{ total: { softLimitGiB, hardLimitGiB }, … }`. So `limits.totalLimitGiB` was permanently `undefined`, every `@if` guarding the quota UI was permanently false, and the page rendered no limit, no usage bar and no health pill. It read exactly like *"no quota set"*. Nothing ever failed, because reading a missing field is not an error.

**The spec is why it survived.** It seeded the fictional shape and silenced the type error with `as never`, so the test agreed with the client's wrong type instead of with the payload. Both were consistently wrong, and consistency passed.

Now:

- Every configured area is listed with its soft and hard limit.
- The warn threshold is **derived from the soft limit** as a share of the hard one, rather than read from `warnAtPercent` — another field the server does not send, which silently fell through to a hard-coded 80% unrelated to the operator's actual soft limit.
- The bar is drawn against the **hard** total (falling back to soft), because hard is what refuses a write.

## Verification

**Mutation-checked — seven mutations, all killed:** env pin no longer winning, a malformed pin becoming `NaN`, dropping `lockedByInfra`, returning a truthy object when nothing is configured, `quota.ts` reading the raw config again, reintroducing the flat type, and the UI reading the field the server never sends.

Three assertions initially tripped on my own comments explaining the strings they forbid — the third time today — so the source is comment-stripped before matching. A gate that fails on its own justification teaches people to delete the justification.

`npm run preflight` and `npm run lint:docs` green.
