### PR TITLE
fix(files): a planned restart made every in-flight job wait out the stall timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A planned restart was treated as a crash: every in-flight embedding job waited out the full stall timeout
+  before resuming.** `stopMediaEmbeddingWorker()` exists — its own comment promises it "completes the in-flight
+  batch" — and the shutdown path never called it. Three consequences from one missing call:
+  - the worker kept **claiming new jobs while the process was draining**, so a job picked up in the last second
+    of life was abandoned instantly;
+  - whatever it held died `processing` with a live claim token, so recovery had to wait out
+    `stalledJobTimeoutMs` — **five minutes by default** — on the next boot before re-queuing it. A rolling
+    restart paid that per in-flight job, per pod;
+  - `closeMongo()` ran while the worker could be mid-write, so its writes failed with connection errors that
+    look like real failures and can spend a retry attempt.
+  - Shutdown now stops the worker and **hands its claims back** (`releaseClaimedJob`): the jobs go straight to
+    `pending` with the backoff cleared, so the next boot starts them immediately. Stall recovery is for when
+    nobody can say what happened; a planned shutdown can say, and saying so costs one write.
+  - **The release does not spend a retry attempt.** The attempt was interrupted, not failed — charging our own
+    deploys against the retry budget is how a file ends up "failed after 3 attempts" having never produced an
+    error.
+  - Guarded on the claim token, so a job already recovered and re-claimed elsewhere is left alone rather than
+    having the claim yanked out from under a worker that is making progress.
+  - `release-claim-on-shutdown-db.test.js` pins all of it against a real MongoDB, including that the release
+    happens **before** `closeMongo` — mutation-verified, since releasing after the connection closes is a fix
+    that silently does nothing.
+
 - **An unresponsive notify sink could stop duplicate scanning for good, silently.** The duplicate scanner POSTs
   to an operator-configured URL when it finds a pair, and that request had **no timeout at all** —
   `ssrfSafeFetch` guards *where* a request may go, not how long it may take, because it passes `init` straight

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -569,6 +569,43 @@ export async function touchJobProgress(
   }
 }
 
