### PR TITLE
test(standalone): no gate can pass while examining nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Development
 
+- **Two gates could pass while examining nothing, and now none can.** Most gates in this suite share one shape:
+  enumerate a set discovered at run time (a directory walk, `git ls-files`), derive a list of offenders, assert it
+  is empty. If the **enumeration** breaks — a renamed directory, a changed pathspec, a declaration syntax that no
+  longer matches — the offender list is empty for the wrong reason and the gate goes green having checked nothing.
+  - `index-ready-poll` walked `server/src` and `stale-nested-config-ref` scanned `git ls-files`, neither asserting
+    the walk found anything. Both now floor their enumeration with a message that says what the number means.
+  - **`gates-cannot-pass-vacuously.test.js` makes it a rule for every gate written from now on**, enumerated over
+    `testing/standalone/` itself. Verified by planting an unfloored gate and watching it fail.
+  - Its exemptions are **properties of the code, not a list of blessed filenames**: reading a NAMED file is not
+    enumeration (a missing file throws, which is loud), and a hardcoded fixture list cannot silently empty. A
+    name-based allowlist is the thing that goes stale and quietly grows.
+  - It floors its own enumeration too, and asserts that its classifier still recognises at least twenty
+    enumerating gates — otherwise a renamed helper would make every gate look non-enumerating and this file would
+    pass while checking nothing, which is the same defect one level up.
+  - Found by running lens 10 (Testing & Quality) on the evidence of the previous day: four gate defects had
+    surfaced **by accident** in a single session — a test reading server-written state from the offline subset, a
+    red run that was a pool-shutdown deadline rather than a test, a metric family undocumented for two releases,
+    and preflight going red with **no output at all** when its command line outgrew a Windows limit.
+  - The scanner behind it corrected itself twice before being trusted: its first version could not match a floor
+    written `serverFiles().length > 100` (the character class stopped at the parenthesis) and its second rejected
+    `> 0` as a floor. Both false positives named gates that were already correct — including one written an hour
+    earlier.
+
 - **The database twin of the #604 join defect is now checked, and the codebase is clean of it.** #604 was a
   reference taken into `config.networks`, a bcrypt hash awaited, and the push landing on an object the config
   reload had already replaced — a join answering success with the peer never recorded. The same shape exists for

