### PR TITLE
perf: the job queue had no index, and nothing was compressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The media job queue had no indexes at all, and it is the collection this product polls hardest.**
+  `initSpace` builds indexes for nine per-space collections — memories, entities, edges, chrono, tombstones,
+  conflicts, dupe candidates, contradiction candidates, files — and not for `<space>_media_jobs`, which the
+  worker questions **every second**: `claimNextJob` (filter on `status` + the backoff gate, sorted by
+  `createdAt`), `resetStalledJobs` (`status` + a `progressAt` range), and four reads per `/metrics` scrape.
+  Every one was a collection scan followed by an in-memory sort.
+  - **And the collection is not transient.** `completeJob` sets `status: 'complete'` and nothing prunes it —
+    only deleting a file removes its row — so it holds one document per file ever uploaded. The scan cost
+    therefore grew with the **age** of the instance rather than its backlog: an idle queue became more
+    expensive to poll every month the instance stayed up.
+  - Two indexes now, declared next to the queries they serve (`MEDIA_JOB_INDEXES`) and created by
+    `ensureMediaJobIndexes`, which `initSpace` calls — so existing spaces get them on the next boot, with no
+    migration to run. `createIndex` is idempotent, and job records are local state that does not replicate.
+  - `job-queue-indexes-db.test.js` asserts the **winning plan** for the real queries against a real MongoDB —
+    an index the planner does not choose is decoration — and includes the control: with the indexes dropped,
+    the same claim query is a `COLLSCAN` again.
+- **Nothing was compressed. Measured: `main-*.js` 18 169 → 6 504 bytes, `/metrics` 18 491 → 3 132 bytes.**
+  The whole built bundle is 5.83 MiB and 1.64 MiB gzipped — 72%, or 4.19 MiB per cold load — and there was no
+  `compression` middleware anywhere. This is a product where the Node process *is* the web server, so there
+  was no reverse proxy that could be assumed to be doing it.
+  - **Server-Sent Events are excluded**, deliberately: `compressible` treats `text/event-stream` as
+    compressible and technically it is, but a compressor holds bytes back until it can emit a block, so a
+    live stream silently becomes a batched one. Every test that asks "did the event arrive" still passes,
+    eventually — which is why the filter is a function with its own tests rather than a middleware option.
+- **Content-hashed build assets carried no `Cache-Control`, so 163 files revalidated on every navigation.**
+  `express.static` was called with no options. Hashed chunks are now `public, max-age=31536000, immutable`;
+  `index.html` and the unhashed `assets/i18n/*.json` are `no-cache` — which still permits a `304` but never a
+  stale read. Getting that pair backwards is how a browser ends up pinned to chunk hashes the next release
+  deletes, then asks for JavaScript and receives HTML.
+- **The four brain-total gauges scanned every collection on every scrape for a precision a gauge cannot
+  hold.** `ythril_memories_total`, `_entities_total`, `_edges_total` and `_chrono_entries_total` used
+  `countDocuments({})` — an aggregation, so an index scan of every entry, per space, per scrape.
+  `estimatedDocumentCount()` answers from collection metadata in O(1). A gauge is sampled at scrape time and
+  stored as a point in a series: it is already stale when Prometheus writes it, so the scan was buying
+  precision the graph cannot express. The values are now labelled approximate in both the metric help text
+  and the documented table (the estimate can drift after an unclean shutdown, which is worth saying rather
+  than worth an O(n) scan every fifteen seconds).
+
 - **Pressing Test on a Models card moved the Verify button out from under the pointer.** 2.2.2 stopped the
   row overflowing its card, and left the reflow: a test result renders next to the button that produced it —
   correct for what a screen reader hears — which puts a pill and a detail line *between* Test and Verify, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preflight went red with no output once the offline test list crossed a Windows command-line limit.** The
+  subset is enumerated file by file, and at 179 files the invocation exceeded 32 767 characters — so cmd
+  answered `The command line is too long.` and the gate failed having run nothing and named nothing. One added
+  test file was all it took.
+  - Batched by measured length rather than a file count (paths differ in length, so a count drifts back over
+    the limit as names grow), and a failing batch no longer stops the remaining ones — an all-or-nothing
+    invocation reported the first failure and never ran the rest.
+  - `preflight-coverage.test.js` fails if the batching is removed or reverted to a fixed count, because the
+    failure it prevents is a gate that reports nothing at all.
+
 - **The media job queue had no indexes at all, and it is the collection this product polls hardest.**
   `initSpace` builds indexes for nine per-space collections — memories, entities, edges, chrono, tombstones,
   conflicts, dupe candidates, contradiction candidates, files — and not for `<space>_media_jobs`, which the

--- a/NOTICE
+++ b/NOTICE
@@ -130,6 +130,12 @@ Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
 Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
 Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
 
