### PR TITLE
chore(release): 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] — 2026-07-30
+
 ### Fixed
 
 - **External vision failed on every image** (`visionProvider: external`). A strict OpenAI-compatible

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release commit for **v2.1.1**. Version bump on the three `package.json` files plus the CHANGELOG heading — the same four-file shape as the 2.1.0 release commit.

## Why a patch

One user-visible bug fix (#556) plus documentation and UX polish. No schema change, no API break, no config migration.

**External vision was broken 100% of the time** for `visionProvider: external` on both 2.0.0 and 2.1.0 — a strict OpenAI-compatible server rejected every request with `Invalid uri format: data:application/octet-stream;base64`, and the media job exhausted its three retries. The cause was not the vision request: `dispatchFileProcessing` defaulted a missing or generic `Content-Type` without ever consulting the file extension, fed by three entry points, and the same wrong value reached four more consumers (speech-to-text, both ffmpeg paths, both face-recognition re-enqueue paths) across five duplicate MIME tables.

Instances upgrading with a queued backlog heal themselves — the worker re-derives the type on read and external vision sniffs the image signature from the bytes. No migration, nothing for an operator to run.

Also in this release, from the queued UX list: the page-renderer and document-converter cards now state what they do *not* do and which card owns that instead, and `responsive-sweep.mjs` drives tab strips and asserts a scroll affordance is visible rather than merely present.

## Verification

- `npm run preflight` — **PASSED** on this commit
- #556 carried the behavioural change and merged green; 21 of 21 mutations killed on its new suite
- The owner exercised the app and gave the go — the release gate for this repo