### PR TITLE
fix(files): the longest step a document job takes was invisible to the stall detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "stuck" for five minutes while jobs complete normally. An operator built it exactly as written and was paged
   two minutes after an OOM restart. The metrics table now carries the restart guard
   (`time() - process_start_time_seconds > 600`) rather than leaving it to a long `for:` and luck.
+- **A document large enough to need a long render could be re-queued forever, at default settings.** The stall
+  detector re-queues a job that has reported no progress for `stalledJobTimeoutMs` (5 min), and progress is
+  reported *between* steps, never inside one. The render of a page window is `pageTimeoutMs × min(maxPages, 20)`
+  — **20 minutes out of the box, four times the stall timeout** — so the sweep re-queued the job mid-render, the
+  replacement rendered the same window, and it was re-queued at the same point. The loop that never finishes,
+  which the stall floor was added to prevent, reached with nothing configured.
+  - **Why the floor missed it:** `hopBudgets()` listed three *config keys*, and this budget is not a config key
+    — it is computed at the call site, so a list of names could never contain it. The same
+    "a hand-maintained list is never proved complete" failure this codebase has now recorded ten times.
+  - **Four more invisible hops came out of the same sweep**, all inline literals: Whisper transcription at
+    **300 000 ms — exactly the stall default**, so a five-minute transcription of long audio could be re-queued
+    in the same instant it legitimately finished; local image captioning (120 000); external captioning
+    (60 000); external face recognition (30 000, which binds if an operator sets `stalledJobTimeoutMs` to its
+    30 000 minimum). None of them was operator-settable, so nobody could have raised the stall timeout to
+    compensate even knowing they existed.
+  - Every budget now has a name that both the call site and the floor use, and the render window lives in
+    `files/converters/render-budget.ts` with the arithmetic pinned. A beat is also emitted *before* the render,
+    so the stall clock starts at the phase boundary rather than partway through the step before it.
+  - **The cost, stated plainly:** the effective stall timeout on a stock install rises from 5 minutes to
+    **30** (1.5 × the render window), so a genuinely wedged job takes longer to be recovered. That is the right
+    trade against re-queueing a working job forever, and lowering `maxPages` or `pageTimeoutMs` lowers the floor
+    with it — a test pins that lever. A planned restart still releases claims immediately, so this does not
+    affect rolling deploys.
+  - Gate: `stall-floor-covers-every-hop` — enumerates every `timeoutMs:` / `AbortSignal.timeout()` call site on
+    the media path from `git ls-files` and asserts each budget reaches `hopBudgets()`, in both directions. The
+    exemption for a too-small budget is *derived from the admin schema's own minimum* rather than a filename
+    allowlist, and it rejects the original defect expression, which merely *contained* a covered name. 7 of 7
+    mutations caught — one of which exposed a hole in the gate's first version.
 
 - **Renaming a space never moved its usage history — the code was unreachable.** `moveSpaceData` had
   `return errors;` directly above the block that re-keys `space_activity`, so `renameSpaceActivity` was dead:

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -956,13 +956,28 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 > replacement starts the same document, reaches the same step, and is re-queued at the same point. A loop that
 > never finishes.
 >
-> Measured at the defaults, nothing comes close — the longest step is `ocrTimeoutMs` at 0.4× the stall
-> timeout. It is reachable by configuration: `ocrTimeoutMs` accepts up to **30 minutes** and the two model
-> budgets up to **10** each, against a 5-minute stall default.
+> **This binds at the defaults, and it is not only reachable by configuration.** The claim that the longest
+> step was `ocrTimeoutMs` at 0.4× the stall timeout counted only the *settable* fields. Two kinds of budget were
+> not settable and therefore not counted:
 >
-> Rather than refuse the setting, **stall detection raises its own threshold** to 1.5× the longest configured
-> step and logs one line saying so. Nothing you set is contradicted; the detector simply stops firing inside a
-> step you authorised. Raise `stalledJobTimeoutMs` past that figure yourself and the line goes away.
+> | step | budget | vs the 5-minute stall default |
+> |---|---|---|
+> | render of one page window | `pageTimeoutMs × min(maxPages, 20)` = **20 min** | **4×** |
+> | audio transcription (Whisper) | 5 min, fixed | **1×** — equal, so indistinguishable without head-room |
+> | image caption (local / external) | 2 min / 1 min | 0.4× / 0.2× |
+> | external face recognition | 30 s | 0.1× |
+>
+> So on a stock install the effective stall timeout is now **30 minutes** (1.5 × the render window), not 5. That
+> is the cost of the fix, and it is the right trade: the alternative was a document large enough to need a
+> >5-minute render being re-queued mid-render, forever. **Lower `maxPages` or `pageTimeoutMs` and the floor
+> comes down with them** — 3-page windows need no raise at all.
+>
+> Rather than refuse a setting, **stall detection raises its own threshold** to 1.5× the longest step and logs
+> one line saying so. Nothing you set is contradicted; the detector simply stops firing inside a step it
+> allows. Raise `stalledJobTimeoutMs` past that figure yourself and the line goes away.
+>
+> Also reachable by configuration, as before: `ocrTimeoutMs` accepts up to **30 minutes** and the two model
+> budgets up to **10** each.
 
 #### ISO 27001 / Data Egress Note
 

