### PR TITLE
fix(spaces): a space's directive had two maximum lengths, one per transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A space's directive had two maximum lengths, depending on which transport wrote it.** REST accepted 4000
+  characters; the MCP `update_space` tool refused anything over 2000. So a purpose written through one door
+  could not be edited through the other — and because the 2.2.2 migration moved legacy `description` text
+  into `meta.purpose` under the 4000 bound, an MCP client could be handed a purpose it was then forbidden to
+  change: a validation error on a field the caller never touched.
+  - One exported constant now (`SPACE_PURPOSE_MAX`), replacing six literals. Unified **up**, because 4000 is
+    what the writer actually stores — advertising less would claim a bound smaller than the data already in
+    the database.
+  - The tool's own description text interpolates the number instead of restating it, since it said "max 2000
+    chars" beside a schema that said 2000 and an API that said 4000, and an agent reads the prose.
+  - Found while writing the release message to the deployment that reads these limits, not by a test. A gate
+    now enumerates every numeric bound on this field out of the tree.
+
 ## [2.2.2] — 2026-08-01
 
 ### Added

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -4,7 +4,7 @@ import { requireAuth, requireAdmin, requireAdminMfa, requireAdminMfaScoped } fro
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
-import { slugify } from '../spaces/_shared.js';
+import { slugify, SPACE_PURPOSE_MAX } from '../spaces/_shared.js';
 import { createSpace, removeSpace } from '../spaces/lifecycle.js';
 import { renameSpace } from '../spaces/rename.js';
 import { updateSpace, reorderSpaces, spaceDescriptionAlias, spaceResponse } from '../spaces/spaces.js';
