### PR TITLE
fix(client): the shipped guides have never been styled at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The shipped guides have never been styled.** Not badly styled — **unstyled**. The Help page and the
+  Markdown file preview both render through `[innerHTML]`, and Angular's emulated encapsulation stamps
+  `_ngcontent-*` only on elements the TEMPLATE creates. So `.doc p` compiled to `.doc p[_ngcontent-xyz]`
+  and matched nothing. No error, no warning: the styles sat in the file looking applied.
+  - 19 dead rules in `help.component.ts`, 13 in `file-manager.component.ts` — every guide and every
+    Markdown preview has rendered at browser defaults since each shipped.
+  - Measured on a booted instance, before → after: `pre` background `transparent` → `rgb(28,33,40)`,
+    `pre` radius `0px` → `8px`, `blockquote` border-left `0px` → `3px`, paragraph `max-width` `none`
+    → `689px`.
+  - New gate `innerhtml-css-reach.test.js`. The first version guessed — it flagged `.xlsx-grid th` and
+    `.detail-desc h4`, both template-built and fine — so it was replaced with a **declared map** of
+    every `[innerHTML]` surface. A component missing from it fails the build, which is the opposite of
+    how this survived: there, having no declaration was the default.
+
+- **And now that rules can land, the guides read like documentation.** A **78ch measure on prose only**
+  (tables and code keep the full width, so nothing scrolls that need not); table headers get a
+  background and 600 weight with tinted even rows — the guides have 25 table cells over 320 characters,
+  so row tracking is not cosmetic; body text 14px/1.65. Screenshot-verified at 1680px, the width the
+  problem only appears at.
+
 ### Documentation
 
 - **The changelog is split by major.** 7,234 lines and 620 KB across 34 releases going back to

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -346,18 +346,18 @@ function xlsxCellText(v: unknown): string {
     .preview-fs-btn:hover { opacity: 1; }
     /* Formatted markdown */
     .md-rendered { line-height: 1.6; word-break: break-word; }
-    .md-rendered h1, .md-rendered h2, .md-rendered h3 { margin: 0.8em 0 0.4em; line-height: 1.25; }
-    .md-rendered h1 { font-size: 1.5em; } .md-rendered h2 { font-size: 1.3em; } .md-rendered h3 { font-size: 1.12em; }
-    .md-rendered p { margin: 0.5em 0; }
-    .md-rendered ul, .md-rendered ol { margin: 0.5em 0; padding-left: 1.5em; }
-    .md-rendered code { background: var(--bg-muted); padding: 0.1em 0.35em; border-radius: 4px; font-family: var(--font-mono, monospace); font-size: 0.9em; }
-    .md-rendered pre { background: var(--bg-muted); padding: 12px; border-radius: 6px; overflow: auto; margin: 0.6em 0; }
-    .md-rendered pre code { background: none; padding: 0; }
-    .md-rendered a { color: var(--accent, #6ea8fe); }
-    .md-rendered blockquote { margin: 0.5em 0; padding-left: 12px; border-left: 3px solid var(--border); color: var(--text-muted); }
-    .md-rendered table { border-collapse: collapse; margin: 0.5em 0; }
-    .md-rendered th, .md-rendered td { border: 1px solid var(--border); padding: 4px 8px; }
-    .md-rendered img { max-width: 100%; }
+    .md-rendered ::ng-deep h1, .md-rendered ::ng-deep h2, .md-rendered ::ng-deep h3 { margin: 0.8em 0 0.4em; line-height: 1.25; }
+    .md-rendered ::ng-deep h1 { font-size: 1.5em; } .md-rendered ::ng-deep h2 { font-size: 1.3em; } .md-rendered ::ng-deep h3 { font-size: 1.12em; }
+    .md-rendered ::ng-deep p { margin: 0.5em 0; }
+    .md-rendered ::ng-deep ul, .md-rendered ::ng-deep ol { margin: 0.5em 0; padding-left: 1.5em; }
+    .md-rendered ::ng-deep code { background: var(--bg-muted); padding: 0.1em 0.35em; border-radius: 4px; font-family: var(--font-mono, monospace); font-size: 0.9em; }
+    .md-rendered ::ng-deep pre { background: var(--bg-muted); padding: 12px; border-radius: 6px; overflow: auto; margin: 0.6em 0; }
+    .md-rendered ::ng-deep pre code { background: none; padding: 0; }
+    .md-rendered ::ng-deep a { color: var(--accent, #6ea8fe); }
+    .md-rendered ::ng-deep blockquote { margin: 0.5em 0; padding-left: 12px; border-left: 3px solid var(--border); color: var(--text-muted); }
+    .md-rendered ::ng-deep table { border-collapse: collapse; margin: 0.5em 0; }
+    .md-rendered ::ng-deep th, .md-rendered ::ng-deep td { border: 1px solid var(--border); padding: 4px 8px; }
+    .md-rendered ::ng-deep img { max-width: 100%; }
     .mermaid-diagram { display: flex; justify-content: center; margin: 0.8em 0; }
     .mermaid-diagram svg { max-width: 100%; height: auto; }
     /* xlsx grid preview */

--- a/client/src/app/pages/settings/help.component.ts
+++ b/client/src/app/pages/settings/help.component.ts
@@ -69,20 +69,42 @@ export type HelpDocId = typeof HELP_DOCS[number]['id'];
 
     .doc { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px;
       padding: 20px 24px; min-width: 0; }
+
+    /*
+     * A reading measure on the PROSE only.
+     *
+     * The guides are long-form — the integration guide is ~7,800 lines — and the pane is as wide as the
+     * window. Without a limit a paragraph ran 200+ characters on a desktop, which is roughly twice the
+     * span an eye tracks back from reliably, so the reader loses their line on every wrap. This is the
+     * single biggest readability problem the page had.
+     *
+     * Applied to text elements individually rather than to the container, because tables and code blocks need
+     * the full width — capping the container would have made every wide table scroll that did not have to.
+     */
+    .doc ::ng-deep :is(p, li, blockquote) { max-width: 78ch; }
+
     /* Long tables and code blocks scroll inside the document rather than widening the page. */
-    .doc :is(pre, table) { max-width: 100%; overflow-x: auto; }
-    .doc table { display: block; border-collapse: collapse; }
-    .doc :is(th, td) { border: 1px solid var(--border-muted); padding: 5px 9px; font-size: 13px; text-align: left; }
-    .doc img { max-width: 100%; height: auto; }
-    .doc h1 { font-size: 22px; margin-top: 0; }
-    .doc h2 { font-size: 18px; margin-top: 28px; }
-    .doc h3 { font-size: 15px; margin-top: 22px; }
-    .doc :is(p, li) { font-size: 13.5px; line-height: 1.6; }
-    .doc code { font-family: var(--font-mono, monospace); font-size: 0.9em; }
-    .doc :not(pre) > code { background: var(--bg-elevated); padding: 1px 5px; border-radius: 4px; }
-    .doc pre { background: var(--bg-elevated); border: 1px solid var(--border-muted); border-radius: 8px; padding: 12px 14px; }
-    .doc blockquote { margin: 14px 0; padding: 2px 14px; border-left: 3px solid var(--accent); color: var(--text-secondary); }
-    .doc hr { border: 0; border-top: 1px solid var(--border-muted); margin: 26px 0; }
+    .doc ::ng-deep :is(pre, table) { max-width: 100%; overflow-x: auto; }
+    .doc ::ng-deep table { display: block; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+    .doc ::ng-deep :is(th, td) { border: 1px solid var(--border-muted); padding: 6px 10px; font-size: 13px; text-align: left;
+      vertical-align: top; }
+    /* Headers and zebra rows. The guides' tables carry PROSE — 25 cells exceed 320 characters — so
+       without a row boundary the eye loses which description belongs to which key. */
+    .doc ::ng-deep th { background: var(--bg-elevated); font-weight: 600; color: var(--text-primary);
+      position: sticky; top: 0; }
+    .doc ::ng-deep tbody tr:nth-child(even) { background: color-mix(in srgb, var(--bg-elevated) 45%, transparent); }
+    .doc ::ng-deep img { max-width: 100%; height: auto; }
+    .doc ::ng-deep h1 { font-size: 22px; margin-top: 0; }
+    .doc ::ng-deep h2 { font-size: 18px; margin-top: 28px; }
+    .doc ::ng-deep h3 { font-size: 15px; margin-top: 22px; }
+    /* 14px over 13.5, and 1.65 over 1.6 — these are read for minutes at a time, not glanced at. */
+    .doc ::ng-deep :is(p, li) { font-size: 14px; line-height: 1.65; }
+    .doc ::ng-deep li + li { margin-top: 3px; }
+    .doc ::ng-deep code { font-family: var(--font-mono, monospace); font-size: 0.9em; }
+    .doc ::ng-deep :not(pre) > code { background: var(--bg-elevated); padding: 1px 5px; border-radius: 4px; }
+    .doc ::ng-deep pre { background: var(--bg-elevated); border: 1px solid var(--border-muted); border-radius: 8px; padding: 12px 14px; }
+    .doc ::ng-deep blockquote { margin: 14px 0; padding: 2px 14px; border-left: 3px solid var(--accent); color: var(--text-secondary); }
+    .doc ::ng-deep hr { border: 0; border-top: 1px solid var(--border-muted); margin: 26px 0; }
 
     .loading { display: flex; align-items: center; gap: 9px; color: var(--text-secondary); font-size: 13px; }
   `],

--- a/testing/standalone/innerhtml-css-reach.test.js
+++ b/testing/standalone/innerhtml-css-reach.test.js
@@ -1,0 +1,108 @@
+/**
+ * CSS written for `[innerHTML]` content must actually be able to reach it.
+ *
+ * ## The defect this exists for
+ *
+ * Angular's emulated encapsulation stamps `_ngcontent-*` on elements the TEMPLATE creates, and compiles
+ * `.doc p` into `.doc p[_ngcontent-xyz]`. Nodes inserted through `[innerHTML]` never carry that attribute
+ * — so **every descendant rule silently matches nothing**. No error, no warning, no console message. The
+ * styles sit right there in the file, they look applied, and they are dead.
+ *
+ * Two surfaces had been that way since each shipped:
+ *
+ *   - `help.component.ts` — the in-product guides, 19 rules
+ *   - `file-manager.component.ts` — the Markdown file preview, 13 rules
+ *
+ * Nobody had ever seen the shipped documentation rendered with its own styling. Measured on a booted
+ * instance, before → after: `pre` background `transparent` → `rgb(28,33,40)`, `blockquote` border-left
+ * `0px` → `3px`, paragraph `max-width` `none` → `689px`.
+ *
+ * ## Why a declared map rather than a heuristic
+ *
+ * The first version guessed: it flagged any descendant rule ending in a markdown-ish tag inside a
+ * component that renders `[innerHTML]`. That reported `.xlsx-grid th` and `.detail-desc h4` — both
+ * template-built, properly encapsulated, entirely fine. A gate whose findings need triage is a gate
+ * people learn to skip.
+ *
+ * So the container class of each rendered surface is **declared** here, and a separate check asserts the
+ * map names every component that uses `[innerHTML]`. Adding a third surface fails the build until it is
+ * classified, which is the opposite of how the original defect survived — there, the absence of any
+ * declaration was the default.
+ *
+ * Run: node --test testing/standalone/innerhtml-css-reach.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+
+const ROOT = 'client/src/app';
+
+/**
+ * Where `[innerHTML]` output lands, per component: the CSS class its rules are rooted at, or `null` when
+ * the component renders innerHTML but styles none of its content.
+ */
+const RENDERED_SURFACES = new Map([
+  ['client/src/app/pages/settings/help.component.ts', '.doc'],
+  ['client/src/app/pages/files/file-manager.component.ts', '.md-rendered'],
+  // Inline SVG built from a path string; the component styles the host, never the injected markup.
+  ['client/src/app/shared/ph-icon.component.ts', null],
+  // Short highlighted fragments injected into a label; no descendant rules target them.
+  ['client/src/app/pages/settings/media-processing/media-processing-page.component.ts', null],
+  ['client/src/app/pages/settings/media-processing/models-tab.component.ts', null],
+  ['client/src/app/pages/settings/space-schema-tab.component.ts', null],
+]);
+
+function sources(dir = ROOT, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = `${dir}/${name}`;
+    if (statSync(p).isDirectory()) { sources(p, out); continue; }
+    if (p.endsWith('.ts') && !p.endsWith('.spec.ts')) out.push(p.replace(/\\/g, '/'));
+  }
+  return out;
+}
+
+/** The `styles: [\`…\`]` block of a component, comments stripped — prose about a selector is not a rule. */
+function stylesBlock(src) {
+  const i = src.indexOf('styles: [`');
+  if (i < 0) return '';
+  const j = src.indexOf('`],', i);
+  const raw = j < 0 ? '' : src.slice(i + 'styles: [`'.length, j);
+  return raw.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('CSS for [innerHTML] content can reach it', () => {
+  const usesInnerHtml = sources().filter(f => readFileSync(f, 'utf8').includes('[innerHTML]'));
+
+  it('finds the components that render innerHTML (the check itself works)', () => {
+    // A refactor that reduced this to zero would make every assertion below pass by examining nothing.
+    assert.ok(usesInnerHtml.length >= 2, `expected components rendering [innerHTML], found ${usesInnerHtml.length}`);
+  });
+
+  it('classifies every component that renders innerHTML — no more, no fewer', () => {
+    assert.deepEqual([...RENDERED_SURFACES.keys()].sort(), usesInnerHtml.sort(),
+      'Every component using [innerHTML] must be declared here — with the CSS class its rules are rooted\n' +
+      'at, or `null` when it styles none of the injected content. A component missing from the map is a\n' +
+      'surface nobody checked, which is exactly how the guides came to render unstyled.');
+  });
+
+  it('every rule rooted at a rendered surface is ::ng-deep', () => {
+    const dead = [];
+    for (const [file, root] of RENDERED_SURFACES) {
+      if (!root) continue;
+      const css = stylesBlock(readFileSync(file, 'utf8'));
+      for (const line of css.split('\n')) {
+        const selector = line.split('{')[0];
+        if (!selector.includes(root) || selector.includes('::ng-deep')) continue;
+        // `.doc { … }` styles the container itself and is correctly encapsulated; only DESCENDANTS break.
+        if (new RegExp(`\\${root}\\s+\\S`).test(selector)) dead.push(`  ${file}\n    ${selector.trim()}`);
+      }
+    }
+
+    assert.deepEqual(dead, [],
+      'These rules target content inserted through [innerHTML] from a component using emulated\n' +
+      'encapsulation — they compile to `sel[_ngcontent-x]` and match NOTHING. The styles look present\n' +
+      'and are dead, with no error anywhere:\n' + dead.join('\n') +
+      '\nAdd `::ng-deep` after the container (`.doc ::ng-deep blockquote`), which keeps the rule scoped to\n' +
+      'this component\'s subtree while letting it reach content the template did not create.');
+  });
+});


### PR DESCRIPTION
You said the guides "are not easy readable for a human". They are not badly styled — they are
**unstyled**, and have been since the Help page shipped.

## The mechanism

Both the Help page and the Markdown file preview render through `[innerHTML]`. Angular's emulated
encapsulation stamps `_ngcontent-*` on elements the **template** creates, and compiles

```css
.doc p { … }        /* what you write */
.doc p[_ngcontent-ng-c920615231] { … }   /* what ships */
```

Nodes inserted through `[innerHTML]` never carry that attribute. So **every descendant rule matched
nothing** — 19 in `help.component.ts`, 13 in `file-manager.component.ts`.

No error. No warning. No console message. The styles sit right there in the file and look applied.

## Proven, not argued

On a booted instance, `<section class="doc">` carries `_ngcontent-ng-c920615231`; the `<p>` inside it
carries **no `_ng` attribute at all**. Computed values:

| property | before | after |
|---|---|---|
| `pre` background | `rgba(0,0,0,0)` | `rgb(28,33,40)` |
| `pre` border-radius | `0px` | `8px` |
| `blockquote` border-left | `0px` | `3px` |
| paragraph `max-width` | `none` | `689px` |

Fixed with `::ng-deep` after the encapsulated container — which keeps each rule scoped to that
component's subtree while letting it reach content the template did not create.

## Second instance, found by sweeping

The Files Markdown preview (`.md-rendered h1`, `p`, `ul`, `pre`, `code`…) has the identical defect and
the identical cause. Both are the *user-visible* markdown surfaces; the other four components using
`[innerHTML]` style none of their injected content, and are declared as such.

## And now that rules can land

- **A 78ch measure on prose only.** Paragraphs ran the full 1,098px pane — roughly twice the span an eye
  tracks back from reliably. Tables and code blocks keep the full width, so nothing scrolls that need not.
- **Table headers** get a background and 600 weight; even rows a tint. These guides carry **25 table cells
  over 320 characters** — row tracking is not cosmetic here.
- **Body 14px/1.65.** Read for minutes at a time, not glanced at.

Screenshot-verified at 1680px — the width the problem only appears at.

## The gate, and the one I threw away

The first version of `innerhtml-css-reach.test.js` guessed: flag any descendant rule ending in a
markdown-ish tag inside a component rendering `[innerHTML]`. It reported `.xlsx-grid th` and
`.detail-desc h4` — both template-built, properly encapsulated, entirely fine.

A gate whose findings need triage is a gate people learn to skip, so it was replaced with a **declared
map** of every `[innerHTML]` surface and the class its rules are rooted at (`null` when it styles none).
A separate check asserts the map names every component using `[innerHTML]`, so a third surface fails the
build until it is classified — the opposite of how this defect survived, where having no declaration was
the default.

Mutation-verified both ways:

| mutation | result |
|---|---|
| revert one `::ng-deep` | fails, naming `.doc blockquote` |
| drop a component from the map | fails, naming the missing file |

## Verification

`npm run preflight` green. Rendered check on a booted scratch instance at 1680×1000, both the user guide
and the integration guide, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