--- a/server/src/files/converters/render-budget.ts
+++ b/server/src/files/converters/render-budget.ts
@@ -1,0 +1,67 @@
+/**
+ * How long ONE render call is allowed to take — as a named value, because a derived one is invisible.
+ *
+ * ## The defect this exists to close
+ *
+ * The render of a page window is the LONGEST single step a document job takes, and the stall detector did not
+ * know it existed. Measured at the DEFAULTS, no configuration change involved:
+ *
+ *     stalledJobTimeoutMs                       300 000 ms
+ *     floor from hopBudgets()  1.5 x ocrTimeoutMs 120 000  ->  300 000 ms  (no raise)
+ *     actual render budget     pageTimeoutMs 60 000 x min(maxPages 50, 20)  ->  1 200 000 ms
+ *
+ * **Four times over.** And a render reports no progress while it runs — the per-page beat fires after the call
+ * returns — so the stall sweep re-queues the job mid-render, the replacement renders the same window, and is
+ * re-queued at the same point. The loop that never finishes, which `stall-floor.ts` was written to prevent,
+ * reached at the defaults rather than through configuration. At the `pageTimeoutMs` ceiling (600 000) it is a
+ * 3 h 20 m silent step against a 15-minute floor.
+ *
+ * ## Why it was invisible
+ *
+ * `hopBudgets()` listed three CONFIG KEYS. This budget is not a config key — it is a product computed at the
+ * call site, so a list of names could never contain it. That is the "a hand-maintained list is never proved
+ * complete" failure again, and the cure is the same one: one named function, used by both the caller and the
+ * stall floor, so the two cannot disagree.
+ */
+
+/**
+ * Pages of head-room a single render call gets, beyond which extra pages buy no extra time.
+ *
+ * A render is one sidecar round trip over a whole window, and its cost grows with the page count until the
+ * sidecar's own parallelism saturates. The cap keeps a large `maxPages` from multiplying the budget without
+ * limit — 20 pages of budget for a 50-page window is the shipped behaviour, preserved here deliberately rather
+ * than re-tuned, because this change is about the stall detector KNOWING the number, not about changing it.
+ */
+export const RENDER_PAGE_BUDGET_CAP = 20;
+
+/** Mirrors the `pageTimeoutMs` default so this module is answerable with a partial config. */
+export const DEFAULT_PAGE_TIMEOUT_MS = 60_000;
+
+/** Mirrors the `maxPages` default — the widest window, and therefore the worst case. */
+export const DEFAULT_MAX_PAGES = 50;
+
+/**
+ * The timeout for one render call of `pages` pages, given the per-page model budget.
+ *
+ * Total and pure: it takes numbers and returns a number, so the value the stall floor uses is provably the
+ * value the call site uses. `pages` is clamped to at least 1 so a zero-page window still gets a real budget
+ * rather than an instant abort.
+ */
+export function renderWindowTimeoutMs(pageTimeoutMs: number, pages: number): number {
+  const perPage = Number.isFinite(pageTimeoutMs) && pageTimeoutMs > 0 ? pageTimeoutMs : DEFAULT_PAGE_TIMEOUT_MS;
+  const n = Number.isFinite(pages) && pages > 0 ? Math.trunc(pages) : 1;
+  return perPage * Math.min(n, RENDER_PAGE_BUDGET_CAP);
+}
+
+/**
+ * The WORST-CASE render budget for a configuration — what the stall detector must not fire inside.
+ *
+ * Uses the configured window size rather than the window actually rendered, because the floor has to hold for
+ * the largest render the config permits, not for the one that happens to be running.
+ */
+export function worstRenderWindowMs(cfg: { pageTimeoutMs?: number; maxPages?: number }): number {
+  return renderWindowTimeoutMs(
+    cfg.pageTimeoutMs ?? DEFAULT_PAGE_TIMEOUT_MS,
+    cfg.maxPages ?? DEFAULT_MAX_PAGES,
+  );
+}

