### PR TITLE
fix(security): a flag read by nothing, and a posture line describing a guard that never existed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A security setting that was read by nothing, and a posture line that described a guard which
+  never existed.** `allowInsecurePlaintext` appeared in `config.json`, in the type, and in the startup
+  security posture — where it reported *"the plaintext-exposure guard is disabled"*. No such guard
+  exists, and no code path reads the flag.
+  - In the first prototype it meant nearly the opposite: it opted the instance **in** to a boot warning
+    when the host had a non-loopback interface. That warning was superseded by the posture block in
+    #276; the flag was left behind with no reader, and the message written for it inverted its meaning.
+  - The key is **retired, not deleted** — a config that sets it still loads, on the same reasoning as
+    `SpaceMeta.tagSuggestions`: silently dropping a key an operator has is a worse trade than a
+    documented retirement. The posture now says it does nothing and names the control that actually
+    rejects plaintext requests (`requireEncryptedTransport`), and says whether *that* is on.
+  - Found by the check below, which is the point of adding it: "nothing documents this" and "nothing
+    uses this" turned out to be the same question asked from two sides.
+
+- **`config-key-docs-coverage` checked one direction only.** It asserted every key in a documented
+  `config.json` example is a real field, and said nothing about the reverse — so a config field could be
+  added and never documented with nothing to report it. The same asymmetry `env-var-docs-coverage` grew
+  a second check to close. Scoped to top-level fields, where a setting with no mention is genuinely
+  lost; machine-managed state (`oauthClients`, `pendingSpaceOp`) is exempt, and a test asserts each
+  exemption's own declaration says it is not hand-edited, so the list cannot quietly absorb a setting.
+
 - **The env-var documentation gate covered a quarter of the settings.** It scoped itself to the
   `YTHRIL_`/`MONGO_`/`MCP_`/`OIDC_` namespaces, so **no model-endpoint variable was ever in scope** —
   not `EMBEDDING_URL`, not `DOC_VLM_URL`, not one of the ten egress slots. That is how three names that

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -683,6 +683,17 @@ loopback is still untrusted. (Address reachability is governed separately by `al
 > proxy hop count. Enable `requireEncryptedTransport` together with a correct `trustProxy`, or every
 > proxied request will look plaintext and be rejected.
 
+⚠️ **`allowInsecurePlaintext` is retired and does nothing.** If you have it in `config.json`, remove it.
+
+In early versions it opted the instance *in* to a boot warning when the host had a non-loopback interface.
+That warning was replaced by the startup security posture, and the key was left behind with no reader —
+while the posture line written for it claimed it "disabled the plaintext-exposure guard", describing a
+guard that never existed under that name. Setting it or clearing it changes nothing either way;
+**`requireEncryptedTransport` above is the control that rejects plaintext requests.**
+
+The key is still accepted so an existing config keeps loading, and the posture now reports it as retired
+rather than as a disabled guard.
+
 **Multi-tenant on shared hardware.** Run each tenant as its own Ythril instance with its **own MongoDB on
 its own encrypted volume/key** — do not share one `mongod` across tenants. That keeps cross-tenant data
 cryptographically isolated (different key + process) while leaving semantic search fully intact, and it

--- a/server/src/config/security-posture.ts
+++ b/server/src/config/security-posture.ts
@@ -101,7 +101,23 @@ export function computeSecurityPosture(): SecurityPosture {
     : { id: 'transport.peers', level: 'pass', message: 'Sync peers must use HTTPS.' });
 
   if (cfg?.allowInsecurePlaintext) {
-    checks.push({ id: 'transport.plaintext', level: 'warn', message: 'allowInsecurePlaintext is on — the plaintext-exposure guard is disabled.' });
+    // RETIRED, and the line has to say so — it used to claim "the plaintext-exposure guard is disabled",
+    // which described a guard that does not exist. The flag's original meaning in the first prototype was
+    // nearly the opposite: it opted the operator IN to a boot warning when the host had a non-loopback
+    // interface. That warning was replaced by this posture block; the flag was left behind, read by
+    // nothing, and the message written for it inverted what it had meant.
+    //
+    // Reported rather than ignored, because an operator who set it believes it is doing something. The
+    // control that actually rejects plaintext is `requireEncryptedTransport`, one check up.
+    checks.push({
+      id: 'transport.plaintext',
+      level: 'warn',
+      message: 'allowInsecurePlaintext is set but does nothing — it is retired and read by no code path. '
+        + (tlsOn
+          ? 'Plaintext requests are already rejected by requireEncryptedTransport; remove the key.'
+          : 'Plaintext requests are NOT rejected — that is requireEncryptedTransport, which is off. '
+            + 'Setting this key does not change it.'),
+    });
   }
 
   // Widening where model/media egress may point is a deliberate operator decision, so it is reported

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1107,6 +1107,20 @@ export interface Config {
    *  (pdf/docx/epub/html/md/txt → markdown chunks). Default 100 MiB; HTML is
    *  additionally capped at 25 MiB because jsdom parses it in-process. */
   maxDocumentConversionBytes?: number;
+  /**
+   * **RETIRED — read by no code path.** Kept so a config that sets it still loads, and so the security
+   * posture can tell the operator it does nothing rather than leaving them to assume it does.
+   *
+   * In the first prototype this opted the instance IN to a boot warning when `allowInsecurePlaintext` was
+   * true and the host had a non-loopback interface — "all traffic including tokens is unencrypted". That
+   * warning was superseded by the posture block (#276), and the flag was left behind with no reader. The
+   * posture line written for it then inverted its meaning, reporting that "the plaintext-exposure guard
+   * is disabled" — a guard that has never existed under that name.
+   *
+   * **The control that actually rejects plaintext requests is {@link requireEncryptedTransport}.** Not
+   * deleted outright, on the same reasoning as `SpaceMeta.tagSuggestions`: silently dropping a key an
+   * operator has in their config is a worse trade than leaving a documented retirement behind.
+   */
   allowInsecurePlaintext?: boolean;
   /**
    * Require the on-disk state files (config/secrets/schema-library/schema-catalogs) to be encrypted

--- a/testing/standalone/config-key-docs-coverage.test.js
+++ b/testing/standalone/config-key-docs-coverage.test.js
@@ -26,6 +26,22 @@
  * declare fields on one line. A line-anchored pattern reported both as undeclared when both are used
  * throughout `files.ts`.
  *
+ * ── The direction this was missing ──────────────────────────────────────────────────────────────
+ *
+ * Everything above checks **doc → code**: a documented key must be real. It said nothing about
+ * **code → doc**, so a config field could be added and never documented, and nothing reported it. That
+ * is the asymmetry `env-var-docs-coverage` grew a second check to close, and the same shape as four
+ * scope-too-narrow defects found in one week.
+ *
+ * Adding it found `allowInsecurePlaintext` — undocumented, and on inspection **read by no code path at
+ * all** while the security posture told the operator it disabled a guard. The gate's value is not the
+ * doc entry; it is that "nothing documents this" and "nothing uses this" turn out to be the same
+ * question asked from two sides.
+ *
+ * Scoped to TOP-LEVEL `Config` fields deliberately. Nested fields are documented in prose and tables
+ * rather than by name, so demanding every one of them would report noise; the top level is the surface
+ * an operator edits and the one where a field with no mention is genuinely lost.
+ *
  * Run: node --test testing/standalone/config-key-docs-coverage.test.js
  */
 import { describe, it } from 'node:test';
@@ -36,6 +52,18 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
 const TYPES = join(ROOT, 'server', 'src', 'config', 'types.ts');
+
+/**
+ * Top-level fields the docs are not expected to name, each with why.
+ *
+ * Only machine-managed state qualifies: written by the app, never hand-edited, and meaningless to an
+ * operator reading a guide. A setting does not belong here — the test below asserts each entry's own type
+ * declaration says it is not hand-edited, so the list cannot quietly absorb one.
+ */
+const MACHINE_MANAGED = new Map([
+  ['oauthClients', 'RFC 7591 dynamic client registrations, written by the MCP OAuth flow'],
+  ['pendingSpaceOp', 'write-ahead marker for a multi-step space operation, cleared on commit'],
+]);
 
 /** Maps whose keys the USER chooses — not config fields. */
 const FREE_FORM = new Set([
@@ -115,5 +143,48 @@ describe('config.json examples in the docs name real fields', () => {
       'types. Unknown keys are IGNORED, so a reader would set them and see no effect:\n' +
       `${[...new Set(bad)].join('\n')}\n` +
       'Fix the doc, or add the field if it was meant to exist.');
+  });
+});
+
+describe('every top-level config field is documented', () => {
+  const docsText = readdirSync(join(ROOT, 'docs'))
+    .filter(n => n.endsWith('.md'))
+    .map(n => readFileSync(join(ROOT, 'docs', n), 'utf8'))
+    .join('\n');
+
+  it('finds the Config interface (the check itself works)', () => {
+    // Same guard the sibling check carries: a parse that silently yields nothing would make the
+    // assertion below pass by examining nothing, which is the failure mode of every coverage gate.
+    assert.ok(topLevelConfigFields().size >= 20,
+      `expected to parse the Config interface, found ${topLevelConfigFields().size} fields`);
+  });
+
+  it('names every one of them somewhere in docs/', () => {
+    // Deliberately generous — a bare mention anywhere counts. Anything this reports is definitively
+    // undocumented rather than merely documented somewhere surprising, so a finding is never a
+    // judgement call about where a setting *should* be written up.
+    const missing = [...topLevelConfigFields()]
+      .filter(k => !MACHINE_MANAGED.has(k))
+      .filter(k => !new RegExp(`\\b${k}\\b`).test(docsText));
+
+    assert.deepEqual(missing, [],
+      'These config fields exist but no doc mentions them, so an operator cannot find them:\n' +
+      missing.map(k => `  ${k}`).join('\n') +
+      '\nDocument them, or — if one turns out to be read by nothing — retire it explicitly.');
+  });
+
+  it('the machine-managed exemptions really are machine-managed', () => {
+    // The failure this forecloses: exempting a genuine setting to make the check pass. Each entry has to
+    // say so in its own doc comment, which is a claim a reviewer can check against the code.
+    const src = readFileSync(TYPES, 'utf8');
+    for (const [field, why] of MACHINE_MANAGED) {
+      const at = src.search(new RegExp(`^\\s{2}${field}\\??\\s*:`, 'm'));
+      assert.ok(at > 0, `${field} should be a top-level Config field (${why})`);
+      // Normalised first: a JSDoc comment wraps, so the phrase routinely reads `not\n   * meant to be
+      // hand-edited` and a `\s+` between the words does not match the leading asterisk.
+      const comment = src.slice(Math.max(0, at - 700), at).replace(/^\s*\*/gm, ' ').replace(/\s+/g, ' ');
+      assert.match(comment, /not\s+(meant to be\s+)?hand-edited/i,
+        `${field} is exempted as machine-managed, so its declaration must say it is not hand-edited`);
+    }
   });
 });


