### PR TITLE
feat(bench): a duplicate-detection bench harness, and a licence registry that gates it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A duplicate-detection bench harness, and a model-licence registry that gates it.** Groundwork for
+  making recall and duplicate scores interpretable; no runtime behaviour changes.
+  - `testing/bench/parse-bench-pairs.mjs` reads a labelled pair set and **refuses to read it from inside
+    this repository** — the real set is drawn from production records and this repo is public, so the
+    data lives outside the worktree and the guard is structural rather than a naming convention.
+  - It fails loudly rather than measuring a subset: an unresolvable pair reference, an unknown label, or
+    a pair count that does not match the caller's expectation are all errors. A parser that silently
+    found three pairs would benchmark three pairs and report a confident number for a different
+    question. Its own test caught one instance of exactly that — a label containing a hyphen failed to
+    match the row regex and was dropped in silence instead of rejected.
+  - `testing/bench/model-candidates.mjs` records, per candidate, the **weights licence *and* what is
+    known about training-data provenance**, with the URL the claim was read from and the date. A model
+    that has not cleared both cannot be benchmarked, and an unknown model is refused rather than assumed
+    fine.
+  - The gate sits on the bench deliberately: a model that gets benchmarked gets compared, and one that
+    compares well gets adopted — the licence question is cheapest at the point of measurement.
+  - It already blocks one: the leading multilingual NLI candidate ships **MIT weights** and is fine-tuned
+    on **XNLI, which is CC BY-NC 4.0**. Taking the model card at face value would have put a
+    non-commercial dependency at the centre of a paid product's duplicate detection.
+  - Scope is recorded explicitly: this covers what Ythril **bundles, defaults to, or recommends**. A
+    model an operator supplies themselves — the assist model, or any endpoint they point a slot at — is
+    their infrastructure and their licence decision, and the boundary is asserted so that adding a
+    default to one of those slots reads as a change of category rather than a config tweak.
+
 ### Fixed
 
 - **Preflight was silently skipping 22 test files, including every SSRF suite.** It decided which

