### PR TITLE
fix(db): a restored backup silently disabled record expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A restored backup silently disabled record expiry.** NDJSON has no date type, so the dump wrote `_expireAt`
+  as a string and the restore returned one. A TTL index only matches BSON dates, so after **any** restore every
+  record the operator had asked to expire became permanent — for as long as that instance ran, with nothing in
+  the log. The instance that loses the guarantee is the one that already had a bad day.
+  - Both sides now use **Extended JSON** (`EJSON`, which ships with the driver). Relaxed mode keeps ordinary
+    values looking like ordinary JSON so a dump stays readable and greppable, while wrapping the types JSON
+    cannot express. **Reading is backward compatible**: on a pre-existing plain-JSON dump `EJSON.parse` behaves
+    exactly as `JSON.parse` did, so old backups still restore — with their old semantics rather than a failure.
+- **A collection the dump recorded as empty did not come back at all.** A dump → drop → restore round trip
+  returned three of four collections and reported success. `initSpace` recreates the per-space ones on the next
+  boot, which is why this was survivable and therefore invisible — but a restore that silently returns less than
+  it took should not rest on a later repair.
+  - Both were found by writing the round-trip the Data-Integrity lens asks for and had never existed: the
+    integration suite proves the endpoints answer, not that the data survives. `backup-restore-round-trip-db.test.js`
+    seeds a 768-float vector, a Date, unicode, an empty string, a nested object and an empty collection, then
+    dumps, **drops the whole database**, restores and compares document for document. Dropping is the point —
+    restoring over live data would let a forgotten collection pass unnoticed.
+
 - **A space recreated with the same id inherited usage it never served, and a renamed space lost its history.**
   `dropSpaceData` removes every collection whose name starts with `<spaceId>_`; `space_activity` is
   **instance-wide**, keyed `<space>:<hour>`, so the prefix drop could not reach it. Found by running the

--- a/server/src/db/dump.ts
+++ b/server/src/db/dump.ts
@@ -20,6 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { MongoClient } from 'mongodb';
+import { EJSON } from 'bson';
 import { log } from '../util/log.js';
 import { dbNameFromUri } from './db-name.js';
 
@@ -73,7 +74,18 @@ export async function dumpDatabase(uri: string, destDir: string): Promise<DumpMa
 
       try {
         for await (const doc of cursor) {
-          stream.write(JSON.stringify(doc) + '\n');
+          // Extended JSON, not `JSON.stringify`.
+          //
+          // NDJSON has no date type, so a plain stringify wrote `_expireAt` as a string — and on restore it came
+          // back a string. The TTL index only matches BSON dates, so every record the operator asked to expire
+          // silently became permanent, for as long as that instance ran. Nothing errors; the retention policy
+          // just stops applying, and only after a restore.
+          //
+          // `EJSON.stringify` in relaxed mode keeps numbers and strings looking like ordinary JSON (so a dump
+          // stays readable and greppable) while wrapping the types JSON cannot express — `{"$date": …}` for a
+          // Date, `{"$oid": …}` for an ObjectId. `EJSON.parse` reverses it, and on a pre-existing plain-JSON dump
+          // it behaves exactly as `JSON.parse` did, so old backups still restore with their old semantics.
+          stream.write(EJSON.stringify(doc, { relaxed: true }) + '\n');
           count++;
         }
       } finally {

--- a/server/src/db/restore.ts
+++ b/server/src/db/restore.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
 import { MongoClient } from 'mongodb';
+import { EJSON } from 'bson';
 import type { DumpManifest } from './dump.js';
 import { log } from '../util/log.js';
 import { dbNameFromUri } from './db-name.js';
@@ -48,6 +49,20 @@ export async function restoreDatabase(uri: string, srcDir: string): Promise<void
         continue;
       }
 
