### PR TITLE
fix(files): five failed paths could not tell one dead endpoint from forty problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Failed embedding jobs are grouped by reason, over all of them rather than the first five.** The Overview
+  panel listed up to five failed paths, which answers *"which file"* and not *"why"* — so with forty failures
+  an operator could not tell one dead endpoint from forty unrelated problems, and the five they saw were
+  whichever came back first. `GET .../embedding-queue` now also returns `failedByReason`, computed over the
+  whole failed set and summed across member spaces before truncating, so a proxy space's grouping is its
+  fleet's grouping.
+  - The panel shows the tally count-first (the number is the diagnosis), hides it when there is only one
+    reason — a panel that says the same thing twice teaches people to skim both — and now says plainly when
+    the path list is not showing everything.
+  - The client tolerates the field being absent, so an older server or a cached response from one still
+    renders the panel instead of failing on it.
+
 - **Retention per chrono TYPE, so telemetry stops displacing knowledge in recall.** Asked for by the canary
   operator, and the reason is not storage — their volumes were 516 and 139 records. It is that a space-wide TTL
   is the wrong axis for a space holding both kinds of thing.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -391,6 +391,7 @@
   "brain.overview.queue.failed": "Fehlgeschlagen",
   "brain.overview.queue.idle": "Keine Einbettungsjobs in der Warteschlange.",
   "brain.overview.queue.unknownError": "Unbekannter Fehler",
+  "brain.overview.queue.failedMore": "{{shown}} von {{total}} Fehlern werden angezeigt.",
   "brain.overview.queue.retryFailed": "Alle fehlgeschlagenen wiederholen",
   "brain.overview.confirmRetryFailedTitle": "Fehlgeschlagene Aufträge wiederholen",
   "brain.overview.confirmRetryFailed": "{{count}} fehlgeschlagene Embedding-Aufträge in diesem Space erneut einreihen?",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -391,6 +391,7 @@
   "brain.overview.queue.failed": "Failed",
   "brain.overview.queue.idle": "No embedding jobs queued.",
   "brain.overview.queue.unknownError": "Unknown error",
+  "brain.overview.queue.failedMore": "Showing {{shown}} of {{total}} failures.",
   "brain.overview.queue.retryFailed": "Retry all failed",
   "brain.overview.confirmRetryFailedTitle": "Retry failed jobs",
   "brain.overview.confirmRetryFailed": "Re-queue {{count}} failed embedding job(s) in this space?",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -391,6 +391,7 @@
   "brain.overview.queue.failed": "Nieudane",
   "brain.overview.queue.idle": "Brak zadań osadzania w kolejce.",
   "brain.overview.queue.unknownError": "Nieznany błąd",
+  "brain.overview.queue.failedMore": "Wyświetlono {{shown}} z {{total}} niepowodzeń.",
   "brain.overview.queue.retryFailed": "Ponów wszystkie nieudane",
   "brain.overview.confirmRetryFailedTitle": "Ponów nieudane zadania",
   "brain.overview.confirmRetryFailed": "Ponownie zakolejkować {{count}} nieudanych zadań osadzania w tej przestrzeni?",

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -246,6 +246,8 @@ export interface EmbeddingQueue {
   complete: number;
   failed: number;
   failedSample: { path: string; lastError: string | null }[];
+  /** Every failure grouped by reason, most common first. Optional so an older server still parses. */
+  failedByReason?: { reason: string | null; count: number }[];
 }
 
 /** One token that can reach a space (F9 Overview token-access matrix). Minimal, non-secret fields only. */

--- a/client/src/app/pages/brain/overview-tab.component.spec.ts
+++ b/client/src/app/pages/brain/overview-tab.component.spec.ts
@@ -148,6 +148,56 @@ describe('OverviewTabComponent', () => {
     expect((noQ.fixture.nativeElement as HTMLElement).querySelector('.fail-list')).toBeNull();
   });
 
