### PR TITLE
feat(sync): bound file-tombstone retention, so a deleted file stops keeping its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     prunes on it, and the peer pull is issued with no `since` at all. Its retention needs the equivalent built
     from push acknowledgement, since that wire protocol carries no `seq`.
 
+- **File tombstones are bounded too — so deleting a file no longer keeps its name forever.** This is the half
+  with the privacy weight: `FileTombstoneDoc.path` is often personal in itself (`patients/john-doe-2024.pdf`),
+  so the record outliving the file meant the file's **name** survived its deletion, permanently.
+  - **A different mechanism, because there is no `seq` to build a floor from.** File tombstones are keyed by
+    `deletedAt`, so the confirmation comes from the **push**: `POST /api/sync/file-tombstones` upserts what it
+    receives and re-propagates it onward, so a 200 proves that peer holds it and will keep passing it on —
+    which makes dropping our copy safe transitively. The engine previously discarded that response
+    (*"Ignore response — best-effort"*); it now records the newest `deletedAt` **from the array it actually
+    sent**, because a file deleted between building the body and reading the reply was never in the payload.
+  - **Only a 200 acknowledges anything.** A 403 is a direction-blocked peer that will never accept our
+    tombstones, and a timeout proves nothing at all; both leave the position unknown, which blocks pruning.
+  - **Timestamps are only compared in the fixed-width UTC form.** ISO8601 sorts lexically as `…Z`, but an
+    offset form (`+02:00`) sorts later while being earlier in real time, so it would move the floor past
+    tombstones nobody has acknowledged. Anything not matching the exact form is treated as unknown.
+  - **The pull is deliberately left unfiltered**, and the reasoning is pinned by a test because the
+    "optimisation" is the obvious next edit. Sending `since=<last pulled>` would skip an old deletion relayed
+    onward later — the tombstone is older than the watermark, so it is never seen and the file stays. The
+    payload problem it would address is already solved by the prune: once every peer's copy is bounded, the
+    full set *is* small.
+  - Gates: `file-tombstone-ack` (18 cases) and `file-tombstone-prune-db` (8, real MongoDB, including that a
+    tombstone with no `deletedAt` is not treated as the epoch — MongoDB does not match a missing field against
+    `$lte`, which is the behaviour relied on). 10 of 10 mutations caught.
+
 ### Fixed
 
 - **Renaming a space never moved its usage history — the code was unreachable.** `moveSpaceData` had

--- a/docs/integration-guide/09-sync-api.md
+++ b/docs/integration-guide/09-sync-api.md
@@ -157,8 +157,15 @@ Each array is capped at 500 items. Response includes per-type counters.
 ### File Sync Artifacts
 
 - `GET /api/sync/manifest?spaceId=general` returns file digest metadata for delta detection.
-- `GET /api/sync/file-tombstones?spaceId=general&since=<ISO>` returns file delete tombstones.
+- `GET /api/sync/file-tombstones?spaceId=general&since=<ISO>` returns file delete tombstones. **The sync engine
+  deliberately omits `since`**: a file tombstone carries its original `deletedAt` and can be relayed onward long
+  afterwards, so filtering by it would skip an older deletion arriving late and the file would stay. Use it only
+  if you can tolerate that.
 - `POST /api/sync/file-tombstones` applies file delete tombstones (`{ spaceId, tombstones: [...] }`).
+  **Your `200` is an acknowledgement.** The sender records the newest `deletedAt` in the batch as your confirmed
+  position and eventually drops its own copies below the minimum across all members — so answer `200` only once
+  the tombstones are durably recorded. `{ applied: 0 }` is a valid acknowledgement (the upsert is idempotent);
+  a non-2xx or a timeout means the sender keeps its copies, which is the safe direction.
 
 ### Merkle Consistency Check
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -47,13 +47,14 @@ Sync can be triggered two ways:
 
 ## Watermarks
 
