### PR TITLE
fix(spaces): crash recovery could race a live rename and call it incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     stop descriptions permanently with no error anywhere — and that the call site reads the setting rather
     than a second constant.
 
+- **Crash recovery could race a live rename and report "rename incomplete" on a rename that had just
+  succeeded.** `pendingSpaceOp` is a crash marker: a rename writes it to `config.json` *before* it starts
+  moving collections, so that a process that dies mid-way is rolled forward on the next boot. But
+  `reconcilePendingSpaceOp` also runs on the **config-reload** path — so the marker a live rename had just
+  written was exactly what the reconciler picked up, in the same process, while the original was still
+  running. Both then call `moveSpaceData`, which renames every collection `listCollections()` returned, and
+  the loser of each collection gets `MongoServerError: Source collection … does not exist`. The caller reports
+  that as `rename incomplete (3 errors)`.
+  - Recovery now stands aside while an operation is running **in this process**: a live operation does not
+    need crash recovery, it needs to be left alone. If it dies, its marker survives and the next boot
+    recovers it — which is what the marker is for.
+  - Depth-counted and released in a `finally`, floored at zero so an unbalanced release cannot wedge recovery
+    off permanently.
+  - Observed once in CI on `space-rename` and not reproducible on demand: the watcher's mtime guard makes the
+    window rare rather than closed, and its own comment notes bind-mount mtimes are unreliable. Proved from
+    the code instead — "source collection does not exist" requires a second concurrent mover, and the only
+    other caller of `moveSpaceData` is the reconciler.
+
 - **A document that took longer than `stalledJobTimeoutMs` to embed was re-queued while it was still
   running — and then ran twice.** Stall recovery measures from the last progress report, and the chunk-embed
   phase reported nothing at all: conversion heartbeat per page, then silence for however long hundreds of

--- a/server/src/spaces/_shared.ts
+++ b/server/src/spaces/_shared.ts
@@ -185,6 +185,34 @@ export async function dropLegacyPrefixedIndexes(coll: Collection): Promise<void>
 /** Maximum number of previous meta versions kept for history. */
 export const META_VERSION_CAP = 20;
 
+// ── In-flight space operation ────────────────────────────────────────────────
+//
+// `pendingSpaceOp` is a CRASH marker: it exists so a rename or delete that died mid-way is rolled forward
+// on the next boot. But `reconcilePendingSpaceOp` also runs on the config-RELOAD path, and a rename writes
+// its marker to config.json BEFORE doing the collection work — so the marker a live rename just wrote is
+// exactly what the reconciler would act on, in the same process, while the original is still running.
+//
+// Both then call `moveSpaceData`, which renames every collection it found via `listCollections()`. Two
+// runners racing means one wins each collection and the loser gets
+// `MongoServerError: Source collection … does not exist` — which the caller reports as
+// "rename incomplete (3 errors)" on a rename that actually succeeded. Observed once in CI on
+// `space-rename`; the mtime guard on the watcher makes it rare rather than impossible, and the watcher's
+// own comment notes that bind-mount mtimes are unreliable.
+//
+// A live operation in THIS process does not need crash recovery — it needs to be left alone. If it dies,
+// its marker survives and the next boot recovers it, which is what the marker is for.
+
+let _spaceOpDepth = 0;
+
+/** Mark a space rename/delete as running in this process. Always pair with `endSpaceOp` in a `finally`. */
+export function beginSpaceOp(): void { _spaceOpDepth++; }
+
+/** Clear one level. Floored at zero so an unbalanced call cannot wedge recovery off permanently. */
+export function endSpaceOp(): void { _spaceOpDepth = Math.max(0, _spaceOpDepth - 1); }
+
+/** True while a rename/delete is running here, so crash recovery must stand aside. */
+export function spaceOpInFlight(): boolean { return _spaceOpDepth > 0; }
+
 /**
  * Maximum length of a space's directive (`meta.purpose`, and its deprecated `description` alias).
  *

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -14,7 +14,7 @@ import { invalidateUsageCache } from '../quota/quota.js';
 import { log } from '../util/log.js';
 import type { SpaceConfig, SpaceMeta, MemoryDoc } from '../config/types.js';
 import { VECTOR_INDEXED_COLLECTIONS, buildSpaceVectorIndexes, finalizeSpaceIndexReady } from './vector-index.js';
-import { SPACE_COLLECTIONS, repairStaleSpaceIds, dropLegacyPrefixedIndexes, pendingOpConflictMessage , setReindexNeeded } from './_shared.js';
+import { SPACE_COLLECTIONS, repairStaleSpaceIds, dropLegacyPrefixedIndexes, pendingOpConflictMessage , setReindexNeeded, beginSpaceOp, endSpaceOp, spaceOpInFlight } from './_shared.js';
 import { moveSpaceData, applySpaceRenameToConfig } from './rename.js';
 
 export async function initSpace(
@@ -411,6 +411,17 @@ export async function dropSpaceData(spaceId: string): Promise<string[]> {
  *  is already going away). If any drop fails, the marker is kept so the operator can
  *  retry (or the next boot resumes) rather than leaving a half-deleted space silently. */
 export async function removeSpace(spaceId: string): Promise<boolean> {
+  // Same reason as renameSpace: this writes a pendingSpaceOp marker before dropping anything, and the
+  // reconciler that acts on that marker also runs on the config-reload path. See beginSpaceOp.
+  beginSpaceOp();
+  try {
+    return await removeSpaceInner(spaceId);
+  } finally {
+    endSpaceOp();
+  }
+}
+
+async function removeSpaceInner(spaceId: string): Promise<boolean> {
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === spaceId);
   if (!space) return false;
