### PR TITLE
fix(files): give a converted document a description, and hide the derived trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A converted document had no description, while its extracted images all had captions.** Reported
+  against 2.1.1: after a PDF converts, the original's file-meta carries `convertedFileId`, `chunkCount`
+  and `embeddingStatus` — and no description, with `matchedText` being literally the filename. Every
+  `_extracted/<id>/image-N.jpg` the same document produced got a full generated caption. So the record a
+  human actually browses was findable only by its filename, while its derived children carried summaries.
+  - The mechanism already existed and simply was not applied: `derivedDescription` is written to the
+    parent only when the operator has not written one, and re-embedded so it becomes searchable. Images
+    set it; documents never did — the same "the rule lives one branch over" shape as the audio `partial`
+    status.
+  - The summary is **extractive, not generated**. Partly cost (this would put a model call on every
+    upload, on instances with no VLM configured), but mainly honesty: a generated summary can assert
+    something the document does not say, and a description that misrepresents a record is worse than
+    none, because search matches it and a reader believes it. Taking the document's own opening prose
+    cannot invent anything — at worst it is unhelpful.
+  - Nothing is produced for an empty or scaffolding-only document; a misleading description is worse
+    than a missing one.
+
+- **`_converted/` and `_extracted/` were visible in the file manager tree**, though the guide said
+  derived artifacts are hidden "from the file manager UI and listing endpoints by default". That was only
+  half true: the file-meta listing excludes derived *records*, but the file-store directory listing had
+  no such filter, so the folders sat in the tree. Reported against 2.1.1.
+  - The doc described the intent, so the code now matches it. `?includeDerived=true` restores the old
+    view for anyone inspecting conversions — the same escape hatch `?includeChunks=true` gives on the
+    metadata side, rather than removing the ability outright.
+  - Applied only at the space root, where the pipeline writes them. A directory of your own with the
+    same name deeper in the tree is left alone.
+
 - **The Models screen listed nine of the pipeline's ten model endpoints — third occurrence.** A customer's
   ticket enumerated their endpoints from that page and missed `vlmModel`, because it had no card at all
   (env-only, `DOC_VLM_MODEL`) *and* the Pipelines tab deep-linked its step to the **vision** card, which

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2799,7 +2799,7 @@ When `strategy: "hi_res"` and `extractImages: true`, Ythril creates one extra st
 
 - **`_extracted/{originalId}/image-{N}.{ext}`** — decoded image bytes written to the space file store. `N` is a 0-based index within the document. The extension (`png`, `jpg`, etc.) is derived from the MIME type reported by the sidecar.
   - `parentFileId` is set to the original document's filemeta `_id`.
-  - The record is hidden from the file manager UI and listing endpoints by default (same as chunks and `_converted/` files).
+  - The record is hidden from the file manager UI and listing endpoints by default (same as chunks and `_converted/` files). Two independent filters implement this, and both have an opt-out: derived *records* are excluded from the file-meta listing unless `?includeChunks=true`, and the `_converted/` and `_extracted/` *directories* are excluded from the file-store listing unless `?includeDerived=true`. Only at the space root, where the pipeline writes them — a directory of your own with the same name deeper in the tree is left alone.
   - Immediately enqueued for the media embedding pipeline — the image will be captioned and face-searched automatically.
 
 This means a PDF containing five embedded photographs will produce:

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -348,7 +348,10 @@ fileStoreRouter.get('/:spaceId', globalRateLimit, requireSpaceAuth, async (req, 
         }
       } catch { /* dir may not exist in this member */ }
     }
-    res.json({ path: normalised, type: 'dir', entries: await enrichEntries(memberIds, normalised, allEntries) });
+    res.json({
+      path: normalised, type: 'dir',
+      entries: await enrichEntries(memberIds, normalised, hideDerivedTrees(normalised, allEntries, req)),
+    });
     return;
   }
 
@@ -864,6 +867,37 @@ fileStoreRouter.patch('/:spaceId', globalRateLimit, requireSpaceAuth, denyReadOn
     res.status(500).json({ error: 'Failed to move path' });
   }
 });
