### PR TITLE
fix(client): a test result moved the Verify button, and re-embed needed the file open

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -23,10 +23,15 @@ delete the scratch config files, drop the scratch DB
 (`node -e "...MongoClient... db('ythril_scratch').dropDatabase()"` using the repo's mongodb package),
 restart. The server caches config in memory — a restart is required.
 
-## Client dev server
+## Client: prefer the BUILT bundle over `ng serve`
 
-`proxy.conf.json` targets 3210 — make a scratch copy pointing at 3260 (must be UTF-8 **without BOM**;
-PowerShell 5.1 `-Encoding utf8` writes a BOM and ng fails with `[1,1] InvalidSymbol`):
+The server already serves the compiled SPA — `express.static(client/dist/browser)` with an index.html
+fallback — so `npm run build:client` and then driving **`http://localhost:3260`** needs no second process, no
+proxy file, and tests the bundle that actually ships. Rebuild after each client edit (~7 s).
+
+Only reach for the dev server when you need HMR or source maps. `proxy.conf.json` targets 3210, so make a
+scratch copy pointing at 3260 (must be UTF-8 **without BOM**; PowerShell 5.1 `-Encoding utf8` writes a BOM
+and ng fails with `[1,1] InvalidSymbol`):
 
 ```powershell
 Set-Location client; npx ng serve --port 4260 --proxy-config <scratch>\proxy.conf.json
@@ -36,10 +41,17 @@ Set-Location client; npx ng serve --port 4260 --proxy-config <scratch>\proxy.con
 
 `npm i playwright` in a scratch dir; launch with `channel: 'msedge'` (installed on this machine — no browser download).
 
-Flow and selectors that work:
-- `/` unauthenticated → redirects to `/login`; click "Run first-time setup" → `/setup`.
-- Setup: `#label`, `#pw`, `#pw2`, submit → `.alert-success`, token in `.code-block span` (save it!), "Continue to sign in".
+Flow and selectors that work (verified 2026-08-01 against the built bundle on :3260):
+- Served from the bundle, the **server itself** redirects `/` → `/setup` on a first run. There is no `/login`
+  hop to click through, so wait for `/(setup|login)` and branch.
+- Setup is **label-only**: `#label` then `#submitBtn`. There are no `#pw`/`#pw2` fields and no
+  `.alert-success` — the token lands in an input, readable as `input#token`'s `value` (or from the page text,
+  `ythril_…`). **Save it: it is shown once.** Behind the dev proxy the older flow (`.code-block span`,
+  "Continue to sign in") may still apply.
 - Login: `#token` + submit; bad token → "Invalid or expired token.".
+- **`/files` redirects to `/brain`.** The file manager is a Brain **tab** ("Files", with a count badge), not
+  its own route. Its upload `<input type=file>` is `hidden` inside a label — `setInputFiles` works on it, but
+  only once the tab is open.
 - Spaces/Tokens create flows are dialogs: "Create New Space" / "Create Token" buttons open them; submit with
   `getByRole('button', {name: 'Create', exact: true})` — `has-text` is case-insensitive and matches the opener button too.
 - Brain tabs (Query, Graph, Files, Entities, Edges, Memories, Chrono, File Meta) carry count badges —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pressing Test on a Models card moved the Verify button out from under the pointer.** 2.2.2 stopped the
