### PR TITLE
fix(files): a raised step budget could put a job in a re-queue loop that never finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A raised step budget could put a job in a re-queue loop that never finishes.** `stalledJobTimeoutMs` recovers
+  a job that has reported no progress for that long — and progress is reported *between* steps, never inside
+  one. So a budget allowing a single call to run longer than the stall timeout meant the job was re-queued
+  **while that call was still working**: since the claim lease shipped, the original run then abandons, the
+  replacement starts the same document, reaches the same step, and is re-queued at the same point. Exactly the
+  "slow job killed and killed again at the same page" failure the per-page heartbeat was written to end,
+  reachable again through configuration.
+  - **Measured before it was changed.** At the defaults nothing comes close: the longest step is `ocrTimeoutMs`
+    at **0.40×** the stall timeout (`pageTimeoutMs` 0.20×, `describeTimeoutMs` 0.10×). The trap is what the admin
+    API accepts — `ocrTimeoutMs` up to **30 minutes** and the two model budgets up to **10** each, against a
+    5-minute stall default. And it is reachable by following our own documentation one step too far: the docs
+    tell a swap-based host to raise the describe budget and large-scan operators to raise the OCR one.
+  - **Stall detection now raises its own threshold** to 1.5× the longest configured step, at both points the
+    worker resolves it (startup sweep and periodic sweep — a config change between boot and the first sweep
+    would otherwise leave one of them wrong), and logs one line naming the step and the figure that would
+    silence it.
+  - **The derived value moves, not the setting.** Rejecting the PATCH would block a legitimate two-step change
+    and would not help a hand-edited `config.json`; clamping the step would override a deliberate decision about
+    how long a model may take. Nothing an operator set is contradicted — the detector stops firing inside a step
+    they authorised.
+  - Head-room rather than an exact match, because a threshold equal to the step budget makes "the step gave up"
+    and "the detector fired" indistinguishable, at the same instant, on every occurrence. Mutation-verified.
+
 ## [2.2.4] — 2026-08-01
 
 ### Added

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -928,7 +928,7 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 | `workerMaxPollIntervalMs` | `WORKER_MAX_POLL_INTERVAL_MS` | `30000` | Max poll interval when idle (ms) |
 | `fallbackToExternal` | `MEDIA_EMBEDDING_FALLBACK_TO_EXTERNAL` | `false` | Use external provider if local fails |
 | `maxFileSizeBytes` | `MAX_FILE_SIZE_BYTES` | `524288000` | Skip embedding for files above this size (500 MiB) |
-| `stalledJobTimeoutMs` | `STALLED_JOB_TIMEOUT_MS` | `300000` | Re-queue a job that has reported no progress for > N ms. Measured from the last heartbeat, not from the claim, and re-queuing now withdraws the running claim so the previous holder stops rather than racing its replacement. Each re-queue logs one `warn` with the file, the silence, the size and the step. |
+| `stalledJobTimeoutMs` | `STALLED_JOB_TIMEOUT_MS` | `300000` | Re-queue a job that has reported no progress for > N ms. **Raised automatically when a single step allows longer than this** — see the note under the document-processing table: a step longer than the stall timeout would be re-queued while it is still running. Measured from the last heartbeat, not from the claim, and re-queuing now withdraws the running claim so the previous holder stops rather than racing its replacement. Each re-queue logs one `warn` with the file, the silence, the size and the step. |
 
 > **Large documents, CPU limits and liveness probes.** With the **bundled in-process** embedder, one ~2 KB
 > chunk costs roughly 200 ms of CPU and blocks the event loop for most of it. A 350 KB document is hundreds
@@ -946,6 +946,23 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 > `embedConcurrency`, raise the CPU allocation with it, and give the probes room:
 > `timeoutSeconds: 10` with `failureThreshold: 6` tolerates a slow answer far better than the defaults do.
 > An **external** embedding endpoint sidesteps the whole question — the CPU work happens on another host.
