### PR TITLE
fix(docs): the env-var documentation gate covered a quarter of the settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The env-var documentation gate covered a quarter of the settings.** It scoped itself to the
+  `YTHRIL_`/`MONGO_`/`MCP_`/`OIDC_` namespaces, so **no model-endpoint variable was ever in scope** —
+  not `EMBEDDING_URL`, not `DOC_VLM_URL`, not one of the ten egress slots. That is how three names that
+  do not exist (`EMBEDDING_BASE_URL`, `RERANK_BASE_URL`, `NLI_BASE_URL`) shipped in the integration
+  guide, where a reader would set them and watch nothing happen.
+  - Scope is now a **denylist**: everything the scan finds, minus an explicit ambient set (the
+    runtime's, the shell's, CI's). A variable in a namespace nobody anticipated is now in scope
+    rather than silently exempt. 30 variables covered became 70.
+  - The scan also missed every name held in a lookup table and read as `process.env[TABLE[key]]` — the
+    vision, STT, face and worker settings among them. Detection now covers those, gated on the file
+    actually indexing `process.env` with a non-literal so prose cannot claim credit for a read.
+  - **Found: three undocumented rate-limit kill-switches** (`SKIP_AUTH_RATE_LIMIT`,
+    `SKIP_GLOBAL_RATE_LIMIT`, `SKIP_SYNC_RATE_LIMIT`), and six storage pins whose names existed nowhere
+    in the source because `storageEnvName` derived them from parts — under a comment claiming they were
+    spelled out so they would be greppable. They are now literals, like the egress slots.
+  - Nine more settings documented: `CLIENT_DIST`, `MODEL_CACHE_DIR`, `EMBEDDING_DIMENSIONS`,
+    `DOC_VLM_WIRE`, `NLI_MODEL`, `NLI_API_KEY`, `RENDER_MAX_BYTES`, `RENDER_MAX_PAGES`,
+    `OFFICE_CONVERT_TIMEOUT`.
+  - `SCREAMING_CASE` in the docs that is deliberately not a setting — API error codes, OIDC example
+    placeholders, a third-party library's env in a sidecar image — is exempted **with a stated reason** 
+    each, and a test asserts nothing on that list is a name the code actually reads. An exemption cannot
+    be used to silence a real finding.
+
 ## [2.2.0] — 2026-07-31
 
 ### Added

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -196,6 +196,22 @@ npm run test:integration
 
 Covers: setup gating, auth, files, spaces, brain CRUD (memories, entities, edges, chrono), schema validation (strict/warn/off, bulk, dry-run), networks, voting, invite handshake, MCP tools (including bulk_write), notifications, about endpoint, sync history, space rename, space deletion, space export, space wipe, conflict resolution, proxy spaces.
 
+#### Rate-limit kill-switches
+
+A test run makes thousands of requests from one IP, so the limiters have to come off. Three env vars do
+that, and they are honoured **only when `NODE_ENV !== 'production'`**:
+
+| Variable | Disables |
+|---|---|
+| `SKIP_AUTH_RATE_LIMIT` | the login / TOTP limiter |
+| `SKIP_GLOBAL_RATE_LIMIT` | the general API limiter |
+| `SKIP_SYNC_RATE_LIMIT` | the peer-sync limiter |
+
+The production check is not belt-and-braces: these limiters are the **only** throttle in front of admin
+TOTP verification, so a leaked value — a copy-pasted compose file, a shared `.env` — must not be able to
+switch them off on a live instance. Setting any of them also logs a loud warning at startup, so a
+misconfigured non-production deployment says so rather than quietly running unthrottled.
+
 ### Sync tests (four Docker instances)
 
 ```bash

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -212,6 +212,8 @@ DEBUG=1 docker compose up
 | `MONGO_URI` | `mongodb://ythril-mongo:27017/ythril?directConnection=true` | MongoDB connection string — any `$vectorSearch`-capable MongoDB works. The database name in the URI is used for all operations. |
 | `NODE_ENV` | `production` | Node environment |
 | `PORT` | `3200` | HTTP listen port |
+| `CLIENT_DIST` | (resolved from the image layout) | Directory the built Angular client is served from. Set by the Dockerfile; override it only when running the server against a client build in a non-standard location — a local dev checkout, or an image you re-layered. |
+| `MODEL_CACHE_DIR` | `/app/model-cache` in the image, else `<DATA_ROOT>/.model-cache` | Where the bundled in-process embedding model's weights are cached. Baked into the image so a cold start does not download them; the `DATA_ROOT` fallback is for running from source. Point it at a persistent volume if you strip the cache out of your image, or **every** boot re-downloads the model. |
 | `DEBUG` | (unset) | Set to `1` for verbose logging |
 | `MONGO_CONNECT_RETRY_MS` | `30000` | How long the **first** MongoDB connection may spend retrying before boot gives up. A container orchestrator's healthcheck can report MongoDB healthy while it is still finishing startup, so the first driver connection can have its socket reset mid-handshake — which used to kill the process outright. Only "not up yet" failures are retried (network errors, server selection, topology closed); bad credentials and a malformed URI fail immediately, because waiting cannot help and retrying would turn a clear error into a boot that appears to hang. Backoff is jittered so several instances starting together do not retry in lockstep. |
 | `SHUTDOWN_DRAIN_MS` | `8000` | How long in-flight HTTP requests get to finish after SIGTERM before their connections are forced shut. On SIGTERM the server stops accepting new connections, waits for the running ones, then flushes config and closes MongoDB. The default is sized for **Docker's 10 s stop grace period** — the whole drain plus the flush has to fit inside it or the container is SIGKILLed mid-write anyway. Kubernetes allows 30 s by default, so raise this if your orchestrator gives you longer. |
@@ -2536,6 +2538,14 @@ lightweight and carries no model weights) or stop it with no effect on today's O
 `ythril-convert` network (no database, no internet egress), non-root and resource-limited. Ythril reaches
 it via `RENDER_SIDECAR_URL`. The **application** default is `http://localhost:8100` (a sidecar in the same network namespace); `docker-compose.yml` overrides it to `http://doc-render:8100`, the service name on the internal network. Both are correct for their layer — check which one applies to your deployment rather than assuming the compose value is the default.
 
