### PR TITLE
fix(files): a refresh replaced the whole listing with a spinner, every four seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Watching an ingest replaced the whole file listing with a spinner every four seconds.** The progress poll
+  called the same loader a first load uses, and the template is *spinner-or-table* — so the table was unmounted
+  and remounted on every tick, for the whole of an ingest. A canary operator, verbatim: *"i only want to see
+  progress bars move while waiting and not a screenflickering."*
+  - **Their diagnosis was the fix**: the view treated *"a refetch is in flight"* as *"we have no data yet"*. The
+    rule now stated as a rule: **a refresh must never re-enter the empty state a first load uses.**
+  - A reload of the **same** directory keeps the rows and updates them in place, marked by a 2px indeterminate
+    hairline instead of an overlay. A navigation to a **different** directory is still a foreground load — rows
+    from the directory you are leaving must not appear under the name of the one you are entering, which is why
+    the classification compares the path rather than trusting the caller. Six callers; asking each to classify
+    itself is how five get it right and one does not.
+  - **A failed refresh no longer discards good rows either.** That is the same defect in another dress, and a
+    transient failure during an ingest is exactly when it happens: the rows stay, marked as not-current, and the
+    next tick clears it. A failed *first* load still reaches the error state rather than an empty folder.
+  - Measured rather than eyeballed, because the flicker is between frames: a MutationObserver plus a 20 Hz DOM
+    sample over three real poll ticks. Against the fix, 280 samples with rows and **0 without**; against the
+    original code, 3 table removals and **72 of 280 samples with no rows at all**. The first attempt at that
+    harness reached the component through `window.ng`, which a production build strips — so it drove nothing and
+    reported a clean pass.
+  - Six specs, mutation-tested 4/4, including the two directions that must NOT regress: a first load still shows
+    the spinner, and a navigation is still a load.
+
 - **"Save retention" in the Danger Zone saved nothing and said it had.** It `await`ed the Observable that
   `updateSpace` returns. Awaiting a cold Observable resolves immediately with the Observable *itself* and never
   subscribes, so **no request was ever sent** — and the success toast fired anyway. Every other call in that

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1467,6 +1467,8 @@
   "brain.error.loadChrono": "Zeitleisteneinträge konnten nicht geladen werden.",
   "brain.error.loadFileMeta": "Dateidatensätze konnten nicht geladen werden.",
   "files.error.loadFiles": "Dateien konnten nicht geladen werden.",
+  "files.refreshing": "Suche nach Änderungen",
+  "files.refreshFailed": "Aktualisierung fehlgeschlagen — die Liste unten ist möglicherweise nicht aktuell. Neuer Versuch folgt.",
   "schemaLib.error.load": "Schema-Bibliothek konnte nicht geladen werden.",
   "graph.error.load": "Graph konnte nicht geladen werden.",
   "auditLog.summary.shown": "Angezeigt",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1467,6 +1467,8 @@
   "brain.error.loadChrono": "Couldn't load timeline entries.",
   "brain.error.loadFileMeta": "Couldn't load file records.",
   "files.error.loadFiles": "Couldn't load files.",
+  "files.refreshing": "Checking for changes",
+  "files.refreshFailed": "Could not refresh — the list below may be out of date. Retrying.",
   "schemaLib.error.load": "Couldn't load the schema library.",
   "graph.error.load": "Couldn't load the graph.",
   "auditLog.summary.shown": "Shown",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1467,6 +1467,8 @@
   "brain.error.loadChrono": "Nie udało się załadować wpisów osi czasu.",
   "brain.error.loadFileMeta": "Nie udało się załadować rekordów plików.",
   "files.error.loadFiles": "Nie udało się załadować plików.",
+  "files.refreshing": "Sprawdzanie zmian",
+  "files.refreshFailed": "Nie udało się odświeżyć — lista poniżej może być nieaktualna. Ponawianie.",
   "schemaLib.error.load": "Nie udało się załadować biblioteki schematów.",
   "graph.error.load": "Nie udało się załadować grafu.",
   "auditLog.summary.shown": "Wyświetlone",

