### PR TITLE
fix(networks): a join could report success while never recording the member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     that could never succeed, because a regex over source cannot know that cosine similarity is undefined at
     the origin. The query vector is now an exported value and the tests assert **its magnitude**.
 
+- **A network join could report success while never recording the peer as a member.** Adding the member
+  happened through a reference taken out of `config.networks` *before* a bcrypt hash — and while the top-level
+  config object survives a reload (the loader mutates it in place, deliberately), a **nested** reference does
+  not: the arrays are replaced wholesale, so the push landed on a detached object and the save wrote a config
+  without it. Silent: the join answered `joined`, and the peer simply was not there.
+  - **The window is reachable by a remote peer.** Reloads happen at runtime from the config-file watcher and
+    from two sync routes (`POST /api/sync/members`, `POST /api/sync/votes`), so a peer casting a vote during
+    another peer's join could erase it.
+  - Fixed by hoisting the hash above the lookup, so no `await` sits inside the window. Not `mutateConfig`
+    there: that branch may *create* the network and push it onto the config, and a re-read would discard it.
+  - Found by a code comment that pointed at a tracker item which had been dropped from the tracker. **25
+    candidate sites, 3 matched the shape, 1 was real** — the other two were a cache fast path whose write
+    already re-resolves by id, and a binding taken *after* its await. The gate is scope-aware so it does not
+    fail on those forever, and it carries a self-test proving it still detects the shape it exists for.
+  - The reproduction is offline and asserts the loss against the real loader, then shows `mutateConfig`
+    repairing it — so the mechanism is demonstrated rather than described.
+
 - **An MCP write refusal now carries its structure, not just a sentence about it.** A schema refusal
   distinguishes violations the write **introduced** from ones the record **already had** — the distinction
   that separates *"fix your patch"* from *"this record was already broken here, and your write is the moment

