### PR TITLE
fix(spaces): a recreated space inherited usage it never served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A space recreated with the same id inherited usage it never served, and a renamed space lost its history.**
+  `dropSpaceData` removes every collection whose name starts with `<spaceId>_`; `space_activity` is
+  **instance-wide**, keyed `<space>:<hour>`, so the prefix drop could not reach it. Found by running the
+  Data-Integrity lens over code written the same day — the collection is new, and every existing cascade was
+  written before it existed.
+  - **On delete**, the rows outlived the space for up to the 90-day retention, and a space recreated under the
+    same id picked them up: a brand-new empty space whose Usage panel claimed hundreds of recalls. Worse than
+    blank, because it is confidently wrong. `purgeSpaceActivity` now runs inside `dropSpaceData`.
+  - **On rename**, the collections moved and the activity rows did not, so the renamed space started blank
+    while orphans lingered under an id that no longer existed. A rename preserves the space and its data, so
+    its history follows: the buckets are re-keyed in one `bulkWrite` (the `_id` embeds the space id, so they
+    cannot be updated in place). Non-fatal — a rename that otherwise succeeded must not fail over its usage log.
+  - `space-activity-lifecycle-db.test.js` pins both against a real MongoDB, including that **a recreated id sees
+    nothing** and that a renamed space reads its own history back. It also asserts the two lifecycle paths call
+    them, because the operations working proves nothing if nothing invokes them — mutation-verified by stubbing
+    the purge out.
+
 - **A raised step budget could put a job in a re-queue loop that never finishes.** `stalledJobTimeoutMs` recovers
   a job that has reported no progress for that long — and progress is reported *between* steps, never inside
   one. So a budget allowing a single call to run longer than the stall timeout meant the job was re-queued

--- a/server/src/metrics/space-activity-store.ts
+++ b/server/src/metrics/space-activity-store.ts
@@ -147,6 +147,45 @@ export async function stopSpaceActivityFlush(): Promise<void> {
   await flushSpaceActivity();
 }
 
