### PR TITLE
fix(preflight): declare which tests need a server instead of guessing from file contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preflight was silently skipping 22 test files, including every SSRF suite.** It decided which
+  standalone tests needed a live server by matching file *contents* against
+  `fetch(|127.0.0.1|localhost:|INSTANCES|BASE_URL`. That guarded one direction — a test that really hits
+  the network without a marker fails loudly with `ECONNREFUSED` — and missed the other entirely: a
+  **pure** test that merely *mentions* one of those strings was excluded and never ran locally.
+  - Measured, not estimated: running every standalone file alone with nothing listening showed **22 of
+    158 were pure and being skipped**, among them `ssrf-hardening`, `ssrf-ip-pinning`,
+    `peer-ssrf-policy`, `oidc-issuer-ssrf`, `log-redaction`, `secrets-permissions` and
+    `config-permissions`. "Preflight PASSED" was not running the SSRF suites.
+  - It cost two red CI runs. #559 failed on an assertion in `private-model-endpoints.test.js`, excluded
+    for containing `127.0.0.1` as test *data* — a blocked address. #562 failed on one in
+    `vlm-endpoint-egress.test.js`, excluded for containing `fetch(` inside its own failure messages.
+  - The split is now **declared**: a test that drives a live server says `@needs-instance` in its
+    header. Preflight went from 120 files to **142 of 158**. Zero files were wrong in the other
+    direction when measured, so the only failure mode a marker introduces is the loud one that was
+    already handled.
+  - A new gate asserts preflight selects on the marker and not on content, that every marked file shows
+    some sign of actually using a server, and that the marked set stays a small minority — a marker used
+    to silence a failure shows up there first.
+
 - **The connection probe disagreed with the pipeline it was probing.** Reported against 2.1.1, same pod,
   minutes apart: `POST /v1/chat/completions → 200` (captions working) beside `GET /v1/v1/models → 404`
   and `GET /v1/api/tags → 404` (the probe). The Models page showed vision **red over a working

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -82,14 +82,32 @@ for (const [file, why] of BUILT_GATES) gate(file, why, file);
 // wait for CI, and waiting for CI is exactly how a PR that changed `toRecallRecord`'s output shipped
 // with the test contradicting it still asserting the old shape.
 //
-// The split is by grep for an instance marker, and the skipped count is PRINTED. A file that reaches
-// the network without one of these markers fails here with ECONNREFUSED rather than being skipped
-// silently — loud and wrong beats quiet and wrong, and the fix is to add the marker.
-const NEEDS_INSTANCE = /fetch\(|127\.0\.0\.1|localhost:|INSTANCES|BASE_URL/;
+// The split is DECLARED, not inferred. A test that drives a live server says `@needs-instance` in its
+// header; everything else runs here.
+//
+// It used to be inferred, by content match on `fetch(|127.0.0.1|localhost:|INSTANCES|BASE_URL`. That
+// guarded the loud direction — a test that really hits the network without a marker fails here with
+// ECONNREFUSED — and completely missed the quiet one: a PURE test that merely MENTIONS one of those
+// strings was silently excluded and never ran locally at all.
+//
+// Measured before replacing it, by running every standalone file alone with nothing listening:
+// **22 of 158 were pure and being skipped**, among them `ssrf-hardening`, `ssrf-ip-pinning`,
+// `peer-ssrf-policy`, `oidc-issuer-ssrf`, `log-redaction`, `secrets-permissions` and
+// `config-permissions`. "Preflight PASSED" was not running the SSRF suites. It cost two red CI runs
+// (#559 and #562), each on an assertion inside a file the heuristic had excluded for containing the
+// word `fetch(` in its own failure messages.
+//
+// Zero files were wrong in the other direction, which is why a declared marker is safe: the failure
+// mode it introduces (a new server-driving test that forgets the marker) is the loud one that was
+// already handled.
+// Anchored to a header line (` * @needs-instance …`), not a bare substring. A bare match self-excluded
+// the very gate that polices this split, because that file necessarily mentions the marker in its
+// assertions — the same "matched test data, not behaviour" mistake the heuristic made, one level up.
+const NEEDS_INSTANCE = /^\s*\*\s*@needs-instance/m;
 const allStandalone = readdirSync('testing/standalone').filter(f => f.endsWith('.test.js')).sort();
 const pure = allStandalone.filter(f => !NEEDS_INSTANCE.test(readFileSync(`testing/standalone/${f}`, 'utf8')));
 console.log(`\n── standalone tests that need no running instance (${pure.length} of ${allStandalone.length}; ` +
-  `${allStandalone.length - pure.length} drive a live server and run in CI) ──`);
+  `${allStandalone.length - pure.length} declare @needs-instance and run in CI) ──`);
 try { run(`node --test --test-concurrency=1 ${pure.map(f => `testing/standalone/${f}`).join(' ')}`); } catch {
   failures.push({ name: 'test:standalone (offline subset)', why: 'server contracts and pure logic — no Docker needed, so no reason to learn this from CI' });
 }