+
+#### Step budgets and the stall detector
+
+> **A single step may not outlast the stall detector, and it no longer can.** `stalledJobTimeoutMs` re-queues
+> a job that has reported no progress for that long, and progress is reported *between* steps — never inside
+> one. So a budget that allows one call to run longer than the stall timeout would have the job re-queued
+> **while that call was still working**: the original run then discovers its claim is gone and abandons, the
+> replacement starts the same document, reaches the same step, and is re-queued at the same point. A loop that
+> never finishes.
+>
+> Measured at the defaults, nothing comes close — the longest step is `ocrTimeoutMs` at 0.4× the stall
+> timeout. It is reachable by configuration: `ocrTimeoutMs` accepts up to **30 minutes** and the two model
+> budgets up to **10** each, against a 5-minute stall default.
+>
+> Rather than refuse the setting, **stall detection raises its own threshold** to 1.5× the longest configured
+> step and logs one line saying so. Nothing you set is contradicted; the detector simply stops firing inside a
+> step you authorised. Raise `stalledJobTimeoutMs` past that figure yourself and the line goes away.
 
 #### ISO 27001 / Data Egress Note
 

--- a/server/src/files/media/stall-floor.ts
+++ b/server/src/files/media/stall-floor.ts
@@ -1,0 +1,101 @@
+/**
+ * The stall timeout can never be shorter than the longest thing a job is allowed to do in one step.
+ *
+ * ## Measured, at the defaults
+ *
+ *     stalledJobTimeoutMs   300 000 ms
+ *     pageTimeoutMs          60 000 ms   0.20x
+ *     ocrTimeoutMs          120 000 ms   0.40x
+ *     describeTimeoutMs      30 000 ms   0.10x
+ *
+ * Safe. The trap is what an operator may configure, from the admin PATCH schema:
+ *
+ *     pageTimeoutMs        1 000 …   600 000 ms   (2x the stall default)
+ *     describeTimeoutMs    1 000 …   600 000 ms   (2x)
+ *     ocrTimeoutMs        10 000 … 1 800 000 ms   (6x)
+ *
+ * ## Why exceeding it is not merely slow
+ *
+ * Each of those is **one call**, and a call reports no progress while it is in flight — the heartbeat fires
+ * between steps, not inside one. So a hop longer than the stall timeout means the job is re-queued *while that
+ * hop is still working*. Since #601 the original run then discovers its claim is gone and abandons; the
+ * replacement starts the same document, reaches the same hop, and is re-queued at the same point. A loop that
+ * never completes — precisely the "slow job killed and killed again at the same page" failure the per-page
+ * heartbeat was introduced to end, reachable again through configuration.
+ *
+ * And reachable by following our own advice one step too far: the docs tell a swap-based host to raise
+ * `describeTimeoutMs` to 60–180 s (safe), and tell large-scan operators to raise `ocrTimeoutMs` (whose ceiling
+ * is thirty minutes).
+ *
+ * ## Why a floor rather than a rejected setting
+ *
+ * Rejecting the PATCH would block a legitimate two-step change (raise the stall timeout, then the hop) and
+ * would not help an instance whose `config.json` was hand-edited. Silently clamping the HOP would override a
+ * deliberate choice about how long a model may take. So the derived value moves instead: the stall detector
+ * uses whichever is larger, and says so once. Nothing an operator set is contradicted — the detector simply
+ * stops firing inside a step it authorised.
+ */
+import { log } from '../../util/log.js';
+
+/**
+ * Head-room over the longest hop. A stall timeout equal to the hop budget would fire in the same instant the
+ * hop legitimately gives up, making the two indistinguishable in the log.
+ */
+export const STALL_FLOOR_FACTOR = 1.5;
+
+export interface StallFloor {
+  /** What the stall detector should use. */
+  ms: number;
+  /** Set when the floor raised the configured value — the reason, ready for a log line. */
+  raised?: { from: number; hop: string; hopMs: number };
+}
+
+/**
+ * The stall timeout to actually use, given the configured hops.
+ *
+ * Pure and total: it takes numbers and returns a number, so the rule can be tested without a config, a
+ * database or a worker.
+ */
+export function effectiveStallTimeoutMs(
+  configuredMs: number,
+  hops: Record<string, number | undefined>,
+): StallFloor {
+  let worst: { hop: string; hopMs: number } | null = null;
+  for (const [hop, hopMs] of Object.entries(hops)) {
+    if (typeof hopMs !== 'number' || !Number.isFinite(hopMs) || hopMs <= 0) continue;
+    if (!worst || hopMs > worst.hopMs) worst = { hop, hopMs };
+  }
+  if (!worst) return { ms: configuredMs };
+
+  const floor = Math.ceil(worst.hopMs * STALL_FLOOR_FACTOR);
+  if (floor <= configuredMs) return { ms: configuredMs };
+  return { ms: floor, raised: { from: configuredMs, hop: worst.hop, hopMs: worst.hopMs } };
+}
+
+/** Remembers what has been warned about, so a sweep every 30 s does not print the same line forever. */
+let _lastWarned = '';
+
+/** The effective timeout, warning at most once per distinct combination. */
+export function stallTimeoutWithWarning(
+  configuredMs: number,
+  hops: Record<string, number | undefined>,
+): number {
+  const { ms, raised } = effectiveStallTimeoutMs(configuredMs, hops);
+  if (raised) {
+    const key = `${raised.from}:${raised.hop}:${raised.hopMs}:${ms}`;
+    if (key !== _lastWarned) {
+      _lastWarned = key;
+      log.warn(`Stall detection: using ${ms} ms instead of the configured ${raised.from} ms, because `
+        + `${raised.hop} allows a single step of ${raised.hopMs} ms. A step longer than the stall timeout `
+        + `reports no progress while it runs, so the job would be re-queued mid-step, abandon its work, and `
+        + `reach the same step again — a loop that never finishes. Raise stalledJobTimeoutMs above `
+        + `${Math.ceil(raised.hopMs * STALL_FLOOR_FACTOR)} ms to silence this.`);
+    }
+  }
+  return ms;
+}
+
+/** Test hook: forget what has been warned about. */
+export function _resetStallWarningForTests(): void {
+  _lastWarned = '';
+}

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -30,7 +30,7 @@
  * provider set (no mid-job swap).
  */
 
