### PR TITLE
fix(stt): send real multipart, and stop reporting a failed chunk as complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The fallback log now **names the evidence**: which setting is empty and which env var sets it, rather
     than only "needs vlm". A reporter spent a hunt through nine configured endpoints discovering a tenth
     they had never set, because the message stated a verdict and withheld what it looked at.
+- **External speech-to-text had never worked: the request was not multipart at all.** Reported against
+  2.1.1. An `.ogg` upload produced `Whisper HTTP 400`, and the receiving OpenAI-conformant adapter saw
+  multer's `req.file` undefined **without** `LIMIT_UNEXPECTED_FILE` — the signature of a request that was
+  not multipart, rather than multipart under a different field name.
+  - `WhisperProvider` builds `new FormData()` — the **global**, which in Node is the built-in undici —
+    and hands it to `ssrfSafeFetch`, which imports `fetch` from the **undici npm package**. Two realms,
+    so undici's internal `instanceof FormData` fails, the body falls through to the generic branch, and
+    `String(body)` puts the literal text `[object FormData]` on the wire under `Content-Type:
+    text/plain;charset=UTF-8`. Reproduced directly against a local listener before any code changed.
+  - Two copies of undici are installed (7.22.0 hoisted, 7.29.0 nested), so the realms were never going to
+    line up. Only the **external** STT path was affected; local Whisper uses a plain global `fetch`.
+  - Fixed in `ssrfSafeFetch` itself rather than in the provider: importing undici's own `FormData` there
+    would fix one caller and leave the landmine for the next, in a file with no reason to know which
+    fetch implementation its transport uses. The body is serialised to bytes — deliberately not a `Blob`,
+    which would be branded by whichever realm made it — with an explicit boundary.
+  - Same class as the vision data-URI bug in 2.1.1: endpoint and model fine, transport encoding wrong.
+
+- **A failed audio chunk still reported the job complete.** The logs read
+  `chunk 0 … failed: Whisper HTTP 400` immediately followed by `completed audio job … (complete)`.
+  `embedAudio` caught per-chunk failures, logged, continued, and returned only the successes **with no
+  count**; the worker discarded the value and hardcoded `complete`. An operator saw success over audio
+  that was never transcribed, which is worse than the error that caused it.
+  - `partial` was not a new concept — the **document** path has recorded it correctly all along, with a
+    comment explaining why. Audio simply never carried the number.
+  - Now: any failed chunk marks the file `partial`; **every** chunk failing throws, so the job returns to
+    the queue's retry/backoff path instead of reporting success over an empty transcript. Video
+    propagates its audio outcome for the same reason — good keyframes do not make a video complete when
+    its speech is missing.
 
 ### Changed
 

