### PR TITLE
fix(files): a swap-based backend could never describe a document, and nothing said so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A single-GPU host that swaps models per request could never generate a document description, and nothing
+  said so.** The describe call's timeout was hardcoded at 30 s, on the reasoning that a description is a
+  nicety on the ingest path and the extractive fallback is always there. That reasoning holds for a resident
+  model. It does not hold for the common self-hosted shape: the call arrives right after the transcription
+  pass, so the backend unloads the vision model this job was using and loads a chat model first — and the
+  load alone can eat the whole budget. Every document then keeps its opening text, `descriptionSource` says
+  `extracted`, and one `warn` per file says "timeout", which reads as a broken model rather than a deadline
+  that does not fit this host. The feature looks unimplemented while working correctly on the next host along.
+  - `documentProcessing.describeTimeoutMs` / `DOC_DESCRIBE_TIMEOUT_MS`, default 30 s (unchanged behaviour for
+    an instance that configures nothing), clamped to 1 s–10 min and settable through the admin API.
+  - **The timeout warning now names the budget and the setting**, and says that a swapping backend spends
+    part of it loading — so the log answers "is my model wrong or my deadline too small?" on the line itself.
+  - Documented with the host shape that needs it, plus the alternative that avoids swapping altogether
+    (give the chat model its own `repairBaseUrl`).
+  - `describe-timeout.test.js` pins the resolution and the clamp — a `0` would abort every call instantly and
+    stop descriptions permanently with no error anywhere — and that the call site reads the setting rather
+    than a second constant.
+
 - **A document that took longer than `stalledJobTimeoutMs` to embed was re-queued while it was still
   running — and then ran twice.** Stall recovery measures from the last progress report, and the chunk-embed
   phase reported nothing at all: conversion heartbeat per page, then silence for however long hundreds of

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -580,6 +580,7 @@ They are never queued, so they do not sit at `pending` waiting for work that wil
 | `pageTimeoutMs` | `60000` | Per-page VLM transcription timeout (VLM modes only). |
 | `concurrency` | `2` | How many pages are transcribed in parallel (VLM modes only). |
 | `ocrTimeoutMs` | `120000` | Timeout (ms) for a single OCR-sidecar call. Applies to **all** modes — OCR is the engine in `ocr` mode and the grounding evidence + fallback floor in the VLM modes — so raise it when large/complex scanned documents need longer than the 2-min default (especially under `repair`). Env override: `DOC_OCR_TIMEOUT_MS`. |
+| `describeTimeoutMs` | `30000` | Timeout (ms) for the single call that writes a converted document's **description**. Failing it costs only the generated prose — the document's own opening text is kept and `descriptionSource` reports `extracted` — so the default is deliberately tight. **Raise it on a single-GPU host that swaps models per request** (see the note below). Env override: `DOC_DESCRIBE_TIMEOUT_MS`. |
 
 > **Why two numbers.** They bound different things. `maxPages` is one round trip; `maxTotalPages` is the
 > job's cost ceiling — every page is a VLM call, so an unbounded walk over a 600-page scan means 600 model
@@ -589,6 +590,19 @@ They are never queued, so they do not sit at `pending` waiting for work that wil
 
 The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,
 Ythril transparently uses OCR — no upload fails because a model isn't wired in yet.