### PR DESCRIPTION
## A flag that does nothing, described as a guard that does not exist

`allowInsecurePlaintext` is in `config.json`, in the `Config` type, and in the startup security posture:

```text
transport.plaintext  WARN  allowInsecurePlaintext is on — the plaintext-exposure guard is disabled.
```

There is no plaintext-exposure guard, and **no code path reads the flag**. `git grep` finds exactly two
references: the type declaration and the line above.

## Its original meaning was nearly the opposite

In the first prototype it opted the instance **in** to a boot warning:

```ts
if (cfg.allowInsecurePlaintext) {
  const hasExternal = /* any non-loopback IPv4 interface */;
  if (hasExternal) log.warn('⚠ allowInsecurePlaintext is true and this host has external network interfaces…');
}
```

That warning was superseded by the posture block in #276. The flag was left behind with no reader, and
the message written for it inverted what it had meant. So:

- an operator who **set** it was told a protection was off;
- an operator who **cleared** it believed one was on.

Neither was true. `requireEncryptedTransport` — the check immediately above it in the same posture block —
is and always was the control that rejects plaintext requests.

## Retired, not deleted

A config that sets the key still loads. Same call `SpaceMeta.tagSuggestions` already established:
silently dropping a key an operator has in their config is a worse trade than leaving a documented
retirement behind, and it keeps the decision reversible.

