### PR TITLE
fix(brain): the Overview assembled itself one card at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Brain Overview assembled itself one card at a time.** Each card rendered only once its own request
+  landed, so every arrival pushed the ones below it down — *"they appear one by one as each request lands, rather
+  than as a laid-out set that fills in"*, the milder half of the same canary report.
+  - Four panels now reserve their space with a placeholder **at the card's settled size**, in the real frame with
+    the real title and hint. The point is the size, not the shimmer: what makes a page look like it is building
+    itself is the layout moving. Measured — the grid is **943 px from the first frame to the last**, with one
+    distinct panel count throughout; before, each card's full height arrived separately.
+  - The placeholder is keyed on a per-panel **pending** flag, not on the value being null, because null cannot
+    say *"not yet"*: `tokenAccess` is null **permanently** for a non-admin (the endpoint 403s) and `completeness`
+    is null after a failure, so a placeholder keyed on null would have sat there forever. Pending is raised only
+    where the values are blanked — a space switch — and never by the live-event refresh, which has good data on
+    screen.
+  - The shared piece is the **lines only**; the frame stays in the caller. A first version drew the frame too and
+    would have rendered an unstyled grey block — `.panel` belongs to the Overview's own styles and view
+    encapsulation does not let a child borrow them. It compiled and it built.
+  - Gate `overview-pending-is-cleared`: every panel must clear its flag on **both** outcomes (eight places), the
+    clearing function must really clear, and the branches and keys — written in two different files — must not
+    drift. It exists because a mutation test showed a gutted clearing function left the whole component spec
+    green. Five specs plus the gate, mutation-tested 5/5 and 5/5, after fixing two assertions of my own that
+    passed against a deliberate break (both sliced from the first textual match of a method name, and both
+    measured the wrong region).
+
 - **Watching an ingest replaced the whole file listing with a spinner every four seconds.** The progress poll
   called the same loader a first load uses, and the template is *spinner-or-table* — so the table was unmounted
   and remounted on every tick, for the whole of an ingest. A canary operator, verbatim: *"i only want to see

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -302,6 +302,7 @@ interface SpaceView {
             <app-overview-tab [space]="sp" [stats]="activeStats()" [needsReindex]="needsReindex()"
               [reindexing]="reindexing()" [about]="aboutInfo()" [embeddingQueue]="embeddingQueue()"
               [openVotes]="overviewVotes()" [tokenAccess]="tokenAccess()" [completeness]="completeness()" [activity]="spaceActivity()"
+              [pending]="overviewPending()"
               (reindex)="runReindex()" (retryFailed)="runRetryFailedEmbeddings()"
               (openTab)="setTab($event)" />
           }
@@ -373,6 +374,30 @@ export class BrainComponent implements OnInit, OnDestroy {
    * its members rather than a list the panel would have to add up itself.
    */
   spaceActivity = signal<SpaceActivity | null>(null);
+
+  /**
+   * Which Overview panels have been blanked for a space switch and are still awaiting their first answer.
+   *
+   * The Overview's cards each render only when their own value arrives, so the board assembled itself one card at
+   * a time and every arrival pushed the ones below it down — the milder half of a canary flicker report. A
+   * skeleton at the card's final size fixes that, but only if it can tell "not yet" from "never".
+   *
+   * `null` alone cannot: `tokenAccess` is null **permanently** for a non-admin (the endpoint 403s), and
+   * `completeness` is null after a failure. A skeleton keyed on null would sit there forever in both cases.
+   *
+   * So pending is set ONLY where the value is blanked — in `selectSpace` — and cleared by both the success and
+   * the failure handler. It is deliberately not set by the live-event refresh: that has good data on screen, and
+   * covering it with a skeleton would be the same defect this exists to remove.
+   */
+  overviewPending = signal<Record<'activity' | 'completeness' | 'queue' | 'tokens', boolean>>({
+    activity: false, completeness: false, queue: false, tokens: false,
+  });
+
+  /** Clear one panel's pending flag — called from both handlers of each loader, success or failure. */
+  private settled(key: 'activity' | 'completeness' | 'queue' | 'tokens'): void {
+    if (!this.overviewPending()[key]) return;
+    this.overviewPending.update(p => ({ ...p, [key]: false }));
+  }
 
   // Reindex
   needsReindex = signal(false);
@@ -517,6 +542,8 @@ export class BrainComponent implements OnInit, OnDestroy {
     this.tokenAccess.set(null);
     this.completeness.set(null);
     this.spaceActivity.set(null);
+    // Blanked and awaiting a first answer — the ONLY place pending is raised. See `overviewPending`.
+    this.overviewPending.set({ activity: true, completeness: true, queue: true, tokens: true });
     this.loadStats(id);
     this.loadSpaceMeta(id);
     this.loadEmbeddingQueue(id);
@@ -569,9 +596,10 @@ export class BrainComponent implements OnInit, OnDestroy {
           meanTopScore: answered > 0 ? Number((weightedScore / answered).toFixed(3)) : null,
           lastUsedAt: lastUsed,
         });
+        this.settled('activity');
       },
       // A failure leaves the signal null and the panel does not render — the same rule completeness follows.
