### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-07-31
+
 ### Added
 
 - **The egress matrix is complete, and a test keeps it that way.** The guide's table of which model

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump + CHANGELOG heading. Nothing else — the work is already on `main` as #556–#572.

## Why minor, not patch

`[Unreleased]` carries new user-facing capability, not only fixes:

- **Verify** — one real request against a configured model, synthetic payload, cold-load tolerant
- **Re-upload confirmation** before a file replaces an existing one and its derived records
- **Per-endpoint private-address permission** (`allowPrivateModelEndpointsBySlot`)
- **Hybrid search** — a lexical BM25 channel fused into recall by RRF
- **`docs/ui-primitives.md`**, offered by the in-product Help page

## The behaviour change that belongs in the release note

**Updates are now validated against the schema.** Creates always were; updates were validated only when
the patch used `deleteFields`, so a `strict` space accepted through `PATCH` values it rejects through
`POST`. Any client relying on that gap will start seeing `422`. The error names whether the violation came
from the change (`introduced`) or was already in the record (`preExisting`), and because validation is of
the merged *result*, including the offending field in the same request repairs it.

## Worth naming for affected operators

On 2.0.0–2.1.1, the document VLM reached an off-instance host with **no SSRF guard and no egress
acknowledgement** whenever `DOC_VLM_URL` was unset and `visionProvider` was `external` — page images
followed the vision endpoint. Fixed in #560. Not a security advisory: the destination is the operator's
own configured host, not a third party. It is in the release body because an affected operator cannot tell
from their side that it happened.

## This release closes the 2.1.1 customer batch

All eight reports shipped as #560–#568, then the three parked decisions as #569–#571, then the
documentation obligation riding on #560 as #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
