### PR TITLE
fix(docker): the image shipped the embedding model twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Docker image shipped the embedding model twice — 482.5 MiB of every pull, of every tag.** A canary
+  operator reported that the three largest layers all changed digest between 2.2.4 and 2.2.5, making a patch
+  upgrade a near-full download; asking the registry which steps those layers were turned up something worse than
+  a layer-ordering problem.
+  - **`chown -R node:node … /app/model-cache` was a 482.5 MiB layer.** A recursive chown rewrites every file's
+    metadata, so Docker copied the entire model tree into a second layer. Measured from the published manifests:
+    layer 10 was the model at 482.5 MiB and layer 13 was that chown at *exactly* 482.5 MiB, which two empty
+    `mkdir`s cannot account for. The ownership is now set inside the step that creates the cache, and the chown
+    layer is **12.3 kB**.
+  - **A 2.2.4 → 2.2.5 pull re-downloaded 1759.9 of 1836.1 MiB — 96%.** Removing the duplicate takes the whole
+    image to ~1353.6 MiB compressed: **26% off every pull**, not only an upgrade.
+  - The model files are also **stamped to a fixed mtime** now. `cp -a` preserved the download's timestamps, which
+    go into the layer tar, so two builds of the identical model produced different layer digests and the layer
+    could never be reused across releases. Determinism is the precondition for that reuse.
+  - Verified on a built image: the layer is 12.3 kB, the cache is `node`-owned, every mtime is the fixed epoch,
+    and the model still loads **with `--network none`** and returns its 768 dimensions.
+  - Still legitimately large and still changing per release: `npm ci` (1.07 GB, moves when the lockfile does) and
+    the apt layer (755 MB). The latter carries `python3 make g++` in the *final* stage purely to compile bcrypt
+    during `npm ci --omit=dev` — moving that build into the builder stage is filed as the next reduction.
+
 - **The Brain Overview assembled itself one card at a time.** Each card rendered only once its own request
   landed, so every arrival pushed the ones below it down — *"they appear one by one as each request lands, rather
   than as a laid-out set that fills in"*, the milder half of the same canary report.

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,13 @@ RUN npm ci --workspace=server --omit=dev
 # downloads per-IP (shared CI egress → intermittent 403), so the fewer fetches the
 # better; the retry/backoff below rides through a transient 403 on the rare build
 # that does have to download. `--mount=type=cache` additionally speeds local rebuilds.
+#
+# The step ends by fixing ownership AND stamping every file to a fixed mtime. Both decide what a user downloads:
+#   - ownership HERE rather than in a later `chown -R`, which would rewrite the whole tree into a second layer.
+#     It did: the published image shipped the model TWICE. See the note by the mkdir near the end of this file.
+#   - a fixed mtime because `cp -a` preserves the download's timestamps, and those land in the layer tar. Two
+#     builds of the identical model then produce different layer digests, so the layer can never be reused across
+#     releases even when nothing about the model changed. Determinism is the precondition for that reuse.
 ENV MODEL_CACHE_DIR=/app/model-cache
 RUN --mount=type=cache,target=/tmp/hf-model-cache \
     printf '%s\n' \
@@ -96,7 +103,9 @@ RUN --mount=type=cache,target=/tmp/hf-model-cache \
     node /app/server/warm.mjs && \
     rm /app/server/warm.mjs && \
     mkdir -p /app/model-cache && \
-    cp -a /tmp/hf-model-cache/. /app/model-cache/
+    cp -a /tmp/hf-model-cache/. /app/model-cache/ && \
+    chown -R node:node /app/model-cache && \
+    find /app/model-cache -exec touch -h -d '@1' {} +
 
 # Copy compiled output from builder
 COPY --from=builder /build/server/dist ./server/dist
@@ -112,8 +121,16 @@ ENV CLIENT_DIST=/app/client/dist/browser
 
 EXPOSE 3200
 
