### PR TITLE
fix(files): the converted document's description was a truncation, not generated prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A converted document's "description" was a truncation, not the generated prose the release note
+  promised.** It was the head of the converted text — on a real invoice, a payment reference cut
+  mid-identifier — while the images extracted from the same document carried full generated captions. The
+  parent record read as unfinished beside its own children. Reported by the canary.
+  - **The description is now written by the model that already reads these files**, answering *what is this
+    file?* — kind of document, parties, date, subject. Local document model, or the assist model when its
+    egress host is acknowledged; neither receives anything it would not already get on the repair pass, and
+    the acknowledgment is re-checked at call time rather than trusted from save time.
+  - **The document's own opening text is kept as `excerpt`** and stays an embedding input. That matters more
+    than it sounds: the extractive text *was* the description, so generating one would have quietly removed
+    the document's own words from what recall matches — a phrase you remember from inside a file would stop
+    finding it.
+  - **`descriptionSource` says which one an instance produced** (`generated` / `extracted`), because that is
+    a claim about provenance and the release note had already made it wrongly once. An instance with no
+    model configured gets the extractive text, which beats nothing — it just is not called generated. A
+    description a person writes clears the label, and the Files detail pane shows it beside the heading.
+    Image captions are labelled too; they always were model output.
+  - A model answer is cleaned up and sanity-checked before it is stored: quotes, `Description:` labels and
+    Markdown scaffolding are stripped, and a refusal or a preamble is rejected in favour of the extractive
+    text rather than stored as if it were content.
+
 - **One server, three incompatible base URLs.** Five model slots each derived their own request URL, and
   they disagreed: vision appended `/chat/completions`, so its base *had* to carry `/v1`; the assist model
   appended `/v1/chat/completions` and text embedding appended `/v1/embeddings`, so theirs had to *not*

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -587,6 +587,14 @@
   "files.detail.previewTab": "Vorschau & Beschreibung",
   "files.detail.metaTab": "Datei-Metadaten",
   "files.detail.description": "Beschreibung",
+
+  "files.detail.descriptionSource.generated": "generiert",
+
+  "files.detail.descriptionSource.generatedHint": "Vom konfigurierten Dokumentmodell aus dem Text der Datei geschrieben. Nicht von einer Person geprüft.",
+
+  "files.detail.descriptionSource.extracted": "aus dem Dokument",
+
+  "files.detail.descriptionSource.extractedHint": "Der Anfang des Dokumenttexts, wörtlich übernommen — es war kein Modell für Beschreibungen konfiguriert.",
   "files.detail.metaSaved": "Metadaten gespeichert.",
   "files.detail.retryQueued": "Neu-Einbettung eingereiht.",
   "files.detail.retryFailed": "Wiederholung fehlgeschlagen:",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -587,6 +587,14 @@
   "files.detail.previewTab": "Preview & description",
   "files.detail.metaTab": "File meta",
   "files.detail.description": "Description",
+
+  "files.detail.descriptionSource.generated": "generated",
+
+  "files.detail.descriptionSource.generatedHint": "Written by the model configured for documents, from the file's own text. It has not been checked by a person.",
+
+  "files.detail.descriptionSource.extracted": "from the document",
+
+  "files.detail.descriptionSource.extractedHint": "The opening of the document's own text, taken verbatim — no model was configured to write a description.",
   "files.detail.metaSaved": "Metadata saved.",
   "files.detail.retryQueued": "Re-embedding queued.",
   "files.detail.retryFailed": "Retry failed:",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -587,6 +587,14 @@
   "files.detail.previewTab": "Podgląd i opis",
   "files.detail.metaTab": "Metadane pliku",
   "files.detail.description": "Opis",
