### PR TITLE
fix(spaces): a space says it is governed before you type, not after you press Save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A space's settings dialog now says it is governed before you type in it.** Saving a change to a
+  networked space submits it for a vote rather than applying it — 2.2.2 made that *legible* (it used to
+  throw silently), but only after the fact: you pressed Save and read a notice. The dialog header now
+  carries a **Governed** badge naming the networks, with the consequence on hover, so the rule is known
+  before the editing starts rather than discovered by finishing it.
+  - Keyed on **membership**, not on `networkStatus`. A quiet network still means Save opens a round; keying
+    it on activity would hide the badge exactly when nothing is happening, which is most of the time.
+  - Read from the space record the list endpoint already returns, so it costs no request and cannot
+    disagree with the network chip the Brain shows for the same space.
+  - Completes the finding behind #587: the crash was the symptom, and *"a governed space says nothing until
+    you press Save"* was the cause.
+
 ### Fixed
 
 - **A space's directive had two maximum lengths, depending on which transport wrote it.** REST accepted 4000

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -831,6 +831,10 @@
   "spaces.create.strictLinkage": "Strenge Verknüpfung",
   "spaces.create.submitButton": "Erstellen",
   "spaces.popup.tab.settings": "Einstellungen",
+
+  "spaces.popup.governed": "Verwaltet",
+
+  "spaces.popup.governedHint": "Dieser Space gehört zu {{networks}}. Änderungen an Zweck, Nutzungshinweisen oder Schema starten in jedem Netzwerk eine Abstimmung, statt sofort zu greifen — die Änderung wird eingereicht, nicht angewendet.",
   "spaces.popup.tab.schema": "Schema",
   "spaces.popup.tab.dangerZone": "Gefahrenzone",
   "spaces.popup.footer.saveChanges": "Änderungen speichern",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -831,6 +831,10 @@
   "spaces.create.strictLinkage": "Strict linkage",
   "spaces.create.submitButton": "Create",
   "spaces.popup.tab.settings": "Settings",
+
+  "spaces.popup.governed": "Governed",
+
+  "spaces.popup.governedHint": "This space belongs to {{networks}}. Saving a change to its purpose, usage notes or schema opens a vote in each network instead of applying at once — the change is submitted, not applied.",
   "spaces.popup.tab.schema": "Schema",
   "spaces.popup.tab.dangerZone": "Danger Zone",
   "spaces.popup.footer.saveChanges": "Save changes",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -831,6 +831,10 @@
   "spaces.create.strictLinkage": "Ścisłe powiązanie",
   "spaces.create.submitButton": "Tworzyć",
   "spaces.popup.tab.settings": "Ustawienia",
+
+  "spaces.popup.governed": "Zarządzany",
+
+  "spaces.popup.governedHint": "Ta przestrzeń należy do {{networks}}. Zapisanie zmiany celu, wskazówek lub schematu otwiera głosowanie w każdej sieci, zamiast zastosować ją od razu — zmiana zostaje zgłoszona, nie zastosowana.",
   "spaces.popup.tab.schema": "Schemat",
   "spaces.popup.tab.dangerZone": "Strefa zagrożenia",
   "spaces.popup.footer.saveChanges": "Zapisz zmiany",

--- a/client/src/app/pages/settings/spaces.component.spec.ts
+++ b/client/src/app/pages/settings/spaces.component.spec.ts
@@ -251,6 +251,47 @@ describe('SpacesComponent — settings dialog rendering', () => {
     }
   });
 