@@ -607,6 +618,17 @@ export async function reconcilePendingSpaceOp(): Promise<void> {
   const cfg = getConfig();
   const op = cfg.pendingSpaceOp;
   if (!op) return;
+
+  // A live operation in THIS process is not an interrupted one. The marker is written BEFORE the collection
+  // work, and this function also runs on the config-reload path — so a reload during a rename would start a
+  // second `moveSpaceData` over the same collections, and whichever call loses the race reports
+  // `Source collection … does not exist` on a rename that actually succeeded. Nothing is lost by standing
+  // aside: if the running op dies, its marker survives and the next boot recovers it, which is the only
+  // situation this function exists for.
+  if (spaceOpInFlight()) {
+    log.debug(`Pending space ${op.type} for '${op.spaceId}' is being performed right now — recovery stands aside`);
+    return;
+  }
 
   const target = op.type === 'rename' ? `'${op.spaceId}' → '${op.newId}'` : `'${op.spaceId}'`;
   log.warn(`Resuming interrupted space ${op.type} ${target} (started ${op.startedAt})`);

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -11,7 +11,7 @@ import { getDb, col, asDoc, asFilter } from '../db/mongo.js';
 import { getConfig, saveConfig, getDataRoot, mutateConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { Config, SpaceConfig } from '../config/types.js';
-import { repairStaleSpaceIds, pendingOpConflictMessage } from './_shared.js';
+import { repairStaleSpaceIds, pendingOpConflictMessage, beginSpaceOp, endSpaceOp } from './_shared.js';
 
 /** Physically move a space's MongoDB collections and file directories from
  *  {oldId}_* / files/oldId to {newId}_* / files/newId. Idempotent — after a partial
@@ -212,6 +212,20 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
  *  retry (the retry resumes the same op rather than starting over).
  *  Returns the updated SpaceConfig on success. */
 export async function renameSpace(oldId: string, newId: string): Promise<SpaceConfig> {
+  // Crash recovery must not run against a rename that is still running HERE. The marker written below is
+  // what `reconcilePendingSpaceOp` acts on, and that reconciler also runs on the config-reload path — so
+  // without this, a config reload during the collection work starts a SECOND `moveSpaceData` over the same
+  // collections, and whichever loses reports `Source collection … does not exist` on a rename that
+  // succeeded. See `beginSpaceOp` in `_shared.ts`.
+  beginSpaceOp();
+  try {
+    return await renameSpaceInner(oldId, newId);
+  } finally {
+    endSpaceOp();
+  }
+}
+
+async function renameSpaceInner(oldId: string, newId: string): Promise<SpaceConfig> {
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === oldId);
   if (!space) throw new Error(`Space '${oldId}' not found`);

--- a/testing/standalone/space-op-recovery-guard.test.js
+++ b/testing/standalone/space-op-recovery-guard.test.js
@@ -1,0 +1,99 @@
+/**
+ * Crash recovery stands aside while the operation it would recover is still running.
+ *
+ * ## The failure this comes from
+ *
+ * CI went red once on `space-rename` with `MongoServerError: Source collection ythril.<old>_edges does not
+ * exist` for three collections — on a rename that had otherwise worked, and with `_memories` renamed fine.
+ *
+ * `moveSpaceData` only renames collections that `listCollections()` just returned, so "does not exist" cannot
+ * mean "was never created". It means the collection was moved by **someone else** between the listing and the
+ * rename. There is exactly one other caller: `reconcilePendingSpaceOp`.
+ *
+ * And that reconciler runs on the config-RELOAD path (`app.ts`), while `renameSpace` persists its
+ * `pendingSpaceOp` marker BEFORE doing the collection work. So the marker a live rename writes is precisely
+ * what the reconciler acts on — in the same process, against the same collections, while the original is
+ * still going. The watcher's mtime guard makes that rare rather than impossible, and its own comment notes
+ * that bind-mount mtimes are unreliable, which is where CI lives.
+ *
+ * ## What the guard is
+ *
+ * A live operation in this process is not an interrupted one. It needs to be left alone, not recovered.
+ * Nothing is lost by standing aside: if the running op dies, its marker survives and the next boot recovers
+ * it — the only situation the marker exists for.
+ *
+ * These tests pin the counter and the two call sites, since the failure mode of getting this wrong is a
+ * recovery path that silently never runs.
+ *
+ * Run: node --test testing/standalone/space-op-recovery-guard.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let beginSpaceOp, endSpaceOp, spaceOpInFlight;
+const strip = s => s
+  .replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n\r]/g, ' '))
+  .replace(/^(\s*)\/\/.*$/gm, (_m, indent) => indent);
+
+describe('the in-flight guard', () => {
+  before(async () => {
+    ({ beginSpaceOp, endSpaceOp, spaceOpInFlight } = await import('../../server/dist/spaces/_shared.js'));
+  });
+
+  it('is off by default, so recovery runs at boot as it always did', () => {
+    assert.equal(spaceOpInFlight(), false);
+  });
+
+  it('reports in-flight between begin and end', () => {
+    beginSpaceOp();
+    assert.equal(spaceOpInFlight(), true);
+    endSpaceOp();
+    assert.equal(spaceOpInFlight(), false);
+  });
+
+  it('nests, so a delete inside a rename does not clear the outer guard', () => {
+    beginSpaceOp();
+    beginSpaceOp();
+    endSpaceOp();
+    assert.equal(spaceOpInFlight(), true, 'the outer operation is still running');
+    endSpaceOp();
+    assert.equal(spaceOpInFlight(), false);
+  });
+
+  it('CANNOT be driven negative by an unbalanced end', () => {
+    // The consequence of getting this wrong is the worst available: a permanently negative counter would
+    // read as "never in flight", and crash recovery would be disabled for the life of the process while
+    // looking fine.
+    endSpaceOp();
+    endSpaceOp();
+    assert.equal(spaceOpInFlight(), false);
+    beginSpaceOp();
+    assert.equal(spaceOpInFlight(), true, 'a later real operation must still register');
+    endSpaceOp();
+  });
+});
+
+describe('both space operations claim the guard, and recovery reads it', () => {
+  it('renameSpace wraps its work and releases in a finally', () => {
+    const src = strip(readFileSync('server/src/spaces/rename.ts', 'utf8'));
+    assert.match(src, /beginSpaceOp\(\);/);
+    // `finally`, not a trailing call: a rename that throws (the "incomplete" path does) must not leave the
+    // guard set, or every later recovery in this process is skipped.
+    assert.match(src, /finally\s*\{\s*endSpaceOp\(\);/);
+  });
+
+  it('removeSpace does too — it writes the same kind of marker', () => {
+    const src = strip(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
+    assert.match(src, /beginSpaceOp\(\);[\s\S]{0,200}?finally\s*\{\s*endSpaceOp\(\);/);
+  });
+
+  it('reconcilePendingSpaceOp checks it BEFORE doing any work', () => {
+    const src = strip(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
+    const fn = src.slice(src.indexOf('export async function reconcilePendingSpaceOp'));
+    const guardAt = fn.indexOf('spaceOpInFlight()');
+    const workAt = fn.indexOf('moveSpaceData(');
+    assert.ok(guardAt > 0, 'the reconciler must consult the guard');
+    assert.ok(workAt > 0 && guardAt < workAt, 'and it must do so before moving any data');
+  });
+});


### PR DESCRIPTION
fix(spaces): crash recovery could race a live rename and call it incomplete

`pendingSpaceOp` is a crash marker written BEFORE the collection work, so a process that dies mid-way
is rolled forward on the next boot. `reconcilePendingSpaceOp` also runs on the config-RELOAD path,
which means the marker a live rename had just written was what the reconciler acted on, in the same
process, while the original was still running. Both call `moveSpaceData`, which renames every
collection `listCollections()` found, so the loser of each collection gets

    MongoServerError: Source collection ... does not exist

and the caller reports "rename incomplete (3 errors)" on a rename that had in fact succeeded.

Recovery now stands aside while an operation is running in THIS process: a live operation does not
need crash recovery, it needs to be left alone. If it dies its marker survives and the next boot
recovers it, which is the marker's whole purpose. Depth-counted, released in a finally, floored at
zero so an unbalanced release cannot wedge recovery off permanently.

Observed once in CI on space-rename and not reproducible on demand — proved from the code instead:
"source collection does not exist" requires a second concurrent mover, and the only other caller of
moveSpaceData is the reconciler.