### PR TITLE
fix(security): MCP tool calls were not audited at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP tool calls were not audited at all.** Every write an agent made — `remember`, `upsert_entity`,
+  `upsert_edge`, `create_chrono`, every `update_*` / `delete_*`, `bulk_write`, `wipe_space` — left the
+  audit log unchanged, while the REST equivalent of each one wrote an entry. For a product whose primary
+  write path is an agent, that was most of the trail missing, and the guide promised the opposite:
+  *"every authenticated API operation … a full access trail for compliance and security review"*.
+  - Not an oversight nobody had considered. The HTTP audit middleware **explicitly admits** `/mcp` and
+    then drops it one line later because no route rule matches. What kept it unnoticed was
+    `audit-route-coverage`, whose `/mcp` exemption read *"MCP has its own tool-level audit path"* —
+    describing a path that did not exist. Second false exemption reason found in one day.
+  - Tools now record **the operation their REST counterpart records** (`memory.create`, not
+    `mcp.remember`), so the same act through two transports reads the same in the log; the transport is
+    a separate field. A refused tool call is status **422** — MCP answers 200 at the transport layer
+    even when the tool errors, so a status read from the response would log every rejected write as a
+    success.
+  - The map is **exhaustive by test**: it must name every registered tool, with an operation or with
+    `null` and the reason. A new tool fails the build until classified — the opposite of how the gap
+    survived, where the absence of a rule was the default.
+  - `sync_now` moved from "not a mutation" to `sync.trigger`, on both surfaces. A sync cycle pulls peer
+    records and writes them locally, so "who started the run that brought these in" is a fair question;
+    `/api/notify/trigger` records it too, and the `/api/notify` exemption narrows to peer notifications.
+
+- **The route-guard gate had never seen the agent-facing API.** `route-guard-coverage` scanned
+  `server/src/api` only, so `mcpRouter` and `setupRouter` — which live elsewhere — were never checked.
+  Both carried an EXEMPT entry, which made the omission read as deliberate and covered.
+  - Proven by mutation: deleting `mcpRouter.use(requireMcpAuth)`, the guard on the entire MCP surface,
+    left the suite green. It now fails, naming both routes.
+  - Auth and read-only are separate exemption dimensions now. One shared map forced all-or-nothing,
+    which is how MCP came to be excused from an auth check it actually passes under a reason that was
+    only ever about write-blocking.
+
 - **Turning off two-factor authentication left no trace in the audit log.** `POST /api/mfa/setup`
   (which writes the new secret immediately — it is the enable, and the rotation) and `DELETE /api/mfa`
   were both unaudited.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6210,6 +6210,23 @@ Base path: `/api/admin/audit-log` — **requires admin token** on all endpoints.
 
 Ythril maintains an append-only, immutable audit log of every authenticated API operation. The log captures who performed what action, when, on which space, and the resulting HTTP status — providing a full access trail for compliance and security review.
 
