### PR TITLE
chore(release): 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.3] — 2026-08-01
+
 ### Changed
 
 - **A space's settings dialog now says it is governed before you type in it.** Saving a change to a

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch. Version bump + CHANGELOG heading; the work is already on `main` as #597–#606.

**This release is the canary's 2.2.2 report** — all seven items — **plus two regressions we shipped to them in
2.2.2**, three defects found by sweeping past their findings, and a performance lens over what their reports
pointed at.

## Their seven

| # | finding | fix |
|---|---|---|
| E.1 | the readiness probe sent a query no backend can answer — crash loops on a live fleet | #599 |
| B | one large document blocked the event loop until liveness killed the pod | #600 |
| A | `stalledJobTimeoutMs` re-queued a live job, which then ran twice | #601 |
| C | no metric could show one long job | #601 |
| E.2 | descriptions never produced on a swap-based single-GPU host | #602 |
| E.3 | a test result moved the Verify button out from under the cursor | #603 |
| E.4 | the Files row offered rename and not re-embed | #603 |

Two of those (E.1, E.3) were **ours from 2.2.2**. E.1 is the sharper lesson: 2.2.2 replaced a lifecycle-field
read with *asking the index whether it serves* — right instinct, and the query was a zero vector, which cannot
be scored against a cosine index. It could never have worked on any backend; where `status` or `queryable`
exist the cheap path returns first, so our own testing never reached it.

C is the uncomfortable one. They asked for a gauge showing one long job in flight.
**`ythril_media_jobs_processing` had been shipping since 1.x** — the entire media-metric family was exposed and
undocumented while every other family was listed. An undocumented metric is a metric that does not exist.

## Found by sweeping past their reports

- Clearing `embedding.baseUrl` from the UI kept the old endpoint — a `200`, no log line, and the field
  repopulated as though the save had been ignored (#600). `rerank` and `nli` had the same two lines in the
  right order.
- 21 consecutive rows of the media-configuration reference rendered as **quoted literal pipes** (#600).
  markdownlint passed on all four such runs: it checks the style of tables it *recognises*.
- A network join could report success while never recording the member (#604) — the site the code comment at
  `loader.ts:365` pointed at, in a tracker item that had been deleted while the comment stayed.

## And the rest

- **#605** — crash recovery raced a live rename and reported "rename incomplete" on a rename that had
  succeeded. This is the `space-rename` CI flake's actual cause.
- **#606** — performance lens: the media job queue had **no indexes** while being polled every second and never
  pruned; nothing was compressed (`main-*.js` 18 169 → 6 504 bytes, whole bundle 5.83 → 1.64 MiB); hashed
  assets had no `Cache-Control`; four gauges scanned every collection per scrape for a precision a gauge
  cannot hold. Plus the preflight fix: at 179 test files the enumerated invocation crossed Windows'
  32 767-character command-line limit, so the gate went red having run nothing and named nothing.
- **#597, #598** — the governed-space badge, and MCP write refusals carrying their classification rather than
  a sentence about it.

## After merge

Tag `v2.2.3`, GitHub Release, verify the images pull from GHCR **and** Docker Hub (amd64 + arm64), then the
canary message — already written at `todo/cust-breituai-converse/_CUSTOMER-MESSAGE-2.2.3.md`, including the
"what we did NOT exercise" section they asked us to keep sending. The largest gap named there is the
`202 vote_pending` path and a networked `description` write: **they have no network at all**, so that surface
needs someone else, or us.