+
+/**
+ * The on-disk trees holding derived artifacts, which the file manager should not present as content.
+ *
+ * `_converted/<id>.md` is the converted Markdown for a binary document; `_extracted/<id>/` holds the
+ * images pulled out of one. Both are outputs of the pipeline, keyed by internal record id, and neither
+ * is a thing a person put there.
+ */
+const DERIVED_TREES = new Set(['_converted', '_extracted']);
+
+/**
+ * Hide the derived trees from a directory listing, unless explicitly asked for.
+ *
+ * The integration guide already said these were "hidden from the file manager UI and listing endpoints
+ * by default (same as chunks and `_converted/` files)" — and that was only ever half true. The file-meta
+ * listing does hide derived RECORDS (`parentFileId` exists ⇒ excluded), but the file store's directory
+ * listing had no such filter, so the folders sat in the tree. A customer reported exactly that mismatch.
+ *
+ * The doc described the intent; the code now matches it. `?includeDerived=true` restores the old view
+ * for anyone who was using it to inspect conversions — the same escape hatch `?includeChunks=true`
+ * provides on the metadata side, rather than removing the ability outright.
+ *
+ * Only at the root, because that is where the pipeline writes them; a user directory that happens to be
+ * called `_converted` deeper in the tree is theirs and is left alone.
+ */
+function hideDerivedTrees(dirPath: string, entries: FileEntry[], req: Request): FileEntry[] {
+  if (req.query['includeDerived'] === 'true') return entries;
+  const atRoot = dirPath === '' || dirPath === '/' || dirPath === '.';
+  if (!atRoot) return entries;
+  return entries.filter(e => !(e.type === 'dir' && DERIVED_TREES.has(e.name)));
+}
 
 // Extensions whose content can execute script when rendered inline by a
 // browser — always served as attachments (stored-XSS guard).