--- a/client/src/app/pages/files/file-manager.component.spec.ts
+++ b/client/src/app/pages/files/file-manager.component.spec.ts
@@ -404,6 +404,139 @@ function fakeFileList(names: string[]): FileList {
   return { ...files, length: files.length, item: (i: number) => files[i] } as unknown as FileList;
 }
 
+/**
+ * A refresh must never re-enter the empty state a first load uses (canary B).
+ *
+ * `loadDir` set `loading` on every call, and the template is `@if (loading()) { spinner } @else { table }` — so
+ * the 4-second progress poll unmounted the entire file listing and replaced it with a spinner, every four
+ * seconds, for the whole of an ingest. Their operator, verbatim: *"i only want to see progress bars move while
+ * waiting and not a screenflickering."*
+ *
+ * These assert the DOM, not the flag: a spinner instead of the table is the symptom, and asserting `loading()`
+ * alone would pass on a template that unmounts for some other reason.
+ */
+describe('FileManagerComponent — a refresh keeps the view (canary B)', () => {
+  /** A listing API whose responses are controllable per call, so a refresh can be observed mid-flight. */
+  function create(entries: FileEntry[], listFiles?: () => Observable<{ entries: FileEntry[] }>) {
+    TestBed.configureTestingModule({
+      imports: [FileManagerComponent, getTranslocoModule()],
+      providers: [
+        { provide: FilesApi, useValue: { ...makeApi(entries), ...(listFiles ? { listFiles } : {}) } },
+        { provide: SpacesApi, useValue: makeApi(entries) },
+        { provide: AuthService, useValue: { token: () => '' } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+      ],
+    });
+    const fixture = TestBed.createComponent(FileManagerComponent);
+    fixture.componentRef.setInput('embeddedSpaceId', 'work');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const rows = (f: { nativeElement: HTMLElement }) => f.nativeElement.querySelectorAll('table tbody tr').length;
+  const spinner = (f: { nativeElement: HTMLElement }) => f.nativeElement.querySelector('.loading-overlay');
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('does not unmount the table while a reload of the SAME directory is in flight', () => {
+    const gate = new Subject<{ entries: FileEntry[] }>();
+    let calls = 0;
+    const fixture = create([fileEntry('a.pdf'), fileEntry('b.pdf')], () => {
+      calls++;
+      return calls === 1 ? of({ entries: [fileEntry('a.pdf'), fileEntry('b.pdf')] }) : gate.asObservable();
+    });
+    expect(rows(fixture)).toBe(2);
+
+    fixture.componentInstance.reloadDir();          // the poll's call
+    fixture.detectChanges();
+
+    // Mid-flight: the rows are still there and the overlay has NOT appeared. This is the whole fix.
+    expect(spinner(fixture)).toBeNull();
+    expect(rows(fixture)).toBe(2);
+    expect(fixture.componentInstance.loading()).toBe(false);
+    expect(fixture.componentInstance.refreshing()).toBe(true);
+
+    gate.next({ entries: [fileEntry('a.pdf'), fileEntry('b.pdf'), fileEntry('c.pdf')] });
+    fixture.detectChanges();
+    expect(rows(fixture)).toBe(3);                  // updated in place
+    expect(fixture.componentInstance.refreshing()).toBe(false);
+  });
+
+  it('shows the hairline while refreshing, and nothing when idle', () => {
+    const gate = new Subject<{ entries: FileEntry[] }>();
+    let calls = 0;
+    const fixture = create([fileEntry('a.pdf')], () => {
+      calls++;
+      return calls === 1 ? of({ entries: [fileEntry('a.pdf')] }) : gate.asObservable();
+    });
+    expect(fixture.nativeElement.querySelector('.fm-refreshing')).toBeNull();
+
+    fixture.componentInstance.reloadDir();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.fm-refreshing')).toBeTruthy();
+
+    gate.next({ entries: [fileEntry('a.pdf')] });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.fm-refreshing')).toBeNull();
+  });
+
+  it('a failed refresh keeps the rows and says they are not current', () => {
+    // A transient failure during an ingest is exactly when this happens, and throwing away good rows for it is
+    // the same defect in another dress.
+    let calls = 0;
+    const fixture = create([fileEntry('a.pdf')], () => {
+      calls++;
+      return calls === 1
+        ? of({ entries: [fileEntry('a.pdf')] })
+        : new Observable<{ entries: FileEntry[] }>(sub => sub.error(new Error('boom')));
+    });
+    expect(rows(fixture)).toBe(1);
+
+    fixture.componentInstance.reloadDir();
+    fixture.detectChanges();
+
+    expect(rows(fixture)).toBe(1);                                       // rows survive
+    expect(spinner(fixture)).toBeNull();
+    expect(fixture.componentInstance.loadError()).toBeNull();            // NOT the first-load error state
+    expect(fixture.componentInstance.refreshFailed()).toBe(true);
+    expect(fixture.nativeElement.querySelector('.fm-stale')).toBeTruthy();
+  });
+
+  it('a FIRST load still shows the spinner — the empty state is not what changed', () => {
+    const gate = new Subject<{ entries: FileEntry[] }>();
+    const fixture = create([], () => gate.asObservable());
+    expect(spinner(fixture)).toBeTruthy();
+    expect(fixture.componentInstance.loading()).toBe(true);
+    gate.next({ entries: [fileEntry('a.pdf')] });
+    fixture.detectChanges();
+    expect(spinner(fixture)).toBeNull();
+  });
+
+  it('a failed FIRST load still reaches the error state, not an empty folder', () => {
+    const fixture = create([], () => new Observable<{ entries: FileEntry[] }>(sub => sub.error(new Error('nope'))));
+    expect(fixture.componentInstance.loadError()).not.toBeNull();
+    expect(fixture.componentInstance.refreshFailed()).toBe(false);
+  });
+
+  it('navigating to a DIFFERENT directory is a load, not a refresh', () => {
+    // Rows from the directory being left must not be shown under the name of the one being entered — which is
+    // why the classification compares the path rather than trusting the caller.
+    const gate = new Subject<{ entries: FileEntry[] }>();
+    let calls = 0;
+    const fixture = create([fileEntry('a.pdf')], () => {
+      calls++;
+      return calls === 1 ? of({ entries: [fileEntry('a.pdf')] }) : gate.asObservable();
+    });
+    expect(rows(fixture)).toBe(1);
+
+    fixture.componentInstance.navigate('/sub');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.loading()).toBe(true);
+    expect(spinner(fixture)).toBeTruthy();
+  });
+});
+
 describe('FileManagerComponent — upload queue (U12)', () => {
   let mock: ReturnType<typeof makeUploadApi>;
 

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -144,6 +144,40 @@ function xlsxCellText(v: unknown): string {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent, HscrollTopDirective],
   styles: [`
+    /* A background refresh, as a 2px indeterminate hairline above the table. Deliberately NOT a spinner and
+       deliberately not an overlay: the whole point is that nothing on screen moves or disappears while a poll
+       is in flight. It reserves its own 2px so the table does not shift when it appears.
+       NO BACKTICKS anywhere in this block — it is one template string. */
+    .fm-refreshing {
+      height: 2px;
+      margin-bottom: 6px;
+      border-radius: 2px;
+      overflow: hidden;
+      background: color-mix(in srgb, var(--accent) 14%, transparent);
+    }
+    .fm-refreshing::after {
+      content: '';
+      display: block;
+      width: 34%;
+      height: 100%;
+      border-radius: 2px;
+      background: var(--accent);
+      animation: fm-slide 1.1s ease-in-out infinite;
+    }
+    @keyframes fm-slide {
+      0%   { transform: translateX(-100%); }
+      100% { transform: translateX(300%); }
+    }
+    /* Honesty when a poll fails: the rows stay, but they are no longer claimed to be current. */
+    .fm-stale {
+      font-size: 12px;
+      color: var(--warning, var(--text-muted));
+      margin-bottom: 6px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .fm-refreshing::after { animation: none; width: 100%; opacity: .5; }
+    }
+
     .toolbar {
       display: flex;
       align-items: center;
@@ -607,6 +641,12 @@ function xlsxCellText(v: unknown): string {
             @if (loading()) {
               <div class="loading-overlay"><span class="spinner"></span></div>
             } @else {
+          <!-- A background refresh is a HAIRLINE, not an unmount. The table below stays exactly where it is and
+               its rows update in place, so the per-row progress bars advance instead of the screen blinking. -->
+          @if (refreshing()) { <div class="fm-refreshing" role="status" [attr.aria-label]="'files.refreshing' | transloco"></div> }
+          @if (refreshFailed()) {
+            <div class="fm-stale">{{ 'files.refreshFailed' | transloco }}</div>
+          }
           <div class="table-wrapper" hscrollTop>
             <table>
               <thead>
@@ -1048,7 +1088,22 @@ export class FileManagerComponent implements OnInit, OnDestroy {
         : String(ka).localeCompare(String(kb)) * sign;
     });
   });
+  /**
+   * True only while a load that has **nothing to show** is in flight — the state that replaces the view.
+   *
+   * A REFRESH must never enter it. It used to: `loadDir` set this on every call, including the 4-second progress
+   * poll, so watching an ingest meant the whole file table was unmounted and replaced by a spinner every four
+   * seconds. A reporting operator, verbatim: *"i only want to see progress bars move while waiting and not a
+   * screenflickering."* They were right about the mechanism too — the view treated "a refetch is in flight" as
+   * "we have no data yet".
+   *
+   * The rule, worth stating as a rule: **a refresh must never re-enter the empty state a first load uses.**
+   */
   loading = signal(false);
+  /** True while a reload of the SAME directory is in flight over rows already on screen. Never unmounts them. */
+  refreshing = signal(false);
+  /** Set when a background refresh failed, so stale rows are not passed off as current. Cleared on success. */
+  refreshFailed = signal(false);
   /** Failure reason for the directory listing; null when it loaded (U3). */
   loadError = signal<string | null>(null);
   loadingSpaces = signal(true);
@@ -1226,17 +1281,46 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * The path `entries()` currently describes, or null before the first successful listing.
+   *
+   * This is what decides load-vs-refresh, rather than a flag at each call site. `loadDir` has six callers (the
+   * navigation effect, the poll, the retry button, and three post-mutation reloads) and asking each to classify
+   * itself is how five get it right and one does not — the exact shape of the retention bug fixed in #632.
+   *
+   * Comparing the PATH is also the only correct rule: rows from the directory you are leaving must not be shown
+   * under the name of the one you are entering, so a navigation is always a foreground load.
+   */
+  private loadedPath: string | null = null;
+
   private loadDir(path: string): void {
-    this.loading.set(true);
-    this.loadError.set(null);
+    // A refresh only when there is something on screen that this listing will replace in place.
+    const isRefresh = this.loadedPath === path && this.entries().length > 0 && this.loadError() === null;
+    if (isRefresh) this.refreshing.set(true);
+    else { this.loading.set(true); this.loadError.set(null); }
     this.filesApi.listFiles(this.activeSpaceId(), path).subscribe({
       next: ({ entries }) => {
         this.entries.set(entries);
+        this.loadedPath = path;
+        this.loadError.set(null);
+        this.refreshFailed.set(false);
         this.loading.set(false);
+        this.refreshing.set(false);
         this.syncProgressPolling();
       },
-      // A failed listing must not fall through to the "empty folder" state (U3).
-      error: (e) => { this.loadError.set(httpErrorReason(e)); this.loading.set(false); },
+      error: (e) => {
+        if (isRefresh) {
+          // A failed POLL must not throw away good rows either — that is the same defect in another dress, and
+          // a transient failure during an ingest is exactly when it would happen. Keep the rows, mark them as
+          // not-current, and let the next tick clear it.
+          this.refreshFailed.set(true);
+          this.refreshing.set(false);
+          return;
+        }
+        // A failed first listing must not fall through to the "empty folder" state (U3).
+        this.loadError.set(httpErrorReason(e));
+        this.loading.set(false);
+      },
     });
   }
 


### PR DESCRIPTION
## Watching an ingest meant the file listing disappeared every four seconds

Canary **B**, symptom 2 — the one they called *"the actual complaint"*. Their operator, verbatim:

> i only want to see progress bars move while waiting and not a screenflickering.

The progress poll called the same loader a first load uses, and the template is:

```html
@if (loading()) { <div class="loading-overlay">…</div> } @else { <table>…</table> }
```

So every tick unmounted the entire table and replaced it with a spinner, for the whole of a job.

**Their diagnosis was the fix.** The view treated *"a refetch is in flight"* the same as *"we have no data yet"*.
The rule, now stated as one:

> **A refresh must never re-enter the empty state a first load uses.**

## What changed

- A reload of the **same** directory keeps the rows and updates them in place, marked by a **2px indeterminate
  hairline** — not a spinner, not an overlay. It reserves its own 2px, so the table does not shift when it appears.
- A navigation to a **different** directory is still a foreground load. Rows from the directory you are leaving
  must not appear under the name of the one you are entering, so the classification compares the **loaded path**
  rather than trusting the caller.
  - That placement is the point: `loadDir` has six callers (the navigation effect, the poll, the retry button, and
    three post-mutation reloads). Asking each to classify itself is how five get it right and one does not — which
    is the shape of the retention bug in #632, in the same codebase, this week.
- **A failed refresh no longer discards good rows.** That is the same defect in another dress, and a transient
  failure during an ingest is exactly when it happens: the rows stay, marked as not-current, and the next tick
  clears it. A failed *first* load still reaches the error state rather than an empty folder.

## Measured, because a screenshot cannot see it

The symptom is an unmount **between frames**. So the page reports on itself: a `MutationObserver` counting table
removals and loading-overlay appearances, plus a 20 Hz DOM sample, over three real poll ticks with the listing
delayed to 1.2 s.

| | with the fix | against the original code |
|---|---|---|
| poll ticks observed | 3 | 3 |
| table removals | **0** | **3** |
| loading-overlay appearances | **0** | **3** |
| refresh hairline appearances | 3 | 0 |
| DOM samples **with** rows | 280 | 208 |
| DOM samples **without** rows | **0** | **72** |

72 of 280 — the table was simply gone for a quarter of the time. That is the flicker, quantified.

**And the first version of that harness was worthless.** It reached the component through `window.ng.getComponent`,
which a production build strips, so it drove nothing and reported a clean pass. Worth recording: that is the
failure mode of every end-to-end check, and the only reason it surfaced is that the numbers looked *too* clean —
zero hairline appearances alongside zero removals. The rewritten harness drives the real code path by rewriting
the listing response so every row reports `processing`, which is the condition that starts the component's own
timer.

## Swept for other instances — there are none

- Only two client components poll with `setInterval`: this one and the shell's conflict badge. The shell's error
  handler already keeps its last known value.
- The Brain Overview's loaders are called only from `selectSpace`, which blanks deliberately before loading a
  *different* space; the two also called on live events (`loadStats`, `loadEmbeddingQueue`) already have
  non-destructive error handlers.

## Not in this PR: canary B symptom 1

*"The Overview does not render its cards until their data arrives."* Confirmed from source and it is narrower than
the report reads: each card is gated on its own input arriving, and **nothing blanks on refresh** — so it is purely
a first-load problem, and the fix is a skeleton at each card's final size rather than a state change. That is a
visual slice wanting a screenshot pair, not a DOM counter, so it is filed separately rather than bolted on here.

## Tests

Six specs asserting the **DOM**, not the flag — a spinner instead of the table is the symptom, and asserting
`loading()` alone would pass on a template that unmounts for some other reason. **Mutation-tested 4/4**, including
the two directions that must not regress: a first load still shows the spinner, and a navigation is still a load.

---

`npm run preflight` PASSED (887 client).
