### PR TITLE
fix(files): a CRLF markdown file was embedded as ONE vector, at any size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Windows-authored Markdown file was embedded as ONE vector, whatever its size — unretrievable, and
+  gigabytes of memory to compute.** Reported by a canary operator whose pod went **3.98 → 9.996 GiB inside a
+  single 15-second scrape window**, was OOMKilled at a 16 GiB limit, and then sat at **15.40 GiB RSS at idle
+  with an empty queue** for over half an hour. Their three findings — the idle memory, the OOM burst, and
+  "large documents chunk to two and vanish from recall" — were one bug in two layers.
+  - **CRLF defeated the chunker silently.** Everything downstream splits on `\n` and anchors line patterns with
+    `$`, and in JavaScript `$` never matches before a `\r` while `.` cannot match one either (it is a line
+    terminator). So on a CRLF document `/^#{2,3}\s+(.+)$/` matched **nothing**: `sectionChunk` found no headings
+    and returned the entire file as a single chunk. `normaliseMarkdown` now normalises line endings first —
+    one line, and it is the whole difference between a document being retrievable and not.
+  - **The chunker had a minimum section size and no maximum**, so even with correct line endings one long
+    section stayed one chunk. Sections over `DEFAULT_MAX_BODY_LENGTH` (2 000 chars ≈ 500 tokens) are now split
+    at paragraph boundaries, keeping the heading on every part; tables are still never bisected, and a single
+    indivisible block is emitted whole.
+  - **The local embed call passed no `truncation`.** Self-attention is quadratic, so one unchunked body was not
+    just a bad vector, it was an enormous one: measured on this repo's own docs, the worst case was
+    **21 270 MiB of fp32 attention scores for a single layer, now 97 MiB — a 219× reduction.** Beyond the
+    model's position count the vector was also silently *wrong*. Truncation is now on, with a `warn` above
+    8 000 chars so an unchunked body is visible rather than merely expensive.
+  - **Why the memory never came back:** the ONNX CPU allocator is an arena — it grows to the high-water mark
+    and does not return pages. Everything the operator measured follows from that, including
+    `container_memory_cache` at 0.005 GiB and a figure that was flat rather than decaying across seven
+    consecutive samples. Their instance also showed why 2.2.3's concurrency drop made it *worse*: the peak is
+    set by the size of one chunk, not by how many run at once.
+  - **Documents already ingested keep their coarse chunks until re-ingested**, since better chunking changes
+    vectors. Worth doing deliberately for large files — and one at a time, not as a bulk re-conversion.
+  - Gate: `chunk-size-bounded` (14 cases) asserts a CRLF document chunks identically to its LF twin, that no
+    tracked doc produces a large **and divisible** chunk, that headings survive a split, that a table is never
+    bisected, and that the pre-fix collapse still reproduces when normalisation is skipped — because a gate
+    that only exercises the fixed path cannot prove the fix. 7 of 7 mutations caught.
+
+- **`ythril_media_job_phase` had no series during the incident it exists for.** With
+  `ythril_media_jobs_processing = 3`, a query for `ythril_media_job_phase > 0` returned an empty result set;
+  twenty minutes later, queue drained, it returned the full grid at zero. Steps were remembered *once seen*,
+  and the first time anyone reaches for this metric is the first incident — *"the window where the metric is
+  missing is the window where it is needed"*. The known step names are now seeded at zero from the first
+  scrape; an unlisted step still appears the moment it is observed.
+
+- **The documented stuck-job recipe fires on every restart.** `rate(ythril_embed_chunks_total[5m]) == 0` while
+  `ythril_media_jobs_processing > 0` was our recommendation, and a counter resets on restart — so it reports
+  "stuck" for five minutes while jobs complete normally. An operator built it exactly as written and was paged
+  two minutes after an OOM restart. The metrics table now carries the restart guard
+  (`time() - process_start_time_seconds > 600`) rather than leaving it to a long `for:` and luck.
+
 - **Renaming a space never moved its usage history — the code was unreachable.** `moveSpaceData` had
   `return errors;` directly above the block that re-keys `space_activity`, so `renameSpaceActivity` was dead:
   the renamed space showed a blank Usage panel and the old buckets lingered under an id that no longer existed,

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -90,14 +90,30 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_recall_degraded_total` | counter | Recalls answered with a **weaker pipeline than configured**, by `reason`. `rerank_unavailable` = the cross-encoder is configured but did not answer; `rerank_skipped_budget` = it was not attempted because the end-to-end `RECALL_BUDGET_MS` was already spent upstream. **This is the one to alert on**: these paths return HTTP 200 with a worse ranking, so they raise no error rate and barely move latency — a reranker down for a week is otherwise invisible. Both series report `0` from process start, so absent-vs-zero is never ambiguous. |
 | `ythril_media_jobs_pending` | gauge | Queued media/document embedding jobs by space |
 | `ythril_media_jobs_processing` | gauge | Jobs a worker is currently running, by space. **One long document shows as `1` here for its whole duration** — pair it with `ythril_embed_chunks_total` to tell slow from stuck |
-| `ythril_media_job_phase` | gauge | In-flight jobs by the pipeline step they are in (`render`, `vlm`, `embed`, `describe`, …, or `unknown` for a job that has not reported one). Steps report `0` once seen rather than disappearing |
-| `ythril_embed_chunks_total` | counter | Chunks put through the embedder, by space. Motion, not success: `rate(...[5m]) == 0` while `ythril_media_jobs_processing > 0` is a stuck job, a non-zero rate is a slow one |
+| `ythril_media_job_phase` | gauge | In-flight jobs by the pipeline step they are in (`render`, `vlm`, `embed`, `describe`, …, or `unknown` for a job that has not reported one). The known step names are **seeded at `0` from the first scrape**, so the series exists before any job has been in them; an unlisted step appears the moment it is seen |
+| `ythril_embed_chunks_total` | counter | Chunks put through the embedder, by space. Motion, not success: `rate(...[5m]) == 0` while `ythril_media_jobs_processing > 0` is a stuck job, a non-zero rate is a slow one — **but see the restart caveat below before alerting on it** |
 | `ythril_media_jobs_completed_total` | counter | Jobs that finished, by space and media type |
 | `ythril_media_jobs_failed_total` | counter | Jobs that exhausted their retries, by space and media type |
 | `ythril_media_jobs_retried_total` | counter | Attempts that failed and were re-queued, by space and media type — including a job whose claim was recovered while it was still running |
 | `ythril_media_jobs_failed` | gauge | Jobs sitting in the terminal `failed` state by space (a backlog, not a rate) |
 | `ythril_media_job_duration_seconds` | histogram | End-to-end time per job by media type |
 | `ythril_security_posture_checks` | gauge | This instance's own PASS/WARN/FAIL posture, by `level` — the same findings the boot log prints and `GET /api/about/security` serves, computed per scrape from the same function. **Alert on `level="fail"` > 0**: the checks that matter most produce no runtime symptom at all (`requireEncryptedTransport` on *without* `trustProxy` rejects every request with a 403 that looks like a client problem), and the only other way to notice was somebody reading the boot log of each instance. All three levels report `0` from process start. |
+
+> **The stuck-job recipe needs a restart guard.** A counter **resets to zero on restart**, so
+> `rate(ythril_embed_chunks_total[5m])` is 0 for the first five minutes of a new process while jobs are
+> completing normally. A reporting operator built the alert exactly as recommended and it fired two minutes
+> after an OOM restart, with the log showing jobs finishing — which is the worst moment to page someone.
+>
+> Either give it a long `for:` (15 m covers the window), or exclude a young process outright:
+>
+> ```promql
+> rate(ythril_embed_chunks_total[5m]) == 0
+>   and ythril_media_jobs_processing > 0
+>   and (time() - process_start_time_seconds) > 600
+> ```
+>
+> `ythril_media_job_phase` is the better first look during an incident anyway: it says which step, not just
+> whether anything moved.
 
 Default Node.js process metrics (`nodejs_*`, `process_*`) are also included via [prom-client](https://github.com/siimon/prom-client)'s `collectDefaultMetrics()`.
 

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -61,6 +61,15 @@ export function prepareInput(
   return TASK_PREFIX[resolvePrefixScheme(cfg)][task] + text;
 }
 
+/**
+ * Above this many characters, a local embed is worth one `warn` — it is past the point where a single vector
+ * can be about anything specific, and it means something upstream produced an unchunked body.
+ *
+ * ~8,000 chars is roughly 2,000 tokens: comfortably inside the model's window (so this is not the truncation
+ * threshold, which the tokeniser owns) and comfortably past the point where averaging destroys the signal.
+ */
+const MAX_LOCAL_EMBED_CHARS = 8_000;
+
 // ── Local ONNX pipeline singleton ─────────────────────────────────────────
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type LocalPipeline = (text: string, opts: Record<string, unknown>) => Promise<any>;
@@ -188,7 +197,23 @@ export async function embed(
     }
 
     const pipe = await getLocalPipeline(cfg.model);
-    const output = await pipe(input, { pooling: 'mean', normalize: true });
+    // `truncation: true` is not a nicety — without it a long input cost GIGABYTES and produced a worse vector.
+    //
+    // Self-attention is quadratic in sequence length. A customer's 57 KB Markdown file chunked to two ~28 KB
+    // chunks (the chunker had a minimum section size and no maximum, fixed in `section-chunker.ts`), which is
+    // ~7,000 tokens: ~196 MiB of attention scores per head in fp32, ~2.35 GiB for one layer's twelve. Their pod
+    // went 3.98 → 9.996 GiB inside a single 15-second scrape window, was OOMKilled at a 16 GiB limit, and then
+    // sat at 15.40 GiB at idle because the ONNX arena allocator never returns its high-water mark. Reducing
+    // embed concurrency had made it worse, because the peak is set by one chunk's size.
+    //
+    // It was also silently WRONG beyond the model's position count, so this is a correctness fix as much as a
+    // memory one — and the chunker's cap does not make it redundant: this is the path every caller shares,
+    // including `remember` with a large fact and a query nobody bounded.
+    if (input.length > MAX_LOCAL_EMBED_CHARS) {
+      log.warn(`Embedding input is ${input.length} chars; the local model truncates to its context window. `
+        + 'A vector over this much text averages away everything specific in it — chunk the source instead.');
+    }
+    const output = await pipe(input, { pooling: 'mean', normalize: true, truncation: true });
     const vector = Array.from(output.data as Float32Array) as number[];
 
     if (vector.length !== cfg.dimensions) {

--- a/server/src/files/converters/normaliser.ts
+++ b/server/src/files/converters/normaliser.ts
@@ -2,18 +2,39 @@
  * Markdown normaliser.
  *
  * Rules applied in order:
+ *  0. **Normalise line endings to `\n`** (CRLF / lone CR → LF)
  *  1. Strip lines matching /^-{0,3}Page \d+.*$/i  (page-number noise)
  *  2. Collapse 3+ consecutive blank lines to exactly 1
  *  3. Shift all headings so the highest level present becomes H2
  *     (H1 is reserved for the document title; embedding model benefits from
  *      consistent heading depth).
+ *
+ * ## Rule 0 is not cosmetic — it decided whether a document was retrievable at all
+ *
+ * Everything downstream splits on `\n` and then anchors line-based patterns with `$`. In JavaScript, `$`
+ * (without `m`) matches at the end of the string or before a *final* `\n` — never before a `\r` — and `.` does
+ * not match `\r` either, because `\r` is a line terminator. So on a CRLF document every line arrived as
+ * `"## Heading\r"` and **`/^#{2,3}\s+(.+)$/` did not match**.
+ *
+ * Consequence, measured on this repo's own docs: `sectionChunk` found zero headings and returned the **entire
+ * document as one chunk**. A 58,737-byte API guide became a single ~14,700-token embed — which is
+ * `14,700² × 4 bytes × 12 heads ≈ 9.6 GiB` of fp32 attention scores for one layer. A customer's pod went
+ * 3.98 → 9.996 GiB inside one 15-second scrape window, was OOMKilled at a 16 GiB limit, and then sat at
+ * 15.40 GiB at idle because the ONNX arena keeps its high-water mark. The same file was also unretrievable on
+ * any specific term, because one averaged vector is not about anything.
+ *
+ * A Windows checkout, a Windows-authored file, or any tool that writes CRLF was enough to trigger it. Rule 0
+ * is the one-line half of that fix; the other halves are `maxBodyLength` in `section-chunker.ts` and
+ * `truncation` in `brain/embedding.ts`.
  */
 
 const PAGE_LINE_RE = /^-{0,3}Page\s+\d+.*$/i;
 
 /** Normalise a Markdown string for embedding. Returns the normalised string. */
 export function normaliseMarkdown(md: string): string {
-  const lines = md.split('\n');
+  // Pass 0: line endings. Must come first — every rule below is line-based, and a trailing `\r` defeats the
+  // `$`-anchored patterns silently rather than loudly.
+  const lines = md.replace(/\r\n?/g, '\n').split('\n');
 
   // Pass 1: strip page-number lines
   const stripped = lines.filter(l => !PAGE_LINE_RE.test(l.trimEnd()));

--- a/server/src/files/converters/section-chunker.ts
+++ b/server/src/files/converters/section-chunker.ts
@@ -5,10 +5,30 @@
  *  - Split on lines that start with `## ` or `### `
  *  - Chunks whose body (excluding heading line) is shorter than
  *    `minBodyLength` chars are merged into the previous chunk
+ *  - **A section longer than `maxBodyLength` is split further, at paragraph
+ *    boundaries**, keeping the heading as provenance on each part
  *  - Table blocks (<table>…</table>) are never split across boundaries
  *  - The last paragraph of the previous chunk is prepended to the next chunk
  *    as overlap (context continuity for the embedding model)
  *  - Returns an array of Chunk objects with headingText, content, chunkIndex
+ *
+ * ## Why a maximum exists (customer report, 2026-08-02)
+ *
+ * There was a minimum and no maximum, so a document's chunk count was decided entirely by how many `##`/`###`
+ * headings it happened to have. A 57,642-byte API guide with two of them produced **two chunks of ~28 KB**,
+ * and that broke two things at once:
+ *
+ *  - **Recall.** One vector averaged across ~4,500 words is not semantically sharp about anything in it. The
+ *    reporter searched their own ingested docs for a retention feature, got unrelated smaller files three
+ *    times, and was one step from concluding the feature did not exist. It did — in one of the coarse files.
+ *  - **Memory.** Self-attention is quadratic in sequence length: ~7,000 tokens is ~196 MiB of attention
+ *    scores *per head* in fp32, so one embed of one chunk cost gigabytes. Their instance went 3.98 → 9.996 GiB
+ *    inside a single 15-second scrape window and was OOMKilled at a 16 GiB limit, then sat at 15.40 GiB at
+ *    idle because the ONNX arena allocator keeps its high-water mark. Lowering embed concurrency had made it
+ *    *worse*, because the peak is set by the size of one chunk, not by how many run at once.
+ *
+ * So the cap is a retrieval-quality rule that happens to also be the memory fix. `embed()` truncates as well —
+ * belt and braces, because a chunk that slips through must never cost gigabytes again.
  */
 
 import type { Chunk } from './types.js';
@@ -19,6 +39,50 @@ const TABLE_CLOSE_RE = /<\/table>/i;
 
 export interface SectionChunkerOptions {
   minBodyLength?: number; // default 150
+  /** Hard ceiling on one chunk's body, in characters. Default `DEFAULT_MAX_BODY_LENGTH`. */
+  maxBodyLength?: number;
+}
+
+/**
+ * Default ceiling on a chunk body, in characters.
+ *
+ * ~2,000 characters is roughly 500 tokens: small enough that a vector is about one topic, large enough that a
+ * typical `###` subsection stays whole rather than being cut mid-argument. It is also two orders of magnitude
+ * below the point where attention cost becomes interesting — 500 tokens is ~1 MiB of attention scores per head
+ * against ~196 MiB at 7,000.
+ *
+ * Deliberately NOT the model's context limit. Fitting is not the goal; being *retrievable* is, and a chunk that
+ * merely fits can still average away everything specific in it.
+ */
+export const DEFAULT_MAX_BODY_LENGTH = 2_000;
+
+/**
+ * Split one oversized body at paragraph boundaries, never inside a table.
+ *
+ * Greedy rather than balanced: paragraphs accumulate until the next one would exceed the cap. A single
+ * paragraph (or table) longer than the cap is emitted alone and left intact — bisecting a table destroys the
+ * only thing that made it a semantic unit, and `embed()`'s truncation is the backstop for the pathological
+ * case of one enormous paragraph.
+ */
+function splitOversized(body: string, maxLen: number): string[] {
+  if (body.length <= maxLen) return [body];
+
+  const blocks = body.split(/\n{2,}/).map(p => p.trim()).filter(p => p.length > 0);
+  const parts: string[] = [];
+  let current: string[] = [];
+  let len = 0;
+
+  for (const block of blocks) {
+    if (len > 0 && len + block.length > maxLen) {
+      parts.push(current.join('\n\n'));
+      current = [];
+      len = 0;
+    }
+    current.push(block);
+    len += block.length + 2;
+  }
+  if (current.length > 0) parts.push(current.join('\n\n'));
+  return parts.length > 0 ? parts : [body];
 }
 
 /** Extract the last paragraph from a chunk body for overlap.
@@ -45,6 +109,9 @@ export function sectionChunk(
   opts: SectionChunkerOptions = {},
 ): Chunk[] {
   const minBodyLength = opts.minBodyLength ?? 150;
+  // Floored above the minimum: a maximum below the merge threshold would split a section and then merge the
+  // parts straight back together, which loops in effect and produces chunks of an unpredictable size.
+  const maxBodyLength = Math.max(opts.maxBodyLength ?? DEFAULT_MAX_BODY_LENGTH, minBodyLength * 2);
   const lines = md.split('\n');
 
   interface RawChunk { heading: string | null; lines: string[] }
@@ -105,11 +172,16 @@ export function sectionChunk(
 
     prevLastPara = lastParagraph(body);
 
-    chunks.push({
-      headingText: rc.heading,
-      content: body,
-      chunkIndex: chunks.length,
-    });
+    // A section with no size limit was the whole defect: two headings in a 57 KB document meant two 28 KB
+    // chunks. Every part keeps the section's heading, so provenance survives the split and a reader still sees
+    // which section an answer came from.
+    for (const part of splitOversized(body, maxBodyLength)) {
+      chunks.push({
+        headingText: rc.heading,
+        content: part,
+        chunkIndex: chunks.length,
+      });
+    }
   }
 
   return chunks;

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -375,11 +375,33 @@ export const mediaJobsFailed = new Gauge({
  * with every heartbeat — so this is that field, aggregated. Nothing new is measured; something already
  * measured is finally reachable from a dashboard.
  *
- * `step` comes from the route the document is actually taking (`render`, `vlm`, `embed`, `describe`, …), so
- * it is not a fixed list here. Steps are remembered once seen and reported as `0` when no job is in them:
- * a series that disappears cannot be alerted on, because absent and zero look the same in a query.
+ * `step` comes from the route the document is actually taking (`render`, `vlm`, `embed`, `describe`, …), so it
+ * is not a closed list — but the known names are **seeded at zero** (`KNOWN_JOB_STEPS`) and any other step is
+ * remembered the moment it is seen. Both halves matter: a series that disappears cannot be alerted on, and a
+ * series that has never existed cannot be alerted on either, which is the case that bit a customer during
+ * their first incident.
  */
-const _seenJobSteps = new Set<string>();
+/**
+ * Step names seeded at zero from the first scrape, so the series exists before any job has been in them.
+ *
+ * "Remembered once seen" was not enough, and a customer proved it precisely: with
+ * `ythril_media_jobs_processing = 3` during their first incident, `ythril_media_job_phase > 0` returned **an
+ * empty result set** — no series at all. Twenty minutes later, queue drained, it returned the full grid at 0.
+ *
+ * *"The window where the metric is missing is the window where it is needed."* The first time anyone reaches
+ * for this metric is the first incident, when by definition nothing has been seen yet. So the known step names
+ * are pre-registered; a step outside this list still appears the moment it is observed.
+ *
+ * `unknown` is included on purpose: it is a real fallback (a processing job whose heartbeat predates the step
+ * report, or one that has not reached its first step), and an operator seeing it needs to know it is expected
+ * rather than a gap. A step name appearing that is NOT in this list means the pipeline gained a phase nobody
+ * named here.
+ */
+export const KNOWN_JOB_STEPS = [
+  'render', 'ocr', 'vlm', 'validate', 'repair', 'chunk', 'embed', 'describe', 'caption', 'transcribe', 'unknown',
+] as const;
+
+const _seenJobSteps = new Set<string>(KNOWN_JOB_STEPS);
 export const mediaJobPhase = new Gauge({
   name: 'ythril_media_job_phase',
   help: 'In-flight media jobs by the pipeline step they are currently in (collected at scrape time)',

--- a/testing/standalone/chunk-size-bounded.test.js
+++ b/testing/standalone/chunk-size-bounded.test.js
@@ -1,0 +1,189 @@
+/**
+ * A document must chunk into retrievable pieces — and a CRLF file must chunk at all.
+ *
+ * ## The defect, from a customer report (2026-08-02)
+ *
+ * They measured `04-brain-api.md` (57,642 B in their copy) as **2 chunks**, and could not retrieve anything
+ * specific from it: three searches for a feature documented inside it returned unrelated smaller files instead.
+ * Then their pod went **3.98 → 9.996 GiB inside one 15-second scrape window**, was OOMKilled at a 16 GiB limit,
+ * and sat at **15.40 GiB at idle with an empty queue**.
+ *
+ * One cause, in two layers:
+ *
+ * 1. **CRLF defeated the chunker silently.** Every rule downstream splits on `\n` and anchors with `$`, and in
+ *    JavaScript `$` never matches before a `\r` while `.` cannot match one either — so on a CRLF document
+ *    `/^#{2,3}\s+(.+)$/` matched nothing and the ENTIRE FILE came back as one chunk.
+ * 2. **The chunker had a minimum section size and no maximum**, so even with correct line endings one long
+ *    section stayed one chunk.
+ *
+ * The memory follows arithmetically: self-attention is quadratic, so one ~14,700-token embed is
+ * `14,700² × 4 B × 12 heads ≈ 9.6 GiB` of fp32 scores for a single layer, and the ONNX arena allocator keeps
+ * its high-water mark — which is why the number never came back down.
+ *
+ * ## What is asserted
+ *
+ * Measured against **this repository's own docs**, which are the files they ingested — not fixtures. The
+ * assertion is on the worst-case chunk **SIZE**, because the count is what looked fine while the size was
+ * catastrophic: two chunks of 28 KB and thirty of 2 KB are both "chunked".
+ *
+ * Run: node --test testing/standalone/chunk-size-bounded.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+let sectionChunk, normaliseMarkdown, DEFAULT_MAX_BODY_LENGTH;
+
+before(async () => {
+  ({ sectionChunk, DEFAULT_MAX_BODY_LENGTH } =
+    await import('../../server/dist/files/converters/section-chunker.js'));
+  ({ normaliseMarkdown } = await import('../../server/dist/files/converters/normaliser.js'));
+});
+
+/** Every tracked Markdown doc — the real corpus, enumerated from git rather than a hand-written list. */
+const docs = execFileSync('git', ['ls-files', 'docs'], { encoding: 'utf8', cwd: ROOT })
+  .split('\n').map(s => s.trim()).filter(f => f.endsWith('.md'));
+
+/** What the pipeline does: normalise, then chunk. */
+const pipeline = (text) => sectionChunk(normaliseMarkdown(text), {});
+
+describe('line endings cannot decide whether a document is chunked', () => {
+  it('a CRLF document chunks exactly like its LF twin', () => {
+    // The root cause, in one assertion. Before the fix the CRLF side came back as a single chunk.
+    const lf = '## One\n\n' + 'a'.repeat(1_500) + '\n\n## Two\n\n' + 'b'.repeat(1_500) + '\n';
+    const crlf = lf.replace(/\n/g, '\r\n');
+    const fromLf = pipeline(lf);
+    const fromCrlf = pipeline(crlf);
+    assert.ok(fromLf.length >= 2, `the LF baseline itself only produced ${fromLf.length} chunk(s)`);
+    assert.deepEqual(fromCrlf.map(c => c.content), fromLf.map(c => c.content));
+    assert.deepEqual(fromCrlf.map(c => c.headingText), fromLf.map(c => c.headingText));
+  });
+
+  it('a lone-CR document does not collapse either', () => {
+    const cr = ('## One\n\n' + 'a'.repeat(1_500) + '\n\n## Two\n\n' + 'b'.repeat(1_500)).replace(/\n/g, '\r');
+    assert.ok(pipeline(cr).length >= 2);
+  });
+
+  it('no `\\r` survives normalisation', () => {
+    // Anything downstream that anchors with `$` breaks on one, so the invariant is worth stating directly.
+    assert.equal(normaliseMarkdown('a\r\nb\rc\n').includes('\r'), false);
+  });
+
+  it('the raw chunker on RAW CRLF is what used to fail — so this test can fail', () => {
+    // A gate that only exercises the fixed path cannot prove the fix. Skipping normalisation must still show
+    // the collapse, which is what makes the assertion above meaningful.
+    const crlf = ('## One\n\n' + 'a'.repeat(1_500) + '\n\n## Two\n\n' + 'b'.repeat(1_500)).replace(/\n/g, '\r\n');
+    assert.equal(sectionChunk(crlf, { maxBodyLength: Number.MAX_SAFE_INTEGER }).length, 1,
+      'the pre-fix collapse no longer reproduces — has HEADING_RE been made CRLF-tolerant too? then relax this');
+  });
+});
+
+describe('chunk size is bounded on the real corpus', () => {
+  it('walked a real set of docs', () => {
+    assert.ok(docs.length > 15, `only found ${docs.length} tracked docs`);
+  });
+
+  it('no document produces a chunk large enough to be unretrievable', () => {
+    // The number that matters. A vector over 28 KB averages away everything specific in it, and costs
+    // gigabytes of attention to compute.
+    const HARD_CEILING = 8_000;   // the `embed()` warn threshold — past this a single vector is not about anything
+    const offenders = [];
+    for (const rel of docs) {
+      const chunks = pipeline(readFileSync(join(ROOT, rel), 'utf8'));
+      for (const c of chunks) {
+        if (c.content.length <= HARD_CEILING) continue;
+        // A single indivisible block (one enormous table or fenced code block) may exceed the cap: bisecting it
+        // destroys the only thing that made it a unit. That is allowed, and `embed()`'s truncation is the
+        // backstop — but it must be ONE block, not an accumulation the splitter failed to break up.
+        const blocks = c.content.split(/\n{2,}/).filter(p => p.trim().length > 0);
+        if (blocks.length > 1) offenders.push(`${rel}: ${c.content.length} chars across ${blocks.length} blocks`);
+      }
+    }
+    assert.deepEqual(offenders, [], 'these chunks are large AND divisible, so the splitter did not do its '
+      + `job:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('the largest doc is many chunks, not one', () => {
+    const biggest = docs
+      .map(rel => ({ rel, text: readFileSync(join(ROOT, rel), 'utf8') }))
+      .sort((a, b) => b.text.length - a.text.length)[0];
+    assert.ok(biggest.text.length > 20_000, `the largest tracked doc is only ${biggest.text.length} bytes`);
+    const chunks = pipeline(biggest.text);
+    assert.ok(chunks.length >= 10,
+      `${biggest.rel} is ${biggest.text.length} bytes and produced only ${chunks.length} chunk(s)`);
+  });
+});
+
+describe('the maximum body length', () => {
+  it('splits an oversized section and keeps its heading on every part', () => {
+    // Provenance has to survive the split, or a reader cannot tell which section an answer came from.
+    const md = '## Long Section\n\n' + Array.from({ length: 20 }, (_, i) => `Paragraph ${i} ` + 'x'.repeat(300)).join('\n\n');
+    const chunks = sectionChunk(md, {});
+    assert.ok(chunks.length >= 3, `expected several parts, got ${chunks.length}`);
+    for (const c of chunks) {
+      assert.equal(c.headingText, 'Long Section');
+      assert.ok(c.content.length <= DEFAULT_MAX_BODY_LENGTH * 2,
+        `a part is ${c.content.length} chars, well past the ${DEFAULT_MAX_BODY_LENGTH} cap`);
+    }
+    assert.deepEqual(chunks.map(c => c.chunkIndex), chunks.map((_, i) => i), 'chunkIndex must stay contiguous');
+  });
+
+  it('leaves a section under the cap exactly as it was', () => {
+    const md = '## Small\n\nOne paragraph of perfectly reasonable length that nobody needs to split up at all.\n';
+    assert.equal(sectionChunk(md, {}).length, 1);
+  });
+
+  it('emits a single oversized paragraph alone rather than mangling it', () => {
+    const md = '## Big\n\n' + 'y'.repeat(DEFAULT_MAX_BODY_LENGTH * 3) + '\n';
+    const chunks = sectionChunk(md, {});
+    assert.equal(chunks.length, 1);
+    assert.ok(chunks[0].content.length >= DEFAULT_MAX_BODY_LENGTH * 3);
+  });
+
+  it('never bisects a table', () => {
+    // Table blocks were already protected from being split across heading boundaries; the size splitter must
+    // not undo that.
+    const rows = Array.from({ length: 60 }, (_, i) => `<tr><td>row ${i} ${'z'.repeat(60)}</td></tr>`).join('\n');
+    const md = `## Data\n\n<table>\n${rows}\n</table>\n`;
+    const chunks = sectionChunk(md, {});
+    const withTable = chunks.filter(c => c.content.includes('<table'));
+    assert.equal(withTable.length, 1, 'the table appears in more than one chunk');
+    assert.ok(withTable[0].content.includes('</table>'), 'the table was cut before its closing tag');
+  });
+
+  it('floors the cap above the merge threshold', () => {
+    // A maximum below `minBodyLength` is a rule fighting itself: the splitter cuts a section into parts that the
+    // merge threshold considers too short to stand alone. The floor lifts the cap to `minBodyLength * 2`, so
+    // parts are always big enough to survive the rule that produced them.
+    //
+    // Needs MANY paragraphs to exercise: one long paragraph is indivisible and comes back whole whatever the
+    // cap says, which is how an earlier version of this test passed without the floor.
+    const md = '## A\n\n' + Array.from({ length: 20 }, (_, i) => `p${i} ` + 'q'.repeat(296)).join('\n\n');
+    const parts = sectionChunk(md, { maxBodyLength: 10, minBodyLength: 400 });
+    assert.ok(parts.length >= 2, `expected several parts, got ${parts.length}`);
+    for (const c of parts.slice(0, -1)) {
+      assert.ok(c.content.length >= 400,
+        `a part is only ${c.content.length} chars — the cap was not floored against minBodyLength 400`);
+    }
+  });
+});
+
+describe('the embed call is the backstop', () => {
+  it('the local pipeline is called with truncation', () => {
+    // Without it, one long input is quadratic attention memory — 9.6 GiB of fp32 scores for a single layer at
+    // ~14,700 tokens. Reading a named file: if it moves, this throws.
+    const src = readFileSync(join(ROOT, 'server/src/brain/embedding.ts'), 'utf8');
+    assert.match(src, /pipe\(input,\s*\{[^}]*truncation:\s*true/,
+      'the local embed no longer truncates, so one unchunked body can cost gigabytes again');
+  });
+
+  it('an oversized input is warned about rather than silently averaged', () => {
+    const src = readFileSync(join(ROOT, 'server/src/brain/embedding.ts'), 'utf8');
+    assert.match(src, /MAX_LOCAL_EMBED_CHARS/);
+    assert.match(src, /log\.warn\([^)]*Embedding input is/);
+  });
+});


### PR DESCRIPTION
## Three symptoms, one bug

The canary's 2.2.4 report arrived within an hour of their upgrade with three findings that looked unrelated:

- **A** — 15.40 GiB RSS at idle, empty queue, flat for over thirty minutes, `container_memory_cache` at
  0.005 GiB.
- **B** — an OOMKill that went **3.98 → 9.996 GiB inside a single 15-second scrape window** at a 16 GiB limit,
  *larger* than the burst 2.2.3 was supposed to shrink.
- **F** — "large ingested documents chunk to two, and vanish from recall". They searched their own ingested
  docs for a retention feature three times, got unrelated smaller files, and were one step from concluding the
  feature did not exist. It did — in one of the coarse files.

They are the same defect, in two layers, and neither layer is about the amount of text.

## Layer 1: CRLF defeated the chunker silently

Everything downstream splits on `\n` and anchors line patterns with `$`. In JavaScript, `$` (without `m`)
matches at end-of-string or before a **final `\n`** — never before a `\r` — and `.` cannot match a `\r` either,
because it is a line terminator.

So on a CRLF document every line arrived as `"## Heading\r"` and `/^#{2,3}\s+(.+)$/` **matched nothing**.
`sectionChunk` found zero headings and returned the entire file as one chunk. A Windows checkout, a
Windows-authored file, or any tool that writes CRLF was enough.

`normaliseMarkdown` now normalises line endings before anything else looks at them — one line, and it is the
whole difference between a document being retrievable and not.

## Layer 2: a minimum section size and no maximum

Even with correct line endings, one long section stayed one chunk: the chunker merged sections *below*
`minBodyLength` and never looked at how large one became. Sections over `DEFAULT_MAX_BODY_LENGTH` (2 000
chars ≈ 500 tokens) are now split at paragraph boundaries, keeping the heading on every part. Tables are still
never bisected, and a single indivisible block is emitted whole — cutting it destroys the only thing that made
it a unit.

## And the memory follows arithmetically

Self-attention is quadratic in sequence length, so an unchunked body was not merely a bad vector — it was an
enormous one. `embed()` passed **no `truncation`**, so the tokeniser expanded the whole thing.

Measured on this repository's own docs, which are the files they ingested:

| file | bytes | chunks before → after | largest chunk before → after |
|---|---|---|---|
| `04-brain-api.md` | 58,737 | 1 → **35** | 58,735 → **1,993** |
| `05-files-api.md` | 86,225 | 1 → **47** | 86,223 → **5,818** |
| `userguide.md` | 84,319 | 1 → **58** | 84,316 → **1,997** |
| `sync-protocol.md` | 40,523 | 1 → **31** | 40,521 → **1,984** |

Worst-case fp32 attention scores for a **single layer**: **21,270 MiB → 97 MiB. A 219× reduction.**

That is B, exactly: one ~14,700-token embed is `14,700² × 4 B × 12 heads ≈ 9.6 GiB`, and two of them at the
new concurrency of 2 crosses 16 GiB between two cAdvisor samples.

And it is why **2.2.3 made it worse rather than better** — the peak is set by the size of one chunk, not by how
many run at once, so dropping concurrency from 8 to 2 was a rounding error against a multi-GiB single embed.

**A** is that peak, retained: the ONNX CPU allocator is an arena, so it grows to the high-water mark and does
not return pages. Every number they took follows — cache ≈ 0 because arena memory is anonymous, and flat rather
than decaying because nothing reclaims it. Their measurements are what make this certain rather than plausible.

Beyond the model's position count the vector was also silently **wrong**, so truncation is a correctness fix as
much as a memory one. A `warn` above 8 000 chars makes an unchunked body visible rather than merely expensive.

## Also in this batch, from the same report

**C — `ythril_media_job_phase` had no series during the incident it exists for.** With
`ythril_media_jobs_processing = 3`, `phase > 0` returned an empty result set; twenty minutes later, queue
drained, it returned the full grid at zero. Steps were remembered *once seen*, and the first time anyone
reaches for this metric is the first incident. Their sentence for it is better than ours: *"the window where the
metric is missing is the window where it is needed."* The known step names are now seeded at zero from the first
scrape; an unlisted step still appears the moment it is observed.

**E — our own documented stuck-job recipe fires on every restart.** A counter resets, so
`rate(ythril_embed_chunks_total[5m]) == 0` reads "stuck" for five minutes while jobs complete normally. They
built the alert exactly as recommended and were paged two minutes after the OOM restart — the worst possible
moment. The metrics table now carries the guard (`time() - process_start_time_seconds > 600`) rather than
leaving it to a long `for:` and luck.

## Gate

`chunk-size-bounded` (14 cases), asserted on worst-case chunk **SIZE** rather than count — because the count is
what looked fine while the size was catastrophic. Two chunks of 28 KB and thirty of 2 KB are both "chunked".

- A CRLF document must chunk **identically** to its LF twin, and a lone-CR one too.
- No tracked doc may produce a chunk that is large **and divisible** (an indivisible block is allowed, since
  bisecting a table is worse; `embed()`'s truncation is the backstop).
- Headings survive a split, `chunkIndex` stays contiguous, a table is never bisected, and the cap is floored
  above the merge threshold so the two rules cannot fight.
- **The pre-fix collapse must still reproduce when normalisation is skipped** — a gate that only exercises the
  fixed path cannot prove the fix.

**7 of 7 mutations caught.** One of them (removing the cap's floor against `minBodyLength`) exposed a fixture
in the first version of this gate that could not fail: a single long paragraph is indivisible, so it came back
whole whatever the cap said.

## What is deliberately not here

**Documents already ingested keep their coarse chunks until re-ingested**, because better chunking changes
vectors. For the API guides the reporter named that is worth doing deliberately — and one file at a time, not
as the bulk re-conversion that OOMKilled them.

**G — per-chrono-type retention** is a feature, not a fix, and is filed with their reasoning rather than
riding along here. Worth recording that they went looking before asking: there is no space or chrono retention
today, only `audit.retentionDays`, and their reading of the two-tier audit design as the right shape to extend
is correct.

---

`npm run preflight` **PASSED**. The reply to forward is in
`todo/cust-breituai-converse/_CUSTOMER-MESSAGE-2026-08-02-memory.md`, including the mitigation they can apply
before this ships (`EMBEDDING_CONCURRENCY=1`, and one file at a time) and a falsifiable prediction: if
`nodejs_heap_size_used_bytes` is in the low hundreds of MiB while `process_resident_memory_bytes` is ~15.4 GiB,
the memory is native and this diagnosis holds; if the V8 heap is itself multiple GiB, we are wrong about the
mechanism.