+
+> **One host shape the 30 s default cannot serve.** The describe call arrives immediately after the
+> transcription pass. On a backend that keeps both models resident it answers in a second or two; on a
+> **single GPU that swaps models per request** it first has to unload the vision model this job was using
+> and load a chat model, and that load alone can exceed the whole budget.
+>
+> Nothing errors when it does. Every document keeps its extractive opening text, `descriptionSource` says
+> `extracted`, and the log carries one timeout warning per file — which reads as a broken model rather than
+> a deadline that does not fit this host, so the feature looks unimplemented while working correctly on the
+> next host along. The warning now names the budget and this setting for that reason.
+>
+> If every document reports it, raise `describeTimeoutMs` to cover a model load (60–180 s is typical) —
+> or give the chat model its own endpoint via `repairBaseUrl`, so nothing has to be swapped at all.
 
 **Repair pass (`repair` level).** When a document's VLM transcription fails the OCR-evidence coverage check,
 the `repair` level runs one bounded repair pass before falling back to OCR: it sends the draft transcription and the

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -81,6 +81,9 @@ const DocumentProcessingPatchSchema = z.object({
   pageTimeoutMs: z.number().int().min(1_000).max(600_000).optional(),
   concurrency: z.number().int().min(1).max(8).optional(),
   ocrTimeoutMs: z.number().int().min(10_000).max(1_800_000).optional(),
+  // The describe call's budget. The floor is low because failing it costs only the generated description;
+  // the ceiling is generous because a single-GPU host may have to load a model before it can answer.
+  describeTimeoutMs: z.number().int().min(1_000).max(600_000).optional(),
   assistModel: AssistModelPatchSchema.optional(),
 }).strict();
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -1127,6 +1127,7 @@ const DOCUMENT_PROCESSING_DEFAULTS: Required<DocumentProcessingConfig> = {
   pageTimeoutMs: 60_000,
   concurrency: 2,
   ocrTimeoutMs: 120_000, // 2 min — the historical hardcoded OCR-sidecar ceiling, now tunable
+  describeTimeoutMs: 30_000, // one call, and its only cost on failure is the generated description
   vlmModel: '',    // empty = no VLM configured → vlm/auto/max fall back to OCR
   vlmBaseUrl: '',  // empty = reuse the media vision provider's (Ollama) URL
   repairModel: '',   // empty = reuse vlmModel for the max-mode repair pass
@@ -1160,6 +1161,10 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     pageTimeoutMs: base.pageTimeoutMs ?? d.pageTimeoutMs,
     concurrency: base.concurrency ?? d.concurrency,
     ocrTimeoutMs: process.env['DOC_OCR_TIMEOUT_MS'] ? Number(process.env['DOC_OCR_TIMEOUT_MS']) : (base.ocrTimeoutMs ?? d.ocrTimeoutMs),
+    // A single-GPU backend that swaps models per request spends the first part of this call LOADING one,
+    // which is why it is tunable at all: at 30 s such a host times out on every document and silently keeps
+    // extractive text instead.
+    describeTimeoutMs: process.env['DOC_DESCRIBE_TIMEOUT_MS'] ? Number(process.env['DOC_DESCRIBE_TIMEOUT_MS']) : (base.describeTimeoutMs ?? d.describeTimeoutMs),
     vlmModel: process.env['DOC_VLM_MODEL'] ?? base.vlmModel ?? d.vlmModel,
     vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
     repairModel: process.env['DOC_REPAIR_MODEL'] ?? base.repairModel ?? d.repairModel,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -528,6 +528,20 @@ export interface DocumentProcessingConfig {
    */
   ocrTimeoutMs?: number;
   /**
+   * Timeout (ms) for the one call that describes a converted document. Default 30000.
+   *
+   * Separate from `pageTimeoutMs` because the constraint is different: this is a single call at the end of a
+   * job, and its failure costs only the generated description — the document's own opening text is kept
+   * instead. 30 s suits a model that is already resident.
+   *
+   * It does not suit a **single-GPU host that swaps models per request**: the describe call arrives right
+   * after the transcription pass, so the backend unloads the vision model and loads the chat model first,
+   * and the load alone can exceed the budget. Every document then falls back to extractive text with one
+   * `warn` about a timeout — the capability looks broken while working correctly on the next host along.
+   * Env: `DOC_DESCRIBE_TIMEOUT_MS`.
+   */
+  describeTimeoutMs?: number;
+  /**
    * F11 — the document-transcription VLM model tag (e.g. a small Qwen2-VL / MiniCPM-V on the bundled
    * Ollama). Empty (default) means no VLM is configured, so `vlm`/`auto`/`max` modes fall back to OCR.
    * Env: `DOC_VLM_MODEL`.

--- a/server/src/files/converters/describe.ts
+++ b/server/src/files/converters/describe.ts
@@ -62,8 +62,22 @@ const MAX_INPUT_CHARS = 6_000;
 /** Long enough for two real sentences, short enough that a rambling model cannot fill the card. */
 const MAX_DESCRIPTION_CHARS = 400;
 
-/** A tight budget: this is on the ingest path, and the extractive fallback is always available. */
-const DESCRIBE_TIMEOUT_MS = 30_000;
+/**
+ * A tight budget by default: this is on the ingest path, and the extractive fallback is always available.
+ *
+ * Configurable because "tight" depends on the backend, not on us. A single-GPU host that swaps models per
+ * request has to UNLOAD the vision model this job was just using and load a chat model before it can answer,
+ * and that load can be most of a minute — so at 30 s every document times out, keeps extractive text, and
+ * logs one warning that reads like a broken model rather than a budget that is too small for this host.
+ */
+const DESCRIBE_TIMEOUT_DEFAULT_MS = 30_000;
+
+/** The configured describe budget, clamped to the range the admin API accepts. */
+export function describeTimeoutMs(cfg: { describeTimeoutMs?: number } = {}): number {
+  const v = cfg.describeTimeoutMs;
+  if (typeof v !== 'number' || !Number.isFinite(v)) return DESCRIBE_TIMEOUT_DEFAULT_MS;
+  return Math.max(1_000, Math.min(600_000, Math.floor(v)));
+}
 
 /**
  * Openings that mean the model answered the wrong question.
@@ -154,13 +168,23 @@ export async function describeDocument(
     const r = await describeDocumentText({
       ...target,
       text: body.slice(0, MAX_INPUT_CHARS),
-      timeoutMs: DESCRIBE_TIMEOUT_MS,
+      timeoutMs: describeTimeoutMs(getDocumentProcessingConfig()),
     });
     const text = sanitiseDescription(r.text);
     if (text) return { text, source: 'generated', excerpt };
     log.debug('Describe: the model returned nothing usable — keeping the document\'s own opening text');
   } catch (err) {
-    log.warn(`Describe: ${err instanceof Error ? err.message : String(err)} — keeping the document's own opening text`);
+    const message = err instanceof Error ? err.message : String(err);
+    // A timeout here is far more often a budget that does not fit this host than a broken model, and the two
+    // read identically in a log. Name the setting on the line, so the next person does not have to guess
+    // whether their model is wrong or their deadline is.
+    const timedOut = /abort|timeout|timed out|deadline/i.test(message);
+    log.warn(`Describe: ${message} — keeping the document's own opening text.`
+      + (timedOut
+        ? ` The budget was ${describeTimeoutMs(getDocumentProcessingConfig())} ms`
+          + ` (documentProcessing.describeTimeoutMs / DOC_DESCRIBE_TIMEOUT_MS). A backend that swaps models`
+          + ` per request spends part of it loading one — raise it if every document reports this.`
+        : ''));
   }
   return excerpt ? { text: excerpt, source: 'extracted', excerpt } : { excerpt };
 }

--- a/testing/standalone/describe-timeout.test.js
+++ b/testing/standalone/describe-timeout.test.js
@@ -1,0 +1,95 @@
+/**
+ * The describe call's budget is the operator's, because "tight" depends on the backend.
+ *
+ * ## The finding
+ *
+ * 30 s was hardcoded, with the reasoning that a description is a nicety on the ingest path and the extractive
+ * fallback is always available. That reasoning is right for a model that is already resident — and wrong for
+ * a **single-GPU host that swaps models per request**, which is a common way to self-host. The describe call
+ * arrives immediately after the transcription pass, so the backend has to unload the vision model and load a
+ * chat model before it can answer, and the load alone can eat the budget.
+ *
+ * The result is the failure shape this repo keeps finding: nothing errors. Every document quietly keeps its
+ * extractive text, `descriptionSource` says `extracted`, and one `warn` per file says "timeout" — which reads
+ * as a broken model rather than a deadline that does not fit this host. The capability looks unimplemented
+ * while working perfectly on the next host along.
+ *
+ * ## What this pins
+ *
+ * The resolution and the clamp, both of which have a wrong answer that is worse than an error: a `0` or
+ * negative budget would abort every call instantly (descriptions silently stop, permanently), and an absurd
+ * one would hold an ingest worker for as long as the caller asked.
+ *
+ * Run: node --test testing/standalone/describe-timeout.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SERVER_SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', 'server', 'src');
+
+let describeTimeoutMs;
+
+describe('describeTimeoutMs', () => {
+  before(async () => {
+    ({ describeTimeoutMs } = await import('../../server/dist/files/converters/describe.js'));
+  });
+
+  it('defaults to the historical 30 s when nothing is configured', () => {
+    // The default is not a preference, it is a promise: an instance that upgrades and configures nothing
+    // must describe documents exactly as it did before this setting existed.
+    assert.equal(describeTimeoutMs(), 30_000);
+    assert.equal(describeTimeoutMs({}), 30_000);
+    assert.equal(describeTimeoutMs({ describeTimeoutMs: undefined }), 30_000);
+  });
+
+  it('honours a raised budget — the whole point for a swap-based backend', () => {
+    assert.equal(describeTimeoutMs({ describeTimeoutMs: 180_000 }), 180_000);
+  });
+
+  it('NEVER returns zero or negative, whatever is configured', () => {
+    // A zero would abort every describe call before it started: descriptions stop, `extracted` everywhere,
+    // one warning per upload, and nothing saying the budget is the cause.
+    for (const v of [0, -1, -60_000, 0.5]) {
+      assert.ok(describeTimeoutMs({ describeTimeoutMs: v }) >= 1_000, `budget ${v}`);
+    }
+  });
+
+  it('clamps an absurd budget rather than holding a worker for it', () => {
+    assert.equal(describeTimeoutMs({ describeTimeoutMs: 86_400_000 }), 600_000);
+  });
+
+  it('ignores a non-numeric or non-finite value', () => {
+    for (const v of [NaN, Infinity, '120000', null, {}]) {
+      assert.equal(describeTimeoutMs({ describeTimeoutMs: v }), 30_000, String(v));
+    }
+  });
+
+  it('floors a fractional value instead of passing it to a timer', () => {
+    assert.equal(describeTimeoutMs({ describeTimeoutMs: 45_000.9 }), 45_000);
+  });
+
+  // ── The setting is only real if it reaches the call and the operator can set it ──
+
+  it('is the value the describe call actually uses — no second hardcoded constant', () => {
+    // The bug was a literal at the call site. A grep is the right check for "is there still one", because
+    // the alternative is a live model call, and the point is precisely that nobody notices this path.
+    const src = readFileSync(join(SERVER_SRC, 'files', 'converters', 'describe.ts'), 'utf8');
+    const callSite = /timeoutMs:\s*describeTimeoutMs\(getDocumentProcessingConfig\(\)\)/;
+    assert.match(src, callSite, 'the describe call must read the configured budget, not a constant');
+    // Any OTHER `timeoutMs: <number>` in this file would be a second, unconfigurable budget.
+    const literals = [...src.matchAll(/timeoutMs:\s*(\d[\d_]*)/g)].map(m => m[1]);
+    assert.deepEqual(literals, [], `hardcoded timeouts remain: ${literals.join(', ')}`);
+  });
+
+  it('is settable through config, env and the admin API — all three, or it is not tunable', () => {
+    const loader = readFileSync(join(SERVER_SRC, 'config', 'loader.ts'), 'utf8');
+    assert.match(loader, /DOC_DESCRIBE_TIMEOUT_MS/, 'env override missing');
+    assert.match(loader, /describeTimeoutMs:\s*\d/, 'default missing from DOCUMENT_PROCESSING_DEFAULTS');
+    const api = readFileSync(join(SERVER_SRC, 'api', 'media-config.ts'), 'utf8');
+    assert.match(api, /describeTimeoutMs:\s*z\.number\(\)/,
+      'a strict() PATCH schema without the field turns setting it into a 400');
+  });
+});


### PR DESCRIPTION
fix(files): a swap-based backend could never describe a document, and nothing said so

The describe call's timeout was hardcoded at 30 s, on the reasoning that a description is a nicety
on the ingest path and the extractive fallback is always available. True for a resident model. Not
true for the common self-hosted shape: on a single GPU that swaps models per request, the call
arrives right after the transcription pass, so the backend unloads the vision model this job was
using and loads a chat model first — and the load alone can eat the whole budget.

Nothing errors when it does. Every document keeps its extractive opening text, descriptionSource
says `extracted`, and one warn per file says "timeout" — which reads as a broken model rather than a
deadline that does not fit this host. The capability looks unimplemented while working correctly on
the next host along.

- `documentProcessing.describeTimeoutMs` / `DOC_DESCRIBE_TIMEOUT_MS`, default 30 s so an instance
  that configures nothing behaves exactly as before. Clamped to 1 s..10 min, settable via the admin
  API (a strict() schema without the field turns setting it into a 400).
- The timeout warning names the budget AND the setting, and says a swapping backend spends part of
  it loading — so the log answers "wrong model or too-small deadline?" on the line itself.
- Documented with the host shape that needs it, and the alternative that avoids swapping: give the
  chat model its own repairBaseUrl.

Gate: describe-timeout (8) — resolution, clamp (a 0 would abort every call instantly and stop
descriptions permanently), and that the call site reads the setting instead of a second constant.
