### PR TITLE
chore(release): 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] — 2026-07-31
+
 ### Fixed
 
 - **MCP tool calls were not audited at all.** Every write an agent made — `remember`, `upsert_entity`,

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump + CHANGELOG heading. The work is already on `main` as #574–#577.

## Patch, and why it should not wait for the next minor

Six fixes. Four came from running the Testing & Quality audit lens over the coverage gates themselves,
with one question: **what does each gate exclude?**

Two of them matter to an operator *before* they lean on the audit log:

- **MCP tool calls were not audited at all.** Every write an agent made — `remember`, `upsert_entity`,
  `bulk_write`, `wipe_space` — left the audit log unchanged, while the REST equivalent of each wrote an
  entry. For a product whose primary write path is an agent, that was most of the trail.
- **Disabling two-factor authentication left no trace either.**

Both were hidden behind exemption entries whose stated reasons were false — *"MCP has its own tool-level
audit path"* (there is none) and *"covered by its own auth events"* (there is exactly one, `auth.failed`).
Neither had ever been true.

## Also in it

- A **security setting read by no code path** (`allowInsecurePlaintext`), while the startup posture told
  operators it disabled a guard that has never existed. Retired, not deleted; the posture now names
  `requireEncryptedTransport`, the control that actually rejects plaintext.
- **`route-guard-coverage` had never scanned the agent-facing API.** `mcpRouter` and `setupRouter` live
  outside `server/src/api`. Proven by mutation: deleting the guard on the entire MCP surface left the
  suite green. It fails now.
- Two documentation gates that covered a fraction of what they claimed — the env-var one was scoped to
  four namespaces, so no model endpoint had ever been checked; the config-key one verified only that
  documented keys are real, never that real fields are documented.

## Upgrade impact

**None.** No schema change, no API change, nothing to reconfigure. A drop-in over 2.2.0.

An agent integration will see new audit entries appear for work it was already doing; nothing it sends
changes. Reads follow the existing `audit.logReads` setting, so a default instance gains mutation entries
only.

One thing worth stating for anyone reading history: **no MCP call was audited before this release.** Their
absence from earlier entries is not evidence they did not happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
