### PR TITLE
docs(egress): complete the egress matrix behind a gate; publish the UI primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The egress matrix is complete, and a test keeps it that way.** The guide's table of which model
+  endpoints send content listed **seven** slots while the code had ten — the reranker, contradiction
+  judge, external face model and two document stages were missing, and so was `DOC_VLM_URL` from the list
+  of guarded endpoints one paragraph above it. That omission was not cosmetic: the document VLM was
+  reaching an off-instance host with no guard at all while the guide stated the opposite invariant.
+  `testing/standalone/egress-matrix.test.js` now asserts the table's slot-key column equals the server's
+  `EGRESS_SLOTS`, that every row is filled in, that the two acknowledgement-gated slots say so, and that
+  every env var named is one the code actually reads — which on its first run found three phantoms
+  (`EMBEDDING_BASE_URL`, `RERANK_BASE_URL`, `NLI_BASE_URL`; the real names drop the `BASE_`) that a
+  reader would have set and watched do nothing.
+
+- **`docs/ui-primitives.md`** — the shared client components (`settings-card`, `status-pill`,
+  `summary-strip`, `relative-time`, `usage-bar`, the confirm dialog, `ph-icon`) with their APIs and the
+  page-PR checklist, linked from the README and the contribution guide. Each replaced two or three
+  divergent implementations of the same idea, and they were discoverable only by reading a page that
+  happened to use one — which is exactly how a fourth badge dialect gets written.
+
 - **Uploading over an existing file now asks first.** Reported against 2.1.1: re-uploading to the same
   path silently replaced the file and hard-removed everything derived from it, with no warning.
   - The behaviour is right — stale chunks for a document that no longer exists would be worse — but it
@@ -98,6 +115,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     never mentioned. A check that enumerates a subset reports "nothing else is exposed" by omission.
 
 ### Fixed
+
+- **A destructive button rendered as the affirmative.** `.icon-btn.danger` existed; `.btn.danger` did
+  not, so `class="btn btn-sm danger"` applied **nothing**. Four buttons were written that way, and the
+  worst was MFA's *"Yes, disable MFA"* — it also carried `btn-primary`, so the control that permanently
+  deletes the TOTP secret was the green affirmative sitting under a red warning. The other three (schema
+  library ×2, webhooks) rendered neutral. Fixed globally rather than at four call sites, on the precedent
+  #533 set when the identical gap turned up on `.icon-btn`: a class that silently does nothing gets
+  written again. Only a screenshot could see this — no test can.
 
 - **Updates are validated against the schema. All of them.** Creates were validated; updates were
   validated **only when the patch used `deleteFields`**.
@@ -290,6 +315,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     its speech is missing.
 
 ### Changed
+
+- **The MFA page's ten inline styles are classes.** A move, not a redesign — every computed value is
+  unchanged, verified per state against a rendered page rather than by reading the diff. It had been
+  deferred on the grounds that "moving declarations around a page nobody can see rendered buys nothing
+  and risks something"; looking at it is what removed the risk, and what turned up the destructive-button
+  defect above.
 
 - **"Model not listed" is no longer reported as degraded.** `modelPresent` is renamed
   `modelEnumerated` — named for what it measured rather than what it was read as. Aliasing routers

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ That's it. Your assistant instantly sees the space's purpose, its schema, and ev
 |---|---|
 | 👤 User / operator | [Workstation Mode](docs/workstation-mode-guide.md) · [User Guide](docs/userguide.md) · [Use-case examples](docs/usecase-examples.md) |
 | 🔌 Integrator (API / MCP) | [Integration Guide](docs/integration-guide.md) · [Network Types](docs/network-types.md) · [Sync Protocol](docs/sync-protocol.md) |
-| 🛠️ Developer | [Contribution Guide](docs/contribution-guide.md) · [Docker Build](docs/docker-build-protocol.md) |
+| 🛠️ Developer | [Contribution Guide](docs/contribution-guide.md) · [UI Primitives](docs/ui-primitives.md) · [Docker Build](docs/docker-build-protocol.md) |
 
 </div>
 

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -84,6 +84,7 @@
   "help.doc.workstation-mode-guide": "Workstation-Modus",
   "help.doc.network-types": "Netzwerktypen",
   "help.doc.sync-protocol": "Sync-Protokoll",
+  "help.doc.ui-primitives": "UI-Primitive",
   "help.doc.dependencies": "Abhängigkeiten & Lizenzen",
   "help.doc.contribution-guide": "Mitwirken",
   "about.card.help": "Dokumentation",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -84,6 +84,7 @@
   "help.doc.workstation-mode-guide": "Workstation mode",
   "help.doc.network-types": "Network types",
   "help.doc.sync-protocol": "Sync protocol",