--- a/server/src/files/converters/vlm-extract.ts
+++ b/server/src/files/converters/vlm-extract.ts
@@ -17,6 +17,7 @@ import { getDocumentProcessingConfig, getMediaEmbeddingConfig, getDocAssistApiKe
 import type { DocExtractionMode } from '../../config/types.js';
 import { UnstructuredConverter, type UnstructuredResult } from './unstructured.js';
 import { renderDocumentPages, isRenderAvailableFor } from './renderer.js';
+import { renderWindowTimeoutMs } from './render-budget.js';
 import { transcribePageImage, repairMarkdown, repairMarkdownExternal, reconcileConsensus } from './vlm-client.js';
 import type { StepProgress } from './types.js';
 import { decideRoute, validateExtraction, bestByEvidence } from './extraction-policy.js';
@@ -130,12 +131,17 @@ export async function vlmExtractDocument(
 
     for (let startPage = 0; pagesRead < pageBudget; startPage += windowSize) {
       const take = Math.min(windowSize, pageBudget - pagesRead);
+      // One beat BEFORE the render, so the stall clock starts when this step does rather than partway through
+      // the one before it — the same reason the describe pass gets one. It does not make the step visible
+      // (nothing reports from inside a single fetch), which is why the stall FLOOR has to know this budget too:
+      // see `render-budget.ts`, where the number now lives so the detector and the call site cannot disagree.
+      onProgress?.({ step: 'render', steps, done: pagesRead, total: Math.min(totalPages, pageBudget) });
       const window = await renderDocumentPages(fileBytes, {
         fileName,
         dpi: cfg.renderDpi,
         maxPages: take,
         startPage,
-        timeoutMs: cfg.pageTimeoutMs * Math.min(take, 20),
+        timeoutMs: renderWindowTimeoutMs(cfg.pageTimeoutMs, take),
       });
       totalPages = window.total;
       if (window.pages.length === 0) {

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -14,7 +14,12 @@ export interface ExternalFace {
 /** Wire shape a provider must return: `{ faces: [{ embedding, boxRaw? }] }`. */
 interface ExternalFaceResponse { faces?: Array<{ embedding?: unknown; boxRaw?: unknown }> }
 
-const TIMEOUT_MS = 30_000;
+/**
+ * Exported so `hopBudgets()` can see it. 30 s is comfortably under the 300 s stall default, but
+ * `stalledJobTimeoutMs` may be set as low as 30 000 (admin schema minimum) — at which point this single call
+ * is exactly the stall timeout, and a job would be re-queued in the same instant the call gave up.
+ */
+export const FACE_TIMEOUT_MS = 30_000;
 /** A single image cannot legitimately contain more than this; caps a hostile or broken provider. */
 const MAX_FACES = 64;
 
@@ -71,7 +76,7 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
         ...(ext?.model ? { model: ext.model } : {}),
         image: imageBytes.toString('base64'),
       }),
-      signal: AbortSignal.timeout(TIMEOUT_MS),
+      signal: AbortSignal.timeout(FACE_TIMEOUT_MS),
     }, {
       // Matches the assist model: a self-hosted recogniser may live on a private cluster address. The
       // guard stays on — DNS-resolve, IP-pin and redirect re-validation all still apply; only the

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -20,6 +20,22 @@ import { extForMimeType, isInformativeMimeType, sniffImageMimeType } from '../mi
 import { chatUrlFor, transcriptionsUrlFor } from '../converters/vlm-endpoint.js';
 
 /**
+ * Per-call budgets, named and exported because the stall detector has to know them.
+ *
+ * They were inline literals, which made them invisible to `hopBudgets()` — a hop longer than
+ * `stalledJobTimeoutMs` reports no progress while it runs (nothing beats from inside a single `fetch`), so the
+ * sweep re-queues the job mid-call and the replacement reaches the same call again. `STT_TIMEOUT_MS` is the
+ * sharp one: at **exactly** the stall default, a five-minute transcription of long audio can be re-queued in
+ * the same instant it would legitimately have finished, which is the indistinguishability
+ * `STALL_FLOOR_FACTOR` exists to prevent. Pinned by `stall-floor-covers-every-hop.test.js`.
+ */
+export const VISION_TIMEOUT_MS = 120_000;
+/** External vision APIs answer faster than a cold local model, and a hung one should not hold a job. */
+export const EXTERNAL_VISION_TIMEOUT_MS = 60_000;
+/** 5 min — long audio. Equal to the default `stalledJobTimeoutMs`, hence the floor. */
+export const STT_TIMEOUT_MS = 300_000;
+
+/**
  * Runtime egress guard. **External** (operator-supplied, public) provider endpoints go through
  * `ssrfSafeFetch` — DNS-resolve + IP-pin + redirect re-validation — closing the save-time-only URL check
  * against DNS-rebinding / redirect-to-internal. **Local** providers (bundled Ollama / Whisper on the trusted
@@ -145,7 +161,7 @@ export class OllamaVisionProvider implements VisionProvider {
             },
           ],
         }),
-        signal: AbortSignal.timeout(120_000),
+        signal: AbortSignal.timeout(VISION_TIMEOUT_MS),
       });
     } catch (err) {
       throw new Error(`Ollama vision unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
@@ -213,7 +229,7 @@ export class ExternalVisionProvider implements VisionProvider {
           ],
           max_tokens: 500,
         }),
-        signal: AbortSignal.timeout(60_000),
+        signal: AbortSignal.timeout(EXTERNAL_VISION_TIMEOUT_MS),
       });
     } catch (err) {
       throw new Error(`External vision unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
@@ -279,7 +295,7 @@ export class WhisperProvider implements SttProvider {
         method: 'POST',
         headers: this.cfg.apiKey ? { Authorization: `Bearer ${this.cfg.apiKey}` } : {},
         body: form,
-        signal: AbortSignal.timeout(300_000), // 5 min — long audio
+        signal: AbortSignal.timeout(STT_TIMEOUT_MS),
       });
     } catch (err) {
       throw new Error(`Whisper unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -67,6 +67,9 @@ import {
   mediaJobDurationSeconds,
 } from '../../metrics/registry.js';
 import { stallTimeoutWithWarning } from './stall-floor.js';
+import { worstRenderWindowMs } from '../converters/render-budget.js';
+import { VISION_TIMEOUT_MS, EXTERNAL_VISION_TIMEOUT_MS, STT_TIMEOUT_MS } from './providers.js';
+import { FACE_TIMEOUT_MS } from './face-external.js';
 
 let running = false;
 let stalledSweepTimer: NodeJS.Timeout | null = null;
@@ -89,6 +92,20 @@ function hopBudgets(): Record<string, number | undefined> {
     pageTimeoutMs: doc.pageTimeoutMs,
     ocrTimeoutMs: doc.ocrTimeoutMs,
     describeTimeoutMs: doc.describeTimeoutMs,
+    // The longest step of all, and it was missing — because it is not a config KEY. The render of a page
+    // window is `pageTimeoutMs x min(maxPages, 20)`, which at the defaults is 1 200 000 ms against a
+    // 300 000 ms stall timeout: four times over, with nothing configured. A list of names could not contain a
+    // derived value, so the value now has a name (`render-budget.ts`) that both the call site and this list
+    // use. `renderWindowMs` rather than a config key on purpose: it is what the detector must not fire inside.
+    renderWindowMs: worstRenderWindowMs(doc),
+    // The media provider calls, which were inline literals and therefore equally invisible. STT is the sharp
+    // one: 300 000 ms is EXACTLY the stall default, so a five-minute transcription could be re-queued in the
+    // same instant it legitimately finished. These are not operator-settable, so nobody could have raised the
+    // stall timeout to compensate even knowing about them.
+    visionTimeoutMs: VISION_TIMEOUT_MS,
+    externalVisionTimeoutMs: EXTERNAL_VISION_TIMEOUT_MS,
+    sttTimeoutMs: STT_TIMEOUT_MS,
+    faceTimeoutMs: FACE_TIMEOUT_MS,
   };
 }
 
@@ -201,8 +218,11 @@ async function workerLoop(): Promise<void> {
   const startupCfg = getMediaEmbeddingConfig();
   // Floored by the longest single hop a job may take: a step longer than the stall timeout reports no
   // progress while it runs, so the job would be re-queued mid-step and reach the same step again forever.
-  // Measured at the defaults it never binds (the worst hop is OCR at 0.40x the timeout); it binds when an
-  // operator raises a hop, which the ceilings invite — ocrTimeoutMs alone goes to thirty minutes.
+  //
+  // It DOES bind at the defaults, and the earlier claim here that it never did was measured against config
+  // keys only. The render of a page window is `pageTimeoutMs x min(maxPages, 20)` = 1 200 000 ms out of the
+  // box, four times the 300 000 ms stall timeout, so the floor now raises to 1 800 000 ms on a stock install.
+  // An operator raising a hop still binds too — ocrTimeoutMs alone goes to thirty minutes.
   const startupStalledTimeoutMs = stallTimeoutWithWarning(
     startupCfg.stalledJobTimeoutMs ?? 300_000,
     hopBudgets(),

--- a/testing/standalone/stall-floor-covers-every-hop.test.js
+++ b/testing/standalone/stall-floor-covers-every-hop.test.js
@@ -1,0 +1,286 @@
+/**
+ * Every timeout on the media path must be a hop the stall detector knows about.
+ *
+ * ## The defect
+ *
+ * `hopBudgets()` listed three CONFIG KEYS — `pageTimeoutMs`, `ocrTimeoutMs`, `describeTimeoutMs` — and the
+ * longest step a document job takes is not a config key. The render of a page window is
+ * `pageTimeoutMs × min(maxPages, 20)`, computed at the call site, so at the DEFAULTS:
+ *
+ *     stalledJobTimeoutMs                                    300 000 ms
+ *     floor from the three keys   1.5 × ocrTimeoutMs 120 000  →  300 000 ms   (no raise)
+ *     actual render budget        60 000 × min(50, 20)        →  1 200 000 ms
+ *
+ * Four times over, with nothing configured. A render reports no progress while it runs, so the stall sweep
+ * re-queued the job mid-render, the replacement rendered the same window, and it was re-queued at the same
+ * point — the loop that never finishes, which `stall-floor.ts` was written to prevent, reachable out of the box.
+ *
+ * ## Why this gate and not just the fix
+ *
+ * The bug was not a wrong number, it was a **hand-maintained list of names that could not contain a derived
+ * value** — the failure this repo has recorded nine other instances of. So the gate enumerates the timeout call
+ * sites from source and asserts each one's budget is represented in the floor's inputs. A new hop added with a
+ * fresh constant fails here rather than in a customer's crash loop.
+ *
+ * Run: node --test testing/standalone/stall-floor-covers-every-hop.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** Media-path source files, from git rather than a directory walk (gitignored/untracked files are not source). */
+const files = execFileSync('git', ['ls-files', 'server/src/files/converters', 'server/src/files/media'], {
+  encoding: 'utf8', cwd: ROOT,
+}).split('\n').map(s => s.trim()).filter(f => f.endsWith('.ts'));
+
+/**
+ * A timeout being handed to a call. Both spellings: the option object the converter clients take, and the raw
+ * `AbortSignal.timeout` the sidecar fetches use.
+ */
+const TIMEOUT_SITE = /(?:timeoutMs:\s*|AbortSignal\.timeout\(\s*)([^,)\n]+)/g;
+
+/**
+ * Budgets the stall floor is fed, by the expression that produces them. A site whose budget is not one of these
+ * is a hop the detector cannot see.
+ *
+ * Matched on the EXPRESSION, not on a filename, so the rule is a property of the code.
+ */
+/**
+ * **Anchored deliberately.** A substring match would accept `cfg.pageTimeoutMs * Math.min(take, 20)` — the
+ * exact expression that caused this bug — because it *contains* a covered name while being four times the
+ * covered value. A derived budget has to go through a named function so both ends use one number.
+ */
+const COVERED = [
+  /^[\w.]*\bpageTimeoutMs$/,               // fed directly as `pageTimeoutMs`
+  /^[\w.]*\bocrTimeoutMs$/,                // fed directly
+  // A CALL is matched by its head only: the site regex stops at the first comma or paren, so a nested
+  // argument list arrives truncated. Anchoring the start is what matters — the defect expression begins with
+  // `cfg.pageTimeoutMs *`, not with one of these names.
+  /^describeTimeoutMs\(/,                  // fed directly (via the describeTimeoutMs() resolver)
+  /^renderWindowTimeoutMs\(/,              // fed as `renderWindowMs` via worstRenderWindowMs()
+  /^worstRenderWindowMs\(/,
+  /^(VISION|EXTERNAL_VISION|STT|FACE)_TIMEOUT_MS$/,   // fed as visionTimeoutMs / sttTimeoutMs / …
+];
+
+/**
+ * The admin schema's floor for `stalledJobTimeoutMs` (`api/media-config.ts`). Asserted below rather than
+ * trusted, because the exemption threshold is derived from it.
+ */
+const MIN_STALL_TIMEOUT_MS = 30_000;
+
+/**
+ * A budget this small can never raise the stall floor, whatever an operator configures:
+ * `floor = ceil(hop × 1.5)`, so a hop below `MIN_STALL_TIMEOUT_MS / 1.5` is always under the smallest
+ * `stalledJobTimeoutMs` the API will accept. Health probes live here. This is a property of the NUMBER, not a
+ * blessed filename — a name-based allowlist is the thing that goes stale and quietly grows.
+ */
+const CANNOT_BIND_MS = MIN_STALL_TIMEOUT_MS / 1.5;
+
+/**
+ * Sites that are deliberately NOT job steps, by what they are rather than by name:
+ *
+ *  - a parameter or field DECLARATION (`timeoutMs: number`) is a type, not a value;
+ *  - a bare `timeoutMs` identifier is a PASS-THROUGH of whatever the caller supplied, and every caller on this
+ *    path passes a covered budget — which the other sites in this scan prove;
+ *  - a default inside the helper being called (`opts.timeoutMs ?? 120_000`) is a fallback for a caller that
+ *    passed nothing.
+ */
+const NOT_A_STEP = [
+  /^number$/,
+  /^timeoutMs$/,
+  /^opts\.timeoutMs\s*\?\?/,
+];
+
+/** A numeric literal (`3_000`) too small to ever bind. Returns null when the expression is not a literal. */
+function literalMs(expr) {
+  return /^[\d_]+$/.test(expr) ? Number(expr.replace(/_/g, '')) : null;
+}
+
+/**
+ * The token to look for in `hopBudgets()` for a given call-site expression — i.e. "what would prove this budget
+ * reaches the stall floor". Returns null for an expression that is not a recognised budget.
+ */
+function budgetToken(expr) {
+  const named = expr.match(/^(VISION|EXTERNAL_VISION|STT|FACE)_TIMEOUT_MS$/);
+  if (named) return named[0];
+  if (/^renderWindowTimeoutMs\(|^worstRenderWindowMs\(/.test(expr)) return 'worstRenderWindowMs';
+  if (/^describeTimeoutMs\(/.test(expr)) return 'describeTimeoutMs';
+  if (/^[\w.]*\bpageTimeoutMs$/.test(expr)) return 'pageTimeoutMs';
+  if (/^[\w.]*\bocrTimeoutMs$/.test(expr)) return 'ocrTimeoutMs';
+  return null;
+}
+
+/** Every distinct budget token actually used to bound a call on the media path. */
+function budgetTokens() {
+  const toks = new Set();
+  for (const rel of files) {
+    for (const m of readFileSync(join(ROOT, rel), 'utf8').matchAll(TIMEOUT_SITE)) {
+      const tok = budgetToken(m[1].trim());
+      if (tok) toks.add(tok);
+    }
+  }
+  return toks;
+}
+
+/** The body of `hopBudgets()` in worker.ts — the object literal the stall floor is actually fed. */
+function hopBudgetsBody() {
+  const worker = readFileSync(join(ROOT, 'server/src/files/media/worker.ts'), 'utf8');
+  const start = worker.indexOf('function hopBudgets(');
+  if (start < 0) return '';
+  const end = worker.indexOf('\n}', start);
+  return end < 0 ? '' : worker.slice(start, end);
+}
+
+/** `{ file, expr }` for every timeout site that is neither covered nor exempt. */
+function uncoveredSites() {
+  const bad = [];
+  for (const rel of files) {
+    const src = readFileSync(join(ROOT, rel), 'utf8');
+    for (const m of src.matchAll(TIMEOUT_SITE)) {
+      const expr = m[1].trim();
+      if (NOT_A_STEP.some(re => re.test(expr))) continue;
+      if (COVERED.some(re => re.test(expr))) continue;
+      const ms = literalMs(expr);
+      if (ms !== null && ms < CANNOT_BIND_MS) continue;
+      bad.push({ file: rel, expr });
+    }
+  }
+  return bad;
+}
+
+describe('the stall floor knows every hop on the media path', () => {
+  it('walked a real set of source files', () => {
+    // Without this the scan can break (a moved directory, a changed pathspec) and report zero offenders for the
+    // wrong reason — the exact vacuity `gates-cannot-pass-vacuously` polices.
+    assert.ok(files.length > 15, `only found ${files.length} media-path source files`);
+  });
+
+  it('found timeout call sites to check', () => {
+    let sites = 0;
+    for (const rel of files) {
+      sites += [...readFileSync(join(ROOT, rel), 'utf8').matchAll(TIMEOUT_SITE)].length;
+    }
+    assert.ok(sites >= 8, `only ${sites} timeout sites found — the pattern probably stopped matching`);
+  });
+
+  it('every timeout handed to a call is a budget the floor is fed', () => {
+    const bad = uncoveredSites();
+    assert.deepEqual(bad, [], 'these hand a timeout to a call using a budget the stall detector never sees, '
+      + 'so a step longer than stalledJobTimeoutMs re-queues the job mid-step and it never finishes:\n  '
+      + bad.map(b => `${b.file}: ${b.expr}`).join('\n  ')
+      + '\n\nEither express it through an existing budget, or add it to hopBudgets() in files/media/worker.ts '
+      + 'AND to COVERED here.');
+  });
+
+  it('every budget used at a call site actually reaches hopBudgets()', () => {
+    // The assertion above only checks the call-site EXPRESSIONS. This checks the other end, and it has to be
+    // derived rather than a list: declaring a budget "covered" here while nobody feeds it to the floor is the
+    // same invisibility one level up. Found by mutation — an earlier version of this gate asserted only the
+    // render budget, so deleting `sttTimeoutMs:` from hopBudgets() passed green.
+    const body = hopBudgetsBody();
+    const missing = [...budgetTokens()].filter(tok => !body.includes(tok));
+    assert.deepEqual(missing, [], 'these budgets are used to bound a call but are not fed to the stall floor, '
+      + `so the detector can fire inside them:\n  ${missing.join('\n  ')}`);
+  });
+
+  it('found the budgets to check, and hopBudgets() itself', () => {
+    // Floors for both halves of the check above: an empty token set or an empty body would pass it vacuously.
+    assert.ok(budgetTokens().size >= 5, `only ${budgetTokens().size} distinct budgets recognised`);
+    assert.ok(hopBudgetsBody().length > 100, 'could not locate the hopBudgets() body in worker.ts');
+  });
+
+  it('the classifier can fail — an uncovered budget is caught', () => {
+    // A gate that can only pass is not a gate.
+    const invented = 'AbortSignal.timeout(MY_NEW_TIMEOUT_MS)';
+    const expr = [...invented.matchAll(TIMEOUT_SITE)][0][1].trim();
+    assert.equal(COVERED.some(re => re.test(expr)), false);
+    assert.equal(NOT_A_STEP.some(re => re.test(expr)), false);
+    assert.equal(literalMs(expr), null);
+  });
+
+  it('rejects the ORIGINAL defect expression, which merely contains a covered name', () => {
+    // The whole bug: `cfg.pageTimeoutMs * Math.min(take, 20)` is 20x `pageTimeoutMs`. A substring match would
+    // have blessed it, and this gate would have passed against the code that caused the crash loop.
+    const bug = 'timeoutMs: cfg.pageTimeoutMs * Math.min(take, 20),';
+    const expr = [...bug.matchAll(TIMEOUT_SITE)][0][1].trim();
+    assert.equal(COVERED.some(re => re.test(expr)), false, `"${expr}" was accepted as a covered budget`);
+    // While the plain pass-through of the same config value is accepted.
+    assert.equal(COVERED.some(re => re.test('cfg.pageTimeoutMs')), true);
+  });
+
+  it('a big raw literal is NOT exempt, only a provably-too-small one', () => {
+    // The exemption is the risky part of this gate: too generous and it excuses the next real hop.
+    assert.ok(literalMs('3_000') < CANNOT_BIND_MS, '3 s probe should be exempt');
+    assert.ok(literalMs('300_000') >= CANNOT_BIND_MS, 'a 5-minute literal must NOT be exempt');
+    assert.ok(literalMs('30_000') >= CANNOT_BIND_MS, 'a 30 s literal must NOT be exempt');
+    assert.equal(literalMs('VISION_TIMEOUT_MS'), null);
+  });
+
+  it('the exemption threshold is derived from the real schema minimum', () => {
+    // If the API ever accepts a smaller stalledJobTimeoutMs, the threshold above stops being provable and the
+    // 3 s probes would need covering too. Read from source so the two cannot drift.
+    const schema = readFileSync(join(ROOT, 'server/src/api/media-config.ts'), 'utf8');
+    const m = schema.match(/stalledJobTimeoutMs:\s*z\.number\(\)\.int\(\)\.min\(([\d_]+)\)/);
+    assert.ok(m, 'could not find the stalledJobTimeoutMs bound in the admin schema');
+    assert.equal(Number(m[1].replace(/_/g, '')), MIN_STALL_TIMEOUT_MS);
+  });
+});
+
+describe('the numbers, at the shipped defaults', () => {
+  let effectiveStallTimeoutMs, worstRenderWindowMs, renderWindowTimeoutMs, RENDER_PAGE_BUDGET_CAP;
+
+  before(async () => {
+    ({ effectiveStallTimeoutMs } = await import('../../server/dist/files/media/stall-floor.js'));
+    ({ worstRenderWindowMs, renderWindowTimeoutMs, RENDER_PAGE_BUDGET_CAP } =
+      await import('../../server/dist/files/converters/render-budget.js'));
+  });
+
+  it('the render window really is 1 200 000 ms out of the box', () => {
+    // The measurement the fix rests on. If a default moves, this says so here rather than in a crash loop.
+    assert.equal(worstRenderWindowMs({}), 1_200_000);
+    assert.equal(renderWindowTimeoutMs(60_000, 50), 1_200_000);
+  });
+
+  it('extra pages beyond the cap buy no extra budget', () => {
+    assert.equal(renderWindowTimeoutMs(60_000, RENDER_PAGE_BUDGET_CAP), 1_200_000);
+    assert.equal(renderWindowTimeoutMs(60_000, 500), 1_200_000);
+    assert.equal(renderWindowTimeoutMs(60_000, 3), 180_000);
+  });
+
+  it('a zero or nonsense page count still gets one page of budget, not an instant abort', () => {
+    for (const n of [0, -5, NaN, undefined]) assert.equal(renderWindowTimeoutMs(60_000, n), 60_000);
+    for (const t of [0, -1, NaN, undefined]) assert.equal(renderWindowTimeoutMs(t, 1), 60_000);
+  });
+
+  it('the floor now RAISES the stall timeout on a stock install — it used not to', () => {
+    // The whole defect in one assertion. With only the three config keys the floor was 300 000 (no raise);
+    // with the render window it is 1.5 × 1 200 000.
+    const hops = {
+      pageTimeoutMs: 60_000, ocrTimeoutMs: 120_000, describeTimeoutMs: 30_000,
+      renderWindowMs: worstRenderWindowMs({}),
+    };
+    const { ms, raised } = effectiveStallTimeoutMs(300_000, hops);
+    assert.equal(ms, 1_800_000);
+    assert.equal(raised?.hop, 'renderWindowMs');
+    assert.equal(raised?.from, 300_000);
+
+    // And the pre-fix inputs are exactly what missed it.
+    const before = effectiveStallTimeoutMs(300_000, {
+      pageTimeoutMs: 60_000, ocrTimeoutMs: 120_000, describeTimeoutMs: 30_000,
+    });
+    assert.equal(before.ms, 300_000);
+    assert.equal(before.raised, undefined);
+  });
+
+  it('lowering maxPages lowers the floor — the operator has a lever', () => {
+    // Worth pinning: the cost of this fix is a slower recovery for a genuinely wedged job, and this is how an
+    // operator buys it back.
+    const hops = (maxPages) => ({ ocrTimeoutMs: 120_000, renderWindowMs: worstRenderWindowMs({ maxPages }) });
+    assert.equal(effectiveStallTimeoutMs(300_000, hops(50)).ms, 1_800_000);
+    assert.equal(effectiveStallTimeoutMs(300_000, hops(3)).ms, 300_000, '3-page windows need no raise');
+  });
+});

--- a/testing/standalone/stall-floor.test.js
+++ b/testing/standalone/stall-floor.test.js
@@ -10,9 +10,16 @@
  *     ocrTimeoutMs          120 000 ms   0.40x   settable to 1 800 000   (6x the stall default)
  *     describeTimeoutMs      30 000 ms   0.10x   settable to   600 000
  *
- * **At the defaults nothing binds.** The trap is what the admin API allows an operator to set — and following
- * our own documentation gets them close to it: the docs tell a swap-based host to raise `describeTimeoutMs`
- * (ceiling 10 min) and tell large-scan operators to raise `ocrTimeoutMs` (ceiling 30 min).
+ * **CORRECTED: it binds at the defaults.** The reading above counted only SETTABLE config keys, and the longest
+ * step is not one — the render of a page window is `pageTimeoutMs x min(maxPages, 20)` = **1 200 000 ms**,
+ * computed at its call site, four times the stall default with nothing configured. Four more inline literals
+ * were invisible for the same reason (Whisper at exactly 300 000, captioning at 120 000 / 60 000, external face
+ * recognition at 30 000). `stall-floor-covers-every-hop.test.js` now enumerates the call sites so a hop cannot
+ * be added without reaching the floor.
+ *
+ * The configuration trap is real as well, and following our own documentation gets an operator close to it: the
+ * docs tell a swap-based host to raise `describeTimeoutMs` (ceiling 10 min) and tell large-scan operators to
+ * raise `ocrTimeoutMs` (ceiling 30 min).
  *
  * ## Why exceeding it loops rather than merely being slow
  *
@@ -119,12 +126,41 @@ describe('the worker uses the floor, not the raw setting', () => {
   });
 
   it('names only DURATION budgets as hops', () => {
-    // `maxPages` and `concurrency` are not durations; including one would raise the floor for no reason and
-    // make recovery slower than it needs to be.
+    // `maxPages` and `concurrency` are not durations; feeding one would raise the floor for no reason and make
+    // recovery slower than it needs to be.
+    //
+    // Checked on the fed VALUES with comments stripped, not on the helper's whole text. The earlier version
+    // grepped the raw source, so it failed the moment a comment mentioned `maxPages` while the code was
+    // correct — and it would equally have passed a count fed under a duration-shaped key. What matters is what
+    // reaches `effectiveStallTimeoutMs`.
     const helper = src.match(/function hopBudgets\(\)[\s\S]*?\n\}/)?.[0] ?? '';
-    assert.ok(helper.includes('pageTimeoutMs') && helper.includes('ocrTimeoutMs')
-      && helper.includes('describeTimeoutMs'), 'the three call budgets must be listed');
-    assert.ok(!/maxPages|concurrency|PollInterval/.test(helper),
-      'a non-duration in hopBudgets would inflate the stall floor');
+    assert.ok(helper.length > 100, 'could not locate hopBudgets()');
+    const code = helper.replace(/\/\/.*$/gm, '');
+
+    const fed = [...code.matchAll(/^\s*(\w+):\s*([^,\n]+),/gm)].map(m => ({ key: m[1], value: m[2].trim() }));
+    assert.ok(fed.length >= 4, `only ${fed.length} hops parsed out of hopBudgets()`);
+
+    for (const { key, value } of fed) {
+      assert.ok(!/^(doc\.)?(maxPages|concurrency)$/.test(value) && !/PollInterval/.test(value),
+        `hopBudgets feeds '${key}: ${value}', which is not a duration — it would inflate the stall floor`);
+      // Every fed value must NAME a millisecond quantity: a config `*TimeoutMs`, a `*_TIMEOUT_MS` constant, or
+      // a helper whose name ends in `Ms`. That admits a DERIVED duration (the render window is
+      // `pageTimeoutMs x min(maxPages, 20)`, computed inside `worstRenderWindowMs`) while still rejecting a
+      // raw count.
+      assert.match(value, /TimeoutMs\b|_TIMEOUT_MS\b|Ms\(/,
+        `hopBudgets feeds '${key}: ${value}', which does not name a millisecond quantity`);
+    }
+
+    const keys = fed.map(f => f.key);
+    for (const required of ['pageTimeoutMs', 'ocrTimeoutMs', 'describeTimeoutMs', 'renderWindowMs']) {
+      assert.ok(keys.includes(required), `hopBudgets no longer feeds ${required}`);
+    }
+  });
+
+  it('feeds the render window, which is the longest step at the DEFAULTS', () => {
+    // The reason this file's opening measurement was wrong: it counted settable config keys, and the render
+    // budget is computed at its call site. 60 000 x min(50, 20) = 1 200 000 ms against a 300 000 ms default.
+    const helper = src.match(/function hopBudgets\(\)[\s\S]*?\n\}/)?.[0] ?? '';
+    assert.match(helper, /renderWindowMs:\s*worstRenderWindowMs\(/);
   });
 });


### PR DESCRIPTION
## The question was wrong, and answering it found something worse

Queue item 2 asked whether the **sum** of a job's hop budgets can outlive the thing watching it. It cannot, and
that half closes as informational: **stall detection measures silence, not duration.** Every phase beats — per
page (`vlm-extract.ts`), per chunk throttled to 2 s (`pipeline.ts`), once before the describe pass
(`worker.ts`) — `/health` returns 200 throughout by design, and the liveness crash loop was event-loop
starvation, fixed in #600.

But enumerating the hops to answer it found one the detector cannot see, and it is the longest step there is:

| | at the shipped defaults |
|---|---|
| `stalledJobTimeoutMs` | 300 000 ms |
| floor computed by `hopBudgets()` | `max(300 000, 1.5 × ocrTimeoutMs 120 000)` = **300 000** (no raise) |
| **actual longest silent step** — one render window | `pageTimeoutMs 60 000 × min(maxPages 50, 20)` = **1 200 000 ms** |

**Four times over, with nothing configured.** A render reports no progress while it runs — nothing beats from
inside a single `fetch`, and the per-page beat fires *after* the call returns — so the sweep re-queued the job
mid-render, the replacement rendered the same window, and it was re-queued at the same point. The loop that
never finishes, which the stall floor was written to prevent, reachable out of the box rather than only through
configuration. At the `pageTimeoutMs` ceiling it is a **3 h 20 m** silent step against a 15-minute floor.

## Why the floor could not see it

`hopBudgets()` was a hand-maintained list of three **config keys**, and this budget is not a config key — it is
a product computed at its call site, so a list of names could never contain it.

Tenth recorded instance of *"a hand-maintained list is never proved complete"*. The previous fix's own header
comment said "at the defaults nothing binds", and it was wrong for exactly the same reason the code was: it
counted the settable fields.

## Four more, from the same sweep

All inline literals, none of them operator-settable:

| hop | budget | vs the 5-minute stall default |
|---|---|---|
| Whisper transcription | **300 000 ms** | **1.0×** — *exactly* equal |
| local image captioning | 120 000 ms | 0.4× |
| external image captioning | 60 000 ms | 0.2× |
| external face recognition | 30 000 ms | binds at the schema's own 30 000 minimum |

Whisper is the sharp one: a five-minute transcription of long audio could be re-queued **in the same instant it
legitimately finished** — the indistinguishability `STALL_FLOOR_FACTOR = 1.5` exists to prevent. And because
none of these is settable, no operator could have raised the stall timeout to compensate even knowing they
existed.

## The fix, and its cost stated plainly

Every budget now has a name that both the call site and the floor use; the render window lives in
`files/converters/render-budget.ts` with its arithmetic pinned. A beat is also emitted **before** the render, so
the stall clock starts at the phase boundary rather than partway through the step before it.

**The effective stall timeout on a stock install rises from 5 minutes to 30** (1.5 × the render window), so a
genuinely wedged job takes longer to be recovered. That is the right trade against re-queueing a *working* job
forever, and the operator has a lever: lowering `maxPages` or `pageTimeoutMs` lowers the floor with it, which a
test pins. A planned restart still releases claims immediately (#612), so rolling deploys are unaffected.

## Gates

**`stall-floor-covers-every-hop`** (14 cases) enumerates every `timeoutMs:` / `AbortSignal.timeout()` call site
on the media path from `git ls-files` and checks **both directions**: the call site uses a named budget, and
that budget reaches `hopBudgets()`.

The second direction is derived, not listed — mutation testing showed an earlier version asserted only the
render budget, so deleting `sttTimeoutMs:` from `hopBudgets()` passed green. Two more properties worth naming:

- the exemption for a too-small budget is computed from the **admin schema's own `stalledJobTimeoutMs`
  minimum**, so it is a property of the number rather than a filename allowlist;
- the matchers are **anchored**, so the original defect expression — `cfg.pageTimeoutMs * Math.min(take, 20)`,
  which *contains* a covered name while being 20× its value — is rejected. A substring match would have blessed
  the code that caused the crash loop.

**`stall-floor`'s "names only DURATION budgets" rule is rewritten and is now strictly stronger.** It grepped raw
source, so it failed the moment a comment mentioned `maxPages` while the code was correct — and it would equally
have passed a raw count fed under a duration-shaped key. It now parses the fed values with comments stripped and
requires each to *name* a millisecond quantity, which admits a derived duration and still rejects a count.

**7 of 7 and 6 of 6 mutations caught**, the latter including the two the old rule would have missed.

---

`npm run preflight` **PASSED**.