-Three high-water marks are kept per member. The first two prevent redundant data transfer; the third is what makes deletion records prunable.
+Four high-water marks are kept per member. The first two prevent redundant data transfer; the last two are what make deletion records prunable.
 
 | Field | Type | Meaning |
 |-------|------|---------|
 | `lastSeqReceived[spaceId]` | `Record<string,number>` | Highest seq we have ever pulled from this peer for this space |
 | `lastSeqPushed[spaceId]` | `Record<string,number>` | Highest seq we have confirmed pushed to this peer for this space |
 | `lastSeqServed[spaceId]` | `Record<string,number>` | Highest `sinceSeq` this peer has pulled **our** tombstones from — its confirmed position in our data ([details](#lastseqserved--the-mirror-watermark-and-why-tombstone-retention-needs-it)) |
+| `lastFileTombstoneAckedAt[spaceId]` | `Record<string,string>` | Newest `deletedAt` among FILE tombstones this peer answered `200` to on a push ([details](#lastfiletombstoneackedat--the-same-bound-for-file-tombstones-from-acknowledgement)) |
 
 All three are stored per member in the config file. After a successful sync they are written through the coalesced asynchronous config flush (`saveConfigSoon`) rather than a blocking synchronous write — sync bookkeeping never stalls the event loop. If a sync fails mid-way, the watermark is not advanced — the next cycle retries from the last safe point, giving at-least-once delivery semantics (re-delivery is harmless: everything is re-derived from `seq`).
 
@@ -153,7 +154,19 @@ The prune (`brain/tombstone-prune.ts`, every 6 h) therefore deletes tombstones w
 | no network carries the space **and** no peer token reaches it | prune everything — the single-instance case |
 | `member.direction === 'push'` | still counted; direction governs our outbound behaviour, not what a peer may `GET` |
 
-**File tombstones are not covered.** `GET /api/sync/file-tombstones` is issued with no `since`, so the full set crosses the wire every cycle and there is no served position to record. Bounding those needs an acknowledgement-based equivalent on the push side, since that endpoint carries no `seq`.
+### `lastFileTombstoneAckedAt` — the same bound for file tombstones, from acknowledgement
+
+File tombstones carry no `seq` (they are keyed by `deletedAt`) and their pull is unfiltered, so there is no served position to record. Their floor comes from the **push** instead: `POST /api/sync/file-tombstones` upserts every tombstone it receives and re-propagates it onward, so a **200** proves that peer now holds it and will keep passing it on — which makes dropping the local copy safe transitively.
+
+`lastFileTombstoneAckedAt[spaceId]` is the newest `deletedAt` in a set the member answered 200 to, and the prune deletes file tombstones at or below `min()` of it across the space's members. Three rules make it safe:
+
+- **The position comes from the array that was sent**, never from a fresh query — a file deleted between building the body and reading the reply was not in the payload.
+- **Only a 200 counts.** A 403 (direction-blocked peer) or a timeout leaves the position unknown, which blocks pruning. `applied: 0` still counts: the upsert is idempotent, so a peer that already held them all legitimately answers zero.
+- **Timestamps are compared only in the fixed-width `…Z` form**, which sorts lexically. An offset form (`+02:00`) sorts later while being earlier in real time, so anything else is treated as unknown rather than compared.
+
+**The file-tombstone pull is deliberately NOT filtered by `since`.** A file tombstone carries its original `deletedAt` and can reach a peer long after that timestamp — a third instance's old deletion relayed onward, or a peer back from a week offline. `deletedAt > since` would skip exactly those, and the file they should delete would stay. The payload concern such a filter would address is answered by the prune instead: once every peer's copy is bounded, the full set is small.
+
+This matters more than the record half: `FileTombstoneDoc.path` is often personal in itself, so an unbounded collection means a deleted file's **name** is retained indefinitely.
 
 ---
 

--- a/server/src/brain/tombstone-prune.ts
+++ b/server/src/brain/tombstone-prune.ts
@@ -26,13 +26,18 @@ import { log } from '../util/log.js';
 import { runExclusive } from '../util/single-flight.js';
 import { tombstoneFloorForSpace } from '../sync/served-watermark.js';
 import type { TombstoneFloor } from '../sync/served-watermark.js';
-import type { TombstoneDoc } from '../config/types.js';
+import { fileTombstoneFloorForSpace } from '../sync/file-tombstone-ack.js';
+import type { FileTombstoneFloor } from '../sync/file-tombstone-ack.js';
+import type { TombstoneDoc, FileTombstoneDoc } from '../config/types.js';
 
 /** Housekeeping, not correctness — a tombstone kept six hours too long costs nothing. */
 const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;   // 6h
 
 export interface TombstonePruneResult {
+  /** Record tombstones removed (bounded by served seq). */
   removed: number;
+  /** File tombstones removed (bounded by push acknowledgement). */
+  filesRemoved: number;
   /** Spaces left alone, by reason — logged so "nothing happened" is diagnosable rather than mysterious. */
   blocked: Record<string, number>;
 }
@@ -71,30 +76,79 @@ export async function pruneSpaceTombstones(spaceId: string): Promise<number> {
   return pruneTombstonesToFloor(spaceId, floor);
 }
 
-/** Prune every real (non-proxy) space, reporting what was skipped and why. */
+/**
+ * Prune every real (non-proxy) space — record tombstones by served seq, file tombstones by acknowledgement —
+ * reporting what was skipped and why.
+ *
+ * The two halves are counted separately because their floors are independent: a space can be prunable for
+ * records and blocked for files (a peer that pulls but never accepts a push) or the reverse.
+ */
 export async function pruneAllTombstones(): Promise<TombstonePruneResult> {
-  const result: TombstonePruneResult = { removed: 0, blocked: {} };
+  const result: TombstonePruneResult = { removed: 0, filesRemoved: 0, blocked: {} };
   let cfg;
   try { cfg = getConfig(); } catch { return result; }   // pre-setup
 
   for (const s of cfg.spaces) {
     if (s.proxyFor) continue;
+
     const floor = tombstoneFloorForSpace(cfg, s.id);
-    if (!floor.prune) {
+    if (floor.prune) {
+      const removed = await pruneTombstonesToFloor(s.id, floor);
+      if (removed > 0) result.removed += removed;
+    } else {
       result.blocked[floor.reason] = (result.blocked[floor.reason] ?? 0) + 1;
       if (floor.blockedBy) {
         log.debug(`Tombstone prune: space '${s.id}' held by '${floor.blockedBy}' (${floor.reason})`);
       }
-      continue;
     }
-    const removed = await pruneSpaceTombstones(s.id);
-    if (removed > 0) result.removed += removed;
+
+    const fileFloor = fileTombstoneFloorForSpace(cfg, s.id);
+    if (fileFloor.prune) {
+      const removed = await pruneFileTombstonesToFloor(s.id, fileFloor);
+      if (removed > 0) result.filesRemoved += removed;
+    } else {
+      result.blocked[fileFloor.reason] = (result.blocked[fileFloor.reason] ?? 0) + 1;
+      if (fileFloor.blockedBy) {
+        log.debug(`File tombstone prune: space '${s.id}' held by '${fileFloor.blockedBy}' (${fileFloor.reason})`);
+      }
+    }
   }
 
   if (result.removed > 0) {
     log.info(`Tombstone prune: removed ${result.removed} tombstone(s) every peer has already applied`);
   }
+  if (result.filesRemoved > 0) {
+    // Worth its own line: this is the one that stops a deleted file's NAME being retained indefinitely.
+    log.info(`Tombstone prune: removed ${result.filesRemoved} file tombstone(s) every peer has acknowledged`);
+  }
   return result;
+}
+
+/**
+ * Delete this space's FILE tombstones at or below an acknowledged position.
+ *
+ * Split from the config read for the same reason as the record version, and it needs its own query because the
+ * key is a `deletedAt` string rather than a `seq`: ISO8601 UTC timestamps compare lexically in MongoDB, and a
+ * document whose `deletedAt` is missing or malformed does not match `$lte` at all — which is the behaviour
+ * relied on here, since an unparseable timestamp cannot be proven delivered.
+ */
+export async function pruneFileTombstonesToFloor(spaceId: string, floor: FileTombstoneFloor): Promise<number> {
+  if (!floor.prune) return -1;
+  try {
+    const res = await col<FileTombstoneDoc>(`${spaceId}_file_tombstones`)
+      .deleteMany(asFilter<FileTombstoneDoc>({ deletedAt: { $lte: floor.upTo } }));
+    return res.deletedCount ?? 0;
+  } catch (err) {
+    log.warn(`File tombstone prune (${spaceId}): ${err instanceof Error ? err.message : String(err)}`);
+    return -1;
+  }
+}
+
+/** Prune one space's file tombstones to the position its peers have acknowledged. */
+export async function pruneSpaceFileTombstones(spaceId: string): Promise<number> {
+  let floor: FileTombstoneFloor;
+  try { floor = fileTombstoneFloorForSpace(getConfig(), spaceId); } catch { return -1; }
+  return pruneFileTombstonesToFloor(spaceId, floor);
 }
 
 let _timer: NodeJS.Timeout | null = null;

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -765,6 +765,11 @@ export interface NetworkMember {
   lastSyncAt?: string;       // ISO8601 — set only on successful sync
   lastSeqReceived?: Record<string, number>;  // spaceId → last seq ingested from this peer
   lastSeqPushed?: Record<string, number>;    // spaceId → last seq we confirmed pushed to this peer
+  /** spaceId → the newest `deletedAt` among FILE tombstones this peer has answered 200 to on a push.
+   *  File tombstones carry no `seq`, so their retention floor is built from acknowledgement rather than from a
+   *  served position (see `sync/file-tombstone-ack.ts`). Only a 200 may advance it: a direction-blocked peer
+   *  that 403s has NOT taken the deletion, and pruning on a rejected push is how a deleted file comes back. */
+  lastFileTombstoneAckedAt?: Record<string, string>;
   /** spaceId → the highest `sinceSeq` this peer has pulled OUR tombstones from, i.e. the position it has
    *  confirmed applying. The mirror of the two above: they are our position in the peer's data, this is the
    *  peer's position in ours, and without it a tombstone can never be safely dropped (see

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -184,12 +184,13 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
       }
     }
 
-    // Update member watermark keys (lastSeqReceived / lastSeqPushed / lastSeqServed).
+    // Update member watermark keys (lastSeqReceived / lastSeqPushed / lastSeqServed /
+    // lastFileTombstoneAckedAt).
     //
-    // All three are keyed by space id, so a rename that misses one silently resets that watermark to
-    // "unknown". For the two pull watermarks that means re-pulling from 0 (idempotent by seq). For
-    // `lastSeqServed` it means the tombstone prune stops until every member has pulled again — safe, and
-    // invisible, which is why it is carried here rather than left to heal.
+    // All four are keyed by space id, so a rename that misses one silently resets that watermark to
+    // "unknown". For the two pull watermarks that means re-pulling from 0 (idempotent by seq). For the two
+    // retention floors it means the tombstone prune stops until every member has pulled (or acked) again —
+    // safe, and invisible, which is why they are carried here rather than left to heal.
     for (const member of net.members) {
       if (member.lastSeqReceived?.[oldId] !== undefined) {
         member.lastSeqReceived[newId] = member.lastSeqReceived[oldId]!;
@@ -202,6 +203,10 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
       if (member.lastSeqServed?.[oldId] !== undefined) {
         member.lastSeqServed[newId] = member.lastSeqServed[oldId]!;
         delete member.lastSeqServed[oldId];
+      }
+      if (member.lastFileTombstoneAckedAt?.[oldId] !== undefined) {
+        member.lastFileTombstoneAckedAt[newId] = member.lastFileTombstoneAckedAt[oldId]!;
+        delete member.lastFileTombstoneAckedAt[oldId];
       }
     }
   }

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -19,6 +19,7 @@ import { getConfig, saveConfig, saveConfigSoon, getSecrets, getFaceRecognitionCo
 import { toSafeRelPath } from '../util/paths.js';
 import { col, asFilter, asDoc, asBulk } from '../db/mongo.js';
 import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
+import { recordFileTombstoneAck, ackedPositionFrom } from './file-tombstone-ack.js';
 import { recordSyncResult, type SyncCounts } from './history.js';
 import { buildFileManifest } from '../files/manifest.js';
 import { log } from '../util/log.js';
@@ -1127,7 +1128,7 @@ async function syncFiles(
         .find(asFilter<FileTombstoneDoc>({ spaceId }))
         .toArray();
       if (ourTombstones.length > 0) {
-        await peerSafeFetch(
+        const ackResp = await peerSafeFetch(
           `${member.url}/api/sync/file-tombstones?networkId=${encodeURIComponent(networkId)}`,
           {
             ...opts(),
@@ -1135,7 +1136,19 @@ async function syncFiles(
             body: JSON.stringify({ spaceId: remoteSpaceId, tombstones: ourTombstones }),
           },
         );
-        // Ignore response — best-effort; peer will log errors internally.
+        // A 200 is a real acknowledgement, and it used to be thrown away. The peer upserts every tombstone it
+        // receives and re-propagates it onward, so a 200 proves this peer now holds them — which is what lets us
+        // drop ours (see `sync/file-tombstone-ack.ts`). The position is taken from the array we actually SENT,
+        // never from a fresh query: a file deleted between building this body and reading the response was not in
+        // the payload, and counting it as delivered would drop a tombstone no peer has seen.
+        //
+        // Anything other than 200 acknowledges nothing. A 403 means a direction-blocked peer that will never
+        // accept our tombstones, and pruning on a rejected push is precisely how a deleted file comes back.
+        if (ackResp.ok) {
+          recordFileTombstoneAck(member.instanceId, spaceId, ackedPositionFrom(ourTombstones));
+        } else {
+          log.debug(`Push file tombstones to ${member.label}: ${ackResp.status} — position not advanced`);
+        }
       }
     } catch (err) {
       log.warn(`Push file tombstones to ${member.label}: ${err}`);

--- a/server/src/sync/file-tombstone-ack.ts
+++ b/server/src/sync/file-tombstone-ack.ts
@@ -1,0 +1,173 @@
+/**
+ * How far each peer has been told about our file deletions — the acknowledgement half of tombstone retention.
+ *
+ * `<space>_file_tombstones` has the same unbounded-growth problem the record tombstones had, plus a privacy
+ * edge the record ones do not: `FileTombstoneDoc.path` is often personal in itself, so deleting a file erases
+ * the file and keeps its **name**, permanently.
+ *
+ * ── Why this cannot reuse the seq floor ──────────────────────────────────────────────────────────────────
+ *
+ * `sync/served-watermark.ts` bounds record tombstones by the `sinceSeq` a peer pulls from. File tombstones have
+ * **no seq at all** — they are keyed by `deletedAt`, and the peer pull is issued with no `since` — so there is
+ * no served position to record.
+ *
+ * The confirmation comes from the PUSH instead, and it is a stronger signal than a pull watermark:
+ * `POST /api/sync/file-tombstones` upserts each tombstone it receives (`$setOnInsert`) and re-propagates it
+ * onward, so a 200 proves that specific peer now holds it. Dropping ours afterwards is therefore safe
+ * transitively — every peer that answered is itself a copy that keeps propagating.
+ *
+ * ── Everything here fails towards KEEPING ────────────────────────────────────────────────────────────────
+ *
+ * Same asymmetry as the record half: a tombstone kept too long is a few hundred bytes, one dropped too early
+ * lets a deleted file come back on the next manifest sync. So a peer whose position is unknown blocks its
+ * space, and "unknown" includes every peer we have never had a 200 from.
+ */
+import type { Config } from '../config/types.js';
+import { getConfig, saveConfigSoon } from '../config/loader.js';
+import { membersServing, peerTokensReaching } from './served-watermark.js';
+
+/** The subset of a member this decision needs — keeps the pure part testable without a config. */
+export interface AckedMember {
+  instanceId: string;
+  label?: string;
+  lastFileTombstoneAckedAt?: Record<string, string>;
+}
+
+export type FileTombstoneFloor =
+  /** Safe to delete file tombstones whose `deletedAt` is at or below `upTo` (ISO8601). */
+  | { prune: true; upTo: string; peers: number }
+  | { prune: false; reason: 'member-never-acked' | 'peer-token-scoped'; blockedBy?: string };
+
+/**
+ * ISO8601 UTC timestamps sort lexically, which is what lets this compare with `<` instead of parsing dates.
+ * That only holds for the fixed-width `Z` form the codebase writes (`new Date().toISOString()`), so anything
+ * else is treated as unknown rather than compared — a `+02:00` offset would sort wrongly and silently move the
+ * floor forward.
+ */
+export function isComparableIso(v: unknown): v is string {
+  return typeof v === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(v);
+}
+
+/**
+ * The newest `deletedAt` every peer has acknowledged, or a reason not to prune.
+ *
+ * Pure in `members` / `peerTokenIds` so every branch is checkable without a database. `direction` is
+ * deliberately not consulted, for the same reason as the record half: it governs our outbound behaviour, not
+ * what a peer holds. A member we never push to simply never acks, and its space is never pruned — safe, and
+ * the caller logs which member is holding the floor.
+ */
+export function fileTombstoneFloor(
+  members: AckedMember[],
+  spaceId: string,
+  peerTokenIds: string[] = [],
+): FileTombstoneFloor {
+  const known = new Set(members.map(m => m.instanceId));
+  const stranger = peerTokenIds.find(id => !known.has(id));
+  if (stranger !== undefined) {
+    return { prune: false, reason: 'peer-token-scoped', blockedBy: stranger };
+  }
+
+  // No members and no peer tokens: these tombstones exist only to propagate, and there is nobody to propagate
+  // to. Nothing is carrying information for anyone, so the path can go.
+  if (members.length === 0) return { prune: true, upTo: '9999-12-31T23:59:59.999Z', peers: 0 };
+
+  let floor: string | null = null;
+  for (const m of members) {
+    const acked = m.lastFileTombstoneAckedAt?.[spaceId];
+    if (!isComparableIso(acked)) {
+      return { prune: false, reason: 'member-never-acked', blockedBy: m.label ?? m.instanceId };
+    }
+    if (floor === null || acked < floor) floor = acked;
+  }
+
+  return { prune: true, upTo: floor as string, peers: members.length };
+}
+
+/** Read the config and answer for one space. */
+export function fileTombstoneFloorForSpace(cfg: Config, spaceId: string): FileTombstoneFloor {
+  return fileTombstoneFloor(membersServing(cfg, spaceId) as AckedMember[], spaceId, peerTokensReaching(cfg, spaceId));
+}
+
+/**
+ * The position a successful push proves, from the array that was actually sent.
+ *
+ * Deliberately computed over the pushed set rather than a fresh query: a file deleted between building the
+ * body and reading the response was never in the payload, and treating it as delivered would drop a tombstone
+ * no peer has seen. Malformed or missing `deletedAt` values are skipped, so one bad row cannot vouch for the
+ * rest — and if none of them is comparable the answer is `null`, meaning "this push proves nothing".
+ */
+export function ackedPositionFrom(pushed: Array<{ deletedAt?: unknown }>): string | null {
+  let max: string | null = null;
+  for (const t of pushed) {
+    if (!isComparableIso(t.deletedAt)) continue;
+    if (max === null || t.deletedAt > max) max = t.deletedAt;
+  }
+  return max;
+}
+
+/**
+ * Fold an acknowledged position into a member's record. Monotonic, and refuses anything not comparable.
+ *
+ * Returns the new value or `null` when nothing should be written, so a caller can skip the config save on the
+ * common no-change path.
+ */
+export function foldAckedAt(current: string | undefined, observed: string | null): string | null {
+  if (observed === null || !isComparableIso(observed)) return null;
+  if (isComparableIso(current) && current >= observed) return null;
+  return observed;
+}
+
+/**
+ * Record that `peerInstanceId` answered 200 to a push containing tombstones up to `ackedAt`.
+ *
+ * **Only a 200 may reach this.** A 403 (a direction-blocked peer that will never accept our tombstones), a
+ * timeout, or a 500 must leave the position unknown: pruning on a push the peer rejected is exactly how a
+ * deleted file comes back.
+ */
+export function recordFileTombstoneAck(
+  peerInstanceId: string | undefined,
+  spaceId: string,
+  ackedAt: string | null,
+): void {
+  let cfg: Config;
+  try { cfg = getConfig(); } catch { return; }   // pre-setup
+  if (applyFileTombstoneAck(cfg, peerInstanceId, spaceId, ackedAt)) saveConfigSoon(cfg);
+}
+
+/** Write the ack into a config object; returns whether anything changed. Mutates in place, takes no `await`. */
+export function applyFileTombstoneAck(
+  cfg: Config,
+  peerInstanceId: string | undefined,
+  spaceId: string,
+  ackedAt: string | null,
+): boolean {
+  if (!peerInstanceId || ackedAt === null) return false;
+  let changed = false;
+  for (const net of cfg.networks ?? []) {
+    if (!net.spaces?.includes(spaceId)) continue;
+    const m = net.members?.find(x => x.instanceId === peerInstanceId);
+    if (!m) continue;
+    const next = foldAckedAt(m.lastFileTombstoneAckedAt?.[spaceId], ackedAt);
+    if (next === null) continue;
+    m.lastFileTombstoneAckedAt ??= {};
+    m.lastFileTombstoneAckedAt[spaceId] = next;
+    changed = true;
+  }
+  return changed;
+}
+
+/*
+ * ── Why the PULL is deliberately left unfiltered ─────────────────────────────────────────────────────────
+ *
+ * The obvious companion change is to send `since=<last pulled>` so an established peer stops re-downloading
+ * every file tombstone it has ever held. It was designed, and then dropped: it trades correctness for a
+ * saving this change already delivers by another route.
+ *
+ * A file tombstone carries the ORIGINAL `deletedAt`, and it can reach a peer long after that timestamp — a
+ * third instance's old deletion relayed onward, a peer that was offline for a week, a network that gained a
+ * member. With `deletedAt > since` we would skip exactly those: the tombstone is older than our watermark, so
+ * we never see it, and the file it should delete stays. `find({spaceId})` with no filter cannot miss one.
+ *
+ * And the payload problem is solved by the prune itself: once every peer's copy is bounded, the full set IS
+ * small. Adding a filter to make an unbounded set cheaper to send is fixing the symptom.
+ */

--- a/testing/standalone/file-tombstone-ack.test.js
+++ b/testing/standalone/file-tombstone-ack.test.js
@@ -1,0 +1,193 @@
+/**
+ * The file-tombstone retention floor — built from acknowledgement, because there is no seq to build it from.
+ *
+ * ## Why this is a different mechanism, not a copy
+ *
+ * Record tombstones are bounded by the `sinceSeq` a peer pulls from (`tombstone-floor.test.js`). File
+ * tombstones have **no seq at all** — they are keyed by `deletedAt` — so the confirmation has to come from the
+ * PUSH: `POST /api/sync/file-tombstones` upserts what it receives and re-propagates it onward, so a 200 proves
+ * that peer now holds it and will keep passing it on.
+ *
+ * That makes three failure modes this file exists for, all of which delete a tombstone no peer has seen:
+ *
+ *   1. **Acking a push that was refused.** A 403 (direction-blocked) or a timeout proves nothing. Advancing on
+ *      anything but a 200 is how a deleted file comes back on the next manifest sync.
+ *   2. **Acking a position from a fresh query** rather than the array that was sent. A file deleted between
+ *      building the body and reading the response was never in the payload.
+ *   3. **Comparing timestamps that do not sort.** ISO8601 UTC compares lexically; an offset form
+ *      (`+02:00`) does not, and would move the floor forward wrongly rather than fail.
+ *
+ * The stake is higher here than for records: `FileTombstoneDoc.path` is often personal in itself, so this is
+ * the half that decides whether a deleted file's NAME is retained forever.
+ *
+ * Run: node --test testing/standalone/file-tombstone-ack.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SPACE = 'kb';
+
+let fileTombstoneFloor, fileTombstoneFloorForSpace, ackedPositionFrom, foldAckedAt, isComparableIso,
+  applyFileTombstoneAck;
+
+before(async () => {
+  ({ fileTombstoneFloor, fileTombstoneFloorForSpace, ackedPositionFrom, foldAckedAt, isComparableIso,
+    applyFileTombstoneAck } = await import('../../server/dist/sync/file-tombstone-ack.js'));
+});
+
+const iso = (day) => `2026-08-${String(day).padStart(2, '0')}T00:00:00.000Z`;
+const acked = (instanceId, day, spaceId = SPACE) => ({
+  instanceId, label: instanceId, lastFileTombstoneAckedAt: { [spaceId]: iso(day) },
+});
+
+describe('file tombstone floor', () => {
+  it('drops everything when there is no peer to propagate to', () => {
+    // A file tombstone exists only to tell peers the file is gone. With no peers it carries the path and
+    // nothing else — which is the privacy finding in one sentence.
+    const f = fileTombstoneFloor([], SPACE, []);
+    assert.equal(f.prune, true);
+    assert.equal(f.peers, 0);
+    assert.ok(f.upTo > iso(31), `upTo was ${f.upTo}, so nothing would match`);
+  });
+
+  it('takes the EARLIEST acknowledged position, not the latest', () => {
+    const f = fileTombstoneFloor([acked('a', 20), acked('b', 3), acked('c', 28)], SPACE);
+    assert.equal(f.prune, true);
+    assert.equal(f.upTo, iso(3));
+  });
+
+  it('order does not decide it', () => {
+    assert.deepEqual(
+      fileTombstoneFloor([acked('a', 5), acked('b', 9)], SPACE),
+      fileTombstoneFloor([acked('b', 9), acked('a', 5)], SPACE),
+    );
+  });
+
+  it('a member that has never acked BLOCKS the prune, and is named', () => {
+    const f = fileTombstoneFloor([acked('a', 20), { instanceId: 'b', label: 'branch-office' }], SPACE);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'member-never-acked');
+    assert.equal(f.blockedBy, 'branch-office');
+  });
+
+  it('an ack for a different space does not count', () => {
+    const f = fileTombstoneFloor([{ instanceId: 'a', lastFileTombstoneAckedAt: { other: iso(20) } }], SPACE);
+    assert.equal(f.prune, false);
+  });
+
+  it('a peer token with no member entry blocks the prune', () => {
+    const f = fileTombstoneFloor([acked('a', 20)], SPACE, ['a', 'ghost']);
+    assert.equal(f.prune, false);
+    assert.equal(f.reason, 'peer-token-scoped');
+    assert.equal(f.blockedBy, 'ghost');
+  });
+
+  it('refuses a timestamp that does not sort lexically', () => {
+    // `2026-08-02T00:00:00+02:00` is EARLIER than `2026-08-02T00:00:00.000Z` in real time but sorts LATER as a
+    // string. Comparing it would move the floor past tombstones nobody has acknowledged.
+    for (const bad of ['2026-08-02T00:00:00+02:00', '2026-08-02', '2026-08-02T00:00:00Z', 1_754_000_000_000, null, '']) {
+      const f = fileTombstoneFloor([{ instanceId: 'a', lastFileTombstoneAckedAt: { [SPACE]: bad } }], SPACE);
+      assert.equal(f.prune, false, `${String(bad)} was accepted as a position`);
+    }
+    assert.equal(isComparableIso(iso(2)), true);
+  });
+
+  it('reads the config: members from every network carrying the space, plus peer tokens', () => {
+    const cfg = {
+      instanceId: 'self', instanceLabel: 'self', spaces: [{ id: SPACE }], tokens: [],
+      networks: [
+        { id: 'n1', spaces: [SPACE], members: [acked('a', 10)] },
+        { id: 'n2', spaces: [SPACE], members: [acked('b', 4)] },
+      ],
+    };
+    assert.equal(fileTombstoneFloorForSpace(cfg, SPACE).upTo, iso(4));
+
+    cfg.tokens = [{ id: 't', peerInstanceId: 'unlisted', spaces: [SPACE] }];
+    assert.equal(fileTombstoneFloorForSpace(cfg, SPACE).prune, false);
+  });
+});
+
+describe('what a push actually proves', () => {
+  it('takes the newest deletedAt from the array that was SENT', () => {
+    const pushed = [{ deletedAt: iso(1) }, { deletedAt: iso(9) }, { deletedAt: iso(4) }];
+    assert.equal(ackedPositionFrom(pushed), iso(9));
+  });
+
+  it('proves nothing from an empty push', () => {
+    assert.equal(ackedPositionFrom([]), null);
+  });
+
+  it('skips a malformed row instead of letting it vouch for the rest', () => {
+    assert.equal(ackedPositionFrom([{ deletedAt: 'yesterday' }, { deletedAt: iso(2) }]), iso(2));
+    assert.equal(ackedPositionFrom([{ deletedAt: 'yesterday' }, {}]), null);
+  });
+
+  it('records an ack, monotonically', () => {
+    const cfg = {
+      spaces: [{ id: SPACE }], tokens: [],
+      networks: [{ id: 'n1', spaces: [SPACE], members: [{ instanceId: 'p1', label: 'p1' }] }],
+    };
+    assert.equal(applyFileTombstoneAck(cfg, 'p1', SPACE, iso(5)), true);
+    assert.equal(cfg.networks[0].members[0].lastFileTombstoneAckedAt[SPACE], iso(5));
+
+    // A later push carrying only OLDER tombstones must not walk the position backwards.
+    assert.equal(applyFileTombstoneAck(cfg, 'p1', SPACE, iso(2)), false);
+    assert.equal(cfg.networks[0].members[0].lastFileTombstoneAckedAt[SPACE], iso(5));
+    assert.equal(applyFileTombstoneAck(cfg, 'p1', SPACE, iso(5)), false, 'no-op must not trigger a config write');
+  });
+
+  it('records nothing without a position — a refused push must leave it unknown', () => {
+    const cfg = {
+      spaces: [{ id: SPACE }], tokens: [],
+      networks: [{ id: 'n1', spaces: [SPACE], members: [{ instanceId: 'p1' }] }],
+    };
+    assert.equal(applyFileTombstoneAck(cfg, 'p1', SPACE, null), false);
+    assert.equal(applyFileTombstoneAck(cfg, undefined, SPACE, iso(5)), false);
+    assert.equal(applyFileTombstoneAck(cfg, 'stranger', SPACE, iso(5)), false);
+    assert.equal(cfg.networks[0].members[0].lastFileTombstoneAckedAt, undefined);
+  });
+
+  it('foldAckedAt refuses an incomparable value rather than storing it', () => {
+    assert.equal(foldAckedAt(undefined, '2026-08-02T00:00:00+02:00'), null);
+    assert.equal(foldAckedAt(undefined, null), null);
+    assert.equal(foldAckedAt('garbage', iso(3)), iso(3), 'a poisoned existing value must be recoverable');
+  });
+});
+
+describe('the engine is wired to ack only a 200', () => {
+  // Named file, so a move throws rather than passing. Two claims are asserted, and both are the difference
+  // between safe and lossy — a source read is the cheapest place to pin them.
+  const src = readFileSync(join(ROOT, 'server/src/sync/engine.ts'), 'utf8');
+
+  it('records the ack from the pushed array, guarded by response.ok', () => {
+    assert.match(src, /if \(ackResp\.ok\)\s*\{\s*\n\s*recordFileTombstoneAck\(member\.instanceId, spaceId, ackedPositionFrom\(ourTombstones\)\)/,
+      'the file-tombstone push no longer acks only on a 200 from the array it sent');
+  });
+
+  it('does not re-query the collection to decide what was acknowledged', () => {
+    // The trap: `find()` again after the push, catching a tombstone created in between and marking it delivered.
+    const block = src.slice(src.indexOf('1b. Push our file tombstones'), src.indexOf('2. Fetch peer manifest'));
+    assert.ok(block.length > 200, 'the push block was not located');
+    assert.equal((block.match(/\.find\(/g) ?? []).length, 1, 'more than one query in the push block');
+  });
+
+  it('the rename carries all four watermarks', () => {
+    const rename = readFileSync(join(ROOT, 'server/src/spaces/rename.ts'), 'utf8');
+    for (const key of ['lastSeqReceived', 'lastSeqPushed', 'lastSeqServed', 'lastFileTombstoneAckedAt']) {
+      assert.ok(rename.includes(`member.${key}?.[oldId] !== undefined`), `rename does not carry ${key}`);
+    }
+  });
+
+  it('the pull is deliberately NOT filtered by `since`, and says why', () => {
+    // A `deletedAt > since` filter would skip an old deletion relayed onward later — the tombstone is older
+    // than our watermark, so we never see it and the file stays. This asserts the reasoning survives, because
+    // the "optimisation" is the obvious next edit somebody makes.
+    const ack = readFileSync(join(ROOT, 'server/src/sync/file-tombstone-ack.ts'), 'utf8');
+    assert.match(ack, /Why the PULL is deliberately left unfiltered/);
+    assert.doesNotMatch(src, /file-tombstones\?spaceId=[^\n]*&since=/,
+      'the file-tombstone pull now sends `since`, which can skip a relayed older deletion');
+  });
+});

--- a/testing/standalone/file-tombstone-prune-db.test.js
+++ b/testing/standalone/file-tombstone-prune-db.test.js
@@ -1,0 +1,121 @@
+/**
+ * Database-level test: the file-tombstone prune deletes what every peer has acknowledged, and nothing above it.
+ *
+ * ## Why a second DB gate rather than a case in the record one
+ *
+ * The key is a `deletedAt` STRING, not a numeric `seq`, and that changes what MongoDB does:
+ *
+ *   - string `$lte` is a lexical comparison, which is only the intended ordering for the fixed-width ISO8601 UTC
+ *     form. A stored offset form (`+02:00`) sorts wrongly, and the driver will happily compare it.
+ *   - a document with **no** `deletedAt` does not match `$lte` at all. That is the behaviour relied on — an
+ *     unparseable timestamp cannot be proven delivered — and it is exactly the case a hand-written JS matcher
+ *     gets backwards (`undefined <= x` is false in JS, but `null` fields DO match some Mongo comparisons).
+ *
+ * The assertion that matters is survival, not removal: a path kept one cycle longer is housekeeping, a path
+ * dropped before a peer acknowledged it means a deleted file returns on the next manifest sync.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/file-tombstone-prune-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'fspace';
+const OTHER = 'ospace';
+
+let mongo, pruneFileTombstonesToFloor, fileTombstoneFloor;
+
+const iso = (day) => `2026-08-${String(day).padStart(2, '0')}T00:00:00.000Z`;
+
+/** One tombstone per day, so "which survived" reads off the days. */
+const tombstone = (day, spaceId = SPACE) => ({
+  _id: `${spaceId}-${day}`,
+  spaceId,
+  path: `patients/report-${day}.pdf`,   // a path is often personal in itself — the reason this prune exists
+  deletedAt: iso(day),
+});
+
+const daysIn = async (spaceId) => {
+  const rows = await mongo.col(`${spaceId}_file_tombstones`).find({}).sort({ deletedAt: 1 }).toArray();
+  return rows.map(r => r.deletedAt);
+};
+
+describe('file tombstone prune (real MongoDB)', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('filetombprune');
+    ({ pruneFileTombstonesToFloor } = await import('../../server/dist/brain/tombstone-prune.js'));
+    ({ fileTombstoneFloor } = await import('../../server/dist/sync/file-tombstone-ack.js'));
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => {
+    await mongo.col(`${SPACE}_file_tombstones`).deleteMany({});
+    await mongo.col(`${OTHER}_file_tombstones`).deleteMany({});
+    await mongo.col(`${SPACE}_file_tombstones`).insertMany([1, 5, 10, 20].map(d => tombstone(d)));
+    await mongo.col(`${OTHER}_file_tombstones`).insertMany([1, 5].map(d => tombstone(d, OTHER)));
+  });
+
+  it('deletes at and below the acknowledged position, keeps the rest', async () => {
+    const removed = await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: iso(10), peers: 2 });
+    assert.equal(removed, 3);
+    assert.deepEqual(await daysIn(SPACE), [iso(20)]);
+  });
+
+  it('keeps the tombstone one tick above the position — the boundary that loses a path', async () => {
+    await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: '2026-08-09T23:59:59.999Z', peers: 1 });
+    assert.deepEqual(await daysIn(SPACE), [iso(10), iso(20)]);
+
+    await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: iso(10), peers: 1 });
+    assert.deepEqual(await daysIn(SPACE), [iso(20)], 'the acknowledged one must go');
+  });
+
+  it('does not touch another space', async () => {
+    await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: iso(31), peers: 0 });
+    assert.deepEqual(await daysIn(SPACE), []);
+    assert.deepEqual(await daysIn(OTHER), [iso(1), iso(5)]);
+  });
+
+  it('deletes NOTHING when no floor was earned', async () => {
+    for (const reason of ['member-never-acked', 'peer-token-scoped']) {
+      const removed = await pruneFileTombstonesToFloor(SPACE, { prune: false, reason });
+      assert.equal(removed, -1, `${reason} reported a prune`);
+      assert.equal((await daysIn(SPACE)).length, 4, `${reason} deleted tombstones`);
+    }
+  });
+
+  it('leaves a tombstone with no deletedAt alone rather than treating it as the epoch', async () => {
+    // It cannot be proven delivered, so it must survive. MongoDB does not match a missing field against `$lte`,
+    // which is the behaviour this depends on — assert it against the driver, not against a belief.
+    await mongo.col(`${SPACE}_file_tombstones`).insertOne({ _id: 'legacy', spaceId: SPACE, path: 'x.pdf' });
+    await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: iso(31), peers: 0 });
+    const left = await mongo.col(`${SPACE}_file_tombstones`).find({}).toArray();
+    assert.deepEqual(left.map(r => r._id), ['legacy']);
+  });
+
+  it('drops the whole collection for a space with no peers — through the real decision', async () => {
+    const floor = fileTombstoneFloor([], SPACE, []);
+    assert.equal(floor.prune, true);
+    assert.equal(await pruneFileTombstonesToFloor(SPACE, floor), 4);
+    assert.deepEqual(await daysIn(SPACE), []);
+  });
+
+  it('leaves the space alone when one member has never acked — through the real decision', async () => {
+    const floor = fileTombstoneFloor(
+      [{ instanceId: 'a', lastFileTombstoneAckedAt: { [SPACE]: iso(20) } }, { instanceId: 'b' }],
+      SPACE,
+    );
+    assert.equal(floor.prune, false);
+    await pruneFileTombstonesToFloor(SPACE, floor);
+    assert.equal((await daysIn(SPACE)).length, 4);
+  });
+
+  it('is idempotent, and reports 0 on a collection that never existed', async () => {
+    await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: iso(5), peers: 1 });
+    assert.equal(await pruneFileTombstonesToFloor(SPACE, { prune: true, upTo: iso(5), peers: 1 }), 0);
+    assert.equal(await pruneFileTombstonesToFloor('never-used', { prune: true, upTo: iso(5), peers: 0 }), 0);
+  });
+});