+  "help.doc.ui-primitives": "UI primitives",
   "help.doc.dependencies": "Dependencies & licences",
   "help.doc.contribution-guide": "Contributing",
   "about.card.help": "Documentation",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -84,6 +84,7 @@
   "help.doc.workstation-mode-guide": "Tryb stacji roboczej",
   "help.doc.network-types": "Typy sieci",
   "help.doc.sync-protocol": "Protokół synchronizacji",
+  "help.doc.ui-primitives": "Prymitywy UI",
   "help.doc.dependencies": "Zależności i licencje",
   "help.doc.contribution-guide": "Współtworzenie",
   "about.card.help": "Dokumentacja",

--- a/client/src/app/pages/settings/help.component.ts
+++ b/client/src/app/pages/settings/help.component.ts
@@ -36,6 +36,7 @@ export const HELP_DOCS = [
   { id: 'workstation-mode-guide', file: 'workstation-mode-guide.md' },
   { id: 'network-types', file: 'network-types.md' },
   { id: 'sync-protocol', file: 'sync-protocol.md' },
+  { id: 'ui-primitives', file: 'ui-primitives.md' },
   { id: 'dependencies', file: 'dependencies.md' },
   { id: 'contribution-guide', file: 'contribution-guide.md' },
 ] as const;

--- a/client/src/app/pages/settings/mfa.component.ts
+++ b/client/src/app/pages/settings/mfa.component.ts
@@ -32,6 +32,19 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
     .code-input:focus { outline: none; border-color: var(--accent); }
     .status-row { display: flex; align-items: center; gap: 12px; }
     img { border-radius: 8px; background: #fff; padding: 8px; }
+
+    /* Lifted from ten inline style="" attributes. The values are unchanged — this is a move, not a
+       redesign: the page is marked "do NOT restructure", and the point was to stop the next reader
+       diffing declarations out of the markup, not to alter what it looks like. */
+    .intro { font-size: 0.88rem; color: var(--text-muted); margin: 0 0 1rem; }
+    .field-label { font-size: 0.8rem; color: var(--text-muted); margin-bottom: 4px; }
+    .field-label.wide { margin-bottom: 6px; }
+    .code-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+    .button-row { display: flex; gap: 10px; }
+    .alert.spaced-above { margin-top: 12px; }
+    .alert.spaced-below { margin-bottom: 12px; }
+    /* The in-button spinner: smaller than the standalone one so it fits the line box. */
+    .spinner.inline { width: 12px; height: 12px; border-width: 2px; }
   `],
   template: `
     <app-settings-card icon="lock" [heading]="'mfa.title' | transloco" [purpose]="'mfa.subtitle' | transloco">
@@ -53,7 +66,7 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
 
       } @else if (state() === 'enrolling') {
 
-        <p style="font-size:0.88rem;color:var(--text-muted);margin:0 0 1rem;">
+        <p class="intro">
           {{ 'mfa.enroll.instructions' | transloco }}
         </p>
         <div class="qr-wrap">
@@ -61,19 +74,19 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
             <img [src]="qrUrl()" [attr.alt]="'mfa.enroll.qrAlt' | transloco" width="200" height="200" />
           }
           <div>
-            <div style="font-size:0.8rem;color:var(--text-muted);margin-bottom:4px;">{{ 'mfa.enroll.manualKey' | transloco }}</div>
+            <div class="field-label">{{ 'mfa.enroll.manualKey' | transloco }}</div>
             <div class="secret-box">{{ secret() }}</div>
           </div>
           <div>
-            <div style="font-size:0.8rem;color:var(--text-muted);margin-bottom:6px;">{{ 'mfa.enroll.enterCode' | transloco }}</div>
-            <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;">
+            <div class="field-label wide">{{ 'mfa.enroll.enterCode' | transloco }}</div>
+            <div class="code-row">
               <input class="code-input" type="text" inputmode="numeric"
                 autocomplete="one-time-code" maxlength="6" [placeholder]="'mfa.enroll.codePlaceholder' | transloco"
                      [attr.aria-label]="'mfa.enroll.codeAriaLabel' | transloco"
                      [(ngModel)]="confirmCode" (keyup.enter)="confirmEnroll()" />
               <button class="btn btn-primary btn-sm" (click)="confirmEnroll()"
                       [disabled]="confirming() || confirmCode.length < 6">