@@ -102,7 +102,7 @@ function findBrokenLibraryRefs(typeSchemas: z.infer<typeof TypeSchemasZ> | undef
 }
 
 const SpaceMetaBody = z.object({
-  purpose: z.string().max(4000).optional(),
+  purpose: z.string().max(SPACE_PURPOSE_MAX).optional(),
   usageNotes: z.string().max(50_000).optional(),
   validationMode: z.enum(['off', 'warn', 'strict']).optional(),
   typeSchemas: TypeSchemasZ.optional(),
@@ -119,7 +119,7 @@ const ProxyForZ = z.union([
 const CreateSpaceBody = z.object({
   id: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/).optional(),
   label: z.string().min(1).max(200),
-  description: z.string().max(4000).optional(),
+  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
   folders: z.array(z.string()).optional(),
   maxGiB: z.number().positive().optional(),
   proxyFor: ProxyForZ.optional(),
@@ -143,7 +143,7 @@ const DupeActionRuleBody = z.object({
 
 const UpdateSpaceBody = z.object({
   label: z.string().min(1).max(200).optional(),
-  description: z.string().max(4000).optional(),
+  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
   maxGiB: z.number().positive().nullable().optional(),
   meta: SpaceMetaBody.optional(),
   dupeRules: z.array(DupeActionRuleBody).max(20).optional(),

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -4,6 +4,7 @@ import { col } from '../../db/mongo.js';
 import { resolveMemberSpaces } from '../../spaces/proxy.js';
 import { WIPE_COLLECTION_TYPES, type WipeCollectionType, wipeSpace } from '../../spaces/lifecycle.js';
 import { updateSpace, spacePurpose } from '../../spaces/spaces.js';
+import { SPACE_PURPOSE_MAX } from '../../spaces/_shared.js';
 
 export const list_spacesTool: ToolHandler = {
   name: 'list_spaces',
@@ -152,8 +153,8 @@ export const update_spaceTool: ToolHandler = {
           properties: {
             space: s.requiredSpace,
             label: { type: 'string', minLength: 1, maxLength: 200, description: 'New display label for the space (1–200 chars).' },
-            purpose: { type: 'string', maxLength: 2000, description: 'New purpose for the space (max 2000 chars) — the space-level directive injected into MCP instructions at handshake.' },
-            description: { type: 'string', maxLength: 2000, description: 'DEPRECATED alias of `purpose`; writes the same field. Removal in 3.0.' },
+            purpose: { type: 'string', maxLength: SPACE_PURPOSE_MAX, description: `New purpose for the space (max ${SPACE_PURPOSE_MAX} chars) — the space-level directive injected into MCP instructions at handshake.` },
+            description: { type: 'string', maxLength: SPACE_PURPOSE_MAX, description: 'DEPRECATED alias of `purpose`; writes the same field. Removal in 3.0.' },
           },
           required: ['space'],
           additionalProperties: false,
@@ -174,7 +175,7 @@ export const update_spaceTool: ToolHandler = {
       throw new Error('At least one of label or purpose must be provided');
     }
     if (newLabel !== undefined && newLabel.length === 0) throw new Error('label must not be empty');
-    if (newDesc !== undefined && newDesc.length > 2000) throw new Error('purpose must not exceed 2000 characters');
+    if (newDesc !== undefined && newDesc.length > SPACE_PURPOSE_MAX) throw new Error(`purpose must not exceed ${SPACE_PURPOSE_MAX} characters`);
     if (newLabel !== undefined && newLabel.length > 200) throw new Error('label must not exceed 200 characters');
     const updates: { label?: string; description?: string } = {};
     if (newLabel !== undefined) updates.label = newLabel;

--- a/server/src/spaces/_shared.ts
+++ b/server/src/spaces/_shared.ts
@@ -185,6 +185,20 @@ export async function dropLegacyPrefixedIndexes(coll: Collection): Promise<void>
 /** Maximum number of previous meta versions kept for history. */
 export const META_VERSION_CAP = 20;
 
+/**
+ * Maximum length of a space's directive (`meta.purpose`, and its deprecated `description` alias).
+ *
+ * One constant because there were six literals for one field, and two of them disagreed: REST accepted
+ * **4000** while the MCP `update_space` tool refused anything over **2000**. So a purpose written through
+ * one transport could not be edited through the other — and the migration that moved legacy `description`
+ * text into `meta.purpose` used the 4000 bound, meaning an MCP client could be handed a purpose it was
+ * forbidden to change.
+ *
+ * Unified UP rather than down: 4000 is what the writer actually stores (`updateSpace` truncates there), so
+ * lowering it would have made the API advertise a limit smaller than the data it already holds.
+ */
+export const SPACE_PURPOSE_MAX = 4000;
+
 /** Generate a URL-safe space ID from a label */
 export function slugify(label: string): string {
   return label

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -8,7 +8,7 @@ import { getConfig, saveConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { SpaceConfig, SpaceMeta, DupeActionRule, DocExtractionMode, ImageLevel, AudioLevel, VideoLevel, TextLevel } from '../config/types.js';
 import { buildSpaceVectorIndexes } from './vector-index.js';
-import { syncSchemaFiles, META_VERSION_CAP } from './_shared.js';
+import { syncSchemaFiles, META_VERSION_CAP, SPACE_PURPOSE_MAX } from './_shared.js';
 
 /**
  * A space's MCP-facing directive, under the one name that still has a store behind it.
@@ -74,7 +74,7 @@ export function updateSpace(
   if (typeof updates.description === 'string') {
     updates = {
       ...updates,
-      meta: { ...(updates.meta ?? space.meta ?? {}), purpose: updates.description.trim().slice(0, 4_000) },
+      meta: { ...(updates.meta ?? space.meta ?? {}), purpose: updates.description.trim().slice(0, SPACE_PURPOSE_MAX) },
     };
   }
   if (updates.maxGiB !== undefined) {

--- a/testing/standalone/purpose-cap-one-limit.test.js
+++ b/testing/standalone/purpose-cap-one-limit.test.js
@@ -1,0 +1,95 @@
+/**
+ * A space's directive has ONE maximum length, whichever transport writes it.
+ *
+ * ## What was wrong
+ *
+ * Six literals for one field, and two of them disagreed: REST accepted **4000** characters
+ * (`SpaceMetaBody.purpose`, and `description` on both create and update), while the MCP `update_space` tool
+ * refused anything over **2000**. So a purpose written through one transport could not be edited through the
+ * other, and the API's two front doors advertised different rules for the same value.
+ *
+ * The sharp end is the migration: legacy `description` text was moved into `meta.purpose` under the 4000
+ * bound, so an MCP client could be handed a purpose it was then forbidden to change — a validation error on
+ * a field the caller never touched, which is the shape of failure the upsert fix in this same release was
+ * about.
+ *
+ * Found while writing the release message to the deployment that reads these limits, not by a test.
+ *
+ * ## What this pins
+ *
+ * One exported constant, and nobody spelling their own. Enumerated from the source rather than asserted
+ * per-site: a hand-listed set of call sites is what let two of six drift in the first place.
+ *
+ * Run: node --test testing/standalone/purpose-cap-one-limit.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+let SPACE_PURPOSE_MAX;
+
+/** Files that could plausibly bound this field — enumerated from the repo, not listed here. */
+const NUL = String.fromCharCode(0);
+const sources = execFileSync('git', ['ls-files', '-z', 'server/src'], { encoding: 'utf8' })
+  .split(NUL).filter(f => f.endsWith('.ts'));
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('the directive cap', () => {
+  before(async () => {
+    ({ SPACE_PURPOSE_MAX } = await import('../../server/dist/spaces/_shared.js'));
+  });
+
+  it('is exported as one constant, at the value the writer actually stores', () => {
+    // Unified UP: `updateSpace` truncates at this value, so a lower advertised limit would claim a bound
+    // smaller than the data already in the database.
+    assert.equal(SPACE_PURPOSE_MAX, 4000);
+  });
+
+  /**
+   * Scoped on `purpose`, ANYWHERE in the tree — and on `description` only inside the two space surfaces.
+   *
+   * `purpose` names exactly one field in this system, so a numeric bound on a line mentioning it is always
+   * this field, in any file, including one added later. `description` is a generic word: a schema-library
+   * entry has its own (1000), a memory record's is 50000. Flagging those would be a gate demanding that
+   * unrelated fields adopt a space's limit — which is how a gate ends up being worked around rather than
+   * obeyed. The narrowing is a claim about the names, not a convenience: check it if either changes.
+   */
+  it('is what every bound on the directive refers to — no file spelling its own number', () => {
+    const SPACE_SURFACES = ['server/src/api/spaces.ts', 'server/src/mcp/tools/spaces.ts'];
+    const offenders = [];
+    for (const file of sources) {
+      const rel = file.split('\\').join('/');
+      const isSpaceSurface = SPACE_SURFACES.includes(rel);
+      strip(readFileSync(file, 'utf8')).split(/\r?\n/).forEach((line, i) => {
+        const namesField = /\bpurpose\b/.test(line) || (isSpaceSurface && /\bdescription\b/.test(line));
+        if (!namesField) return;
+        // `usageNotes`, `label` and `tagSuggestions` have their own, deliberately different limits.
+        if (/usageNotes|label|tagSuggestions/.test(line)) return;
+        const bound = line.match(/(?:\.max\(|maxLength:\s*|length\s*>\s*)(\d[\d_]*)/);
+        if (bound) offenders.push(`${rel}:${i + 1} bounds it at ${bound[1]} literally`);
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'use SPACE_PURPOSE_MAX from spaces/_shared.ts:\n  ' + offenders.join('\n  '));
+  });
+
+  it('the MCP tool and the REST schema resolve to the SAME number', () => {
+    // The disagreement itself, asserted rather than assumed away: both sides now read one identifier, so
+    // this fails if either is given its own literal again.
+    const mcp = strip(readFileSync('server/src/mcp/tools/spaces.ts', 'utf8'));
+    const rest = strip(readFileSync('server/src/api/spaces.ts', 'utf8'));
+    for (const [name, src] of [['mcp/tools/spaces.ts', mcp], ['api/spaces.ts', rest]]) {
+      assert.match(src, /SPACE_PURPOSE_MAX/, `${name} must use the shared constant`);
+      assert.ok(!/maxLength: 2000|max\(2000\)|> 2000/.test(src), `${name} still carries the old 2000 bound`);
+    }
+  });
+
+  it('the tool advertises the real number to a client, not a stale sentence', () => {
+    // The description string said "max 2000 chars" beside a maxLength of 2000. Interpolated now, so the
+    // prose cannot drift from the schema — an agent reads the prose.
+    const mcp = strip(readFileSync('server/src/mcp/tools/spaces.ts', 'utf8'));
+    assert.match(mcp, /max \$\{SPACE_PURPOSE_MAX\} chars/);
+  });
+});


### PR DESCRIPTION
REST accepted **4000** characters for a space's directive. The MCP `update_space` tool refused anything over
**2000**. One field, two limits, and which one applied depended on which door you came through.

The sharp end is 2.2.2's own migration: legacy `description` text moved into `meta.purpose` under the 4000
bound, so an MCP client could be handed a purpose it was then **forbidden to edit** — a validation error on a
field the caller never touched, which is precisely the shape of the upsert defect fixed in the same release.

## The fix

Six literals for one field, now one exported constant (`SPACE_PURPOSE_MAX`). Unified **up**: 4000 is what
`updateSpace` actually stores, so advertising less would claim a bound smaller than the data already in the
database.

The tool's own `description` text interpolates the number instead of restating it. It said *"max 2000 chars"*
beside a schema that said 2000 and an API that said 4000 — and an agent reads the prose, not the schema.

## Docs

Already correct at 4000 in all three places (`06-spaces-api.md` create, update, and the meta field table), so
the mismatch was code-side only and **no documentation changed**. That is also why the doc gate never caught
it: the doc agreed with one of the two numbers.

## How it was found, and the gate that replaces that

Writing the 2.2.2 release message to the deployment that reads these limits — checking my own claim about the
cap before telling them what it was. Not by a test.

The gate enumerates every numeric bound on this field out of the tree, rather than checking the sites I
happened to touch:

- **`purpose` anywhere** — it names exactly one field in this system, so a bound on a line mentioning it is
  always this field, in any file, including one added later.
- **`description` only inside the two space surfaces** — it is a generic word, and its other uses (a
  schema-library entry at 1000, a memory at 50000) are unrelated fields that must not be dragged to a space's
  limit. A gate that demanded that would be worked around rather than obeyed. The narrowing is a claim about
  the names and is written down as one.

**Mutation-checked:** restoring the 2000 on either side fails two of the four cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