-# Pre-create mount-point directories owned by node so volume mounts are writable
-RUN mkdir -p /data /config && chown -R node:node /data /config /app/model-cache
+# Pre-create mount-point directories owned by node so volume mounts are writable.
+#
+# `/app/model-cache` is NOT chowned here, and that is the point. A `chown -R` rewrites every file's metadata, so
+# Docker copied the whole 482.5 MiB model tree into a SECOND layer — the published image shipped the embedding
+# model TWICE, in every tag, on every pull. Measured against the registry: layer 10 was the model at 482.5 MiB and
+# layer 13 was this chown at exactly 482.5 MiB, which no `mkdir` of two empty directories can account for.
+#
+# The ownership is set inside the RUN that creates the cache instead, so it lands in that one layer.
+# `/data` and `/config` are empty, so chowning them costs nothing.
+RUN mkdir -p /data /config && chown -R node:node /data /config
 
 # Run as non-root user
 USER node


### PR DESCRIPTION
## The image shipped the embedding model twice

Canary **F** reported that a patch upgrade was a near-full download: 14 layers, and the three largest
(533.7 + 482.5 + 482.5 MiB) all changed digest between 2.2.4 and 2.2.5. Their pull took 5m30s at ~5.6 MiB/s, which
with `strategy: Recreate` is 5–6 minutes of downtime on a **patch** release.

They framed it as a layer-ordering problem, and the Dockerfile already had the ordering right — `npm ci` and the
model download sit above the app-source `COPY`s on purpose. So before designing a reorder, I asked the registry
which steps those layers actually are: manifest plus config blob for both tags, no pull, no build, a few KB over
the wire.

```
#   size(MiB)  changed  step
  5     258.0  CHANGED  RUN apt-get update && apt-get install … python3 make g++ ffmpeg
  9     533.7  CHANGED  RUN npm ci --workspace=server --omit=dev
 10     482.5  CHANGED  RUN … model download … cp -a /tmp/hf-model-cache/. /app/model-cache/
 13     482.5  CHANGED  RUN mkdir -p /data /config && chown -R node:node /data /config /app/model-cache
```

**Layer 13 is a `chown`, and it is 482.5 MiB — exactly the size of layer 10.** A recursive chown rewrites every
file's metadata, so Docker copied the entire model tree into a second layer. Two empty `mkdir`s cannot account for
half a gigabyte; the image has been shipping the model twice, in every tag, on every pull.

That was not visible from the Dockerfile, and no reorder would have touched it.

## The fix

Set the ownership inside the step that creates the cache, so it lands in that one layer, and chown only the two
genuinely empty mount points at the end.

The model files are also **stamped to a fixed mtime**. `cp -a` preserves the download's timestamps and those go
into the layer tar, so two builds of the identical model produce different layer digests — meaning the layer could
never be reused across releases even when nothing about the model changed. Determinism is the precondition for
that reuse; this does not by itself prove reuse will happen, which needs two releases to observe.

## Verified on a built image

```
12.3kB | RUN mkdir -p /data /config && chown -R node:node /data /config     ← was 482.5 MiB
 548MB | RUN … model download … cp -a … && chown -R … && find … touch      ← the only copy
```

- `/app/model-cache` is `node:node`, and `model.onnx` is 547,310,275 bytes.
- every mtime in the tree is the fixed epoch (one distinct value).
- **the model still loads with `--network none`** and returns its 768 dimensions — the offline-start guarantee is
  what the ownership and timestamps could plausibly have broken, so it is the check that matters.

## What this is worth

| | |
|---|---|
| a 2.2.4 → 2.2.5 pull re-downloaded | **1759.9 of 1836.1 MiB — 96%** |
| removing the duplicate takes the image to | **~1353.6 MiB compressed** |
| saving | **26% off every pull**, of every tag, not only an upgrade |

## What is still large, and honestly so

- **`npm ci` — 1.07 GB.** It moves when the lockfile moves, which a release usually does. Legitimate.
- **the apt layer — 755 MB.** `apt-get update` is not reproducible, so this layer differs between any two builds.
  More to the point, it carries **`python3 make g++` in the *final* stage** purely to compile the bcrypt native
  addon during `npm ci --omit=dev`. Nothing at runtime needs a compiler.

Moving that compile into the builder stage is the next real reduction, and it is filed rather than bundled here:
the addon has to be built against the same Node ABI and the copy has to preserve the native binaries, so it needs
its own build plus an offline boot to prove bcrypt still loads.

---

`npm run preflight` PASSED (391 server + 892 client). The image build itself is exercised by CI.
