### PR TITLE
fix(files): one large document could stop the instance answering HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Clearing the embedding endpoint from the UI kept the old one, with a `200` and no log line.** The admin
+  PATCH handler deleted the cleared key from the *patch* and then spread the patch over the stored block — so
+  the `null` was gone before it could meet the value it was meant to clear. The configured URL survived, and
+  the save response, resolved from the config that had just not changed, put it straight back in the field:
+  the documented way back to the bundled ONNX model did nothing, and looked like a save that was ignored.
+  - `rerank` and `nli` in the same handler were already correct: they merge first and delete from the result.
+    The embedding branch had the same two lines in the other order.
+  - The merge is now `config/embedding-patch.ts`, a pure function, because the reason this survived is that
+    exercising it needed a running server. `testing/standalone/embedding-patch-merge.test.js` pins the
+    ordering — and fails against the previous shape, in four places.
+  - Same pass: a stored `apiKey` left in `config.json` by an older version is now dropped on any embedding
+    PATCH instead of being merged forward.
+
+- **One large document could stop the instance answering HTTP, and Kubernetes killed it for that.** A 358 KB
+  report is hundreds of chunks. Each in-process chunk embed holds the event loop for ~200 ms, and the
+  pipeline ran **eight at once with nothing yielding in between** — so for minutes at a time there was no
+  turn left for the callback that answers `/health`. The probe timed out, the pod restarted, the persisted
+  job resumed on boot, and it happened again: a crash loop over a document that was converting **correctly**,
+  with no error, no `failed` status and nothing naming the file. Reported by the canary, who had
+  `Readiness probe failed: context deadline exceeded (awaiting headers)` and ~190 MiB of a 10 Gi limit — the
+  memory ceiling everyone reaches for was never the constraint.
+  - **Concurrency is now sized per embedder**: `2` for the bundled in-process model, `8` for an HTTP
+    endpoint, overridable via `embedding.embedConcurrency` / `EMBEDDING_CONCURRENCY` and clamped to 1…32.
+    The two are different problems — an external endpoint is network-bound and wants sockets in flight; the
+    bundled one is CPU-bound and shares the loop.
+  - **The pipeline yields between chunks** (`setImmediate`). `await` on an already-settled promise does not
+    yield to the macrotask queue, so pending I/O sat behind the entire run.
+  - Measured inside the shipped image, 16 chunks: the old shape blocked the loop for **2 482 ms** at a
+    stretch (a 50 ms timer fired **once in 4.7 s**); the new one peaks at **547 ms** and finishes **22%
+    faster** — eight concurrent CPU-bound inferences thrash rather than parallelise, so the old setting was
+    paying for its own outage.
+  - Not sized from `os.availableParallelism()`: it reports the **host's** cores, not the cgroup limit. On the
+    reporting deployment — 4 CPU on a 16-core node — core detection would have "left headroom" of 15 and
+    oversubscribed exactly as before.
+  - `docs/integration-guide/05-files-api.md` carries the numbers plus the `livenessProbe` shape
+    (`timeoutSeconds: 10`, `failureThreshold: 6`) that tolerates a slow answer.
+
+- **21 consecutive rows of the media-configuration reference rendered as quoted literal pipes, not a table.**
+  Rows written directly under a note with no blank line between them are absorbed into that note by
+  CommonMark's lazy continuation; rows appended one blank line below a finished table have no header or
+  delimiter row and are simply a paragraph containing `|` characters. Every `embedding.*`, `mediaEmbedding.*`
+  and worker-tuning setting was in the first category — inside the 2.1 rename note — and three further runs
+  were in the second. `markdownlint` passed on all four: it checks the style of tables it *recognises*, and
+  these had stopped being tables.
+  - Fixed in `05-files-api.md` (three runs) and `11-setup-api.md` (the security-posture gauge).
+  - `testing/standalone/docs-tables-render.test.js` now enumerates every `|`-row run in `docs/` and fails on
+    either spelling, with the detector itself pinned by self-tests — the found-by-eye version of this check
+    would have gone on passing.
+
 - **The vector-index readiness probe sent a query no backend can answer, and waited 600 s per index for it.**
   2.2.2 replaced a lifecycle-field read with *asking* the index whether it serves — the right instinct, with
   the wrong query: a **zero vector**, which cannot be scored against a cosine index.
@@ -52,7 +101,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The gate that let this through asserted the probe was "a real vector query, cheap" — all true of a query
     that could never succeed, because a regex over source cannot know that cosine similarity is undefined at
     the origin. The query vector is now an exported value and the tests assert **its magnitude**.
-
 
 - **An MCP write refusal now carries its structure, not just a sentence about it.** A schema refusal
   distinguishes violations the write **introduced** from ones the record **already had** — the distinction

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -570,15 +570,15 @@ They are never queued, so they do not sit at `pending` waiting for work that wil
 | `renderDpi` | `150` | Page rasterization DPI for the render sidecar (VLM modes only). |
 | `maxPages` | `50` | Pages rendered per **render call** — one sidecar round trip's memory/latency bound. Not how much of a document is read: longer documents are walked in windows of this size. |
 | `maxTotalPages` | `200` | Pages read from **one document** in total, across windows. Beyond this the extraction stops and says so, in the log and in the stored markdown. |
+| `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
+| `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
+| `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `repair`). Env override: `DOC_OCR_TIMEOUT_MS`. |
 
 > **Why two numbers.** They bound different things. `maxPages` is one round trip; `maxTotalPages` is the
 > job's cost ceiling — every page is a VLM call, so an unbounded walk over a 600-page scan means 600 model
 > calls and, with an external endpoint, 600 pages of content leaving the instance, on an upload nobody is
 > watching. Raise `maxTotalPages` deliberately. In `max` mode the consensus pass is skipped for a document
 > that had to be walked, since it re-transcribes every page with a second model.
-| `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
-| `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
-| `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `repair`). Env override: `DOC_OCR_TIMEOUT_MS`. |
 
 The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,
 Ythril transparently uses OCR — no upload fails because a model isn't wired in yet.
