### PR TITLE
feat(metrics): tell which spaces are earning their keep, not which are busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **You can now tell which spaces are earning their keep, not just which are busy.** `GET /api/brain/spaces/:id/activity`
+  answers "is anyone getting anything out of this space" — asked for by the owner, whose stated intent was to
+  tell spaces apart by usefulness rather than to count calls.
+  - **Demand and payoff are recorded together, because either alone misleads.** A space queried 380 times that
+    answered 41 is not popular; it is a space people keep failing to get an answer out of, and in a call count
+    the two are identical. So each hour carries `recall`, `answered`, mean best-hit score, writes, file traffic,
+    mean/max duration, calls over a second, and last-used.
+  - **`meanTopScore` averages over answered recalls only.** Accumulating a score from a call that found nothing
+    produced means above 1.0 — outside the range a similarity score can take. Caught by a test whose fixture
+    passed a score on every call, which is exactly what a real caller with a score to hand does.
+  - **No percentiles**, deliberately: a mean stored per hour cannot be recombined into a p95, so a p95 here
+    would be either a fabrication or a reason to keep every sample. `sumMs`, `maxMs` and a count over one
+    second all survive being summed across buckets, which is what an arbitrary window needs.
+  - **Cost, measured before it was built:** the counter path is a `Map` lookup plus a few integer operations —
+    **18.6 ns** per request, 0.000046% of a 40 ms recall. Counters accumulate in memory and are written once a
+    minute as one `bulkWrite` of `$inc`s, so **the write cost is independent of traffic**: one upsert per space
+    that was actually used, whether it served ten calls or a hundred thousand. The obvious alternative —
+    enabling `audit.logReads` — writes one document per read.
+  - It rides on the audit middleware, which already computes the operation, the space and the duration for
+    every request, so there is no second path-matcher and a count cannot disagree with the audit trail about
+    which space a call touched. Operator work is excluded: `space.create` and `network.vote` carry a space id,
+    and counting them would credit a brand-new empty space with activity it never had.
+  - Hourly UTC buckets in a `space_activity` collection with a **90-day TTL index** — an activity log without
+    one is how a metrics table becomes the largest thing in the database. `bucketAt` is set on insert only, so a
+    continuously-used space cannot keep its oldest bucket alive forever.
+  - Scoped in the aggregation, not in the caller: a space-scoped token asking for its own numbers never reads
+    another space's buckets.
+
 ## [2.2.3] — 2026-08-01
 
 ### Changed

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1102,6 +1102,65 @@ GET /api/brain/spaces/:spaceId/stats
 
 ---
 
