### PR TITLE
fix(brain): per-type retention only ever fired on chrono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Per-type retention only ever fired on chrono.** The tier is documented as reaching *"every record of that
+  type, in any of the four typed collections"*, with `entity.ticket` as its worked example, and for entities,
+  memories and edges it did nothing at all.
+  - **The cause was one missing argument, in six places.** `expiryForCreate` reads `typed ? … : undefined`, and
+    only `chrono.ts` passed `typed`. Every *update* site omitted it too, chrono's included — so even chrono
+    applied the tier to records written after the policy and not to records edited after it.
+  - **Thirty unit cases and eleven database cases covered it and all passed.** They hand the resolver its
+    `collection`; nothing asserted a *caller* supplies one. Unit-green, integration-absent — the same shape as
+    the missing Schema-tab control above, one layer in.
+  - **Edges key on `label`, not `type`** — an edge document carries both, and the schema is keyed by label.
+    Reading `type` finds a schema that is never there and looks like it worked, so `applyExpiryToUpdate` now
+    takes the collection and the existing document and works the field out itself rather than trusting six call
+    sites to pick right.
+  - **The backfill pass walked chrono only**, so even with the create path fixed, a window set today would never
+    have reached yesterday's records in the other three collections. It now walks all four. `files` stays out: no
+    type, so no schema window. `contentDays` is still stamped on chrono alone — writing `_contentExpireAt` where
+    no sweep reads it would put a policy in the data that never fires.
+  - **A dormant policy switching on is now announced.** A window configured months ago through the API begins
+    deleting records the first time the pass reaches it. That is the documented behaviour, and it gets one `info`
+    line per space and type naming the window rather than a debug-level count.
+  - Gates: `retention-reaches-every-collection` parses the call sites and fails if any create or update in a
+    typed collection omits its collection, or if the backfill's collection list narrows; plus a database gate
+    proving an `entity` window lands in `_expireAt`, that an edge is found by its label (its `type` is set to
+    something different on purpose, so a wrong-field resolver cannot pass by luck), and that no content window is
+    stamped outside chrono. Mutation-tested 5/5, each mutant being the original bug in one of its forms.
+
 - **A chrono's `properties` no longer goes with its embedding when a content window lapses.** The canary asked
   whether the two can expire separately — so a type can go **semantically silent while staying queryable by
   field** — and was holding a space's configuration until the answer. They were right to ask: for an alert

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -155,9 +155,13 @@ Rules worth knowing before you configure it:
   window means "redact sooner", not "exempt from deletion".
 - **A `contentDays` at or past the delete window is ignored**, because it could never fire, and a policy that
   silently does nothing is worse than a rejected one.
-- **It applies to records you already have.** A background pass stamps existing chronos from **their own
+- **It applies to records you already have.** A background pass stamps existing records from **their own
   `createdAt`**, not from when you enabled the policy — so switching it on prunes the backlog rather than
-  granting everything a fresh full window.
+  granting everything a fresh full window. It never re-slides an expiry a record already has, so a deliberate
+  per-record `ttlDays` is safe from it, and the first time it reaches a space+type it logs one `info` line
+  naming the window: a dormant policy that starts deleting records should say so.
+  - **This is the schema tier only.** Changing the space-wide `recordTtlDays` does *not* reach back over records
+    written before the change — that would start deleting history on every space that has ever set one.
 - The schema lives in space meta, so this tier is **governed and replicated**: in a network the policy is agreed
   and each instance then expires its own copy locally, and the tombstones converge.
 - **A type defined by `$ref` has no window.** A schema-library entry cannot carry `retention` — its schema

--- a/server/src/brain/chrono-redaction.ts
+++ b/server/src/brain/chrono-redaction.ts
@@ -2,6 +2,17 @@
  * The chrono content-redaction pass, and the lazy backfill that makes schema-tier retention apply to records
  * that already exist.
  *
+ * ## The backfill covers all four typed collections; redaction is chrono-only
+ *
+ * Those are two different reasons, not one inconsistency. **Redaction** removes `description`, `matchedText` and
+ * the embedding — chrono's field names, and the tier is declared chrono-only in `CONTENT_TIER_COLLECTIONS`.
+ * **Backfill** just stamps `_expireAt` from a policy, which every typed collection has.
+ *
+ * It did not, until now. The schema tier is documented as reaching *"every record of that type, in any of the
+ * four typed collections"*, and for entities, memories and edges nothing had ever stamped a record: the create
+ * path never passed its collection to the resolver, so it silently fell through to the space default, and this
+ * pass only ever walked chrono. `files` stays out on purpose — a file has no type, so it has no schema window.
+ *
  * ## Why this is lazy rather than a boot migration
  *
  * `<space>_chrono` is **synced data**: it replicates to peers by whole-document upsert. A boot migration would
@@ -33,7 +44,11 @@ import {
   recordExpiry, recordContentExpiry, needsContentRedaction, REDACTED_CHRONO_FIELDS, declaredRetention,
   type RetentionSpace,
 } from './chrono-retention.js';
