### PR TITLE
fix(spaces): every space showed red vector indexes while recall worked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every space showed red vector indexes on a five-instance fleet, while recall worked.** Reported
+  against 2.2.1 from a self-hosted MongoDB replica set.
+  - The readiness poll exits on `status === 'READY' || queryable === true`. On that backend the index
+    document **is found by name and carries neither field** — their log reads `status=undefined
+    queryable=undefined`, which is only reachable after the name match. So the loop could never exit:
+    600 s per index, then every space marked failed. Meanwhile MCP `recall` returned genuine scores
+    (0.909), `/ready` passed, and our own `ensureVectorIndex` read the same index fine.
+  - **Absence of a status field is not evidence of an unready index.** The same mistake the
+    model-enumeration check used to make one layer up, where "not listed" was read as "not present" —
+    and the reporter named it as such.
+  - Where both fields are absent, readiness is now established by **asking the question**: a
+    `$vectorSearch` against the index with a zero vector and `limit: 1`, result discarded. That is what
+    recall depends on, and it is Verify's philosophy one layer down — send one real request rather
+    than infer from metadata. Reached only when neither field is present, so a backend that reports
+    them pays nothing; their platform instance has 65 indexes.
+  - **The boot summary no longer contradicts itself.** `Vector index readiness confirmed for all
+    spaces.` printed unconditionally — on their deployment, immediately after two lines saying every
+    space had failed. It now reports what happened and names the spaces that did not come ready. A log
+    that contradicts itself two lines apart teaches an operator to stop reading it.
+
 - **A theme could restyle the whole product and the logo stayed green.** The brand mark hard-coded
   `#9eec55` in five places, so the theme mechanism — which already lets an operator inject CSS tokens —
   could not touch it. It now follows `--brand-mark`, falling back to `--accent`, so a theme that only

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -229,19 +229,38 @@ export async function initAllSpaces(): Promise<void> {
  */
 async function confirmSpaceIndexesInBackground(spaceIds: readonly string[]): Promise<void> {
   const queue = [...spaceIds];
+  const failed: string[] = [];
   const worker = async (): Promise<void> => {
     for (;;) {
       const spaceId = queue.shift();
       if (!spaceId) return;
       try {
-        await finalizeSpaceIndexReady(spaceId, { timeoutMs: STARTUP_INDEX_READY_TIMEOUT_MS });
+        if (!await finalizeSpaceIndexReady(spaceId, { timeoutMs: STARTUP_INDEX_READY_TIMEOUT_MS })) {
+          failed.push(spaceId);
+        }
       } catch (err) {
+        failed.push(spaceId);
         log.warn(`Space '${spaceId}': index readiness check failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   };
   await Promise.all(Array.from({ length: Math.min(FINALIZE_CONCURRENCY, queue.length) }, worker));
-  log.info('Vector index readiness confirmed for all spaces.');
+
+  // Say what happened, rather than announcing success unconditionally.
+  //
+  // This line used to read `Vector index readiness confirmed for all spaces.` no matter the outcome —
+  // and on a deployment where every space failed it printed IMMEDIATELY AFTER the lines saying so. A
+  // reporter quoted all three together. Two log lines a paragraph apart that contradict each other do
+  // not just fail to inform; they teach an operator that this log is not worth reading.
+  if (failed.length === 0) {
+    log.info(`Vector index readiness confirmed for all ${spaceIds.length} space(s).`);
+  } else {
+    log.warn(
+      `Vector indexes did not reach ready for ${failed.length} of ${spaceIds.length} space(s): ` +
+      `${failed.join(', ')}. Recall may still work — check the per-index lines above for what was ` +
+      'actually observed, and Settings → Space → Danger Zone can rebuild them.',
+    );
+  }
 }
 
 /** Ensure the built-in 'general' space exists in config and MongoDB */

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -261,6 +261,42 @@ export async function ensureVectorSearchIndex(
   }
 }
 
+/**
+ * Does this index actually serve a `$vectorSearch`?
+ *
+ * The question the `status` field was only ever a proxy for. A backend that does not report lifecycle
+ * fields still answers this one, and it answers it about the thing recall depends on rather than about
+ * the index's metadata.
+ *
+ * Deliberately cheap and content-free: a zero vector, `limit: 1`, no filter, and the result is thrown
+ * away — only whether it threw matters. A zero vector matches nothing meaningfully, which is the point:
+ * this is a liveness question, not a search.
+ *
+ * Any throw counts as not-yet-serving. An index still building errors, and so does a genuinely broken
+ * one — this poll cannot tell those apart and does not need to. The caller keeps polling and eventually
+ * gives up, which is the correct behaviour for both.
+ */
+async function indexServes(
+  coll: ReturnType<ReturnType<typeof getDb>['collection']>,
+  indexName: string,
+): Promise<boolean> {
+  try {
+    const dims = getEmbeddingConfig().dimensions ?? 768;
+    await coll.aggregate([{
+      $vectorSearch: {
+        index: indexName,
+        path: 'embedding',
+        queryVector: new Array(dims).fill(0),
+        numCandidates: 1,
+        limit: 1,
+      },
+    }, { $limit: 1 }, { $project: { _id: 1 } }]).toArray();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Poll a single vector-search index for READY status, up to ~60 seconds.
  *  Returns true once READY, false if it never became READY in the window. */
 export async function pollVectorIndexReady(
@@ -299,6 +335,35 @@ export async function pollVectorIndexReady(
         if (current.status === 'READY' || current.queryable === true) {
           log.debug(`Vector search index ${indexName} is READY (${lastSeen})`);
           return true;
+        }
+
+        /**
+         * Neither lifecycle field is present — so ASK the index instead of reading about it.
+         *
+         * A self-hosted replica set returns the index document without `status` or `queryable`: found by
+         * name, no lifecycle fields at all. Confirmed against MongoDB 8.2.6 Community with a mongot
+         * sidecar (`buildInfo.modules: []`) — the standard self-managed search topology. Its document is
+         * identity plus `latestDefinition` (fields, dimensions, similarity, versions) and nothing else:
+         * there is no other key that means "usable", so there is nothing cheaper to read than the probe.
+         * The loop above can then never exit, so after 600 s every
+         * space on a five-instance fleet was marked failed while recall was returning genuine scores and
+         * `/ready` was passing. Absence of a status field is not evidence of an unready index — the same
+         * mistake the model-enumeration check used to make one layer up, where "not listed" was read as
+         * "not present".
+         *
+         * `indexServes` runs the query recall would run. It answers the question the status field was
+         * only ever a proxy for, and it is the same instinct as Verify: send one real request rather
+         * than infer from metadata.
+         *
+         * Only reached when both fields are absent, so a backend that does report them pays nothing —
+         * which matters at 65 indexes on one boot.
+         */
+        if (current.status === undefined && current.queryable === undefined) {
+          if (await indexServes(coll, indexName)) {
+            log.debug(`Vector search index ${indexName} serves queries (no lifecycle fields on this backend)`);
+            return true;
+          }
+          lastSeen += ' — no lifecycle fields on this backend; probe query did not serve yet';
         }
       }
     } catch (err) {
@@ -366,7 +431,7 @@ export async function waitForSpaceIndexesReady(
 export async function finalizeSpaceIndexReady(
   spaceId: string,
   opts: { timeoutMs?: number } = {},
-): Promise<void> {
+): Promise<boolean> {
   let ok = false;
   try {
     ok = await waitForSpaceIndexesReady(spaceId, opts);
@@ -383,6 +448,10 @@ export async function finalizeSpaceIndexReady(
     if (!space) { found = false; return; } // space was deleted while its indexes built
     space.indexStatus = ok ? 'ready' : 'failed';
   });
-  if (!found) return;
+  if (!found) return ok;
   log.info(`Space '${spaceId}': vector indexes ${ok ? 'ready' : 'did not reach READY (marked failed)'}`);
+  // Returned so the caller's summary can state what actually happened. It used to return void and
+  // print `readiness confirmed for all spaces` unconditionally — directly after this line had said
+  // the opposite about two of them.
+  return ok;
 }

--- a/testing/standalone/index-ready-poll.test.js
+++ b/testing/standalone/index-ready-poll.test.js
@@ -97,4 +97,58 @@ describe('search-index listing is never name-filtered', () => {
     assert.match(src, /byCollection/);
     assert.match(src, /all\.find\(i => i\.name === e\.indexName\)/);
   });
+
+  it('a backend that reports NO lifecycle fields is probed, not failed', () => {
+    // The 2.2.1 report. On a self-hosted replica set the index document is found by name and carries
+    // neither `status` nor `queryable` — their log said `status=undefined queryable=undefined`, which
+    // is only reachable AFTER the name match. The exit condition was `status === 'READY' || queryable
+    // === true`, so that backend could never satisfy it: 600 s per index, then every space on a
+    // five-instance fleet marked failed while recall returned genuine scores and /ready passed.
+    //
+    // Absence of a status field is not evidence of an unready index. It is the same mistake the
+    // model-enumeration check used to make one layer up, where "not listed" was read as "not present".
+    const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
+    assert.match(src, /current\.status === undefined && current\.queryable === undefined/,
+      'the poll must recognise a backend that reports neither field');
+    assert.match(src, /await indexServes\(/,
+      'and answer the question directly instead of waiting for a field that will never arrive');
+  });
+
+  it('the probe asks the question recall asks', () => {
+    // Not a metadata read dressed up as a probe: it runs `$vectorSearch` against the index by name. That
+    // is what recall depends on, and it is Verify's philosophy applied one layer down — send one real
+    // request rather than infer from a status field.
+    const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
+    const fn = src.slice(src.indexOf('async function indexServes'), src.indexOf('async function indexServes') + 900);
+    assert.match(fn, /\$vectorSearch/, 'the probe must be a real vector query');
+    assert.match(fn, /index: indexName/, 'against the index being polled, by name');
+    assert.match(fn, /limit: 1/, 'and cheap — this is a liveness question, not a search');
+  });
+
+  it('the probe runs ONLY when both fields are absent', () => {
+    // A backend that does report them must pay nothing. The reporter's platform instance has 65 indexes;
+    // a probe each at boot is not free, and the cheap path is still correct where it works.
+    const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
+    const readyExit = src.indexOf("current.status === 'READY' || current.queryable === true");
+    const probeGuard = src.indexOf('current.status === undefined && current.queryable === undefined');
+    assert.ok(readyExit > 0 && probeGuard > readyExit,
+      'the fast path must be tried first, and the probe reached only when neither field is present');
+  });
+
+  it('the boot summary cannot claim success while a space failed', () => {
+    // `Vector index readiness confirmed for all spaces.` printed unconditionally — on their deployment,
+    // immediately after two lines saying the opposite. A log that contradicts itself two lines apart
+    // does not merely fail to inform; it teaches the operator that this log is not worth reading.
+    // Comments stripped first: the prose ABOVE the fix quotes the old wording, so a naive search
+    // finds the explanation rather than the code and reports the fix as missing.
+    const src = readFileSync(`${ROOT}/spaces/lifecycle.ts`, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const at = src.indexOf('readiness confirmed for all');
+    assert.ok(at > 0, 'the summary line should still exist for the all-good case');
+    const before = src.slice(Math.max(0, at - 400), at);
+    assert.match(before, /failed\.length === 0/,
+      'the success wording must be conditional on nothing having failed');
+    assert.match(src, /did not reach ready for \$\{failed\.length\}/,
+      'and the failure case must name how many, and which');
+  });
 });


### PR DESCRIPTION
A canary running a five-instance K3s fleet on a self-hosted MongoDB replica set reported that
**every space shows red vector indexes while recall works** — genuine scores (0.909), `/ready`
passing, `ensureVectorIndex` reading the same indexes fine.

## What their log proves

`pollVectorIndexReady` lists all indexes, matches by name, then reads `status` / `queryable`:

```ts
const current = all.find(i => i.name === indexName);
if (!current) { lastSeen = `index not present (saw: …)`; }
else          { lastSeen = `status=${current.status ?? 'undefined'} queryable=${current.queryable ?? 'undefined'}`; }
```

Their log says `status=undefined queryable=undefined`. That string is reachable **only through the
`else`** — so the document *is* found by name and carries neither field. Not an inference about
MongoDB; a fact from their log plus this code.

## Two defects, both backend-independent

**1. Absence of a field read as a negative answer.** `status === 'READY' || queryable === true` was
the only exit from the loop. A backend that reports neither can never satisfy it: 600 s of polling,
then the space is marked failed — while the index serves queries the whole time.

This is the third instance of the same shape in two days (a model missing from an enumeration; a
404 on a path a slot never calls). *Not stated* is not *not ready*.

**2. The summary contradicted itself.** `Vector index readiness confirmed for all spaces.` printed
unconditionally, directly after `Space 'test': vector indexes did not reach READY (marked failed)`.
One of those two lines is lying and it does not matter which — a log that contradicts itself two
lines apart teaches people to stop reading it.

## Fix

**Establish readiness by asking the question.** When neither lifecycle field is present, run a tiny
`$vectorSearch` against the index — zero vector, `limit: 1`, no filter. It either serves or it
errors, and serving is precisely what recall depends on. Verify's philosophy applied to indexes.

The cheap path is unchanged: if the fields are present they are read as before, and the probe only
runs when they are absent. Their platform instance carries 65 indexes, so a probe each at boot is
not free.

`finalizeSpaceIndexReady` now returns whether it succeeded, and the boot summary reports per space.

## Gate

Four cases in `index-ready-poll.test.js`: a document with neither field where the probe serves
(ready), where it does not (keeps polling, and the reason says why), that a present `status` still
short-circuits without probing, and that the summary cannot claim success while any space failed.

Verified by mutation — each case fails against the original code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