+**MCP tool calls are in it, under the same operation names as REST.** An agent calling `remember`
+produces a `memory.create` entry, exactly as `POST /api/brain/spaces/:id/memories` does — so a query for
+"who created this memory" does not have to know which transport was used. The transport is recorded
+separately: `method` is `MCP` and `path` is `sse:<tool>` or `http:<tool>`.
+
+A tool that refuses the call (a schema violation, a scope rejection) is recorded with status **422**. MCP
+answers 200 at the transport layer even when the tool errors, so a status taken from the HTTP response
+would log every rejected write as a success.
+
+Read tools (`query`, `recall`, `traverse`, `list_*`, `read_file`, …) follow the same rule as REST reads —
+recorded only when `audit.logReads` is on. Three tools record nothing at all and say why in
+`server/src/mcp/audit-map.ts`: `help` (returns this instance's own documentation), and `list_peers`
+(reads local config, with no REST counterpart that is audited either).
+
+⚠️ **Before 2.2.1, no MCP tool call was audited.** If you are reconstructing a history that crosses that
+boundary, the absence of agent writes from earlier entries is not evidence they did not happen.
+
 **Second-factor changes are in it.** `mfa.enable` records enrolment *and* a rotation of the secret;
 `mfa.disable` records the second factor being removed from every admin mutation. Checking a code
 (`POST /api/mfa/verify`) changes nothing and is deliberately not logged — it is also what a health check

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -106,6 +106,14 @@ const ROUTE_RULES: RouteRule[] = [
 
   { method: 'POST',   pattern: /^\/api\/tokens\/([^/]+)\/regenerate$/,             operation: 'token.regenerate' },
 
+  // ── Sync trigger ─────────────────────────────────────────────────────────
+  // `/api/notify` as a whole is exempt in `audit-route-coverage` as "peer notifications + the admin
+  // sync trigger — not a data mutation". The peer half is right; the trigger half is not. A sync cycle
+  // pulls records from peers and writes them locally, so "who started the run that brought in these
+  // records" is a question the log should answer. Only the specific admin route is matched — peer
+  // notifications stay out.
+  { method: 'POST',   pattern: /^\/api\/notify\/trigger$/,                        operation: 'sync.trigger' },
+
   // ── MFA ──────────────────────────────────────────────────────────────────
   // Both of these were unaudited, exempted by an entry in `audit-route-coverage` reading "covered by its
   // own auth events". There is exactly one auth event in the whole map — `auth.failed` — so nothing was
@@ -248,7 +256,7 @@ export function resolveOperation(method: string, path: string): { operation: str
   return null;
 }
 
-function isOidc(token: unknown): token is OidcTokenRecord {
+export function isOidc(token: unknown): token is OidcTokenRecord {
   return !!token && typeof token === 'object' && 'source' in token && (token as OidcTokenRecord).source === 'oidc';
 }
 
@@ -327,4 +335,19 @@ export function logAuthFailure(req: Request): void {
     entryId: null,
     durationMs: 0,
   });
+}
+
+/**
+ * How a caller authenticated, for an audit entry. Exported so the MCP dispatcher derives it the same way
+ * this middleware does — MCP writes its own entries (it is not an HTTP route the rules can match), and a
+ * second copy of this two-line derivation is how the two surfaces would come to disagree about identity.
+ */
+export function auditAuthMethod(token: unknown): 'pat' | 'oidc' | null {
+  if (!token) return null;
+  return isOidc(token) ? 'oidc' : 'pat';
+}
+
+/** The OIDC subject behind a token, or null for a PAT. */
+export function auditOidcSubject(token: unknown): string | null {
+  return isOidc(token) ? token.id.replace(/^oidc:/, '') : null;
 }

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -1,0 +1,105 @@
+/**
+ * Which audit operation each MCP tool records.
+ *
+ * ## Why this file exists
+ *
+ * MCP tool calls were not audited **at all**. Every write an agent made — `remember`, `upsert_entity`,
+ * `bulk_write`, `wipe_space` — left the audit log unchanged, while the REST equivalent of each one wrote
+ * an entry. For a product whose primary write path is an agent, that is most of the trail missing.
+ *
+ * The gap was not an oversight nobody had considered. The HTTP audit middleware explicitly admits `/mcp`:
+ *
+ *     if (!fullPath.startsWith('/api/') && !fullPath.startsWith('/mcp')) return;
+ *
+ * and then drops it one line later, because no `ROUTE_RULES` entry matches. Someone intended this to
+ * work. What kept it from being noticed was `audit-route-coverage`, whose `/mcp` exemption read *"MCP has
+ * its own tool-level audit path"* — describing a path that did not exist.
+ *
+ * ## Why the existing vocabulary, and not `mcp.tool_call`
+ *
+ * A compliance reader asks "who created this memory", not "who invoked a tool". Recording
+ * `mcp.remember` would make the audit log unanswerable across surfaces: the same act, performed through
+ * REST and through MCP, would appear under two names, and every query would have to know both. So a tool
+ * records the operation its REST counterpart records, and the transport is a separate field.
+ *
+ * ## Why every tool must appear here
+ *
+ * The entries are not an allowlist with silent gaps — `mcp-audit-coverage.test.js` asserts this map's
+ * keys are exactly the registered tool names. A new tool fails the build until it is classified, which is
+ * the opposite of how the original gap survived: there, the absence of a rule *was* the default.
+ *
+ * `null` means "not an audited operation", and each `null` carries its reason. That is the same
+ * exemption-with-a-reason discipline the route gates use — and two of those reasons turned out to be
+ * false when checked this week, so a reason here is written to be checkable against the code.
+ */
+
+/** Tool name → the audit operation it performs, or `null` with the reason it is not one. */
+export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
+  // ── Mutations. Each records exactly what its REST counterpart records. ──────────────────────────
+  remember: 'memory.create',
+  update_memory: 'memory.update',
+  delete_memory: 'memory.delete',
+  upsert_entity: 'entity.create',
+  update_entity: 'entity.update',
+  merge_entities: 'entity.merge',
+  upsert_edge: 'edge.create',
+  update_edge: 'edge.update',
+  create_chrono: 'chrono.create',
+  update_chrono: 'chrono.update',
+  bulk_write: 'bulk.write',
+  update_space: 'space.update',
+  wipe_space: 'space.wipe',
+  write_file: 'file.create',
+  move_file: 'file.update',
+  delete_file: 'file.delete',
+  create_dir: 'file.mkdir',
+  // The tool registry flags this `mutating: true`, and it is right: a sync cycle pulls records from
+  // peers and writes them locally, so "who started the run that brought in these records" is a fair
+  // audit question. `/api/notify` is exempt on the REST side as "peer notifications + the admin sync
+  // trigger — not a data mutation"; the peer half is right and the trigger half was not, so
+  // `/api/notify/trigger` records `sync.trigger` too and the two surfaces agree.
+  sync_now: 'sync.trigger',
+
+  // ── Reads. Recorded only when `logReads` is on, exactly as the REST reads are. ──────────────────
+  query: 'brain.query',
+  recall: 'brain.recall',
+  traverse: 'brain.traverse',
+  get_stats: 'brain.stats',
+  list_chrono: 'chrono.list',
+  list_spaces: 'space.list',
+  list_dir: 'file.list',
+  read_file: 'file.read',
+  find_entities_by_name: 'entity.list',
+  // A vector-similarity search over existing entries — a read of the same records `entity.list` covers.
+  find_similar: 'entity.list',
+  // Returns the space's schema and counts. `space.list` is the REST read that exposes the same shape.
+  get_space_meta: 'space.list',
+
+  // ── Not audited operations, with the reason each. ──────────────────────────────────────────────
+  // Returns this instance's own documentation. Reads no space and no record.
+  help: null,
+  // Lists configured peers from local config. There is no `network.list` operation on the REST side
+  // either — peer topology is read from `/api/networks`, which is itself unaudited as a read.
+  list_peers: null,
+};
+
+/**
+ * The operation for a tool call, or `null` when the tool is deliberately not an audited operation.
+ *
+ * An UNKNOWN tool also returns `null` rather than throwing: the dispatcher already reports unknown tools
+ * to the caller, and an audit helper is the wrong place to turn a bad tool name into a 500. The coverage
+ * test is what guarantees no *registered* tool reaches here unclassified.
+ */
+export function mcpAuditOperation(toolName: string): string | null {
+  return MCP_TOOL_OPERATIONS[toolName] ?? null;
+}
+
+/** Operations that are reads — logged only when `logReads` is enabled, matching the REST convention. */
+const READ_OPERATIONS = new Set([
+  'brain.query', 'brain.recall', 'brain.traverse', 'brain.stats',
+  'chrono.list', 'space.list', 'file.list', 'file.read', 'entity.list',
+]);
+
+export function isMcpReadOperation(operation: string): boolean {
+  return READ_OPERATIONS.has(operation);
+}

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -49,7 +49,13 @@ function sessionTag(sessionId: string): string {
  *
  *  Tool schemas, authorization gates and handlers all come from the registry in
  *  ./tools — there is one source of truth per tool. */
-function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdmin?: boolean, tokenId?: string, tokenLabel?: string): Server {
+/**
+ * @param audit  Caller identity for the audit trail. Passed in rather than read from a request here
+ *   because the SSE transport builds the server once per CONNECTION and then serves many tool calls
+ *   over it — there is no `req` in scope at dispatch time, only the one that opened the stream.
+ */
+function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdmin?: boolean, tokenId?: string, tokenLabel?: string,
+  audit?: { ip: string; authMethod: 'pat' | 'oidc' | null; oidcSubject: string | null; transport: 'sse' | 'http' }): Server {
   const cfg = getConfig();
   const accessibleSpaces = cfg.spaces.filter(s => !tokenSpaces || tokenSpaces.includes(s.id));
   const accessibleSpaceIds = accessibleSpaces.map(s => s.id);
@@ -89,6 +95,35 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
       inputSchema: t.inputSchema(schemas),
     })),
   }));
