### PR TITLE
fix(models): one base URL, every OpenAI-compatible slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One server, three incompatible base URLs.** Five model slots each derived their own request URL, and
+  they disagreed: vision appended `/chat/completions`, so its base *had* to carry `/v1`; the assist model
+  appended `/v1/chat/completions` and text embedding appended `/v1/embeddings`, so theirs had to *not*
+  carry it. An operator pointing several slots at one OpenAI-compatible server therefore had no spelling
+  that satisfied them all — a reporter had already worked around it by configuring two base URLs for one
+  host.
+  - **The probe normalises**, which is what made this dangerous rather than merely annoying: the Models
+    card goes green off `/v1/models` while inference 404s on `/v1/v1/embeddings`. A failing embedder does
+    not announce itself — it surfaces as recall that quietly returns nothing.
+  - **`…:8080` and `…:8080/v1` now both work, in every slot.** Route paths are spelled in one module and
+    every builder normalises; a gate enumerates the routes out of that module and fails if any other file
+    re-derives one. The same fix had already been applied slot-by-slot twice (2.2 for vision, earlier in
+    this release for speech-to-text) — each time a caller that concatenated its own path was missed.
+  - The reranker is deliberately exempt: two incompatible rerank dialects are in wide use and there the
+    operator's URL *declares* which one (`…/rerank` = TEI, `…/v1/rerank` = Cohere), so normalising it
+    would erase the signal.
+
 - **A red dot over a provably working speech-to-text pipeline.** The card asked the endpoint for a list of
   its models, got a `404`, and reported **unreachable** — while Verify, which sends generated silence down
   the real path, was green. Their service serves exactly one route, `POST /v1/audio/transcriptions`: a list

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -590,7 +590,7 @@ see the egress table above. You can optionally point a **bigger, external model*
 
 | Field | Description |
 |---|---|
-| `baseUrl` | External **OpenAI-compatible** endpoint (`POST {baseUrl}/v1/chat/completions`). Validated against SSRF on save (must be a public http(s) URL — no private/loopback/metadata addresses) and reached only through the SSRF-guarded fetch. Env: `DOC_ASSIST_URL`. |
+| `baseUrl` | External **OpenAI-compatible** endpoint (`POST {baseUrl}/chat/completions`, with `/v1` inserted if the base does not already carry it — `…:8080` and `…:8080/v1` both work). Validated against SSRF on save (must be a public http(s) URL — no private/loopback/metadata addresses) and reached only through the SSRF-guarded fetch. Env: `DOC_ASSIST_URL`. |
 
 > **Self-hosting inference on a private address?** The `local` / `external` choice selects a **wire
 > protocol**, not a trust level: `local` speaks Ollama's (`/api/chat`), `external` speaks OpenAI's
@@ -821,7 +821,7 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `levels.{images,audio,video,text}` | — | `auto` | Per-class instance ceiling; set a class to `off` to take it offline. **This is the media on/off control** (the `enabled` / `MEDIA_EMBEDDING_ENABLED` master switch was removed). |
 | `visionProvider` | `VISION_PROVIDER` | `local` | Wire protocol, not trust level: `local` (Ollama `/api/chat`) or `external` (OpenAI `/chat/completions`). A self-hosted OpenAI-compatible server needs `external` — see `allowPrivateModelEndpoints` for one on a private address. |
 | `sttProvider` | `STT_PROVIDER` | `local` | Wire protocol, not trust level: `local` (bundled Whisper) or `external` (OpenAI-compatible). Both speak `/v1/audio/transcriptions`. |
-| `vision.baseUrl` | `VISION_BASE_URL` | `http://ollama:11434` | Vision service endpoint, **whatever the provider** (short name resolves in both Docker Compose and the K8s `ythril` namespace). Legacy alias: `OLLAMA_URL`. |
+| `vision.baseUrl` | `VISION_BASE_URL` | `http://ollama:11434` | Vision service endpoint, **whatever the provider** (short name resolves in both Docker Compose and the K8s `ythril` namespace). On an OpenAI-compatible provider, `…:8080` and `…:8080/v1` both work. Legacy alias: `OLLAMA_URL`. |
 | `vision.model` | `VISION_MODEL` | `moondream` | Vision model name |
 | `vision.apiKey` | `VISION_API_KEY` | — | API key for external vision provider (stored in `secrets.json`, never in `config.json`) |
 | `stt.baseUrl` | `STT_BASE_URL` | `http://whisper:8000` | STT service endpoint, **whatever the backend**. `…:8000` and `…:8000/v1` both work — the transcription URL is normalised the same way the vision and assist endpoints are, so one base URL serves all three. Legacy alias: `WHISPER_URL`. |