+  row overflowing its card, and left the reflow: a test result renders next to the button that produced it —
+  correct for what a screen reader hears — which puts a pill and a detail line *between* Test and Verify, so
+  the result pushed Verify onto the next line and the next click landed on whatever had slid into its place.
+  Actions are now laid out before results (`order`), leaving the markup and the reading order alone.
+  - Measured in Edge against the built bundle, vision card, failing Test: `Test left=295 Verify left=419`
+    both before and after the result arrives; with the rules removed on the same live DOM, Verify drops to
+    `left=295` and 33 px lower — the reported behaviour, reproduced and then fixed on one page.
+  - jsdom has no layout engine, so a unit test cannot measure this. `models-tab.component.spec.ts` fails if
+    the rules are deleted, and the numbers live in the PR.
+- **Re-embedding a file needed you to open it first.** The action lived only in the docked detail pane, so
+  repairing a file whose embedding had failed meant opening the file — while the row was already showing the
+  failure. It is on the row now, as an icon, next to the status that prompts it.
+  - Offered only for a settled job: a `pending` or `processing` file answers a retry with `409`, and an
+    action whose only outcome is a refusal is worse than one that is not there.
+  - A re-queue in flight greys out **that row**, not the list — the in-flight marker is the path, not a
+    boolean, because one shared flag reads as "everything is busy".
+  - **Rename is a pencil.** It was the one text button among icons, so the word set the actions column's
+    width on every row; the label is kept for hover and assistive tech.
+  - Verified in a browser: four buttons, every icon actually painted (an unregistered Phosphor icon renders
+    an empty `svg` with no error at all), and one click re-queues with a toast instead of opening the file.
+
 - **A single-GPU host that swaps models per request could never generate a document description, and nothing
   said so.** The describe call's timeout was hardcoded at 30 s, on the reasoning that a description is a
   nicety on the ingest path and the extractive fallback is always there. That reasoning holds for a resident

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -570,6 +570,7 @@
   "files.download": "Herunterladen",
   "files.downloadFailed": "Download fehlgeschlagen.",
   "files.renameEntryAriaLabel": "Eintrag umbenennen",
+  "files.reembedAriaLabel": "Datei neu einbetten",
   "files.deleteEntryAriaLabel": "Eintrag löschen",
   "files.closePreviewAriaLabel": "Vorschau schließen",
   "files.emptyFolder.title": "Leerer Ordner",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -570,6 +570,7 @@
   "files.download": "Download",
   "files.downloadFailed": "Download failed.",
   "files.renameEntryAriaLabel": "Rename entry",
+  "files.reembedAriaLabel": "Re-embed file",
   "files.deleteEntryAriaLabel": "Delete entry",
   "files.closePreviewAriaLabel": "Close preview",
   "files.emptyFolder.title": "Empty folder",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -570,6 +570,7 @@
   "files.download": "Pobierać",
   "files.downloadFailed": "Pobieranie nie powiodło się.",
   "files.renameEntryAriaLabel": "Zmień nazwę wpisu",
+  "files.reembedAriaLabel": "Ponownie osadź plik",
   "files.deleteEntryAriaLabel": "Usuń wpis",
   "files.closePreviewAriaLabel": "Zamknij podgląd",
   "files.emptyFolder.title": "Pusty folder",

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -694,3 +694,128 @@ describe('FileManagerComponent — live refresh on the shell tick', () => {
     });
   });
 });
