### PR TITLE
fix(probe): derive the probe URL the way inference does, and stop calling an unlisted model degraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The connection probe disagreed with the pipeline it was probing.** Reported against 2.1.1, same pod,
+  minutes apart: `POST /v1/chat/completions → 200` (captions working) beside `GET /v1/v1/models → 404`
+  and `GET /v1/api/tags → 404` (the probe). The Models page showed vision **red over a working
+  pipeline**.
+  - The probe tried `${base}/v1/models` then `${base}/api/tags` **blindly, for every target and every
+    provider** — `external` was computed per target but only ever selected the fetch implementation,
+    never the endpoint. Vision-external is the one target whose base is expected to already contain
+    `/v1`, so it got `/v1/v1/models`; the Ollama fallback then fired against an OpenAI provider, which
+    is where the reporter's `/v1/api/tags` came from.
+  - Removing the `/v1` to satisfy the probe made it **green while inference 404'd** — a green dot over a
+    broken pipeline, and the worse of the two directions.
+  - The list URL now comes from `listUrlFor`, the same helper the inference path derives its chat URL
+    from, so the probe cannot disagree with the thing it probes. `…:8080` and `…:8080/v1` both work.
+  - If the endpoint answers on the *other* protocol, that is now reported as a **provider-type
+    mismatch** rather than a bare success — reachable, but inference will use the other wire and fail.
+  - Failures name the URL that was tried. A bare "unreachable" cannot distinguish a wrong base path from
+    a dead endpoint, and the two need opposite fixes.
+
 - **The document VLM could not work against any OpenAI-compatible server, and its egress was unguarded.**
   Reported against 2.1.1 from a self-hosted Kubernetes deployment: with `visionProvider: external` and
   `DOC_VLM_MODEL` set, one PDF produced `POST /render → 200`, `POST /v1/api/chat → 404`, and a fallback to
@@ -64,6 +82,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     its speech is missing.
 
 ### Changed
+
+- **"Model not listed" is no longer reported as degraded.** `modelPresent` is renamed
+  `modelEnumerated` — named for what it measured rather than what it was read as. Aliasing routers
+  (llama-swap roles), gateways and Azure deployments deliberately serve names they keep out of
+  enumerations, so absence from a model list is **no information at all**, and turning it into a yellow
+  dot manufactured a warning from an absence of evidence. A reporter's vision endpoint was fully working
+  and permanently yellow for exactly this reason.
+  - This is the honesty rule `health-summary.ts` already applied one file over, where a component nobody
+    configured is explicitly not a fault.
+  - The status pill drops the `warn` variant for this case in all three locales, and the label now reads
+    "model not listed (normal for routers)" rather than "model not found".
 
 - **Inverted the egress audit.** PR #546 audited `ssrfSafeFetch` *call sites* and found all 13 correct — a
   set that cannot, by construction, contain an egress that should have been guarded and is not, which is

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1434,7 +1434,7 @@
   "mediaProcessing.test.unreachable": "Nicht erreichbar",
   "mediaProcessing.test.reachable": "Erreichbar",
   "mediaProcessing.test.modelFound": "Erreichbar · Modell gefunden",
-  "mediaProcessing.test.modelMissing": "Erreichbar · Modell nicht gefunden",
+  "mediaProcessing.test.modelNotEnumerated": "Erreichbar · Modell nicht aufgelistet (bei Routern normal)",
   "mediaProcessing.health.ok": "funktioniert",
   "mediaProcessing.health.degraded": "erreichbar, aber das Modell wurde nicht gefunden",
   "mediaProcessing.health.down": "antwortet nicht",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1434,7 +1434,7 @@
   "mediaProcessing.test.unreachable": "Unreachable",
   "mediaProcessing.test.reachable": "Reachable",
   "mediaProcessing.test.modelFound": "Reachable · model found",
-  "mediaProcessing.test.modelMissing": "Reachable · model not found",
+  "mediaProcessing.test.modelNotEnumerated": "Reachable · model not listed (normal for routers)",
   "mediaProcessing.health.ok": "working",
   "mediaProcessing.health.degraded": "reachable, but the model was not found",
   "mediaProcessing.health.down": "not responding",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1434,7 +1434,7 @@
   "mediaProcessing.test.unreachable": "Nieosiągalny",
   "mediaProcessing.test.reachable": "Osiągalny",
   "mediaProcessing.test.modelFound": "Osiągalny · model znaleziony",
-  "mediaProcessing.test.modelMissing": "Osiągalny · nie znaleziono modelu",
+  "mediaProcessing.test.modelNotEnumerated": "Osiągalny · model niewymieniony (normalne dla routerów)",
   "mediaProcessing.health.ok": "działa",
   "mediaProcessing.health.degraded": "osiągalny, ale nie znaleziono modelu",
   "mediaProcessing.health.down": "nie odpowiada",

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.spec.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.spec.ts
@@ -65,7 +65,7 @@ function make(cfg: Record<string, unknown> = cfgFixture(), confirmResult = true)
   TestBed.resetTestingModule();
   const confirm = vi.fn().mockResolvedValue(confirmResult);
   const patch = vi.fn().mockReturnValue(of({ ok: true, config: cfg }));