+  /**
+   * A governed space says so BEFORE you type.
+   *
+   * Saving a networked space answers `202 vote_pending`: the change is submitted for a vote, not applied.
+   * The notice added with that fix explains it *afterwards*, which is the wrong end of the interaction —
+   * an operator should know the rules of the dialog before they start editing in it. Membership is already
+   * on the space record, so the badge is free.
+   */
+  it('shows the governed badge, naming the networks, for a networked space', () => {
+    const fixture = create([s]);
+    const c = fixture.componentInstance;
+    c.state.openSettings({ ...s, networks: [
+      { id: 'n1', label: 'Research Federation', type: 'democratic' },
+      { id: 'n2', label: 'Ops Braintree', type: 'braintree' },
+    ] } as never);
+    fixture.detectChanges();
+    expect(c.governedBy()).toBe('Research Federation, Ops Braintree');
+    expect(text(fixture)).toContain('spaces.popup.governed');
+  });
+
+  it('shows NOTHING for a space in no network', () => {
+    // The badge has to be absent, not empty: a permanent chip that sometimes means nothing is noise, and
+    // most spaces are in no network at all.
+    const fixture = create([s]);
+    const c = fixture.componentInstance;
+    c.state.openSettings(s);
+    fixture.detectChanges();
+    expect(c.governedBy()).toBeNull();
+    expect(text(fixture)).not.toContain('spaces.popup.governed');
+  });
+
+  it('keys on MEMBERSHIP, not on whether something is happening', () => {
+    // `networkStatus: 'idle'` means the network is quiet — and Save still opens a vote. Keying the badge
+    // on activity would hide it exactly when nothing is going on, which is most of the time.
+    const fixture = create([s]);
+    const c = fixture.componentInstance;
+    c.state.openSettings({ ...s, networkStatus: 'idle', networks: [{ id: 'n1', label: 'Quiet Net', type: 'democratic' }] } as never);
+    fixture.detectChanges();
+    expect(c.governedBy()).toBe('Quiet Net');
+  });
+
   it('the create dialog is gated on showCreateDialog', () => {
     const fixture = create([s]);
     const c = fixture.componentInstance;

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -27,13 +27,14 @@ import { SpaceSchemaTabComponent } from './space-schema-tab.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { SpaceCreateDialogComponent } from './space-create-dialog.component';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { StatusPillComponent } from '../../shared/status-pill.component';
 
 @Component({
   selector: 'app-spaces',
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, DragDropModule, PhIconComponent, SummaryStripComponent,
     SpaceSettingsTabComponent, SpaceDuplicatesTabComponent, SpaceDangerTabComponent, SpaceSchemaTabComponent,
-    SpaceCreateDialogComponent, ModalDirective, HscrollTopDirective],
+    SpaceCreateDialogComponent, ModalDirective, HscrollTopDirective, StatusPillComponent],
   // Provided here (not root) so each mount gets its own settings state, with a lifetime tied to
   // this component rather than the app.
   providers: [SpacesStore, SpaceSettingsState],
@@ -54,6 +55,20 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
               <div style="font-weight:600;font-size:16px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ state.settingsSpace()!.label }}</div>
               <div style="font-size:12px;color:var(--text-muted);font-family:var(--font-mono);">{{ state.settingsSpace()!.id }}</div>
             </div>
+            <!-- Governed BEFORE you type, not after you press Save.
+                 Saving a networked space answers 202 vote_pending: the change is submitted for a vote
+                 rather than applied. That used to be discovered by pressing the button — the notice
+                 explains it afterwards, which is the wrong end of the interaction to learn it. The
+                 membership is already on the space record (its networks array), so this costs no request. -->
+            @if (governedBy(); as nets) {
+              <!-- The link icon, because that is what the sidebar already uses for Networks; the pill has
+                   to read as the same concept, not a new one. (No users/gavel icon is registered, and an
+                   unregistered name renders BLANK with no error.) -->
+              <app-status-pill variant="pending" icon="link"
+                [attr.title]="'spaces.popup.governedHint' | transloco: { networks: nets }">
+                {{ 'spaces.popup.governed' | transloco }}
+              </app-status-pill>
+            }
             <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="attemptClose()"><ph-icon name="x" [size]="14"/></button>
           </div>
           <div class="sp-tabs">
@@ -219,6 +234,21 @@ export class SpacesComponent implements OnInit {
       { label: this.transloco.translate('spaces.summary.storage'), value: `${totalUsed.toFixed(totalUsed < 10 ? 2 : 1)} GiB` },
       { label: this.transloco.translate('spaces.summary.indexing'), value: String(attention), variant: attention ? 'warn' : 'ok' },
     ];
+  });
+
+  /**
+   * The networks governing the open space, as a readable list — or null when it is governed by none.
+   *
+   * Read from the space record the list endpoint already returns (`networks`), so the badge costs no
+   * request and cannot disagree with the chip the Brain shows for the same space.
+   *
+   * Deliberately not keyed on `networkStatus`: that reports whether something is *happening* (a vote, a
+   * sync, a degraded peer), and a quiet network still means Save opens a round. The question the badge
+   * answers is "is this space governed", which is membership.
+   */
+  governedBy = computed(() => {
+    const nets = this.state.settingsSpace()?.networks ?? [];
+    return nets.length > 0 ? nets.map(n => n.label).join(', ') : null;
   });
 
   spaceSearch = signal('');

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -473,6 +473,13 @@ Click **Create New Space**. Fill in:
 
 Click the gear icon on any space row to open its settings panel. Changes save and close automatically. An accidental click **outside** the panel won't close it (so you can't lose half-typed edits that way) — close it deliberately with **✕**, **Cancel**, or **Escape**; if you have unsaved changes you'll be asked to confirm.
 
