### PR TITLE
fix(brain): a dead notify sink could stop duplicate scanning for good, silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Scoped in the aggregation, not in the caller: a space-scoped token asking for its own numbers never reads
     another space's buckets.
 
+### Fixed
+
+- **An unresponsive notify sink could stop duplicate scanning for good, silently.** The duplicate scanner POSTs
+  to an operator-configured URL when it finds a pair, and that request had **no timeout at all** —
+  `ssrfSafeFetch` guards *where* a request may go, not how long it may take, because it passes `init` straight
+  through. A sink that accepted the connection and never answered hung the `await` forever, inside a scheduled
+  sweep, with nothing logged.
+  - Ten seconds now. Nothing waits on that POST: the duplicate is already recorded and the notification is a
+    courtesy, so a sink that cannot acknowledge in ten seconds is one whose reply we do not need.
+- **Four scheduled sweeps had no reentrancy guard, so a slow pass overlapped the next one.** The duplicate
+  scanner, the contradiction scanner, candidate pruning and the TTL sweep were each started with
+  `schedule(cron, …)` or `setInterval(…)`, and a timer does not wait for its previous callback.
+  - Not hypothetical for these four: the contradiction scanner calls an NLI model **per pair**, so a large space
+    against a slow judge routinely outlives its schedule — and two overlapping passes double the model calls
+    while both write the same candidates collection. Combined with the missing timeout above, every later tick
+    started another pass that hung in the same place: pending requests accumulating without bound, and
+    duplicate scanning stopped for that space with no error to explain it.
+  - All four now go through `runExclusive`, which **skips** rather than queues — each pass recomputes from
+    current state, so a skipped tick costs a delay and nothing else, while queueing is what turns a slow
+    dependency into an unbounded backlog.
+  - The skip logs the elapsed time of the pass still running (`the previous pass has been running for 412s`),
+    because "a pass is still running" is not actionable and "slower than its schedule, by roughly this much" is.
+  - The label is released in a `finally`. A guard that leaks its label on a thrown error is worse than no guard:
+    the sweep would be off for the lifetime of the process, and nothing would say so.
+  - `single-flight.test.js` pins the skip, the release-on-throw, label independence, and — enumerated from
+    source — that every scheduled sweep is guarded and every `ssrfSafeFetch` call site passes a signal, with
+    pass-through wrappers exempt by name. Both mutations (removing the timeout, unguarding the sweep) fail it.
+
 ## [2.2.3] — 2026-08-01
 
 ### Changed

--- a/server/src/brain/candidate-prune.ts
+++ b/server/src/brain/candidate-prune.ts
@@ -35,6 +35,7 @@ import { col, asFilter } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { DupeScanType } from '../config/types.js';
+import { runExclusive } from '../util/single-flight.js';
 
 /** Both collections key their rows by the same singular vocabulary. */
 const COLLECTION_SUFFIX: Record<string, string> = {
@@ -167,7 +168,7 @@ let _timer: NodeJS.Timeout | null = null;
  */
 export function startCandidatePrune(): void {
   if (_timer) return;
-  _timer = setInterval(() => { void pruneAllSpaces().catch(err => log.error(`Candidate prune cycle: ${err}`)); }, PRUNE_INTERVAL_MS);
+  _timer = setInterval(() => { void runExclusive('Candidate prune', () => pruneAllSpaces()); }, PRUNE_INTERVAL_MS);
   _timer.unref();   // never keep the process alive for housekeeping
   log.debug('Candidate prune worker started');
 }

--- a/server/src/brain/contradiction-scanner.ts
+++ b/server/src/brain/contradiction-scanner.ts
@@ -40,6 +40,7 @@ import { extraClaimFields, fetchStructuredClaims, type ClaimMap } from './struct
 import { recordContradiction } from './contradiction-candidates.js';
 import { nliConfigured, nliIsLocal } from './nli-client.js';
 import type { ContradictionScannerConfig, DupeScanStateDoc, DupeScanType } from '../config/types.js';
+import { runExclusive } from '../util/single-flight.js';
 
 const SCAN_STATE = 'ythril_dupe_scan_state';
 const DEFAULT_BATCH_SIZE = 200;
@@ -354,7 +355,10 @@ export function startContradictionScanner(): void {
     return;
   }
   _task = schedule(cron, () => {
-    runContradictionScanAllSpaces().catch(err => log.error(`Scheduled contradiction scan error: ${err}`));
+    // Guarded: this sweep calls an NLI model PER PAIR, so on a large space against a slow judge a pass
+    // routinely outlives its schedule — and two overlapping passes double the model calls while both write
+    // the same candidates collection.
+    void runExclusive('Contradiction scan', () => runContradictionScanAllSpaces());
   });
   log.info(`Contradiction scanner scheduled (${cron})`);
 }

