### PR TITLE
feat(brain): retention per chrono TYPE, so telemetry stops displacing knowledge in recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Retention per chrono TYPE, so telemetry stops displacing knowledge in recall.** Asked for by the canary
+  operator, and the reason is not storage — their volumes were 516 and 139 records. It is that a space-wide TTL
+  is the wrong axis for a space holding both kinds of thing.
+  - **The problem, in their measurement:** deploy `event`s are content-free by design, so they cluster tightly
+    and match anything on the topic. A cross-space recall for *"how is the platform deployed and what runs on
+    the server"* returned **four near-identical `platform-apps deployed` chronos at 0.874**, above the
+    guideline it should have surfaced at 0.823. Meanwhile `health-snapshot` / `metrics-snapshot` records must be
+    kept far longer than any prune window, because they exist to be trended and 90 days is one quarter with no
+    year-over-year. One number cannot serve both.
+  - `chronoRetention` on the space sets `{ days, contentDays }` per type, overriding `recordTtlDays` for the
+    types it names. **Two tiers, taken from the audit log's design rather than invented** — which is what they
+    asked for by name: `contentDays` drops the detail (`description`, `matchedText`, `properties` **and the
+    embedding**) and sets `contentRedacted: true`, so that a deploy happened is still recorded while it stops
+    competing in semantic search; `days` deletes the record through the normal path, so it tombstones and
+    propagates.
+  - **Dropping the vector is the point, not a side effect.** A record that keeps its embedding keeps winning
+    searches for content that is no longer there.
+  - Precedence is documented and pinned: a per-record `ttlDays` wins (including `0`/`null` for never); a type
+    named with only `contentDays` still deletes on the space schedule; and a `contentDays` at or past the delete
+    window is ignored, because it could never fire and a policy that silently does nothing is worse than a
+    rejected one.
+  - **It applies to records that already exist.** A self-healing pass on the existing TTL sweep stamps them
+    from **their own `createdAt`**, so enabling the policy prunes the backlog instead of granting everything a
+    fresh full window. Lazy rather than a boot migration because chrono is synced data — a boot migration would
+    stamp local copies while a peer's unstamped ones came back on the next pull.
+  - Gates: `chrono-retention` (22 cases, pure) and `chrono-retention-db` (10, real MongoDB — including that the
+    record **survives** redaction, which is the whole promise of the first tier). 10 of 10 mutations caught,
+    every one of them in the direction of removing more than the operator asked for.
+
 - **Tombstones are no longer kept forever — and the bound is a peer watermark, not an expiry date.**
   `<space>_tombstones` was the last growing collection with no retention at all: one document per deletion,
   removed only by wiping the space. On an instance whose agents write and delete, the tombstones eventually

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -95,6 +95,49 @@ expiry is stamped on the file's metadata record; when it lapses, the sweep runs 
 (the blob, its embedding chunks, conversion artifacts and any queued job — not just the record), the same as
 `DELETE /api/files/:spaceId`. The space-wide `recordTtlDays` default applies to uploads that omit `ttlDays`.
 
