### PR TITLE
fix(client): a link in a guide could dump you on the Brain page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A link in a guide could dump you on the Brain page.** Reported by the owner. Any link the Help
+  page did not recognise "kept its default behaviour" — which sounds harmless and is not: the browser
+  resolves the relative href against `/settings/help`, the router matches nothing, and the wildcard
+  lands the reader on **Brain**. A documentation link that moves you somewhere unrelated is worse than
+  one that does nothing.
+  - Two populations hit it. **External links** unloaded the whole app in the same tab — a guide is a
+    reference someone reads *while* working, so that throws away whatever they had open. And **links
+    into a subdirectory** were never matched at all: the pattern accepted a bare filename only, so
+    every `integration-guide/NN-part.md#anchor` fell through. That second population is one I created
+    hours earlier by splitting the guide.
+  - Now: an in-document anchor scrolls; a markdown link at **any depth** resolves to the guide that
+    owns it — including a part of a split guide — and opens it; anything else opens in a **new tab**
+    with `noopener,noreferrer`. Nothing reaches the router. A ctrl/cmd-click is still left to the
+    browser, because the reader may have meant a background tab.
+  - Both tests that previously pinned this behaviour asserted the broken half — *"keeps its default
+    behaviour"* and *"is left entirely alone"*. They now assert the tab.
+
 - **The shipped guides have never been styled.** Not badly styled — **unstyled**. The Help page and the
   Markdown file preview both render through `[innerHTML]`, and Angular's emulated encapsulation stamps
   `_ngcontent-*` only on elements the TEMPLATE creates. So `.doc p` compiled to `.doc p[_ngcontent-xyz]`

--- a/client/src/app/pages/settings/help.component.spec.ts
+++ b/client/src/app/pages/settings/help.component.spec.ts
@@ -144,20 +144,55 @@ describe('HelpComponent', () => {
       expect(fetched).not.toContain('assets/docs/integration-guide.md');
     });
 
