### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-07-30
+
 ### Added
 
 - **Storage quotas are env-pinnable** — `STORAGE_{TOTAL,FILES,BRAIN}_{SOFT,HARD}_GIB`, on the same

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump ×3 and `[Unreleased]` closed as `[2.1.0]`. **No code changes.**

## Why tag now

Two of the thirty-six commits since v2.0.0 are **upgrade-blocking** for existing 2.0.x deployments, and the tag is how they get the fix:

| | |
|---|---|
| **#550** | Boot no longer waits on vector index builds. 2.0.0 polled every index for READY serially at startup, 60s ceiling each — ~65 minutes on a 13-space instance, enough to blow a 60-minute `startupProbe` budget and have a healthy upgrade killed mid-migration. |
| **#552** | The poll never observed READY in the first place — ~67s per index even on an *empty* instance, because two callers used a name-filtered `listSearchIndexes` overload that returned nothing. **Without this, #550 alone would have marked healthy spaces `failed`.** |

## The rest, all from the same customer feedback

- **#546** — the private-model-endpoint probe refused every self-hosted endpoint despite the opt-in being on; plus SSRF refusals that log, honest posture reporting, and `mcp.publicUrl`.
- **#547** — media env vars named after what they configure (`VISION_BASE_URL`, `STT_BASE_URL`, `STT_MODEL`) with warning aliases, and "Diagnosing a Misconfiguration" in the integration guide.
- **#548 / #551** — the narrow-window table, and the drawn scroll control above it.
- **#549** — the two models the Models screen never listed (office renderer, contradiction judge), and About's pending state.
- **#553** — env-pinnable storage quotas, and the quota UI that had never rendered at all.

## Semver

Minor. `[Unreleased]` carries no breaking changes — the `MEDIA_EMBEDDING_ENABLED` removal already shipped in 2.0.0.

`[Unreleased]` is left in place and empty so the next change has somewhere to go.

## After merge

Tag `v2.1.0` → `publish.yml` builds and publishes the image. **The release gate is the owner exercising the app**, not this PR going green.