-      error: () => { if (this.activeSpaceId() === spaceId) this.spaceActivity.set(null); },
+      error: () => { if (this.activeSpaceId() === spaceId) this.spaceActivity.set(null); this.settled('activity'); },
     });
   }
 
@@ -579,16 +607,17 @@ export class BrainComponent implements OnInit, OnDestroy {
    *  still active; a failure leaves the signal null and the panel simply does not render. */
   private loadCompleteness(spaceId: string): void {
     this.spacesApi.getCompleteness(spaceId).subscribe({
-      next: r => { if (this.activeSpaceId() === spaceId) this.completeness.set(r); },
-      error: () => { if (this.activeSpaceId() === spaceId) this.completeness.set(null); },
+      next: r => { if (this.activeSpaceId() === spaceId) this.completeness.set(r); this.settled('completeness'); },
+      error: () => { if (this.activeSpaceId() === spaceId) this.completeness.set(null); this.settled('completeness'); },
     });
   }
 
   /** Fetch the embedding-job backlog for a space; only stores it while that space is still active. */
   private loadEmbeddingQueue(spaceId: string): void {
     this.brainApi.getEmbeddingQueue(spaceId).subscribe({
-      next: q => { if (this.activeSpaceId() === spaceId) this.embeddingQueue.set(q); },
-      error: () => {},
+      next: q => { if (this.activeSpaceId() === spaceId) this.embeddingQueue.set(q); this.settled('queue'); },
+      // A failed refresh keeps the last good value on purpose; it only has to stop the skeleton.
+      error: () => this.settled('queue'),
     });
   }
 
@@ -596,8 +625,9 @@ export class BrainComponent implements OnInit, OnDestroy {
    *  caller leaves the signal null, which keeps the panel hidden. Only stores it while still active. */
   private loadTokenAccess(spaceId: string): void {
     this.brainApi.getTokenAccess(spaceId).subscribe({
-      next: r => { if (this.activeSpaceId() === spaceId) this.tokenAccess.set(r.tokens); },
-      error: () => { if (this.activeSpaceId() === spaceId) this.tokenAccess.set(null); },
+      next: r => { if (this.activeSpaceId() === spaceId) this.tokenAccess.set(r.tokens); this.settled('tokens'); },
+      // A 403 for a non-admin lands here and is permanent — clearing pending is what stops a forever-skeleton.
+      error: () => { if (this.activeSpaceId() === spaceId) this.tokenAccess.set(null); this.settled('tokens'); },
     });
   }
 

--- a/client/src/app/pages/brain/overview-tab.component.spec.ts
+++ b/client/src/app/pages/brain/overview-tab.component.spec.ts
@@ -416,7 +416,9 @@ describe('OverviewTabComponent — the usage panel', () => {
     expect(el.textContent).toContain('63 ms');
   });
 
-  it('hides the panel entirely until the fetch lands, and does not crash on null', () => {
+  it('hides the panel when the fetch has landed with nothing, and does not crash on null', () => {
+    // `pending` defaults to false, which is "settled with no data" — the panel stays hidden, as it always has.
+    // The loading case is a skeleton and is covered in its own block below.
     const { el, c } = render(null);
     expect(c.answerRate()).toBeNull();
     expect(el.textContent).not.toContain('brain.overview.useTitle');
@@ -427,5 +429,81 @@ describe('OverviewTabComponent — the usage panel', () => {
       .not.toContain('brain.overview.useSlow');
     expect(render(activity({ calls: 10, recall: 10, answered: 10, over1s: 3, maxMs: 1840 })).el.textContent)
       .toContain('brain.overview.useSlow');
+  });
+});
+
+/**
+ * The board must be LAID OUT from the first frame (canary B, symptom 1).
+ *
+ * Each card rendered only once its own request landed, so the Overview assembled itself one card at a time and
+ * every arrival pushed the ones below it down: *"they appear one by one as each request lands, rather than as a
+ * laid-out set that fills in."*
+ *
+ * A skeleton fixes that only if it can tell **not yet** from **never** — `tokenAccess` is null permanently for a
+ * non-admin (the endpoint 403s) and `completeness` is null after a failure, so a placeholder keyed on null alone
+ * would sit there forever. Hence a separate `pending` map, raised only where the value is blanked.
+ */
+describe('OverviewTabComponent — first-load skeletons', () => {
+  const PENDING = { activity: true, completeness: true, queue: true, tokens: true };
+
+  function render(pending: Partial<typeof PENDING> = {}) {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [OverviewTabComponent, getTranslocoModule()],
+      providers: [provideRouter([]), { provide: ConfirmDialogService, useValue: { confirm: vi.fn() } }],
+    });
+    const fixture = TestBed.createComponent(OverviewTabComponent);
+    fixture.componentRef.setInput('space', space());
+    fixture.componentRef.setInput('stats', STATS);
+    fixture.componentRef.setInput('pending', { activity: false, completeness: false, queue: false, tokens: false, ...pending });
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    return { fixture, el };
+  }
+
+  const busy = (el: HTMLElement) => el.querySelectorAll('.panel[aria-busy="true"]').length;
+  const titles = (el: HTMLElement) => [...el.querySelectorAll('.grid > .panel h3')].map(h => h.textContent?.trim());
+
+  it('reserves a card for every panel still awaiting its first answer', () => {
+    const { el } = render(PENDING);
+    expect(busy(el)).toBe(4);
+    // The frame is the real one, so the placeholder is identifiable rather than an anonymous grey box.
+    for (const key of ['brain.overview.useTitle', 'brain.overview.compTitle', 'brain.overview.queueTitle', 'brain.overview.tokenTitle']) {
+      expect(titles(el), key).toContain(key);
+    }
+  });
+
+  it('the board has the SAME cards, in the same order, loading or settled', () => {
+    // This is the whole fix: what makes the page look like it is assembling itself is the layout moving.
+    const loading = titles(render(PENDING).el);
+    const settled = titles(render({}).el);
+    // Settled-with-no-data hides the four optional panels; loading shows their frames. Every OTHER card must be
+    // in the same place in both, and the four must appear in loading exactly where they will land.
+    expect(loading.filter(t => !settled.includes(t)).sort()).toEqual([
+      'brain.overview.compTitle', 'brain.overview.queueTitle', 'brain.overview.tokenTitle', 'brain.overview.useTitle',
+    ]);
+    expect(settled.every(t => loading.includes(t))).toBe(true);
+  });
+
+  it('reserves nothing once a panel has settled, even with no data', () => {
+    // The difference that makes the skeleton safe: a non-admin never gets tokenAccess, and a forever-skeleton
+    // would be worse than the missing card.
+    const { el } = render({});
+    expect(busy(el)).toBe(0);
+    expect(titles(el)).not.toContain('brain.overview.tokenTitle');
+  });
+
+  it('is per panel — one still loading does not reserve the others', () => {
+    const { el } = render({ tokens: true });
+    expect(busy(el)).toBe(1);
+    expect(titles(el)).toContain('brain.overview.tokenTitle');
+    expect(titles(el)).not.toContain('brain.overview.useTitle');
+  });
+
+  it('draws lines, not a spinner — the size is the point', () => {
+    const { el } = render(PENDING);
+    const lines = el.querySelectorAll('app-skeleton-lines .sk-line');
+    expect(lines.length).toBe(4 + 4 + 3 + 3);          // the per-card row counts
+    expect(el.querySelector('.panel[aria-busy="true"] .spinner')).toBeNull();
   });
 });

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -15,6 +15,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, input, output } f
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { StatusPillComponent, StatusVariant } from '../../shared/status-pill.component';
+import { SkeletonLinesComponent } from '../../shared/skeleton-lines.component';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -30,7 +31,7 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
   selector: 'app-overview-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, RouterLink, DatePipe],
+  imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, SkeletonLinesComponent, RouterLink, DatePipe],
   styles: [`
     :host { display: block; }
 
@@ -278,6 +279,15 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
             }
           </div>
         </section>
+      } @else if (pending().activity) {
+        <section class="panel span-all" [attr.aria-busy]="true">
+          <header class="panel-h">
+            <span class="ic"><ph-icon name="broadcast" [size]="16"/></span>
+            <div><h3>{{ 'brain.overview.useTitle' | transloco }}</h3>
+              <p>{{ 'brain.overview.useHint' | transloco }}</p></div>
+          </header>
+          <div class="panel-b"><app-skeleton-lines [rows]="4" /></div>
+        </section>
       }
 
       <!-- ── Completeness ───────────────────────────────────────────── -->
@@ -324,6 +334,15 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
             </div>
           </section>
         }
+      } @else if (pending().completeness) {
+        <section class="panel" [attr.aria-busy]="true">
+          <header class="panel-h">
+            <span class="ic"><ph-icon name="check-circle" [size]="16"/></span>
+            <div><h3>{{ 'brain.overview.compTitle' | transloco }}</h3>
+              <p>{{ 'brain.overview.compHint' | transloco }}</p></div>
+          </header>
+          <div class="panel-b"><app-skeleton-lines [rows]="4" /></div>
+        </section>
       }
 
       <!-- ── Indexing ───────────────────────────────────────────────── -->
@@ -419,6 +438,15 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
               </button>
             }
           </div>
+        </section>
+      } @else if (pending().queue) {
+        <section class="panel" [attr.aria-busy]="true">
+          <header class="panel-h">
+            <span class="ic"><ph-icon name="stack" [size]="16"/></span>
+            <div><h3>{{ 'brain.overview.queueTitle' | transloco }}</h3>
+              <p>{{ 'brain.overview.queueHint' | transloco }}</p></div>
+          </header>
+          <div class="panel-b"><app-skeleton-lines [rows]="3" /></div>
         </section>
       }
 
@@ -519,6 +547,15 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
             }
           </div>
         </section>
+      } @else if (pending().tokens) {
+        <section class="panel" [attr.aria-busy]="true">
+          <header class="panel-h">
+            <span class="ic"><ph-icon name="key" [size]="16"/></span>
+            <div><h3>{{ 'brain.overview.tokenTitle' | transloco }}</h3>
+              <p>{{ 'brain.overview.tokenHint' | transloco }}</p></div>
+          </header>
+          <div class="panel-b"><app-skeleton-lines [rows]="3" /></div>
+        </section>
       }
     </div>
   `,
@@ -546,6 +583,17 @@ export class OverviewTabComponent {
    * about which member answered.
    */
   activity = input<SpaceActivity | null>(null);
+
+  /**
+   * Which panels have been blanked for a space switch and are still awaiting a first answer.
+   *
+   * Separate from the values because `null` cannot say it: `tokenAccess` is null **permanently** for a non-admin
+   * (the endpoint 403s) and `completeness` is null after a failure, so a skeleton keyed on null alone would sit
+   * there forever. The parent raises these only where it blanks, and clears each from both handlers.
+   */
+  pending = input<Record<'activity' | 'completeness' | 'queue' | 'tokens', boolean>>({
+    activity: false, completeness: false, queue: false, tokens: false,
+  });
   /** Emitted (after a confirm) so the shell's existing reindex flow runs — no duplicate API path. */
   /** A collection tile was clicked — the shell switches to that tab. */
   openTab = output<CollectionTab>();

--- a/client/src/app/shared/skeleton-lines.component.ts
+++ b/client/src/app/shared/skeleton-lines.component.ts
@@ -1,0 +1,79 @@
+/**
+ * Shimmer placeholder lines, for a card whose data has not arrived yet.
+ *
+ * ## Why this is only the LINES
+ *
+ * The Brain Overview's cards each render once their own request lands, so the board assembled itself one card at
+ * a time and every arrival pushed the ones below it down. A canary operator reported it as the milder half of a
+ * flicker: *"they appear one by one as each request lands, rather than as a laid-out set that fills in."*
+ *
+ * **The point is the SIZE, not the shimmer** — what makes a page feel like it is building itself is the layout
+ * moving. So the fix is to reserve the card's space, which means the card's FRAME has to be the real one.
+ *
+ * A first version of this component drew the frame too (`<section class="panel">`, header and all). It compiled,
+ * it built, and it would have rendered an unstyled grey block: `.panel` and `.panel-h` belong to the Overview's
+ * own style block, and view encapsulation does not let a child borrow them. Duplicating them here would have been
+ * worse than the bug — the two copies drift, and the placeholder would stop matching the height it exists to
+ * reserve.
+ *
+ * So the caller keeps its own frame and puts this inside its body. Reusable part reusable, sized part sized by
+ * the thing being sized.
+ */
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-skeleton-lines',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+@for (w of rowList(); track $index) {
+  <p class="sk-line" [style.width.%]="w"></p>
+}
+  `,
+  styles: [`
+    /* Quiet on purpose: this is furniture, not content, and it must not read as a card with something in it.
+       NO BACKTICKS in this block — it is one template string. */
+    :host { display: block; opacity: .6; }
+    .sk-line {
+      height: 13px;
+      margin: 0 0 11px;
+      border-radius: 6px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border-muted);
+      position: relative;
+      overflow: hidden;
+    }
+    .sk-line:last-child { margin-bottom: 0; }
+    /* One slow sweep, so several placeholders on screen do not read as a light show. */
+    .sk-line::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--text-muted) 14%, transparent), transparent);
+      transform: translateX(-100%);
+      animation: sk-sweep 1.6s ease-in-out infinite;
+    }
+    @keyframes sk-sweep {
+      0%   { transform: translateX(-100%); }
+      100% { transform: translateX(100%); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .sk-line::after { animation: none; }
+    }
+  `],
+})
+export class SkeletonLinesComponent {
+  /** How many lines to reserve — match the card's settled height, or it moves the layout in the other direction. */
+  rows = input<number>(3);
+
+  /**
+   * Line widths as percentages, varied so the block does not read as one solid rectangle.
+   *
+   * Derived, never random: `Math.random()` would relayout on every change-detection pass — a flicker of its own,
+   * and untestable.
+   */
+  rowList(): number[] {
+    const widths = [92, 78, 85, 64, 88, 72];
+    return Array.from({ length: Math.max(1, this.rows()) }, (_, i) => widths[i % widths.length]!);
+  }
+}

--- a/testing/standalone/overview-pending-is-cleared.test.js
+++ b/testing/standalone/overview-pending-is-cleared.test.js
@@ -1,0 +1,112 @@
+/**
+ * Every Overview panel that can show a first-load skeleton must clear its pending flag on BOTH outcomes.
+ *
+ * ## The failure this exists for
+ *
+ * The skeleton is keyed on a `pending` map rather than on the value being null, because null cannot say "not
+ * yet": `tokenAccess` is null **permanently** for a non-admin (the endpoint 403s) and `completeness` is null
+ * after a failure. A placeholder keyed on null alone would sit there forever in both cases.
+ *
+ * That makes the *clearing* load-bearing, and it happens in eight places — the success and failure handler of
+ * each of four loaders. Drop one and a non-admin gets a permanent shimmer where a card should be, or a card that
+ * failed to load never admits it. The page still works, nothing throws, and no unit test can see it: the
+ * component spec renders the child with `pending` handed in, so it cannot know whether the parent ever lowers it.
+ *
+ * That is not a hypothetical — this gate exists because a mutation test proved it. Breaking `settled()` so it
+ * never clears anything left the whole component spec green.
+ *
+ * Run: node --test testing/standalone/overview-pending-is-cleared.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const BRAIN = 'client/src/app/pages/brain/brain.component.ts';
+const OVERVIEW = 'client/src/app/pages/brain/overview-tab.component.ts';
+
+const src = readFileSync(join(ROOT, BRAIN), 'utf8');
+
+/** The four panels, and the loader whose two handlers must clear each one. */
+const PANELS = [
+  { key: 'activity',     loader: 'loadSpaceActivity' },
+  { key: 'completeness', loader: 'loadCompleteness' },
+  { key: 'queue',        loader: 'loadEmbeddingQueue' },
+  { key: 'tokens',       loader: 'loadTokenAccess' },
+];
+
+/** The body of one loader method, sliced to its own closing brace rather than a character count. */
+function loaderBody(name) {
+  const start = src.indexOf(`private ${name}(`);
+  assert.ok(start > 0, `${name} not found in ${BRAIN}`);
+  const end = src.indexOf('\n  }', start);
+  assert.ok(end > start, `could not find the end of ${name}`);
+  return src.slice(start, end);
+}
+
+describe('an Overview skeleton can always be dismissed', () => {
+  it('found the loaders — the pattern still matches', () => {
+    for (const p of PANELS) assert.ok(loaderBody(p.loader).length > 60, `${p.loader} body looks empty`);
+  });
+
+  it('each loader clears its own pending flag, on success AND on failure', () => {
+    const bad = [];
+    for (const p of PANELS) {
+      const body = loaderBody(p.loader);
+      const clears = [...body.matchAll(new RegExp(`settled\\('${p.key}'\\)`, 'g'))].length;
+      // One per handler. A loader with a single call has covered one outcome and left the other hanging.
+      if (clears !== 2) bad.push(`${p.loader} clears '${p.key}' ${clears}x, expected 2 (next: + error:)`);
+      if (!/error:/.test(body)) bad.push(`${p.loader} has no error handler at all`);
+    }
+    assert.deepEqual(bad, [], 'a pending flag that is never lowered is a skeleton that never goes away — and a '
+      + `non-admin never gets tokenAccess at all:\n  ${bad.join('\n  ')}`);
+  });
+
+  it('pending is raised ONLY where the values are blanked', () => {
+    // Raising it anywhere else would cover good data with a placeholder — the defect this whole change removes.
+    // `overviewPending.set(` is the raise; `.update(` inside `settled()` is the lower.
+    const raises = [...src.matchAll(/overviewPending\.set\(/g)].length;
+    assert.equal(raises, 1, 'pending must be raised in exactly one place (selectSpace, beside the blanks)');
+    // Anchored on the METHOD, not the first textual match — `selectSpace(` appears in the template first, and
+    // slicing from there measured 19k characters of the wrong thing.
+    const at = src.indexOf('  selectSpace(id: string): void {');
+    assert.ok(at > 0, 'selectSpace method not found');
+    const selectSpace = src.slice(at, src.indexOf('\n  }', at));
+    assert.match(selectSpace, /overviewPending\.set\(\{ activity: true, completeness: true, queue: true, tokens: true \}\)/,
+      'the space switch must raise all four, since it blanks all four');
+  });
+
+  it('`settled` really lowers the flag', () => {
+    // The call-site checks above pass whether or not the function does anything, which a mutation test proved:
+    // gutting the body left every one of them green.
+    const at = src.indexOf('  private settled(');
+    assert.ok(at > 0, 'settled() not found');
+    const body = src.slice(at, src.indexOf('\n  }', at));
+    assert.match(body, /overviewPending\.update\(/, 'settled() must actually lower the flag');
+    assert.ok(!/if \(true\)/.test(body), 'settled() has been short-circuited');
+  });
+
+  it('the live-event refresh does NOT raise it', () => {
+    // That path has good data on screen. A skeleton over it would be the original bug, arriving on a timer.
+    // Anchored on the METHOD — `onLiveEvent(` is CALLED before it is declared, and slicing from the first
+    // textual match measured the SSE handler instead, so this assertion passed against a deliberate break.
+    const at = src.indexOf('  private onLiveEvent(');
+    assert.ok(at > 0, 'onLiveEvent method not found');
+    const live = src.slice(at, src.indexOf('\n  }', at));
+    assert.ok(!/overviewPending/.test(live),
+      'the live-event refresh must not raise pending — it would cover data already on screen');
+  });
+
+  it('every pending key has a skeleton branch, and every branch has a key', () => {
+    // The two halves are written in different files, so a rename in one is invisible in the other.
+    const ov = readFileSync(join(ROOT, OVERVIEW), 'utf8');
+    for (const p of PANELS) {
+      assert.match(ov, new RegExp(`@else if \\(pending\\(\\)\\.${p.key}\\)`),
+        `no skeleton branch for '${p.key}' in ${OVERVIEW}`);
+    }
+    const branches = [...ov.matchAll(/@else if \(pending\(\)\.(\w+)\)/g)].map(m => m[1]).sort();
+    assert.deepEqual(branches, PANELS.map(p => p.key).sort(),
+      'the skeleton branches and the pending keys have drifted apart');
+  });
+});


### PR DESCRIPTION
## The board assembled itself one card at a time

Canary **B**, symptom 1 — the milder half, now that #634 has fixed the one they called the actual complaint:

> The Overview does not render its cards until their data arrives — they appear one by one as each request lands,
> rather than as a laid-out set that fills in.

Each panel is gated on its own input, and the parent fetches four of them separately. So the page arrived in
pieces and every arrival pushed everything below it down.

## The point is the size, not the shimmer

What makes a page look like it is building itself is **the layout moving**. So the fix reserves the card's space —
its real frame, its real title and hint, and body lines at the height the content will occupy.

Measured on a staggered load (each of the four requests delayed 1.5–4.5 s), sampling the board every 100 ms for
8 s:

| | |
|---|---|
| first sample with panels | t=100 ms, **8 panels** |
| settled | t=7900 ms, **8 panels** |
| distinct panel counts while loading | **[8]** — the board never grows |
| grid height, min → max | **943 → 943 px**, spread **0 px** |
| skeletons on screen at once | 4 |

Screenshot pair attached in the branch's verification run: the loading and settled boards are the same layout,
each placeholder replaced in situ.

## `null` cannot say "not yet"

A placeholder keyed on the value being null would have been wrong in two directions:

- **`tokenAccess` is null permanently for a non-admin** — the endpoint 403s. That card would have shimmered
  forever for every non-admin operator.
- **`completeness` is null after a failure.** Same outcome, on any instance where the request fails.

So the skeleton is keyed on a separate per-panel `pending` map, raised **only where the values are blanked** (the
space switch) and cleared from **both** handlers of each loader. It is deliberately never raised by the live-event
refresh — that path has good data on screen, and covering it would be the bug #634 just removed, arriving on a
timer instead of a poll.

## The shared piece is the lines, not the frame

A first version of the component drew the whole panel: `<section class="panel">`, header, the lot. It compiled, it
built, and it would have rendered an **unstyled grey block** — `.panel` and `.panel-h` belong to the Overview's own
style block, and view encapsulation does not let a child borrow them.

Duplicating those rules into the child would have been worse than the bug: two copies drift, and the placeholder
would stop matching the height it exists to reserve. So the caller keeps its own frame and puts
`<app-skeleton-lines>` in the body. Reusable part reusable, sized part sized by the thing being sized.

Also: the line widths are **derived, never random**. `Math.random()` would relayout on every change-detection
pass — a flicker of its own, and untestable.

## Gate: `overview-pending-is-cleared`

A flag that is never lowered is a placeholder that never goes away, and the clearing happens in **eight** places —
the success and failure handler of each of four loaders. The gate requires all eight, requires the clearing
function to actually clear, requires `pending` to be raised in exactly one place, requires the live-event path not
to raise it, and requires the branches and the keys — written in two different files — not to have drifted.

**It exists because a mutation test proved it was needed:** gutting the clearing function left the entire
component spec green, because that spec renders the child with `pending` handed in and cannot know whether the
parent ever lowers it.

## Two of my own assertions were wrong, and mutation-testing found them

Both sliced from the **first textual match** of a method name — and `selectSpace(` appears in the template, while
`onLiveEvent(` appears in its caller, each well before its own declaration. So both measured the wrong region and
passed against a deliberate break:

- the "raised only where blanked" check was reading 19 000 characters of template;
- the "live-event does not raise it" check was reading the SSE handler instead of the method.

Anchored on the declarations now. That is three times in this batch that a slice taken by convenience rather than
by syntax made a test agree with whatever it was pointed at — recorded in the tracker as a rule.

## Tests

5 component specs (**mutation-tested 5/5**, including a skeleton that renders after settling, a branch keyed on
the wrong panel's flag, and row counts that stop matching) plus the 6-assertion gate (**mutation-tested 5/5**).

---

`npm run preflight` PASSED (391 server + 892 client).