@@ -845,7 +845,7 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 > `lockedByInfra` tracks whichever spelling you used, so the Settings UI renders the field read-only
 > either way.
 | `embedding.provider` | `EMBEDDING_PROVIDER` | `local` | Text-embedding endpoint trust: `local` (bundled ONNX or an internal HTTP endpoint, plain fetch) or `external` (public endpoint, reached through the SSRF-guarded fetch). Config lives at top-level `config.embedding` but is edited on **Settings → Media Processing**. |
-| `embedding.baseUrl` | `EMBEDDING_URL` | — | Embedding HTTP endpoint (OpenAI-compatible `/v1/embeddings`). Blank = the bundled in-process ONNX model. |
+| `embedding.baseUrl` | `EMBEDDING_URL` | — | Embedding HTTP endpoint (OpenAI-compatible `/v1/embeddings`). `…:8080` and `…:8080/v1` both work. Blank = the bundled in-process ONNX model. |
 | `embedding.model` | `EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5` | Embedding model. **Changing the model / `dimensions` / `similarity` / `prefixScheme` re-indexes every vector** (the UI requires an explicit confirmation; `POST /api/brain/spaces/:id/reindex` runs it). |
 | `embedding.prefixScheme` | `EMBEDDING_PREFIX_SCHEME` | `auto` | Task-prefix convention the model expects: `nomic` (`search_document:` / `search_query:` prefixes, trailing space included), `qwen` (instruction on the query only, passages bare), `none` (symmetric models — OpenAI `text-embedding-3-*`, bge-m3), or `auto`. **`auto` reproduces the behaviour this instance had before the field existed: `nomic` for the bundled model, `none` over HTTP — so upgrading changes no vector.** If you run nomic or Qwen behind an endpoint, set this explicitly and reindex — asymmetric models retrieve measurably worse without the prefix, and nothing errors when it is missing. |
 | `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `768` | Vector width the model emits. Must match the model — a mismatch is not detected at write time, it surfaces as recall that returns nothing. Listed with `model` above as a re-index trigger. |

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { getDataRoot, getEmbeddingConfig } from '../config/loader.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
 import { allowPrivateForSlot } from '../config/model-egress-policy.js';
+import { embeddingsUrlFor } from '../files/converters/vlm-endpoint.js';
 import { log } from '../util/log.js';
 import { embeddingDurationSeconds, embeddingQueueDepth } from '../metrics/registry.js';
 
@@ -93,7 +94,11 @@ async function embedViaHttp(
   input: string,
   cfg: ReturnType<typeof getEmbeddingConfig>,
 ): Promise<EmbeddingResult> {
-  const url = `${cfg.baseUrl!.replace(/\/$/, '')}/v1/embeddings`;
+  // Normalised rather than concatenated: appending `/v1/embeddings` meant this slot required a base
+  // WITHOUT `/v1` while vision required one WITH it, for the same server. The probe normalises, so the
+  // Models card went green off `/v1/models` while every embed 404'd on `/v1/v1/embeddings` — and a failing
+  // embedder does not announce itself, it shows up as recall that returns nothing.
+  const url = embeddingsUrlFor(cfg.baseUrl!);
   // External endpoints go through the SSRF-guarded fetch (DNS-resolve + IP-pin + redirect re-validation);
   // a local/trusted endpoint (e.g. on-cluster Ollama, private address) uses a plain fetch, which the guard
   // would rightly reject. Mirrors the vision/STT provider split (SSRF follow-up part 2).

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -214,7 +214,10 @@ function repairContent(draft: string, evidence: string, issues?: string[]): stri
 export async function repairMarkdownExternal(
   opts: { baseUrl: string; model: string; apiKey?: string; draft: string; evidence: string; issues?: string[]; timeoutMs?: number },
 ): Promise<VlmTranscription> {
-  const url = `${opts.baseUrl.replace(/\/$/, '')}/v1/chat/completions`;
+  // The same builder the local path uses. This function is the one `normalizeOpenAiBase` was written for —
+  // its comment names it — and it went on appending `/v1/chat/completions` itself, so the assist slot
+  // required a base WITHOUT `/v1` while vision required one WITH it. Both accept either now.
+  const url = chatUrlFor('openai', opts.baseUrl);
   let res: Response;
   try {
     res = await ssrfSafeFetch(url, {

--- a/server/src/files/converters/vlm-endpoint.ts
+++ b/server/src/files/converters/vlm-endpoint.ts
@@ -70,6 +70,25 @@ export function normalizeOpenAiBase(baseUrl: string): string {
   return /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
 }
 
+/**
+ * ## Every OpenAI route is spelled HERE, once
+ *
+ * The four builders below are the only places an OpenAI-compatible route path appears in the server, and
+ * a test enumerates the route literals to keep it that way. That is not tidiness — five slots had been
+ * deriving their URLs independently and had arrived at three incompatible rules for the same server:
+ *
+ *   - vision appended `/chat/completions`, so its base HAD to carry `/v1`;
+ *   - the assist model appended `/v1/chat/completions` and text embedding appended `/v1/embeddings`, so
+ *     theirs had to NOT carry it;
+ *   - the probe normalised, so it agreed with whichever half happened to match.
+ *
+ * An operator running one server for several slots therefore had no spelling that satisfied them all —
+ * exactly the configuration a reporter had to invent, with two base URLs for one host. Worse, the probe's
+ * agreement is what makes it dangerous rather than merely annoying: the dot goes green off a normalised
+ * `/v1/models` while inference 404s on `/v1/v1/embeddings`, and the failure surfaces as recall that
+ * silently returns nothing.
+ */
+
 /** The path a chat completion is POSTed to, for each wire. */
 export function chatUrlFor(wire: VlmWire, baseUrl: string): string {
   return wire === 'ollama'
@@ -83,6 +102,16 @@ export function listUrlFor(wire: VlmWire, baseUrl: string): string {
   return wire === 'ollama'
     ? `${baseUrl.replace(/\/+$/, '')}/api/tags`
     : `${normalizeOpenAiBase(baseUrl)}/models`;
+}
+
+/** Where text embeddings are POSTed. OpenAI-compatible only — the bundled model is in-process. */
+export function embeddingsUrlFor(baseUrl: string): string {
+  return `${normalizeOpenAiBase(baseUrl)}/embeddings`;
+}
+
+/** Where audio is POSTed for transcription. Whisper webservices and the OpenAI API share this route. */
+export function transcriptionsUrlFor(baseUrl: string): string {
+  return `${normalizeOpenAiBase(baseUrl)}/audio/transcriptions`;
 }
 
 /**

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -17,7 +17,7 @@ import { log } from '../../util/log.js';
 import { ssrfSafeFetch } from '../../util/ssrf.js';
 import { allowPrivateForSlot, type EgressSlot } from '../../config/model-egress-policy.js';
 import { extForMimeType, isInformativeMimeType, sniffImageMimeType } from '../mime.js';
-import { normalizeOpenAiBase } from '../converters/vlm-endpoint.js';
+import { chatUrlFor, transcriptionsUrlFor } from '../converters/vlm-endpoint.js';
 
 /**
  * Runtime egress guard. **External** (operator-supplied, public) provider endpoints go through
@@ -121,7 +121,9 @@ export class OllamaVisionProvider implements VisionProvider {
   async caption(imageBytes: Buffer, _mimeType: string): Promise<string> {
     const base = (this.cfg.baseUrl ?? 'http://ollama.ythril.svc.cluster.local:11434').replace(/\/$/, '');
     const model = this.cfg.model ?? 'moondream';  // `moondream2` is not a valid Ollama registry name
-    const url = `${base}/api/chat`;
+    // Same builder as every other slot, on the Ollama wire. Nothing was wrong with this one — it is here
+    // so the rule has no exceptions to remember: a slot names its wire, not its route.
+    const url = chatUrlFor('ollama', base);
     const b64 = imageBytes.toString('base64');
 
     let res: Response;
@@ -172,7 +174,10 @@ export class ExternalVisionProvider implements VisionProvider {
   async caption(imageBytes: Buffer, mimeType: string): Promise<string> {
     const base = (this.cfg.baseUrl ?? 'https://api.openai.com/v1').replace(/\/$/, '');
     const model = this.cfg.model ?? 'gpt-4o-mini';
-    const url = `${base}/chat/completions`;
+    // Normalised: this appended `/chat/completions` bare, so vision was the one slot whose base HAD to
+    // carry `/v1` — while the assist model and text embedding appended it themselves and so required the
+    // opposite. One server, two base URLs, and a reporter configuring exactly that to keep both working.
+    const url = chatUrlFor('openai', base);
     const b64 = imageBytes.toString('base64');
     // A data URI must carry a real media type. `data:application/octet-stream;base64,…` is what a
     // strict OpenAI-compatible server (llama.cpp's llama-server among them) rejects outright:
@@ -245,10 +250,8 @@ export class WhisperProvider implements SttProvider {
     // Normalised, not concatenated. `${base}/v1/audio/transcriptions` is correct for a bare host and wrong
     // for the documented OpenAI base — `https://api.openai.com/v1` became `/v1/v1/audio/transcriptions`
     // and 404'd, while the list probe normalises and reported the endpoint fine. That is #562's
