### PR TITLE
fix(brain): updates are validated against the schema — all of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Updates are validated against the schema. All of them.** Creates were validated; updates were
+  validated **only when the patch used `deleteFields`**.
+  - Every other patch skipped validation entirely, so `PATCH { properties: { status: "nonsense" } }`
+    wrote a value the same space rejects at create time, in a space explicitly set to `strict`. The
+    stricter a space's schema, the wider the gap — the write path an operator relies on to keep records
+    conformant was the one path that did not check. All eight surfaces are covered: the four REST
+    `PATCH` routes and the four `update_*` MCP tools, which had no schema validation at all.
+  - The **merged** record is validated, not the patch. A patch is a fragment, and "does this fragment
+    satisfy the schema" has no useful answer: a required property the patch does not mention is present
+    in the record and absent from the patch, so the fragment check would fail every partial update.
+  - **The error says whose fault it is.** Validating the merged record means a record that was *already*
+    non-compliant — written before the schema tightened, imported, or synced from a peer with different
+    meta — now fails on any edit, including one unrelated to the offending field. Reporting that as
+    "your change is invalid" is false in the way that costs an afternoon. Violations are classified
+    against the record's prior state into `introduced` (this patch caused it) and `preExisting` (it
+    didn't), and the message names which situation applies. Identity is field **and** reason, so a new
+    failure on an already-failing field is not waved through as pre-existing; the value is excluded, so
+    an unchanged violation whose value the patch altered is not blamed on the patch.
+  - Both kinds block in `strict`: the merged record is what gets stored, and storing a known-invalid
+    record because it was already invalid is how a space drifts permanently out of conformance. The
+    record is not trapped — validation is of the merged result, so a patch that includes the offending
+    field repairs it, and the error says exactly that.
+  - The MCP tools import the API layer's gate rather than reimplementing it. `update_chrono` shipped
+    once without the type allowlist `create_chrono` enforced; two copies of a validation rule is how
+    that happens.
+
 - **Two concurrent space-meta votes no longer overwrite each other.** A `meta_change` round stored the
   whole merged meta and applied it wholesale on conclusion, so the later of two overlapping rounds
   reverted the earlier one's edit.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -3691,6 +3691,40 @@ Each space can define a schema in its `meta` block that governs what data is acc
 > defined yet, `strict` still accepts every type and label, so it never blocks a brand-new empty space;
 > it starts mattering the moment you define a schema.
 
+**Updates validate the record as it will be.** A `PATCH` (and the matching `update_*` MCP tool) validates
+the **merged** result — the stored record with your patch applied — not the patch on its own. Validating
+the fragment would fail every partial update that does not restate every required property, so the answer
+would be meaningless. In `strict` mode a violating update is refused with `422`:
+
+```json
+{
+  "error": "schema_violation",
+  "message": "The change violates this space's schema: status.",
+  "violations": [ { "field": "status", "value": "nonsense", "reason": "not in enum: open, closed" } ],
+  "introduced": [ { "field": "status", "…": "…" } ],
+  "preExisting": []
+}
+```
+
+`introduced` and `preExisting` are the same violations, split by **whose fault they are**:
+
+| Field | Meaning |
+|-------|---------|
+| `introduced` | Not present before this patch. Your change caused it. |
+| `preExisting` | Present before and still present. Your change neither caused nor fixed it. |
+
+A record can be non-compliant before you touch it — written before the schema tightened, imported, or
+synced from a peer with different meta. Both kinds block, because the merged record is what gets stored
+and storing a known-invalid record is how a space drifts permanently out of conformance. The record is
+**not** trapped: validation is of the merged result, so including the offending field in the same request
+repairs it and the write succeeds. The `message` says which of the two situations applies, so you are not
+sent after a field you did not touch.
+
+In `warn` mode the write proceeds and the same three lists are reported.
+
+*New in 2.2.* Previously an update was validated only when the request used `deleteFields`; every other
+patch could write a value the same space rejects at create time.
+
 **Schema structure — `typeSchemas`:**
 
 The schema is expressed as a single `typeSchemas` object on the space `meta`. It groups configuration by knowledge type (`entity`, `edge`, `memory`, `chrono`) and then by type name (e.g. `"service"`, `"depends_on"`). Each entry is a `TypeSchema` object:

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -14,6 +14,7 @@ import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembe
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
 import type { ChronoStatus } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { classifyUpdateViolations } from './update-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const chronoRouter = Router();
@@ -226,6 +227,31 @@ chronoRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceA
   // Snapshot for the audit change list — see the note in memories.ts. Read before the write, since
   // `updateChrono` returns only the new document.
   const prior = await findFirstAcrossMembers(wt.target, mid => getChronoById(mid, id));