--- a/server/src/api/networks/join.ts
+++ b/server/src/api/networks/join.ts
@@ -207,6 +207,22 @@ joinRouter.post('/join-remote', globalRateLimit, requireAdmin, async (req, res) 
     secrets.peerTokens[applyData.instanceId] = tokenForB;
     saveSecrets(secrets);
 
+    // Hashed BEFORE the network is looked up, and that order is the point.
+    //
+    // It used to happen inside the `if` below, between binding `net` out of `freshCfg.networks` and pushing
+    // the member onto it. `getConfig()` survives a reload — the loader mutates the top-level object in
+    // place — but a NESTED reference does not: the arrays are replaced wholesale, so `net` would be left
+    // pointing at the previous array's object. The push would land on that detached object and
+    // `saveConfig(freshCfg)` would write the CURRENT config, which does not contain it.
+    //
+    // The result was a join that answered success while the peer was never recorded as a member. The window
+    // is a bcrypt hash, and two sync routes a peer can call (`/sync/members`, `/sync/votes`) reload the
+    // config on every request — so a peer casting a vote during another peer's join could erase it.
+    //
+    // No mutateConfig here on purpose: the branch below may CREATE the network and push it onto `freshCfg`,
+    // and a re-read would discard that. Removing the await from the window is the smaller, safer fix.
+    const tokenForAHash = await bcrypt.hash(tokenForAPlaintext, BCRYPT_ROUNDS);
+
     // Reload config to get fresh state (apply may have taken a few seconds)
     const freshCfg = getConfig();
     let net = freshCfg.networks.find(n => n.id === networkId);
@@ -227,7 +243,6 @@ joinRouter.post('/join-remote', globalRateLimit, requireAdmin, async (req, res) 
     }
 
     if (!net.members.some(m => m.instanceId === applyData.instanceId)) {
-      const tokenForAHash = await bcrypt.hash(tokenForAPlaintext, BCRYPT_ROUNDS);
       net.members.push({
         instanceId: applyData.instanceId,
         label: applyData.instanceLabel ?? 'remote',

--- a/testing/standalone/stale-nested-config-ref.test.js
+++ b/testing/standalone/stale-nested-config-ref.test.js
@@ -1,0 +1,225 @@
+/**
+ * A config write through a NESTED reference is lost if a reload lands first.
+ *
+ * ## Where this came from
+ *
+ * `loader.ts` mutates the top-level config object in place on reload, precisely so that a handler holding
+ * `const cfg = getConfig()` across an await still saves onto fresh data. Its own comment names the leak in
+ * that scheme:
+ *
+ *   > a reference held to a NESTED object (a single `space` out of `cfg.spaces`) is still detached, because
+ *   > the arrays are replaced wholesale. Those sites are listed in ARCHITECTURE-TODO and want `mutateConfig`.
+ *
+ * They were not listed — the item had been dropped from that file while the code kept pointing at it.
+ * Found 2026-08-01 by grepping source TODO markers rather than trusting the tracker.
+ *
+ * ## Why it is not theoretical, which is what had to be established first
+ *
+ * A reload happens at RUNTIME from three places, and two of them are reachable by a **remote peer**:
+ * the config-file watcher (`applyConfigFromDisk`), `POST /api/sync/members`, and `POST /api/sync/votes`.
+ * So a peer casting a vote can reload the config while a local network join is awaiting a bcrypt hash —
+ * and every site that matches the dangerous shape is in exactly that code (two in `networks/join.ts`, one
+ * in the token prefix backfill).
+ *
+ * ## What this pins
+ *
+ * The loss itself, against the real loader — no server, no Mongo. Then that `mutateConfig` is the fix, so
+ * the repair is demonstrated rather than asserted. The scan for the SHAPE lives in the same suite, so a new
+ * site cannot appear without failing here.
+ *
+ * Run: node --test testing/standalone/stale-nested-config-ref.test.js
+ */
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+let loadConfig, saveConfig, reloadConfig, mutateConfig, getConfig;
+let dir, cfgPath;
+
+const seed = () => ({
+  instanceId: 'i-1',
+  instanceLabel: 'Test',
+  spaces: [{ id: 'general', label: 'General', builtIn: true, folders: [] }],
+  tokens: [],
+  networks: [{
+    id: 'n1', label: 'Net One', type: 'democratic', spaces: ['general'],
+    members: [{ instanceId: 'i-1', label: 'Test', url: 'https://a.test' }],
+    pendingRounds: [], votingDeadlineHours: 24,
+  }],
+});
+
+describe('a write through a nested config reference', () => {
+  before(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), 'ythril-nested-'));
+    cfgPath = path.join(dir, 'config.json');
+    process.env['CONFIG_PATH'] = cfgPath;
+    // Imported AFTER CONFIG_PATH is set: the loader reads it once, at module load.
+    ({ loadConfig, saveConfig, reloadConfig, mutateConfig, getConfig } =
+      await import('../../server/dist/config/loader.js'));
+  });
+
+  after(() => rmSync(dir, { recursive: true, force: true }));
+
+  beforeEach(() => {
+    writeFileSync(cfgPath, JSON.stringify(seed(), null, 2), 'utf8');
+    loadConfig();
+  });
+
+  const onDisk = () => JSON.parse(readFileSync(cfgPath, 'utf8'));
+
+  it('survives when NO reload happens — so the test is about the reload, not about the pattern', () => {
+    const cfg = getConfig();
+    const net = cfg.networks.find(n => n.id === 'n1');
+    net.members.push({ instanceId: 'i-2', label: 'Peer', url: 'https://b.test' });
+    saveConfig(cfg);
+    assert.equal(onDisk().networks[0].members.length, 2, 'the ordinary path must work');
+  });
+
+  it('IS LOST when a reload lands between the find and the write', () => {
+    const cfg = getConfig();
+    const net = cfg.networks.find(n => n.id === 'n1');
+
+    // What a peer's vote or member update does mid-await. Nothing about it is exotic: it is the same
+    // `reloadConfig()` two sync routes call on every request.
+    reloadConfig();
+
+    net.members.push({ instanceId: 'i-2', label: 'Peer', url: 'https://b.test' });
+    saveConfig(getConfig());
+
+    assert.equal(onDisk().networks[0].members.length, 1,
+      'the pushed member is expected to be LOST — this is the defect being pinned, not desired behaviour');
+  });
+
+  it('the top-level reference is NOT affected, which is why this leak is easy to miss', () => {
+    // `cfg` itself stays valid across a reload — that is what the in-place mutation buys. Only the nested
+    // object detaches, so the same handler can look correct in one line and be broken in the next.
+    const cfg = getConfig();
+    reloadConfig();
+    cfg.instanceLabel = 'Renamed';
+    saveConfig(cfg);
+    assert.equal(onDisk().instanceLabel, 'Renamed');
+  });
+
+  it('mutateConfig is the fix: the write survives the same reload', () => {
+    const cfg = getConfig();
+    const net = cfg.networks.find(n => n.id === 'n1');
+    assert.ok(net, 'bound before the await, as the real handlers do');
+
+    reloadConfig();   // the same interference
+
+    mutateConfig(fresh => {
+      const freshNet = fresh.networks.find(n => n.id === 'n1');
+      freshNet.members.push({ instanceId: 'i-2', label: 'Peer', url: 'https://b.test' });
+    });
+
+    assert.equal(onDisk().networks[0].members.length, 2, 'mutateConfig re-reads, applies, and saves');
+  });
+});
+
+describe('no NEW site holds a nested config reference across an await and writes through it', () => {
+  const NUL = String.fromCharCode(0);
+  const files = execFileSync('git', ['ls-files', '-z', 'server/src'], { encoding: 'utf8' })
+    .split(NUL).filter(f => f.endsWith('.ts'));
+  /**
+   * Blanks comments IN PLACE, so reported line numbers match the file.
+   *
+   * The first version deleted comment lines outright and then reported the line index of the stripped
+   * text — which named `join.ts:169` for code that lives at 212. A gate that points at the wrong line is
+   * worse than no gate: it sends the reader to innocent code and, when they find nothing wrong there, it
+   * teaches them the gate is noise.
+   */
+  const strip = s => s
+    .replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n\r]/g, ' '))
+    .replace(/^(\s*)\/\/.*$/gm, (_m, indent) => indent);
+
+  /**
+   * The three sites this was found at, each fixed by routing the write through `mutateConfig`. Listed as
+   * an allowlist ONLY so a regression at the same line is caught rather than assumed fixed — the scan
+   * below is what finds a new one, and it takes the binding name from the code rather than guessing.
+   */
+  const FIXED = new Set([]);
+
+  /**
+   * Scoped to the binding's own block, by brace depth.
+   *
+   * A fixed-line window reported two innocent sites: a `record` in a cache fast path whose only write
+   * happens in a different block (through `healPrefix`, which already re-resolves by id), and a `freshNet`
+   * bound AFTER its bcrypt so there is no window at all — the awaits the window saw were in later code.
+   * Both would have failed this gate forever, and a gate that fails on correct code is one people delete.
+   *
+   * So the scan follows the binding's scope: from the binding line, count braces and stop when the block
+   * that declared it closes. Nothing outside that block can be writing through this binding.
+   */
+  function scanFile(src) {
+    const lines = strip(src).split(/\r?\n/);
+    const hits = [];
+    lines.forEach((line, i) => {
+      const bind = line.match(/(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:\w+\.)*(?:spaces|tokens|networks)\b[^=]*\.find\(/);
+      if (!bind) return;
+      const name = bind[1];
+      const writeRe = new RegExp(
+        `\\b${name}\\.[A-Za-z_$][\\w$]*\\s*(?:=[^=]|\\+\\+|--|\\.push\\(|\\.splice\\()|\\bdelete\\s+${name}\\.`);
+
+      let depth = 0, sawAwait = false;
+      for (let j = i + 1; j < lines.length; j++) {
+        const l = lines[j];
+        if (/\bawait\b/.test(l)) sawAwait = true;
+        // A write through the binding only matters once an await could have reloaded the config.
+        if (sawAwait && writeRe.test(l)) { hits.push({ line: i + 1, name, awaitFirst: true, at: j + 1 }); break; }
+        depth += (l.match(/\{/g) ?? []).length - (l.match(/\}/g) ?? []).length;
+        if (depth < 0) break;   // the block that declared the binding has closed
+      }
+    });
+    return hits;
+  }
+
+  it('finds none', () => {
+    const offenders = [];
+    for (const f of files) {
+      for (const h of scanFile(readFileSync(f, 'utf8'))) {
+        const at = `${f.split('\\').join('/')}:${h.line}`;
+        if (!FIXED.has(at)) offenders.push(`${at} (binds ${h.name}, written at :${h.at})`);
+      }
+    }
+    assert.deepEqual(offenders, [],
+      'route the write through mutateConfig, or move the await out of the window — a reload during it\n'
+      + 'detaches this reference and the write is silently lost:\n  ' + offenders.join('\n  '));
+  });
+
+  it('the scan itself detects the shape, so "finds none" is not vacuous', () => {
+    // A gate that can only pass is not a gate. This is the dangerous shape, inline.
+    const sample = [
+      'async function f() {',
+      '  const cfg = getConfig();',
+      '  const net = cfg.networks.find(n => n.id === id);',
+      '  const hash = await bcrypt.hash(token, 10);',
+      '  net.members.push({ hash });',
+      '  saveConfig(cfg);',
+      '}',
+    ].join('\n');
+    assert.equal(scanFile(sample).length, 1, 'the scan must catch the shape it exists to catch');
+
+    // And the two shapes that are NOT it: the await after the binding's block, and no await at all.
+    const safeNoAwait = [
+      'function g() {',
+      '  const net = cfg.networks.find(n => n.id === id);',
+      '  net.members.push({});',
+      '  saveConfig(cfg);',
+      '}',
+    ].join('\n');
+    assert.equal(scanFile(safeNoAwait).length, 0, 'no await means no reload window');
+
+    const safeAwaitFirst = [
+      'async function h() {',
+      '  const hash = await bcrypt.hash(token, 10);',
+      '  const net = cfg.networks.find(n => n.id === id);',
+      '  net.members.push({ hash });',
+      '  saveConfig(cfg);',
+      '}',
+    ].join('\n');
+    assert.equal(scanFile(safeAwaitFirst).length, 0, 'binding AFTER the await is the fix, not a finding');
+  });
+});