+
+/**
+ * R.7 — the row's own actions.
+ *
+ * Re-embedding lived only in the detail pane, so repairing a file whose embedding had failed meant opening
+ * it first — while the row was already showing the failure. These pin the two decisions that make the row
+ * button safe to offer: WHICH rows get it (a pending or processing job answers a retry with a 409, and an
+ * action whose only outcome is a refusal is worse than an absent one), and that a re-queue in flight greys
+ * out THAT row rather than every row.
+ */
+describe('FileManagerComponent — row actions', () => {
+  const FAILED = { ...fileEntry('broken.pdf'), embeddingStatus: 'failed' } as FileEntry;
+  const DONE = { ...fileEntry('good.pdf'), embeddingStatus: 'complete' } as FileEntry;
+  const RUNNING = { ...fileEntry('busy.pdf'), embeddingStatus: 'processing' } as FileEntry;
+  const QUEUED = { ...fileEntry('waiting.pdf'), embeddingStatus: 'pending' } as FileEntry;
+  const PLAIN = fileEntry('notes.txt');
+  const DIR = fileEntry('folder', true);
+
+  function create(entries: FileEntry[]) {
+    const retryEmbedding = vi.fn(() => of({ ok: true }));
+    const api = { ...makeApi(entries), retryEmbedding } as any;
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [FileManagerComponent, getTranslocoModule()],
+      providers: [
+        { provide: FilesApi, useValue: api },
+        { provide: SpacesApi, useValue: api },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: BrainStore, useValue: new BrainStore() },
+      ],
+    });
+    const fixture = TestBed.createComponent(FileManagerComponent);
+    fixture.componentRef.setInput('embeddedSpaceId', 'work');
+    fixture.detectChanges();
+    return { fixture, c: fixture.componentInstance, retryEmbedding };
+  }
+
+  it('offers re-embed for a file whose job has settled', () => {
+    const { c } = create([FAILED, DONE]);
+    expect(c.canRequeue(FAILED)).toBe(true);
+    expect(c.canRequeue(DONE)).toBe(true);
+  });
+
+  it('does NOT offer it while a job is pending or processing — the server answers those with a 409', () => {
+    const { c } = create([RUNNING, QUEUED]);
+    expect(c.canRequeue(RUNNING)).toBe(false);
+    expect(c.canRequeue(QUEUED)).toBe(false);
+  });
+
+  it('does not offer it for a directory, or for a file with no job at all', () => {
+    const { c } = create([DIR, PLAIN]);
+    expect(c.canRequeue(DIR)).toBe(false);
+    expect(c.canRequeue(PLAIN)).toBe(false);
+  });
+
+  it('re-queues the row it was clicked on, by path', () => {
+    const { c, retryEmbedding } = create([FAILED, DONE]);
+    c.requeueEmbedding(FAILED);
+    expect(retryEmbedding).toHaveBeenCalledWith('work', 'broken.pdf');
+  });
+
+  it('marks only THAT path as in flight, so one retry does not grey out the list', () => {
+    // A shared boolean was the obvious version of this, and it reads as "the whole list is busy".
+    const pending = new Subject<unknown>();
+    const retryEmbedding = vi.fn(() => pending as unknown as Observable<unknown>);
+    const api = { ...makeApi([FAILED, DONE]), retryEmbedding } as any;
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [FileManagerComponent, getTranslocoModule()],
+      providers: [
+        { provide: FilesApi, useValue: api },
+        { provide: SpacesApi, useValue: api },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: BrainStore, useValue: new BrainStore() },
+      ],
+    });
+    const fixture = TestBed.createComponent(FileManagerComponent);
+    fixture.componentRef.setInput('embeddedSpaceId', 'work');
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+
+    c.requeueEmbedding(FAILED);
+    expect(c.requeueingPath()).toBe('broken.pdf');
+    expect(c.requeueingPath()).not.toBe(c.relPath(DONE));
+
+    pending.next({ ok: true });
+    pending.complete();
+    expect(c.requeueingPath()).toBe('');
+  });
+
+  it('clears the in-flight path when the request fails, so the button comes back', () => {
+    const failing = { ...makeApi([FAILED]), retryEmbedding: vi.fn(() => new Observable(s => s.error({ status: 409 }))) } as any;
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [FileManagerComponent, getTranslocoModule()],
+      providers: [
+        { provide: FilesApi, useValue: failing },
+        { provide: SpacesApi, useValue: failing },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: BrainStore, useValue: new BrainStore() },
+      ],
+    });
+    const fixture = TestBed.createComponent(FileManagerComponent);
+    fixture.componentRef.setInput('embeddedSpaceId', 'work');
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+    c.requeueEmbedding(FAILED);
+    expect(c.requeueingPath()).toBe('');
+  });
+
+  it('renders rename as an icon with its label kept for hover and assistive tech', () => {
+    // The word "Rename" was the one text button among icons, so it set the actions column width on every
+    // row. The label has to survive the change or the button becomes unlabelled.
+    const { fixture } = create([FAILED]);
+    const html = fixture.nativeElement.innerHTML as string;
+    expect(html).toContain('files.renameEntryAriaLabel');
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('tbody button')) as HTMLElement[];
+    const renameBtn = buttons.find(b => (b.getAttribute('aria-label') ?? '').includes('renameEntryAriaLabel'));
+    expect(renameBtn).toBeTruthy();
+    expect(renameBtn!.querySelector('ph-icon, svg')).toBeTruthy();
+  });
+});

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -672,7 +672,28 @@ function xlsxCellText(v: unknown): string {
                           [attr.aria-label]="'files.downloadAriaLabel' | transloco"
                         ><ph-icon name="download-simple" [size]="16"/></button>
                       }