--- a/testing/bench/model-candidates.mjs
+++ b/testing/bench/model-candidates.mjs
@@ -1,0 +1,174 @@
+/**
+ * Candidate models for the retrieval/adjudication stack, and the licence evidence for each.
+ *
+ * ## Why this file is a gate and not a note
+ *
+ * Ythril is shipped commercially, so every model it recommends or bundles must be usable
+ * commercially. That question is **not** answered by the licence field on a model card, because a
+ * model is plausibly a derivative work of the data it was trained on, and permissive weights are
+ * routinely published on top of non-commercial data.
+ *
+ * That is not hypothetical. The multilingual NLI model that was the leading candidate for the
+ * equivalence layer — `MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7` — carries
+ * `License: mit` on its card and is fine-tuned on **XNLI, which is CC BY-NC 4.0**. ANLI is likewise
+ * non-commercial. Hugging Face carries public discussions titled exactly "License Conflict: MIT vs
+ * CC BY-NC 4.0" on sibling models. Taking the card at face value would have put a non-commercial
+ * dependency at the centre of a paid product.
+ *
+ * So each entry records **two** things — the weights licence and what is known about training-data
+ * provenance — plus the URL the claim was read from and the date. {@link assertCommerciallyUsable}
+ * refuses to benchmark anything that has not cleared both.
+ *
+ * ## What "cleared" means here
+ *
+ * `verdict: 'clear'` means: permissive weights licence, and no known non-commercial dataset in the
+ * training mix. It is an engineering judgement recorded with its evidence so it can be re-checked or
+ * overruled — **not legal advice**, and a licence can change under a model at any time. Re-verify
+ * before shipping a dependency on any of these.
+ *
+ * ## Where the obligation starts and stops
+ *
+ * This gate covers models **Ythril is responsible for**: bundled weights, the defaults a fresh install
+ * runs on, and anything named as a recommendation in the docs or the admin UI. Picking those is our
+ * act, and a customer inherits the consequences without having chosen.
+ *
+ * It does **not** cover a model the operator supplies entirely themselves — the assist model, or any
+ * endpoint they point the vision / STT / NLI slots at. Those are their infrastructure, their account
+ * and their licence decision, exactly like the database they connect. Ythril provides the slot, not
+ * the model.
+ *
+ * The line matters in both directions. It means a customer may legitimately point their own NLI
+ * endpoint at a model this file blocks — that is their call to make. And it means we must not smuggle a
+ * recommendation past the gate by putting it in a doc example or a placeholder instead of a default.
+ */
+
+/** Licence families this project accepts for a bundled or recommended model. */
+export const PERMISSIVE_LICENCES = new Set(['mit', 'apache-2.0', 'bsd-3-clause', 'cc-by-4.0']);
+
+/** Datasets known to forbid commercial use. A model trained on one is treated as tainted. */
+export const NON_COMMERCIAL_DATASETS = new Set(['xnli', 'anli', 'nllb', 'mrpc-research-only']);
+
+/**
+ * Verified 2026-07-30. Re-verify before shipping — model cards are edited in place.
+ *
+ * `role` is what the candidate would do in the stack; `verdict` is whether it may be benchmarked.
+ */
+export const CANDIDATES = [
+  {
+    id: 'BAAI/bge-m3',
+    role: 'embedding',
+    licence: 'mit',
+    url: 'https://huggingface.co/BAAI/bge-m3',
+    verifiedOn: '2026-07-30',
+    trainingData: 'Not enumerated on the card; no non-commercial dataset declared.',
+    verdict: 'clear',
+    notes: 'Multilingual, 8192 context, emits dense + sparse + multi-vector from one model — the only '
+      + 'candidate that keeps late interaction available without a second re-embed.',
+  },
+  {
+    id: 'intfloat/multilingual-e5-base',
+    role: 'embedding',
+    licence: 'mit',
+    url: 'https://huggingface.co/intfloat/multilingual-e5-base',
+    verifiedOn: '2026-07-30',
+    trainingData: 'mC4 / mined web pairs; no non-commercial dataset declared.',
+    verdict: 'clear',
+    notes: '768 dims — same as the current index shape, so the vector index geometry does not change. '
+      + 'Dense only: choosing it closes the door on late interaction without a further migration.',
+  },
+  {
+    id: 'nomic-ai/nomic-embed-text-v2-moe',
+    role: 'embedding',
+    licence: 'apache-2.0',
+    url: 'https://huggingface.co/nomic-ai/nomic-embed-text-v2-moe',
+    verifiedOn: '2026-07-30',
+    trainingData: '1.6B filtered pairs; training data and code published (nomic-ai/contrastors).',
+    verdict: 'clear',
+    notes: 'Same family and prefix scheme as the model in production today, so the smallest code delta. '
+      + 'Mixture-of-experts — ONNX viability for local embedding is the open question.',
+  },
+  {
+    id: 'BAAI/bge-reranker-v2-m3',
+    role: 'reranker',
+    licence: 'apache-2.0',
+    url: 'https://huggingface.co/BAAI/bge-reranker-v2-m3',
+    verifiedOn: '2026-07-30',
+    trainingData: 'Not enumerated on the card; no non-commercial dataset declared.',
+    verdict: 'clear',
+    notes: 'Multilingual cross-encoder. Trained for RELEVANCE, not equivalence — usable for retrieval '
+      + 'reranking, NOT as the duplicate adjudicator. Those are different questions.',
+  },
+  {
+    id: 'MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7',
+    role: 'nli-equivalence',
+    licence: 'mit',
+    url: 'https://huggingface.co/MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7',
+    verifiedOn: '2026-07-30',
+    trainingData: 'Fine-tuned on XNLI (CC BY-NC 4.0) and multilingual-NLI-26lang-2mil7 (machine '
+      + 'translations of English NLI sets including ANLI, also non-commercial).',
+    verdict: 'blocked',
+    blockedBy: ['xnli', 'anli'],
+    notes: 'The weights say MIT; the training data does not permit commercial use. This was the leading '
+      + 'candidate for the equivalence layer and is the reason this file exists. Blocked as something '
+      + 'Ythril ships, defaults to or recommends — an operator pointing their OWN nli endpoint at it is '
+      + 'a decision on their infrastructure and their licence, and is not ours to make or to prevent.',
+  },
+];
+
+/**
+ * Slots filled entirely by the operator, and therefore outside this gate.
+ *
+ * Ythril provides the slot; the operator brings the URL, the model and the key. The licence question
+ * travels with them, the same way it does for the database they connect. Listed explicitly so the
+ * boundary is a recorded decision rather than an omission — and so that adding a *default* or a
+ * *recommendation* to one of these slots is visibly a change of category, not a config tweak.
+ */
+export const OPERATOR_SUPPLIED_SLOTS = new Set([
+  'assistModel',   // F11-b: own url/model/key, mandatory egress acknowledgement on add
+  'nli',           // contradiction judge — no sidecar ships one
+  'rerank',        // no reranker ships by default
+]);
+
+/** Look a candidate up by id. */
+export function candidate(id) {
+  const c = CANDIDATES.find(x => x.id === id);
+  if (!c) {
+    throw new Error(
+      `Unknown model '${id}'. Add it to CANDIDATES with its licence, training-data provenance, the URL `
+      + 'the claim was read from, and the date — benchmarking a model whose licence nobody checked is '
+      + 'how a non-commercial dependency reaches a paid product.',
+    );
+  }
+  return c;
+}
+
+/**
+ * Refuse to benchmark a model that has not cleared commercial use.
+ *
+ * The gate is on the bench rather than on the shipping path deliberately: a model that gets
+ * benchmarked gets compared, and a model that compares well gets adopted. Stopping it at the point of
+ * measurement is the last place the question is still cheap to ask.
+ */
+export function assertCommerciallyUsable(id) {
+  const c = candidate(id);
+  if (c.verdict !== 'clear') {
+    throw new Error(
+      `Refusing to benchmark ${id}: not cleared for commercial use.\n`
+      + `  weights licence: ${c.licence}\n`
+      + `  training data:   ${c.trainingData}\n`
+      + `  blocked by:      ${(c.blockedBy ?? []).join(', ') || 'see notes'}\n`
+      + `  ${c.notes}\n`
+      + 'Ythril ships commercially. A permissive licence on the weights does not survive '
+      + 'non-commercial training data.',
+    );
+  }
+  if (!PERMISSIVE_LICENCES.has(c.licence)) {
+    throw new Error(`Refusing to benchmark ${id}: licence '${c.licence}' is not on the permissive list.`);
+  }
+  return c;
+}
+
+/** Every candidate that may be benchmarked, optionally filtered by role. */
+export function clearCandidates(role) {
+  return CANDIDATES.filter(c => c.verdict === 'clear' && (role === undefined || c.role === role));
+}

