### PR TITLE
fix(security): turning off two-factor authentication left no trace in the audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Turning off two-factor authentication left no trace in the audit log.** `POST /api/mfa/setup`
+  (which writes the new secret immediately — it is the enable, and the rotation) and `DELETE /api/mfa`
+  were both unaudited.
+  - They were exempted by an entry in `audit-route-coverage` reading *"MFA enrolment/verification —
+    covered by its own auth events"*. The audit map holds **one** auth event, `auth.failed`, so nothing
+    was covering them. Disabling the second factor for every admin mutation is arguably the most
+    audit-worthy action in the product, and it was silent.
+  - Now `mfa.enable` and `mfa.disable`, named so a rotation and a removal are distinguishable. The
+    exemption narrows to `/api/mfa/verify`, which checks a code and mutates nothing — and is what a
+    health check calls repeatedly.
+  - Found by the Testing & Quality audit lens, asking of each gate not what it asserts but **what it
+    excludes**. An exemption reason is a factual claim; this one was false.
+
 - **A security setting that was read by nothing, and a posture line that described a guard which
   never existed.** `allowInsecurePlaintext` appeared in `config.json`, in the type, and in the startup
   security posture — where it reported *"the plaintext-exposure guard is disabled"*. No such guard

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6210,6 +6210,12 @@ Base path: `/api/admin/audit-log` — **requires admin token** on all endpoints.
 
 Ythril maintains an append-only, immutable audit log of every authenticated API operation. The log captures who performed what action, when, on which space, and the resulting HTTP status — providing a full access trail for compliance and security review.
 