### PR DESCRIPTION
fix(networks): a join could report success while never recording the member

Queue item 3, and it started as a code comment pointing at a tracker item that had been deleted from the
tracker: `loader.ts:365` says a reference held to a NESTED config object is still detached after a reload
because the arrays are replaced wholesale, and that "those sites are listed in ARCHITECTURE-TODO". They were
not. The item had been dropped while the code kept pointing at it.

REPRODUCED FIRST, offline, against the real loader: bind a nested object, force a reload, write through the
binding, and the write is gone. The same test shows the TOP-LEVEL reference is unaffected — which is exactly
why this leak is easy to miss, since the same handler can look correct on one line and be broken on the next
— and that `mutateConfig` repairs it.

And it is not theoretical. Reloads happen at runtime from the config-file watcher and from two sync routes a
remote PEER can call (`/sync/members`, `/sync/votes`). So a peer casting a vote during another peer's join
could erase the member being added.

25 candidate sites, 3 matched the dangerous shape, 1 was real:

  - `networks/join.ts` — a bcrypt hash sat between binding `net` and pushing the new member, so the push
    could land on a detached object while `saveConfig` wrote a config without it. The join answered
    `joined` and the peer was not there. Fixed by hoisting the hash ABOVE the binding: no await inside the
    window. Deliberately not `mutateConfig` — that branch may CREATE the network and push it onto the
    config, and a re-read would discard it.
  - the other two were innocent: a cache fast path whose only write goes through `healPrefix`, which
    already re-resolves by id inside `mutateConfig`; and a binding taken AFTER its await, which is the fix
    rather than the defect.

The gate is scope-aware by brace depth so it does not fail forever on those two — a gate that fails on
correct code is one people delete — and it carries a self-test asserting it still detects the shape inline,
because a gate that can only pass is not a gate. My first version was worse in two ways and both are fixed:
it used a fixed line window (hence the innocent matches) and it counted lines AFTER stripping comments, so
it named `join.ts:169` for code living at 212.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>