+      // A collection the dump recorded as EMPTY still has to come back.
+      //
+      // Skipping it left the restored instance without the collection at all: a dump→drop→restore round trip
+      // returned three of four collections and reported success. `initSpace` recreates the per-space ones on the
+      // next boot, which is why this was survivable and therefore invisible — but a restore that silently
+      // returns less than it took is not something to leave resting on a later repair.
+      if (expectedCount === 0) {
+        await db.createCollection(name).catch(() => {
+          // Already there (a restore over a live database) — nothing to do.
+        });
+        log.debug(`restore: ${name} ← 0 docs (collection created)`);
+        continue;
+      }
+
       // Drop existing data before restoring
       await db.collection(name).drop().catch(() => {
         // Ignore "ns not found" — collection may not exist yet on a fresh DB
@@ -66,7 +81,10 @@ export async function restoreDatabase(uri: string, srcDir: string): Promise<void
       for await (const line of rl) {
         const trimmed = line.trim();
         if (!trimmed) continue;
-        batch.push(JSON.parse(trimmed) as Record<string, unknown>);
+        // Extended JSON, matching the dump. On a pre-existing plain-JSON dump this behaves exactly as
+        // `JSON.parse` did — EJSON only reinterprets the `$date`/`$oid` wrappers it wrote itself — so older
+        // backups still restore, with their old (string-dated) semantics rather than a hard failure.
+        batch.push(EJSON.parse(trimmed) as Record<string, unknown>);
 
         if (batch.length >= INSERT_BATCH_SIZE) {
           await col.insertMany(batch, { ordered: false });

--- a/testing/standalone/backup-restore-round-trip-db.test.js
+++ b/testing/standalone/backup-restore-round-trip-db.test.js
@@ -1,0 +1,165 @@
+/**
+ * Database-level test: a backup actually restores. Every collection, every document, every value.
+ *
+ * ## Why this did not exist
+ *
+ * `dumpDatabase` and `restoreDatabase` have shipped since the migration feature, and the endpoints that drive
+ * them are exercised by the integration suite — which proves they answer, not that the data survives. The
+ * Data-Integrity lens names the gap exactly: *backup/restore round-trip actually verified*. A backup nobody has
+ * restored is a belief, not a backup, and the failure mode is the worst kind: discovered when it is needed.
+ *
+ * ## What is asserted
+ *
+ * Seed a populated space, dump, **destroy the database**, restore, and compare document-for-document — including
+ * the two things a naive round-trip loses without anyone noticing:
+ *
+ *   - **BSON types.** `_expireAt` is a `Date`, and NDJSON has no date type. A round-trip through
+ *     `JSON.stringify` turns it into a string, the TTL index stops matching it, and records that should expire
+ *     never do — silently, for as long as the instance runs.
+ *   - **Embeddings.** A vector is an array of ~768 floats. Precision loss or truncation there does not throw; it
+ *     degrades recall, which nobody attributes to a restore weeks later.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/backup-restore-round-trip-db.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason, testMongoUri } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'roundtrip';
+const DB = 'ythril_harness_roundtrip';
+
+let mongo, dumpDatabase, restoreDatabase, dir, uri;
+
+/** A populated space: records with a vector, a Date, unicode, and an empty-but-present collection. */
+const SEED = {
+  [`${SPACE}_memories`]: [
+    {
+      _id: 'm1', spaceId: SPACE, fact: 'Ünïcode — em dash, quotes "x", emoji 🌍', tags: ['a', 'b'],
+      seq: 1, createdAt: '2026-08-01T10:00:00.000Z', updatedAt: '2026-08-01T10:00:00.000Z',
+      embedding: Array.from({ length: 768 }, (_, i) => (i % 17) / 17 - 0.5),
+      _expireAt: new Date('2026-12-01T00:00:00.000Z'),
+    },
+    { _id: 'm2', spaceId: SPACE, fact: '', tags: [], seq: 2, createdAt: 'x', updatedAt: 'x' },
+  ],
+  [`${SPACE}_entities`]: [
+    { _id: 'e1', spaceId: SPACE, name: 'Acme', type: 'org', seq: 3, properties: { nested: { deep: [1, 2, 3] } } },
+  ],
+  [`${SPACE}_edges`]: [
+    { _id: 'g1', spaceId: SPACE, from: 'e1', to: 'e1', label: 'self', seq: 4 },
+  ],
+  [`${SPACE}_tombstones`]: [],   // present but empty — the manifest must still carry it
+};
+
+describe('backup → restore round-trip', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('roundtrip');
+    ({ dumpDatabase } = await import('../../server/dist/db/dump.js'));
+    ({ restoreDatabase } = await import('../../server/dist/db/restore.js'));
+    uri = testMongoUri(DB);
+    dir = mkdtempSync(join(tmpdir(), 'ythril-roundtrip-'));
+
+    for (const [name, docs] of Object.entries(SEED)) {
+      await mongo.getDb().createCollection(name);
+      if (docs.length) await mongo.col(name).insertMany(docs.map(d => ({ ...d })));
+    }
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('dumps every seeded collection, with counts', async () => {
+    const manifest = await dumpDatabase(uri, dir);
+    const named = new Map(manifest.collections.map(c => [c.name, c.count]));
+    for (const [name, docs] of Object.entries(SEED)) {
+      assert.ok(named.has(name), `${name} is missing from the manifest — it would not be restored`);
+      assert.equal(named.get(name), docs.length, `${name} count`);
+    }
+    assert.ok(existsSync(join(dir, 'manifest.json')));
+  });
+
+  it('restores after the database is DESTROYED — the case a backup exists for', async () => {
+    // Dropping the whole database is the point: restoring over live data proves far less, because a collection
+    // the dump forgot would still be there and the comparison would pass.
+    await dumpDatabase(uri, dir);
+    await mongo.getDb().dropDatabase();
+    assert.equal((await mongo.getDb().listCollections().toArray()).length, 0, 'the database must be empty first');
+
+    await restoreDatabase(uri, dir);
+    const after = (await mongo.getDb().listCollections().toArray()).map(c => c.name).sort();
+    assert.deepEqual(after, Object.keys(SEED).sort(), 'every collection must come back, including the empty one');
+  });
+
+  it('brings every document back byte-for-byte, including unicode and an empty string', async () => {
+    for (const [name, docs] of Object.entries(SEED)) {
+      const restored = await mongo.col(name).find({}).sort({ _id: 1 }).toArray();
+      assert.equal(restored.length, docs.length, `${name} document count`);
+      for (const original of docs) {
+        const got = restored.find(r => r._id === original._id);
+        assert.ok(got, `${name}/${original._id} did not come back`);
+        for (const [k, v] of Object.entries(original)) {
+          if (k === '_expireAt' || k === 'embedding') continue;   // asserted with their own rules below
+          assert.deepEqual(got[k], v, `${name}/${original._id}.${k}`);
+        }
+      }
+    }
+  });
+
+  it('keeps `_expireAt` a Date — a string there silently disables the TTL', async () => {
+    // NDJSON has no date type. Through a naive JSON round-trip this becomes a string, the TTL index stops
+    // matching it, and records that should expire never do. Nothing errors, ever.
+    const m = await mongo.col(`${SPACE}_memories`).findOne({ _id: 'm1' });
+    assert.ok(m._expireAt instanceof Date, `_expireAt came back as ${typeof m._expireAt}`);
+    assert.equal(m._expireAt.toISOString(), '2026-12-01T00:00:00.000Z');
+  });
+
+  it('keeps the embedding intact, to full precision', async () => {
+    // Truncation or precision loss here does not throw — it degrades recall, which nobody attributes to a
+    // restore weeks later.
+    const m = await mongo.col(`${SPACE}_memories`).findOne({ _id: 'm1' });
+    assert.equal(m.embedding.length, 768, 'vector width');
+    const expected = SEED[`${SPACE}_memories`][0].embedding;
+    for (let i = 0; i < expected.length; i++) {
+      assert.equal(m.embedding[i], expected[i], `embedding[${i}]`);
+    }
+  });
+
+  it('keeps nested structures, not a flattened copy', async () => {
+    const e = await mongo.col(`${SPACE}_entities`).findOne({ _id: 'e1' });
+    assert.deepEqual(e.properties, { nested: { deep: [1, 2, 3] } });
+  });
+
+  it('is idempotent — restoring twice leaves one copy, not two', async () => {
+    // Each collection is dropped before insert. If that ever stops being true, a re-run doubles every record and
+    // the duplicate-detector inherits the mess.
+    await restoreDatabase(uri, dir);
+    assert.equal(await mongo.col(`${SPACE}_memories`).countDocuments({}), 2);
+  });
+
+  it('refuses a directory with no manifest instead of restoring nothing quietly', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'ythril-nomanifest-'));
+    try {
+      await assert.rejects(restoreDatabase(uri, empty), /manifest/i);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('the dump is readable NDJSON, one document per line', async () => {
+    // If the format ever changes, this says so here rather than at the moment someone needs the backup.
+    const manifest = JSON.parse(readFileSync(join(dir, 'manifest.json'), 'utf8'));
+    assert.ok(manifest.collections.length >= Object.keys(SEED).length);
+    const file = join(dir, `${SPACE}_entities.ndjson`);
+    assert.ok(existsSync(file), `expected ${file}`);
+    const lines = readFileSync(file, 'utf8').trim().split('\n').filter(Boolean);
+    assert.equal(lines.length, 1);
+    assert.equal(JSON.parse(lines[0])._id, 'e1');
+  });
+});


### PR DESCRIPTION
fix(db): a restored backup silently disabled record expiry

Queue item 5, lens 8's "backup/restore round-trip actually verified". Nobody had restored one: the
integration suite proves the endpoints answer, not that the data survives. A backup nobody has restored
is a belief, not a backup — and the failure mode is the worst kind, discovered when it is needed.

Writing the round-trip found two defects on its first run.

1. `_expireAt` came back as a STRING. NDJSON has no date type, so `JSON.stringify` wrote the Date as a
   string and `JSON.parse` returned one. A TTL index only matches BSON dates, so after any restore every
   record the operator had asked to expire silently became permanent, for as long as that instance ran.
   Nothing errors. The retention policy just stops applying, and only after a restore — so the instance
   that loses the guarantee is the one that already had a bad day.

   Both sides now use Extended JSON (`EJSON`, which ships with the driver). Relaxed mode keeps ordinary
   values looking like ordinary JSON, so a dump stays readable and greppable, while wrapping the types
   JSON cannot express. Reading is backward compatible: `EJSON.parse` on a pre-existing plain-JSON dump
   behaves exactly as `JSON.parse` did, so old backups still restore — with their old semantics rather
   than a hard failure.

2. A collection the dump recorded as EMPTY did not come back at all. A dump→drop→restore round trip
   returned three of four collections and reported success. `initSpace` recreates the per-space ones on
   the next boot, which is why this was survivable and therefore invisible — but a restore that silently
   returns less than it took is not something to leave resting on a later repair.

Gate: backup-restore-round-trip-db (9, real MongoDB). Seeds a populated space — a 768-float vector, a
Date, unicode with an em dash and an emoji, an empty string, a nested object, and a present-but-empty
collection — then dumps, DROPS THE WHOLE DATABASE, restores, and compares document for document.

Dropping the database is the point: restoring over live data proves far less, because a collection the
dump forgot would still be there and the comparison would pass. The vector is compared element by
element, because precision loss there does not throw — it degrades recall, which nobody attributes to a
restore weeks later. Both defects above fail this gate on the pre-fix code.