-  const post = vi.fn().mockReturnValue(of({ reachable: true, modelPresent: true }));
+  const post = vi.fn().mockReturnValue(of({ reachable: true, modelEnumerated: true }));
   const http = { get: vi.fn().mockReturnValue(of(cfg)), patch, post } as unknown as HttpClient;
   TestBed.configureTestingModule({
     imports: [getTranslocoModule()],
@@ -442,8 +442,11 @@ describe('MediaProcessingStateService — test connection', () => {
   it('distinguishes unreachable from reachable-but-missing-model', () => {
     const { c } = make();
     expect(c.testPillVariant({ reachable: false } as never)).toBe('error');
-    expect(c.testPillVariant({ reachable: true, modelPresent: false } as never)).toBe('warn');
-    expect(c.testPillVariant({ reachable: true, modelPresent: true } as never)).toBe('ok');
+    // Not enumerating a model is informational, never a warning: aliasing routers and gateways serve
+    // names they deliberately do not list, so absence carries no information. This asserted 'warn',
+    // which is what kept a working vision endpoint permanently yellow.
+    expect(c.testPillVariant({ reachable: true, modelEnumerated: false } as never)).toBe('ok');
+    expect(c.testPillVariant({ reachable: true, modelEnumerated: true } as never)).toBe('ok');
   });
 
   it('records the result against the target that was tested', () => {

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
@@ -195,11 +195,19 @@ export class MediaProcessingStateService {
       } } })),
     });
   }
-  testPillVariant(r: TestResult): StatusVariant { return !r.reachable ? 'error' : (r.modelPresent === false ? 'warn' : 'ok'); }
+  /**
+   * Not enumerating a model is NOT a warning.
+   *
+   * This returned `warn` for `modelEnumerated === false`, which made a working endpoint permanently
+   * yellow: aliasing routers (llama-swap roles), gateways and Azure deployments deliberately do not list
+   * the names they serve, so absence from the list carries no information at all. Only unreachable is a
+   * fault; everything else is informational, and Verify is what actually answers "does the model work".
+   */
+  testPillVariant(r: TestResult): StatusVariant { return !r.reachable ? 'error' : 'ok'; }
   testPillLabelKey(r: TestResult): string {
     if (!r.reachable) return 'mediaProcessing.test.unreachable';
-    if (r.modelPresent === false) return 'mediaProcessing.test.modelMissing';
-    if (r.modelPresent === true) return 'mediaProcessing.test.modelFound';
+    if (r.modelEnumerated === false) return 'mediaProcessing.test.modelNotEnumerated';
+    if (r.modelEnumerated === true) return 'mediaProcessing.test.modelFound';
     return 'mediaProcessing.test.reachable';
   }
 

--- a/client/src/app/pages/settings/media-processing/media-processing.types.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing.types.ts
@@ -11,7 +11,8 @@ export interface ProviderCfg { label?: string; baseUrl?: string; model?: string;
 /** Result of probing a model endpoint (reachability + whether the model is present). F11-PR5b. */
 export interface TestResult {
   ok: boolean; reachable: boolean; status?: number; models?: string[];
-  modelPresent?: boolean; detail?: string; latencyMs: number;
+  /** Whether the endpoint LISTED the model — not whether it serves it. See `classifyStage` on the server. */
+  modelEnumerated?: boolean; detail?: string; latencyMs: number;
 }
 
 export type TestTarget = 'vision' | 'stt' | 'assist' | 'embedding' | 'rerank' | 'nli';

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2543,7 +2543,20 @@ Switching tabs with unsaved changes prompts rather than discarding them.
 
 **Infra-managed lock (F11).** On managed infrastructure you can set every media/model value in `config.json` (or the environment) and forbid changes through the admin UI/API — the same posture as `YTHRIL_MONGO_INFRA_MANAGED` for the database. Set `mediaEmbedding.infraManaged: true` in `config.json`, **or** `YTHRIL_MEDIA_INFRA_MANAGED=true` in the environment. When active, `PATCH /api/admin/media-config` returns **409** with `code: "INFRA_MANAGED"` and **Settings → Media Processing** renders read-only (a "managed by infrastructure" banner is shown; *Test connection* still works). Individual fields can instead be pinned one at a time by setting their env var (e.g. `VISION_MODEL`, `DOC_ASSIST_URL`) — those appear in `lockedByInfra` and are locked individually. Use `infraManaged` when the whole block is owned by infrastructure.
 
-**Test connection (F11).** `POST /api/admin/media-config/test-connection` (admin + MFA) probes a configured endpoint — `{ "target": "vision" | "stt" | "assist" | "embedding" | "nli" }` — by listing its models (OpenAI-compatible `/v1/models`, falling back to Ollama `/api/tags`). It performs **no inference and sends no document content**, so it is safe to run before acknowledging egress. External endpoints go through the SSRF-guarded fetch; local (trusted) endpoints use a direct fetch. The response reports `{ reachable, modelPresent?, models, latencyMs, detail? }`. Settings → Media Processing exposes a **Test connection** button per provider card.
+**Test connection (F11).** `POST /api/admin/media-config/test-connection` (admin + MFA) probes a configured endpoint — `{ "target": "vision" | "stt" | "assist" | "embedding" | "nli" }` — by listing its models. It performs **no inference and sends no document content**, so it is safe to run before acknowledging egress. External endpoints go through the SSRF-guarded fetch; local (trusted) endpoints use a direct fetch. The response reports `{ reachable, modelEnumerated?, models, latencyMs, detail? }`. Settings → Media Processing exposes a **Test connection** button per provider card.
+
+The list URL is derived from the **same rule the inference call uses** — `/models` for an OpenAI-compatible
+base (which already carries `/v1`; `…:8080` and `…:8080/v1` both work), `/api/tags` for a local Ollama. A
+probe that normalised differently from the thing it probes would report a red dot over a working pipeline,
+or worse, a green one over a broken pipeline. If the endpoint answers on the *other* protocol, the probe
+says so explicitly rather than simply failing — that means the provider type is set wrong and inference
+will fail even though the endpoint is up.
+
+> **`modelEnumerated: false` is not a fault.** It means the endpoint did not *list* the configured name,
+> which is normal and deliberate for aliasing routers (llama-swap roles), gateways and Azure deployments —
+> they serve names they keep out of user-facing pickers. Absence from a list is not evidence a model is
+> unavailable, so it is reported as informational and never as degraded. To find out whether a model
+> actually answers, make a real request.
 
 **Pipeline status.** `GET /api/admin/pipeline-status` (admin) returns the health of the whole pipeline in one read-only payload — it mutates nothing and sends no document content. It reports three things:
 

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -17,6 +17,7 @@ import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl, ssrfSafeFetch } from '../util/ssrf.js';
 import { allowPrivateModelEndpoints, isLocalModelEndpoint } from '../config/model-egress-policy.js';