+Two limits are set **on the sidecar**, not in Ythril's config — they bound what an untrusted document can
+make it do, so they belong to the process that parses it:
+
+| Env (on the sidecar) | Default | Meaning |
+|---|---|---|
+| `RENDER_MAX_BYTES` | `104857600` (100 MiB) | Largest document the renderer will accept. |
+| `RENDER_MAX_PAGES` | `500` | Hard ceiling on pages rendered per request, whatever `maxPages` asks for. |
+
 #### Office-render sidecar (`doc-office`) — optional
 
 `doc-render` only opens PDFs, so **office** documents (DOCX, EPUB, PPTX, XLSX, ODT, RTF…) in a `vlm`/`auto`/
@@ -2551,6 +2561,12 @@ Everything stays **on-box** on the isolated `ythril-convert` network — no page
 instance. Ythril reaches it via `RENDER_OFFICE_SIDECAR_URL` (default `http://doc-office:8100` in compose).
 When it is absent, office docs simply use OCR, unchanged. LibreOffice is MPL-2.0 / LGPL-3.0 (not AGPL) and
 runs as a separate process, so it does not affect Ythril's licensing.
+
+It honours `RENDER_MAX_BYTES` and `RENDER_MAX_PAGES` exactly as `doc-render` does, plus one of its own:
+
+| Env (on the sidecar) | Default | Meaning |
+|---|---|---|
+| `OFFICE_CONVERT_TIMEOUT` | `120` | Seconds `soffice` gets to convert the document to PDF before the attempt is abandoned and the upload falls back to OCR. Raise it for very large spreadsheets; a LibreOffice conversion that hangs holds a worker slot until this fires. |
 
 #### Document Processing Configuration
 