### PR DESCRIPTION
## The half that keeps a name after you delete the file

#619 bounded record tombstones. This is the other half of the same finding, and the one with the privacy
weight: `FileTombstoneDoc.path` is often personal in itself (`patients/john-doe-2024.pdf`), so a file
tombstone outliving its file meant the file's **name** survived its deletion, permanently. Record tombstones
carry no content — id, type, `deletedAt`, `seq` — which is why they were the easier half.

## Why the seq floor could not be reused

File tombstones have **no `seq` at all**. They are keyed by `deletedAt`, and their pull is unfiltered, so
there is no served position to record.

The confirmation comes from the **push** instead, and it is a stronger signal than a pull watermark because it
is per-tombstone rather than per-position: `POST /api/sync/file-tombstones` upserts every tombstone it receives
(`$setOnInsert`) and re-propagates it onward, so a 200 proves that peer now holds it and will keep passing it
on. Dropping our copy afterwards is safe transitively — every peer that answered is itself a copy that keeps
propagating.

The engine was discarding that response. Literally:

```ts
        );
        // Ignore response — best-effort; peer will log errors internally.
```

## Three rules, each the difference between safe and lossy

- **The position comes from the array that was SENT**, never from a fresh query. A file deleted between
  building the body and reading the reply was not in the payload, and counting it as delivered would drop a
  tombstone no peer has seen.