--- a/testing/standalone/gates-cannot-pass-vacuously.test.js
+++ b/testing/standalone/gates-cannot-pass-vacuously.test.js
@@ -1,0 +1,156 @@
+/**
+ * A gate that enumerates something must prove the enumeration found something.
+ *
+ * ## The failure this catches
+ *
+ * Most gates in this suite share one shape: enumerate a set discovered at run time (a directory walk,
+ * `git ls-files`, the docs helpers), derive a list of offenders, assert the list is empty. If the ENUMERATION
+ * breaks — a renamed directory, a changed pathspec, a declaration syntax that no longer matches — the offender
+ * list is empty for the wrong reason and the gate goes green **while examining nothing**.
+ *
+ * That is not hypothetical here. This lens pass found two live instances (`index-ready-poll` walking
+ * `server/src`, and the `stale-nested-config-ref` scanner over `git ls-files`), and the day before it, four gate
+ * defects surfaced by accident: a test reading server-written state from inside the offline subset, a red run
+ * that was a pool-shutdown deadline rather than a test, a metric family undocumented for two releases, and
+ * preflight going red **with no output at all** once its command line outgrew a Windows limit.
+ *
+ * The cure is one assertion — a floor on the enumeration, with a message saying what it means:
+ *
+ *     assert.ok(files.length > 100, `only walked ${files.length} source files`);
+ *
+ * ## Deliberate exemptions, by rule rather than by name
+ *
+ * - **Reading NAMED files is not enumeration.** If the file moves, `readFileSync` throws. A loud failure needs
+ *   no floor, and requiring one flagged `describe-timeout`, whose emptiness assertion is additionally guarded by
+ *   a positive `assert.match` on the same file.
+ * - **A hardcoded fixture list cannot silently empty**, so a gate driven by one needs no floor either.
+ *
+ * Both exemptions are properties of the code, not a list of blessed filenames — a name-based allowlist is the
+ * thing that goes stale and quietly grows.
+ *
+ * Run: node --test testing/standalone/gates-cannot-pass-vacuously.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIR = join(fileURLToPath(new URL('.', import.meta.url)));
+
+/** Asserting a derived list is empty — the vacuity-prone shape. */
+const EMPTY_ASSERT = [
+  /assert\.deepEqual\(\s*\w+\s*,\s*\[\s*\]/,
+  /assert\.deepStrictEqual\(\s*\w+\s*,\s*\[\s*\]/,
+  /assert\.equal\(\s*\w+\.length\s*,\s*0\s*\)/,
+  /assert\.strictEqual\(\s*\w+\.length\s*,\s*0\s*\)/,
+];
+
+/**
+ * A set discovered at RUN TIME. `readFileSync` of a named path is excluded on purpose — see the exemptions
+ * above.
+ */
+const ENUMERATES = /readdirSync|execFileSync\('git', \['ls-files|execSync\('git ls-files|allDocsText\(|docFiles\(/;
+
+/** A lower bound proving the enumeration found something. `> 0` counts — it is the most natural way to write it. */
+const HAS_FLOOR = [
+  /assert\.ok\([^;]*\.length\s*>\s*0/,
+  /assert\.ok\([^;]*\.length\s*>=?\s*[1-9]/,
+  /assert\.ok\([^;]*\.size\s*>\s*0/,
+  /assert\.ok\([^;]*\.size\s*>=?\s*[1-9]/,
+  /assert\.ok\(\s*\w+\s*>=?\s*[1-9]/,
+  /length,\s*[1-9]\d*\)/,
+  /toBeGreaterThan/,
+];
+
+/** A hardcoded list cannot silently become empty. */
+const HARDCODED_LIST = /const\s+[A-Z_]+\s*=\s*\[\s*\n?\s*\[?['"[]/;
+
+/** `{ name, enumerates, assertsEmpty, floored }` for one test file's text. */
+export function classifyGate(src) {
+  const assertsEmpty = EMPTY_ASSERT.some(re => re.test(src));
+  const enumerates = ENUMERATES.test(src);
+  const floored = HAS_FLOOR.some(re => re.test(src)) || HARDCODED_LIST.test(src);
+  return { assertsEmpty, enumerates, floored };
+}
+
+const gateFiles = readdirSync(DIR).filter(f => f.endsWith('.test.js')).sort();
+
+describe('no gate can pass while examining nothing', () => {
+  it('every enumerating gate floors its enumeration', () => {
+    const unfloored = [];
+    for (const name of gateFiles) {
+      if (name === 'gates-cannot-pass-vacuously.test.js') continue;   // it floors itself below
+      const c = classifyGate(readFileSync(join(DIR, name), 'utf8'));
+      if (c.assertsEmpty && c.enumerates && !c.floored) unfloored.push(name);
+    }
+    assert.deepEqual(unfloored, [], 'these assert an empty offender list over a run-time enumeration with no '
+      + `floor on it, so a broken enumeration passes green:\n  ${unfloored.join('\n  ')}\n\n`
+      + 'Add one assertion naming what it means, e.g.\n'
+      + '  assert.ok(files.length > 100, `only walked ${files.length} source files`);');
+  });
+
+  it('floors its OWN enumeration', () => {
+    // Without this, the check above is the very thing it forbids.
+    assert.ok(gateFiles.length > 100, `only found ${gateFiles.length} gate files in ${DIR}`);
+  });
+
+  it('finds a meaningful number of enumerating gates — the classifier still works', () => {
+    // If `ENUMERATES` stops matching (a helper renamed, a call rewritten), every gate looks non-enumerating and
+    // this file passes while checking nothing. That is the same defect, one level up.
+    const enumerating = gateFiles.filter(n => {
+      const c = classifyGate(readFileSync(join(DIR, n), 'utf8'));
+      return c.enumerates && c.assertsEmpty;
+    });
+    assert.ok(enumerating.length >= 20, `only ${enumerating.length} enumerating gates recognised`);
+  });
+
+  // ── The classifier must be able to fail ──────────────────────────────────────────────────────────
+  it('flags an enumerating gate with no floor', () => {
+    const bad = `
+      import { readdirSync, readFileSync } from 'node:fs';
+      const files = readdirSync('server/src');
+      it('none', () => {
+        const offenders = files.filter(f => readFileSync(f, 'utf8').includes('bad'));
+        assert.deepEqual(offenders, []);
+      });`;
+    const c = classifyGate(bad);
+    assert.ok(c.enumerates && c.assertsEmpty && !c.floored, JSON.stringify(c));
+  });
+
+  it('accepts the same gate once a floor is added', () => {
+    const good = `
+      import { readdirSync, readFileSync } from 'node:fs';
+      const files = readdirSync('server/src');
+      it('none', () => {
+        assert.ok(files.length > 0, 'the walk found nothing');
+        const offenders = files.filter(f => readFileSync(f, 'utf8').includes('bad'));
+        assert.deepEqual(offenders, []);
+      });`;
+    assert.equal(classifyGate(good).floored, true);
+  });
+
+  it('does not demand a floor from a gate that reads NAMED files', () => {
+    // A missing named file throws. That is loud, so no floor is needed — and demanding one here is what would
+    // make this gate annoying enough to delete.
+    const named = `
+      import { readFileSync } from 'node:fs';
+      it('none', () => {
+        const src = readFileSync('server/src/app.ts', 'utf8');
+        const offenders = [...src.matchAll(/bad/g)];
+        assert.equal(offenders.length, 0);
+      });`;
+    assert.equal(classifyGate(named).enumerates, false);
+  });
+
+  it('does not demand a floor from a hardcoded fixture list', () => {
+    const fixture = `
+      import { readdirSync } from 'node:fs';
+      const SWEEPS = ['a', 'b', 'c'];
+      it('none', () => {
+        const offenders = SWEEPS.filter(s => !readdirSync('x').includes(s));
+        assert.deepEqual(offenders, []);
+      });`;
+    assert.equal(classifyGate(fixture).floored, true);
+  });
+});

--- a/testing/standalone/index-ready-poll.test.js
+++ b/testing/standalone/index-ready-poll.test.js
@@ -52,8 +52,12 @@ function codeOf(file) {
 
 describe('search-index listing is never name-filtered', () => {
   it('no caller passes a name to listSearchIndexes', () => {
+    const all = sources();
+    // Floor the enumeration. Without this a broken walk yields no files, no offenders, and a green gate that
+    // examined nothing — the exact failure this lens pass went looking for.
+    assert.ok(all.length > 100, `only walked ${all.length} source files`);
     const offenders = [];
-    for (const f of sources()) {
+    for (const f of all) {
       const code = codeOf(f);
       code.split('\n').forEach((line, i) => {
         // Anything other than an empty argument list.

--- a/testing/standalone/stale-nested-config-ref.test.js
+++ b/testing/standalone/stale-nested-config-ref.test.js
@@ -177,6 +177,9 @@ describe('no NEW site holds a nested config reference across an await and writes
   }
 
   it('finds none', () => {
+    // Floor the enumeration first: `git ls-files` returning nothing — a moved directory, a changed pathspec —
+    // would make this gate pass while scanning zero files.
+    assert.ok(files.length > 100, `only ${files.length} tracked sources scanned`);
     const offenders = [];
     for (const f of files) {
       for (const h of scanFile(readFileSync(f, 'utf8'))) {


### PR DESCRIPTION
test(standalone): no gate can pass while examining nothing

Audit rotation, lens 10 (Testing & Quality), chosen on the evidence rather than by preference: four gate
defects had surfaced BY ACCIDENT in the previous session — a test reading server-written state from inside
the offline subset, a red run that was a pool-shutdown deadline rather than a test, a metric family
undocumented for two releases, and preflight going red with NO OUTPUT AT ALL once its command line
outgrew a Windows limit.

Most gates here share one shape: enumerate a set discovered at run time (a directory walk, git ls-files),
derive a list of offenders, assert it is empty. If the ENUMERATION breaks — a renamed directory, a changed
pathspec, a declaration syntax that no longer matches — the offender list is empty for the wrong reason
and the gate goes green having checked nothing.

Two live instances: index-ready-poll walked server/src and stale-nested-config-ref scanned git ls-files,
neither asserting the walk found anything. Both now floor their enumeration, with a message that says
what the number means.

gates-cannot-pass-vacuously.test.js makes it a rule for every gate written from now on, enumerated over
testing/standalone/ itself:

- Its exemptions are PROPERTIES OF THE CODE, not blessed filenames. Reading a named file is not
  enumeration (a missing file throws, which is loud); a hardcoded fixture list cannot silently empty. A
  name-based allowlist is the thing that goes stale and quietly grows.
- It floors its own enumeration, and asserts its classifier still recognises at least twenty enumerating
  gates — otherwise a renamed helper makes every gate look non-enumerating and this file passes while
  checking nothing, which is the same defect one level up.
- Four self-tests: it must flag an unfloored gate, accept the same gate once floored, and NOT demand a
  floor from either exempt shape.
- Verified by planting an unfloored gate in the suite and watching the meta-gate fail on it by name.

The scanner behind this corrected itself twice before I trusted it: the first version could not match a
floor written `serverFiles().length > 100` (its character class stopped at the parenthesis) and the second
rejected `> 0` as a floor. Both false positives accused gates that were already correct — one of them
written an hour earlier. A scanner's own false positives are the first thing to check, not the last.