@@ -2674,7 +2690,8 @@ They are never queued, so they do not sit at `pending` waiting for work that wil
 | `extractImages` | `true` | When `true` and `strategy` is `"hi_res"`, embedded images found in document partitions are decoded and saved as `_extracted/{originalId}/image-{N}.{ext}` subfiles. Each is automatically enqueued for the full media pipeline (caption + face recognition). Has no effect when strategy is not `"hi_res"`. |
 | `mode` | `"vlm"` | How thoroughly documents are read, low to high: `"off"` · `"ocr"` · `"vlm"` · `"repair"`, plus `"auto"`. **`"off"` means documents are stored but never analysed** — no text is extracted, so nothing in them can be recalled; those uploads are recorded as `skipped` rather than queued. `"ocr"` is OCR-only (the unstructured sidecar). `"vlm"` renders each page and transcribes it with a vision model, using OCR as grounding evidence and falling back to OCR if the result doesn't validate (so it is **never worse than OCR**). `"repair"` adds a validation-driven **repair** pass (below) on top of `"vlm"`, plus a second-model consensus pass when a `verifyModel` is set. `"auto"` means **as much as this instance can actually do** — it resolves to `"repair"` when a repair model is configured, otherwise `"vlm"`, otherwise `"ocr"`, so with no `vlmModel` set it is byte-for-byte the OCR-only path. `"max"` is the previous name for `"repair"` and is still accepted on read. |
 | `vlmModel` | `""` | Ollama vision model used for `vlm` / `auto` / `repair` (e.g. a bundled `moondream`, or a larger model you wire in). Empty ⇒ the VLM path is unavailable and extraction stays on OCR. Env override: `DOC_VLM_MODEL`. |
-| `vlmBaseUrl` | `""` | Endpoint for the VLM. Empty ⇒ falls back to the media vision provider's `baseUrl`, then `http://ollama:11434`. Env override: `DOC_VLM_URL`. |
+| `vlmBaseUrl` | `""` | Endpoint for the VLM. Empty ⇒ falls back to the media vision provider's `baseUrl`, then `http://ollama:11434`. Env override: `DOC_VLM_URL`. **Setting this marks the slot as a separate service**, so the call goes through the SSRF-guarded fetch — a private address then needs `allowPrivateModelEndpointsBySlot.docVlm` (or the instance-wide flag). |
+| *(no config key)* | — | `DOC_VLM_WIRE` — which protocol the document VLM speaks: `ollama` (`/api/chat`) or, by default, `openai` (`/chat/completions`). Env-only, because the URL cannot tell us: `http://host:11434` is either. The default matches what self-hosted inference servers overwhelmingly serve; set `DOC_VLM_WIRE=ollama` only when you point `DOC_VLM_URL` at a **separate Ollama**. It applies to all three document slots, which share one endpoint resolver. |
 | `repairModel` | `""` | Used by the **`repair`** level — and by **`auto`**, which resolves to `repair` whenever this is set. Model used for the repair pass when a page's VLM output fails OCR-evidence validation — it reconciles the draft against the OCR text in one extra text-only call. Empty ⇒ reuses `vlmModel`. Set this to wire in a stronger model you host. Env override: `DOC_REPAIR_MODEL`. |
 | `repairBaseUrl` | `""` | Endpoint for the repair model. Empty ⇒ reuses `vlmBaseUrl`. Env override: `DOC_REPAIR_URL`. |
 | `verifyModel` | `""` | Engages on the **`repair`** level, and on **`auto`** when a repair model is set (F11-d consensus). A *second* document VLM. When set, the repair level runs it as an independent second transcription of each page, reconciles it with the primary draft against the OCR text, and keeps the highest-coverage result — **never worse** than the primary. Empty ⇒ no consensus pass. Best set to a *different* model than `vlmModel`. Env override: `DOC_VERIFY_MODEL`. |
@@ -3001,7 +3018,11 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `embedding.baseUrl` | `EMBEDDING_URL` | — | Embedding HTTP endpoint (OpenAI-compatible `/v1/embeddings`). Blank = the bundled in-process ONNX model. |
 | `embedding.model` | `EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5` | Embedding model. **Changing the model / `dimensions` / `similarity` / `prefixScheme` re-indexes every vector** (the UI requires an explicit confirmation; `POST /api/brain/spaces/:id/reindex` runs it). |
 | `embedding.prefixScheme` | `EMBEDDING_PREFIX_SCHEME` | `auto` | Task-prefix convention the model expects: `nomic` (`search_document:` / `search_query:` prefixes, trailing space included), `qwen` (instruction on the query only, passages bare), `none` (symmetric models — OpenAI `text-embedding-3-*`, bge-m3), or `auto`. **`auto` reproduces the behaviour this instance had before the field existed: `nomic` for the bundled model, `none` over HTTP — so upgrading changes no vector.** If you run nomic or Qwen behind an endpoint, set this explicitly and reindex — asymmetric models retrieve measurably worse without the prefix, and nothing errors when it is missing. |