--- a/server/src/brain/dupe-scanner.ts
+++ b/server/src/brain/dupe-scanner.ts
@@ -39,6 +39,7 @@ import {
 import { computeMergePlan, applyResolutions, executeMerge } from './merge.js';
 import { emitWebhookEvent } from '../webhooks/dispatcher.js';
 import type { DupeCandidateDoc, DupeScanStateDoc, DupeScanType, DupeActionRule } from '../config/types.js';
+import { runExclusive } from '../util/single-flight.js';
 
 const DEFAULT_SCHEDULE = '0 3 * * *';   // 03:00 daily
 const DEFAULT_BATCH_SIZE = 200;
@@ -179,6 +180,14 @@ async function tryAutoMerge(spaceId: string, seed: RecallResult, match: RecallRe
   }
 }
 
+/**
+ * How long a notify sink gets to answer.
+ *
+ * Ten seconds because nothing waits on this: the duplicate has already been recorded, and the POST is a
+ * courtesy. A sink that cannot acknowledge in ten seconds is a sink whose reply we do not need, and the
+ * alternative — the previous behaviour — was an unbounded wait inside a scheduled sweep.
+ */
+const NOTIFY_TIMEOUT_MS = 10_000;
 async function fireNotify(spaceId: string, type: DupeScanType, a: RecallResult, b: RecallResult, score: number, overrideUrl?: string): Promise<void> {
   const entry = { type, score, a, b };
   if (overrideUrl) {
@@ -191,6 +200,10 @@ async function fireNotify(spaceId: string, type: DupeScanType, a: RecallResult, 
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ event: 'duplicate.detected', spaceId, timestamp: new Date().toISOString(), ...entry }),
+        // No timeout at all until now. `ssrfSafeFetch` guards WHERE the request may go, not how long it may
+        // take — it passes `init` straight through — so a sink that accepted the connection and never
+        // answered hung this await forever, inside a scheduled sweep, with no error to show for it.
+        signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS),
       });
       resp.body?.cancel?.();
     } catch (err) {
@@ -383,7 +396,7 @@ export function startDupeScanner(): void {
     return;
   }
   _task = schedule(cron, () => {
-    runDupeScanAllSpaces().catch(err => log.error(`Scheduled dupe scan error: ${err}`));
+    void runExclusive('Dupe scan', () => runDupeScanAllSpaces());
   });
   log.info(`Duplicate scanner scheduled (${cron})`);
 }

--- a/server/src/brain/ttl-sweep.ts
+++ b/server/src/brain/ttl-sweep.ts
@@ -17,6 +17,7 @@ import { deleteEntity } from './entities.js';
 import { deleteEdge } from './edges.js';
 import { deleteChrono } from './chrono.js';
 import { deleteFileCascade } from '../files/delete-cascade.js';
+import { runExclusive } from '../util/single-flight.js';
 
 const SWEEP_INTERVAL_MS = 5 * 60_000; // 5 min
 const SWEEP_BATCH = 500;              // max deletions per collection per cycle