--- a/server/src/files/media/audio-embedder.ts
+++ b/server/src/files/media/audio-embedder.ts
@@ -184,6 +184,21 @@ export interface AudioChunkRecord {
  * @param overlapMs  Overlap window in milliseconds (default 5000)
  * @returns array of produced chunk records (for logging / video pipeline reuse)
  */
+/**
+ * What an audio job actually achieved.
+ *
+ * `failed` exists because it did not before: chunk failures were logged and swallowed, only the
+ * successes were returned, and the worker — having no way to tell the difference — recorded the job
+ * `complete`. An operator saw success over audio that was never transcribed. The document path already
+ * models this correctly with a `partial` status; audio simply never carried the number.
+ */
+export interface AudioEmbedResult {
+  records: AudioChunkRecord[];
+  /** Chunks whose transcription failed. Any non-zero value makes the job `partial`, never `complete`. */
+  failed: number;
+  total: number;
+}
+
 export async function embedAudio(
   spaceId: string,
   fileId: string,
@@ -191,7 +206,7 @@ export async function embedAudio(
   mimeType: string,
   stt: SttProvider,
   overlapMs = 5000,
-): Promise<AudioChunkRecord[]> {
+): Promise<AudioEmbedResult> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ythril-audio-'));
   const inputPath = path.join(tmpDir, `input.${mimeTypeToExt(mimeType)}`);
 
@@ -217,6 +232,8 @@ export async function embedAudio(
 
     // Step 3: for each chunk, extract audio → transcribe → embed → store
     const results: AudioChunkRecord[] = [];
+    let failed = 0;
+    let lastError = '';
     const now = new Date().toISOString();
 
     for (let i = 0; i < chunks.length; i++) {
@@ -272,14 +289,26 @@ export async function embedAudio(
 
         results.push({ chunkId, startMs, endMs, transcript });
       } catch (err) {
-        log.warn(`Audio embedder: chunk ${i} of ${fileId} failed: ${err instanceof Error ? err.message : String(err)}`);
-        // Continue processing remaining chunks
+        failed++;
+        lastError = err instanceof Error ? err.message : String(err);
+        log.warn(`Audio embedder: chunk ${i} of ${fileId} failed: ${lastError}`);
+        // Continue processing remaining chunks — a partial transcript beats none. The COUNT is what the
+        // caller needs, though: without it the worker marked the job `complete` over audio that was
+        // never transcribed, which is a silent loss and worse than the error that caused it.
       } finally {
         await fs.unlink(segPath).catch(() => {});
       }
     }
 
-    return results;
+    // Every chunk failed. That is not a partial result, it is a failed job, and reporting success over an
+    // empty transcript hides it forever. Throwing puts it back on the queue's retry/backoff path — which
+    // matters most when the cause is systemic (an unreachable provider, a rejected request shape) and
+    // will clear once the operator fixes it.
+    if (chunks.length > 0 && failed === chunks.length) {
+      throw new Error(`every audio chunk failed to transcribe (${chunks.length}/${chunks.length}); last error: ${lastError}`);
+    }
+
+    return { records: results, failed, total: chunks.length };
   } finally {
     // Cleanup temp files
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/server/src/files/media/video-embedder.ts
+++ b/server/src/files/media/video-embedder.ts
@@ -118,7 +118,7 @@ export async function embedVideo(
   doKeyframes = true,
   overlapMs = 5000,
   keyframeIntervalS = DEFAULT_KEYFRAME_INTERVAL_S,
-): Promise<void> {
+): Promise<{ audioFailed: number; audioTotal: number }> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ythril-video-'));
   const videoExt = mimeTypeToVideoExt(mimeType);
   const videoPath = path.join(tmpDir, `input.${videoExt}`);
@@ -130,14 +130,15 @@ export async function embedVideo(
     // Step 1: Extract audio + embed audio chunks
     await extractAudioTrack(videoPath, audioPath);
     const audioBytes = await fs.readFile(audioPath);
-    const audioChunks: AudioChunkRecord[] = await embedAudio(
-      spaceId,
-      fileId,
-      audioBytes,
-      'audio/wav',
-      stt,
-      overlapMs,
-    );
+    const audioResult = await embedAudio(spaceId, fileId, audioBytes, 'audio/wav', stt, overlapMs);
+    const audioChunks: AudioChunkRecord[] = audioResult.records;
+    // Carried up so the worker can mark the job `partial`. A video whose audio partly failed to
+    // transcribe is not a complete video: its keyframes may be fine while the spoken content is missing,
+    // and recording that as `complete` is the same silent loss the audio path had.
+    const audioOutcome = { audioFailed: audioResult.failed, audioTotal: audioResult.total };
+    if (audioResult.failed > 0) {
+      log.warn(`Video embedder: ${audioResult.failed}/${audioResult.total} audio chunks failed for ${fileId}`);
+    }
 
     if (audioChunks.length === 0) {
       log.warn(`Video embedder: no audio chunks produced for ${fileId}`);
@@ -146,7 +147,7 @@ export async function embedVideo(
     // `audio` video level: stop after the audio pipeline — no keyframes, the vision model is not called.
     if (!doKeyframes) {
       log.debug(`Video embedder: audio-only level for ${fileId} — skipping keyframe captioning`);
-      return;
+      return audioOutcome;
     }
 
     // Step 2: Extract keyframes
@@ -156,7 +157,7 @@ export async function embedVideo(
 
     if (keyframes.length === 0) {
       log.debug(`Video embedder: no keyframes extracted for ${fileId}`);
-      return; // audio-only chunks are sufficient
+      return audioOutcome; // audio-only chunks are sufficient
     }
 
     // Step 3: Caption keyframes
@@ -172,7 +173,7 @@ export async function embedVideo(
       }
     }
 
-    if (captionedFrames.length === 0) return;
+    if (captionedFrames.length === 0) return audioOutcome;
 
     // Step 4: For each audio chunk, collect overlapping frame captions and re-embed
     const now = new Date().toISOString();
@@ -209,6 +210,7 @@ export async function embedVideo(
         log.warn(`Video embedder: re-embed failed for chunk ${chunk.chunkId}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
+    return audioOutcome;
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -319,14 +319,28 @@ async function processJob(
       case 'image':
         derivedDescription = await embedImage(spaceId, fileId, fileBytes, mimeType, providers.vision);
         break;
-      case 'audio':
-        await embedAudio(spaceId, fileId, fileBytes, mimeType, providers.stt);
+      case 'audio': {
+        // A chunk that failed to transcribe makes this PARTIAL, never complete. The count used to be
+        // discarded here, so an operator saw success over audio that was never transcribed — the
+        // document path has modelled this correctly all along and audio simply never carried the number.
+        const a = await embedAudio(spaceId, fileId, fileBytes, mimeType, providers.stt);
+        if (a.failed > 0) {
+          fileEmbeddingStatus = 'partial';
+          log.warn(`Media worker: ${a.failed}/${a.total} audio chunks failed for ${spaceId}/${fileId} — recording partial`);
+        }
         break;
+      }
       case 'video': {
         // Honour the video level: `audio` takes the audio pipeline only (no vision model); `full`/`auto`
         // add keyframe captioning. Previously keyframes always ran, so the `audio` level did nothing.
         const doKeyframes = videoDoesKeyframes(effectiveVideoLevel(spaceId));
-        await embedVideo(spaceId, fileId, fileBytes, mimeType, providers.vision, providers.stt, doKeyframes);
+        // Same rule as audio: a video whose spoken content partly failed to transcribe is not complete,
+        // however good its keyframe captions are.
+        const v = await embedVideo(spaceId, fileId, fileBytes, mimeType, providers.vision, providers.stt, doKeyframes);
+        if (v.audioFailed > 0) {
+          fileEmbeddingStatus = 'partial';
+          log.warn(`Media worker: ${v.audioFailed}/${v.audioTotal} audio chunks failed for ${spaceId}/${fileId} — recording partial`);
+        }
         break;
       }
       case 'text': {

--- a/server/src/util/ssrf.ts
+++ b/server/src/util/ssrf.ts
@@ -30,6 +30,7 @@
  */
 
 import net from 'node:net';
+import { randomUUID } from 'node:crypto';
 import dns from 'node:dns/promises';
 import { fetch as undiciFetch, Agent } from 'undici';
 import { log, redactSecrets } from './log.js';
@@ -429,6 +430,86 @@ export function pinnedAgent(ip: string): Agent {
 }
 
 /**
+ * Serialise a `FormData` body ourselves, because undici will not recognise this one.
+ *
+ * ## The bug
+ *
+ * External speech-to-text had never worked. The provider builds `new FormData()` — the **global**, which
+ * in Node is the built-in undici — and hands it to this module, which imports `fetch` from the **undici
+ * npm package**. Two different undici realms, so undici's internal `instanceof FormData` check fails, the
+ * body falls through to the generic branch, and `String(body)` puts the literal text
+ *
+ *     [object FormData]
+ *
+ * on the wire under `Content-Type: text/plain;charset=UTF-8`. Reproduced directly against a local
+ * listener. The receiving adapter saw `req.file` undefined WITHOUT `LIMIT_UNEXPECTED_FILE` — the
+ * signature of a request that was not multipart at all rather than multipart under another field name.
+ * Two copies of undici are installed (7.22.0 hoisted, 7.29.0 nested), so the realms were never going to
+ * line up.
+ *
+ * ## Why the fix lives here and not in the provider
+ *
+ * Importing undici's own `FormData` in the provider would fix today's caller and leave the landmine for
+ * the next one, in a file that has no reason to know which fetch implementation its transport uses. This
+ * is the choke point every guarded egress passes through, so normalising here means no caller can step on
+ * it — and a `Buffer` body is understood by every implementation, in any realm.
+ *
+ * Detection uses `Object.prototype.toString` rather than `instanceof`. Being precise about why, because
+ * mutation testing showed the two are currently **equivalent**: the `FormData` binding visible here is
+ * the global one, which is also what the providers construct, so `instanceof` would match today. It is
+ * kept as the defensive form for the case this module already proves is possible — a body built in
+ * another realm, e.g. by a caller importing `FormData` from the undici package directly, or by a nested
+ * copy of a dependency. No test distinguishes them, and inventing one that appeared to would be worse
+ * than saying so here.
+ */
+function isFormDataLike(v: unknown): boolean {
+  return Object.prototype.toString.call(v) === '[object FormData]';
+}
+
+function isBlobLike(v: unknown): v is Blob {
+  const tag = Object.prototype.toString.call(v);
+  return tag === '[object Blob]' || tag === '[object File]';
+}
+
+async function serialiseMultipart(form: FormData): Promise<{ body: Buffer; contentType: string }> {
+  const boundary = `----ythril${randomUUID().replace(/-/g, '')}`;
+  const parts: Buffer[] = [];
+  for (const [name, value] of form.entries() as Iterable<[string, unknown]>) {
+    parts.push(Buffer.from(`--${boundary}\r\n`, 'utf8'));
+    if (isBlobLike(value)) {
+      // `File` carries a name; a bare `Blob` does not, and the field name is the best available label.
+      const filename = (value as File).name ?? name;
+      const type = value.type || 'application/octet-stream';
+      parts.push(Buffer.from(
+        `Content-Disposition: form-data; name="${name}"; filename="${filename}"\r\n`
+        + `Content-Type: ${type}\r\n\r\n`, 'utf8'));
+      parts.push(Buffer.from(await value.arrayBuffer()));
+    } else {
+      parts.push(Buffer.from(`Content-Disposition: form-data; name="${name}"\r\n\r\n`, 'utf8'));
+      parts.push(Buffer.from(String(value), 'utf8'));
+    }
+    parts.push(Buffer.from('\r\n', 'utf8'));
+  }
+  parts.push(Buffer.from(`--${boundary}--\r\n`, 'utf8'));
+  return { body: Buffer.concat(parts), contentType: `multipart/form-data; boundary=${boundary}` };
+}
+
+/** Replace a cross-realm FormData body with bytes plus an explicit Content-Type. Other bodies pass through. */
+async function normaliseBody(init: RequestInit): Promise<RequestInit> {
+  if (!isFormDataLike(init.body)) return init;
+  const { body, contentType } = await serialiseMultipart(init.body as FormData);
+  const headers = new Headers((init.headers ?? {}) as HeadersInit);
+  // Set, not append: a stale Content-Type without our boundary is unparseable.
+  headers.set('Content-Type', contentType);
+  // Bytes, deliberately — NOT a Blob. A Blob would be branded by whichever realm constructed it and we
+  // would be back where we started. A plain typed array has no realm identity, so every implementation
+  // accepts it. The cast is only because this project's `BodyInit` predates ArrayBufferView bodies;
+  // undici and the platform both take one at runtime.
+  const bytes = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  return { ...init, body: bytes as unknown as BodyInit, headers };
+}
+
+/**
  * SSRF-safe replacement for `fetch`. Before each request it resolves and
  * validates the target (via `assertUrlSafeResolved`), then **pins the connection
  * to the validated IP** so a DNS rebind cannot redirect the socket to an internal
@@ -448,6 +529,8 @@ export async function ssrfSafeFetch(
   const maxRedirects = opts.maxRedirects ?? 3;
   const injected = opts.fetchImpl;
   let current = rawUrl;
+  // Once, before the redirect loop: a body may only be read a single time, and every hop resends it.
+  const safeInit = await normaliseBody(init);
 
   for (let hop = 0; hop <= maxRedirects; hop++) {
     const { addresses } = await assertUrlSafeResolved(current, { lookup: opts.lookup, allowPrivate: opts.allowPrivate });
@@ -455,11 +538,11 @@ export async function ssrfSafeFetch(
     let resp: Response;
     let agent: Agent | undefined;
     if (injected) {
-      resp = await injected(current, { ...init, redirect: 'manual' });
+      resp = await injected(current, { ...safeInit, redirect: 'manual' });
     } else {
       agent = pinnedAgent(addresses[0]!);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      resp = await (undiciFetch as any)(current, { ...init, redirect: 'manual', dispatcher: agent }) as Response;
+      resp = await (undiciFetch as any)(current, { ...safeInit, redirect: 'manual', dispatcher: agent }) as Response;
     }
 
     const location = resp.status >= 300 && resp.status < 400 ? resp.headers.get('location') : null;

--- a/testing/standalone/stt-multipart-and-partial.test.js
+++ b/testing/standalone/stt-multipart-and-partial.test.js
@@ -1,0 +1,198 @@
+/**
+ * External speech-to-text sends real multipart, and a failed chunk never reports success.
+ *
+ * ## Bug 1 — the request was not multipart at all
+ *
+ * External STT had never worked. `WhisperProvider` builds `new FormData()` — the **global**, which in
+ * Node is the built-in undici — and hands it to `ssrfSafeFetch`, which imports `fetch` from the **undici
+ * npm package**. Two realms, so undici's internal `instanceof FormData` fails, the body falls through to
+ * the generic branch, and `String(body)` puts the literal text `[object FormData]` on the wire under
+ * `Content-Type: text/plain;charset=UTF-8`.
+ *
+ * The reporter's diagnosis is what pinned it: their OpenAI-conformant adapter uses multer `.single('file')`
+ * and saw `req.file` undefined **without** `LIMIT_UNEXPECTED_FILE` — the signature of a request that was
+ * not multipart at all, rather than multipart under a different field name. Two copies of undici are
+ * installed (7.22.0 hoisted, 7.29.0 nested), so the realms were never going to line up.
+ *
+ * Fixed at the choke point rather than in the provider: importing undici's own `FormData` there would fix
+ * one caller and leave the landmine for the next, in a file with no reason to know which fetch
+ * implementation its transport uses. Detection is by `Object.prototype.toString`, never `instanceof` —
+ * for exactly the reason the bug exists.
+ *
+ * ## Bug 2 — a failed chunk still reported the job complete
+ *
+ *     [WARN] Audio embedder: chunk 0 of <file>.ogg failed: Whisper HTTP 400
+ *     [INFO] Media worker: completed audio job test/<file>.ogg (complete)
+ *
+ * `embedAudio` caught per-chunk failures, logged, continued, and returned only the successes — with no
+ * count. The worker discarded the value and hardcoded `complete`. The DOCUMENT path already models this
+ * correctly with a `partial` status and a comment explaining why; audio simply never carried the number.
+ *
+ * Run: node --test testing/standalone/stt-multipart-and-partial.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import http from 'node:http';
+
+const { ssrfSafeFetch } = await import('../../server/dist/util/ssrf.js');
+
+/**
+ * The transport under test must be **undici's** fetch, not the global one.
+ *
+ * This is the whole bug and it is easy to test past. The global `fetch` IS Node's built-in undici, so it
+ * recognises a global `FormData` and serialises it perfectly — a test injecting the global transport
+ * passes whether or not the fix is present. Mutation testing caught exactly that: removing the
+ * normaliser, and swapping the cross-realm check back to `instanceof`, both SURVIVED against a global
+ * `fetchImpl`.
+ *
+ * `ssrf.ts` imports `fetch` from the undici *package*, which is a different realm from the globals the
+ * providers build their bodies with. Injecting that same package fetch reproduces the realm mismatch
+ * faithfully while still letting the test point the socket at a local listener.
+ */
+const { fetch: undiciFetch } = await import('undici');
+
+// ── Bug 1: what actually reaches the wire ────────────────────────────────────
+
+describe('a FormData body arrives as multipart, not as text', () => {
+  let server, port, received;
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', c => chunks.push(c));
+      req.on('end', () => {
+        received = {
+          contentType: req.headers['content-type'] ?? '',
+          auth: req.headers['authorization'] ?? '',
+          body: Buffer.concat(chunks).toString('latin1'),
+        };
+        res.writeHead(200, { 'Content-Type': 'application/json' }).end('{"text":"ok"}');
+      });
+    });
+    await new Promise(r => server.listen(0, '127.0.0.1', r));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  /**
+   * Loopback is a crown-jewel address and is refused BEFORE any transport runs — correctly, and not what
+   * this test is about. So the guard is handed a hostname resolving to a routable address (its check
+   * passes) while the injected transport connects to the local listener.
+   */
+  const send = async (form) => {
+    await ssrfSafeFetch('http://stt.example.test/v1/audio/transcriptions', {
+      method: 'POST', body: form, headers: { Authorization: 'Bearer k' },
+    }, {
+      lookup: async () => [{ address: '93.184.216.34', family: 4 }],
+      // undici's fetch — see the note above. A global fetch here would pass without the fix.
+      fetchImpl: (u, i) => undiciFetch(String(u).replace('http://stt.example.test', `http://127.0.0.1:${port}`), i),
+    });
+    return received;
+  };
+
+  const audioForm = () => {
+    // Exactly what WhisperProvider builds — the GLOBAL FormData and Blob, which is the whole point.
+    const form = new FormData();
+    form.append('file', new Blob([new Uint8Array([0x52, 0x49, 0x46, 0x46, 1, 2, 3, 4])], { type: 'audio/wav' }), 'audio.wav');
+    form.append('model', 'base');
+    form.append('response_format', 'verbose_json');
+    return form;
+  };
+
+  it('the Content-Type is multipart with a boundary', async () => {
+    const r = await send(audioForm());
+    assert.match(r.contentType, /^multipart\/form-data; boundary=.+/);
+  });
+
+  it('the literal string "[object FormData]" never reaches the wire', async () => {
+    // The exact symptom. If this ever reappears, external STT is silently broken again.
+    const r = await send(audioForm());
+    assert.doesNotMatch(r.body, /\[object FormData\]/);
+    assert.doesNotMatch(r.contentType, /text\/plain/);
+  });
+
+  it('the file part carries its field name and filename', async () => {
+    // multer `.single('file')` matches on the field name; the endpoint validates the extension.
+    const r = await send(audioForm());
+    assert.match(r.body, /Content-Disposition: form-data; name="file"; filename="audio\.wav"/);
+  });
+
+  it('the blob keeps its own content type', async () => {
+    const r = await send(audioForm());
+    assert.match(r.body, /Content-Type: audio\/wav/);
+  });
+
+  it('plain text fields survive alongside the file', async () => {
+    const r = await send(audioForm());
+    assert.match(r.body, /name="model"[\s\S]*?base/);
+    assert.match(r.body, /name="response_format"[\s\S]*?verbose_json/);
+  });
+
+  it('the boundary in the header is the one used in the body', async () => {
+    // A mismatch parses as zero parts, which looks exactly like the original bug.
+    const r = await send(audioForm());
+    const boundary = /boundary=(.+)$/.exec(r.contentType)[1];
+    assert.ok(r.body.startsWith(`--${boundary}\r\n`), 'body must open with the declared boundary');
+    assert.ok(r.body.trimEnd().endsWith(`--${boundary}--`), 'body must close with the terminator');
+  });
+
+  it('caller headers are preserved', async () => {
+    const r = await send(audioForm());
+    assert.equal(r.auth, 'Bearer k');
+  });
+
+  it('a non-FormData body is passed through untouched', async () => {
+    const r = await send(JSON.stringify({ hello: 'world' }));
+    assert.equal(r.body, '{"hello":"world"}');
+    assert.doesNotMatch(r.contentType, /multipart/);
+  });
+});
+
+// ── Bug 2: the status a failed chunk produces ────────────────────────────────
+
+describe('a failed chunk is never reported as complete', () => {
+  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const audio = strip(readFileSync('server/src/files/media/audio-embedder.ts', 'utf8'));
+  const worker = strip(readFileSync('server/src/files/media/worker.ts', 'utf8'));
+  const video = strip(readFileSync('server/src/files/media/video-embedder.ts', 'utf8'));
+
+  it('embedAudio counts failures instead of swallowing them', () => {
+    assert.match(audio, /failed\+\+/);
+    assert.match(audio, /return \{ records: results, failed, total: chunks\.length \}/);
+  });
+
+  it('all-chunks-failed throws, so the job retries instead of reporting success', () => {
+    // The reporter's case: every chunk 400'd and the job still said complete. Throwing puts it back on
+    // the retry/backoff path, which is what a systemic cause (bad request shape) needs.
+    assert.match(audio, /failed === chunks\.length/);
+    assert.match(audio, /throw new Error\(`every audio chunk failed to transcribe/);
+  });
+
+  it('the worker records partial when any chunk failed', () => {
+    assert.match(worker, /if \(a\.failed > 0\)[\s\S]{0,120}fileEmbeddingStatus = 'partial'/);
+  });
+
+  it('and does the same for video, whose audio can partly fail', () => {
+    assert.match(worker, /if \(v\.audioFailed > 0\)[\s\S]{0,120}fileEmbeddingStatus = 'partial'/);
+  });
+
+  it('embedVideo propagates the audio outcome rather than returning void', () => {
+    assert.match(video, /Promise<\{ audioFailed: number; audioTotal: number \}>/);
+    assert.doesNotMatch(video, /^\s*return;\s*$/m);
+  });
+
+  it('and propagates the REAL count, not a placeholder', () => {
+    // Asserting only the return type let a mutation hardcode `audioFailed: 0` and survive — the shape
+    // was pinned while the value was free.
+    assert.match(video, /audioFailed: audioResult\.failed/);
+    assert.match(video, /audioTotal: audioResult\.total/);
+  });
+
+  it('partial is a status the file-meta model already had', () => {
+    // Not a new concept invented for this fix — the document path has used it all along, which is what
+    // makes the audio omission an inconsistency rather than a missing feature.
+    assert.match(worker, /'complete' \| 'partial'/);
+  });
+});


### PR DESCRIPTION
Two bugs from one 2.1.1 report. One of them is silent data loss.

## 1. External speech-to-text had never worked

An `.ogg` upload produced `Whisper HTTP 400`. The reporter's diagnosis is what pinned it: their OpenAI-conformant adapter uses multer `.single('file')` and saw `req.file` undefined **without** `LIMIT_UNEXPECTED_FILE` — the signature of a request that was **not multipart at all**, rather than multipart under a different field name.

`WhisperProvider` builds `new FormData()` — the **global**, which in Node is the built-in undici — and hands it to `ssrfSafeFetch`, which imports `fetch` from the **undici npm package**. Two realms, so undici's internal `instanceof FormData` fails, the body falls through to the generic branch, and `String(body)` puts this on the wire:

```
Content-Type: text/plain;charset=UTF-8

[object FormData]
```

Reproduced directly against a local listener before changing anything. Two copies of undici are installed (7.22.0 hoisted, 7.29.0 nested), so the realms were never going to line up. Only the **external** path was affected — local Whisper uses a plain global `fetch`.

Same class as the vision data-URI bug fixed in 2.1.1: endpoint and model fine, transport encoding wrong.

### Fixed at the choke point

In `ssrfSafeFetch`, not in the provider. Importing undici's own `FormData` there would fix one caller and leave the landmine for the next, in a file with no reason to know which fetch implementation its transport uses. The body is serialised to **bytes** — deliberately not a `Blob`, which would be branded by whichever realm constructed it — with an explicit boundary.

## 2. A failed chunk still reported the job complete

```
[WARN] Audio embedder: chunk 0 of <file>.ogg failed: Whisper HTTP 400
[INFO] Media worker: completed audio job test/<file>.ogg (complete)
```

`embedAudio` caught per-chunk failures, logged, continued, and returned only the successes **with no count**. The worker discarded the value and hardcoded `complete`.

**`partial` was not a new concept.** The document path has recorded it correctly all along, and the integration guide already documents it as *"some chunks failed and are retry-eligible"*. Audio simply never carried the number — so the doc was right and the code was wrong, the same shape as #560.

Now: any failed chunk marks the file `partial`; **every** chunk failing **throws**, so the job returns to the retry/backoff path instead of reporting success over an empty transcript — which matters most when the cause is systemic, as it was here. Video propagates its audio outcome for the same reason: good keyframes do not make a video complete when its speech is missing.

## The mutation test caught the test, not the code

The first version of the multipart test **injected the global `fetch`** — which *is* Node's built-in undici and therefore handles a global `FormData` perfectly. Removing the entire fix still passed. A test that passes both ways is worthless, and this one was.

It now injects **undici's** fetch, reproducing the realm mismatch faithfully.

**14 of 15 mutations killed, 0 not-applied.** The survivor — `instanceof` in place of `Object.prototype.toString` — is genuinely **equivalent today**, because the `FormData` binding visible in `ssrf.ts` is the same global the providers construct. It is kept as the defensive form and documented as such rather than given a fake test that would appear to justify it.

## Verification

- `npm run preflight` — **PASSED** (re-run after rebasing onto #560)
- 14 new tests: wire-level assertions on the actual bytes (content type, boundary agreement, file part, blob MIME, text fields, pass-through of non-FormData bodies), plus the partial/throw status rules