### PR TITLE
fix(files): a slow document was re-queued as a stuck one, and then ran twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A document that took longer than `stalledJobTimeoutMs` to embed was re-queued while it was still
+  running — and then ran twice.** Stall recovery measures from the last progress report, and the chunk-embed
+  phase reported nothing at all: conversion heartbeat per page, then silence for however long hundreds of
+  chunks take. So the phase that takes the longest was the one that looked wedged, and recovery did what it
+  is for — except the previous holder was alive. Two runs then embedded the same file concurrently, writing
+  the same chunk `_id`s and competing for the CPU the first one was already too slow on, with `attempts`
+  climbing until the job failed for "exhausted retries" having never actually failed.
+  - **The embed phase heartbeats**, throttled to one write every 2 s, and its `progress` reports
+    `embed done/total` — so the phase is visible in the Files view as well as to the stall detector.
+  - **A claim can now be withdrawn.** Recovery clears the job's `claimToken`; the next heartbeat from the old
+    holder matches nothing, and that run abandons instead of racing its replacement. It does not `failJob`
+    (which would spend a second attempt on a job that did nothing wrong) and cannot `completeJob` (which
+    would report a re-queued job as done).
+  - **The re-queue log is a `warn` that names the file, how long it was silent, its size, the step it had
+    reached and which attempt it was** — and says which of the two things it is: "if the file is large and
+    the instance is CPU-bound this is a slow job being killed, not a stuck one". It used to be
+    `reset 1 stalled job(s) to pending` at `info`.
+  - Pinned by `job-lease-db.test.js` against a real MongoDB — the question is whether an update *matched*,
+    which only a database can answer — plus `job-lease.test.js` for the throttle, the abandonment signal and
+    the warning text. Both mutations (recovery not clearing the token, heartbeat ignoring it) fail the suite.
+- **Every media-pipeline metric was exposed and undocumented — including the one that was asked for.** A
+  fleet debugging a document that would not finish asked for a gauge showing one long job in flight;
+  `ythril_media_jobs_processing` had been shipping since 1.x. It, `ythril_media_jobs_pending`,
+  `_completed_total`, `_failed_total`, `_retried_total`, `_failed` and `ythril_media_job_duration_seconds`
+  were absent from the metrics table while every other family was listed. An undocumented metric is one an
+  operator cannot find.
+  - All seven are documented now, and `metric-docs-coverage.test.js` enumerates `metrics/registry.ts` in both
+    directions, so a metric added without a row fails the build rather than being found by a customer.
+  - Two genuinely missing signals added, because "a job is running" was never the question:
+    **`ythril_media_job_phase{space,step}`** — in-flight jobs by the pipeline step they are in, aggregated
+    from the step report the worker already writes; and **`ythril_embed_chunks_total{space}`** — chunks put
+    through the embedder. `rate(ythril_embed_chunks_total[5m]) == 0` while `ythril_media_jobs_processing > 0`
+    is a stuck job; a non-zero rate is a slow one. That distinction is what the crash loop lacked.
+  - A step reports `0` once it has been seen rather than dropping out of the scrape: an absent series and a
+    zero one are the same query result, so a disappearing label silently stops an alert from evaluating.
+
 - **Clearing the embedding endpoint from the UI kept the old one, with a `200` and no log line.** The admin
   PATCH handler deleted the cleared key from the *patch* and then spread the patch over the stored block — so
   the `null` was gone before it could meet the value it was meant to clear. The configured URL survived, and

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -300,6 +300,13 @@ fabricated progress. `progressAt` is the last report, which is what distinguishe
 wedged one — compare it against `stalledJobTimeoutMs`. Both fields are absent once the job finishes,
 and while a claimed job has not yet reported its first step.
 
+The `embed` step reports too, throttled to one write every 2 s. Until 2.2.3 it did not, so a document with
+more than `stalledJobTimeoutMs` of chunk-embedding in it looked wedged from the moment conversion finished:
+recovery re-queued it mid-flight, a second worker started the same file over, and both ran at once. Recovery
+now also **withdraws the claim** it re-queues, so the previous holder stops at its next heartbeat instead of
+racing its replacement — the abandoned run logs `abandoning …, its claim was recovered`, and the re-queue
+itself logs one `warn` naming the file, how long it was silent, its size and the step it had reached.
+
 Media files (image/audio/video) are likewise queued and report `embeddingStatus` of `pending`,
 `disabled` (media embedding turned off) or `skipped` (over `maxFileSizeBytes`). Only the `"text"`
 bypass is fully synchronous: it stores a single flat embedding with no chunking and no job.
@@ -907,7 +914,7 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `workerMaxPollIntervalMs` | `WORKER_MAX_POLL_INTERVAL_MS` | `30000` | Max poll interval when idle (ms) |
 | `fallbackToExternal` | `MEDIA_EMBEDDING_FALLBACK_TO_EXTERNAL` | `false` | Use external provider if local fails |
 | `maxFileSizeBytes` | `MAX_FILE_SIZE_BYTES` | `524288000` | Skip embedding for files above this size (500 MiB) |