@@ -87,7 +88,7 @@ async function ensureSweepIndexes(): Promise<void> {
 export function startTtlSweep(): void {
   if (_sweepTimer) return;
   void ensureSweepIndexes();
-  _sweepTimer = setInterval(() => { void sweepExpired().catch(err => log.error(`TTL sweep cycle: ${err}`)); }, SWEEP_INTERVAL_MS);
+  _sweepTimer = setInterval(() => { void runExclusive('TTL sweep', () => sweepExpired()); }, SWEEP_INTERVAL_MS);
   _sweepTimer.unref(); // don't keep the process alive
   log.debug('TTL sweep worker started');
 }

--- a/server/src/util/single-flight.ts
+++ b/server/src/util/single-flight.ts
@@ -1,0 +1,79 @@
+/**
+ * One pass at a time, for work that runs on a schedule.
+ *
+ * ## The failure this exists for
+ *
+ * Four background sweeps — the duplicate scanner, the contradiction scanner, candidate pruning and the TTL
+ * sweep — were each started with `schedule(cron, …)` or `setInterval(…)` and **no reentrancy guard**. A timer
+ * does not wait for the previous callback: if a pass takes longer than its interval, the next one starts
+ * anyway, and they stack.
+ *
+ * That is not a hypothetical for these four. The contradiction scanner calls an NLI model **per pair**, so a
+ * large space against a slow judge routinely outlives its schedule; and the duplicate scanner POSTs to an
+ * operator-configured notify URL, which — until this was written — had no timeout at all, so a sink that
+ * accepted the connection and never answered hung the pass **forever**. Every subsequent tick then began
+ * another pass that hung in the same place: unbounded accumulation of pending requests, duplicated model
+ * calls, two passes writing the same candidates collection, and not one error line to explain it.
+ *
+ * ## Why skip rather than queue
+ *
+ * These are sweeps, not jobs: each pass recomputes from current state, so a skipped tick costs nothing but a
+ * delay, and the next one picks up everything the skipped one would have done. Queueing would preserve work
+ * that is about to be redone anyway, and it is queueing that turns a slow dependency into an unbounded backlog.
+ *
+ * ## Why the skip is logged with an elapsed time
+ *
+ * "Skipped, a pass is still running" is not actionable. "Skipped, the previous pass has been running for
+ * 412 s" says the sweep is slower than its schedule and roughly by how much — the same reason the stalled-job
+ * warning carries its elapsed time rather than just announcing a re-queue.
+ */
+import { log } from './log.js';
+
+/** Label → when the in-flight pass started. Absent means nothing is running. */
+const _inFlight = new Map<string, number>();
+
+/**
+ * Run `fn` unless a pass with the same label is still going.
+ *
+ * Returns `true` when it ran, `false` when the tick was skipped — so a caller can count skips if it ever wants
+ * to. Never throws: `fn`'s rejection is reported and swallowed, because the caller is a timer callback and an
+ * unhandled rejection there takes the process down in strict Node configurations.
+ */
+export async function runExclusive(label: string, fn: () => Promise<unknown>): Promise<boolean> {
+  const startedAt = _inFlight.get(label);
+  if (startedAt !== undefined) {
+    const seconds = Math.round((Date.now() - startedAt) / 1000);
+    log.warn(`${label}: skipping this tick — the previous pass has been running for ${seconds}s. `
+      + `The sweep is slower than its schedule; overlapping passes would duplicate its work.`);
+    return false;
+  }
+
+  _inFlight.set(label, Date.now());
+  try {
+    await fn();
+    return true;
+  } catch (err) {
+    log.error(`${label} failed: ${err instanceof Error ? err.message : String(err)}`);
+    return true;   // it ran; it simply did not succeed
+  } finally {
+    // A `finally` and not a trailing statement: a throw that escaped the catch above (an error thrown while
+    // logging, say) must still release the label, or the sweep is off for the lifetime of the process.
+    _inFlight.delete(label);
+  }
+}
+
+/** True while a pass with this label is running. For tests and for a diagnostic endpoint. */
+export function isRunning(label: string): boolean {
+  return _inFlight.has(label);
+}
+
+/** How long the in-flight pass has been going, in ms, or null when nothing is running. */
+export function runningForMs(label: string, now = Date.now()): number | null {
+  const startedAt = _inFlight.get(label);
+  return startedAt === undefined ? null : now - startedAt;
+}
+
+/** Release everything. Tests only — a leaked label between suites would silently disable a sweep. */
+export function _resetSingleFlightForTests(): void {
+  _inFlight.clear();
+}

--- a/testing/standalone/single-flight.test.js
+++ b/testing/standalone/single-flight.test.js
@@ -1,0 +1,171 @@
+/**
+ * One pass at a time, and every outbound call has a deadline.
+ *
+ * ## The findings (lens 7, Reliability & Resilience)
+ *
+ * 1. **Four scheduled sweeps had no reentrancy guard.** The duplicate scanner, the contradiction scanner,
+ *    candidate pruning and the TTL sweep were each started with `schedule(cron, …)` or `setInterval(…)`, and a
+ *    timer does not wait for its previous callback. A pass that outlives its interval simply overlaps the next
+ *    one. The contradiction scanner calls an NLI model **per pair**, so that is routine on a large space
+ *    against a slow judge, and two passes then double the model calls while both write the same collection.
+ *
+ * 2. **The duplicate scanner's notify POST had no timeout at all.** `ssrfSafeFetch` guards *where* a request
+ *    may go, not how long it may take — it passes `init` straight through. So an operator-configured sink that
+ *    accepted the connection and never answered hung that `await` **forever**, inside a scheduled sweep, and
+ *    every later tick started another pass that hung in the same place. Unbounded accumulation of pending
+ *    requests, no error line, and duplicate scanning silently stopped for that space.
+ *
+ * The two compound: the missing timeout is what made the missing guard unbounded rather than merely wasteful.
+ *
+ * Run: node --test testing/standalone/single-flight.test.js
+ */
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SERVER_SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', 'server', 'src');
+
+let runExclusive, isRunning, runningForMs, _resetSingleFlightForTests;
+
+describe('runExclusive', () => {
+  before(async () => {
+    ({ runExclusive, isRunning, runningForMs, _resetSingleFlightForTests } =
+      await import('../../server/dist/util/single-flight.js'));
+  });
+
+  beforeEach(() => { _resetSingleFlightForTests(); });
+
+  it('runs the first pass', async () => {
+    let ran = false;
+    assert.equal(await runExclusive('x', async () => { ran = true; }), true);
+    assert.equal(ran, true);
+  });
+
+  it('SKIPS a second pass while the first is still running', async () => {
+    // The whole point. A timer firing again mid-pass must not start a second one.
+    let release;
+    const gate = new Promise(r => { release = r; });
+    let secondRan = false;
+
+    const first = runExclusive('sweep', () => gate);
+    const skipped = await runExclusive('sweep', async () => { secondRan = true; });
+
+    assert.equal(skipped, false, 'the overlapping tick should have been skipped');
+    assert.equal(secondRan, false, 'and its work must not have run');
+    release();
+    await first;
+  });
+
+  it('releases the label when the pass finishes, so the NEXT tick runs', async () => {
+    await runExclusive('sweep', async () => {});
+    assert.equal(isRunning('sweep'), false);
+    assert.equal(await runExclusive('sweep', async () => {}), true);
+  });
+
+  it('releases the label when the pass THROWS — otherwise the sweep is off for the process lifetime', async () => {
+    // The failure mode that makes a guard worse than none: one thrown error and the sweep never runs again.
+    assert.equal(await runExclusive('sweep', async () => { throw new Error('boom'); }), true);
+    assert.equal(isRunning('sweep'), false);
+    assert.equal(await runExclusive('sweep', async () => {}), true);
+  });
+
+  it('never rejects — it is called from a timer, where an unhandled rejection can end the process', async () => {
+    await assert.doesNotReject(runExclusive('sweep', async () => { throw new Error('boom'); }));
+    await assert.doesNotReject(runExclusive('sweep', async () => { throw 'a string'; }));
+  });
+
+  it('keeps labels independent — one slow sweep must not block a different one', async () => {
+    let release;
+    const gate = new Promise(r => { release = r; });
+    const slow = runExclusive('slow', () => gate);
+    assert.equal(await runExclusive('other', async () => {}), true);
+    release();
+    await slow;
+  });
+
+  it('reports how long the in-flight pass has been running, for the skip message', async () => {
+    // "Skipped, a pass is still running" is not actionable. "…running for 412s" says the sweep is slower than
+    // its schedule and roughly by how much.
+    let release;
+    const gate = new Promise(r => { release = r; });
+    const p = runExclusive('sweep', () => gate);
+    const started = runningForMs('sweep');
+    assert.ok(started !== null && started >= 0);
+    assert.equal(runningForMs('nothing-running'), null);
+    release();
+    await p;
+    assert.equal(runningForMs('sweep'), null);
+  });
+});
+
+describe('every scheduled sweep is guarded', () => {
+  // Enumerated from source: a fifth sweep added without the guard is the regression this catches, and it would
+  // otherwise be invisible until two passes overlapped in production.
+  const SWEEPS = [
+    ['brain/dupe-scanner.ts', 'Dupe scan'],
+    ['brain/contradiction-scanner.ts', 'Contradiction scan'],
+    ['brain/candidate-prune.ts', 'Candidate prune'],
+    ['brain/ttl-sweep.ts', 'TTL sweep'],
+  ];
+
+  for (const [file, label] of SWEEPS) {
+    it(`${file} schedules through runExclusive`, () => {
+      const src = readFileSync(join(SERVER_SRC, file), 'utf8');
+      assert.match(src, new RegExp(`runExclusive\\('${label}'`), `${file} must guard its scheduled pass`);
+      // And nothing schedules the bare call beside it.
+      assert.doesNotMatch(src, /(?:schedule\(cron|setInterval)\([^)]*\)\s*=>\s*\{?\s*(?:void\s+)?\w+\(\)\.catch/,
+        `${file} still schedules an unguarded pass`);
+    });
+  }
+});
+
+describe('outbound calls carry a deadline', () => {
+  /**
+   * `ssrfSafeFetch` does NOT add a timeout — it passes `init` through, so every caller must supply one. That is
+   * easy to forget precisely because the name promises safety, and forgetting it produced an unbounded wait
+   * inside a scheduled sweep.
+   *
+   * Wrappers that take an `init` from their own caller are exempt by name: they cannot know the deadline, and
+   * their callers are checked instead.
+   */
+  const PASS_THROUGH_WRAPPERS = [
+    'brain/embedding.ts',            // hands `init` to the transformers/OpenAI client
+    'brain/nli-client.ts',           // builds `init` with its own AbortSignal.timeout, then branches
+    'brain/rerank-client.ts',        // same shape as nli-client
+    'files/converters/vlm-client.ts',
+    'files/media/providers.ts',
+    'auth/oidc.ts',                  // openid-client supplies the request options
+    'api/media-config.ts',           // probe helper builds `init` above the call
+    'sync/peer-fetch.ts',            // composes `{ ...init, signal }`
+    'api/local-agent.ts',            // wrapper that injects AbortSignal.timeout itself
+  ];
+
+  it('every ssrfSafeFetch call site passes a signal, or is a named pass-through wrapper', () => {
+    const offenders = [];
+    const walk = (dir) => {
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, e.name);
+        if (e.isDirectory()) { walk(p); continue; }
+        if (!e.name.endsWith('.ts')) continue;
+        const rel = p.slice(SERVER_SRC.length + 1).replace(/\\/g, '/');
+        if (rel === 'util/ssrf.ts' || PASS_THROUGH_WRAPPERS.includes(rel)) continue;
+        const src = readFileSync(p, 'utf8');
+        // Each call site plus the object literal that follows it, up to the closing of that argument.
+        for (const m of src.matchAll(/ssrfSafeFetch\(([\s\S]{0,700}?)\n\s*\}?\s*\)?;/g)) {
+          if (!/signal\s*:/.test(m[1])) {
+            offenders.push(`${rel}: ssrfSafeFetch with no signal`);
+          }
+        }
+      }
+    };
+    walk(SERVER_SRC);
+    assert.deepEqual(offenders, [], `outbound calls with no deadline:\n  ${offenders.join('\n  ')}\n\n`
+      + '`ssrfSafeFetch` guards WHERE a request goes, not how long it may take. A sink that accepts the\n'
+      + 'connection and never answers hangs the await forever — and inside a scheduled sweep that is silent.');
+  });
+});
+
+// Imported late so the enumeration above reads clearly; Node hoists it regardless.
+import { readdirSync } from 'node:fs';


