### PR TITLE
feat(ops): the posture is alertable, and a failure carries the id you can grep for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The security posture is countable, so a fleet can alert on it.** `ythril_security_posture_checks{level}`
+  reports the same PASS/WARN/FAIL findings the boot log prints and `GET /api/about/security` serves —
+  computed per scrape from the same function, so the metric and the endpoint cannot disagree. **Alert on
+  `level="fail"` > 0.**
+  - Found by the observability audit: both existing surfaces are pull-only and human-shaped, so the way a
+    five-instance fleet learned that an instance came up misconfigured was somebody reading its boot log.
+    And the checks that matter most produce no runtime symptom — `requireEncryptedTransport` on *without*
+    `trustProxy` rejects every request with a 403 that looks like a client problem.
+  - All three levels report `0` from process start: absent and zero look identical in a graph and mean
+    opposite things.
+
+- **A failure in the UI now carries the request id you can grep for.** Every response already had an
+  `X-Request-Id` header and the server already logged that id with each unhandled error — and the UI showed
+  *"Internal server error"* with nothing to quote, so the link between a visible failure and its log line
+  existed in the protocol and stopped at the only place a person meets it.
+  - Appended for **server-side** failures only (5xx, or a request that got no answer). A 4xx explains
+    itself, and an id on every validation message trains people to ignore the id when it matters.
+  - It goes through the single function every error surface in the app already used, which is why it lands
+    everywhere at once — and which is why that function now has a test file of its own.
+
 - **An Extract tab on the file detail pane — what retrieval actually sees.** Hiding `_converted/` and
   `_extracted/` matched the documentation and was asked for, and it removed the only way to answer *"what
   did the pipeline actually extract from this file?"* — the first question anyone asks when a document is

--- a/client/src/app/core/http-error.spec.ts
+++ b/client/src/app/core/http-error.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * `httpErrorReason` — the one place an HTTP failure becomes words a person reads.
+ *
+ * It had no test of its own, which is how the observability gap below survived: every error surface in the
+ * app funnels through here, so an omission here is an omission everywhere at once.
+ *
+ * ## The finding (observability audit, lens 9)
+ *
+ * The server mints a correlation id per request, returns it as `X-Request-Id`, and logs it with every
+ * unhandled error. The UI dropped it — so a 500 read "Internal server error" and the person looking at it
+ * had nothing to quote, while the answer sat in the server log behind a key they could not see.
+ */
+import { describe, it, expect } from 'vitest';
+import { httpErrorReason } from './http-error';
+
+/** An HttpErrorResponse-shaped object: only the fields the function reads. */
+const res = (over: Record<string, unknown> = {}) => ({
+  status: 500,
+  statusText: 'Internal Server Error',
+  headers: { get: (n: string) => (n === 'X-Request-Id' ? 'req-1234' : null) },
+  ...over,
+});
+
+describe('httpErrorReason — the message', () => {
+  it('prefers the server\'s own error text', () => {
+    expect(httpErrorReason(res({ status: 400, error: { error: 'Space not found' } })))
+      .toBe('Space not found');
+  });
+
+  it('falls back to status text, then status, then a JS message', () => {
+    expect(httpErrorReason(res({ status: 404, statusText: 'Not Found', headers: undefined }))).toBe('404 Not Found');
+    expect(httpErrorReason({ status: 418 })).toBe('HTTP 418');
+    expect(httpErrorReason({ message: 'boom' })).toBe('boom');
+  });
+
+  it('returns empty when there is nothing useful, rather than inventing a reason', () => {
+    expect(httpErrorReason(null)).toBe('');
+    expect(httpErrorReason({})).toBe('');
+  });
+});
+
+describe('httpErrorReason — the request id', () => {
+  it('appends it to a server fault, so the reader can quote it', () => {
+    expect(httpErrorReason(res({ error: { error: 'Internal server error' } })))
+      .toBe('Internal server error (request req-1234)');
+  });
+
+  it('appends it to a request that never got an answer (status 0)', () => {
+    // A transport failure is exactly when the server log is the only record of what happened.
+    expect(httpErrorReason(res({ status: 0, statusText: 'Unknown Error', error: undefined })))
+      .toContain('request req-1234');
+  });
+
+  it('does NOT append it to a 4xx the caller caused', () => {
+    // A validation message is self-explanatory, and an id on every one of them is noise that trains people
+    // to ignore the id when it matters.
+    expect(httpErrorReason(res({ status: 400, error: { error: 'tags must be an array' } })))
+      .toBe('tags must be an array');
+    expect(httpErrorReason(res({ status: 404, error: { error: 'Not found' } }))).toBe('Not found');
+  });
+
+  it('is unchanged when the header is absent, or the error is not an HTTP response at all', () => {
+    expect(httpErrorReason(res({ headers: { get: () => null }, error: { error: 'oops' } }))).toBe('oops');
+    expect(httpErrorReason(res({ headers: undefined, error: { error: 'oops' } }))).toBe('oops');
+    expect(httpErrorReason(new Error('plain throw'))).toBe('plain throw');
+  });
+
+  it('survives a headers object that throws — this runs inside every error path', () => {
+    const hostile = res({ error: { error: 'oops' }, headers: { get: () => { throw new Error('no'); } } });
+    expect(httpErrorReason(hostile)).toBe('oops');
+  });
+
+  it('reports the id alone when there is genuinely nothing else', () => {
+    // Status 0 with no status text and no message: a request that never reached anything. Every other
+    // shape has a base to append to — a 500 still reads "HTTP 500 (request …)".
+    expect(httpErrorReason(res({ status: 0, statusText: '', error: undefined, message: '' })))
+      .toBe('request req-1234');
+    expect(httpErrorReason(res({ status: 500, statusText: '', error: undefined, message: '' })))
+      .toBe('HTTP 500 (request req-1234)');
+  });
+});