-    // probe-disagrees-with-inference defect, still live in this slot: every other OpenAI-compatible caller
-    // was moved onto `normalizeOpenAiBase` and the transcription URL was not. One base URL now works for
-    // the vision, assist and speech slots at once, which is what an operator configuring one server expects.
-    const url = `${normalizeOpenAiBase(base)}/audio/transcriptions`;
+    // probe-disagrees-with-inference defect; the route now comes from the one module that spells it.
+    const url = transcriptionsUrlFor(base);
 
     // Build multipart/form-data using FormData.
     //

--- a/testing/standalone/openai-base-one-rule.test.js
+++ b/testing/standalone/openai-base-one-rule.test.js
@@ -1,0 +1,138 @@
+/**
+ * One base URL, every OpenAI-compatible slot.
+ *
+ * ## What was wrong
+ *
+ * Five slots derived their own request URL from the operator's base, and had arrived at three
+ * incompatible rules for the same server:
+ *
+ *     vision            ${base}/chat/completions          -> base MUST carry /v1
+ *     assist model      ${base}/v1/chat/completions       -> base must NOT carry /v1
+ *     text embedding    ${base}/v1/embeddings             -> base must NOT carry /v1
+ *     speech-to-text    ${base}/v1/audio/transcriptions   -> base must NOT carry /v1   (fixed in #588)
+ *     the probe         normalizeOpenAiBase(base)/models  -> either
+ *
+ * So an operator running one server for several slots had no spelling that satisfied them all, which is
+ * the configuration a reporter had to invent: two base URLs for one host, to keep vision and assist
+ * working at the same time.
+ *
+ * The probe is what makes this dangerous rather than merely annoying. It normalises, so it agrees with
+ * whichever half happens to match: the Models card goes green off `/v1/models` while every embed 404s on
+ * `/v1/v1/embeddings` — and a failing embedder does not announce itself, it surfaces as recall returning
+ * nothing.
+ *
+ * ## What this pins
+ *
+ * The route paths are spelled in ONE module, every builder normalises, and no other file in the server
+ * re-spells a route. The last part is the one that matters: the fix has now been applied slot-by-slot
+ * three times (#562 vision, #588 speech, this one for assist and embedding), each time because a new
+ * caller concatenated its own path.
+ *
+ * Run: node --test testing/standalone/openai-base-one-rule.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
+
+const ROUTES_SRC = 'server/src/files/converters/vlm-endpoint.ts';
+
+const {
+  normalizeOpenAiBase, chatUrlFor, listUrlFor, embeddingsUrlFor, transcriptionsUrlFor,
+} = await import('../../server/dist/files/converters/vlm-endpoint.js');
+
+/** Strip comments — a route path quoted in prose is documentation, not a second derivation. */
+const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('every OpenAI route builder normalises the base', () => {
+  // The three spellings an operator plausibly types. `…/v1` is the documented OpenAI form and what the
+  // vision and assist cards' own placeholder text shows.
+  const spellings = ['http://srv:8080', 'http://srv:8080/v1', 'http://srv:8080/v1/'];
+
+  for (const [name, build, expected] of [
+    ['chatUrlFor', b => chatUrlFor('openai', b), 'http://srv:8080/v1/chat/completions'],
+    ['listUrlFor', b => listUrlFor('openai', b), 'http://srv:8080/v1/models'],
+    ['embeddingsUrlFor', embeddingsUrlFor, 'http://srv:8080/v1/embeddings'],
+    ['transcriptionsUrlFor', transcriptionsUrlFor, 'http://srv:8080/v1/audio/transcriptions'],
+  ]) {
+    it(`${name} lands on one place for every spelling of the base`, () => {
+      for (const s of spellings) {
+        assert.equal(build(s), expected, `spelling: ${s}`);
+      }
+    });
+  }
+
+  it('never produces /v1/v1, which is the 404 every one of these bugs produced', () => {
+    for (const s of spellings) {
+      for (const url of [chatUrlFor('openai', s), listUrlFor('openai', s), embeddingsUrlFor(s), transcriptionsUrlFor(s)]) {
+        assert.ok(!url.includes('/v1/v1'), url);
+      }
+    }
+  });
+
+  it('leaves the Ollama wire alone — its routes live under /api, with no /v1 anywhere', () => {
+    assert.equal(chatUrlFor('ollama', 'http://ollama:11434'), 'http://ollama:11434/api/chat');
+    assert.equal(listUrlFor('ollama', 'http://ollama:11434/'), 'http://ollama:11434/api/tags');
+  });
+
+  it('normalizeOpenAiBase is idempotent — running it twice cannot add a second /v1', () => {
+    const once = normalizeOpenAiBase('http://srv:8080');
+    assert.equal(normalizeOpenAiBase(once), once);
+  });
+});
+
+describe('no other file re-spells a route', () => {
+  /**
+   * The routes are read OUT of the module that owns them rather than listed here.
+   *
+   * A hand-listed set is what let this recur: each fix covered the paths someone remembered. Enumerating
+   * from the source means a fifth route added to `vlm-endpoint.ts` tomorrow is covered by this gate the
+   * moment it exists.
+   */
+  const routes = [...new Set(
+    [...strip(readFileSync(ROUTES_SRC, 'utf8')).matchAll(/`\$\{[^`]*?\}(\/[a-z0-9/-]+)`/g)].map(m => m[1]),
+  )]
+    // `/v1` is the version prefix `normalizeOpenAiBase` appends, not a route. Left in, it would flag the
+    // normaliser's own callers — and `/v1/rerank`, where the prefix is part of a deliberate dialect signal.
+    .filter(r => r !== '/v1');
+
+  it('the route table was actually found', () => {
+    // If the regex stops matching, every assertion below passes vacuously — which is how a gate becomes
+    // decoration. Assert the shape of what was enumerated, not just that it is non-empty.
+    assert.ok(routes.length >= 4, `expected at least 4 route paths, enumerated ${routes.length}: ${routes}`);
+    for (const r of ['/chat/completions', '/models', '/embeddings', '/audio/transcriptions']) {
+      assert.ok(routes.includes(r), `${r} should have been enumerated from ${ROUTES_SRC}: got ${routes}`);
+    }
+  });
+
+  /**
+   * `rerank-client.ts` is the one file allowed to spell `/v1/rerank`, and the reason is factual rather
+   * than historical: two incompatible rerank dialects are in wide use, and there the operator's URL
+   * DECLARES which one — `…/rerank` is read as TEI, `…/v1/rerank` as Cohere, a bare host gets
+   * `/v1/rerank` appended. It already handles the path being present, so it cannot double it. Normalising
+   * that URL would erase the signal the dialect choice depends on.
+   */
+  const EXEMPT = new Map([['server/src/brain/rerank-client.ts', '/rerank']]);
+
+  it('every OpenAI route path in the server comes from the one module', () => {
+    const files = globSync('server/src/**/*.ts').filter(f => !f.replace(/\\/g, '/').endsWith(ROUTES_SRC));
+    const offenders = [];
+    for (const file of files) {
+      const rel = file.replace(/\\/g, '/');
+      const src = strip(readFileSync(file, 'utf8'));
+      for (const route of routes) {
+        if (EXEMPT.get(rel) === route) continue;
+        // A route appended directly to an interpolated base. The optional `/v1` is not optional
+        // decoration: the first version of this gate matched `}${route}` only, so it caught the vision
+        // shape (`${base}/chat/completions`) and MISSED both shapes it was written for
+        // (`${base}/v1/embeddings`, `${base}/v1/chat/completions`) — passing vacuously on the exact code
+        // that prompted it. Mutation-checked in both spellings since.
+        if (new RegExp(`\\}(?:/v1)?${route.replace(/\//g, '\\/')}`).test(src)) {
+          offenders.push(`${rel} builds ${route} itself`);
+        }
+      }
+    }
+    assert.deepEqual(offenders, [],
+      `derive these from vlm-endpoint.ts (chatUrlFor / listUrlFor / embeddingsUrlFor / transcriptionsUrlFor):\n${offenders.join('\n')}`);
+  });
+});