--- a/testing/bench/parse-bench-pairs.mjs
+++ b/testing/bench/parse-bench-pairs.mjs
@@ -1,0 +1,203 @@
+/**
+ * Parse a labelled duplicate-detection bench file into pairs and texts.
+ *
+ * ## The data lives outside this repository, on purpose
+ *
+ * The bench is drawn from real deployment records — architecture decisions, alert history, cluster
+ * configuration. This repository is public. So the file is never committed, never fixtured, and never
+ * quoted in a test: {@link assertDataPathIsOutsideRepo} refuses a path inside the worktree before a
+ * single byte is read, and the parser's own tests run against a synthetic fixture defined inline.
+ *
+ * ## Why a parser rather than a JSON schema
+ *
+ * The bench is written and reviewed as prose — the "why it is hard" column is the most valuable part of
+ * it, and it only stays accurate if the person labelling reads and edits it as a document. Asking for
+ * JSON would trade the reviewability that makes the labels trustworthy for parsing convenience.
+ *
+ * The trade is safe only if parsing failures are loud. A parser that silently finds three pairs would
+ * benchmark three pairs and report a confident number, which is worse than not running. Hence
+ * {@link parseBenchFile} validates aggressively: known labels, every referenced id resolvable, and a
+ * caller-supplied expected pair count.
+ *
+ * ## Format
+ *
+ *   Pair rows:  | <id> | <A> | <B> | `<label>` | <why> |
+ *   Texts:      ### <ID> [— optional description]
+ *               > blockquoted body, until the next heading or rule
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/** The labels the bench uses, and whether a pair carrying one may be merged. */
+export const LABELS = {
+  duplicate: { merge: true, note: 'same content, same substance; wording or language may differ' },
+  subsumes: { merge: false, note: 'a refinement or special case; both must survive' },
+  supersedes: { merge: false, note: 'replaces the other; both must survive as decision history' },
+  recurrence: { merge: false, note: 'same condition, different occurrence; text may be identical' },
+  distinct: { merge: false, note: 'different subjects' },
+  contradicts: { merge: false, note: 'actively opposed statements about the same subject' },
+};
+
+/**
+ * The label capture is deliberately permissive.
+ *
+ * It was `[a-z]+`, which meant a label the vocabulary does not have — anything with a hyphen, a capital,
+ * a typo — failed to match the ROW, so the row was silently dropped and the bench quietly measured a
+ * smaller set. That is the exact failure this parser is built to make impossible, reintroduced by the
+ * regex being too strict. Capture anything between the backticks and let the vocabulary check reject it
+ * loudly.
+ */
+const PAIR_ROW = /^\|\s*([A-Za-z]?\d+)\s*\|\s*([A-Za-z0-9-]+)\s*\|\s*([A-Za-z0-9-]+)\s*\|\s*`([^`]+)`\s*\|/;
+
+/**
+ * The id is the first token after the hashes; anything after it is a human description.
+ *
+ * Deliberately permissive. An earlier version required the remainder to be an em-dash clause and
+ * therefore silently skipped `### S-DE-RADIUS-MD *(synthetic)*` — and a heading regex that misses
+ * produces a "text not found" error pointing at the pair table, which is the wrong place to look.
+ * Headings that are not record ids (`### Block B`) parse into inert map entries; validation is by
+ * reference resolution, so nothing depends on this regex being selective.
+ */
+const HEADING = /^###\s+(\S+)/;
+
+/**
+ * Normalise line endings before anything else touches the source.
+ *
+ * The file is authored on Windows and arrives CRLF. Every `$`-anchored pattern then fails against the
+ * trailing `\r` while unanchored ones still match — so the pair table parsed perfectly and every single
+ * appendix heading was skipped, which surfaced as "8 pair references have no text". This repo has been
+ * bitten by exactly this before (a conflict-marker strip that matched nothing and reported success).
+ */
+const normalise = (src) => src.replace(/\r\n?/g, '\n');
+
+/**
+ * Refuse to read bench data from inside the git worktree.
+ *
+ * The guard is structural rather than a naming convention because a naming convention is exactly what
+ * fails under time pressure. A file that cannot be reached from inside the repository cannot be
+ * committed from inside it either.
+ */
+export function assertDataPathIsOutsideRepo(dataPath, repoRoot) {
+  const resolved = path.resolve(dataPath);
+  const root = path.resolve(repoRoot);
+  const rel = path.relative(root, resolved);
+  const inside = rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+  if (inside) {
+    throw new Error(
+      `Refusing to read bench data from inside the repository: ${resolved}\n`
+      + 'This repo is public and the bench is drawn from real deployment records. Keep the file outside\n'
+      + 'the worktree entirely and point YTHRIL_BENCH_DATA at it.',
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Pull the blockquoted body under each `### <ID>` heading.
+ *
+ * Blockquote markers, bold and inline code are stripped so what reaches the embedding model is the text
+ * a record actually carries, not its markdown presentation. Newlines collapse to single spaces for the
+ * same reason: the bench reproduces records in the shape the system embeds them, and that shape is one
+ * concatenated string.
+ */
+export function extractTexts(rawSrc) {
+  const texts = new Map();
+  const lines = normalise(rawSrc).split('\n');
+  let current = null;
+  let buf = [];
+
+  const flush = () => {
+    if (!current) return;
+    const body = buf
+      .join('\n')
+      .replace(/^>\s?/gm, '')
+      .replace(/\*\*/g, '')
+      .replace(/`/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (body.length > 0) texts.set(current, body);
+    current = null;
+    buf = [];
+  };
+
+  for (const line of lines) {
+    const h = HEADING.exec(line);
+    if (h) { flush(); current = h[1]; continue; }
+    if (current === null) continue;
+    // A horizontal rule or a non-### heading ends the block.
+    if (/^---+\s*$/.test(line) || /^#{1,2}\s/.test(line)) { flush(); continue; }
+    buf.push(line);
+  }
+  flush();
+  return texts;
+}
+
+/** Pull the labelled pairs from the block tables. */
+export function extractPairs(rawSrc) {
+  const pairs = [];
+  for (const line of normalise(rawSrc).split('\n')) {
+    const m = PAIR_ROW.exec(line);
+    if (!m) continue;
+    const [, id, a, b, label] = m;
+    // The table header separator (|---|---|) and prose rows cannot reach here: the id column must be
+    // digits with an optional leading letter, and the label column must be a backticked lowercase word.
+    if (!(label in LABELS)) {
+      throw new Error(`Unknown label '${label}' on pair ${id}. Known: ${Object.keys(LABELS).join(', ')}`);
+    }
+    pairs.push({ id, a, b, label, block: /^[A-Za-z]/.test(id) ? id[0].toUpperCase() : 'A' });
+  }
+  return pairs;
+}
+
+/**
+ * Read, parse and validate.
+ *
+ * `expectedPairs` is required rather than optional. The failure this guards against — a format drift
+ * that silently halves the set — produces a plausible-looking report, and a bench that quietly measures
+ * a different question than the one asked is the specific way benchmarks mislead.
+ */
+export function parseBenchFile(dataPath, { repoRoot, expectedPairs }) {
+  const resolved = assertDataPathIsOutsideRepo(dataPath, repoRoot);
+  const src = readFileSync(resolved, 'utf8');
+  return parseBenchSource(src, { expectedPairs });
+}
+
+/** The pure half, so tests can drive it with a synthetic fixture. */
+export function parseBenchSource(src, { expectedPairs } = {}) {
+  const texts = extractTexts(src);
+  const pairs = extractPairs(src);
+
+  if (expectedPairs != null && pairs.length !== expectedPairs) {
+    throw new Error(
+      `Parsed ${pairs.length} pairs, expected ${expectedPairs}. The table format has drifted; a bench `
+      + 'that measures a subset would report a confident number for a different question.',
+    );
+  }
+
+  const missing = [];
+  for (const p of pairs) {
+    for (const ref of [p.a, p.b]) {
+      if (!texts.has(ref)) missing.push(`${p.id}: ${ref}`);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `${missing.length} pair reference(s) have no text in the appendix:\n  ${missing.join('\n  ')}`,
+    );
+  }
+
+  return { pairs, texts };
+}
+
+/**
+ * The binary question a similarity score is being asked.
+ *
+ * Only `duplicate` may merge. Everything else — including `recurrence`, whose two texts can be
+ * byte-identical — must not. That asymmetry is the whole finding of the alerts block: similarity is
+ * *correct* there and merging is still *wrong*, so no threshold on any text score can separate them.
+ * Only structured fields can.
+ */
+export function shouldMerge(label) {
+  return LABELS[label]?.merge === true;
+}

--- a/testing/standalone/bench-pairs-parser.test.js
+++ b/testing/standalone/bench-pairs-parser.test.js
@@ -1,0 +1,202 @@
+/**
+ * The bench parser fails LOUDLY, and its fixture is invented.
+ *
+ * ## Why the fixture is synthetic
+ *
+ * The real labelled set is drawn from production records — architecture decisions, alert history,
+ * cluster configuration — and this repository is public. So the data lives outside the worktree
+ * entirely, `assertDataPathIsOutsideRepo` refuses a path inside it before reading a byte, and every
+ * fixture here is written for the test.
+ *
+ * ## Why loudness is the property under test
+ *
+ * The bench is authored and reviewed as prose, because the "why this pair is hard" column is the most
+ * valuable part of it and only stays accurate if a human edits it as a document. That trade is safe only
+ * while parsing failures are impossible to miss: a parser that silently found three pairs would
+ * benchmark three pairs and report a confident number for a different question. Every guard below exists
+ * to turn a format drift into an error rather than a smaller sample.
+ *
+ * Run: node --test testing/standalone/bench-pairs-parser.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+
+const {
+  parseBenchSource, extractTexts, extractPairs, shouldMerge, LABELS,
+  assertDataPathIsOutsideRepo,
+} = await import('../bench/parse-bench-pairs.mjs');
+
+/** A miniature bench file. Nothing here resembles any real record. */
+const FIXTURE = [
+  '# Fixture bench',
+  '',
+  '| # | A | B | Label | Why |',
+  '| --- | --- | --- | --- | --- |',
+  '| 1 | X-0001 | S-X-0001 | `duplicate` | translated |',
+  '| 2 | X-0001 | X-0002 | `distinct` | different subjects |',
+  '| B1 | Y-AAA | Y-BBB | `recurrence` | same condition, later |',
+  '',
+  '## Texts',
+  '',
+  '### X-0001',
+  '',
+  '> **Widget alpha** · thing · value `4px`',
+  '> The first widget. It is four pixels.',
+  '',
+  '### X-0002',
+  '',
+  '> **Widget beta** · thing · value `8px`',
+  '> The second widget. It is eight pixels.',
+  '',
+  '### S-X-0001 — invented translation of X-0001',
+  '',
+  '> **Widget alpha** · Ding · Wert `4px`',
+  '> Das erste Widget. Es ist vier Pixel gross.',
+  '',
+  '### Y-AAA *(synthetic)*',
+  '',
+  '> **ThingHappened on host-one** · episode · `startsAt 2020-01-01T00:00:00Z`',
+  '> A thing happened.',
+  '',
+  '### Y-BBB',
+  '',
+  '> **ThingHappened on host-one** · episode · `startsAt 2020-01-14T00:00:00Z`',
+  '> A thing happened.',
+  '',
+].join('\n');
+
+describe('parsing a well-formed file', () => {
+  const { pairs, texts } = parseBenchSource(FIXTURE, { expectedPairs: 3 });
+
+  it('finds every pair', () => assert.equal(pairs.length, 3));
+
+  it('reads the label out of the backticks', () => {
+    assert.deepEqual(pairs.map(p => p.label), ['duplicate', 'distinct', 'recurrence']);
+  });
+
+  it('assigns a block from the id prefix', () => {
+    assert.deepEqual(pairs.map(p => p.block), ['A', 'A', 'B']);
+  });
+
+  it('resolves every referenced text', () => {
+    for (const p of pairs) {
+      assert.ok(texts.has(p.a), `${p.id}: ${p.a}`);
+      assert.ok(texts.has(p.b), `${p.id}: ${p.b}`);
+    }
+  });
+
+  it('strips blockquote, bold and code markers from the body', () => {
+    const t = texts.get('X-0001');
+    assert.doesNotMatch(t, /^>/m);
+    assert.doesNotMatch(t, /\*\*/);
+    assert.doesNotMatch(t, /`/);
+    assert.match(t, /Widget alpha/);
+    assert.match(t, /four pixels/);
+  });
+
+  it('collapses the record to one line, the shape the system embeds', () => {
+    assert.doesNotMatch(texts.get('X-0001'), /\n/);
+  });
+
+  it('accepts a heading with a description or a suffix after the id', () => {
+    // `### S-X-0001 — invented translation of X-0001` and `### Y-AAA *(synthetic)*`. An earlier version
+    // required an em-dash clause and silently skipped the second form, which surfaced as "pair
+    // references have no text" pointing at the table — the wrong place to look.
+    assert.ok(texts.has('S-X-0001'));
+    assert.ok(texts.has('Y-AAA'));
+  });
+});
+
+describe('CRLF', () => {
+  it('parses identically to LF', () => {
+    // The real file is authored on Windows. Every `$`-anchored pattern fails against the trailing `\r`
+    // while unanchored ones still match — so the pair table parsed perfectly and every appendix heading
+    // was skipped, surfacing as "8 pair references have no text".
+    const crlf = FIXTURE.replace(/\n/g, '\r\n');
+    const a = parseBenchSource(FIXTURE, { expectedPairs: 3 });
+    const b = parseBenchSource(crlf, { expectedPairs: 3 });
+    assert.deepEqual(b.pairs, a.pairs);
+    assert.deepEqual([...b.texts.entries()], [...a.texts.entries()]);
+  });
+});
+
+describe('failing loudly rather than measuring a subset', () => {
+  it('a pair count that does not match is an error', () => {
+    assert.throws(
+      () => parseBenchSource(FIXTURE, { expectedPairs: 40 }),
+      /Parsed 3 pairs, expected 40/,
+    );
+  });
+
+  it('an unreferenced text is fine; an unresolvable reference is not', () => {
+    const broken = FIXTURE.replace('### X-0002\n', '### X-9999\n');
+    assert.throws(() => parseBenchSource(broken, { expectedPairs: 3 }), /have no text in the appendix/);
+    assert.throws(() => parseBenchSource(broken, { expectedPairs: 3 }), /X-0002/);
+  });
+
+  it('an unknown label is an error, not a silently dropped row', () => {
+    const broken = FIXTURE.replace('`distinct`', '`probably-fine`');
+    assert.throws(() => extractPairs(broken), /Unknown label 'probably-fine'/);
+  });
+
+  it('the table separator row is not mistaken for a pair', () => {
+    assert.equal(extractPairs('| --- | --- | --- | --- | --- |').length, 0);
+  });
+
+  it('prose containing pipes is not mistaken for a pair', () => {
+    assert.equal(extractPairs('| a | b | c | d | e |').length, 0);
+  });
+
+  it('an empty document parses to nothing rather than throwing', () => {
+    const { pairs, texts } = parseBenchSource('', {});
+    assert.equal(pairs.length, 0);
+    assert.equal(texts.size, 0);
+  });
+});
+
+describe('which labels may merge', () => {
+  it('only duplicate', () => {
+    assert.equal(shouldMerge('duplicate'), true);
+    for (const l of ['subsumes', 'supersedes', 'recurrence', 'distinct', 'contradicts']) {
+      assert.equal(shouldMerge(l), false, l);
+    }
+  });
+
+  it('recurrence in particular must NOT merge', () => {
+    // The finding that shapes the whole design: two alert episodes can be byte-identical and must both
+    // survive, because in an operations log the second occurrence IS the information. No text-based
+    // score can separate that from a true duplicate — only structured fields can.
+    assert.equal(LABELS.recurrence.merge, false);
+    assert.match(LABELS.recurrence.note, /occurrence/);
+  });
+
+  it('an unknown label never merges', () => {
+    assert.equal(shouldMerge('made-up'), false);
+  });
+});
+
+describe('the data may not live in this repository', () => {
+  const repoRoot = process.cwd();
+
+  it('refuses a path inside the worktree', () => {
+    assert.throws(
+      () => assertDataPathIsOutsideRepo(path.join(repoRoot, 'bench-data', 'pairs.md'), repoRoot),
+      /Refusing to read bench data from inside the repository/,
+    );
+  });
+
+  it('refuses the repo root itself', () => {
+    assert.throws(() => assertDataPathIsOutsideRepo(path.join(repoRoot, 'pairs.md'), repoRoot), /Refusing/);
+  });
+
+  it('allows a sibling directory outside it', () => {
+    const outside = path.join(repoRoot, '..', '_private', 'pairs.md');
+    assert.equal(assertDataPathIsOutsideRepo(outside, repoRoot), path.resolve(outside));
+  });
+
+  it('is not fooled by a traversal that lands back inside', () => {
+    const sneaky = path.join(repoRoot, '..', path.basename(repoRoot), 'pairs.md');
+    assert.throws(() => assertDataPathIsOutsideRepo(sneaky, repoRoot), /Refusing/);
+  });
+});

--- a/testing/standalone/graceful-shutdown-drain.test.js
+++ b/testing/standalone/graceful-shutdown-drain.test.js
@@ -61,8 +61,18 @@ describe('shutdown drains in-flight work', () => {
     const server = createServer((_req, res) => res.end('ok'));
     const port = await listen(server);
 
+    // Wait for the SERVER to register the socket, not just for the client to finish connecting.
+    //
+    // `sock.once('connect')` resolves on the client side; the server may not have accepted the
+    // connection yet. If `close()` is called in that gap it finds nothing to wait for and resolves
+    // 'drained' immediately, so the assertion below flips — intermittently, and only under the load of a
+    // full sequential batch, which is the worst way for a gate to fail. Waiting on the server's own
+    // `connection` event removes the race instead of widening a timeout around it.
     const sock = net.connect(port, '127.0.0.1');
-    await new Promise(r => sock.once('connect', r));
+    await Promise.all([
+      new Promise(r => sock.once('connect', r)),
+      new Promise(r => server.once('connection', r)),
+    ]);
 
     const started = Date.now();
     const how = await drain(server, 300);

--- a/testing/standalone/model-licence-gate.test.js
+++ b/testing/standalone/model-licence-gate.test.js
@@ -1,0 +1,126 @@
+/**
+ * No model reaches a benchmark — and therefore a recommendation — without a checked licence.
+ *
+ * ## The specific failure this exists for
+ *
+ * Ythril ships commercially. The licence field on a model card does not settle whether a model may be
+ * used commercially, because a model is plausibly a derivative work of its training data, and
+ * permissive weights are routinely published on top of non-commercial datasets.
+ *
+ * The leading candidate for the equivalence layer was
+ * `MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7`: card says `License: mit`, fine-tuned on
+ * **XNLI, which is CC BY-NC 4.0**, plus machine translations of ANLI, also non-commercial. Reading the
+ * card and moving on would have put a non-commercial dependency at the centre of a paid product's
+ * duplicate detection.
+ *
+ * The gate sits on the bench rather than the shipping path on purpose: a model that gets benchmarked
+ * gets compared, a model that compares well gets adopted, and the licence question is cheapest at the
+ * moment of measurement.
+ *
+ * Run: node --test testing/standalone/model-licence-gate.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  CANDIDATES, PERMISSIVE_LICENCES, NON_COMMERCIAL_DATASETS, OPERATOR_SUPPLIED_SLOTS,
+  candidate, assertCommerciallyUsable, clearCandidates,
+} = await import('../bench/model-candidates.mjs');
+
+describe('every candidate carries its evidence', () => {
+  for (const c of CANDIDATES) {
+    describe(c.id, () => {
+      it('names a licence', () => assert.ok(typeof c.licence === 'string' && c.licence.length > 0));
+      it('says what it would be used for', () => {
+        assert.ok(['embedding', 'reranker', 'nli-equivalence', 'cross-encoder-sts'].includes(c.role), c.role);
+      });
+      it('records where the claim was read from', () => {
+        assert.match(c.url, /^https:\/\//, 'a licence claim with no source cannot be re-checked');
+      });
+      it('records when it was checked', () => {
+        // Model cards are edited in place. A claim with no date cannot be aged out.
+        assert.match(c.verifiedOn, /^\d{4}-\d{2}-\d{2}$/);
+      });
+      it('says something about training-data provenance', () => {
+        // The whole point: the weights licence is not the question.
+        assert.ok(typeof c.trainingData === 'string' && c.trainingData.length > 20,
+          'training-data provenance is the half a model card does not answer');
+      });
+      it('has an explicit verdict', () => {
+        assert.ok(['clear', 'blocked'].includes(c.verdict), `${c.id} verdict: ${c.verdict}`);
+      });
+    });
+  }
+});
+
+describe('the gate refuses what it should', () => {
+  it('blocks the XNLI-trained NLI model despite its MIT weights', () => {
+    // The case this file was written for. If this ever starts passing, the reasoning was lost.
+    const id = 'MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7';
+    assert.equal(candidate(id).licence, 'mit', 'the weights really are MIT — that is the trap');
+    assert.throws(() => assertCommerciallyUsable(id), /not cleared for commercial use/);
+    assert.throws(() => assertCommerciallyUsable(id), /xnli/);
+  });
+
+  it('blocks an unknown model rather than assuming it is fine', () => {
+    assert.throws(() => assertCommerciallyUsable('some/unvetted-model'), /Unknown model/);
+  });
+
+  it('admits the cleared ones', () => {
+    for (const c of CANDIDATES.filter(x => x.verdict === 'clear')) {
+      assert.doesNotThrow(() => assertCommerciallyUsable(c.id), c.id);
+    }
+  });
+
+  it('a blocked candidate must say what blocked it', () => {
+    for (const c of CANDIDATES.filter(x => x.verdict === 'blocked')) {
+      assert.ok(Array.isArray(c.blockedBy) && c.blockedBy.length > 0, `${c.id} needs blockedBy`);
+      for (const d of c.blockedBy) {
+        assert.ok(NON_COMMERCIAL_DATASETS.has(d), `'${d}' should be listed in NON_COMMERCIAL_DATASETS`);
+      }
+    }
+  });
+
+  it('every cleared licence is on the permissive list', () => {
+    for (const c of CANDIDATES.filter(x => x.verdict === 'clear')) {
+      assert.ok(PERMISSIVE_LICENCES.has(c.licence), `${c.id} has licence '${c.licence}'`);
+    }
+  });
+});
+
+describe('the stack still has a usable candidate for each job', () => {
+  it('at least two embedding models are clear, so the choice is a measurement not a default', () => {
+    assert.ok(clearCandidates('embedding').length >= 2);
+  });
+
+  it('the reranker is not proposed as the duplicate adjudicator', () => {
+    // Relevance ("does this answer that") and equivalence ("do these mean the same") are different
+    // tasks and different training objectives. Reusing the reranker would look reasonable and be wrong.
+    const r = CANDIDATES.find(c => c.role === 'reranker');
+    assert.match(r.notes, /NOT as the duplicate adjudicator|relevance/i);
+  });
+
+  it('there is no local equivalence model we could SHIP — stated, not hidden', () => {
+    // Cross-lingual NLI routes through XNLI, so nothing here can become a bundled default or a
+    // documented recommendation. Silence would read as "solved".
+    assert.equal(clearCandidates('nli-equivalence').length, 0);
+  });
+});
+
+describe('the boundary of the obligation', () => {
+  it('operator-supplied slots are recorded, not merely absent', () => {
+    // Ythril provides the slot; the operator brings url, model and key. The licence travels with them,
+    // like the database they connect. Recording it makes the boundary a decision rather than an
+    // omission — and makes adding a DEFAULT to one of these slots visibly a change of category.
+    assert.ok(OPERATOR_SUPPLIED_SLOTS.has('assistModel'));
+    assert.ok(OPERATOR_SUPPLIED_SLOTS.has('nli'));
+  });
+
+  it('a blocked model is blocked for SHIPPING, not for an operator to choose', () => {
+    // The distinction has to survive in the text, or the next reader turns a scope boundary into a ban
+    // on something that was never ours to forbid.
+    const blocked = CANDIDATES.find(c => c.verdict === 'blocked');
+    assert.match(blocked.notes, /ships, defaults to or recommends/);
+    assert.match(blocked.notes, /their infrastructure and their licence/);
+  });
+});


### PR DESCRIPTION
Groundwork for making recall and duplicate scores interpretable. **No runtime behaviour changes** — everything here is under `testing/`.

## The data never touches this repo

`parse-bench-pairs.mjs` **refuses to read its input from inside the worktree**. The real labelled set is drawn from production records — architecture decisions, alert history, cluster configuration — and this repository is public. The guard is structural rather than a naming convention: a file that cannot be reached from inside the repo cannot be committed from inside it either. Every fixture in the tests is invented.

## It fails loudly rather than measuring a subset

The bench is authored and reviewed as prose, because the *"why this pair is hard"* column is the most valuable part of it and only stays accurate if a human edits it as a document. That trade is safe only while parsing failures are impossible to miss — a parser that silently found three pairs would benchmark three pairs and report a confident number for a different question.

So an unresolvable pair reference, an unknown label, or a pair count that does not match the caller's expectation are all **errors**.

Its own test caught one instance of exactly that failure: a label containing a hyphen did not match the row regex, so the row was **dropped in silence** instead of rejected. The capture is now permissive and the vocabulary check does the rejecting.

## The licence registry, and why it is a gate

`model-candidates.mjs` records **two** things per candidate — the weights licence *and* what is known about training-data provenance — plus the URL the claim was read from and the date, because model cards are edited in place.

**It already blocks one.** The leading multilingual NLI candidate for the equivalence layer ships `License: mit` and is fine-tuned on **XNLI, which is CC BY-NC 4.0**. Ythril ships commercially; reading the card and moving on would have put a non-commercial dependency at the centre of a paid product's duplicate detection.

The gate sits on the *bench* deliberately: a model that gets benchmarked gets compared, and one that compares well gets adopted. The licence question is cheapest at the point of measurement.

### Scope is recorded, not assumed

This covers what Ythril **bundles, defaults to, or recommends**. A model the operator supplies themselves — the assist model, or any endpoint they point a slot at — is their infrastructure and their licence decision, exactly like the database they connect.

That boundary is asserted in both directions: a blocked model is blocked *for shipping*, not for an operator to choose, and adding a default to an operator-supplied slot reads as a change of category rather than a config tweak.

## Also: a flake that #563 exposed

Making preflight run 23 more files surfaced one. `graceful-shutdown-drain` waited on the **client's** `connect` event before calling `close()` — but the server may not have accepted the socket yet, and in that gap `close()` finds nothing to wait for and resolves `'drained'` instead of `'forced'`. Intermittent, and only under the load of a full sequential batch, which is the worst way for a gate to fail.

Now it waits on the server's own `connection` event. **The race is removed rather than a timeout widened around it** — my first attempt raised a ceiling from 2s to 10s, which addressed the wrong assertion.

## Verification

- `npm run preflight` — **PASSED three consecutive times** (the flake needed repetition to trust)
- 21 parser tests against a synthetic fixture, covering CRLF, both heading forms, and all four loud-failure paths
- 40 licence-registry tests, including that the XNLI-trained model stays blocked
- The real file still parses to its expected 40 pairs / 54 texts