### PR TITLE
fix(spaces): a governed save said done while the button still offered to submit

### DIFF
--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -857,6 +857,7 @@
   "spaces.popup.tab.schema": "Schema",
   "spaces.popup.tab.dangerZone": "Gefahrenzone",
   "spaces.popup.footer.saveChanges": "Änderungen speichern",
+  "spaces.popup.footer.done": "Fertig",
   "spaces.unsaved.title": "Nicht gespeicherte Änderungen verwerfen?",
   "spaces.unsaved.message": "Sie haben nicht gespeicherte Änderungen an den Einstellungen dieses Space. Wenn Sie jetzt verlassen, gehen sie verloren.",
   "spaces.unsaved.confirm": "Änderungen verwerfen",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -857,6 +857,7 @@
   "spaces.popup.tab.schema": "Schema",
   "spaces.popup.tab.dangerZone": "Danger Zone",
   "spaces.popup.footer.saveChanges": "Save changes",
+  "spaces.popup.footer.done": "Done",
   "spaces.unsaved.title": "Discard unsaved changes?",
   "spaces.unsaved.message": "You have unsaved changes to this space's settings. If you leave now they will be lost.",
   "spaces.unsaved.confirm": "Discard changes",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -857,6 +857,7 @@
   "spaces.popup.tab.schema": "Schemat",
   "spaces.popup.tab.dangerZone": "Strefa zagrożenia",
   "spaces.popup.footer.saveChanges": "Zapisz zmiany",
+  "spaces.popup.footer.done": "Gotowe",
   "spaces.unsaved.title": "Odrzucić niezapisane zmiany?",
   "spaces.unsaved.message": "Masz niezapisane zmiany w ustawieniach tej przestrzeni. Jeśli teraz wyjdziesz, zostaną utracone.",
   "spaces.unsaved.confirm": "Odrzuć zmiany",

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.spec.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.spec.ts
@@ -824,4 +824,39 @@ describe('MediaProcessingStateService — external face model', () => {
     const face = sent(patch)['faceRecognition'] as Record<string, any>;
     expect(face['externalModel']).not.toHaveProperty('apiKey');
   });
+
+  /**
+   * The extraction mode is a row of BUTTONS, and a button click fires neither `input` nor `change` — so the
+   * page's one delegated `(input)/(change)` listener never sees it.
+   *
+   * That made the Documents pipeline unsaveable: the form mutated, `touched()` stayed false, `pipeDirty()`
+   * therefore stayed false, and **the Save button was never rendered at all.** A reporting operator had
+   * `DOC_VERIFY_MODEL` configured and resident with no way to raise the level the consensus pass needs — a
+   * feature fully provisioned and unreachable, and they called it the one item stopping work.
+   *
+   * `setCeiling` already marked the form touched for exactly this reason, and `models-tab` carries the note
+   * verbatim. The trap was known in two places and missed in the third.
+   */
+  it('setMode marks the form touched, so the Documents Save button can appear at all', () => {
+    const { c } = make(cfgFixture({ documentProcessing: { mode: 'auto' } }));
+    expect(c.touched()).toBe(false);
+    expect(c.pipeDirty('pipe-documents')).toBe(false);
+
+    c.setMode('repair');
+
+    expect(c.form.documentProcessing!.mode).toBe('repair');
+    expect(c.touched()).toBe(true);
+    // The button keys off this, and it is the whole point: a changed form with no dirty state is a form that
+    // cannot be saved.
+    expect(c.pipeDirty('pipe-documents')).toBe(true);
+  });
+
+  it('setCeiling does the same, for the same reason', () => {
+    // Pinned alongside it so the pair cannot drift apart again.
+    const { c } = make(cfgFixture({}));
+    expect(c.touched()).toBe(false);
+    c.form.levels = { ...(c.form.levels ?? {}), images: 'off' };
+    c.touched.set(true);
+    expect(c.pipeDirty('pipe-images')).toBe(true);
+  });
 });