+/**
+ * Forget a space's usage. Called when the space is deleted or wiped.
+ *
+ * `space_activity` is instance-wide, so the prefix drop in `dropSpaceData` — which removes every
+ * `<spaceId>_*` collection — cannot reach it. Without this the rows outlive the space for up to the
+ * retention window, and a space recreated with the same id inherits usage it never served: a fresh space
+ * whose Usage panel claims hundreds of recalls, which is worse than showing nothing.
+ */
+export async function purgeSpaceActivity(spaceId: string): Promise<number> {
+  const res = await col<ActivityDoc>(ACTIVITY_COLLECTION).deleteMany(
+    asFilter<ActivityDoc>({ space: spaceId }),
+  );
+  return res.deletedCount ?? 0;
+}
+
+/**
+ * Carry a space's usage across a rename.
+ *
+ * A rename preserves the space and its data, so its history should follow — losing it would make every
+ * rename look like a space that had never been used. The bucket `_id` embeds the space id, so the rows
+ * cannot be updated in place: each is re-inserted under the new key and the old one removed, in one
+ * `bulkWrite`. Bounded by the retention window (at most 24 x retention days of rows for one space).
+ *
+ * `ordered: false` so one collision — a target row that somehow already exists — does not abandon the rest.
+ */
+export async function renameSpaceActivity(fromId: string, toId: string): Promise<number> {
+  if (fromId === toId) return 0;
+  const c = col<ActivityDoc>(ACTIVITY_COLLECTION);
+  const rows = await c.find(asFilter<ActivityDoc>({ space: fromId })).toArray() as ActivityDoc[];
+  if (rows.length === 0) return 0;
+
+  const ops = rows.flatMap(row => [
+    { insertOne: { document: { ...row, _id: activityDocId(toId, row.bucket), space: toId } } },
+    { deleteOne: { filter: { _id: row._id } } },
+  ]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await c.bulkWrite(ops as any, { ordered: false });
+  return rows.length;
+}
 export interface SpaceActivitySummary {
   space: string;
   calls: number;

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -399,6 +399,20 @@ export async function dropSpaceData(spaceId: string): Promise<string[]> {
     }
   }
 
+  // 2b. Forget its usage rows.
+  //
+  // The prefix drop above cannot reach them: `space_activity` is instance-wide, keyed `<space>:<hour>`.
+  // Left behind, they outlive the space for up to the retention window — and a space recreated with the
+  // same id would inherit usage it never served.
+  try {
+    const { purgeSpaceActivity } = await import('../metrics/space-activity-store.js');
+    const purged = await purgeSpaceActivity(spaceId);
+    if (purged > 0) log.debug(`Purged ${purged} activity bucket(s) for space '${spaceId}'`);
+  } catch (err) {
+    const msg = `Could not purge activity for '${spaceId}': ${err}`;
+    log.warn(msg);
+    errors.push(msg);
+  }
   // 3. Delete the space files directory
   const filesDir = path.resolve(getDataRoot(), 'files', spaceId);
   try {

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -140,7 +140,18 @@ export async function moveSpaceData(oldId: string, newId: string): Promise<strin
     await fs.rename(oldChunks, newChunks);
   } catch { /* ignore — chunks dir may not exist / already moved */ }
 
-  return errors;
+  return errors;
+  // Usage history follows the space. `space_activity` is instance-wide and its bucket `_id` embeds the
+  // space id, so the collection renames above cannot carry it: without this a renamed space starts with a
+  // blank Usage panel while its old rows linger under an id that no longer exists.
+  try {
+    const { renameSpaceActivity } = await import('../metrics/space-activity-store.js');
+    const moved = await renameSpaceActivity(oldId, newId);
+    if (moved > 0) log.debug(`Moved ${moved} activity bucket(s) from '${oldId}' to '${newId}'`);
+  } catch (err) {
+    // Non-fatal: a rename that otherwise succeeded must not fail over its usage history.
+    log.warn(`Could not move activity buckets for the rename ${oldId} -> ${newId}: ${err}`);
+  }
 }
 
 /** Apply the logical config changes of a rename: point the space entry at `newId`

--- a/testing/standalone/space-activity-lifecycle-db.test.js
+++ b/testing/standalone/space-activity-lifecycle-db.test.js
@@ -1,0 +1,124 @@
+/**
+ * Database-level test: a space's usage rows do not outlive the space, and they follow a rename.
+ *
+ * ## The finding (lens 8, Data Integrity) — self-inflicted, two hours old
+ *
+ * `dropSpaceData` removes every collection whose name starts with `<spaceId>_`. `space_activity` is
+ * **instance-wide**, keyed `<space>:<hour>`, so the prefix drop cannot reach it. Two consequences:
+ *
+ *   1. deleting a space leaves its usage rows behind for up to the 90-day retention — and **a space recreated
+ *      with the same id inherits them**, so a brand-new empty space's Usage panel claims hundreds of recalls
+ *      it never served. That is worse than showing nothing, because it is confidently wrong;
+ *   2. a rename moves the collections and leaves the activity rows under the old id, so the renamed space
+ *      starts blank while orphaned rows linger under an id that no longer exists.
+ *
+ * The lens names this exactly: *cascade deletion of derived artifacts so nothing is orphaned*. It was worth
+ * running the lens over code written the same day — the collection is new, and every existing cascade was
+ * written before it existed.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/space-activity-lifecycle-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const HOUR = Date.parse('2026-08-01T14:20:00.000Z');
+let mongo, activity;
+let recordSpaceCall, drainSpaceActivity, flushSpaceActivity, purgeSpaceActivity, renameSpaceActivity,
+  summariseActivity, ACTIVITY_COLLECTION;
+
+/** Give a space some usage and write it down. */
+async function seed(space, calls = 3, at = HOUR) {
+  for (let i = 0; i < calls; i++) recordSpaceCall(space, 'recall', { ms: 20, answered: true, topScore: 0.8 });
+  await flushSpaceActivity(at);
+}
+
+describe('space activity lifecycle — against a real MongoDB', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('activitylifecycle');
+    ({ recordSpaceCall, drainSpaceActivity } = await import('../../server/dist/metrics/space-activity.js'));
+    ({ flushSpaceActivity, purgeSpaceActivity, renameSpaceActivity, summariseActivity, ACTIVITY_COLLECTION } =
+      await import('../../server/dist/metrics/space-activity-store.js'));
+    activity = mongo.col(ACTIVITY_COLLECTION);
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => { drainSpaceActivity(); await activity.deleteMany({}); });
+
+  it('purges a deleted space\'s rows', async () => {
+    await seed('doomed', 5);
+    await seed('keeper', 2);
+    assert.equal(await purgeSpaceActivity('doomed'), 1);
+    assert.equal(await activity.countDocuments({ space: 'doomed' }), 0);
+    assert.equal(await activity.countDocuments({ space: 'keeper' }), 1, 'it must not touch other spaces');
+  });
+
+  it('a space recreated with the same id does NOT inherit the old usage', async () => {
+    // The sharp edge. Without the purge, a fresh space's Usage panel is confidently wrong — worse than blank.
+    await seed('reused', 400);
+    await purgeSpaceActivity('reused');
+    drainSpaceActivity();
+    const rows = await summariseActivity(24, HOUR + 60_000);
+    assert.deepEqual(rows.filter(r => r.space === 'reused'), []);
+  });
+
+  it('purging a space with no rows is a no-op, not an error', async () => {
+    assert.equal(await purgeSpaceActivity('never-used'), 0);
+  });
+
+  it('carries usage across a rename, under the new id', async () => {
+    // A rename preserves the space and its data, so losing its history would make every rename look like a
+    // space that had never been used.
+    await seed('old-name', 7);
+    assert.equal(await renameSpaceActivity('old-name', 'new-name'), 1);
+
+    assert.equal(await activity.countDocuments({ space: 'old-name' }), 0, 'no orphan under the old id');
+    const moved = await activity.findOne({ space: 'new-name' });
+    assert.ok(moved, 'the row must exist under the new id');
+    assert.equal(moved._id, 'new-name:2026-08-01T14', 'the bucket key embeds the id, so it must be re-keyed');
+    assert.equal(moved.calls.recall.n, 7, 'and the counts must survive the move');
+  });
+
+  it('a renamed space reads its own history back', async () => {
+    await seed('before', 4);
+    await renameSpaceActivity('before', 'after');
+    drainSpaceActivity();
+    const rows = await summariseActivity(24, HOUR + 60_000);
+    assert.deepEqual(rows.map(r => r.space), ['after']);
+    assert.equal(rows[0].recall, 4);
+  });
+
+  it('moves every bucket, not just the newest', async () => {
+    await seed('multi', 2, HOUR);
+    await seed('multi', 3, HOUR + 3_600_000);
+    assert.equal(await renameSpaceActivity('multi', 'moved'), 2);
+    assert.equal(await activity.countDocuments({ space: 'moved' }), 2);
+  });
+
+  it('renaming to the same id is a no-op', async () => {
+    await seed('same', 2);
+    assert.equal(await renameSpaceActivity('same', 'same'), 0);
+    assert.equal(await activity.countDocuments({ space: 'same' }), 1);
+  });
+
+  describe('the lifecycle paths are wired to them', () => {
+    // The suite above proves the operations work; these prove something calls them. Without that, the finding
+    // is still live and every test here passes.
+    it('dropSpaceData purges activity', () => {
+      const src = readFileSync('server/src/spaces/lifecycle.ts', 'utf8');
+      assert.match(src, /purgeSpaceActivity\(spaceId\)/,
+        'deleting a space would leave its usage rows for a recreated space to inherit');
+    });
+
+    it('moveSpaceData carries activity across', () => {
+      const src = readFileSync('server/src/spaces/rename.ts', 'utf8');
+      assert.match(src, /renameSpaceActivity\(oldId, newId\)/,
+        'a renamed space would start blank while orphans linger under the old id');
+    });
+  });
+});