--- a/testing/standalone/config-loader.test.js
+++ b/testing/standalone/config-loader.test.js
@@ -13,6 +13,8 @@
  * then verify the server didn't crash and responds normally.
  *
  * Run: node --test testing/standalone/config-loader.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/config-write-safety.test.js
+++ b/testing/standalone/config-write-safety.test.js
@@ -17,6 +17,8 @@
  * reload-config.test.js / quota.test.js / space-op-recovery.test.js.
  *
  * Run: node --test testing/standalone/config-write-safety.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/embed-origins.test.js
+++ b/testing/standalone/embed-origins.test.js
@@ -13,6 +13,8 @@
  *  - the running server's CSP advertises frame-ancestors 'self' by default
  *
  * Run: node --test testing/standalone/embed-origins.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before } from 'node:test';

--- a/testing/standalone/embedding-failure-reporting.test.js
+++ b/testing/standalone/embedding-failure-reporting.test.js
@@ -16,6 +16,8 @@
  * the original embedding config no matter what.
  *
  * Run: node --test testing/standalone/embedding-failure-reporting.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/graceful-shutdown-drain.test.js
+++ b/testing/standalone/graceful-shutdown-drain.test.js
@@ -69,7 +69,11 @@ describe('shutdown drains in-flight work', () => {
     const took = Date.now() - started;
 
     assert.equal(how, 'forced', 'an idle socket must trigger the forced phase');
-    assert.ok(took < 2_000, `the drain must give up on schedule, took ${took}ms`);
+    // The invariant is BOUNDEDNESS, not latency: without the forced phase this hangs until the
+    // orchestrator SIGKILLs the process. A tight ceiling measures the scheduler instead — at 2s it
+    // flaked once inside a 140-file sequential batch and passed on the retry, which is the worst kind of
+    // gate. 10s still fails an unbounded wait instantly and cannot be tripped by load.
+    assert.ok(took < 10_000, `the drain must be bounded, took ${took}ms`);
     sock.destroy();
   });
 });

--- a/testing/standalone/metrics.test.js
+++ b/testing/standalone/metrics.test.js
@@ -11,6 +11,8 @@
  *  - Active tokens gauge is non-negative
  *
  * Run: node --test testing/standalone/metrics.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before } from 'node:test';

--- a/testing/standalone/notify-rate-limit.test.js
+++ b/testing/standalone/notify-rate-limit.test.js
@@ -14,6 +14,8 @@
  *   - instance C (no kill-switch) must still enforce the real 429
  *
  * Run: node --test testing/standalone/notify-rate-limit.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it } from 'node:test';

--- a/testing/standalone/oidc-silent-refresh.test.js
+++ b/testing/standalone/oidc-silent-refresh.test.js
@@ -11,6 +11,8 @@
  *  - The SPA's CSP allows same-origin iframing (frame-ancestors 'self')
  *
  * Run: node --test testing/standalone/oidc-silent-refresh.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it } from 'node:test';

