### PR TITLE
fix(spaces): the readiness probe sent a query no backend can answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The vector-index readiness probe sent a query no backend can answer, and waited 600 s per index for it.**
+  2.2.2 replaced a lifecycle-field read with *asking* the index whether it serves — the right instinct, with
+  the wrong query: a **zero vector**, which cannot be scored against a cosine index.
+
+  ```text
+  Executor error … caused by :: Cosine similarity cannot be calculated against a zero vector.
+  ```
+
+  Reproduced locally against Atlas Local, not inferred. **It was never backend-specific.** Where `status` or
+  `queryable` exist the cheap path returns first and the probe is never reached — which is exactly why our own
+  testing never saw it. The one fleet that did reach it got a permanent, deterministic refusal reported as
+  *"not ready yet"*: 600 s per index, 65 indexes, spaces marked failed while `recall` answered **the same
+  index at 0.913 twenty seconds later**, plus readiness-probe timeouts that restarted pods. Reported by the
+  canary, who supplied that matched pair and correctly concluded the probe was the broken thing.
+  - **A unit vector** now, valid under cosine, dotProduct and euclidean alike, with `numCandidates` off the
+    boundary. An empty result was always accepted — only *serving* was ever the question.
+  - **The error is no longer swallowed.** `catch { return false }` discarded the one fact that would have
+    made this a five-minute diagnosis, and left an operator reading "probe query did not serve yet" with no
+    way to learn what the backend had said.
+  - **A rejected query is not an unready index.** A refusal of the *request* (zero vector, bad
+    `numCandidates`, wrong dimensionality, no `$vectorSearch` at all) stops the poll immediately, says what
+    the backend said, and treats the index as usable — the index exists and the backend reports no lifecycle
+    fields, so there is nothing left to wait for. Absence of evidence is not evidence of absence, which is
+    the rule this probe exists to honour and the one it was breaking.
+  - **The probe is bounded** (`maxTimeMS`), so a stalled call cannot occupy the loop. 65 unbounded probes at
+    boot is a plausible source of the event-loop starvation that showed up as kubelet restarts.
+  - The gate that let this through asserted the probe was "a real vector query, cheap" — all true of a query
+    that could never succeed, because a regex over source cannot know that cosine similarity is undefined at
+    the origin. The query vector is now an exported value and the tests assert **its magnitude**.
+
+
 - **An MCP write refusal now carries its structure, not just a sentence about it.** A schema refusal
   distinguishes violations the write **introduced** from ones the record **already had** — the distinction
   that separates *"fix your patch"* from *"this record was already broken here, and your write is the moment

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -268,32 +268,93 @@ export async function ensureVectorSearchIndex(
  * fields still answers this one, and it answers it about the thing recall depends on rather than about
  * the index's metadata.
  *
- * Deliberately cheap and content-free: a zero vector, `limit: 1`, no filter, and the result is thrown
- * away — only whether it threw matters. A zero vector matches nothing meaningfully, which is the point:
- * this is a liveness question, not a search.
+ * Cheap and content-free: a UNIT vector, `limit: 1`, no filter, result discarded. An empty result is a
+ * perfectly good answer — only whether the query was *served* matters.
  *
- * Any throw counts as not-yet-serving. An index still building errors, and so does a genuinely broken
- * one — this poll cannot tell those apart and does not need to. The caller keeps polling and eventually
- * gives up, which is the correct behaviour for both.
+ * ## Why a unit vector, and not the zero vector this shipped with
+ *
+ * A zero vector cannot be scored against a cosine index, and mongot says so outright:
+ *
+ *     Executor error … caused by :: Cosine similarity cannot be calculated against a zero vector.
+ *
+ * So the probe threw **every single time, on every backend** — verified locally against Atlas Local, not
+ * inferred. It was never backend-specific: on a backend that reports `status`/`queryable` the cheap path
+ * returns first and the probe is never reached, which is exactly why our own testing never saw it. The one
+ * deployment that DID reach it — a self-hosted replica set with no lifecycle fields — got a permanent,
+ * deterministic failure dressed up as "not ready yet", 600 s per index, 65 indexes.
+ *
+ * A unit vector (`[1, 0, 0, …]`) is a valid query against any similarity function. It matches nothing in
+ * particular, which is still the point.
+ *
+ * `numCandidates: 10` rather than 1: `numCandidates >= limit` is the documented contract, and 1 sat on the
+ * boundary for no benefit.
+ *
+ * ## Why the error is returned instead of swallowed
+ *
+ * This used to be `catch { return false }`. That discarded the single most useful fact in the entire
+ * incident — the reason — and left the operator reading "probe query did not serve yet" for ten minutes
+ * with no way to learn what the backend had actually said. The caller now logs it, and can tell a query
+ * that will NEVER work from an index that is still building.
  */
+type ProbeOutcome =
+  | { serves: true }
+  /** `permanent` = the backend rejected the query itself, so waiting cannot help. */
+  | { serves: false; error: string; permanent: boolean };
+
+/**
+ * Errors that mean "this query is not valid here", as opposed to "not yet".
+ *
+ * Matched on the message because that is what the driver surfaces for an executor error; each entry is a
+ * refusal of the REQUEST, and no amount of polling turns one into a success.
+ */
+export const PERMANENT_PROBE_ERRORS = [
+  /zero vector/i,               // cosine cannot score it — what shipped in #585
+  /numCandidates/i,             // outside the accepted range for this backend
+  /queryVector/i,               // wrong dimensionality or malformed
+  /\$vectorSearch is not allowed/i,
+  /unrecognized pipeline stage/i,   // no vector search on this deployment at all
+];
+
+/**
+ * The probe's query vector: a unit vector of the configured width.
+ *
+ * Exported so a test can assert the SHAPE rather than grep for it. The previous test asserted the probe was
+ * "a real vector query, cheap" — both true of the zero vector that could never be scored. A regex over
+ * source cannot know that cosine similarity is undefined at the origin; an assertion on the value can.
+ */
+export function probeQueryVector(dims: number): number[] {
+  const v = new Array(dims).fill(0);
+  v[0] = 1;   // valid under cosine, dotProduct and euclidean alike
+  return v;
+}
+
+/** `numCandidates` for the probe. Must be >= `limit`; 1 sat on the boundary for no benefit. */
+export const PROBE_NUM_CANDIDATES = 10;
+
 async function indexServes(
   coll: ReturnType<ReturnType<typeof getDb>['collection']>,
   indexName: string,
-): Promise<boolean> {
+): Promise<ProbeOutcome> {
+  const dims = getEmbeddingConfig().dimensions ?? 768;
   try {
-    const dims = getEmbeddingConfig().dimensions ?? 768;
     await coll.aggregate([{
       $vectorSearch: {
         index: indexName,
         path: 'embedding',
-        queryVector: new Array(dims).fill(0),
-        numCandidates: 1,
+        queryVector: probeQueryVector(dims),
+        numCandidates: PROBE_NUM_CANDIDATES,
         limit: 1,
       },
-    }, { $limit: 1 }, { $project: { _id: 1 } }]).toArray();
-    return true;
-  } catch {
-    return false;
+    }, { $limit: 1 }, { $project: { _id: 1 } }], {
+      // A probe must never be the thing that blocks. Without a cap, a mongot that accepts the query and
+      // then stalls holds this call — and 65 of those at boot is a plausible way to starve the event loop
+      // that answers /health, which is what the reporting fleet saw as kubelet restarts.
+      maxTimeMS: 5_000,
+    }).toArray();
+    return { serves: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { serves: false, error, permanent: PERMANENT_PROBE_ERRORS.some(re => re.test(error)) };
   }
 }
 