@@ -632,6 +632,10 @@ see the egress table above. You can optionally point a **bigger, external model*
 | Field | Description |
 |---|---|
 | `baseUrl` | External **OpenAI-compatible** endpoint (`POST {baseUrl}/chat/completions`, with `/v1` inserted if the base does not already carry it — `…:8080` and `…:8080/v1` both work). Validated against SSRF on save (must be a public http(s) URL — no private/loopback/metadata addresses) and reached only through the SSRF-guarded fetch. Env: `DOC_ASSIST_URL`. |
+| `model` | Model tag to request. Env: `DOC_ASSIST_MODEL`. |
+| `apiKey` | Optional bearer token. Stored in `secrets.json` (never `config.json`), masked in the admin API. Env: `DOC_ASSIST_API_KEY`. |
+| `uses` | Which tasks the external model powers — `["repair"]` today (the repair pass); more are planned. Empty ⇒ configured but inert (no egress). |
+| `acknowledgedHost` | The endpoint host the operator acknowledged egress to. **Required to match `baseUrl`'s host whenever `uses` is non-empty** — the admin API rejects the save otherwise, and the extractor re-checks it at runtime, so document content never leaves the box without recorded consent. |
 
 > **Self-hosting inference on a private address?** The `local` / `external` choice selects a **wire
 > protocol**, not a trust level: `local` speaks Ollama's (`/api/chat`), `external` speaks OpenAI's
@@ -709,11 +713,6 @@ see the egress table above. You can optionally point a **bigger, external model*
 > target, the address it resolved to, and the setting that would permit it — so a blocked endpoint is
 > diagnosable from the container log, not only from whatever a dialog happened to show. The line is
 > redacted like any other, so a key in a query string is not echoed into the log.