-                      <button class="btn-ghost btn btn-sm" (click)="startRename(entry)">{{ 'files.rename' | transloco }}</button>
+                      @if (canRequeue(entry)) {
+                        <!-- Re-embedding was reachable only from the detail pane, so fixing a file whose
+                             embedding failed meant OPENING it first — and the row already tells you it
+                             failed. The action belongs where the diagnosis is. Hidden while a job is
+                             pending or processing: the server refuses that with a 409, and an action that
+                             exists only to be refused is worse than one that is absent. -->
+                        <button
+                          type="button"
+                          class="btn-ghost btn btn-sm"
+                          [disabled]="requeueingPath() === relPath(entry)"
+                          (click)="requeueEmbedding(entry)"
+                          [attr.title]="'brain.fileMeta.retryEmbedding' | transloco"
+                          [attr.aria-label]="'files.reembedAriaLabel' | transloco"
+                        ><ph-icon name="arrows-clockwise" [size]="16"/></button>
+                      }
+                      <!-- Rename is a pencil, not the word: it sat as the one text button among icons, so it
+                           set the width of the actions column on every row and pushed delete off the edge on
+                           a narrow window. Same label, on hover and for assistive tech. -->
+                      <button class="btn-ghost btn btn-sm" (click)="startRename(entry)"
+                        [attr.title]="'files.rename' | transloco"
+                        [attr.aria-label]="'files.renameEntryAriaLabel' | transloco"
+                      ><ph-icon name="pencil-simple" [size]="16"/></button>
                       <button class="icon-btn danger" (click)="deleteEntry(entry)" [attr.aria-label]="'files.deleteEntryAriaLabel' | transloco"><ph-icon name="x" [size]="16"/></button>
                     </td>
                   </tr>
@@ -847,7 +868,9 @@ function xlsxCellText(v: unknown): string {
                       <button class="btn btn-sm btn-primary" type="submit" [disabled]="metaSaving()">{{ 'common.save' | transloco }}</button>
                       <button class="btn btn-sm btn-secondary" type="button" (click)="cancelMeta()">{{ 'common.cancel' | transloco }}</button>
                       @if (pf.embeddingStatus === 'failed' || pf.embeddingStatus === 'partial') {
-                        <button class="btn btn-sm btn-ghost" type="button" [disabled]="retrying()" (click)="retryMeta(pf)">{{ 'brain.fileMeta.retryEmbedding' | transloco }}</button>
+                        <button class="btn btn-sm btn-ghost" type="button"
+                          [disabled]="requeueingPath() === relPath(pf)"
+                          (click)="requeueEmbedding(pf)">{{ 'brain.fileMeta.retryEmbedding' | transloco }}</button>
                       }
                     </div>
                   </form>
@@ -1142,8 +1165,14 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   metaEditModel = { description: '', tags: [] as string[], entityIds: '', memoryIds: [] as string[], chronoIds: [] as string[] };
   metaSaving = signal(false);
   metaError = signal<string | null>(null);
-  /** True while a retry-embedding request for the open file is in flight. */
-  retrying = signal(false);
+  /**
+   * The path whose re-embed request is in flight, or '' when none is.
+   *
+   * A path rather than a boolean because the action is now on every row as well as in the detail pane: one
+   * shared boolean would grey out every row's button while a single file was being re-queued, which reads as
+   * "the whole list is busy".
+   */
+  requeueingPath = signal('');
 
   // ── Tree sidebar state ───────────────────────────────────────────────────
   sidebarOpen = signal(localStorage.getItem('ythril.sidebar') !== 'closed');
@@ -1664,7 +1693,8 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   }
 
   /** Space-relative path of an entry (matches the FileMeta `_id`/`path`; leading slashes stripped). */