-import type { ChronoEntry } from '../config/types.js';
+import { COLLECTION_SUFFIX, TYPE_FIELD } from './ttl.js';
+import type { ChronoEntry, KnowledgeType } from '../config/types.js';
+
+/** Every collection the schema tier can reach. `files` is absent: a file has no type, so no schema window. */
+const TYPED_COLLECTIONS: readonly KnowledgeType[] = ['entity', 'memory', 'edge', 'chrono'];
 
 /** Max records touched per space per pass, so one enormous space cannot monopolise a sweep cycle. */
 const BATCH = 500;
@@ -45,50 +60,86 @@ export interface ChronoRetentionResult {
   redacted: number;
 }
 
-/** The chrono types whose schema declares a retention window — the cheap check that skips the common case. */
+/** The types in one collection whose schema declares a retention window — the check that skips the common case. */
+export function policedTypes(space: RetentionSpace, collection: KnowledgeType): string[] {
+  return declaredRetention(space).filter(r => r.collection === collection).map(r => r.type);
+}
+
+/** Kept as the chrono-specific name the redaction pass and its tests read. */
 export function policedChronoTypes(space: RetentionSpace): string[] {
-  return declaredRetention(space).filter(r => r.collection === 'chrono').map(r => r.type);
+  return policedTypes(space, 'chrono');
 }
 
 /**
- * Stamp chrono records that a schema policy covers but that carry no expiry yet.
+ * Windows already reported at info, so switching a policy on announces itself ONCE rather than per sweep.
+ *
+ * Process-lifetime, deliberately not persisted: a restart re-announcing the active delete policies is useful,
+ * and a stamp count in a debug line was not enough. Bounded by the number of policed types.
+ */
+const announced = new Set<string>();
+
+/**
+ * Stamp records that a schema policy covers but that carry no expiry yet.
  *
  * Only fetches records missing BOTH stamps, so a settled collection costs one indexed miss per cycle.
+ *
+ * **Schema tier only.** A record written before the SPACE default was set is deliberately left alone: widening
+ * this to `recordTtlDays` would start deleting historic records on every space that has ever set one, which is a
+ * far larger blast radius than the policy change the operator made.
  */