+import { listUrlFor, type VlmWire } from '../files/converters/vlm-endpoint.js';
 import { log } from '../util/log.js';
 import { providerSignature, getActiveProviderSignature } from '../files/media/worker.js';
 import { MIN_CANDIDATE_MULTIPLIER, MAX_CANDIDATE_MULTIPLIER } from '../brain/rerank-client.js';
@@ -638,17 +639,47 @@ interface ProbeResult {
   status?: number;
   endpoint?: string;
   models?: string[];
-  /** Whether the configured model appears in the endpoint's model list (undefined when no model/list). */
-  modelPresent?: boolean;
+  /**
+   * Whether the configured model appears in the endpoint's model list (undefined when no model/list).
+   *
+   * Named for what it measured, not for what it was read as. As `modelPresent` it asserted the model
+   * exists; the check can only see an enumeration, and aliasing routers, gateways and Azure deployments
+   * routinely serve names they do not list. `false` here is *no information* and must never be reported
+   * as degraded — see `classifyStage`.
+   */
+  modelEnumerated?: boolean;
   detail?: string;
   latencyMs: number;
 }
 
-/** Probe a model endpoint by LISTING its models — OpenAI-compatible `/v1/models` first, then Ollama
- *  `/api/tags`. Bounded 5s. No inference call, so it's cheap and sends no document content.
- *  Exported for unit testing. */
+/**
+ * Probe a model endpoint by LISTING its models. Bounded 5s, no inference call, no document content.
+ *
+ * ## Why the URL is derived rather than guessed
+ *
+ * This used to try `${base}/v1/models` and then `${base}/api/tags`, **blindly, for every target and
+ * every provider** — `external` was computed per target but only ever chose the fetch implementation,
+ * never the endpoint. That is wrong in both directions:
+ *
+ *   - Vision-external is the one target whose base is expected to already contain `/v1` (the OpenAI
+ *     convention, and what `ExternalVisionProvider` assumes). Hardcoding `/v1/models` produced
+ *     `/v1/v1/models` → 404, then fell through to Ollama's `/api/tags` → 404. A reporter's Models page
+ *     showed vision red while captions were being generated successfully.
+ *   - Removing the `/v1` to satisfy the probe made the probe **green and inference 404** — a green dot
+ *     over a broken pipeline, which is the worse direction and the reason this is not merely cosmetic.
+ *
+ * The URL now comes from `listUrlFor`, the same helper the inference path derives its chat URL from, so
+ * a probe cannot disagree with the thing it is probing. `normalizeOpenAiBase` means `…:8080` and
+ * `…:8080/v1` both work.
+ *
+ * On failure it makes ONE diagnostic attempt on the other wire — not to succeed, but so that a
+ * mis-selected provider type reports *"this endpoint answers Ollama's API; set the provider to local"*
+ * instead of an unexplained red dot.
+ *
+ * Exported for unit testing.
+ */
 export async function probeModelEndpoint(
-  opts: { baseUrl: string; model?: string; apiKey?: string; external: boolean },
+  opts: { baseUrl: string; model?: string; apiKey?: string; external: boolean; wire?: VlmWire },
 ): Promise<ProbeResult> {
   const started = Date.now();
   const base = opts.baseUrl.replace(/\/$/, '');
@@ -665,10 +696,19 @@ export async function probeModelEndpoint(
         ssrfSafeFetch(url, init, { allowPrivate: allowPrivateModelEndpoints() })
     : (url: string, init: RequestInit) => fetch(url, init);
 
-  const attempts: Array<{ url: string; parse: (j: unknown) => string[] }> = [
-    { url: `${base}/v1/models`, parse: (j) => ((j as { data?: Array<{ id?: string }> })?.data ?? []).map(m => m?.id).filter((x): x is string => !!x) },
-    { url: `${base}/api/tags`, parse: (j) => ((j as { models?: Array<{ name?: string }> })?.models ?? []).map(m => m?.name).filter((x): x is string => !!x) },
+  const parseOpenAi = (j: unknown): string[] =>
+    ((j as { data?: Array<{ id?: string }> })?.data ?? []).map(m => m?.id).filter((x): x is string => !!x);
+  const parseOllama = (j: unknown): string[] =>
+    ((j as { models?: Array<{ name?: string }> })?.models ?? []).map(m => m?.name).filter((x): x is string => !!x);
+
+  // The wire this endpoint is configured to speak comes first; the other is tried only so a failure can
+  // explain itself. `wire` defaults to `openai` — every target except a local Ollama speaks it.
+  const wire: VlmWire = opts.wire ?? 'openai';
+  const attempts: Array<{ url: string; wire: VlmWire; parse: (j: unknown) => string[] }> = [
+    { url: listUrlFor(wire, base), wire, parse: wire === 'ollama' ? parseOllama : parseOpenAi },
   ];
+  const otherWire: VlmWire = wire === 'ollama' ? 'openai' : 'ollama';
+  attempts.push({ url: listUrlFor(otherWire, base), wire: otherWire, parse: otherWire === 'ollama' ? parseOllama : parseOpenAi });
 
   let lastErr = '';
   for (const a of attempts) {
@@ -678,17 +718,31 @@ export async function probeModelEndpoint(
         const json = await res.json().catch(() => ({}));
         const models = a.parse(json);
         // Ollama tags carry a `:tag` suffix (e.g. `moondream:latest`); match exact or `<model>:*`.
-        const modelPresent = opts.model
+        const modelEnumerated = opts.model
           ? models.some(m => m === opts.model || m.startsWith(`${opts.model}:`))
           : undefined;
-        return { ok: true, reachable: true, status: res.status, endpoint: a.url, models: models.slice(0, 50), modelPresent, latencyMs: Date.now() - started };
+        // Answered on the OTHER wire: reachable, but the provider type is set wrong, and inference will
+        // fail even though this probe just succeeded. Say which, rather than reporting a bare success
+        // that the pipeline will then contradict.
+        const mismatch = a.wire !== wire
+          ? `endpoint answers ${a.wire === 'ollama' ? "Ollama's API" : "the OpenAI-compatible API"} at ${a.url}, `
+            + `but this target is configured as ${wire === 'ollama' ? 'local (Ollama)' : 'external (OpenAI-compatible)'} — `
+            + 'inference will use the other protocol and fail. Switch the provider type.'
+          : undefined;
+        return {
+          ok: !mismatch, reachable: true, status: res.status, endpoint: a.url,
+          models: models.slice(0, 50), modelEnumerated, detail: mismatch,
+          latencyMs: Date.now() - started,
+        };
       }
       lastErr = `HTTP ${res.status} at ${a.url}`;
     } catch (err) {
-      lastErr = err instanceof Error ? err.message : String(err);
+      lastErr = `${err instanceof Error ? err.message : String(err)} (at ${a.url})`;
     }
   }
-  return { ok: false, reachable: false, detail: lastErr || 'no compatible model-list endpoint responded', latencyMs: Date.now() - started };
+  // Name the URL that was tried. A bare "unreachable" leaves an operator unable to tell a wrong base
+  // path from a genuinely dead endpoint — the two look identical from the dot and need opposite fixes.
+  return { ok: false, reachable: false, detail: lastErr || `no model list at ${listUrlFor(wire, base)}`, latencyMs: Date.now() - started };
 }
 
 function maskSecrets(cfg: ReturnType<typeof getMediaEmbeddingConfig>): unknown {

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -31,7 +31,7 @@ import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl } from '../util/ssrf.js';
 import { allowPrivateModelEndpoints, isLocalModelEndpoint } from '../config/model-egress-policy.js';
 import { probeModelEndpoint } from './media-config.js';
-import { resolveVlmEndpoint } from '../files/converters/vlm-endpoint.js';
+import { resolveVlmEndpoint, type VlmWire } from '../files/converters/vlm-endpoint.js';
 import { getDb } from '../db/mongo.js';
 import { faceRecognitionAllowed } from '../files/converters/media-level.js';
 import { VECTOR_INDEXED_COLLECTIONS } from '../spaces/vector-index.js';
@@ -135,6 +135,13 @@ async function probeSidecar(s: (typeof SIDECARS)[number]): Promise<SidecarStatus
 export interface StageSpec {
   key: string;
   label: string;
+  /**
+   * Which protocol this endpoint speaks, so the probe derives the same URL inference will.
+   *
+   * Only a *local* vision provider speaks Ollama's; everything else is OpenAI-compatible. Absent means
+   * `openai`, which is the safe default — it is what self-hosted inference servers overwhelmingly serve.
+   */
+  wire?: VlmWire;
   model?: string;
   baseUrl?: string;
   /** Never appears in the response — it exists only to authenticate the probe. */
@@ -155,7 +162,9 @@ function modelStages(): StageSpec[] {
   return [
     // A blank embedding baseUrl means the bundled in-process ONNX model — no endpoint to reach.
     { key: 'embedding', label: 'Text embedding', model: emb.model, baseUrl: emb.baseUrl ?? undefined, apiKey: getEmbeddingApiKey(), external: emb.provider === 'external' },
-    { key: 'vision', label: 'Vision', model: media.vision?.model, baseUrl: media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: media.visionProvider === 'external' },
+    // The only Ollama-protocol target: a LOCAL vision provider. Its base is a bare host and its routes
+    // are `/api/*`; every other target here is OpenAI-compatible.
+    { key: 'vision', label: 'Vision', model: media.vision?.model, baseUrl: media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: media.visionProvider === 'external', wire: media.visionProvider === 'external' ? 'openai' : 'ollama' },
     { key: 'stt', label: 'Speech-to-text', model: media.stt?.model, baseUrl: media.stt?.baseUrl, apiKey: media.stt?.apiKey, external: media.sttProvider === 'external' },
     // The document stages fall back to the vision endpoint exactly as the pipeline itself does, so the
     // dot reports the endpoint that would really be called rather than the one nominally configured.
@@ -174,6 +183,7 @@ function modelStages(): StageSpec[] {
         baseUrl: e.baseUrl || undefined,
         apiKey: e.apiKey,
         external: e.external,
+        wire: e.wire,
       };
     }),
     // The assist model is external by definition — it is the one path that sends content off-instance.
@@ -245,8 +255,35 @@ export function classifyStage(s: StageSpec, res: ProbeOutcome | undefined): Mode
   // suffix, so an exact match or a `<model>:` prefix both count. An endpoint that lists nothing is not
   // evidence either way, so it stays `ok` rather than being accused of a missing model.
   const models = res.models ?? [];
-  const present = models.length === 0 ? undefined : models.some(m => m === s.model || m.startsWith(`${s.model}:`));
-  if (present === false) return { ...base, state: 'degraded', latencyMs: res.latencyMs, detail: `endpoint is up but does not list "${s.model}"` };
+  const enumerated = models.length === 0 ? undefined : models.some(m => m === s.model || m.startsWith(`${s.model}:`));
+
+  /**
+   * Absence from a model list is NOT evidence of a missing model.
+   *
+   * This used to return `degraded`, and the field it read was called `modelPresent` — a name asserting
+   * something the check never established. Aliasing routers (llama-swap roles), gateways, LiteLLM,
+   * Azure deployment names: all routinely serve names they deliberately do not enumerate, precisely so
+   * that internal role names stay out of user-facing pickers. A reporter's vision endpoint was fully
+   * working and permanently yellow for exactly that reason, and their assist model still is.
+   *
+   * Three outcomes are distinguishable here and only one of them is a fault:
+   *   - unreachable            → genuinely down (handled above)
+   *   - reachable, listed      → good evidence, though still not proof it will load
+   *   - reachable, NOT listed  → *no information at all*
+   *
+   * Reporting the third as degraded manufactures a warning out of an absence of evidence — the same
+   * dishonesty `health-summary.ts` already refuses one file over, where a component nobody configured
+   * is explicitly not a problem. So it stays `ok`, and says what it saw.
+   *
+   * The honest way to answer "does my configured model actually work" is one real request against it,
+   * which is what the Verify action is for.
+   */
+  if (enumerated === false) {
+    return {
+      ...base, state: 'ok', latencyMs: res.latencyMs,
+      detail: `endpoint reachable; "${s.model}" is not enumerated by this endpoint (normal for aliasing routers and gateways) — use Verify to check it actually answers`,
+    };
+  }
   return { ...base, state: 'ok', latencyMs: res.latencyMs };
 }
 
@@ -263,7 +300,11 @@ async function probeModelStages(): Promise<ModelStageStatus[]> {
     }
     // No `model` is passed: one probe serves several stages, so the per-stage match happens in
     // classifyStage against the returned list.
-    const res = await probeModelEndpoint({ baseUrl: baseUrl!, apiKey, external })
+    //
+    // `wire` is what makes the probe agree with inference. Without it every endpoint was tried as
+    // `/v1/models` first, which is right for four targets and wrong for the one whose base already
+    // carries `/v1` — producing `/v1/v1/models` and a red dot over a working vision pipeline.
+    const res = await probeModelEndpoint({ baseUrl: baseUrl!, apiKey, external, wire: group[0].wire })
       .catch(err => ({ reachable: false, detail: err instanceof Error ? err.message : String(err), latencyMs: 0 }));
     results.set(id, res);
   }));

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -163,7 +163,11 @@ function modelStages(): StageSpec[] {
     // A blank embedding baseUrl means the bundled in-process ONNX model — no endpoint to reach.
     { key: 'embedding', label: 'Text embedding', model: emb.model, baseUrl: emb.baseUrl ?? undefined, apiKey: getEmbeddingApiKey(), external: emb.provider === 'external' },
     // The only Ollama-protocol target: a LOCAL vision provider. Its base is a bare host and its routes
-    // are `/api/*`; every other target here is OpenAI-compatible.
+    // live under `/api/`; every other target here is OpenAI-compatible.
+    //
+    // (Written without a star after that slash on purpose: several checks strip block comments with a
+    // non-greedy `/*…*/` match, and a `/*` inside a line comment swallows everything to the next `*/`.
+    // That is not hypothetical — it is what turned this file's own egress test red.)
     { key: 'vision', label: 'Vision', model: media.vision?.model, baseUrl: media.vision?.baseUrl, apiKey: media.vision?.apiKey, external: media.visionProvider === 'external', wire: media.visionProvider === 'external' ? 'openai' : 'ollama' },
     { key: 'stt', label: 'Speech-to-text', model: media.stt?.model, baseUrl: media.stt?.baseUrl, apiKey: media.stt?.apiKey, external: media.sttProvider === 'external' },
     // The document stages fall back to the vision endpoint exactly as the pipeline itself does, so the

--- a/testing/standalone/pipeline-status.test.js
+++ b/testing/standalone/pipeline-status.test.js
@@ -34,13 +34,21 @@ describe('classifyStage — the three failures that all look like "nothing was e
     assert.equal(r.latencyMs, 12);
   });
 