-import { getConfig, getMediaEmbeddingConfig } from '../../config/loader.js';
+import { getConfig, getMediaEmbeddingConfig , getDocumentProcessingConfig } from '../../config/loader.js';
 import { toSafeRelPath } from '../../util/paths.js';
 import { isProxySpace } from '../../spaces/proxy.js';
 import type { MediaJobDoc } from '../../config/types.js';
@@ -66,6 +66,7 @@ import {
   mediaJobsRetriedTotal,
   mediaJobDurationSeconds,
 } from '../../metrics/registry.js';
+import { stallTimeoutWithWarning } from './stall-floor.js';
 
 let running = false;
 let stalledSweepTimer: NodeJS.Timeout | null = null;
@@ -75,6 +76,22 @@ let providerRefreshTimer: NodeJS.Timeout | null = null;
 const PROVIDER_REFRESH_MS = 2_000;
 
 /** Start the media embedding worker loop. Idempotent — safe to call multiple times. */
+/**
+ * The budgets that bound ONE step of a job — the things the stall detector must not fire inside.
+ *
+ * Named individually rather than "every number in the config": `maxPages` and `concurrency` are not durations,
+ * and `workerPollIntervalMs` bounds the loop rather than a step. A wrong entry here would raise the stall
+ * floor for no reason and make recovery slower than it needs to be.
+ */
+function hopBudgets(): Record<string, number | undefined> {
+  const doc = getDocumentProcessingConfig();
+  return {
+    pageTimeoutMs: doc.pageTimeoutMs,
+    ocrTimeoutMs: doc.ocrTimeoutMs,
+    describeTimeoutMs: doc.describeTimeoutMs,
+  };
+}
+
 export function startMediaEmbeddingWorker(): void {
   if (running) return;
   running = true;
@@ -182,7 +199,14 @@ export function getActiveProviderSignature(): string {
 
 async function workerLoop(): Promise<void> {
   const startupCfg = getMediaEmbeddingConfig();
-  const startupStalledTimeoutMs = startupCfg.stalledJobTimeoutMs ?? 300_000;
+  // Floored by the longest single hop a job may take: a step longer than the stall timeout reports no
+  // progress while it runs, so the job would be re-queued mid-step and reach the same step again forever.
+  // Measured at the defaults it never binds (the worst hop is OCR at 0.40x the timeout); it binds when an
+  // operator raises a hop, which the ceilings invite — ocrTimeoutMs alone goes to thirty minutes.
+  const startupStalledTimeoutMs = stallTimeoutWithWarning(
+    startupCfg.stalledJobTimeoutMs ?? 300_000,
+    hopBudgets(),
+  );
 
   let currentPollMs = startupCfg.workerPollIntervalMs ?? 1_000;
 
@@ -204,7 +228,12 @@ async function workerLoop(): Promise<void> {
     if (!running) return;
     const ids = getLocalSpaceIds();
     if (ids.length === 0) return;
-    const stalledTimeoutMs = getMediaEmbeddingConfig().stalledJobTimeoutMs ?? 300_000;
+    // Re-read AND re-floored on every fire: the hop budgets are hot-reloadable too, so a raised OCR timeout
+    // must move the stall floor without a restart.
+    const stalledTimeoutMs = stallTimeoutWithWarning(
+      getMediaEmbeddingConfig().stalledJobTimeoutMs ?? 300_000,
+      hopBudgets(),
+    );
     void resetStalledJobs(ids, stalledTimeoutMs).catch(err =>
       log.warn(`Media worker: periodic stalled reset error: ${err instanceof Error ? err.message : String(err)}`),
     );

--- a/testing/standalone/stall-floor.test.js
+++ b/testing/standalone/stall-floor.test.js
@@ -1,0 +1,130 @@
+/**
+ * The stall timeout can never be shorter than the longest single step a job may take.
+ *
+ * ## The measurement this came from
+ *
+ * Read out of the compiled config rather than assumed:
+ *
+ *     stalledJobTimeoutMs   300 000 ms   (default)
+ *     pageTimeoutMs          60 000 ms   0.20x   settable to   600 000
+ *     ocrTimeoutMs          120 000 ms   0.40x   settable to 1 800 000   (6x the stall default)
+ *     describeTimeoutMs      30 000 ms   0.10x   settable to   600 000
+ *
+ * **At the defaults nothing binds.** The trap is what the admin API allows an operator to set — and following
+ * our own documentation gets them close to it: the docs tell a swap-based host to raise `describeTimeoutMs`
+ * (ceiling 10 min) and tell large-scan operators to raise `ocrTimeoutMs` (ceiling 30 min).
+ *
+ * ## Why exceeding it loops rather than merely being slow
+ *
+ * Each of those budgets bounds ONE call, and a call reports no progress while it is in flight — the heartbeat
+ * fires between steps, not inside one. So a hop longer than the stall timeout means the job is re-queued *while
+ * that hop is still working*; since the claim lease shipped, the original run then abandons, the replacement
+ * starts the same document, reaches the same hop, and is re-queued at the same point. That is the "slow job
+ * killed and killed again at the same page" failure the per-page heartbeat was written to end, reachable again
+ * through configuration.
+ *
+ * Run: node --test testing/standalone/stall-floor.test.js
+ */
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let effectiveStallTimeoutMs, stallTimeoutWithWarning, STALL_FLOOR_FACTOR, _resetStallWarningForTests;
+
+const STALL_DEFAULT = 300_000;
+
+describe('effectiveStallTimeoutMs', () => {
+  before(async () => {
+    ({ effectiveStallTimeoutMs, stallTimeoutWithWarning, STALL_FLOOR_FACTOR, _resetStallWarningForTests } =
+      await import('../../server/dist/files/media/stall-floor.js'));
+  });
+
+  beforeEach(() => { _resetStallWarningForTests(); });
+
+  it('does not bind at the shipped defaults — the worst hop is OCR at 0.40x', () => {
+    // If this ever starts binding out of the box, either a default grew or the stall default shrank, and the
+    // recovery delay changed for every instance without anyone deciding to.
+    const { ms, raised } = effectiveStallTimeoutMs(STALL_DEFAULT, {
+      pageTimeoutMs: 60_000, ocrTimeoutMs: 120_000, describeTimeoutMs: 30_000,
+    });
+    assert.equal(ms, STALL_DEFAULT);
+    assert.equal(raised, undefined);
+  });
+
+  it('raises the timeout when a hop exceeds it, and says which hop', () => {
+    // The reachable case: an operator raises the OCR ceiling for a large scan.
+    const { ms, raised } = effectiveStallTimeoutMs(STALL_DEFAULT, { ocrTimeoutMs: 1_800_000 });
+    assert.equal(ms, 1_800_000 * STALL_FLOOR_FACTOR);
+    assert.equal(raised.hop, 'ocrTimeoutMs');
+    assert.equal(raised.hopMs, 1_800_000);
+    assert.equal(raised.from, STALL_DEFAULT);
+  });
+
+  it('leaves head-room over the hop rather than matching it exactly', () => {
+    // Equal values would make "the hop gave up" and "the detector fired" indistinguishable in the log, at the
+    // same instant, on every occurrence.
+    const { ms } = effectiveStallTimeoutMs(100_000, { ocrTimeoutMs: 100_000 });
+    assert.ok(ms > 100_000, `expected head-room, got ${ms}`);
+    assert.ok(STALL_FLOOR_FACTOR > 1);
+  });
+
+  it('picks the LONGEST hop, not the first or the last', () => {
+    const { raised } = effectiveStallTimeoutMs(STALL_DEFAULT, {
+      pageTimeoutMs: 400_000, ocrTimeoutMs: 900_000, describeTimeoutMs: 500_000,
+    });
+    assert.equal(raised.hop, 'ocrTimeoutMs');
+  });
+
+  it('ignores absent, zero and non-finite budgets instead of treating them as huge', () => {
+    // A missing budget must not raise the floor: the recovery delay would grow because a field was undefined.
+    const { ms, raised } = effectiveStallTimeoutMs(STALL_DEFAULT, {
+      pageTimeoutMs: undefined, ocrTimeoutMs: 0, describeTimeoutMs: NaN, other: Infinity,
+    });
+    assert.equal(ms, STALL_DEFAULT);
+    assert.equal(raised, undefined);
+  });
+
+  it('respects a stall timeout the operator already set high enough', () => {
+    // Raising stalledJobTimeoutMs is the documented way to silence this. It must actually silence it.
+    const { ms, raised } = effectiveStallTimeoutMs(3_000_000, { ocrTimeoutMs: 1_800_000 });
+    assert.equal(ms, 3_000_000);
+    assert.equal(raised, undefined);
+  });
+
+  it('warns once per distinct combination, not once per sweep', () => {
+    // The sweep fires every 30 s at most; the same line forever is how a real warning becomes wallpaper.
+    const hops = { ocrTimeoutMs: 1_800_000 };
+    assert.equal(stallTimeoutWithWarning(STALL_DEFAULT, hops), 2_700_000);
+    assert.equal(stallTimeoutWithWarning(STALL_DEFAULT, hops), 2_700_000);
+    assert.equal(stallTimeoutWithWarning(STALL_DEFAULT, { ocrTimeoutMs: 900_000 }), 1_350_000);
+  });
+});
+
+describe('the worker uses the floor, not the raw setting', () => {
+  // The suite above proves the rule. This proves it is applied — at BOTH points the worker resolves the
+  // timeout, since a config change between boot and the first sweep would otherwise leave one of them wrong.
+  const src = readFileSync('server/src/files/media/worker.ts', 'utf8');
+
+  it('floors the startup sweep', () => {
+    assert.match(src, /const startupStalledTimeoutMs = stallTimeoutWithWarning\(/);
+  });
+
+  it('floors the periodic sweep too', () => {
+    assert.match(src, /const stalledTimeoutMs = stallTimeoutWithWarning\(/);
+  });
+
+  it('never passes a raw configured value to resetStalledJobs', () => {
+    // The regression this catches: someone "simplifies" one call site back to the plain config read.
+    assert.doesNotMatch(src, /resetStalledJobs\([^)]*stalledJobTimeoutMs \?\? 300_000/);
+  });
+
+  it('names only DURATION budgets as hops', () => {
+    // `maxPages` and `concurrency` are not durations; including one would raise the floor for no reason and
+    // make recovery slower than it needs to be.
+    const helper = src.match(/function hopBudgets\(\)[\s\S]*?\n\}/)?.[0] ?? '';
+    assert.ok(helper.includes('pageTimeoutMs') && helper.includes('ocrTimeoutMs')
+      && helper.includes('describeTimeoutMs'), 'the three call budgets must be listed');
+    assert.ok(!/maxPages|concurrency|PollInterval/.test(helper),
+      'a non-duration in hopBudgets would inflate the stall floor');
+  });
+});


### PR DESCRIPTION
fix(files): a raised step budget could put a job in a re-queue loop that never finishes

Item 1 of the cleaned queue — the one lens-7 angle that survived reading the code — measured first.

stalledJobTimeoutMs recovers a job that has reported no progress for that long, and progress is reported
BETWEEN steps, never inside one. So a budget that allows a single call to run longer than the stall
timeout means the job is re-queued while that call is still working: since the claim lease shipped the
original run then abandons, the replacement starts the same document, reaches the same step, and is
re-queued at the same point. That is the "slow job killed and killed again at the same page" failure the
per-page heartbeat was written to end, reachable again through configuration.

Measured from the compiled config, not assumed (a regex over source returned nulls, and a measurement
built on nulls would have proved whatever I already believed):

    stalledJobTimeoutMs   300 000 ms   default
    pageTimeoutMs          60 000 ms   0.20x   settable to   600 000   (2x the stall default)
    ocrTimeoutMs          120 000 ms   0.40x   settable to 1 800 000   (6x)
    describeTimeoutMs      30 000 ms   0.10x   settable to   600 000   (2x)

So at the defaults nothing comes close. The trap is what the admin API accepts — and it is reachable by
following our own documentation one step too far, since the docs tell a swap-based host to raise the
describe budget and large-scan operators to raise the OCR one.

Stall detection now raises its own threshold to 1.5x the longest configured step, at BOTH points the
worker resolves it (a config change between boot and the first sweep would otherwise leave one wrong),
and logs one line naming the step and the figure that would silence it.

The derived value moves, not the setting. Rejecting the PATCH would block a legitimate two-step change
(raise the stall timeout, then the hop) and would not help a hand-edited config.json; clamping the step
would override a deliberate decision about how long a model may take. Nothing an operator set is
contradicted — the detector simply stops firing inside a step they authorised.

Head-room rather than an exact match: a threshold equal to the step budget makes "the step gave up" and
"the detector fired" indistinguishable, at the same instant, every time.

Gate: stall-floor (11). The rule (longest hop wins, absent/zero/non-finite ignored, a high enough
setting respected, one warning per combination) plus four checks that it is APPLIED — both sweep sites
floored, no raw configured value reaching resetStalledJobs, and only duration budgets counted as hops.
Mutation-verified: a factor of 1.0 fails the head-room test.