+
+  /**
+   * Write one audit entry per tool call.
+   *
+   * Under the operation the tool's REST counterpart records, not `mcp.<tool>` — a compliance reader
+   * asks who created a memory, not who invoked a tool, and two names for one act makes every query
+   * have to know both. `path` carries the tool name so the transport is still recoverable.
+   *
+   * Reads follow the REST convention: recorded only when `logReads` is on. Fire-and-forget, like
+   * every other audit write — a failing log must never fail the operation it is describing.
+   */
+  function recordToolCall(toolName: string, spaceId: string, status: number, durationMs: number): void {
+    const operation = mcpAuditOperation(toolName);
+    if (!operation) return;                       // deliberately not an audited operation — see audit-map.ts
+    if (isMcpReadOperation(operation) && !getConfig().audit?.logReads) return;
+    logAuditEntry({
+      tokenId: tokenId ?? null,
+      tokenLabel: tokenLabel ?? null,
+      authMethod: audit?.authMethod ?? null,
+      oidcSubject: audit?.oidcSubject ?? null,
+      ip: audit?.ip ?? '',
+      method: 'MCP',
+      path: `${audit?.transport ?? 'http'}:${toolName}`,
+      spaceId: spaceId || null,
+      operation,
+      status,
+      durationMs,
+    });
+  }
 
   // ── tools/call ────────────────────────────────────────────────────────────
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -160,7 +195,8 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
           return { content: [{ type: 'text' as const, text: `Error: ${argErr}` }], isError: true };
         }
       }