-| `stalledJobTimeoutMs` | `STALLED_JOB_TIMEOUT_MS` | `300000` | Re-queue jobs stuck in processing for > N ms |
+| `stalledJobTimeoutMs` | `STALLED_JOB_TIMEOUT_MS` | `300000` | Re-queue a job that has reported no progress for > N ms. Measured from the last heartbeat, not from the claim, and re-queuing now withdraws the running claim so the previous holder stops rather than racing its replacement. Each re-queue logs one `warn` with the file, the silence, the size and the step. |
 
 > **Large documents, CPU limits and liveness probes.** With the **bundled in-process** embedder, one ~2 KB
 > chunk costs roughly 200 ms of CPU and blocks the event loop for most of it. A 350 KB document is hundreds

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -88,6 +88,15 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_sync_items_pushed_total` | counter | Items sent by type |
 | `ythril_sync_duration_seconds` | histogram | Time per sync cycle |
 | `ythril_recall_degraded_total` | counter | Recalls answered with a **weaker pipeline than configured**, by `reason`. `rerank_unavailable` = the cross-encoder is configured but did not answer; `rerank_skipped_budget` = it was not attempted because the end-to-end `RECALL_BUDGET_MS` was already spent upstream. **This is the one to alert on**: these paths return HTTP 200 with a worse ranking, so they raise no error rate and barely move latency — a reranker down for a week is otherwise invisible. Both series report `0` from process start, so absent-vs-zero is never ambiguous. |
+| `ythril_media_jobs_pending` | gauge | Queued media/document embedding jobs by space |
+| `ythril_media_jobs_processing` | gauge | Jobs a worker is currently running, by space. **One long document shows as `1` here for its whole duration** — pair it with `ythril_embed_chunks_total` to tell slow from stuck |
+| `ythril_media_job_phase` | gauge | In-flight jobs by the pipeline step they are in (`render`, `vlm`, `embed`, `describe`, …, or `unknown` for a job that has not reported one). Steps report `0` once seen rather than disappearing |
+| `ythril_embed_chunks_total` | counter | Chunks put through the embedder, by space. Motion, not success: `rate(...[5m]) == 0` while `ythril_media_jobs_processing > 0` is a stuck job, a non-zero rate is a slow one |
+| `ythril_media_jobs_completed_total` | counter | Jobs that finished, by space and media type |
+| `ythril_media_jobs_failed_total` | counter | Jobs that exhausted their retries, by space and media type |
+| `ythril_media_jobs_retried_total` | counter | Attempts that failed and were re-queued, by space and media type — including a job whose claim was recovered while it was still running |
+| `ythril_media_jobs_failed` | gauge | Jobs sitting in the terminal `failed` state by space (a backlog, not a rate) |
+| `ythril_media_job_duration_seconds` | histogram | End-to-end time per job by media type |
 | `ythril_security_posture_checks` | gauge | This instance's own PASS/WARN/FAIL posture, by `level` — the same findings the boot log prints and `GET /api/about/security` serves, computed per scrape from the same function. **Alert on `level="fail"` > 0**: the checks that matter most produce no runtime symptom at all (`requireEncryptedTransport` on *without* `trustProxy` rejects every request with a 403 that looks like a client problem), and the only other way to notice was somebody reading the boot log of each instance. All three levels report `0` from process start. |
 
 Default Node.js process metrics (`nodejs_*`, `process_*`) are also included via [prom-client](https://github.com/siimon/prom-client)'s `collectDefaultMetrics()`.

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1712,6 +1712,15 @@ export interface MediaJobDoc {
    */
   progress?: { step: string; steps: string[]; done?: number; total?: number };
   /**
+   * Identifies the RUN that holds this job, not the job. Set on claim, cleared by stall recovery.
+   *
+   * Every heartbeat matches on it, so a run whose job was recovered while it was still working discovers
+   * that on its next tick and abandons — instead of embedding the same file alongside the new claimant,
+   * writing the same chunk ids, and possibly reporting `complete` on a job the queue has re-queued.
+   * Absent on jobs claimed by a build that predates the field; the heartbeat then behaves as it used to.
+   */
+  claimToken?: string | null;
+  /**
    * ISO8601 — when set on a `pending` job, the worker MUST NOT claim it
    * until this timestamp has passed. Used for exponential retry backoff so
    * a fast-failing "poison pill" job can’t monopolise the queue and starve

--- a/server/src/files/converters/pipeline.ts
+++ b/server/src/files/converters/pipeline.ts
@@ -33,6 +33,8 @@ import type { StepProgress } from './types.js';
 import { log } from '../../util/log.js';
 import { enqueueMediaJob } from '../media/job-queue.js';
 import { embedConcurrency } from './embed-concurrency.js';
+import { JobLeaseLostError, shouldHeartbeat } from '../media/lease.js';
+import { embedChunksTotal } from '../../metrics/registry.js';
 
 export type InputFormat = 'pdf' | 'docx' | 'epub' | 'html' | 'md' | 'txt' | 'text' | 'auto';
 
@@ -299,6 +301,19 @@ export async function storeConversionResults(
   chunks: Chunk[],
   convertedMarkdown: string | null,
   extractedImages: ExtractedImage[] = [],
+  /**
+   * Progress + lease, for the phase that takes the longest and reported neither.
+   *
+   * Conversion heartbeats per page; embedding did not heartbeat at all, so on a document with more than
+   * `stalledJobTimeoutMs` worth of chunks the queue concluded the job was wedged and re-queued it while it
+   * was still running. `onProgress` is what stops that, and `shouldStop` is what makes the *loser* of a
+   * recovery stop instead of racing the new claimant.
+   */
+  opts: {
+    onProgress?: (p: StepProgress) => void;
+    /** Checked between chunks; true means the claim is gone and this run throws `JobLeaseLostError`. */
+    shouldStop?: () => boolean;
+  } = {},
 ): Promise<{ chunkCount: number; convertedFileId: string | null; embedFailures: number }> {
   const originalId = toDocId(originalFilePath);
   const now = new Date().toISOString();
@@ -398,6 +413,22 @@ export async function storeConversionResults(
 
   const chunkDocs: FileMetaDoc[] = new Array(chunks.length);
 
+  // Heartbeat bookkeeping for this phase. `embedded` counts finished chunks across all workers, so the
+  // report is the document's progress rather than one worker's.
+  const EMBED_STEPS = ['embed'];
+  let embedded = 0;
+  let lastBeatAt = Date.now();
+  function reportChunk(): void {
+    embedded++;
+    // Motion, in a form a dashboard can rate(). Unthrottled on purpose: the heartbeat below is a database
+    // write and this is an in-process increment, and it is the counter that distinguishes slow from stuck.
+    embedChunksTotal.labels({ space: spaceId }).inc();
+    const isLast = embedded === chunks.length;
+    if (!opts.onProgress || !shouldHeartbeat(lastBeatAt, Date.now(), isLast)) return;
+    lastBeatAt = Date.now();
+    opts.onProgress({ step: 'embed', steps: EMBED_STEPS, done: embedded, total: chunks.length });
+  }
+
   let cursor = 0;
   async function embedWorker(): Promise<void> {
     for (;;) {
@@ -430,6 +461,13 @@ export async function storeConversionResults(
       // that answer /health) can sit behind the whole run. `setImmediate` puts this worker behind them
       // instead. Cheap: one macrotask per chunk against ~200 ms of work.
       await new Promise<void>(resolve => setImmediate(resolve));
+
+      // Say so, and check we are still the run that is allowed to. Both ride on the same tick: the
+      // heartbeat is throttled to one write per 2 s, and the lease answer it returns is what `shouldStop`
+      // reports here. A recovered job's old holder stops within a beat instead of embedding the same file
+      // alongside its replacement.
+      reportChunk();
+      if (opts.shouldStop?.()) throw new JobLeaseLostError(spaceId, originalId);
 
       chunkDocs[i] = {
         _id: chunkId,

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -12,6 +12,7 @@ import type { StepProgress } from '../converters/types.js';
 import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { withJitter } from '../../util/backoff.js';
+import { newClaimToken, stalledJobWarning } from './lease.js';
 
 const MAX_ATTEMPTS = 3;
 
@@ -333,7 +334,12 @@ export async function claimNextJob(
         ],
       }),
       asUpdate<MediaJobDoc>({
-        $set: { status: 'processing', claimedAt: now, progressAt: now, claimableAfter: null, updatedAt: now },
+        // `claimToken` identifies THIS run of THIS job. Stall recovery clears it, so a heartbeat from a
+        // holder whose job was recovered matches nothing and the old run learns it has been replaced.
+        $set: {
+          status: 'processing', claimedAt: now, progressAt: now, claimableAfter: null, updatedAt: now,
+          claimToken: newClaimToken(),
+        },
         $inc: { attempts: 1 },
       }),
       { returnDocument: 'after', sort: { createdAt: 1 } },
@@ -505,16 +511,28 @@ export async function touchJobProgress(
   spaceId: string,
   jobId: string,
   progress?: StepProgress,
-): Promise<void> {
+  claimToken?: string | null,
+): Promise<boolean> {
   const now = new Date().toISOString();
   try {
-    await jobCollection(spaceId).updateOne(
-      asFilter<MediaJobDoc>({ _id: jobId, status: 'processing' }),
+    const res = await jobCollection(spaceId).updateOne(
+      // With a token, the heartbeat is also a lease check: it matches only while this run still holds the
+      // claim. Without one (an older caller), it degrades to the previous behaviour rather than failing.
+      asFilter<MediaJobDoc>({
+        _id: jobId,
+        status: 'processing',
+        ...(claimToken ? { claimToken } : {}),
+      }),
       // The step report rides along in the write the heartbeat already performs — reporting which
       // step is running costs nothing extra on top of saying that something happened.
       asUpdate<MediaJobDoc>({ $set: { progressAt: now, ...(progress ? { progress } : {}) } }),
     );
-  } catch { /* best-effort — see above */ }
+    return res.matchedCount > 0;
+  } catch {
+    // A failed heartbeat is not evidence the lease is gone — a dropped connection would otherwise abort a
+    // healthy job. Report "still ours" and let stall detection do its job on the next tick.
+    return true;
+  }
 }
 
 export async function resetStalledJobs(
@@ -538,12 +556,26 @@ export async function resetStalledJobs(
           // immediately re-claimable. Without this, a job that crashed mid-
           // execution would carry a stale future `claimableAfter` from a prior
           // failure and remain invisible to the worker until that timestamp.
-          $set: { status: 'pending', claimedAt: null, claimableAfter: null, updatedAt: now },
+          //
+          // `claimToken: null` is how the PREVIOUS holder finds out. If it is still alive — a slow job, not
+          // a dead one — its next heartbeat matches nothing and it abandons instead of racing the new run.
+          $set: { status: 'pending', claimedAt: null, claimableAfter: null, claimToken: null, updatedAt: now },
           $inc: { attempts: 1 },
         },
-        { returnDocument: 'after', sort: { claimedAt: 1 } },
+        { returnDocument: 'before', sort: { claimedAt: 1 } },
       ) as MediaJobDoc | null;
       if (!claimed) break;
+      // One WARN per job, naming the file, the silence, the size and the step. `returnDocument: 'before'`
+      // above is what makes that possible: the pre-reset document still carries the progress the job had
+      // reached, which is the whole diagnostic — the reset itself is not news, what it interrupted is.
+      let sizeBytes: number | undefined;
+      try {
+        const meta = await fileCollection(spaceId).findOne(
+          asFilter<FileMetaDoc>({ _id: claimed._id }), { projection: { sizeBytes: 1 } },
+        ) as { sizeBytes?: number } | null;
+        sizeBytes = meta?.sizeBytes;
+      } catch { /* the warning is worth more without the size than not at all */ }
+      log.warn(stalledJobWarning({ ...claimed, spaceId }, Date.now(), sizeBytes));
       // Crash-recovered jobs are immediately claimable again — re-arm the hint, otherwise the
       // claim walk would skip this space until the next full scan.
       markSpaceMayHaveWork(spaceId);
@@ -551,8 +583,10 @@ export async function resetStalledJobs(
     }
   }
 
-  if (reset > 0) {
-    log.info(`Media worker: reset ${reset} stalled job(s) to pending`);
+  if (reset > 1) {
+    // Each job already logged its own WARN above; this only adds the shape of a batch — several at once is
+    // a pod that died, one at a time is a job being outrun by the timeout.
+    log.info(`Media worker: reset ${reset} stalled job(s) to pending in one sweep`);
   }
 }
 

--- a/server/src/files/media/lease.ts
+++ b/server/src/files/media/lease.ts
@@ -1,0 +1,105 @@
+/**
+ * A worker's claim on a job, and what happens when it loses one.
+ *
+ * ## Why a token
+ *
+ * Stall recovery flips a `processing` job back to `pending` when nothing has reported progress for
+ * `stalledJobTimeoutMs`. Recovery is what makes a crashed pod's work resumable, so it cannot be removed —
+ * but until now it also had no way to tell the *previous* holder that its claim was gone. When a live job
+ * was recovered (because the phase it was in reported no progress), the outcome was two runs on the same
+ * file: the old one still embedding, the new one starting over, each writing the same chunk `_id`s, both
+ * competing for the same CPU that the first one was already too slow on.
+ *
+ * The token is compared on every heartbeat. Recovery clears it, so the next heartbeat from the old holder
+ * matches nothing, and that is the signal to stop — one extra field, no extra round trip, and it uses the
+ * write the heartbeat was already making.
+ *
+ * ## Why the loser stops rather than finishes
+ *
+ * The recovered job is `pending` with `attempts` already incremented: the queue has decided a new run owns
+ * this file. If the old run finished anyway it would write chunks the new run then overwrites, and could
+ * report `complete` on a job the queue has re-queued — a completed job with a live claimant.
+ */
+
+/** A fresh claim token. Random rather than time-based: two pods claiming in the same millisecond must differ. */
+export function newClaimToken(): string {
+  // `randomUUID` is available on Node 18+; this module is imported by the worker, never by the client.
+  return crypto.randomUUID();
+}
+
+/**
+ * Thrown when a job's claim was taken away while it was running.
+ *
+ * Not a failure of the work: the file is fine and another claimant is already on it. The worker treats it
+ * as an abandonment — no `failJob` (which would burn an attempt and write a `lastError` describing nothing
+ * wrong), no `completeJob` (which would mark a re-queued job done).
+ */
+export class JobLeaseLostError extends Error {
+  readonly spaceId: string;
+  readonly jobId: string;
+
+  constructor(spaceId: string, jobId: string) {
+    super(`Lease lost for ${spaceId}/${jobId} — the job was re-queued while it was still running`);
+    this.name = 'JobLeaseLostError';
+    this.spaceId = spaceId;
+    this.jobId = jobId;
+  }
+}
+
+/** True when `err` is a lost lease, including across module instances (name check, not `instanceof`). */
+export function isLeaseLost(err: unknown): boolean {
+  return err instanceof JobLeaseLostError
+    || (err instanceof Error && err.name === 'JobLeaseLostError');
+}
+
+/**
+ * How long a heartbeat may be withheld while a phase makes many small steps.
+ *
+ * Chunk embedding lands a step every ~200 ms and each heartbeat is a database write, so an unthrottled
+ * heartbeat would triple the writes the phase performs to say nothing new. 2 s is far below any usable
+ * `stalledJobTimeoutMs` (the minimum the API accepts is 30 s) and far above the cost of a write.
+ */
+export const HEARTBEAT_MIN_INTERVAL_MS = 2_000;
+
+/**
+ * Should this step's heartbeat be written, given when the last one was?
+ *
+ * `isLast` forces a write so the final state of a phase is always recorded — a progress bar that stops at
+ * 47/50 because the last three steps fell inside the throttle window reads as a hang.
+ */
+export function shouldHeartbeat(lastWriteAt: number, now: number, isLast = false): boolean {
+  return isLast || now - lastWriteAt >= HEARTBEAT_MIN_INTERVAL_MS;
+}
+
+/**
+ * One line describing a job that stall recovery is about to re-queue.
+ *
+ * Exists because the log said `reset 1 stalled job(s) to pending` at `info`, which names neither the file
+ * nor how long it was quiet — so a fleet whose large documents were being recovered mid-flight had a
+ * `WARN`-free log and no way to connect the restarts to a document. Everything an operator needs to decide
+ * "too slow" vs "wedged" goes on the line: which file, how long silent, how big, which step it was in, and
+ * which attempt this is.
+ */
+export function stalledJobWarning(job: {
+  spaceId?: string;
+  _id?: string;
+  filePath?: string;
+  progressAt?: string | null;
+  claimedAt?: string | null;
+  attempts?: number;
+  maxAttempts?: number;
+  progress?: { step?: string; done?: number; total?: number } | null;
+}, nowMs: number, sizeBytes?: number): string {
+  const since = job.progressAt ?? job.claimedAt ?? null;
+  const quietMs = since ? Math.max(0, nowMs - Date.parse(since)) : NaN;
+  const quiet = Number.isFinite(quietMs) ? `${Math.round(quietMs / 1000)}s` : 'unknown time';
+  const where = job.progress?.step
+    ? `${job.progress.step}${job.progress.done !== undefined ? ` ${job.progress.done}/${job.progress.total ?? '?'}` : ''}`
+    : 'no step reported';
+  const size = sizeBytes !== undefined && Number.isFinite(sizeBytes)
+    ? `${(sizeBytes / 1024).toFixed(0)} KiB` : 'unknown size';
+  return `Media worker: re-queued ${job.spaceId ?? '?'}/${job.filePath ?? job._id ?? '?'} after ${quiet}`
+    + ` with no progress (${size}, last step: ${where}, attempt ${job.attempts ?? '?'}/${job.maxAttempts ?? '?'}).`
+    + ` If the file is large and the instance is CPU-bound this is a slow job being killed, not a stuck one:`
+    + ` raise stalledJobTimeoutMs or lower embedding.embedConcurrency.`;
+}

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -53,6 +53,8 @@ import {
 } from '../converters/pipeline.js';
 import type { ResolvedFormat } from '../converters/pipeline.js';
 import { ConversionUnavailableError } from '../converters/types.js';
+import type { StepProgress } from '../converters/types.js';
+import { isLeaseLost } from './lease.js';
 import { effectiveDocExtractionMode } from '../converters/extraction-level.js';
 import { effectiveTextLevel, effectiveVideoLevel, videoDoesKeyframes } from '../converters/media-level.js';
 import fs from 'fs/promises';
@@ -284,6 +286,17 @@ async function processJob(
   const mimeType = mimeTypeForPath(filePath, job.mimeType);
   const endTimer = mediaJobDurationSeconds.startTimer({ media_type: mediaType });
 
+  // The claim this run holds. Every heartbeat carries it, and the answer says whether the claim is still
+  // ours: stall recovery clears the token, so a job recovered while this run was still working reports
+  // `false` on the next beat. `leaseLost` is what the long phases poll to stop early — without it a
+  // recovered job runs twice, both runs writing the same chunk ids and competing for the same CPU.
+  let leaseLost = false;
+  const heartbeat = (p?: StepProgress): void => {
+    void touchJobProgress(spaceId, String(fileId), p, job.claimToken).then(stillOurs => {
+      if (!stillOurs) leaseLost = true;
+    });
+  };
+
   try {
     // Load file bytes from disk
     const absolutePath = resolveFilePath(spaceId, filePath);
@@ -372,12 +385,15 @@ async function processJob(
           {
             mode: spaceMode,
             textLevel: spaceTextLevel,
-            onProgress: (p) => { void touchJobProgress(spaceId, String(fileId), p); },
+            onProgress: heartbeat,
           },
         );
         if (chunks.length > 0 || extractedImages.length > 0) {
           const { chunkCount, convertedFileId, embedFailures } = await storeConversionResults(
             spaceId, filePath, chunks, convertedMarkdown, extractedImages,
+            // Embedding is the longest phase and reported nothing, so a document with more than
+            // `stalledJobTimeoutMs` of chunks in it was recovered mid-flight every time.
+            { onProgress: heartbeat, shouldStop: () => leaseLost },
           );
           const metaUpdate: Record<string, unknown> = { chunkCount };
           if (convertedFileId) metaUpdate['convertedFileId'] = convertedFileId;
@@ -398,6 +414,9 @@ async function processJob(
           // generated, and on an invoice the head of the text is a payment reference cut mid-identifier.
           // `describeDocument` asks the model that already reads these files what the file IS, keeps the
           // document's own opening prose as the excerpt either way, and reports which one it produced.
+          // One beat before the describe pass: it is a single model call with its own timeout, so the stall
+          // clock should start when the phase does rather than partway through the one before it.
+          heartbeat({ step: 'describe', steps: ['describe'] });
           const described = await describeDocument(convertedMarkdown, chunks);
           derivedDescription = described.text;
           derivedSource = described.source;
@@ -452,6 +471,17 @@ async function processJob(
     log.info(`Media worker: completed ${mediaType} job ${spaceId}/${fileId} (${fileEmbeddingStatus})`);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // A lost lease is not a failed job. Stall recovery has already put this file back in the queue with an
+    // attempt spent, and another claimant is on it: calling failJob here would spend a SECOND attempt and
+    // write a `lastError` describing nothing that went wrong, and calling completeJob would report a
+    // re-queued job as done. So this run simply stops, and says why at WARN so the pair is visible.
+    if (isLeaseLost(err)) {
+      log.warn(`Media worker: abandoning ${spaceId}/${fileId} — its claim was recovered while it was still`
+        + ` running, and another attempt now owns it. This means the job was slower than`
+        + ` stalledJobTimeoutMs, not stuck: see the re-queue warning above for how long it was silent.`);
+      mediaJobsRetriedTotal.labels({ space: spaceId, media_type: mediaType }).inc();
+      return;
+    }
     log.warn(`Media worker: job ${spaceId}/${fileId} failed: ${message}`);
     // An oversized document will never shrink — fail permanently instead of
     // burning the retry budget re-reading a file the pipeline refuses to convert.

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -354,6 +354,65 @@ export const mediaJobsFailed = new Gauge({
   },
 });
 
+/**
+ * Which phase the in-flight jobs are in, counted by step.
+ *
+ * `ythril_media_jobs_processing` already says a job is running, and that is where the diagnosis stopped: a
+ * fleet with one 358 KB document saw `processing 1` for twenty minutes and could not tell reading from
+ * embedding from wedged. The jobs themselves have carried a step report for a while — the worker writes it
+ * with every heartbeat — so this is that field, aggregated. Nothing new is measured; something already
+ * measured is finally reachable from a dashboard.
+ *
+ * `step` comes from the route the document is actually taking (`render`, `vlm`, `embed`, `describe`, …), so
+ * it is not a fixed list here. Steps are remembered once seen and reported as `0` when no job is in them:
+ * a series that disappears cannot be alerted on, because absent and zero look the same in a query.
+ */
+const _seenJobSteps = new Set<string>();
+export const mediaJobPhase = new Gauge({
+  name: 'ythril_media_job_phase',
+  help: 'In-flight media jobs by the pipeline step they are currently in (collected at scrape time)',
+  labelNames: ['space', 'step'] as const,
+  registers: [register],
+  async collect() {
+    try {
+      const cfg = getConfig();
+      for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
+        const rows = await col(`${space.id}_media_jobs`)
+          .find({ status: 'processing' }, { projection: { progress: 1 } })
+          .toArray() as Array<{ progress?: { step?: string } }>;
+        const counts = new Map<string, number>();
+        for (const r of rows) {
+          // A processing job with no step report is not "no jobs": it is a job whose phase predates the
+          // heartbeat, or one that has not reached its first step yet. Both are visible as `unknown`.
+          const step = r.progress?.step ?? 'unknown';
+          counts.set(step, (counts.get(step) ?? 0) + 1);
+        }
+        for (const step of counts.keys()) _seenJobSteps.add(step);
+        for (const step of _seenJobSteps) this.set({ space: space.id, step }, counts.get(step) ?? 0);
+      }
+    } catch { /* MongoDB may not be ready */ }
+  },
+});
+
+/**
+ * Chunks embedded, as they are embedded.
+ *
+ * The signal a fleet actually needs is not "how many jobs are running" but "is this one moving". A gauge
+ * cannot answer that; a counter can — `rate(ythril_embed_chunks_total[5m]) == 0` while
+ * `ythril_media_jobs_processing > 0` is the difference between a slow document and a stuck one, and it was
+ * exactly the question nobody could answer during a liveness crash loop.
+ *
+ * Counted per chunk regardless of whether the vector came out: a chunk that failed to embed still moved
+ * the job forward, and `ythril_media_jobs_*` already carry the failure story.
+ */
+export const embedChunksTotal = new Counter({
+  name: 'ythril_embed_chunks_total',
+  help: 'Document chunks put through the embedder, by space (motion, not success)',
+  labelNames: ['space'] as const,
+  registers: [register],
+});
+embedChunksTotal.labels({ space: '' }).inc(0);
+
 // ── Silent degradation ───────────────────────────────────────────────────────
 /**
  * Recall answered, but with a weaker pipeline than the instance is configured for.

--- a/testing/standalone/job-lease-db.test.js
+++ b/testing/standalone/job-lease-db.test.js
@@ -1,0 +1,165 @@
+/**
+ * Database-level test: a re-queued job's previous holder finds out.
+ *
+ * ## What was broken
+ *
+ * Stall recovery flips a `processing` job back to `pending` when nothing has reported progress for
+ * `stalledJobTimeoutMs`. That is what makes a crashed pod's work resumable — but it had no way to tell the
+ * previous holder, and the previous holder is not always dead. A phase that reported no progress (chunk
+ * embedding reported none at all) looked identical to a wedged one, so a large document was recovered
+ * mid-flight and then run TWICE: the original still embedding, the new claimant starting over, both writing
+ * the same chunk `_id`s and competing for the CPU the first one was already too slow on.
+ *
+ * The lease is one field. Every heartbeat matches on it; recovery clears it; a heartbeat that matches
+ * nothing is the signal to stop. The question "did this update match the document" has exactly one correct
+ * answer and MongoDB is the only thing that knows it, which is why this test is database-level: a fixture
+ * matcher would be asserting the author's belief about `matchedCount`.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/job-lease-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const OLD = '2026-07-22T11:00:00.000Z';   // long before any cutoff → stalled
+
+let mongo, jobs, files;
+let touchJobProgress, resetStalledJobs, claimNextJob, enqueueMediaJob;
+
+/** A `processing` job as a worker would have left it, with an explicit claim token. */
+async function insertProcessing(id, claimToken, progressAt = OLD) {
+  await jobs.insertOne({
+    _id: id, spaceId: SPACE, filePath: id, mimeType: 'application/pdf', mediaType: 'text',
+    status: 'processing', attempts: 1, maxAttempts: 3, lastError: null,
+    claimedAt: OLD, progressAt, claimToken,
+    progress: { step: 'embed', steps: ['embed'], done: 143, total: 512 },
+    createdAt: OLD, updatedAt: OLD,
+  });
+}
+
+describe('job lease — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('joblease');
+    ({ touchJobProgress, resetStalledJobs, claimNextJob, enqueueMediaJob } =
+      await import('../../server/dist/files/media/job-queue.js'));
+    jobs = mongo.col(`${SPACE}_media_jobs`);
+    files = mongo.col(`${SPACE}_files`);
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => { await jobs.deleteMany({}); await files.deleteMany({}); });
+
+  it('a claim carries a token, and the token is what the heartbeat matches', async () => {
+    await jobs.insertOne({
+      _id: 'fresh.pdf', spaceId: SPACE, filePath: 'fresh.pdf', mimeType: 'application/pdf',
+      mediaType: 'text', status: 'pending', attempts: 0, maxAttempts: 3, lastError: null,
+      claimedAt: null, createdAt: OLD, updatedAt: OLD,
+    });
+    const claimed = await claimNextJob([SPACE]);
+    assert.ok(claimed, 'the job should be claimable');
+    assert.ok(claimed.claimToken, 'a claim with no token cannot be checked');
+
+    assert.equal(await touchJobProgress(SPACE, 'fresh.pdf', undefined, claimed.claimToken), true);
+    assert.equal(await touchJobProgress(SPACE, 'fresh.pdf', undefined, 'some-other-run'), false,
+      'a token from another run must not pass');
+  });
+
+  it('recovery CLEARS the token, so the old holder\'s next heartbeat reports false', async () => {
+    // This is the whole fix: the previous holder learns it has been replaced, on the write it was already
+    // making, and stops instead of racing the new claimant.
+    await insertProcessing('slow.pdf', 'run-one');
+    await resetStalledJobs([SPACE], 60_000);
+
+    const after = await jobs.findOne({ _id: 'slow.pdf' });
+    assert.equal(after.status, 'pending', 'recovery still re-queues the job');
+    assert.equal(after.claimToken, null, 'and hands the old holder a way to notice');
+
+    assert.equal(await touchJobProgress(SPACE, 'slow.pdf', undefined, 'run-one'), false);
+  });
+
+  it('a heartbeat from a replaced holder does not resurrect the job it lost', async () => {
+    // The dangerous version of this bug: the old holder's heartbeat sets `progressAt` and `status` stays
+    // whatever it is, so a losing run could keep a re-queued job looking alive and hide it from the sweep.
+    await insertProcessing('slow.pdf', 'run-one');
+    await resetStalledJobs([SPACE], 60_000);
+    const requeuedAt = (await jobs.findOne({ _id: 'slow.pdf' })).updatedAt;
+
+    await touchJobProgress(SPACE, 'slow.pdf', { step: 'embed', steps: ['embed'], done: 200, total: 512 }, 'run-one');
+
+    const after = await jobs.findOne({ _id: 'slow.pdf' });
+    assert.equal(after.status, 'pending', 'still pending — the new claimant owns it');
+    assert.equal(after.progressAt, OLD, 'the losing run did not advance the clock');
+    assert.equal(after.progress.done, 143, 'nor overwrite the progress the sweep recorded');
+    assert.equal(after.updatedAt, requeuedAt);
+  });
+
+  it('the new claimant gets a DIFFERENT token, and the old one stays locked out', async () => {
+    await insertProcessing('slow.pdf', 'run-one');
+    await resetStalledJobs([SPACE], 60_000);
+
+    const reclaimed = await claimNextJob([SPACE]);
+    assert.ok(reclaimed, 'a recovered job must be immediately re-claimable');
+    assert.notEqual(reclaimed.claimToken, 'run-one');
+    assert.equal(await touchJobProgress(SPACE, 'slow.pdf', undefined, reclaimed.claimToken), true);
+    assert.equal(await touchJobProgress(SPACE, 'slow.pdf', undefined, 'run-one'), false);
+  });
+
+  it('a heartbeat WITHOUT a token still works — jobs claimed by the previous build', async () => {
+    // Rolling upgrade: a job claimed before this field existed has no token, and its worker passes none.
+    // Refusing those would abandon every in-flight job on deploy.
+    await insertProcessing('legacy.pdf', undefined);
+    assert.equal(await touchJobProgress(SPACE, 'legacy.pdf', undefined, undefined), true);
+    const after = await jobs.findOne({ _id: 'legacy.pdf' });
+    assert.notEqual(after.progressAt, OLD, 'the heartbeat landed');
+  });
+
+  it('a job that is not processing never matches, token or no token', async () => {
+    await insertProcessing('done.pdf', 'run-one');
+    await jobs.updateOne({ _id: 'done.pdf' }, { $set: { status: 'complete' } });
+    assert.equal(await touchJobProgress(SPACE, 'done.pdf', undefined, 'run-one'), false);
+    assert.equal(await touchJobProgress(SPACE, 'done.pdf'), false);
+  });
+
+  it('a live job is left alone — the token does not change what counts as stalled', async () => {
+    await insertProcessing('busy.pdf', 'run-one', new Date().toISOString());
+    await resetStalledJobs([SPACE], 60_000);
+    const after = await jobs.findOne({ _id: 'busy.pdf' });
+    assert.equal(after.status, 'processing');
+    assert.equal(after.claimToken, 'run-one', 'a working job keeps its claim');
+    assert.equal(await touchJobProgress(SPACE, 'busy.pdf', undefined, 'run-one'), true);
+  });
+
+  it('recovery reads the file size for its warning without failing when there is no file record', async () => {
+    // The warning does one extra lookup per recovered job. A missing filemeta record (deleted source,
+    // sync in flight) must not turn recovery into an exception — recovery is the last line of defence.
+    await insertProcessing('orphan.pdf', 'run-one');
+    await assert.doesNotReject(resetStalledJobs([SPACE], 60_000));
+    assert.equal((await jobs.findOne({ _id: 'orphan.pdf' })).status, 'pending');
+
+    await insertProcessing('sized.pdf', 'run-two');
+    await files.insertOne({ _id: 'sized.pdf', spaceId: SPACE, path: 'sized.pdf', sizeBytes: 358_400 });
+    await assert.doesNotReject(resetStalledJobs([SPACE], 60_000));
+    assert.equal((await jobs.findOne({ _id: 'sized.pdf' })).status, 'pending');
+  });
+
+  it('still increments attempts once per recovery', async () => {
+    // `returnDocument` changed from 'after' to 'before' so the warning can name the step the job reached.
+    // The counter must be unaffected by that: a second increment would burn the retry budget twice as fast.
+    await insertProcessing('slow.pdf', 'run-one');
+    await resetStalledJobs([SPACE], 60_000);
+    assert.equal((await jobs.findOne({ _id: 'slow.pdf' })).attempts, 2);
+  });
+
+  it('enqueue does not invent a token — only a claim does', async () => {
+    await files.insertOne({ _id: 'new.pdf', spaceId: SPACE, path: 'new.pdf', sizeBytes: 10 });
+    await enqueueMediaJob(SPACE, 'new.pdf', 'application/pdf', 'text');
+    const queued = await jobs.findOne({ _id: 'new.pdf' });
+    assert.equal(queued.status, 'pending');
+    assert.ok(!queued.claimToken, 'a pending job has no holder to identify');
+  });
+});

--- a/testing/standalone/job-lease.test.js
+++ b/testing/standalone/job-lease.test.js
@@ -1,0 +1,118 @@
+/**
+ * The pure parts of a job's claim: the heartbeat throttle, the abandonment signal, and the line an
+ * operator actually reads when a job is re-queued.
+ *
+ * `job-lease-db.test.js` covers the lease itself against a real MongoDB, because that is where the
+ * question "did this write match the document" is answered. This file covers the decisions that surround
+ * it, which a database cannot check:
+ *
+ *   - a heartbeat every ~200 ms would triple the writes the embedding phase makes to say nothing new, and
+ *     an unconditional throttle would swallow the LAST step so a bar stops at 47/50 and reads as a hang;
+ *   - the re-queue log used to be `reset 1 stalled job(s) to pending` at `info` — no file, no elapsed time,
+ *     no size, so a fleet whose large documents were being killed mid-flight had nothing to grep for.
+ *
+ * Run: node --test testing/standalone/job-lease.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let shouldHeartbeat, stalledJobWarning, newClaimToken, isLeaseLost, JobLeaseLostError,
+  HEARTBEAT_MIN_INTERVAL_MS;
+
+const NOW = Date.parse('2026-08-01T12:00:00.000Z');
+
+describe('job lease helpers', () => {
+  before(async () => {
+    ({ shouldHeartbeat, stalledJobWarning, newClaimToken, isLeaseLost, JobLeaseLostError,
+      HEARTBEAT_MIN_INTERVAL_MS } = await import('../../server/dist/files/media/lease.js'));
+  });
+
+  describe('shouldHeartbeat', () => {
+    it('throttles steps that land faster than the interval', () => {
+      assert.equal(shouldHeartbeat(NOW, NOW + 200), false, 'a chunk lands every ~200 ms');
+      assert.equal(shouldHeartbeat(NOW, NOW + HEARTBEAT_MIN_INTERVAL_MS), true);
+    });
+
+    it('ALWAYS writes the last step, however soon it lands', () => {
+      // Otherwise the final state of a phase can fall inside the throttle window and the last report
+      // anyone sees is 47/50 — indistinguishable from stopping at 47.
+      assert.equal(shouldHeartbeat(NOW, NOW + 1, true), true);
+    });
+
+    it('stays well inside any usable stall timeout', () => {
+      // The admin API's floor for stalledJobTimeoutMs is 30 s. A throttle anywhere near that would be a
+      // stall detector racing its own heartbeat.
+      assert.ok(HEARTBEAT_MIN_INTERVAL_MS <= 5_000, `${HEARTBEAT_MIN_INTERVAL_MS} is too coarse`);
+    });
+  });
+
+  describe('newClaimToken', () => {
+    it('differs between two claims taken in the same millisecond', () => {
+      const tokens = new Set(Array.from({ length: 200 }, () => newClaimToken()));
+      assert.equal(tokens.size, 200, 'two pods can claim in the same tick — a timestamp would collide');
+    });
+  });
+
+  describe('isLeaseLost', () => {
+    it('recognises the error', () => {
+      assert.equal(isLeaseLost(new JobLeaseLostError('general', 'doc.pdf')), true);
+    });
+
+    it('recognises one built by a different module instance', () => {
+      // `instanceof` fails across duplicate module copies (dist vs src, or a bundler), and the worker's
+      // decision between "abandon" and "fail and burn an attempt" hangs off this answer.
+      const e = new Error('Lease lost');
+      e.name = 'JobLeaseLostError';
+      assert.equal(isLeaseLost(e), true);
+    });
+
+    it('does not swallow ordinary failures', () => {
+      for (const e of [new Error('embedder down'), new TypeError('x'), 'string', null, undefined]) {
+        assert.equal(isLeaseLost(e), false, String(e));
+      }
+    });
+  });
+
+  describe('stalledJobWarning', () => {
+    const job = {
+      spaceId: 'reporting',
+      _id: 'reports/q1.pdf',
+      filePath: 'reports/q1.pdf',
+      progressAt: '2026-08-01T11:54:00.000Z',   // 6 minutes of silence
+      claimedAt: '2026-08-01T11:40:00.000Z',
+      attempts: 2,
+      maxAttempts: 3,
+      progress: { step: 'embed', done: 143, total: 512 },
+    };
+
+    it('names the file, the silence, the size, the step and the attempt', () => {
+      const line = stalledJobWarning(job, NOW, 358_400);
+      assert.match(line, /reporting\/reports\/q1\.pdf/);
+      assert.match(line, /360s/, 'elapsed since the last sign of life, not since the claim');
+      assert.match(line, /350 KiB/);
+      assert.match(line, /embed 143\/512/, 'which step it was in is the diagnostic');
+      assert.match(line, /attempt 2\/3/);
+    });
+
+    it('says what to do about it — slow is not stuck', () => {
+      const line = stalledJobWarning(job, NOW, 358_400);
+      assert.match(line, /stalledJobTimeoutMs/);
+      assert.match(line, /embedConcurrency/);
+    });
+
+    it('measures from claimedAt when the job never ticked', () => {
+      const line = stalledJobWarning({ ...job, progressAt: null }, NOW, 1024);
+      assert.match(line, /1200s/, 'an old build claimed it and never heartbeat');
+    });
+
+    it('degrades instead of throwing when fields are missing', () => {
+      // It is a log line for a recovery path: a missing size or an unparseable date must not turn the
+      // warning into an exception inside the sweep that is trying to recover jobs.
+      const line = stalledJobWarning({}, NOW, undefined);
+      assert.match(line, /unknown time/);
+      assert.match(line, /unknown size/);
+      assert.match(line, /no step reported/);
+      assert.doesNotThrow(() => stalledJobWarning({ progressAt: 'not-a-date' }, NOW, NaN));
+    });
+  });
+});

--- a/testing/standalone/media-phase-metric-db.test.js
+++ b/testing/standalone/media-phase-metric-db.test.js
@@ -1,0 +1,110 @@
+/**
+ * Database-level test: the phase gauge reports zeros, not silence.
+ *
+ * `ythril_media_jobs_processing` says a job is running. It cannot say *what it is doing*, which is the only
+ * question worth asking when one document has been "processing" for twenty minutes — reading, embedding, or
+ * wedged all look identical. `ythril_media_job_phase` aggregates the step the worker already records with
+ * every heartbeat, so the answer costs no new instrumentation.
+ *
+ * The failure mode being pinned is the one that makes a metric useless rather than wrong: a label set that
+ * *disappears* when its count drops to zero. `embed` present at 1 and then absent is indistinguishable, in
+ * PromQL, from a metric that was never emitted — so an alert on "stuck in embed" silently stops evaluating
+ * exactly when the job leaves that phase. Once a step has been seen it must report `0`.
+ *
+ * A gauge with a `collect()` hook can only be checked against a real database: the numbers come out of a
+ * query, and a fixture would be asserting the test's own aggregation.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/media-phase-metric-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const TEMP_CONFIG = path.join(path.dirname(fileURLToPath(import.meta.url)), 'tmp-phase-metric-config.json');
+let mongo, jobs, mediaJobPhase, embedChunksTotal;
+
+/** Read the gauge the way a scrape does — through collect(), not by trusting the last set(). */
+async function phaseCounts() {
+  const { values } = await mediaJobPhase.get();
+  const out = {};
+  for (const v of values) if (v.labels.space === SPACE) out[v.labels.step] = v.value;
+  return out;
+}
+
+async function insertProcessing(id, step) {
+  await jobs.insertOne({
+    _id: id, spaceId: SPACE, filePath: id, mimeType: 'application/pdf', mediaType: 'text',
+    status: 'processing', attempts: 1, maxAttempts: 3, lastError: null,
+    claimedAt: new Date().toISOString(), progressAt: new Date().toISOString(),
+    ...(step ? { progress: { step, steps: [step], done: 1, total: 9 } } : {}),
+    createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+  });
+}
+
+describe('ythril_media_job_phase — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    // The gauge enumerates spaces from config, so give the loader a real one on disk — the same way the
+    // other loader-backed standalone tests do, rather than a test-only hook inside production code.
+    fs.writeFileSync(TEMP_CONFIG, JSON.stringify({
+      instanceId: 'phase-metric-test', instanceName: 'Phase', tokens: [], networks: [],
+      spaces: [{ id: SPACE, name: 'General' }],
+    }));
+    process.env['CONFIG_PATH'] = TEMP_CONFIG;
+
+    mongo = await openTestMongo('phasemetric');
+    ({ mediaJobPhase, embedChunksTotal } = await import('../../server/dist/metrics/registry.js'));
+    (await import('../../server/dist/config/loader.js')).loadConfig();
+    jobs = mongo.col(`${SPACE}_media_jobs`);
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.unlinkSync(TEMP_CONFIG); } catch { /* already gone */ }
+  });
+
+  beforeEach(async () => { await jobs.deleteMany({}); });
+
+  it('counts in-flight jobs by the step they are in', async () => {
+    await insertProcessing('a.pdf', 'embed');
+    await insertProcessing('b.pdf', 'embed');
+    await insertProcessing('c.pdf', 'vlm');
+
+    const counts = await phaseCounts();
+    assert.equal(counts.embed, 2);
+    assert.equal(counts.vlm, 1);
+  });
+
+  it('reports a step it has SEEN as 0 rather than dropping the series', async () => {
+    await insertProcessing('a.pdf', 'embed');
+    assert.equal((await phaseCounts()).embed, 1);
+
+    await jobs.deleteMany({});
+    const after = await phaseCounts();
+    assert.equal(after.embed, 0, 'an absent series cannot be alerted on — 0 is the whole point');
+  });
+
+  it('shows a job with no step report as `unknown`, not as no job at all', async () => {
+    await insertProcessing('legacy.pdf', null);
+    assert.equal((await phaseCounts()).unknown, 1);
+  });
+
+  it('ignores jobs that are not processing', async () => {
+    await insertProcessing('a.pdf', 'embed');
+    await jobs.updateOne({ _id: 'a.pdf' }, { $set: { status: 'complete' } });
+    assert.equal((await phaseCounts()).embed, 0);
+  });
+
+  it('the chunk counter exists from startup, so a dashboard has a series before the first job', async () => {
+    // Pre-initialised with .inc(0), matching the convention the other counters follow: a panel that reads
+    // `rate(ythril_embed_chunks_total[5m])` must not be empty until the first document arrives.
+    const { values } = await embedChunksTotal.get();
+    assert.ok(values.length >= 1, 'no series — the HELP/TYPE lines would be missing too');
+  });
+});

--- a/testing/standalone/metric-docs-coverage.test.js
+++ b/testing/standalone/metric-docs-coverage.test.js
@@ -1,0 +1,82 @@
+/**
+ * Every metric the instance exposes is in the docs, and every metric the docs name exists.
+ *
+ * ## The finding
+ *
+ * The whole media-pipeline family — `ythril_media_jobs_pending`, `_processing`, `_completed_total`,
+ * `_failed_total`, `_retried_total`, `_failed` and `ythril_media_job_duration_seconds` — was exposed on
+ * `/metrics` and absent from the documentation, while every other family (http, brain, sync, mcp, auth,
+ * storage, degradation, posture) was listed. Seven metrics, none of them findable.
+ *
+ * That is not a documentation nicety. A fleet debugging a document that would not finish asked for a gauge
+ * to show one long job — and `ythril_media_jobs_processing` had been shipping the whole time. The docs are
+ * how an operator learns a metric exists, so an undocumented metric is, in practice, a metric that does not
+ * exist; and being told to add one that is already there is the shape of the cost.
+ *
+ * ## Why enumerate the registry
+ *
+ * A hand-written list is how this happened: someone added the media family and did not add nine rows to a
+ * table in another directory. This reads `metrics/registry.ts` and compares both directions, so the next
+ * metric added without a row fails here instead of being discovered by a customer.
+ *
+ * Run: node --test testing/standalone/metric-docs-coverage.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { allDocsText } from './_docs.mjs';
+
+const SERVER_SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', 'server', 'src');
+const REGISTRY = join(SERVER_SRC, 'metrics', 'registry.ts');
+
+/** Metric names as the registry declares them. */
+function registryMetrics() {
+  const src = readFileSync(REGISTRY, 'utf8');
+  return [...src.matchAll(/name:\s*'(ythril_[a-z0-9_]+)'/g)].map(m => m[1]);
+}
+
+/** Metric names the docs present as rows of the exposed-metrics table. */
+function documentedMetrics(text) {
+  return [...text.matchAll(/^\|\s*`(ythril_[a-z0-9_]+)`\s*\|/gm)].map(m => m[1]);
+}
+
+describe('metrics — registry and docs agree', () => {
+  const exposed = registryMetrics();
+  const docsText = allDocsText();
+  const documented = documentedMetrics(docsText);
+
+  it('finds a meaningful number of metrics (the scan itself still works)', () => {
+    // If a refactor changes how metrics are declared, this test must fail LOUDLY rather than quietly
+    // comparing two empty lists and passing.
+    // A floor, not a count: this asks "did the scan still parse anything", and must not need editing every
+    // time a metric is added or the docs are reordered.
+    assert.ok(exposed.length >= 20, `only found ${exposed.length} metrics in registry.ts`);
+    assert.ok(documented.length >= 20, `only found ${documented.length} documented metrics`);
+  });
+
+  it('every metric the instance exposes is documented', () => {
+    const missing = exposed.filter(n => !docsText.includes(n));
+    assert.deepEqual(missing, [], `exposed on /metrics, absent from the docs:\n  ${missing.join('\n  ')}\n\n`
+      + 'Add a row to the "Metrics exposed" table in docs/integration-guide/11-setup-api.md. An\n'
+      + 'undocumented metric is one an operator cannot find, which is how a fleet came to ask for a gauge\n'
+      + 'that already existed.');
+  });
+
+  it('every metric the docs name actually exists', () => {
+    const known = new Set(exposed);
+    // Node's own process metrics are documented as a family, not per name, so anything not in the registry
+    // and not prefixed `ythril_` is out of scope for this direction.
+    const ghosts = documented.filter(n => !known.has(n));
+    assert.deepEqual(ghosts, [], `documented but not exposed — an operator would alert on nothing:\n  `
+      + `${ghosts.join('\n  ')}\n\nFix the doc, or restore the metric if it was renamed.`);
+  });
+
+  it('no metric is documented twice', () => {
+    // Two rows for one metric is how a rename half-lands: the old row survives and reads as a second signal.
+    const seen = new Set(), dupes = [];
+    for (const n of documented) { if (seen.has(n)) dupes.push(n); seen.add(n); }
+    assert.deepEqual(dupes, [], `duplicate rows: ${dupes.join(', ')}`);
+  });
+});


### PR DESCRIPTION
## What broke

Stall recovery re-queues a `processing` job that has reported no progress for `stalledJobTimeoutMs`. It
measures from the last progress report — which was the fix for exactly this class — but the **chunk-embed
phase reported nothing at all**. Conversion heartbeats per page, then silence for however long hundreds of
chunks take. So the longest phase of a job was the one phase that looked wedged.

Recovery then did what it exists for, except the previous holder was still alive:

- two runs embedding the same file concurrently, writing the same chunk `_id`s;
- the second competing for the CPU the first was already too slow on (see #600 — this is the same fleet);
- `attempts` climbing on every sweep, until the job "exhausted retries" having never once failed;
- and the only log line was `Media worker: reset 1 stalled job(s) to pending`, at `info`, naming no file.

## The fix

**The embed phase heartbeats**, throttled to one write per 2 s, reporting `embed done/total` — so the phase
is visible in the Files view as well as to the stall detector.

**A claim can now be withdrawn.** `claimNextJob` stamps a `claimToken`; every heartbeat matches on it;
recovery clears it. The old holder's next beat matches nothing, and that run abandons:

- it does **not** `failJob` — that would spend a second attempt on a job that did nothing wrong;
- it **cannot** `completeJob` — that would report a re-queued job as done, with a live claimant.

One field, no extra round trip: it rides on the write the heartbeat was already making.

**The re-queue log is a `warn`** naming the file, how long it was silent, its size, the step it had reached
and which attempt it was — and it says which of the two things this is:

```text
Media worker: re-queued reporting/reports/q1.pdf after 360s with no progress (350 KiB,
last step: embed 143/512, attempt 2/3). If the file is large and the instance is CPU-bound
this is a slow job being killed, not a stuck one: raise stalledJobTimeoutMs or lower
embedding.embedConcurrency.
```

`returnDocument` on the recovery update changed from `'after'` to `'before'` so the pre-reset document can
supply that step — the reset itself is not news, what it interrupted is.

## Observability — the same finding, one layer up

The ask was "a gauge so one long job is visible". **`ythril_media_jobs_processing` has been shipping since
1.x.** It, `_pending`, `_completed_total`, `_failed_total`, `_retried_total`, `_failed` and
`ythril_media_job_duration_seconds` were exposed on `/metrics` and **absent from the docs**, while every other
family — http, brain, sync, mcp, auth, storage, degradation, posture — was listed. An undocumented metric is
one an operator cannot find.

- All seven are documented, and `metric-docs-coverage.test.js` enumerates `metrics/registry.ts` in both
  directions. The next metric added without a row fails the build instead of being found by a customer.
- Two signals were genuinely missing, because "a job is running" was never the question:

| metric | answers |
|---|---|
| `ythril_media_job_phase{space,step}` | *what* the in-flight jobs are doing — aggregated from the step report the worker already writes, so it costs no new instrumentation |
| `ythril_embed_chunks_total{space}` | whether it is **moving**: `rate(...[5m]) == 0` while `jobs_processing > 0` is stuck, a non-zero rate is slow |

A step reports `0` once seen rather than dropping out of the scrape — an absent series and a zero one are the
same PromQL result, so a disappearing label silently stops an alert evaluating at the moment the phase ends.

## Gates

| gate | what it pins |
|---|---|
| `job-lease-db` (10, real MongoDB) | "did this update match the document" is not a fixture question. Fails when recovery stops clearing the token, and when the heartbeat stops matching on it |
| `job-lease` (11) | throttle (including: the LAST step always writes), abandonment detection across module copies, and every field of the warning line |
| `media-phase-metric-db` (5) | phase counts, `unknown` for a job with no step, and zero-not-absent — that last one fails against a version that only reports steps currently present |
| `metric-docs-coverage` (4) | both directions; fires against `main` naming all seven undocumented metrics |