-export async function backfillChronoExpiry(spaceId: string, space: RetentionSpace): Promise<number> {
-  const types = policedChronoTypes(space);
+export async function backfillTypedExpiry(
+  spaceId: string,
+  space: RetentionSpace,
+  collection: KnowledgeType,
+): Promise<number> {
+  const types = policedTypes(space, collection);
   if (types.length === 0) return 0;
   let stamped = 0;
 
-  const rows = await col<ChronoEntry>(`${spaceId}_chrono`)
+  const name = `${spaceId}_${COLLECTION_SUFFIX[collection]}`;
+  const typeField = TYPE_FIELD[collection];
+  const rows = await col(name)
     .find(
-      asFilter<ChronoEntry>({
-        type: { $in: types },
+      asFilter({
+        [typeField]: { $in: types },
         _expireAt: { $exists: false },
         _contentExpireAt: { $exists: false },
       }),
-      { projection: { _id: 1, type: 1, createdAt: 1 } },
+      { projection: { _id: 1, [typeField]: 1, createdAt: 1 } },
     )
     .limit(BATCH)
-    .toArray() as unknown as Array<{ _id: string; type: string; createdAt?: string }>;
+    .toArray() as unknown as Array<Record<string, unknown> & { _id: string; createdAt?: string }>;
 
   for (const r of rows) {
     // From the record's OWN creation time. Using `now` would hand every existing record a fresh full window,
     // which is the opposite of what enabling a retention policy means.
     const createdMs = Date.parse(r.createdAt ?? '');
     if (!Number.isFinite(createdMs)) continue;   // cannot date it ⇒ cannot expire it
+    const type = typeof r[typeField] === 'string' ? r[typeField] as string : undefined;
     const $set: Record<string, unknown> = {};
-    const expireAt = recordExpiry(space, 'chrono', r.type, createdMs);
-    const contentAt = recordContentExpiry(space, 'chrono', r.type, createdMs);
+    const expireAt = recordExpiry(space, collection, type, createdMs);
+    const contentAt = recordContentExpiry(space, collection, type, createdMs);
     if (expireAt) $set['_expireAt'] = expireAt;
     if (contentAt) $set['_contentExpireAt'] = contentAt;
     if (Object.keys($set).length === 0) continue;
-    await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(
-      asFilter<ChronoEntry>({ _id: r._id }), asUpdate<ChronoEntry>({ $set }),
-    );
+    // A policy configured months ago and never applied begins deleting records the moment this pass reaches it.
+    // That is the documented behaviour and it is still worth saying out loud, once, at info.
+    const key = `${spaceId}|${collection}|${type ?? ''}`;
+    if (!announced.has(key)) {
+      announced.add(key);
+      log.info(`Retention: '${spaceId}' ${collection}/${type} is being stamped from its schema window`
+        + `${expireAt ? ` — delete at ${expireAt.toISOString()} for the oldest in this batch` : ''}`
+        + `${contentAt ? `, detail dropped at ${contentAt.toISOString()}` : ''}`);
+    }
+    await col(name).updateOne(asFilter({ _id: r._id }), asUpdate({ $set }));
     stamped++;
   }
   return stamped;
+}
+
+/** Chrono-only alias, kept because the redaction pass and its DB tests are chrono-specific by nature. */
+export async function backfillChronoExpiry(spaceId: string, space: RetentionSpace): Promise<number> {
+  return backfillTypedExpiry(spaceId, space, 'chrono');
 }
 
 /** Drop the content of records whose content window has lapsed, keeping the record. */
@@ -131,7 +182,11 @@ export async function sweepChronoRetention(now: Date = new Date()): Promise<Chro
     if (s.proxyFor?.length) continue;
     const space: RetentionSpace = { recordTtlDays: s.recordTtlDays, meta: s.meta };
     try {
-      result.stamped += await backfillChronoExpiry(s.id, space);
+      // All four typed collections, not just chrono. The schema tier is documented as reaching every one of
+      // them, and for three of them nothing had ever stamped a record.
+      for (const collection of TYPED_COLLECTIONS) {
+        result.stamped += await backfillTypedExpiry(s.id, space, collection);
+      }
       result.redacted += await redactLapsedChronoContent(s.id, now);
     } catch (err) {
       log.warn(`Chrono retention (${s.id}): ${err instanceof Error ? err.message : String(err)}`);

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -200,7 +200,8 @@ export async function updateChrono(
     } catch { /* embedding unavailable — keep existing embedding */ }
   }
 
-  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset); // F10
+  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+    { collection: 'chrono', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
   await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -125,7 +125,8 @@ export async function upsertEdge(
     if (tags !== undefined) $set['tags'] = effectiveTags;
     if (properties !== undefined) $set['properties'] = mergedEdgeProperties(existing as EdgeDoc, properties);
     const $unset: Record<string, unknown> = {};
-    applyExpiryToUpdate(spaceId, ttlDays, (existing as EdgeDoc)._expireAt != null, $set, $unset); // F10
+    applyExpiryToUpdate(spaceId, ttlDays, (existing as EdgeDoc)._expireAt != null, $set, $unset,
+      { collection: 'edge', existing: existing as unknown as Record<string, unknown> }); // F10
     const updateOp: Record<string, unknown> = { $set };
     if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
     await collection.updateOne(
@@ -166,7 +167,9 @@ export async function upsertEdge(
     seq,
     ...embeddingFields,
   };
-  stampExpiryOnCreate(spaceId, doc, ttlDays);
+  // `doc.label`, NOT `doc.type` — an edge has both, and the schema is keyed by label (see validateEdgeWrite).
+  // Passing `type` here would look right and read a schema that is never there.
+  stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'edge', type: doc.label });
   await collection.insertOne(asDoc<EdgeDoc>(doc));
   if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   return doc;
@@ -322,7 +325,8 @@ export async function updateEdgeById(
     $set['matchedText'] = embedText;
   } catch { /* embedding unavailable — keep existing embedding */ }
 
-  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset); // F10
+  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+    { collection: 'edge', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
   await collection.updateOne(asFilter<EdgeDoc>({ _id: id }), asUpdate<EdgeDoc>(updateOp));

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -143,7 +143,8 @@ export async function upsertEntity(
     const $set: Record<string, unknown> = { name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields };
     if (description !== undefined) $set['description'] = description;
     const $unset: Record<string, unknown> = {};
-    applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset); // F10
+    applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+      { collection: 'entity', existing: existing as unknown as Record<string, unknown> }); // F10
     const updateOp: Record<string, unknown> = { $set };
     if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
     await collection.updateOne(
@@ -193,7 +194,9 @@ export async function upsertEntity(
     ...embeddingFields,
   };
   if (description !== undefined) doc.description = description;
-  stampExpiryOnCreate(spaceId, doc, ttlDays);
+  // `typed` is what makes the SCHEMA tier reachable. Omit it and the resolver silently falls through to the
+  // space default, so a window set on `typeSchemas.entity.<type>.retention` does nothing at all.
+  stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'entity', type: doc.type });
   await collection.insertOne(asDoc<EntityDoc>(doc));
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
@@ -305,7 +308,8 @@ export async function updateEntityById(
     $set['matchedText'] = embedText;
   } catch { /* embedding unavailable — keep existing embedding */ }
 
-  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset); // F10
+  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+    { collection: 'entity', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
   await collection.updateOne(asFilter<EntityDoc>({ _id: id }), asUpdate<EntityDoc>(updateOp));

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -82,7 +82,8 @@ export async function remember(
   if (type !== undefined) doc.type = type;
   if (description !== undefined) doc.description = description;
   if (properties !== undefined) doc.properties = properties;
-  stampExpiryOnCreate(spaceId, doc, ttlDays);
+  // See entities.ts: without `typed` the schema tier is unreachable and the space default applies instead.
+  stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'memory', type: doc.type });
   await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(doc));
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
@@ -165,7 +166,8 @@ export async function updateMemory(
     } catch { /* embedding unavailable — keep existing embedding */ }
   }
 