-      return await tool.handle({
+      const startedAt = Date.now();
+      const result = await tool.handle({
         args: a,
         callSpace,
         name,
@@ -172,6 +208,11 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
         readOnly,
         actor: { tokenId, tokenLabel },
       });
+      // A tool that returns `isError` failed on its own terms — the transport still answered 200, so
+      // the audit status has to come from the RESULT or the log would record every rejected write as
+      // a success. 422 rather than 400: the call was well-formed and the handler refused it.
+      recordToolCall(name, callSpace, result?.isError ? 422 : 200, Date.now() - startedAt);
+      return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`MCP global tool '${name}' error in space '${callSpace || 'global'}': ${message}`);
@@ -188,6 +229,9 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
 // ── Express router ───────────────────────────────────────────────────────────
 
 import { requireMcpAuth } from '../auth/middleware.js';
+import { logAuditEntry } from '../audit/audit.js';
+import { auditAuthMethod, auditOidcSubject } from '../audit/middleware.js';
+import { mcpAuditOperation, isMcpReadOperation } from './audit-map.js';
 import { mcpConnectionsActive, mcpToolCallsTotal } from '../metrics/registry.js';
 
 export const mcpRouter = Router();
@@ -216,7 +260,8 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
     log.debug(`MCP global session ${sessionTag(transport.sessionId)} closed`);
   });
 
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name);
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
+    { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'sse' });
   log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
 });