-  private relPath(entry: FileEntry): string {
+  /** Public because the template compares it against `requeueingPath()` to disable one row's button. */
+  relPath(entry: FileEntry): string {
     return this.join(this.currentPath(), entry.name).replace(/^\/+/, '');
   }
 
@@ -1731,16 +1761,37 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Re-queue embedding for the open file (shown only when its status is failed/partial). */
-  retryMeta(entry: FileEntry): void {
-    this.retrying.set(true);
-    this.filesApi.retryEmbedding(this.activeSpaceId(), this.relPath(entry)).subscribe({
+  /**
+   * Can this entry's embedding be re-queued from its row?
+   *
+   * Not while a job is `pending` or `processing`: the server answers those with a `409`, and an action whose
+   * only outcome is a refusal is worse than one that is not offered. A file with no status at all has no job
+   * to retry — an upload still in flight, or a type this instance does not embed.
+   */
+  canRequeue(entry: FileEntry): boolean {
+    if (!entry.isFile || !entry.embeddingStatus) return false;
+    return entry.embeddingStatus !== 'pending' && entry.embeddingStatus !== 'processing';
+  }
+
+  /**
+   * Re-queue embedding for one file, from its row or from the open detail pane.
+   *
+   * One method for both, because they are the same request with the same three outcomes; two copies is how
+   * the row would end up with a different toast, or without the list refresh that makes the new status show.
+   */
+  requeueEmbedding(entry: FileEntry): void {
+    const path = this.relPath(entry);
+    this.requeueingPath.set(path);
+    this.filesApi.retryEmbedding(this.activeSpaceId(), path).subscribe({
       next: () => {
-        this.retrying.set(false);
+        this.requeueingPath.set('');
         this.toast.success(this.transloco.translate('files.detail.retryQueued'));
         this.reloadDir();
       },
-      error: (e) => { this.retrying.set(false); this.toast.error(`${this.transloco.translate('files.detail.retryFailed')} ${httpErrorReason(e)}`.trim()); },
+      error: (e) => {
+        this.requeueingPath.set('');
+        this.toast.error(`${this.transloco.translate('files.detail.retryFailed')} ${httpErrorReason(e)}`.trim());
+      },
     });
   }
 

--- a/client/src/app/pages/settings/media-processing/models-tab.component.spec.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.spec.ts
@@ -5,6 +5,7 @@
  * selectable/removable. These tests exercise the component logic directly (no template render), so the
  * services are light mocks.
  */
+import { readFileSync } from 'node:fs';
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -259,5 +260,44 @@ describe('ModelsTabComponent — per-card Save button', () => {
     (saveIn(fixture, 'vision') as HTMLButtonElement).click();
 
     expect(spy).toHaveBeenCalledWith('vision');
+  });
+});
+
+/**
+ * R.6 — a result arriving must not move the buttons.
+ *
+ * A test result is rendered next to the button that produced it, which is right for what a screen reader
+ * hears and wrong for layout: the pill and detail line sit BETWEEN Test and Verify in the DOM, so pressing
+ * Test pushed Verify out from under the pointer that had just been over it, and the next click landed on
+ * whatever had slid into that spot. The fix lays the actions out first with `order`, leaving DOM order alone.
+ *
+ * jsdom has no layout engine, so this cannot be measured here. It WAS measured, in Edge against the built
+ * bundle, on the vision card with a failing Test:
+ *
+ *     with the order rules:     Test left=295  Verify left=419   (result wrapped to a second line)
+ *     order rules removed:      Test left=295  Verify left=295, top +33px  (Verify fell to line 2)
+ *
+ * What this test can do is fail if the rules are deleted or reordered — the measurement lives in the PR,
+ * the rule lives here.
+ */
+describe('ModelsTabComponent — the footer row does not reflow under the cursor', () => {
+  // Read from the project root: under vitest, `import.meta.url` is not a file: URL, so `new URL(...)` throws
+  // before a single assertion runs. Vitest's cwd is `client/`.
+  const source = readFileSync('src/app/pages/settings/media-processing/models-tab.component.ts', 'utf8');
+
+  it('lays out the action buttons before any result', () => {
+    expect(source).toMatch(/\.testrow > button\s*\{[^}]*order:\s*0/);
+    expect(source).toMatch(/\.testrow > app-status-pill,\s*\.testrow > \.hint\s*\{[^}]*order:\s*1/);
+  });
+
+  it('keeps Save at the far end, after the results', () => {
+    // Save is the card's own action and belongs at the end of the row, not beside Test as a peer.
+    expect(source).toMatch(/\.testrow \.card-save\s*\{[^}]*order:\s*2[^}]*margin-left:\s*auto/);
+  });
+
+  it('still wraps rather than overflowing the card', () => {
+    // B.3: nowrap is what pushed Verify outside the card entirely. The order rules must not reintroduce it.
+    expect(source).toMatch(/\.testrow\s*\{[^}]*flex-wrap:\s*wrap/);
+    expect(source).not.toMatch(/\.testrow\s*\{[^}]*flex-wrap:\s*nowrap/);
   });
 });

--- a/client/src/app/pages/settings/media-processing/models-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.ts
@@ -83,9 +83,18 @@ import { TestTarget } from './media-processing.types';
     .testrow { display: flex; gap: 10px; row-gap: 8px; align-items: center; flex-wrap: wrap; min-height: 34px; }
     .testrow > :not(.hint) { flex: none; }
     .testrow .hint { margin: 0; min-width: 0; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    /* THE BUTTONS DO NOT MOVE WHEN A RESULT ARRIVES.
+       A test result is rendered where it belongs in the DOM — next to the button that produced it, which is
+       what a screen reader should hear — and that put a pill and a detail line BETWEEN Test and Verify. So
+       clicking Test pushed Verify sideways, out from under the pointer that had just been over it: the next
+       click landed on whatever had slid into that spot. Visual order is a layout concern, so it is fixed
+       here rather than by reordering the markup: actions are laid out first, results after them. Wrapping the
+       results in a div instead would also change what assistive tech reads, which is not the bug. */
+    .testrow > button { order: 0; }
+    .testrow > app-status-pill, .testrow > .hint { order: 1; }
     /* Save belongs to the card it sits in and appears only when that card has an unsaved change, so it
        is pushed to the far end of the row rather than sitting beside Test as a peer action. */
-    .testrow .card-save { margin-left: auto; }
+    .testrow .card-save { order: 2; margin-left: auto; }
   `],
   template: `
     <div class="cards">

--- a/testing/standalone/secrets-permissions.test.js
+++ b/testing/standalone/secrets-permissions.test.js
@@ -16,6 +16,16 @@
  * To run these tests meaningfully, execute them inside the Linux Docker
  * container or in a Linux CI environment.
  *
+ * @needs-instance — reads files the SERVER wrote (config.json, secrets.json, token.txt under
+ * testing/sync/configs/a/); runs in CI, skipped by preflight.
+ *
+ * That declaration was missing, and the gap is not cosmetic: `config.json` is a bind-mounted file that
+ * SURVIVES `npm run test:down`, while `token.txt` is written at boot and does not. So after a teardown this
+ * suite still selected the test-stack config, then died in `before()` with
+ * `ENOENT … testing/sync/configs/a/token.txt` — and took four sibling tests down as cancelled. Preflight
+ * reported a red gate for a stack that was deliberately stopped, which is the "gitignored generated state"
+ * trap: existence of one artefact was read as evidence that all of them are there.
+ *
  * Run: node --test testing/standalone/secrets-permissions.test.js
  */
 


### PR DESCRIPTION
Two reported residuals, same theme: an action that is present but not where you can use it. Both were
verified in a real browser against the **built bundle**, because neither is visible to a test that does not
measure layout or look at what was painted.

## R.6 — pressing Test moved the Verify button out from under the pointer

2.2.2 stopped the footer row overflowing its card and left the reflow. A test result renders next to the
button that produced it — right for what a screen reader hears — which puts a pill and a detail line
*between* Test and Verify, so the result pushed Verify onto the next line and the next click landed on
whatever had slid into its place.

Actions are laid out before results now (`order`), leaving the markup and the reading order untouched. A
wrapper div would have fixed the layout and changed what assistive tech reads, which is not the bug.

Measured in Edge on the vision card (its default endpoint does not resolve, so Test fails fast):

| state | Test | Verify | row height |
|---|---|---|---|
| no result yet | `left=295` | `left=419` | 34 px |
| with a test result | `left=295` | **`left=419`** | 59 px (result wrapped below) |
| same DOM, `order` rules removed | `left=295` | **`left=295`, 33 px lower** | 62 px |

The third row is 2.2.2's behaviour reproduced on the same live page, so this is a before/after on one
instance rather than an assertion that a rule exists. jsdom has no layout engine, so the unit test is a
tripwire on the rules and the measurement is the proof.

## R.7 — re-embedding needed you to open the file first

The action lived only in the docked detail pane, so repairing a file whose embedding had failed meant opening
it — while the row was already showing the failure. It is on the row now, next to the status that prompts it.

- **Offered only for a settled job.** A `pending` or `processing` file answers a retry with `409`; an action
  whose only outcome is a refusal is worse than one that is not there. A file with no status has no job.
- **The in-flight marker is the path, not a boolean** — one shared flag greys out every row and reads as
  "the whole list is busy".
- **Rename is a pencil.** It was the one text button among icons, so the word set the actions column's width
  on every row. The label is kept for hover and for assistive tech.

Verified in the browser: four buttons, and **every icon actually paints** — an unregistered Phosphor icon
renders an empty `<svg>` with no error at all, so the assertion is the rendered geometry plus a `<path>`, not
the presence of the element. One click re-queues (`✓ Re-embedding queued.`) and does not open the file.

## Two housekeeping commits

- **`chore(verify)`** — the server serves `client/dist/browser` with an index.html fallback, so a scratch
  instance can be driven straight from the built bundle: no `ng serve`, no proxy file, and it exercises what
  ships. Three selectors in the skill had gone stale and cost a failed run each (the server itself redirects
  `/` → `/setup`; setup is label-only; `/files` redirects to `/brain` because the file manager is a Brain tab).
- **`test(standalone)`** — `secrets-permissions.test.js` reads files the *server* writes but never declared
  `@needs-instance`. `config.json` is bind-mounted and survives `npm run test:down`; `token.txt` is written at
  boot and does not — so after a teardown the suite still selected the test-stack config, died in `before()`
  with `ENOENT` on `token.txt`, and took four sibling tests down as cancelled. It still runs in CI, where the
  stack is up and the mode bits mean something. Offline subset 176 → 175, declared 16 → 17.

## Gates

| gate | what it pins |
|---|---|
| `file-manager.component.spec` (+7) | which rows offer re-embed, the by-path in-flight marker, that a failure clears it, and that rename keeps its label. A `canRequeue` that always returns true fails it |
| `models-tab.component.spec` (+3) | the `order` rules exist and `flex-wrap: wrap` is not reverted; deleting `.testrow > button { order: 0 }` fails it |