+| `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `768` | Vector width the model emits. Must match the model — a mismatch is not detected at write time, it surfaces as recall that returns nothing. Listed with `model` above as a re-index trigger. |
 | `embedding.apiKey` | `EMBEDDING_API_KEY` | — | API key for an external embedding endpoint (stored in `secrets.json`, masked in the API). |
+| `mediaEmbedding.nli.baseUrl` | `NLI_URL` | — | Contradiction-judge endpoint. **Blank = contradiction detection has no judge** and the Contradictions view is empty by design, not by failure. Same locality rule as the reranker: a loopback or dot-less host is a sidecar and gets a plain fetch; anything else goes through the SSRF-guarded fetch. It sees **pairs of stored record texts**, so it is an egress path of the same weight as vision or STT. |
+| `mediaEmbedding.nli.model` | `NLI_MODEL` | — | NLI model name, e.g. an mDeBERTa or DeBERTa cross-encoder. Required alongside `baseUrl`. |
+| `mediaEmbedding.nli.apiKey` | `NLI_API_KEY` | — | API key for the contradiction judge (stored in `secrets.json`, masked in the API). |
 | `mediaEmbedding.rerank.baseUrl` | `RERANK_URL` | — | Reranker endpoint. **Blank = reranking is off** (there is no separate toggle). A URL ending in `/rerank` is read as the text-embeddings-inference request shape; anything else gets `/v1/rerank` appended and the Cohere/Jina shape. A loopback or dot-less host is treated as a sidecar and reached with a plain fetch; anything else goes through the SSRF-guarded fetch. |
 | `mediaEmbedding.rerank.model` | `RERANK_MODEL` | — | Cross-encoder model, e.g. `BAAI/bge-reranker-v2-m3`. Required alongside `baseUrl` — reranking is on only when both are set. |
 | `mediaEmbedding.rerank.candidateMultiplier` | `RERANK_CANDIDATE_MULTIPLIER` | `4` | Candidates fetched per requested result before reranking (2–10, and capped at 100 candidates absolutely). A reranker can only re-order what the vector search already found, so this over-fetch is the whole mechanism; at 1 it would reorder exactly the results you would have got anyway. |

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -670,9 +670,28 @@ export interface ResolvedStorageConfig {
 const STORAGE_AREAS = ['total', 'files', 'brain'] as const;
 const STORAGE_TIERS = [['soft', 'softLimitGiB'], ['hard', 'hardLimitGiB']] as const;
 
-/** `STORAGE_TOTAL_HARD_GIB` etc. Spelled out rather than derived, so the names are greppable. */
+/**
+ * The six storage pins, written out.
+ *
+ * The comment here used to claim they were "spelled out rather than derived, so the names are greppable"
+ * while the function derived them from `area` and `tier` — so none of the six existed anywhere in the
+ * source, `grep STORAGE_TOTAL_HARD_GIB` found nothing, and the doc-coverage gate could not tell them from
+ * names that do not exist. Same fix as `SLOT_ENV_VARS` in the egress policy: six literals is the price of
+ * a setting an operator can search for.
+ */
+const STORAGE_ENV_NAMES: Record<string, string> = {
+  'total.soft': 'STORAGE_TOTAL_SOFT_GIB',
+  'total.hard': 'STORAGE_TOTAL_HARD_GIB',
+  'files.soft': 'STORAGE_FILES_SOFT_GIB',
+  'files.hard': 'STORAGE_FILES_HARD_GIB',
+  'brain.soft': 'STORAGE_BRAIN_SOFT_GIB',
+  'brain.hard': 'STORAGE_BRAIN_HARD_GIB',
+};
+
+/** `STORAGE_TOTAL_HARD_GIB` etc., from the table above. */
 function storageEnvName(area: string, tier: string): string {
-  return `STORAGE_${area.toUpperCase()}_${tier.toUpperCase()}_GIB`;
+  return STORAGE_ENV_NAMES[`${area}.${tier}`]
+    ?? `STORAGE_${area.toUpperCase()}_${tier.toUpperCase()}_GIB`;
 }
 
 export function getStorageConfig(): ResolvedStorageConfig | undefined {

--- a/testing/standalone/env-var-docs-coverage.test.js
+++ b/testing/standalone/env-var-docs-coverage.test.js
@@ -42,8 +42,64 @@ function walk(dir, out = []) {
   return out;
 }
 
-/** Only this project's own namespaces — NODE_ENV, PATH and friends are not ours to document. */
-const OURS = /^(YTHRIL_|MONGO_|MCP_|OIDC_)/;
+/**
+ * Which variables are ours to document: everything the scan finds, minus an explicit ambient list.
+ *
+ * It used to be an allowlist of four namespaces — `YTHRIL_`/`MONGO_`/`MCP_`/`OIDC_` — which is the wrong
+ * polarity for a completeness gate. **No model-endpoint variable was ever in scope**: not `EMBEDDING_URL`,
+ * not `DOC_VLM_URL`, not one of the ten slots. That blind spot let three names that do not exist
+ * (`EMBEDDING_BASE_URL`, `RERANK_BASE_URL`, `NLI_BASE_URL` — the real ones drop the `BASE_`) ship in the
+ * integration guide's egress matrix, where a reader would set them and watch nothing happen.
+ *
+ * A denylist fails the right way round. A new variable in a namespace nobody anticipated is now *in* scope
+ * and has to be documented or explicitly excused; under the allowlist it was silently exempt. Widening it
+ * brought 40 more variables into scope and cost 9 doc entries, which is the ratio that makes a gate worth
+ * having rather than worth suppressing.
+ */
+const AMBIENT = new Set([
+  // The runtime's and the shell's, not ours.
+  'NODE_ENV', 'NODE_OPTIONS', 'PATH', 'HOME', 'TMPDIR', 'TEMP', 'TMP', 'HOSTNAME', 'TZ', 'LANG', 'SHELL',
+  'PWD', 'COMSPEC', 'SYSTEMROOT', 'USERPROFILE', 'APPDATA', 'LOCALAPPDATA',
+  // CI-provided.
+  'CI', 'GITHUB_TOKEN', 'GITHUB_ACTIONS', 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24',
+]);
+
+/**
+ * `SCREAMING_CASE` in the docs that is deliberately **not** a setting of ours.
+ *
+ * Each is listed with why, because an unexplained exemption is how a real finding gets waved through
+ * later by someone extending the list. Nothing here may be a variable this codebase reads — the check
+ * below asserts exactly that, so an entry added to silence a genuine finding fails.
+ */
+const NOT_A_SETTING = new Map([
+  // API error codes, documented so a client can branch on them.
+  ['INFRA_MANAGED', 'API error code'],
+  ['FEATURE_DISABLED', 'API error code'],
+  ['MFA_REQUIRED', 'API error code'],
+  ['MERKLE_DIVERGENCE', 'sync conflict code'],
+  ['REPARENT_REVERT_AVAILABLE', 'network notification code'],
+  ['ERR_ERL_UNEXPECTED_X_FORWARDED_FOR', 'an express-rate-limit error code, quoted in a troubleshooting note'],
+  // Source identifiers named in prose.
+  ['EGRESS_SLOTS', 'a TypeScript constant the egress matrix is checked against'],
+  ['FETCH_TIMEOUT_MS', 'a sync-engine constant, not settable'],
+  ['BATCH_FETCH_TIMEOUT_MS', 'a sync-engine constant, not settable'],
+  // Placeholders in copy-paste examples.
+  ['YOUR_TENANT_ID', 'placeholder in an OIDC example'],
+  ['YOUR_CLIENT_ID', 'placeholder in an OIDC example'],
+  ['YOUR_API_IDENTIFIER', 'placeholder in an OIDC example'],
+  ['YOUR_PASSWORD', 'placeholder in a login example'],
+  ['YOUR_TOKEN', 'placeholder in a curl example'],
+  // Other processes' environment, documented because an operator has to set them somewhere else.
+  ['DOCKERHUB_USERNAME', 'a GitHub Actions secret, not read by the app'],
+  ['DOCKERHUB_TOKEN', 'a GitHub Actions secret, not read by the app'],
+  ['NUMBA_CACHE_DIR', "a third-party library's env, set in a sidecar image"],
+  ['HF_HUB_OFFLINE', "a third-party library's env, set in a sidecar image"],
+  ['XDG_CACHE_HOME', "a third-party library's env, set in a sidecar image"],
+  // Removed settings the docs still name so an upgrader can find out they are gone.
+  ['MEDIA_EMBEDDING_ENABLED', 'removed in 2.0.0; documented as a breaking change'],
+]);
+
+const OURS = (name) => !AMBIENT.has(name);
 
 const NAME = '([A-Z][A-Z0-9_]{2,})';
 const READ_PATTERNS = [
@@ -84,7 +140,7 @@ function collectUsage() {
     // Gated on the file actually indexing `process.env` with a non-literal, so a module that merely
     // MENTIONS a variable name in prose or an error message does not get credit for reading it.
     if (/process\.env\[\s*[A-Za-z_$]/.test(src)) {
-      for (const m of src.matchAll(/['"]((?:YTHRIL_|MONGO_|MCP_|OIDC_)[A-Z0-9_]{2,})['"]/g)) add(m[1], f);
+      for (const m of src.matchAll(/['"]([A-Z][A-Z0-9_]{2,})['"]/g)) add(m[1], f);
     }
 
     // Compose / Dockerfile interpolation: ${VAR} and ${VAR:-default}.
@@ -100,12 +156,26 @@ function collectUsage() {
   return used;
 }
 
-function collectDocumented() {
+/**
+ * What the docs *name as a setting*, as opposed to what they merely capitalise.
+ *
+ * `SCREAMING_CASE` in prose is not only env vars — the guides are full of `HTTP`, `JSON`, `OCR`, `VLM`,
+ * `TOTP`, `SSRF`. While the scope was four namespaces the prefix filtered those out for free; a denylist
+ * does not, so the shape of the token has to.
+ *
+ * The rule: an underscore, **or** a name the code actually reads. An env var in this project either
+ * carries an underscore (`EMBEDDING_URL`, `RENDER_MAX_BYTES`) or is a single well-known word the code
+ * demonstrably reads (`PORT`, `DEBUG`). An acronym has neither. That keeps the phantom check pointed at
+ * the class of mistake it exists for — `EMBEDDING_BASE_URL` for `EMBEDDING_URL`, a name shaped exactly
+ * like a setting and belonging to nothing.
+ */
+function collectDocumented(used) {
   const docs = new Map();
   for (const f of readdirSync(join(ROOT, 'docs')).filter(n => n.endsWith('.md'))) {
     const src = readFileSync(join(ROOT, 'docs', f), 'utf8');
     for (const m of src.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/g)) {
-      if (!OURS.test(m[1])) continue;
+      if (!OURS(m[1])) continue;
+      if (!m[1].includes('_') && !used.has(m[1])) continue;
       // A trailing underscore is never a real variable — it is the stub left behind when prose names a
       // FAMILY of them, `YTHRIL_ALLOW_PRIVATE_<SLOT>` or `YTHRIL_ALLOW_PRIVATE_*`, and the word-boundary
       // match keeps only the prefix. Counting those as documented settings makes the reverse check report
@@ -120,19 +190,19 @@ function collectDocumented() {
 
 describe('env vars — docs and code agree', () => {
   const used = collectUsage();
-  const documented = collectDocumented();
+  const documented = collectDocumented(used);
 
   it('finds a meaningful number of variables (the scan itself still works)', () => {
     // Guards against a refactor silently breaking the patterns and turning both checks green by
     // finding nothing — the failure mode where a gate quietly stops gating.
-    const ours = [...used.keys()].filter(n => OURS.test(n));
+    const ours = [...used.keys()].filter(n => OURS(n));
     assert.ok(ours.length >= 25, `expected the scan to find our env vars, found ${ours.length}`);
     assert.ok(documented.size >= 15, `expected docs to name our env vars, found ${documented.size}`);
   });
 
   it('every variable the code reads is documented', () => {
     const missing = [...used.entries()]
-      .filter(([name]) => OURS.test(name) && !documented.has(name))
+      .filter(([name]) => OURS(name) && !documented.has(name))
       .map(([name, files]) => `  ${name}  (read in ${[...files].slice(0, 2).join(', ')})`);
 
     assert.equal(missing.length, 0,
@@ -141,10 +211,19 @@ describe('env vars — docs and code agree', () => {
       'our namespaces if they are genuinely internal.');
   });
 
+  it('the not-a-setting list never hides a real setting', () => {
+    // The failure this forecloses: a genuine undocumented variable gets silenced by adding it to the
+    // exemption list rather than documenting it. If the code reads a name on that list, the list is
+    // wrong, not the finding.
+    const wrong = [...NOT_A_SETTING.keys()].filter(n => used.has(n));
+    assert.deepEqual(wrong, [],
+      'these are exempted as "not a setting" but the code reads them — document them instead');
+  });
+
   it('every variable the docs name actually exists', () => {
     // The nastier direction: a reader copies it into .env, it does nothing, and nothing explains why.
     const phantom = [...documented.entries()]
-      .filter(([name]) => !used.has(name))
+      .filter(([name]) => !used.has(name) && !NOT_A_SETTING.has(name))
       .map(([name, docs]) => `  ${name}  (documented in ${[...docs].join(', ')})`);
 
     assert.equal(phantom.length, 0,


### PR DESCRIPTION
## The hole #572's phantoms came through

#572 added a matrix-specific check that caught three documented env vars which do not exist —
`EMBEDDING_BASE_URL`, `RERANK_BASE_URL`, `NLI_BASE_URL` (the real names drop the `BASE_`). A reader would
have set them and watched nothing happen.

The obvious question is why the gate built for exactly that, `env-var-docs-coverage`, said nothing. It
scoped itself to four namespaces:

```js
const OURS = /^(YTHRIL_|MONGO_|MCP_|OIDC_)/;
```

**No model-endpoint variable has ever been in scope.** Not `EMBEDDING_URL`, not `DOC_VLM_URL`, not one of
the ten egress slots, not the worker settings, not the storage pins.

## Denylist, not allowlist

That is the wrong polarity for a completeness gate. An allowlist exempts by default, so the settings
nobody thought to add a prefix rule for are exactly the ones that go unchecked. Scope is now everything
the scan finds minus an explicit ambient set (the runtime's, the shell's, CI's). **30 variables covered
became 70.**

## Two detection gaps, both fixed first

Widening the scan surfaced findings that were about the scanner rather than the docs. A gate that
manufactures noise gets suppressed, so both were fixed before the scope change landed:

- **Lookup-table reads were invisible.** `process.env[TABLE[key]]` — how the vision, STT, face and worker
  settings are read — matched no pattern. Now counted, gated on the file actually indexing `process.env`
  with a non-literal, so a module that merely *mentions* a name in prose or an error message gets no
  credit for reading it.
- **`SCREAMING_CASE` in prose is not only env vars.** The guides are full of `HTTP`, `JSON`, `OCR`,
  `TOTP`, `SSRF`. The namespace prefix filtered those out for free; a denylist does not, so the shape of
  the token has to: an underscore, or a name the code demonstrably reads. That keeps the phantom check
  pointed at its actual target — a token shaped exactly like a setting and belonging to nothing.

## What it found

**Three undocumented rate-limit kill-switches.** `SKIP_AUTH_RATE_LIMIT`, `SKIP_GLOBAL_RATE_LIMIT`,
`SKIP_SYNC_RATE_LIMIT` — honoured only when `NODE_ENV !== 'production'`, which is not belt-and-braces:
these limiters are the only throttle in front of admin TOTP verification, so a leaked value must not be
able to switch them off on a live instance. Now documented, including that.

**Six storage pins that existed nowhere in the source.** `storageEnvName` derived them from `area` and
`tier` — under a comment claiming they were *"spelled out rather than derived, so the names are
greppable"*. They were not; `grep STORAGE_TOTAL_HARD_GIB` found nothing. Literals now, matching how
`SLOT_ENV_VARS` was written in #569.

**Nine more undocumented settings:** `CLIENT_DIST`, `MODEL_CACHE_DIR`, `EMBEDDING_DIMENSIONS`,
`DOC_VLM_WIRE`, `NLI_MODEL`, `NLI_API_KEY`, `RENDER_MAX_BYTES`, `RENDER_MAX_PAGES`,
`OFFICE_CONVERT_TIMEOUT`.

`DOC_VLM_WIRE` is worth singling out: it is the switch that makes the document VLM work against a separate
**Ollama** rather than an OpenAI-compatible server, and it shipped in #560 undocumented.

## The exemption list has its own gate

Documented `SCREAMING_CASE` that is genuinely not a setting — API error codes (`MFA_REQUIRED`,
`MERKLE_DIVERGENCE`), OIDC example placeholders (`YOUR_TENANT_ID`), a third-party library's env in a
sidecar image (`HF_HUB_OFFLINE`), a setting removed in 2.0.0 and documented as removed — is exempted with
a **stated reason each**.

A test asserts that nothing on that list is a name the code actually reads. The failure it forecloses is
the obvious one: silencing a genuine undocumented variable by adding it to the exemption list instead of
documenting it.

## Verification

`npm run preflight` green. `npm run lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