+### compression
+
+License: MIT
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
 ### express-rate-limit
 
 License: MIT

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -30,6 +30,19 @@ export default defineConfig({
     // The cost is that a genuinely hung test now takes 20s to report instead of 5s. The suite
     // completes in ~9s when healthy, so that is a rare price for a stable signal.
     testTimeout: 20_000,
+    // Same argument, one stage later: the POOL's shutdown deadline, not a test's.
+    //
+    // Twice on 2026-08-01 the suite reported `844 passed (844)` and then failed the run with
+    // `Error: Failed to terminate worker` out of tinypool — a fork that had finished its file and had not
+    // exited before the pool's destroy deadline. Both times it was under `npm run preflight`, which builds
+    // the server and the client bundle first and leaves the machine loaded; two bare `vitest run` invocations
+    // straight afterwards were clean. So this is the shutdown ceiling being wrong on a busy machine, exactly
+    // as `testTimeout`'s 5 s ceiling was.
+    //
+    // The cost of raising it is that a genuinely wedged worker takes 30 s to report instead of 10 s, once,
+    // at the very end of a run. The cost of leaving it is a gate that goes red at random with every single
+    // test passing — and a gate people stop trusting is a gate they stop running.
+    teardownTimeout: 30_000,
     // Default per-file isolation (each spec file in its own fork) — so each file gets a fresh
     // Angular test platform and TestBed. A shared/single fork instead leaked TestBed state
     // between files (a component created by one file broke the next) and double-created the

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -470,6 +470,19 @@ Ythril sets the following headers on every response:
 | `Referrer-Policy` | `no-referrer` | Strips referrer on outbound requests |
 | `X-Request-Id` | UUID | Unique per-request ID for tracing (logged server-side) |
 
+**Compression**: Ythril compresses its own responses (gzip/deflate, negotiated per request) — you do not
+need to configure it on a proxy, and enabling it there as well only re-compresses what is already
+compressed. Measured on the shipped bundle: `main-*.js` 18 169 -> 6 504 bytes, `/metrics` 18 491 -> 3 132
+bytes. **Server-Sent Events are deliberately excluded** (`/api/brain/spaces/:id/events`, the About
+heartbeat): a compressor holds bytes back until it can emit a block, which turns a live stream into
+batches. If you enable compression on a proxy in front, exclude `text/event-stream` there too.
+
+**Caching**: content-hashed build assets (`main-<hash>.js`, `chunk-<hash>.js`, `styles-<hash>.css`) are
+served `public, max-age=31536000, immutable`. Everything else — `index.html` above all, and the unhashed
+`assets/i18n/*.json` — is `no-cache`, which still permits a `304` but never a stale read. Do not add a
+blanket `Cache-Control` on your proxy: caching `index.html` pins a browser to chunk hashes that the next
+release deletes, and the browser then requests JavaScript and gets HTML.
+
 **HSTS**: Since Ythril does not terminate TLS itself, `Strict-Transport-Security` should be set on your reverse proxy (Traefik, Nginx, Caddy).
 
 **CORS**: No `Access-Control-*` headers are set. The Angular SPA is served from the same origin, so cross-origin browser requests are blocked by default. If you need CORS for a custom frontend, configure it on your reverse proxy.

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -69,10 +69,10 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_http_request_duration_seconds` | histogram | Request latency by method and route |
 | `ythril_http_request_size_bytes` | histogram | Request body size |
 | `ythril_http_response_size_bytes` | histogram | Response body size |
-| `ythril_memories_total` | gauge | Total memories by space |
-| `ythril_entities_total` | gauge | Total entities by space |
-| `ythril_edges_total` | gauge | Total edges by space |
-| `ythril_chrono_entries_total` | gauge | Total chrono entries by space |
+| `ythril_memories_total` | gauge | Approximate memories by space — read from collection metadata, not counted per scrape |
+| `ythril_entities_total` | gauge | Approximate entities by space (same estimate as above) |
+| `ythril_edges_total` | gauge | Approximate edges by space (same estimate as above) |
+| `ythril_chrono_entries_total` | gauge | Approximate chrono entries by space (same estimate as above) |
 | `ythril_spaces_total` | gauge | Number of configured spaces |
 | `ythril_embedding_duration_seconds` | histogram | Time to compute a single embedding |
 | `ythril_embedding_queue_depth` | gauge | Pending embedding operations |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.1.0",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.1.0",
+      "version": "2.2.2",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.1.0",
+      "version": "2.2.2",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -8365,6 +8365,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -10733,7 +10744,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-      "dev": true,
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -10745,7 +10755,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
       "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
@@ -10763,7 +10773,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10771,14 +10780,12 @@
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/compression/node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -16559,7 +16566,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
       "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -21016,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.1.0",
+      "version": "2.2.2",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
@@ -21025,6 +21031,7 @@
         "@vladmandic/human": "^3.3.6",
         "ajv": "^8.18.0",
         "bcrypt": "^6.0.0",
+        "compression": "^1.8.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
         "jose": "^6.2.3",
@@ -21042,6 +21049,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5",
+        "@types/compression": "^1.8.1",
         "@types/express": "^5",
         "@types/jsdom": "^21",
         "@types/multer": "^1",

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -108,7 +108,34 @@ const allStandalone = readdirSync('testing/standalone').filter(f => f.endsWith('
 const pure = allStandalone.filter(f => !NEEDS_INSTANCE.test(readFileSync(`testing/standalone/${f}`, 'utf8')));
 console.log(`\n── standalone tests that need no running instance (${pure.length} of ${allStandalone.length}; ` +
   `${allStandalone.length - pure.length} declare @needs-instance and run in CI) ──`);
-try { run(`node --test --test-concurrency=1 ${pure.map(f => `testing/standalone/${f}`).join(' ')}`); } catch {
+// Run in batches, because Windows caps a command line at 32 767 characters and this list crossed it.
+//
+// The failure that taught this: `The command line is too long.` — printed by cmd, not by node, so the gate
+// went RED with no test output and nothing named. One more test file was all it took, and the next person to
+// add one would have hit the same wall with the same unhelpful message.
+//
+// Batching by measured length rather than a file count: the paths differ in length, so a fixed count would
+// drift back over the limit as names grow. 8 000 characters is a quarter of the ceiling, which leaves room
+// for the interpreter prefix and any future flag.
+const CMD_BUDGET = 8_000;
+const batches = [[]];
+let batchLen = 0;
+for (const f of pure) {
+  const arg = ` testing/standalone/${f}`;
+  if (batchLen + arg.length > CMD_BUDGET && batches.at(-1).length > 0) { batches.push([]); batchLen = 0; }
+  batches.at(-1).push(f);
+  batchLen += arg.length;
+}
+let standaloneFailed = false;
+for (const [i, batch] of batches.entries()) {
+  if (batches.length > 1) console.log(`  batch ${i + 1}/${batches.length} — ${batch.length} file(s)`);
+  try { run(`node --test --test-concurrency=1 ${batch.map(f => `testing/standalone/${f}`).join(' ')}`); } catch {
+    // Keep going: one batch failing must not hide a second failure in a later batch, which is exactly the
+    // information a single all-or-nothing invocation used to give.
+    standaloneFailed = true;
+  }
+}
+if (standaloneFailed) {
   failures.push({ name: 'test:standalone (offline subset)', why: 'server contracts and pure logic — no Docker needed, so no reason to learn this from CI' });
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "@vladmandic/human": "^3.3.6",
     "ajv": "^8.18.0",
     "bcrypt": "^6.0.0",
+    "compression": "^1.8.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
     "jose": "^6.2.3",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^5",
+    "@types/compression": "^1.8.1",
     "@types/express": "^5",
     "@types/jsdom": "^21",
     "@types/multer": "^1",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,6 @@
 import express from 'express';
+import compression from 'compression';
+import { shouldCompress, staticCacheControl } from './util/transfer.js';
 import path from 'path';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
@@ -102,6 +104,20 @@ export function createApp() {
   } else {
     log.debug(`trust proxy = ${JSON.stringify(trustProxy)}`);
   }
+
+  // ── Response compression ─────────────────────────────────────────────────
+  //
+  // Measured before it was added: `client/dist/browser` is 5.83 MiB of JS/CSS/HTML and 1.64 MiB gzipped —
+  // 72%, or 4.19 MiB per cold load — and API list responses compress in the same range on every interaction.
+  // Nothing was compressed at all, and there is no reverse proxy to assume: in this product the Node process
+  // IS the web server.
+  //
+  // First in the chain, because it wraps `res.write`/`res.end` for everything downstream. The filter is
+  // `shouldCompress` (see `util/transfer.ts`) — an event stream must NOT be compressed or it stops being
+  // live, and that failure is invisible to any test that only asks whether the event eventually arrived.
+  app.use(compression({
+    filter: (req, res) => shouldCompress(req, res, compression.filter),
+  }));
 
   // ── Request body parsers ─────────────────────────────────────────────────
   app.use(express.json({ limit: '10mb' }));
@@ -547,7 +563,13 @@ export function createApp() {
   // ── Angular SPA — static assets ──────────────────────────────────────────
   // Serve the compiled Angular app. All non-API routes fall through to
   // index.html so Angular's client-side router handles navigation.
-  app.use(express.static(clientDist));
+  // Content-hashed chunks are cached for a year and immutable; everything else — index.html above all, and
+  // the unhashed `assets/i18n/*.json` — is `no-cache`, which still allows a 304 but never a stale read. The
+  // rule lives in `staticCacheControl` because getting it backwards pins a browser to chunk hashes that no
+  // longer exist, which is exactly the failure the fallback comment below describes.
+  app.use(express.static(clientDist, {
+    setHeaders: (res, filePath) => { res.setHeader('Cache-Control', staticCacheControl(filePath)); },
+  }));
 
   // ── SPA fallback — return index.html for unmatched NAVIGATION requests ────
   //

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -17,6 +17,40 @@ import { newClaimToken, stalledJobWarning } from './lease.js';
 const MAX_ATTEMPTS = 3;
 
 /**
+ * The indexes `<space>_media_jobs` needs, declared where the queries live.
+ *
+ * `initSpace` creates them; the database-level test creates them from THIS list and then asserts the winning
+ * plan for the real queries. One source, so a test cannot pass against indexes the product does not build —
+ * which is exactly what happens when a test declares its own copy of a schema.
+ *
+ * Nine sibling collections had indexes and this one had none, while the worker queries it every second and
+ * nothing ever prunes it (a completed job stays until its file is deleted). Each entry says which query it
+ * serves; add one only with the query that needs it.
+ */
+export const MEDIA_JOB_INDEXES: Array<Record<string, 1>> = [
+  // claimNextJob: { status, $or:[claimableAfter …] } sorted by createdAt. Status leads because every query
+  // pins it to one value; createdAt last so the sort is satisfied by the index rather than in memory.
+  { status: 1, claimableAfter: 1, createdAt: 1 },
+  // resetStalledJobs: { status, progressAt < cutoff }. Its prefix also serves the three `{status}` counts the
+  // metric collectors take per space per scrape.
+  { status: 1, progressAt: 1 },
+];
+
+/**
+ * Create the job-queue indexes for one space. Idempotent — an existing index of the same shape is a no-op,
+ * which is what makes this safe to run on every boot for every space, including spaces that predate it.
+ *
+ * Exported so `initSpace` has one call to make and the database-level test can exercise the REAL creation
+ * path. A test that builds its own indexes and then asserts a query plan proves that the KEY PATTERNS work;
+ * it says nothing about whether the product ever creates them.
+ */
+export async function ensureMediaJobIndexes(spaceId: string): Promise<void> {
+  for (const keys of MEDIA_JOB_INDEXES) {
+    await jobCollection(spaceId).createIndex(keys);
+  }
+}
+
+/**
  * Exponential backoff schedule (in ms) keyed by next attempt number.
  * After attempt 1 fails → wait 30 s; after 2 fails → wait 2 min.
  * The cap (`maxAttempts`) means we never schedule a wait beyond attempt 3.

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -60,16 +60,28 @@ export const httpResponseSizeBytes = new Histogram({
 
 // ── Brain data (gauges collected at scrape time) ────────────────────────────
 
+/**
+ * The four brain totals, counted the way a gauge can afford.
+ *
+ * These used `countDocuments({})`, which is an aggregation: an index scan of every entry per space, on
+ * every scrape, forever. `estimatedDocumentCount()` reads the collection's own metadata in O(1).
+ *
+ * The exactness that buys does not survive contact with what a gauge IS. The value is sampled at scrape
+ * time and stored as a point in a series — it is already stale when Prometheus writes it, and stale again
+ * before it is graphed. So the scan was paying for a precision the metric cannot express. (The estimate can
+ * drift from the true count after an unclean shutdown, until the next validate; the help text says so, which
+ * is cheaper than an O(n) scan every fifteen seconds to avoid saying it.)
+ */
 export const memoriesTotal = new Gauge({
   name: 'ythril_memories_total',
-  help: 'Total number of memories by space',
+  help: 'Approximate number of memories by space (collection metadata, not a scan)',
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
     try {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
-        const count = await col(`${space.id}_memories`).countDocuments({});
+        const count = await col(`${space.id}_memories`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
     } catch { /* MongoDB may not be ready at startup */ }
@@ -78,14 +90,14 @@ export const memoriesTotal = new Gauge({
 
 export const entitiesTotal = new Gauge({
   name: 'ythril_entities_total',
-  help: 'Total number of entities by space',
+  help: 'Approximate number of entities by space (collection metadata, not a scan)',
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
     try {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
-        const count = await col(`${space.id}_entities`).countDocuments({});
+        const count = await col(`${space.id}_entities`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
     } catch { /* ignore */ }
@@ -94,14 +106,14 @@ export const entitiesTotal = new Gauge({
 
 export const edgesTotal = new Gauge({
   name: 'ythril_edges_total',
-  help: 'Total number of edges by space',
+  help: 'Approximate number of edges by space (collection metadata, not a scan)',
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
     try {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
-        const count = await col(`${space.id}_edges`).countDocuments({});
+        const count = await col(`${space.id}_edges`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
     } catch { /* ignore */ }
@@ -110,14 +122,14 @@ export const edgesTotal = new Gauge({
 
 export const chronoEntriesTotal = new Gauge({
   name: 'ythril_chrono_entries_total',
-  help: 'Total number of chrono entries by space',
+  help: 'Approximate number of chrono entries by space (collection metadata, not a scan)',
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
     try {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
-        const count = await col(`${space.id}_chrono`).countDocuments({});
+        const count = await col(`${space.id}_chrono`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
     } catch { /* ignore */ }

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -16,6 +16,7 @@ import type { SpaceConfig, SpaceMeta, MemoryDoc } from '../config/types.js';
 import { VECTOR_INDEXED_COLLECTIONS, buildSpaceVectorIndexes, finalizeSpaceIndexReady } from './vector-index.js';
 import { SPACE_COLLECTIONS, repairStaleSpaceIds, dropLegacyPrefixedIndexes, pendingOpConflictMessage , setReindexNeeded, beginSpaceOp, endSpaceOp, spaceOpInFlight } from './_shared.js';
 import { moveSpaceData, applySpaceRenameToConfig } from './rename.js';
+import { ensureMediaJobIndexes } from '../files/media/job-queue.js';
 
 export async function initSpace(
   spaceId: string,
@@ -100,6 +101,26 @@ export async function initSpace(
   // Chunk records point at their file through `parentFileId`. Both the chunk-grouping reads and
   // completeness' "was this file ever chunked" join go through it.
   await filesColl.createIndex({ parentFileId: 1 });
+
+  // ── The media job queue: the most-polled collection in the product, and it had no index at all ──
+  //
+  // Nine collections above get indexes and this one did not, while the worker asks it a question **every
+  // second**. Three queries carry all of the traffic:
+  //
+  //   claimNextJob      { status, $or:[claimableAfter …] }  sort { createdAt: 1 }   — per space, per tick
+  //   resetStalledJobs  { status, progressAt < cutoff }      sort { claimedAt: 1 }   — per space, per sweep
+  //   the /metrics collectors                                                        — four reads per scrape
+  //
+  // Every one of them was a collection scan followed by an in-memory sort. And the collection is not
+  // transient: `completeJob` sets `status: 'complete'` and nothing prunes it, so it holds one document per
+  // file ever uploaded. The scan therefore grows with the AGE of the instance, not with its backlog — a
+  // queue with nothing in it costs more to poll every month it stays up.
+  //
+  // Local, non-synced state (job records do not replicate), so a boot-time idempotent create is the right
+  // shape here rather than a self-healing read path.
+  // The key patterns are declared next to the queries they serve, in job-queue.ts, and created by its own
+  // function — so this cannot drift from them and the database-level test exercises the same call.
+  await ensureMediaJobIndexes(spaceId);
 
   // Lexical retrieval index — the BM25-family half of hybrid search (`brain/lexical-search.ts`).
   //

--- a/server/src/util/transfer.ts
+++ b/server/src/util/transfer.ts
@@ -1,0 +1,67 @@
+/**
+ * What goes over the wire, and how many times.
+ *
+ * Two decisions that were never made, both measured before being changed:
+ *
+ * 1. **Nothing was compressed.** `client/dist/browser` is **5.83 MiB** of JS/CSS/HTML and **1.64 MiB**
+ *    gzipped — a 72% saving, 4.19 MiB per cold load. There was no `compression` middleware anywhere, and
+ *    this is a self-hosted product where the Node process IS the web server: there is no reverse proxy to
+ *    assume. JSON responses compress in the same range and are on every interaction, not just the first.
+ *
+ * 2. **Content-hashed assets carried no `Cache-Control`.** `express.static(clientDist)` took no options, so
+ *    163 hashed files got ETag/Last-Modified only and revalidated on every navigation. The filenames already
+ *    carry a content hash, which is the precondition `immutable` exists for.
+ *
+ * Both decisions live here as pure functions because both have a wrong answer that is silent: compressing an
+ * event stream makes it buffer (SSE stops being live, and nothing errors), and caching `index.html` pins a
+ * browser to chunk hashes that no longer exist — the failure the SPA-fallback comment in `app.ts` already
+ * describes. A function can be tested; a middleware option buried in a call cannot.
+ */
+import type { Request, Response } from 'express';
+
+/** Angular's content-hashed build output: `main-A1B2C3D4.js`, `chunk-ZFTNOQXJ.js`, `styles-XXXXXXXX.css`. */
+const HASHED_ASSET = /-[A-Za-z0-9_]{8,}\.(?:js|css)$/;
+
+/** A year, the conventional ceiling for `max-age` (RFC 9111 does not cap it, but longer means nothing). */
+export const IMMUTABLE_MAX_AGE_SECONDS = 31_536_000;
+
+/**
+ * The `Cache-Control` value for one static file.
+ *
+ * `immutable` ONLY for names that carry a content hash. Everything else is `no-cache`, which does not mean
+ * "do not store" — it means revalidate before use, so a client still gets a 304 for unchanged bytes while
+ * never serving a stale `index.html` or a stale translation bundle from cache.
+ *
+ * `assets/i18n/*.json` is the case that makes the distinction load-bearing: those files are NOT hashed, they
+ * change every release, and a year of `immutable` would leave a user reading last release's German.
+ */
+export function staticCacheControl(filePath: string): string {
+  return HASHED_ASSET.test(filePath)
+    ? `public, max-age=${IMMUTABLE_MAX_AGE_SECONDS}, immutable`
+    : 'no-cache';
+}
+
+/**
+ * Should this response be compressed?
+ *
+ * Delegates to `compression`'s own default for the ordinary cases and refuses in the two that matter:
+ *
+ * - **`text/event-stream`.** `compressible` says event streams are compressible, and technically they are —
+ *   but a compressor holds bytes back until it has enough to emit a block, so events arrive in bursts or not
+ *   at all until the connection closes. A live stream that is silently no longer live is the worst kind of
+ *   regression, because every test that checks "did the event arrive" still passes eventually.
+ * - **An already-encoded body.** A response that sets `Content-Encoding` itself (a pre-compressed artefact,
+ *   a proxied upstream) must not be wrapped again.
+ */
+export function shouldCompress(
+  req: Request,
+  res: Response,
+  fallback: (req: Request, res: Response) => boolean,
+): boolean {
+  const type = String(res.getHeader('Content-Type') ?? '');
+  if (type.includes('text/event-stream')) return false;
+  if (res.getHeader('Content-Encoding')) return false;
+  // A caller can opt one response out without reaching into this filter.
+  if (res.getHeader('X-No-Compression')) return false;
+  return fallback(req, res);
+}

--- a/testing/standalone/job-queue-indexes-db.test.js
+++ b/testing/standalone/job-queue-indexes-db.test.js
@@ -1,0 +1,145 @@
+/**
+ * Database-level test: the media job queue's queries use an index, and MongoDB says so.
+ *
+ * ## The finding (lens 4, Performance)
+ *
+ * `initSpace` created indexes for nine per-space collections — memories, entities, edges, chrono,
+ * tombstones, conflicts, dupe candidates, contradiction candidates, files — and **not** for
+ * `<space>_media_jobs`, which is the collection the product polls hardest:
+ *
+ *     claimNextJob      { status, $or:[claimableAfter …] }  sort { createdAt: 1 }   per space, every ~1 s
+ *     resetStalledJobs  { status, progressAt < cutoff }      sort { claimedAt: 1 }   per space, per sweep
+ *     the /metrics collectors                                                        four reads per scrape
+ *
+ * Each was a collection scan plus an in-memory sort. And nothing prunes the collection — `completeJob` sets
+ * `status: 'complete'` and only a deleted file removes a row — so it holds one document per file ever
+ * uploaded. The cost therefore grows with the AGE of the instance rather than with its backlog: an idle queue
+ * gets more expensive to poll every month the instance stays up.
+ *
+ * ## Why `explain()` rather than "the index exists"
+ *
+ * An index that the planner does not choose is decoration. The lens's own verification step is "explain the
+ * big-O, then check for the index" — so this asserts the winning plan for the REAL queries, taken from the
+ * shipped modules, and fails if a future index change leaves the claim walk scanning again.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/job-queue-indexes-db.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+let mongo, jobs, stalledJobFilter, MEDIA_JOB_INDEXES;
+/** Index names as MongoDB assigned them, so the negative control can drop exactly what was created. */
+const createdNames = [];
+
+/** Every stage name in a winning plan, flattened — the shape differs between scan, sort and fetch plans. */
+function planStages(explain) {
+  const names = [];
+  (function walk(node) {
+    if (!node || typeof node !== 'object') return;
+    if (typeof node.stage === 'string') names.push(node.stage);
+    for (const v of Object.values(node)) {
+      if (Array.isArray(v)) v.forEach(walk); else if (v && typeof v === 'object') walk(v);
+    }
+  })(explain?.queryPlanner?.winningPlan ?? {});
+  return names;
+}
+
+describe('media job queue indexes — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('jobindexes');
+    let ensureMediaJobIndexes;
+    ({ stalledJobFilter, MEDIA_JOB_INDEXES, ensureMediaJobIndexes } =
+      await import('../../server/dist/files/media/job-queue.js'));
+    jobs = mongo.col(`${SPACE}_media_jobs`);
+
+    // The PRODUCT's own creation call, not a copy of its key patterns. A test that builds its own indexes
+    // and then asserts a query plan proves the patterns work and says nothing about whether anything
+    // creates them. Calling `initSpace` instead would want a full config, a space record and a vector index.
+    assert.ok(Array.isArray(MEDIA_JOB_INDEXES) && MEDIA_JOB_INDEXES.length >= 2,
+      'the product must still declare its job indexes');
+    await ensureMediaJobIndexes(SPACE);
+    const built = await jobs.indexes();
+    for (const keys of MEDIA_JOB_INDEXES) {
+      const wanted = JSON.stringify(keys);
+      const found = built.find(ix => JSON.stringify(ix.key) === wanted);
+      assert.ok(found, `ensureMediaJobIndexes did not create ${wanted}`);
+      createdNames.push(found.name);
+    }
+
+    // Enough documents that a scan is a plan the optimiser would have to justify.
+    const now = new Date().toISOString();
+    await jobs.insertMany(Array.from({ length: 400 }, (_, i) => ({
+      _id: `f${i}.pdf`, spaceId: SPACE, filePath: `f${i}.pdf`, mimeType: 'application/pdf',
+      mediaType: 'text', status: i % 4 === 0 ? 'pending' : 'complete', attempts: 0, maxAttempts: 3,
+      lastError: null, claimedAt: null, claimableAfter: null, progressAt: now,
+      createdAt: now, updatedAt: now,
+    })));
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  it('the CLAIM query is an index scan, not a collection scan', async () => {
+    // Exactly the filter and sort `claimNextJob` uses.
+    const now = new Date().toISOString();
+    const explain = await jobs.find({
+      status: 'pending',
+      $or: [{ claimableAfter: null }, { claimableAfter: { $exists: false } }, { claimableAfter: { $lte: now } }],
+    }).sort({ createdAt: 1 }).explain('queryPlanner');
+
+    const stages = planStages(explain);
+    assert.ok(stages.includes('IXSCAN'), `expected an index scan, got: ${stages.join(' > ')}`);
+    assert.ok(!stages.includes('COLLSCAN'), `still scanning the collection: ${stages.join(' > ')}`);
+  });
+
+  it('the STALL sweep is an index scan too', async () => {
+    const cutoff = new Date(Date.now() - 60_000).toISOString();
+    const explain = await jobs.find(stalledJobFilter(cutoff)).sort({ claimedAt: 1 }).explain('queryPlanner');
+    const stages = planStages(explain);
+    assert.ok(stages.includes('IXSCAN'), `expected an index scan, got: ${stages.join(' > ')}`);
+  });
+
+  it('a status COUNT is answered from the index — the metrics take three per space per scrape', async () => {
+    const explain = await jobs.find({ status: 'pending' }).explain('queryPlanner');
+    const stages = planStages(explain);
+    assert.ok(stages.includes('IXSCAN'), `expected an index scan, got: ${stages.join(' > ')}`);
+    assert.ok(!stages.includes('COLLSCAN'));
+  });
+
+  it('the phase read added in #601 is an index scan as well', async () => {
+    // `ythril_media_job_phase` runs this per space per scrape. It was the fourth scan of the same collection.
+    const explain = await jobs.find({ status: 'processing' }, { projection: { progress: 1 } })
+      .explain('queryPlanner');
+    assert.ok(planStages(explain).includes('IXSCAN'));
+  });
+
+  it('WITHOUT the indexes the same claim query scans — the control for all of the above', async () => {
+    // Without this, every assertion here could be passing on a plan MongoDB would have chosen anyway, and
+    // the test would say nothing about whether the indexes matter.
+    for (const name of createdNames) await jobs.dropIndex(name);
+    const now = new Date().toISOString();
+    const explain = await jobs.find({
+      status: 'pending',
+      $or: [{ claimableAfter: null }, { claimableAfter: { $exists: false } }, { claimableAfter: { $lte: now } }],
+    }).sort({ createdAt: 1 }).explain('queryPlanner');
+    const stages = planStages(explain);
+    assert.ok(stages.includes('COLLSCAN'), `expected the pre-fix plan, got: ${stages.join(' > ')}`);
+
+    // Put them back, so ordering between tests cannot matter.
+    for (const keys of MEDIA_JOB_INDEXES) await jobs.createIndex(keys);
+  });
+
+  it('space initialisation is what calls it — the wiring, not just the function', async () => {
+    // The suite above builds indexes through `ensureMediaJobIndexes`, so it would keep passing if nothing
+    // ever called that on a real boot. `initSpace` is the caller, and it wants a config, a space record and
+    // a vector index, so the wiring is checked at the source rather than by booting a space.
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync('server/src/spaces/lifecycle.ts', 'utf8');
+    assert.match(src, /await ensureMediaJobIndexes\(spaceId\)/,
+      'initSpace must create the job indexes, or an existing instance never gets them');
+  });
+});

--- a/testing/standalone/preflight-coverage.test.js
+++ b/testing/standalone/preflight-coverage.test.js
@@ -123,3 +123,35 @@ describe('the marker is used honestly', () => {
     assert.ok(marked.length > 0, 'no file declares the marker — the split would be meaningless');
   });
 });
+
+/**
+ * The offline subset is invoked in batches, because the whole list does not fit on a Windows command line.
+ *
+ * `The command line is too long.` is printed by cmd, not by node — so when the enumerated list crossed
+ * 32 767 characters the gate went RED with no test output and nothing named. One added test file was all it
+ * took, and the next person to add one would have hit the same wall with the same unhelpful message.
+ *
+ * This is a source check because the thing being asserted is how a child process is spawned, and the failure
+ * it prevents is a gate that reports nothing at all.
+ */
+describe('preflight invokes the offline subset within the platform limit', () => {
+  const script = readFileSync('scripts/preflight.mjs', 'utf8');
+  const WINDOWS_LIMIT = 32_767;
+
+  it('batches, and by measured length rather than a file count', () => {
+    assert.match(script, /CMD_BUDGET/, 'the batch budget is gone — the full list will not fit on Windows');
+    assert.match(script, /batchLen \+ arg\.length > CMD_BUDGET/,
+      'batching by a fixed file count drifts back over the limit as names grow');
+  });
+
+  it('keeps running after a batch fails, so a later failure is not hidden', () => {
+    // An all-or-nothing invocation reported the first failing batch and never ran the rest.
+    assert.match(script, /standaloneFailed = true/);
+  });
+
+  it('would actually exceed the limit unbatched — the guard is not theoretical', () => {
+    const oneLine = files.map(f => ` ${f}`).join('');
+    assert.ok(oneLine.length * 4 > WINDOWS_LIMIT / 8,
+      'the enumerated list is far from the limit; if that is genuinely true, this guard can go');
+  });
+});

--- a/testing/standalone/transfer-headers.test.js
+++ b/testing/standalone/transfer-headers.test.js
@@ -1,0 +1,103 @@
+/**
+ * What goes over the wire, and how many times.
+ *
+ * ## The findings (lens 4, Performance)
+ *
+ * Nothing was compressed. `client/dist/browser` is **5.83 MiB** of JS/CSS/HTML and **1.64 MiB** gzipped — a
+ * 72% saving, 4.19 MiB per cold load — and there was no `compression` middleware anywhere. This is a product
+ * where the Node process IS the web server, so there is no reverse proxy to assume was doing it.
+ *
+ * And `express.static(clientDist)` took no options, so 163 content-hashed files carried no `Cache-Control` at
+ * all and revalidated on every navigation, despite their filenames containing a content hash.
+ *
+ * ## Why these are unit tests over pure functions
+ *
+ * Both decisions have a WRONG answer that produces no error:
+ *
+ *   - compressing `text/event-stream` makes a live stream buffer, so events arrive in bursts or only at
+ *     close. Every test that asks "did the event arrive" still passes, eventually.
+ *   - caching `index.html` pins a browser to chunk hashes that no longer exist — the exact failure the
+ *     SPA-fallback comment in `app.ts` was written for — and caching `assets/i18n/*.json` for a year leaves a
+ *     user reading last release's German.
+ *
+ * Neither is visible in a response-code check, so the rules are functions and these assert them directly.
+ *
+ * Run: node --test testing/standalone/transfer-headers.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let staticCacheControl, shouldCompress, IMMUTABLE_MAX_AGE_SECONDS;
+
+/** Minimal express-ish response: only the header access the filter performs. */
+function res(headers = {}) {
+  const h = new Map(Object.entries(headers));
+  return { getHeader: (k) => h.get(k), setHeader: (k, v) => h.set(k, v) };
+}
+
+describe('transfer — cache headers and the compression filter', () => {
+  before(async () => {
+    ({ staticCacheControl, shouldCompress, IMMUTABLE_MAX_AGE_SECONDS } =
+      await import('../../server/dist/util/transfer.js'));
+  });
+
+  describe('staticCacheControl', () => {
+    it('marks content-hashed chunks immutable for a year', () => {
+      for (const f of ['main-A1B2C3D4.js', 'chunk-ZFTNOQXJ.js', 'styles-5IMT3BWC.css',
+        '/app/client/dist/browser/chunk-4YGO2JET.js']) {
+        const cc = staticCacheControl(f);
+        assert.match(cc, /immutable/, f);
+        assert.match(cc, new RegExp(`max-age=${IMMUTABLE_MAX_AGE_SECONDS}`), f);
+      }
+    });
+
+    it('NEVER caches index.html — it is what names the current chunk hashes', () => {
+      // Cache this and a browser asks for chunks that were deleted by the next build. The SPA fallback
+      // comment in app.ts exists because of that exact loop.
+      assert.equal(staticCacheControl('index.html'), 'no-cache');
+      assert.equal(staticCacheControl('/app/client/dist/browser/index.html'), 'no-cache');
+    });
+
+    it('does not cache UNHASHED assets — translations change every release', () => {
+      for (const f of ['assets/i18n/de.json', 'assets/logo.svg', 'favicon.ico', 'prerendered-routes.json']) {
+        assert.equal(staticCacheControl(f), 'no-cache', f);
+      }
+    });
+
+    it('does not mistake a short suffix for a content hash', () => {
+      // `-min.js` or `-v2.css` are names, not hashes. Caching them for a year would be permanent.
+      assert.equal(staticCacheControl('vendor-min.js'), 'no-cache');
+      assert.equal(staticCacheControl('theme-v2.css'), 'no-cache');
+    });
+  });
+
+  describe('shouldCompress', () => {
+    const yes = () => true;
+
+    it('refuses to compress an event stream, whatever the default says', () => {
+      // `compressible` considers text/event-stream compressible, and a compressor holds bytes back until it
+      // can emit a block — so SSE stops being live and nothing reports it.
+      assert.equal(shouldCompress({}, res({ 'Content-Type': 'text/event-stream' }), yes), false);
+      assert.equal(shouldCompress({}, res({ 'Content-Type': 'text/event-stream; charset=utf-8' }), yes), false);
+    });
+
+    it('refuses a body that is already encoded', () => {
+      assert.equal(shouldCompress({}, res({ 'Content-Type': 'application/json', 'Content-Encoding': 'gzip' }), yes), false);
+    });
+
+    it('honours an explicit opt-out header', () => {
+      assert.equal(shouldCompress({}, res({ 'Content-Type': 'application/json', 'X-No-Compression': '1' }), yes), false);
+    });
+
+    it('otherwise defers to the library default — it decides by content type, and we do not repeat that table', () => {
+      assert.equal(shouldCompress({}, res({ 'Content-Type': 'application/json' }), yes), true);
+      assert.equal(shouldCompress({}, res({ 'Content-Type': 'image/png' }), () => false), false,
+        'a JPEG/PNG must stay uncompressed, and that call belongs to `compressible`');
+    });
+
+    it('does not throw when a response has no Content-Type yet', () => {
+      // The filter runs before headers are flushed, so an absent type is normal, not an error.
+      assert.equal(shouldCompress({}, res({}), yes), true);
+    });
+  });
+});


### PR DESCRIPTION
Audit rotation, **lens 4 (Performance)**. Four findings, each measured before it was changed, shipped as one
PR because they are the same sentence four times — *the request costs more than it needs to* — and three of
the four run with no user present.

## 1. The media job queue had no indexes at all

`initSpace` builds indexes for **nine** per-space collections — memories, entities, edges, chrono, tombstones,
conflicts, dupe candidates, contradiction candidates, files. Not for `<space>_media_jobs`, which is the
collection this product questions hardest:

| query | shape | frequency |
|---|---|---|
| `claimNextJob` | `{status, $or:[claimableAfter …]}` sorted by `createdAt` | per space, every **~1 s** while busy, plus a full scan across every space every 30 s |
| `resetStalledJobs` | `{status, progressAt < cutoff}` sorted by `claimedAt` | per space, per sweep |
| `/metrics` collectors | three `{status}` counts + one `{status:'processing'}` read | **four per space per scrape** |

Every one was a `COLLSCAN` followed by an in-memory sort.

**And the collection is not transient.** `completeJob` sets `status: 'complete'`, and the only deletes are for
a deleted file or directory — so it holds one document per file *ever uploaded*. The scan cost therefore grew
with the **age** of the instance rather than its backlog: an idle queue became more expensive to poll every
month the instance stayed up.

Two indexes now, declared next to the queries they serve (`MEDIA_JOB_INDEXES`) and created by
`ensureMediaJobIndexes`, which `initSpace` calls — so existing spaces get them on the next boot with no
migration to run. `createIndex` is idempotent, and job records are local state that does not replicate.

## 2. Nothing was compressed

Measured against the running server, not inferred:

| response | identity | gzip |
|---|---|---|
| `main-SICP7AKQ.js` | 18 169 B | **6 504 B** |
| `/metrics` | 18 491 B | **3 132 B** |
| whole `client/dist/browser` | 5.83 MiB | **1.64 MiB** (72%, 4.19 MiB per cold load) |

There was no `compression` middleware anywhere, and no reverse proxy to assume was doing it: in this product
the Node process *is* the web server.

**Server-Sent Events are excluded, deliberately.** `compressible` calls `text/event-stream` compressible and
technically it is — but a compressor holds bytes back until it can emit a block, so a live stream silently
becomes a batched one, and every test that asks "did the event arrive" still passes *eventually*. Verified on
the running server: `/api/brain/spaces/general/events` answers `200` with `Content-Type: text/event-stream`
and **no** `Content-Encoding`.

## 3. Content-hashed assets had no `Cache-Control`

`express.static(clientDist)` was called with no options, so 163 hashed files carried ETag/Last-Modified only
and revalidated on every navigation — despite their filenames already containing a content hash.

```text
main-SICP7AKQ.js   Cache-Control: public, max-age=31536000, immutable
index.html         Cache-Control: no-cache
```

`no-cache` still permits a `304`; it forbids serving without asking. Getting that pair backwards is how a
browser ends up pinned to chunk hashes the next release deleted — then it requests JavaScript and receives
HTML, which is the failure the SPA-fallback comment right below already describes. `assets/i18n/*.json` is the
case that makes the distinction load-bearing: unhashed, changes every release, and a year of `immutable` would
leave a user reading last release's German.

## 4. The brain totals scanned every collection, every scrape

`ythril_memories_total`, `_entities_total`, `_edges_total` and `_chrono_entries_total` used
`countDocuments({})` — an aggregation, so an index scan of every entry, per space, per scrape.
`estimatedDocumentCount()` answers from collection metadata in `O(1)`.

The exactness that bought does not survive contact with what a gauge *is*: the value is sampled at scrape time
and stored as a point in a series, so it is already stale when Prometheus writes it. The scan was paying for a
precision the graph cannot express. Labelled approximate in the metric help text and the documented table.

## Also here, because preflight found them

- **`NOTICE` gained a `compression` entry.** The repo's own licence gate caught the omission on the first
  preflight run — attribution is the obligation that survives a permissive licence, and `npm install` is a
  one-line change that nothing else connects to a legal file.
- **`teardownTimeout: 30_000` in `client/vitest.config.ts`.** Twice today the suite reported `844 passed (844)`
  and then failed the run with tinypool's `Failed to terminate worker` — both under `preflight`, which builds
  the server and the client bundle first and leaves the machine loaded; two bare `vitest run` invocations
  immediately afterwards were clean. The pool's shutdown ceiling was wrong on a busy machine, exactly as
  `testTimeout`'s 5 s was. **Not a retry** — every test passed each time, and the QA tracker's note about not
  buying a green board with a retry still stands.

## Gates

| gate | what it pins |
|---|---|
| `job-queue-indexes-db` (6, real MongoDB) | the **winning plan** for the real queries — an index the planner does not choose is decoration. Includes the control (with the indexes dropped, the same claim query is a `COLLSCAN` again) and a check that `initSpace` is what calls the creation, since the suite would otherwise pass on indexes nothing ever builds |
| `transfer-headers` (9) | `immutable` only for hashed names — never `index.html`, never i18n JSON, and not for `-min.js`-style suffixes — and SSE never compressed, even though the library's default would |