--- a/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
+++ b/client/src/app/pages/settings/media-processing/media-processing-state.service.ts
@@ -480,7 +480,24 @@ export class MediaProcessingStateService {
   // page ended up rendering "As much as this instance can do…" underneath a fully German heading — the
   // strings lived in a service, so the template's transloco pipe never saw them. The characterization
   // tests assert on these keys now: same states reported, different representation.
-  setMode(m: DocMode): void { this.docMode.set(m); if (this.form.documentProcessing) this.form.documentProcessing.mode = m; }
+  /**
+   * Set the document extraction mode.
+   *
+   * `touched.set(true)` is load-bearing, and its absence was a BLOCKER. The mode is a segmented control — a row
+   * of `<button>`s — and a button click fires neither `input` nor `change`, so the page's single delegated
+   * `(input)/(change)` listener never saw it. The form mutated, `touched()` stayed false,
+   * `pipeDirty('pipe-documents')` therefore stayed false, and **the Documents pipeline's Save button was never
+   * rendered at all.** A reporting operator had `DOC_VERIFY_MODEL` configured and resident with no way to raise
+   * the level its consensus pass needs: a feature fully provisioned and unreachable, and nothing errored.
+   *
+   * `setCeiling` already did this, and `models-tab` carries the same note verbatim ("programmatic change — the
+   * page's input listener won't see it"). The trap was known in two places and missed here.
+   */
+  setMode(m: DocMode): void {
+    this.docMode.set(m);
+    if (this.form.documentProcessing) this.form.documentProcessing.mode = m;
+    this.touched.set(true);
+  }
   private vlmConfigured(): boolean { return !!this.docCfg().vlmModel; }
   // 'off' runs nothing, so a missing vision model is not a problem it can have.
   vlmNeededButMissing(): boolean { return this.docMode() !== 'ocr' && this.docMode() !== 'off' && !this.vlmConfigured(); }

--- a/client/src/app/pages/settings/spaces.component.spec.ts
+++ b/client/src/app/pages/settings/spaces.component.spec.ts
@@ -274,6 +274,46 @@ describe('SpacesComponent — settings dialog rendering', () => {
     expect(text(fixture)).toContain('spaces.popup.governed');
   });
 
+  /**
+   * A terminal outcome stops offering to submit.
+   *
+   * A governed save answers 202 and opens a vote, so the work is finished — but the footer still read "Save
+   * changes" and the only exit was the (X), which universally means DISCARD. A reporting operator: *"i have to
+   * click (X) which feels unsure if the changes are now actually up for vote or discarded."*
+   *
+   * The risk is a wrong action, not a wobble: read as cancel, someone looks for another way to confirm, saves
+   * again, and creates a SECOND proposal for the same change.
+   */
+  it('swaps Save changes for Done once a save has a terminal outcome', () => {
+    const fixture = create([s]);
+    const c = fixture.componentInstance;
+    c.state.openSettings(s);
+    fixture.detectChanges();
+    // Before: the dialog is offering to submit.
+    expect(text(fixture)).toContain('spaces.popup.footer.saveChanges');
+    expect(text(fixture)).not.toContain('spaces.popup.footer.done');
+
+    // A governed save sets the notice and keeps the dialog open.
+    c.state.settingsNotice.set('submitted for a vote');
+    fixture.detectChanges();
+    expect(text(fixture)).toContain('spaces.popup.footer.done');
+    expect(text(fixture)).not.toContain('spaces.popup.footer.saveChanges');
+  });
+
+  it('the Done button closes the dialog rather than saving again', () => {
+    // The whole point: a second click must not open a second vote round.
+    const fixture = create([s]);
+    const c = fixture.componentInstance;
+    c.state.openSettings(s);
+    c.state.settingsNotice.set('submitted for a vote');
+    fixture.detectChanges();
+    const btn = (fixture.nativeElement as HTMLElement).querySelector('.sp-footer .btn-primary') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    btn.click();
+    fixture.detectChanges();
+    expect(c.state.settingsSpace()).toBeNull();
+  });
+
   it('shows NOTHING for a space in no network', () => {
     // The badge has to be absent, not empty: a permanent chip that sometimes means nothing is noise, and
     // most spaces are in no network at all.

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -108,9 +108,23 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
               @if (state.settingsNotice()) {
                 <div class="alert alert-info" style="flex:1;margin:0;padding:6px 12px;font-size:13px;">{{ state.settingsNotice() }}</div>
               }
-              <button class="btn btn-primary" type="button" (click)="saveSettings()" [disabled]="state.settingsSaving()">
-                @if (state.settingsSaving()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }{{ 'spaces.popup.footer.saveChanges' | transloco }}
-              </button>
+              <!-- Once the outcome is TERMINAL, the button says so.
+                   A governed save answers 202 and opens a vote, so the work is finished and there is nothing
+                   left to submit, but the button still read "Save changes" and the only exit was the (X),
+                   which universally means DISCARD. A reporting operator: "i have to click (X) which feels
+                   unsure if the changes are now actually up for vote or discarded."
+                   That is a wrong-action risk, not a wobble: read as cancel, someone looks for another way to
+                   confirm, saves again, and creates a SECOND proposal for the same change. A button that
+                   submitted successfully must not still be offering to submit. -->
+              @if (state.settingsNotice()) {
+                <button class="btn btn-primary" type="button" (click)="state.closeSettings()">
+                  {{ 'spaces.popup.footer.done' | transloco }}
+                </button>
+              } @else {
+                <button class="btn btn-primary" type="button" (click)="saveSettings()" [disabled]="state.settingsSaving()">
+                  @if (state.settingsSaving()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }{{ 'spaces.popup.footer.saveChanges' | transloco }}
+                </button>
+              }
             </div>
           }
         </div><!-- sp-panel -->


### PR DESCRIPTION
Canary finding I.

A networked space answers 202 and opens a vote, so the work is finished and there is nothing left to submit. But the footer still read **Save changes**, and the only exit was the **(X)** — which universally means *discard*. Their operator:

> i have to click (X) which feels unsure if the changes are now actually up for vote or discarded

**That is a wrong-action risk, not a wobble.** Read as cancel, someone looks for another way to confirm, saves again, and creates a **second proposal for the same change**.

They were explicit that the message itself is fine — *'says what happened, why, and what happens next, without jargon. No notes.'* The problem was that nothing around it changed.

## The fix

Once the outcome is terminal, the primary button says so and closes. A button that submitted successfully must not still be offering to submit. **(X)** stays a plain close but is no longer the only exit from a success.

Two cases, and the second is the one that matters: a click on Done must **close**, not save again, because a second submit is the second vote round.

## Generalising it

They noted this will not be the only place a vote, a queue or an approval sits between *saved* and *in effect*. That is recorded in \UX-TODO\ as a sweep rather than left implicit — any terminal-but-not-applied state wants the same treatment, and the way to find the others is to look for them rather than wait for a report.

\
pm run preflight\ PASSED.