### PR TITLE
feat(sync): bound tombstone retention by what peers have actually been served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Tombstones are no longer kept forever — and the bound is a peer watermark, not an expiry date.**
+  `<space>_tombstones` was the last growing collection with no retention at all: one document per deletion,
+  removed only by wiping the space. On an instance whose agents write and delete, the tombstones eventually
+  outnumber the live records and every sync page walks past them.
+  - **An age-based TTL would have been the wrong fix**, and an easy one to ship. Tombstones are served by
+    `seq > sinceSeq`, so a peer offline longer than any window comes back, never learns of the deletion, and
+    pushes its live copy — a retention fix turning into *"deleted records keep coming back"* weeks later, with
+    nothing left to point at. The floor is what peers have **provably been served** instead, so below it every
+    peer has already applied the deletion and resurrection is impossible by construction.
+  - **The prerequisite did not exist.** `lastSeqReceived` / `lastSeqPushed` are our position in a peer's data;
+    nothing recorded a peer's position in ours, because every pull handler read `sinceSeq` off the query string
+    and threw it away. `GET /api/sync/tombstones` now records it as `lastSeqServed` — the same coalesced config
+    write the pull watermark uses, after the read, so a bookkeeping failure can never cost a peer its tombstones.
+  - **Everything unknown resolves to "keep".** A member that has never pulled blocks its space (which is every
+    member until it pulls once after this upgrade); a floor of zero prunes nothing; and *no members* does not
+    mean *no peers* — a manually provisioned peer token, or an asymmetric network only the other side holds,
+    authorises by token space-scope with no member entry, so a space is prunable only when no network lists it
+    **and** no `peerInstanceId` token is scoped to it. `TokenRecord.spaces` omitted means **all** spaces, so one
+    unscoped peer token makes every space unprunable. A single-instance install therefore drops the whole
+    collection, which is the common case and the largest win.
+  - `direction` deliberately does not exclude a member: it governs our outbound behaviour, not what a peer may
+    GET from us. A push-only network never prunes, and the log names the member holding the floor down.
+  - Gates: `tombstone-floor` (33 cases, offline and pure) and `tombstone-prune-db` (9, real MongoDB, including
+    that the tombstone one seq **above** the floor survives). 14 of 14 mutations caught, in both spellings —
+    a floor too high, and a floor where there should be none.
+  - **The file half is not done, and the comment that claimed it was is fixed.**
+    `FileTombstoneDoc.deletedAt` was documented as *"used by peers to prune expired tombstones"*; nothing
+    prunes on it, and the peer pull is issued with no `since` at all. Its retention needs the equivalent built
+    from push acknowledgement, since that wire protocol carries no `seq`.
+
 ### Fixed
+
+- **Renaming a space never moved its usage history — the code was unreachable.** `moveSpaceData` had
+  `return errors;` directly above the block that re-keys `space_activity`, so `renameSpaceActivity` was dead:
+  the renamed space showed a blank Usage panel and the old buckets lingered under an id that no longer existed,
+  which is precisely what the comment above the dead block says it prevents.
+  - It passed review, the test suite and a clean `tsc` because **TypeScript's default for `allowUnreachableCode`
+    only greys the code out in an editor**. Both tsconfigs now set `allowUnreachableCode: false` and
+    `allowUnusedLabels: false`, making the whole defect class a compile error; the repo had exactly one
+    instance, and the server, the client bundle and all 855 client tests build clean with the flag on.
+  - `client/tsconfig.json` does not extend `tsconfig.base.json`, so the flag has to be set in both files or half
+    the codebase keeps the old behaviour. `unreachable-code-is-an-error.test.js` asserts both, and that the four
+    dependent configs still inherit — a one-line silent revert would otherwise take the protection with it.
 
 - **A restored backup silently disabled record expiry.** NDJSON has no date type, so the dump wrote `_expireAt`
   as a string and the restore returned one. A TTL index only matches BSON dates, so after **any** restore every

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,6 +8,11 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // See the note in tsconfig.base.json: a statement after a `return` cost a renamed space its usage history,
+    // and by default tsc only greys it out in an editor. The client does not extend the base config, so the
+    // flag has to be set in both places or half the codebase keeps the old behaviour.
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
     "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true,

--- a/docs/integration-guide/09-sync-api.md
+++ b/docs/integration-guide/09-sync-api.md
@@ -149,6 +149,11 @@ Each array is capped at 500 items. Response includes per-type counters.
 - `GET /api/sync/tombstones?spaceId=general&sinceSeq=0` returns grouped `{ memories, entities, edges, chrono }` tombstones.
 - `POST /api/sync/tombstones` accepts `{ tombstones: [...] }` and applies deletions.
 
+**The `sinceSeq` you send is recorded.** The serving instance stores it as `lastSeqServed` for your peer identity and prunes tombstones that every member has pulled past — that is the only retention bound on the collection, because an age-based one would let a long-absent peer resurrect a deleted record. Two consequences for an integrator:
+
+- **Send your real watermark, and never a value higher than what you have applied.** Claiming a position you have not reached lets the other side drop tombstones you still need.
+- **A peer that never pulls tombstones blocks pruning for its spaces** — deliberately, since "has not pulled" and "has caught up" must not look alike.
+
 ### File Sync Artifacts
 
 - `GET /api/sync/manifest?spaceId=general` returns file digest metadata for delta detection.

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -47,14 +47,15 @@ Sync can be triggered two ways:
 
 ## Watermarks
 
-Two independent high-water marks prevent redundant data transfer:
+Three high-water marks are kept per member. The first two prevent redundant data transfer; the third is what makes deletion records prunable.
 
 | Field | Type | Meaning |
 |-------|------|---------|
 | `lastSeqReceived[spaceId]` | `Record<string,number>` | Highest seq we have ever pulled from this peer for this space |
 | `lastSeqPushed[spaceId]` | `Record<string,number>` | Highest seq we have confirmed pushed to this peer for this space |
