### PR TITLE
fix(vlm): the document VLM speaks either wire, and never egresses unguarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The document VLM could not work against any OpenAI-compatible server, and its egress was unguarded.**
+  Reported against 2.1.1 from a self-hosted Kubernetes deployment: with `visionProvider: external` and
+  `DOC_VLM_MODEL` set, one PDF produced `POST /render → 200`, `POST /v1/api/chat → 404`, and a fallback to
+  OCR — doc-render rasterising pages that were then discarded.
+  - `/api/chat` is **Ollama's** route. `vlm-client.postChat()` hardcoded it, so llama.cpp, llama-swap,
+    vLLM and LocalAI all 404'd, and **no `baseUrl` could fix it** — dropping `/v1` merely yields
+    `/api/chat` again. The client now speaks either wire, selected from the resolved endpoint.
+  - **Two unguarded egress paths**, from one assumption that stopped being true: *the document stages are
+    local*. That held while the VLM was the bundled Ollama; `visionProvider: external` falsified it,
+    because an empty `vlmBaseUrl` means "reuse the vision endpoint".
+    - `postChat` used a bare `fetch` — no SSRF guard, no egress acknowledgement — while sending **page
+      images**.
+    - `pipeline-status.modelStages()` hardcoded `external: false` on `doc-vlm`, `doc-repair` and
+      `doc-verify`, whose `baseUrl` falls back to the same vision endpoint the line above classifies with
+      `visionProvider === 'external'`. Same URL, opposite verdicts — so discovery went out unguarded too.
+  - **This was live, not latent.** Failing safe was a property of the target, not of the code: an
+    OpenAI-compatible server 404s `/api/chat`, but a **remote Ollama** answers 200. Those deployments were
+    egressing page images silently while the pipeline reported success.
+  - Both call sites now read **one resolver** (`files/converters/vlm-endpoint.ts`), so the route decision
+    and the calls it authorises can no longer be about different servers.
+  - `normalizeOpenAiBase` lands with it: `…:8080` and `…:8080/v1` now resolve identically, so one URL
+    serves every OpenAI-compatible caller. The reporter had been running two different base URLs for the
+    same server to satisfy two conventions, and that workaround is what hid the bug.
+  - The fallback log now **names the evidence**: which setting is empty and which env var sets it, rather
+    than only "needs vlm". A reporter spent a hunt through nine configured endpoints discovering a tenth
+    they had never set, because the message stated a verdict and withheld what it looked at.
+
 ### Changed
+
+- **Inverted the egress audit.** PR #546 audited `ssrfSafeFetch` *call sites* and found all 13 correct — a
+  set that cannot, by construction, contain an egress that should have been guarded and is not, which is
+  exactly how both VLM paths survived it. The new gate asks the opposite question: every bare `fetch` of a
+  possible model endpoint must be chosen by a locality test, or be a declared piece of infrastructure with
+  a stated reason. It found one further gap on its first run, recorded as a parked decision (the vision
+  and STT providers select their guard from the *provider type*, and the guide itself notes that
+  `local`/`external` is a wire protocol, not a trust level).
+- The integration guide gains an **egress table** — every model slot, what it sends, what guards it, and
+  whether an acknowledgement is required. Its list of SSRF-guarded endpoints had omitted the document VLM,
+  and its claim that no document content leaves by default was true only while the VLM was the bundled
+  model. The doc described the intended behaviour correctly; the code has been moved to match it.
 
 - **Hybrid search can now surface a record the vector channel missed entirely.** The lexical (BM25)
   channel previously *reordered* the vector candidate pool but could never add to it, and that bound had

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -387,8 +387,28 @@ Two private addresses in the same cluster can behave differently, and that is no
 
 - **Render/conversion sidecars** (`CONVERSION_SIDECAR_URL`, doc-render) are reached with a plain `fetch`.
   They are declared infrastructure, expected to be private, and are not subject to the egress guard.
-- **Model provider endpoints** (vision, STT, embedding, rerank, NLI, document assist) go through the
-  SSRF-guarded fetch, because those URLs are admin-settable and become egress targets.
+- **Model provider endpoints** (vision, STT, embedding, rerank, NLI, document VLM, document assist) go
+  through the SSRF-guarded fetch, because those URLs are admin-settable and become egress targets.
+
+#### Which model endpoints send content, and what guards them
+
+An endpoint is only as private as the host it points at. This table is what actually happens, per slot —
+`Guard` is the SSRF-guarded fetch (DNS resolution, IP pinning, redirect re-validation, crown-jewel ranges
+blocked; `allowPrivateModelEndpoints` lifts only the private-address refusal).
+
+| Slot | Env | Sends | Guard | Acknowledgement |
+|---|---|---|---|---|
+| Embedding | `EMBEDDING_BASE_URL` | record + query text | yes, when external | — |
+| Vision (captions) | `OLLAMA_URL` | uploaded images | yes, when the provider is `external` | — |
+| Speech-to-text | `STT_BASE_URL` | uploaded audio | yes, when the provider is `external` | — |
+| Reranker | `RERANK_BASE_URL` | the query **and** the passages it matched | yes, unless the URL is local | — |
+| Contradiction judge | `NLI_BASE_URL` | pairs of stored records | yes, unless the URL is local | — |
+| **Document VLM** | `DOC_VLM_URL`, `DOC_VLM_MODEL` | **rendered page images** | yes, unless it is the bundled model | — |
+| Assist model | `DOC_ASSIST_URL` | draft transcription + OCR text | yes, always | **required** |
+
+Two things worth reading twice. The **document VLM inherits the vision endpoint** when `DOC_VLM_URL` is
+unset — so pointing vision at an external provider also points the VLM there, and page images follow.
+And the assist model is the only slot that demands an explicit egress acknowledgement before it will run.
 
 So a green sidecar next to a refused model endpoint tells you cluster DNS and reachability are fine, and
 the difference is policy. That is the point at which `allowPrivateModelEndpoints` is the answer.
@@ -2652,9 +2672,12 @@ Three properties worth knowing before enabling it:
   discarded (a wrong width would corrupt gallery similarity rather than fail loudly), and the number of
   faces accepted from one response is capped.
 