+/**
+ * Hand a claim back, because this process is going away — the opposite of a crash.
+ *
+ * Stall recovery exists for the case where nobody can say what happened. A planned shutdown CAN say, and
+ * saying so is worth a write: without this the job sits `processing` with a live token until
+ * `stalledJobTimeoutMs` elapses on the next boot, so a rolling restart costs up to five minutes of dead time
+ * per in-flight job for no reason.
+ *
+ * Guarded on the token so a job that has meanwhile been recovered and re-claimed by another run is left alone:
+ * releasing it then would yank the claim out from under a worker that is making progress.
+ */
+export async function releaseClaimedJob(spaceId: string, jobId: string, claimToken?: string | null): Promise<boolean> {
+  const now = new Date().toISOString();
+  try {
+    const res = await jobCollection(spaceId).updateOne(
+      asFilter<MediaJobDoc>({
+        _id: jobId,
+        status: 'processing',
+        ...(claimToken ? { claimToken } : {}),
+      }),
+      // `claimableAfter: null` so the next boot can pick it up immediately: this was not a failure, so there
+      // is nothing to back off from. `attempts` is deliberately NOT incremented — the attempt did not fail,
+      // it was interrupted, and charging it would spend the retry budget on our own deploys.
+      asUpdate<MediaJobDoc>({
+        $set: { status: 'pending', claimedAt: null, claimToken: null, claimableAfter: null, updatedAt: now },
+      }),
+    );
+    if (res.matchedCount > 0) markSpaceMayHaveWork(spaceId);
+    return res.matchedCount > 0;
+  } catch (err) {
+    // Best-effort by design: this runs during shutdown, where the database connection may already be going.
+    // Failing to release is exactly the old behaviour — stall recovery still catches it.
+    log.debug(`Could not release claim on ${spaceId}/${jobId}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
 export async function resetStalledJobs(
   spaceIds: string[],
   stalledJobTimeoutMs: number,

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -37,7 +37,7 @@ import type { MediaJobDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { createMediaProviders } from './providers.js';
 import type { MediaProviderBundle } from './providers.js';
-import { claimNextJob, completeJob, failJob, resetStalledJobs, cancelMediaJob, currentWorkEpoch, waitForWork, wakeWorkers, touchJobProgress } from './job-queue.js';
+import { claimNextJob, completeJob, failJob, resetStalledJobs, cancelMediaJob, currentWorkEpoch, waitForWork, wakeWorkers, touchJobProgress , releaseClaimedJob } from './job-queue.js';
 import { embedImage } from './image-embedder.js';
 import { embedAudio } from './audio-embedder.js';
 import { embedVideo } from './video-embedder.js';
@@ -83,6 +83,29 @@ export function startMediaEmbeddingWorker(): void {
 }
 
 /** Stop the worker loop gracefully (completes the in-flight batch). */
+/** Claims this process currently holds. Small by construction: bounded by `workerConcurrency`. */
+const _heldJobs = new Set<{ spaceId: string; jobId: string; claimToken?: string | null }>();
+
+/**
+ * Hand back every claim this process holds, for a PLANNED shutdown.
+ *
+ * Awaited by the shutdown path before the database connection closes. Each release is guarded on the claim
+ * token, so a job that has already been recovered and re-claimed elsewhere is left alone.
+ */
+export async function releaseHeldJobs(): Promise<number> {
+  const held = [..._heldJobs];
+  if (held.length === 0) return 0;
+  const results = await Promise.all(
+    held.map(h => releaseClaimedJob(h.spaceId, h.jobId, h.claimToken)),
+  );
+  const released = results.filter(Boolean).length;
+  if (released > 0) {
+    log.info(`Media embedding worker: handed back ${released} claim(s) on shutdown — they are pending again, `
+      + `so the next boot starts them immediately instead of waiting out stalledJobTimeoutMs.`);
+  }
+  return released;
+}
+
 export function stopMediaEmbeddingWorker(): void {
   running = false;
   if (stalledSweepTimer) {
@@ -266,7 +289,14 @@ async function workerLoop(): Promise<void> {
     currentPollMs = workerPollIntervalMs;
 
     // Process jobs concurrently
-    await Promise.allSettled(claimed.map(job => processJob(job, jobProviders)));
+    // Track what this process holds, so a planned shutdown can hand the claims back instead of leaving
+    // them to time out. Removed in a `finally` per job — a leaked entry would make shutdown try to release a
+    // job that has already completed, which the token guard would refuse anyway, but noisily.
+    await Promise.allSettled(claimed.map(job => {
+      const held = { spaceId: job.spaceId, jobId: String(job._id), claimToken: job.claimToken };
+      _heldJobs.add(held);
+      return processJob(job, jobProviders).finally(() => { _heldJobs.delete(held); });
+    }));
 
     // Brief pause to prevent tight loop when constantly finding work
     await sleep(currentPollMs);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -199,6 +199,12 @@ async function main(): Promise<void> {
     stopSyncScheduler();
     stopBackupScheduler();
     stopDupeScanner();
+    // The media worker was never stopped here, though `stopMediaEmbeddingWorker` exists and promises to
+    // complete the in-flight batch. Without it the worker kept CLAIMING new jobs while the process drained —
+    // a job picked up in the last second of life is abandoned instantly — and whatever it held died
+    // `processing` with a live token, so the next boot waited out the full stall timeout before re-queuing it.
+    const { stopMediaEmbeddingWorker } = await import('./files/media/worker.js');
+    stopMediaEmbeddingWorker();
     const { stopRetryWorker } = await import('./webhooks/dispatcher.js');
     stopRetryWorker();
 
@@ -217,6 +223,12 @@ async function main(): Promise<void> {
     await flushConfig();
     // The last partial minute of per-space usefulness counters. After the drain, so calls that finished while
     // connections were closing are counted too — and before `closeMongo`, since this needs the connection.
+    // Hand back any claim this process still holds, before the connection goes. A planned shutdown can say
+    // what happened; stall recovery exists for when nobody can.
+    const { releaseHeldJobs } = await import('./files/media/worker.js');
+    await releaseHeldJobs().catch(err =>
+      log.debug(`Shutdown: releasing held jobs failed: ${err instanceof Error ? err.message : String(err)}`));
+
     const { stopSpaceActivityFlush } = await import('./metrics/space-activity-store.js');
     await stopSpaceActivityFlush().catch(err =>
       log.debug(`Shutdown: space activity flush failed: ${err instanceof Error ? err.message : String(err)}`));

--- a/testing/standalone/release-claim-on-shutdown-db.test.js
+++ b/testing/standalone/release-claim-on-shutdown-db.test.js
@@ -1,0 +1,116 @@
+/**
+ * Database-level test: a planned shutdown hands its claims back instead of waiting out the stall timer.
+ *
+ * ## The finding (lens 7, Reliability & Resilience)
+ *
+ * `stopMediaEmbeddingWorker()` exists, and its own doc comment promises it "completes the in-flight batch".
+ * The shutdown path never called it. Three consequences, all from one missing call:
+ *
+ *   1. the worker kept CLAIMING new jobs while the process drained — a job picked up in the last second of
+ *      life is abandoned instantly;
+ *   2. whatever it held died with `status: processing` and a live claim token, so recovery had to wait out the
+ *      full `stalledJobTimeoutMs` (five minutes by default) on the next boot before re-queuing it. A rolling
+ *      restart pays that per in-flight job, per pod;
+ *   3. `closeMongo()` ran while the worker might be mid-write, so its writes failed with connection errors
+ *      that look like real failures and can spend a retry attempt.
+ *
+ * Stall recovery is for when nobody can say what happened. A planned shutdown CAN say, and saying so is worth
+ * one write.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/release-claim-on-shutdown-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const NOW = new Date().toISOString();
+
+let mongo, jobs, releaseClaimedJob, claimNextJob;
+
+async function insertProcessing(id, claimToken, attempts = 1) {
+  await jobs.insertOne({
+    _id: id, spaceId: SPACE, filePath: id, mimeType: 'application/pdf', mediaType: 'text',
+    status: 'processing', attempts, maxAttempts: 3, lastError: null,
+    claimedAt: NOW, progressAt: NOW, claimToken,
+    // A backoff left over from an earlier failure: releasing must clear it, or the recovered job is invisible
+    // to the claim walk until that timestamp passes.
+    claimableAfter: new Date(Date.now() + 600_000).toISOString(),
+    createdAt: NOW, updatedAt: NOW,
+  });
+}
+
+describe('releaseClaimedJob — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('releaseclaim');
+    ({ releaseClaimedJob, claimNextJob } = await import('../../server/dist/files/media/job-queue.js'));
+    jobs = mongo.col(`${SPACE}_media_jobs`);
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => { await jobs.deleteMany({}); });
+
+  it('makes the job pending again, immediately claimable', async () => {
+    await insertProcessing('doc.pdf', 'run-one');
+    assert.equal(await releaseClaimedJob(SPACE, 'doc.pdf', 'run-one'), true);
+
+    const after = await jobs.findOne({ _id: 'doc.pdf' });
+    assert.equal(after.status, 'pending');
+    assert.equal(after.claimToken, null);
+    assert.equal(after.claimedAt, null);
+    assert.equal(after.claimableAfter, null, 'a stale backoff would hide the job from the claim walk');
+
+    // And the claim walk can actually pick it up on the next boot — the point of the whole exercise.
+    const reclaimed = await claimNextJob([SPACE]);
+    assert.equal(reclaimed?._id, 'doc.pdf');
+  });
+
+  it('does NOT spend a retry attempt — the attempt was interrupted, not failed', async () => {
+    // Charging our own deploys against the job's retry budget is how a file ends up "failed after 3 attempts"
+    // having never once produced an error.
+    await insertProcessing('doc.pdf', 'run-one', 1);
+    await releaseClaimedJob(SPACE, 'doc.pdf', 'run-one');
+    assert.equal((await jobs.findOne({ _id: 'doc.pdf' })).attempts, 1);
+  });
+
+  it('refuses to release a job that has been re-claimed by someone else', async () => {
+    // Guarded on the token: releasing here would yank the claim out from under a worker making progress.
+    await insertProcessing('doc.pdf', 'run-two');
+    assert.equal(await releaseClaimedJob(SPACE, 'doc.pdf', 'run-one'), false);
+    assert.equal((await jobs.findOne({ _id: 'doc.pdf' })).status, 'processing');
+  });
+
+  it('leaves a job that already finished alone', async () => {
+    await insertProcessing('doc.pdf', 'run-one');
+    await jobs.updateOne({ _id: 'doc.pdf' }, { $set: { status: 'complete' } });
+    assert.equal(await releaseClaimedJob(SPACE, 'doc.pdf', 'run-one'), false);
+    assert.equal((await jobs.findOne({ _id: 'doc.pdf' })).status, 'complete');
+  });
+
+  it('never throws — it runs while the connection may already be closing', async () => {
+    await assert.doesNotReject(releaseClaimedJob(SPACE, 'missing.pdf', 'run-one'));
+  });
+
+  describe('the shutdown path is wired to it', () => {
+    // The suite above proves the function works. These prove something calls it — otherwise the whole finding
+    // is still live and the tests pass.
+    const shutdown = readFileSync('server/src/index.ts', 'utf8');
+
+    it('stops the media worker, so it cannot claim while draining', () => {
+      assert.match(shutdown, /stopMediaEmbeddingWorker\(\);/,
+        'the worker kept claiming new jobs during shutdown');
+    });
+
+    it('hands back held claims before the database connection closes', () => {
+      const releaseAt = shutdown.indexOf('releaseHeldJobs()');
+      const closeAt = shutdown.indexOf('await closeMongo()');
+      assert.ok(releaseAt > 0, 'nothing releases the claims this process holds');
+      assert.ok(closeAt > releaseAt, 'the release must happen BEFORE closeMongo, or it cannot write');
+    });
+  });
+});


### PR DESCRIPTION
fix(files): a planned restart made every in-flight job wait out the stall timeout

Audit rotation, lens 7 (Reliability & Resilience), second finding.

stopMediaEmbeddingWorker() exists and its own doc comment promises it "completes the in-flight batch".
The shutdown path never called it. Three consequences from one missing call:

- The worker kept CLAIMING new jobs while the process was draining, so a job picked up in the last
  second of life was abandoned instantly.
- Whatever it held died `processing` with a live claim token, so recovery had to wait out
  stalledJobTimeoutMs — five minutes by default — on the next boot before re-queuing it. A rolling
  restart paid that per in-flight job, per pod.
- closeMongo() ran while the worker could be mid-write, so its writes failed with connection errors
  that look like real failures and can spend a retry attempt.

Shutdown now stops the worker and hands its claims back. The jobs go to `pending` with claimedAt,
claimToken and claimableAfter cleared, so the next boot claims them immediately. Stall recovery is for
when nobody can say what happened; a planned shutdown CAN say, and saying so costs one write.

- The release does NOT increment attempts. The attempt was interrupted, not failed — charging our own
  deploys against the retry budget is how a file ends up "failed after 3 attempts" having never once
  produced an error.
- It is guarded on the claim token, so a job already recovered and re-claimed elsewhere is left alone
  rather than having its claim yanked out from under a worker that is making progress.
- It is best-effort and never throws: it runs while the connection may already be closing, and failing
  to release is exactly the old behaviour — stall recovery still catches it.

Gate: release-claim-on-shutdown-db (7, real MongoDB). The released job is immediately claimable
(asserted by actually claiming it), attempts is unchanged, a re-claimed or finished job is refused, and
the shutdown path is wired to it — including that the release happens BEFORE closeMongo.
Mutation-verified: moving the release after closeMongo fails the gate, because a fix that runs after the
connection closes silently does nothing.