--- a/client/src/app/core/http-error.ts
+++ b/client/src/app/core/http-error.ts
@@ -3,16 +3,58 @@
  * thrown error) for display in an error state or toast. Prefers the server's
  * own `{ error: string }` body, then the HTTP status text, then the JS message.
  * Returns '' when nothing useful is available (the UI then shows a generic line).
+ *
+ * ## The request id (observability audit, lens 9)
+ *
+ * Every response carries `X-Request-Id`, and the server logs that id with every unhandled error:
+ *
+ *     [ERROR] Unhandled error [ba355eee-3829-4d0e-859e-bc6b4947364d]: Config not loaded
+ *
+ * So the link between a failure and its log line existed at the protocol level and stopped at the only
+ * place a person meets it: the UI showed *"Internal server error"* with nothing to quote. An API consumer
+ * could read the header; an operator looking at the screen could not, and neither could anyone filing a
+ * report about it. One instance of "diagnosable in principle, undiagnosable in practice".
+ *
+ * The id is appended to a SERVER-side failure only. A 4xx the caller caused is self-explanatory and the id
+ * would be noise on every validation message; a 5xx (or a transport failure, status 0) is the case where
+ * the answer is in the server log and the reader needs the key to find it.
  */
+
+/** Response header carrying the per-request correlation id, set for every response by `app.ts`. */
+const REQUEST_ID_HEADER = 'X-Request-Id';
+
+/** Errors worth correlating: a server fault, or a request that never got an answer at all. */
+function worthCorrelating(status: number | undefined): boolean {
+  return status === 0 || status === undefined || status >= 500;
+}
+
 export function httpErrorReason(err: unknown): string {
-  const e = err as { error?: { error?: unknown }; statusText?: string; status?: number; message?: string } | null;
+  const e = err as {
+    error?: { error?: unknown };
+    statusText?: string;
+    status?: number;
+    message?: string;
+    // HttpHeaders, narrowed to the one method used — `headers` is absent on a plain thrown Error.
+    headers?: { get(name: string): string | null };
+  } | null;
   if (!e) return '';
-  const serverMsg = e.error?.error;
-  if (typeof serverMsg === 'string' && serverMsg.trim()) return serverMsg;
-  if (typeof e.statusText === 'string' && e.statusText && e.statusText !== 'OK') {
-    return e.status ? `${e.status} ${e.statusText}` : e.statusText;
-  }
-  if (typeof e.status === 'number' && e.status > 0) return `HTTP ${e.status}`;
-  if (typeof e.message === 'string' && e.message.trim()) return e.message;
-  return '';
+
+  const base = (() => {
+    const serverMsg = e.error?.error;
+    if (typeof serverMsg === 'string' && serverMsg.trim()) return serverMsg;
+    if (typeof e.statusText === 'string' && e.statusText && e.statusText !== 'OK') {
+      return e.status ? `${e.status} ${e.statusText}` : e.statusText;
+    }
+    if (typeof e.status === 'number' && e.status > 0) return `HTTP ${e.status}`;
+    if (typeof e.message === 'string' && e.message.trim()) return e.message;
+    return '';
+  })();
+
+  if (!worthCorrelating(e.status)) return base;
+  let id: string | null = null;
+  // Defensive: `headers.get` throws on nothing real, but this runs inside every error path in the app and
+  // must never be the reason an error message fails to render.
+  try { id = e.headers?.get(REQUEST_ID_HEADER) ?? null; } catch { id = null; }
+  if (!id) return base;
+  return base ? `${base} (request ${id})` : `request ${id}`;
 }

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -89,7 +89,15 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_sync_duration_seconds` | histogram | Time per sync cycle |
 | `ythril_recall_degraded_total` | counter | Recalls answered with a **weaker pipeline than configured**, by `reason`. `rerank_unavailable` = the cross-encoder is configured but did not answer; `rerank_skipped_budget` = it was not attempted because the end-to-end `RECALL_BUDGET_MS` was already spent upstream. **This is the one to alert on**: these paths return HTTP 200 with a worse ranking, so they raise no error rate and barely move latency — a reranker down for a week is otherwise invisible. Both series report `0` from process start, so absent-vs-zero is never ambiguous. |
 
+| `ythril_security_posture_checks` | gauge | This instance's own PASS/WARN/FAIL posture, by `level` — the same findings the boot log prints and `GET /api/about/security` serves, computed per scrape from the same function. **Alert on `level="fail"` > 0**: the checks that matter most produce no runtime symptom at all (`requireEncryptedTransport` on *without* `trustProxy` rejects every request with a 403 that looks like a client problem), and the only other way to notice was somebody reading the boot log of each instance. All three levels report `0` from process start. |
+
 Default Node.js process metrics (`nodejs_*`, `process_*`) are also included via [prom-client](https://github.com/siimon/prom-client)'s `collectDefaultMetrics()`.
+
+**Correlating a failure with its log line.** Every response carries an `X-Request-Id` header, and the server
+logs that id with any unhandled error (`Unhandled error [<id>]: …`). The admin UI now **shows the id in the
+message** for a server-side failure (5xx, or a request that got no answer at all), so a bug report can quote
+it and an operator can grep for it. It is deliberately not appended to a 4xx: a validation message explains
+itself, and an id on every one of them trains people to ignore the id when it matters.
 
 **Kubernetes example** (Prometheus Operator `ServiceMonitor`):
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -62,6 +62,14 @@ async function main(): Promise<void> {
     // (S2), and MongoDB auth. Advisory by default; `security.strict` aborts boot on any FAIL.
     {
       const { computeSecurityPosture, formatPostureLines, securityStrict } = await import('./config/security-posture.js');
+      // The same findings, countable on /metrics, so a fleet does not learn about a misconfigured instance
+      // by someone reading its boot log. Registered here rather than imported inside `registry.ts`, which
+      // nearly every module pulls in — see `setPostureProvider`. Re-computed per scrape, never cached: the
+      // posture depends on config that a running instance can change.
+      {
+        const { setPostureProvider } = await import('./metrics/registry.js');
+        setPostureProvider(() => computeSecurityPosture().checks);
+      }
       const posture = computeSecurityPosture();
       const issues = posture.checks.filter(c => c.level !== 'pass');
       if (issues.length === 0) {

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -391,3 +391,57 @@ export const recallDegradedTotal = new Counter({
 for (const reason of ['rerank_unavailable', 'rerank_skipped_budget']) {
   recallDegradedTotal.labels({ reason }).inc(0);
 }
+
+// ── Security posture (observability audit, lens 9) ────────────────────────────
+
+/**
+ * The instance's own PASS/WARN/FAIL posture, countable.
+ *
+ * `computeSecurityPosture()` already produces this: it is printed once at boot and served on
+ * `GET /api/about/security` (admin-only). Both are pull-only and human-shaped, which means a fleet learns
+ * that an instance came up misconfigured by someone reading its boot log. On a five-instance fleet nobody
+ * reads five boot logs, and the checks that matter most are exactly the ones that produce no runtime
+ * symptom — `requireEncryptedTransport` off, or on WITHOUT `trustProxy`, which rejects every request.
+ *
+ * So the same finding set is a gauge, and an operator can alert on it:
+ *
+ *     ythril_security_posture_checks{level="fail"} > 0
+ *
+ * Computed at scrape time from the same function, never a second copy of the rules — a posture metric that
+ * could disagree with the endpoint would be worse than no metric.
+ *
+ * Pre-declared for all three levels so a healthy instance reports `fail 0` rather than nothing: absent and
+ * zero look identical in a graph and mean opposite things, which is the trap `recallDegradedTotal` above
+ * documents one metric up.
+ */
+export const securityPostureChecks = new Gauge({
+  name: 'ythril_security_posture_checks',
+  help: 'Security-posture checks by level (pass/warn/fail) — alert on level="fail"',
+  labelNames: ['level'] as const,
+  registers: [register],
+  collect() {
+    try {
+      const counts: Record<string, number> = { pass: 0, warn: 0, fail: 0 };
+      for (const c of postureProvider?.() ?? []) {
+        if (c.level in counts) counts[c.level] = (counts[c.level] ?? 0) + 1;
+      }
+      for (const [level, n] of Object.entries(counts)) this.set({ level }, n);
+    } catch {
+      /* A metrics scrape must never be the thing that fails. */
+    }
+  },
+});
+
+/**
+ * How the posture reaches the gauge without this module importing config.
+ *
+ * `registry.ts` is imported by nearly every file, so pulling `security-posture` (and therefore the config
+ * loader) in here would invert the dependency direction and risk a cycle. `index.ts` registers the provider
+ * once at boot instead. Unregistered — in a test, or before boot finishes — the gauge reports zeros, which
+ * is the honest answer for "no posture has been computed".
+ */
+let postureProvider: (() => Array<{ level: string }>) | null = null;
+export function setPostureProvider(fn: () => Array<{ level: string }>): void {
+  postureProvider = fn;
+}
+for (const level of ['pass', 'warn', 'fail']) securityPostureChecks.set({ level }, 0);

--- a/testing/standalone/posture-metric.test.js
+++ b/testing/standalone/posture-metric.test.js
@@ -1,0 +1,104 @@
+/**
+ * The security posture is countable, so a fleet can alert on it (observability audit, lens 9).
+ *
+ * ## The finding
+ *
+ * `computeSecurityPosture()` produces PASS/WARN/FAIL checks that are printed once at boot and served on
+ * `GET /api/about/security`. Both are pull-only and human-shaped, so the way a fleet learned that an
+ * instance came up misconfigured was somebody reading its boot log. Nobody reads five boot logs — and the
+ * checks that matter most are the ones with no runtime symptom at all: `requireEncryptedTransport` off, or
+ * on WITHOUT `trustProxy`, which rejects every request with a 403 that looks like a client problem.
+ *
+ * ## What this pins
+ *
+ * The gauge exists, counts by level, is derived from the SAME function as the endpoint (never a second copy
+ * of the rules), reports zeros rather than nothing when no posture has been computed, and cannot make a
+ * scrape fail.
+ *
+ * Run: node --test testing/standalone/posture-metric.test.js
+ */
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let register, securityPostureChecks, setPostureProvider;
+
+/** The value of one label of the gauge, read back out of the registry. */
+async function level(name) {
+  const json = await register.getSingleMetric('ythril_security_posture_checks').get();
+  return json.values.find(v => v.labels.level === name)?.value;
+}
+
+describe('ythril_security_posture_checks', () => {
+  before(async () => {
+    ({ register, securityPostureChecks, setPostureProvider } = await import('../../server/dist/metrics/registry.js'));
+  });
+
+  beforeEach(() => setPostureProvider(() => []));
+
+  it('is registered, with a level label and an alertable name', () => {
+    assert.ok(register.getSingleMetric('ythril_security_posture_checks'), 'the gauge must be on the registry');
+  });
+
+  it('reports ZERO for every level when nothing has been computed', async () => {
+    // Absent and zero look identical in a graph and mean opposite things: "no findings" versus "nobody
+    // asked". An alert on fail > 0 must not depend on a series existing.
+    for (const l of ['pass', 'warn', 'fail']) {
+      assert.equal(await level(l), 0, `level=${l}`);
+    }
+  });
+
+  it('counts the findings by level', async () => {
+    setPostureProvider(() => ([
+      { level: 'pass' }, { level: 'pass' }, { level: 'warn' }, { level: 'fail' },
+    ]));
+    await register.metrics();               // a scrape triggers collect()
+    assert.equal(await level('pass'), 2);
+    assert.equal(await level('warn'), 1);
+    assert.equal(await level('fail'), 1);
+  });
+
+  it('drops back to zero when a finding is resolved, instead of keeping the high-water mark', async () => {
+    setPostureProvider(() => ([{ level: 'fail' }]));
+    await register.metrics();
+    assert.equal(await level('fail'), 1);
+    setPostureProvider(() => ([{ level: 'pass' }]));
+    await register.metrics();
+    assert.equal(await level('fail'), 0, 'a fixed instance must stop alerting');
+    assert.equal(await level('pass'), 1);
+  });
+
+  it('ignores a level it does not know rather than inventing a series', async () => {
+    setPostureProvider(() => ([{ level: 'catastrophe' }, { level: 'warn' }]));
+    await register.metrics();
+    assert.equal(await level('warn'), 1);
+    assert.equal(await level('catastrophe'), undefined);
+  });
+
+  it('a scrape survives a provider that throws', async () => {
+    // The posture reads config. A metrics scrape must never be the thing that fails because of it.
+    setPostureProvider(() => { throw new Error('config not loaded'); });
+    const text = await register.metrics();
+    assert.match(text, /ythril_security_posture_checks/);
+  });
+});
+
+describe('the metric and the endpoint cannot disagree', () => {
+  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('both derive from computeSecurityPosture, and the metric holds no rules of its own', () => {
+    // A posture metric that could disagree with `GET /api/about/security` would be worse than no metric.
+    const boot = strip(readFileSync('server/src/index.ts', 'utf8'));
+    assert.match(boot, /setPostureProvider\(\(\) => computeSecurityPosture\(\)\.checks\)/);
+    const reg = strip(readFileSync('server/src/metrics/registry.ts', 'utf8'));
+    assert.ok(!/requireEncryptedTransport|trustProxy|allowInsecurePeers/.test(reg),
+      'the registry must not restate any posture rule — it counts what the one computer returns');
+  });
+
+  it('the registry does not import the config loader to do it', () => {
+    // `registry.ts` is imported by nearly every module; pulling the config loader in here inverts the
+    // dependency direction. The provider is registered at boot instead.
+    const reg = strip(readFileSync('server/src/metrics/registry.ts', 'utf8'));
+    assert.ok(!/from '\.\.\/config\/security-posture/.test(reg));
+  });
+});


### PR DESCRIPTION
Observability audit — **lens 9** of the multi-lens rotation. Two findings, both the same shape: the
information existed and stopped one step short of the person who needed it.

## The correlation id never reached the reader

Every response carries `X-Request-Id`. The server logs that id with every unhandled error:

```text
[ERROR] Unhandled error [ba355eee-3829-4d0e-859e-bc6b4947364d]: Config not loaded
```

And the UI showed **"Internal server error"** with nothing to quote. So the link between a visible failure and
its log line existed at the protocol level and disappeared at the only place a human meets it — an API
consumer could read the header; an operator looking at the screen, or anyone filing a report about it, could
not.

Appended in `httpErrorReason`, the one function every error surface in the app already funnels through — one
edit, landing everywhere at once, which is also why that function now has a test file of its own (it had
none). **Server-side failures only** (5xx, or a request that got no answer): a 4xx explains itself, and an id
on every validation message is what trains people to ignore the id on the day it matters.

## The posture had no alerting hook

`computeSecurityPosture()` produces PASS/WARN/FAIL checks, printed once at boot and served on
`GET /api/about/security`. Both are pull-only and human-shaped, so the way a **five-instance fleet** learns
that an instance came up misconfigured is somebody reading its boot log. And the checks that matter most
produce **no runtime symptom at all** — `requireEncryptedTransport` on *without* `trustProxy` rejects every
request with a 403 that looks like a client problem.

```text
ythril_security_posture_checks{level="fail"} > 0
```

Computed per scrape from the same function. **Never a second copy of the rules** — a posture metric that could
disagree with the endpoint would be worse than no metric, and a test asserts the registry restates none of
them. The provider is registered at boot rather than imported inside `registry.ts`, which nearly every module
pulls in, so the dependency direction stays right. All three levels report `0` from process start, because
absent and zero look identical in a graph and mean opposite things.

## What the audit examined and found sound

So this reads as a report rather than a fishing trip:

- `/metrics` coverage of the media worker, the queues (pending/processing/failed), sync, and recall
  degradation — thorough already;
- secret redaction in logs, and audit-route coverage for mutating verbs — both already gated;
- boot config validation, including the `security.strict` abort on a FAIL posture;
- backup/restore — an admin API *and* a user-guide section;
- the upgrade path: three durable config migrations, all idempotent, all documented in the deprecations
  tracker.

**Next rotation: lens 4 (Performance).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