- **Only a 200 acknowledges anything.** A 403 is a direction-blocked peer that will never accept our
  tombstones; a timeout proves nothing. Both leave the position unknown, which blocks pruning. But
  `applied: 0` **does** count — the upsert is idempotent, so a peer that already held them all legitimately
  answers zero, and reading that as "not delivered" would freeze the floor forever.
- **Timestamps are compared only in the fixed-width `…Z` form.** ISO8601 sorts lexically in that form; an
  offset form (`+02:00`) sorts **later** while being **earlier** in real time, so comparing it would move the
  floor past tombstones nobody has acknowledged. Anything else is treated as unknown rather than compared.

The keep-on-unknown rules are inherited from #619 verbatim: a member that has never acked blocks its space, a
peer token with no member entry blocks it, and a space with no peers at all drops the collection — those
tombstones exist *only* to propagate, so with nobody to propagate to they carry a path and nothing else.

## One thing designed, then deliberately dropped

The obvious companion change is `since=<last pulled>` on the pull, so an established peer stops re-downloading
every file tombstone that has ever existed. It is in the diff only as a comment explaining why it is absent,
plus a test that fails if someone adds it.

A file tombstone carries its **original** `deletedAt` and can reach a peer long after that timestamp — a third
instance's old deletion relayed onward, a peer back from a week offline, a network that gained a member. With
`deletedAt > since` we would skip exactly those: the tombstone is older than our watermark, so we never see it,
and the file it should delete stays. `find({spaceId})` with no filter cannot miss one.

And the payload problem it would address is answered by the prune itself: once every peer's copy is bounded,
the full set **is** small. Filtering to make an unbounded set cheaper to send is fixing the symptom.

## Gates

- **`file-tombstone-ack`** — 18 cases, offline and pure. The earliest ack wins rather than the latest, an
  offset timestamp is refused rather than compared, `applied: 0` counts while a non-200 does not, the position
  is taken over the pushed array, the ack never walks backwards, and the engine is asserted to record it
  *inside* the `ackResp.ok` branch (a named-file read — the decision is worthless if the wiring goes, and
  "stopped acking" looks identical to "no peer has acked yet", which this design treats as a reason not to
  prune).
- **`file-tombstone-prune-db`** — 8 cases against a real MongoDB: the `deletedAt` boundary, a sibling space
  untouched, idempotence, and that a tombstone with **no** `deletedAt` survives. MongoDB does not match a
  missing field against `$lte`, and that is depended on here rather than believed — an unparseable timestamp
  cannot be proven delivered.
- **10 of 10 mutations caught**, in both spellings: a floor too high (drops a path no peer acknowledged) and a
  floor where there should be none.

---

`npm run preflight` **PASSED**. Rebased onto #619 rather than stacked, so this is a single commit on top of
current `main`.