+> **A `Governed` badge in the panel header means Save opens a vote.** The space belongs to one or more
+> networks (hover the badge to see which), so a change to its purpose, usage notes or schema is **submitted
+> for a vote** in each network rather than applied immediately — you'll see *"saved as a proposal"* and the
+> change takes effect when the vote passes. Local, operational settings (storage quota, auto-delete window,
+> extraction and media-analysis overrides, duplicate rules) are never voted and apply at once. No badge
+> means the space is in no network and everything applies immediately.
+
 **Settings tab:** Update the display name, purpose, usage notes for AI assistants, storage quota, auto-delete window, document-extraction mode, and per-space **media-analysis** levels — grouped into **Identity**, **Purpose**, **Limits**, **Document extraction**, and **Media analysis** cards. The Media analysis card lets you override, per space, how **images**, **audio**, **video**, and **text** are analysed on upload (each defaulting to **Inherit instance default**). As with extraction, each picker only offers the levels **the instance ceiling allows** (set per class under **Settings → Media Processing**) — a space can never analyse more than the instance permits, so higher levels are hidden and a note names the ceiling. When a storage quota, auto-delete window, or extraction override is left blank, the field's own placeholder (**Unlimited** / **No expiry**) or the **Use instance default** / **Inherit** option shows what the default will be.
 
 - **Auto-delete records after (days)** — an optional space-wide expiry. Every record (memory, entity, edge, chrono entry) created or updated in the space is deleted automatically this many days later. Leave it blank or `0` to keep records forever. Individual writes can override the default (or opt out) with their own per-record TTL via the API. Deletion propagates over sync, so an expired record won't come back from a connected peer.


### PR DESCRIPTION
Queue item 1 (`UX-TODO.md`). This is the **finding** behind #587 rather than its symptom.

Saving a change to a networked space submits it for a vote instead of applying it. #587 made that legible —
it used to throw silently inside its own success handler, so Save did nothing and said nothing — but only
*after the fact*: you pressed the button and then read a notice explaining that nothing had been applied.
That is the wrong end of the interaction to learn the rules of a dialog you are already editing in.

The header now carries a **Governed** badge naming the networks, with the consequence on hover.

## Two decisions worth stating

**Keyed on membership, not on `networkStatus`.** A quiet network still means Save opens a round, so keying the
badge on whether something is *happening* (`vote` / `syncing` / `degraded` / `idle`) would hide it exactly when
nothing is — which is most of the time. `idle` is the tempting condition to use and it is the wrong one, so
there is a test for that case specifically.

**No new data.** Read from the space record `GET /api/spaces` already returns (`networks[]`), so the badge
costs no request and cannot disagree with the network chip the Brain draws for the same space.

## Details

- The **link** icon, because that is what the sidebar already uses for Networks — the pill has to read as the
  same concept, not a new one. Also: no users/gavel icon is registered, and an unregistered `ph-icon` name
  renders **blank with no error**.
- The distinction the hover text makes, because it is the one an operator needs: purpose / usage notes /
  schema are governed; the local operational settings (quota, auto-delete, extraction and media-analysis
  overrides, duplicate rules) are never voted and apply at once.
- User guide updated with the same distinction.

**Mutation-checked:** removing the badge fails the render assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