+
+  // Validate the entry AS IT WILL BE. This path had NO property validation at all — the `type` allowlist
+  // above was the whole of it — so a patch could write a property the same space rejects at create time.
+  // Merging first is what makes the check meaningful: a required property the patch does not mention is
+  // present in the record and absent from the patch.
+  if (prior) {
+    const meta = getSpaceMeta(wt.target);
+    const priorProps = (prior.properties ?? {}) as Record<string, unknown>;
+    const check = classifyUpdateViolations(
+      meta,
+      validateChrono(meta ?? {}, { type: prior.type, properties: priorProps }),
+      validateChrono(meta ?? {}, { type: type ?? prior.type, properties: safeProps ?? priorProps }),
+    );
+    if (check.blocked) {
+      res.status(422).json({
+        error: 'schema_violation',
+        message: check.message,
+        violations: check.all,
+        introduced: check.introduced,
+        preExisting: check.preExisting,
+      });
+      return;
+    }
+  }
+
   const updated = await findFirstAcrossMembers(wt.target, mid => updateChrono(mid, id, {
     title, type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -16,6 +16,7 @@ import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEdge } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { classifyUpdateViolations } from './update-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const edgesRouter = Router();
@@ -215,29 +216,40 @@ edgesRouter.patch('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAut
   if (Object.keys(updates).length === 0 && !dfPaths && !ttlDaysProvided) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
   const memberIds = resolveMemberSpaces(wt.target);
   for (const mid of memberIds) {
-    // Schema validation after deleteFields + merge
-    if (dfPaths) {
-      const existing = await getEdgeById(mid, id);
-      if (!existing) continue;
+    // Validate the edge AS IT WILL BE, on every patch — not only when `deleteFields` is present. That
+    // branch used to be the whole of update validation, so a patch that moved `label` outside the
+    // allowlist wrote a value the same space rejects at create time. One read, shared with the audit
+    // snapshot below.
+    const existing = await getEdgeById(mid, id);
+    if (!existing) continue;
+    {
       const resultProps = updates.properties !== undefined
         ? { ...(existing.properties ?? {}), ...updates.properties }
         : { ...(existing.properties ?? {}) };
       const sim: Record<string, unknown> = { properties: resultProps };
-      applyDeleteFieldsPaths(sim, dfPaths);
+      if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       const simProps = (sim['properties'] ?? {}) as Record<string, unknown>;
       const meta = getSpaceMeta(mid);
-      const violations = validateEdge(meta ?? {}, { label: updates.label ?? existing.label, properties: simProps });
-      const validation = applyValidation(meta, violations);
-      if (validation.blocked) {
-        res.status(422).json({ error: 'schema_violation', message: 'deleteFields + merge result violates required properties', violations: validation.warnings });
+      const check = classifyUpdateViolations(
+        meta,
+        validateEdge(meta ?? {}, { label: existing.label, properties: existing.properties ?? {} }),
+        validateEdge(meta ?? {}, { label: updates.label ?? existing.label, properties: simProps }),
+      );
+      if (check.blocked) {
+        res.status(422).json({
+          error: 'schema_violation',
+          message: check.message,
+          violations: check.all,
+          introduced: check.introduced,
+          preExisting: check.preExisting,
+        });
         return;
       }
     }
-    // Snapshot for the audit change list — see the note in memories.ts.
-    const prior = await getEdgeById(mid, id);
+    // Snapshot for the audit change list, from the read above — see the note in memories.ts.
     const updated = await updateEdgeById(mid, id, updates, dfPaths, webhookToken(req), ttlDaysFromBody(req.body));
     if (updated) {
-      req.auditSnapshots = { before: prior ?? {}, after: updated };
+      req.auditSnapshots = { before: existing ?? {}, after: updated };
       res.json(updated);
       return;
     }

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -17,6 +17,7 @@ import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEntity } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { classifyUpdateViolations } from './update-validation.js';
 import { tagContains, textContains, propertiesValueContains } from '../../brain/tag-filter.js';
 
 export const entitiesRouter = Router();
@@ -243,10 +244,13 @@ entitiesRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSp
   if (Object.keys(updates).length === 0 && !dfPaths && !ttlDaysProvided) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
   const memberIds = resolveMemberSpaces(wt.target);
   for (const mid of memberIds) {
-    // Fetch existing entity to validate schema after deleteFields + merge
-    if (dfPaths) {
-      const existing = await getEntityById(mid, id);
-      if (!existing) continue;
+    // Validate the entity AS IT WILL BE, on every patch — not only when `deleteFields` is present. That
+    // branch used to be the whole of update validation, so a patch that set `type` outside the allowlist,
+    // or a property outside its enum, wrote a value the same space rejects at create time. One read,
+    // shared with the audit snapshot below.
+    const existing = await getEntityById(mid, id);
+    if (!existing) continue;
+    {
       // Build the resulting entity state to validate against schema
       const resultName = updates.name ?? existing.name;
       const resultType = updates.type ?? existing.type;
@@ -258,23 +262,30 @@ entitiesRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSp
         : { ...(existing.properties ?? {}) };
       // Build a simulation and apply deleteFields for schema check
       const sim: Record<string, unknown> = { properties: resultProps, tags: resultTags, description: updates.description !== undefined ? updates.description : existing.description };
-      applyDeleteFieldsPaths(sim, dfPaths);
+      if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       const simProps = (sim['properties'] ?? {}) as Record<string, unknown>;
-      // Schema validation after deleteFields + merge
       const meta = getSpaceMeta(mid);
-      const violations = validateEntity(meta ?? {}, { name: resultName, type: resultType, properties: simProps, tags: sim['tags'] as string[] });
-      const validation = applyValidation(meta, violations);
-      if (validation.blocked) {
-        res.status(422).json({ error: 'schema_violation', message: 'deleteFields + merge result violates required properties', violations: validation.warnings });
+      const check = classifyUpdateViolations(
+        meta,
+        validateEntity(meta ?? {}, { name: existing.name, type: existing.type, properties: existing.properties ?? {}, tags: existing.tags ?? [] }),
+        validateEntity(meta ?? {}, { name: resultName, type: resultType, properties: simProps, tags: sim['tags'] as string[] }),
+      );
+      if (check.blocked) {
+        res.status(422).json({
+          error: 'schema_violation',
+          message: check.message,
+          violations: check.all,
+          introduced: check.introduced,
+          preExisting: check.preExisting,
+        });
         return;
       }
     }
-    // Snapshot for the audit change list — see the note in memories.ts. Interactive single-record path
-    // only; `properties` is deliberately not allowlisted, so handing the record over cannot publish it.
-    const prior = await getEntityById(mid, id);
+    // Snapshot for the audit change list, from the read above — see the note in memories.ts.
+    // `properties` is deliberately not allowlisted, so handing the record over cannot publish it.
     const updated = await updateEntityById(mid, id, updates, dfPaths, webhookToken(req), ttlDaysFromBody(req.body));
     if (updated) {
-      req.auditSnapshots = { before: prior ?? {}, after: updated };
+      req.auditSnapshots = { before: existing ?? {}, after: updated };
       res.json(updated);
       return;
     }

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -18,6 +18,7 @@ import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage,
 import { validateMemory } from '../../spaces/schema-validation.js';
 import type { MemoryDoc } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, buildMemoryFilter, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { classifyUpdateViolations } from './update-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const memoriesRouter = Router();
@@ -208,32 +209,47 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
   if (Object.keys(updates).length === 0 && !dfPaths && !ttlDaysProvided) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
   const memberIds = resolveMemberSpaces(wt.target);
   for (const mid of memberIds) {
-    // Schema validation after deleteFields + merge for memories
-    if (dfPaths) {
-      const existing = await listMemories(mid, { _id: id }, 1, 0);
-      if (existing.length === 0) continue;
+    // Validate the record AS IT WILL BE, on every patch — not only when `deleteFields` is present.
+    //
+    // That branch used to be the whole of update validation, so any other patch wrote values the same
+    // space rejects at create time. Merging first is what makes the check meaningful: a required property
+    // the patch does not mention is present in the record and absent from the patch, so validating the
+    // fragment answers a question nobody asked.
+    //
+    // The read this needs is the same one the audit snapshot below needed, so it is done once and shared
+    // rather than issued twice per patch.
+    const existing = await listMemories(mid, { _id: id }, 1, 0);
+    if (existing.length === 0) continue;
+    {
       const mem = existing[0]!;
-      const resultProps = updates.properties ?? (mem.properties != null ? { ...mem.properties } : {});
+      const priorProps = mem.properties != null ? { ...mem.properties } : {};
+      const resultProps = updates.properties ?? { ...priorProps };
       const sim: Record<string, unknown> = { properties: resultProps };
-      applyDeleteFieldsPaths(sim, dfPaths);
+      if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       const simProps = (sim['properties'] ?? {}) as Record<string, unknown>;
       const meta = getSpaceMeta(mid);
-      const violations = validateMemory(meta ?? {}, { properties: simProps });
-      const validation = applyValidation(meta, violations);
-      if (validation.blocked) {
-        res.status(422).json({ error: 'schema_violation', message: 'deleteFields + merge result violates required properties', violations: validation.warnings });
+      const check = classifyUpdateViolations(
+        meta,
+        validateMemory(meta ?? {}, { type: mem.type, properties: priorProps }),
+        validateMemory(meta ?? {}, { type: mem.type, properties: simProps }),
+      );
+      if (check.blocked) {
+        res.status(422).json({
+          error: 'schema_violation',
+          message: check.message,
+          violations: check.all,
+          introduced: check.introduced,
+          preExisting: check.preExisting,
+        });
         return;
       }
     }
-    // Snapshot for the audit change list. One extra read, on the interactive single-record path only —
-    // bulk writes go through `bulk.write`, which has no allowlist, and peer sync never reaches this
-    // route at all. `audit-changes.ts` reads only the allowlisted fields, so handing the whole record
-    // over cannot publish `properties` (deliberately unlisted: its keys are user-chosen and could hold
-    // a pasted credential).
-    const prior = await listMemories(mid, { _id: id }, 1, 0);
+    // Snapshot for the audit change list, taken from the read above. `audit-changes.ts` reads only the
+    // allowlisted fields, so handing the whole record over cannot publish `properties` (deliberately
+    // unlisted: its keys are user-chosen and could hold a pasted credential).
     const updated = await updateMemory(mid, id, updates, dfPaths, webhookToken(req), ttlDaysFromBody(req.body));
     if (updated) {
-      req.auditSnapshots = { before: prior[0] ?? {}, after: updated };
+      req.auditSnapshots = { before: existing[0] ?? {}, after: updated };
       res.json(updated);
       return;
     }

--- a/server/src/api/brain/update-validation.ts
+++ b/server/src/api/brain/update-validation.ts
@@ -1,0 +1,152 @@
+/**
+ * Schema validation on UPDATE — of the record as it will be, and honest about whose fault a violation is.
+ *
+ * ## The hole
+ *
+ * Creates were validated. Updates were validated **only when the patch used `deleteFields`** — the branch
+ * that exists because removing a required property is an obvious way to break a record. Every other patch
+ * skipped validation entirely, so `PATCH { properties: { status: "nonsense" } }` wrote a value the same
+ * space would have rejected at create time, in a space explicitly set to `strict`. The stricter a space's
+ * schema, the wider the gap: the write path an operator relies on to keep records conformant was the one
+ * path that did not check.
+ *
+ * Validating the **merged** record rather than the patch is what makes this correct. A patch is a fragment;
+ * "does this fragment satisfy the schema" is not a question with a useful answer, because a required
+ * property the patch does not mention is present in the record and absent from the patch.
+ *
+ * ## Whose fault
+ *
+ * Once the merged record is validated, a second problem appears immediately: a record that was **already**
+ * non-compliant — written before the schema tightened, imported, or synced from a peer with different
+ * meta — now fails validation on any edit, including an edit that has nothing to do with the offending
+ * field. Reporting that as "your change is invalid" is false, and it is the kind of false that costs an
+ * afternoon: the operator stares at a field they did not touch.
+ *
+ * So violations are split against the record's prior state:
+ *
+ *   - **introduced** — not present before this patch. The patch caused it.
+ *   - **pre-existing** — present before and still present. The patch did not cause it, and did not fix it.
+ *
+ * Both block, in a `strict` space. That is deliberate rather than a half-measure: the merged record is what
+ * gets stored, and storing a known-invalid record because it was already invalid is how a space drifts
+ * permanently out of conformance. And the record is not trapped — validation is of the *merged* result, so
+ * a patch that repairs the pre-existing violation passes. The error names exactly what to include.
+ */
+import type { SchemaViolation } from '../../spaces/schema-validation.js';
+import type { SpaceMeta } from '../../config/types.js';
+import { resolveMemberSpaces } from '../../spaces/proxy.js';
+import { applyValidation, getSpaceMeta } from './_shared.js';
+
+/**
+ * Identity of a violation for before/after comparison.
+ *
+ * Field **and** reason, not field alone. One field can fail two ways at once — a property that is both
+ * the wrong type and outside its enum — and keying on the field would let a patch introduce a second,
+ * different violation on an already-failing field and have it reported as pre-existing. The value is
+ * deliberately excluded: an unchanged violation whose value the patch altered (`"a"` → `"b"`, both outside
+ * the enum) is the same defect, still the record's own, and calling it newly introduced would blame the
+ * patch for a constraint it did not break.
+ */
+const key = (v: SchemaViolation) => `${v.field}\u0000${v.reason}`;
+
+export interface UpdateValidation {
+  /** True when the write must be refused (strict space, at least one violation of the merged record). */
+  blocked: boolean;
+  /** Violations this patch caused. */
+  introduced: SchemaViolation[];
+  /** Violations the record already had, which this patch neither caused nor fixed. */
+  preExisting: SchemaViolation[];
+  /** Everything, for the `violations` field of the response — warn mode reports without blocking. */
+  all: SchemaViolation[];
+  /** Ready-to-send message naming which of the two situations applies. */
+  message: string;
+}
+
+/**
+ * Classify the merged record's violations against the record's prior ones.
+ *
+ * `beforeViolations` is what the SAME validator says about the record as it stands now. Recomputing it
+ * rather than trusting a stored flag matters: the space's meta can have tightened since the record was
+ * written, and the question here is not "was this record valid when created" but "is this field's failure
+ * something this patch is responsible for".
+ */
+export function classifyUpdateViolations(
+  meta: SpaceMeta | undefined,
+  beforeViolations: SchemaViolation[],
+  afterViolations: SchemaViolation[],
+): UpdateValidation {
+  const before = new Set(beforeViolations.map(key));
+  const introduced = afterViolations.filter(v => !before.has(key(v)));
+  const preExisting = afterViolations.filter(v => before.has(key(v)));
+
+  const verdict = applyValidation(meta, afterViolations);
+
+  return {
+    blocked: verdict.blocked,
+    introduced,
+    preExisting,
+    all: afterViolations,
+    message: describeUpdateViolations(introduced, preExisting),
+  };
+}
+
+/**
+ * Find which member space holds the record, and that space's meta.
+ *
+ * On a proxy space the record lives in exactly one member, and the schema that governs it is **that
+ * member's**, not the proxy's. Resolving the two together is the only way an MCP tool can validate
+ * against the right meta without re-implementing member resolution per tool — four copies of which is how
+ * three of them would end up validating against the proxy.
+ */
+export async function locateForUpdate<T>(
+  spaceId: string,
+  load: (memberId: string) => Promise<T | null | undefined>,
+): Promise<{ memberId: string; record: T; meta: SpaceMeta | undefined } | undefined> {
+  for (const memberId of resolveMemberSpaces(spaceId)) {
+    const record = await load(memberId);
+    if (record != null) return { memberId, record, meta: getSpaceMeta(memberId) };
+  }
+  return undefined;
+}
+
+/**
+ * The MCP-side gate. Same verdict, thrown rather than returned — MCP tools report failure by throwing.
+ *
+ * It exists so the two surfaces cannot drift. `update_chrono` already shipped once without the type
+ * allowlist that `create_chrono` enforced, and this is the same shape of hole one layer down: an agent
+ * writing through MCP would otherwise store values the REST route now refuses for the identical record.
+ */
+export function assertUpdateAllowed(check: UpdateValidation): void {
+  if (check.blocked) throw new Error(`schema_violation: ${check.message}`);
+}
+
+/**
+ * The sentence an operator reads.
+ *
+ * Three distinct situations, because collapsing them is what makes a validation error useless:
+ *   - only introduced   → the patch is wrong; fix the patch
+ *   - only pre-existing → the patch is fine; the record was already broken here, and this write is the
+ *                         moment to repair it
+ *   - both              → say both, and say which is which, or the operator debugs the wrong one first
+ */
+export function describeUpdateViolations(
+  introduced: SchemaViolation[],
+  preExisting: SchemaViolation[],
+): string {
+  const names = (vs: SchemaViolation[]) => [...new Set(vs.map(v => v.field))].join(', ');
+
+  if (introduced.length > 0 && preExisting.length === 0) {
+    return `The change violates this space's schema: ${names(introduced)}.`;
+  }
+  if (introduced.length === 0 && preExisting.length > 0) {
+    return `This record was already non-compliant before your change: ${names(preExisting)}. `
+      + 'Your edit did not cause it, but the merged record is what gets stored, so the write is refused '
+      + 'until those field(s) are fixed — include them in this same request to repair the record.';
+  }
+  if (introduced.length > 0 && preExisting.length > 0) {
+    return `The change violates this space's schema: ${names(introduced)}. `
+      + `Separately, this record was already non-compliant before your change: ${names(preExisting)} — `
+      + 'include those field(s) in the same request to repair them.';
+  }
+  return 'The merged record satisfies this space\'s schema.';
+}

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -1,6 +1,8 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
-import { ChronoFilter, createChrono, listChrono, updateChrono, parseRecurrence } from '../../brain/chrono.js';
+import { ChronoFilter, createChrono, getChronoById, listChrono, updateChrono, parseRecurrence } from '../../brain/chrono.js';
+// The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
+import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
@@ -239,6 +241,23 @@ export const update_chronoTool: ToolHandler = {
       const rec = parseRecurrence(a['recurrence']);
       if (!rec.ok) throw new Error(rec.error);
       updates['recurrence'] = rec.value;
+    }
+
+    // Validate the entry AS IT WILL BE, against the meta of the member space it actually lives in. The
+    // type allowlist above is not the whole schema: property constraints applied at `create_chrono` and
+    // nowhere on this path, so an agent could write a value the same space refuses on creation.
+    const found = await locateForUpdate(wt.target, mid => getChronoById(mid, id));
+    if (found) {
+      const prior = found.record;
+      const priorProps = (prior.properties ?? {}) as Record<string, unknown>;
+      assertUpdateAllowed(classifyUpdateViolations(
+        found.meta,
+        validateChrono(found.meta ?? {}, { type: prior.type, properties: priorProps }),
+        validateChrono(found.meta ?? {}, {
+          type: (updates['type'] as string | undefined) ?? prior.type,
+          properties: (updates['properties'] as Record<string, unknown> | undefined) ?? priorProps,
+        }),
+      ));
     }
 
     const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2], ctx.actor, ttlDaysFromArgs(a));

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -1,7 +1,9 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
-import { validateDeleteFields } from '../../brain/delete-fields.js';
-import { traverseGraph, updateEdgeById, upsertEdge } from '../../brain/edges.js';
+import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
+import { getEdgeById, traverseGraph, updateEdgeById, upsertEdge } from '../../brain/edges.js';
+// The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
+import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateEdge } from '../../spaces/schema-validation.js';
@@ -123,6 +125,29 @@ export const update_edgeTool: ToolHandler = {
     if (typeof a['type'] === 'string') updates.type = (a['type'] as string).trim();
     const ttlDays = ttlDaysFromArgs(a);
     if (Object.keys(updates).length === 0 && !dfPaths && ttlDays === undefined) throw new Error('At least one of label, description, tags, properties, weight, type, deleteFields, or ttlDays must be provided');
+
+    // Validate the edge AS IT WILL BE, against the meta of the member space it actually lives in. This
+    // path had no schema validation at all, so `label` could be moved outside the allowlist that
+    // `upsert_edge` enforces on the very same record.
+    const found = await locateForUpdate(wt.target, mid => getEdgeById(mid, id));
+    if (found) {
+      const prior = found.record;
+      const sim: Record<string, unknown> = {
+        properties: updates.properties !== undefined
+          ? { ...(prior.properties ?? {}), ...updates.properties }
+          : { ...(prior.properties ?? {}) },
+      };
+      if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
+      assertUpdateAllowed(classifyUpdateViolations(
+        found.meta,
+        validateEdge(found.meta ?? {}, { label: prior.label, properties: prior.properties ?? {} }),
+        validateEdge(found.meta ?? {}, {
+          label: updates.label ?? prior.label,
+          properties: (sim['properties'] ?? {}) as Record<string, unknown>,
+        }),
+      ));
+    }
+
     const updatedEdge = await findFirstAcrossMembers(wt.target, mid => updateEdgeById(mid, id, updates, dfPaths, ctx.actor, ttlDays));
     if (!updatedEdge) throw new Error(`Edge '${id}' not found`);
     return {

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -1,7 +1,9 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, uuidSchema, unitScoreSchema } from './shared.js';
-import { validateDeleteFields } from '../../brain/delete-fields.js';
-import { findEntitiesByName, updateEntityById, upsertEntity } from '../../brain/entities.js';
+import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
+import { findEntitiesByName, getEntityById, updateEntityById, upsertEntity } from '../../brain/entities.js';
+// The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
+import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
 import { type PropertyResolution, applyResolutions, computeMergePlan, executeMerge, validateResolution } from '../../brain/merge.js';
 import { getConfig } from '../../config/loader.js';
 import { isProxySpace, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
@@ -133,6 +135,35 @@ export const update_entityTool: ToolHandler = {
     }
     const ttlDays = ttlDaysFromArgs(a);
     if (Object.keys(updates).length === 0 && !dfPaths && ttlDays === undefined) throw new Error('At least one of name, type, description, tags, properties, deleteFields, or ttlDays must be provided');
+
+    // Validate the entity AS IT WILL BE, against the meta of the member space it actually lives in. This
+    // path had no schema validation at all, so `type` could be moved outside the allowlist that
+    // `upsert_entity` enforces on the very same record.
+    const found = await locateForUpdate(wt.target, mid => getEntityById(mid, id));
+    if (found) {
+      const prior = found.record;
+      const resultTags = updates.tags !== undefined
+        ? Array.from(new Set([...(prior.tags ?? []), ...updates.tags]))
+        : prior.tags ?? [];
+      const sim: Record<string, unknown> = {
+        properties: updates.properties !== undefined
+          ? { ...(prior.properties ?? {}), ...updates.properties }
+          : { ...(prior.properties ?? {}) },
+        tags: resultTags,
+      };
+      if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
+      assertUpdateAllowed(classifyUpdateViolations(
+        found.meta,
+        validateEntity(found.meta ?? {}, { name: prior.name, type: prior.type, properties: prior.properties ?? {}, tags: prior.tags ?? [] }),
+        validateEntity(found.meta ?? {}, {
+          name: updates.name ?? prior.name,
+          type: updates.type ?? prior.type,
+          properties: (sim['properties'] ?? {}) as Record<string, unknown>,
+          tags: sim['tags'] as string[],
+        }),
+      ));
+    }
+
     const updatedEnt = await findFirstAcrossMembers(wt.target, mid => updateEntityById(mid, id, updates, dfPaths, ctx.actor, ttlDays));
     if (!updatedEnt) throw new Error(`Entity '${id}' not found`);
     return {

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -9,7 +9,11 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { validateDeleteFields } from '../../brain/delete-fields.js';
 import { findEntitiesByIds } from '../../brain/entities.js';
 import { assertRefsResolve, UUID_V4_PATTERN } from '../../brain/entity-refs.js';
-import { deleteMemory, remember, updateMemory } from '../../brain/memory.js';
+import { deleteMemory, listMemories, remember, updateMemory } from '../../brain/memory.js';
+import { applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
+// The API layer's write gate, imported rather than reimplemented: `update_chrono` once shipped without
+// the allowlist `create_chrono` enforced, and two copies of a validation rule is how that happens.
+import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { resolveWriteTarget, findFirstAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
@@ -189,6 +193,21 @@ export const update_memoryTool: ToolHandler = {
 
     const ttlDays = ttlDaysFromArgs(a);
     if (Object.keys(updates).length === 0 && !dfPaths && ttlDays === undefined) throw new Error('At least one of fact, tags, entityIds, description, properties, deleteFields, or ttlDays must be provided');
+
+    // Validate the memory AS IT WILL BE, against the meta of the member space it actually lives in.
+    // This path had no schema validation at all, so an agent could write through MCP a value the same
+    // space refuses at `remember` time — and, since #571, one the REST route refuses too.
+    const found = await locateForUpdate(wt.target, async mid => (await listMemories(mid, { _id: id }, 1, 0))[0]);
+    if (found) {
+      const priorProps = (found.record.properties ?? {}) as Record<string, unknown>;
+      const sim: Record<string, unknown> = { properties: updates.properties ?? { ...priorProps } };
+      if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
+      assertUpdateAllowed(classifyUpdateViolations(
+        found.meta,
+        validateMemory(found.meta ?? {}, { type: found.record.type, properties: priorProps }),
+        validateMemory(found.meta ?? {}, { type: found.record.type, properties: (sim['properties'] ?? {}) as Record<string, unknown> }),
+      ));
+    }
 
     // Search member spaces sequentially — consistent with REST endpoint behaviour.
     const updated = await findFirstAcrossMembers(wt.target, mid => updateMemory(mid, id, updates, dfPaths, ctx.actor, ttlDays));

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -303,6 +303,17 @@ describe('audit changes — file meta and entity merge (the two held back from s
       [{ field: 'absorbedName', from: 'Acme Corp', to: null }]);
   });
 
+  /**
+   * A real before-snapshot: `before` reads a variable holding the pre-write record, not `{}`.
+   *
+   * The identifier is not pinned. It used to be spelled `prior` everywhere, and #571 folded that read
+   * into the one update validation already needed — renaming it to `existing` and breaking four
+   * assertions that were checking a variable NAME while claiming to check that the snapshot exists. The
+   * property worth holding is "before comes from a read", so that is what this matches; `before: {}`
+   * still fails, which is the mutation that matters.
+   */
+  const SNAPSHOT = /req\.auditSnapshots = \{ before: [A-Za-z_$][\w$]*(?:\[0\])? \?\? \{\}, after: updated \}/;
+
   it('both routes actually supply snapshots — checked per SITE, not per file', () => {
     // The #471 rule: an allowlist with no route behind it records nothing while claiming coverage.
     //
@@ -310,25 +321,22 @@ describe('audit changes — file meta and entity merge (the two held back from s
     // file-level "does it mention auditSnapshots" check passes when either one is deleted — mutation
     // proved it, by removing the PATCH snapshot while every test stayed green.
     const entities = read('server/src/api/brain/entities.ts');
-    assert.match(entities, /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/,
-      'entity.update must snapshot around its PATCH');
+    assert.match(entities, SNAPSHOT, 'entity.update must snapshot around its PATCH');
     assert.match(entities, /before: \{ absorbedName: absorbed\.name \}/,
       'entity.merge must snapshot the absorbed name');
 
-    assert.match(read('server/src/api/brain/file-meta.ts'),
-      /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/);
+    assert.match(read('server/src/api/brain/file-meta.ts'), SNAPSHOT);
   });
 
   it('every record route that was wired still has its snapshot', () => {
     // Derived rather than enumerated, same lesson as the If-Match coverage fix: a per-file check rots
     // the moment a file gains a second site.
-    const WIRED = {
-      'server/src/api/brain/memories.ts': /req\.auditSnapshots = \{ before: prior\[0\] \?\? \{\}, after: updated \}/,
-      'server/src/api/brain/edges.ts': /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/,
-      'server/src/api/brain/chrono.ts': /req\.auditSnapshots = \{ before: prior \?\? \{\}, after: updated \}/,
-    };
-    for (const [file, pattern] of Object.entries(WIRED)) {
-      assert.match(read(file), pattern, `${file} lost its audit snapshot`);
+    for (const file of [
+      'server/src/api/brain/memories.ts',
+      'server/src/api/brain/edges.ts',
+      'server/src/api/brain/chrono.ts',
+    ]) {
+      assert.match(read(file), SNAPSHOT, `${file} lost its audit snapshot`);
     }
   });
 

--- a/testing/standalone/update-validation.test.js
+++ b/testing/standalone/update-validation.test.js
@@ -1,0 +1,213 @@
+/**
+ * Updates validate the record AS IT WILL BE, and say whose fault a violation is.
+ *
+ * ## The hole
+ *
+ * Creates were validated. Updates were validated **only when the patch used `deleteFields`** — the branch
+ * that exists because removing a required property is an obvious way to break a record. Every other patch
+ * skipped validation, so `PATCH { properties: { status: "nonsense" } }` wrote a value the same space
+ * rejects at create time, in a space explicitly set to `strict`. The stricter the schema, the wider the
+ * gap: the one write path an operator relies on to keep records conformant was the one that did not check.
+ *
+ * ## Why the merged record, and not the patch
+ *
+ * A patch is a fragment. "Does this fragment satisfy the schema" has no useful answer, because a required
+ * property the patch does not mention is present in the record and absent from the patch — so validating
+ * the fragment would fail every partial update that happens not to restate every required field.
+ *
+ * ## Why the split
+ *
+ * Validating the merged record surfaces a second problem immediately: a record that was **already**
+ * non-compliant — written before the schema tightened, imported, or synced from a peer with different
+ * meta — now fails on any edit, including one that has nothing to do with the offending field. Reporting
+ * that as "your change is invalid" is false in the way that costs an afternoon: the operator stares at a
+ * field they did not touch. So violations are classified against the record's prior state, and the message
+ * names which situation applies.
+ *
+ * Run: node --test testing/standalone/update-validation.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let classifyUpdateViolations;
+let describeUpdateViolations;
+let assertUpdateAllowed;
+
+const STRICT = { validationMode: 'strict' };
+const WARN = { validationMode: 'warn' };
+const OFF = { validationMode: 'off' };
+
+const v = (field, reason) => ({ field, value: 'whatever', reason });
+
+describe('update validation', () => {
+  before(async () => {
+    ({ classifyUpdateViolations, describeUpdateViolations, assertUpdateAllowed } =
+      await import('../../server/dist/api/brain/update-validation.js'));
+  });
+
+  describe('classification', () => {
+    it('calls a violation the patch caused "introduced"', () => {
+      const out = classifyUpdateViolations(STRICT, [], [v('status', 'not in enum')]);
+      assert.deepEqual(out.introduced.map(x => x.field), ['status']);
+      assert.deepEqual(out.preExisting, []);
+      assert.equal(out.blocked, true);
+    });
+
+    it('calls a violation the record already had "pre-existing"', () => {
+      const already = [v('owner', 'required property missing')];
+      const out = classifyUpdateViolations(STRICT, already, already);
+      assert.deepEqual(out.preExisting.map(x => x.field), ['owner']);
+      assert.deepEqual(out.introduced, []);
+    });
+
+    it('separates the two when both are present', () => {
+      const out = classifyUpdateViolations(
+        STRICT,
+        [v('owner', 'required property missing')],
+        [v('owner', 'required property missing'), v('status', 'not in enum')],
+      );
+      assert.deepEqual(out.introduced.map(x => x.field), ['status']);
+      assert.deepEqual(out.preExisting.map(x => x.field), ['owner']);
+    });
+
+    it('does not credit a patch for fixing one violation while adding another on the same field', () => {
+      // Keyed on field AND reason. One field can fail two ways at once, and keying on the field alone
+      // would let a NEW failure on an already-failing field be waved through as pre-existing.
+      const out = classifyUpdateViolations(
+        STRICT,
+        [v('count', 'not a number')],
+        [v('count', 'below minimum')],
+      );
+      assert.deepEqual(out.introduced.map(x => x.reason), ['below minimum']);
+      assert.deepEqual(out.preExisting, []);
+    });
+
+    it('still calls it pre-existing when the patch changed the value but not the failure', () => {
+      // The value is deliberately excluded from the identity: "a" -> "b", both outside the enum, is the
+      // same defect the record already had. Blaming the patch for a constraint it did not break sends the
+      // operator after the wrong field.
+      const before = [{ field: 'status', value: 'a', reason: 'not in enum' }];
+      const after = [{ field: 'status', value: 'b', reason: 'not in enum' }];
+      const out = classifyUpdateViolations(STRICT, before, after);
+      assert.deepEqual(out.preExisting.map(x => x.field), ['status']);
+      assert.deepEqual(out.introduced, []);
+    });
+
+    it('reports nothing when the merged record is clean', () => {
+      const out = classifyUpdateViolations(STRICT, [v('owner', 'required property missing')], []);
+      assert.equal(out.blocked, false);
+      assert.deepEqual(out.all, []);
+      assert.deepEqual(out.introduced, []);
+      assert.deepEqual(out.preExisting, []);
+    });
+
+    it('a patch that REPAIRS a pre-existing violation passes', () => {
+      // The record is not trapped: validation is of the merged result, so including the broken field in
+      // the same request fixes it. That is what makes blocking on a pre-existing violation defensible
+      // rather than a dead end.
+      const out = classifyUpdateViolations(STRICT, [v('owner', 'required property missing')], []);
+      assert.equal(out.blocked, false);
+    });
+  });
+
+  describe('validation mode', () => {
+    it('blocks only in strict', () => {
+      const after = [v('status', 'not in enum')];
+      assert.equal(classifyUpdateViolations(STRICT, [], after).blocked, true);
+      assert.equal(classifyUpdateViolations(WARN, [], after).blocked, false);
+      assert.equal(classifyUpdateViolations(OFF, [], after).blocked, false);
+      assert.equal(classifyUpdateViolations(undefined, [], after).blocked, false);
+    });
+
+    it('still classifies in warn mode, so the report says whose fault it is', () => {
+      // Warn mode writes the record and reports; a report that cannot tell the operator which field is
+      // theirs is the same failure as a blocking error that cannot.
+      const out = classifyUpdateViolations(WARN, [v('owner', 'missing')], [v('owner', 'missing'), v('status', 'bad')]);
+      assert.equal(out.blocked, false);
+      assert.deepEqual(out.introduced.map(x => x.field), ['status']);
+      assert.deepEqual(out.preExisting.map(x => x.field), ['owner']);
+    });
+  });
+
+  describe('the message', () => {
+    it('blames the change when only the change is at fault', () => {
+      const m = describeUpdateViolations([v('status', 'x')], []);
+      assert.match(m, /change violates/i);
+      assert.match(m, /status/);
+      assert.ok(!/already non-compliant/i.test(m), 'must not imply a pre-existing problem there is none of');
+    });
+
+    it('exonerates the change when the record was already broken', () => {
+      const m = describeUpdateViolations([], [v('owner', 'x')]);
+      assert.match(m, /already non-compliant/i);
+      assert.match(m, /did not cause it/i);
+      assert.match(m, /same request/i, 'must say how to get unstuck');
+    });
+
+    it('says both, and which is which', () => {
+      const m = describeUpdateViolations([v('status', 'x')], [v('owner', 'y')]);
+      assert.match(m, /change violates[^.]*status/i);
+      assert.match(m, /already non-compliant[^.]*owner/i);
+    });
+
+    it('lists each field once even when it fails several ways', () => {
+      const m = describeUpdateViolations([v('status', 'not in enum'), v('status', 'wrong type')], []);
+      assert.equal(m.match(/status/g).length, 1);
+    });
+  });
+
+  describe('the MCP gate', () => {
+    it('throws on a blocked verdict and is silent otherwise', () => {
+      assert.throws(
+        () => assertUpdateAllowed(classifyUpdateViolations(STRICT, [], [v('status', 'x')])),
+        /schema_violation.*status/s,
+      );
+      assert.doesNotThrow(() => assertUpdateAllowed(classifyUpdateViolations(WARN, [], [v('status', 'x')])));
+    });
+  });
+});
+
+// ── The wiring, so no write surface can quietly skip the gate again ──────────
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('every update path runs the gate', () => {
+  // Eight surfaces for four record types. The asymmetry this prevents is not hypothetical: `update_chrono`
+  // shipped without the type allowlist `create_chrono` enforced, and REST/MCP disagreeing about the same
+  // record is the same bug one layer up. A constraint looks enforced right up until someone uses the
+  // other door.
+  const PATHS = [
+    'server/src/api/brain/memories.ts',
+    'server/src/api/brain/entities.ts',
+    'server/src/api/brain/edges.ts',
+    'server/src/api/brain/chrono.ts',
+    'server/src/mcp/tools/memory.ts',
+    'server/src/mcp/tools/entity.ts',
+    'server/src/mcp/tools/edge.ts',
+    'server/src/mcp/tools/chrono.ts',
+  ];
+
+  for (const p of PATHS) {
+    it(`${p} calls classifyUpdateViolations`, () => {
+      assert.match(strip(readFileSync(p, 'utf8')), /classifyUpdateViolations\(/,
+        'this update surface must validate the merged record');
+    });
+  }
+
+  it('no update path still gates validation behind deleteFields alone', () => {
+    // The exact shape of the original hole: `if (dfPaths) { ...validate... }`. Validation must run
+    // unconditionally and merely *apply* the deletions when they are present.
+    const offenders = PATHS.filter(p => /if \(dfPaths\) \{[\s\S]{0,600}?validate(Memory|Entity|Edge|Chrono)\(/
+      .test(strip(readFileSync(p, 'utf8'))));
+    assert.deepEqual(offenders, [],
+      'validation must not be conditional on deleteFields — that was the original gap');
+  });
+
+  it('the MCP tools import the API gate rather than reimplementing it', () => {
+    for (const p of PATHS.filter(x => x.includes('/mcp/'))) {
+      assert.match(readFileSync(p, 'utf8'), /from '\.\.\/\.\.\/api\/brain\/update-validation\.js'/,
+        'two copies of a validation rule is how the surfaces drift apart');
+    }
+  });
+});


### PR DESCRIPTION
## The hole

Creates were validated. Updates were validated **only when the patch used `deleteFields`** — the branch
that exists because removing a required property is an obvious way to break a record.

Every other patch skipped validation entirely:

```http
PATCH /api/brain/spaces/ops/memories/:id
{ "properties": { "status": "nonsense" } }        → 200, stored
POST  /api/brain/spaces/ops/memories
{ "properties": { "status": "nonsense" }, … }     → 400 schema_violation
```

Same space, same field, same `strict` mode. The stricter a space's schema, the wider the gap — the write
path an operator relies on to keep records conformant was the one path that did not check.

**All eight surfaces are covered now**: the four REST `PATCH` routes and the four `update_*` MCP tools,
which had no schema validation at all. The MCP tools import the API layer's gate rather than
reimplementing it — `update_chrono` shipped once without the type allowlist `create_chrono` enforced, and
two copies of a validation rule is how that happens.

## Why the merged record, not the patch

A patch is a fragment. "Does this fragment satisfy the schema" has no useful answer: a required property
the patch does not mention is present in the record and absent from the patch, so the fragment check
would reject every partial update that happens not to restate every required field.

## Why the error is split

Validating the merged record surfaces a second problem immediately. A record can be **already**
non-compliant — written before the schema tightened, imported, or synced from a peer with different meta
— and now fails on any edit, including one with nothing to do with the offending field. Reporting that as
"your change is invalid" is false in the way that costs an afternoon: the operator stares at a field they
did not touch.

```json
{
  "error": "schema_violation",
  "message": "This record was already non-compliant before your change: owner. Your edit did not cause it, but the merged record is what gets stored, so the write is refused until those field(s) are fixed — include them in this same request to repair the record.",
  "violations": [ … ],
  "introduced": [],
  "preExisting": [ { "field": "owner", "reason": "required property missing" } ]
}
```

| Field | Meaning |
|---|---|
| `introduced` | Not present before this patch. The patch caused it. |
| `preExisting` | Present before and still present. The patch neither caused nor fixed it. |

Identity is **field and reason**: one field can fail two ways, and keying on the field alone would let a
*new* failure on an already-failing field be waved through as pre-existing. The **value is excluded**: an
unchanged violation whose value the patch altered (`"a"` → `"b"`, both outside the enum) is the same
defect, still the record's own.

**Both kinds block in `strict`.** The merged record is what gets stored, and storing a known-invalid
record because it was already invalid is how a space drifts permanently out of conformance. The record is
not trapped — validation is of the merged *result*, so a patch that includes the offending field repairs
it, and the message says exactly that.

## Incidental

The prior-record read the gate needs is the one the audit snapshot already took, so it is shared rather
than issued twice per patch. That renamed a local (`prior` → `existing`), which broke four assertions in
`audit-changes.test.js` that were matching a variable **name** while claiming to check that the snapshot
exists — they now match the property worth holding (`before` comes from a read, not `{}`).

## Verification

- `npm run preflight` green.
- New suite `testing/standalone/update-validation.test.js` — 24 tests: classification in all four shapes,
  the field+reason identity, the value exclusion, mode handling (warn still classifies), the three
  message forms, the MCP throw, and a wiring gate asserting all eight surfaces call the validator, that
  none still hides validation behind `if (dfPaths)`, and that the MCP tools import the gate rather than
  copying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