+**Second-factor changes are in it.** `mfa.enable` records enrolment *and* a rotation of the secret;
+`mfa.disable` records the second factor being removed from every admin mutation. Checking a code
+(`POST /api/mfa/verify`) changes nothing and is deliberately not logged — it is also what a health check
+calls repeatedly. Both mutations were unaudited before 2.2.1; if you are reconstructing a history that
+crosses that boundary, their absence from earlier entries is not evidence they did not happen.
+
 ### What changed (`changes`)
 
 Some operations additionally record the field values they altered:

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -106,6 +106,18 @@ const ROUTE_RULES: RouteRule[] = [
 
   { method: 'POST',   pattern: /^\/api\/tokens\/([^/]+)\/regenerate$/,             operation: 'token.regenerate' },
 
+  // ── MFA ──────────────────────────────────────────────────────────────────
+  // Both of these were unaudited, exempted by an entry in `audit-route-coverage` reading "covered by its
+  // own auth events". There is exactly one auth event in the whole map — `auth.failed` — so nothing was
+  // covering them, and turning off the second factor for every admin mutation left no trace at all.
+  //
+  // `setup` writes the new secret immediately (the confirm-with-a-code step is client-side), so it IS the
+  // enable, and it is also the ROTATE when MFA is already on. One operation name for both: the audit entry
+  // records that the secret changed, which is what a reader needs — and distinguishing them would require
+  // reading state the middleware does not have.
+  { method: 'POST',   pattern: /^\/api\/mfa\/setup$/,                              operation: 'mfa.enable' },
+  { method: 'DELETE', pattern: /^\/api\/mfa$/,                                     operation: 'mfa.disable' },
+
   // ── Webhook operations ───────────────────────────────────────────────────
   // These rules used to point at `/api/notify/webhooks`, but the router is mounted at
   // `/api/admin/webhooks` — so webhook CRUD was entirely unaudited. A webhook exfiltrates

--- a/testing/standalone/audit-route-coverage.test.js
+++ b/testing/standalone/audit-route-coverage.test.js
@@ -50,7 +50,10 @@ const EXEMPT = new Map([
   // First-run setup happens before any token exists, so there is nobody to attribute it to.
   ['/api/setup', 'first-run setup — runs before any identity exists'],
   // Auth/session endpoints have their own dedicated audit events (auth.failed, token.*).
-  ['/api/mfa', 'MFA enrolment/verification — covered by its own auth events'],
+  // Narrowed from `/api/mfa`, which read "covered by its own auth events" and was not true: the map holds
+  // exactly one auth event (`auth.failed`), so enabling and disabling the second factor were both silent.
+  // They are audited now (`mfa.enable` / `mfa.disable`); only the read-only code check stays exempt.
+  ['/api/mfa/verify', 'checks a TOTP code and returns valid/invalid — mutates nothing'],
   ['/api/oidc', 'OIDC login callbacks — covered by auth events'],
   ['/api/invite', 'network invite handshake — peer-facing'],
   ['/api/local-agent', 'workstation connector handshake — not a brain mutation'],
@@ -176,11 +179,23 @@ describe('Audit coverage — every mutating route must resolve to an operation',
       ['PUT', '/api/spaces/sample/schema', 'space schema write'],
       ['POST', '/api/spaces/reorder', 'space reorder'],
       ['DELETE', '/api/brain/spaces/sample/files', 'file metadata delete'],
+      ['POST', '/api/mfa/setup', 'MFA enable / secret rotation'],
+      ['DELETE', '/api/mfa', 'MFA disable'],
     ];
     for (const [method, p, what] of mustAudit) {
       const hit = resolveOperation(method, p);
       assert.ok(hit && !hit.read, `${what} (${method} ${p}) must produce an audit entry`);
     }
+  });
+
+  it('turning the second factor off is distinguishable in the log', () => {
+    // Not just "audited" — named. An operator scanning for how MFA came to be off needs the entry to say
+    // so, and `mfa.disable` beside `mfa.enable` is what makes a rotation and a removal tell apart.
+    assert.equal(resolveOperation('DELETE', '/api/mfa')?.operation, 'mfa.disable');
+    assert.equal(resolveOperation('POST', '/api/mfa/setup')?.operation, 'mfa.enable');
+    // The read-only code check stays out of the log — it is the one MFA route that changes nothing, and
+    // it is also the one a health-check hits repeatedly.
+    assert.equal(resolveOperation('POST', '/api/mfa/verify'), null);
   });
 
   it('a space rename is recorded as space.rename, not swallowed by space.update', () => {


### PR DESCRIPTION
## Disabling two-factor authentication produced no audit entry

`POST /api/mfa/setup` writes the new TOTP secret immediately — the "confirm with a code" step is
client-side only — so it **is** the enable, and the rotation when MFA is already on. `DELETE /api/mfa`
removes the secret entirely.

Neither produced an audit entry.

## The exemption said they were covered

```js
['/api/mfa', 'MFA enrolment/verification — covered by its own auth events'],
```

`audit-route-coverage` exists precisely to stop a mutating route going unaudited, and it was told, in
prose, that these were handled elsewhere. The audit map holds **exactly one** auth event:

```console
$ grep -c "operation: '" server/src/audit/middleware.ts
110
$ grep -o "operation: 'auth[a-z.]*'" -r server/src
server/src/audit/middleware.ts:operation: 'auth.failed'
```

Nothing was covering them. The claim had never been true.

## What the gap is, precisely

**Not authorisation.** `DELETE /api/mfa` is behind `requireAdminMfa`, so it still demands a current TOTP
code — a stolen admin PAT alone cannot turn the second factor off. That guard is intact and untouched here.

**The gap is that the action was unrecordable.** An insider disabling MFA, or an attacker who obtained
both factors, left the log exactly as they found it. For a control whose entire purpose is to gate every
admin mutation, "how did this come to be off, and when" was a question the audit log could not answer.

## The fix

| route | operation |
|---|---|
| `POST /api/mfa/setup` | `mfa.enable` |
| `DELETE /api/mfa` | `mfa.disable` |
| `POST /api/mfa/verify` | *(still exempt)* |

Two names rather than one: an operator reconstructing how MFA came to be off needs a rotation and a
removal to read differently. The exemption narrows to `/api/mfa/verify`, which checks a code and mutates
nothing — and is what a health check calls repeatedly, so keeping it out of the log is a decision, not an
oversight. Its reason now says that instead.

Pinned by name in the `mustAudit` list and by a dedicated test, so a future tidy-up of the rules cannot
quietly re-broaden the exemption.

## How it was found

The Testing & Quality audit lens, run with one question: **what does each gate exclude?**

That is the seventh instance this week of a check being narrower than it reads — after the Models page
listing 9 of 10 endpoints, the guide's guarded-endpoint bullet omitting the one unguarded endpoint, the
egress matrix documenting 7 slots of 10, `env-var-docs-coverage` covering a quarter of the settings,
`config-key-docs-coverage` checking one direction, and a posture line describing a guard that never
existed.

It is the first where the narrowing came with a **stated justification**. The other six were scopes nobody
had written down; this one had a reason sitting beside it, and reading the reason was enough to be
reassured. An exemption reason is a factual claim about the system, and it deserves to be checked against
the code like any other claim.

## A note for anyone reading old logs

The docs now say it: both mutations were unaudited before this change. If you are reconstructing a history
that crosses that boundary, their absence from earlier entries is not evidence they did not happen.

## Verification

`npm run preflight` green. `audit-route-coverage` passes with the narrowed exemption — which it would not
if either route were still unmapped, since that is the check's whole job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
