### PR TITLE
chore(release): 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4] — 2026-08-01
+
 ### Added
 
 - **The Spaces list can now be sorted by which spaces are actually answering.** A Usage column (calls over the

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch. Version bump + CHANGELOG heading; the work is already on `main` as #608–#612.

**Cut today rather than next week for one reason: #612.** The canary runs a K3s fleet whose pods restart —
that is how the 2.2.2 crash loop was found in the first place — and until #612 every in-flight embedding job
waited out `stalledJobTimeoutMs` (five minutes by default) after each restart before resuming. Holding that
fix back would have meant sending them a 2.2.3 message today and a 2.2.4 message tomorrow, for two test cycles
where one will do.

## Reliability (#611, #612) — lens 7

- **A dead notify sink could stop duplicate scanning for good, silently.** The scanner's POST to an
  operator-configured URL had **no timeout at all**: `ssrfSafeFetch` guards *where* a request goes, not how long
  it may take. A sink that accepted the connection and never answered hung a scheduled sweep forever.
- **Four scheduled sweeps had no reentrancy guard** — duplicate, contradiction, candidate-prune, TTL. A timer
  does not wait for its callback, and the contradiction scanner calls an NLI model *per pair*, so outliving its
  schedule is routine. Combined with the above, every later tick started another pass that hung in the same
  place: pending requests accumulating without bound, and duplicate scanning stopped with nothing logged.
- **A planned restart was treated as a crash.** `stopMediaEmbeddingWorker()` existed and shutdown never called
  it, so the worker kept claiming while draining and its in-flight jobs waited out the stall timeout on the next
  boot. Shutdown now stops it and hands the claims back — `pending`, backoff cleared, **without** spending a
  retry attempt, because the attempt was interrupted rather than failed.

## Per-space usefulness (#608, #609, #610)

Asked for by the owner, whose stated intent was *"to be able to tell apart which spaces are how useful"* —
which a call count cannot answer. A space queried 380 times that answered 41 is not popular; it is a space
people keep failing to get an answer out of, and in a counter the two are identical.

- Demand **and** payoff per space, per hour: calls, recalls, **answered**, mean best-hit score, writes,
  mean/max duration, calls over a second, last used. 90-day TTL, hourly UTC buckets.
- **18.6 ns per request** on the counter path, and the write cost is **independent of traffic** — one `$inc`
  upsert per active space per minute, whether it served ten calls or a hundred thousand.
- A Usage panel on the Brain Overview, and a sortable Usage column on Settings → Spaces (busiest first, and
  worst answer rate first — the ordering that finds a content gap).
- A never-asked space has **no** answer rate and sorts last, rather than being zero-filled and ranked as the
  worst offender: those are different problems with different fixes.
- No percentiles anywhere. A mean stored per hour cannot be recombined into a p95, so one would be a
  fabrication; `sumMs`, `maxMs` and a count over one second all survive being summed across any window.

## After merge

Tag `v2.2.4`, GitHub Release, verify the images pull from GHCR **and** Docker Hub (`ythril/ythril` — the wrong
repo name answers `denied`, which reads exactly like a missing tag), then the canary message, which now covers
2.2.3 **and** 2.2.4 in one send.