+
+  "files.detail.descriptionSource.generated": "wygenerowany",
+
+  "files.detail.descriptionSource.generatedHint": "Napisany przez model skonfigurowany dla dokumentów, na podstawie tekstu pliku. Nie został sprawdzony przez człowieka.",
+
+  "files.detail.descriptionSource.extracted": "z dokumentu",
+
+  "files.detail.descriptionSource.extractedHint": "Początek tekstu dokumentu, przepisany dosłownie — nie skonfigurowano modelu do pisania opisów.",
   "files.detail.metaSaved": "Zapisano metadane.",
   "files.detail.retryQueued": "Ponowne osadzanie w kolejce.",
   "files.detail.retryFailed": "Ponowna próba nie powiodła się:",

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -371,6 +371,10 @@ export interface FileMeta {
   spaceId: string;
   path: string;
   description?: string;
+  /** Where an instance-written `description` came from. Absent when a person wrote it. */
+  descriptionSource?: 'generated' | 'extracted';
+  /** A converted document's own opening prose — kept whatever the description says, and embedded. */
+  excerpt?: string;
   tags: string[];
   entityIds?: string[];
   chronoIds?: string[];

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -336,6 +336,10 @@ function xlsxCellText(v: unknown): string {
     .detail-desc { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }
     .detail-desc h4 { margin: 0 0 6px; font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-muted); }
     .detail-desc p { margin: 0; white-space: pre-wrap; word-break: break-word; line-height: 1.5; }
+    /* Provenance sits inside the heading, quieter than it: it qualifies the description rather than
+       announcing itself. Lower-case against the upper-case heading so it reads as an aside. */
+    .detail-desc .desc-src { margin-left: 8px; padding: 1px 6px; border: 1px solid var(--border); border-radius: 10px;
+      font-size: 0.92em; text-transform: none; letter-spacing: 0; color: var(--text-muted); cursor: help; }
     .detail-meta-form .field { margin-bottom: 12px; }
     .detail-meta-form label { display: block; margin-bottom: 4px; font-size: 0.8em; color: var(--text-muted); }
     .detail-meta-form textarea { width: 100%; resize: vertical; }
@@ -697,7 +701,15 @@ function xlsxCellText(v: unknown): string {
                   </div>
                   @if (selectedMeta()?.description) {
                     <div class="detail-desc">
-                      <h4>{{ 'files.detail.description' | transloco }}</h4>
+                      <h4>
+                        {{ 'files.detail.description' | transloco }}
+                        <!-- Whose words these are. The release note said "generated" while the value was
+                             the head of the document's own text, and nothing on screen could tell them
+                             apart; a description a person typed carries no badge at all. -->
+                        @if (selectedMeta()!.descriptionSource; as src) {
+                          <span class="desc-src" [attr.title]="'files.detail.descriptionSource.' + src + 'Hint' | transloco">{{ 'files.detail.descriptionSource.' + src | transloco }}</span>
+                        }
+                      </h4>
                       <p>{{ selectedMeta()!.description }}</p>
                     </div>
                   }

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -241,6 +241,28 @@ retries are exhausted). Once complete, the record carries `chunkCount` and (for 
 `convertedFileId`, and the chunk records are recall-searchable. To see the chunks themselves, pass
 `?includeChunks=true` — they are hidden by default (see below).
 
+**The parent record also gains a description**, so the file a person actually opens is findable by more
+than its name:
+
+| field | what it is |
+|---|---|
+| `description` | one short paragraph answering *what is this file?* — kind of document, parties, date, subject |
+| `descriptionSource` | `generated` when a model wrote it, `extracted` when it is the opening of the document's own text. **Absent** when a person wrote the description themselves |
+| `excerpt` | the document's own opening prose, verbatim. Present whatever `descriptionSource` says, and an embedding input in its own right |
+
+> **Why both.** The description answers what the file *is*; the excerpt is what makes a phrase a reader
+> remembers *from the document* find the parent record. The description used to be the excerpt — the head
+> of the converted text — which on an invoice is a payment reference cut mid-identifier.
+>
+> **`generated` is a claim, so it is recorded rather than assumed.** An instance with no document model
+> configured produces the extractive text and says `extracted`; it is better than nothing, and it is not
+> generated. A `PATCH` that sets `description` without declaring a source clears the field, because the
+> words are then the caller's own.
+>
+> The text is sent to the local document model, or to the assist model **only when its egress host is
+> acknowledged** — the same gate the repair pass applies, re-checked at call time. Neither slot receives
+> anything it would not already receive on the repair path.
+
 **While a file is in flight the record also carries step progress**, so a caller can report *which
 stage* is running rather than just that something is:
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -350,6 +350,20 @@ Clicking a file opens a **docked detail pane** to the right of the list (the lis
 
   A **full-screen** button (top-right of the preview) expands the preview to fill the window; **Escape** or its close button collapses it back to the docked pane.
 
+  **Where the description came from.** For an uploaded document Ythril writes one itself, and labels it so
+  you know whose words you are reading:
+
+  - **generated** — the model configured for documents answered *what is this file?* from the file's own
+    text. Nobody has checked it, which is what the label is for.
+  - **from the document** — the opening of the document's own text, taken verbatim. This is what an
+    instance with no document model configured produces.
+  - **no label** — a person wrote it. Editing the description on the **File meta** side removes any label,
+    because the words become yours.
+
+  The document's own opening text is kept either way and is searchable, so a phrase you remember from
+  inside a file still finds it — even when the description is a generated summary that does not contain
+  that phrase.
+
 - **File meta** *(in the Brain)* — the editable metadata record: **description**, **tags**, and links to **entities**, **memories** and **chrono** entries, plus a **Retry** action to re-queue embedding for a failed or partial file. This is where the former *File Meta* tab's editing now lives. (On the standalone Files page, outside the Brain, the pane shows preview + description only.)
 
 Press **Escape** or the close button to dismiss the pane. Use arrow keys to move to the previous or next file in the directory.

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -504,7 +504,9 @@ searchRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth,
                       .toArray() as Array<{ name: string }>
                   : [];
                 const entityNames = entityDocs.map(e => e.name);
-                const result = await embed(fileEmbedText(doc.path, doc.tags ?? [], doc.description, doc.properties, entityNames));
+                // `excerpt` included, or a reindex would silently re-embed every converted document
+                // without the document's own text — dropping exactly the phrases a reader searches for.
+                const result = await embed(fileEmbedText(doc.path, doc.tags ?? [], doc.description, doc.properties, entityNames, doc.excerpt));
                 await col<FileMetaDoc>(`${mid}_files`).updateOne(
                   { _id: doc._id },
                   { $set: { embedding: result.vector, embeddingModel: result.model } },

--- a/server/src/brain/embed-text.ts
+++ b/server/src/brain/embed-text.ts
@@ -110,6 +110,16 @@ export function fileEmbedText(
   description?: string,
   properties?: Record<string, string | number | boolean>,
   entityNames: string[] = [],
+  /**
+   * A converted document's own opening prose, when it has one.
+   *
+   * Appended rather than replacing the description because the two answer different questions. Once
+   * `description` became generated prose, a search for a phrase the reader remembers *from the document*
+   * had nothing to match on the parent record — the extractive text used to be the description, and
+   * generating one would have quietly removed it from the embedding. Last, so the fields that identify
+   * the record still lead.
+   */
+  excerpt?: string,
 ): string {
   const parts: string[] = [filePath];
   if (entityNames.length > 0) parts.push(entityNames.join(' '));
@@ -119,5 +129,10 @@ export function fileEmbedText(
     const vals = Object.values(properties).map(v => String(v)).filter(v => v.trim());
     if (vals.length > 0) parts.push(vals.join(' '));
   }
+  // Skipped when it merely repeats the description — which is exactly the case on an instance with no
+  // model configured, where the extractive text IS the description. Embedding it twice would weight one
+  // paragraph of one record against everything else in the space.
+  const trimmedExcerpt = excerpt?.trim();
+  if (trimmedExcerpt && trimmedExcerpt !== description?.trim()) parts.push(trimmedExcerpt);
   return parts.join(' ');
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1457,6 +1457,25 @@ export interface FileMetaDoc {
   spaceId: string;
   path: string;         // same as _id — carried as a queryable field
   description?: string; // human-readable summary (optional)
+  /**
+   * Where `description` came from, when the instance wrote it rather than a person.
+   *
+   * `generated` = a model answered "what is this file?"; `extracted` = the document's own opening prose,
+   * taken verbatim, which is what an instance with no model configured produces. Absent for a description
+   * a human wrote, and for records written before the field existed.
+   *
+   * It exists because "generated" is a claim about provenance: the release note said generated while the
+   * value was a truncation of the first paragraph, and nothing in the record could tell the two apart.
+   */
+  descriptionSource?: 'generated' | 'extracted';
+  /**
+   * The document's own opening prose — never invented, and an embedding input in its own right.
+   *
+   * Kept alongside a generated `description` because the two are wanted for different things: the
+   * description answers what the file IS, the excerpt is what makes a remembered phrase from the document
+   * find the parent record. Only present on converted documents.
+   */
+  excerpt?: string;
   tags: string[];       // tags for filtering and recall scoping
   entityIds?: string[];  // linked entity IDs
   chronoIds?: string[];  // linked chrono entry IDs

--- a/server/src/files/converters/describe.ts
+++ b/server/src/files/converters/describe.ts
@@ -1,0 +1,166 @@
+/**
+ * The converted document's description — generated prose, with the document's own words as the fallback.
+ *
+ * ## What was wrong
+ *
+ * `summariseMarkdown` (which this wraps) is **extractive**: it takes the head of the converted text. That
+ * was the right first move — it made the parent record findable, where before its `matchedText` was
+ * literally the filename — but on a real invoice the head of the text is a payment reference cut
+ * mid-identifier, and the release note called the field *generated*. The images the same document produced
+ * DO get generated captions, so the parent read as unfinished sitting beside its own children.
+ *
+ * ## What changed, and what deliberately did not
+ *
+ * `summariseMarkdown`'s own doc comment argues against generation, and the argument still holds: a
+ * generated description can assert something the document does not say, and search will match it while a
+ * reader believes it. So the extractive text does not go away — it is kept as the record's `excerpt`, which
+ * is what feeds the embedding. The two fields want different things:
+ *
+ *   - `description`   — one short generated paragraph answering *what is this file?*
+ *   - `excerpt`       — the document's own opening prose, never invented, always present
+ *   - `matchedText`   — built from both, so recall matches a remembered phrase AND the semantics
+ *
+ * And because "generated" is a claim about provenance, the record says which one it got:
+ * `descriptionSource: 'generated' | 'extracted'`. An instance with no model configured produces the
+ * extractive text — which beats nothing — and must not call it generated.
+ *
+ * ## Egress
+ *
+ * Text goes to the local document model, or to the operator's assist model **only when its egress host is
+ * acknowledged** — the same gate `vlm-extract` re-checks before routing a repair, re-checked here rather
+ * than trusted, so a description can never become the thing that leaks a document. Both slots already
+ * receive document text on the repair path; this adds no new egress surface.
+ */
+
+import { getDocumentProcessingConfig, getDocAssistApiKey } from '../../config/loader.js';
+import { log } from '../../util/log.js';
+import { describeDocumentText } from './vlm-client.js';
+import { resolveVlmEndpoint, vlmSlotUsable } from './vlm-endpoint.js';
+import { summariseMarkdown } from './summarise.js';
+import type { Chunk } from './types.js';
+
+/** Where a description came from. `extracted` is the document's own opening text, taken verbatim. */
+export type DescriptionSource = 'generated' | 'extracted';
+
+export interface DocumentDescription {
+  /** Absent when the document yielded nothing worth saying — better than a misleading sentence. */
+  text?: string;
+  source?: DescriptionSource;
+  /** The document's own opening prose. Present whenever the text yielded any, whatever `source` says. */
+  excerpt?: string;
+}
+
+/**
+ * How much of the document the model is shown.
+ *
+ * The head, because that is where identity lives — letterhead, title, parties, date, subject line. Sending
+ * the whole document would cost tokens on every upload to answer a question the first page answers, and on
+ * a metered assist model it would cost money per page nobody reads.
+ */
+const MAX_INPUT_CHARS = 6_000;
+
+/** Long enough for two real sentences, short enough that a rambling model cannot fill the card. */
+const MAX_DESCRIPTION_CHARS = 400;
+
+/** A tight budget: this is on the ingest path, and the extractive fallback is always available. */
+const DESCRIBE_TIMEOUT_MS = 30_000;
+
+/**
+ * Openings that mean the model answered the wrong question.
+ *
+ * A refusal or a preamble stored as a description is worse than the extractive text, because it reads as
+ * content. Matched at the START only — a document that genuinely discusses an AI assistant must not be
+ * refused its description.
+ */
+const NON_ANSWER = /^(?:i'?m sorry|i cannot|i can'?t|as an ai|here'?s|here is|certainly|of course|okay|understood|sure)(?=[\s,!.:;]|$)/i;
+
+/**
+ * Clean up what a chat model returns so it can be stored as prose.
+ *
+ * Models wrap answers in quotes, prefix them with `Description:`, or emit a Markdown heading despite being
+ * told not to. Returns undefined when nothing usable survives — the caller then keeps the extractive text.
+ */
+export function sanitiseDescription(raw: string): string | undefined {
+  let s = (raw ?? '')
+    .replace(/^\s*```[a-z]*\s*/i, '').replace(/```\s*$/, '')   // fenced block
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')                        // heading markers
+    .replace(/^\s*(description|summary)\s*:\s*/i, '')          // label the prompt asked it not to write
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^["'“”'']+|["'“”'']+$/g, '')                     // wrapping quotes
+    .trim();
+  if (!s) return undefined;
+  if (NON_ANSWER.test(s)) return undefined;
+  // No letters means no sentence — a model that answered with punctuation or an empty list.
+  if (!/[a-zA-Z]/.test(s)) return undefined;
+  if (s.length > MAX_DESCRIPTION_CHARS) {
+    const cut = s.slice(0, MAX_DESCRIPTION_CHARS);
+    const lastStop = Math.max(cut.lastIndexOf('. '), cut.lastIndexOf('! '), cut.lastIndexOf('? '));
+    // Prefer ending on a sentence; failing that a word. A description ending mid-word looks like corruption.
+    s = lastStop > MAX_DESCRIPTION_CHARS * 0.5
+      ? cut.slice(0, lastStop + 1)
+      : `${cut.slice(0, cut.lastIndexOf(' ')).trimEnd()}…`;
+  }
+  return s;
+}
+
+/**
+ * The endpoint a description may be sent to, or null when there is none.
+ *
+ * Exported because "which host, and was it acknowledged" is the whole security-relevant decision here, and
+ * it is worth testing on its own rather than only through a call that needs a live model.
+ */
+export function describeTarget(): { baseUrl: string; model: string; wire?: 'ollama' | 'openai'; external?: boolean; apiKey?: string; slot: 'docRepair' | 'assist' } | null {
+  const cfg = getDocumentProcessingConfig();
+  const assist = cfg.assistModel;
+  if (assist?.baseUrl && assist.model) {
+    // The ACK is the gate, re-checked here rather than trusted from save time — the same rule the repair
+    // path applies, for the same reason: config.json could have been hand-edited.
+    let acknowledged = false;
+    try { acknowledged = assist.acknowledgedHost === new URL(assist.baseUrl).host; } catch { acknowledged = false; }
+    if (acknowledged) {
+      return { baseUrl: assist.baseUrl, model: assist.model, wire: 'openai', external: true, apiKey: getDocAssistApiKey(), slot: 'assist' };
+    }
+    log.debug('Describe: an assist model is configured but its egress host is not acknowledged — using the local document model');
+  }
+  const local = resolveVlmEndpoint('repair');
+  if (!vlmSlotUsable(local)) return null;
+  return { ...local, slot: 'docRepair' };
+}
+
+/**
+ * Describe a converted document: generated prose when a model is available, its own opening text otherwise.
+ *
+ * Never throws. A description is a nicety on the ingest path — a model that is down, slow or babbling must
+ * degrade to the extractive text, not fail the upload.
+ */
+export async function describeDocument(
+  markdown: string | null,
+  chunks: Chunk[] = [],
+): Promise<DocumentDescription> {
+  const excerpt = summariseMarkdown(markdown, chunks);
+  const body = (markdown && markdown.trim())
+    ? markdown
+    : chunks.map(c => [c.headingText, c.content].filter(Boolean).join('. ')).join('\n\n');
+  if (!body.trim()) return {};
+
+  const target = describeTarget();
+  if (!target) {
+    // No model anywhere. The extractive head beats nothing — it just must not be called generated.
+    return excerpt ? { text: excerpt, source: 'extracted', excerpt } : {};
+  }
+
+  try {
+    const r = await describeDocumentText({
+      ...target,
+      text: body.slice(0, MAX_INPUT_CHARS),
+      timeoutMs: DESCRIBE_TIMEOUT_MS,
+    });
+    const text = sanitiseDescription(r.text);
+    if (text) return { text, source: 'generated', excerpt };
+    log.debug('Describe: the model returned nothing usable — keeping the document\'s own opening text');
+  } catch (err) {
+    log.warn(`Describe: ${err instanceof Error ? err.message : String(err)} — keeping the document's own opening text`);
+  }
+  return excerpt ? { text: excerpt, source: 'extracted', excerpt } : { excerpt };
+}

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -199,6 +199,33 @@ export async function reconcileConsensus(
   );
 }
 
+const DESCRIBE_PROMPT =
+  'You are writing a one-paragraph description of a document, for a file listing. Say what KIND of ' +
+  'document it is, who it is between or from, its date if one is stated, and what it concerns. Two ' +
+  'sentences at most, plain prose, no Markdown, no heading, no preamble, no bullet points. Use ONLY facts ' +
+  'stated in the text below: if something is not there, leave it out — do not guess and do not describe ' +
+  'what the document might be. Answer with the description only.';
+
+/**
+ * Describe a document in one short paragraph — text-only, and the same call for either target.
+ *
+ * The slot is the caller's to choose because that is what decides the egress policy: the local document
+ * model (`docRepair`, the text-only document slot) or the operator's acknowledged assist model (`assist`).
+ * Both already receive document text on the repair path, so this adds no new egress surface — which is the
+ * reason it is one function taking a target rather than a local/external pair like `repairMarkdown*`.
+ *
+ * Throws on unreachable/HTTP error, like every other call here, so the caller falls back.
+ */
+export async function describeDocumentText(
+  opts: VlmTarget & { text: string; slot?: EgressSlot },
+): Promise<VlmTranscription> {
+  return postChat(
+    asEndpoint(opts, opts.slot ?? 'docRepair'),
+    [{ role: 'user', content: `${DESCRIBE_PROMPT}\n\n--- DOCUMENT ---\n${opts.text}` }],
+    opts.timeoutMs ?? 60_000,
+  );
+}
+
 /** Build the shared repair user-message content (draft + OCR evidence + flagged issues). */
 function repairContent(draft: string, evidence: string, issues?: string[]): string {
   const flagged = issues?.length ? `\n\nValidation flagged: ${issues.join('; ')}.` : '';

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -134,6 +134,10 @@ export async function updateFileMeta(
     chronoIds?: string[];
     memoryIds?: string[];
     properties?: Record<string, string | number | boolean>;
+    /** Provenance of an instance-written description. Omit when a human wrote it — see `FileMetaDoc`. */
+    descriptionSource?: 'generated' | 'extracted';
+    /** A converted document's own opening prose. Kept whatever the description says, and embedded. */
+    excerpt?: string;
   },
 ): Promise<FileMetaDoc | null> {
   const normalised = toDocId(filePath);
@@ -144,27 +148,40 @@ export async function updateFileMeta(
   const descForEmbed = opts.description !== undefined ? opts.description : existing.description;
   const tagsForEmbed = opts.tags !== undefined ? opts.tags : existing.tags;
   const propsForEmbed = opts.properties !== undefined ? opts.properties : existing.properties;
+  // Falls back to the stored value like every other embedding input: an unrelated edit — a tag, a link —
+  // re-embeds the record, and reading the excerpt only from `opts` would silently drop the document's own
+  // text out of the embedding on the first tag change after conversion.
+  const excerptForEmbed = opts.excerpt !== undefined ? opts.excerpt : existing.excerpt;
   // Use the incoming entityIds if being updated, otherwise fall back to existing
   const entityIdsForEmbed: string[] = opts.entityIds !== undefined ? opts.entityIds : (existing.entityIds ?? []);
   const entityNames = await resolveEntityNames(spaceId, entityIdsForEmbed);
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
   try {
-    const embedText = fileEmbedText(normalised, tagsForEmbed, descForEmbed, propsForEmbed, entityNames);
+    const embedText = fileEmbedText(normalised, tagsForEmbed, descForEmbed, propsForEmbed, entityNames, excerptForEmbed);
     const embResult = await embed(embedText);
     embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
   } catch { /* best-effort */ }
 
   const $set: Record<string, unknown> = { updatedAt: now, ...embeddingFields };
   if (opts.description !== undefined) $set['description'] = opts.description;
+  if (opts.descriptionSource !== undefined) $set['descriptionSource'] = opts.descriptionSource;
+  if (opts.excerpt !== undefined) $set['excerpt'] = opts.excerpt;
   if (opts.tags !== undefined) $set['tags'] = opts.tags;
   if (opts.entityIds !== undefined) $set['entityIds'] = opts.entityIds;
   if (opts.chronoIds !== undefined) $set['chronoIds'] = opts.chronoIds;
   if (opts.memoryIds !== undefined) $set['memoryIds'] = opts.memoryIds;
   if (opts.properties !== undefined) $set['properties'] = opts.properties;
 
+  // A description written WITHOUT declaring a source is a person's own words — the API and the UI edit
+  // it that way — so the old provenance has to go with it. Leaving a stale `generated` behind would have
+  // the record claim a model wrote what an operator just typed, which is the one thing this field exists
+  // to stop being ambiguous.
+  const $unset: Record<string, ''> = {};
+  if (opts.description !== undefined && opts.descriptionSource === undefined) $unset['descriptionSource'] = '';
+
   await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
     asFilter<FileMetaDoc>({ _id: normalised }),
-    asUpdate<FileMetaDoc>({ $set }),
+    asUpdate<FileMetaDoc>(Object.keys($unset).length > 0 ? { $set, $unset } : { $set }),
   );
 
   // Face recognition side-effects when entity links change.

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -45,7 +45,7 @@ import { col, asFilter } from '../../db/mongo.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { updateFileMeta, markFileMetaDeleted } from '../file-meta.js';
 import { mimeTypeForPath } from '../mime.js';
-import { summariseMarkdown } from '../converters/summarise.js';
+import { describeDocument } from '../converters/describe.js';
 import {
   runConversionPipeline,
   storeConversionResults,
@@ -312,6 +312,11 @@ async function processJob(
 
     // Run the appropriate embedder
     let derivedDescription: string | undefined;
+    // What produced `derivedDescription`, and the document's own opening prose when there is one. Both are
+    // written to the parent record: "generated" is a claim about provenance, and the extractive text is
+    // what keeps a phrase remembered FROM the document able to find the parent.
+    let derivedSource: 'generated' | 'extracted' | undefined;
+    let derivedExcerpt: string | undefined;
     // Final file embeddingStatus for a job that completes without retrying. Text
     // conversion may embed some chunks and fail others; a partial result is recorded
     // as 'partial' (not 'complete') so it stays visible and retry-eligible (B3).
@@ -319,6 +324,10 @@ async function processJob(
     switch (mediaType) {
       case 'image':
         derivedDescription = await embedImage(spaceId, fileId, fileBytes, mimeType, providers.vision);
+        // A caption IS model output, so the record says so. It was the reference point for the whole
+        // complaint — the images carried generated captions while the parent carried a truncation — and it
+        // had no provenance of its own either.
+        if (derivedDescription) derivedSource = 'generated';
         break;
       case 'audio': {
         // A chunk that failed to transcribe makes this PARTIAL, never complete. The count used to be
@@ -384,7 +393,15 @@ async function processJob(
           // when the operator has not written one, and re-embedded so it is searchable. Images set it;
           // documents never did. This is the same "the rule exists one branch over" shape as the audio
           // `partial` status.
-          derivedDescription = summariseMarkdown(convertedMarkdown, chunks);
+          //
+          // It was EXTRACTIVE — the head of the converted text — while the release note called it
+          // generated, and on an invoice the head of the text is a payment reference cut mid-identifier.
+          // `describeDocument` asks the model that already reads these files what the file IS, keeps the
+          // document's own opening prose as the excerpt either way, and reports which one it produced.
+          const described = await describeDocument(convertedMarkdown, chunks);
+          derivedDescription = described.text;
+          derivedSource = described.source;
+          derivedExcerpt = described.excerpt;
           await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
             asFilter<FileMetaDoc>({ _id: fileId }),
             { $set: metaUpdate },
@@ -408,16 +425,24 @@ async function processJob(
         throw new Error(`Unknown mediaType: ${String(mediaType)}`);
     }
 
-    // Write AI-generated caption to parent file meta description if not already set by user.
-    // This also re-embeds the parent file meta so the caption is searchable on the file itself.
-    if (derivedDescription) {
+    // Write the derived description to the parent file meta if the user has not set one.
+    // This also re-embeds the parent file meta so the description is searchable on the file itself.
+    if (derivedDescription || derivedExcerpt) {
       const parentMeta = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
         asFilter<FileMetaDoc>({ _id: fileId }),
         { projection: { description: 1 } },
       );
-      if (!parentMeta?.description?.trim()) {
-        await updateFileMeta(spaceId, filePath, { description: derivedDescription }).catch(err =>
-          log.warn(`Media worker: failed to write caption to file meta ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
+      const operatorWrote = !!parentMeta?.description?.trim();
+      // The excerpt goes in even when a person has written their own description: it is the document's own
+      // text, not a competing summary, and it is what makes a remembered phrase find this record. Only the
+      // description itself is theirs to keep.
+      const update = {
+        ...(operatorWrote || !derivedDescription ? {} : { description: derivedDescription, descriptionSource: derivedSource }),
+        ...(derivedExcerpt ? { excerpt: derivedExcerpt } : {}),
+      };
+      if (Object.keys(update).length > 0) {
+        await updateFileMeta(spaceId, filePath, update).catch(err =>
+          log.warn(`Media worker: failed to write description to file meta ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
         );
       }
     }

--- a/testing/standalone/document-description.test.js
+++ b/testing/standalone/document-description.test.js
@@ -1,0 +1,164 @@
+/**
+ * The converted parent's description is generated prose — and says so when it is not.
+ *
+ * ## The report
+ *
+ * `summariseMarkdown` (#567) is **extractive**: it takes the head of the converted text. On a real invoice
+ * that is a payment reference cut mid-identifier. The release note called the field *generated*, and the
+ * images the same document produced DO get generated captions — so the parent read as unfinished sitting
+ * beside its own children.
+ *
+ * ## What this pins
+ *
+ * Three things, and the third is the one that keeps the feature honest:
+ *
+ *  1. A model's answer is cleaned up before it is stored — models wrap answers in quotes, label them
+ *     `Description:`, and sometimes answer the wrong question entirely.
+ *  2. With no model configured the extractive text survives, because it beats nothing.
+ *  3. It is never CALLED generated in that case. `descriptionSource` records which one an instance
+ *     produced, because "generated" is a claim about provenance and the release note already made it
+ *     once while the value was a truncation.
+ *
+ * Plus the embedding: the document's own opening prose stays an embedding input in its own right. Once
+ * `description` became generated prose, a search for a phrase a reader remembers FROM the document had
+ * nothing on the parent record to match — the extractive text used to BE the description.
+ *
+ * Run: node --test testing/standalone/document-description.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const { sanitiseDescription } = await import('../../server/dist/files/converters/describe.js');
+const { fileEmbedText } = await import('../../server/dist/brain/embed-text.js');
+const { summariseMarkdown } = await import('../../server/dist/files/converters/summarise.js');
+
+describe('sanitiseDescription — what a chat model actually returns', () => {
+  it('keeps a good answer as it is', () => {
+    const s = sanitiseDescription('An invoice from Northwind Traders to Acme GmbH, dated 3 March 2026, for cloud hosting.');
+    assert.equal(s, 'An invoice from Northwind Traders to Acme GmbH, dated 3 March 2026, for cloud hosting.');
+  });
+
+  it('strips the label the prompt asked it not to write', () => {
+    assert.equal(sanitiseDescription('Description: A lease agreement between two parties.'),
+      'A lease agreement between two parties.');
+    assert.equal(sanitiseDescription('Summary:  A quarterly report.'), 'A quarterly report.');
+  });
+
+  it('strips wrapping quotes and Markdown scaffolding', () => {
+    assert.equal(sanitiseDescription('"A shipping manifest."'), 'A shipping manifest.');
+    assert.equal(sanitiseDescription('## A shipping manifest.'), 'A shipping manifest.');
+    assert.equal(sanitiseDescription('```\nA shipping manifest.\n```'), 'A shipping manifest.');
+  });
+
+  it('collapses the newlines a model uses for a list it was told not to produce', () => {
+    assert.equal(sanitiseDescription('An invoice.\n\nFrom Northwind.'), 'An invoice. From Northwind.');
+  });
+
+  it('REFUSES a non-answer rather than storing it as content', () => {
+    // A refusal or a preamble stored as a description is worse than the extractive text, because it
+    // reads as content and search will match it.
+    for (const junk of [
+      "I'm sorry, I cannot help with that.",
+      'As an AI language model, I cannot read documents.',
+      "Sure! Here's a description of the document.",
+      'Certainly, this document appears to be…',
+      '',
+      '   ',
+      '...',
+      '- ',
+    ]) {
+      assert.equal(sanitiseDescription(junk), undefined, `should have been refused: ${JSON.stringify(junk)}`);
+    }
+  });
+
+  it('does not refuse a document that is genuinely ABOUT an AI assistant', () => {
+    // The non-answer patterns are anchored at the start for exactly this: matching them anywhere would
+    // deny a description to a whole class of real documents.
+    const s = sanitiseDescription('A design note on how the assistant handles refusals, written by the platform team.');
+    assert.match(s, /^A design note/);
+  });
+
+  it('caps a rambling answer, preferring a sentence end over a word break', () => {
+    const long = `${'A '.repeat(100)}invoice. ${'B '.repeat(200)}`;
+    const s = sanitiseDescription(long);
+    assert.ok(s.length <= 401, `length ${s.length}`);
+    assert.ok(s.endsWith('invoice.') || s.endsWith('…'), s.slice(-20));
+  });
+});
+
+describe('the extractive text is not lost', () => {
+  it('is a separate embedding input, so a remembered phrase still finds the parent', () => {
+    const withExcerpt = fileEmbedText('invoices/2026-03.pdf', ['invoice'], 'An invoice from Northwind to Acme.',
+      undefined, [], 'Payment reference NW-8831-2026 is due within 30 days.');
+    assert.match(withExcerpt, /NW-8831-2026/);
+    assert.match(withExcerpt, /An invoice from Northwind/);
+  });
+
+  it('is not embedded twice when it IS the description', () => {
+    // The no-model case: the extractive text is the description. Embedding it twice would weight one
+    // paragraph of one record against everything else in the space.
+    const same = 'Payment reference NW-8831-2026 is due within 30 days.';
+    const text = fileEmbedText('invoices/2026-03.pdf', [], same, undefined, [], same);
+    assert.equal(text.split('NW-8831-2026').length - 1, 1, text);
+  });
+
+  it('changes nothing for a record that has no excerpt', () => {
+    // Every existing file record is in this case, and a changed embedding input means a changed vector.
+    const before = fileEmbedText('a/b.pdf', ['x'], 'desc', { k: 'v' }, ['Acme']);
+    const after = fileEmbedText('a/b.pdf', ['x'], 'desc', { k: 'v' }, ['Acme'], undefined);
+    assert.equal(before, after);
+  });
+
+  it('still produces the extractive text itself — unchanged, and still the fallback', () => {
+    const s = summariseMarkdown('# Quarterly report\n\nRevenue grew by eleven percent this quarter.');
+    assert.match(s, /Revenue grew by eleven percent/);
+  });
+});
+
+describe('provenance is recorded, not assumed', () => {
+  const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const src = path => strip(readFileSync(path, 'utf8'));
+
+  it('the extractive fallback is never labelled generated', () => {
+    const describeSrc = src('server/src/files/converters/describe.ts');
+    // Every place a source is chosen: `extracted` must accompany the excerpt fallback, and `generated`
+    // must only follow a model answer that survived sanitising.
+    assert.match(describeSrc, /source: 'generated'[\s\S]{0,80}excerpt/, 'a generated description keeps the excerpt too');
+    assert.ok(!/source: 'generated'\s*,\s*excerpt\s*}\s*;?\s*}\s*$/.test(describeSrc));
+    assert.match(describeSrc, /text: excerpt, source: 'extracted'/,
+      'the no-model path must label the extractive text as extracted');
+  });
+
+  it('an unacknowledged assist host is never sent document text', () => {
+    // The ACK is re-checked at call time rather than trusted from save time — the same rule the repair
+    // path applies, because config.json can be hand-edited.
+    const describeSrc = src('server/src/files/converters/describe.ts');
+    assert.match(describeSrc, /acknowledgedHost === new URL\(assist\.baseUrl\)\.host/);
+    // And the fall-through has to be the LOCAL model, not "send it anyway".
+    assert.match(describeSrc, /if \(acknowledged\)[\s\S]{0,400}?resolveVlmEndpoint\('repair'\)/);
+  });
+
+  it('a description a person writes drops the provenance rather than inheriting it', () => {
+    const metaSrc = src('server/src/files/file-meta.ts');
+    assert.match(metaSrc, /\$unset\['descriptionSource'\]/,
+      'a stale `generated` would have the record claim a model wrote what an operator typed');
+  });
+
+  it('the worker writes the excerpt even when an operator owns the description', () => {
+    // The excerpt is the document's own text, not a competing summary: only the description is theirs.
+    const workerSrc = src('server/src/files/media/worker.ts');
+    assert.match(workerSrc, /operatorWrote[\s\S]{0,200}?derivedExcerpt \? \{ excerpt: derivedExcerpt \}/);
+  });
+
+  it('an image caption is labelled generated too — it always was model output', () => {
+    const workerSrc = src('server/src/files/media/worker.ts');
+    assert.match(workerSrc, /embedImage[\s\S]{0,400}?derivedSource = 'generated'/);
+  });
+
+  it('a reindex re-embeds the excerpt instead of dropping it', () => {
+    // The whole-space reindex builds its own embed text. Missing the excerpt there would silently strip
+    // the document's own words out of every converted record's embedding.
+    assert.match(src('server/src/api/brain/search.ts'), /fileEmbedText\([^)]*doc\.excerpt\)/);
+  });
+});

--- a/testing/standalone/document-summary.test.js
+++ b/testing/standalone/document-summary.test.js
@@ -148,13 +148,19 @@ describe('the worker wires it to the parent record', () => {
   const w = strip(WORKER);
 
   it('the document path sets derivedDescription', () => {
-    assert.match(w, /derivedDescription = summariseMarkdown\(convertedMarkdown, chunks\)/);
+    // Through `describeDocument` now, which asks a model what the file IS and keeps this extractive text
+    // as the record's excerpt and its fallback. The rest of this file still pins the extraction itself —
+    // it is the value an instance with no model configured gets, so it never stopped mattering.
+    // See document-description.test.js for the generated half.
+    assert.match(w, /const described = await describeDocument\(convertedMarkdown, chunks\)/);
+    assert.match(w, /derivedDescription = described\.text/);
   });
 
   it('through the SAME writer images use, which respects an operator-set description', () => {
     // Not a second write path: an operator-written description must outrank a generated one, and that
     // rule already lives in the existing block.
-    assert.match(w, /if \(!parentMeta\?\.description\?\.trim\(\)\)/);
-    assert.match(w, /updateFileMeta\(spaceId, filePath, \{ description: derivedDescription \}\)/);
+    assert.match(w, /const operatorWrote = !!parentMeta\?\.description\?\.trim\(\)/);
+    assert.match(w, /updateFileMeta\(spaceId, filePath, update\)/);
+    assert.match(w, /operatorWrote \|\| !derivedDescription \? \{\} : \{ description: derivedDescription/);
   });
 });


### PR DESCRIPTION
Canary item **B.7**.

`summariseMarkdown` (#567) is **extractive** — it takes the head of the converted text. On a real invoice
that is a payment reference cut mid-identifier. The release note called the field *generated*, and the
images extracted from the same document *do* carry generated captions, so the parent record read as
unfinished sitting beside its own children.

## What the model is asked

*What is this file?* — kind of document, parties, date, subject — over the head of the converted text,
which is where a document's identity lives (letterhead, title, parties, subject line). Two sentences,
temperature 0, 30 s budget, no Markdown.

Target: the local document model, or the assist model **only when its egress host is acknowledged**. The
ACK is re-checked at call time rather than trusted from save time — the same rule `vlm-extract` applies
before routing a repair, for the same reason: `config.json` can be hand-edited. Neither slot receives
anything it would not already receive on the repair pass, so this adds **no new egress surface**.

## The regression this would have been

The extractive text *was* the description. Generating one would have quietly removed the document's own
words from the parent's embedding — so a phrase a reader remembers *from inside* a file would stop finding
the file, with nothing failing anywhere.

So it is kept as `excerpt` and stays an embedding input:

- preserved on unrelated edits — `updateFileMeta` falls back to the stored value, or the first tag change
  after conversion would drop it;
- included in the **whole-space reindex**, which builds its own embed text — missing it there would have
  stripped it from every converted record;
- not embedded twice when it *is* the description (the no-model case), which would weight one paragraph of
  one record against everything else in the space.

## Provenance, because "generated" is a claim

`descriptionSource`: `generated` | `extracted`, absent when a person wrote it.

- No model configured → the extractive text, labelled `extracted`. It beats nothing; it is just not
  generated.
- A `PATCH` that sets `description` without declaring a source **clears** the label — the words are the
  caller's now, and a stale `generated` would have the record claim a model wrote what an operator typed.
- **Image captions are labelled too.** They were the reference point for the whole complaint and had no
  provenance of their own either.
- The Files detail pane shows it beside the heading, with a hint that says nobody has checked a generated
  one.

## Guard rails on the model output

`summarise.ts`'s own doc comment argues against generation — a generated description can assert something
the document does not say, and search will match it while a reader believes it. That argument is why the
extractive text is still there, still the fallback, and still tested. On top of it, output is sanitised:
quotes, `Description:` labels and Markdown scaffolding stripped, length capped on a sentence boundary, and
a refusal or a preamble **rejected** in favour of the extractive text rather than stored as if it were
content. The non-answer patterns are anchored at the start, so a document genuinely *about* an AI assistant
still gets described — there is a test for exactly that.

## Gates

`document-description.test.js` (17 cases): sanitising, the refusal set, the anchoring, the excerpt's
embedding behaviour in all three shapes, and source-level assertions that the extractive fallback is never
labelled generated, that an unacknowledged host is never sent document text, that a human edit drops the
label, and that the reindex passes the excerpt. `document-summary.test.js` keeps pinning the extraction
itself — it is what an instance with no model gets, so it never stopped mattering.

Docs: the filemeta field table in `05-files-api.md`, and *Where the description came from* in the user
guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