+#### Per-chrono-type retention
+
+A space-wide TTL is the wrong axis for a space that mixes telemetry with knowledge. Deploy `event`s are
+content-free by design, so they cluster tightly and **displace real answers in recall**; `health-snapshot` and
+`metrics-snapshot` records exist to be trended, and a 90-day cap is one quarter with no year-over-year. One
+number cannot serve both.
+
+`chronoRetention` on the space (`PATCH /api/spaces/:id`) sets a window **per chrono type**, overriding
+`recordTtlDays` for the types it names:
+
+```json
+{
+  "chronoRetention": {
+    "event":            { "days": 90, "contentDays": 14 },
+    "episode":          { "days": 90 },
+    "health-snapshot":  { "days": 3650 },
+    "metrics-snapshot": { "days": 3650 }
+  }
+}
+```
+
+Two tiers, the same shape the audit log uses for its change payloads:
+
+| field | effect |
+|---|---|
+| `contentDays` | The **detail** goes — `description`, `matchedText`, `properties` and the embedding — and `contentRedacted: true` is set with `contentRedactedAt`. The record stays: *that* a deploy happened is still true, and it no longer competes in semantic search, because a record with no vector cannot win one. |
+| `days` | The record is deleted, through the normal delete path, so it tombstones and propagates to peers. |
+
+Rules worth knowing before you configure it:
+
+- **A per-record `ttlDays` still wins**, including `0`/`null` for "never expire". Someone said what they wanted
+  for that record.
+- **A type named with only `contentDays`** still deletes on the space's `recordTtlDays` schedule. Setting a
+  content window means "redact sooner", not "exempt from deletion".
+- **A `contentDays` at or past the delete window is ignored**, because it could never fire, and a policy that
+  silently does nothing is worse than a rejected one.
+- **It applies to records you already have.** A background pass stamps existing chronos from **their own
+  `createdAt`**, not from when you enabled the policy — so switching it on prunes the backlog rather than
+  granting everything a fresh full window.
+- Local and operational, like `recordTtlDays`: never governed by a network vote, never synced. Each instance
+  applies the same policy to its own copy and the tombstones converge.
+- `null` or `{}` clears the policy.
+
 ---
 
 ### Get a Memory by ID

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -151,6 +151,19 @@ const UpdateSpaceBody = z.object({
   dupeRulesOnInsert: z.boolean().optional(),
   // F10: auto-TTL in days. 0/null clears it; a positive value stamps every new/updated record.
   recordTtlDays: z.number().int().nonnegative().max(36500).nullable().optional(),
+  // Per-chrono-type retention (canary ask, 2026-08-02). Overrides `recordTtlDays` for the types named, because
+  // a telemetry space wants deploy `event`s pruned and `health-snapshot`s kept for trending, and one space-wide
+  // number cannot express both. `days` deletes (through the normal path, so it tombstones); `contentDays`
+  // drops the detail and the vector while keeping the record. `null` clears the whole policy.
+  chronoRetention: z.record(
+    z.string().min(1).max(64),
+    z.object({
+      days: z.number().int().positive().max(36500).optional(),
+      contentDays: z.number().int().positive().max(36500).optional(),
+    }).strict().refine(v => v.days !== undefined || v.contentDays !== undefined, {
+      message: 'each chronoRetention entry needs days, contentDays, or both',
+    }),
+  ).nullable().optional(),
   // F11-c: per-space document-extraction mode override. null clears it (inherit the instance default).
   // `max` is accepted as the legacy spelling of `repair` and normalised on the way in.
   documentExtraction: z.enum(DOC_EXTRACTION_MODES_IN).nullable().optional(),
@@ -160,8 +173,8 @@ const UpdateSpaceBody = z.object({
   audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
   videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
   textAnalysis: z.enum(TEXT_LEVELS).nullable().optional(),
-}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
-  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
+}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.chronoRetention !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
+  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, chronoRetention, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
 });
 
 const ReorderSpacesBody = z.object({
@@ -345,7 +358,7 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
   }
 
   const spaces = visibleSpaces.map((space, idx) => {
-    const { id, label, builtIn, folders, maxGiB, flex, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, textAnalysis, indexStatus } = space;
+    const { id, label, builtIn, folders, maxGiB, flex, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, chronoRetention, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, textAnalysis, indexStatus } = space;
     return {
     id, label, builtIn, folders, maxGiB, flex,
     // Deprecated alias of `meta.purpose`, derived rather than stored — see `spaceDescriptionAlias`.
@@ -360,6 +373,7 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     ...(dupeMergeSurvivor ? { dupeMergeSurvivor } : {}),
     ...(dupeRulesOnInsert ? { dupeRulesOnInsert } : {}),
     ...(recordTtlDays ? { recordTtlDays } : {}),
+    ...(chronoRetention ? { chronoRetention } : {}),
     ...(documentExtraction ? { documentExtraction } : {}),
     // Only present when the space overrides the instance — an absent field means 'follows the
     // instance', which the UI renders differently from an explicit choice.
@@ -524,6 +538,16 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
     const ttl = parsed.data.recordTtlDays && parsed.data.recordTtlDays > 0 ? parsed.data.recordTtlDays : undefined;
     updateSpace(id, { recordTtlDays: ttl });
     if (ttl) void ensureTtlIndex(id).catch(err => log.warn(`ensureTtlIndex ${id}: ${err}`));
+  }
+
+  // Per-chrono-type retention — same treatment: local, immediate, never voted. `null` or an empty object
+  // clears the policy. The index matters more here than for `recordTtlDays`: the redaction pass has its own
+  // sweep query, so without it a space that enables this would be scanned every five minutes.
+  if (parsed.data.chronoRetention !== undefined) {
+    const policy = parsed.data.chronoRetention;
+    const next = policy && Object.keys(policy).length > 0 ? policy : undefined;
+    updateSpace(id, { chronoRetention: next });
+    if (next) void ensureTtlIndex(id).catch(err => log.warn(`ensureTtlIndex ${id}: ${err}`));
   }
 
   // A space may pick any extraction mode up to the instance ceiling and nothing beyond. The client only

--- a/server/src/brain/chrono-redaction.ts
+++ b/server/src/brain/chrono-redaction.ts
@@ -1,0 +1,150 @@
+/**
+ * The chrono content-redaction pass, and the lazy backfill that makes per-type retention apply to records that
+ * already exist.
+ *
+ * ## Why this is lazy rather than a boot migration
+ *
+ * `<space>_chrono` is **synced data**: it replicates to peers by whole-document upsert. A boot migration would
+ * stamp local copies while a peer's older copies came back unstamped on the next pull, so the policy would
+ * apply on some instances and not others depending on who booted when. Self-healing on a timer is the shape
+ * synced data requires — see `_REFERENCE.md → migration-strategy`. It is also what makes a policy CHANGE take
+ * effect: an operator who sets `chronoRetention` today expects it to apply to the records they already have,
+ * not only to ones written from now on.
+ *
+ * ## What the two passes do
+ *
+ * **Backfill** stamps `_expireAt` / `_contentExpireAt` from the record's own `createdAt`, not from now — so
+ * turning the policy on does not grant every existing record a fresh full window. It only ever ADDS a stamp
+ * that is missing; it never re-slides one, because that is how a record with a deliberate per-record `ttlDays`
+ * would silently have it overwritten.
+ *
+ * **Redaction** drops the bulky, recallable half and sets `contentRedacted: true`. It writes through the
+ * collection directly rather than the update path on purpose: this is not a user edit, it must not bump `seq`
+ * or fire a `chrono.updated` webhook, and every instance performs it independently from the same policy and
+ * the same `createdAt`, so the result converges without needing to replicate.
+ *
+ * Dropping `embedding` is the point, not a side effect: the reported failure was content-free deploy events
+ * winning semantic searches over real knowledge, and a record with no vector cannot win one.
+ */
+import { col, asFilter, asUpdate } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+import {
+  chronoExpiry, chronoContentExpiry, needsContentRedaction, REDACTED_CHRONO_FIELDS,
+  type RetentionSpace,
+} from './chrono-retention.js';
+import type { ChronoEntry } from '../config/types.js';
+
+/** Max records touched per space per pass, so one enormous space cannot monopolise a sweep cycle. */
+const BATCH = 500;
+
+export interface ChronoRetentionResult {
+  /** Records given a missing `_expireAt` / `_contentExpireAt` from an existing policy. */
+  stamped: number;
+  /** Records whose content window lapsed and whose detail was dropped. */
+  redacted: number;
+}
+
+/** True when this space has any per-type policy at all — the cheap check that skips the common case. */
+export function hasChronoPolicy(space: RetentionSpace): boolean {
+  const p = space.chronoRetention;
+  return !!p && Object.keys(p).length > 0;
+}
+
+/**
+ * Stamp records that a policy covers but that carry no expiry yet.
+ *
+ * Only fetches records missing BOTH stamps, so a settled collection costs one indexed miss per cycle.
+ */
+export async function backfillChronoExpiry(spaceId: string, space: RetentionSpace): Promise<number> {
+  if (!hasChronoPolicy(space)) return 0;
+  const types = Object.keys(space.chronoRetention ?? {});
+  let stamped = 0;
+
+  const rows = await col<ChronoEntry>(`${spaceId}_chrono`)
+    .find(
+      asFilter<ChronoEntry>({
+        type: { $in: types },
+        _expireAt: { $exists: false },
+        _contentExpireAt: { $exists: false },
+      }),
+      { projection: { _id: 1, type: 1, createdAt: 1 } },
+    )
+    .limit(BATCH)
+    .toArray() as unknown as Array<{ _id: string; type: string; createdAt?: string }>;
+
+  for (const r of rows) {
+    // From the record's OWN creation time. Using `now` would hand every existing record a fresh full window,
+    // which is the opposite of what enabling a retention policy means.
+    const createdMs = Date.parse(r.createdAt ?? '');
+    if (!Number.isFinite(createdMs)) continue;   // cannot date it ⇒ cannot expire it
+    const $set: Record<string, unknown> = {};
+    const expireAt = chronoExpiry(space, r.type, createdMs);
+    const contentAt = chronoContentExpiry(space, r.type, createdMs);
+    if (expireAt) $set['_expireAt'] = expireAt;
+    if (contentAt) $set['_contentExpireAt'] = contentAt;
+    if (Object.keys($set).length === 0) continue;
+    await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(
+      asFilter<ChronoEntry>({ _id: r._id }), asUpdate<ChronoEntry>({ $set }),
+    );
+    stamped++;
+  }
+  return stamped;
+}
+
+/** Drop the content of records whose content window has lapsed, keeping the record. */
+export async function redactLapsedChronoContent(spaceId: string, now: Date): Promise<number> {
+  let redacted = 0;
+  const rows = await col<ChronoEntry>(`${spaceId}_chrono`)
+    .find(
+      asFilter<ChronoEntry>({ _contentExpireAt: { $lte: now }, contentRedacted: { $ne: true } }),
+      { projection: { _id: 1, description: 1, matchedText: 1, properties: 1, embedding: 1, embeddingModel: 1, contentRedacted: 1 } },
+    )
+    .limit(BATCH)
+    .toArray() as unknown as Array<Record<string, unknown> & { _id: string }>;
+
+  for (const r of rows) {
+    // Already bare (a chrono with only a title) — mark it so the query stops returning it, but do not pretend
+    // detail was removed.
+    const $unset: Record<string, ''> = {};
+    if (needsContentRedaction(r)) {
+      for (const f of REDACTED_CHRONO_FIELDS) if (r[f] !== undefined) $unset[f] = '';
+    }
+    await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(
+      asFilter<ChronoEntry>({ _id: r._id }),
+      asUpdate<ChronoEntry>({
+        $set: { contentRedacted: true, contentRedactedAt: now.toISOString() },
+        ...(Object.keys($unset).length > 0 ? { $unset } : {}),
+      }),
+    );
+    redacted++;
+  }
+  return redacted;
+}
+
+/** Both passes across every real space. Best-effort per space: one bad collection must not stop the rest. */
+export async function sweepChronoRetention(now: Date = new Date()): Promise<ChronoRetentionResult> {
+  const result: ChronoRetentionResult = { stamped: 0, redacted: 0 };
+  let cfg;
+  try { cfg = getConfig(); } catch { return result; }   // pre-setup
+
+  for (const s of cfg.spaces) {
+    if (s.proxyFor?.length) continue;
+    const space: RetentionSpace = { recordTtlDays: s.recordTtlDays, chronoRetention: s.chronoRetention };
+    try {
+      result.stamped += await backfillChronoExpiry(s.id, space);
+      result.redacted += await redactLapsedChronoContent(s.id, now);
+    } catch (err) {
+      log.warn(`Chrono retention (${s.id}): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (result.redacted > 0) {
+    log.info(`Chrono retention: dropped the detail of ${result.redacted} record(s) past their content window `
+      + '(the records themselves are kept)');
+  }
+  if (result.stamped > 0) {
+    log.debug(`Chrono retention: stamped ${result.stamped} existing record(s) from the per-type policy`);
+  }
+  return result;
+}

--- a/server/src/brain/chrono-retention.ts
+++ b/server/src/brain/chrono-retention.ts
@@ -1,0 +1,133 @@
+/**
+ * Per-chrono-type retention — the rule, kept pure.
+ *
+ * ## Why a space-wide TTL was the wrong axis
+ *
+ * From a canary operator, 2026-08-02. Their `operation-logs` space holds deploy `event`s next to
+ * `health-snapshot` and `metrics-snapshot` records, and the two want opposite treatment:
+ *
+ *   - **Deploy events are content-free by design**, so they are semantically almost identical to each other
+ *     and to anything mentioning deployment. A cross-space recall for *"how is the platform deployed and what
+ *     runs on the server"* returned **four near-identical `platform-apps deployed` chronos at 0.874**,
+ *     outranking the guideline it should have surfaced at 0.823. They displace knowledge.
+ *   - **Snapshots exist to be trended** (`diskServerDaysToFull`, `mongoDataSizeGiB`, `trivyCriticalCVEs`) and
+ *     are one per run, so retaining them is nearly free — while 90 days is a single quarter with no
+ *     year-over-year comparison.
+ *
+ * So this is a **recall-quality** feature that happens to look like a storage one. Their volumes were 516 and
+ * 139 records; nobody was worried about disk.
+ *
+ * ## Two tiers, borrowed rather than invented
+ *
+ * The audit log already splits "the entry" from "the payload inside it" (`audit.recordChangeRetentionDays`),
+ * and the operator asked for that shape by name. It maps exactly:
+ *
+ *   contentDays  →  drop the bulky, recallable part; keep the fact. `contentRedacted: true` so a reader can
+ *                   tell "there was no detail" from "there was, and it expired".
+ *   days         →  delete the record, through the normal delete path so it tombstones and propagates.
+ *
+ * **Dropping the vector is the point of the first tier**, not a side effect: a record with no embedding is
+ * still listed and still queryable by field, but it can no longer win a semantic search — which is precisely
+ * the problem that was reported.
+ *
+ * ## Precedence
+ *
+ * A per-record `ttlDays` on the write beats everything (someone said what they wanted for that record); then
+ * the per-type policy; then the space's `recordTtlDays`. Absent everywhere means no expiry, as before.
+ */
+
+const DAY_MS = 86_400_000;
+
+/** Per-type policy as stored on the space. Both fields optional so a type can set one tier only. */
+export interface ChronoTypeRetention {
+  days?: number;
+  contentDays?: number;
+}
+
+export type ChronoRetentionPolicy = Record<string, ChronoTypeRetention>;
+
+/** The subset of a space this decision needs — so every branch is testable without a config. */
+export interface RetentionSpace {
+  recordTtlDays?: number;
+  chronoRetention?: ChronoRetentionPolicy;
+}
+
+/** A positive, finite day count, or undefined. Rejects 0 and negatives: those mean "no policy", not "instant". */
+function days(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : undefined;
+}
+
+/**
+ * Retention in days for a chrono of this type: the per-type value, else the space default.
+ *
+ * A type named in the policy with no `days` deliberately falls through to the space default rather than
+ * meaning "keep forever" — the operator's intent when they set only `contentDays` is "redact sooner, delete on
+ * the usual schedule", and reading it as an exemption would silently retain records they expected to go.
+ */
+export function chronoRetentionDays(space: RetentionSpace, type: string): number | undefined {
+  return days(space.chronoRetention?.[type]?.days) ?? days(space.recordTtlDays);
+}
+
+/**
+ * Days after which a chrono of this type loses its content but keeps its fact, or undefined for never.
+ *
+ * Clamped below the delete window: a content window at or past the delete window can never fire, and a policy
+ * that silently does nothing is worse than a rejected one. Clamping rather than erroring keeps a two-step
+ * config edit (lower `days`, then lower `contentDays`) from failing halfway.
+ */
+export function chronoContentDays(space: RetentionSpace, type: string): number | undefined {
+  const content = days(space.chronoRetention?.[type]?.contentDays);
+  if (content === undefined) return undefined;
+  const total = chronoRetentionDays(space, type);
+  if (total !== undefined && content >= total) return undefined;
+  return content;
+}
+
+/** `now + days` as a BSON Date, or undefined. `from` is the record's creation time, not the sweep's clock. */
+function plusDays(from: number, d: number | undefined): Date | undefined {
+  return d === undefined ? undefined : new Date(from + d * DAY_MS);
+}
+
+/**
+ * The `_expireAt` a chrono of this type should carry.
+ *
+ * `ttlDays` follows the same contract as `expiryForCreate`: `0`/`null` is an explicit "never expire" and wins
+ * over any policy, a positive number wins, and omitted defers to the type policy then the space default.
+ */
+export function chronoExpiry(
+  space: RetentionSpace,
+  type: string,
+  createdAtMs: number,
+  ttlDays?: number | null,
+): Date | undefined {
+  if (ttlDays === 0 || ttlDays === null) return undefined;
+  const explicit = days(ttlDays);
+  if (explicit !== undefined) return plusDays(createdAtMs, explicit);
+  return plusDays(createdAtMs, chronoRetentionDays(space, type));
+}
+
+/** When this chrono's content should be dropped, or undefined if it never should. */
+export function chronoContentExpiry(
+  space: RetentionSpace,
+  type: string,
+  createdAtMs: number,
+): Date | undefined {
+  return plusDays(createdAtMs, chronoContentDays(space, type));
+}
+
+/**
+ * Fields removed when a chrono's content window lapses.
+ *
+ * `embedding` and `embeddingModel` go with the text: leaving the vector behind would keep the record winning
+ * semantic searches for content that is no longer there, which is the failure this feature exists to fix.
+ * `title`, `type`, `startsAt`, `tags` and the id links stay — that is the "it happened" half.
+ */
+export const REDACTED_CHRONO_FIELDS = [
+  'description', 'matchedText', 'properties', 'embedding', 'embeddingModel',
+] as const;
+
+/** True when this record still has anything worth redacting — so the sweep does not rewrite it forever. */
+export function needsContentRedaction(doc: Record<string, unknown>): boolean {
+  if (doc['contentRedacted'] === true) return false;
+  return REDACTED_CHRONO_FIELDS.some(f => doc[f] !== undefined);
+}

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -148,7 +148,9 @@ export async function createChrono(
   if (fields.properties !== undefined) doc.properties = fields.properties;
   if (fields.recurrence !== undefined) doc.recurrence = fields.recurrence;
 
-  stampExpiryOnCreate(spaceId, doc, ttlDays);
+  // The type is passed so per-type retention applies: a telemetry space prunes deploy `event`s while keeping
+  // `health-snapshot`/`metrics-snapshot` for trending, which one space-wide TTL cannot express.
+  stampExpiryOnCreate(spaceId, doc, ttlDays, doc.type);
   await col<ChronoEntry>(`${spaceId}_chrono`).insertOne(asDoc<ChronoEntry>(doc));
   if (actor) emitWebhookEvent({ event: 'chrono.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   // Advisory only — the entry is stored either way.

--- a/server/src/brain/ttl-sweep.ts
+++ b/server/src/brain/ttl-sweep.ts
@@ -18,6 +18,7 @@ import { deleteEdge } from './edges.js';
 import { deleteChrono } from './chrono.js';
 import { deleteFileCascade } from '../files/delete-cascade.js';
 import { runExclusive } from '../util/single-flight.js';
+import { sweepChronoRetention } from './chrono-redaction.js';
 
 const SWEEP_INTERVAL_MS = 5 * 60_000; // 5 min
 const SWEEP_BATCH = 500;              // max deletions per collection per cycle
@@ -65,6 +66,12 @@ export async function sweepExpired(now: Date = new Date()): Promise<number> {
     }
   }
   if (total > 0) log.info(`TTL sweep deleted ${total} expired record(s)`);
+
+  // Per-chrono-type retention rides the same cycle: its backfill and content-redaction passes are the same
+  // shape of work on the same clock, and running them here means one timer rather than two doing housekeeping
+  // over the same collections. Failures are contained inside it — a retention problem must not stop deletions.
+  await sweepChronoRetention(now).catch(err => log.warn(`Chrono retention sweep: ${err}`));
+
   return total;
 }
 

--- a/server/src/brain/ttl.ts
+++ b/server/src/brain/ttl.ts
@@ -10,6 +10,7 @@
 import { col } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
+import { chronoExpiry, chronoContentExpiry, type RetentionSpace } from './chrono-retention.js';
 
 const DAY_MS = 86_400_000;
 
@@ -30,16 +31,51 @@ function spaceTtlExpiry(spaceId: string): Date | undefined {
  * Expiry to stamp on **create**: a per-record `ttlDays > 0` wins; `ttlDays` 0/null means "never expire"
  * (no stamp even if the space has a default); omitted falls back to the space's `recordTtlDays`.
  */
-export function expiryForCreate(spaceId: string, ttlDays?: number | null): Date | undefined {
+export function expiryForCreate(spaceId: string, ttlDays?: number | null, chronoType?: string): Date | undefined {
   if (ttlDays === 0 || ttlDays === null) return undefined;
   if (typeof ttlDays === 'number' && ttlDays > 0) return new Date(Date.now() + ttlDays * DAY_MS);
+  // A chrono type may carry its own window, which overrides the space default (see `chrono-retention.ts`: a
+  // telemetry space wants deploy events pruned and health snapshots kept, and one space-wide number cannot
+  // express both).
+  if (chronoType !== undefined) {
+    const space = retentionSpace(spaceId);
+    if (space) return chronoExpiry(space, chronoType, Date.now(), ttlDays);
+  }
   return spaceTtlExpiry(spaceId);
 }
 
-/** Set `_expireAt` on a create doc in place when an expiry applies. */
-export function stampExpiryOnCreate(spaceId: string, doc: { _expireAt?: Date }, ttlDays?: number | null): void {
-  const expireAt = expiryForCreate(spaceId, ttlDays);
+/** Set `_expireAt` (and, for a chrono type with a content window, `_contentExpireAt`) on a create doc. */
+export function stampExpiryOnCreate(
+  spaceId: string,
+  doc: { _expireAt?: Date; _contentExpireAt?: Date },
+  ttlDays?: number | null,
+  chronoType?: string,
+): void {
+  const expireAt = expiryForCreate(spaceId, ttlDays, chronoType);
   if (expireAt) doc._expireAt = expireAt;
+  const contentAt = contentExpiryForCreate(spaceId, chronoType);
+  if (contentAt) doc._contentExpireAt = contentAt;
+}
+
+/**
+ * When this record's CONTENT should be dropped while the record itself stays — chrono only.
+ *
+ * Deliberately not gated on a per-record `ttlDays`: that says when the record goes, and says nothing about
+ * whether its detail is worth keeping for the whole of that. An operator who set `ttlDays` for one record and
+ * a content window for its type meant both.
+ */
+export function contentExpiryForCreate(spaceId: string, chronoType?: string): Date | undefined {
+  if (chronoType === undefined) return undefined;
+  const space = retentionSpace(spaceId);
+  return space ? chronoContentExpiry(space, chronoType, Date.now()) : undefined;
+}
+
+/** The retention-relevant fields of a space, or undefined pre-setup / for an unknown id. */
+function retentionSpace(spaceId: string): RetentionSpace | undefined {
+  try {
+    const s = getConfig().spaces.find(x => x.id === spaceId);
+    return s ? { recordTtlDays: s.recordTtlDays, chronoRetention: s.chronoRetention } : undefined;
+  } catch { return undefined; }
 }
 
 /**
@@ -73,4 +109,11 @@ export async function ensureTtlIndex(spaceId: string): Promise<void> {
       log.warn(`ensureTtlIndex ${spaceId}_${c}: ${err}`);
     }
   }));
+  // Chrono only: the content-redaction pass has its own sweep query, and without an index it would scan the
+  // whole collection every five minutes on a space that never uses the feature.
+  try {
+    await col(`${spaceId}_chrono`).createIndex({ _contentExpireAt: 1 }, { name: 'ttl_contentExpireAt', sparse: true });
+  } catch (err) {
+    log.warn(`ensureTtlIndex ${spaceId}_chrono content: ${err}`);
+  }
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -235,6 +235,28 @@ export interface SpaceConfig {
    *  `now + recordTtlDays` and deleted by the TTL sweep once it lapses (through the normal delete path,
    *  so it tombstones + syncs). A per-record `ttlDays` on a write overrides this. Absent = no auto-TTL. */
   recordTtlDays?: number;
+  /**
+   * Per-CHRONO-TYPE retention, overriding `recordTtlDays` for the types named (canary ask, 2026-08-02).
+   *
+   * A space-wide TTL is the wrong axis for a telemetry space. The reporting operator's `operation-logs` space
+   * holds deploy `event`s alongside `health-snapshot`/`metrics-snapshot` records, and the two want opposite
+   * treatment: the events should go (they are content-free by design, so they cluster tightly and **displace
+   * knowledge in recall** — four near-identical `platform-apps deployed` chronos scored 0.874 against the
+   * guideline they wanted at 0.823), while the snapshots must stay far longer because they exist to be
+   * trended, and 90 days is one quarter with no year-over-year.
+   *
+   * Two tiers per type, taken from the audit log's design because it is the right shape and reusing it beats
+   * inventing a second one:
+   *
+   *   - `contentDays` — after this, the bulky, recallable part goes (`description`, `matchedText`,
+   *     `properties`, the vector) and `contentRedacted: true` is set. The record stays: **that a deploy
+   *     happened is still true, the detail is not kept, and it stops competing in recall.**
+   *   - `days` — after this, the record is deleted through the normal path, so it tombstones and propagates.
+   *
+   * Local and operational, like `recordTtlDays` beside it: never governed, never synced. A per-record
+   * `ttlDays` on a write still wins over both. Absent, or a type not named, falls back to `recordTtlDays`.
+   */
+  chronoRetention?: Record<string, { days?: number; contentDays?: number }>;
   /** Vector-search index lifecycle for a newly created space (B1). Creation now
    *  returns immediately with 'building' and the (slow, up-to-minutes) Atlas index
    *  builds finish asynchronously — flipping this to 'ready', or 'failed' if a build
@@ -1462,6 +1484,15 @@ export interface ChronoEntry {
   embeddingModel?: string;
   /** Absolute expiry (F10) — see MemoryDoc._expireAt. */
   _expireAt?: Date;
+  /** When this entry's CONTENT should be dropped while the entry itself stays — the first tier of
+   *  `SpaceConfig.chronoRetention`. Set from the type's `contentDays`; absent means never. */
+  _contentExpireAt?: Date;
+  /** True once the content window lapsed and the detail was dropped. Present so a reader can tell
+   *  "this record never had a description" from "it did, and it expired" — the same distinction
+   *  `changesRedacted` draws in the audit log. */
+  contentRedacted?: boolean;
+  /** ISO8601 — when the redaction happened. */
+  contentRedactedAt?: string;
 }
 
 export interface TombstoneDoc {

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -61,7 +61,7 @@ export function spaceResponse<T extends { meta?: SpaceMeta }>(space: T): T & { d
  *  Returns the updated SpaceConfig, or null if the space was not found. */
 export function updateSpace(
   spaceId: string,
-  updates: { label?: string; description?: string; maxGiB?: number | null; meta?: SpaceMeta; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | null; documentExtraction?: DocExtractionMode | null; imageAnalysis?: ImageLevel | null; audioAnalysis?: AudioLevel | null; videoAnalysis?: VideoLevel | null; textAnalysis?: TextLevel | null },
+  updates: { label?: string; description?: string; maxGiB?: number | null; meta?: SpaceMeta; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | null; chronoRetention?: Record<string, { days?: number; contentDays?: number }> | null; documentExtraction?: DocExtractionMode | null; imageAnalysis?: ImageLevel | null; audioAnalysis?: AudioLevel | null; videoAnalysis?: VideoLevel | null; textAnalysis?: TextLevel | null },
 ): SpaceConfig | null {
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === spaceId);
@@ -94,6 +94,11 @@ export function updateSpace(
   // F10 auto-TTL — local operational setting; `in` so an explicit clear (undefined) removes it.
   if ('recordTtlDays' in updates) {
     space.recordTtlDays = updates.recordTtlDays && updates.recordTtlDays > 0 ? updates.recordTtlDays : undefined;
+  }
+  // Per-chrono-type retention — same contract: local, immediate, cleared by an explicit empty/null.
+  if ('chronoRetention' in updates) {
+    const p = updates.chronoRetention;
+    space.chronoRetention = p && Object.keys(p).length > 0 ? p : undefined;
   }
   // F11-c per-space extraction-mode override — local operational setting; `in` so an explicit clear removes it.
   if ('documentExtraction' in updates) {

--- a/testing/standalone/chrono-retention-db.test.js
+++ b/testing/standalone/chrono-retention-db.test.js
@@ -1,0 +1,161 @@
+/**
+ * Database-level test: the backfill and content-redaction passes, against a real MongoDB.
+ *
+ * The pure rule is covered by `chrono-retention.test.js`. This covers what only the driver can settle:
+ *
+ *  - `$unset` really removes the fields (a `$set: undefined` silently does nothing in some drivers);
+ *  - the sweep query matches by `_contentExpireAt` and skips already-redacted records, so a settled collection
+ *    costs one indexed miss rather than a rewrite every five minutes;
+ *  - the backfill stamps from each record's own `createdAt`, which is the difference between enabling a policy
+ *    that prunes the backlog and one that grants every existing record a fresh full window;
+ *  - **the record survives redaction.** That is the whole promise of the first tier: "that a deploy happened is
+ *    still true, the detail is not kept".
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/chrono-retention-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'telemetry';
+const DAY = 86_400_000;
+
+let mongo, backfillChronoExpiry, redactLapsedChronoContent, hasChronoPolicy;
+
+/** The reporter's own policy shape. */
+const POLICY = {
+  recordTtlDays: 90,
+  chronoRetention: {
+    event: { days: 90, contentDays: 14 },
+    'health-snapshot': { days: 3650 },
+  },
+};
+
+const chrono = (id, type, createdAt, extra = {}) => ({
+  _id: id, spaceId: SPACE, type, title: `${type} ${id}`,
+  description: 'deployed platform-apps to production',
+  matchedText: 'deployed platform-apps to production',
+  properties: { revision: 'abc123' },
+  embedding: Array.from({ length: 8 }, (_, i) => i / 8),
+  embeddingModel: 'nomic-embed-text-v1.5',
+  startsAt: createdAt, status: 'done', tags: ['deploy'], entityIds: ['e1'], memoryIds: [],
+  createdAt, updatedAt: createdAt, seq: 1,
+  author: { instanceId: 'self' },
+  ...extra,
+});
+
+const load = async (id) => mongo.col(`${SPACE}_chrono`).findOne({ _id: id });
+
+describe('chrono retention (real MongoDB)', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('chronoretention');
+    ({ backfillChronoExpiry, redactLapsedChronoContent, hasChronoPolicy } =
+      await import('../../server/dist/brain/chrono-redaction.js'));
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => { await mongo.col(`${SPACE}_chrono`).deleteMany({}); });
+
+  it('stamps an existing record from its OWN createdAt', async () => {
+    const created = new Date(Date.now() - 60 * DAY).toISOString();
+    await mongo.col(`${SPACE}_chrono`).insertOne(chrono('e-old', 'event', created));
+
+    assert.equal(await backfillChronoExpiry(SPACE, POLICY), 1);
+    const doc = await load('e-old');
+    // 90 days from creation, i.e. 30 days from now — NOT 90 days from now.
+    const expected = Date.parse(created) + 90 * DAY;
+    assert.equal(doc._expireAt.getTime(), expected);
+    assert.equal(doc._contentExpireAt.getTime(), Date.parse(created) + 14 * DAY);
+    assert.ok(doc._expireAt.getTime() < Date.now() + 90 * DAY,
+      'the record was given a fresh full window instead of being dated from its creation');
+  });
+
+  it('stamps a snapshot with its long window and no content window', async () => {
+    const created = new Date(Date.now() - 200 * DAY).toISOString();
+    await mongo.col(`${SPACE}_chrono`).insertOne(chrono('h1', 'health-snapshot', created));
+    await backfillChronoExpiry(SPACE, POLICY);
+    const doc = await load('h1');
+    assert.equal(doc._expireAt.getTime(), Date.parse(created) + 3650 * DAY);
+    assert.equal(doc._contentExpireAt, undefined, 'a snapshot must never be redacted — it exists to be trended');
+  });
+
+  it('leaves a record that already carries an expiry alone', async () => {
+    // Re-sliding would silently override a deliberate per-record `ttlDays`.
+    const created = new Date(Date.now() - 10 * DAY).toISOString();
+    const pinned = new Date(Date.now() + 5 * DAY);
+    await mongo.col(`${SPACE}_chrono`).insertOne({ ...chrono('e-pinned', 'event', created), _expireAt: pinned });
+    assert.equal(await backfillChronoExpiry(SPACE, POLICY), 0);
+    assert.equal((await load('e-pinned'))._expireAt.getTime(), pinned.getTime());
+  });
+
+  it('ignores a record it cannot date', async () => {
+    await mongo.col(`${SPACE}_chrono`).insertOne(chrono('e-bad', 'event', 'not-a-date'));
+    assert.equal(await backfillChronoExpiry(SPACE, POLICY), 0);
+    assert.equal((await load('e-bad'))._expireAt, undefined);
+  });
+
+  it('does nothing at all without a policy', async () => {
+    await mongo.col(`${SPACE}_chrono`).insertOne(chrono('e1', 'event', new Date().toISOString()));
+    assert.equal(hasChronoPolicy({ recordTtlDays: 90 }), false);
+    assert.equal(await backfillChronoExpiry(SPACE, { recordTtlDays: 90 }), 0);
+    assert.equal((await load('e1'))._expireAt, undefined);
+  });
+
+  it('drops the detail and the vector, and KEEPS the record', async () => {
+    const created = new Date(Date.now() - 30 * DAY).toISOString();
+    await mongo.col(`${SPACE}_chrono`).insertOne({
+      ...chrono('e2', 'event', created), _contentExpireAt: new Date(Date.now() - DAY),
+    });
+
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 1);
+    const doc = await load('e2');
+    assert.ok(doc, 'the record itself must survive — that is the whole point of the first tier');
+    assert.equal(doc.contentRedacted, true);
+    assert.ok(typeof doc.contentRedactedAt === 'string');
+    for (const gone of ['description', 'matchedText', 'properties', 'embedding', 'embeddingModel']) {
+      assert.equal(doc[gone], undefined, `${gone} survived redaction`);
+    }
+    for (const kept of ['title', 'type', 'startsAt', 'tags', 'entityIds', 'status', 'createdAt']) {
+      assert.notEqual(doc[kept], undefined, `${kept} must survive redaction`);
+    }
+  });
+
+  it('does not touch a record whose content window has not lapsed', async () => {
+    await mongo.col(`${SPACE}_chrono`).insertOne({
+      ...chrono('e3', 'event', new Date().toISOString()), _contentExpireAt: new Date(Date.now() + 10 * DAY),
+    });
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 0);
+    assert.equal((await load('e3')).description, 'deployed platform-apps to production');
+  });
+
+  it('does not touch a record with no content window at all', async () => {
+    await mongo.col(`${SPACE}_chrono`).insertOne(chrono('h2', 'health-snapshot', new Date().toISOString()));
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 0);
+    assert.equal((await load('h2')).embedding.length, 8);
+  });
+
+  it('is idempotent — a second pass finds nothing to do', async () => {
+    await mongo.col(`${SPACE}_chrono`).insertOne({
+      ...chrono('e4', 'event', new Date().toISOString()), _contentExpireAt: new Date(Date.now() - DAY),
+    });
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 1);
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 0,
+      'an already-redacted record must drop out of the sweep query, not be rewritten every cycle');
+  });
+
+  it('marks a record that had no detail rather than looping on it', async () => {
+    await mongo.col(`${SPACE}_chrono`).insertOne({
+      _id: 'bare', spaceId: SPACE, type: 'event', title: 'deployed', startsAt: '2026-01-01T00:00:00.000Z',
+      status: 'done', tags: [], entityIds: [], memoryIds: [], createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z', seq: 1, author: { instanceId: 'self' },
+      _contentExpireAt: new Date(Date.now() - DAY),
+    });
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 1);
+    assert.equal((await load('bare')).contentRedacted, true);
+    assert.equal(await redactLapsedChronoContent(SPACE, new Date()), 0);
+  });
+});

--- a/testing/standalone/chrono-retention.test.js
+++ b/testing/standalone/chrono-retention.test.js
@@ -1,0 +1,194 @@
+/**
+ * Per-chrono-type retention — the rule, every branch, without a database.
+ *
+ * ## Where the requirement came from
+ *
+ * A canary operator, 2026-08-02. Their `operation-logs` space holds deploy `event`s next to `health-snapshot`
+ * and `metrics-snapshot` records, and the two want opposite treatment — so a space-wide TTL is the wrong axis:
+ *
+ *   - deploy events are **content-free by design**, so they cluster tightly and displace knowledge. A recall
+ *     for *"how is the platform deployed and what runs on the server"* returned four near-identical
+ *     `platform-apps deployed` chronos at 0.874, above the guideline they wanted at 0.823;
+ *   - snapshots exist to be **trended**, and 90 days is one quarter with no year-over-year.
+ *
+ * It is a recall-quality feature, not a storage one: their volumes were 516 and 139 records.
+ *
+ * ## What must not go wrong
+ *
+ * The dangerous direction is deleting or redacting MORE than the operator asked for — a snapshot series
+ * silently truncated, or a per-record `ttlDays` overridden by a type policy. Every case below is about
+ * precedence and about a policy that cannot fire.
+ *
+ * Run: node --test testing/standalone/chrono-retention.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const DAY = 86_400_000;
+const T0 = Date.parse('2026-01-01T00:00:00.000Z');
+
+let chronoRetentionDays, chronoContentDays, chronoExpiry, chronoContentExpiry,
+  needsContentRedaction, REDACTED_CHRONO_FIELDS;
+
+before(async () => {
+  ({ chronoRetentionDays, chronoContentDays, chronoExpiry, chronoContentExpiry,
+    needsContentRedaction, REDACTED_CHRONO_FIELDS } =
+    await import('../../server/dist/brain/chrono-retention.js'));
+});
+
+/** The reporter's actual configuration, as the shape they asked for. */
+const TELEMETRY = {
+  recordTtlDays: 90,
+  chronoRetention: {
+    event: { days: 90, contentDays: 14 },
+    episode: { days: 90 },
+    'health-snapshot': { days: 3650 },
+    'metrics-snapshot': { days: 3650 },
+  },
+};
+
+describe('which window applies', () => {
+  it('a type with its own window overrides the space default', () => {
+    assert.equal(chronoRetentionDays(TELEMETRY, 'health-snapshot'), 3650);
+    assert.equal(chronoRetentionDays(TELEMETRY, 'event'), 90);
+  });
+
+  it('a type not named falls back to the space default', () => {
+    assert.equal(chronoRetentionDays(TELEMETRY, 'meeting'), 90);
+  });
+
+  it('no policy and no space default means no expiry at all', () => {
+    assert.equal(chronoRetentionDays({}, 'event'), undefined);
+    assert.equal(chronoExpiry({}, 'event', T0), undefined);
+  });
+
+  it('a type with ONLY contentDays still deletes on the space schedule', () => {
+    // Reading "no days" as "keep forever" would silently retain records the operator expected to go — they set
+    // a content window to redact SOONER, not to exempt the type from deletion.
+    const space = { recordTtlDays: 90, chronoRetention: { event: { contentDays: 7 } } };
+    assert.equal(chronoRetentionDays(space, 'event'), 90);
+    assert.equal(chronoContentDays(space, 'event'), 7);
+  });
+
+  it('rejects zero and negative windows rather than expiring instantly', () => {
+    for (const bad of [0, -1, NaN, Infinity, '30', null, undefined]) {
+      const space = { chronoRetention: { event: { days: bad } } };
+      assert.equal(chronoRetentionDays(space, 'event'), undefined, `days=${String(bad)} was accepted`);
+    }
+  });
+});
+
+describe('the per-record ttlDays still wins', () => {
+  it('an explicit ttlDays beats the type policy', () => {
+    const e = chronoExpiry(TELEMETRY, 'health-snapshot', T0, 5);
+    assert.equal(e.getTime(), T0 + 5 * DAY);
+  });
+
+  it('ttlDays 0 or null means never expire, whatever the policy says', () => {
+    assert.equal(chronoExpiry(TELEMETRY, 'event', T0, 0), undefined);
+    assert.equal(chronoExpiry(TELEMETRY, 'event', T0, null), undefined);
+  });
+
+  it('an omitted ttlDays defers to the policy', () => {
+    assert.equal(chronoExpiry(TELEMETRY, 'event', T0).getTime(), T0 + 90 * DAY);
+    assert.equal(chronoExpiry(TELEMETRY, 'health-snapshot', T0).getTime(), T0 + 3650 * DAY);
+  });
+
+  it('expiry is measured from the record, not from now', () => {
+    // The backfill stamps existing records from their own createdAt. Using `now` would hand every one of them a
+    // fresh full window, which is the opposite of enabling a retention policy.
+    const older = Date.parse('2020-06-01T00:00:00.000Z');
+    assert.equal(chronoExpiry(TELEMETRY, 'event', older).getTime(), older + 90 * DAY);
+  });
+});
+
+describe('the content tier cannot be set up to never fire', () => {
+  it('a content window at or past the delete window is ignored', () => {
+    // It could never fire — the record is gone first — and a policy that silently does nothing is worse than a
+    // rejected one.
+    for (const contentDays of [90, 120]) {
+      const space = { chronoRetention: { event: { days: 90, contentDays } } };
+      assert.equal(chronoContentDays(space, 'event'), undefined, `contentDays=${contentDays} was kept`);
+    }
+  });
+
+  it('a content window inside the delete window applies', () => {
+    assert.equal(chronoContentDays(TELEMETRY, 'event'), 14);
+    assert.equal(chronoContentExpiry(TELEMETRY, 'event', T0).getTime(), T0 + 14 * DAY);
+  });
+
+  it('a content window is checked against the SPACE default when the type sets no days', () => {
+    const space = { recordTtlDays: 10, chronoRetention: { event: { contentDays: 30 } } };
+    assert.equal(chronoContentDays(space, 'event'), undefined, '30 > the 10-day space default, so it can never fire');
+  });
+
+  it('a type with no content window never redacts', () => {
+    assert.equal(chronoContentDays(TELEMETRY, 'health-snapshot'), undefined);
+    assert.equal(chronoContentExpiry(TELEMETRY, 'health-snapshot', T0), undefined);
+  });
+});
+
+describe('what redaction removes', () => {
+  it('drops the vector along with the text', () => {
+    // The whole point: a record that keeps its embedding keeps winning semantic searches for content that is no
+    // longer there, which is the reported failure.
+    assert.ok(REDACTED_CHRONO_FIELDS.includes('embedding'));
+    assert.ok(REDACTED_CHRONO_FIELDS.includes('matchedText'));
+    assert.ok(REDACTED_CHRONO_FIELDS.includes('description'));
+  });
+
+  it('keeps the fact — title, type, when, tags and links are NOT removed', () => {
+    for (const kept of ['title', 'type', 'startsAt', 'tags', 'entityIds', 'memoryIds', 'status']) {
+      assert.equal(REDACTED_CHRONO_FIELDS.includes(kept), false, `${kept} must survive redaction`);
+    }
+  });
+
+  it('does not rewrite a record that is already redacted', () => {
+    assert.equal(needsContentRedaction({ contentRedacted: true, description: 'x' }), false);
+  });
+
+  it('reports nothing to do for a record that never had detail', () => {
+    assert.equal(needsContentRedaction({ title: 'deployed' }), false);
+    assert.equal(needsContentRedaction({ description: 'a note' }), true);
+    assert.equal(needsContentRedaction({ embedding: [0.1] }), true);
+  });
+});
+
+describe('the feature is reachable and wired', () => {
+  // Named files. A rule nothing calls is a rule that does not exist, and this one is invisible when broken:
+  // records simply keep accumulating, which is what the operator reported in the first place.
+  it('the chrono write passes its type so the policy applies', () => {
+    const src = readFileSync(join(ROOT, 'server/src/brain/chrono.ts'), 'utf8');
+    assert.match(src, /stampExpiryOnCreate\(spaceId,\s*doc,\s*ttlDays,\s*doc\.type\)/);
+  });
+
+  it('the API accepts and clears the policy', () => {
+    const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
+    assert.match(src, /chronoRetention: z\.record\(/, 'the space PATCH does not accept chronoRetention');
+    assert.match(src, /updateSpace\(id, \{ chronoRetention: next \}\)/);
+    assert.match(src, /chronoRetention !== undefined/, 'the at-least-one-field refine does not list it');
+  });
+
+  it('the sweep runs both passes', () => {
+    const src = readFileSync(join(ROOT, 'server/src/brain/ttl-sweep.ts'), 'utf8');
+    assert.match(src, /sweepChronoRetention\(now\)/);
+    const red = readFileSync(join(ROOT, 'server/src/brain/chrono-redaction.ts'), 'utf8');
+    assert.match(red, /backfillChronoExpiry/);
+    assert.match(red, /redactLapsedChronoContent/);
+  });
+
+  it('the backfill dates records from createdAt, never from now', () => {
+    // The one line that decides whether enabling a policy prunes the backlog or resets it.
+    const red = readFileSync(join(ROOT, 'server/src/brain/chrono-redaction.ts'), 'utf8');
+    assert.match(red, /Date\.parse\(r\.createdAt/);
+    assert.doesNotMatch(red, /chronoExpiry\(space, r\.type, Date\.now\(\)/);
+  });
+
+  it('the content-expiry sweep query is indexed', () => {
+    const ttl = readFileSync(join(ROOT, 'server/src/brain/ttl.ts'), 'utf8');
+    assert.match(ttl, /createIndex\(\{ _contentExpireAt: 1 \}/);
+  });
+});


### PR DESCRIPTION
## Not a storage feature — a recall-quality one

The canary asked for this (their finding **G**), and the owner moved it to the top of the queue. Worth being
clear about what it is *not*: their two telemetry spaces hold **516 and 139 chronos**. Nobody is worried about
disk.

The problem is that a space-wide TTL is the wrong **axis** for a space holding telemetry and knowledge together,
and their measurement is the argument:

- **Deploy `event`s are content-free by design**, so they cluster tightly and match anything on the topic. A
  cross-space recall for *"how is the platform deployed and what runs on the server"* returned **four
  near-identical `platform-apps deployed` chronos at 0.874**, above the guideline it should have surfaced at
  **0.823**. They displace real answers.
- **`health-snapshot` / `metrics-snapshot` must be kept far LONGER** than any prune window. They exist to be
  trended (`diskServerDaysToFull`, `mongoDataSizeGiB`, `trivyCriticalCVEs`), they are one per run, and 90 days
  is a single quarter with no year-over-year comparison.

One number cannot serve both, which is why a blanket space TTL — the obvious thing to build — would have been
wrong for them.

## Two tiers, borrowed rather than invented

They asked for the audit log's shape by name (*"we would rather you reused it than invented a second one"*), and
it maps exactly:

```json
{
  "chronoRetention": {
    "event":            { "days": 90, "contentDays": 14 },
    "episode":          { "days": 90 },
    "health-snapshot":  { "days": 3650 },
    "metrics-snapshot": { "days": 3650 }
  }
}
```

| field | effect |
|---|---|
| `contentDays` | Drop the detail — `description`, `matchedText`, `properties` **and the embedding** — and set `contentRedacted: true` with `contentRedactedAt`. The record stays: *that* a deploy happened is still recorded. |
| `days` | Delete the record, through the normal delete path, so it tombstones and propagates to peers. |

**Dropping the vector is the point, not a side effect.** A record that keeps its embedding keeps winning
semantic searches for content that is no longer there — which is precisely the failure being fixed. After
redaction the record is still listed and still queryable by field; it simply cannot compete in recall.

`contentRedacted` exists for the same reason `changesRedacted` does in the audit log: so a reader can tell *"this
record never had a description"* from *"it did, and it expired"*.

## Precedence, and the three ways this could quietly do the wrong thing

Every one of these is pinned by a test, because the dangerous direction is removing **more** than the operator
asked for.

- **A per-record `ttlDays` still wins**, including `0`/`null` for "never expire". Someone said what they wanted
  for that record.
- **A type named with only `contentDays` still deletes on the space schedule.** Reading it as an exemption would
  silently retain records the operator expected to go — their intent is "redact sooner", not "keep forever".
- **A `contentDays` at or past the delete window is ignored.** It could never fire (the record is gone first),
  and a policy that silently does nothing is worse than a rejected one. Clamped rather than erroring, so a
  two-step edit (lower `days`, then lower `contentDays`) does not fail halfway.

## It applies to records you already have

Otherwise the feature would be theoretical: an operator enabling retention today means the backlog, not just
tomorrow's writes.

A pass on the existing TTL sweep stamps existing chronos from **their own `createdAt`** — not from now, which
would hand every record a fresh full window and prune nothing. It only ever *adds* a missing stamp; it never
re-slides an existing one, because that is how a deliberate per-record `ttlDays` would be overwritten without
anyone noticing.

**Lazy rather than a boot migration, deliberately.** `<space>_chrono` is synced data — it replicates by
whole-document upsert — so a boot migration would stamp local copies while a peer's unstamped ones came back on
the next pull, and the policy would apply on some instances and not others depending on who booted when.
Self-healing on a timer is the shape synced data requires.

The redaction write goes through the collection rather than the update path on purpose: it is not a user edit,
so it must not bump `seq` or fire `chrono.updated`. Every instance performs it independently from the same policy
and the same `createdAt`, so the result converges without replicating.

## Gates

- **`chrono-retention`** — 22 cases, pure. Precedence in both directions, zero/negative/non-finite windows
  rejected rather than treated as instant, a content window that could never fire, and that the redaction field
  set includes the vector while `title`/`type`/`startsAt`/`tags`/links survive.
- **`chrono-retention-db`** — 10 cases against a real MongoDB: **the record survives redaction** (the whole
  promise of the first tier), a snapshot is never redacted, a record already carrying an expiry is left alone, a
  record whose `createdAt` cannot be parsed is skipped rather than expired, and an already-redacted record drops
  out of the sweep query instead of being rewritten every five minutes.
- **10 of 10 mutations caught**, every one in the direction of removing more than was asked for: precedence
  inverted, the content tier allowed to outlive the record, the backfill re-dated from `now`, the vector left
  behind, and the wiring dropped.

## Scope

Local and operational, sitting beside `recordTtlDays`: never governed by a network vote, never synced. `null` or
`{}` clears the policy. The `_contentExpireAt` sweep query is indexed, so a space that never enables this is one
indexed miss per cycle rather than a collection scan.

---

`npm run preflight` **PASSED**.