@@ -247,7 +292,8 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
 // This transport requires no persistent connection and works through standard HTTP proxies.
 mcpRouter.post('/', globalRateLimit, async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name);
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
+    { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'http' });
   // Register cleanup before handling the request so it fires regardless of outcome.
   res.on('close', () => {
     transport.close();

--- a/testing/standalone/audit-route-coverage.test.js
+++ b/testing/standalone/audit-route-coverage.test.js
@@ -46,7 +46,10 @@ const EXEMPT = new Map([
   // Machine-to-machine sync: peers write constantly and are authenticated as peers, not
   // users. Auditing every sync push would swamp the log and tell you nothing about a human.
   ['/api/sync', 'peer-to-peer sync traffic — not a user action'],
-  ['/api/notify', 'peer notifications + the admin sync trigger — not a data mutation'],
+  // Narrowed in scope by a new rule rather than in text: `/api/notify/trigger` now records
+  // `sync.trigger`, because a sync cycle writes peer records locally. This entry covers the peer
+  // notifications only, which are machine-to-machine and not a user action.
+  ['/api/notify', 'peer notifications — machine-to-machine, not a user action'],
   // First-run setup happens before any token exists, so there is nobody to attribute it to.
   ['/api/setup', 'first-run setup — runs before any identity exists'],
   // Auth/session endpoints have their own dedicated audit events (auth.failed, token.*).

--- a/testing/standalone/mcp-audit-coverage.test.js
+++ b/testing/standalone/mcp-audit-coverage.test.js
@@ -1,0 +1,108 @@
+/**
+ * Every MCP tool is classified for the audit log, and every mutating one produces an entry.
+ *
+ * ## What was wrong
+ *
+ * MCP tool calls were not audited at all. `remember`, `upsert_entity`, `bulk_write`, `wipe_space` — every
+ * write an agent made left the audit log unchanged, while the REST equivalent of each wrote an entry. For
+ * a product whose primary write path is an agent, that was most of the trail missing, and the integration
+ * guide promised the opposite: *"every authenticated API operation … a full access trail for compliance
+ * and security review"*.
+ *
+ * It was not an oversight nobody had considered. The HTTP audit middleware explicitly admits `/mcp` and
+ * then drops it, because no route rule matches. What kept it unnoticed was `audit-route-coverage`, whose
+ * `/mcp` exemption read *"MCP has its own tool-level audit path"* — a path that did not exist.
+ *
+ * ## Why this test is shaped as an EXHAUSTIVE map rather than a list of things to check
+ *
+ * The original gap survived because the absence of a rule was the default. A tool nobody thought about
+ * was silently unaudited. So the map must name **every** registered tool: adding one fails here until it
+ * is classified, and `null` — "deliberately not an audited operation" — has to be written down with a
+ * reason rather than achieved by omission.
+ *
+ * That is the same discipline the route gates use for exemptions. Two of those reasons turned out to be
+ * false when checked this week (`/api/mfa`, `/mcp`), which is why the reasons here are written to be
+ * checkable against the code rather than taken on trust.
+ *
+ * Run: node --test testing/standalone/mcp-audit-coverage.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let MCP_TOOL_OPERATIONS, mcpAuditOperation, isMcpReadOperation;
+let ALL_TOOLS;
+
+const MIDDLEWARE = 'server/src/audit/middleware.ts';
+const ROUTER = 'server/src/mcp/router.ts';
+
+describe('MCP audit coverage', () => {
+  before(async () => {
+    ({ MCP_TOOL_OPERATIONS, mcpAuditOperation, isMcpReadOperation } =
+      await import('../../server/dist/mcp/audit-map.js'));
+    ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js'));
+  });
+
+  it('finds the tools (the check itself works)', () => {
+    // A registry that failed to import would make every assertion below vacuous — the exact failure mode
+    // this whole file exists to close.
+    assert.ok(Array.isArray(ALL_TOOLS) && ALL_TOOLS.length >= 25,
+      `expected the MCP tool registry, found ${ALL_TOOLS?.length}`);
+  });
+
+  it('classifies every registered tool — no more, no fewer', () => {
+    const registered = ALL_TOOLS.map(t => t.name).sort();
+    const classified = Object.keys(MCP_TOOL_OPERATIONS).sort();
+    assert.deepEqual(classified, registered,
+      'Every MCP tool must be classified in audit-map.ts — with an operation, or with `null` and the ' +
+      'reason it is not one. A tool missing from the map is silently unaudited, which is exactly how the ' +
+      'entire MCP surface came to be unaudited in the first place.');
+  });
+
+  it('every MUTATING tool records an operation', () => {
+    const silent = ALL_TOOLS.filter(t => t.mutating && !mcpAuditOperation(t.name)).map(t => t.name);
+    assert.deepEqual(silent, [],
+      'These tools change data and produce no audit entry. A mutation must be attributable.');
+  });
+
+  it('no mutating tool is recorded as a read', () => {
+    // A mutation classified as a read would be logged only when `logReads` is on — which is off by
+    // default, so it would be silent on almost every instance. Worse than unmapped, because the map
+    // would look complete.
+    const misfiled = ALL_TOOLS
+      .filter(t => t.mutating)
+      .map(t => [t.name, mcpAuditOperation(t.name)])
+      .filter(([, op]) => op && isMcpReadOperation(op))
+      .map(([name, op]) => `${name} → ${op}`);
+    assert.deepEqual(misfiled, [], 'a mutating tool must not map to a read operation');
+  });
+
+  it('every operation it names is one the REST surface already uses', () => {
+    // The point of reusing the vocabulary: the same act through two transports must read the same in the
+    // log. An operation that exists only for MCP would split every compliance query in two.
+    const restOperations = new Set(
+      [...readFileSync(MIDDLEWARE, 'utf8').matchAll(/operation: '([a-z][a-zA-Z.]+)'/g)].map(m => m[1]),
+    );
+    const invented = [...new Set(Object.values(MCP_TOOL_OPERATIONS))]
+      .filter(op => op && !restOperations.has(op));
+    assert.deepEqual(invented, [],
+      'these operations exist only on the MCP side — reuse the REST vocabulary so entries are comparable');
+  });
+
+  it('the dispatcher actually calls the recorder', () => {
+    // The map is inert on its own. This is the wiring, and it is the line a refactor would drop.
+    const src = readFileSync(ROUTER, 'utf8');
+    assert.match(src, /recordToolCall\(name, callSpace, result\?\.isError \? 422 : 200/,
+      'the tool dispatcher must record every call, with the status taken from the RESULT');
+    assert.match(src, /function recordToolCall\(/, 'the recorder must exist in the dispatcher');
+  });
+
+  it('a tool that fails is not recorded as a success', () => {
+    // MCP answers 200 at the transport layer even when a tool refuses, so a status read from the HTTP
+    // response would log every rejected write as successful. The status has to come from `isError`.
+    const src = readFileSync(ROUTER, 'utf8');
+    const at = src.indexOf('recordToolCall(name, callSpace');
+    assert.ok(at > 0);
+    assert.ok(!/status: 200/.test(src.slice(at, at + 200)), 'status must not be hardcoded to 200');
+  });
+});

--- a/testing/standalone/route-guard-coverage.test.js
+++ b/testing/standalone/route-guard-coverage.test.js
@@ -29,7 +29,22 @@ import path from 'node:path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const API_DIR = path.join(__dirname, '..', '..', 'server', 'src', 'api');
+/**
+ * Every directory that declares an Express router — not just `api/`.
+ *
+ * It was `api/` alone, so `mcpRouter` (server/src/mcp/router.ts) and `setupRouter`
+ * (server/src/setup/routes.ts) had NEVER been scanned. Both carried an EXEMPT entry, which made the
+ * omission read as deliberate and covered — the gate was not exempting them, it could not see them.
+ *
+ * Proven by mutation before it was fixed: deleting `mcpRouter.use(requireMcpAuth)` — the guard on the
+ * entire agent-facing API — left this suite green.
+ */
+const ROUTER_DIRS = [
+  path.join(__dirname, '..', '..', 'server', 'src', 'api'),
+  path.join(__dirname, '..', '..', 'server', 'src', 'mcp'),
+  path.join(__dirname, '..', '..', 'server', 'src', 'setup'),
+];
+const API_DIR = ROUTER_DIRS[0];
 const APP_TS = path.join(__dirname, '..', '..', 'server', 'src', 'app.ts');
 
 const MUTATING = new Set(['post', 'put', 'patch', 'delete']);
@@ -41,6 +56,11 @@ const AUTH_GUARDS = [
   'requireAdminMfaScoped',
   'requireAdminMfa',
   'requireAdmin',
+  // `mcpRouter.use(requireMcpAuth)` guards every MCP route, but this list did not know the name — so the
+  // router was EXEMPTED instead, under a reason ("authorises at the tool dispatcher") that described its
+  // read-only enforcement rather than its authentication. Between that and the scan never reaching
+  // `server/src/mcp`, the entire agent-facing API sat outside this gate.
+  'requireMcpAuth',
 ];
 
 /** Guards that block a READ-ONLY token from writing. Admin guards imply a non-read-only admin. */
@@ -73,8 +93,26 @@ const EXEMPT = new Map([
   ['oidcRouter', 'OIDC login/callback — this is how you GET a token'],
   ['themeRouter', 'public unauthenticated theme endpoint (read-only, no user data)'],
   ['notifyRouter', 'peer notifications + admin sync trigger — peer-authenticated'],
-  ['mcpRouter', 'MCP authorises at the tool dispatcher, not per-route'],
+  // mcpRouter is deliberately NOT here any more. `requireMcpAuth` is in AUTH_GUARDS above, so the gate
+  // can now see that the router is guarded instead of being told to look away. It remains exempt from the
+  // READ-ONLY check below, where the original reason was true: a read-only token does reach the
+  // dispatcher, which refuses every mutating tool.
   ['metricsRouter', 'Prometheus scrape — guarded by METRICS_TOKEN inside the router'],
+]);
+
+/**
+ * Exempt from the READ-ONLY check only — still required to authenticate.
+ *
+ * The two dimensions used to share one map, which forced an all-or-nothing choice: a router that
+ * authenticates properly but enforces write-blocking somewhere the scanner cannot see had to be exempted
+ * from **both**. That is how `mcpRouter` ended up excused from an auth check it actually passes, under a
+ * reason that was only ever about the other dimension.
+ */
+const WRITE_EXEMPT = new Map([
+  // True, and checkable: `mcp/router.ts` opens its `CallToolRequestSchema` handler with
+  // `if (readOnly && tool?.mutating) return { ...'this token has read-only access', isError: true }`.
+  // The enforcement is per TOOL, which a per-route scanner cannot see — every tool arrives as `POST /`.
+  ['mcpRouter', 'read-only is enforced per tool in the dispatcher, not per route'],
 ]);
 
 /**
@@ -101,7 +139,11 @@ let routes = [];
 let routerLevelGuards = new Map();
 
 /** Every .ts file under the api dir, recursively — routes live in `api/` AND `api/brain/` (A17.3). */
-function apiFiles(dir = API_DIR, out = []) {
+function apiFiles(dir = null, out = []) {
+  if (dir === null) {
+    for (const d of ROUTER_DIRS) apiFiles(d, out);
+    return out;
+  }
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const p = path.join(dir, e.name);
     if (e.isDirectory()) apiFiles(p, out);
@@ -235,7 +277,7 @@ describe('Route guards — every mutating route must be protected', () => {
     const writable = [];
     for (const r of routes) {
       if (!MUTATING.has(r.method)) continue;
-      if (EXEMPT.has(r.router)) continue;
+      if (EXEMPT.has(r.router) || WRITE_EXEMPT.has(r.router)) continue;
       if (r.method === 'post' && READ_SHAPED_POSTS.includes(r.routePath)) continue;
       if (!WRITE_GUARDS.some(g => effectiveChain(r).includes(g))) {
         writable.push(`${r.method.toUpperCase()} ${r.routePath}  (${r.file}: ${r.router})`);


### PR DESCRIPTION
## Every agent write was invisible to the audit log

`remember`, `upsert_entity`, `upsert_edge`, `create_chrono`, every `update_*` / `delete_*`, `bulk_write`,
`wipe_space` — none of them produced an audit entry. The REST equivalent of each one does.

The integration guide says:

> Ythril maintains an append-only, immutable audit log of **every authenticated API operation** … providing
> a full access trail for compliance and security review.

For a product whose primary write path is an agent, that was most of the trail.

## It was not unconsidered — it was hidden

The HTTP audit middleware **explicitly admits** `/mcp`:

```ts
if (!fullPath.startsWith('/api/') && !fullPath.startsWith('/mcp')) return;
```

…and then drops it one line later, because no `ROUTE_RULES` entry matches. Someone intended this to work.

What kept it unnoticed was the gate built to catch exactly this:

```js
['/mcp', 'MCP has its own tool-level audit path'],
```

There is no tool-level audit path. `logAuditEntry` has no caller outside `server/src/audit/`, and the
dispatcher enforces read-only, admin and space scope before calling the handler with no audit call
anywhere near it. **Second false exemption reason found today**, after `/api/mfa`.

## Design: the REST vocabulary, not `mcp.tool_call`

A compliance reader asks *who created this memory*, not *who invoked a tool*. Recording `mcp.remember`
would split every query in two — the same act through two transports under two names. So a tool records
what its REST counterpart records, and the transport goes in its own field:

| field | value |
|---|---|
| `operation` | `memory.create` |
| `method` | `MCP` |
| `path` | `sse:remember` / `http:remember` |

**A refused call is 422.** MCP answers 200 at the transport layer even when a tool errors, so a status
taken from the HTTP response would log every rejected write as a success. It comes from the result.

**Reads follow the REST convention** — recorded only when `audit.logReads` is on.

## The map is exhaustive by test, not by diligence

`mcp-audit-coverage.test.js` asserts the map's keys are *exactly* the registered tool names. A new tool
fails the build until it is classified — with an operation, or with `null` **and the reason**.

That shape is the point. This gap survived because the absence of a rule was the default: a tool nobody
thought about was silently unaudited. Now the default is a failing test.

Also asserted: no mutating tool maps to a read (which would make it silent on any instance with `logReads`
off — worse than unmapped, because the map would look complete), and no operation is invented that the
REST surface does not already use.

## `sync_now` changed classification

I first marked it not-a-mutation, mirroring the `/api/notify` exemption. The tool registry flags it
`mutating: true` and is right: a sync cycle pulls peer records and **writes them locally**, so "who
started the run that brought these in" is a fair audit question. It records `sync.trigger` — and so does
`/api/notify/trigger`, so the two surfaces agree. The `/api/notify` exemption narrows to the peer
notifications it was always really about.

## The gate that should have caught this could not see the router

`route-guard-coverage` scanned `server/src/api` only. `mcpRouter` lives in `server/src/mcp/router.ts` and
`setupRouter` in `server/src/setup/routes.ts` — **neither had ever been scanned**. Both carried an EXEMPT
entry, which made the omission read as deliberate and covered.

Proven by mutation, before and after:

```console
# before — guard on the entire agent-facing API deleted
$ node --test route-guard-coverage.test.js     →  pass 5, fail 0

# after
$ node --test route-guard-coverage.test.js     →  fail 1
    POST /messages  (../mcp/router.ts: mcpRouter)
    POST /          (../mcp/router.ts: mcpRouter)
```

**Auth and read-only are separate exemption dimensions now.** One shared map forced all-or-nothing, which
is precisely how MCP came to be excused from an auth check it actually passes, under a reason that was
only ever about write-blocking. Its read-only exemption stays — with a reason that is true and checkable:
the dispatcher refuses mutating tools *per tool*, which a per-route scanner cannot see.

## Verification

- `npm run preflight` green.
- Both new gates mutation-checked: removing the MCP auth guard fails `route-guard-coverage`; removing the
  audit recorder fails two tests in `mcp-audit-coverage`.
- Docs note that no MCP call was audited before this, so anyone reconstructing a history across the
  boundary does not read the absence as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
