### PR TITLE
fix(brain): an upsert was validated against the payload, not the record it writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A partial upsert onto a complete record was refused as incomplete.** In a `strict` space, setting one
+  property of a conformant entity failed with `schema_violation` naming required properties the record
+  already had — because `upsertEntity` merges into the stored record (`{ ...stored, ...incoming }`) while
+  the callers validated the **incoming payload**. The thing validated was not the thing written.
+  - **Worse for edges**, where identity is `(from, to, label)` and no id appears in the call: every repeat
+    upsert merges, with nothing in the payload to suggest it.
+  - Six sites, both transports: `upsert_entity`, `upsert_edge`, `POST .../entities`, `POST .../edges`, and
+    both halves of the bulk importer — which fetched the prior record two lines *after* validating, for
+    its own inserted-vs-updated counter. The merge target was in hand; validation just did not use it.
+  - This is the update defect from 2.2 (#571) on the write path that sweep did not reach. The classifier
+    is reused unchanged, so an upsert onto an already-non-compliant record reports `preExisting` rather
+    than blaming the caller, and repairs in the same request.
+  - The merge rule now lives with the writer (`mergedEntityWrite`, `mergedEdgeProperties`,
+    `findEdgeByTriplet`) instead of being re-derived by each caller, and `update-validation.ts` moved to
+    `brain/write-validation.ts` — it governs both write paths now, and `brain/` cannot import `api/`.
+  - `upsert-validation.test.js` pins the reported case, the insert that must still fail, warn/off
+    reporting, and — enumerated from the writers rather than hand-listed — that no upsert path hands a raw
+    payload to a validator. A hand-listed set is exactly how the first sweep missed all six.
+
 - **Every space showed red vector indexes on a five-instance fleet, while recall worked.** Reported
   against 2.2.1 from a self-hosted MongoDB replica set.
   - The readiness poll exits on `status === 'READY' || queryable === true`. On that backend the index

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -583,10 +583,10 @@ Each space can define a schema in its `meta` block that governs what data is acc
 > defined yet, `strict` still accepts every type and label, so it never blocks a brand-new empty space;
 > it starts mattering the moment you define a schema.
 
-**Updates validate the record as it will be.** A `PATCH` (and the matching `update_*` MCP tool) validates
-the **merged** result — the stored record with your patch applied — not the patch on its own. Validating
-the fragment would fail every partial update that does not restate every required property, so the answer
-would be meaningless. In `strict` mode a violating update is refused with `422`:
+**Every write validates the record as it will be.** A `PATCH` (and the matching `update_*` MCP tool)
+validates the **merged** result — the stored record with your patch applied — not the patch on its own.
+Validating the fragment would fail every partial update that does not restate every required property, so
+the answer would be meaningless. In `strict` mode a violating update is refused with `422`:
 
 ```json
 {
@@ -614,8 +614,16 @@ sent after a field you did not touch.
 
 In `warn` mode the write proceeds and the same three lists are reported.
 
+**An upsert onto an existing record is an update, and is validated the same way.** `POST .../entities`
+with an `id` that already exists merges into the stored record, so it is the merged form that is checked —
+you can set one property without restating the rest. For edges the identity is `(from, to, label)` with no
+id involved at all, so **every** repeat `POST .../edges` merges. An upsert that lands on nothing is an
+insert, and there the payload *is* the record: required properties must be present.
+
 *New in 2.2.* Previously an update was validated only when the request used `deleteFields`; every other
-patch could write a value the same space rejects at create time.
+patch could write a value the same space rejects at create time. *New in 2.3.* An upsert was validated
+against the incoming payload rather than the merged record, so a partial upsert onto a complete record was
+refused for properties that record already had.
 
 **Schema structure — `typeSchemas`:**
 

--- a/server/src/api/brain/_shared.ts
+++ b/server/src/api/brain/_shared.ts
@@ -57,33 +57,12 @@ export function ttlDaysError(body: unknown): string | null {
 
 // ── Schema validation helpers ─────────────────────────────────────────────
 
-/** Look up the meta block for a space from config, with library refs resolved. Returns undefined if none. */
-export function getSpaceMeta(spaceId: string): SpaceMeta | undefined {
-  const cfg = getConfig();
-  const meta = cfg.spaces.find(s => s.id === spaceId)?.meta;
-  if (!meta) return undefined;
-  return resolveMetaRefs(meta);
-}
-
 /**
- * Apply schema validation to a write operation.
- * Returns { blocked: true, violations } when strict mode rejects the write.
- * Returns { blocked: false, warnings } when warn mode lets the write through.
- * Returns { blocked: false, warnings: [] } when validation is off or no meta.
+ * Both now live in `spaces/schema-validation.ts`, beside the validator they belong to, so that
+ * `brain/` can reach them without importing `api/`. Re-exported here because every route already
+ * imports them from `_shared` and there is no reason for those to change.
  */
-export function applyValidation(
-  meta: SpaceMeta | undefined,
-  violations: SchemaViolation[],
-): { blocked: boolean; warnings: SchemaViolation[] } {
-  if (!meta || !meta.validationMode || meta.validationMode === 'off' || violations.length === 0) {
-    return { blocked: false, warnings: [] };
-  }
-  if (meta.validationMode === 'strict') {
-    return { blocked: true, warnings: violations };
-  }
-  // warn mode
-  return { blocked: false, warnings: violations };
-}
+export { getSpaceMeta, applyValidation } from '../../spaces/schema-validation.js';
 
 /** Build a MongoDB filter from `tag` and `entity` query params */
 export function buildMemoryFilter(query: Record<string, unknown>): Record<string, unknown> {

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -14,7 +14,7 @@ import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembe
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
 import type { ChronoStatus } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
-import { classifyUpdateViolations } from './update-validation.js';
+import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const chronoRouter = Router();

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -15,8 +15,8 @@ import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
 import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEdge } from '../../spaces/schema-validation.js';
-import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
-import { classifyUpdateViolations } from './update-validation.js';
+import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { classifyEdgeUpsert, classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const edgesRouter = Router();
@@ -78,12 +78,11 @@ edgesRouter.post('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, de
       : undefined;
   const safeTags: string[] | undefined = Array.isArray(tags) ? tags : undefined;
 
-  // Schema validation
-  const meta = getSpaceMeta(wt.target);
-  const violations = validateEdge(meta ?? {}, { label: label.trim(), properties: safeProps });
-  const validation = applyValidation(meta, violations);
-  if (validation.blocked) {
-    res.status(400).json({ error: 'schema_violation', violations: validation.warnings });
+  // Schema validation of the record this upsert will PRODUCE. (from, to, label) IS an edge's identity,
+  // so a repeat POST merges into the stored edge — there is no id in the request to signal it.
+  const check = await classifyEdgeUpsert(wt.target, { from: from.trim(), to: to.trim(), label: label.trim(), properties: safeProps });
+  if (check.blocked) {
+    res.status(400).json({ error: 'schema_violation', message: check.message, violations: check.all, introduced: check.introduced, preExisting: check.preExisting });
     return;
   }
   const ttlErr = ttlDaysError(req.body);
@@ -95,7 +94,7 @@ edgesRouter.post('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, de
     webhookToken(req), ttlDaysFromBody(req.body),
   );
   const result: Record<string, unknown> = { ...edge };
-  if (validation.warnings.length > 0) result['warnings'] = validation.warnings;
+  if (check.warnings.length > 0) result['warnings'] = check.warnings;
   res.status(201).json(result);
 });
 

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -16,8 +16,8 @@ import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEntity } from '../../spaces/schema-validation.js';
-import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
-import { classifyUpdateViolations } from './update-validation.js';
+import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { classifyEntityUpsert, classifyUpdateViolations } from '../../brain/write-validation.js';
 import { tagContains, textContains, propertiesValueContains } from '../../brain/tag-filter.js';
 
 export const entitiesRouter = Router();
@@ -65,12 +65,11 @@ entitiesRouter.post('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAu
   const safeDesc: string | undefined = typeof description === 'string' ? description : undefined;
   const safeId: string | undefined = typeof id === 'string' ? id : undefined;
 
-  // Schema validation
-  const meta = getSpaceMeta(wt.target);
-  const violations = validateEntity(meta ?? {}, { name: name.trim(), type: type.trim(), properties });
-  const validation = applyValidation(meta, violations);
-  if (validation.blocked) {
-    res.status(400).json({ error: 'schema_violation', violations: validation.warnings });
+  // Schema validation of the record this upsert will PRODUCE. `upsertEntity` merges into the stored
+  // record when `id` matches, so the payload on its own is not the thing being written.
+  const check = await classifyEntityUpsert(wt.target, { name: name.trim(), type: type.trim(), properties, tags }, safeId);
+  if (check.blocked) {
+    res.status(400).json({ error: 'schema_violation', message: check.message, violations: check.all, introduced: check.introduced, preExisting: check.preExisting });
     return;
   }
   const ttlErr = ttlDaysError(req.body);
@@ -80,7 +79,7 @@ entitiesRouter.post('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAu
     const { entity, warning } = await upsertEntity(wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId, undefined, webhookToken(req), ttlDaysFromBody(req.body));
     const result: Record<string, unknown> = { ...entity };
     if (warning) result['warning'] = warning;
-    if (validation.warnings.length > 0) result['warnings'] = validation.warnings;
+    if (check.warnings.length > 0) result['warnings'] = check.warnings;
     res.status(201).json(result);
   } catch (err) {
     res.status(500).json({ error: 'Internal server error' });

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -18,7 +18,7 @@ import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage,
 import { validateMemory } from '../../spaces/schema-validation.js';
 import type { MemoryDoc } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, buildMemoryFilter, ttlDaysFromBody, ttlDaysError } from './_shared.js';
-import { classifyUpdateViolations } from './update-validation.js';
+import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 
 export const memoriesRouter = Router();

--- a/server/src/brain/bulk.ts
+++ b/server/src/brain/bulk.ts
@@ -18,10 +18,10 @@ import {
 } from '../spaces/schema-validation.js';
 import { isStrictLinkage } from '../spaces/proxy.js';
 import { remember } from './memory.js';
-import { upsertEntity } from './entities.js';
-import { upsertEdge } from './edges.js';
+import { upsertEntity, mergedEntityWrite } from './entities.js';
+import { upsertEdge, findEdgeByTriplet, mergedEdgeProperties } from './edges.js';
 import { createChrono } from './chrono.js';
-import type { EntityDoc, EdgeDoc, ChronoType, ChronoStatus } from '../config/types.js';
+import type { EntityDoc, ChronoType, ChronoStatus } from '../config/types.js';
 
 /** Max items processed per collection in a single bulk call. */
 export const BULK_MAX_PER_TYPE = 500;
@@ -135,10 +135,13 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     const ttlDays = bulkTtlDays(item['ttlDays']);
     if (ttlDays === TTL_INVALID) { errors.push({ type: 'entity', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
-      if (schemaFails('entity', i, validateEntity(meta ?? {}, { name, type, properties }))) continue;
+      // The MERGED record, not the payload — an id that matches an existing entity makes this an
+      // update, and the importer had the merge target in hand two lines later for its own counter.
       const existing = rawId
         ? await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId }))
         : null;
+      const mergedEnt = mergedEntityWrite(existing as EntityDoc | null, { tags: strArray(item['tags']), properties });
+      if (schemaFails('entity', i, validateEntity(meta ?? {}, { name, type, properties: mergedEnt.properties, tags: mergedEnt.tags }))) continue;
       const result = await upsertEntity(spaceId, name, type, strArray(item['tags']), properties,
         typeof item['description'] === 'string' ? item['description'] : undefined, rawId, undefined, undefined, ttlDays);
       if (existing) updated.entities++; else inserted.entities++;
@@ -162,8 +165,8 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     const ttlDays = bulkTtlDays(item['ttlDays']);
     if (ttlDays === TTL_INVALID) { errors.push({ type: 'edge', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
-      if (schemaFails('edge', i, validateEdge(meta ?? {}, { label, properties }))) continue;
-      const existing = await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }));
+      const existing = await findEdgeByTriplet(spaceId, from, to, label);
+      if (schemaFails('edge', i, validateEdge(meta ?? {}, { label, properties: mergedEdgeProperties(existing, properties) ?? {} }))) continue;
       await upsertEdge(spaceId, from, to, label,
         typeof item['weight'] === 'number' ? item['weight'] : undefined,
         typeof item['type'] === 'string' ? item['type'] : undefined,

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -49,6 +49,38 @@ export async function resolveEdgeEntityNames(spaceId: string, fromId: string, to
  * Upsert a directed edge (from → to with label).
  * One edge per (from, to, label) triplet.
  */
+/**
+ * The edge an upsert would land on, by its identity triplet.
+ *
+ * An edge has no user-supplied id: `(from, to, label)` IS the identity, and three separate places
+ * re-derived that filter — the upsert itself, the bulk importer's inserted-vs-updated counter, and now
+ * validation. One of them getting it wrong would silently validate against the wrong record.
+ */
+export async function findEdgeByTriplet(
+  spaceId: string, from: string, to: string, label: string,
+): Promise<EdgeDoc | null> {
+  return await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ spaceId, from, to, label })) as EdgeDoc | null;
+}
+
+/**
+ * The properties an upsert will actually store: the stored ones with the incoming ones laid over.
+ *
+ * Exported because schema validation has to run against the record that will EXIST, and until this was
+ * shared it re-derived the rule from the outside — badly. An edge's identity is `(from, to, label)`, so
+ * every repeat upsert of an existing edge merges, with no id involved and nothing in the caller's payload
+ * to hint at it. Validating the payload alone refused patches whose merged result was perfectly valid.
+ *
+ * `undefined` properties mean "do not touch", which is why that case returns the stored value rather than
+ * an empty object — the difference between "no properties supplied" and "properties cleared".
+ */
+export function mergedEdgeProperties(
+  existing: { properties?: Record<string, string | number | boolean> } | null | undefined,
+  incoming: Record<string, string | number | boolean> | undefined,
+): Record<string, string | number | boolean> | undefined {
+  if (incoming === undefined) return existing?.properties;
+  return { ...(existing?.properties ?? {}), ...incoming };
+}
+
 export async function upsertEdge(
   spaceId: string,
   from: string,
@@ -63,7 +95,7 @@ export async function upsertEdge(
   ttlDays?: number | null,
 ): Promise<EdgeDoc> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
-  const existing = await collection.findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }));
+  const existing = await findEdgeByTriplet(spaceId, from, to, label);
 
   const seq = await nextSeq(spaceId);
   const now = new Date().toISOString();
@@ -73,9 +105,7 @@ export async function upsertEdge(
   const effectiveTags = tags !== undefined
     ? Array.from(new Set([...((existing as EdgeDoc | null)?.tags ?? []), ...tags]))
     : ((existing as EdgeDoc | null)?.tags ?? []);
-  const effectiveProps = properties !== undefined
-    ? { ...((existing as EdgeDoc | null)?.properties ?? {}), ...properties }
-    : (existing as EdgeDoc | null)?.properties;
+  const effectiveProps = mergedEdgeProperties(existing as EdgeDoc | null, properties);
 
   // Embed the edge text (best-effort) — resolve entity names so the vector captures semantics
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
@@ -93,10 +123,7 @@ export async function upsertEdge(
     if (description !== undefined) $set['description'] = description;
     // When tags are provided, persist the merged result; otherwise leave existing tags unchanged
     if (tags !== undefined) $set['tags'] = effectiveTags;
-    if (properties !== undefined) {
-      const mergedProps = { ...((existing as EdgeDoc).properties ?? {}), ...properties };
-      $set['properties'] = mergedProps;
-    }
+    if (properties !== undefined) $set['properties'] = mergedEdgeProperties(existing as EdgeDoc, properties);
     const $unset: Record<string, unknown> = {};
     applyExpiryToUpdate(spaceId, ttlDays, (existing as EdgeDoc)._expireAt != null, $set, $unset); // F10
     const updateOp: Record<string, unknown> = { $set };

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -86,6 +86,26 @@ export interface UpsertResult {
  *
  * Callers that need name-based lookup should use `findEntitiesByName`.
  */
+/**
+ * The tags and properties an upsert will actually store, given the record it lands on.
+ *
+ * Both are MERGES, not replacements: an upsert that mentions one property keeps the rest. That rule
+ * belongs to this function so that schema validation can ask what the stored record will look like
+ * instead of guessing. It used to guess, and it guessed the payload — so a partial upsert against a
+ * complete record was refused for missing required properties the record already had and kept.
+ *
+ * `existing` is null for an insert, where the merge is the identity function.
+ */
+export function mergedEntityWrite(
+  existing: { tags?: string[]; properties?: Record<string, string | number | boolean> } | null | undefined,
+  incoming: { tags?: string[]; properties?: Record<string, string | number | boolean> },
+): { tags: string[]; properties: Record<string, string | number | boolean> } {
+  return {
+    tags: Array.from(new Set([...(existing?.tags ?? []), ...(incoming.tags ?? [])])),
+    properties: { ...(existing?.properties ?? {}), ...(incoming.properties ?? {}) },
+  };
+}
+
 export async function upsertEntity(
   spaceId: string,
   name: string,
@@ -111,8 +131,7 @@ export async function upsertEntity(
   // Embed the entity text (best-effort — if embedding fails we still store the entity)
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
   try {
-    const mergedTags = existing ? Array.from(new Set([...(existing.tags ?? []), ...tags])) : tags;
-    const mergedProps = existing ? { ...(existing.properties ?? {}), ...properties } : properties;
+    const { tags: mergedTags, properties: mergedProps } = mergedEntityWrite(existing, { tags, properties });
     const effectiveDesc = description ?? existing?.description;
     const embedText = entityEmbedText(name, type, mergedTags, effectiveDesc, mergedProps);
     const embResult = await embed(embedText);
@@ -120,8 +139,7 @@ export async function upsertEntity(
   } catch { /* embedding unavailable — entity stored without vector */ }
 
   if (existing) {
-    const updatedTags = Array.from(new Set([...(existing.tags ?? []), ...tags]));
-    const mergedProps = { ...(existing.properties ?? {}), ...properties };
+    const { tags: updatedTags, properties: mergedProps } = mergedEntityWrite(existing, { tags, properties });
     const $set: Record<string, unknown> = { name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields };
     if (description !== undefined) $set['description'] = description;
     const $unset: Record<string, unknown> = {};

--- a/server/src/brain/write-validation.ts
+++ b/server/src/brain/write-validation.ts
@@ -1,5 +1,5 @@
 /**
- * Schema validation on UPDATE — of the record as it will be, and honest about whose fault a violation is.
+ * Schema validation on WRITE — of the record as it will be, and honest about whose fault a violation is.
  *
  * ## The hole
  *
@@ -32,10 +32,12 @@
  * permanently out of conformance. And the record is not trapped — validation is of the *merged* result, so
  * a patch that repairs the pre-existing violation passes. The error names exactly what to include.
  */
-import type { SchemaViolation } from '../../spaces/schema-validation.js';
-import type { SpaceMeta } from '../../config/types.js';
-import { resolveMemberSpaces } from '../../spaces/proxy.js';
-import { applyValidation, getSpaceMeta } from './_shared.js';
+import { validateEntity, validateEdge, type SchemaViolation } from '../spaces/schema-validation.js';
+import type { SpaceMeta } from '../config/types.js';
+import { resolveMemberSpaces } from '../spaces/proxy.js';
+import { applyValidation, getSpaceMeta } from '../spaces/schema-validation.js';
+import { getEntityById, mergedEntityWrite } from './entities.js';
+import { findEdgeByTriplet, mergedEdgeProperties } from './edges.js';
 
 /**
  * Identity of a violation for before/after comparison.
@@ -58,6 +60,13 @@ export interface UpdateValidation {
   preExisting: SchemaViolation[];
   /** Everything, for the `violations` field of the response — warn mode reports without blocking. */
   all: SchemaViolation[];
+  /**
+   * The violations to SURFACE, per the space's validation mode: the full list under `warn` or `strict`,
+   * empty when validation is `off`. `all` is what the validator found; this is what the mode says to
+   * tell the caller about. Keeping the two apart is what let the create routes adopt this classifier
+   * without starting to emit warnings in spaces that had deliberately switched validation off.
+   */
+  warnings: SchemaViolation[];
   /** Ready-to-send message naming which of the two situations applies. */
   message: string;
 }
@@ -83,6 +92,7 @@ export function classifyUpdateViolations(
 
   return {
     blocked: verdict.blocked,
+    warnings: verdict.warnings,
     introduced,
     preExisting,
     all: afterViolations,
@@ -149,4 +159,96 @@ export function describeUpdateViolations(
       + 'include those field(s) in the same request to repair them.';
   }
   return 'The merged record satisfies this space\'s schema.';
+}
+
+/**
+ * ## The same hole, on the other write path
+ *
+ * Everything above fixes UPDATE. An upsert has exactly the same shape and was missed: `upsertEntity`
+ * merges `{ ...stored.properties, ...incoming }`, and `upsertEdge` does too — but the six call sites
+ * validated the INCOMING payload. A partial upsert against a complete record was refused for required
+ * properties the record already had and would keep.
+ *
+ * Reported by an operator whose agent could not patch one field of a conformant record in a strict
+ * space. It is worse for edges than for entities: an edge is identified by `(from, to, label)` with no
+ * id anywhere in the call, so EVERY repeat upsert merges and there is nothing in the payload to suggest
+ * it might.
+ *
+ * The classification is the update one, unchanged — an upsert onto an existing record IS an update, and
+ * a record that was already non-compliant should not blame the caller for it either.
+ */
+
+/** An upsert onto nothing is an insert: no prior record, so nothing can be pre-existing. */
+const INSERT_HAS_NO_PRIOR: SchemaViolation[] = [];
+
+/**
+ * The whole decision, given the record the upsert lands on — no database.
+ *
+ * Split from the loading wrapper below so the rule can be tested for what it IS: which record gets
+ * validated. A test that has to stand up MongoDB to ask "did you validate the merged form?" is a test
+ * that will be written once and never extended, and this defect survived precisely because the merge
+ * was invisible from where validation ran.
+ *
+ * `existing` null means insert: nothing to merge, and nothing that could be pre-existing.
+ */
+export function classifyEntityUpsertAgainst(
+  meta: SpaceMeta | undefined,
+  existing: { name: string; type: string; properties?: Record<string, string | number | boolean>; tags?: string[] } | null,
+  incoming: { name: string; type: string; properties?: Record<string, string | number | boolean>; tags?: string[] },
+): UpdateValidation {
+  const merged = mergedEntityWrite(existing, incoming);
+  const after = validateEntity(meta ?? {}, {
+    name: incoming.name, type: incoming.type, properties: merged.properties, tags: merged.tags,
+  });
+  const before = existing
+    ? validateEntity(meta ?? {}, {
+      name: existing.name, type: existing.type, properties: existing.properties ?? {}, tags: existing.tags ?? [],
+    })
+    : INSERT_HAS_NO_PRIOR;
+  return classifyUpdateViolations(meta, before, after);
+}
+
+/** As above, for an edge. Its identity is `(from, to, label)`, so only the properties can merge. */
+export function classifyEdgeUpsertAgainst(
+  meta: SpaceMeta | undefined,
+  existing: { label: string; properties?: Record<string, string | number | boolean> } | null,
+  incoming: { label: string; properties?: Record<string, string | number | boolean> },
+): UpdateValidation {
+  const after = validateEdge(meta ?? {}, {
+    label: incoming.label, properties: mergedEdgeProperties(existing, incoming.properties) ?? {},
+  });
+  const before = existing
+    ? validateEdge(meta ?? {}, { label: existing.label, properties: existing.properties ?? {} })
+    : INSERT_HAS_NO_PRIOR;
+  return classifyUpdateViolations(meta, before, after);
+}
+
+/**
+ * Validate an entity upsert against the record it will produce.
+ *
+ * `id` is what makes an upsert an update — omitted, or unknown, and this is a plain insert whose merged
+ * form is the payload itself. Callers pass the space they resolved to write to, so a proxy validates
+ * against the member that will hold the record rather than against the proxy's own meta.
+ */
+export async function classifyEntityUpsert(
+  spaceId: string,
+  incoming: { name: string; type: string; properties?: Record<string, string | number | boolean>; tags?: string[] },
+  id: string | undefined,
+): Promise<UpdateValidation> {
+  const existing = id ? await getEntityById(spaceId, id) : null;
+  return classifyEntityUpsertAgainst(getSpaceMeta(spaceId), existing, incoming);
+}
+
+/**
+ * Validate an edge upsert against the record it will produce.
+ *
+ * No id parameter: `(from, to, label)` IS the identity, so the lookup is the identity itself — which is
+ * why every repeat upsert of an existing edge merges, with nothing in the call to suggest it.
+ */
+export async function classifyEdgeUpsert(
+  spaceId: string,
+  incoming: { from: string; to: string; label: string; properties?: Record<string, string | number | boolean> },
+): Promise<UpdateValidation> {
+  const existing = await findEdgeByTriplet(spaceId, incoming.from, incoming.to, incoming.label);
+  return classifyEdgeUpsertAgainst(getSpaceMeta(spaceId), existing, incoming);
 }

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -2,7 +2,7 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
 import { ChronoFilter, createChrono, getChronoById, listChrono, updateChrono, parseRecurrence } from '../../brain/chrono.js';
 // The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
-import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
+import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -2,8 +2,8 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 import { getEdgeById, traverseGraph, updateEdgeById, upsertEdge } from '../../brain/edges.js';
-// The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
-import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
+// The shared write gate, imported rather than reimplemented — see the note in memory.ts.
+import { assertUpdateAllowed, classifyEdgeUpsert, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateEdge } from '../../spaces/schema-validation.js';
@@ -57,12 +57,15 @@ export const upsert_edgeTool: ToolHandler = {
       if (!UUID_V4_RE.test(to)) throw new Error('to must be a valid UUID v4 (entity ID), not a name');
     }
 
-    // Schema validation (single pass)
+    // Schema validation of the record this upsert will PRODUCE. An edge's identity is (from, to, label)
+    // with no id in the call at all, so EVERY repeat upsert merges into the stored edge — and nothing in
+    // the payload hints at it. Validating the payload alone made a one-property patch look incomplete.
     const edgeMetaRaw = getConfig().spaces.find(s => s.id === wt.target)?.meta;
     const edgeMeta = edgeMetaRaw ? resolveMetaRefs(edgeMetaRaw) : undefined;
-    const edgeSchemaViolations = edgeMeta ? validateEdge(edgeMeta, { label: label.trim(), properties: edgeProps }) : [];
-    if (edgeSchemaViolations.length > 0 && edgeMeta?.validationMode === 'strict') {
-      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(edgeSchemaViolations)}` }], isError: true };
+    const edgeCheck = await classifyEdgeUpsert(wt.target, { from, to, label: label.trim(), properties: edgeProps });
+    const edgeSchemaViolations = edgeCheck.all;
+    if (edgeCheck.blocked) {
+      return { content: [{ type: 'text' as const, text: `Error: schema_violation: ${edgeCheck.message}\n${JSON.stringify(edgeSchemaViolations)}` }], isError: true };
     }
 
     const edgeTtlDays = ttlDaysFromArgs(a);

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -2,8 +2,8 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { UUID_V4_RE, TTL_DAYS_SCHEMA, ttlDaysFromArgs, uuidSchema, unitScoreSchema } from './shared.js';
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 import { findEntitiesByName, getEntityById, updateEntityById, upsertEntity } from '../../brain/entities.js';
-// The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
-import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
+// The shared write gate, imported rather than reimplemented — see the note in memory.ts.
+import { assertUpdateAllowed, classifyEntityUpsert, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
 import { type PropertyResolution, applyResolutions, computeMergePlan, executeMerge, validateResolution } from '../../brain/merge.js';
 import { getConfig } from '../../config/loader.js';
 import { isProxySpace, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
@@ -53,12 +53,15 @@ export const upsert_entityTool: ToolHandler = {
     const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
     if (!wt.ok) throw new Error(wt.error);
 
-    // Schema validation (single pass)
+    // Schema validation of the record this upsert will PRODUCE, not of the payload. With an `id` that
+    // matches, `upsertEntity` merges into the stored record, so validating the payload alone refused
+    // partial patches whose merged result was perfectly conformant.
     const entMetaRaw = getConfig().spaces.find(s => s.id === wt.target)?.meta;
     const entMeta = entMetaRaw ? resolveMetaRefs(entMetaRaw) : undefined;
-    const entSchemaViolations = entMeta ? validateEntity(entMeta, { name: eName.trim(), type: eType.trim(), properties: props }) : [];
-    if (entSchemaViolations.length > 0 && entMeta?.validationMode === 'strict') {
-      return { content: [{ type: 'text' as const, text: `Error: schema_violation\n${JSON.stringify(entSchemaViolations)}` }], isError: true };
+    const entCheck = await classifyEntityUpsert(wt.target, { name: eName.trim(), type: eType.trim(), properties: props, tags }, rawId);
+    const entSchemaViolations = entCheck.all;
+    if (entCheck.blocked) {
+      return { content: [{ type: 'text' as const, text: `Error: schema_violation: ${entCheck.message}\n${JSON.stringify(entSchemaViolations)}` }], isError: true };
     }
 
     // Insert-time duplicate check defaults ON for the interactive upsert tool

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -13,7 +13,7 @@ import { deleteMemory, listMemories, remember, updateMemory } from '../../brain/
 import { applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 // The API layer's write gate, imported rather than reimplemented: `update_chrono` once shipped without
 // the allowlist `create_chrono` enforced, and two copies of a validation rule is how that happens.
-import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../api/brain/update-validation.js';
+import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { resolveWriteTarget, findFirstAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';

--- a/server/src/spaces/schema-validation.ts
+++ b/server/src/spaces/schema-validation.ts
@@ -13,7 +13,7 @@
  */
 
 import type { SpaceMeta, PropertySchema, TypeSchema } from '../config/types.js';
-import { getSchemaLibrary } from '../config/loader.js';
+import { getSchemaLibrary, getConfig } from '../config/loader.js';
 import { hasReDoSRisk, MAX_PATTERN_LENGTH } from '../util/redos.js';
 
 // ── Violation type ─────────────────────────────────────────────────────────
@@ -358,4 +358,41 @@ function safeRegexTest(pattern: string, value: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Look up the meta block for a space from config, with library refs resolved. Returns undefined if none.
+ *
+ * Lived in `api/brain/_shared.ts` until the upsert-validation fix, which needed it from `brain/bulk.ts`.
+ * `brain/` does not import `api/` — a layering worth keeping — and this function is not an HTTP concern:
+ * it reads config and resolves schema refs, both of which live here. `_shared.ts` re-exports it, so no
+ * route changed.
+ */
+export function getSpaceMeta(spaceId: string): SpaceMeta | undefined {
+  const cfg = getConfig();
+  const meta = cfg.spaces.find(s => s.id === spaceId)?.meta;
+  if (!meta) return undefined;
+  return resolveMetaRefs(meta);
+}
+
+/**
+ * Apply schema validation to a write operation.
+ * Returns { blocked: true, violations } when strict mode rejects the write.
+ * Returns { blocked: false, warnings } when warn mode lets the write through.
+ * Returns { blocked: false, warnings: [] } when validation is off or no meta.
+ *
+ * One definition, because the alternative is each write path deciding for itself what `strict` means.
+ */
+export function applyValidation(
+  meta: SpaceMeta | undefined,
+  violations: SchemaViolation[],
+): { blocked: boolean; warnings: SchemaViolation[] } {
+  if (!meta || !meta.validationMode || meta.validationMode === 'off' || violations.length === 0) {
+    return { blocked: false, warnings: [] };
+  }
+  if (meta.validationMode === 'strict') {
+    return { blocked: true, warnings: violations };
+  }
+  // warn mode
+  return { blocked: false, warnings: violations };
 }

--- a/testing/standalone/update-validation.test.js
+++ b/testing/standalone/update-validation.test.js
@@ -43,7 +43,7 @@ const v = (field, reason) => ({ field, value: 'whatever', reason });
 describe('update validation', () => {
   before(async () => {
     ({ classifyUpdateViolations, describeUpdateViolations, assertUpdateAllowed } =
-      await import('../../server/dist/api/brain/update-validation.js'));
+      await import('../../server/dist/brain/write-validation.js'));
   });
 
   describe('classification', () => {
@@ -204,9 +204,9 @@ describe('every update path runs the gate', () => {
       'validation must not be conditional on deleteFields — that was the original gap');
   });
 
-  it('the MCP tools import the API gate rather than reimplementing it', () => {
+  it('the MCP tools import the shared gate rather than reimplementing it', () => {
     for (const p of PATHS.filter(x => x.includes('/mcp/'))) {
-      assert.match(readFileSync(p, 'utf8'), /from '\.\.\/\.\.\/api\/brain\/update-validation\.js'/,
+      assert.match(readFileSync(p, 'utf8'), /from '\.\.\/\.\.\/brain\/write-validation\.js'/,
         'two copies of a validation rule is how the surfaces drift apart');
     }
   });

--- a/testing/standalone/upsert-validation.test.js
+++ b/testing/standalone/upsert-validation.test.js
@@ -1,0 +1,260 @@
+/**
+ * An upsert is validated against the record it will WRITE, not against the payload.
+ *
+ * ## The defect
+ *
+ * `upsertEntity` merges into the stored record when `id` matches: `{ ...stored.properties, ...incoming }`.
+ * `upsertEdge` does the same, and its identity is `(from, to, label)` — no id anywhere in the call, so
+ * EVERY repeat upsert of an existing edge merges and nothing in the payload hints at it.
+ *
+ * Six call sites validated the incoming payload instead. In a `strict` space, patching one property of a
+ * conformant record was refused for required properties the record already had and would keep. Reported
+ * by an operator whose agent could not update a complete record one field at a time.
+ *
+ * ## Why this is the update defect again
+ *
+ * #571 fixed exactly this for `update_*` — validate the merged record, and split violations into
+ * introduced vs pre-existing so a record that was already non-compliant does not blame the caller. That
+ * sweep stopped at the update tools and never reached upsert, which is the same write with a different
+ * name. So the fix here is not new machinery: it is the same classifier, given the record the upsert
+ * lands on.
+ *
+ * ## What this file pins
+ *
+ * The pure decision (`classify*UpsertAgainst`) rather than the loading wrapper, because the question is
+ * *which record gets validated* and that is decided before any database call. Plus a source-level check
+ * that no upsert path has gone back to handing a raw payload to a validator — the sites are enumerated
+ * from the writers they call, not hand-listed, since a hand-listed set is how the first sweep missed
+ * these.
+ *
+ * Run: node --test testing/standalone/upsert-validation.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+
+let classifyEntityUpsertAgainst;
+let classifyEdgeUpsertAgainst;
+let mergedEntityWrite;
+let mergedEdgeProperties;
+
+/** A space that requires `owner` on every `machine` entity, and `since` on every edge. */
+const STRICT_ENTITY = {
+  validationMode: 'strict',
+  typeSchemas: {
+    entity: {
+      machine: {
+        propertySchemas: {
+          owner: { type: 'string', required: true },
+          rack: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const STRICT_EDGE = {
+  validationMode: 'strict',
+  typeSchemas: {
+    edge: {
+      'runs-on': {
+        propertySchemas: {
+          since: { type: 'string', required: true },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const WARN_ENTITY = { ...STRICT_ENTITY, validationMode: 'warn' };
+const OFF_ENTITY = { ...STRICT_ENTITY, validationMode: 'off' };
+
+/** The stored record: complete, conformant, exactly what the reporter had. */
+const STORED = { name: 'node-7', type: 'machine', properties: { owner: 'platform', rack: 'B12' }, tags: ['prod'] };
+
+describe('upsert validation', () => {
+  before(async () => {
+    ({ classifyEntityUpsertAgainst, classifyEdgeUpsertAgainst } =
+      await import('../../server/dist/brain/write-validation.js'));
+    ({ mergedEntityWrite } = await import('../../server/dist/brain/entities.js'));
+    ({ mergedEdgeProperties } = await import('../../server/dist/brain/edges.js'));
+  });
+
+  describe('the reported case', () => {
+    it('accepts a partial patch of a complete record', () => {
+      // The payload alone has no `owner`, which is required. The MERGED record has it, from the store.
+      const out = classifyEntityUpsertAgainst(STRICT_ENTITY, STORED,
+        { name: 'node-7', type: 'machine', properties: { rack: 'C03' } });
+      assert.equal(out.blocked, false,
+        'a patch whose merged result is conformant must not be refused — this is the reported defect');
+      assert.deepEqual(out.all, []);
+    });
+
+    it('still refuses the same payload as a NEW record', () => {
+      // Same fragment, nothing to merge with: now `owner` really is missing.
+      const out = classifyEntityUpsertAgainst(STRICT_ENTITY, null,
+        { name: 'node-9', type: 'machine', properties: { rack: 'C03' } });
+      assert.equal(out.blocked, true, 'an insert has no stored record to supply the required property');
+      assert.deepEqual(out.introduced.map(x => x.field), ['properties.owner']);
+      assert.deepEqual(out.preExisting, [], 'nothing can pre-exist on a record that does not exist yet');
+    });
+
+    it('refuses a patch that breaks the merged record', () => {
+      // Overwriting a required property with the wrong type is the caller's doing, merge or no merge.
+      const out = classifyEntityUpsertAgainst(STRICT_ENTITY, STORED,
+        { name: 'node-7', type: 'machine', properties: { owner: 42 } });
+      assert.equal(out.blocked, true, 'validating the merged record must not become validating nothing');
+      assert.deepEqual(out.introduced.map(x => x.field), ['properties.owner']);
+    });
+  });
+
+  describe('an already-broken record does not blame the caller', () => {
+    const BROKEN = { name: 'node-3', type: 'machine', properties: { rack: 'A01' }, tags: [] };
+
+    it('reports the record\'s own violation as pre-existing, not introduced', () => {
+      const out = classifyEntityUpsertAgainst(STRICT_ENTITY, BROKEN,
+        { name: 'node-3', type: 'machine', properties: { rack: 'A02' } });
+      assert.deepEqual(out.preExisting.map(x => x.field), ['properties.owner']);
+      assert.deepEqual(out.introduced, [], 'the caller touched `rack`, not `owner`');
+      assert.match(out.message, /already non-compliant/);
+      assert.equal(out.blocked, true, 'the merged record is still what gets stored');
+    });
+
+    it('lets the same upsert repair it', () => {
+      const out = classifyEntityUpsertAgainst(STRICT_ENTITY, BROKEN,
+        { name: 'node-3', type: 'machine', properties: { owner: 'platform' } });
+      assert.equal(out.blocked, false);
+    });
+  });
+
+  describe('edges merge with no id in sight', () => {
+    const STORED_EDGE = { label: 'runs-on', properties: { since: '2024-01-01', note: 'primary' } };
+
+    it('accepts a partial patch of a complete edge', () => {
+      const out = classifyEdgeUpsertAgainst(STRICT_EDGE, STORED_EDGE,
+        { label: 'runs-on', properties: { note: 'secondary' } });
+      assert.equal(out.blocked, false);
+    });
+
+    it('refuses the same payload for a new edge', () => {
+      const out = classifyEdgeUpsertAgainst(STRICT_EDGE, null,
+        { label: 'runs-on', properties: { note: 'secondary' } });
+      assert.equal(out.blocked, true);
+      assert.deepEqual(out.introduced.map(x => x.field), ['properties.since']);
+    });
+
+    it('treats absent properties as "leave them alone", not "clear them"', () => {
+      // `properties: undefined` is the caller saying nothing about properties. Reading it as {} would
+      // wipe a required field and refuse an upsert that only sets, say, a weight.
+      const out = classifyEdgeUpsertAgainst(STRICT_EDGE, STORED_EDGE, { label: 'runs-on' });
+      assert.equal(out.blocked, false);
+      assert.deepEqual(mergedEdgeProperties(STORED_EDGE, undefined), STORED_EDGE.properties);
+    });
+  });
+
+  describe('validation mode still decides what is surfaced', () => {
+    const PATCH = { name: 'node-9', type: 'machine', properties: { rack: 'C03' } };
+
+    it('warn mode reports without blocking', () => {
+      const out = classifyEntityUpsertAgainst(WARN_ENTITY, null, PATCH);
+      assert.equal(out.blocked, false);
+      assert.deepEqual(out.warnings.map(x => x.field), ['properties.owner'], 'warn mode still tells the caller');
+    });
+
+    it('off mode surfaces nothing at all', () => {
+      const out = classifyEntityUpsertAgainst(OFF_ENTITY, null, PATCH);
+      assert.equal(out.blocked, false);
+      assert.deepEqual(out.warnings, [],
+        'a space that switched validation off must not start receiving warnings because the create ' +
+        'routes adopted this classifier');
+      assert.equal(out.all.length, 1, '`all` is what the validator found; `warnings` is what the mode says to say');
+    });
+  });
+
+  describe('the merge rule lives with the writer', () => {
+    it('merges properties and unions tags', () => {
+      const out = mergedEntityWrite({ tags: ['a'], properties: { x: 1, y: 2 } }, { tags: ['b'], properties: { y: 3 } });
+      assert.deepEqual(out.properties, { x: 1, y: 3 });
+      assert.deepEqual(out.tags.sort(), ['a', 'b']);
+    });
+
+    it('is the identity on an insert', () => {
+      const out = mergedEntityWrite(null, { tags: ['b'], properties: { y: 3 } });
+      assert.deepEqual(out, { tags: ['b'], properties: { y: 3 } });
+    });
+  });
+
+  describe('no upsert path validates a raw payload', () => {
+    /**
+     * Enumerated from the WRITERS, not hand-listed: every file that calls `upsertEntity` or `upsertEdge`
+     * is a site where a merge happens, and therefore a site that must not validate the payload. Hand-
+     * listing is how the #571 sweep missed all six of these.
+     */
+    const WRITER_CALLERS = [
+      'server/src/mcp/tools/entity.ts',
+      'server/src/mcp/tools/edge.ts',
+      'server/src/api/brain/entities.ts',
+      'server/src/api/brain/edges.ts',
+      'server/src/brain/bulk.ts',
+    ];
+
+    const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+    it('the enumeration matches reality (the check itself works)', () => {
+      // If a new file starts calling a merging writer, it belongs in this list — and the assertion below
+      // has to see it. A gate whose scope is stale reads like coverage it does not have.
+      const roots = ['server/src/mcp/tools', 'server/src/api/brain', 'server/src/brain'];
+      const found = [];
+      const walk = dir => {
+        for (const name of readdirSync(dir)) {
+          const p = `${dir}/${name}`;
+          if (statSync(p).isDirectory()) { walk(p); continue; }
+          if (!p.endsWith('.ts')) continue;
+          const src = strip(readFileSync(p, 'utf8'));
+          if (/\b(?:await\s+)?upsertEntity\(|\b(?:await\s+)?upsertEdge\(/.test(src)) found.push(p.replace(/\\/g, '/'));
+        }
+      };
+      for (const r of roots) walk(r);
+      // The writers' own modules define the functions; exclude the definitions, keep the callers. The
+      // path has to be anchored — `brain/entities.ts` also matches `api/brain/entities.ts`, which is a
+      // caller, and dropping it would have made this check silently ignore two of the six sites.
+      const callers = found.filter(p => !/^server\/src\/brain\/(entities|edges)\.ts$/.test(p));
+      assert.deepEqual(callers.sort(), [...WRITER_CALLERS].sort(),
+        'a new caller of upsertEntity/upsertEdge must be checked here — it merges, so it must not ' +
+        'validate the payload');
+    });
+
+    it('every one of them validates the merged record', () => {
+      const offenders = [];
+      for (const p of WRITER_CALLERS) {
+        const src = strip(readFileSync(p, 'utf8'));
+        const usesClassifier = /classify(Entity|Edge)Upsert\(/.test(src);
+        // bulk.ts composes the merge itself (it needs the prior record for its own counters), so it is
+        // allowed to call the validator directly — as long as what it hands over came from the writer's
+        // merge helper and not from the request.
+        const usesMergeHelper = /merged(EntityWrite|EdgeProperties)\(/.test(src);
+        if (!usesClassifier && !usesMergeHelper) offenders.push(p);
+      }
+      assert.deepEqual(offenders, [],
+        'an upsert merges into the stored record, so validating the incoming payload validates a record ' +
+        'that will never exist. Use classifyEntityUpsert / classifyEdgeUpsert, or the writer\'s merge ' +
+        'helper if you already hold the prior record.');
+    });
+
+    it('no caller passes the request payload straight to a validator', () => {
+      // The exact shape of the defect: `validateEntity(meta, { ..., properties: <the payload> })` with no
+      // merge in between. Matching the payload identifiers the six sites actually used.
+      const offenders = [];
+      for (const p of WRITER_CALLERS) {
+        const src = strip(readFileSync(p, 'utf8'));
+        for (const m of src.matchAll(/validate(?:Entity|Edge)\([^)]*properties:\s*([A-Za-z_$][\w$]*)/g)) {
+          const arg = m[1];
+          if (/^(props|properties|edgeProps|safeProps)$/.test(arg)) offenders.push(`${p} — properties: ${arg}`);
+        }
+      }
+      assert.deepEqual(offenders, [],
+        'that identifier is the incoming payload. The merged record is what gets stored.');
+    });
+  });
+});


### PR DESCRIPTION
In a `strict` space, setting one property of a complete, conformant entity failed with
`schema_violation` naming required properties **the record already had**.

## Why

`upsertEntity` merges into the stored record:

```ts
const mergedProps = { ...(existing.properties ?? {}), ...properties };
```

Every caller validated the **incoming payload**. So the record that was validated is not the record
that gets written — and a fragment can never satisfy a schema whose required properties live in the
stored half.

It is worse for edges. An edge's identity is `(from, to, label)`; there is no id in the call at all,
so **every** repeat upsert of an existing edge merges, and nothing in the payload hints that it will.

## Every instance, not just the reported one

| site | writer | merges when |
|---|---|---|
| `mcp/tools/entity.ts` | `upsertEntity` | `id` matches |
| `api/brain/entities.ts` | `upsertEntity` | `id` matches |
| `mcp/tools/edge.ts` | `upsertEdge` | always |
| `api/brain/edges.ts` | `upsertEdge` | always |
| `brain/bulk.ts` (entities) | `upsertEntity` | `id` matches |
| `brain/bulk.ts` (edges) | `upsertEdge` | always |

`bulk.ts` is the sharpest: it fetched the prior record two lines **after** validating, for its own
inserted-vs-updated counter. The merge target was in hand; validation just did not use it.

`remember` and `createChrono` are pure inserts — nothing to merge, correct as they stand.

## This is #571 again

#571 fixed exactly this for `update_*`: validate the merged record, and split violations into
`introduced` vs `preExisting` so a record that was already non-compliant does not blame the caller.
That sweep stopped at the update tools and never reached upsert, which is the same write under a
different name. The classifier is reused unchanged, so an upsert onto a broken record still reports
`preExisting` and can repair it in the same request.

## Shape of the fix

- The merge rule moves to the writer — `mergedEntityWrite`, `mergedEdgeProperties`,
  `findEdgeByTriplet` — instead of being re-derived by each caller. Three places had independently
  re-derived the edge identity triplet.
- `api/brain/update-validation.ts` → `brain/write-validation.ts`. It governs both write paths now,
  and `brain/bulk.ts` needs it while `brain/` does not import `api/`. `getSpaceMeta` and
  `applyValidation` moved to `spaces/schema-validation.ts` for the same reason; `_shared.ts`
  re-exports them, so no route changed.
- `UpdateValidation` gains `warnings` — the mode-aware list — so the create routes could adopt the
  classifier without starting to emit warnings in spaces that had switched validation `off`.

## Gate

`upsert-validation.test.js`: the reported case, the insert that must still fail, a patch that
genuinely breaks the merged record, pre-existing classification, warn/off reporting, and the merge
rule itself. Mutation-checked — reverting the merge kills three cases.

Plus a source-level check enumerated **from the writers**: every file calling `upsertEntity` or
`upsertEdge` must validate a merged record, and none may pass a payload identifier to a validator. A
hand-listed set is precisely how the first sweep missed all six of these. Its own first version had
the bug it was written to catch — `brain/entities.ts` also matches `api/brain/entities.ts`, so two
of the six were being silently excluded until the path was anchored.

Reported by the canary running a five-instance K3s fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