-**External assist model (F11-b) — hosted egress, opt-in and acknowledged.** By default every extraction path
-is local (the bundled Ollama VLM / OCR sidecar): no document content leaves your instance. You can optionally
-point a **bigger, external model** at specific tasks under `documentProcessing.assistModel`:
+**External assist model (F11-b) — hosted egress, opt-in and acknowledged.** With the bundled models, every
+extraction path is local (the bundled Ollama VLM / OCR sidecar) and no document content leaves your
+instance. Note the precondition: the document VLM falls back to the **vision** endpoint when `DOC_VLM_URL`
+is unset, so an external vision provider makes the VLM external too and rendered page images go with it —
+see the egress table above. You can optionally point a **bigger, external model** at specific tasks under
+`documentProcessing.assistModel`:
 
 | Field | Description |
 |---|---|

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -31,6 +31,7 @@ import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl } from '../util/ssrf.js';
 import { allowPrivateModelEndpoints, isLocalModelEndpoint } from '../config/model-egress-policy.js';
 import { probeModelEndpoint } from './media-config.js';
+import { resolveVlmEndpoint } from '../files/converters/vlm-endpoint.js';
 import { getDb } from '../db/mongo.js';
 import { faceRecognitionAllowed } from '../files/converters/media-level.js';
 import { VECTOR_INDEXED_COLLECTIONS } from '../spaces/vector-index.js';