-                @if (confirming()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                @if (confirming()) { <span class="spinner inline"></span> }
                 {{ 'mfa.enroll.confirmButton' | transloco }}
               </button>
               <button class="btn btn-secondary btn-sm" (click)="cancel()">{{ 'common.cancel' | transloco }}</button>
@@ -81,18 +94,21 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
           </div>
         </div>
         @if (enrollError()) {
-          <div class="alert alert-error" style="margin-top:12px;">{{ enrollError() }}</div>
+          <div class="alert alert-error spaced-above">{{ enrollError() }}</div>
         }
 
       } @else if (state() === 'disabling') {
 
-        <div class="alert alert-error" style="margin-bottom:12px;">
+        <div class="alert alert-error spaced-below">
           {{ 'mfa.disable.warning' | transloco }}
         </div>
-        <div style="display:flex;gap:10px;">
+        <div class="button-row">
           <button class="btn btn-secondary btn-sm" (click)="cancel()">{{ 'common.cancel' | transloco }}</button>
-          <button class="btn btn-primary btn-sm danger" (click)="confirmDisable()" [disabled]="disabling()">
-            @if (disabling()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+          <!-- btn-secondary, not btn-primary: the primary fill is the accent green and it was winning
+               over the danger class, so the button that permanently deletes the TOTP secret rendered as
+               the affirmative. Only visible in a screenshot; no test could see it. -->
+          <button class="btn btn-secondary btn-sm danger" (click)="confirmDisable()" [disabled]="disabling()">
+            @if (disabling()) { <span class="spinner inline"></span> }
             {{ 'mfa.disable.confirmButton' | transloco }}
           </button>
         </div>
@@ -100,7 +116,7 @@ type MfaState = 'idle' | 'enrolling' | 'disabling';
       }
 
       @if (successMsg()) {
-        <div class="alert alert-success" style="margin-top:12px;">{{ successMsg() }}</div>
+        <div class="alert alert-success spaced-above">{{ successMsg() }}</div>
       }
     </app-settings-card>
   `,

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -249,6 +249,27 @@ button:disabled, .btn:disabled {
   background: var(--error-dim);
 }
 
+/*
+ * `.btn.danger` — the same treatment, for the spelling four buttons already use.
+ *
+ * `.icon-btn.danger` exists; `.btn.danger` did not, so `class="btn btn-sm danger"` applied NOTHING. Four
+ * buttons were written that way: the MFA disable ("the secret will be permanently deleted"), which
+ * carried `btn-primary` and therefore rendered as the green AFFIRMATIVE for an irreversible action; and
+ * three ghost/secondary delete buttons in the schema library and webhooks, which rendered neutral.
+ *
+ * Fixed here rather than by rewriting four call sites, for the reason #533 gave when the identical gap
+ * turned up on `.icon-btn`: a class that silently does nothing will be written again, and per-page fixes
+ * leave the next one broken. Same declarations as `.btn-danger`, so the two spellings cannot diverge.
+ */
+.btn.danger {
+  background: transparent;
+  color: var(--error);
+  border-color: var(--error);
+}
+.btn.danger:not(:disabled):hover {
+  background: var(--error-dim);
+}
+
 .btn-ghost {
   background: transparent;
   color: var(--text-secondary);

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -16,10 +16,11 @@ Audience: developers and maintainers working on Ythril source code.
 6. [Container Images](#container-images)
 7. [Releasing a New Version](#releasing-a-new-version)
 8. [Engineering Principles](#engineering-principles)
-9. [Code Style](#code-style)
-10. [Commit Conventions](#commit-conventions)
-11. [Pull Request Checklist](#pull-request-checklist)
-12. [License](#license)
+9. [UI Primitives](#ui-primitives)
+10. [Code Style](#code-style)
+11. [Commit Conventions](#commit-conventions)
+12. [Pull Request Checklist](#pull-request-checklist)
+13. [License](#license)
 
 ---
 
@@ -421,6 +422,19 @@ Choose a migration strategy by **whether the data syncs across networks**, becau
 - **Synced data → self-healing (lazy), never a one-time boot migration.** The per-space MongoDB record collections that replicate across networks — memories, entities, edges, chrono, `{space}_files`, and their fields — can be silently reverted by a **mixed-version peer**: an older-version instance that rewrites a record with a higher `seq` replaces the *whole* document and undoes any boot migration. So don't migrate these on boot — **repair or derive the field on access**, so it re-heals after any cross-version clobber. Examples: token prefixes backfilled on first use (`index.ts`); a file's raw size (`sizeFileBytes`) re-`stat`'d from disk when a record lacks it.
 - **Local, non-synced state → an idempotent boot migration is fine.** State the single instance owns and no peer overwrites — `config.json` (loader migrations), at-rest state-file encryption, index creation (`ensureIndex`/TTL) — converges once on boot and stays. Keep it idempotent (a no-op once applied) so re-running is free.
 - **A stored-field rename on a synced collection is the fragile case.** It changes the wire format, so mixed-version peers see a blank for the name they don't know until everyone upgrades. Do it only at a major release, document it as breaking, and prefer pairing it with a self-healing field for anything that must stay correct.
+
+---
+
+## UI Primitives
+
+Client work has a shared component set — `settings-card`, `status-pill`, `summary-strip`,
+`relative-time`, `usage-bar`, the confirm dialog and `ph-icon`. Each of them replaced two or three
+divergent implementations of the same idea, so **reach for one before writing new markup**: a bespoke
+badge on one page becomes the next thing someone has to reconcile.
+
+They were discoverable only by reading a page that happened to use one, which is exactly how a fourth
+badge dialect gets written. The API of each, with the page-PR checklist that goes with them, is in
+**[UI Primitives](ui-primitives.md)**.
 
 ---
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -387,28 +387,51 @@ Two private addresses in the same cluster can behave differently, and that is no
 
 - **Render/conversion sidecars** (`CONVERSION_SIDECAR_URL`, doc-render) are reached with a plain `fetch`.
   They are declared infrastructure, expected to be private, and are not subject to the egress guard.
-- **Model provider endpoints** (vision, STT, embedding, rerank, NLI, document VLM, document assist) go
-  through the SSRF-guarded fetch, because those URLs are admin-settable and become egress targets.
+- **Model provider endpoints** — every slot in the egress matrix below — go through the SSRF-guarded
+  fetch, because those URLs are admin-settable and become egress targets.
 
-#### Which model endpoints send content, and what guards them
+#### Egress matrix — which model endpoints send content, and what guards them
 
-An endpoint is only as private as the host it points at. This table is what actually happens, per slot —
+An endpoint is only as private as the host it points at. This table is what actually happens, per slot.
 `Guard` is the SSRF-guarded fetch (DNS resolution, IP pinning, redirect re-validation, crown-jewel ranges
-blocked; `allowPrivateModelEndpoints` lifts only the private-address refusal).
+blocked; the private-address permission lifts only the private-address refusal).
 
-| Slot | Env | Sends | Guard | Acknowledgement |
-|---|---|---|---|---|
-| Embedding | `EMBEDDING_BASE_URL` | record + query text | yes, when external | — |
-| Vision (captions) | `OLLAMA_URL` | uploaded images | yes, when the provider is `external` | — |
-| Speech-to-text | `STT_BASE_URL` | uploaded audio | yes, when the provider is `external` | — |
-| Reranker | `RERANK_BASE_URL` | the query **and** the passages it matched | yes, unless the URL is local | — |
-| Contradiction judge | `NLI_BASE_URL` | pairs of stored records | yes, unless the URL is local | — |
-| **Document VLM** | `DOC_VLM_URL`, `DOC_VLM_MODEL` | **rendered page images** | yes, unless it is the bundled model | — |
-| Assist model | `DOC_ASSIST_URL` | draft transcription + OCR text | yes, always | **required** |
+**It is complete, and a test keeps it that way.** `Slot key` is the identifier the code uses, and
+`testing/standalone/egress-matrix.test.js` asserts this table's key column equals the server's own
+`EGRESS_SLOTS` — the same list the per-slot permission and the security posture enumerate. The reason for
+a gate rather than diligence: this table had **seven** rows while the code had ten, and the omission was
+not cosmetic. `DOC_VLM_URL` was missing from the list of guarded endpoints above while the document VLM
+was reaching an off-instance host with no guard at all — the doc stated the invariant the code had
+broken, and nothing compared the two.
 
-Two things worth reading twice. The **document VLM inherits the vision endpoint** when `DOC_VLM_URL` is
-unset — so pointing vision at an external provider also points the VLM there, and page images follow.
-And the assist model is the only slot that demands an explicit egress acknowledgement before it will run.
+| Slot | Slot key | Env | Sends | Guard | Acknowledgement |
+|---|---|---|---|---|---|
+| Embedding | `embedding` | `EMBEDDING_URL` | record + query text | yes, when the provider is `external` | — |
+| Vision (captions) | `vision` | `OLLAMA_URL` | uploaded images | yes, when the provider is `external` | — |
+| Speech-to-text | `stt` | `STT_BASE_URL` | uploaded audio | yes, when the provider is `external` | — |
+| Reranker | `rerank` | `RERANK_URL` | the query **and** the passages it matched | yes, unless the URL is local | — |
+| Contradiction judge | `nli` | `NLI_URL` | pairs of stored records | yes, unless the URL is local | — |
+| **Document VLM** | `docVlm` | `DOC_VLM_URL`, `DOC_VLM_MODEL` | **rendered page images** | yes, unless it is the bundled model | — |
+| Document repair | `docRepair` | `DOC_REPAIR_URL`, `DOC_REPAIR_MODEL` | draft transcription + OCR text | yes, unless it is the bundled model | — |
+| Document verify | `docVerify` | `DOC_VERIFY_URL`, `DOC_VERIFY_MODEL` | draft transcription + OCR text | yes, unless it is the bundled model | — |
+| Assist model | `assist` | `DOC_ASSIST_URL` | draft transcription + OCR text | yes, always | **required** |
+| External face model | `faceExternal` | `FACE_RECOGNITION_EXTERNAL_MODEL` | **face crops (biometric data)** | yes, always | **required** |
+
+Four things worth reading twice:
+
+- The **document VLM, repair and verify slots inherit the vision endpoint** when their own base URL is
+  unset — so pointing vision at an external provider points all three there, and page images follow.
+- **Two slots demand an explicit egress acknowledgement** before they will run: the assist model, because
+  it is the path that sends document content off the instance; and the external face model, because its
+  payload is biometric. Consent is keyed off the endpoint being *usable*, not off a tick, so it cannot be
+  side-stepped by configuring an endpoint and acknowledging nothing.
+- "Unless the URL is local" means the bundled/sidecar shape — loopback, or a bare hostname with no dot
+  (a compose or cluster service name). Anything else is egress. An unparseable URL is treated as **not**
+  local, so a malformed endpoint gets the guard rather than a bare fetch.
+- Each slot's private-address permission is **its own** (`allowPrivateModelEndpointsBySlot`, or
+  `YTHRIL_ALLOW_PRIVATE_<SLOT>`), resolved per-slot → instance-wide → closed. The full precedence rules
+  are with the assist-model settings under
+  [Document Processing Configuration](#document-processing-configuration).
 
 So a green sidecar next to a refused model endpoint tells you cluster DNS and reachability are fine, and
 the difference is policy. That is the point at which `allowPrivateModelEndpoints` is the answer.

--- a/docs/ui-primitives.md
+++ b/docs/ui-primitives.md
@@ -1,0 +1,167 @@
+# UI primitives
+
+The shared Angular components every settings and list page is built from. Written down because they were
+discoverable only by reading another page that happened to use them — so a page PR could plausibly
+re-roll a badge, a timestamp format or a usage bar without ever learning one existed. Each of these
+replaced two or three divergent implementations; re-rolling one puts a fourth dialect back.
+
+All live in `client/src/app/shared/` (except `ConfirmDialogService`, in `client/src/app/core/`), are
+standalone, and are `OnPush`. Import the component class directly into your component's `imports`.
+
+**Use these before writing new markup.** If a primitive is *almost* right, extend the primitive — a
+variant on `StatusPill` serves every page; a bespoke badge on one page serves one page and becomes the
+next thing someone has to reconcile.
+
+---
+
+## `<app-settings-card>` — the grouping block
+
+The standard container for a settings section: icon + heading + one-line purpose, an optional status pill
+in the header, and your content in the body. Replaces ad-hoc `.section` blocks and inline-styled `div`s.
+
+```html
+<app-settings-card icon="image" heading="Vision" purpose="Captions uploaded images.">
+  <app-status-pill pill variant="active">Local · Ollama</app-status-pill>
+  <!-- body content -->
+</app-settings-card>
+```
+
+| Input | Type | Notes |
+|---|---|---|
+| `heading` | `string` | **required** |
+| `icon` | `string` | a registered `ph-icon` name |
+| `purpose` | `string` | one line, sentence case — what the section is *for*, not what the controls do |
+
+Content projected with the `pill` attribute lands in the header; everything else lands in the body.
+
+---
+
+## `<app-status-pill>` — the one status vocabulary
+
+Every "what state is this in?" signal. Before it there were three badge dialects
+(`badge-red/green/gray`, `badge-active/failing`, `badge-2xx/4xx`), so the same state looked different on
+three screens.
+
+```html
+<app-status-pill variant="warn" [dot]="true">Expiring</app-status-pill>
+<app-status-pill variant="error" icon="warning">Failing</app-status-pill>
+```
+
+| Input | Type | Default |
+|---|---|---|
+| `variant` | `'active' \| 'ok' \| 'warn' \| 'error' \| 'off' \| 'env' \| 'pending'` | `'off'` |
+| `icon` | `string` | `''` |
+| `dot` | `boolean` | `false` |
+
+`env` is for "pinned by an infrastructure env var" — a state, not a severity. Reach for it instead of
+greying out a control with no explanation.
+
+---
+
+## `<app-summary-strip>` — the answer above the fold
+
+The operator-first row at the top of a list or settings page: the headline counts, with the ones that
+need attention coloured. **Every list page gets one.** It is the difference between a page that answers
+"is anything wrong here?" at a glance and one that makes you read a table.
+
+```html
+<app-summary-strip
+  heading="Tokens"
+  [items]="[{ label: 'Active', value: 4 }, { label: 'Expiring', value: 1, variant: 'warn' }]" />
+```
+
+| Input | Type | Default |
+|---|---|---|
+| `heading` | `string` | `''` |
+| `items` | `SummaryItem[]` | `[]` |
+
+```ts
+interface SummaryItem { label: string; value: string | number; variant?: StatusVariant }
+```
+
+Content projected after the items renders inside the strip — that is where a `<app-usage-bar>` goes.
+
+---
+
+## `<app-relative-time>` — the one timestamp treatment
+
+Renders a locale-aware relative label ("2 hours ago") with the absolute time on hover, `tabular-nums`,
+and a machine-readable `<time datetime>`. **Every timestamp in the app goes through it.**
+
+```html
+<app-relative-time [value]="token.lastUsed" />
+```
+
+`value` is required and accepts a `Date`, an ISO string, or epoch milliseconds.
+
+The formatting function is exported and pure — pass `nowMs` (and optionally a locale) to test it
+deterministically rather than mocking the clock.
+
+---
+
+## `<app-usage-bar>` — "X of Y used"
+
+One bar with health thresholds; colour tracks the fill (`ok` → `warn` at `warnAtPercent` → `danger` at
+95%). Consolidated storage's `usage-bar-*` and about's `disk-bar-*`, which drew the same concept two ways.
+
+```html
+<app-usage-bar [used]="usedGiB" [total]="limitGiB" [warnAtPercent]="80" />
+```
+
+| Input | Type | Default |
+|---|---|---|
+| `used` | `number` | **required** |
+| `total` | `number \| null` | `null` — renders as "unlimited", not as a full bar |
+| `warnAtPercent` | `number` | `80` |
+
+---
+
+## `ConfirmDialogService` — never `window.confirm`
+
+Themed, CDK-backed, and awaitable. Native `confirm()` is unstyled, untranslatable and blocks the event
+loop.
+
+```ts
+private readonly confirmDialog = inject(ConfirmDialogService);
+
+if (await this.confirmDialog.confirm({ title, message, danger: true })) { /* … */ }
+```
+
+| Field | Notes |
+|---|---|
+| `title`, `message` | required; **already localised by the caller** |
+| `confirmLabel`, `cancelLabel` | default to `common.confirm` / `common.cancel` |
+| `danger` | styles the confirm button red — use it for every destructive action |
+| `requireText` | disables confirm until the user types this exact string. Use for irreversible actions (the type-the-id ritual) |
+| `requireTextLabel` | the label above that input, e.g. "Type the space id" |
+
+Cancel is the default action; Confirm is the one that has to be chosen.
+
+---
+
+## `<ph-icon>` — icons
+
+Inline SVG from Phosphor Icons (regular weight), embedded at build time — no runtime fetches.
+
+```html
+<ph-icon name="trash" [size]="18" />
+```
+
+⚠️ **An unregistered name renders blank with no error.** Add the path to the `ICONS` map in
+`ph-icon.component.ts` when you use a new one. `npm run preflight` fails on an unregistered name — it
+has bitten this codebase twice, both times invisibly.
+
+---
+
+## Checklist for a page PR
+
+Not primitives, but the same class of thing — verify these on whatever page you touch:
+
+- `<app-relative-time>` on every timestamp; `tabular-nums` on every numeric column.
+- Every user-facing string through transloco. No hardcoded English — `en`, `de` and `pl` all need the
+  key, and the client unit tests check coverage.
+- `<ph-icon>` rather than a raw glyph.
+- A `<app-summary-strip>` on every list page.
+- A visible in-flight state on every async action.
+- An unsaved-changes guard on every editable form.
+- Destructive actions: `danger` on the button *and* on the confirm dialog.

--- a/testing/standalone/egress-matrix.test.js
+++ b/testing/standalone/egress-matrix.test.js
@@ -1,0 +1,128 @@
+/**
+ * The documented egress matrix matches the code's actual set of admin-settable model endpoints.
+ *
+ * ## Why this is a gate and not a review item
+ *
+ * The guide already stated the invariant the code had broken. Its list of endpoints that go through the
+ * SSRF-guarded fetch did not mention `DOC_VLM_URL` — while the document VLM was reaching an off-instance
+ * host with **no guard at all**, silently, on any deployment pointing vision at a remote Ollama. And one
+ * paragraph over, the guide promised *"no document content leaves your instance"* by default, which was
+ * false in exactly that configuration.
+ *
+ * Neither statement was wrong when written. Both went stale because a slot was added and nothing compared
+ * the prose to the code. A customer found it; a reviewer would have had to hold ten slot names in their
+ * head to notice the seventh row was the last one.
+ *
+ * So the matrix is machine-checked against `EGRESS_SLOTS` — the same canonical list the per-slot
+ * permission resolver and the security posture enumerate. Adding a model slot now fails here until the
+ * table gains its row, which is the only mechanism that makes "the docs are complete" a fact rather than
+ * an intention.
+ *
+ * Deliberately checks COMPLETENESS and IDENTITY, not prose. What a slot "sends" is judgement and belongs
+ * to a human; *that the slot appears at all* is not, and is precisely what went missing.
+ *
+ * Run: node --test testing/standalone/egress-matrix.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const GUIDE = 'docs/integration-guide.md';
+
+let EGRESS_SLOTS;
+let rows;
+
+/**
+ * Parse the matrix out of the guide.
+ *
+ * Anchored on the heading rather than on a line number, and it asserts it found a table at all — a
+ * parser that silently matches nothing turns this whole file green while checking nothing, which is the
+ * same class of failure it exists to catch.
+ */
+function parseMatrix(md) {
+  const heading = md.indexOf('#### Egress matrix');
+  assert.ok(heading > 0, 'the guide must have an "Egress matrix" section');
+  const after = md.slice(heading);
+  const headerAt = after.search(/^\| Slot \| Slot key \|/m);
+  assert.ok(headerAt > 0, 'the matrix must have a `Slot | Slot key | …` header row');
+
+  const lines = after.slice(headerAt).split(/\r?\n/);
+  const out = [];
+  for (const line of lines.slice(2)) {              // skip the header and its separator
+    if (!line.startsWith('|')) break;               // table ends at the first non-row line
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    out.push({
+      label: cells[0],
+      key: (cells[1] ?? '').replace(/`/g, ''),
+      env: cells[2] ?? '',
+      sends: cells[3] ?? '',
+      guard: cells[4] ?? '',
+      ack: cells[5] ?? '',
+    });
+  }
+  return out;
+}
+
+describe('egress matrix ↔ code', () => {
+  before(async () => {
+    ({ EGRESS_SLOTS } = await import('../../server/dist/config/model-egress-policy.js'));
+    rows = parseMatrix(readFileSync(GUIDE, 'utf8'));
+  });
+
+  it('the parser found the table', () => {
+    // Guards the scanner itself. Every assertion below is vacuous on an empty parse.
+    assert.ok(rows.length >= 8, `parsed only ${rows.length} matrix rows`);
+  });
+
+  it('documents exactly the slots the code has — no more, no fewer', () => {
+    const documented = rows.map(r => r.key).sort();
+    const actual = [...EGRESS_SLOTS].sort();
+    assert.deepEqual(documented, actual,
+      'the egress matrix must list every admin-settable model endpoint. A slot in the code and not the ' +
+      'table is an undocumented egress path; a slot in the table and not the code is a setting a reader ' +
+      'will configure and watch do nothing.');
+  });
+
+  it('every row is filled in', () => {
+    for (const r of rows) {
+      assert.ok(r.label.length > 0, `${r.key}: needs a human-readable name`);
+      assert.ok(r.env.includes('`'), `${r.key}: must name its env var(s)`);
+      assert.ok(r.sends.length > 0, `${r.key}: must say what it sends`);
+      assert.ok(r.guard.length > 0, `${r.key}: must say when it is guarded`);
+    }
+  });
+
+  it('the two acknowledgement-gated slots are marked as such', () => {
+    // The assist model sends document content off the instance; the face model sends biometric data.
+    // Both refuse to run without a recorded acknowledgement, and a matrix that did not say so would
+    // understate the two rows a reader most needs to stop on.
+    const required = rows.filter(r => /required/i.test(r.ack)).map(r => r.key).sort();
+    assert.deepEqual(required, ['assist', 'faceExternal']);
+  });
+
+  it('the guarded-endpoints bullet no longer enumerates a stale subset', () => {
+    // It used to list seven slots by name — and the one it omitted was the unguarded one. A prose list
+    // that has to be kept in sync with a table two lines below it will not be; it now points at the
+    // matrix instead, which is the thing this test checks.
+    const md = readFileSync(GUIDE, 'utf8');
+    const bullet = md.slice(md.indexOf('- **Model provider endpoints**'), md.indexOf('#### Egress matrix'));
+    assert.ok(bullet.length > 0 && bullet.length < 400, 'expected the short bullet above the matrix');
+    assert.match(bullet, /egress matrix/i, 'the bullet should defer to the matrix rather than re-list slots');
+  });
+
+  it('every documented env var is real', () => {
+    // The nastier direction: a reader copies the name into their manifest, it does nothing, and there is
+    // no error to explain why.
+    //
+    // `env-var-docs-coverage` cannot see these — it scopes itself to the `YTHRIL_`/`MONGO_`/`MCP_`/
+    // `OIDC_` namespaces, and every model endpoint sits outside all four. On its first run this check
+    // found three phantoms shipped in the matrix (`EMBEDDING_BASE_URL`, `RERANK_BASE_URL`,
+    // `NLI_BASE_URL`; the real names drop the `BASE_`), which is what that blind spot costs.
+    const names = rows.flatMap(r => [...r.env.matchAll(/`([A-Z][A-Z0-9_]{2,})`/g)].map(m => m[1]));
+    assert.ok(names.length >= 10, `expected the matrix to name env vars, found ${names.length}`);
+    const src = ['server/src/config/loader.ts', 'server/src/config/types.ts']
+      .map(f => readFileSync(f, 'utf8')).join('\n');
+    const missing = names.filter(n => !src.includes(n));
+    assert.deepEqual(missing, [], `documented but not read anywhere: ${missing.join(', ')}`);
+  });
+});