+| `lastSeqServed[spaceId]` | `Record<string,number>` | Highest `sinceSeq` this peer has pulled **our** tombstones from — its confirmed position in our data ([details](#lastseqserved--the-mirror-watermark-and-why-tombstone-retention-needs-it)) |
 
-Both are stored per member in the config file. After a successful sync they are written through the coalesced asynchronous config flush (`saveConfigSoon`) rather than a blocking synchronous write — sync bookkeeping never stalls the event loop. If a sync fails mid-way, the watermark is not advanced — the next cycle retries from the last safe point, giving at-least-once delivery semantics (re-delivery is harmless: everything is re-derived from `seq`).
+All three are stored per member in the config file. After a successful sync they are written through the coalesced asynchronous config flush (`saveConfigSoon`) rather than a blocking synchronous write — sync bookkeeping never stalls the event loop. If a sync fails mid-way, the watermark is not advanced — the next cycle retries from the last safe point, giving at-least-once delivery semantics (re-delivery is harmless: everything is re-derived from `seq`).
 
 ---
 
@@ -77,7 +78,7 @@ The sync engine uses two helpers to translate between remote and local space IDs
 | `remoteToLocal(remoteSpaceId)` | Remote space ID | Local space ID (or identity if no mapping) | Pull — storing fetched documents in the correct local collection |
 | `localToRemote(localSpaceId)` | Local space ID | Remote space ID (or identity if no mapping) | Push — querying the peer's API with the space ID it expects |
 
-**Watermark keys** use the **remote** space ID (the one the peer recognises). This ensures that `lastSeqReceived` and `lastSeqPushed` align with the peer's `seq` counters regardless of the local alias.
+**Watermark keys use the LOCAL space ID.** The sync loop iterates `net.spaces` (local IDs) and keys all three watermarks by that value, while sending `remoteSpaceId` on the wire — so an aliased space stores its watermarks under the name this instance uses, not the peer's. That is also what makes them survive a local rename, which rewrites the keys by local ID (`applySpaceRenameToConfig`).
 
 **API calls** (`GET /api/sync/memories?spaceId=...`) always use the **remote** space ID so the peer returns the correct data.
 
@@ -135,6 +136,24 @@ All document `_id` values (`memories`, `entities`, `edges`, `chrono`) are **UUID
 After all four document types (memories, entities, edges, chrono) are pulled, `lastSeqReceived[spaceId]` is advanced to the highest `seq` seen **among documents authored by the peer** (`doc.author.instanceId === member.instanceId`) and written to config. On the next cycle the watermark is passed as `sinceSeq` so the peer returns only documents newer than that point.
 
 Docs that originate from a third instance but were relayed through the peer (e.g. during braintree or pubsub fanout) deliberately do not advance the watermark. Those relayed docs may carry a `seq` assigned by their true author's counter, which can be much higher than the peer's own counter. Allowing them to advance `lastSeqReceived` would cause the engine to skip the peer's locally-written documents on the next pull.
+
+### `lastSeqServed` — the mirror watermark, and why tombstone retention needs it
+
+`lastSeqReceived` and `lastSeqPushed` are **our** position in a peer's data. `lastSeqServed[spaceId]` is the opposite: the highest `sinceSeq` that peer has pulled **our** tombstones from, i.e. the position it has confirmed applying. It is recorded on the serving side by `GET /api/sync/tombstones`, keyed by the authenticated peer, after the read.
+
+It exists because tombstone retention cannot be time-based. Tombstones are served by `seq > sinceSeq`, so a peer that was offline longer than any expiry window comes back, never sees the deletion, and pushes its live copy — the deleted record returns. A floor built from `min(lastSeqServed)` across every member of every network carrying the space has no such hole: below it, every peer has already applied the deletion.
+
+The prune (`brain/tombstone-prune.ts`, every 6 h) therefore deletes tombstones with `seq <= min(lastSeqServed)`, and treats every unknown as a reason to keep:
+
+| situation | outcome |
+|---|---|
+| a member has no `lastSeqServed` for the space | **no prune** — including every member until it pulls once after upgrading |
+| the minimum is 0 | **no prune** |
+| a `peerInstanceId` token is scoped to the space but has no member entry | **no prune** — it can pull and has nowhere to record a position (`TokenRecord.spaces` omitted means *all* spaces) |
+| no network carries the space **and** no peer token reaches it | prune everything — the single-instance case |
+| `member.direction === 'push'` | still counted; direction governs our outbound behaviour, not what a peer may `GET` |
+
+**File tombstones are not covered.** `GET /api/sync/file-tombstones` is issued with no `since`, so the full set crosses the wire every cycle and there is no served position to record. Bounding those needs an acknowledgement-based equivalent on the push side, since that endpoint carries no `seq`.
 
 ---
 

--- a/server/src/api/sync/tombstones.ts
+++ b/server/src/api/sync/tombstones.ts
@@ -15,7 +15,8 @@ import { log } from '../../util/log.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { TombstoneDoc, FileTombstoneDoc } from '../../config/types.js';
-import { spaceAllowed, isNonPeerSyncWrite, NON_PEER_WRITE_MESSAGE, isDirectionalWriteBlocked } from './_shared.js';
+import { spaceAllowed, isNonPeerSyncWrite, NON_PEER_WRITE_MESSAGE, isDirectionalWriteBlocked, callerPeerId } from './_shared.js';
+import { recordServedSeq } from '../../sync/served-watermark.js';
 
 export const syncTombstonesRouter = Router();
 
@@ -27,6 +28,11 @@ export const syncTombstonesRouter = Router();
 /**
  * GET /api/sync/tombstones?spaceId=&networkId=&sinceSeq=
  * Bulk tombstone export for efficient deletion sync.
+ *
+ * Also records how far this peer has been served (`lastSeqServed`), which is what makes the tombstones
+ * prunable at all — see `sync/served-watermark.ts`. This is the right hook for it: `pullFromPeer` calls this
+ * endpoint first, once per space per cycle, with the peer's raw confirmed watermark, whereas the
+ * record-family GETs page with opaque cursors.
  */
 syncTombstonesRouter.get('/tombstones', syncRateLimit, requireAuth, async (req, res) => {
   try {
@@ -40,6 +46,9 @@ syncTombstonesRouter.get('/tombstones', syncRateLimit, requireAuth, async (req, 
     const entities = await listTombstones(spaceId, since, pageSize, 'entity');
     const edges = await listTombstones(spaceId, since, pageSize, 'edge');
     const chrono = await listTombstones(spaceId, since, pageSize, 'chrono');
+
+    // After the read, so a bookkeeping failure can never cost the peer its tombstones.
+    recordServedSeq(callerPeerId(req.authToken as Record<string, unknown>), spaceId, since);
     res.json({
       memories,
       entities,

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -80,6 +80,10 @@ export async function startConfiguredInstanceServices(): Promise<void> {
   // that never enabled them.
   const { startCandidatePrune } = await import('./brain/candidate-prune.js');
   startCandidatePrune();
+  // Drops tombstones every peer has confirmed applying. Deliberately NOT hung off the sync engine: a space
+  // with no peers never syncs, and that is precisely the space whose whole tombstone collection is droppable.
+  const { startTombstonePrune } = await import('./brain/tombstone-prune.js');
+  startTombstonePrune();
   // Redacts the `changes` payload on brain record-edit audit entries past their shorter retention.
   // The entry itself keeps `audit.retentionDays` — only the user content inside it expires early.
   const { startAuditChangeRetention } = await import('./audit/change-retention.js');

--- a/server/src/brain/tombstone-prune.ts
+++ b/server/src/brain/tombstone-prune.ts
@@ -1,0 +1,115 @@
+/**
+ * Bound tombstone retention — the only growing collection that had no bound at all.
+ *
+ * The audit log and webhook deliveries carry per-document TTLs, `space_activity` keeps 90 days, review
+ * findings have `candidate-prune`. `<space>_tombstones` kept one document per deletion forever, and the only
+ * thing that removed them was wiping the space. On an instance whose agents write and delete, the tombstones
+ * eventually outnumber the live records and every sync page walks past them.
+ *
+ * ── Why this is not a TTL ────────────────────────────────────────────────────────────────────────────────
+ *
+ * `listTombstones` serves by `seq > sinceSeq`, so a peer that was away resumes from its own watermark. Delete
+ * by AGE and a peer offline longer than the window comes back, never learns of the deletion, and pushes its
+ * live copy: the retention fix becomes "deleted records keep coming back" weeks later. The floor here is what
+ * peers have provably been served instead — below it, every peer has already applied the deletion, so
+ * resurrection is impossible by construction rather than unlikely. See `sync/served-watermark.ts`.
+ *
+ * ── Why its own timer ────────────────────────────────────────────────────────────────────────────────────
+ *
+ * Not hung off the sync engine: a space with no peers never syncs, and that is exactly the space whose entire
+ * tombstone collection is droppable. Not a Mongo TTL index either — the condition is a per-space number read
+ * from config, which an index cannot express.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+import { runExclusive } from '../util/single-flight.js';
+import { tombstoneFloorForSpace } from '../sync/served-watermark.js';
+import type { TombstoneFloor } from '../sync/served-watermark.js';
+import type { TombstoneDoc } from '../config/types.js';
+
+/** Housekeeping, not correctness — a tombstone kept six hours too long costs nothing. */
+const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;   // 6h
+
+export interface TombstonePruneResult {
+  removed: number;
+  /** Spaces left alone, by reason — logged so "nothing happened" is diagnosable rather than mysterious. */
+  blocked: Record<string, number>;
+}
+
+/**
+ * Delete this space's tombstones at or below a floor already decided.
+ *
+ * Split from the config read so the DELETE can be exercised against a real MongoDB without a config file —
+ * `$lte` on a mixed collection is exactly the kind of thing a hand-written matcher agrees with while the
+ * driver does not. Takes the decision as a value and refuses to invent one: a `prune: false` floor deletes
+ * nothing, which is the behaviour a caller that forgot to check must still get.
+ *
+ * Best-effort and fail-closed: any error leaves the collection alone and returns -1, so a bad read can never
+ * look like "there was nothing to remove".
+ */
+export async function pruneTombstonesToFloor(spaceId: string, floor: TombstoneFloor): Promise<number> {
+  if (!floor.prune) return -1;
+  try {
+    const res = await col<TombstoneDoc>(`${spaceId}_tombstones`)
+      .deleteMany(asFilter<TombstoneDoc>({ seq: { $lte: floor.upTo } }));
+    return res.deletedCount ?? 0;
+  } catch (err) {
+    log.warn(`Tombstone prune (${spaceId}): ${err instanceof Error ? err.message : String(err)}`);
+    return -1;
+  }
+}
+
+/**
+ * Prune one space's record tombstones to the floor its peers have earned.
+ *
+ * Returns the number removed, or -1 when the space was skipped, so the caller can report the two apart.
+ */
+export async function pruneSpaceTombstones(spaceId: string): Promise<number> {
+  let floor: TombstoneFloor;
+  try { floor = tombstoneFloorForSpace(getConfig(), spaceId); } catch { return -1; }
+  return pruneTombstonesToFloor(spaceId, floor);
+}
+
+/** Prune every real (non-proxy) space, reporting what was skipped and why. */
+export async function pruneAllTombstones(): Promise<TombstonePruneResult> {
+  const result: TombstonePruneResult = { removed: 0, blocked: {} };
+  let cfg;
+  try { cfg = getConfig(); } catch { return result; }   // pre-setup
+
+  for (const s of cfg.spaces) {
+    if (s.proxyFor) continue;
+    const floor = tombstoneFloorForSpace(cfg, s.id);
+    if (!floor.prune) {
+      result.blocked[floor.reason] = (result.blocked[floor.reason] ?? 0) + 1;
+      if (floor.blockedBy) {
+        log.debug(`Tombstone prune: space '${s.id}' held by '${floor.blockedBy}' (${floor.reason})`);
+      }
+      continue;
+    }
+    const removed = await pruneSpaceTombstones(s.id);
+    if (removed > 0) result.removed += removed;
+  }
+
+  if (result.removed > 0) {
+    log.info(`Tombstone prune: removed ${result.removed} tombstone(s) every peer has already applied`);
+  }
+  return result;
+}
+
+let _timer: NodeJS.Timeout | null = null;
+
+/**
+ * Start the background prune. Always on: it only removes tombstones every peer has confirmed applying, so
+ * there is no behaviour an operator would want to opt out of and nothing to configure wrong.
+ */
+export function startTombstonePrune(): void {
+  if (_timer) return;
+  _timer = setInterval(() => { void runExclusive('Tombstone prune', () => pruneAllTombstones()); }, PRUNE_INTERVAL_MS);
+  _timer.unref();   // never keep the process alive for housekeeping
+  log.debug('Tombstone prune worker started');
+}
+
+export function stopTombstonePrune(): void {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -765,6 +765,11 @@ export interface NetworkMember {
   lastSyncAt?: string;       // ISO8601 — set only on successful sync
   lastSeqReceived?: Record<string, number>;  // spaceId → last seq ingested from this peer
   lastSeqPushed?: Record<string, number>;    // spaceId → last seq we confirmed pushed to this peer
+  /** spaceId → the highest `sinceSeq` this peer has pulled OUR tombstones from, i.e. the position it has
+   *  confirmed applying. The mirror of the two above: they are our position in the peer's data, this is the
+   *  peer's position in ours, and without it a tombstone can never be safely dropped (see
+   *  `sync/served-watermark.ts`). Monotonic; absent means "never pulled", which blocks pruning. */
+  lastSeqServed?: Record<string, number>;
   consecutiveFailures?: number;  // incremented on each failed sync; reset to 0 on success
   parentInstanceId?: string; // braintree only
   /** Set during a temporary reparent; stores the original parent so it can be restored. */
@@ -1469,8 +1474,18 @@ export interface TombstoneDoc {
 export interface FileTombstoneDoc {
   _id: string;         // UUID
   spaceId: string;
-  path: string;        // relative path (same convention as ManifestEntry.path)
-  deletedAt: string;   // ISO8601 — used by peers to prune expired tombstones
+  /** Relative path (same convention as ManifestEntry.path). NOTE: a path is often personal in itself, so this
+   *  record outliving the file means the file's NAME survives its deletion. That is the reason retention here
+   *  matters, and it is not bounded yet — see below. */
+  path: string;
+  /** ISO8601. **Nothing prunes on this today.** It used to be documented as "used by peers to prune expired
+   *  tombstones", which was never true: the peer pull (`GET /api/sync/file-tombstones`) is called with no
+   *  `since` at all, so the full set goes over the wire every cycle and none of it is ever removed. Record
+   *  tombstones ARE bounded, by a served-seq floor (`sync/served-watermark.ts`); the file half needs the
+   *  equivalent built from push acknowledgement, because its wire protocol has no seq. Until then, treat this
+   *  field as provenance only — a comment describing behaviour that does not exist is worse than none,
+   *  because it stops the next reader looking. */
+  deletedAt: string;
 }
 
 export interface FileMetaDoc {

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -140,7 +140,6 @@ export async function moveSpaceData(oldId: string, newId: string): Promise<strin
     await fs.rename(oldChunks, newChunks);
   } catch { /* ignore — chunks dir may not exist / already moved */ }
 
-  return errors;
   // Usage history follows the space. `space_activity` is instance-wide and its bucket `_id` embeds the
   // space id, so the collection renames above cannot carry it: without this a renamed space starts with a
   // blank Usage panel while its old rows linger under an id that no longer exists.
@@ -152,6 +151,8 @@ export async function moveSpaceData(oldId: string, newId: string): Promise<strin
     // Non-fatal: a rename that otherwise succeeded must not fail over its usage history.
     log.warn(`Could not move activity buckets for the rename ${oldId} -> ${newId}: ${err}`);
   }
+
+  return errors;
 }
 
 /** Apply the logical config changes of a rename: point the space entry at `newId`
@@ -183,7 +184,12 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
       }
     }
 
-    // Update member watermark keys (lastSeqReceived / lastSeqPushed)
+    // Update member watermark keys (lastSeqReceived / lastSeqPushed / lastSeqServed).
+    //
+    // All three are keyed by space id, so a rename that misses one silently resets that watermark to
+    // "unknown". For the two pull watermarks that means re-pulling from 0 (idempotent by seq). For
+    // `lastSeqServed` it means the tombstone prune stops until every member has pulled again — safe, and
+    // invisible, which is why it is carried here rather than left to heal.
     for (const member of net.members) {
       if (member.lastSeqReceived?.[oldId] !== undefined) {
         member.lastSeqReceived[newId] = member.lastSeqReceived[oldId]!;
@@ -192,6 +198,10 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
       if (member.lastSeqPushed?.[oldId] !== undefined) {
         member.lastSeqPushed[newId] = member.lastSeqPushed[oldId]!;
         delete member.lastSeqPushed[oldId];
+      }
+      if (member.lastSeqServed?.[oldId] !== undefined) {
+        member.lastSeqServed[newId] = member.lastSeqServed[oldId]!;
+        delete member.lastSeqServed[oldId];
       }
     }
   }

--- a/server/src/sync/served-watermark.ts
+++ b/server/src/sync/served-watermark.ts
@@ -1,0 +1,191 @@
+/**
+ * How far each peer has been served — the missing half of the sync watermarks.
+ *
+ * `NetworkMember.lastSeqReceived` and `.lastSeqPushed` record OUR position in a peer's data. Nothing
+ * recorded the position a peer reached in OURS: every pull handler reads `sinceSeq` off the query string and
+ * throws it away. That one missing write is why tombstones could never be pruned.
+ *
+ * ── Why a served watermark and not a retention window ────────────────────────────────────────────────────
+ *
+ * Tombstones are served by `seq > sinceSeq` (see `brain/tombstones.ts` and `GET /api/sync/tombstones`), so a
+ * peer that was away resumes from its own watermark and pulls every tombstone above it. Age has nothing to
+ * do with it. Delete a tombstone by age and a peer offline longer than the window comes back, never sees the
+ * deletion, and pushes its live copy — turning a retention fix into "deleted records keep coming back",
+ * weeks later, with no way to tell where the record came from.
+ *
+ * A floor built from what peers have actually been served makes that impossible by construction rather than
+ * unlikely: below the floor, every peer has already applied the deletion.
+ *
+ * ── Everything here fails towards KEEPING ────────────────────────────────────────────────────────────────
+ *
+ * The asymmetry is the whole design. Keeping a tombstone too long costs a few hundred bytes; dropping one too
+ * early resurrects a deleted record. So every unknown resolves to "do not prune", and the reasons are
+ * enumerated rather than defaulted, so a caller can log WHY nothing happened.
+ */
+import { getConfig, saveConfigSoon } from '../config/loader.js';
+import type { Config, NetworkMember } from '../config/types.js';
+
+/** The subset of a member this decision needs — so the pure part is testable without a config. */
+export interface ServedMember {
+  instanceId: string;
+  label?: string;
+  lastSeqServed?: Record<string, number>;
+}
+
+export type TombstoneFloor =
+  /** Safe to delete tombstones with `seq <= upTo`. */
+  | { prune: true; upTo: number; peers: number }
+  /** Not safe. `reason` is for the log; `blockedBy` names the member when one is at fault. */
+  | { prune: false; reason: 'member-never-pulled' | 'peer-token-scoped' | 'floor-at-zero'; blockedBy?: string };
+
+/**
+ * Peer instance ids that can reach `spaceId` through a token rather than a member entry.
+ *
+ * `spaceAllowed` has a documented fallback: a peer we do not list as a member — a manually provisioned peer
+ * token, or an asymmetric network whose config only the other side holds — is authorised by plain token
+ * space-scope. Such a peer pulls tombstones and has no member record to write a watermark to, so its
+ * existence must block pruning entirely.
+ *
+ * **`TokenRecord.spaces` omitted means ALL spaces**, so one unscoped peer token makes every space
+ * unprunable. That is the correct reading of the config, not an oversight: we cannot prove where an
+ * unscoped token has been.
+ */
+export function peerTokensReaching(cfg: Config, spaceId: string): string[] {
+  return (cfg.tokens ?? [])
+    .filter(t => typeof t.peerInstanceId === 'string' && t.peerInstanceId !== '')
+    .filter(t => t.spaces === undefined || t.spaces.includes(spaceId))
+    .map(t => t.peerInstanceId as string);
+}
+
+/** Members of every network that carries this space, deduplicated by instance id. */
+export function membersServing(cfg: Config, spaceId: string): NetworkMember[] {
+  const seen = new Map<string, NetworkMember>();
+  for (const net of cfg.networks ?? []) {
+    if (!net.spaces?.includes(spaceId)) continue;
+    for (const m of net.members ?? []) {
+      if (!seen.has(m.instanceId)) seen.set(m.instanceId, m);
+    }
+  }
+  return [...seen.values()];
+}
+
+/**
+ * The highest seq every peer has provably been served for this space.
+ *
+ * Pure in `members` and `peerTokenIds` so each branch is checkable without a database or a config file — and
+ * these branches are where the data loss would be, not in the delete itself.
+ *
+ * `direction` is deliberately NOT used to exclude a member. It governs what WE do outbound; it does not stop
+ * a peer from issuing a GET. So a `push`-only member still counts, and a network of them never prunes. That
+ * is the safe direction of the trade, and the caller logs which member holds the floor down so it is
+ * diagnosable rather than mysterious.
+ */
+export function tombstoneFloor(
+  members: ServedMember[],
+  spaceId: string,
+  peerTokenIds: string[] = [],
+): TombstoneFloor {
+  const known = new Set(members.map(m => m.instanceId));
+  const stranger = peerTokenIds.find(id => !known.has(id));
+  if (stranger !== undefined) {
+    // A peer that can read us but has nowhere to record a watermark. Nothing it has seen is knowable.
+    return { prune: false, reason: 'peer-token-scoped', blockedBy: stranger };
+  }
+
+  if (members.length === 0) {
+    // No members and no peer tokens: nobody can pull tombstones from this space, so none of them are
+    // carrying information for anyone. This is the single-instance install — the common case, and the
+    // largest win.
+    return { prune: true, upTo: Number.MAX_SAFE_INTEGER, peers: 0 };
+  }
+
+  let floor = Number.MAX_SAFE_INTEGER;
+  for (const m of members) {
+    const served = m.lastSeqServed?.[spaceId];
+    if (typeof served !== 'number' || !Number.isFinite(served)) {
+      return { prune: false, reason: 'member-never-pulled', blockedBy: m.label ?? m.instanceId };
+    }
+    if (served < floor) floor = served;
+  }
+
+  // A floor of zero says the least-advanced peer has confirmed nothing. Nothing to do, and reporting it as
+  // a prune of `seq <= 0` would be a lie in the log.
+  if (floor <= 0) return { prune: false, reason: 'floor-at-zero' };
+
+  return { prune: true, upTo: floor, peers: members.length };
+}
+
+/** Read the config and answer for one space. Thin wrapper so callers do not assemble the inputs twice. */
+export function tombstoneFloorForSpace(cfg: Config, spaceId: string): TombstoneFloor {
+  return tombstoneFloor(membersServing(cfg, spaceId), spaceId, peerTokensReaching(cfg, spaceId));
+}
+
+/**
+ * Fold a newly observed `sinceSeq` into a member's served watermark.
+ *
+ * Monotonic by `Math.max`: a peer may legitimately re-request from an older position (a retry, a restarted
+ * pull, a peer that lost its own watermark), and taking that at face value would drop the floor and re-serve
+ * tombstones we had already dropped. It also must never move on a malformed value — `sinceSeq` arrives as a
+ * query-string integer from a remote caller, and `parseInt('abc')` is `NaN`, which compares false against
+ * everything and would otherwise poison the record.
+ *
+ * Returns the new value, or `null` when nothing should be written — so the caller can skip the config save
+ * entirely on the overwhelmingly common no-change path.
+ */
+export function foldServedSeq(current: number | undefined, observed: number): number | null {
+  if (!Number.isFinite(observed) || !Number.isInteger(observed) || observed <= 0) return null;
+  if (current !== undefined && Number.isFinite(current) && current >= observed) return null;
+  return observed;
+}
+
+/**
+ * Record that `peerInstanceId` has pulled our tombstones for `spaceId` from `sinceSeq`.
+ *
+ * Called from the tombstone pull handler on the hot path, so it is deliberately cheap and silent: it writes
+ * only when the value actually moves, and it uses the same coalesced `saveConfigSoon` as the pull watermark
+ * one layer up. Losing the write on a crash costs a prune cycle, never a tombstone.
+ *
+ * A caller with no peer identity (an admin token, the UI, a manual curl) records nothing. It has no member
+ * entry to write to, and treating a local read as a peer having caught up is exactly the mistake that would
+ * drop tombstones a real peer still needs.
+ */
+export function recordServedSeq(
+  peerInstanceId: string | undefined,
+  spaceId: string,
+  sinceSeq: number,
+): void {
+  let cfg: Config;
+  try { cfg = getConfig(); } catch { return; }   // pre-setup
+  if (applyServedSeq(cfg, peerInstanceId, spaceId, sinceSeq)) saveConfigSoon(cfg);
+}
+
+/**
+ * Write the watermark into a config object; returns whether anything changed.
+ *
+ * Separated from the config read and the save so the decision is testable against a plain object — the branches
+ * that matter (an unknown peer, a network that does not carry the space, a value that must not move) are all
+ * here, and none of them needs a config file or a running instance.
+ *
+ * Mutates `cfg` in place, and takes no `await`, so it cannot be holding a detached reference across a reload
+ * (the mechanism behind #346/#348/#353/#604).
+ */
+export function applyServedSeq(
+  cfg: Config,
+  peerInstanceId: string | undefined,
+  spaceId: string,
+  sinceSeq: number,
+): boolean {
+  if (!peerInstanceId) return false;
+  let changed = false;
+  for (const net of cfg.networks ?? []) {
+    if (!net.spaces?.includes(spaceId)) continue;
+    const m = net.members?.find(x => x.instanceId === peerInstanceId);
+    if (!m) continue;
+    const next = foldServedSeq(m.lastSeqServed?.[spaceId], sinceSeq);
+    if (next === null) continue;
+    m.lastSeqServed ??= {};
+    m.lastSeqServed[spaceId] = next;
+    changed = true;
+  }
+  return changed;
+}

--- a/testing/standalone/tombstone-floor.test.js
+++ b/testing/standalone/tombstone-floor.test.js
@@ -1,0 +1,311 @@
+/**
+ * The tombstone prune floor — every branch that decides whether a deletion record may be dropped.
+ *
+ * ## Why this is the test that matters
+ *
+ * Tombstones had no retention bound at all, and the obvious fix — delete them after N days — is wrong in a way
+ * that only shows up weeks later. They are served by `seq > sinceSeq`, so a peer that was offline longer than
+ * the window comes back, never learns of the deletion, and pushes its live copy: the retention fix turns into
+ * "deleted records keep coming back", with nothing left to point at.
+ *
+ * So the floor is built from what peers have provably been served, and **every unknown must resolve to "keep"**.
+ * That asymmetry is the whole design: keeping a tombstone too long costs a few hundred bytes, dropping one too
+ * early resurrects a deleted record. The cases below are that asymmetry, one branch at a time — all pure, so
+ * none of them needs a database or a config file.
+ *
+ * Mutation-checked in both spellings of the defect:
+ *   - floor too HIGH (`Math.max` instead of the minimum, or ignoring a member with no record) → a tombstone a
+ *     peer still needs is deleted. Caught by "the minimum wins" and "a member that never pulled blocks".
+ *   - floor absent (treating "no members" as "no peers") → the whole collection goes on an instance a peer
+ *     token can still read. Caught by the peer-token cases.
+ *
+ * Run: node --test testing/standalone/tombstone-floor.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+let tombstoneFloor, tombstoneFloorForSpace, foldServedSeq, peerTokensReaching, membersServing, applyServedSeq;
+
+/** Repo root — vitest-style `import.meta.url` URL building is not portable here, and this file is run by node. */
+const ROOT = process.cwd();
+
+before(async () => {
+  ({ tombstoneFloor, tombstoneFloorForSpace, foldServedSeq, peerTokensReaching, membersServing, applyServedSeq } =
+    await import('../../server/dist/sync/served-watermark.js'));
+});
+
+const SPACE = 'kb';
+
+/** A member that has pulled up to `seq`. */
+const served = (instanceId, seq, spaceId = SPACE) => ({
+  instanceId, label: instanceId, lastSeqServed: { [spaceId]: seq },
+});
+
+describe('tombstone floor — when a deletion record may be dropped', () => {
+  it('drops everything when there is no peer at all — the single-instance install', () => {
+    // The common case and the largest win: nobody can pull tombstones from this space, so not one of them is
+    // carrying information for anyone.
+    const f = tombstoneFloor([], SPACE, []);
+    assert.equal(f.prune, true);
+    assert.equal(f.peers, 0);
+    assert.ok(f.upTo >= Number.MAX_SAFE_INTEGER, `upTo was ${f.upTo}, so tombstones would survive`);
+  });
+
+  it('takes the MINIMUM served position, not the maximum', () => {
+    // A `Math.max` here deletes tombstones the slowest peer has never seen. This is the mutation that loses
+    // data, and it passes every "does it prune?" test that does not check the number.
+    const f = tombstoneFloor([served('a', 900), served('b', 40), served('c', 12_000)], SPACE);
+    assert.equal(f.prune, true);
+    assert.equal(f.upTo, 40);
+  });
+
+  it('order does not decide it', () => {
+    const asc = tombstoneFloor([served('a', 5), served('b', 90)], SPACE);
+    const desc = tombstoneFloor([served('b', 90), served('a', 5)], SPACE);
+    assert.deepEqual(asc, desc);
+    assert.equal(asc.upTo, 5);
+  });
+
+  it('a member that has never pulled BLOCKS the prune, and is named', () => {
+    // Absence of evidence is not evidence of having caught up. This is also every member's state immediately
+    // after an upgrade, so a fresh instance prunes nothing until it has earned the right to.
+    const f = tombstoneFloor([served('a', 900), { instanceId: 'b', label: 'branch-office' }], SPACE);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'member-never-pulled');
+    assert.equal(f.blockedBy, 'branch-office');
+  });
+
+  it('a record for a DIFFERENT space does not count as this space', () => {
+    const f = tombstoneFloor([{ instanceId: 'a', lastSeqServed: { other: 5_000 } }], SPACE);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'member-never-pulled');
+  });
+
+  it('rejects a non-numeric or non-finite record instead of coercing it', () => {
+    for (const bad of [undefined, null, NaN, Infinity, '900', {}]) {
+      const f = tombstoneFloor([{ instanceId: 'a', lastSeqServed: { [SPACE]: bad } }], SPACE);
+      assert.equal(f.prune, false, `${String(bad)} was treated as a position`);
+    }
+  });
+
+  it('a floor of zero prunes nothing, and says so', () => {
+    // `seq <= 0` matches no tombstone, and reporting it as a prune would put a lie in the log.
+    const f = tombstoneFloor([served('a', 0)], SPACE);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'floor-at-zero');
+  });
+
+  it('one advanced peer cannot carry a peer that has confirmed nothing', () => {
+    const f = tombstoneFloor([served('a', 50_000), served('b', 0)], SPACE);
+    assert.equal(f.prune, false);
+  });
+
+  // ── The peer that has no member entry ────────────────────────────────────────────────────────────
+  //
+  // `spaceAllowed` authorises a manually provisioned peer token, or an asymmetric network we do not hold the
+  // config for, by plain token space-scope — with no member record to write a watermark to. Treating "no
+  // members" as "no peers" would drop the whole collection out from under such a peer.
+
+  it('a peer token with no member entry blocks the prune', () => {
+    const f = tombstoneFloor([], SPACE, ['ghost-instance']);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'peer-token-scoped');
+    assert.equal(f.blockedBy, 'ghost-instance');
+  });
+
+  it('blocks even when every KNOWN member is fully caught up', () => {
+    const f = tombstoneFloor([served('a', 9_000)], SPACE, ['a', 'ghost-instance']);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'peer-token-scoped');
+  });
+
+  it('a peer token that IS a member does not block — it has somewhere to record', () => {
+    const f = tombstoneFloor([served('a', 700)], SPACE, ['a']);
+    assert.equal(f.prune, true);
+    assert.equal(f.upTo, 700);
+  });
+});
+
+describe('reading the config — who can reach this space', () => {
+  /** Minimal config shaped like the real one. */
+  const cfg = (over = {}) => ({
+    instanceId: 'self', instanceLabel: 'self', tokens: [], spaces: [{ id: SPACE }], networks: [], ...over,
+  });
+
+  it('counts a peer token scoped to the space', () => {
+    const c = cfg({ tokens: [{ id: 't1', peerInstanceId: 'p1', spaces: [SPACE] }] });
+    assert.deepEqual(peerTokensReaching(c, SPACE), ['p1']);
+  });
+
+  it('an UNSCOPED peer token reaches every space — omitted `spaces` means all', () => {
+    // The trap: `spaces: undefined` reads as "no spaces" if you only check `includes`. It means the opposite,
+    // and one such token makes every space unprunable. We cannot prove where an unscoped token has been.
+    const c = cfg({ tokens: [{ id: 't1', peerInstanceId: 'p1' }] });
+    assert.deepEqual(peerTokensReaching(c, SPACE), ['p1']);
+    assert.deepEqual(peerTokensReaching(c, 'some-other-space'), ['p1']);
+    assert.equal(tombstoneFloorForSpace(c, SPACE).prune, false);
+  });
+
+  it('ignores an ordinary token — only a peer token can pull sync', () => {
+    const c = cfg({ tokens: [{ id: 't1', spaces: [SPACE] }, { id: 't2', admin: true }] });
+    assert.deepEqual(peerTokensReaching(c, SPACE), []);
+    assert.equal(tombstoneFloorForSpace(c, SPACE).prune, true);
+  });
+
+  it('ignores a peer token scoped to other spaces only', () => {
+    const c = cfg({ tokens: [{ id: 't1', peerInstanceId: 'p1', spaces: ['elsewhere'] }] });
+    assert.deepEqual(peerTokensReaching(c, SPACE), []);
+  });
+
+  it('ignores an empty-string peerInstanceId rather than blocking on a blank', () => {
+    const c = cfg({ tokens: [{ id: 't1', peerInstanceId: '', spaces: [SPACE] }] });
+    assert.deepEqual(peerTokensReaching(c, SPACE), []);
+  });
+
+  it('collects members from every network carrying the space, deduplicated', () => {
+    const c = cfg({
+      networks: [
+        { id: 'n1', spaces: [SPACE], members: [served('a', 10), served('b', 20)] },
+        { id: 'n2', spaces: [SPACE], members: [served('b', 20), served('c', 30)] },
+        { id: 'n3', spaces: ['elsewhere'], members: [served('z', 1)] },
+      ],
+    });
+    assert.deepEqual(membersServing(c, SPACE).map(m => m.instanceId), ['a', 'b', 'c']);
+  });
+
+  it('takes the min ACROSS networks — a space in two networks answers to both', () => {
+    const c = cfg({
+      networks: [
+        { id: 'n1', spaces: [SPACE], members: [served('a', 5_000)] },
+        { id: 'n2', spaces: [SPACE], members: [served('b', 7)] },
+      ],
+    });
+    const f = tombstoneFloorForSpace(c, SPACE);
+    assert.equal(f.prune, true);
+    assert.equal(f.upTo, 7);
+  });
+
+  it('a member in an unrelated network cannot hold this space back', () => {
+    const c = cfg({
+      networks: [
+        { id: 'n1', spaces: [SPACE], members: [served('a', 300)] },
+        { id: 'n2', spaces: ['elsewhere'], members: [{ instanceId: 'never-pulled' }] },
+      ],
+    });
+    const f = tombstoneFloorForSpace(c, SPACE);
+    assert.equal(f.prune, true);
+    assert.equal(f.upTo, 300);
+  });
+
+  it('survives a config with no networks and no tokens key', () => {
+    const f = tombstoneFloorForSpace({ spaces: [], tokens: [], networks: [] }, SPACE);
+    assert.equal(f.prune, true);
+  });
+});
+
+describe('recording where a peer has been served', () => {
+  const cfg = () => ({
+    instanceId: 'self', instanceLabel: 'self', tokens: [], spaces: [{ id: SPACE }],
+    networks: [{ id: 'n1', spaces: [SPACE], members: [{ instanceId: 'p1', label: 'p1' }] }],
+  });
+
+  it('records the position for the member that pulled', () => {
+    const c = cfg();
+    assert.equal(applyServedSeq(c, 'p1', SPACE, 400), true);
+    assert.equal(c.networks[0].members[0].lastSeqServed[SPACE], 400);
+  });
+
+  it('records nothing for a caller with no peer identity', () => {
+    // An admin token, the UI, a manual curl. Treating a local read as a peer having caught up is exactly how a
+    // tombstone a real peer still needs would get dropped.
+    const c = cfg();
+    assert.equal(applyServedSeq(c, undefined, SPACE, 400), false);
+    assert.equal(c.networks[0].members[0].lastSeqServed, undefined);
+  });
+
+  it('records nothing for a peer we do not list as a member', () => {
+    const c = cfg();
+    assert.equal(applyServedSeq(c, 'stranger', SPACE, 400), false);
+  });
+
+  it('records nothing for a space the network does not carry', () => {
+    const c = cfg();
+    assert.equal(applyServedSeq(c, 'p1', 'elsewhere', 400), false);
+    assert.equal(c.networks[0].members[0].lastSeqServed, undefined);
+  });
+
+  it('reports no change when the value would not move — so the config is not rewritten per request', () => {
+    // This runs on the sync hot path. A write on every pull would rewrite config.json for nothing.
+    const c = cfg();
+    applyServedSeq(c, 'p1', SPACE, 400);
+    assert.equal(applyServedSeq(c, 'p1', SPACE, 400), false);
+    assert.equal(applyServedSeq(c, 'p1', SPACE, 399), false);
+    assert.equal(c.networks[0].members[0].lastSeqServed[SPACE], 400);
+  });
+
+  it('records the same member in every network that carries the space', () => {
+    const c = cfg();
+    c.networks.push({ id: 'n2', spaces: [SPACE], members: [{ instanceId: 'p1', label: 'p1' }] });
+    assert.equal(applyServedSeq(c, 'p1', SPACE, 12), true);
+    assert.equal(c.networks[1].members[0].lastSeqServed[SPACE], 12);
+  });
+
+  it('keeps other spaces\' positions when one advances', () => {
+    const c = cfg();
+    c.networks[0].spaces.push('second');
+    applyServedSeq(c, 'p1', SPACE, 10);
+    applyServedSeq(c, 'p1', 'second', 99);
+    assert.deepEqual(c.networks[0].members[0].lastSeqServed, { [SPACE]: 10, second: 99 });
+  });
+});
+
+describe('the pull handler is actually wired to record it', () => {
+  // Reading a NAMED file, not an enumeration: if it moves, this throws. The decision above is worthless if
+  // nothing calls it, and "the feature quietly stopped recording" looks identical to "no peer has pulled yet" —
+  // which this design deliberately treats as a reason NOT to prune, so the failure would be silent forever.
+  const src = readFileSync(join(ROOT, 'server/src/api/sync/tombstones.ts'), 'utf8');
+
+  it('the tombstone GET records the served position, keyed by the authenticated peer', () => {
+    assert.match(src, /recordServedSeq\(\s*callerPeerId\(/,
+      'GET /api/sync/tombstones no longer records lastSeqServed, so the prune floor can never rise');
+  });
+
+  it('records AFTER the tombstones are read', () => {
+    // Ordering is the claim that a bookkeeping failure cannot cost the peer its tombstones.
+    const read = src.indexOf('listTombstones(spaceId');
+    const record = src.indexOf('recordServedSeq(');
+    assert.ok(read > 0 && record > read, `listTombstones at ${read}, recordServedSeq at ${record}`);
+  });
+
+  it('the space rename carries the new watermark with the other two', () => {
+    // All three are keyed by space id. A rename that misses one resets the floor silently.
+    const rename = readFileSync(join(ROOT, 'server/src/spaces/rename.ts'), 'utf8');
+    for (const key of ['lastSeqReceived', 'lastSeqPushed', 'lastSeqServed']) {
+      assert.ok(rename.includes(`member.${key}?.[oldId] !== undefined`), `rename does not carry ${key}`);
+    }
+  });
+});
+
+describe('the served watermark only ever moves forward', () => {
+  it('accepts a higher position', () => {
+    assert.equal(foldServedSeq(10, 40), 40);
+    assert.equal(foldServedSeq(undefined, 1), 1);
+  });
+
+  it('refuses to go BACKWARDS', () => {
+    // A peer legitimately re-requests from an older position — a retry, a restarted pull, a peer that lost its
+    // own watermark. Taking that at face value drops the floor and re-serves tombstones we already dropped.
+    assert.equal(foldServedSeq(500, 20), null);
+    assert.equal(foldServedSeq(500, 500), null, 'an unchanged value must not trigger a config write');
+  });
+
+  it('refuses a malformed value instead of poisoning the record', () => {
+    // `sinceSeq` is a query-string integer from a remote caller. `parseInt('abc')` is NaN, which compares false
+    // against everything — stored, it would make the member look permanently un-advanceable.
+    for (const bad of [NaN, Infinity, -1, 0, 1.5]) {
+      assert.equal(foldServedSeq(10, bad), null, `${String(bad)} was accepted`);
+    }
+  });
+});

--- a/testing/standalone/tombstone-prune-db.test.js
+++ b/testing/standalone/tombstone-prune-db.test.js
@@ -1,0 +1,135 @@
+/**
+ * Database-level test: the tombstone prune deletes what every peer has applied, and NOTHING above that.
+ *
+ * ## Why the floor gate is not enough
+ *
+ * `tombstone-floor` proves the decision. This proves the delete, against a real MongoDB, because the two ways
+ * this loses data both live in the query rather than the decision:
+ *
+ *   - `$lte` vs `$lt` — an off-by-one at the boundary deletes the tombstone the slowest peer is about to ask
+ *     for. One document, and the record it protects comes back.
+ *   - a filter that matches more than it should — a missing/`null` `seq`, a stringly-typed one, another space's
+ *     collection. A hand-written matcher agrees with the author; the driver is the only authority.
+ *
+ * The direction that matters is the survival assertion, not the removal one: a prune that deletes too little is
+ * housekeeping left undone, and a prune that deletes too much resurrects deleted records on the next sync.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/tombstone-prune-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'tspace';
+const OTHER = 'ospace';
+
+let mongo, pruneTombstonesToFloor, tombstoneFloor;
+
+/** One tombstone per seq, so "which survived" reads directly off the seqs. */
+const tombstone = (seq, spaceId = SPACE) => ({
+  _id: `${spaceId}-doc-${seq}`,
+  spaceId,
+  type: 'memory',
+  deletedAt: '2026-08-01T00:00:00.000Z',
+  instanceId: 'self',
+  seq,
+});
+
+const seqsIn = async (spaceId) => {
+  const rows = await mongo.col(`${spaceId}_tombstones`).find({}).sort({ seq: 1 }).toArray();
+  return rows.map(r => r.seq);
+};
+
+describe('tombstone prune (real MongoDB)', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('tombprune');
+    ({ pruneTombstonesToFloor } = await import('../../server/dist/brain/tombstone-prune.js'));
+    ({ tombstoneFloor } = await import('../../server/dist/sync/served-watermark.js'));
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => {
+    await mongo.col(`${SPACE}_tombstones`).deleteMany({});
+    await mongo.col(`${OTHER}_tombstones`).deleteMany({});
+    await mongo.col(`${SPACE}_tombstones`).insertMany([10, 20, 30, 40, 50].map(s => tombstone(s)));
+    await mongo.col(`${OTHER}_tombstones`).insertMany([10, 20].map(s => tombstone(s, OTHER)));
+  });
+
+  it('deletes at and below the floor, and keeps the rest', async () => {
+    const removed = await pruneTombstonesToFloor(SPACE, { prune: true, upTo: 30, peers: 2 });
+    assert.equal(removed, 3);
+    assert.deepEqual(await seqsIn(SPACE), [40, 50]);
+  });
+
+  it('keeps the tombstone one above the floor — the boundary that loses a record', async () => {
+    // `$lt` where `$lte` is meant (or the reverse) is invisible to a count assertion and deletes exactly the
+    // document the slowest peer is about to ask for.
+    await pruneTombstonesToFloor(SPACE, { prune: true, upTo: 39, peers: 1 });
+    assert.deepEqual(await seqsIn(SPACE), [40, 50]);
+
+    await pruneTombstonesToFloor(SPACE, { prune: true, upTo: 40, peers: 1 });
+    assert.deepEqual(await seqsIn(SPACE), [50], 'seq 40 must go when the floor reaches it');
+  });
+
+  it('does not touch another space\'s tombstones', async () => {
+    await pruneTombstonesToFloor(SPACE, { prune: true, upTo: Number.MAX_SAFE_INTEGER, peers: 0 });
+    assert.deepEqual(await seqsIn(SPACE), []);
+    assert.deepEqual(await seqsIn(OTHER), [10, 20], 'a sibling space was pruned by a per-space sweep');
+  });
+
+  it('deletes NOTHING when the floor says not to prune', async () => {
+    for (const reason of ['member-never-pulled', 'peer-token-scoped', 'floor-at-zero']) {
+      const removed = await pruneTombstonesToFloor(SPACE, { prune: false, reason });
+      assert.equal(removed, -1, `${reason} reported a prune`);
+      assert.deepEqual(await seqsIn(SPACE), [10, 20, 30, 40, 50], `${reason} deleted tombstones`);
+    }
+  });
+
+  it('drops the whole collection for a space with no peers — the single-instance win', async () => {
+    // End to end through the real decision rather than a hand-made floor: no members, no peer tokens.
+    const floor = tombstoneFloor([], SPACE, []);
+    assert.equal(floor.prune, true);
+    const removed = await pruneTombstonesToFloor(SPACE, floor);
+    assert.equal(removed, 5);
+    assert.deepEqual(await seqsIn(SPACE), []);
+  });
+
+  it('leaves a space alone when one member has never pulled — through the real decision', async () => {
+    const floor = tombstoneFloor(
+      [{ instanceId: 'a', lastSeqServed: { [SPACE]: 50 } }, { instanceId: 'b' }],
+      SPACE,
+    );
+    assert.equal(floor.prune, false);
+    await pruneTombstonesToFloor(SPACE, floor);
+    assert.deepEqual(await seqsIn(SPACE), [10, 20, 30, 40, 50]);
+  });
+
+  it('ignores a tombstone with no seq rather than deleting it as if it were zero', async () => {
+    // A legacy or malformed document has no position, so it cannot be proven delivered. MongoDB does NOT match
+    // a missing field against `$lte`, which is the behaviour relied on here — and precisely the kind of thing a
+    // JS matcher gets wrong in the other direction.
+    await mongo.col(`${SPACE}_tombstones`).insertOne({
+      _id: 'legacy', spaceId: SPACE, type: 'memory', deletedAt: '2026-01-01T00:00:00.000Z', instanceId: 'self',
+    });
+    await pruneTombstonesToFloor(SPACE, { prune: true, upTo: Number.MAX_SAFE_INTEGER, peers: 0 });
+    const left = await mongo.col(`${SPACE}_tombstones`).find({}).toArray();
+    assert.deepEqual(left.map(r => r._id), ['legacy']);
+  });
+
+  it('is idempotent — a second sweep removes nothing and reports zero', async () => {
+    await pruneTombstonesToFloor(SPACE, { prune: true, upTo: 30, peers: 1 });
+    const second = await pruneTombstonesToFloor(SPACE, { prune: true, upTo: 30, peers: 1 });
+    assert.equal(second, 0);
+    assert.deepEqual(await seqsIn(SPACE), [40, 50]);
+  });
+
+  it('answers 0, not -1, on a collection that does not exist', async () => {
+    // A space that has never deleted anything must not look like a failed prune in the log.
+    const removed = await pruneTombstonesToFloor('never-used-space', { prune: true, upTo: 99, peers: 0 });
+    assert.equal(removed, 0);
+  });
+});

--- a/testing/standalone/unreachable-code-is-an-error.test.js
+++ b/testing/standalone/unreachable-code-is-an-error.test.js
@@ -1,0 +1,87 @@
+/**
+ * Unreachable code must stay a compile ERROR, in every tsconfig that compiles product code.
+ *
+ * ## The defect that put this here
+ *
+ * `moveSpaceData` ended with:
+ *
+ *     return errors;
+ *     // Usage history follows the space. ...
+ *     try { const { renameSpaceActivity } = await import(...); ... }
+ *
+ * So renaming a space never moved its usage buckets: the renamed space showed a blank Usage panel and the old
+ * rows lingered under an id that no longer existed — the exact failure the comment above the dead block says it
+ * prevents. It survived review, the test suite and a clean `tsc`, because TypeScript's default for
+ * `allowUnreachableCode` is "grey it out in the editor" and nothing else. The gate that would have caught it is
+ * a compiler flag, and it costs nothing.
+ *
+ * ## Why a test about a config file
+ *
+ * The protection is one line, in two files, and deleting either is silent — the build stays green and the
+ * codebase quietly goes back to accepting statements that cannot run. `client/tsconfig.json` deliberately does
+ * NOT extend `tsconfig.base.json`, so the flag genuinely has to be in both places; a single source of truth is
+ * not available to assert instead.
+ *
+ * Reading NAMED files, not an enumeration: if one moves, this throws.
+ *
+ * Run: node --test testing/standalone/unreachable-code-is-an-error.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** Every tsconfig that compiles product code, and what each one covers. */
+const CONFIGS = [
+  ['tsconfig.base.json', 'the server (server/tsconfig.json extends it)'],
+  ['client/tsconfig.json', 'the client app and its specs (both extend it)'],
+];
+
+/** JSON with comments — the repo uses them for exactly the rationale this asserts. */
+const parseJsonc = (text) => JSON.parse(
+  text.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, ''),
+);
+
+describe('unreachable code is a compile error', () => {
+  for (const [file, covers] of CONFIGS) {
+    it(`${file} sets allowUnreachableCode: false — ${covers}`, () => {
+      const cfg = parseJsonc(readFileSync(join(ROOT, file), 'utf8'));
+      assert.equal(
+        cfg.compilerOptions?.allowUnreachableCode, false,
+        `${file} no longer errors on unreachable code, so a statement after a return compiles silently again `
+        + '(that is how renameSpaceActivity ended up dead in moveSpaceData)',
+      );
+    });
+
+    it(`${file} sets allowUnusedLabels: false`, () => {
+      // Same class, same one-line cure: a stray label is either a typo or dead structure.
+      const cfg = parseJsonc(readFileSync(join(ROOT, file), 'utf8'));
+      assert.equal(cfg.compilerOptions?.allowUnusedLabels, false, `${file} allows unused labels`);
+    });
+  }
+
+  it('the server tsconfig still inherits from the base', () => {
+    // If it stops extending, the flag above stops applying to the server and this file's first case would
+    // keep passing while proving nothing about the code it is meant to protect.
+    const server = parseJsonc(readFileSync(join(ROOT, 'server/tsconfig.json'), 'utf8'));
+    assert.match(String(server.extends), /tsconfig\.base\.json$/);
+    assert.equal(server.compilerOptions?.allowUnreachableCode, undefined,
+      'the server config now sets this itself — either fine, or a sign the inheritance broke; check both');
+  });
+
+  it('the client app and spec configs still inherit from client/tsconfig.json', () => {
+    for (const f of ['client/tsconfig.app.json', 'client/tsconfig.spec.json']) {
+      const cfg = parseJsonc(readFileSync(join(ROOT, f), 'utf8'));
+      assert.match(String(cfg.extends), /tsconfig\.json$/, `${f} no longer extends the client base config`);
+    }
+  });
+
+  it('the comment-stripping parser is not the thing being tested', () => {
+    // A parser that quietly returned `{}` would make every assertion above vacuous.
+    const parsed = parseJsonc('{\n  // a line comment\n  "compilerOptions": { "allowUnreachableCode": false }\n}');
+    assert.equal(parsed.compilerOptions.allowUnreachableCode, false);
+    assert.throws(() => parseJsonc('{ not json'));
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,12 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
+    // Unreachable code is an ERROR, not an editor hint. `moveSpaceData` returned before the block that carries
+    // a renamed space's usage history across, so `renameSpaceActivity` never ran — a silent data loss the
+    // reviewer, the tests and `tsc` all walked past, because the default for this flag only greys the code out
+    // in an editor. There is no legitimate use for a statement that cannot run.
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,


### PR DESCRIPTION
## The collection nothing ever deleted from

`<space>_tombstones` was the last growing collection with no retention bound at all: one document per
deletion, kept permanently, removed only by wiping the space. Every other growing collection has a bound —
the audit log and webhook deliveries carry per-document TTLs, `space_activity` keeps 90 days, review
findings have `candidate-prune`. On an instance whose agents write and delete, the tombstones eventually
outnumber the live records and every sync page walks past them.

## Why the obvious fix is the wrong one

A retention window would have been a two-line change, and it would have been a data-loss bug on a delay.

Tombstones are served by `seq > sinceSeq`. A peer that was away resumes from **its own** watermark and pulls
every tombstone above it — age has nothing to do with what it needs. Delete by age and a peer offline longer
than the window comes back, never learns of the deletion, and pushes its live copy. The symptom arrives weeks
after the change, as *"deleted records keep coming back"*, with nothing left to point at.

So the floor is built from what peers have **provably been served**. Below it, every peer has already applied
the deletion, and resurrection is impossible by construction rather than unlikely.

## The prerequisite did not exist

`lastSeqReceived` and `lastSeqPushed` are **our** position in a peer's data. Nothing recorded a peer's
position in **ours**: every pull handler read `sinceSeq` off the query string and threw it away. Confirmed by
grep before designing anything — no `lastSeqServed` / `peerWatermark` / `servedUpTo` anywhere in the tree.

`GET /api/sync/tombstones` is the right hook. `pullFromPeer` calls it first, once per space per cycle, with
the peer's raw confirmed watermark, while the record-family GETs page with opaque cursors. The write happens
**after** the read and goes through the same coalesced config flush the pull watermark uses, so a bookkeeping
failure can never cost a peer its tombstones, and a crash costs a prune cycle rather than a deletion record.

## Every unknown resolves to KEEP

The asymmetry is the whole design: a tombstone kept too long costs a few hundred bytes, one dropped too early
resurrects a deleted record.

| situation | outcome |
|---|---|
| a member has no recorded position | **no prune** — including every member until it pulls once after this upgrade |
| the minimum position is 0 | **no prune** |
| a `peerInstanceId` token is scoped to the space but has no member entry | **no prune** |
| no network carries the space **and** no peer token reaches it | prune everything |
| `member.direction === 'push'` | still counted |

Two of those rows are the ones worth arguing about.

**"No members" is not "no peers."** `spaceAllowed` has a documented fallback: a manually provisioned peer
token, or an asymmetric network whose config only the other side holds, is authorised by plain token
space-scope with **no member entry to write a watermark to**. So a space is prunable only when no network
lists it *and* no peer token is scoped to it — and `TokenRecord.spaces` omitted means **all** spaces, so one
unscoped peer token makes every space unprunable. We cannot prove where an unscoped token has been. A
single-instance install has neither, so it drops the whole collection: the common case, and the largest win.

**`direction` deliberately does not exclude a member.** It governs our outbound behaviour, not what a peer
may `GET` from us, so a `push`-only member can still pull. Consequence, accepted: a push-only network never
prunes. The log names the member holding the floor down so this is diagnosable rather than mysterious.

## Gates

- **`tombstone-floor`** — 33 cases, offline and pure. The minimum wins rather than the maximum, order does
  not decide it, a non-numeric position is refused rather than coerced, an unscoped peer token blocks every
  space, a space in two networks answers to both, the watermark never moves backwards, and the pull handler
  is actually wired to record it (reading named files — the decision is worthless if nothing calls it, and
  "stopped recording" looks identical to "no peer has pulled yet", which this design treats as a reason not
  to prune, so the failure would be silent forever).
- **`tombstone-prune-db`** — 9 cases against a real MongoDB, including that the tombstone one seq **above**
  the floor survives, that a sibling space is untouched, and that a legacy tombstone with no `seq` is not
  treated as zero (MongoDB does not match a missing field against `$lte` — precisely what a hand-written
  matcher gets wrong).
- **14 of 14 mutations caught**, in both spellings of the defect: a floor too high (deletes what a peer still
  needs) and a floor where there should be none (deletes the collection under a peer-token peer).

## Two things found on the way

**1. Renaming a space never moved its usage history, because the code was unreachable.**

```ts
  return errors;
  // Usage history follows the space. ...
  try { const { renameSpaceActivity } = await import(...); ... }
```

So `renameSpaceActivity` was dead: a renamed space showed a blank Usage panel while the old buckets lingered
under an id that no longer existed — exactly what the comment above the dead block says it prevents. It
passed review, the test suite and a clean `tsc`, because **TypeScript's default for `allowUnreachableCode`
only greys the code out in an editor.**

Both tsconfigs now set `allowUnreachableCode: false` and `allowUnusedLabels: false`, making the whole class a
compile error. The repo had exactly one instance; the server, the client bundle and all 855 client tests
build clean with the flag on. `client/tsconfig.json` does not extend `tsconfig.base.json`, so it has to be
set in both files or half the codebase keeps the old behaviour — `unreachable-code-is-an-error.test.js`
asserts both, plus that the four dependent configs still inherit, because a one-line silent revert would
otherwise take the protection with it.

**2. `docs/sync-protocol.md` had the watermark keyspace backwards.** It claimed watermark keys use the
**remote** space id. They use the **local** one: the sync loop iterates `net.spaces` (local ids) and keys all
three watermarks by that value while sending `remoteSpaceId` on the wire. The rename path agrees with the
code, so the doc was the odd one out. Corrected in place — it is load-bearing for the field added here.

## Deliberately not in this change

File tombstones. `FileTombstoneDoc.deletedAt` was documented as *"used by peers to prune expired
tombstones"*, and nothing prunes on it — the comment is fixed here. Their pull is issued with **no `since`
at all**, so the full set crosses the wire every cycle and there is no served position to record. Bounding
them needs an acknowledgement-based equivalent on the push side (a 200 from `POST /file-tombstones` proves
the peer recorded it and will re-propagate), which also fixes a payload that grows with every file ever
deleted. That is its own change, and it is the half that carries the privacy weight, since a file path is
often personal in itself.

---

`npm run preflight` **PASSED**. Record tombstones carry no content — id, type, `deletedAt`, `seq` — so record
erasure was already clean; this is about the collection that never stopped growing.
