### PR TITLE
docs(userguide): three 2.2 features never reached the guide a user reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Three 2.2 features never reached the user guide.** The integration guide had them all; the guide a
+  non-integrator actually reads had none of them.
+  - **Verify** — a button on four provider cards, with no user-facing explanation of what it sends
+    (generated payloads, never your data), what `still-loading` means, or why silence transcribing to
+    nothing is a pass.
+  - **The re-upload confirmation** — a new dialog, undocumented, including that it asks once per batch
+    and that Cancel is the default.
+  - **Update validation** — an edit can now be refused for a field the user did not touch, when the
+    record was already non-compliant. Without the guide saying so, that reads as a bug.
+  - The doc-coverage gates check env vars, config keys, routes, MCP tools and shipped guides. **None of
+    them can see that a user-facing UI feature never got written up** — the same blind spot in a
+    different dimension.
+
+
 ## [2.2.1] — 2026-07-31
 
 ### Fixed

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -293,6 +293,14 @@ The file manager lets you upload, download, organise, and preview files within e
 
 **Uploading:** Click **↑ Upload** in the toolbar, or drag and drop files directly onto the file list. Large files are uploaded in chunks automatically.
 
+**Uploading over a file that already exists asks first.** *New in 2.2.* A file with the same name in the
+same folder is **replaced**, and everything derived from the old one is removed and rebuilt: conversion
+chunks, extracted images, and any description generated from them. The dialog names all of that, because
+what you need to weigh is that the derived records disappear — not that some bytes change.
+
+You are asked **once for a whole batch**, not once per file: a drop of twenty files where three collide is
+one question. **Cancel is the default**, and Replace is styled as destructive. There is no undo.
+
 **Actions per row:**
 
 | Action | How |
@@ -448,6 +456,15 @@ Click the gear icon on any space row to open its settings panel. Changes save an
 **Schema tab:** Define what data this space accepts. A **Schema validation** bar at the very top holds the space-wide **Validation mode** and **Strict linkage** controls — these govern *every* type in the space, not the collection you happen to be viewing. Below it, the entity / edge / memory / chrono collections each list their types on the left; click one to edit its rules in a stable panel on the right (you don't lose your place editing a type or property, and several property editors can be open at once).
 
 - **Validation mode** — `off` means anything goes; `warn` lets writes through but flags violations; `strict` blocks invalid writes entirely.
+  > **Editing is checked too, as of 2.2.** Previously only *creating* a record was validated; an edit
+  > could save a value the same space would have rejected on create. Now the record **as it will be** —
+  > yours plus the existing fields — is checked before it saves.
+  >
+  > This can refuse an edit for a field you did not touch, when the record was already invalid: written
+  > before you tightened the schema, or imported, or synced from another brain. The message says which is
+  > which — *"the change violates…"* versus *"this record was already non-compliant before your
+  > change…"* — so you are not sent looking at the wrong field. To get unstuck, fix the named field in
+  > the same save; validation is of the result, so the record repairs itself.
 - **Strict linkage** — when on, references between items must be valid IDs and deletion of referenced items is blocked.
 - **Type schemas** — define per-type rules under each knowledge type (entity, memory, edge, chrono). For each named type you can set:
   - **Naming pattern** — a regex the name must match.
@@ -634,6 +651,34 @@ rather than just saying it failed. Two cases account for almost all of them:
 
 Every refusal is also written to the server log with the same detail, so an administrator can find it
 without you having to reproduce the click.
+
+### Verify — does the model actually answer?
+
+*New in 2.2.*
+
+**Test connection** asks "is something there". It cannot answer *does my model work* — an endpoint can be
+reachable, list your model, and still fail on every real request. **Verify** sends one real request and
+tells you what came back. There is a button on the **Vision**, **Speech-to-text**, **Embedding** and
+**Assist** cards.
+
+**It never sends your data.** The payload is always generated: a 1×1 transparent image, a few
+milliseconds of synthesised silence, or the word `ping`. It goes through the same code path the worker
+uses, so a transport problem shows up here instead of on someone's first upload.
+
+Four outcomes:
+
+| Result | Meaning |
+|---|---|
+| **OK** | The model answered. A short sample of what it returned is shown. |
+| **Still loading** | It did not answer within 3 minutes. Not a failure — a backend that swaps models onto a shared GPU can legitimately take 30 seconds or more on the first call. Try again. |
+| **Failed** | It answered, but wrongly — or the call errored. The detail names what happened. |
+| **Not configured** | No model is set for that card. |
+
+Silence transcribing to no text is a **pass** for speech-to-text: the payload is silent, so reaching a
+proper response *is* the result.
+
+Verify costs a real request, so on a metered endpoint it costs money. It is recorded in the audit log for
+that reason; Test connection, which only lists models, is not.
 
 ### Privacy note
 


### PR DESCRIPTION
## Three 2.2 features never reached the guide a user reads

The integration guide has all of them. `docs/userguide.md` — the one someone opens when a button they
just pressed does something unexpected — had **none**.

### Verify

A button on four provider cards, shipped in #566, with zero mentions in the user guide. A user pressing it
had nothing telling them:

- it sends a **generated** payload (a 1×1 PNG, synthesised silence, the word `ping`) and never their data;
- **still loading** is not a failure — a backend swapping models onto a shared GPU legitimately takes 30 s+;
- silence transcribing to **no text is a pass** for speech-to-text, not an empty result;
- it costs a real request, which is why it is audited and Test connection is not.

### The re-upload confirmation

A new dialog, undocumented — including the two things worth knowing before clicking through it: it asks
**once for a whole batch**, and **Cancel is the default** because there is no undo.

### Update validation

An edit can now be refused over a field the user **did not touch**, when the record was already
non-compliant — imported, synced from another brain, or written before the schema tightened. Undocumented,
that reads as a bug rather than as the message it actually prints.

The guide now explains the `introduced` / `preExisting` distinction in plain terms, and how to get
unstuck: fix the named field in the same save, because validation is of the *result*.

## The blind spot worth naming

The doc-coverage gates check env vars, config keys, route paths, MCP tools, and that every shipped guide
is offered by the in-product Help page. **None of them can see that a user-facing UI feature was never
written up.**

That is the same shape as everything else found this week — a check narrower than it reads — except here
no gate can close it. A mechanical check enumerates what the code *declares*, and "there is a button here
now" is not declared anywhere a scanner can reach. It stays a human obligation, which is worth knowing
rather than papering over with a gate that would only pretend.

## Verification

`npm run preflight` green, `npm run lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