--- a/testing/standalone/env-var-docs-coverage.test.js
+++ b/testing/standalone/env-var-docs-coverage.test.js
@@ -106,6 +106,11 @@ function collectDocumented() {
     const src = readFileSync(join(ROOT, 'docs', f), 'utf8');
     for (const m of src.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/g)) {
       if (!OURS.test(m[1])) continue;
+      // A trailing underscore is never a real variable — it is the stub left behind when prose names a
+      // FAMILY of them, `YTHRIL_ALLOW_PRIVATE_<SLOT>` or `YTHRIL_ALLOW_PRIVATE_*`, and the word-boundary
+      // match keeps only the prefix. Counting those as documented settings makes the reverse check report
+      // a phantom for every family the docs describe, which is a finding about the scanner, not the docs.
+      if (m[1].endsWith('_')) continue;
       if (!docs.has(m[1])) docs.set(m[1], new Set());
       docs.get(m[1]).add(f);
     }


### PR DESCRIPTION
Three tracker items and one defect they turned up. All the same kind of problem: something true that
nothing was keeping true.

## 1. The egress matrix was incomplete — now gated

The guide's table of which model endpoints send content listed **seven** slots while the code had ten.
Missing: the reranker, contradiction judge, external face model, and two of the three document stages.
And `DOC_VLM_URL` was absent from the *"these go through the SSRF-guarded fetch"* bullet one paragraph
above it.