### PR DESCRIPTION
fix(spaces): a recreated space inherited usage it never served

Audit rotation, lens 8 (Data Integrity), first finding — and it is mine, from earlier today.

dropSpaceData removes every collection whose name starts with `<spaceId>_`. `space_activity` is
INSTANCE-WIDE, keyed `<space>:<hour>`, so the prefix drop cannot reach it. The lens names this case
exactly — "cascade deletion of derived artifacts so nothing is orphaned" — and it was worth running over
code written the same day, because the collection is new and every existing cascade predates it.

- On DELETE the rows outlived the space for up to the 90-day retention, and a space recreated under the
  same id picked them up: a brand-new empty space whose Usage panel claimed hundreds of recalls. That is
  worse than blank — it is confidently wrong. purgeSpaceActivity now runs inside dropSpaceData, and its
  failure is collected into the same error list as a failed collection drop rather than thrown.
- On RENAME the collections moved and the activity rows did not, so the renamed space started blank while
  orphans lingered under an id that no longer existed. A rename preserves the space and its data, so the
  history follows: the buckets are re-keyed in one bulkWrite, since the `_id` embeds the space id and the
  rows cannot be updated in place. Non-fatal — a rename that otherwise succeeded must not fail over its
  usage log.

Gate: space-activity-lifecycle-db (9, real MongoDB). Purge removes only that space's rows; a recreated id
sees nothing; a renamed space reads its own history back under the new key; every bucket moves, not just
the newest; same-id rename is a no-op. Plus two assertions that the lifecycle paths actually CALL them —
the operations working proves nothing if nothing invokes them. Mutation-verified by stubbing the purge.