@@ -158,9 +159,23 @@ function modelStages(): StageSpec[] {
     { key: 'stt', label: 'Speech-to-text', model: media.stt?.model, baseUrl: media.stt?.baseUrl, apiKey: media.stt?.apiKey, external: media.sttProvider === 'external' },
     // The document stages fall back to the vision endpoint exactly as the pipeline itself does, so the
     // dot reports the endpoint that would really be called rather than the one nominally configured.
-    { key: 'doc-vlm', label: 'Document VLM', model: doc.vlmModel, baseUrl: doc.vlmBaseUrl || media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: false },
-    { key: 'doc-repair', label: 'Document repair', model: doc.repairModel || doc.vlmModel, baseUrl: doc.repairBaseUrl || doc.vlmBaseUrl || media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: false },
-    { key: 'doc-verify', label: 'Document verify', model: doc.verifyModel, baseUrl: doc.verifyBaseUrl || doc.vlmBaseUrl || media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: false },
+    //
+    // `external` comes from the SAME resolver the extractor uses. It used to be hardcoded `false` on all
+    // three — on a `baseUrl` that falls back to the vision endpoint, which the line above classifies with
+    // `visionProvider === 'external'`. Same URL, opposite verdicts, and since `probeModelEndpoint`
+    // branches `external ? ssrfSafeFetch : fetch`, three stages probed an off-instance host over an
+    // unguarded fetch (and skipped the route's `isSsrfSafeUrl` pre-check with it).
+    ...(['vlm', 'repair', 'verify'] as const).map(slot => {
+      const e = resolveVlmEndpoint(slot);
+      return {
+        key: `doc-${slot}` as const,
+        label: slot === 'vlm' ? 'Document VLM' : slot === 'repair' ? 'Document repair' : 'Document verify',
+        model: e.model || undefined,
+        baseUrl: e.baseUrl || undefined,
+        apiKey: e.apiKey,
+        external: e.external,
+      };
+    }),
     // The assist model is external by definition — it is the one path that sends content off-instance.
     { key: 'assist', label: 'Assist model', model: doc.assistModel?.model, baseUrl: doc.assistModel?.baseUrl, apiKey: getDocAssistApiKey(), external: true },
     // The reranker is a RETRIEVAL stage, not an ingestion one, but it belongs on the same board: it is

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -13,6 +13,7 @@
  */
 import { ssrfSafeFetch } from '../../util/ssrf.js';
 import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
+import { chatUrlFor, type VlmWire } from './vlm-endpoint.js';
 
 export interface VlmTranscription {
   text: string;
@@ -22,48 +23,132 @@ export interface VlmTranscription {
 
 const MAX_OUTPUT_TOKENS = 4096; // bound per-page output so a hostile page can't drive unbounded generation
 
-/** POST one non-streamed chat turn to Ollama `/api/chat` (temperature 0, bounded output). Throws on
- *  unreachable / HTTP error / model error so the caller can fall back. Shared by transcription + repair. */
+/** One chat turn, before it is serialised for a particular wire. `images` are base64, image-only turns. */
+interface ChatTurn { role: 'user'; content: string; images?: string[] }
+
+/**
+ * POST one non-streamed chat turn, on whichever wire the endpoint speaks.
+ *
+ * ## Why this branches
+ *
+ * It used to hardcode Ollama's `/api/chat`, which meant `vlmModel` could not work against **any**
+ * OpenAI-compatible server — llama.cpp, llama-swap, vLLM, LocalAI all 404 that route, and no `baseUrl`
+ * fixes it because dropping `/v1` merely yields `/api/chat` again. doc-render rasterised pages that were
+ * then thrown away.
+ *
+ * ## Why every non-bundled call is guarded
+ *
+ * It also used a bare `fetch`. That was written when the VLM was the bundled local Ollama and the file
+ * said so — *"repairMarkdown uses the bundled local Ollama (no egress)"*. `visionProvider: external`
+ * falsified it, because an empty `vlmBaseUrl` means "reuse the vision endpoint": page images then went to
+ * an off-instance host with no SSRF guard and no egress acknowledgement. It failed safe only against
+ * OpenAI-compatible targets; a **remote Ollama** answers `/api/chat` with 200, so those deployments were
+ * egressing silently while the pipeline reported success.
+ *
+ * So the guard follows the ENDPOINT, not the wire: an Ollama that is not ours gets the same treatment as
+ * an OpenAI one. The bundled local path keeps its plain `fetch` — guarding it would refuse the default
+ * deployment, whose model sits on a private cluster address.
+ */
 async function postChat(
-  baseUrl: string,
-  model: string,
-  messages: Array<Record<string, unknown>>,
+  endpoint: { baseUrl: string; model: string; wire: VlmWire; external: boolean; apiKey?: string },
+  turns: ChatTurn[],
   timeoutMs: number,
 ): Promise<VlmTranscription> {
-  const url = `${baseUrl.replace(/\/$/, '')}/api/chat`;
+  const url = chatUrlFor(endpoint.wire, endpoint.baseUrl);
+  const body = endpoint.wire === 'ollama'
+    ? {
+      model: endpoint.model,
+      stream: false,
+      options: { temperature: 0, num_predict: MAX_OUTPUT_TOKENS },
+      messages: turns.map(t => (t.images ? { role: t.role, content: t.content, images: t.images } : { role: t.role, content: t.content })),
+    }
+    : {
+      model: endpoint.model,
+      temperature: 0,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      // OpenAI carries images as data URIs in a content array. `image/png` because the render sidecar
+      // emits PNG; a wrong type here is what broke external vision in 2.0.0 (see files/mime.ts).
+      messages: turns.map(t => (t.images
+        ? {
+          role: t.role,
+          content: [
+            { type: 'text', text: t.content },
+            ...t.images.map(b64 => ({ type: 'image_url', image_url: { url: `data:image/png;base64,${b64}` } })),
+          ],
+        }
+        : { role: t.role, content: t.content })),
+    };
+
+  const init: RequestInit = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(endpoint.apiKey ? { Authorization: `Bearer ${endpoint.apiKey}` } : {}),
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  };
+
   let res: Response;
   try {
-    res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model,
-        stream: false,
-        options: { temperature: 0, num_predict: MAX_OUTPUT_TOKENS },
-        messages,
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    res = endpoint.external
+      // Guard on: DNS-resolve, IP-pin, redirect re-validation, crown-jewel ranges blocked. `allowPrivate`
+      // only lifts the private-address rejection, so a self-hosted model on a cluster address still works.
+      ? await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateModelEndpoints() })
+      : await fetch(url, init);
   } catch (err) {
     throw new Error(`VLM unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
   }
   if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`VLM HTTP ${res.status}: ${body.slice(0, 200)}`);
+    const body2 = await res.text().catch(() => '');
+    throw new Error(`VLM HTTP ${res.status}: ${body2.slice(0, 200)}`);
   }
-  const json = await res.json() as { message?: { content?: string }; done_reason?: string; error?: string };
-  if (json.error) throw new Error(`VLM error: ${json.error}`);
-  return { text: json.message?.content ?? '', truncated: json.done_reason === 'length' };
+
+  if (endpoint.wire === 'ollama') {
+    const json = await res.json() as { message?: { content?: string }; done_reason?: string; error?: string };
+    if (json.error) throw new Error(`VLM error: ${json.error}`);
+    return { text: json.message?.content ?? '', truncated: json.done_reason === 'length' };
+  }
+  const json = await res.json() as {
+    choices?: Array<{ message?: { content?: string }; finish_reason?: string }>; error?: unknown;
+  };
+  if (json.error) throw new Error(`VLM error: ${typeof json.error === 'string' ? json.error : JSON.stringify(json.error).slice(0, 200)}`);
+  const choice = json.choices?.[0];
+  return { text: choice?.message?.content ?? '', truncated: choice?.finish_reason === 'length' };
 }
 
-/** Transcribe one page image to Markdown via a local Ollama VLM. Throws on unreachable/HTTP error. */
+/**
+ * How an endpoint is described to this module.
+ *
+ * `wire` and `external` default to the bundled-Ollama shape, so a caller that passes only
+ * `baseUrl`/`model` gets byte-for-byte the pre-unification behaviour. That is deliberate: it keeps the
+ * local path's existing tests meaningful as a regression net rather than something rewritten to fit.
+ */
+export interface VlmTarget {
+  baseUrl: string;
+  model: string;
+  wire?: VlmWire;
+  external?: boolean;
+  apiKey?: string;
+  timeoutMs?: number;
+}
+
+const asEndpoint = (t: VlmTarget) => ({
+  baseUrl: t.baseUrl,
+  model: t.model,
+  wire: t.wire ?? 'ollama' as VlmWire,
+  external: t.external ?? false,
+  apiKey: t.apiKey,
+});
+
+/** Transcribe one page image to Markdown. Throws on unreachable/HTTP error so the caller falls back. */
 export async function transcribePageImage(
   imageBytes: Buffer,
-  opts: { baseUrl: string; model: string; prompt: string; timeoutMs?: number },
+  opts: VlmTarget & { prompt: string },
 ): Promise<VlmTranscription> {
   const b64 = imageBytes.toString('base64');
   return postChat(
-    opts.baseUrl, opts.model,
+    asEndpoint(opts),
     [{ role: 'user', content: opts.prompt, images: [b64] }],
     opts.timeoutMs ?? 60_000,
   );
@@ -79,10 +164,10 @@ const REPAIR_PROMPT =
 /** Reconcile a draft VLM transcription against the OCR evidence in one text-only pass (max-mode repair).
  *  Throws on unreachable/HTTP error so the caller can fall back to OCR. */
 export async function repairMarkdown(
-  opts: { baseUrl: string; model: string; draft: string; evidence: string; issues?: string[]; timeoutMs?: number },
+  opts: VlmTarget & { draft: string; evidence: string; issues?: string[] },
 ): Promise<VlmTranscription> {
   return postChat(
-    opts.baseUrl, opts.model,
+    asEndpoint(opts),
     [{ role: 'user', content: repairContent(opts.draft, opts.evidence, opts.issues) }], // text-only — no page image
     opts.timeoutMs ?? 60_000,
   );
@@ -99,12 +184,12 @@ const CONSENSUS_PROMPT =
  *  Text-only, temperature 0, via the local model. Throws on unreachable/HTTP error so the caller can keep the
  *  primary draft. */
 export async function reconcileConsensus(
-  opts: { baseUrl: string; model: string; draftA: string; draftB: string; evidence: string; timeoutMs?: number },
+  opts: VlmTarget & { draftA: string; draftB: string; evidence: string },
 ): Promise<VlmTranscription> {
   const content =
     `${CONSENSUS_PROMPT}\n\n--- DRAFT A ---\n${opts.draftA}\n\n--- DRAFT B ---\n${opts.draftB}\n\n--- OCR TEXT ---\n${opts.evidence}`;
   return postChat(
-    opts.baseUrl, opts.model,
+    asEndpoint(opts),
     [{ role: 'user', content }], // text-only — no page image
     opts.timeoutMs ?? 60_000,
   );

--- a/server/src/files/converters/vlm-endpoint.ts
+++ b/server/src/files/converters/vlm-endpoint.ts
@@ -1,0 +1,136 @@
+/**
+ * Where the document VLM actually lives, and how to talk to it — resolved in ONE place.
+ *
+ * ## The bug this exists to make impossible
+ *
+ * The document-VLM endpoint was resolved twice, by two files that disagreed:
+ *
+ *   - `vlm-client.postChat()` hardcoded Ollama's `/api/chat` and used a bare `fetch`.
+ *   - `pipeline-status.modelStages()` hardcoded `external: false` for `doc-vlm`, `doc-repair` and
+ *     `doc-verify` — on a `baseUrl` that falls back to **the vision endpoint**, which the line directly
+ *     above classifies with `visionProvider === 'external'`. Same URL, opposite verdicts.
+ *
+ * Both encoded the same stale assumption: *the document stages are local*. That was true while the VLM
+ * was the bundled Ollama and `vlmBaseUrl` defaulted to it. `visionProvider: external` broke it and
+ * neither site was revisited, which produced two failures at once:
+ *
+ *   1. **`vlmModel` could not work against any OpenAI-compatible server.** `/api/chat` is Ollama's route;
+ *      llama.cpp, llama-swap, vLLM and LocalAI do not serve it, and no `baseUrl` fixes that — dropping
+ *      `/v1` just yields `/api/chat`. doc-render rasterised pages that were then discarded.
+ *   2. **Unguarded, unacknowledged egress.** Page images went out over a bare `fetch`: no SSRF guard, and
+ *      none of the egress acknowledgement `repairMarkdownExternal` demands for the same class of
+ *      destination. It failed safe only against OpenAI-compatible targets, which 404 `/api/chat`. A
+ *      **remote Ollama** — a common setup — answers 200, so for those deployments page images were
+ *      leaving silently while the pipeline reported success.
+ *
+ * A reporter found both. The integration guide already promised otherwise: its list of SSRF-guarded model
+ * endpoints omits the document VLM, and it states that no document content leaves the instance by
+ * default. The code was wrong, not the doc.
+ *
+ * ## The rule
+ *
+ * `external` is a property of **the endpoint**, not of the caller. It is resolved here, once, and both
+ * the inference path and the status board read it from this function. A second opinion about the same
+ * URL is the bug.
+ */
+
+import { getMediaEmbeddingConfig, getDocumentProcessingConfig } from '../../config/loader.js';
+
+/** Which wire protocol an endpoint speaks. Selected by provider type, never guessed from the URL. */
+export type VlmWire = 'ollama' | 'openai';
+
+export interface VlmEndpoint {
+  /** Empty when nothing is configured — callers must treat the VLM as unavailable. */
+  baseUrl: string;
+  model: string;
+  wire: VlmWire;
+  /**
+   * True when this endpoint is NOT the bundled local model, and egress therefore has to be guarded.
+   *
+   * Derived from the provider the URL actually belongs to, not from whether the address looks private.
+   * A private address is not evidence of being in-instance: the reporter's endpoint is a cluster-internal
+   * hostname and is emphatically a separate service.
+   */
+  external: boolean;
+  apiKey?: string;
+}
+
+/**
+ * Ensure exactly one `/v1` on an OpenAI-compatible base.
+ *
+ * The convention is that the base *includes* it — `https://api.openai.com/v1`, and
+ * `ExternalVisionProvider` appends only `/chat/completions`. But `repairMarkdownExternal` appended
+ * `/v1/chat/completions`, so the same server needed two different base URLs to satisfy both callers, and
+ * a reporter had to configure exactly that to keep vision and assist working simultaneously.
+ *
+ * Normalising means one URL works everywhere: `…:8080` and `…:8080/v1` both resolve to `…:8080/v1`.
+ */
+export function normalizeOpenAiBase(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  return /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
+}
+
+/** The path a chat completion is POSTed to, for each wire. */
+export function chatUrlFor(wire: VlmWire, baseUrl: string): string {
+  return wire === 'ollama'
+    ? `${baseUrl.replace(/\/+$/, '')}/api/chat`
+    : `${normalizeOpenAiBase(baseUrl)}/chat/completions`;
+}
+
+/** The model-list URL for each wire — the same derivation the inference call uses, so a probe cannot
+ *  disagree with the thing it is probing. */
+export function listUrlFor(wire: VlmWire, baseUrl: string): string {
+  return wire === 'ollama'
+    ? `${baseUrl.replace(/\/+$/, '')}/api/tags`
+    : `${normalizeOpenAiBase(baseUrl)}/models`;
+}
+
+/**
+ * Resolve one document-model slot.
+ *
+ * All three slots (`vlm`, `repair`, `verify`) fall back to the vision endpoint exactly as the pipeline
+ * does, so the resolved endpoint is the one that would really be called — and crucially they inherit the
+ * vision endpoint's **provider type** along with its URL. Inheriting the URL while asserting `external:
+ * false` is precisely the defect this replaces.
+ */
+export function resolveVlmEndpoint(slot: 'vlm' | 'repair' | 'verify'): VlmEndpoint {
+  const media = getMediaEmbeddingConfig();
+  const doc = getDocumentProcessingConfig();
+
+  const ownBase =
+    slot === 'vlm' ? doc.vlmBaseUrl
+      : slot === 'repair' ? (doc.repairBaseUrl || doc.vlmBaseUrl)
+        : (doc.verifyBaseUrl || doc.vlmBaseUrl);
+
+  const model =
+    slot === 'vlm' ? (doc.vlmModel ?? '')
+      : slot === 'repair' ? (doc.repairModel || doc.vlmModel || '')
+        : (doc.verifyModel ?? '');
+
+  // No dedicated URL ⇒ this slot IS the vision endpoint, provider type included.
+  if (!ownBase) {
+    const visionExternal = media.visionProvider === 'external';
+    return {
+      baseUrl: media.vision?.baseUrl ?? '',
+      model,
+      wire: visionExternal ? 'openai' : 'ollama',
+      external: visionExternal,
+      apiKey: media.vision?.apiKey,
+    };
+  }
+
+  // A dedicated URL was set. It is a separate service by definition — the bundled model is reached
+  // through the vision config, never through an override — so it is external and speaks OpenAI unless
+  // the operator pointed it at an Ollama.
+  //
+  // `DOC_VLM_WIRE` exists because the URL cannot tell us: `http://host:11434` might be Ollama and might
+  // be an OpenAI-compatible server on an arbitrary port. Defaulting to `openai` matches what
+  // self-hosted inference servers overwhelmingly speak; an operator running a separate Ollama sets it.
+  const wire: VlmWire = (process.env['DOC_VLM_WIRE'] === 'ollama') ? 'ollama' : 'openai';
+  return { baseUrl: ownBase, model, wire, external: true, apiKey: media.vision?.apiKey };
+}
+
+/** True when this slot has both an endpoint and a model, i.e. it can actually run. */
+export function vlmSlotUsable(e: VlmEndpoint): boolean {
+  return e.baseUrl.length > 0 && e.model.length > 0;
+}

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -20,6 +20,24 @@ import { renderDocumentPages, isRenderAvailableFor } from './renderer.js';
 import { transcribePageImage, repairMarkdown, repairMarkdownExternal, reconcileConsensus } from './vlm-client.js';
 import type { StepProgress } from './types.js';
 import { decideRoute, validateExtraction, bestByEvidence } from './extraction-policy.js';
+import { resolveVlmEndpoint, vlmSlotUsable, type VlmEndpoint } from './vlm-endpoint.js';
+
+/**
+ * Say WHICH gate closed, and what was found there.
+ *
+ * `decideRoute`'s reason names the missing capability ("needs vlm"); it cannot name the setting, because
+ * it never saw one. A reporter spent a hunt through nine configured model endpoints discovering a tenth
+ * they had never set, because the log stated a verdict and withheld its evidence. Everything here is
+ * config-shape, never a URL or a key.
+ */
+function explainMissing(vlm: VlmEndpoint, verify: VlmEndpoint, render: boolean): string {
+  const missing: string[] = [];
+  if (!vlm.model) missing.push('documentProcessing.vlmModel is empty (set DOC_VLM_MODEL)');
+  else if (!vlm.baseUrl) missing.push('no VLM endpoint resolved — set DOC_VLM_URL, or configure the vision provider it falls back to');
+  if (!render) missing.push('the page renderer is unavailable (RENDER_SIDECAR_URL)');
+  if (verify.model && !verify.baseUrl) missing.push('documentProcessing.verifyModel is set but no endpoint resolved');
+  return missing.length > 0 ? ` — ${missing.join('; ')}` : '';
+}
 
 /**
  * Pages read from one document across all render windows, when unconfigured.
@@ -54,7 +72,15 @@ export async function vlmExtractDocument(
   const render = await isRenderAvailableFor(fileName);
   // `repair` reuses the VLM (or a wired-in repairModel), so it's available whenever the VLM is; decideRoute
   // only actually schedules the repair stage for `max` mode.
-  const route = decideRoute(mode, { ocr: true, render, vlm: !!cfg.vlmModel, repair: !!cfg.vlmModel, verify: !!cfg.verifyModel });
+  // Resolved once, here: every downstream call uses THESE endpoints, so the route decision and the calls
+  // it authorises can never be about different servers.
+  const vlmEp = resolveVlmEndpoint('vlm');
+  const repairEp = resolveVlmEndpoint('repair');
+  const verifyEp = resolveVlmEndpoint('verify');
+  const route = decideRoute(mode, {
+    ocr: true, render,
+    vlm: vlmSlotUsable(vlmEp), repair: vlmSlotUsable(repairEp), verify: vlmSlotUsable(verifyEp),
+  });
   // The sections of the bar: this document's actual route, so nothing is drawn that will not run.
   const steps = route.stages as string[];
 
@@ -68,12 +94,15 @@ export async function vlmExtractDocument(
   }
 
   if (route.ocrOnly) {
-    if (route.fallbackReason) log.info(`VLM extract: ${route.fallbackReason}`);
+    // Name the evidence, not just the verdict. "mode 'vlm' needs vlm; fell back to OCR" cost a reporter a
+    // hunt through nine configured endpoints to discover a tenth they had never set — the message knew
+    // which gate closed and did not say. Now it names the setting and what was found there.
+    if (route.fallbackReason) log.info(`VLM extract: ${route.fallbackReason}${explainMissing(vlmEp, verifyEp, render)}`);
     return { ...(ocr as UnstructuredResult), extractionPath: 'ocr' };
   }
 
   // ── VLM path ────────────────────────────────────────────────────────────────
-  const baseUrl = cfg.vlmBaseUrl || getMediaEmbeddingConfig().vision?.baseUrl || 'http://ollama:11434';
+  const baseUrl = vlmEp.baseUrl;
   try {
     // ── Segmented render + transcribe ─────────────────────────────────────────────────────────────
     //
@@ -121,7 +150,7 @@ export async function vlmExtractDocument(
 
       const windowParts = await mapLimit(window.pages, cfg.concurrency, async (img) => {
         const t = await transcribePageImage(img, {
-          baseUrl, model: cfg.vlmModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
+          ...vlmEp, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
         });
         // A finished page is the smallest honest unit of progress on this path — it is what makes a
         // long document slow rather than wedged. Counting completions rather than using the map index
@@ -167,7 +196,7 @@ export async function vlmExtractDocument(
         log.info(`VLM extract: '${fileName}' was read in segments — skipping the consensus pass (it would re-transcribe all ${pagesRead} pages).`);
       }
       if (!segmented && route.stages.includes('verify') && cfg.verifyModel && evidence.trim()) {
-        const consensus = await runConsensus(firstWindowPages, markdown, evidence, cfg, baseUrl).catch(err => {
+        const consensus = await runConsensus(firstWindowPages, markdown, evidence, cfg, verifyEp, repairEp).catch(err => {
           log.warn(`VLM extract: consensus pass errored (${err instanceof Error ? err.message : err}) — keeping primary`);
           return null;
         });
@@ -206,7 +235,7 @@ export async function vlmExtractDocument(
               draft: markdown, evidence, issues: v.issues, timeoutMs: cfg.pageTimeoutMs,
             })
           : await repairMarkdown({
-              baseUrl: cfg.repairBaseUrl || baseUrl, model: repairModel, draft: markdown, evidence, issues: v.issues,
+              ...repairEp, model: repairModel, draft: markdown, evidence, issues: v.issues,
               timeoutMs: cfg.pageTimeoutMs,
             });
         const repaired = r.text.trim();
@@ -246,12 +275,14 @@ async function runConsensus(
   primary: string,
   evidence: string,
   cfg: ReturnType<typeof getDocumentProcessingConfig>,
-  baseUrl: string,
+  // Resolved by the caller so every stage of one extraction talks to the endpoints the route was decided
+  // against. Re-deriving them here is how the two halves came to disagree in the first place.
+  verifyEp: VlmEndpoint,
+  repairEp: VlmEndpoint,
 ): Promise<{ text: string; coverage: number }> {
-  const verifyBase = cfg.verifyBaseUrl || baseUrl;
   const parts = await mapLimit(pages, cfg.concurrency, async (img) => {
     const t = await transcribePageImage(img, {
-      baseUrl: verifyBase, model: cfg.verifyModel, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
+      ...verifyEp, prompt: TRANSCRIBE_PROMPT, timeoutMs: cfg.pageTimeoutMs,
     });
     return t.text.trim();
   });
@@ -264,7 +295,7 @@ async function runConsensus(
   if (second) {
     try {
       const r = await reconcileConsensus({
-        baseUrl: cfg.repairBaseUrl || baseUrl, model: cfg.repairModel || cfg.vlmModel,
+        ...repairEp,
         draftA: primary, draftB: second, evidence, timeoutMs: cfg.pageTimeoutMs,
       });
       const reconciled = r.text.trim();

--- a/testing/standalone/vlm-endpoint-egress.test.js
+++ b/testing/standalone/vlm-endpoint-egress.test.js
@@ -1,0 +1,227 @@
+/**
+ * The document VLM speaks the right wire, and never egresses unguarded.
+ *
+ * ## The two bugs
+ *
+ * A reporter running self-hosted Kubernetes found both in one PDF upload:
+ *
+ *     POST /render              -> 200   (rasterisation fine)
+ *     POST /v1/api/chat         -> 404   (VLM, user-agent "node")
+ *     POST /v1/chat/completions -> 200   (captions, user-agent "undici")
+ *
+ * **1. `vlmModel` could not work against any OpenAI-compatible server.** `postChat` hardcoded Ollama's
+ * `/api/chat`; llama.cpp, llama-swap, vLLM and LocalAI do not serve it, and no `baseUrl` fixes that —
+ * dropping `/v1` merely yields `/api/chat` again. doc-render rasterised pages that were then discarded.
+ *
+ * **2. Two unguarded egress paths**, from one stale assumption ("the document stages are local", true
+ * only while the VLM was the bundled Ollama):
+ *   - `vlm-client.postChat` used a bare `fetch` — that is the `"node"` user-agent, sending page images;
+ *   - `pipeline-status.modelStages()` hardcoded `external: false` on `doc-vlm`/`doc-repair`/`doc-verify`,
+ *     whose `baseUrl` falls back to the **vision** endpoint that the line above classifies with
+ *     `visionProvider === 'external'`. Same URL, opposite verdicts — so discovery went out unguarded too.
+ *
+ * Neither carried the SSRF guard nor the egress acknowledgement the assist model demands for the same
+ * class of destination. It failed safe only against OpenAI-compatible targets, which 404 `/api/chat`; a
+ * **remote Ollama** answers 200, so those deployments were egressing page images silently while the
+ * pipeline reported success.
+ *
+ * The integration guide already promised otherwise — its list of SSRF-guarded model endpoints omits the
+ * document VLM, and it states no document content leaves by default. The code was wrong, not the doc.
+ *
+ * Run: node --test testing/standalone/vlm-endpoint-egress.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const ENDPOINT_SRC = 'server/src/files/converters/vlm-endpoint.ts';
+const CLIENT_SRC = 'server/src/files/converters/vlm-client.ts';
+const STATUS_SRC = 'server/src/api/pipeline-status.ts';
+
+const ep = await (async () => {
+  const ts = await import('typescript');
+  const js = ts.default.transpileModule(readFileSync(ENDPOINT_SRC, 'utf8'), {
+    compilerOptions: { module: ts.default.ModuleKind.ESNext, target: ts.default.ScriptTarget.ES2022 },
+  }).outputText
+    // The resolver itself needs config; only the pure URL helpers are exercised here.
+    .replace(/^import .*$/m, '');
+  return import(`data:text/javascript;base64,${Buffer.from(js, 'utf8').toString('base64')}`);
+})();
+
+const { normalizeOpenAiBase, chatUrlFor, listUrlFor } = ep;
+
+describe('one base URL works for every OpenAI-compatible caller', () => {
+  it('adds /v1 when absent', () => {
+    assert.equal(normalizeOpenAiBase('http://host:8080'), 'http://host:8080/v1');
+  });
+
+  it('does not double it when present', () => {
+    // The reported failure was `/v1/v1/models`. Both spellings must land on the same place.
+    assert.equal(normalizeOpenAiBase('http://host:8080/v1'), 'http://host:8080/v1');
+  });
+
+  it('tolerates a trailing slash either way', () => {
+    assert.equal(normalizeOpenAiBase('http://host:8080/'), 'http://host:8080/v1');
+    assert.equal(normalizeOpenAiBase('http://host:8080/v1/'), 'http://host:8080/v1');
+  });
+
+  it('THE case that was broken: one identical URL serves both conventions', () => {
+    // The reporter had to configure two DIFFERENT base URLs for the same server, because vision appended
+    // `/chat/completions` (base with /v1) and assist appended `/v1/chat/completions` (base without). That
+    // workaround is what hid the bug. Both spellings must now resolve identically.
+    const withV1 = chatUrlFor('openai', 'http://host:8080/v1');
+    const without = chatUrlFor('openai', 'http://host:8080');
+    assert.equal(withV1, without);
+    assert.equal(withV1, 'http://host:8080/v1/chat/completions');
+  });
+});
+
+describe('each wire gets its own routes', () => {
+  it('ollama chat', () => assert.equal(chatUrlFor('ollama', 'http://o:11434'), 'http://o:11434/api/chat'));
+  it('openai chat', () => assert.equal(chatUrlFor('openai', 'http://h:8080'), 'http://h:8080/v1/chat/completions'));
+  it('ollama list', () => assert.equal(listUrlFor('ollama', 'http://o:11434'), 'http://o:11434/api/tags'));
+  it('openai list', () => assert.equal(listUrlFor('openai', 'http://h:8080'), 'http://h:8080/v1/models'));
+
+  it('never produces the reported 404 shapes', () => {
+    for (const base of ['http://h:8080', 'http://h:8080/v1']) {
+      assert.doesNotMatch(chatUrlFor('openai', base), /\/v1\/v1\//);
+      assert.doesNotMatch(listUrlFor('openai', base), /\/v1\/v1\//);
+      assert.doesNotMatch(chatUrlFor('openai', base), /\/api\/chat/);
+      assert.doesNotMatch(listUrlFor('openai', base), /\/api\/tags/);
+    }
+  });
+
+  it('the probe and the inference call derive from the SAME base', () => {
+    // A probe that normalises differently from the thing it probes is the original defect in miniature:
+    // `/v1/models` against a base already carrying `/v1` is how the Models page went red over a working
+    // pipeline. Both URLs must hang off one resolved base — not merely share a parent directory.
+    for (const base of ['http://h:8080', 'http://h:8080/v1', 'http://h:8080/']) {
+      const oa = `${normalizeOpenAiBase(base)}/`;
+      assert.ok(chatUrlFor('openai', base).startsWith(oa), `openai chat ${base}`);
+      assert.ok(listUrlFor('openai', base).startsWith(oa), `openai list ${base}`);
+
+      const ol = `${base.replace(/\/+$/, '')}/`;
+      assert.ok(chatUrlFor('ollama', base).startsWith(ol), `ollama chat ${base}`);
+      assert.ok(listUrlFor('ollama', base).startsWith(ol), `ollama list ${base}`);
+    }
+  });
+});
+
+// ── The wiring, so neither unguarded path can come back ──────────────────────
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('egress is guarded whenever the endpoint is not the bundled model', () => {
+  const client = strip(readFileSync(CLIENT_SRC, 'utf8'));
+
+  it('postChat routes external through ssrfSafeFetch', () => {
+    assert.match(client, /endpoint\.external[\s\S]{0,200}ssrfSafeFetch\(url, init/);
+  });
+
+  it('and passes the private-address opt-in, so a self-hosted model still works', () => {
+    assert.match(client, /allowPrivate: allowPrivateModelEndpoints\(\)/);
+  });
+
+  it('the bundled local path keeps its plain fetch', () => {
+    // Guarding it unconditionally would refuse the DEFAULT deployment, whose Ollama is on a private
+    // cluster address with `allowPrivateModelEndpoints` off.
+    assert.match(client, /: await fetch\(url, init\)/);
+  });
+
+  it('no call site hardcodes a wire path any more', () => {
+    assert.doesNotMatch(client, /\$\{baseUrl[^}]*\}\/api\/chat/);
+    assert.match(client, /chatUrlFor\(endpoint\.wire, endpoint\.baseUrl\)/);
+  });
+});
+
+describe('the status board and the extractor cannot disagree', () => {
+  const status = strip(readFileSync(STATUS_SRC, 'utf8'));
+
+  it('document stages no longer hardcode external: false', () => {
+    // The exact defect: three stages asserting `false` on a URL the line above them classifies.
+    assert.doesNotMatch(status, /key: 'doc-(vlm|repair|verify)'[\s\S]{0,200}external: false/);
+  });
+
+  it('they read the shared resolver instead', () => {
+    assert.match(status, /resolveVlmEndpoint\(slot\)/);
+    assert.match(status, /external: e\.external/);
+  });
+});
+
+describe('no operator-configurable URL is fetched without the guard', () => {
+  /**
+   * The inverted audit.
+   *
+   * #546 audited `ssrfSafeFetch` CALL SITES and pronounced all 13 correct. That set cannot, by
+   * construction, contain an egress that should have been guarded and is not — which is exactly how both
+   * VLM paths survived it. This asks the opposite question: which files reach the network at all, and is
+   * each one either guarded or a declared piece of infrastructure?
+   */
+  const NUL = String.fromCharCode(0);
+  const files = execFileSync('git', ['ls-files', '-z', 'server/src'], { encoding: 'utf8' })
+    .split(NUL).filter(f => f.endsWith('.ts'));
+
+  /**
+   * Files whose URLs are NOT operator-configurable model endpoints, and may fetch freely.
+   *
+   * Sidecars are declared infrastructure: their URLs come from env the deployment sets for itself, they
+   * are expected to be private, and the integration guide documents them as outside the egress guard.
+   * The local agent is loopback-only unless `YTHRIL_LOCAL_AGENT_ALLOW_REMOTE` is set, and demands HTTPS
+   * in remote mode — its own gate, deliberately separate from the model-egress one.
+   *
+   * The document VLM was never in this category: its endpoint follows an admin-settable model provider.
+   */
+  const NOT_A_MODEL_ENDPOINT = new Map([
+    ['server/src/files/converters/renderer.ts', 'render sidecars (RENDER_SIDECAR_URL) — declared infrastructure'],
+    ['server/src/files/converters/unstructured.ts', 'conversion sidecar (CONVERSION_SIDECAR_URL) — declared infrastructure'],
+    ['server/src/api/pipeline-status.ts', 'sidecar /health probes; model endpoints go through probeModelEndpoint'],
+    ['server/src/api/local-agent.ts', 'loopback-only by default; its own remote opt-in + HTTPS requirement'],
+    ['server/src/util/ssrf.ts', 'the guard itself'],
+    // KNOWN GAP, deliberately listed rather than hidden. `OllamaVisionProvider` (and `WhisperProvider`
+    // via `egressFetch(this.external)`) select the guard from the PROVIDER TYPE, and the integration
+    // guide itself notes that `local`/`external` is a wire protocol, not a trust level — so
+    // `visionProvider: local` aimed at a REMOTE Ollama egresses unguarded, exactly as the document VLM
+    // did. Closing it refuses configurations that work today, so the rule is an owner decision:
+    // `_PARKED-DECISIONS.md` D3. Removing this entry is the fix.
+    ['server/src/files/media/providers.ts', 'PARKED D3 — guard chosen by provider type, not by where the URL points'],
+  ]);
+
+  /** A bare `fetch` is fine when the line choosing it tested where the endpoint lives. */
+  const GUARD_PREDICATES = /isLocalEndpoint\(|isLocalModelEndpoint\(|\.external\b|external\s*\?|egressFetch\(/;
+
+  it('every bare fetch of a model endpoint is chosen by a locality test', () => {
+    // The inverted audit. #546 audited ssrfSafeFetch CALL SITES and pronounced all 13 correct — a set
+    // that cannot, by construction, contain an egress that should have been guarded and is not. That is
+    // exactly how the VLM's bare fetch survived it. This asks the opposite question.
+    const offenders = [];
+    for (const f of files) {
+      if (NOT_A_MODEL_ENDPOINT.has(f)) continue;
+      const src = strip(readFileSync(f, 'utf8'));
+      // `fetch(` but not `ssrfSafeFetch(` / `peerSafeFetch(` / `egressFetch(` / `.fetch(`.
+      for (const m of src.matchAll(/(?<![A-Za-z.])fetch\(/g)) {
+        const window = src.slice(Math.max(0, m.index - 220), m.index);
+        if (!GUARD_PREDICATES.test(window)) {
+          offenders.push(`${f} (line ${src.slice(0, m.index).split('\n').length})`);
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders, [],
+      'An unconditional bare fetch on what may be an operator-configurable model endpoint. Choose the\n'
+      + 'client from where the endpoint lives — plain fetch for the bundled local model, ssrfSafeFetch\n'
+      + 'otherwise — or add the file to NOT_A_MODEL_ENDPOINT with the reason:\n  '
+      + offenders.join('\n  '),
+    );
+  });
+
+  it('the exemption list is not stale', () => {
+    // A file that stops fetching should leave the list, or the list stops meaning anything.
+    const dead = [...NOT_A_MODEL_ENDPOINT.keys()].filter(f => !files.includes(f));
+    assert.deepEqual(dead, [], `listed but no longer tracked: ${dead.join(', ')}`);
+  });
+
+  it('the scan actually reads the tree', () => {
+    assert.ok(files.length > 100, `expected the server sources, got ${files.length}`);
+  });
+});


### PR DESCRIPTION
## The report

Self-hosted Kubernetes, 2.1.1. `visionProvider: external`, `DOC_VLM_MODEL` set. One PDF:

```
POST /render              -> 200   (rasterisation fine)
POST /v1/api/chat         -> 404   (VLM, user-agent "node")
POST /v1/chat/completions -> 200   (captions, user-agent "undici")
```

Then `VLM extract failed (VLM HTTP 404)` and a fallback to OCR. The caption path honours `visionProvider`; the document-VLM path did not. **Two different user agents were the tell** — two HTTP clients, not one client with a branch.

## Two bugs, one stale assumption

*The document stages are local.* True while the VLM was the bundled Ollama. `visionProvider: external` falsified it, because an empty `vlmBaseUrl` means **"reuse the vision endpoint"** — and nothing was revisited.

### 1. `vlmModel` could not work against any OpenAI-compatible server

`postChat()` hardcoded Ollama's `/api/chat`. llama.cpp, llama-swap, vLLM and LocalAI all 404 it, and **no `baseUrl` fixes that** — dropping `/v1` just yields `/api/chat` again. doc-render rasterised pages that were then thrown away.

### 2. Two unguarded egress paths

| path | what leaked |
|---|---|
| `vlm-client.postChat` — bare `fetch` | **rendered page images** |
| `pipeline-status.modelStages()` — `external: false` hardcoded on `doc-vlm`/`doc-repair`/`doc-verify` | discovery requests |

The second is the sharper one. Those three stages take `baseUrl` from **the vision endpoint** — the line directly above them classifies that same URL with `visionProvider === 'external'`. Same URL, opposite verdicts. Since `probeModelEndpoint` branches `external ? ssrfSafeFetch : fetch`, discovery went out unguarded and skipped the route's `isSsrfSafeUrl` pre-check with it.

Neither path carried the SSRF guard, nor the egress acknowledgement the assist model demands for the same class of destination.

### This was live, not latent

Failing safe was a property of the **target**, not the code. An OpenAI-compatible server 404s `/api/chat` — but a **remote Ollama answers 200**. Those deployments were egressing page images silently, with the pipeline reporting success. The reporter's 404 was an artefact of running llama.cpp.

## The fix

One resolver (`files/converters/vlm-endpoint.ts`) decides `baseUrl` / `wire` / `external` per slot. Both the extractor and the status board read it, so the route decision and the calls it authorises can no longer be about different servers. `postChat` speaks either wire, and **the guard follows the endpoint, not the wire** — a remote Ollama gets the same treatment as an OpenAI host.

`normalizeOpenAiBase` lands here rather than in a later PR, because a unified wire has to agree with itself about `/v1`. `…:8080` and `…:8080/v1` now resolve identically. The reporter had been running **two different base URLs for the same server** to satisfy the two conventions — that workaround is what hid the bug, so the test uses one identical URL for both targets.

The fallback log now names its evidence — which setting is empty and which env var sets it. A reporter spent a hunt through nine configured endpoints to discover a tenth they had never set, because the message stated a verdict and withheld what it looked at.

## The characterization result

**The 6 pre-existing `vlm-client` tests pass unmodified.** `wire` and `external` default to the bundled-Ollama shape, so the local path is byte-for-byte unchanged — which is what makes those tests a regression net rather than something rewritten to fit the refactor.

## Inverting the egress audit

#546 audited `ssrfSafeFetch` **call sites** and found all 13 correct. That set cannot, by construction, contain an egress that *should* have been guarded and is not — exactly how both VLM paths survived it. The new gate asks the opposite question: every bare `fetch` of a possible model endpoint must be chosen by a locality test, or be declared infrastructure with a stated reason.

It found one further gap on its first run: `OllamaVisionProvider` and `WhisperProvider` select their guard from the **provider type**, and the guide itself notes that `local`/`external` is *a wire protocol, not a trust level* — so `visionProvider: local` aimed at a remote Ollama has the same hole. **Parked as D3 rather than built here**: closing it refuses configurations that work today, so the rule is an owner decision. The gate lists it explicitly rather than hiding it, and removing that entry is the fix.

## Docs

The guide already promised this. Its list of SSRF-guarded endpoints omitted the document VLM, and its claim that no document content leaves by default was true only while the VLM was the bundled model. The doc described the intended behaviour correctly, so **the code moved to match it** — and it gains an **egress table**: every model slot, what it sends, what guards it, whether an acknowledgement is required.

## Verification

- `npm run preflight` — **PASSED**
- 6 pre-existing tests green **unmodified**; 19 new across wire selection, `/v1` normalisation, guard routing, the two call sites, and the inverted audit