-  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset); // F10
+  applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+    { collection: 'memory', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
   await col<MemoryDoc>(`${spaceId}_memories`).updateOne(

--- a/server/src/brain/ttl.ts
+++ b/server/src/brain/ttl.ts
@@ -19,6 +19,26 @@ const DAY_MS = 86_400_000;
  *  deleter runs the full file cascade, and only file-level records ever carry `_expireAt`.) */
 export const TTL_COLLECTIONS = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
 
+/**
+ * The Mongo collection suffix for each typed knowledge collection.
+ *
+ * `KnowledgeType` is singular (`entity`) and the collection is plural (`<space>_entities`) — a mapping that was
+ * open-coded in five places and is the sort of thing a fifth caller gets wrong once.
+ */
+export const COLLECTION_SUFFIX: Record<KnowledgeType, string> = {
+  entity: 'entities', memory: 'memories', edge: 'edges', chrono: 'chrono',
+};
+
+/**
+ * The document field that names a record's type, per collection.
+ *
+ * **Edges key on `label`, not `type`** — `EdgeDoc` has both, and `validateEdgeWrite` looks the schema up by
+ * `label`. Reading `type` for an edge finds a schema that is never there and looks like it worked.
+ */
+export const TYPE_FIELD: Record<KnowledgeType, 'type' | 'label'> = {
+  entity: 'type', memory: 'type', edge: 'label', chrono: 'type',
+};
+
 function spaceRecordTtlDays(spaceId: string): number | undefined {
   try { return getConfig().spaces.find(s => s.id === spaceId)?.recordTtlDays; } catch { return undefined; }
 }
@@ -88,8 +108,16 @@ function retentionSpace(spaceId: string): RetentionSpace | undefined {
  * Apply the TTL to an **update**'s `$set`/`$unset` in place:
  *   - `ttlDays > 0` → set a new expiry;
  *   - `ttlDays` 0/null → clear the expiry (opt the record out of the space default);
- *   - omitted → apply the space default **only when the record has no expiry yet** (`hasExistingExpiry`
+ *   - omitted → apply the resolved default **only when the record has no expiry yet** (`hasExistingExpiry`
  *     false), never re-sliding an existing one.
+ *
+ * `typed` carries the same schema tier as the create path. Without it this resolved straight to the SPACE
+ * default, so a record that gained an expiry on update got the space number even when its own type declared a
+ * shorter one — the type's window applied to records written after the policy and not to records edited after it.
+ *
+ * It takes the **collection plus the existing document**, not a type string, and works the type out itself. Seven
+ * call sites would otherwise each have to pick the right field and the right precedence, and the bug this fixes
+ * is precisely a caller getting that wrong: `edge` keys on `label` while its sibling collections key on `type`.
  */
 export function applyExpiryToUpdate(
   spaceId: string,
@@ -97,13 +125,32 @@ export function applyExpiryToUpdate(
   hasExistingExpiry: boolean,
   $set: Record<string, unknown>,
   $unset: Record<string, unknown>,
+  typed?: { collection: KnowledgeType; existing: Record<string, unknown> },
 ): void {
   if (ttlDays === 0 || ttlDays === null) { $unset['_expireAt'] = ''; return; }
   if (typeof ttlDays === 'number' && ttlDays > 0) { $set['_expireAt'] = new Date(Date.now() + ttlDays * DAY_MS); return; }
   if (!hasExistingExpiry) {
-    const expireAt = spaceTtlExpiry(spaceId);
+    const expireAt = expiryForCreate(spaceId, undefined, typed && {
+      collection: typed.collection,
+      // The type the record will HAVE, not the one it had: an update that changes the type must resolve against
+      // the new one, or a record moved into a policed type keeps the old type's window.
+      type: effectiveType(typed.collection, $set, typed.existing),
+    });
     if (expireAt) $set['_expireAt'] = expireAt;
   }
+}
+
+/** The type a record will carry after this `$set` is applied — the update's value if it sets one, else current. */
+export function effectiveType(
+  collection: KnowledgeType,
+  $set: Record<string, unknown>,
+  existing: Record<string, unknown>,
+): string | undefined {
+  const field = TYPE_FIELD[collection];
+  const next = $set[field];
+  if (typeof next === 'string') return next;
+  const current = existing[field];
+  return typeof current === 'string' ? current : undefined;
 }
 
 /** Ensure the (plain, non-TTL) `_expireAt` index that keeps the sweep query cheap. */

--- a/testing/standalone/retention-every-collection-db.test.js
+++ b/testing/standalone/retention-every-collection-db.test.js
@@ -1,0 +1,170 @@
+/**
+ * Database-level test: a schema retention window reaches entities, memories and edges — not only chrono.
+ *
+ * This is the assertion that would have FAILED before the fix, and the reason the existing 30 unit cases plus
+ * 11 DB cases all passed while the feature did nothing outside chrono: they all supply `collection` themselves.
+ * Nothing exercised the three collections whose callers never supplied it.
+ *
+ * Covers what only the driver can settle:
+ *
+ *  - the backfill query matches on the right FIELD per collection — `label` for edges, `type` for the rest.
+ *    A `type` filter on an edge matches nothing and the pass would report a clean zero;
+ *  - each collection's records are stamped from their own `createdAt`, in their own collection name
+ *    (`<space>_entities`, not `<space>_entity`);
+ *  - `contentDays` is not stamped outside chrono even when a type declares it, because no sweep implements it
+ *    there and a `_contentExpireAt` nothing reads is a lie in the data;
+ *  - files are untouched: no type, so no schema window.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/retention-every-collection-db.test.js
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'mixed';
+const DAY = 86_400_000;
+
+let mongo, backfillTypedExpiry, policedTypes;
+
+/**
+ * A window on one type in each typed collection — the canary's actual shape: a space holds ticket entities that
+ * must outlive their status-change chronos.
+ *
+ * `edge.depends-on` is keyed by LABEL, which is the trap: an edge document has both `label` and `type`.
+ */
+const POLICY = {
+  meta: {
+    typeSchemas: {
+      entity: { ticket: { retention: { days: 365 } } },
+      memory: { note: { retention: { days: 30 } } },
+      edge:   { 'depends-on': { retention: { days: 60 } } },
+      chrono: { event: { retention: { days: 90, contentDays: 14 } } },
+    },
+  },
+};
+
+/** A window with `contentDays` on a NON-chrono type — accepted by the API, implemented by no sweep. */
+const CONTENT_OUTSIDE_CHRONO = {
+  meta: { typeSchemas: { entity: { ticket: { retention: { days: 365, contentDays: 30 } } } } },
+};
+
+const ago = (days) => new Date(Date.now() - days * DAY).toISOString();
+
+const base = (id, createdAt) => ({
+  _id: id, spaceId: SPACE, createdAt, updatedAt: createdAt, seq: 1, author: { instanceId: 'self' },
+});
+
+const docs = {
+  entities: (id, type, createdAt) => ({ ...base(id, createdAt), name: id, type, tags: [] }),
+  memories: (id, type, createdAt) => ({ ...base(id, createdAt), fact: `fact ${id}`, type, tags: [], entityIds: [] }),
+  // `label` is the schema key; `type` is set to something DIFFERENT on purpose, so a resolver reading the wrong
+  // field cannot accidentally pass.
+  edges:    (id, label, createdAt) => ({ ...base(id, createdAt), from: 'a', to: 'b', label, type: 'unrelated', tags: [] }),
+  chrono:   (id, type, createdAt) => ({ ...base(id, createdAt), type, title: id, startsAt: createdAt, status: 'done', tags: [], entityIds: [], memoryIds: [] }),
+};
+
+const load = (coll, id) => mongo.col(`${SPACE}_${coll}`).findOne({ _id: id });
+
+describe('schema retention reaches every typed collection (real MongoDB)', { skip }, () => {
+  before(async () => {
+    mongo = await openTestMongo('retentionevery');
+    ({ backfillTypedExpiry, policedTypes } = await import('../../server/dist/brain/chrono-redaction.js'));
+  });
+
+  after(async () => { await closeTestMongo(); });
+
+  beforeEach(async () => {
+    for (const c of ['entities', 'memories', 'edges', 'chrono', 'files']) {
+      await mongo.col(`${SPACE}_${c}`).deleteMany({});
+    }
+  });
+
+  it('finds the policed types in each collection', () => {
+    assert.deepEqual(policedTypes(POLICY, 'entity'), ['ticket']);
+    assert.deepEqual(policedTypes(POLICY, 'memory'), ['note']);
+    assert.deepEqual(policedTypes(POLICY, 'edge'), ['depends-on']);
+    assert.deepEqual(policedTypes(POLICY, 'chrono'), ['event']);
+  });
+
+  it('stamps an ENTITY from its own createdAt — the documented example that did nothing', async () => {
+    const created = ago(100);
+    await mongo.col(`${SPACE}_entities`).insertOne(docs.entities('t-1', 'ticket', created));
+
+    assert.equal(await backfillTypedExpiry(SPACE, POLICY, 'entity'), 1);
+    const doc = await load('entities', 't-1');
+    assert.equal(doc._expireAt.getTime(), Date.parse(created) + 365 * DAY);
+  });
+
+  it('stamps a MEMORY', async () => {
+    const created = ago(10);
+    await mongo.col(`${SPACE}_memories`).insertOne(docs.memories('m-1', 'note', created));
+
+    assert.equal(await backfillTypedExpiry(SPACE, POLICY, 'memory'), 1);
+    assert.equal((await load('memories', 'm-1'))._expireAt.getTime(), Date.parse(created) + 30 * DAY);
+  });
+
+  it('stamps an EDGE by its label, not its type', async () => {
+    const created = ago(5);
+    await mongo.col(`${SPACE}_edges`).insertOne(docs.edges('e-1', 'depends-on', created));
+
+    assert.equal(await backfillTypedExpiry(SPACE, POLICY, 'edge'), 1,
+      'the backfill found no edge — it is almost certainly querying `type` instead of `label`');
+    assert.equal((await load('edges', 'e-1'))._expireAt.getTime(), Date.parse(created) + 60 * DAY);
+  });
+
+  it('leaves a type with no window alone, in every collection', async () => {
+    const created = ago(400);
+    await mongo.col(`${SPACE}_entities`).insertOne(docs.entities('p-1', 'person', created));
+    await mongo.col(`${SPACE}_memories`).insertOne(docs.memories('m-2', 'idea', created));
+    await mongo.col(`${SPACE}_edges`).insertOne(docs.edges('e-2', 'mentions', created));
+
+    for (const c of ['entity', 'memory', 'edge']) {
+      assert.equal(await backfillTypedExpiry(SPACE, POLICY, c), 0, c);
+    }
+    assert.equal((await load('entities', 'p-1'))._expireAt, undefined);
+    assert.equal((await load('memories', 'm-2'))._expireAt, undefined);
+    assert.equal((await load('edges', 'e-2'))._expireAt, undefined);
+  });
+
+  it('never re-slides an expiry that is already there', async () => {
+    // A record carrying a deliberate per-record ttlDays must not have it quietly overwritten by the policy.
+    const created = ago(100);
+    const own = new Date(Date.now() + 3 * DAY);
+    await mongo.col(`${SPACE}_entities`).insertOne({ ...docs.entities('t-2', 'ticket', created), _expireAt: own });
+
+    assert.equal(await backfillTypedExpiry(SPACE, POLICY, 'entity'), 0);
+    assert.equal((await load('entities', 't-2'))._expireAt.getTime(), own.getTime());
+  });
+
+  it('does NOT stamp a content window outside chrono', async () => {
+    // The API accepts `contentDays` on any collection; only chrono's sweep implements it. Writing
+    // `_contentExpireAt` where nothing reads it would put a policy in the data that never fires.
+    const created = ago(100);
+    await mongo.col(`${SPACE}_entities`).insertOne(docs.entities('t-3', 'ticket', created));
+
+    assert.equal(await backfillTypedExpiry(SPACE, CONTENT_OUTSIDE_CHRONO, 'entity'), 1);
+    const doc = await load('entities', 't-3');
+    assert.equal(doc._expireAt.getTime(), Date.parse(created) + 365 * DAY);
+    assert.equal(doc._contentExpireAt, undefined,
+      '_contentExpireAt was stamped on an entity, where no sweep will ever read it');
+  });
+
+  it('skips a record whose createdAt cannot be parsed rather than expiring it now', async () => {
+    await mongo.col(`${SPACE}_entities`).insertOne(docs.entities('t-4', 'ticket', 'not-a-date'));
+    assert.equal(await backfillTypedExpiry(SPACE, POLICY, 'entity'), 0);
+    assert.equal((await load('entities', 't-4'))._expireAt, undefined);
+  });
+
+  it('a space with no schema windows costs nothing', async () => {
+    await mongo.col(`${SPACE}_entities`).insertOne(docs.entities('t-5', 'ticket', ago(100)));
+    for (const c of ['entity', 'memory', 'edge', 'chrono']) {
+      assert.equal(await backfillTypedExpiry(SPACE, { recordTtlDays: 90 }, c), 0, c);
+    }
+    // The SPACE tier deliberately does not backfill: widening it would start deleting historic records on every
+    // space that ever set one.
+    assert.equal((await load('entities', 't-5'))._expireAt, undefined);
+  });
+});

--- a/testing/standalone/retention-reaches-every-collection.test.js
+++ b/testing/standalone/retention-reaches-every-collection.test.js
@@ -1,0 +1,124 @@
+/**
+ * The schema retention tier must reach every typed collection — not just the one it was written for.
+ *
+ * ## The failure this exists for
+ *
+ * `retention` on a type resolved correctly and applied to nothing outside chrono. Three of the four typed
+ * collections called the TTL stamper WITHOUT their collection:
+ *
+ *     chrono.ts     stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'chrono', type: doc.type })
+ *     entities.ts   stampExpiryOnCreate(spaceId, doc, ttlDays)
+ *     memory.ts     stampExpiryOnCreate(spaceId, doc, ttlDays)
+ *     edges.ts      stampExpiryOnCreate(spaceId, doc, ttlDays)
+ *
+ * and `expiryForCreate` reads `typed ? … : undefined`, so the omission fell through to the space default in
+ * silence. Every update site omitted it too, chrono's included. Meanwhile the API accepted the field, the guide
+ * documented it as covering all four collections with an `entity.ticket` worked example, and the Schema tab
+ * offered an input for it.
+ *
+ * **Why 30 passing unit tests did not catch it.** They test the pure resolver with `collection` handed in. Every
+ * branch is covered. Nothing asserted that a *caller* supplies it — which is the entire bug.
+ *
+ * So this gate reads the CALL SITES, and a companion DB test proves an `entity` window reaches `_expireAt`.
+ *
+ * Run: node --test testing/standalone/retention-reaches-every-collection.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** file → the collection literal its TTL calls must pass. */
+const TYPED = {
+  'server/src/brain/entities.ts': 'entity',
+  'server/src/brain/memory.ts':   'memory',
+  'server/src/brain/edges.ts':    'edge',
+  'server/src/brain/chrono.ts':   'chrono',
+};
+
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/** Every `stampExpiryOnCreate(` / `applyExpiryToUpdate(` call in a file, with its full argument text. */
+function ttlCalls(src) {
+  const out = [];
+  const re = /(stampExpiryOnCreate|applyExpiryToUpdate)\(/g;
+  let m;
+  while ((m = re.exec(src))) {
+    // Walk to the matching close paren so a multi-line call is one call.
+    let depth = 1, i = re.lastIndex;
+    while (i < src.length && depth > 0) {
+      if (src[i] === '(') depth++;
+      else if (src[i] === ')') depth--;
+      i++;
+    }
+    const args = src.slice(re.lastIndex, i - 1);
+    // Skip the definitions themselves (ttl.ts) — they have a typed parameter, not an argument.
+    if (/^\s*$/.test(args)) continue;
+    out.push({ fn: m[1], args, line: src.slice(0, m.index).split('\n').length });
+  }
+  return out;
+}
+
+describe('the schema retention tier reaches every typed collection', () => {
+  it('found the call sites — the pattern still matches', () => {
+    const total = Object.keys(TYPED).reduce((n, f) => n + ttlCalls(read(f)).length, 0);
+    assert.ok(total >= 10, `only found ${total} TTL call sites across the four typed collections`);
+  });
+
+  it('every create and update passes its collection', () => {
+    const bad = [];
+    for (const [file, kt] of Object.entries(TYPED)) {
+      for (const c of ttlCalls(read(file))) {
+        if (!c.args.includes(`collection: '${kt}'`)) bad.push(`${file}:${c.line} ${c.fn} — no collection: '${kt}'`);
+      }
+    }
+    assert.deepEqual(bad, [], 'these TTL calls omit their collection, so the resolver falls through to the space '
+      + `default and the type's own retention window does nothing:\n  ${bad.join('\n  ')}\n\n`
+      + "Pass `{ collection: '<kind>', … }` as the last argument.");
+  });
+
+  it('an edge keys on `label`, never on `type`', () => {
+    // EdgeDoc has BOTH, and `validateEdgeWrite` looks the schema up by label. Reading `type` for an edge finds
+    // a schema that is never there and looks like it worked, which is worse than not passing anything.
+    const src = read('server/src/brain/edges.ts');
+    for (const c of ttlCalls(src)) {
+      if (!c.args.includes("collection: 'edge'")) continue;
+      assert.ok(!/type:\s*doc\.type|type:\s*existing\.type/.test(c.args),
+        `edges.ts:${c.line} resolves its retention type from \`type\`; the schema is keyed by \`label\``);
+    }
+    const ttl = read('server/src/brain/ttl.ts');
+    assert.match(ttl, /TYPE_FIELD[\s\S]{0,200}edge:\s*'label'/,
+      "ttl.ts must map edge -> 'label' in TYPE_FIELD");
+  });
+
+  it('the backfill pass walks all four collections, not only chrono', () => {
+    // The half that made the tier apply to records that already exist. Chrono had it; the other three did not,
+    // so a window set today would never reach yesterday's records even once the create path was fixed.
+    const src = read('server/src/brain/chrono-redaction.ts');
+    assert.match(src, /TYPED_COLLECTIONS[^=]*=\s*\[\s*'entity',\s*'memory',\s*'edge',\s*'chrono'\s*\]/,
+      'TYPED_COLLECTIONS must list all four typed collections');
+    assert.match(src, /for \(const collection of TYPED_COLLECTIONS\)[\s\S]{0,200}backfillTypedExpiry/,
+      'the sweep must call backfillTypedExpiry for each collection');
+    // Files stay out: no type, so no schema window. Asserted so nobody "completes" the list.
+    assert.ok(!/TYPED_COLLECTIONS[^=]*=[^\]]*'file/.test(src),
+      'files have no type and therefore no schema window — they must not be in TYPED_COLLECTIONS');
+  });
+
+  it('switching a dormant policy on is announced, not silent', () => {
+    // A window configured months ago through the API starts deleting records the first time this pass reaches
+    // it. That is the documented behaviour and still worth one info line per space+type.
+    const src = read('server/src/brain/chrono-redaction.ts');
+    assert.match(src, /announced\.has\(key\)/, 'the first stamp for a space+type must be reported once');
+    assert.match(src, /log\.info\(`Retention:/, 'that report must be at info, not debug');
+  });
+
+  it('the documented worked example is the one that was broken', () => {
+    // 04-brain-api.md promises the tier on `entity`, with `ticket` as its example. If that claim is ever
+    // narrowed to chrono, this gate should be reconsidered rather than silently disagreeing with the docs.
+    const doc = read('docs/integration-guide/04-brain-api.md');
+    assert.match(doc, /"entity":\s*\{[\s\S]{0,120}"retention"/,
+      'the guide no longer shows an entity retention example — check whether the tier’s scope changed');
+  });
+});


### PR DESCRIPTION
## The tier resolved correctly and applied to nothing outside chrono

`04-brain-api.md` says the schema tier reaches *"every record of that type, in **any of the four typed
collections**"*, and its worked example is:

```json
"entity": { "ticket": { "retention": { "days": 365 } } }
```

That did nothing. Neither did a window on a memory type, or an edge label.

**One missing argument, in six places.** `expiryForCreate` reads `typed ? retentionSpace(spaceId) : undefined`,
and only `chrono.ts` passed `typed`:

```
chrono.ts     stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'chrono', type: doc.type })
entities.ts   stampExpiryOnCreate(spaceId, doc, ttlDays)
memory.ts     stampExpiryOnCreate(spaceId, doc, ttlDays)
edges.ts      stampExpiryOnCreate(spaceId, doc, ttlDays)
```

Every **update** site omitted it as well, chrono's included — so even chrono applied the tier to records written
after a policy and not to records edited after it.

Found while reading these call sites to plan the next feature, not from a report. It is the same defect class as
#631 one layer in, and #631 makes it urgent: that PR ships a **Delete records after** input on entity, memory and
edge types, and for those three it would write a number nothing reads. Exactly the dishonest control #631 removed.

## Why 41 passing tests did not catch it

`chrono-retention` (30 cases) and `chrono-retention-db` (11 cases) hand the resolver its `collection`. Every
branch is covered and every assertion is correct. Nothing asserted that a **caller** supplies one — which is the
entire bug. Unit-green, integration-absent.

So the new gate reads the **call sites**, and its companion proves the effect in the database.

## Four gaps, one cause

**1. Create.** The three collections pass `typed`.

**2. Update.** `applyExpiryToUpdate` now takes the **collection plus the existing document** and works the type
out itself, rather than a type string. Six call sites would otherwise each pick a field and a precedence, and the
bug being fixed is precisely a caller getting that wrong:

> **An edge keys on `label`, not `type`.** `EdgeDoc` carries both, and `validateEdgeWrite` looks the schema up by
> `label`. Reading `type` for an edge finds a schema that is never there and *looks like it worked* — worse than
> passing nothing, which at least falls back to something real.

It also resolves against the type the record **will have**, not the one it had, so moving a record into a policed
type applies the new window rather than the old one.

**3. Backfill.** `chrono-redaction.ts` is the pass that makes a policy apply to records that already exist, and it
walked chrono only — so even with the create path fixed, a window set today would never reach yesterday's records
in the other three collections. It now walks all four.

- **`files` stays out**, asserted, so nobody "completes" the list: a file has no type, so it has no schema window.
- **`contentDays` is still stamped on chrono alone.** The API accepts it anywhere; only chrono's sweep implements
  it. Writing `_contentExpireAt` where nothing reads it would put a policy in the data that never fires.
- **Schema tier only.** Widening the backfill to `recordTtlDays` would start deleting historic records on every
  space that has ever set one — a far larger blast radius than the change an operator made. Documented as such.

**4. A dormant policy switching on now says so.** A window configured months ago through the API begins deleting
records the first time this pass reaches it. That is the documented behaviour and still worth one `info` line per
space and type, naming the window, instead of a debug-level count.

## Gates

**`retention-reaches-every-collection`** parses each TTL call — brace-matched, so a multi-line call is one call —
and fails if any create or update in a typed collection omits its collection. Plus: that edges never resolve from
`type`, that `TYPE_FIELD` maps edge to `label`, that the backfill's collection list is all four and does not
include files, that the first stamp is announced at `info`, and that the guide still shows the `entity` example
this gate exists to keep honest.

**`retention-every-collection-db`** (9 cases, real MongoDB) proves the effect: an `entity` window lands in
`_expireAt` dated from the record's own `createdAt`; a memory window lands; **an edge is found by its label — its
`type` is deliberately set to something different, so a wrong-field resolver cannot pass by luck**; a type with no
window is untouched; an existing expiry is never re-slid; no `_contentExpireAt` outside chrono; an unparseable
`createdAt` is skipped rather than expired now; a space with no windows costs nothing.

**Mutation-tested 5/5**, each mutant being the original bug in one of its forms: entities create loses its
collection; an update site loses its collection; the backfill narrows to chrono; `TYPE_FIELD` maps edge to `type`;
`CONTENT_TIER_COLLECTIONS` widens past chrono. All caught.

---

`npm run preflight` PASSED (356 server + 878 client).