--- a/testing/standalone/preflight-coverage.test.js
+++ b/testing/standalone/preflight-coverage.test.js
@@ -1,0 +1,99 @@
+/**
+ * Preflight must not silently skip a test.
+ *
+ * ## What went wrong
+ *
+ * Preflight runs the standalone tests that need no live server, and it decided which those were by
+ * CONTENT MATCH: `fetch(|127.0.0.1|localhost:|INSTANCES|BASE_URL`. That guarded one direction — a test
+ * that really does hit the network without a marker fails loudly with ECONNREFUSED — and completely
+ * missed the other: a **pure** test that merely *mentions* one of those strings was excluded and never
+ * ran locally at all.
+ *
+ * Measured by running every standalone file alone with nothing listening: **22 of 158 were pure and
+ * being skipped**, among them `ssrf-hardening`, `ssrf-ip-pinning`, `peer-ssrf-policy`,
+ * `oidc-issuer-ssrf`, `log-redaction`, `secrets-permissions` and `config-permissions`. "Preflight
+ * PASSED" was not running the SSRF suites.
+ *
+ * It cost two red CI runs. #559 failed on an assertion in `private-model-endpoints.test.js`, excluded
+ * for containing `127.0.0.1` as test *data* — a blocked address. #562 failed on one in
+ * `vlm-endpoint-egress.test.js`, excluded for containing the word `fetch(` inside its own failure
+ * messages. Both were pure. Both passed a green preflight minutes before CI rejected them.
+ *
+ * ## The rule now
+ *
+ * The split is **declared**, not inferred: a test that drives a live server says `@needs-instance` in
+ * its header. Everything else runs in preflight. Zero files were wrong in that direction when measured,
+ * so the only failure mode a marker introduces is the loud one that was already handled.
+ *
+ * Run: node --test testing/standalone/preflight-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const PREFLIGHT = readFileSync('scripts/preflight.mjs', 'utf8');
+
+const NUL = String.fromCharCode(0);
+const files = execFileSync('git', ['ls-files', '-z', 'testing/standalone'], { encoding: 'utf8' })
+  .split(NUL).filter(f => f.endsWith('.test.js')).sort();
+
+const marked = files.filter(f => readFileSync(f, 'utf8').includes('@needs-instance'));
+
+describe('the exclusion is declared, not guessed', () => {
+  it('preflight selects on the marker', () => {
+    // Asserts the SELECTOR, not its exact spelling — the pattern is anchored to a header line
+    // (` * @needs-instance …`) and that detail is free to change.
+    assert.match(PREFLIGHT, /const NEEDS_INSTANCE = \/[^\n]*@needs-instance/);
+  });
+
+  it('the marker match is anchored, so a file that merely mentions it is not excluded', () => {
+    // An unanchored match excluded THIS file, which necessarily names the marker in its assertions —
+    // the same "matched test data, not behaviour" mistake the old heuristic made, one level up.
+    assert.match(PREFLIGHT, /const NEEDS_INSTANCE = \/\^/, 'the pattern must be line-anchored');
+  });
+
+  it('and NOT on a content heuristic', () => {
+    // The exact shape that skipped 22 pure files. Matching test data is not evidence about behaviour.
+    assert.doesNotMatch(
+      PREFLIGHT,
+      /NEEDS_INSTANCE = \/[^/]*(fetch\\\(|127\\\.0\\\.0\\\.1|localhost:|BASE_URL)/,
+      'inferring from file contents excludes pure tests that merely mention a URL or the word fetch',
+    );
+  });
+
+  it('the skipped count is printed, so an exclusion is visible in the run', () => {
+    assert.match(PREFLIGHT, /declare @needs-instance and run in CI/);
+  });
+});
+
+describe('the marker is used honestly', () => {
+  it('every marked file really does look like it drives a server', () => {
+    // A marker added by reflex is an exclusion nobody notices. If a file claims to need an instance, it
+    // should show some sign of reaching one.
+    const suspicious = marked.filter(f => {
+      const src = readFileSync(f, 'utf8');
+      return !/BASE_URL|INSTANCES|127\.0\.0\.1|localhost:\d|:3200/.test(src);
+    });
+    assert.deepEqual(suspicious, [], `these declare @needs-instance but show no sign of using one:\n  ${suspicious.join('\n  ')}`);
+  });
+
+  it('the marked set stays a small minority', () => {
+    // Measured at 16 of 158. A jump means either a burst of integration tests, or markers being used to
+    // silence a failure — the second is the one worth catching, and it will show up here first.
+    assert.ok(marked.length <= 30, `${marked.length} files declare @needs-instance; that was 16 when measured`);
+    assert.ok(marked.length / files.length < 0.25, 'more than a quarter of standalone tests need a server?');
+  });
+
+  it('the marker carries an explanation, not just a token', () => {
+    for (const f of marked) {
+      const line = readFileSync(f, 'utf8').split('\n').find(l => l.includes('@needs-instance'));
+      assert.ok(line.length > 30, `${f}: bare marker with no reason — say what it drives`);
+    }
+  });
+
+  it('the scan actually reads the tree', () => {
+    assert.ok(files.length > 100, `expected the standalone suite, got ${files.length}`);
+    assert.ok(marked.length > 0, 'no file declares the marker — the split would be meaningless');
+  });
+});

--- a/testing/standalone/quota.test.js
+++ b/testing/standalone/quota.test.js
@@ -17,6 +17,8 @@
  *  - Dev stack:   config/config.json                (docker-compose.yml)
  *
  * Run: node --test testing/quota.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/rate-limit.test.js
+++ b/testing/standalone/rate-limit.test.js
@@ -19,6 +19,8 @@
  * Note: Rate-limit windows are per-minute. Tests use instance C (port 3202)
  * so they don't affect tests on A and B — and any test hitting instance C
  * within a minute of this file must expect residual 429s.
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before } from 'node:test';

--- a/testing/standalone/ready.test.js
+++ b/testing/standalone/ready.test.js
@@ -14,6 +14,8 @@
  *
  * Note: The test accepts both 200 (all checks pass) and 503 (some check fails)
  * because MongoDB / mongot availability is environment-dependent.
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it } from 'node:test';

--- a/testing/standalone/reload-config.test.js
+++ b/testing/standalone/reload-config.test.js
@@ -16,6 +16,8 @@
  * the same config.json file on instance A.
  *
  * Run: node --test testing/standalone/reload-config.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/seq-block-reservation.test.js
+++ b/testing/standalone/seq-block-reservation.test.js
@@ -12,6 +12,8 @@
  * under concurrent reservation, which is exactly when a naive read-then-write would collide.
  *
  * Run: node --test testing/standalone/seq-block-reservation.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/spa-fallback-assets.test.js
+++ b/testing/standalone/spa-fallback-assets.test.js
@@ -15,6 +15,8 @@
  *
  * Run: node --test testing/standalone/spa-fallback-assets.test.js
  * Pre-requisite: the test stack (`npm run test:up`) — these assert against a running instance.
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before } from 'node:test';

--- a/testing/standalone/space-op-recovery.test.js
+++ b/testing/standalone/space-op-recovery.test.js
@@ -16,6 +16,8 @@
  * reload-config.test.js / quota.test.js.
  *
  * Run: node --test testing/standalone/space-op-recovery.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/theme.test.js
+++ b/testing/standalone/theme.test.js
@@ -9,6 +9,8 @@
  *  - Security headers are present on theme responses
  *
  * Run: node --test testing/standalone/theme.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it, before, after } from 'node:test';

--- a/testing/standalone/waitfor-diagnostics.test.js
+++ b/testing/standalone/waitfor-diagnostics.test.js
@@ -13,6 +13,8 @@
  *    REMEMBERS the last one and reports it
  *
  * Run: node --test testing/standalone/waitfor-diagnostics.test.js
+ *
+ * @needs-instance — drives a live server on :3200; runs in CI, skipped by preflight.
  */
 
 import { describe, it } from 'node:test';