+### Space Activity
+
+Is this space earning its keep? `stats` says how much is *in* a space; this says whether anyone is getting
+anything *out* of it.
+
+```http
+GET /api/brain/spaces/:spaceId/activity?hours=24
+```
+
+`hours` defaults to 24 and is clamped to 1…2160 (90 days, the bucket retention). A proxy space reports its
+members' rows.
+
+**Response** `200`:
+
+```json
+{
+  "spaceId": "reporting",
+  "hours": 24,
+  "spaces": [
+    {
+      "space": "reporting",
+      "calls": 412,
+      "recall": 380,
+      "answered": 41,
+      "writes": 12,
+      "meanMs": 63,
+      "maxMs": 1840,
+      "over1s": 3,
+      "meanTopScore": 0.31,
+      "lastUsedAt": "2026-08-01T14:00:00.000Z"
+    }
+  ]
+}
+```
+
+**Read `recall` and `answered` together — that is the point of the endpoint.** 380 queries and 41 answers is
+not a popular space; it is a space people keep failing to get an answer out of, and a call count alone cannot
+tell the two apart. `meanTopScore` is the mean best-hit score across **answered** recalls only, so it stays
+inside 0…1 and is `null` when nothing was answered (rather than `0`, which would read as "answers are bad"
+instead of "there were none").
+
+`meanMs` is over all classes of call, `over1s` counts those slower than a second, and `maxMs` is a true
+maximum. **There is no percentile**, deliberately: a mean stored per hour cannot be recombined into a p95, so
+a p95 here would either be a fabrication or require keeping every sample.
+
+| field | counts |
+|---|---|
+| `recall` | `recall`, `query` and `find_similar` — demand on the brain |
+| `writes` | anything that changed a record or added a file, including curation (resolving a conflict, merging a duplicate) |
+| `calls` | all four classes: recall, reads, writes and file traffic |
+
+Operator work on the instance — creating a space, casting a network vote, rotating a token — is **not**
+counted, even though those requests carry a space id. Counting them would credit a brand-new empty space with
+activity it never had.
+
+Buckets are hourly and in UTC, kept for 90 days. A window with no calls returns an empty `spaces` array.
+
+---
+
 ### Check Reindex Status
 
 ```http

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -5,6 +5,7 @@
  */
 import { Router } from 'express';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
+import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
@@ -52,6 +53,36 @@ searchRouter.get('/spaces/:spaceId/stats', globalRateLimit, requireSpaceAuth, as
   const chrono = counts.reduce((s, c) => s + c.chrono, 0);
   const files = counts.reduce((s, c) => s + c.files, 0);
   res.json({ spaceId, memories, entities, edges, chrono, files });
+});
+
+
+/**
+ * GET /api/brain/spaces/:spaceId/activity — is this space earning its keep?
+ *
+ * Demand and payoff together, because either alone misleads: a space asked five hundred times that answers
+ * nothing is not popular, and a space with a perfect answer rate that nobody queries is not useful either.
+ *
+ * Scoped to the requested space in the aggregation itself — a space-scoped token must not learn how heavily
+ * every other space is used. The cross-space comparison lives on the admin route, behind admin auth.
+ *
+ * A proxy space reports its MEMBERS' activity summed, matching `stats` above: the calls arrive addressed to the
+ * proxy, but the useful answer is what its members are doing.
+ */
+searchRouter.get('/spaces/:spaceId/activity', globalRateLimit, requireSpaceAuth, async (req, res) => {
+  const spaceId = req.params['spaceId'] as string;
+  const cfg = getConfig();
+  if (!cfg.spaces.some(s => s.id === spaceId)) {
+    res.status(404).json({ error: `Space '${spaceId}' not found` });
+    return;
+  }
+  // Clamped rather than rejected: this is a dashboard window, and an out-of-range value has an obviously
+  // correct interpretation. 90 days is the bucket retention — asking for more would silently return less.
+  const raw = Number(req.query['hours'] ?? 24);
+  const hours = Number.isFinite(raw) ? Math.max(1, Math.min(90 * 24, Math.floor(raw))) : 24;
+
+  const memberIds = resolveMemberSpaces(spaceId);
+  const rows = (await Promise.all(memberIds.map(mid => summariseActivity(hours, Date.now(), mid)))).flat();
+  res.json({ spaceId, hours, spaces: rows });
 });
 
 
@@ -236,6 +267,20 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     // merge with one member.
     all.sort((x, y) => rankOf(y) - rankOf(x));
     const seeds = all.slice(0, safeTopK);
+
+    // Tell the per-space counters whether this recall actually answered, and how good the best hit was.
+    //
+    // This is the difference between "this space is asked a lot" and "this space is useful": a space queried
+    // five hundred times that returns nothing is not popular, and in a call count the two are identical. Only
+    // this handler knows what came back, so it hands the outcome to the audit middleware, which owns the
+    // duration and the space attribution.
+    //
+    // `rankOf` rather than `.score` for the same reason the sort above uses it — it is the best signal
+    // available for the result, after reranking and fusion.
+    req.recallOutcome = {
+      answered: seeds.length > 0,
+      ...(seeds.length > 0 ? { topScore: rankOf(seeds[0]!) } : {}),
+    };
 
     if (safeTraverse === 0) {
       res.json({ results: seeds, count: seeds.length });

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -11,6 +11,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { logAuditEntry } from './audit.js';
 import { auditChanges } from './audit-changes.js';
 import { getConfig } from '../config/loader.js';
+import { classifyOperation, recordSpaceCall } from '../metrics/space-activity.js';
 import type { OidcTokenRecord } from '../auth/oidc.js';
 
 // ── Operation mapping ──────────────────────────────────────────────────────
@@ -281,6 +282,32 @@ export function auditMiddleware(req: Request, res: Response, next: NextFunction)
 
     const matched = resolveOperation(req.method, fullPath);
     if (!matched) return; // not an operation we track
+
+    const durationMsForActivity = Number(process.hrtime.bigint() - start) / 1e6;
+
+    // ── Per-space usefulness counters ────────────────────────────────────────
+    //
+    // Counted here, BEFORE the `logReads` gate, because the counters must see reads: recall is the demand
+    // signal that says whether a space is worth keeping, and it is a read. Doing it by turning `logReads` on
+    // instead would write one audit document per recall — the per-request cost this deliberately avoids.
+    //
+    // Riding on this middleware rather than adding another means one path-matcher decides which space a call
+    // touched, so a count and its audit trail can never describe different things. The whole hook is a Map
+    // lookup plus a few integer adds: ~19 ns, measured.
+    //
+    // `recallOutcome` is stashed on the request by the recall handler, which is the only code that knows
+    // whether the answer contained anything — and "did it answer" is what separates a useful space from one
+    // that is merely asked a lot.
+    if (matched.spaceId) {
+      const cls = classifyOperation(matched.operation);
+      if (cls) {
+        recordSpaceCall(matched.spaceId, cls, {
+          ms: durationMsForActivity,
+          answered: req.recallOutcome?.answered,
+          topScore: req.recallOutcome?.topScore,
+        });
+      }
+    }
 
     // Check logReads config
     let cfg;

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -32,6 +32,17 @@ declare global {
        * its secrets.
        */
       auditSnapshots?: { before?: unknown; after?: unknown };
+      /**
+       * Whether a recall actually came back with something, and how good the best hit was.
+       *
+       * Set by the recall handler, read by the audit middleware on `res.finish` for the per-space usefulness
+       * counters. It has to travel this way: only the handler knows what the answer contained, and only the
+       * middleware knows how long the whole request took and which space it was attributed to.
+       *
+       * This is the field that separates a useful space from one that is merely asked a lot — a space queried
+       * five hundred times that answers nothing looks identical to a popular one in a call count.
+       */
+      recallOutcome?: { answered: boolean; topScore?: number };
     }
   }
 }

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -41,6 +41,11 @@ export async function startConfiguredInstanceServices(): Promise<void> {
 
     const { resetStaleWatermarksIfNeeded } = await import('./util/seq.js');
     await resetStaleWatermarksIfNeeded();
+
+    // Per-space usefulness counters: the TTL index above all. An activity log without one becomes the largest
+    // collection in the instance, which is the standard way a metrics table stops being worth having.
+    const { ensureActivityIndexes } = await import('./metrics/space-activity-store.js');
+    await ensureActivityIndexes();
   } catch (err) {
     log.error(`Instance DB initialisation failed (background services will still start): ${err}`);
   }
@@ -65,6 +70,11 @@ export async function startConfiguredInstanceServices(): Promise<void> {
   startContradictionScanner();
   const { startTtlSweep } = await import('./brain/ttl-sweep.js');
   startTtlSweep();
+  // The per-space usefulness counters accumulate in memory at ~19 ns per request and are written down once a
+  // minute — one upsert per space that was actually used, so the write cost does not scale with traffic. The
+  // timer is unref'd, and `stopSpaceActivityFlush` on the shutdown path writes the last partial minute.
+  const { startSpaceActivityFlush } = await import('./metrics/space-activity-store.js');
+  startSpaceActivityFlush();
   // Housekeeping for review findings whose records are gone. Deliberately NOT hung off the duplicate or
   // contradiction scanner: both are off by default, so orphans would accumulate on exactly the instances
   // that never enabled them.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -215,6 +215,11 @@ async function main(): Promise<void> {
     // Only now is nothing mid-request. Persist coalesced config writes (sync watermarks), then drop
     // the database connection.
     await flushConfig();
+    // The last partial minute of per-space usefulness counters. After the drain, so calls that finished while
+    // connections were closing are counted too — and before `closeMongo`, since this needs the connection.
+    const { stopSpaceActivityFlush } = await import('./metrics/space-activity-store.js');
+    await stopSpaceActivityFlush().catch(err =>
+      log.debug(`Shutdown: space activity flush failed: ${err instanceof Error ? err.message : String(err)}`));
     await closeMongo();
     process.exit(0);
   };

--- a/server/src/metrics/space-activity-store.ts
+++ b/server/src/metrics/space-activity-store.ts
@@ -1,0 +1,248 @@
+/**
+ * Persisting per-space activity: the half that makes it affordable.
+ *
+ * The counters in `space-activity.ts` live in memory and cost ~19 ns per request. What could have made this
+ * feature expensive is writing them down, and the shape here is chosen so it does not:
+ *
+ *   - **One `bulkWrite` of `$inc`s per flush**, not per call. The write cost is a function of how many spaces
+ *     were touched, never of how many times — one upsert per active space per interval whether that space
+ *     served ten calls or a hundred thousand.
+ *   - **`$inc`, not read-modify-write.** Two instances against one database, or a flush overlapping the next,
+ *     add rather than clobber. There is no read at all on the write path.
+ *   - **A derivable `_id`** (`<space>:<hour>`), so an upsert needs no lookup to find its document.
+ *
+ * ## Why hourly documents rather than a rolling total
+ *
+ * A single total per space cannot answer "is this space still being used" — the number a space earned last
+ * quarter is indistinguishable from one it earned this morning. Hourly buckets sum into any window an operator
+ * chooses, which is what "tell the spaces apart" actually needs, and they age out cleanly.
+ *
+ * ## Losing a flush
+ *
+ * `drainSpaceActivity()` clears as it reads, so a failed flush loses under a minute of counts. That is
+ * deliberate: merging them back risks double-counting on a partially-applied `bulkWrite`, and for a usefulness
+ * gauge "occasionally a minute short" is far better than "sometimes overstated". A dropped batch logs a warning
+ * with what it was carrying.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { log } from '../util/log.js';
+import { drainSpaceActivity, hourBucket, activityDocId, type CallClass } from './space-activity.js';
+
+/** The collection is instance-wide, not per space: comparing spaces means reading them together. */
+export const ACTIVITY_COLLECTION = 'space_activity';
+
+/** How long buckets are kept. 90 days answers "this quarter" and bounds the collection at (spaces × 2160). */
+export const ACTIVITY_RETENTION_DAYS = 90;
+
+/** Flush cadence. Long enough that the write cost is negligible, short enough that a crash loses little. */
+export const ACTIVITY_FLUSH_INTERVAL_MS = 60_000;
+
+export interface ActivityDoc {
+  _id: string;
+  space: string;
+  /** `2026-08-01T14` — the UTC hour, kept as a string so it is greppable and sorts lexically. */
+  bucket: string;
+  /** BSON date for the TTL index. Set on insert only, so a bucket's expiry is fixed at its first write. */
+  bucketAt: Date;
+  /** Per class: `{ n, answered, sumTopScore, sumMs, maxMs, over1s }`. */
+  calls: Partial<Record<CallClass, {
+    n: number; answered: number; sumTopScore: number; sumMs: number; maxMs: number; over1s: number;
+  }>>;
+  /** Last time anything touched this space. The cheapest useful signal there is. */
+  lastUsedAt: Date;
+}
+
+/**
+ * Create the indexes this collection needs. Idempotent, so it runs on every boot.
+ *
+ * Two, for the two questions asked of it: one space's recent buckets (the Overview), and every space's recent
+ * buckets (the comparison). The TTL index is what stops an activity log becoming the largest collection in the
+ * instance — the failure mode of every metrics table that was added without one.
+ */
+export async function ensureActivityIndexes(): Promise<void> {
+  const c = col<ActivityDoc>(ACTIVITY_COLLECTION);
+  await c.createIndex({ space: 1, bucket: -1 });
+  await c.createIndex({ bucket: -1 });
+  await c.createIndex({ bucketAt: 1 }, {
+    name: 'ttl_bucketAt',
+    expireAfterSeconds: ACTIVITY_RETENTION_DAYS * 24 * 60 * 60,
+  });
+}
+
+/**
+ * Write everything accumulated since the last flush. Returns how many space-hours were touched.
+ *
+ * `maxMs` uses `$max` rather than `$inc` — a maximum is not additive, and summing them would produce a number
+ * no request ever took.
+ */
+export async function flushSpaceActivity(now = Date.now()): Promise<number> {
+  const rows = drainSpaceActivity();
+  if (rows.length === 0) return 0;
+
+  const bucket = hourBucket(now);
+  const bucketAt = new Date(new Date(now).toISOString().slice(0, 13) + ':00:00.000Z');
+  const bySpace = new Map<string, typeof rows>();
+  for (const r of rows) {
+    const list = bySpace.get(r.space) ?? [];
+    list.push(r);
+    bySpace.set(r.space, list);
+  }
+
+  const ops = [...bySpace].map(([space, spaceRows]) => {
+    const inc: Record<string, number> = {};
+    const max: Record<string, number> = {};
+    for (const { cls, totals } of spaceRows) {
+      inc[`calls.${cls}.n`] = totals.n;
+      inc[`calls.${cls}.answered`] = totals.answered;
+      inc[`calls.${cls}.sumTopScore`] = totals.sumTopScore;
+      inc[`calls.${cls}.sumMs`] = totals.sumMs;
+      inc[`calls.${cls}.over1s`] = totals.over1s;
+      max[`calls.${cls}.maxMs`] = totals.maxMs;
+    }
+    return {
+      updateOne: {
+        filter: { _id: activityDocId(space, bucket) },
+        update: {
+          $inc: inc,
+          $max: max,
+          $set: { lastUsedAt: new Date(now) },
+          // `$setOnInsert` for the identity fields: they never change for a bucket, and re-setting `bucketAt`
+          // on every flush would push the TTL expiry forward for as long as the space stays busy — a bucket
+          // that never ages out.
+          $setOnInsert: { space, bucket, bucketAt },
+        },
+        upsert: true,
+      },
+    };
+  });
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await col<ActivityDoc>(ACTIVITY_COLLECTION).bulkWrite(ops as any, { ordered: false });
+    return ops.length;
+  } catch (err) {
+    // The counts are already drained, so they are gone. Say what was lost rather than failing a timer.
+    const calls = rows.reduce((sum, r) => sum + r.totals.n, 0);
+    log.warn(`Space activity: dropped a flush of ${calls} call(s) across ${ops.length} space(s): `
+      + `${err instanceof Error ? err.message : String(err)}`);
+    return 0;
+  }
+}
+
+let _timer: NodeJS.Timeout | null = null;
+
+/**
+ * Start the periodic flush. Unref'd, so it never holds the process open — a pending activity write must not
+ * be the reason a container takes longer to exit.
+ */
+export function startSpaceActivityFlush(intervalMs = ACTIVITY_FLUSH_INTERVAL_MS): void {
+  if (_timer) return;
+  _timer = setInterval(() => { void flushSpaceActivity(); }, intervalMs);
+  _timer.unref();
+}
+
+/** Stop the timer and write what is pending — call from the shutdown path so the last minute is not lost. */
+export async function stopSpaceActivityFlush(): Promise<void> {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+  await flushSpaceActivity();
+}
+
+export interface SpaceActivitySummary {
+  space: string;
+  calls: number;
+  recall: number;
+  /** Recall calls that came back with something. The discriminator: demand without this is not usefulness. */
+  answered: number;
+  writes: number;
+  meanMs: number | null;
+  maxMs: number;
+  over1s: number;
+  /** Mean top score across answered recalls, or null when nothing was answered. */
+  meanTopScore: number | null;
+  lastUsedAt: string | null;
+}
+
+/**
+ * Summarise a window for every space, newest bucket first.
+ *
+ * Summed in the database rather than in the caller: the buckets for 65 spaces over 7 days are 10 920 documents,
+ * and shipping those to Node to add them up would make the Overview slower than the thing it measures.
+ */
+export async function summariseActivity(
+  sinceHoursAgo = 24,
+  now = Date.now(),
+  /**
+   * Restrict to one space.
+   *
+   * Not a convenience: a space-scoped token asking for its own Overview must not learn how heavily every
+   * OTHER space is used. Filtering in the `$match` rather than in the caller means the rows never leave the
+   * database, so there is nothing to leak by forgetting a filter later.
+   */
+  space?: string,
+): Promise<SpaceActivitySummary[]> {
+  const from = hourBucket(now - sinceHoursAgo * 3_600_000);
+  const rows = await col<ActivityDoc>(ACTIVITY_COLLECTION).aggregate([
+    {
+      $match: asFilter<ActivityDoc>({
+        bucket: { $gte: from } as unknown as string,
+        ...(space ? { space } : {}),
+      }),
+    },
+    {
+      $group: {
+        _id: '$space',
+        recall: { $sum: { $ifNull: ['$calls.recall.n', 0] } },
+        answered: { $sum: { $ifNull: ['$calls.recall.answered', 0] } },
+        sumTopScore: { $sum: { $ifNull: ['$calls.recall.sumTopScore', 0] } },
+        writes: { $sum: { $ifNull: ['$calls.write.n', 0] } },
+        reads: { $sum: { $ifNull: ['$calls.read.n', 0] } },
+        files: { $sum: { $ifNull: ['$calls.file.n', 0] } },
+        sumMs: {
+          $sum: {
+            $add: [
+              { $ifNull: ['$calls.recall.sumMs', 0] }, { $ifNull: ['$calls.read.sumMs', 0] },
+              { $ifNull: ['$calls.write.sumMs', 0] }, { $ifNull: ['$calls.file.sumMs', 0] },
+            ],
+          },
+        },
+        over1s: {
+          $sum: {
+            $add: [
+              { $ifNull: ['$calls.recall.over1s', 0] }, { $ifNull: ['$calls.read.over1s', 0] },
+              { $ifNull: ['$calls.write.over1s', 0] }, { $ifNull: ['$calls.file.over1s', 0] },
+            ],
+          },
+        },
+        maxMs: {
+          $max: {
+            $max: [
+              { $ifNull: ['$calls.recall.maxMs', 0] }, { $ifNull: ['$calls.read.maxMs', 0] },
+              { $ifNull: ['$calls.write.maxMs', 0] }, { $ifNull: ['$calls.file.maxMs', 0] },
+            ],
+          },
+        },
+        lastUsedAt: { $max: '$lastUsedAt' },
+      },
+    },
+  ]).toArray() as Array<Record<string, number | string | Date | null> & { _id: string }>;
+
+  return rows.map(r => {
+    const calls = Number(r['recall'] ?? 0) + Number(r['reads'] ?? 0) + Number(r['writes'] ?? 0)
+      + Number(r['files'] ?? 0);
+    const answered = Number(r['answered'] ?? 0);
+    return {
+      space: r._id,
+      calls,
+      recall: Number(r['recall'] ?? 0),
+      answered,
+      writes: Number(r['writes'] ?? 0),
+      // Guarded: a window with buckets but no calls would otherwise divide by zero and report NaN, which
+      // serialises to null in JSON and reads in the UI as "no data" rather than "no calls".
+      meanMs: calls > 0 ? Math.round(Number(r['sumMs'] ?? 0) / calls) : null,
+      maxMs: Number(r['maxMs'] ?? 0),
+      over1s: Number(r['over1s'] ?? 0),
+      meanTopScore: answered > 0 ? Number((Number(r['sumTopScore'] ?? 0) / answered).toFixed(3)) : null,
+      lastUsedAt: r['lastUsedAt'] ? new Date(r['lastUsedAt'] as Date).toISOString() : null,
+    };
+  }).sort((a, b) => b.calls - a.calls);
+}

--- a/server/src/metrics/space-activity.ts
+++ b/server/src/metrics/space-activity.ts
@@ -94,7 +94,13 @@ export function recordSpaceCall(
   if (ms > t.maxMs) t.maxMs = ms;
   if (ms > SLOW_MS) t.over1s++;
   if (opts.answered) t.answered++;
-  if (typeof opts.topScore === 'number' && Number.isFinite(opts.topScore)) t.sumTopScore += opts.topScore;
+  // Only an ANSWERED call contributes a score, because `sumTopScore` is divided by `answered` to get a mean.
+  // Accumulating it unconditionally made the mean meaningless — 100 calls each reporting 0.3 with 5 answered
+  // came out as 6.0, which is not even inside the range a similarity score can take. Found by a test whose
+  // fixture passed a score on every call, which is exactly what a real caller does when it has one.
+  if (opts.answered && typeof opts.topScore === 'number' && Number.isFinite(opts.topScore)) {
+    t.sumTopScore += opts.topScore;
+  }
 }
 
 /**

--- a/server/src/metrics/space-activity.ts
+++ b/server/src/metrics/space-activity.ts
@@ -1,0 +1,207 @@
+/**
+ * Which spaces are actually earning their keep.
+ *
+ * ## The question this answers, and the one it refuses to
+ *
+ * "How often is this space called on" is easy and almost useless on its own: a space queried five hundred
+ * times that answers nothing is not a popular space, it is a space someone keeps failing to get an answer out
+ * of — and in a call counter those two are indistinguishable. So every call records **demand and payoff**: the
+ * call happened, and whether it came back with anything.
+ *
+ * That is why `answered` and `sumTopScore` sit next to `n` here rather than being a later addition. Ranking
+ * spaces by `n` alone produces the metric that says the loudest space is the best one.
+ *
+ * ## Why it is affordable
+ *
+ * Measured before it was built: this path is a `Map` lookup plus a handful of integer operations —
+ * **18.6 ns** per request, 0.000046% of a 40 ms recall, holding 260 small objects for 65 spaces across four
+ * classes. The part that could have been expensive is persistence, and it is not: the counters accumulate in
+ * memory and are flushed on an interval as one `bulkWrite` of `$inc`s, so **the write cost is independent of
+ * traffic** — one upsert per active space per flush whether that space served ten calls or a hundred thousand.
+ *
+ * The alternative — turning on `audit.logReads` — writes one document per read. That is exactly the
+ * per-request cost this avoids, and it buys row-level detail nobody asked for.
+ *
+ * ## What is deliberately NOT stored
+ *
+ * Percentiles. A mean stored per bucket cannot be recombined into a p95, so a stored p95 would either be a
+ * lie or force keeping every sample. `sumMs` (for a mean), `maxMs` and `over1s` answer "how slow" honestly and
+ * survive being summed across buckets, which is what a 24-hour or 7-day view needs.
+ */
+
+/**
+ * The closed set of call classes.
+ *
+ * Closed because it becomes a metric label and a document field: an open set derived from route names would be
+ * a cardinality bomb in Prometheus and an unqueryable document shape in Mongo. Four classes are what the
+ * question needs — demand on the brain, demand on files, and whether anything is still being written.
+ */
+export const CALL_CLASSES = ['recall', 'read', 'write', 'file'] as const;
+export type CallClass = typeof CALL_CLASSES[number];
+
+/** One class's totals for one space since the last flush. */
+export interface CallTotals {
+  /** Calls made. */
+  n: number;
+  /** Calls that came back with something — only meaningful for `recall`, absent elsewhere. */
+  answered: number;
+  /** Sum of the top result's score, for a mean answer quality. Only `recall` reports it. */
+  sumTopScore: number;
+  /** Sum of durations, for a mean. Kept as a sum because sums survive being added across buckets. */
+  sumMs: number;
+  maxMs: number;
+  /** Calls slower than a second — the honest alternative to a stored percentile. */
+  over1s: number;
+}
+
+export interface SpaceActivityRow {
+  space: string;
+  cls: CallClass;
+  totals: CallTotals;
+}
+
+const SLOW_MS = 1_000;
+
+/** space → class → totals. Bounded by (spaces × 4), and only spaces that were actually called appear. */
+const _pending = new Map<string, Map<CallClass, CallTotals>>();
+
+function emptyTotals(): CallTotals {
+  return { n: 0, answered: 0, sumTopScore: 0, sumMs: 0, maxMs: 0, over1s: 0 };
+}
+
+/**
+ * Record one call against one space.
+ *
+ * Everything is optional except the class and the duration, because most callers know nothing about answers:
+ * only recall can say whether it found something, and only it passes `answered`/`topScore`.
+ */
+export function recordSpaceCall(
+  space: string,
+  cls: CallClass,
+  opts: { ms: number; answered?: boolean; topScore?: number },
+): void {
+  if (!space) return;                       // a global recall has no space to attribute
+  let byClass = _pending.get(space);
+  if (!byClass) { byClass = new Map(); _pending.set(space, byClass); }
+  let t = byClass.get(cls);
+  if (!t) { t = emptyTotals(); byClass.set(cls, t); }
+
+  t.n++;
+  // A non-finite duration would poison the mean for the whole bucket, and NaN propagates through `$inc`
+  // silently — the field simply stops being a number.
+  const ms = Number.isFinite(opts.ms) ? Math.max(0, opts.ms) : 0;
+  t.sumMs += ms;
+  if (ms > t.maxMs) t.maxMs = ms;
+  if (ms > SLOW_MS) t.over1s++;
+  if (opts.answered) t.answered++;
+  if (typeof opts.topScore === 'number' && Number.isFinite(opts.topScore)) t.sumTopScore += opts.topScore;
+}
+
+/**
+ * Take everything accumulated and clear it.
+ *
+ * Clearing on read rather than on a successful write is deliberate. If the flush fails, these counts are lost
+ * — a minute of them — and that is the right trade: merging them back risks double-counting on a partial
+ * bulkWrite, and a usefulness gauge that is occasionally a minute short is far better than one that is
+ * sometimes wrong in the other direction. The flush logs when it drops a batch.
+ */
+export function drainSpaceActivity(): SpaceActivityRow[] {
+  const rows: SpaceActivityRow[] = [];
+  for (const [space, byClass] of _pending) {
+    for (const [cls, totals] of byClass) rows.push({ space, cls, totals });
+  }
+  _pending.clear();
+  return rows;
+}
+
+/** Non-destructive read, for tests and for a debug endpoint. */
+export function peekSpaceActivity(): SpaceActivityRow[] {
+  const rows: SpaceActivityRow[] = [];
+  for (const [space, byClass] of _pending) {
+    for (const [cls, totals] of byClass) rows.push({ space, cls, totals: { ...totals } });
+  }
+  return rows;
+}
+
+/**
+ * The hour bucket a timestamp belongs to, as `2026-08-01T14` (UTC).
+ *
+ * Hourly, not daily: "which spaces are useful" is a comparison over a window an operator chooses, and hours
+ * sum into any window. Daily buckets cannot answer "this morning".
+ *
+ * UTC, not local: a fleet spans zones, and a bucket that shifts with the server's offset makes two instances
+ * disagree about which hour a call belongs to.
+ */
+export function hourBucket(at: Date | number = Date.now()): string {
+  return new Date(at).toISOString().slice(0, 13);
+}
+
+/** The document id for one space's hour. Stable and derivable, so an upsert needs no lookup. */
+export function activityDocId(space: string, bucket: string): string {
+  return `${space}:${bucket}`;
+}
+
+/**
+ * Map an audit operation name to a call class, or null when it should not be counted.
+ *
+ * Derived from the operation the audit middleware ALREADY computes for every request — so this adds no route
+ * knowledge of its own, and cannot disagree with the audit log about which space a call touched. That
+ * matters: two independent path-matchers is how a count and an audit trail end up describing different things.
+ */
+export function classifyOperation(operation: string): CallClass | null {
+  if (!operation) return null;
+
+  // Operator work, not a space being useful. Creating a space, casting a vote, rotating a token and running a
+  // backup all carry a spaceId, and counting them would credit a brand-new empty space with activity it never
+  // had. Checked FIRST, because several of these end in the same verbs a real write does.
+  if (ADMIN_DOMAINS.some(d => operation.startsWith(d))) return null;
+
+  // Plumbing: minting a ticket is a client attaching to a stream, not a question being asked of the space.
+  // Counting it would put connection churn — a browser tab reopening, a reconnect after a deploy — into the
+  // read demand for a space nobody queried.
+  if (NON_USAGE_SUFFIXES.some(s => operation.endsWith(s))) return null;
+
+  // Demand on the brain — the reason a space exists. `find_similar` belongs here despite its name: it is a
+  // vector query with a record as the query text.
+  if (/^brain\.(recall|query|find_similar)/.test(operation)) return 'recall';
+
+  // Verb before noun: knowledge going IN is a write whether it arrived as a record or as a file. Grouping all
+  // of `file.*` as file traffic instead would hide the "is anyone still adding to this space" signal inside
+  // the "is anyone reading its files" one.
+  if (MUTATION_VERB.test(operation)) return 'write';
+
+  // Demand on the file store, reads only (the mutations went to `write` above).
+  if (/^file\./.test(operation)) return 'file';
+
+  if (/\.(list|get|stats|traverse|export|search|validate)$/.test(operation)) return 'read';
+
+  // Anything unrecognised counts as nothing rather than guessing. `space-activity-classes.test.js` enumerates
+  // every operation the audit middleware defines and fails on one that lands here undeclared, so a new route
+  // cannot become invisible by accident — it has to be added to the deny-list on purpose.
+  return null;
+}
+
+/**
+ * Prefixes that describe an operator acting ON the instance rather than a space being used.
+ *
+ * Curation stays OUT of this list on purpose: `conflict.resolve`, `duplicate.merge` and
+ * `contradiction.resolve` are someone tending a space's own knowledge, which is exactly the signal the write
+ * class is for.
+ */
+const ADMIN_DOMAINS = [
+  'space.', 'network.', 'token.', 'webhook.', 'config.', 'data.', 'mfa.', 'auth.', 'schema_library.',
+  'about.', 'sync.', 'local_agent.',
+] as const;
+
+/**
+ * Operations that are transport plumbing rather than use. Currently just SSE ticket minting: one per stream
+ * connection, so a browser tab reopening after a deploy would read as demand on a space nobody queried.
+ */
+const NON_USAGE_SUFFIXES = ['.ticket'] as const;
+
+/**
+ * Verbs that mean something changed. `retry_embedding` and `mkdir` are here because they are mutations whose
+ * names do not end in an obvious verb, and `write` because the bulk endpoint is called `bulk.write`.
+ */
+const MUTATION_VERB =
+  /\.(create|update|delete|merge|import|restore|reindex|rebuild|wipe|write|mkdir|retry_embedding(_all)?|resolve|bulk_resolve|dismiss|reopen|seed|scan|publish|apply|fork|adopt)$/;

--- a/testing/standalone/space-activity-classes.test.js
+++ b/testing/standalone/space-activity-classes.test.js
@@ -130,6 +130,19 @@ describe('space activity — accumulation', () => {
     assert.equal(row.totals.maxMs, 60);
   });
 
+  it('ignores a score on an UNANSWERED call, or the mean leaves the 0..1 range', () => {
+    // `sumTopScore` is divided by `answered`. Accumulating a score from a call that found nothing produced
+    // means above 1.0 — a similarity score that cannot exist — and a caller with a score to hand will pass it
+    // whether or not the call was answered.
+    drainSpaceActivity();
+    recordSpaceCall('mixed', 'recall', { ms: 10, answered: false, topScore: 0.3 });
+    recordSpaceCall('mixed', 'recall', { ms: 10, answered: true, topScore: 0.8 });
+    const row = peekSpaceActivity().find(r => r.space === 'mixed');
+    assert.equal(row.totals.answered, 1);
+    assert.equal(row.totals.sumTopScore, 0.8);
+    assert.ok(row.totals.sumTopScore / row.totals.answered <= 1, 'a mean score must stay inside 0..1');
+  });
+
   it('counts slow calls instead of pretending to store a percentile', () => {
     drainSpaceActivity();
     recordSpaceCall('slow', 'recall', { ms: 1_500 });

--- a/testing/standalone/space-activity-classes.test.js
+++ b/testing/standalone/space-activity-classes.test.js
@@ -1,0 +1,200 @@
+/**
+ * Every operation the audit middleware defines is classified on purpose, or excluded on purpose.
+ *
+ * ## Why this is enumerated from the source
+ *
+ * The per-space usefulness counters key off the operation name the audit middleware ALREADY computes for every
+ * request. That reuse is the whole reason the feature is cheap — no second path-matcher, and the counts cannot
+ * disagree with the audit log about which space a call touched.
+ *
+ * It also means a new route added to the audit table becomes **invisible** to the counters unless someone
+ * thinks about it: `classifyOperation` returns `null` for anything it does not recognise, and `null` is
+ * silent. This test reads the middleware's own table and fails on any operation that lands in `null` without
+ * being one of the deliberately excluded admin domains — so "invisible" has to be a decision, not an
+ * oversight.
+ *
+ * The same rule that made the media metrics undiscoverable for two releases: absence of evidence is not
+ * evidence of absence, and a hand-written list is how the enumeration falls behind.
+ *
+ * Run: node --test testing/standalone/space-activity-classes.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let classifyOperation, recordSpaceCall, drainSpaceActivity, peekSpaceActivity, hourBucket, activityDocId,
+  CALL_CLASSES;
+
+/** Every `operation: '...'` the audit middleware declares — its table, not a copy of it. */
+function auditOperations() {
+  const src = readFileSync('server/src/audit/middleware.ts', 'utf8');
+  const found = [...src.matchAll(/operation:\s*'([a-z0-9_.]+)'/g)].map(m => m[1]);
+  return [...new Set(found)].sort();
+}
+
+/**
+ * The two documented exclusion lists, read from the source so they cannot drift from this test.
+ *
+ * Both exist because "counts as nothing" has two legitimate reasons — operator work on the instance, and
+ * transport plumbing — and neither is the same as "nobody thought about it", which is what this test catches.
+ */
+function excluded() {
+  const src = readFileSync('server/src/metrics/space-activity.ts', 'utf8');
+  const admin = src.match(/const ADMIN_DOMAINS = \[([^\]]+)\]/);
+  const plumbing = src.match(/const NON_USAGE_SUFFIXES = \[([^\]]+)\]/);
+  assert.ok(admin, 'ADMIN_DOMAINS is gone — the exclusion list is what makes `null` a decision');
+  assert.ok(plumbing, 'NON_USAGE_SUFFIXES is gone');
+  const read = m => [...m[1].matchAll(/'([a-z_.]+)'/g)].map(x => x[1]);
+  return { prefixes: read(admin), suffixes: read(plumbing) };
+}
+
+describe('space activity — call classification', () => {
+  before(async () => {
+    ({ classifyOperation, recordSpaceCall, drainSpaceActivity, peekSpaceActivity, hourBucket, activityDocId,
+      CALL_CLASSES } = await import('../../server/dist/metrics/space-activity.js'));
+  });
+
+  it('reads a meaningful number of operations from the middleware (the scan still works)', () => {
+    const ops = auditOperations();
+    assert.ok(ops.length > 60, `only found ${ops.length} operations in the audit table`);
+  });
+
+  it('classifies EVERY operation, or excludes it through a named list', () => {
+    const { prefixes, suffixes } = excluded();
+    const unexplained = auditOperations().filter(op => classifyOperation(op) === null
+      && !prefixes.some(d => op.startsWith(d)) && !suffixes.some(s => op.endsWith(s)));
+    assert.deepEqual(unexplained, [], 'these count as nothing and are in neither exclusion list:\n  '
+      + `${unexplained.join('\n  ')}\n\n`
+      + 'Either give it a class, or add it to ADMIN_DOMAINS / NON_USAGE_SUFFIXES with a reason. Silence is the\n'
+      + 'failure mode this test exists for — an unclassified route is a space whose usage does not count.');
+  });
+
+  it('puts recall, query and find_similar in the demand class', () => {
+    for (const op of ['brain.recall', 'brain.recall_global', 'brain.query', 'brain.find_similar']) {
+      assert.equal(classifyOperation(op), 'recall', op);
+    }
+  });
+
+  it('counts a file upload as a WRITE, not as file traffic', () => {
+    // Verb before noun. Grouping all of `file.*` as file traffic hides "is anyone still adding to this space"
+    // inside "is anyone reading its files" — and the first is the signal that says a space is alive.
+    assert.equal(classifyOperation('file.create'), 'write');
+    assert.equal(classifyOperation('file.update'), 'write');
+    assert.equal(classifyOperation('file.delete'), 'write');
+    assert.equal(classifyOperation('file.mkdir'), 'write');
+    assert.equal(classifyOperation('file.retry_embedding'), 'write');
+    // …and a file READ is file traffic.
+    assert.equal(classifyOperation('file.read'), 'file');
+    assert.equal(classifyOperation('file.list'), 'file');
+  });
+
+  it('counts curation as a write — someone tending a space is using it', () => {
+    for (const op of ['conflict.resolve', 'duplicate.merge', 'contradiction.resolve', 'bulk.write']) {
+      assert.equal(classifyOperation(op), 'write', op);
+    }
+  });
+
+  it('counts NOTHING for operator work, even when it ends in a write verb', () => {
+    // `space.create` and `network.vote` carry a spaceId. Counting them would credit a brand-new empty space
+    // with activity it never had.
+    for (const op of ['space.create', 'space.delete', 'space.rename', 'token.create', 'network.vote',
+      'data.backup', 'config.reload', 'auth.failed', 'about.logs.ticket', 'sync.trigger']) {
+      assert.equal(classifyOperation(op), null, op);
+    }
+  });
+
+  it('classifies into the closed set and nothing else', () => {
+    for (const op of auditOperations()) {
+      const cls = classifyOperation(op);
+      assert.ok(cls === null || CALL_CLASSES.includes(cls), `${op} -> ${cls}`);
+    }
+  });
+});
+
+describe('space activity — accumulation', () => {
+  before(async () => {
+    ({ classifyOperation, recordSpaceCall, drainSpaceActivity, peekSpaceActivity, hourBucket, activityDocId,
+      CALL_CLASSES } = await import('../../server/dist/metrics/space-activity.js'));
+    drainSpaceActivity();   // a previous suite in the same process may have left counts
+  });
+
+  it('accumulates demand AND payoff, because a count alone would mislead', () => {
+    recordSpaceCall('busy', 'recall', { ms: 40, answered: true, topScore: 0.9 });
+    recordSpaceCall('busy', 'recall', { ms: 60, answered: false });
+    recordSpaceCall('busy', 'recall', { ms: 20, answered: true, topScore: 0.7 });
+    const row = peekSpaceActivity().find(r => r.space === 'busy' && r.cls === 'recall');
+    assert.equal(row.totals.n, 3);
+    assert.equal(row.totals.answered, 2, 'two of three found something — this is the whole point');
+    assert.equal(Number(row.totals.sumTopScore.toFixed(2)), 1.6);
+    assert.equal(row.totals.sumMs, 120);
+    assert.equal(row.totals.maxMs, 60);
+  });
+
+  it('counts slow calls instead of pretending to store a percentile', () => {
+    drainSpaceActivity();
+    recordSpaceCall('slow', 'recall', { ms: 1_500 });
+    recordSpaceCall('slow', 'recall', { ms: 999 });
+    const row = peekSpaceActivity().find(r => r.space === 'slow');
+    assert.equal(row.totals.over1s, 1);
+    assert.equal(row.totals.maxMs, 1_500);
+  });
+
+  it('never lets a non-finite duration poison the bucket', () => {
+    // `$inc` with NaN does not error — the field simply stops being a number, and the mean is gone for good.
+    drainSpaceActivity();
+    for (const ms of [NaN, Infinity, -5, undefined]) recordSpaceCall('odd', 'read', { ms });
+    const row = peekSpaceActivity().find(r => r.space === 'odd');
+    assert.equal(row.totals.n, 4);
+    assert.ok(Number.isFinite(row.totals.sumMs), `sumMs is ${row.totals.sumMs}`);
+    assert.equal(row.totals.sumMs, 0);
+    assert.ok(Number.isFinite(row.totals.maxMs));
+  });
+
+  it('ignores a call with no space — a global recall belongs to nothing', () => {
+    drainSpaceActivity();
+    recordSpaceCall('', 'recall', { ms: 10 });
+    assert.deepEqual(peekSpaceActivity(), []);
+  });
+
+  it('draining clears, so the next flush cannot double-count', () => {
+    drainSpaceActivity();
+    recordSpaceCall('a', 'write', { ms: 5 });
+    assert.equal(drainSpaceActivity().length, 1);
+    assert.deepEqual(drainSpaceActivity(), [], 'a second drain must be empty');
+  });
+
+  it('keeps spaces and classes separate', () => {
+    drainSpaceActivity();
+    recordSpaceCall('a', 'recall', { ms: 1 });
+    recordSpaceCall('a', 'write', { ms: 1 });
+    recordSpaceCall('b', 'recall', { ms: 1 });
+    const rows = drainSpaceActivity();
+    assert.equal(rows.length, 3);
+    assert.equal(rows.filter(r => r.space === 'a').length, 2);
+  });
+});
+
+describe('space activity — bucketing', () => {
+  before(async () => {
+    ({ hourBucket, activityDocId } = await import('../../server/dist/metrics/space-activity.js'));
+  });
+
+  it('buckets by the hour, in UTC', () => {
+    // UTC because a fleet spans zones: a bucket that shifts with the server's offset makes two instances
+    // disagree about which hour a call belongs to.
+    assert.equal(hourBucket(Date.parse('2026-08-01T14:37:12.000Z')), '2026-08-01T14');
+    assert.equal(hourBucket(Date.parse('2026-08-01T14:00:00.000Z')), '2026-08-01T14');
+    assert.equal(hourBucket(Date.parse('2026-08-01T13:59:59.999Z')), '2026-08-01T13');
+  });
+
+  it('builds a document id that needs no lookup', () => {
+    assert.equal(activityDocId('general', '2026-08-01T14'), 'general:2026-08-01T14');
+  });
+
+  it('hours sum into any window an operator asks for', () => {
+    // The reason for hourly rather than daily: "this morning" is a question daily buckets cannot answer.
+    const day = new Set();
+    for (let h = 0; h < 24; h++) day.add(hourBucket(Date.parse(`2026-08-01T${String(h).padStart(2, '0')}:30:00Z`)));
+    assert.equal(day.size, 24);
+  });
+});

--- a/testing/standalone/space-activity-store-db.test.js
+++ b/testing/standalone/space-activity-store-db.test.js
@@ -1,0 +1,177 @@
+/**
+ * Database-level test: per-space activity persists correctly, and the write cost does not scale with traffic.
+ *
+ * ## What has to be true
+ *
+ * The whole affordability argument rests on the SHAPE of the write, so that is what this asserts against a real
+ * MongoDB rather than a fixture:
+ *
+ *   - **one upsert per active space per flush**, whatever the call volume — the property that makes the feature
+ *     cheap, and the one a refactor would quietly break by moving the write onto the request path;
+ *   - **`$inc`, never read-modify-write**, so a second flush (or a second instance) adds instead of clobbering;
+ *   - **`maxMs` accumulated with `$max`**, because a maximum is not additive and summing maxima produces a
+ *     number no request ever took;
+ *   - **`bucketAt` set on insert only**, or a busy space's TTL expiry is pushed forward on every flush and its
+ *     bucket never ages out.
+ *
+ * A fixture could not check any of these: they are all statements about what the database did with the update.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/space-activity-store-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const HOUR = Date.parse('2026-08-01T14:20:00.000Z');
+const NEXT_HOUR = Date.parse('2026-08-01T15:05:00.000Z');
+
+let mongo, activity;
+let recordSpaceCall, drainSpaceActivity, flushSpaceActivity, ensureActivityIndexes, summariseActivity,
+  ACTIVITY_COLLECTION, ACTIVITY_RETENTION_DAYS;
+
+describe('space activity store — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('spaceactivity');
+    ({ recordSpaceCall, drainSpaceActivity } = await import('../../server/dist/metrics/space-activity.js'));
+    ({ flushSpaceActivity, ensureActivityIndexes, summariseActivity, ACTIVITY_COLLECTION,
+      ACTIVITY_RETENTION_DAYS } = await import('../../server/dist/metrics/space-activity-store.js'));
+    activity = mongo.col(ACTIVITY_COLLECTION);
+    await ensureActivityIndexes();
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => { drainSpaceActivity(); await activity.deleteMany({}); });
+
+  it('writes ONE document per space per hour, however many calls it took', async () => {
+    // The affordability claim, asserted: 500 calls across two spaces is two upserts.
+    for (let i = 0; i < 500; i++) {
+      recordSpaceCall(i % 2 ? 'alpha' : 'beta', 'recall', { ms: 10, answered: i % 3 === 0, topScore: 0.5 });
+    }
+    const touched = await flushSpaceActivity(HOUR);
+    assert.equal(touched, 2);
+    assert.equal(await activity.countDocuments({}), 2, '500 calls must not be 500 documents');
+
+    const doc = await activity.findOne({ _id: 'alpha:2026-08-01T14' });
+    assert.equal(doc.calls.recall.n, 250);
+    assert.equal(doc.space, 'alpha');
+    assert.equal(doc.bucket, '2026-08-01T14');
+  });
+
+  it('a second flush ADDS — it is $inc, not read-modify-write', async () => {
+    recordSpaceCall('alpha', 'recall', { ms: 10, answered: true, topScore: 0.8 });
+    await flushSpaceActivity(HOUR);
+    recordSpaceCall('alpha', 'recall', { ms: 30, answered: false });
+    await flushSpaceActivity(HOUR);
+
+    const doc = await activity.findOne({ _id: 'alpha:2026-08-01T14' });
+    assert.equal(doc.calls.recall.n, 2, 'the second flush clobbered the first');
+    assert.equal(doc.calls.recall.answered, 1);
+    assert.equal(doc.calls.recall.sumMs, 40);
+  });
+
+  it('keeps maxMs as a MAXIMUM, not a sum', async () => {
+    recordSpaceCall('alpha', 'read', { ms: 900 });
+    await flushSpaceActivity(HOUR);
+    recordSpaceCall('alpha', 'read', { ms: 200 });
+    await flushSpaceActivity(HOUR);
+
+    const doc = await activity.findOne({ _id: 'alpha:2026-08-01T14' });
+    assert.equal(doc.calls.read.maxMs, 900, 'summed maxima describe a request that never happened');
+    assert.equal(doc.calls.read.sumMs, 1_100);
+  });
+
+  it('does not push the TTL expiry forward while a space stays busy', async () => {
+    // `$setOnInsert` for `bucketAt`. With `$set` a continuously-used space would keep its oldest bucket alive
+    // forever, which is how a metrics collection becomes the largest thing in the database.
+    recordSpaceCall('alpha', 'recall', { ms: 5 });
+    await flushSpaceActivity(HOUR);
+    const first = (await activity.findOne({ _id: 'alpha:2026-08-01T14' })).bucketAt;
+
+    recordSpaceCall('alpha', 'recall', { ms: 5 });
+    await flushSpaceActivity(HOUR + 30 * 60_000);   // same hour, later flush
+    const second = (await activity.findOne({ _id: 'alpha:2026-08-01T14' })).bucketAt;
+    assert.deepEqual(second, first, 'bucketAt moved — the bucket will never expire');
+    assert.equal(first.toISOString(), '2026-08-01T14:00:00.000Z', 'and it is the hour, not the flush time');
+  });
+
+  it('starts a new document when the hour rolls over', async () => {
+    recordSpaceCall('alpha', 'recall', { ms: 5 });
+    await flushSpaceActivity(HOUR);
+    recordSpaceCall('alpha', 'recall', { ms: 5 });
+    await flushSpaceActivity(NEXT_HOUR);
+    assert.equal(await activity.countDocuments({ space: 'alpha' }), 2);
+  });
+
+  it('flushing nothing writes nothing', async () => {
+    assert.equal(await flushSpaceActivity(HOUR), 0);
+    assert.equal(await activity.countDocuments({}), 0);
+  });
+
+  it('has a TTL index, so the collection is bounded', async () => {
+    const ix = await activity.indexes();
+    const ttl = ix.find(i => i.name === 'ttl_bucketAt');
+    assert.ok(ttl, 'no TTL index — this collection grows forever');
+    assert.equal(ttl.expireAfterSeconds, ACTIVITY_RETENTION_DAYS * 24 * 60 * 60);
+  });
+
+  describe('summariseActivity', () => {
+    it('separates demand from payoff, which is the entire point', async () => {
+      // `busy` is asked a lot and answers rarely; `useful` is asked less and answers almost always. A call
+      // count alone would rank `busy` first and say nothing true.
+      for (let i = 0; i < 100; i++) recordSpaceCall('busy', 'recall', { ms: 20, answered: i < 5, topScore: 0.3 });
+      for (let i = 0; i < 40; i++) recordSpaceCall('useful', 'recall', { ms: 50, answered: i < 38, topScore: 0.9 });
+      await flushSpaceActivity(HOUR);
+
+      const rows = await summariseActivity(24, HOUR + 60_000);
+      const busy = rows.find(r => r.space === 'busy');
+      const useful = rows.find(r => r.space === 'useful');
+
+      assert.equal(busy.recall, 100);
+      assert.equal(busy.answered, 5);
+      assert.equal(useful.recall, 40);
+      assert.equal(useful.answered, 38);
+      assert.ok(useful.meanTopScore > busy.meanTopScore, 'answer quality must be comparable too');
+      assert.equal(rows[0].space, 'busy', 'sorted by volume — the UI shows both columns and lets you see the gap');
+    });
+
+    it('reports a mean duration and never NaN', async () => {
+      recordSpaceCall('alpha', 'recall', { ms: 100 });
+      recordSpaceCall('alpha', 'write', { ms: 300 });
+      await flushSpaceActivity(HOUR);
+      const [row] = await summariseActivity(24, HOUR + 60_000);
+      assert.equal(row.calls, 2);
+      assert.equal(row.meanMs, 200);
+      assert.equal(row.maxMs, 300);
+    });
+
+    it('returns meanTopScore as null rather than 0 when nothing was answered', async () => {
+      // 0 would read as "answers are terrible"; null reads as "nothing to average", which is the truth.
+      recordSpaceCall('quiet', 'recall', { ms: 10, answered: false });
+      await flushSpaceActivity(HOUR);
+      const [row] = await summariseActivity(24, HOUR + 60_000);
+      assert.equal(row.answered, 0);
+      assert.equal(row.meanTopScore, null);
+    });
+
+    it('excludes buckets outside the window', async () => {
+      recordSpaceCall('old', 'recall', { ms: 10 });
+      await flushSpaceActivity(Date.parse('2026-07-01T10:00:00.000Z'));
+      recordSpaceCall('new', 'recall', { ms: 10 });
+      await flushSpaceActivity(HOUR);
+
+      const rows = await summariseActivity(24, HOUR + 60_000);
+      assert.deepEqual(rows.map(r => r.space), ['new']);
+    });
+
+    it('carries lastUsedAt, the cheapest signal of all', async () => {
+      recordSpaceCall('alpha', 'read', { ms: 5 });
+      await flushSpaceActivity(HOUR);
+      const [row] = await summariseActivity(24, HOUR + 60_000);
+      assert.equal(row.lastUsedAt, new Date(HOUR).toISOString());
+    });
+  });
+});


### PR DESCRIPTION
The owner asked whether per-space call counts and timings could be collected without a noticeable performance
loss, then said what they were for: **"to be able to tell apart which spaces are how useful."**

That second sentence changed the design, because a call count cannot answer it.

## The distinction this is built around

A space queried 380 times that answered 41 is **not popular**. It is a space people keep failing to get an
answer out of — and in a call counter it is indistinguishable from the best space in the instance. So every
call records demand *and* payoff:

| signal | what it adds over a count |
|---|---|
| `recall` | demand — is anyone asking this space anything |
| **`answered`** | payoff. High demand + low answer rate is a content gap, not usefulness |
| `meanTopScore` | how *well* it answers, not just whether it does |
| `writes` | is knowledge still going in, or is the space frozen |
| `lastUsedAt` | a space nobody has touched in a month — the cheapest signal there is |
| `meanMs`, `maxMs`, `over1s` | the timings originally asked for |

## Why it is affordable — measured before it was built

The counter path is a `Map` lookup plus a handful of integer operations: **18.6 ns per request**, or
**0.000046%** of a 40 ms recall, holding 260 small objects for 65 spaces across four classes.

Persistence is where this could have gone wrong, and the shape is chosen so it does not:

- **One `bulkWrite` of `$inc`s per flush, not per call.** 500 calls across two spaces is *two* upserts —
  asserted in the test. The write cost is a function of how many spaces were used, never how many times.
- **`$inc`, never read-modify-write**, so a second flush, or a second instance against one database, adds
  rather than clobbers.
- **`$max` for `maxMs`** — a maximum is not additive, and summing maxima describes a request that never
  happened.
- **`$setOnInsert` for `bucketAt`**, or a continuously-used space keeps its oldest bucket alive past the TTL
  forever.
- **A 90-day TTL index.** An activity log without one becomes the largest collection in the instance, which is
  how a metrics table stops being worth having.

The obvious alternative — enabling `audit.logReads` — writes **one Mongo document per read**. That is exactly
the per-request cost the question was about, and it buys row-level detail nobody asked for.

## Where it hooks in, and why there

The audit middleware already computes the operation, the space and the duration for **every** request. Riding
on it means one path-matcher decides which space a call touched, so a count can never disagree with the audit
trail. The hook sits **before** the `logReads` gate on purpose: recall is a read, and recall is the demand
signal.

`answered`/`topScore` come from the recall handler through `req.recallOutcome`, because only the handler knows
what came back and only the middleware knows how long the request took and which space it belonged to.
`rankOf` rather than `.score`, so reranking and fusion are respected — the same reason the merge sort above it
uses `rankOf`.

**Operator work counts as nothing.** `space.create` and `network.vote` carry a space id; counting them would
credit a brand-new empty space with activity it never had.

## A defect the tests found

`sumTopScore` accumulated on **unanswered** calls, so dividing it by the answered count produced means above
`1.0` — outside the range a similarity score can take. The fixture that exposed it passed a score on every
call, which is exactly what a real caller with a score to hand does. Now only answered calls contribute, and a
test pins the mean inside 0…1.

## No percentiles

Deliberately. A mean stored per hour cannot be recombined into a p95, so a p95 here would be either a
fabrication or a reason to keep every sample. `sumMs`, `maxMs` and a count over one second all survive being
summed across buckets, which is what an arbitrary window needs.

## Gates

| gate | what it pins |
|---|---|
| `space-activity-classes` (17) | It **enumerates every operation the audit middleware defines** and fails on one that classifies as nothing without being in a named exclusion list — because `null` is silent, and an unclassified route is a space whose usage does not count. It found four on its first run, each now a decision. Mutation-verified: dropping `find_similar` from the recall class fails the suite |
| `space-activity-store-db` (12, real MongoDB) | one document per space per hour however many calls, `$inc` adding across flushes, `maxMs` staying a maximum, the TTL expiry not moving, and demand being separable from payoff |

## Not in this PR

The UI. Telling spaces apart means seeing them side by side, so that is the Overview panel **and** sortable
columns on the Spaces list — one space in isolation compares to nothing. The endpoint is documented and the
data starts accumulating as soon as this merges, so the panel has real numbers to render when it arrives.