-
-| `model` | Model tag to request. Env: `DOC_ASSIST_MODEL`. |
-| `apiKey` | Optional bearer token. Stored in `secrets.json` (never `config.json`), masked in the admin API. Env: `DOC_ASSIST_API_KEY`. |
-| `uses` | Which tasks the external model powers — `["repair"]` today (the repair pass); more are planned. Empty ⇒ configured but inert (no egress). |
-| `acknowledgedHost` | The endpoint host the operator acknowledged egress to. **Required to match `baseUrl`'s host whenever `uses` is non-empty** — the admin API rejects the save otherwise, and the extractor re-checks it at runtime, so document content never leaves the box without recorded consent. |
 
 ⚠️ **This is the only setting that sends document content off the instance.** When a task is assigned, the
 external model receives OCR-extracted text and draft transcriptions (and, for future image-based tasks,
@@ -885,8 +884,12 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 >
 > `lockedByInfra` tracks whichever spelling you used, so the Settings UI renders the field read-only
 > either way.
+
+| Field | Env var | Default | Description |
+|---|---|---|---|
 | `embedding.provider` | `EMBEDDING_PROVIDER` | `local` | Text-embedding endpoint trust: `local` (bundled ONNX or an internal HTTP endpoint, plain fetch) or `external` (public endpoint, reached through the SSRF-guarded fetch). Config lives at top-level `config.embedding` but is edited on **Settings → Media Processing**. |
 | `embedding.baseUrl` | `EMBEDDING_URL` | — | Embedding HTTP endpoint (OpenAI-compatible `/v1/embeddings`). `…:8080` and `…:8080/v1` both work. Blank = the bundled in-process ONNX model. |
+| `embedding.embedConcurrency` | `EMBEDDING_CONCURRENCY` | 2 in-process / 8 external | How many chunk embeds run at once while converting one document. Defaults differ by embedder **on purpose**: the bundled model is CPU-bound and shares the event loop that answers `/health`, while an HTTP endpoint does the work elsewhere. Clamped to 1…32. See the note below before raising it. |
 | `embedding.model` | `EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5` | Embedding model. **Changing the model / `dimensions` / `similarity` / `prefixScheme` re-indexes every vector** (the UI requires an explicit confirmation; `POST /api/brain/spaces/:id/reindex` runs it). |
 | `embedding.prefixScheme` | `EMBEDDING_PREFIX_SCHEME` | `auto` | Task-prefix convention the model expects: `nomic` (`search_document:` / `search_query:` prefixes, trailing space included), `qwen` (instruction on the query only, passages bare), `none` (symmetric models — OpenAI `text-embedding-3-*`, bge-m3), or `auto`. **`auto` reproduces the behaviour this instance had before the field existed: `nomic` for the bundled model, `none` over HTTP — so upgrading changes no vector.** If you run nomic or Qwen behind an endpoint, set this explicitly and reindex — asymmetric models retrieve measurably worse without the prefix, and nothing errors when it is missing. |
 | `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `768` | Vector width the model emits. Must match the model — a mismatch is not detected at write time, it surfaces as recall that returns nothing. Listed with `model` above as a re-index trigger. |
@@ -905,6 +908,23 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `fallbackToExternal` | `MEDIA_EMBEDDING_FALLBACK_TO_EXTERNAL` | `false` | Use external provider if local fails |
 | `maxFileSizeBytes` | `MAX_FILE_SIZE_BYTES` | `524288000` | Skip embedding for files above this size (500 MiB) |
 | `stalledJobTimeoutMs` | `STALLED_JOB_TIMEOUT_MS` | `300000` | Re-queue jobs stuck in processing for > N ms |
+
+> **Large documents, CPU limits and liveness probes.** With the **bundled in-process** embedder, one ~2 KB
+> chunk costs roughly 200 ms of CPU and blocks the event loop for most of it. A 350 KB document is hundreds
+> of chunks — minutes of work — and if enough of them run at once, HTTP stops being answered for seconds at a
+> time. A Kubernetes `livenessProbe` on `/health` then kills a container that is working correctly, the
+> persisted job resumes after the restart, and the result is a crash loop with **no error and no `failed`
+> status** to point at the document.
+>
+> Measured inside the shipped image, 16 chunks: at concurrency 8 with no yielding, the loop was blocked for
+> **2.5 s at a stretch** (a 50 ms timer fired once in 4.7 s). At concurrency 2 with a yield between chunks it
+> was 0.5 s — and finished **22% faster**, because concurrent CPU-bound inferences thrash rather than
+> parallelise.
+>
+> The defaults above are chosen for that reason, and the pipeline yields between chunks. If you raise
+> `embedConcurrency`, raise the CPU allocation with it, and give the probes room:
+> `timeoutSeconds: 10` with `failureThreshold: 6` tolerates a slow answer far better than the defaults do.
+> An **external** embedding endpoint sidesteps the whole question — the CPU work happens on another host.
 
 #### ISO 27001 / Data Egress Note
 

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -88,7 +88,6 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_sync_items_pushed_total` | counter | Items sent by type |
 | `ythril_sync_duration_seconds` | histogram | Time per sync cycle |
 | `ythril_recall_degraded_total` | counter | Recalls answered with a **weaker pipeline than configured**, by `reason`. `rerank_unavailable` = the cross-encoder is configured but did not answer; `rerank_skipped_budget` = it was not attempted because the end-to-end `RECALL_BUDGET_MS` was already spent upstream. **This is the one to alert on**: these paths return HTTP 200 with a worse ranking, so they raise no error rate and barely move latency — a reranker down for a week is otherwise invisible. Both series report `0` from process start, so absent-vs-zero is never ambiguous. |
-
 | `ythril_security_posture_checks` | gauge | This instance's own PASS/WARN/FAIL posture, by `level` — the same findings the boot log prints and `GET /api/about/security` serves, computed per scrape from the same function. **Alert on `level="fail"` > 0**: the checks that matter most produce no runtime symptom at all (`requireEncryptedTransport` on *without* `trustProxy` rejects every request with a 403 that looks like a client problem), and the only other way to notice was somebody reading the boot log of each instance. All three levels report `0` from process start. |
 
 Default Node.js process metrics (`nodejs_*`, `process_*`) are also included via [prom-client](https://github.com/siimon/prom-client)'s `collectDefaultMetrics()`.

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -23,6 +23,8 @@ import { listUrlFor, type VlmWire } from '../files/converters/vlm-endpoint.js';
 import { log } from '../util/log.js';
 import { providerSignature, getActiveProviderSignature } from '../files/media/worker.js';
 import { MIN_CANDIDATE_MULTIPLIER, MAX_CANDIDATE_MULTIPLIER } from '../brain/rerank-client.js';
+import { MAX_EMBED_CONCURRENCY } from '../files/converters/embed-concurrency.js';
+import { mergeEmbeddingPatch } from '../config/embedding-patch.js';
 
 export const mediaConfigRouter = Router();
 
@@ -94,6 +96,10 @@ const EmbeddingPatchSchema = z.object({
   // Also re-indexes every vector: the prefix is part of the embedded string, so changing the scheme
   // changes the vector for identical text. Gated by the same client confirmation as model/dimensions.
   prefixScheme: z.enum(['auto', 'none', 'nomic', 'qwen']).optional(),
+  // Chunk-embed concurrency. Accepted here as well as by env so an operator can tune it without a redeploy;
+  // the ceiling is the one `embedConcurrency()` clamps to, imported rather than repeated. Absent means "use
+  // the per-embedder default", which is why there is no value that means that — clearing it is `null`.
+  embedConcurrency: z.number().int().min(1).max(MAX_EMBED_CONCURRENCY).optional().nullable(),
   apiKey: z.string().max(512).optional().nullable(),
 }).strict();
 
@@ -501,12 +507,10 @@ mediaConfigRouter.patch('/', requireAdminMfa, (req, res) => {
     // media merge and apply it separately (apiKey already routed to secrets above).
     delete merged['embedding'];
     if (parsed.data.embedding) {
-      const e = { ...parsed.data.embedding } as Record<string, unknown>;
-      delete e['apiKey']; // never in config.json
-      // null baseUrl clears it (switch back to the bundled local ONNX model).
-      if (e['baseUrl'] === null) delete e['baseUrl'];
+      // Merge, then clear — see mergeEmbeddingPatch. Doing it the other way round (delete the null from the
+      // patch, then spread) is what made `baseUrl: null` a no-op instead of "back to the bundled model".
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cfg.embedding = { ...(cfg.embedding as any ?? {}), ...e };
+      cfg.embedding = mergeEmbeddingPatch(cfg.embedding as any, parsed.data.embedding) as any;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cfg.mediaEmbedding = merged as any;

--- a/server/src/config/embedding-patch.ts
+++ b/server/src/config/embedding-patch.ts
@@ -1,0 +1,36 @@
+/**
+ * Merging an admin PATCH into the stored `config.embedding` block.
+ *
+ * This is a pure function in its own module for one reason: the merge had a bug that only a running server
+ * could see, and it survived because the only way to exercise it was a running server.
+ *
+ * The bug: the route deleted a cleared key from the **patch** and then spread the patch over the existing
+ * block — so the `null` was gone before it could clear anything and the previous value survived. Clearing
+ * `embedding.baseUrl` from the UI (which sends `baseUrl: null`, the documented "back to the bundled ONNX
+ * model" gesture) silently kept the configured endpoint, and the save response — resolved from the config it
+ * had just failed to change — repopulated the field as though the save had been ignored.
+ *
+ * `rerank` and `nli` in the same handler get this right by merging FIRST and deleting from the RESULT. That
+ * ordering is the whole content of this function.
+ */
+
+/** Keys where "cleared" is a meaningful state: absent means the default, not zero. */
+const CLEARABLE = ['baseUrl', 'embedConcurrency'] as const;
+
+/**
+ * `existing` merged with `patch`, with cleared keys removed and `apiKey` never present.
+ *
+ * `apiKey` is routed to `secrets.json` by the caller; it must not reach `config.json` even if a client sends
+ * it, which is why it is dropped here rather than trusted to have been deleted upstream.
+ */
+export function mergeEmbeddingPatch(
+  existing: Record<string, unknown> | undefined,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...(existing ?? {}), ...patch };
+  delete merged['apiKey'];
+  for (const key of CLEARABLE) {
+    if (key in patch && (patch[key] === null || patch[key] === '')) delete merged[key];
+  }
+  return merged;
+}

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -792,6 +792,10 @@ export function getEmbeddingConfig() {
     baseUrl: process.env['EMBEDDING_URL'] ?? base.baseUrl,
     model: process.env['EMBEDDING_MODEL'] ?? base.model ?? 'nomic-ai/nomic-embed-text-v1.5',
     dimensions: process.env['EMBEDDING_DIMENSIONS'] ? Number(process.env['EMBEDDING_DIMENSIONS']) : (base.dimensions ?? 768),
+    // Left `undefined` when unset on purpose: `embedConcurrency()` picks a different default per embedder,
+    // so a number here would flatten that distinction. Clamping happens there, in one place.
+    embedConcurrency: process.env['EMBEDDING_CONCURRENCY']
+      ? Number(process.env['EMBEDDING_CONCURRENCY']) : base.embedConcurrency,
     similarity: base.similarity ?? ('cosine' as const),
     provider: (process.env['EMBEDDING_PROVIDER'] as 'local' | 'external' | undefined) ?? base.provider ?? 'local',
     // 'auto' resolves to the pre-existing behaviour (see resolvePrefixScheme in brain/embedding.ts), so an
@@ -1066,6 +1070,7 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   if (process.env['EMBEDDING_DIMENSIONS']) locked.push('embedding.dimensions');
   if (process.env['EMBEDDING_PREFIX_SCHEME']) locked.push('embedding.prefixScheme');
   if (process.env['EMBEDDING_API_KEY']) locked.push('embedding.apiKey');
+  if (process.env['EMBEDDING_CONCURRENCY']) locked.push('embedding.embedConcurrency');
 
   return {
     // Per-class ceilings, filled per field so a partial `levels` block cannot drop the classes it

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -248,6 +248,13 @@ export interface EmbeddingConfig {
   /** If set, route embedding requests to this OpenAI-compatible HTTP endpoint.
    *  If absent, the bundled local ONNX model is used (default, works out of the box). */
   baseUrl?: string;
+  /**
+   * How many chunk embeds may run at once while converting one document. Absent = per-embedder default:
+   * low for the bundled in-process model (CPU-bound, and it shares the event loop that answers `/health`),
+   * higher for an HTTP endpoint (network-bound, the work is elsewhere). See `embed-concurrency.ts` for the
+   * measurements. Raise it only with CPU headroom to spare; clamped to 1…32.
+   */
+  embedConcurrency?: number;
   model: string;
   dimensions: number;
   similarity: 'cosine' | 'dotProduct' | 'euclidean';

--- a/server/src/files/converters/embed-concurrency.ts
+++ b/server/src/files/converters/embed-concurrency.ts
@@ -1,0 +1,49 @@
+/**
+ * How many chunk embeds may run at once — and why the answer differs by embedder.
+ *
+ * ## What was measured
+ *
+ * With the bundled in-process ONNX model, one chunk embed of ~1.8 KB takes **~208 ms** and blocks the event
+ * loop for essentially all of it: a 50 ms timer sampled during a run showed **mean 161 ms / max 222 ms of
+ * lag**. Measured inside the shipped image, not inferred.
+ *
+ * That is fine for one chunk. The pipeline ran **eight** of them at once, and the in-process embedder is
+ * CPU-bound, so eight concurrent inferences do not go eight times faster — they saturate every core and leave
+ * nothing for the thread that answers `/health`. On a reporting fleet a 358 KB document took ~6 minutes and
+ * the pod was killed repeatedly by an ordinary liveness probe while it was working correctly: no error, no
+ * `failed` status, just restarts. Nothing pointed at the document.
+ *
+ * ## Why this is not sized from the core count
+ *
+ * `os.availableParallelism()` reports the HOST's cores, not the cgroup CPU limit. The reporting deployment is
+ * capped at 4 CPU on a 16-core node, so core detection would have "left headroom" of 15 and oversubscribed
+ * exactly as before. A container's real budget is not visible from inside it, so the in-process default is a
+ * deliberately conservative constant instead of a computed one, and an operator with headroom can raise it.
+ *
+ * An EXTERNAL embedding endpoint is network-bound: the work happens elsewhere, this process is waiting on
+ * sockets, and eight in flight is the right call. Same constant for both was the mistake.
+ */
+
+/** In-process default: low enough to leave the event loop responsive on a small CPU allocation. */
+export const IN_PROCESS_EMBED_CONCURRENCY = 2;
+
+/** External default: the work is on another host, so this is a socket-count question, not a CPU one. */
+export const EXTERNAL_EMBED_CONCURRENCY = 8;
+
+/** Hard ceiling on the operator override, so a typo cannot turn into hundreds of parallel requests. */
+export const MAX_EMBED_CONCURRENCY = 32;
+
+/**
+ * Resolve the chunk-embed concurrency for the configured embedder.
+ *
+ * `baseUrl` present ⇒ external. A blank/absent baseUrl is the bundled in-process model, which is the case
+ * that starves the loop. An explicit `embedConcurrency` wins for either, clamped to at least 1 — a zero or a
+ * negative would otherwise stall ingestion completely, which is a worse failure than a slow one.
+ */
+export function embedConcurrency(cfg: { baseUrl?: string | null; embedConcurrency?: number }): number {
+  const external = !!cfg.baseUrl?.trim();
+  const dflt = external ? EXTERNAL_EMBED_CONCURRENCY : IN_PROCESS_EMBED_CONCURRENCY;
+  const override = cfg.embedConcurrency;
+  if (typeof override !== 'number' || !Number.isFinite(override)) return dflt;
+  return Math.max(1, Math.min(MAX_EMBED_CONCURRENCY, Math.floor(override)));
+}

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -26,12 +26,13 @@ import { writeFile, writeFileBytes } from '../files.js';
 import { resolveSafePathChecked } from '../sandbox.js';
 import { col, asFilter, asDoc } from '../../db/mongo.js';
 import { embed } from '../../brain/embedding.js';
-import { getConfig, getDocumentProcessingConfig } from '../../config/loader.js';
+import { getConfig, getDocumentProcessingConfig, getEmbeddingConfig } from '../../config/loader.js';
 import { vlmExtractDocument } from './vlm-extract.js';
 import type { FileMetaDoc, AuthorRef, DocExtractionMode, TextLevel } from '../../config/types.js';
 import type { StepProgress } from './types.js';
 import { log } from '../../util/log.js';
 import { enqueueMediaJob } from '../media/job-queue.js';
+import { embedConcurrency } from './embed-concurrency.js';
 
 export type InputFormat = 'pdf' | 'docx' | 'epub' | 'html' | 'md' | 'txt' | 'text' | 'auto';
 
@@ -387,7 +388,12 @@ export async function storeConversionResults(
   // the batch. It is still stored WITHOUT a vector — its text is preserved but it is invisible
   // to $vectorSearch — and counted, so the caller reports the job as partial/failed rather
   // than silently "complete".
-  const EMBED_CONCURRENCY = 8;
+  // Sized per embedder, because the two are different problems: an external endpoint is network-bound and
+  // wants sockets in flight, while the bundled in-process model is CPU-bound and eight at once simply
+  // saturates the machine. Measured: one in-process chunk embed blocks the event loop for ~200 ms, so eight
+  // concurrent ones on a small CPU allocation leave nothing for the thread that answers /health — which is
+  // how a 358 KB document turned into a liveness-probe crash loop with no error anywhere.
+  const EMBED_CONCURRENCY = embedConcurrency(getEmbeddingConfig());
   const INSERT_BATCH = 200;
 
   const chunkDocs: FileMetaDoc[] = new Array(chunks.length);
@@ -415,6 +421,15 @@ export async function storeConversionResults(
         embedFailures++;
         log.warn(`Chunk embed failed for ${spaceId}/${chunkId}: ${err instanceof Error ? err.message : String(err)}`);
       }
+
+      // Hand the event loop a turn between chunks.
+      //
+      // An in-process embed blocks it for ~200 ms (measured), and a large document is hundreds of them
+      // back to back. `await` on a promise that is already settled does NOT yield to the macrotask queue —
+      // it resumes in the same tick's microtask drain — so without this, pending I/O callbacks (the ones
+      // that answer /health) can sit behind the whole run. `setImmediate` puts this worker behind them
+      // instead. Cheap: one macrotask per chunk against ~200 ms of work.
+      await new Promise<void>(resolve => setImmediate(resolve));
 
       chunkDocs[i] = {
         _id: chunkId,

--- a/testing/standalone/docs-tables-render.test.js
+++ b/testing/standalone/docs-tables-render.test.js
@@ -1,0 +1,102 @@
+/**
+ * Every markdown table row in the docs actually renders as a table.
+ *
+ * ## The defect this pins
+ *
+ * A `| field | value |` row is only a table cell when the run of rows is a *table*. There are two ways to
+ * write rows that render as literal pipes in a paragraph, and **neither one errors, warns, or fails any
+ * lint we run**:
+ *
+ *   1. **No delimiter row.** GFM needs `| header |` + `|---|---|` before the body. Append rows one blank
+ *      line below a finished table and they are a new block with no header — a paragraph of pipes.
+ *   2. **Lazy continuation.** Put rows directly under a paragraph or blockquote with no blank line between
+ *      and CommonMark absorbs them into that block. Inside a blockquote they render as *quoted* pipes.
+ *
+ * When this was written, four runs in the shipped guide were broken this way — including **21 consecutive
+ * rows** (every `embedding.*`, `mediaEmbedding.*` and worker-tuning setting) swallowed into the end of the
+ * 2.1 rename note. The configuration reference operators are pointed at was a wall of quoted pipes, and it
+ * had been for as long as the note had been there. `markdownlint` passed on all four: it checks the style
+ * of tables it recognises, and these were not tables.
+ *
+ * That is the same class as an unregistered icon or an absent metric series — the failure mode is silence,
+ * so only an enumerating check finds it.
+ *
+ * Run: node --test testing/standalone/docs-tables-render.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DOCS_ROOT, docFiles } from './_docs.mjs';
+
+/** `|---|:--:|` and friends. At least one dash, nothing but dashes, colons, pipes and spaces. */
+const DELIMITER = /^\|[\s:|-]*-[\s:|-]*\|\s*$/;
+
+/**
+ * Runs of `|`-rows that will not render as a table, as `{ line, rows, why }`.
+ *
+ * Fenced blocks are skipped: a code sample showing broken markdown is not broken markdown.
+ */
+export function brokenTableRuns(text) {
+  const lines = text.split(/\r?\n/);
+  const found = [];
+  let fenced = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*(```|~~~)/.test(lines[i])) { fenced = !fenced; continue; }
+    if (fenced || !lines[i].startsWith('|')) continue;
+
+    let end = i;
+    while (end + 1 < lines.length && lines[end + 1].startsWith('|')) end++;
+    const run = lines.slice(i, end + 1);
+    const before = i === 0 ? '' : lines[i - 1];
+
+    // A heading directly above is fine — it opens a new block, so the rows are not continuing anything.
+    const glued = before.trim() !== '' && !before.startsWith('#') && !before.startsWith('|');
+
+    if (!run.some(l => DELIMITER.test(l))) found.push({ line: i + 1, rows: run.length, why: 'no delimiter row' });
+    else if (glued) found.push({ line: i + 1, rows: run.length, why: `glued to: ${before.slice(0, 60)}` });
+
+    i = end;
+  }
+  return found;
+}
+
+describe('docs table rows render as tables', () => {
+  it('has no run of rows that renders as literal pipes', () => {
+    const broken = [];
+    for (const rel of docFiles()) {
+      for (const b of brokenTableRuns(readFileSync(join(DOCS_ROOT, rel), 'utf8'))) {
+        broken.push(`docs/${rel}:${b.line} — ${b.rows} row(s), ${b.why}`);
+      }
+    }
+    assert.deepEqual(broken, [], `table rows that will not render as a table:\n  ${broken.join('\n  ')}\n\n`
+      + 'Fix: keep the rows contiguous with their header+delimiter, and leave a blank line between a\n'
+      + 'paragraph/blockquote and the table below it. If a note has to sit mid-table, repeat the header row.');
+  });
+
+  // The check above passes on an empty docs tree and on a detector that returns nothing. These pin that it
+  // detects, in each spelling — the 21-row case was the "glued" spelling, and a delimiter-only check would
+  // have missed it entirely.
+  it('detects rows with no delimiter row', () => {
+    const runs = brokenTableRuns('Some prose.\n\n| `a` | 1 |\n| `b` | 2 |\n');
+    assert.equal(runs.length, 1);
+    assert.match(runs[0].why, /no delimiter/);
+    assert.equal(runs[0].rows, 2);
+  });
+
+  it('detects rows swallowed by the block above them', () => {
+    const runs = brokenTableRuns('> a note\n> that ends here.\n| H | H |\n|---|---|\n| `a` | 1 |\n');
+    assert.equal(runs.length, 1, 'a well-formed table glued to a blockquote still does not render');
+    assert.match(runs[0].why, /glued to: > that ends here\./);
+  });
+
+  it('accepts a well-formed table, and one under a heading', () => {
+    assert.deepEqual(brokenTableRuns('Prose.\n\n| H | H |\n|---|---|\n| `a` | 1 |\n'), []);
+    assert.deepEqual(brokenTableRuns('## Heading\n| H | H |\n|:-:|---|\n| `a` | 1 |\n'), []);
+  });
+
+  it('ignores broken tables shown inside a fenced example', () => {
+    assert.deepEqual(brokenTableRuns('```markdown\n| `a` | 1 |\n| `b` | 2 |\n```\n'), []);
+  });
+});

--- a/testing/standalone/embed-concurrency.test.js
+++ b/testing/standalone/embed-concurrency.test.js
@@ -1,0 +1,77 @@
+/**
+ * Chunk-embed concurrency is sized per embedder, because the two are different problems.
+ *
+ * ## What was measured, inside the shipped image
+ *
+ * One in-process chunk embed (~1.8 KB) takes ~208 ms and blocks the event loop for essentially all of it.
+ * Eight of them at once, which is what shipped:
+ *
+ *     conc 8, no yield   total 4730ms   loop lag max 2482ms   50ms-timer fired 1 time in 4.7s
+ *     conc 2, yield      total 3677ms   loop lag max  547ms   fired 8 times
+ *
+ * So the old shape was **22% slower AND blocked the loop for 2.5 s at a stretch** — eight concurrent
+ * CPU-bound inferences on a capped allocation thrash rather than parallelise. On a reporting fleet, a 358 KB
+ * document turned into repeated liveness kills: `Readiness probe failed: context deadline exceeded (awaiting
+ * headers)`, no error, no `failed` status, ~190 MiB of a 10 Gi limit. Nothing pointed at the document.
+ *
+ * ## Why not sized from the core count
+ *
+ * `os.availableParallelism()` reports the HOST's cores, not the cgroup limit. The reporting deployment is
+ * capped at 4 CPU on a 16-core node — core detection would have "left headroom" of 15 and oversubscribed
+ * exactly as before. That is why the in-process default is a conservative constant with an operator override,
+ * and this file pins that reasoning as behaviour.
+ *
+ * Run: node --test testing/standalone/embed-concurrency.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let embedConcurrency, IN_PROCESS_EMBED_CONCURRENCY, EXTERNAL_EMBED_CONCURRENCY, MAX_EMBED_CONCURRENCY;
+
+describe('embedConcurrency', () => {
+  before(async () => {
+    ({ embedConcurrency, IN_PROCESS_EMBED_CONCURRENCY, EXTERNAL_EMBED_CONCURRENCY, MAX_EMBED_CONCURRENCY } =
+      await import('../../server/dist/files/converters/embed-concurrency.js'));
+  });
+
+  it('is LOW for the bundled in-process model — it is CPU-bound and shares the loop', () => {
+    assert.equal(embedConcurrency({}), IN_PROCESS_EMBED_CONCURRENCY);
+    assert.equal(embedConcurrency({ baseUrl: '' }), IN_PROCESS_EMBED_CONCURRENCY);
+    assert.equal(embedConcurrency({ baseUrl: '   ' }), IN_PROCESS_EMBED_CONCURRENCY,
+      'whitespace is not an endpoint');
+    assert.equal(embedConcurrency({ baseUrl: null }), IN_PROCESS_EMBED_CONCURRENCY);
+    assert.ok(IN_PROCESS_EMBED_CONCURRENCY < EXTERNAL_EMBED_CONCURRENCY, 'the whole point of the split');
+  });
+
+  it('is HIGHER for an external endpoint — the work is on another host', () => {
+    assert.equal(embedConcurrency({ baseUrl: 'http://emb:8080' }), EXTERNAL_EMBED_CONCURRENCY);
+    assert.equal(embedConcurrency({ baseUrl: 'https://api.example.com/v1' }), EXTERNAL_EMBED_CONCURRENCY);
+  });
+
+  it('honours an operator override for either embedder', () => {
+    assert.equal(embedConcurrency({ embedConcurrency: 6 }), 6);
+    assert.equal(embedConcurrency({ baseUrl: 'http://emb:8080', embedConcurrency: 1 }), 1);
+  });
+
+  it('NEVER returns zero or a negative, whatever is configured', () => {
+    // A zero would stall ingestion completely — a worse failure than a slow one, and the kind that reads as
+    // "uploads do nothing" with no error anywhere.
+    for (const v of [0, -1, -100, 0.4]) {
+      assert.ok(embedConcurrency({ embedConcurrency: v }) >= 1, `override ${v}`);
+    }
+  });
+
+  it('clamps an absurd override rather than obeying it', () => {
+    assert.equal(embedConcurrency({ embedConcurrency: 5000 }), MAX_EMBED_CONCURRENCY);
+  });
+
+  it('ignores a non-numeric or non-finite override and uses the default', () => {
+    for (const v of [undefined, NaN, Infinity, '8']) {
+      assert.equal(embedConcurrency({ embedConcurrency: v }), IN_PROCESS_EMBED_CONCURRENCY, String(v));
+    }
+  });
+
+  it('floors a fractional override instead of passing it to a loop bound', () => {
+    assert.equal(embedConcurrency({ embedConcurrency: 3.9 }), 3);
+  });
+});

--- a/testing/standalone/embedding-patch-merge.test.js
+++ b/testing/standalone/embedding-patch-merge.test.js
@@ -1,0 +1,81 @@
+/**
+ * Clearing an embedding field from the admin API actually clears it.
+ *
+ * The UI's "go back to the bundled model" gesture is `PATCH { embedding: { baseUrl: null } }` — the same
+ * shape `rerank` and `nli` use to switch themselves off. The embedding branch of that handler deleted the
+ * null from the PATCH and then spread the patch over the stored block, so the null never met the stored
+ * value: the configured endpoint survived, and the save response (resolved from the config that had just not
+ * changed) put the old URL straight back in the field. It reads as "the save was ignored", with a 200 and
+ * no log line.
+ *
+ * The ordering is the whole fix, and ordering is exactly what a source-level check cannot see, so this
+ * exercises the merge itself.
+ *
+ * Run: node --test testing/standalone/embedding-patch-merge.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mergeEmbeddingPatch;
+
+describe('mergeEmbeddingPatch', () => {
+  before(async () => {
+    ({ mergeEmbeddingPatch } = await import('../../server/dist/config/embedding-patch.js'));
+  });
+
+  it('CLEARS baseUrl on null — the previous endpoint must not survive', () => {
+    const out = mergeEmbeddingPatch({ baseUrl: 'http://emb:8080', model: 'nomic' }, { baseUrl: null });
+    assert.ok(!('baseUrl' in out), `baseUrl survived the clear: ${JSON.stringify(out)}`);
+    assert.equal(out.model, 'nomic', 'clearing one field must not drop the others');
+  });
+
+  it('clears on an empty string too', () => {
+    const out = mergeEmbeddingPatch({ baseUrl: 'http://emb:8080' }, { baseUrl: '' });
+    assert.ok(!('baseUrl' in out));
+  });
+
+  it('clears embedConcurrency back to the per-embedder default', () => {
+    // Absent is meaningful here: the default differs by embedder, so a stored 0 or 2 is not the same thing.
+    const out = mergeEmbeddingPatch({ embedConcurrency: 16 }, { embedConcurrency: null });
+    assert.ok(!('embedConcurrency' in out));
+  });
+
+  it('sets a new value, and leaves untouched fields alone', () => {
+    const out = mergeEmbeddingPatch(
+      { baseUrl: 'http://old:8080', model: 'nomic', dimensions: 768 },
+      { baseUrl: 'http://new:8080', embedConcurrency: 4 },
+    );
+    assert.equal(out.baseUrl, 'http://new:8080');
+    assert.equal(out.embedConcurrency, 4);
+    assert.equal(out.model, 'nomic');
+    assert.equal(out.dimensions, 768);
+  });
+
+  it('never lets apiKey into the config block — it belongs in secrets.json', () => {
+    const out = mergeEmbeddingPatch({ model: 'nomic' }, { apiKey: 'sk-live-secret' });
+    assert.ok(!('apiKey' in out), 'an API key in config.json is the thing this repo is careful about');
+    assert.ok(!JSON.stringify(out).includes('sk-live-secret'));
+  });
+
+  it('drops a stored apiKey that a previous version had written', () => {
+    const out = mergeEmbeddingPatch({ apiKey: 'sk-legacy', model: 'nomic' }, { model: 'qwen' });
+    assert.ok(!('apiKey' in out), 'the merge is also the migration');
+  });
+
+  it('does not mutate the stored block it was handed', () => {
+    const existing = { baseUrl: 'http://emb:8080' };
+    mergeEmbeddingPatch(existing, { baseUrl: null });
+    assert.equal(existing.baseUrl, 'http://emb:8080', 'saveConfig writes the object it was given');
+  });
+
+  it('handles a first-ever patch with nothing stored', () => {
+    assert.deepEqual(mergeEmbeddingPatch(undefined, { model: 'nomic' }), { model: 'nomic' });
+    assert.deepEqual(mergeEmbeddingPatch(undefined, { baseUrl: null }), {});
+  });
+
+  it('leaves a field alone when the patch omits it — absent is not cleared', () => {
+    // The client sends the whole block, but a scripted PATCH sends one field; omission must not mean delete.
+    const out = mergeEmbeddingPatch({ baseUrl: 'http://emb:8080' }, { model: 'nomic' });
+    assert.equal(out.baseUrl, 'http://emb:8080');
+  });
+});


### PR DESCRIPTION
## What broke

A 358 KB report on the canary's reporting fleet turned into a restart loop. What they had to work with:

```text
Readiness probe failed: context deadline exceeded (awaiting headers)
```

…and ~190 MiB of a 10 Gi memory limit. No error, no `failed` status, nothing naming the file. The memory
ceiling everyone reaches for first was never the constraint.

A document that size is hundreds of chunks. Each **in-process** chunk embed holds the event loop for ~200 ms,
and `storeConversionResults` ran **eight at once with nothing yielding between them** — so for minutes at a
stretch there was no turn left for the callback that answers `/health`. The probe timed out, Kubernetes
killed a container that was working correctly, the persisted job resumed on boot, and it happened again.

## Measured, not reasoned about

Inside the shipped image, 16 chunks of ~1.8 KB, with a 50 ms interval timer standing in for the probe:

| shape | total | max loop lag | 50 ms timer |
|---|---|---|---|
| conc 8, no yield (shipped) | 4 730 ms | **2 482 ms** | fired **once** in 4.7 s |
| conc 2, yield (this PR) | 3 677 ms | 547 ms | fired 8 times |

The old shape was **22% slower as well as blocking** — eight concurrent CPU-bound inferences thrash rather
than parallelise. The setting was paying for its own outage.

## The fix

- **Concurrency is sized per embedder** (`files/converters/embed-concurrency.ts`): `2` in-process, `8` for an
  HTTP endpoint, overridable by `embedding.embedConcurrency` / `EMBEDDING_CONCURRENCY`, clamped to 1…32.
  They are different problems — an external endpoint is network-bound and wants sockets in flight; the
  bundled one is CPU-bound and shares the loop with the HTTP server.
- **The pipeline yields between chunks** (`setImmediate`). `await` on an already-settled promise resumes in
  the same tick's microtask drain, so it does *not* let pending I/O callbacks through; that is why the
  existing `await embed(...)` was not already enough.
- **Not sized from `os.availableParallelism()`.** It reports the *host's* cores, not the cgroup limit. The
  reporting deployment is capped at 4 CPU on a 16-core node, so core detection would have "left headroom" of
  15 and oversubscribed exactly as before — the careful-looking version of the same bug.
- Docs carry the numbers and the `livenessProbe` shape (`timeoutSeconds: 10`, `failureThreshold: 6`) that
  tolerates a slow answer.

## Two silent defects found on the way

Both are the same class as the headline — a wrong outcome that produces no error.

**Clearing the embedding endpoint did nothing.** `PATCH { embedding: { baseUrl: null } }` is how the UI goes
back to the bundled model. The handler deleted the cleared key from the **patch** and then spread the patch
over the stored block, so the `null` was gone before it could meet the value it was meant to clear. The
configured URL survived and the save response — resolved from the config that had just not changed — put it
back in the field: a `200` that reads as "the save was ignored". `rerank` and `nli` in the same handler merge
first and delete from the result; the embedding branch had the same two lines in the other order. The merge
is now `config/embedding-patch.ts`, a pure function, because *needing a running server to exercise it* is why
this lasted. Same pass: a stored `apiKey` from an older version is now dropped rather than merged forward.

**21 consecutive rows of the media-configuration reference were not a table.** They rendered as *quoted
literal pipes* — every `embedding.*`, `mediaEmbedding.*` and worker-tuning setting, swallowed into the end of
the 2.1 rename note by CommonMark's lazy continuation (rows directly under a paragraph with no blank line
between belong to that paragraph). Three further runs elsewhere had been appended one blank line below a
finished table, leaving them with no header or delimiter row. `markdownlint` passed on all four: it checks the
style of tables it *recognises*, and these had stopped being tables.

## Gates

| gate | what it pins |
|---|---|
| `embed-concurrency` (7) | per-embedder default, override honoured, clamped, never 0 or negative |
| `embedding-patch-merge` (9) | clear actually clears; **fails in 4 places** against the previous merge order |
| `docs-tables-render` (5) | every `\|`-row run in `docs/` renders as a table, in both spellings of the defect, detector self-tested; catches all four runs as they stand in `main` |

Reported by the canary. Their other findings (stalled-job lease, an in-flight embedding gauge, a configurable
describe timeout) are queued behind this one in damage order.
