### PR TITLE
fix(client): a theme could restyle the whole product and the logo stayed green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A theme could restyle the whole product and the logo stayed green.** The brand mark hard-coded
+  `#9eec55` in five places, so the theme mechanism — which already lets an operator inject CSS tokens —
+  could not touch it. It now follows `--brand-mark`, falling back to `--accent`, so a theme that only
+  sets an accent gets a matching mark for free.
+  - A CSS variable rather than one SVG file per colour: any hex works, not a fixed palette somebody has
+    to keep extending. The colours moved from SVG attributes into CSS properties because
+    `fill="var(--x)"` in an attribute does not resolve.
+
+- **A backtick in an inline template or styles block ends the string early**, and the compiler reports
+  it at `@Component` or at some line in the middle of the CSS — never at the backtick. It is always in a
+  comment, quoting an identifier the way every other comment in this codebase does. Six debugging
+  detours in one day, so `inline-template-backticks.test.js` now names the real cause. Its first version
+  reported a false positive on the ordinary `` ` `` -on-its-own-line closing shape; a gate about a
+  confusing error is worse than no gate if its own findings need triage.
+
 - **A link in a guide could dump you on the Brain page.** Reported by the owner. Any link the Help
   page did not recognise "kept its default behaviour" — which sounds harmless and is not: the browser
   resolves the relative href against `/settings/help`, the router matches nothing, and the wildcard

--- a/client/src/app/shared/brand-logo.component.ts
+++ b/client/src/app/shared/brand-logo.component.ts
@@ -17,6 +17,22 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
     .bl { display: inline-flex; align-items: center; gap: 2px; font-weight: 700; letter-spacing: -0.03em;
       line-height: 1; color: var(--text-primary); }
     .bl-mark { flex-shrink: 0; display: block; }
+
+    /*
+     * The mark's colour is a THEME TOKEN, not a constant.
+     *
+     * #9eec55 was hard-coded in five places, so a theme could restyle the entire product and the logo
+     * stayed green. --brand-mark overrides it directly; absent that it follows --accent, so a theme
+     * that only sets an accent gets a matching mark for free — which is what an operator actually wants.
+     *
+     * These are CSS properties rather than SVG attributes on purpose: fill="var(--x)" in an attribute
+     * does not resolve. As CSS they do, and they beat shipping one file per colour — any hex works, not
+     * a fixed palette somebody has to extend.
+     */
+    .bl-mark { --bl: var(--brand-mark, var(--accent, #9eec55)); }
+    .bl-glyph { fill: var(--bl); }
+    .bl-ring  { stroke: var(--bl); }
+    .bl-c     { stop-color: var(--bl); }
     .bl-sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden;
       clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
   `],
@@ -28,13 +44,13 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
             <stop offset="0%" stop-color="#1a1f26"/><stop offset="58%" stop-color="#0a0c0f"/><stop offset="100%" stop-color="#040507"/>
           </radialGradient>
           <radialGradient id="blHalo" cx="50%" cy="47%" r="50%">
-            <stop offset="0%" stop-color="#9eec55" stop-opacity="0.55"/><stop offset="55%" stop-color="#9eec55" stop-opacity="0.12"/><stop offset="100%" stop-color="#9eec55" stop-opacity="0"/>
+            <stop class="bl-c" offset="0%" stop-opacity="0.55"/><stop class="bl-c" offset="55%" stop-opacity="0.12"/><stop class="bl-c" offset="100%" stop-opacity="0"/>
           </radialGradient>
         </defs>
         <circle cx="16" cy="16" r="15.5" fill="url(#blOrb)"/>
-        <circle cx="16" cy="16" r="15.3" fill="none" stroke="#9eec55" stroke-opacity="0.16" stroke-width="0.7"/>
+        <circle class="bl-ring" cx="16" cy="16" r="15.3" fill="none" stroke-opacity="0.16" stroke-width="0.7"/>
         <circle cx="16" cy="15.2" r="9.5" fill="url(#blHalo)"/>
-        <g fill="#9eec55">
+        <g class="bl-glyph">
           <path d="M5.8 6 L16 19 L26.2 6 L23.1 7.7 L16 14.6 L8.9 7.7 Z"/>
           <path d="M13.3 13.6 L18.7 13.6 L16 27 Z"/>
         </g>