+  it('groups failures by reason when there is more than one, and says how many the list omits', () => {
+    // Five paths answer "which file", not "why". With forty failures an operator could not tell one dead
+    // endpoint from forty unrelated problems, and the sample is whichever five came back first.
+    const many = setup();
+    many.fixture.componentRef.setInput('embeddingQueue', {
+      pending: 0, processing: 0, complete: 100, failed: 40,
+      failedSample: Array.from({ length: 5 }, (_, i) => ({ path: `docs/f${i}.pdf`, lastError: 'vision model down' })),
+      failedByReason: [
+        { reason: 'vision model down', count: 38 },
+        { reason: null, count: 2 },
+      ],
+    });
+    many.fixture.detectChanges();
+    const el = many.fixture.nativeElement as HTMLElement;
+    const reasons = el.querySelector('.fail-reasons');
+    expect(reasons).toBeTruthy();
+    expect(reasons!.textContent).toContain('38');
+    expect(reasons!.textContent).toContain('vision model down');
+    // The count is over EVERY failure, not the five in the sample.
+    expect(reasons!.textContent).not.toContain('5 ');
+    // And the list says plainly that it is not showing everything.
+    expect(el.querySelector('.fail-more')).toBeTruthy();
+  });
+
+  it('hides the grouping when it would only repeat the list, and survives a server that omits it', () => {
+    // One reason adds nothing over the per-path list — a panel that says the same thing twice trains people
+    // to skim both.
+    const one = setup();
+    one.fixture.componentRef.setInput('embeddingQueue', {
+      pending: 0, processing: 0, complete: 3, failed: 1,
+      failedSample: [{ path: 'docs/bad.pdf', lastError: 'vision model down' }],
+      failedByReason: [{ reason: 'vision model down', count: 1 }],
+    });
+    one.fixture.detectChanges();
+    const oneEl = one.fixture.nativeElement as HTMLElement;
+    expect(oneEl.querySelector('.fail-reasons')).toBeNull();
+    expect(oneEl.querySelector('.fail-more')).toBeNull();   // the sample covers all 1
+
+    // An older server (or a cached response from one) sends no `failedByReason` at all. The panel must render.
+    const legacy = setup();
+    legacy.fixture.componentRef.setInput('embeddingQueue', {
+      pending: 0, processing: 0, complete: 3, failed: 2,
+      failedSample: [{ path: 'docs/bad.pdf', lastError: 'boom' }],
+    });
+    legacy.fixture.detectChanges();
+    const legacyEl = legacy.fixture.nativeElement as HTMLElement;
+    expect(legacyEl.querySelector('.fail-list')).toBeTruthy();
+    expect(legacyEl.querySelector('.fail-reasons')).toBeNull();
+  });
+
   it('shows a "retry all failed" button only when failed > 0, and emits after the confirm', async () => {
     // failed > 0 → button present; the confirm-accepted click emits retryFailed once.
     const withFail = setup({ confirm: true });

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -118,6 +118,13 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
     .fail-list li { display: flex; flex-direction: column; gap: 1px; font-size: 11.5px; border-top: 1px solid var(--border-muted); padding-top: 6px; }
     .fail-list .fp { font-family: var(--font-mono, monospace); color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .fail-list .fe { color: var(--error); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    /* Reasons read as a count-first tally, deliberately unlike the path list below it: the eye should land on
+       "38" before the message, because the number is the diagnosis. */
+    .fail-reasons { list-style: none; margin: 12px 0 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+    .fail-reasons li { display: flex; align-items: baseline; gap: 8px; font-size: 11.5px; }
+    .fail-reasons .rc { font-family: var(--font-mono, monospace); font-weight: 650; color: var(--error); min-width: 2.5ch; text-align: right; flex: none; }
+    .fail-reasons .re { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .fail-more { font-size: 11px; margin: 6px 0 0; }
 
     .vote-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 9px; }
     .vote-list li { border: 1px solid var(--border-muted); border-radius: 8px; padding: 9px 11px; background: var(--bg-elevated); }
@@ -360,12 +367,29 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
             @if (q.failed === 0 && q.pending === 0 && q.processing === 0) {
               <div class="muted" style="margin-top:12px;">{{ 'brain.overview.queue.idle' | transloco }}</div>
             }
+            <!-- Reasons first, and only when they add something. Five paths answer "which file"; the
+                 grouping answers "why", over EVERY failure rather than the arbitrary first five — which is
+                 the difference between one dead endpoint and forty unrelated problems. Hidden when there is
+                 a single reason, because then the list below already says it. -->
+            @if (failureReasons().length > 1) {
+              <ul class="fail-reasons">
+                @for (r of failureReasons(); track r.reason) {
+                  <li>
+                    <span class="rc">{{ r.count }}</span>
+                    <span class="re" [title]="r.reason">{{ r.reason || ('brain.overview.queue.unknownError' | transloco) }}</span>
+                  </li>
+                }
+              </ul>
+            }
             @if (q.failedSample.length) {
               <ul class="fail-list">
                 @for (f of q.failedSample; track f.path) {
                   <li><span class="fp" [title]="f.path">{{ f.path }}</span><span class="fe" [title]="f.lastError">{{ f.lastError || ('brain.overview.queue.unknownError' | transloco) }}</span></li>
                 }
               </ul>
+              @if (q.failed > q.failedSample.length) {
+                <p class="muted fail-more">{{ 'brain.overview.queue.failedMore' | transloco: { shown: q.failedSample.length, total: q.failed } }}</p>
+              }
             }
             @if (q.failed > 0) {
               <button class="btn btn-sm btn-secondary retry-failed-btn" type="button" style="margin-top:12px;" (click)="requestRetryFailed()">
@@ -523,6 +547,16 @@ export class OverviewTabComponent {
     if (!a || a.recall === 0) return null;
     return Math.round((a.answered / a.recall) * 100);
   });
+
+  /**
+   * Failed jobs grouped by reason, most common first — over the whole failed set, not the five-path sample.
+   *
+   * Tolerates the field being absent so an older server (or a cached response from one) renders the panel
+   * rather than throwing on `.length`: absent and empty both mean "nothing to add here".
+   */
+  failureReasons = computed<Array<{ reason: string | null; count: number }>>(
+    () => this.embeddingQueue()?.failedByReason ?? [],
+  );
 
   total = computed(() => {
     const s = this.stats();

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -25,7 +25,7 @@ import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-s
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import type { FileMetaDoc } from '../../config/types.js';
-import { fetchJobProgress, getMediaJobCounts, type MediaJobCounts } from '../../files/media/job-queue.js';
+import { fetchJobProgress, getMediaJobCounts, FAILED_SAMPLE_LIMIT, FAILED_REASON_LIMIT, type MediaJobCounts } from '../../files/media/job-queue.js';
 import { tagContains } from '../../brain/tag-filter.js';
 
 
@@ -258,13 +258,23 @@ fileMetaRouter.get('/spaces/:spaceId/embedding-queue', globalRateLimit, requireS
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const total: MediaJobCounts = { pending: 0, processing: 0, complete: 0, failed: 0, failedSample: [] };
+  const total: MediaJobCounts = {
+    pending: 0, processing: 0, complete: 0, failed: 0, failedSample: [], failedByReason: [],
+  };
+  // Reasons are summed across member spaces before truncating, so a proxy space's grouping is the grouping of
+  // its whole fleet rather than of whichever member was iterated first.
+  const reasons = new Map<string | null, number>();
   for (const mid of resolveMemberSpaces(spaceId)) {
     const c = await getMediaJobCounts(mid);
     total.pending += c.pending; total.processing += c.processing; total.complete += c.complete; total.failed += c.failed;
     total.failedSample.push(...c.failedSample);
+    for (const r of c.failedByReason) reasons.set(r.reason, (reasons.get(r.reason) ?? 0) + r.count);
   }
-  total.failedSample = total.failedSample.slice(0, 5);
+  total.failedSample = total.failedSample.slice(0, FAILED_SAMPLE_LIMIT);
+  total.failedByReason = [...reasons.entries()]
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, FAILED_REASON_LIMIT);
   res.json(total);
 });
 

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -78,6 +78,12 @@ function fileCollection(spaceId: string) {
 
 // ── Queue summary (F9 Overview embedding-queue panel) ────────────────────────
 
+/** How many individual failed jobs to name. A list, not a report — the grouping below is the report. */
+export const FAILED_SAMPLE_LIMIT = 5;
+
+/** Distinct failure reasons to return. Beyond a handful the answer is "lots of different things". */
+export const FAILED_REASON_LIMIT = 10;
+
 export interface MediaJobCounts {
   pending: number;
   processing: number;
@@ -85,27 +91,54 @@ export interface MediaJobCounts {
   failed: number;
   /** Up to a few failed jobs (file path + reason) for the panel to surface, not the whole failed set. */
   failedSample: Array<{ path: string; lastError: string | null }>;
+  /**
+   * Every failure grouped by reason, most common first — computed over the WHOLE failed set, not the sample.
+   *
+   * `failedSample` shows five paths, which answers "which file" and not "why", and with forty failures an
+   * operator could not tell one dead endpoint from forty unrelated problems. The counts here do not depend on
+   * which five happened to come back first.
+   */
+  failedByReason: Array<{ reason: string | null; count: number }>;
 }
 
 /**
- * Count this space's embedding jobs by status, plus a small sample of failed ones (path + reason).
- * One aggregation over `${spaceId}_media_jobs`; a missing collection aggregates to all-zero. Per single
- * space — callers sum across members for a proxy space.
+ * Count this space's embedding jobs by status, a small sample of failed ones (path + reason), and every
+ * failure grouped by reason.
+ *
+ * A missing collection aggregates to all-zero. Per single space — callers sum across members for a proxy
+ * space. The two failure queries only run when something has actually failed, so the common case is one
+ * aggregation.
  */
 export async function getMediaJobCounts(spaceId: string): Promise<MediaJobCounts> {
   const rows = await jobCollection(spaceId)
     .aggregate([{ $group: { _id: '$status', n: { $sum: 1 } } }])
     .toArray() as Array<{ _id: string; n: number }>;
-  const c: MediaJobCounts = { pending: 0, processing: 0, complete: 0, failed: 0, failedSample: [] };
+  const c: MediaJobCounts = {
+    pending: 0, processing: 0, complete: 0, failed: 0, failedSample: [], failedByReason: [],
+  };
   for (const r of rows) {
     if (r._id === 'pending' || r._id === 'processing' || r._id === 'complete' || r._id === 'failed') c[r._id] = r.n;
   }
   if (c.failed > 0) {
     const failed = await jobCollection(spaceId)
       .find(asFilter<MediaJobDoc>({ status: 'failed' }), { projection: { _id: 1, lastError: 1 } })
-      .limit(5)
+      .limit(FAILED_SAMPLE_LIMIT)
       .toArray() as Array<{ _id: string; lastError: string | null }>;
     c.failedSample = failed.map(d => ({ path: d._id, lastError: d.lastError ?? null }));
+
+    // With 40 failures an operator saw five paths and could not tell whether they shared a cause. Grouping
+    // by reason answers the question the sample was standing in for — "is this one broken endpoint or forty
+    // different problems?" — at one aggregation rather than forty rows, and it covers EVERY failure rather
+    // than the arbitrary first few.
+    const byReason = await jobCollection(spaceId)
+      .aggregate([
+        { $match: { status: 'failed' } },
+        { $group: { _id: { $ifNull: ['$lastError', null] }, n: { $sum: 1 } } },
+        { $sort: { n: -1 } },
+        { $limit: FAILED_REASON_LIMIT },
+      ])
+      .toArray() as Array<{ _id: string | null; n: number }>;
+    c.failedByReason = byReason.map(r => ({ reason: r._id ?? null, count: r.n }));
   }
   return c;
 }


### PR DESCRIPTION
## The cap was never the limitation

The queue item read *"the failure sample is capped at five"*, and raising the cap would have missed the point.
`failedSample` returns up to five failed jobs with their paths — which answers **which file** and says nothing
about **why** — and the five are whichever came back first, not a representative set.

With forty failures an operator cannot tell a single broken vision endpoint from forty unrelated problems, and
that is the only question worth asking at that point. Forty paths would not have answered it either.

## What changed

`GET .../embedding-queue` now also returns `failedByReason`: every failure grouped by `lastError`, most common
first, computed over the **whole** failed set.

```json
{
  "failed": 40,
  "failedSample": [ { "path": "docs/a.pdf", "lastError": "vision model down" } ],
  "failedByReason": [
    { "reason": "vision model down", "count": 38 },
    { "reason": null, "count": 2 }
  ]
}
```

Summed across member spaces **before** truncating, so a proxy space's grouping is its fleet's grouping rather
than whichever member happened to be iterated first. Both failure queries only run when something has actually
failed, so the common case is still a single aggregation.

## The panel

- **Count-first**, deliberately unlike the path list below it. The number is the diagnosis, so the eye should
  land on `38` before the message.
- **Hidden when there is only one reason** — the list already says it, and a panel that states the same thing
  twice teaches people to skim both.
- The path list now **says when it is not showing everything**, instead of quietly ending at five.
- The client tolerates `failedByReason` being **absent**, so an older server — or a cached response from one —
  renders the panel rather than throwing on `.length`. Absent and empty both mean "nothing to add here".

Two client cases cover it, including the older-server path and the single-reason case; the suite is 857.

## One stale tracker item removed, verified rather than assumed

`QA-TODO.md`'s first item claimed preflight under-runs the standalone suite because `NEEDS_INSTANCE` is a
content heuristic. **It shipped.** The split is a declared `@needs-instance` header marker, anchored to a header
line, and the code comment carries the measurement that motivated it: 22 of 158 files were pure and being
skipped, among them every SSRF suite.

That is the third item in this batch found labelled OPEN while already done — read against the source, not
trusted from the checkbox.

---

`npm run preflight` **PASSED**.
