### PR TITLE
feat(security): per-endpoint private-address permission, not one instance-wide flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     their infrastructure and their licence decision, and the boundary is asserted so that adding a
     default to one of those slots reads as a change of category rather than a config tweak.
 
+- **The private-address permission is now per endpoint, not per instance.**
+  `allowPrivateModelEndpointsBySlot` (and `YTHRIL_ALLOW_PRIVATE_<SLOT>` for each of the ten model slots),
+  resolved **per-slot → instance-wide → closed**.
+  - `allowPrivateModelEndpoints` was all-or-nothing, which is the wrong shape for the deployment that
+    prompted this: every model on the operator's own infra except one that genuinely lives on the public
+    internet. Reaching the internal nine required turning the flag on — which also relaxed the guard on
+    the tenth, the single endpoint where a private-address resolution is a red flag rather than a
+    convenience. The flag made the whole estate's posture a function of its least-strict member.
+  - A per-slot value wins **in both directions**, and the second direction is the feature:
+    `{ "assist": false }` under a global `true` keeps the one external endpoint strict. A design where
+    per-slot could only widen would not have addressed the report at all.
+  - **Save time and probe time resolve the same permission the inference client will.** Previously all
+    three read one global answer; per-slot, disagreeing would mean a green Test Connection on a call that
+    is then refused, or the reverse. `probeModelEndpoint` now takes a **required** `slot` — a default
+    would have it report a verdict computed under some other endpoint's policy — and `endpointId` folds
+    the resolved permission into the grouping key, so two stages that share a base URL but not a policy
+    are probed separately instead of one answering for the other.
+  - **No setting here reaches the crown jewels.** Loopback, link-local / cloud IMDS and the unspecified
+    address stay blocked for every slot at both admission points, including via DNS rebinding. Tested
+    with every slot permission simultaneously on.
+  - **Env/config only**, like the flag it refines: an endpoint that becomes an egress target must not be
+    widenable from the admin API, and a test asserts the key never appears in the config route.
+  - Rejection messages name the exact knob for the slot that was refused — and say nothing when that slot
+    *already* permits private addresses, because then the refusal was a crown jewel and no setting lifts
+    it. Telling an operator to enable a flag that is already on is how a support round-trip starts.
+  - The security posture now reports **per endpoint**: `egress.privateModelEndpoints` (the permission is
+    actually in use), `egress.unreachableModelEndpoints` (configured privately with no permission for its
+    slot — cannot work, and fails at inference rather than at save) and `egress.perSlotOverrides` (slots
+    departing from the instance-wide flag, so the endpoint deliberately kept strict is visible rather
+    than implied). All three can appear at once; the old if/else on one boolean could only ever show one.
+  - The exposure enumeration went from **four endpoints to all ten** — the reranker, contradiction judge,
+    external face model and three document stages were admin-configurable egress targets the posture
+    never mentioned. A check that enumerates a subset reports "nothing else is exposed" by omission.
+
 ### Fixed
 
 - **A converted document had no description, while its extracted images all had captions.** Reported

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -2740,8 +2740,52 @@ see the egress table above. You can optionally point a **bigger, external model*
 > one, which is the DNS-rebinding case. A declared-private `external` endpoint is therefore more tightly
 > guarded than a `local` provider, which uses a plain `fetch`.
 >
-> The instance reports this in its startup security posture and at `GET /api/about/security`
-> (`egress.privateModelEndpoints`).
+> **Per endpoint, when one model is genuinely external.** The instance-wide flag is all-or-nothing, which
+> is the wrong shape for the common deployment: every model on your own infra except one that really does
+> live on the public internet. Turning the flag on to reach the internal ones also relaxes the guard on
+> that one external endpoint — the single place where a private-address resolution means something is
+> wrong rather than "this is my cluster". So each endpoint carries its own setting:
+>
+> ```json
+> {
+>   "allowPrivateModelEndpoints": true,
+>   "allowPrivateModelEndpointsBySlot": { "assist": false }
+> }
+> ```
+>
+> **Precedence is per-slot → instance-wide → closed**, and a per-slot value wins **in both directions**.
+> The `false` above is the point of the example: nine endpoints reach the cluster, and the assist model —
+> the one path that sends document content off the instance — stays strict. Slots you leave out inherit
+> the instance-wide flag; with neither set, private addresses are refused.
+>
+> | Slot | What it governs | Env var |
+> | --- | --- | --- |
+> | `vision` | Image captioning provider | `YTHRIL_ALLOW_PRIVATE_VISION` |
+> | `stt` | Speech-to-text provider | `YTHRIL_ALLOW_PRIVATE_STT` |
+> | `embedding` | Text embedding endpoint | `YTHRIL_ALLOW_PRIVATE_EMBEDDING` |
+> | `rerank` | Cross-encoder reranker | `YTHRIL_ALLOW_PRIVATE_RERANK` |
+> | `nli` | Contradiction judge | `YTHRIL_ALLOW_PRIVATE_NLI` |
+> | `docVlm` | Document page transcription | `YTHRIL_ALLOW_PRIVATE_DOC_VLM` |
+> | `docRepair` | Document repair pass (local model) | `YTHRIL_ALLOW_PRIVATE_DOC_REPAIR` |
+> | `docVerify` | Document verify pass | `YTHRIL_ALLOW_PRIVATE_DOC_VERIFY` |
+> | `assist` | External assist model (F11-b) | `YTHRIL_ALLOW_PRIVATE_ASSIST` |
+> | `faceExternal` | External face recogniser | `YTHRIL_ALLOW_PRIVATE_FACE_EXTERNAL` |
+>
+> The env vars accept `true` **or** `false` — unlike the instance-wide one, a `false` here is meaningful,
+> because it is how you pin one endpoint strict from the Deployment. Anything other than those two exact
+> strings is not a setting and defers to the instance-wide flag. Like the instance-wide flag, none of these
+> is settable through the admin API.
+>
+> No per-slot setting reaches the crown jewels: loopback, link-local / cloud metadata and the unspecified
+> address stay blocked for every slot, at both save time and resolution time.
+>
+> The instance reports this in its startup security posture and at `GET /api/about/security`:
+> `egress.privateModelEndpoints` (endpoints the permission is actually being used for),
+> `egress.unreachableModelEndpoints` (endpoints configured privately with **no** permission for their slot
+> — these cannot work, and fail silently at inference rather than at save), and
+> `egress.perSlotOverrides` (slots whose setting departs from the instance-wide flag, so the one endpoint
+> you deliberately kept strict is visible rather than implied). All three can appear at once, which is
+> exactly what a mixed estate looks like.
 >
 > **Reading that posture line when your endpoints are DNS names.** The check is synchronous and does
 > **not** resolve DNS — resolving at boot would make the posture block hang on a slow resolver. An

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -626,9 +626,9 @@ rather than just saying it failed. Two cases account for almost all of them:
   is on a private network address. Ythril refuses those by default, because an admin-settable URL that
   the server will call is the classic way to make a server fetch things it should not. If the endpoint is
   a model server you run yourself, that refusal is wrong for your case and an administrator can permit it