### PR DESCRIPTION
fix(brain): a dead notify sink could stop duplicate scanning for good, silently

Audit rotation, lens 7 (Reliability & Resilience). Two findings that compound, both in code that runs
with no user present.

1. The duplicate scanner's notify POST had NO timeout. ssrfSafeFetch guards WHERE a request may go, not
   how long it may take — it passes init straight through — so an operator-configured sink that accepted
   the connection and never answered hung that await forever, inside a scheduled sweep, with nothing
   logged. Ten seconds now: the duplicate is already recorded and the POST is a courtesy, so a sink that
   cannot acknowledge in ten seconds is one whose reply we do not need.

2. Four scheduled sweeps had no reentrancy guard — the duplicate scanner, the contradiction scanner,
   candidate pruning and the TTL sweep. A timer does not wait for its previous callback, so a pass that
   outlives its interval simply overlaps the next one.

   Not hypothetical for these four: the contradiction scanner calls an NLI model PER PAIR, so a large
   space against a slow judge routinely outlives its schedule, and two overlapping passes double the
   model calls while both write the same candidates collection. Together with finding 1, every later
   tick started another pass that hung in the same place — pending requests accumulating without bound,
   and duplicate scanning stopped for that space with no error to explain it.

All four now go through runExclusive, which SKIPS rather than queues: each pass recomputes from current
state, so a skipped tick costs a delay and nothing else, while queueing is what turns a slow dependency
into an unbounded backlog. The skip logs how long the running pass has been going, because "a pass is
still running" is not actionable and "slower than its schedule, by roughly this much" is. The label is
released in a finally — a guard that leaks its label on a throw is worse than no guard, because the
sweep would then be off for the lifetime of the process and nothing would say so.

Gate: single-flight (12). Behaviour for the skip, the release-on-throw, and label independence; plus two
enumerations from source — every scheduled sweep is guarded, and every ssrfSafeFetch call site passes a
signal, with pass-through wrappers exempt BY NAME so a new caller cannot inherit the exemption. Both
mutations fail it: removing the notify timeout, and unguarding the scheduled pass.