That omission was the bug, not a footnote: the document VLM was reaching an off-instance host with **no
guard at all** whenever `DOC_VLM_URL` was unset and vision was external (fixed in #560). The guide stated
the invariant the code had broken, and nothing compared the two.

So the matrix is now machine-checked. `testing/standalone/egress-matrix.test.js` asserts:

- the table's `Slot key` column **equals** the server's `EGRESS_SLOTS` — the same canonical list the
  per-slot permission resolver and the security posture enumerate;
- every row is filled in (name, env, what it sends, when it is guarded);
- the two acknowledgement-gated slots (`assist`, `faceExternal`) say so;
- the bullet above defers to the matrix rather than re-listing a stale subset;
- every env var named is one the code actually reads.

**That last check found three phantoms already shipped**: `EMBEDDING_BASE_URL`, `RERANK_BASE_URL`,
`NLI_BASE_URL`. The real names drop the `BASE_`. A reader would have set them and watched nothing happen.
`env-var-docs-coverage` could not see them — it scopes to the `YTHRIL_`/`MONGO_`/`MCP_`/`OIDC_`
namespaces, and every model endpoint sits outside all four. (It also learned to ignore trailing-underscore
stubs, so prose naming a *family* — `YTHRIL_ALLOW_PRIVATE_<SLOT>` — no longer reports a phantom.)

## 2. `docs/ui-primitives.md`

The shared client components with their real APIs: `settings-card`, `status-pill`, `summary-strip`,
`relative-time`, `usage-bar`, `ConfirmDialogService`, `ph-icon`, plus the page-PR checklist. Linked from
the README, the contribution guide, and the in-product Help page (all three locales).

Each of them replaced two or three divergent implementations of the same idea. They were discoverable
only by reading a page that happened to use one — which is exactly how a fourth badge dialect gets
written.

## 3. The MFA page's ten inline styles are classes

A move, not a redesign. The item had been deferred on the grounds that *"moving declarations around a page
nobody can see rendered buys nothing and risks something"* — so this booted a scratch instance, enrolled a
real TOTP, and read the computed value of every lifted declaration in each of the three states.

Every lifted declaration verified against the rendered page: `intro` at 0.88rem / `--text-muted` /
1rem bottom margin, both field labels, the flex-wrap code row, the 12px button row, both alert
offsets, the 12px in-button spinner. No console errors in any state.

## 4. What looking at it found: a destructive button rendered as the affirmative

`.icon-btn.danger` exists. **`.btn.danger` did not** — so `class="btn btn-sm danger"` applied nothing.
Four buttons are written that way. The worst also carried `btn-primary`:

> **Disabling MFA removes the TOTP requirement for admin mutations. The secret will be permanently
> deleted from secrets.json.**
>
> `[ Cancel ]` `[ Yes, disable MFA ]` ← green, the accent affirmative

The control that permanently deletes the TOTP secret was the green *yes* sitting directly under its own
red warning. The other three (schema library ×2, webhooks) rendered neutral.

Fixed **globally** rather than at four call sites, on the precedent #533 set when the identical gap turned
up on `.icon-btn`: a class that silently does nothing gets written again, and per-page fixes leave the
next one broken. Same declarations as `.btn-danger`, so the two spellings cannot diverge. Verified across
all four base variants by reading computed styles off a live page — `.btn.danger` is (0,2,0) and wins over
`.btn-ghost`/`.btn-secondary`/`.btn-primary` at (0,1,0).

No test can see this one. That is the argument for taking the screenshot.

## Verification

- `npm run preflight` green — which is also what caught the new guide not being offered by the in-product
  Help page.
- New suite `testing/standalone/egress-matrix.test.js` — 6 tests.
- Rendered verification of the MFA page in idle / enrolling / disabling, plus a computed-style probe of
  `.btn.danger` against every base variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