-  with `allowPrivateModelEndpoints` — see
-  [Diagnosing a Misconfiguration](integration-guide.md#diagnosing-a-misconfiguration). It cannot be
-  enabled from this page, on purpose.
+  — for that one endpoint alone, or instance-wide — see
+  [Diagnosing a Misconfiguration](integration-guide.md#diagnosing-a-misconfiguration). The message names
+  the exact setting for the endpoint you were testing. It cannot be enabled from this page, on purpose.
 - **"Blocked SSRF target … 169.254.x" or a loopback address** — these stay blocked whatever the setting.
   Point the endpoint at a real service address.
 

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -16,7 +16,9 @@ import type { MediaLevelCeilings } from '../config/types.js';
 import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl, ssrfSafeFetch } from '../util/ssrf.js';
-import { allowPrivateModelEndpoints, isLocalModelEndpoint } from '../config/model-egress-policy.js';
+import {
+  allowPrivateForSlot, isLocalModelEndpoint, privateAddressHint, type EgressSlot,
+} from '../config/model-egress-policy.js';
 import { listUrlFor, type VlmWire } from '../files/converters/vlm-endpoint.js';
 import { log } from '../util/log.js';
 import { providerSignature, getActiveProviderSignature } from '../files/media/worker.js';
@@ -231,26 +233,27 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
   // Local providers are trusted (cluster DNS — `*.svc.cluster.local`, addressed
   // via NetworkPolicy). External providers are admin-typed URLs that must
   // resolve to a public endpoint, never to private networks or cloud metadata.
-  // Instance-wide opt-in for self-hosted endpoints on private addresses (env/config only — never a
-  // field on this PATCH, so the admin API cannot widen its own egress).
-  const allowPrivate = allowPrivateModelEndpoints();
+  // Opt-in for self-hosted endpoints on private addresses (env/config only — never a field on this PATCH,
+  // so the admin API cannot widen its own egress). Resolved PER SLOT: the save-time check has to agree with
+  // what the runtime client will actually be allowed to do, or one of the two is lying. A single instance-
+  // wide answer here would accept a private URL for the one endpoint the operator deliberately kept strict.
   const effectiveVisionType = parsed.data.visionProvider ?? activeCfg.visionProvider ?? 'local';
   const effectiveSttType    = parsed.data.sttProvider    ?? activeCfg.sttProvider    ?? 'local';
   if (effectiveVisionType === 'external' && parsed.data.vision?.baseUrl
-      && !isSsrfSafeUrl(parsed.data.vision.baseUrl, allowPrivate)) {
-    res.status(400).json({ error: 'vision.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
+      && !isSsrfSafeUrl(parsed.data.vision.baseUrl, allowPrivateForSlot('vision'))) {
+    res.status(400).json({ error: 'vision.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('vision') });
     return;
   }
   if (effectiveSttType === 'external' && parsed.data.stt?.baseUrl
-      && !isSsrfSafeUrl(parsed.data.stt.baseUrl, allowPrivate)) {
-    res.status(400).json({ error: 'stt.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
+      && !isSsrfSafeUrl(parsed.data.stt.baseUrl, allowPrivateForSlot('stt'))) {
+    res.status(400).json({ error: 'stt.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('stt') });
     return;
   }
   // Text-embedding external endpoint — same SSRF rule (only when the effective provider is external).
   const effectiveEmbType = parsed.data.embedding?.provider ?? getEmbeddingConfig().provider ?? 'local';
   if (effectiveEmbType === 'external' && parsed.data.embedding?.baseUrl
-      && !isSsrfSafeUrl(parsed.data.embedding.baseUrl, allowPrivate)) {
-    res.status(400).json({ error: 'embedding.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
+      && !isSsrfSafeUrl(parsed.data.embedding.baseUrl, allowPrivateForSlot('embedding'))) {
+    res.status(400).json({ error: 'embedding.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('embedding') });
     return;
   }
 
@@ -265,8 +268,8 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     return;
   }
   if (rerankPatch?.baseUrl && !isLocalModelEndpoint(rerankPatch.baseUrl)
-      && !isSsrfSafeUrl(rerankPatch.baseUrl, allowPrivate)) {
-    res.status(400).json({ error: 'rerank.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
+      && !isSsrfSafeUrl(rerankPatch.baseUrl, allowPrivateForSlot('rerank'))) {
+    res.status(400).json({ error: 'rerank.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('rerank') });
     return;
   }
 
@@ -278,8 +281,8 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     return;
   }
   if (nliPatch?.baseUrl && !isLocalModelEndpoint(nliPatch.baseUrl)
-      && !isSsrfSafeUrl(nliPatch.baseUrl, allowPrivate)) {
-    res.status(400).json({ error: 'nli.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + (allowPrivate ? '' : ' (set allowPrivateModelEndpoints / YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true to permit a self-hosted endpoint on a private address)') });
+      && !isSsrfSafeUrl(nliPatch.baseUrl, allowPrivateForSlot('nli'))) {
+    res.status(400).json({ error: 'nli.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('nli') });
     return;
   }
 
@@ -303,8 +306,8 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     const effBaseUrl = facePatch?.baseUrl ?? existingFace.baseUrl;
     const effAck = facePatch?.acknowledgedHost ?? existingFace.acknowledgedHost;
     if (effBaseUrl) {
-      if (!isSsrfSafeUrl(effBaseUrl, allowPrivate)) {
-        res.status(400).json({ error: 'faceRecognition.externalModel.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+      if (!isSsrfSafeUrl(effBaseUrl, allowPrivateForSlot('faceExternal'))) {
+        res.status(400).json({ error: 'faceRecognition.externalModel.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('faceExternal') });
         return;
       }
       let host: string;
@@ -343,8 +346,8 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     const effMode = parsed.data.documentProcessing?.mode ?? activeCfg.documentProcessing?.mode ?? 'vlm';
     const repairReachable = effMode === 'repair' || effMode === 'auto';
     if (repairReachable && effBaseUrl) {
-      if (!isSsrfSafeUrl(effBaseUrl, allowPrivate)) {
-        res.status(400).json({ error: 'assistModel.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' });
+      if (!isSsrfSafeUrl(effBaseUrl, allowPrivateForSlot('assist'))) {
+        res.status(400).json({ error: 'assistModel.baseUrl rejected: must be a public http(s) URL (no private/loopback/metadata addresses)' + privateAddressHint('assist') });
         return;
       }
       let host: string;
@@ -572,13 +575,15 @@ mediaConfigRouter.post('/test-connection', requireAdminMfa, async (req, res) => 
     res.status(400).json({ error: `No endpoint is configured for ${target}. Save one first, then test.` });
     return;
   }
-  // External endpoints must be public — refuse to probe private/loopback/metadata addresses.
-  if (external && !isSsrfSafeUrl(baseUrl, allowPrivateModelEndpoints())) {
-    res.status(400).json({ error: `The ${target} endpoint is not a public http(s) URL (SSRF-blocked).` });
+  // External endpoints must be public — refuse to probe private/loopback/metadata addresses. Resolved for
+  // THIS target: the probe must agree with what inference will actually be allowed to do, or an operator
+  // who allowed a private address for one slot gets a green test on a call that would then be refused.
+  if (external && !isSsrfSafeUrl(baseUrl, allowPrivateForSlot(target))) {
+    res.status(400).json({ error: `The ${target} endpoint is not a public http(s) URL (SSRF-blocked).${privateAddressHint(target)}` });
     return;
   }
 
-  const result = await probeModelEndpoint({ baseUrl, model, apiKey, external })
+  const result = await probeModelEndpoint({ baseUrl, model, apiKey, external, slot: target })
     .catch(err => ({ ok: false, reachable: false, detail: err instanceof Error ? err.message : String(err), latencyMs: 0 }));
   res.json({ target, external, model: model ?? null, ...result });
 });
@@ -679,7 +684,7 @@ interface ProbeResult {
  * Exported for unit testing.
  */
 export async function probeModelEndpoint(
-  opts: { baseUrl: string; model?: string; apiKey?: string; external: boolean; wire?: VlmWire },
+  opts: { baseUrl: string; model?: string; apiKey?: string; external: boolean; wire?: VlmWire; slot: EgressSlot },
 ): Promise<ProbeResult> {
   const started = Date.now();
   const base = opts.baseUrl.replace(/\/$/, '');
@@ -693,7 +698,7 @@ export async function probeModelEndpoint(
   // their endpoint works, so the bug reported the configuration as broken while inference would have run.
   const doFetch = opts.external
     ? (url: string, init: RequestInit) =>
-        ssrfSafeFetch(url, init, { allowPrivate: allowPrivateModelEndpoints() })
+        ssrfSafeFetch(url, init, { allowPrivate: allowPrivateForSlot(opts.slot) })
     : (url: string, init: RequestInit) => fetch(url, init);
 
   const parseOpenAi = (j: unknown): string[] =>

--- a/server/src/api/pipeline-status.ts
+++ b/server/src/api/pipeline-status.ts
@@ -29,7 +29,9 @@ import { getConfig, getMediaEmbeddingConfig, getEmbeddingConfig, getEmbeddingApi
 import { requireAdmin } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { isSsrfSafeUrl } from '../util/ssrf.js';
-import { allowPrivateModelEndpoints, isLocalModelEndpoint } from '../config/model-egress-policy.js';
+import {
+  allowPrivateForSlot, EGRESS_SLOTS, isLocalModelEndpoint, type EgressSlot,
+} from '../config/model-egress-policy.js';
 import { probeModelEndpoint } from './media-config.js';
 import { resolveVlmEndpoint, type VlmWire } from '../files/converters/vlm-endpoint.js';
 import { getDb } from '../db/mongo.js';
@@ -232,9 +234,28 @@ export function hostOf(url: string | undefined): string | null {
   try { return new URL(url).host; } catch { return url; }
 }
 
-/** The key identifying one endpoint+credential pair. Stages sharing it share a single probe. */
+/**
+ * The egress slot a stage's calls belong to — what decides whether that endpoint may resolve privately.
+ *
+ * The document stages spell their keys `doc-vlm`/`doc-repair`/`doc-verify` (built as `doc-${slot}`), so
+ * this is the one place the kebab key and the camelCase policy slot are reconciled.
+ */
+export function slotForStage(key: string): EgressSlot {
+  const camel = key.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+  return (EGRESS_SLOTS as readonly string[]).includes(camel) ? camel as EgressSlot : 'assist';
+}
+
+/**
+ * The key identifying one endpoint+credential pair. Stages sharing it share a single probe.
+ *
+ * The resolved egress permission is part of the identity, not an afterthought. Two stages can point at the
+ * same base URL and still disagree about whether it may resolve to a private address — that is precisely
+ * the per-slot setting doing its job — and collapsing them into one probe would report the strict stage's
+ * verdict using the permissive stage's policy (or the reverse). Identical policy, which is the normal case,
+ * still yields one probe.
+ */
 export function endpointId(s: StageSpec): string {
-  return `${s.baseUrl} ${s.external} ${s.apiKey ?? ''}`;
+  return `${s.baseUrl} ${s.external} ${s.apiKey ?? ''} ${allowPrivateForSlot(slotForStage(s.key))}`;
 }
 
 /**
@@ -319,7 +340,9 @@ async function probeModelStages(): Promise<ModelStageStatus[]> {
   const results = new Map<string, ProbeOutcome>();
   await Promise.all([...byEndpoint.entries()].map(async ([id, group]) => {
     const { baseUrl, external, apiKey } = group[0];
-    if (external && !isSsrfSafeUrl(baseUrl!, allowPrivateModelEndpoints())) {
+    // Every stage in the group resolved to the same permission — it is part of `endpointId`.
+    const slot = slotForStage(group[0].key);
+    if (external && !isSsrfSafeUrl(baseUrl!, allowPrivateForSlot(slot))) {
       results.set(id, { blocked: true });
       return;
     }
@@ -329,7 +352,7 @@ async function probeModelStages(): Promise<ModelStageStatus[]> {
     // `wire` is what makes the probe agree with inference. Without it every endpoint was tried as
     // `/v1/models` first, which is right for four targets and wrong for the one whose base already
     // carries `/v1` — producing `/v1/v1/models` and a red dot over a working vision pipeline.
-    const res = await probeModelEndpoint({ baseUrl: baseUrl!, apiKey, external, wire: group[0].wire })
+    const res = await probeModelEndpoint({ baseUrl: baseUrl!, apiKey, external, wire: group[0].wire, slot })
       .catch(err => ({ reachable: false, detail: err instanceof Error ? err.message : String(err), latencyMs: 0 }));
     results.set(id, res);
   }));

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { getDataRoot, getEmbeddingConfig } from '../config/loader.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
-import { allowPrivateModelEndpoints } from '../config/model-egress-policy.js';
+import { allowPrivateForSlot } from '../config/model-egress-policy.js';
 import { log } from '../util/log.js';
 import { embeddingDurationSeconds, embeddingQueueDepth } from '../metrics/registry.js';
 
@@ -97,12 +97,13 @@ async function embedViaHttp(
   // External endpoints go through the SSRF-guarded fetch (DNS-resolve + IP-pin + redirect re-validation);
   // a local/trusted endpoint (e.g. on-cluster Ollama, private address) uses a plain fetch, which the guard
   // would rightly reject. Mirrors the vision/STT provider split (SSRF follow-up part 2).
-  // External → SSRF-guarded. `allowPrivateModelEndpoints` lets a self-hosted OpenAI-compatible
+  // External → SSRF-guarded. `allowPrivateForSlot('embedding')` lets a self-hosted OpenAI-compatible
   // embedding server live on a cluster address without dropping the guard: DNS-pinning and redirect
-  // re-validation still apply, only the private-address rejection lifts.
+  // re-validation still apply, only the private-address rejection lifts. Per-slot, so an operator whose
+  // embedder is on-cluster but whose assist model is a public vendor does not have to relax both.
   const doFetch = cfg.provider === 'external'
     ? (((url: string, init?: RequestInit) =>
-        ssrfSafeFetch(url, init ?? {}, { allowPrivate: allowPrivateModelEndpoints() })) as unknown as typeof fetch)
+        ssrfSafeFetch(url, init ?? {}, { allowPrivate: allowPrivateForSlot('embedding') })) as unknown as typeof fetch)
     : fetch;
   let response: Response;
   try {

--- a/server/src/brain/nli-client.ts
+++ b/server/src/brain/nli-client.ts
@@ -16,7 +16,7 @@
  * attacker-supplied endpoint cannot be used to reach cluster-internal services.
  */
 import { getMediaEmbeddingConfig } from '../config/loader.js';
-import { allowPrivateModelEndpoints, isLocalModelEndpoint as isLocalEndpoint } from '../config/model-egress-policy.js';
+import { allowPrivateForSlot, isLocalModelEndpoint as isLocalEndpoint } from '../config/model-egress-policy.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
 
@@ -98,7 +98,7 @@ export async function classify(premise: string, hypothesis: string): Promise<Nli
   try {
     const res = isLocalEndpoint(nli.baseUrl)
       ? await fetch(url, init)
-      : await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateModelEndpoints() });
+      : await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateForSlot('nli') });
     if (!res.ok) {
       log.warn(`NLI classify: ${res.status} from the judge endpoint — treating as no verdict`);
       return null;

--- a/server/src/brain/rerank-client.ts
+++ b/server/src/brain/rerank-client.ts
@@ -18,7 +18,7 @@
  * vector order. A reranker that is down must degrade search quality, never break search.
  */
 import { getMediaEmbeddingConfig } from '../config/loader.js';
-import { allowPrivateModelEndpoints, isLocalModelEndpoint } from '../config/model-egress-policy.js';
+import { allowPrivateForSlot, isLocalModelEndpoint } from '../config/model-egress-policy.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
 
@@ -158,7 +158,7 @@ export async function rerank(
   try {
     const res = isLocalModelEndpoint(cfg.baseUrl)
       ? await fetch(url, init)
-      : await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateModelEndpoints() });
+      : await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateForSlot('rerank') });
     if (!res.ok) {
       log.warn(`Rerank: HTTP ${res.status} from the reranker — keeping the vector order`);
       return null;

--- a/server/src/config/model-egress-exposure.ts
+++ b/server/src/config/model-egress-exposure.ts
@@ -13,6 +13,8 @@
  */
 import { getConfig, getMediaEmbeddingConfig, getEmbeddingConfig } from './loader.js';
 import { isSsrfSafeUrl } from '../util/ssrf.js';
+import { allowPrivateForSlot, isLocalModelEndpoint, type EgressSlot } from './model-egress-policy.js';
+import { resolveVlmEndpoint } from '../files/converters/vlm-endpoint.js';
 
 export type EndpointClass = 'public' | 'private' | 'hostname' | 'invalid';
 
@@ -22,6 +24,10 @@ export interface EndpointExposure {
   /** Host as configured (never the full URL — a query string could carry a key). */
   host: string;
   klass: EndpointClass;
+  /** The policy slot deciding whether THIS endpoint may resolve privately. */
+  slot: EgressSlot;
+  /** What that slot resolved to — per-slot setting if present, else the instance-wide flag. */
+  allowsPrivate: boolean;
 }
 
 /**
@@ -52,28 +58,56 @@ export function classifyEndpoint(raw: string): { host: string; klass: EndpointCl
   return { host, klass: 'invalid' };                               // blocked either way — crown jewel
 }
 
-/** Every EXTERNAL provider endpoint currently configured, with its classification. */
+/**
+ * Every EXTERNAL provider endpoint currently configured, with its classification and its own permission.
+ *
+ * Covers **all ten** egress slots, not the four this once listed. The omissions were not cosmetic: the
+ * reranker, the contradiction judge, the external face model and the three document stages are all
+ * admin-configurable egress targets, and one of them (the document VLM) turned out to be egressing with no
+ * guard at all. A posture check that enumerates a subset reports "nothing else is exposed" by omission —
+ * the same absence-as-evidence mistake the classifier below refuses to make about hostnames.
+ */
 export function modelEndpointExposure(): EndpointExposure[] {
   const out: EndpointExposure[] = [];
-  const add = (provider: string, url: string | undefined | null) => {
+  const add = (provider: string, slot: EgressSlot, url: string | undefined | null) => {
     if (!url) return;
-    out.push({ provider, ...classifyEndpoint(url) });
+    out.push({ provider, slot, allowsPrivate: allowPrivateForSlot(slot), ...classifyEndpoint(url) });
   };
 
   try {
     const media = getMediaEmbeddingConfig();
-    if (media.visionProvider === 'external') add('vision', media.vision?.baseUrl);
-    if (media.sttProvider === 'external') add('stt', media.stt?.baseUrl);
+    if (media.visionProvider === 'external') add('vision', 'vision', media.vision?.baseUrl);
+    if (media.sttProvider === 'external') add('stt', 'stt', media.stt?.baseUrl);
+    // No provider switch for these two — a reranker or judge is either the bundled sidecar or it is egress,
+    // and the LOCAL-endpoint predicate is what the clients themselves branch on.
+    if (media.rerank?.baseUrl && !isLocalModelEndpoint(media.rerank.baseUrl)) add('rerank', 'rerank', media.rerank.baseUrl);
+    if (media.nli?.baseUrl && !isLocalModelEndpoint(media.nli.baseUrl)) add('contradictionJudge', 'nli', media.nli.baseUrl);
+    // Biometric egress: face crops. External whenever configured at all.
+    add('faceModel', 'faceExternal', media.faceRecognition?.externalModel?.baseUrl);
   } catch { /* pre-setup */ }
 
   try {
     const emb = getEmbeddingConfig();
-    if (emb.provider === 'external') add('embedding', emb.baseUrl);
+    if (emb.provider === 'external') add('embedding', 'embedding', emb.baseUrl);
+  } catch { /* pre-setup */ }
+
+  try {
+    // The document stages resolve exactly as the extractor does, including the fall back to the vision
+    // endpoint when no document base URL is set — which is how page images reached an off-instance host
+    // that nothing on this list mentioned.
+    for (const [docSlot, provider, slot] of [
+      ['vlm', 'documentVlm', 'docVlm'],
+      ['repair', 'documentRepair', 'docRepair'],
+      ['verify', 'documentVerify', 'docVerify'],
+    ] as const) {
+      const e = resolveVlmEndpoint(docSlot);
+      if (e.external) add(provider, slot, e.baseUrl);
+    }
   } catch { /* pre-setup */ }
 
   try {
     // The assist model is external by definition (F11-b) — no provider switch to check.
-    add('documentAssist', getConfig().mediaEmbedding?.documentProcessing?.assistModel?.baseUrl);
+    add('documentAssist', 'assist', getConfig().mediaEmbedding?.documentProcessing?.assistModel?.baseUrl);
   } catch { /* pre-setup */ }
 
   return out;

--- a/server/src/config/model-egress-policy.ts
+++ b/server/src/config/model-egress-policy.ts
@@ -31,6 +31,96 @@ export function allowPrivateModelEndpoints(): boolean {
 }
 
 /**
+ * The model slots that can become egress targets, each settable on its own.
+ *
+ * Keyed by slot rather than by URL, because the same host can legitimately hold several of them and the
+ * question "may THIS endpoint reach a private address" is per-endpoint.
+ */
+export const EGRESS_SLOTS = [
+  'vision', 'stt', 'embedding', 'rerank', 'nli',
+  'assist', 'docVlm', 'docRepair', 'docVerify', 'faceExternal',
+] as const;
+export type EgressSlot = (typeof EGRESS_SLOTS)[number];
+
+/**
+ * The env var pinning each slot. Written out rather than derived from the slot name.
+ *
+ * Deriving it (`YTHRIL_ALLOW_PRIVATE_${snake(slot)}`) is shorter and worse: the names then exist nowhere
+ * in the source, so `grep YTHRIL_ALLOW_PRIVATE_DOC_VLM` finds nothing, and the doc-coverage gate — which
+ * looks for exactly that — cannot tell a documented setting from a phantom one. Ten literals is the price
+ * of a setting an operator can actually search for.
+ */
+export const SLOT_ENV_VARS = {
+  vision: 'YTHRIL_ALLOW_PRIVATE_VISION',
+  stt: 'YTHRIL_ALLOW_PRIVATE_STT',
+  embedding: 'YTHRIL_ALLOW_PRIVATE_EMBEDDING',
+  rerank: 'YTHRIL_ALLOW_PRIVATE_RERANK',
+  nli: 'YTHRIL_ALLOW_PRIVATE_NLI',
+  assist: 'YTHRIL_ALLOW_PRIVATE_ASSIST',
+  docVlm: 'YTHRIL_ALLOW_PRIVATE_DOC_VLM',
+  docRepair: 'YTHRIL_ALLOW_PRIVATE_DOC_REPAIR',
+  docVerify: 'YTHRIL_ALLOW_PRIVATE_DOC_VERIFY',
+  faceExternal: 'YTHRIL_ALLOW_PRIVATE_FACE_EXTERNAL',
+} as const satisfies Record<EgressSlot, string>;
+
+/** The env var pinning one slot's permission. */
+export function slotEnvVar(slot: EgressSlot): string {
+  return SLOT_ENV_VARS[slot];
+}
+
+/**
+ * The "here is how to allow this" tail for a rejected private URL — empty when the slot ALREADY allows
+ * private addresses, because then the rejection is a crown-jewel one and no setting will lift it. Telling
+ * an operator to enable a flag that is already on is how a support round-trip starts.
+ *
+ * Exported next to the resolver on purpose: the message names the exact knob the resolver reads, and the
+ * two drifting apart is what turns a correct guard into an unactionable error.
+ */
+export function privateAddressHint(slot: EgressSlot): string {
+  if (allowPrivateForSlot(slot)) return '';
+  return ` (set allowPrivateModelEndpointsBySlot.${slot}, ${slotEnvVar(slot)}=true, or the instance-wide`
+    + ' allowPrivateModelEndpoints, to permit a self-hosted endpoint on a private address — loopback and'
+    + ' cloud-metadata addresses stay blocked regardless)';
+}
+
+/**
+ * May THIS endpoint resolve to a private address?
+ *
+ * Per-slot **overrides** the global flag in both directions, which is the whole point. The global
+ * `allowPrivateModelEndpoints` is all-or-nothing, so an operator running everything on their own infra
+ * except one genuinely external model had to enable it globally — loosening the guard on precisely the
+ * endpoint where a private-address resolution is a red flag rather than a convenience. Per-slot is
+ * least-privilege: `YTHRIL_ALLOW_PRIVATE_ASSIST=false` keeps that one strict while the internal ones stay
+ * reachable.
+ *
+ * Precedence: **per-slot (if set, wins) → global → closed.** A per-slot `false` beating a global `true`
+ * is not an edge case; it is the case this exists for.
+ *
+ * Env or config, never the admin API — same reason the global flag is read here rather than passed
+ * through media-config: a field that turns into an egress target must not be widenable from the admin
+ * surface. And no setting here reaches the crown-jewel ranges: loopback, link-local / cloud metadata and
+ * the unspecified address stay blocked in `ssrfSafeFetch` whatever this returns.
+ */
+export function allowPrivateForSlot(slot: EgressSlot): boolean {
+  const env = process.env[SLOT_ENV_VARS[slot]];
+  if (env === 'true') return true;
+  if (env === 'false') return false;
+  try {
+    const perSlot = getConfig().allowPrivateModelEndpointsBySlot?.[slot];
+    if (typeof perSlot === 'boolean') return perSlot;
+  } catch { /* config not loaded yet — fall through to the global, which is closed by default */ }
+  return allowPrivateModelEndpoints();
+}
+
+/** Slots whose setting differs from the global flag — what the posture must report instead of one boolean. */
+export function egressSlotOverrides(): Array<{ slot: EgressSlot; allowPrivate: boolean }> {
+  const globalAllows = allowPrivateModelEndpoints();
+  return EGRESS_SLOTS
+    .map(slot => ({ slot, allowPrivate: allowPrivateForSlot(slot) }))
+    .filter(s => s.allowPrivate !== globalAllows);
+}
+
+/**
  * True for a bundled/sidecar endpoint — loopback or a bare hostname with no dot, i.e. a compose or
  * cluster service name. Those get a plain `fetch`; anything else is egress and goes through
  * `ssrfSafeFetch`.

--- a/server/src/config/security-posture.ts
+++ b/server/src/config/security-posture.ts
@@ -9,7 +9,7 @@
  */
 import { getConfig, getMongoUri, atRestEncryptionActive } from './loader.js';
 import { requireEncryptedTransport, allowInsecurePeersRaw } from './transport-security.js';
-import { allowPrivateModelEndpoints } from './model-egress-policy.js';
+import { allowPrivateModelEndpoints, egressSlotOverrides } from './model-egress-policy.js';
 import { allowPrivateOidcIssuer } from './oidc-egress-policy.js';
 import { modelEndpointExposure, formatExposure, classifyEndpoint } from './model-egress-exposure.js';
 import { publicBaseUrlIsFallback } from './public-url.js';
@@ -112,30 +112,61 @@ export function computeSecurityPosture(): SecurityPosture {
   // set; "vision → 10.1.2.3 (private)" tells them what it actually reaches, which is the thing that
   // makes this check load-bearing. A hostname is named as a hostname — only the resolution-time guard
   // knows where it points, and claiming otherwise here would be a guess.
-  if (allowPrivateModelEndpoints()) {
+  //
+  // Split PER ENDPOINT rather than by the instance-wide flag, because the two conditions below are no
+  // longer mutually exclusive. Once each slot carries its own permission, the intended deployment — every
+  // model on the operator's own infra except one that is genuinely on the public internet — has widened
+  // endpoints and strict endpoints at the same time. An if/else on one global boolean would report only
+  // whichever branch the flag happened to select and stay silent about the other half of the estate.
+  {
     const exposure = modelEndpointExposure();
-    const privateOnes = exposure.filter(e => e.klass === 'private');
-    const unresolved = exposure.filter(e => e.klass === 'hostname');
-    checks.push(exposure.length === 0
-      ? {
-          id: 'egress.privateModelEndpoints',
-          level: 'warn',
-          message: 'allowPrivateModelEndpoints is on but no external model/media endpoint is configured — nothing is using the permission.',
-        }
-      : {
-          id: 'egress.privateModelEndpoints',
-          level: 'warn',
-          message: `allowPrivateModelEndpoints is on. ${formatExposure(exposure)}. ${exposureCount(privateOnes.length, unresolved.length, exposure.length)} SSRF guarding, IP-pinning and redirect re-validation still apply; loopback, link-local/IMDS and cloud-metadata addresses stay blocked.`,
-        });
-  } else {
-    // Flag off, but an endpoint may still be pointed at a private literal — that config cannot work, and
-    // silently failing at inference is exactly what the reporter hit. Say so.
-    const stuck = modelEndpointExposure().filter(e => e.klass === 'private' || e.klass === 'invalid');
-    if (stuck.length > 0) {
+    // Endpoints the permission is actually doing something for: a private literal, or a hostname that
+    // might resolve to one. A public endpoint under a widened slot is not using the permission.
+    const widened = exposure.filter(e => e.allowsPrivate && (e.klass === 'private' || e.klass === 'hostname'));
+    // Endpoints configured privately with NO permission for their slot. These cannot work: the call is
+    // refused at request time, which surfaces as a model that is "configured" and silently never answers.
+    const stuck = exposure.filter(e => !e.allowsPrivate && (e.klass === 'private' || e.klass === 'invalid'));
+
+    if (widened.length > 0) {
+      const privateOnes = widened.filter(e => e.klass === 'private');
+      const unresolved = widened.filter(e => e.klass === 'hostname');
       checks.push({
         id: 'egress.privateModelEndpoints',
         level: 'warn',
-        message: `External model endpoint(s) point at addresses this instance will refuse to call: ${formatExposure(stuck)}. Set allowPrivateModelEndpoints (or YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS=true) for a self-hosted endpoint on a private address; cloud-metadata addresses stay blocked regardless.`,
+        message: `Private model endpoints are permitted for: ${formatExposure(widened)}. ${exposureCount(privateOnes.length, unresolved.length, widened.length)} SSRF guarding, IP-pinning and redirect re-validation still apply; loopback, link-local/IMDS and cloud-metadata addresses stay blocked.`,
+      });
+    } else if (allowPrivateModelEndpoints()) {
+      checks.push({
+        id: 'egress.privateModelEndpoints',
+        level: 'warn',
+        message: 'allowPrivateModelEndpoints is on but no configured model/media endpoint is using the permission — every one of them is public, or none is configured.',
+      });
+    }
+
+    if (stuck.length > 0) {
+      // Its own check id, not a fallback branch of the one above: with per-slot settings both can be true
+      // at once, and a single id would let one overwrite the other in any consumer keyed by it.
+      checks.push({
+        id: 'egress.unreachableModelEndpoints',
+        level: 'warn',
+        message: `Model endpoint(s) point at addresses this instance will refuse to call: ${formatExposure(stuck)}. Permit a self-hosted endpoint on a private address per slot (allowPrivateModelEndpointsBySlot / YTHRIL_ALLOW_PRIVATE_<SLOT>=true) or instance-wide (allowPrivateModelEndpoints); cloud-metadata addresses stay blocked regardless.`,
+      });
+    }
+  }
+
+  // Slots whose permission departs from the instance-wide flag. Reported as a `pass`, not a warning: this
+  // is the operator having been MORE precise than the global flag allows, and the whole point of naming it
+  // is that a per-slot `false` under a global `true` is otherwise invisible — nothing else in the posture
+  // would ever mention the one endpoint they deliberately kept strict.
+  {
+    const overrides = egressSlotOverrides();
+    if (overrides.length > 0) {
+      checks.push({
+        id: 'egress.perSlotOverrides',
+        level: 'pass',
+        message: `Per-endpoint egress permissions differ from the instance-wide setting for: ${
+          overrides.map(o => `${o.slot} (${o.allowPrivate ? 'private permitted' : 'strict'})`).join('; ')
+        }.`,
       });
     }
   }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1203,6 +1203,28 @@ export interface Config {
    * Overridable via YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS.
    */
   allowPrivateModelEndpoints?: boolean;
+  /**
+   * Per-endpoint override of {@link allowPrivateModelEndpoints}, keyed by model slot
+   * (`vision`, `stt`, `embedding`, `rerank`, `nli`, `assist`, `docVlm`, `docRepair`, `docVerify`,
+   * `faceExternal`).
+   *
+   * The global flag is all-or-nothing, which is wrong for the common deployment: everything on the
+   * operator's own infra except one model that genuinely lives on the public internet. Turning the global
+   * flag on to reach the internal ones also relaxes the guard on that one external endpoint — the single
+   * place where a private-address resolution means "something is wrong", not "this is my cluster".
+   *
+   * A value here **wins over the global in both directions**, so `{ "assist": false }` alongside
+   * `allowPrivateModelEndpoints: true` keeps the external slot strict. Slots left out inherit the global.
+   * Env override per slot: `YTHRIL_ALLOW_PRIVATE_<SLOT>` (`YTHRIL_ALLOW_PRIVATE_DOC_VLM`, …), accepting
+   * `true` **or** `false` — a `false` is meaningful here, unlike on the global flag.
+   *
+   * Same admin-surface exclusion as the global flag, and the crown-jewel ranges stay blocked regardless.
+   */
+  allowPrivateModelEndpointsBySlot?: Partial<Record<
+    'vision' | 'stt' | 'embedding' | 'rerank' | 'nli'
+    | 'assist' | 'docVlm' | 'docRepair' | 'docVerify' | 'faceExternal',
+    boolean
+  >>;
   /** Dynamically-registered OAuth clients (RFC 7591) for the MCP browser
    *  authorization flow. Populated automatically when a client registers; not
    *  meant to be hand-edited. See mcp/oauth.ts. */

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -12,7 +12,7 @@
  * acknowledgment (enforced at config-save time).
  */
 import { ssrfSafeFetch } from '../../util/ssrf.js';
-import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
+import { allowPrivateForSlot, type EgressSlot } from '../../config/model-egress-policy.js';
 import { chatUrlFor, type VlmWire } from './vlm-endpoint.js';
 
 export interface VlmTranscription {
@@ -50,7 +50,7 @@ interface ChatTurn { role: 'user'; content: string; images?: string[] }
  * deployment, whose model sits on a private cluster address.
  */
 async function postChat(
-  endpoint: { baseUrl: string; model: string; wire: VlmWire; external: boolean; apiKey?: string },
+  endpoint: { baseUrl: string; model: string; wire: VlmWire; external: boolean; apiKey?: string; slot: EgressSlot },
   turns: ChatTurn[],
   timeoutMs: number,
 ): Promise<VlmTranscription> {
@@ -94,7 +94,9 @@ async function postChat(
     res = endpoint.external
       // Guard on: DNS-resolve, IP-pin, redirect re-validation, crown-jewel ranges blocked. `allowPrivate`
       // only lifts the private-address rejection, so a self-hosted model on a cluster address still works.
-      ? await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateModelEndpoints() })
+      // Resolved for THIS slot: transcription and repair can sit on different hosts, and the document VLM
+      // being on-cluster is no reason to let the assist model reach a private address.
+      ? await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateForSlot(endpoint.slot) })
       : await fetch(url, init);
   } catch (err) {
     throw new Error(`VLM unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
@@ -133,12 +135,13 @@ export interface VlmTarget {
   timeoutMs?: number;
 }
 
-const asEndpoint = (t: VlmTarget) => ({
+const asEndpoint = (t: VlmTarget, slot: EgressSlot) => ({
   baseUrl: t.baseUrl,
   model: t.model,
   wire: t.wire ?? 'ollama' as VlmWire,
   external: t.external ?? false,
   apiKey: t.apiKey,
+  slot,
 });
 
 /** Transcribe one page image to Markdown. Throws on unreachable/HTTP error so the caller falls back. */
@@ -148,7 +151,7 @@ export async function transcribePageImage(
 ): Promise<VlmTranscription> {
   const b64 = imageBytes.toString('base64');
   return postChat(
-    asEndpoint(opts),
+    asEndpoint(opts, 'docVlm'),
     [{ role: 'user', content: opts.prompt, images: [b64] }],
     opts.timeoutMs ?? 60_000,
   );
@@ -167,7 +170,7 @@ export async function repairMarkdown(
   opts: VlmTarget & { draft: string; evidence: string; issues?: string[] },
 ): Promise<VlmTranscription> {
   return postChat(
-    asEndpoint(opts),
+    asEndpoint(opts, 'docRepair'),
     [{ role: 'user', content: repairContent(opts.draft, opts.evidence, opts.issues) }], // text-only — no page image
     opts.timeoutMs ?? 60_000,
   );
@@ -189,7 +192,8 @@ export async function reconcileConsensus(
   const content =
     `${CONSENSUS_PROMPT}\n\n--- DRAFT A ---\n${opts.draftA}\n\n--- DRAFT B ---\n${opts.draftB}\n\n--- OCR TEXT ---\n${opts.evidence}`;
   return postChat(
-    asEndpoint(opts),
+    // Consensus runs on the same VLM endpoint as transcription — same slot, same policy.
+    asEndpoint(opts, 'docVlm'),
     [{ role: 'user', content }], // text-only — no page image
     opts.timeoutMs ?? 60_000,
   );
@@ -230,7 +234,7 @@ export async function repairMarkdownExternal(
       // Lets a self-hosted OpenAI-compatible assist model live on a private cluster address. The guard
       // itself stays on: DNS-resolve, IP-pin and redirect re-validation all still apply — only the
       // private-address rejection lifts, and crown-jewel ranges remain blocked.
-      allowPrivate: allowPrivateModelEndpoints(),
+      allowPrivate: allowPrivateForSlot('assist'),
     });
   } catch (err) {
     throw new Error(`assist model unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -1,6 +1,6 @@
 import { ssrfSafeFetch } from '../../util/ssrf.js';
 import { getConfig, getSecrets } from '../../config/loader.js';
-import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
+import { allowPrivateForSlot } from '../../config/model-egress-policy.js';
 import { log } from '../../util/log.js';
 
 /** One detected face, in exactly the shape the in-process recogniser produces. */
@@ -77,7 +77,7 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
       // guard stays on — DNS-resolve, IP-pin and redirect re-validation all still apply; only the
       // private-address rejection lifts. Without this the WRITE check accepts such an endpoint and every
       // call then fails, which is a configurable feature that silently does not work.
-      allowPrivate: allowPrivateModelEndpoints(),
+      allowPrivate: allowPrivateForSlot('faceExternal'),
     });
     if (!res.ok) {
       log.warn(`External face model: HTTP ${res.status} — falling back to in-process recognition`);

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -15,7 +15,7 @@
 import type { MediaProviderConfig } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { ssrfSafeFetch } from '../../util/ssrf.js';
-import { allowPrivateModelEndpoints } from '../../config/model-egress-policy.js';
+import { allowPrivateForSlot, type EgressSlot } from '../../config/model-egress-policy.js';
 import { extForMimeType, isInformativeMimeType, sniffImageMimeType } from '../mime.js';
 
 /**
@@ -25,14 +25,18 @@ import { extForMimeType, isInformativeMimeType, sniffImageMimeType } from '../mi
  * internal network) keep a plain `fetch`: their addresses are private, which `ssrfSafeFetch` would (rightly)
  * reject. The provider CLASS already encodes which is which (Ollama/Whisper = local; External* = external).
  */
-const egressFetch = (external: boolean): typeof fetch => {
+const egressFetch = (external: boolean, slot: EgressSlot): typeof fetch => {
   if (!external) return fetch;
   // An operator running a self-hosted OpenAI-compatible server on a cluster address needs the EXTERNAL
   // protocol at a PRIVATE address. Note what this relaxes and what it does not: ssrfSafeFetch still
   // resolves DNS, pins the resolved IP for the connection and re-validates redirects — only the
   // private-address rejection lifts, and crown-jewel ranges (loopback, link-local/IMDS) stay blocked
   // either way. This path therefore stays better guarded than a `local` provider, which uses plain fetch.
-  const allowPrivate = allowPrivateModelEndpoints();
+  //
+  // Resolved per SLOT, not globally: vision on the cluster and STT at a vendor is a normal split, and the
+  // global flag would have to be on for the first — relaxing the guard on the second, where a private
+  // resolution is exactly the anomaly worth refusing.
+  const allowPrivate = allowPrivateForSlot(slot);
   return ((url: string, init?: RequestInit) =>
     ssrfSafeFetch(url, init ?? {}, { allowPrivate })) as unknown as typeof fetch;
 };
@@ -184,7 +188,7 @@ export class ExternalVisionProvider implements VisionProvider {
     let res: Response;
     try {
       // External endpoint → SSRF-guarded egress.
-      res = await egressFetch(true)(url, {
+      res = await egressFetch(true, 'vision')(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -261,7 +265,7 @@ export class WhisperProvider implements SttProvider {
     let res: Response;
     try {
       // Local Whisper → plain fetch (private address); external → SSRF-guarded egress.
-      res = await egressFetch(this.external)(url, {
+      res = await egressFetch(this.external, 'stt')(url, {
         method: 'POST',
         headers: this.cfg.apiKey ? { Authorization: `Bearer ${this.cfg.apiKey}` } : {},
         body: form,

--- a/testing/standalone/env-var-docs-coverage.test.js
+++ b/testing/standalone/env-var-docs-coverage.test.js
@@ -73,6 +73,20 @@ function collectUsage() {
     const src = readFileSync(f, 'utf8');
     for (const re of READ_PATTERNS) for (const m of src.matchAll(re)) add(m[1], f);
 
+    // Env names held in a lookup table and read as `process.env[TABLE[key]]`.
+    //
+    // Same class of miss as the helper calls above, and added for the same reason. The per-slot egress
+    // permissions are ten variables whose names live in one `Record<Slot, string>`; every one is really
+    // read, just not at a `process.env['LITERAL']` site. Without this the scan would call all ten
+    // phantoms and the honest fix — writing the names out so an operator can grep them — would be what
+    // triggered the failure.
+    //
+    // Gated on the file actually indexing `process.env` with a non-literal, so a module that merely
+    // MENTIONS a variable name in prose or an error message does not get credit for reading it.
+    if (/process\.env\[\s*[A-Za-z_$]/.test(src)) {
+      for (const m of src.matchAll(/['"]((?:YTHRIL_|MONGO_|MCP_|OIDC_)[A-Z0-9_]{2,})['"]/g)) add(m[1], f);
+    }
+
     // Compose / Dockerfile interpolation: ${VAR} and ${VAR:-default}.
     //
     // ONLY for those files. Applying it to TypeScript matches ordinary template-literal

--- a/testing/standalone/face-external.test.js
+++ b/testing/standalone/face-external.test.js
@@ -104,12 +104,16 @@ describe('the embedder falls back instead of dropping faces', () => {
 describe('the external face endpoint honours the egress policy', () => {
   const src = readFileSync(new URL('../../server/src/files/media/face-external.ts', import.meta.url), 'utf8');
 
-  it('passes allowPrivateModelEndpoints to the guard', () => {
+  it('passes the private-endpoint policy for its own slot to the guard', () => {
     // Without it the guard rejects a self-hosted recogniser on a cluster address at RUNTIME, even though
     // the write path accepted it — a configurable feature that silently does not work. That was the one
     // real finding of the 2026-07-29 audit, and it was in this file.
-    assert.ok(src.includes('allowPrivate: allowPrivateModelEndpoints()'),
-      'the operator private-endpoint policy must reach the fetch');
+    //
+    // Slot-scoped since the per-endpoint permission landed, and this is the slot where that matters most:
+    // the payload is face crops, i.e. biometric data. An operator widening egress for their embedding
+    // server has said nothing about where biometrics may go.
+    assert.ok(src.includes("allowPrivate: allowPrivateForSlot('faceExternal')"),
+      'the operator private-endpoint policy for the faceExternal slot must reach the fetch');
   });
 
   it('is an EXTERNAL provider, so it is guarded rather than plain-fetched', () => {

--- a/testing/standalone/nli-config-surface.test.js
+++ b/testing/standalone/nli-config-surface.test.js
@@ -47,7 +47,10 @@ describe('NLI is a first-class model surface', () => {
       // The same rule as every other model endpoint: a non-local URL is egress and must pass the guard.
       assert.match(MEDIA_CONFIG, /nliPatch\?\.baseUrl && !isLocalModelEndpoint\(nliPatch\.baseUrl\)/);
       assert.match(MEDIA_CONFIG, /nli\.baseUrl rejected/);
-      assert.match(MEDIA_CONFIG, /nli\.baseUrl rejected[^\n]*allowPrivateModelEndpoints/);
+      // The hint is built by `privateAddressHint('nli')`, which names both the per-slot knob and the
+      // instance-wide flag — and stays empty when the slot already permits private addresses, since then
+      // the refusal was a crown jewel that no setting lifts.
+      assert.match(MEDIA_CONFIG, /nli\.baseUrl rejected[^\n]*privateAddressHint\('nli'\)/);
     });
 
     it('routes the key to secrets.json and never lets it reach config.json', () => {

--- a/testing/standalone/per-endpoint-egress.test.js
+++ b/testing/standalone/per-endpoint-egress.test.js
@@ -1,0 +1,245 @@
+/**
+ * Standalone tests: PER-ENDPOINT private-address permission.
+ *
+ * The deployment that motivated this (owner, 2026-07-30): *"all on own infra except one that is on
+ * external"*. Nine model endpoints on a private cluster, one genuine public vendor. Under the
+ * instance-wide `allowPrivateModelEndpoints`, reaching the nine required turning the flag on — which also
+ * relaxed the private-address rejection on the tenth, the single endpoint where a private resolution means
+ * something has gone wrong rather than "this is my cluster". The flag made the estate's security posture a
+ * function of its least-strict member.
+ *
+ * So the permission is resolved per SLOT, and a per-slot value beats the global **in both directions**.
+ * That second direction is the whole feature: `{ assist: false }` under a global `true` is what keeps the
+ * one external endpoint strict, and a design where per-slot could only widen would not have helped at all.
+ *
+ * What per-slot must NOT be able to do:
+ *   - reach a crown jewel (loopback, link-local / cloud IMDS, unspecified) — those are refused whatever any
+ *     setting says, at both admission points
+ *   - become settable from the admin API — an endpoint that turns into an egress target must not be
+ *     widenable by the instance's own admin, which is the same rule the global flag has always had
+ *
+ * Run: node --test testing/standalone/per-endpoint-egress.test.js
+ */
+
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let allowPrivateForSlot;
+let allowPrivateModelEndpoints;
+let egressSlotOverrides;
+let privateAddressHint;
+let slotEnvVar;
+let EGRESS_SLOTS;
+let isSsrfSafeUrl;
+let assertUrlSafeResolved;
+
+const GLOBAL_KEY = 'YTHRIL_ALLOW_PRIVATE_MODEL_ENDPOINTS';
+
+/** Must stay blocked with every setting on — these are what SSRF actually targets. */
+const CROWN_JEWELS = [
+  'http://127.0.0.1:8080',
+  'http://localhost:8080',
+  'http://169.254.169.254/latest/meta-data/',
+  'http://metadata.google.internal/computeMetadata/v1/',
+  'http://[::1]:8080',
+  'http://0.0.0.0:8080',
+];
+
+const resolvesTo = (address, family = 4) => async () => [{ address, family }];
+
+/** Env keys this suite writes, restored wholesale so no test leaks into the next. */
+let saved;
+function snapshotEnv(keys) {
+  saved = new Map(keys.map(k => [k, process.env[k]]));
+}
+function restoreEnv() {
+  for (const [k, v] of saved) {
+    if (v === undefined) delete process.env[k]; else process.env[k] = v;
+  }
+}
+
+describe('per-endpoint egress permission', () => {
+  let allKeys;
+
+  before(async () => {
+    ({
+      allowPrivateForSlot, allowPrivateModelEndpoints, egressSlotOverrides,
+      privateAddressHint, slotEnvVar, EGRESS_SLOTS,
+    } = await import('../../server/dist/config/model-egress-policy.js'));
+    ({ isSsrfSafeUrl, assertUrlSafeResolved } = await import('../../server/dist/util/ssrf.js'));
+    allKeys = [GLOBAL_KEY, ...EGRESS_SLOTS.map(slotEnvVar)];
+  });
+
+  beforeEach(() => {
+    snapshotEnv(allKeys);
+    for (const k of allKeys) delete process.env[k];
+  });
+  afterEach(restoreEnv);
+
+  describe('the slot vocabulary', () => {
+    it('covers every model endpoint that can egress', () => {
+      // Written down rather than derived, for the reason the pipeline board learned the hard way: a
+      // reporter enumerated NINE endpoints from the Models screen and missed the tenth, because the
+      // document stages build their keys as `doc-${slot}` and no literal exists to grep for. A set that is
+      // silently short reports "nothing else is exposed" by omission.
+      assert.deepEqual([...EGRESS_SLOTS].sort(), [
+        'assist', 'docRepair', 'docVerify', 'docVlm', 'embedding',
+        'faceExternal', 'nli', 'rerank', 'stt', 'vision',
+      ]);
+    });
+
+    it('derives a distinct, screaming-snake env var for each', () => {
+      const names = EGRESS_SLOTS.map(slotEnvVar);
+      assert.equal(new Set(names).size, names.length, 'two slots must never share an env var');
+      assert.equal(slotEnvVar('docVlm'), 'YTHRIL_ALLOW_PRIVATE_DOC_VLM');
+      assert.equal(slotEnvVar('vision'), 'YTHRIL_ALLOW_PRIVATE_VISION');
+      assert.equal(slotEnvVar('faceExternal'), 'YTHRIL_ALLOW_PRIVATE_FACE_EXTERNAL');
+      for (const n of names) assert.match(n, /^YTHRIL_ALLOW_PRIVATE_[A-Z_]+$/);
+    });
+  });
+
+  describe('precedence: per-slot → global → closed', () => {
+    it('is closed for every slot by default', () => {
+      for (const slot of EGRESS_SLOTS) {
+        assert.equal(allowPrivateForSlot(slot), false, `${slot} must default to strict`);
+      }
+    });
+
+    it('inherits the global when the slot says nothing', () => {
+      process.env[GLOBAL_KEY] = 'true';
+      for (const slot of EGRESS_SLOTS) {
+        assert.equal(allowPrivateForSlot(slot), true, `${slot} should inherit the instance-wide flag`);
+      }
+    });
+
+    it('a per-slot true widens one slot without touching the others', () => {
+      process.env[slotEnvVar('embedding')] = 'true';
+      assert.equal(allowPrivateForSlot('embedding'), true);
+      assert.equal(allowPrivateModelEndpoints(), false, 'the global flag must stay off');
+      for (const slot of EGRESS_SLOTS.filter(s => s !== 'embedding')) {
+        assert.equal(allowPrivateForSlot(slot), false, `${slot} must not be widened by embedding's setting`);
+      }
+    });
+
+    it('a per-slot FALSE overrides a global true — the case this exists for', () => {
+      // Everything on the operator's own infra except the assist model, which is a public vendor.
+      process.env[GLOBAL_KEY] = 'true';
+      process.env[slotEnvVar('assist')] = 'false';
+      assert.equal(allowPrivateForSlot('assist'), false,
+        'the one deliberately-external endpoint must stay strict under a permissive global');
+      for (const slot of EGRESS_SLOTS.filter(s => s !== 'assist')) {
+        assert.equal(allowPrivateForSlot(slot), true, `${slot} should still reach the operator's cluster`);
+      }
+    });
+
+    it('only the exact strings "true" and "false" are settings — anything else defers', () => {
+      // Same strictness the global flag has. A typo must not silently mean "closed" when the global says
+      // open: that would be a per-slot value nobody set, quietly overriding one they did.
+      process.env[GLOBAL_KEY] = 'true';
+      for (const value of ['1', 'yes', 'TRUE', 'False', 'on', '']) {
+        process.env[slotEnvVar('vision')] = value;
+        assert.equal(allowPrivateForSlot('vision'), true, `"${value}" must not be read as a per-slot setting`);
+      }
+    });
+  });
+
+  describe('what the posture reports', () => {
+    it('names nothing when every slot agrees with the global', () => {
+      assert.deepEqual(egressSlotOverrides(), []);
+      process.env[GLOBAL_KEY] = 'true';
+      assert.deepEqual(egressSlotOverrides(), []);
+    });
+
+    it('names the strict slot under a permissive global', () => {
+      // The invisible case: with the global on, nothing else in the posture would ever mention the one
+      // endpoint the operator deliberately kept strict.
+      process.env[GLOBAL_KEY] = 'true';
+      process.env[slotEnvVar('assist')] = 'false';
+      assert.deepEqual(egressSlotOverrides(), [{ slot: 'assist', allowPrivate: false }]);
+    });
+
+    it('names the widened slot under a strict global', () => {
+      process.env[slotEnvVar('docVlm')] = 'true';
+      assert.deepEqual(egressSlotOverrides(), [{ slot: 'docVlm', allowPrivate: true }]);
+    });
+  });
+
+  describe('the rejection message', () => {
+    it('names the exact knob for the slot that was refused', () => {
+      const hint = privateAddressHint('rerank');
+      assert.match(hint, /allowPrivateModelEndpointsBySlot\.rerank/);
+      assert.match(hint, /YTHRIL_ALLOW_PRIVATE_RERANK=true/);
+      assert.match(hint, /cloud-metadata addresses stay blocked/,
+        'the message must not imply the setting unlocks everything');
+    });
+
+    it('says nothing when the slot ALREADY allows private addresses', () => {
+      // Then the refusal was a crown jewel and no setting will lift it. Telling an operator to enable a
+      // flag that is already on is how a support round-trip starts.
+      process.env[slotEnvVar('rerank')] = 'true';
+      assert.equal(privateAddressHint('rerank'), '');
+    });
+  });
+
+  describe('crown jewels are not reachable through any slot', () => {
+    it('are refused at save time with every slot permission on', () => {
+      process.env[GLOBAL_KEY] = 'true';
+      for (const slot of EGRESS_SLOTS) process.env[slotEnvVar(slot)] = 'true';
+      for (const url of CROWN_JEWELS) {
+        assert.equal(isSsrfSafeUrl(url, allowPrivateForSlot('vision')), false, `${url} must stay blocked`);
+      }
+    });
+
+    it('are refused at resolution time too', async () => {
+      process.env[slotEnvVar('vision')] = 'true';
+      const allow = allowPrivateForSlot('vision');
+      assert.equal(allow, true, 'precondition: the slot is permissive');
+      // A hostname that resolves to the cloud metadata address — the DNS-rebinding shape the static check
+      // cannot see. The permission relaxes ordinary private ranges; it does not touch this one.
+      await assert.rejects(
+        assertUrlSafeResolved('http://models.example.com/v1', { allowPrivate: allow, lookup: resolvesTo('169.254.169.254') }),
+        /169\.254|blocked|refus/i,
+      );
+      await assert.rejects(
+        assertUrlSafeResolved('http://models.example.com/v1', { allowPrivate: allow, lookup: resolvesTo('127.0.0.1') }),
+        /127\.0\.0\.1|loopback|blocked|refus/i,
+      );
+    });
+
+    it('a permissive slot DOES reach an ordinary private address — otherwise the setting is decorative', async () => {
+      process.env[slotEnvVar('vision')] = 'true';
+      await assert.doesNotReject(assertUrlSafeResolved(
+        'http://vllm.models.svc.cluster.local:8080',
+        { allowPrivate: allowPrivateForSlot('vision'), lookup: resolvesTo('10.1.2.3') },
+      ));
+    });
+  });
+
+  describe('it stays off the admin surface', () => {
+    // The rule the global flag has always had, restated because per-slot multiplies the places it could
+    // leak in: ten keys instead of one. An admin who can widen their own egress has an SSRF primitive, and
+    // the config field is the only thing standing between the two.
+    const CONFIG_KEY = 'allowPrivateModelEndpointsBySlot';
+
+    it('is not accepted by the media-config PATCH schema', () => {
+      const src = readFileSync('server/src/api/media-config.ts', 'utf8');
+      const code = src.split('\n')
+        .filter(l => { const t = l.trim(); return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*'); })
+        .join('\n');
+      assert.ok(!code.includes(CONFIG_KEY),
+        `${CONFIG_KEY} must never appear in the admin config route — env and config.json only`);
+    });
+
+    it('is not written by any route', () => {
+      // Reading it is the point; assigning it from a request body is the hole.
+      const src = readFileSync('server/src/config/model-egress-policy.ts', 'utf8');
+      assert.match(src, new RegExp(`getConfig\\(\\)\\.${CONFIG_KEY}`),
+        'the resolver should READ the config key');
+      for (const f of ['server/src/api/media-config.ts', 'server/src/api/pipeline-status.ts']) {
+        assert.ok(!new RegExp(`${CONFIG_KEY}\\s*[=:]`).test(readFileSync(f, 'utf8')),
+          `${f} must not assign ${CONFIG_KEY}`);
+      }
+    });
+  });
+});

--- a/testing/standalone/rerank.test.js
+++ b/testing/standalone/rerank.test.js
@@ -127,7 +127,9 @@ describe('the source keeps its contracts', () => {
   it('guards a non-local endpoint with ssrfSafeFetch', () => {
     // The URL is admin-settable; a plain fetch would follow a redirect into link-local metadata.
     assert.ok(src.includes('ssrfSafeFetch('), 'must call ssrfSafeFetch');
-    assert.ok(src.includes('allowPrivate: allowPrivateModelEndpoints()'),
+    // Scoped to the reranker's own slot: a widened embedding endpoint says nothing about where the
+    // reranker may point, and vice versa.
+    assert.ok(src.includes("allowPrivate: allowPrivateForSlot('rerank')"),
       'the operator private-endpoint policy must reach the fetch, or a self-hosted reranker on a cluster address silently never works');
     assert.ok(src.includes('isLocalModelEndpoint('), 'the local/remote split must use the shared predicate');
   });

--- a/testing/standalone/ssrf-allow-private-coverage.test.js
+++ b/testing/standalone/ssrf-allow-private-coverage.test.js
@@ -109,9 +109,24 @@ describe('ssrfSafeFetch callers decide allowPrivate deliberately', () => {
     const at = src.indexOf('export async function probeModelEndpoint');
     assert.ok(at > 0, 'probeModelEndpoint should exist');
     const body = src.slice(at, at + 2000);
-    assert.match(body, /ssrfSafeFetch\([^;]*allowPrivate:\s*allowPrivateModelEndpoints\(\)/s,
-      'probeModelEndpoint must honour allowPrivateModelEndpoints, or it reports every private self-hosted ' +
-      'endpoint as blocked while inference against it actually works');
+    // Per SLOT, not instance-wide. The probe has to resolve the same permission the inference client will,
+    // and those two now differ per endpoint: an operator who kept one slot strict must see that slot's
+    // probe refuse, and an operator who widened another must see that one go through.
+    assert.match(body, /ssrfSafeFetch\([^;]*allowPrivate:\s*allowPrivateForSlot\(opts\.slot\)/s,
+      'probeModelEndpoint must honour the egress permission of the slot it is probing, or it reports a ' +
+      'private self-hosted endpoint as blocked while inference against it actually works (or the reverse)');
+  });
+
+  it('the probe cannot be called without naming its slot', () => {
+    // The failure this forecloses is a silent default. If `slot` were optional with a fallback, a new
+    // caller would inherit whichever slot the fallback names — and the probe would report a verdict
+    // computed under a policy belonging to a different endpoint. Making it required turns that into a
+    // compile error at the call site, where the answer is known.
+    const src = readFileSync(`${ROOT}/api/media-config.ts`, 'utf8');
+    const at = src.indexOf('export async function probeModelEndpoint');
+    const sig = src.slice(at, src.indexOf('): Promise<ProbeResult>', at));
+    assert.match(sig, /slot:\s*EgressSlot/, 'probeModelEndpoint must take a required `slot`');
+    assert.ok(!/slot\?:/.test(sig), '`slot` must not be optional — a default would probe under another endpoint\'s policy');
   });
 
   it('webhook delivery does NOT inherit the model opt-in', () => {
@@ -126,8 +141,12 @@ describe('ssrfSafeFetch callers decide allowPrivate deliberately', () => {
     const code = src.split('\n')
       .filter(l => { const t = l.trim(); return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*'); })
       .join('\n');
-    assert.ok(!code.includes('allowPrivateModelEndpoints'),
-      'webhook delivery must not consult allowPrivateModelEndpoints — a self-hosted model endpoint says ' +
-      'nothing about where a webhook may point');
+    // Both spellings: the per-slot resolver is the one a future change would actually reach for, and a
+    // check that names only the old function would wave it through.
+    for (const banned of ['allowPrivateModelEndpoints', 'allowPrivateForSlot']) {
+      assert.ok(!code.includes(banned),
+        `webhook delivery must not consult ${banned} — a self-hosted model endpoint says nothing about ` +
+        'where a webhook may point');
+    }
   });
 });

--- a/testing/standalone/vlm-endpoint-egress.test.js
+++ b/testing/standalone/vlm-endpoint-egress.test.js
@@ -120,7 +120,24 @@ describe('egress is guarded whenever the endpoint is not the bundled model', () 
   });
 
   it('and passes the private-address opt-in, so a self-hosted model still works', () => {
-    assert.match(client, /allowPrivate: allowPrivateModelEndpoints\(\)/);
+    // Resolved for the endpoint's own slot. Transcription, repair and the external assist model are three
+    // separate egress decisions — the document VLM sitting on the cluster is not a reason to let the assist
+    // model, the one path that sends content off-instance, reach a private address.
+    assert.match(client, /allowPrivate: allowPrivateForSlot\(endpoint\.slot\)/);
+    assert.match(client, /allowPrivate: allowPrivateForSlot\('assist'\)/);
+  });
+
+  it('each entry point names its own slot', () => {
+    for (const [fn, slot] of [
+      ['transcribePageImage', 'docVlm'],
+      ['repairMarkdown', 'docRepair'],
+      ['reconcileConsensus', 'docVlm'],
+    ]) {
+      const at = client.indexOf(`export async function ${fn}`);
+      assert.ok(at > 0, `${fn} should exist`);
+      assert.match(client.slice(at, at + 600), new RegExp(`asEndpoint\\(opts, '${slot}'\\)`),
+        `${fn} must resolve egress under the ${slot} slot`);
+    }
   });
 
   it('the bundled local path keeps its plain fetch', () => {


### PR DESCRIPTION
## The report

Owner, on a deployment with ten model endpoints: *"All on own infra except one that is on external."*

`allowPrivateModelEndpoints` is instance-wide. Reaching the nine internal endpoints means turning it
on — which also relaxes the private-address rejection on the tenth, the one endpoint that genuinely
lives on the public internet and therefore the one place where a private-address resolution means
something has gone wrong rather than "this is my cluster". The flag made the estate's posture a
function of its least-strict member.

## What changed

Each of the ten model slots carries its own permission:

```json
{
  "allowPrivateModelEndpoints": true,
  "allowPrivateModelEndpointsBySlot": { "assist": false }
}
```

Resolved **per-slot → instance-wide → closed**, with a per-slot value winning **in both directions**.
The `false` is the point: nine endpoints reach the cluster, and the assist model — the one path that
sends document content off the instance — stays strict. A design where per-slot could only widen would
not have addressed the report.

Slots: `vision`, `stt`, `embedding`, `rerank`, `nli`, `docVlm`, `docRepair`, `docVerify`, `assist`,
`faceExternal`, each with a `YTHRIL_ALLOW_PRIVATE_<SLOT>` env var accepting `true` **or** `false` —
a `false` is meaningful here, because it is how one endpoint is pinned strict from the Deployment.

## The three places that had to agree

Save time, probe time and inference previously read one global answer, so they could not disagree.
Per-slot they can, and a disagreement is a green Test Connection on a call that is then refused
(or the reverse — worse, since it reports a working endpoint as broken).

- `probeModelEndpoint` takes a **required** `slot`. Optional-with-a-default would have it report a
  verdict computed under some other endpoint's policy; required turns that into a compile error at the
  call site, where the answer is known.
- `endpointId` folds the resolved permission into the grouping key. Stages sharing a base URL were
  probed once as an optimisation; two stages can now share a URL and disagree about policy, and
  collapsing them would have one answering for the other. Identical policy — the normal case — still
  yields one probe.
- The save-time `isSsrfSafeUrl` checks resolve the same slot the client will.

## What per-slot cannot do

- **Reach a crown jewel.** Loopback, link-local / cloud IMDS and the unspecified address stay blocked
  for every slot at both admission points, including when a hostname *resolves* to one. Tested with all
  ten permissions simultaneously on, at save time and at resolution time.
- **Become admin-settable.** Env/config only, same rule the global flag has always had — an endpoint
  that becomes an egress target must not be widenable by the instance's own admin. A test asserts the
  key never appears in the config route, and the webhook-dispatcher guard now bans both the old function
  name and the new per-slot one (a check naming only the old one would wave the new one through).

## Posture, per endpoint

Three ids, all of which can appear at once — which is what a mixed estate looks like, and what the old
if/else on one boolean could not express:

| id | means |
| --- | --- |
| `egress.privateModelEndpoints` | the permission is actually being used by these endpoints |
| `egress.unreachableModelEndpoints` | configured privately with **no** permission for its slot — cannot work, and fails at inference rather than at save |
| `egress.perSlotOverrides` | slots departing from the instance-wide flag, so the endpoint deliberately kept strict is visible rather than implied |

The exposure enumeration went from **four endpoints to all ten**. The reranker, contradiction judge,
external face model and three document stages were admin-configurable egress targets the posture never
mentioned — and a check that enumerates a subset reports "nothing else is exposed" by omission.

## Two smaller things worth naming

**Env names are written out, not derived.** `YTHRIL_ALLOW_PRIVATE_${snake(slot)}` is shorter and worse:
the names would then exist nowhere in the source, so `grep YTHRIL_ALLOW_PRIVATE_DOC_VLM` finds nothing
and the doc-coverage gate cannot distinguish a documented setting from a phantom.

**That gate needed a matching pattern.** It only saw `process.env['LITERAL']`, so ten names held in a
lookup table read as `process.env[TABLE[slot]]` would all have been reported as phantoms — meaning the
honest fix above was what tripped it. The new pattern is the same class as the `envTrue(...)` one
already there, gated on the file actually indexing `process.env` with a non-literal so a module that
merely mentions a name in prose gets no credit.

## Verification

- `npm run preflight` green (1937 offline standalone tests, 0 failures).
- New suite `testing/standalone/per-endpoint-egress.test.js` — 17 tests: slot vocabulary, precedence in
  both directions, strict-string parsing, posture overrides, hint text, crown jewels at both admission
  points, admin-surface exclusion.
- Mutation-checked: removing the per-slot `false` branch (the one that makes the owner's case work)
  fails 2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