### PR DESCRIPTION
## Preflight was not running the SSRF suites

It decided which standalone tests needed a live server by matching file **contents** against `fetch(|127.0.0.1|localhost:|INSTANCES|BASE_URL`.

That guarded one direction — a test that really hits the network without a marker fails loudly with `ECONNREFUSED` — and missed the other entirely: a **pure** test that merely *mentions* one of those strings was excluded and never ran locally.

## Measured, not estimated

Running every standalone file alone with nothing listening:

**22 of 158 were pure and being skipped**, including:

`ssrf-hardening` · `ssrf-ip-pinning` · `peer-ssrf-policy` · `oidc-issuer-ssrf` · `log-redaction` · `secrets-permissions` · `config-permissions` · `private-model-endpoints` · `vlm-endpoint-egress` · `probe-endpoint` · `vlm-client` · `stt-multipart-and-partial`

**Zero** were wrong in the other direction. That asymmetry is why a declared marker is safe: the only failure mode it introduces (a new server-driving test that forgets the marker) is the loud one that was already handled.

## It cost two red CI runs

| PR | failed on | excluded because |
|---|---|---|
| #559 | `private-model-endpoints.test.js` | contains `127.0.0.1` as test **data** — a blocked address |
| #562 | `vlm-endpoint-egress.test.js` | contains `fetch(` inside its own **failure messages** |

Both files are pure. Both PRs had a green preflight minutes earlier.

## The fix

A test that drives a live server says `@needs-instance` in its header. Everything else runs. **143 of 159, up from 120.**

## Two things this surfaced immediately

Both fixed here, because they are what "these files now run" means:

- **The new gate self-excluded.** An unanchored match on `@needs-instance` hit the gate's own assertions — the same *matched test data, not behaviour* mistake as the heuristic, one level up. The pattern is now anchored to a header line, and the gate asserts that anchoring.
- **`graceful-shutdown-drain` flaked** once inside a 140-file sequential batch and passed on retry. Its `took < 2_000` assertion measures the scheduler; the invariant is **boundedness** — without the forced phase it hangs until the orchestrator SIGKILLs the process. Raised to 10s, which still fails an unbounded wait instantly and cannot be tripped by load. A tight timing assertion in a gate is worse than no assertion.

## The gate

`preflight-coverage.test.js` asserts preflight selects on the marker and **not** on content, that the match is anchored, that every marked file shows some sign of actually using a server, and that the marked set stays a small minority — a marker used to silence a failure shows up there first.

## Verification

- `npm run preflight` — **PASSED**, twice, stable at 143/159
- The 22 newly-included files all pass