--- a/testing/standalone/inline-template-backticks.test.js
+++ b/testing/standalone/inline-template-backticks.test.js
@@ -1,0 +1,89 @@
+/**
+ * No backtick inside an Angular inline `template:` or `styles:` block.
+ *
+ * A component's template and styles are template literals. A backtick anywhere inside one — including in
+ * a comment, which is where it always is — terminates the string early. What follows becomes code, and
+ * TypeScript reports the failure at the `@Component` decorator or at a line number in the middle of the
+ * CSS. It never points at the backtick.
+ *
+ * This has now cost six separate debugging detours: writing `.doc` or `--brand-mark` in a CSS comment,
+ * exactly as one would in any other comment in this codebase, where the convention is to quote
+ * identifiers. The habit is correct everywhere else, which is precisely why it keeps happening here.
+ *
+ * A compiler error does eventually catch it, so this is not about correctness — it is about the minutes
+ * spent reading an error that points somewhere else. The message below names the real cause.
+ *
+ * Run: node --test testing/standalone/inline-template-backticks.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+
+const ROOT = 'client/src/app';
+
+function sources(dir = ROOT, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = `${dir}/${name}`;
+    if (statSync(p).isDirectory()) { sources(p, out); continue; }
+    if (p.endsWith('.ts') && !p.endsWith('.spec.ts')) out.push(p.replace(/\\/g, '/'));
+  }
+  return out;
+}
+
+/** The inline `template:` and `styles: [...]` literals of a component, with where each starts. */
+function inlineBlocks(src) {
+  const out = [];
+  for (const key of ['template: `', 'styles: [`']) {
+    let i = src.indexOf(key);
+    while (i >= 0) {
+      const start = i + key.length;
+      // The literal ends at the first UNESCAPED backtick — which is the whole point: if one appears
+      // early, that is where the compiler thinks the block ends too.
+      const end = src.indexOf('`', start);
+      out.push({ key, start, end, line: src.slice(0, start).split('\n').length });
+      i = src.indexOf(key, end < 0 ? start : end + 1);
+    }
+  }
+  return out;
+}
+
+describe('inline component templates and styles contain no backticks', () => {
+  const files = sources();
+
+  it('finds the components (the check itself works)', () => {
+    const withInline = files.filter(f => /(?:template|styles): \[?`/.test(readFileSync(f, 'utf8')));
+    assert.ok(withInline.length >= 20, `expected inline-template components, found ${withInline.length}`);
+  });
+
+  it('no block is terminated early by a stray backtick', () => {
+    const offenders = [];
+    for (const f of files) {
+      const src = readFileSync(f, 'utf8').replace(/\r\n/g, '\n');
+      for (const b of inlineBlocks(src)) {
+        if (b.end < 0) continue;
+        const body = src.slice(b.start, b.end);
+        // A complete block's closing backtick is followed — after any whitespace or newlines — by the
+        // punctuation that ends the property: `,` or `]` or the decorator's own `}`. Requiring that
+        // punctuation IMMEDIATELY after reported a false positive on the common
+        //
+        //     template: `
+        //       …
+        //     `
+        //     })
+        //
+        // shape, where a newline sits between. A false finding in a gate about a confusing error is
+        // worse than no gate.
+        if (/^\s*[,\]}]/.test(src.slice(b.end + 1, b.end + 12))) continue;
+        offenders.push(`  ${f}:${b.line}  ${b.key.trim()} — first backtick closes it after ` +
+          `${body.split('\n').length} line(s): ${JSON.stringify(body.slice(-60))}`);
+      }
+    }
+
+    assert.deepEqual(offenders, [],
+      'A backtick inside an inline template or styles block ends the string early. Everything after it\n' +
+      'is parsed as code, and the compiler reports the error at @Component or at some line in the middle\n' +
+      'of the CSS — never at the backtick. It is almost always in a COMMENT, quoting an identifier the\n' +
+      'way every other comment in this codebase does:\n' + offenders.join('\n') +
+      '\nWrite the identifier bare, or in single quotes.');
+  });
+});


### PR DESCRIPTION
> "i would like to have the ythril-mark.svg in other colors as well so themes can apply a different color. at least: red,blue,pink,green,yellow,white, other basic colors?"

## Why a variable and not eight files

The mark hard-coded `#9eec55` in **five** places — two gradient stops, the ring stroke, the glyph fill.
The theme mechanism already lets an operator inject CSS tokens; it simply could not reach any of them.

```css
.bl-mark  { --bl: var(--brand-mark, var(--accent, #9eec55)); }
.bl-glyph { fill: var(--bl); }
.bl-ring  { stroke: var(--bl); }
.bl-c     { stop-color: var(--bl); }
```

That serves red, blue, pink, green, yellow, white **and every other hex** — with no palette to keep
extending. And because it falls back to `--accent`, a theme that only sets an accent gets a matching mark
for free, which is almost certainly the behaviour you actually want.

The colours had to move from SVG **attributes** into CSS **properties**: `fill="var(--x)"` in an attribute
does not resolve. As a property it does, and the SVG is in the template so encapsulation reaches it.

`docs/assets/ythril-mark.svg` is untouched — GitHub loads it as a file, where no page CSS reaches. If you
want coloured variants for markdown they should be **generated** from that one source rather than
hand-maintained; say the word.

## A gate for the trap this walked into

Writing the comment above cost the **sixth** debugging detour today from one cause: a backtick inside an
inline `template:`/`styles:` block ends the template literal early. The compiler then reports the failure
at `@Component`, or at some line in the middle of the CSS. **Never at the backtick.**

It is always in a comment, quoting an identifier the way every other comment in this codebase does — the
habit is correct everywhere else, which is precisely why it recurs.

**The gate's first version was wrong**, which is worth recording. It flagged the ordinary closing shape

```ts
template: `
  …
`
})
```

because it demanded the closing punctuation *immediately* after the backtick. A gate about a confusing
error is worse than no gate when its own findings need triage, so the detector skips whitespace first.
Mutation-verified by putting a backtick back into the comment this PR just fixed — it fails, naming file
and line.

`npm run preflight` green.