The posture line now says the key does nothing, names the real control, **and reports whether that control
is on** — which is the answer the operator was actually looking for when they read the line:

```text
allowInsecurePlaintext is set but does nothing — it is retired and read by no code path.
Plaintext requests are NOT rejected — that is requireEncryptedTransport, which is off.
Setting this key does not change it.
```

## How it was found, which is the more useful half

`config-key-docs-coverage` asserted every key in a documented `config.json` example is a real field — the
phantom direction — and said **nothing** about the reverse. So a config field could be added and never
documented, with nothing to report it. That is the asymmetry `env-var-docs-coverage` grew a second check
to close, and the sixth instance this week of a check being narrower than it reads.

Adding the missing direction reported exactly one field: `allowInsecurePlaintext`. Chasing why it was
undocumented is what turned up that it was also unread.

**"Nothing documents this" and "nothing uses this" turn out to be the same question asked from two sides.**

Scoped to **top-level** `Config` fields deliberately — nested fields are documented in prose and tables
rather than by name, so demanding each one would report noise; the top level is the surface an operator
edits. Machine-managed state (`oauthClients`, `pendingSpaceOp`) is exempt, and a third test asserts each
exemption's own type declaration says it is not hand-edited — so the exemption list cannot quietly absorb
a real setting.

## Verification

`npm run preflight` green, `npm run lint:docs` clean. The new checks fail on the pre-fix tree: the
coverage check reports `allowInsecurePlaintext`, and the exemption check fails if either exempted field
loses its "not hand-edited" declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