-  it('reachable but NOT serving the model is degraded, not ok and not down', () => {
-    // The operator typed a model name the endpoint has never heard of. The endpoint is fine; the
-    // extraction will still produce nothing. Reporting this as `down` would send them to check the
-    // wrong thing entirely.
+  it('reachable but NOT LISTING the model is informational — not degraded', () => {
+    // This asserted `degraded`, on the reading that a name the endpoint has never heard of means the
+    // extraction will produce nothing. That reading does not hold: aliasing routers (llama-swap roles),
+    // gateways and Azure deployments deliberately serve names they keep OUT of their enumerations,
+    // precisely so internal role names stay out of user-facing pickers. A reporter's vision endpoint was
+    // captioning successfully and permanently yellow because of this rule.
+    //
+    // Absence from a list is not evidence of absence. Three outcomes exist here and only one is a fault:
+    // unreachable (down), listed (good evidence), not listed (NO information). The third now stays `ok`
+    // and says what it saw. Whether the model actually answers is a question only a real request can
+    // settle — which is what Verify is for.
     const r = classifyStage(stage(), up(['llava:7b', 'qwen2.5:3b']));
-    assert.equal(r.state, 'degraded');
-    assert.match(r.detail, /does not list "moondream"/);
+    assert.equal(r.state, 'ok');
+    assert.match(r.detail, /not enumerated/);
+    assert.match(r.detail, /aliasing routers/);
   });
 
   it('configured but unreachable is down, and carries the reason', () => {
@@ -77,8 +85,11 @@ describe('classifyStage — the three failures that all look like "nothing was e
   it('matches an Ollama `:tag` suffix as well as an exact name', () => {
     assert.equal(classifyStage(stage({ model: 'moondream' }), up(['moondream:v2'])).state, 'ok');
     assert.equal(classifyStage(stage({ model: 'moondream' }), up(['moondream'])).state, 'ok');
-    // ...but not a different model that merely starts with the same letters.
-    assert.equal(classifyStage(stage({ model: 'llama' }), up(['llama-guard'])).state, 'degraded');
+    // ...but not a different model that merely starts with the same letters. Still `ok` now — the point
+    // is that it is NOT counted as enumerated, which the detail line reports.
+    const near = classifyStage(stage({ model: 'llama' }), up(['llama-guard']));
+    assert.equal(near.state, 'ok');
+    assert.match(near.detail, /not enumerated/);
   });
 });
 

--- a/testing/standalone/probe-endpoint.test.js
+++ b/testing/standalone/probe-endpoint.test.js
@@ -1,7 +1,28 @@
 /**
- * F11-PR5b — model-endpoint probe (`media-config.probeModelEndpoint`), tested against a mock HTTP server.
- * Covers the OpenAI `/v1/models` path, the Ollama `/api/tags` fallback, model-presence matching (incl. the
- * `<model>:tag` suffix), and the unreachable path. `external:false` so it uses a plain fetch to 127.0.0.1.
+ * The model-endpoint probe agrees with the thing it probes.
+ *
+ * ## What was wrong
+ *
+ * The probe tried `${base}/v1/models` and then `${base}/api/tags` — blindly, for every target and every
+ * provider. `external` was computed per target but only ever chose the fetch implementation, never the
+ * endpoint. Reported against 2.1.1, same pod, minutes apart:
+ *
+ *     POST /v1/chat/completions  -> 200  (inference, working)
+ *     GET  /v1/v1/models         -> 404  (probe)
+ *     GET  /v1/api/tags          -> 404  (probe, second attempt)
+ *
+ * Vision-external is the one target whose base already contains `/v1` (the OpenAI convention). So the
+ * Models page showed vision red while captions were being generated successfully — and removing the
+ * `/v1` to satisfy the probe made it **green while inference 404'd**, which is the worse direction and
+ * the reason this is not cosmetic.
+ *
+ * The URL now comes from `listUrlFor`, the same helper the inference path uses.
+ *
+ * ## And what "model not listed" is allowed to mean
+ *
+ * Nothing. Aliasing routers (llama-swap roles), gateways and Azure deployments deliberately serve names
+ * they do not enumerate, so absence from the list is not evidence of anything. The field is
+ * `modelEnumerated` — named for what it measured — and `false` is never a fault.
  *
  * Run: node --test testing/standalone/probe-endpoint.test.js
  */
@@ -11,8 +32,10 @@ import http from 'node:http';
 
 // ── Mock model endpoint ───────────────────────────────────────────────────────
 const state = { v1: 200, tags: 200, v1Body: null, tagsBody: null };
+const seen = [];
 const server = http.createServer((req, res) => {
   const url = req.url ?? '';
+  seen.push(url);
   if (url.startsWith('/v1/models')) {
     res.writeHead(state.v1, { 'content-type': 'application/json' });
     res.end(state.v1Body ?? JSON.stringify({ data: [{ id: 'gpt-4o' }, { id: 'text-embedding-3' }] }));
@@ -43,37 +66,74 @@ describe('probeModelEndpoint', () => {
     assert.equal(r.ok, true);
     assert.equal(r.reachable, true);
     assert.match(r.endpoint, /\/v1\/models$/);
-    assert.equal(r.modelPresent, true);
+    assert.equal(r.modelEnumerated, true);
     assert.ok(r.models.includes('gpt-4o'));
   });
 
-  it('reports modelPresent=false when the configured model is absent', async () => {
+  it('THE REPORTED BUG: a base that already carries /v1 is not doubled', async () => {
+    // `…:8080/v1` produced `…:8080/v1/v1/models` → 404, then `/v1/api/tags` → 404, and the operator was
+    // shown a red dot over a pipeline that was captioning successfully.
     state.v1 = 200; state.v1Body = null;
-    const r = await probeModelEndpoint({ baseUrl: base, model: 'not-there', external: false });
-    assert.equal(r.reachable, true);
-    assert.equal(r.modelPresent, false);
+    seen.length = 0;
+    const r = await probeModelEndpoint({ baseUrl: `${base}/v1`, model: 'gpt-4o', external: false });
+    assert.equal(r.reachable, true, 'must reach the endpoint with /v1 already in the base');
+    assert.match(r.endpoint, /\/v1\/models$/);
+    assert.ok(!seen.some(u => u.includes('/v1/v1/')), `never request /v1/v1/: ${seen.join(', ')}`);
   });
 
-  it('falls back to Ollama /api/tags when /v1/models 404s, matching the <model>:tag suffix', async () => {
+  it('and a base WITHOUT /v1 lands on the same place', async () => {
+    // One URL has to serve every OpenAI-compatible caller — a reporter was running two different base
+    // URLs for the same server to satisfy two conventions, and that workaround hid the bug.
+    state.v1 = 200; state.v1Body = null;
+    const withV1 = await probeModelEndpoint({ baseUrl: `${base}/v1`, external: false });
+    const without = await probeModelEndpoint({ baseUrl: base, external: false });
+    assert.equal(withV1.endpoint, without.endpoint);
+  });
+
+  it('a local Ollama target is probed on ITS wire, not the OpenAI one', async () => {
+    state.tags = 200; state.tagsBody = null;
+    seen.length = 0;
+    const r = await probeModelEndpoint({ baseUrl: base, model: 'moondream', external: false, wire: 'ollama' });
+    assert.equal(r.reachable, true);
+    assert.match(r.endpoint, /\/api\/tags$/);
+    assert.equal(r.modelEnumerated, true, 'moondream should match moondream:latest');
+    assert.equal(seen[0], '/api/tags', 'the configured wire is tried FIRST, not as a fallback');
+  });
+
+  it('answering on the other wire is reported as a provider-type mismatch, not a plain success', async () => {
+    // Reachable, but inference will use the other protocol and fail. A bare "reachable" here would be a
+    // green dot over a pipeline that cannot work.
     state.v1 = 404; state.tags = 200; state.tagsBody = null;
     const r = await probeModelEndpoint({ baseUrl: base, model: 'moondream', external: false });
     assert.equal(r.reachable, true);
-    assert.match(r.endpoint, /\/api\/tags$/);
-    assert.equal(r.modelPresent, true, 'moondream should match moondream:latest');
+    assert.equal(r.ok, false, 'a wire mismatch is not an OK result');
+    assert.match(r.detail, /Ollama/);
+    assert.match(r.detail, /Switch the provider type/);
     state.v1 = 200;
   });
 
-  it('modelPresent is undefined when no model is given (reachability only)', async () => {
+  it('modelEnumerated is undefined when no model is given (reachability only)', async () => {
     state.v1 = 200; state.v1Body = null;
     const r = await probeModelEndpoint({ baseUrl: base, external: false });
     assert.equal(r.reachable, true);
-    assert.equal(r.modelPresent, undefined);
+    assert.equal(r.modelEnumerated, undefined);
   });
 
-  it('reports unreachable when nothing responds', async () => {
+  it('reports modelEnumerated=false when the name is not listed — informational, still ok', async () => {
+    state.v1 = 200; state.v1Body = null;
+    const r = await probeModelEndpoint({ baseUrl: base, model: 'a-router-alias', external: false });
+    assert.equal(r.reachable, true);
+    assert.equal(r.modelEnumerated, false);
+    assert.equal(r.ok, true, 'not listing a name is not a failure — routers do it deliberately');
+  });
+
+  it('reports unreachable when nothing responds, and names the URL it tried', async () => {
     const r = await probeModelEndpoint({ baseUrl: 'http://127.0.0.1:1', model: 'x', external: false });
     assert.equal(r.ok, false);
     assert.equal(r.reachable, false);
     assert.ok(typeof r.latencyMs === 'number');
+    // A bare "unreachable" cannot distinguish a wrong base path from a dead endpoint, and the two need
+    // opposite fixes.
+    assert.match(r.detail, /127\.0\.0\.1:1/);
   });
 });


### PR DESCRIPTION
## The report

Same pod, minutes apart, on 2.1.1:

```
POST /v1/chat/completions  -> 200  (captions working)
GET  /v1/v1/models         -> 404  (probe)
GET  /v1/api/tags          -> 404  (probe, second attempt)
```

The Models page showed vision **red over a working pipeline**.

## Why

The probe tried `/v1/models` then `/api/tags` on the base — **blindly, for every target and every provider**. `external` was computed per target but only ever selected the *fetch implementation*, never the endpoint. So:

- **Vision-external** is the one target whose base is expected to already contain `/v1` (the OpenAI convention). It got `/v1/v1/models`.
- The Ollama fallback then fired against an OpenAI provider — that is the reporter's `/v1/api/tags`, and why it looked like branching on the wrong variable. There was no branching at all.

And the workaround is worse than the bug: removing the `/v1` to satisfy the probe makes it **green while inference 404s**. A green dot over a broken pipeline is the direction that hides failure, which is why this is not cosmetic.

## The fix

The list URL comes from `listUrlFor` — the same helper the inference path derives its chat URL from (added in #560). A probe cannot disagree with the thing it probes, and `…:8080` and `…:8080/v1` both work.

Two things it now says out loud:

- **Answering on the other wire** is a provider-type mismatch, not a bare success. Reachable, but inference will use the other protocol and fail — so it says which, instead of returning green.
- **Failures name the URL tried.** A bare "unreachable" cannot distinguish a wrong base path from a dead endpoint, and those need opposite fixes.

## "Model not listed" is no longer degraded

`modelPresent` → **`modelEnumerated`**, named for what it measured rather than what it was read as.

Aliasing routers (llama-swap roles), gateways and Azure deployments deliberately serve names they keep *out* of enumerations, precisely so internal role names stay out of user-facing pickers. So absence from a list is **no information at all**, and reporting it as yellow manufactured a warning from an absence of evidence. The reporter's vision endpoint was captioning successfully and permanently yellow for exactly this reason; their assist model still is.

Three outcomes exist and only one is a fault: unreachable (**down**), listed (good evidence, still not proof), **not listed (nothing)**. This is the honesty rule `health-summary.ts` already applies one file over, where a component nobody configured is explicitly not a problem.

The status pill drops its `warn` variant for this case, in all three locales.

## Two existing assertions rewritten, not deleted

`pipeline-status.test.js` pinned the old behaviour, including the near-miss case (`llama` vs `llama-guard`). Both now assert `ok` **with the detail reporting it was not enumerated** — the reasoning is written into the test so the next reader sees why the rule changed rather than that it was relaxed.

## Deliberately not here

**Verify** — one minimal real request against the configured name, content-free (a 1×1 PNG for vision), with a **cold-load-tolerant timeout and a distinct "still loading" state**, since a swapping backend serving several roles off one GPU makes a ~35 s first call normal. It is the only honest liveness check, and it needs UI work plus its own verification pass. Same PR will carry the Models-page completeness gate and the missing VLM card.

## Verification

- `npm run preflight` — **PASSED** (re-run after rebasing onto #561)
- 8 probe tests including the reported `/v1/v1/` case and the both-spellings-agree case