-    it('a link to a document the page does not offer keeps its default behaviour', async () => {
-      // Swallowing it would make a dead link silently do nothing, which is harder to report than a
-      // visible failure.
+    it('a link into a SPLIT guide opens that guide', async () => {
+      // The old pattern accepted a bare filename only, so every link into `integration-guide/` fell
+      // through to the browser — which resolves it against /settings/help, finds no route, and lands the
+      // reader on Brain. A documentation link that moves you to a different page is worse than a dead one.
+      const s = withHtml('<a href="integration-guide/04-brain-api.md#schema-validation">see</a>');
+      await flush();
+      s.f.detectChanges();
+      const ev = clickLink(s.f);
+      expect(ev.defaultPrevented).toBe(true);
+      expect(s.c.active()).toBe('integration-guide');
+    });
+
+    it('a link to a document the page does not offer opens in a new tab, never in the router', async () => {
+      // Previously this "kept its default behaviour", which sounds harmless and is not: the router
+      // swallows the relative href and redirects to Brain.
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
       const s = withHtml('<a href="secret-notes.md">see</a>');
       await flush();
       s.f.detectChanges();
-      expect(clickLink(s.f).defaultPrevented).toBe(false);
+      expect(clickLink(s.f).defaultPrevented).toBe(true);
+      expect(open).toHaveBeenCalledWith('assets/docs/secret-notes.md', '_blank', 'noopener,noreferrer');
+      open.mockRestore();
     });
 
-    it('an external link is left entirely alone', async () => {
+    it('an external link opens in a new tab rather than unloading the app', async () => {
+      // The guide is a reference someone reads WHILE working. A same-tab navigation throws away whatever
+      // they had open, and `noopener,noreferrer` keeps the new page from reaching back through it.
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
       const s = withHtml('<a href="https://example.com/x">out</a>');
       await flush();
       s.f.detectChanges();
-      expect(clickLink(s.f).defaultPrevented).toBe(false);
+      expect(clickLink(s.f).defaultPrevented).toBe(true);
+      expect(open).toHaveBeenCalledWith('https://example.com/x', '_blank', 'noopener,noreferrer');
+      open.mockRestore();
+    });
+
+    it('a modified click is left for the browser to handle', async () => {
+      // Ctrl/cmd-click already means "new tab". Intercepting it would replace the reader's intent with
+      // ours, and they may have meant a background tab.
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+      const s = withHtml('<a href="https://example.com/x">out</a>');
+      await flush();
+      s.f.detectChanges();
+      const a2 = (s.f.nativeElement as HTMLElement).querySelector('.doc article a')!;
+      const ev = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, ctrlKey: true });
+      a2.dispatchEvent(ev);
+      expect(ev.defaultPrevented).toBe(false);
+      expect(open).not.toHaveBeenCalled();
+      open.mockRestore();
     });
 
     it('a ctrl/cmd-click is never swallowed — open-in-new-tab still works', async () => {

--- a/client/src/app/pages/settings/help.component.ts
+++ b/client/src/app/pages/settings/help.component.ts
@@ -225,16 +225,37 @@ export class HelpComponent implements OnInit {
       return;
     }
 
-    // A relative `<file>.md` (optionally with its own #anchor) — only if that guide is actually offered.
-    const crossDoc = /^(?:\.\/)?([a-z0-9-]+)\.md(?:#(.*))?$/i.exec(href);
+    // A relative markdown link, at any depth: `userguide.md`, `./userguide.md`, `../integration-guide.md`,
+    // `integration-guide/04-brain-api.md#schema-validation`.
+    //
+    // The depth matters now that a guide is split across a subdirectory. The old pattern only accepted a
+    // bare filename, so every link into `integration-guide/` fell through — and "falling through" is not
+    // the harmless default it reads as: the browser resolves the relative href against `/settings/help`,
+    // the router finds no route, and the wildcard lands the reader on **Brain**. A documentation link
+    // that dumps you on a different page is worse than one that does nothing.
+    const crossDoc = /^(?:\.{0,2}\/)*([a-z0-9-]+(?:\/[a-z0-9-]+)*\.md)(?:#(.*))?$/i.exec(href);
     if (crossDoc) {
-      const target = HELP_DOCS.find(d => d.file === `${crossDoc[1]}.md`);
-      // An unoffered target keeps its default behaviour rather than being silently swallowed: a dead
-      // link that visibly does nothing is easier to report than one that is quietly ignored.
-      if (!target) return;
       ev.preventDefault();
-      this.open(target.id, crossDoc[2]);
+      const path = crossDoc[1]!;
+      const target = HELP_DOCS.find(d =>
+        d.file === path || ('parts' in d && (d.parts as readonly string[]).includes(path)));
+      if (target) { this.open(target.id, crossDoc[2]); return; }
+      // A markdown file this page does not offer. `help-docs-coverage` should make that impossible, but
+      // if it happens the reader gets the raw document in a new tab rather than being silently moved.
+      this.openExternally(`assets/docs/${path}${crossDoc[2] ? `#${crossDoc[2]}` : ''}`);
+      return;
     }
+
+    // Anything else — an absolute URL, a mailto:, a link to a repo file. A same-tab navigation would
+    // unload the app and lose whatever the reader was doing; the guide is a reference they are reading
+    // *while* working.
+    ev.preventDefault();
+    this.openExternally(href);
+  }
+
+  /** Open in a new tab, without handing the opener over. */
+  private openExternally(url: string): void {
+    window.open(url, '_blank', 'noopener,noreferrer');
   }
 
   /** Bring a heading into view by its slug id. Missing ids are a no-op — a stale anchor in a document


### PR DESCRIPTION
> "the links didnt work last time i checked if they werent within the doc they navigated to brain"

Confirmed, and worse than reported.

## Why "default behaviour" was the bug

```ts
if (!target) return;   // "keeps its default behaviour"
```

That reads as harmless. It is not: the browser resolves the relative href against `/settings/help`, the
Angular router matches nothing, and the **wildcard route redirects to Brain**. A documentation link that
moves you somewhere unrelated is worse than a dead one — it also loses your place in a long guide.

## Two populations

**External links** unloaded the whole app in the same tab. A guide is a reference someone reads *while*
working; a same-tab navigation throws away whatever they had open.

**Links into a subdirectory were never matched at all.** The pattern accepted a bare filename:

```ts
/^(?:\.\/)?([a-z0-9-]+)\.md(?:#(.*))?$/i
```

So every `integration-guide/04-brain-api.md#schema-validation` fell through — and there are now 20+ of
those, because **I created that population hours earlier by splitting the guide**. The two tests covering
this area asserted the broken behaviour, so nothing caught it.

## Now

| link | behaviour |
|---|---|
| `#anchor` | scrolls, and updates the URL fragment |
| `userguide.md`, `integration-guide/04-brain-api.md#x` | resolves to the owning guide — including a **part** of a split guide — and opens it in place |
| anything else | **new tab**, `noopener,noreferrer` |
| ctrl/cmd/middle click | left to the browser |

Nothing reaches the router.

The last row matters: ctrl-click already means "new tab", and intercepting it would replace the reader's
intent with ours when they may have wanted a background tab.

## Tests

The two that pinned this area asserted the broken half — *"keeps its default behaviour"* and *"is left
entirely alone"*. They now assert the tab. Two more added: a link into a split guide opens that guide,
and a modified click passes through untouched.

`npm run preflight` green — 802 client tests.