--- a/server/src/files/converters/summarise.ts
+++ b/server/src/files/converters/summarise.ts
@@ -1,0 +1,100 @@
+/**
+ * A one-line summary of a converted document, for the record a human actually browses.
+ *
+ * ## Why this exists
+ *
+ * After a PDF converts, its file-meta carries `convertedFileId`, `chunkCount` and `embeddingStatus` —
+ * and no description. Its `matchedText` is literally the filename. Meanwhile every
+ * `_extracted/<id>/image-N.jpg` the same document produced gets a full generated caption from the vision
+ * model. So the parent was findable only by its filename while its derived children carried summaries,
+ * which is precisely backwards: the parent is the thing anyone opens.
+ *
+ * ## Extractive, not generative
+ *
+ * No model call. Two reasons, and the second is the one that matters:
+ *
+ *  - Summarising every document would put a VLM call on the ingest path of every upload, on an instance
+ *    that may have no VLM configured at all.
+ *  - More importantly, a generated summary can be **wrong** — it can assert something the document does
+ *    not say. A description that quietly misrepresents a record is worse than no description, because
+ *    search will match it and a reader will believe it. Taking the document's own opening prose cannot
+ *    invent anything: at worst it is unhelpful.
+ *
+ * So: the first real sentence or two of the document's own text, with the scaffolding removed.
+ */
+
+import type { Chunk } from './types.js';
+
+/** Roughly a card's worth of text — long enough to identify a document, short enough to scan. */
+const MAX_CHARS = 240;
+
+/**
+ * Strip the Markdown that carries no meaning when read as a sentence.
+ *
+ * Deliberately conservative. This is not a Markdown parser and does not try to be — it removes the
+ * decorations that would read as noise in a one-line description and leaves everything else alone,
+ * because mangling the text is worse than leaving a stray character in it.
+ */
+function flatten(md: string): string {
+  return md
+    .replace(/^---[\s\S]*?^---/m, ' ')          // YAML front-matter
+    .replace(/```[\s\S]*?```/g, ' ')            // fenced code
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')         // heading markers (keep the heading TEXT)
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')      // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')    // links → their text
+    .replace(/^\s{0,3}>\s?/gm, '')              // blockquotes
+    .replace(/^\s{0,3}([-*+]|\d+\.)\s+/gm, '')  // list markers
+    .replace(/^\s*\|.*\|\s*$/gm, ' ')           // table rows — cell soup reads as gibberish
+    .replace(/[*_`~]/g, '')                     // inline emphasis / code
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** True for text that would tell a reader nothing — page furniture rather than content. */
+function isNoise(s: string): boolean {
+  // No length floor beyond "not empty". An earlier version dropped anything under 12 characters, which
+  // threw away real headings — "Overview." is the first thing a reader wants and is nine characters.
+  // What actually distinguishes furniture from content is having no letters, or being a page/figure
+  // label; both are checked directly.
+  if (s.length < 3) return true;
+  if (!/[a-zA-Z]/.test(s)) return true;                  // page numbers, rules, symbols
+  if (/^(page|figure|table)\s+\d+\s*\.?$/i.test(s)) return true;
+  return false;
+}
+
+/**
+ * Summarise a converted document.
+ *
+ * Falls back from the whole converted Markdown to the chunk bodies, because the two extraction paths do
+ * not both produce a single document: `md`/`txt` sources are already Markdown and yield `null` there.
+ * Returns undefined when there is nothing worth saying — an empty or noise-only document gets no
+ * description rather than a misleading one.
+ */
+export function summariseMarkdown(md: string | null, chunks: Chunk[] = []): string | undefined {
+  const source = (md && md.trim())
+    ? md
+    : chunks.map(c => [c.headingText, c.content].filter(Boolean).join('. ')).join('\n\n');
+
+  const flat = flatten(source ?? '');
+  if (!flat) return undefined;
+
+  // Sentence-ish split. Keeping the terminator makes the result read as prose rather than as a fragment.
+  const parts = flat.split(/(?<=[.!?])\s+/).map(s => s.trim()).filter(s => !isNoise(s));
+  if (parts.length === 0) return undefined;
+
+  let out = '';
+  for (const p of parts) {
+    if (out && (out.length + 1 + p.length) > MAX_CHARS) break;
+    out = out ? `${out} ${p}` : p;
+    if (out.length >= MAX_CHARS) break;
+  }
+  if (!out) out = parts[0]!;
+
+  if (out.length > MAX_CHARS) {
+    // Cut on a word boundary; a description ending mid-word looks like corruption.
+    const cut = out.slice(0, MAX_CHARS);
+    const lastSpace = cut.lastIndexOf(' ');
+    out = `${(lastSpace > MAX_CHARS * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+  }
+  return out;
+}

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -45,6 +45,7 @@ import { col, asFilter } from '../../db/mongo.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { updateFileMeta, markFileMetaDeleted } from '../file-meta.js';
 import { mimeTypeForPath } from '../mime.js';
+import { summariseMarkdown } from '../converters/summarise.js';
 import {
   runConversionPipeline,
   storeConversionResults,
@@ -371,6 +372,19 @@ async function processJob(
           );
           const metaUpdate: Record<string, unknown> = { chunkCount };
           if (convertedFileId) metaUpdate['convertedFileId'] = convertedFileId;
+          // Give the PARENT record a summary, through the SAME path images already use.
+          //
+          // Reported: after a PDF converts, its filemeta carries `convertedFileId`, `chunkCount` and
+          // `embeddingStatus` — and no description, with `matchedText` being literally the filename.
+          // Meanwhile every `_extracted/.../image-N.jpg` child gets a full generated caption. So the
+          // record a human actually browses was findable only by its filename while its derived
+          // children carried summaries.
+          //
+          // The mechanism was already here: `derivedDescription` is written to the parent below, only
+          // when the operator has not written one, and re-embedded so it is searchable. Images set it;
+          // documents never did. This is the same "the rule exists one branch over" shape as the audio
+          // `partial` status.
+          derivedDescription = summariseMarkdown(convertedMarkdown, chunks);
           await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
             asFilter<FileMetaDoc>({ _id: fileId }),
             { $set: metaUpdate },

--- a/testing/standalone/document-summary.test.js
+++ b/testing/standalone/document-summary.test.js
@@ -1,0 +1,160 @@
+/**
+ * A converted document gets a description, so the record a human browses is findable.
+ *
+ * ## The report
+ *
+ * After a PDF converts, its file-meta carries `convertedFileId`, `chunkCount` and `embeddingStatus` —
+ * and no description, with `matchedText` being literally the filename. Meanwhile every
+ * `_extracted/<id>/image-N.jpg` the same document produced gets a full generated caption from the vision
+ * model. The parent was findable only by filename while its derived children carried summaries, which is
+ * exactly backwards: the parent is the thing anyone opens.
+ *
+ * ## The mechanism already existed
+ *
+ * `derivedDescription` is written to the parent by the worker — only when the operator has not written
+ * one, and re-embedded afterwards so it becomes searchable. Images set it. Documents never did. Same
+ * shape as the audio `partial` status: the rule was implemented one branch over and not applied here.
+ *
+ * ## Extractive on purpose
+ *
+ * No model call. Partly cost — this would put a VLM call on every upload, on instances with no VLM at
+ * all — but mainly honesty: a generated summary can assert something the document does not say, and a
+ * description that misrepresents a record is worse than none, because search matches it and a reader
+ * believes it. Taking the document's own opening prose cannot invent anything.
+ *
+ * Run: node --test testing/standalone/document-summary.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const { summariseMarkdown } = await import('../../server/dist/files/converters/summarise.js');
+const WORKER = readFileSync('server/src/files/media/worker.ts', 'utf8');
+
+const chunk = (headingText, content, chunkIndex = 0) => ({ headingText, content, chunkIndex });
+
+describe('it reads the document, and only the document', () => {
+  it('takes the opening prose', () => {
+    const s = summariseMarkdown('# Quarterly report\n\nRevenue grew by eleven percent this quarter. Costs were flat.');
+    assert.match(s, /Quarterly report/);
+    assert.match(s, /Revenue grew by eleven percent/);
+  });
+
+  it('keeps heading TEXT while dropping the hashes', () => {
+    const s = summariseMarkdown('### Executive summary\n\nThe migration completed without downtime.');
+    assert.match(s, /Executive summary/);
+    assert.doesNotMatch(s, /#/);
+  });
+
+  it('never invents anything — every word is from the source', () => {
+    // The property that makes an extractive summary safe to put in a searchable field.
+    const src = 'The contract renews annually. Termination requires ninety days notice.';
+    const s = summariseMarkdown(src);
+    for (const word of s.replace(/[.…]/g, '').split(/\s+/).filter(Boolean)) {
+      assert.ok(src.includes(word), `"${word}" is not in the source`);
+    }
+  });
+});
+
+describe('scaffolding is removed, content is not', () => {
+  it('drops YAML front-matter', () => {
+    const s = summariseMarkdown('---\ntitle: x\nauthor: y\n---\n\nThe actual opening sentence is here.');
+    assert.match(s, /actual opening sentence/);
+    assert.doesNotMatch(s, /author/);
+  });
+
+  it('drops fenced code, which reads as noise in a one-liner', () => {
+    const s = summariseMarkdown('```js\nconst x = 1;\n```\n\nThis document explains the build process.');
+    assert.match(s, /explains the build process/);
+    assert.doesNotMatch(s, /const x/);
+  });
+
+  it('keeps link text but not the URL', () => {
+    const s = summariseMarkdown('See [the appendix](https://example.test/a) for the full table of results here.');
+    assert.match(s, /the appendix/);
+    assert.doesNotMatch(s, /example\.test/);
+  });
+
+  it('drops table rows rather than emitting cell soup', () => {
+    const s = summariseMarkdown('| a | b |\n| - | - |\n| 1 | 2 |\n\nThe table above lists the measured values.');
+    assert.match(s, /table above lists/);
+    assert.doesNotMatch(s, /\|/);
+  });
+
+  it('drops list markers and emphasis, keeping the words', () => {
+    const s = summariseMarkdown('- **First** item of the introduction\n- _Second_ item of the introduction');
+    assert.doesNotMatch(s, /[*_]/);
+    assert.match(s, /First item/);
+  });
+
+  it('strips image syntax entirely', () => {
+    const s = summariseMarkdown('![a diagram](x.png)\n\nThe diagram shows the request path end to end.');
+    assert.match(s, /diagram shows the request path/);
+    assert.doesNotMatch(s, /x\.png/);
+  });
+});
+
+describe('it refuses to produce a misleading description', () => {
+  it('empty input yields nothing', () => {
+    assert.equal(summariseMarkdown(''), undefined);
+    assert.equal(summariseMarkdown(null), undefined);
+    assert.equal(summariseMarkdown('   \n\n  '), undefined);
+  });
+
+  it('a document of pure scaffolding yields nothing', () => {
+    assert.equal(summariseMarkdown('```\ncode\n```\n\n| a |\n| - |'), undefined);
+  });
+
+  it('page furniture is not a summary', () => {
+    assert.equal(summariseMarkdown('Page 4'), undefined);
+    assert.equal(summariseMarkdown('12345'), undefined);
+  });
+});
+
+describe('it falls back to chunks when there is no converted Markdown', () => {
+  it('md and txt sources yield null Markdown, so chunks are the source', () => {
+    const s = summariseMarkdown(null, [chunk('Overview', 'This note records the outage timeline.')]);
+    assert.match(s, /Overview/);
+    assert.match(s, /outage timeline/);
+  });
+
+  it('prefers the Markdown when both are present', () => {
+    const s = summariseMarkdown('The converted document body is authoritative here.', [chunk(null, 'chunk text')]);
+    assert.match(s, /converted document body/);
+    assert.doesNotMatch(s, /chunk text/);
+  });
+});
+
+describe('length', () => {
+  const long = `${'Sentence number one is reasonably long and descriptive. '.repeat(40)}`;
+
+  it('is bounded', () => {
+    assert.ok(summariseMarkdown(long).length <= 241, summariseMarkdown(long).length);
+  });
+
+  it('never ends mid-word', () => {
+    const s = summariseMarkdown(`${'x'.repeat(50)} ${long}`);
+    assert.doesNotMatch(s, /\w…$/, 'a description cut mid-word looks like corruption');
+  });
+
+  it('a short document is returned whole, with no ellipsis', () => {
+    const s = summariseMarkdown('A short note about the migration.');
+    assert.equal(s, 'A short note about the migration.');
+  });
+});
+
+describe('the worker wires it to the parent record', () => {
+  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const w = strip(WORKER);
+
+  it('the document path sets derivedDescription', () => {
+    assert.match(w, /derivedDescription = summariseMarkdown\(convertedMarkdown, chunks\)/);
+  });
+
+  it('through the SAME writer images use, which respects an operator-set description', () => {
+    // Not a second write path: an operator-written description must outrank a generated one, and that
+    // rule already lives in the existing block.
+    assert.match(w, /if \(!parentMeta\?\.description\?\.trim\(\)\)/);
+    assert.match(w, /updateFileMeta\(spaceId, filePath, \{ description: derivedDescription \}\)/);
+  });
+});


### PR DESCRIPTION
Two reports from the same 2.1.1 batch, both about the file surface.

## 1. The parent record had no description

After a PDF converts, the original's file-meta carries `convertedFileId`, `chunkCount` and `embeddingStatus` — and **no description**, with `matchedText` being literally the filename.

Meanwhile every `_extracted/<id>/image-N.jpg` that same document produced gets a full generated caption from the vision model. So the record a human actually browses was findable only by its filename, while its derived children carried summaries. Exactly backwards.

### The mechanism already existed

`derivedDescription` is written to the parent by the worker — only when the operator has not written one, and re-embedded afterwards so it becomes searchable. **Images set it. Documents never did.** Same "the rule lives one branch over" shape as the audio `partial` status in #561.

### Extractive, not generated — and that is the point

Partly cost: a model call on the ingest path of *every* upload, on instances with no VLM configured at all.

Mainly honesty. A generated summary can assert something the document **does not say**, and a description that misrepresents a record is worse than none — search matches it and a reader believes it. Taking the document's own opening prose cannot invent anything; at worst it is unhelpful. A test asserts every word of the output appears in the source.

Nothing is produced for an empty or scaffolding-only document. A misleading description is worse than a missing one.

> A first pass discarded anything under twelve characters as noise, which threw away real headings — *"Overview."* is the first thing a reader wants and is nine characters. What actually separates furniture from content is having no letters, or being a page/figure label; both are now checked directly.

## 2. `_converted/` and `_extracted/` were visible in the file manager

The guide says derived artifacts are hidden *"from the file manager UI and listing endpoints by default"*. That was **half true**: the file-meta listing excludes derived *records* (`parentFileId` exists ⇒ excluded), but the file-store **directory** listing had no filter at all, so the folders sat in the tree.

The doc described the intent, so the code moves — the same call as #560 and #561.

`?includeDerived=true` restores the old view for anyone inspecting conversions, mirroring the `?includeChunks=true` escape hatch on the metadata side rather than removing the ability outright. Applied **only at the space root**, where the pipeline writes them; a directory of your own with the same name deeper in the tree is left alone.

## Verification

- `npm run preflight` — **PASSED**
- 19 summariser tests: scaffolding removal (front-matter, fenced code, tables, links, lists, images), the refusals (empty / scaffolding-only / page furniture), the chunk fallback for `md`/`txt` sources which yield no converted Markdown, length bounding, never cutting mid-word, and that every word of the output comes from the source