### PR DESCRIPTION
Found sweeping the slot that #588 fixed — and the sweep is the point. This is the **third** slot-by-slot
repair of the same defect (#562 vision, #588 speech-to-text, this one for assist and embedding), because
each fix covered the paths somebody remembered.

## Five slots, three incompatible rules, one server

```text
vision            ${base}/chat/completions          base MUST carry /v1
assist model      ${base}/v1/chat/completions       base must NOT carry /v1
text embedding    ${base}/v1/embeddings             base must NOT carry /v1
speech-to-text    ${base}/v1/audio/transcriptions   base must NOT carry /v1   (fixed in #588)
the probe         normalizeOpenAiBase(base)/models  either
```

An operator pointing several slots at one OpenAI-compatible server had **no spelling that satisfied them
all** — which is the configuration a reporter had already invented for themselves: two base URLs for one
host, to keep vision and assist working simultaneously. `normalizeOpenAiBase`'s own comment names
`repairMarkdownExternal` as the reason it exists; that function then went on appending its own path.

**Why this is dangerous rather than annoying.** The probe normalises, so it agrees with whichever half
happens to match. The Models card goes green off `/v1/models` while every embed 404s on
`/v1/v1/embeddings` — and a failing embedder does not announce itself. It surfaces as recall that quietly
returns nothing, on an instance whose health screen is entirely green.

## The fix

Route paths are spelled in **one module** — `chatUrlFor`, `listUrlFor`, `embeddingsUrlFor`,
`transcriptionsUrlFor` — and every builder normalises. `…:8080` and `…:8080/v1` both work in every slot.

The local Ollama vision provider moved onto the same builder even though nothing was wrong with it, so the
rule has no exceptions to remember: **a slot names its wire, not its route.**

Kept in `files/converters/vlm-endpoint.ts` rather than moved to a new module: `vlm-endpoint-egress.test.js`
scans that file's source as a security gate, and `brain/` already imports from `files/` in two places. The
correctness of the URL rule is the deliverable; a file move would be unrelated risk in the same PR.

## The gate, and the hole it had

`openai-base-one-rule.test.js` enumerates the route literals **out of the owning module** and fails if any
other file re-derives one. Enumerated rather than listed, because a hand-listed set is how this recurred
three times.

**Mutation-checked, and it mattered.** The first version matched `}${route}` only — so it caught the vision
shape (`${base}/chat/completions`) and **missed both shapes it was written for**
(`${base}/v1/embeddings`, `${base}/v1/chat/completions`). It would have passed vacuously on the exact code
that prompted it. The regex now allows the optional `/v1`, and both spellings were verified to fail the
gate.

It also earned its keep during development: it caught `${base}/api/chat` in the local vision provider, which
I had not planned to touch.

**Exemption:** `rerank-client.ts` may spell `/v1/rerank`. The reason is factual, not historical — two
incompatible rerank dialects are in wide use and there the operator's URL *declares* which one
(`…/rerank` = TEI, `…/v1/rerank` = Cohere, bare host gets `/v1/rerank`). It already handles the path being
present, so it cannot double it, and normalising would erase the signal the dialect choice depends on.

Docs: the `vision.baseUrl`, `embedding.baseUrl` and assist `baseUrl` rows now say both spellings work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