@@ -359,11 +420,24 @@ export async function pollVectorIndexReady(
          * which matters at 65 indexes on one boot.
          */
         if (current.status === undefined && current.queryable === undefined) {
-          if (await indexServes(coll, indexName)) {
+          const probe = await indexServes(coll, indexName);
+          if (probe.serves) {
             log.debug(`Vector search index ${indexName} serves queries (no lifecycle fields on this backend)`);
             return true;
           }
-          lastSeen += ' — no lifecycle fields on this backend; probe query did not serve yet';
+          // A rejected QUERY is not an unready index. Waiting cannot fix it, and the previous version spent
+          // 600 s per index doing exactly that — then marked working spaces failed. Stop, say what the
+          // backend said, and treat readiness as unknown rather than false: absence of evidence is not
+          // evidence of absence, which is the rule this whole probe exists to honour.
+          if (probe.permanent) {
+            log.warn(
+              `Vector search index ${indexName}: cannot be probed on this backend — ${probe.error}. `
+              + 'Treating it as usable: the index exists and this deployment reports no lifecycle fields, '
+              + 'so there is nothing left to wait for. Recall will report the truth if it is not.',
+            );
+            return true;
+          }
+          lastSeen += ` — no lifecycle fields on this backend; probe did not serve: ${probe.error}`;
         }
       }
     } catch (err) {

--- a/testing/standalone/probe-query-validity.test.js
+++ b/testing/standalone/probe-query-validity.test.js
@@ -1,0 +1,97 @@
+/**
+ * The readiness probe sends a query the backend can actually answer.
+ *
+ * ## What shipped, and what it cost
+ *
+ * #585 replaced a lifecycle-field read with "ask the index whether it serves" — the right instinct. The
+ * query it asked with was a **zero vector**, and a zero vector cannot be scored against a cosine index:
+ *
+ *     Executor error … caused by :: Cosine similarity cannot be calculated against a zero vector.
+ *
+ * Verified locally against Atlas Local, not inferred. So the probe threw every time, on every backend. It
+ * was never backend-specific: where `status`/`queryable` exist the cheap path returns first and the probe is
+ * never reached, which is exactly why our own testing never saw it. The one fleet that DID reach it got a
+ * permanent, deterministic failure reported as "not ready yet" — 600 s per index, 65 indexes, spaces marked
+ * failed while `recall` answered the same index at 0.913, and readiness-probe timeouts that restarted pods.
+ *
+ * ## Why the existing test did not catch it
+ *
+ * `index-ready-poll.test.js` asserted the probe "asks the question recall asks": that it is a `$vectorSearch`
+ * against the index by name, and cheap. All three were true of a query that could never succeed. A regex over
+ * source cannot know that cosine similarity is undefined at the origin — so this file asserts the VALUE.
+ *
+ * Run: node --test testing/standalone/probe-query-validity.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let probeQueryVector, PROBE_NUM_CANDIDATES, PERMANENT_PROBE_ERRORS;
+
+describe('the probe query vector', () => {
+  before(async () => {
+    ({ probeQueryVector, PROBE_NUM_CANDIDATES, PERMANENT_PROBE_ERRORS } =
+      await import('../../server/dist/spaces/vector-index.js'));
+  });
+
+  it('is NOT the zero vector — the defect, asserted as a value', () => {
+    for (const dims of [768, 1536, 384, 3072]) {
+      const v = probeQueryVector(dims);
+      assert.equal(v.length, dims, `width must match the configured dimensions (${dims})`);
+      assert.ok(v.some(x => x !== 0), 'a zero vector cannot be scored under cosine similarity');
+    }
+  });
+
+  it('has a non-zero magnitude, which is the property that actually matters', () => {
+    // Not "contains a 1" — the requirement is that the vector has a direction. Stated as the norm so a
+    // future change to which component is set still satisfies it honestly.
+    const v = probeQueryVector(768);
+    const norm = Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+    assert.ok(norm > 0, 'the probe vector must have a direction to be scoreable');
+  });
+
+  it('keeps numCandidates >= limit, the documented contract', () => {
+    // The probe uses limit 1. numCandidates was 1 — legal but on the boundary, for no benefit.
+    assert.ok(PROBE_NUM_CANDIDATES >= 1);
+    assert.ok(PROBE_NUM_CANDIDATES >= 10, 'a little headroom costs nothing at limit 1');
+  });
+});
+
+describe('a rejected query is not an unready index', () => {
+  before(async () => {
+    ({ PERMANENT_PROBE_ERRORS } = await import('../../server/dist/spaces/vector-index.js'));
+  });
+
+  const classify = msg => PERMANENT_PROBE_ERRORS.some(re => re.test(msg));
+
+  it('classifies the exact error this bug produced as PERMANENT', () => {
+    // Verbatim from mongot via Atlas Local. If this ever stops matching, the poller goes back to waiting
+    // 600 s per index for something that cannot happen.
+    assert.equal(classify(
+      'Executor error during aggregate command on namespace: ythril.places_edges :: caused by :: '
+      + 'Cosine similarity cannot be calculated against a zero vector.'), true);
+  });
+
+  it('classifies the other ways a backend refuses the REQUEST', () => {
+    for (const msg of [
+      'Invalid $vectorSearch: numCandidates must be greater than or equal to limit',
+      'queryVector has 768 dimensions but the index expects 1536',
+      '$vectorSearch is not allowed in this atlas tier',
+      'Unrecognized pipeline stage name: $vectorSearch',
+    ]) {
+      assert.equal(classify(msg), true, msg);
+    }
+  });
+
+  it('does NOT classify a still-building or transient error as permanent', () => {
+    // These are the cases where waiting is exactly right. Getting this wrong in the other direction means
+    // declaring an index usable while it is still being built.
+    for (const msg of [
+      'PlanExecutor error during aggregation :: caused by :: index not found',
+      'Index with name general_memories_embedding is currently building',
+      'connection 42 to 10.1.2.3:27017 timed out',
+      'operation exceeded time limit',
+    ]) {
+      assert.equal(classify(msg), false, msg);
+    }
+  });
+});


### PR DESCRIPTION
**Canary report 2026-08-01, item E.1 — and it is a regression I shipped in #585.** Their fleet is restarting
now, so this goes first.

2.2.2 replaced a lifecycle-field read with *asking* the index whether it serves. Right instinct, wrong query:
a **zero vector**, which cannot be scored against a cosine index. Verified locally against Atlas Local rather
than inferred:

```text
THREW  zero vector, numCandidates 1,  limit 1  ::  Cosine similarity cannot be calculated
                                                   against a zero vector.
OK     unit vector, numCandidates 10, limit 1  ::  rows=0
```

**So the probe threw every time, on every backend.** It was never backend-specific — where `status` or
`queryable` exist the cheap path returns first and the probe is never reached, which is exactly why our own
testing never saw it.

## What it cost them

600 s per index, 65 indexes, 15 at a time, spaces marked failed — while `recall` answered **the same index at
0.913 twenty seconds later**. They supplied that matched pair and concluded the probe was the broken thing,
not the index or the backend. They were more right than they knew: it is broken everywhere.

On top of that, three pod restarts with `Readiness probe failed: context deadline exceeded (awaiting headers)`
— the process not answering HTTP at all, at ~190 MiB of a 10 Gi limit. 65 unbounded probes is a plausible
source of that starvation, which is why the probe is bounded here too.

## The fix

- **A unit vector**, valid under cosine, dotProduct and euclidean alike, with `numCandidates` off the
  boundary. An empty result was always accepted — only *serving* was ever the question.
- **The error is no longer swallowed.** `catch { return false }` discarded the single most useful fact in the
  whole incident and left an operator reading *"probe query did not serve yet"* with no way to learn what the
  backend had said.
- **A rejected query is not an unready index.** A refusal of the *request* stops the poll immediately, logs
  what the backend said, and treats the index as usable: it exists, this backend reports no lifecycle fields,
  so there is nothing left to wait for. *Absence of evidence is not evidence of absence* — the rule this probe
  exists to honour, and the one it was breaking.
- **Bounded** with `maxTimeMS`, so a stalled probe cannot occupy the event loop.

## Why the existing gate missed it

`index-ready-poll.test.js` asserted the probe was "a real vector query, against the index by name, and
cheap". **Every word of that was true of a query that could never succeed** — a regex over source cannot know
that cosine similarity is undefined at the origin.

So the query vector is an exported value now and the new test asserts **its magnitude**, not its spelling,
plus the error-classification table in both directions: the verbatim zero-vector error must classify as
permanent, and a still-building or timeout error must not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
