### PR TITLE
fix(governance): a meta_change vote applies its own fields, not a stale whole-meta snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two concurrent space-meta votes no longer overwrite each other.** A `meta_change` round stored the
+  whole merged meta and applied it wholesale on conclusion, so the later of two overlapping rounds
+  reverted the earlier one's edit.
+  - The sequence: meta at v7; Alice proposes a new `purpose`, Bob proposes `strictLinkage`; both rounds
+    carry a full snapshot of v7 plus their own patch. Alice's passes (v8). Bob's passes and replaces the
+    meta with his snapshot — which still holds **v7's purpose**. Nothing reports it: the round passed,
+    the vote is recorded as carried, and the resulting meta is internally consistent, just missing an
+    edit the network voted to make. Rounds stay open for `votingDeadlineHours`, so this is not a race —
+    it is what happens whenever two operators configure a space in the same week.
+  - A round now records `metaChangedFields` and `baseMetaVersion`, and conclusion applies only those
+    fields, re-merged into whatever the meta says at that moment. `typeSchemas` merges per
+    knowledge-type, matching what the PATCH path already does.
+  - **Same-field collisions resolve to the round's value** — the network voted for it, and refusing to
+    apply a carried motion would relocate the silent loss rather than remove it. The overwrite is logged
+    with the field, the round's base version and the current one, so the superseded operator can find
+    out. Conflict detection recovers the round's base from the space's own `previousVersions` history,
+    which is what distinguishes "somebody else changed this field" from "this round is changing it" —
+    without it the warning would fire on every ordinary concurrent edit of *different* fields and be
+    learned into invisibility. When the base has rolled out of the capped history, the overwrite is
+    reported rather than assumed uncontested.
+  - **Rounds gossip**, so one proposed by a peer on an older build carries neither field and applies
+    wholesale, exactly as before — its proposer computed the snapshot as the complete intended result,
+    and field-merging an unknown changed-set would apply nothing at all. The absent version is the
+    compatibility switch, with the pre-upgrade behaviour as the fallback.
+
 - **A converted document had no description, while its extracted images all had captions.** Reported
   against 2.1.1: after a PDF converts, the original's file-meta carries `convertedFileId`, `chunkCount`
   and `embeddingStatus` — and no description, with `matchedText` being literally the filename. Every

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3357,6 +3357,22 @@ If the space participates in a network and `meta` is included, the update trigge
 { "status": "vote_pending", "rounds": [...], "message": "Meta change requires network vote" }
 ```
 
+**Two meta votes can be open at once, and they no longer overwrite each other.** A round records the
+fields it proposes and the `meta.version` it was computed against; when it passes, only those fields are
+applied, re-merged into whatever the meta says at that moment. Rounds stay open for
+`votingDeadlineHours`, so a second proposal landing before the first concludes is ordinary — previously
+the later round wrote back a full snapshot taken when it opened, silently reverting the earlier one's
+edit with a correctly-recorded carried vote to hide it.
+
+When two rounds change the **same** field the later one to conclude wins: the network voted for that
+value, and refusing to apply a carried motion would relocate the silent loss rather than remove it. The
+overwrite is written to the server log naming the field, the round's base version and the current one, so
+the superseded operator can find out.
+
+A round proposed by a peer running an older build carries neither field and is applied wholesale, exactly
+as before — its proposer computed the snapshot as the complete intended result, so field-merging an
+unknown changed-set would apply nothing at all.
+
 > **MCP tool:** `update_space` — accepts `label` and `description`. Requires `admin: true`.
 
 ---

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -22,6 +22,7 @@ import { log } from '../util/log.js';
 import { buildSpaceVectorIndexes } from '../spaces/vector-index.js';
 import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../util/ssrf.js';
 import { peerSafeFetch } from '../sync/peer-fetch.js';
+import { proposedMetaFields } from '../sync/meta-round-merge.js';
 import type { SpaceMeta, KnowledgeType, TypeSchema } from '../config/types.js';
 import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
 import { writeFile as writeSpaceFile } from '../files/files.js';
@@ -558,6 +559,12 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
           votes: [{ instanceId: cfg.instanceId, vote: 'yes', castAt: now }],
           spaceId: id,
           pendingMeta: mergedMeta as SpaceMeta,
+          // Provenance, so conclusion can apply just this patch rather than this whole snapshot. Rounds
+          // stay open for `votingDeadlineHours`, so a second proposal landing before the first concludes
+          // is ordinary, and without these two fields the later one reverts the earlier one's edit with
+          // no error anywhere. See sync/meta-round-merge.ts.
+          metaChangedFields: proposedMetaFields(parsed.data.meta ?? {}),
+          baseMetaVersion: space.meta?.version ?? 0,
         });
         rounds.push({ networkId: net.id, networkLabel: net.label, roundId });
       }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -775,6 +775,23 @@ export interface VoteRound {
   pendingMember?: NetworkMember;  // stored on join rounds; added to members when vote passes
   spaceId?: string;              // populated for space_deletion and meta_change rounds
   pendingMeta?: SpaceMeta;       // stored on meta_change rounds; applied when vote passes
+  /**
+   * Top-level `meta` fields the proposer changed (meta_change rounds).
+   *
+   * Conclusion applies only these, re-merged into whatever the meta says at that moment, so two rounds
+   * that touch different fields no longer overwrite each other — `pendingMeta` is a full snapshot of the
+   * meta as it stood when the round opened, and applying it wholesale silently reverts anything that
+   * concluded in between. See `sync/meta-round-merge.ts`.
+   */
+  metaChangedFields?: string[];
+  /**
+   * The space's `meta.version` the proposal was computed against (meta_change rounds).
+   *
+   * Rounds gossip, so this is absent on any round proposed by a peer predating field-merge — and that
+   * absence is the compatibility switch: such a round applies wholesale, exactly as before. It cannot
+   * field-merge, because the changed-field list it never recorded would merge nothing at all.
+   */
+  baseMetaVersion?: number;
   requiredVoters?: string[];     // braintree only: instanceIds that must ALL vote yes
 }
 

--- a/server/src/sync/governance.ts
+++ b/server/src/sync/governance.ts
@@ -14,6 +14,8 @@ import { log } from '../util/log.js';
 import { updateSpace } from '../spaces/spaces.js';
 import { peerSafeFetch } from './peer-fetch.js';
 import { buildBraintreeAncestors } from '../util/braintree.js';
+import { applyMetaRound, type MetaRoundProposal } from './meta-round-merge.js';
+import type { SpaceMeta } from '../config/types.js';
 
 /**
  * Recompute the braintree ancestor voter set for a round from this instance's
@@ -144,9 +146,24 @@ export function concludeRoundIfReady(
         });
       }
     }
-    // On meta_change round pass: apply the pending meta to the space
+    // On meta_change round pass: apply the fields this round proposed to the space's CURRENT meta.
+    //
+    // Not `{ meta: round.pendingMeta }`. That snapshot was computed when the round opened, and rounds stay
+    // open for `votingDeadlineHours` — so writing it wholesale reverts every field another round changed
+    // in the meantime, with no error and a correctly-recorded carried vote to hide it.
     if (round.type === 'meta_change' && round.spaceId && round.pendingMeta) {
-      updateSpace(round.spaceId, { meta: round.pendingMeta });
+      const currentMeta = getConfig().spaces.find(s => s.id === round.spaceId)?.meta;
+      const applied = applyMetaRound(currentMeta, round as MetaRoundProposal);
+      updateSpace(round.spaceId, { meta: applied.meta as SpaceMeta });
+      if (applied.conflicts.length > 0) {
+        // The vote wins — the network decided this value — but the operator whose edit it superseded has
+        // to be able to find out, and the only place that can say so is here.
+        log.warn(
+          `meta_change round ${round.roundId} overwrote field(s) changed since it was proposed ` +
+          `(space ${round.spaceId}, based on meta v${round.baseMetaVersion}, now v${currentMeta?.version ?? 0}): ` +
+          `${applied.conflicts.join(', ')} — the passed vote wins`,
+        );
+      }
     }
     return true;
   }

--- a/server/src/sync/meta-round-merge.ts
+++ b/server/src/sync/meta-round-merge.ts
@@ -1,0 +1,182 @@
+/**
+ * Applying a passed `meta_change` round without discarding everyone else's edits.
+ *
+ * ## The loss
+ *
+ * A `meta_change` round stored the **whole merged meta** — the proposer's patch already folded into the
+ * base they read — and applying it was `updateSpace(spaceId, { meta: round.pendingMeta })`, a wholesale
+ * replace. That is correct for one round at a time and silently destructive for two:
+ *
+ *   1. The space's meta is at version 7.
+ *   2. Alice proposes a new `purpose`. Her round carries the full meta: new purpose, v7's everything else.
+ *   3. Bob proposes `strictLinkage: true`. His round carries the full meta: v7's purpose, new flag.
+ *   4. Alice's round passes → purpose updated, version 8.
+ *   5. Bob's round passes → the whole meta is replaced by his snapshot, which still holds **v7's purpose**.
+ *
+ * Alice's change is gone. Nothing reports it: the round passed, the vote is recorded as carried, and the
+ * space's meta is internally consistent — just missing an edit the network voted to make. Rounds run for
+ * `votingDeadlineHours` (hours, sometimes days), so overlapping proposals are not an exotic race; they are
+ * the normal cadence of a network where more than one operator configures a space.
+ *
+ * ## What is applied instead
+ *
+ * Only the fields the proposer actually changed. The round records them (`metaChangedFields`) alongside
+ * the meta version it was computed against (`baseMetaVersion`), and conclusion re-merges those fields into
+ * whatever the meta says **now**, rather than into whatever it said when the round opened.
+ *
+ * ## Same-field conflict: the vote wins
+ *
+ * When two rounds change the *same* field, the later-concluding one takes effect. That is the deliberate
+ * answer, not a fallback that got left in:
+ *
+ *   - The network **voted** for that value. Refusing to apply a passed round because the field moved would
+ *     turn a carried motion into a silent no-op, which is the failure this module exists to remove, just
+ *     relocated.
+ *   - Reopening or re-voting cannot be done here — conclusion runs on every peer independently, and a
+ *     decision that needs a new round is not a decision one peer may take alone.
+ *
+ * So the conflict is *reported*, not resolved by refusal: {@link applyMetaRound} returns which fields were
+ * overwritten while the meta had moved on, and the caller logs them. An operator whose edit was superseded
+ * learns it from the log rather than from noticing the value is wrong weeks later.
+ *
+ * ## Peers that have not upgraded
+ *
+ * `VoteRound` is gossiped, so a round proposed by an older peer arrives with neither field set. Those apply
+ * **wholesale**, exactly as before. This is the only safe reading: an older proposer computed
+ * `pendingMeta` as the complete intended result, and field-merging a round whose changed-field list is
+ * unknown would apply an empty set — a passed round that changes nothing at all. The absence of the
+ * version is therefore the compatibility switch, and the pre-upgrade behaviour is the fallback.
+ */
+import type { SpaceMeta } from '../config/types.js';
+
+/** The parts of a `VoteRound` this module reads. Kept structural so it is testable without a full round. */
+export interface MetaRoundProposal {
+  /** The full merged meta computed when the round was proposed. */
+  pendingMeta: SpaceMeta;
+  /**
+   * Top-level meta fields the proposer changed. Absent on rounds from peers predating field-merge — see
+   * the module header for why those must still apply wholesale.
+   */
+  metaChangedFields?: string[];
+  /** The space's `meta.version` the proposal was computed against. Absent on pre-upgrade rounds. */
+  baseMetaVersion?: number;
+}
+
+/** Housekeeping the space layer owns — a round must never carry these across. */
+const HOUSEKEEPING = ['version', 'updatedAt', 'previousVersions'] as const;
+
+export interface MetaRoundApplication {
+  /** The meta to hand to `updateSpace`. */
+  meta: Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'>;
+  /** Fields whose current value the round overwrote while the meta had moved past its base version. */
+  conflicts: string[];
+  /** True when the round carried no provenance and was applied wholesale (pre-upgrade proposer). */
+  wholesale: boolean;
+}
+
+/**
+ * Compute the meta a passed `meta_change` round should produce, given the space's meta right now.
+ *
+ * Pure: takes the current meta and the round, returns the result and what it collided with. Conclusion
+ * happens independently on every peer, so this has to be a function of state both peers can see — anything
+ * read from local wall-clock or ambient config would let two peers apply the same round differently.
+ */
+export function applyMetaRound(current: SpaceMeta | undefined, round: MetaRoundProposal): MetaRoundApplication {
+  const strip = (m: SpaceMeta): Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'> => {
+    const { version: _v, updatedAt: _u, previousVersions: _p, ...rest } = m;
+    return rest;
+  };
+
+  const fields = round.metaChangedFields?.filter(f => !(HOUSEKEEPING as readonly string[]).includes(f));
+
+  // Pre-upgrade round, or one whose proposer recorded no provenance: apply exactly as before. Field-merging
+  // an unknown changed-set would mean applying nothing, so a carried motion would silently do nothing.
+  if (round.baseMetaVersion === undefined || fields === undefined) {
+    return { meta: strip(round.pendingMeta), conflicts: [], wholesale: true };
+  }
+
+  const base = current ? strip(current) : {};
+  const merged: Record<string, unknown> = { ...base };
+  const proposed = strip(round.pendingMeta) as Record<string, unknown>;
+  // Only when the meta has actually moved since the proposal can an overwrite be a conflict. Equal
+  // versions mean nothing else concluded in between, so every write is uncontested.
+  const moved = (current?.version ?? 0) !== round.baseMetaVersion;
+
+  /**
+   * The meta as it stood when the round was proposed, recovered from the space's own version history.
+   *
+   * Without it, "the meta moved and this round is writing field X" is indistinguishable from "someone
+   * else changed field X" — and reporting the first as a collision would fire on every ordinary
+   * concurrent edit of *different* fields, which is precisely the case this module makes safe. A warning
+   * that cries wolf on the normal path is one operators learn to skip.
+   *
+   * `previousVersions` is capped, so on a space with a burst of edits the base may have rolled off. Then
+   * the coarse rule stands: report the overwrite rather than assert it was uncontested. Over-reporting a
+   * genuinely rare case is the right side to err on; the value is still applied either way.
+   */
+  const baseMeta: Record<string, unknown> | undefined =
+    current?.version === round.baseMetaVersion
+      ? (base as Record<string, unknown>)
+      : current?.previousVersions?.find(h => h.version === round.baseMetaVersion)?.meta as Record<string, unknown> | undefined;
+
+  const differs = (a: unknown, b: unknown) => JSON.stringify(a) !== JSON.stringify(b);
+  /** Did somebody ELSE change this field since the round was proposed? */
+  const contested = (field: string, currentValue: unknown, incoming: unknown) =>
+    moved
+    && differs(currentValue, incoming)                          // the round is actually changing it now
+    && (baseMeta === undefined || differs(baseMeta[field], currentValue)); // and not from where it started
+
+  const conflicts: string[] = [];
+
+  for (const field of fields) {
+    if (field === 'typeSchemas') {
+      // Merged per knowledge-type and per type name rather than replaced, matching what `mergeSpaceMeta`
+      // does on the request path. A type another round added stays; one this round added or edited wins.
+      //
+      // A type the proposer *deleted* is therefore not deleted here — but it was never deletable this way:
+      // under merge semantics an absent type is indistinguishable from a removed one, which is exactly why
+      // deletion goes through the schema PUT with its own precondition instead.
+      const currentTs = ((base as SpaceMeta).typeSchemas ?? {}) as Record<string, object>;
+      const proposedTs = ((proposed as SpaceMeta).typeSchemas ?? {}) as Record<string, object>;
+      const baseTs = ((baseMeta?.['typeSchemas'] ?? {}) as Record<string, object>);
+      const mergedTs: Record<string, unknown> = { ...currentTs };
+      for (const [kt, ktMap] of Object.entries(proposedTs)) {
+        if (!ktMap) continue;
+        mergedTs[kt] = { ...(currentTs[kt] ?? {}), ...ktMap };
+        // Per knowledge-type, on the same rule as a scalar: contested only if this round changes it AND
+        // it is no longer where the round found it.
+        if (moved && differs(currentTs[kt], mergedTs[kt])
+            && (baseMeta === undefined || differs(baseTs[kt], currentTs[kt]))) {
+          conflicts.push(`typeSchemas.${kt}`);
+        }
+      }
+      merged['typeSchemas'] = mergedTs;
+      continue;
+    }
+
+    const incoming = proposed[field];
+    if (contested(field, merged[field], incoming)) conflicts.push(field);
+    // `undefined` is a real proposal: it is how a scalar is cleared. Deleting the key rather than assigning
+    // it keeps the stored object free of explicit-undefined properties, which JSON round-trips away anyway.
+    if (incoming === undefined) delete merged[field];
+    else merged[field] = incoming;
+  }
+
+  return {
+    meta: merged as Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'>,
+    conflicts,
+    wholesale: false,
+  };
+}
+
+/**
+ * Which top-level meta fields a PATCH body actually proposes to change.
+ *
+ * Taken from the request body's own keys, not from diffing the result against the base. A patch that sets
+ * a field to the value it already holds is still a proposal to set it — the network votes on the intent,
+ * and diffing would quietly drop that field from the round so a concurrent change to it would win by
+ * default.
+ */
+export function proposedMetaFields(incoming: Partial<SpaceMeta>): string[] {
+  return Object.keys(incoming).filter(k => !(HOUSEKEEPING as readonly string[]).includes(k));
+}

--- a/testing/standalone/meta-round-merge.test.js
+++ b/testing/standalone/meta-round-merge.test.js
@@ -1,0 +1,259 @@
+/**
+ * A passed `meta_change` round applies its own fields, not a stale snapshot of the whole meta.
+ *
+ * The loss it prevents, in the order it happens on a real network:
+ *
+ *   1. The space's meta is at version 7.
+ *   2. Alice proposes a new `purpose`. Her round carries the FULL meta — new purpose, v7's everything else.
+ *   3. Bob proposes `strictLinkage: true`. His round carries the FULL meta — v7's purpose, new flag.
+ *   4. Alice's round passes. Purpose updated, version 8.
+ *   5. Bob's round passes. The whole meta is replaced by his snapshot, still holding **v7's purpose**.
+ *
+ * Alice's change is gone, and nothing anywhere says so: the round passed, the vote is recorded as carried,
+ * and the resulting meta is internally consistent. Rounds stay open for `votingDeadlineHours` — hours,
+ * often days — so this is not an exotic race, it is what happens whenever two operators configure a space
+ * in the same week.
+ *
+ * Two behaviours are load-bearing and easy to get backwards, so both are pinned here:
+ *
+ *   - **Same-field collision resolves to the round's value.** The network voted for it. Refusing to apply
+ *     a carried motion because the field moved would relocate the silent loss, not remove it.
+ *   - **A round with no provenance applies WHOLESALE.** Rounds gossip, so one proposed by a peer that
+ *     predates field-merge arrives with neither `metaChangedFields` nor `baseMetaVersion`. Field-merging
+ *     an unknown changed-set would merge nothing — a passed round that does nothing at all.
+ *
+ * Run: node --test testing/standalone/meta-round-merge.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let applyMetaRound;
+let proposedMetaFields;
+
+/** The space's meta as it stood when both proposals were computed. */
+const V7 = {
+  version: 7,
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  purpose: 'original purpose',
+  usageNotes: 'original notes',
+  strictLinkage: false,
+  typeSchemas: { memory: { note: { properties: { a: {} } } } },
+  previousVersions: [{ version: 6, meta: {}, updatedAt: '2026-06-01T00:00:00.000Z' }],
+};
+
+/** What a proposer stores: the base with its own patch already merged in. */
+const proposalFrom = (base, patch) => ({
+  pendingMeta: { ...base, ...patch },
+  metaChangedFields: Object.keys(patch),
+  baseMetaVersion: base.version ?? 0,
+});
+
+/**
+ * What `updateSpace` does after a round is applied: bump the counter and push the outgoing meta onto
+ * `previousVersions`. Modelled here rather than skipped, because that history is where conflict detection
+ * recovers the round's base from — a test that dropped it would exercise only the degraded path.
+ */
+const commit = (previous, applied) => {
+  const { previousVersions: _drop, ...snapshot } = previous;
+  return {
+    ...applied.meta,
+    version: (previous.version ?? 0) + 1,
+    updatedAt: '2026-07-02T00:00:00.000Z',
+    previousVersions: [
+      { version: previous.version ?? 0, meta: snapshot, updatedAt: previous.updatedAt },
+      ...(previous.previousVersions ?? []),
+    ],
+  };
+};
+
+describe('meta_change round application', () => {
+  before(async () => {
+    ({ applyMetaRound, proposedMetaFields } = await import('../../server/dist/sync/meta-round-merge.js'));
+  });
+
+  describe('the concurrent-edit loss', () => {
+    it('a second round does not revert the first round\'s field', () => {
+      const alice = proposalFrom(V7, { purpose: 'alice purpose' });
+      const bob = proposalFrom(V7, { strictLinkage: true });
+
+      // Alice concludes first.
+      const afterAlice = applyMetaRound(V7, alice);
+      assert.equal(afterAlice.meta.purpose, 'alice purpose');
+      assert.deepEqual(afterAlice.conflicts, [], 'nothing had moved yet');
+
+      const v8 = commit(V7, afterAlice);
+
+      // Bob concludes second, against the meta as it now stands.
+      const afterBob = applyMetaRound(v8, bob);
+      assert.equal(afterBob.meta.strictLinkage, true, 'Bob\'s field is applied');
+      assert.equal(afterBob.meta.purpose, 'alice purpose',
+        'Alice\'s edit must survive — reverting it is the defect this whole module exists for');
+      assert.deepEqual(afterBob.conflicts, [], 'different fields are not a conflict, only a later base');
+    });
+
+    it('fields nobody proposed are left exactly as they are', () => {
+      const round = proposalFrom(V7, { purpose: 'new' });
+      const current = { ...V7, version: 9, usageNotes: 'someone else changed this' };
+      const { meta } = applyMetaRound(current, round);
+      assert.equal(meta.usageNotes, 'someone else changed this');
+    });
+
+    it('never writes housekeeping fields back', () => {
+      // `version`, `updatedAt` and `previousVersions` belong to the space layer, which re-adds them.
+      // A round carrying v7's copies into a v9 write would rewind the counter and the history with it.
+      const round = proposalFrom(V7, { purpose: 'new' });
+      const { meta } = applyMetaRound({ ...V7, version: 9 }, round);
+      for (const k of ['version', 'updatedAt', 'previousVersions']) {
+        assert.ok(!(k in meta), `${k} must not be carried by the round`);
+      }
+    });
+
+    it('ignores housekeeping even if a round names it as changed', () => {
+      // A hand-built or hostile round could list `version` among its changed fields; the space layer's
+      // counter is not something a vote may set.
+      const round = {
+        pendingMeta: { ...V7, version: 2, purpose: 'new' },
+        metaChangedFields: ['version', 'previousVersions', 'purpose'],
+        baseMetaVersion: 7,
+      };
+      const { meta } = applyMetaRound({ ...V7, version: 9 }, round);
+      assert.ok(!('version' in meta));
+      assert.ok(!('previousVersions' in meta));
+      assert.equal(meta.purpose, 'new');
+    });
+  });
+
+  describe('same-field collision — the vote wins, and says so', () => {
+    it('applies the round\'s value over one changed since it was proposed', () => {
+      const alice = proposalFrom(V7, { purpose: 'alice purpose' });
+      const bob = proposalFrom(V7, { purpose: 'bob purpose' });
+
+      const v8 = commit(V7, applyMetaRound(V7, alice));
+      const afterBob = applyMetaRound(v8, bob);
+
+      assert.equal(afterBob.meta.purpose, 'bob purpose', 'the passed vote is applied, not discarded');
+      assert.deepEqual(afterBob.conflicts, ['purpose'], 'and the overwrite is reported');
+    });
+
+    it('reports nothing when the base version still matches', () => {
+      // Same version means nothing concluded in between, so every write is uncontested — reporting a
+      // conflict here would train an operator to ignore the warning.
+      const round = proposalFrom(V7, { purpose: 'new' });
+      assert.deepEqual(applyMetaRound(V7, round).conflicts, []);
+    });
+
+    it('reports nothing when the meta moved but landed on the same value', () => {
+      // Two operators proposing the identical value is agreement, not collision.
+      const round = proposalFrom(V7, { purpose: 'same' });
+      const moved = { ...V7, version: 8, purpose: 'same' };
+      assert.deepEqual(applyMetaRound(moved, round).conflicts, []);
+    });
+
+    it('reports the overwrite when the base rolled out of the version history', () => {
+      // `previousVersions` is capped. With the base gone there is no way to tell "somebody else changed
+      // this" from "this round is changing it", so the coarse rule stands and the overwrite is reported.
+      // Over-reporting a rare case beats asserting an uncontested write that was not.
+      const round = proposalFrom(V7, { strictLinkage: true });
+      const farLater = { ...V7, version: 40, previousVersions: [{ version: 39, meta: {}, updatedAt: 'x' }] };
+      assert.deepEqual(applyMetaRound(farLater, round).conflicts, ['strictLinkage']);
+    });
+
+    it('clearing a scalar is a real proposal, not an absent one', () => {
+      const round = { pendingMeta: { ...V7, purpose: undefined }, metaChangedFields: ['purpose'], baseMetaVersion: 7 };
+      const { meta } = applyMetaRound(V7, round);
+      assert.ok(!('purpose' in meta), 'an undefined proposal clears the field rather than being skipped');
+    });
+  });
+
+  describe('typeSchemas merge per knowledge-type', () => {
+    it('keeps a type another round added', () => {
+      const round = proposalFrom(V7, {
+        typeSchemas: { memory: { note: { properties: { a: {}, b: {} } } } },
+      });
+      const current = {
+        ...V7, version: 8,
+        typeSchemas: { memory: { note: { properties: { a: {} } }, task: { properties: {} } } },
+      };
+      const { meta } = applyMetaRound(current, round);
+      assert.ok(meta.typeSchemas.memory.task, 'a concurrently-added type must survive');
+      assert.deepEqual(meta.typeSchemas.memory.note.properties, { a: {}, b: {} }, 'and this round\'s edit applies');
+    });
+
+    it('does not disturb a knowledge type the round never mentions', () => {
+      const round = proposalFrom(V7, { typeSchemas: { memory: { note: { properties: { z: {} } } } } });
+      const current = { ...V7, version: 8, typeSchemas: { ...V7.typeSchemas, entity: { person: {} } } };
+      const { meta } = applyMetaRound(current, round);
+      assert.deepEqual(meta.typeSchemas.entity, { person: {} });
+    });
+
+    it('reports the colliding knowledge type by name', () => {
+      const round = proposalFrom(V7, { typeSchemas: { memory: { note: { properties: { b: {} } } } } });
+      const current = { ...V7, version: 8, typeSchemas: { memory: { note: { properties: { c: {} } } } } };
+      const { conflicts } = applyMetaRound(current, round);
+      assert.deepEqual(conflicts, ['typeSchemas.memory']);
+    });
+  });
+
+  describe('rounds from peers that have not upgraded', () => {
+    it('apply wholesale when the base version is absent', () => {
+      // The compatibility switch. An older proposer computed pendingMeta as the complete intended result.
+      const legacy = { pendingMeta: { ...V7, purpose: 'legacy purpose' } };
+      const current = { ...V7, version: 12, usageNotes: 'changed since' };
+      const out = applyMetaRound(current, legacy);
+      assert.equal(out.wholesale, true);
+      assert.equal(out.meta.purpose, 'legacy purpose');
+      assert.equal(out.meta.usageNotes, 'original notes', 'wholesale means wholesale — the old behaviour');
+    });
+
+    it('apply wholesale when the changed-field list is absent', () => {
+      // Belt and braces: a round with a version but no field list must not field-merge an empty set, which
+      // would be a carried motion that changes nothing.
+      const half = { pendingMeta: { ...V7, purpose: 'p' }, baseMetaVersion: 7 };
+      const out = applyMetaRound({ ...V7, version: 8 }, half);
+      assert.equal(out.wholesale, true);
+      assert.equal(out.meta.purpose, 'p');
+    });
+
+    it('a modern round is never treated as wholesale', () => {
+      const out = applyMetaRound(V7, proposalFrom(V7, { purpose: 'p' }));
+      assert.equal(out.wholesale, false);
+    });
+
+    it('an empty changed-field list is honoured, not mistaken for absent', () => {
+      // `[]` says "this round proposes nothing", which is different from "we do not know what it proposes".
+      const round = { pendingMeta: { ...V7, purpose: 'ignored' }, metaChangedFields: [], baseMetaVersion: 7 };
+      const out = applyMetaRound({ ...V7, version: 8, purpose: 'kept' }, round);
+      assert.equal(out.wholesale, false);
+      assert.equal(out.meta.purpose, 'kept');
+    });
+  });
+
+  describe('a space with no meta yet', () => {
+    it('applies the round\'s fields onto an empty base', () => {
+      const round = { pendingMeta: { purpose: 'first' }, metaChangedFields: ['purpose'], baseMetaVersion: 0 };
+      const { meta, conflicts } = applyMetaRound(undefined, round);
+      assert.equal(meta.purpose, 'first');
+      assert.deepEqual(conflicts, []);
+    });
+  });
+
+  describe('proposedMetaFields', () => {
+    it('reads the patch keys, not a diff against the base', () => {
+      // A patch setting a field to the value it already holds is still a proposal to set it. Diffing would
+      // drop it from the round, so a concurrent change to that field would win by default — the network
+      // voted on the intent, not on whether the bytes differed.
+      assert.deepEqual(proposedMetaFields({ purpose: 'unchanged' }), ['purpose']);
+    });
+
+    it('drops housekeeping keys a client may have echoed back', () => {
+      assert.deepEqual(
+        proposedMetaFields({ version: 3, updatedAt: 'x', previousVersions: [], purpose: 'p' }),
+        ['purpose'],
+      );
+    });
+
+    it('is empty for an empty patch', () => {
+      assert.deepEqual(proposedMetaFields({}), []);
+    });
+  });
+});


### PR DESCRIPTION
## The loss

A `meta_change` round stored the **whole merged meta** — the proposer's patch already folded into the
base they read — and conclusion applied it with `updateSpace(spaceId, { meta: round.pendingMeta })`, a
wholesale replace. Correct for one round at a time; silently destructive for two:

1. The space's meta is at version 7.
2. Alice proposes a new `purpose`. Her round carries the full meta: new purpose, v7's everything else.
3. Bob proposes `strictLinkage: true`. His round carries the full meta: v7's purpose, new flag.
4. Alice's round passes → purpose updated, version 8.
5. Bob's round passes → the meta is replaced by his snapshot, which still holds **v7's purpose**.

Alice's change is gone. Nothing reports it: the round passed, the vote is recorded as carried, and the
space's meta is internally consistent — just missing an edit the network voted to make. Rounds run for
`votingDeadlineHours` (hours, often days), so overlapping proposals are not an exotic race; they are the
normal cadence of a network where more than one operator configures a space.

## What is applied instead

Only the fields the proposer actually changed. A round records `metaChangedFields` and the
`baseMetaVersion` it was computed against, and conclusion re-merges those fields into whatever the meta
says **now**. `typeSchemas` merges per knowledge-type, matching what the PATCH path already does — so a
type another round added survives, and one this round edited wins.

## Same-field collision: the vote wins, and says so

The later-concluding round takes effect. This is the deliberate answer, not a leftover:

- The network **voted** for that value. Refusing to apply a passed round because the field moved turns a
  carried motion into a silent no-op — the same failure, relocated.
- Reopening cannot be decided here: conclusion runs on every peer independently, and a decision that
  needs a new round is not one peer's to take.

So the collision is *reported*. `applyMetaRound` returns which fields it overwrote and governance logs
them with the round's base version and the current one, so a superseded operator learns it from the log
rather than from noticing the value is wrong weeks later.

**Detection recovers the round's base from the space's own `previousVersions` history.** That is what
separates "somebody else changed this field" from "this round is changing it" — without it the warning
fires on every ordinary concurrent edit of *different* fields, and a warning that cries wolf on the
normal path is one operators learn to skip. When the base has rolled out of the capped history the
overwrite is reported rather than assumed uncontested; over-reporting a rare case is the right side to
err on, and the value is applied either way.

## Peers that have not upgraded

`VoteRound` gossips, so a round proposed by an older peer arrives with neither field. Those apply
**wholesale**, exactly as before. That is the only safe reading: an older proposer computed
`pendingMeta` as the complete intended result, and field-merging a round whose changed-field list is
unknown would apply an empty set — a passed round that changes nothing at all. The absent version is the
compatibility switch; the pre-upgrade behaviour is the fallback.

## Verification

- `npm run preflight` green.
- New suite `testing/standalone/meta-round-merge.test.js` — 20 tests: the concurrent-edit sequence
  end-to-end, housekeeping never carried (including when a hostile round names `version` as changed),
  collision reporting with and without recoverable history, `typeSchemas` per-KT merge, all four
  wholesale-fallback shapes (`[]` is honoured, not mistaken for absent), and a space with no meta yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
