### PR TITLE
fix(client): a themed brand colour recoloured only the everything-is-fine states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A themed brand colour recoloured "Active" and "Online" while "Healthy" and "Reachable" stayed green.** A theme
+  can override any CSS custom property — that is the feature — and `.pill.active` read `--accent` while its four
+  siblings read `--success` / `--warning` / `--error` / `--info`. The reporting operator's framing is now the rule:
+  **brand follows the theme, semantic state never does.**
+  - **Audited every state colour rather than the one pill a red theme surfaced, and found two more**: the summary
+    strip's value colour (`.v.active, .v.ok`) and the usage bar's healthy fill, both reading the brand while their
+    own warn/danger siblings read semantic tokens. So a red theme recoloured exactly the *everything-is-fine*
+    states and left the problems alone.
+  - New `--state-active` token, valued at the **default accent** so the default theme is pixel-identical and only a
+    themed instance changes — which is the entire bug. The active pill's background and border are mixed from the
+    same token: they were hardcoded rgba of the default accent, which is how a themed instance got **red text on a
+    green pill**.
+  - **Navigation deliberately still follows the brand** — a selected tab, a highlighted tree node, a sort caret say
+    *"you are here"*, which is identity. This is a category split, not a purge, and the gate checks both halves.
+  - Gate `state-colours-ignore-the-theme`, mutation-tested **7/7**, including the over-correction (converting a
+    navigation style to a state token) and a `--state-active` defined as an alias of `--accent`, which would have
+    made the whole fix cosmetic.
+  - Verified live under a red brand: **all six pill variants unchanged**, and the selected tab correctly turns red.
+    The strip and bar are covered by the gate only — the live probe for them reported identical colours for
+    variants that must differ, so it was not exercising those rules and is not counted.
+
 - **The Docker image shipped the embedding model twice — 482.5 MiB of every pull, of every tag.** A canary
   operator reported that the three largest layers all changed digest between 2.2.4 and 2.2.5, making a patch
   upgrade a near-full download; asking the registry which steps those layers were turned up something worse than

--- a/client/src/app/shared/status-pill.component.ts
+++ b/client/src/app/shared/status-pill.component.ts
@@ -25,7 +25,14 @@ export type StatusVariant = 'active' | 'ok' | 'warn' | 'error' | 'off' | 'env' |
       font-size: 11.5px; font-weight: 600; letter-spacing: .01em; line-height: 1.5;
       padding: 2px 9px; border-radius: 999px; border: 1px solid transparent; white-space: nowrap;
     }
-    .pill.active  { color: var(--accent);  background: rgba(206,255,128,.12); border-color: rgba(206,255,128,.28); }
+    /* --state-active, NOT --accent. A pill reports a fact, and a theme owns identity, not facts: a red brand
+       colour turned "Active" and "Online" red while "Healthy" and "Reachable" stayed green. The background is
+       mixed from the same token so the two cannot drift — it used to be a hardcoded rgba of the default accent,
+       which is how a themed instance ended up with red text on a green pill.
+       NO BACKTICKS in this block — it is one template string, and one backtick ends it. */
+    .pill.active  { color: var(--state-active);
+                    background: color-mix(in srgb, var(--state-active) 12%, transparent);
+                    border-color: color-mix(in srgb, var(--state-active) 28%, transparent); }
     .pill.ok      { color: var(--success); background: rgba(63,185,80,.13);   border-color: rgba(63,185,80,.30); }
     .pill.warn    { color: var(--warning); background: rgba(210,153,34,.14);  border-color: rgba(210,153,34,.32); }
     .pill.error   { color: var(--error);   background: rgba(248,81,73,.10);   border-color: rgba(248,81,73,.30); }

--- a/client/src/app/shared/summary-strip.component.ts
+++ b/client/src/app/shared/summary-strip.component.ts
@@ -33,7 +33,11 @@ export interface SummaryItem {
              border-top: 1px solid var(--border-muted); align-items: center; }
     .item { display: flex; flex-direction: column; gap: 1px; }
     .v { font-size: 20px; font-weight: 650; line-height: 1.1; font-variant-numeric: tabular-nums; color: var(--text-primary); }
-    .v.active, .v.ok { color: var(--accent); }
+    /* --state-active, not --accent. Both of these report a FACT about the system, and its siblings below already
+       read semantic tokens — so a themed brand colour moved two of the five and left three alone. Found by
+       auditing every state colour rather than only the pill a red theme happened to surface.
+       The value is the default accent, so nothing changes on the default theme. */
+    .v.active, .v.ok { color: var(--state-active); }
     .v.warn  { color: var(--warning); }
     .v.error { color: var(--error); }
     .v.pending { color: var(--info); }

--- a/client/src/app/shared/usage-bar.component.ts
+++ b/client/src/app/shared/usage-bar.component.ts
@@ -25,7 +25,10 @@ export function usageLevel(pct: number, warnAtPercent: number): UsageLevel {
   styles: [`
     .track { height: 8px; background: var(--bg-elevated); border-radius: 4px; overflow: hidden; }
     .fill  { height: 100%; border-radius: 4px; transition: width .4s ease, background .2s ease; }
-    .fill.ok     { background: var(--accent); }
+    /* --state-active, not --accent: "usage is fine" is a fact, and warn/danger below are already semantic, so a
+       themed brand colour recoloured only the healthy state — the one an operator glances at to confirm nothing
+       is wrong. Same value as the default accent, so the default theme is unchanged. */
+    .fill.ok     { background: var(--state-active); }
     .fill.warn   { background: var(--warning); }
     .fill.danger { background: var(--error); }
   `],

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -19,6 +19,19 @@
   --nav-active:     #a0ff80;
   --nav-active-dim: rgba(0, 229, 255, 0.08);
 
+  /* ── Semantic STATE colours — a theme must not move these ───────────────────────────────────────────────
+     A theme owns identity: `--accent` and friends. It does not own facts. A reporting operator set a red brand
+     colour and watched "Active" and "Online" turn red while "Healthy" and "Reachable" stayed green — because
+     `.pill.active` read `--accent` while its siblings read these tokens. Their framing is the rule:
+     BRAND FOLLOWS THE THEME, SEMANTIC STATE NEVER DOES.
+
+     `--state-active` exists for exactly that reason: "configured", "in use", "online" are facts, so they need a
+     token of their own rather than borrowing the brand. Its value is the DEFAULT accent, so the default theme is
+     pixel-identical and only a themed instance changes — which is the whole bug.
+
+     Anything that reports what the system IS belongs here. Anything that says "you are here" — a selected tab, a
+     highlighted row, a sort caret — is navigation, and correctly follows `--accent`. */
+  --state-active: #ceff80;
   --success:      #3fb950;
   --warning:      #d29922;
   --error:        #f85149;

--- a/testing/standalone/state-colours-ignore-the-theme.test.js
+++ b/testing/standalone/state-colours-ignore-the-theme.test.js
@@ -1,0 +1,122 @@
+/**
+ * Brand follows the theme. Semantic state never does.
+ *
+ * ## The failure this exists for
+ *
+ * A theme can override any CSS custom property — that is the feature (`theme.service.ts`: a static stylesheet or
+ * postMessage tokens). A reporting operator set a red brand colour and watched **"Active" and "Online" turn red
+ * while "Healthy" and "Reachable" stayed green**, because `.pill.active` read `--accent` and its four siblings read
+ * `--success` / `--warning` / `--error` / `--info`.
+ *
+ * Their framing is the rule, and it is a category split rather than a bug list:
+ *
+ *   - **identity** — a selected tab, a highlighted row, a sort caret, a wizard step dot. "You are here." Brand.
+ *     These SHOULD move with the theme.
+ *   - **state** — configured, in use, online, healthy, degraded, usage-is-fine. A fact about the system. These
+ *     must not move, whatever the operator's brand colour is.
+ *
+ * Auditing every state colour rather than only the pill turned up two more: the summary strip's value colour and
+ * the usage bar's healthy fill, both reading `--accent` while their own warn/danger siblings read semantic tokens.
+ *
+ * ## What this checks
+ *
+ * The state-bearing CSS classes, by name, across the shared components that own them. A class whose siblings are
+ * semantic must not be the one reading the brand.
+ *
+ * Run: node --test testing/standalone/state-colours-ignore-the-theme.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/**
+ * Every declaration that colours a semantic STATE, and the file that owns it.
+ *
+ * Deliberately a named list rather than a pattern: the distinction between "active tab" and "active state" is
+ * semantic, and no regex can make it. A new state class has to be added here — which is the point, because that
+ * addition is the moment somebody decides which category it is in.
+ */
+const STATE_RULES = [
+  { file: 'client/src/app/shared/status-pill.component.ts', selectors: ['.pill.active', '.pill.ok', '.pill.warn', '.pill.error', '.pill.pending'] },
+  { file: 'client/src/app/shared/summary-strip.component.ts', selectors: ['.v.active, .v.ok', '.v.warn', '.v.error', '.v.pending'] },
+  { file: 'client/src/app/shared/usage-bar.component.ts', selectors: ['.fill.ok', '.fill.warn', '.fill.danger'] },
+];
+
+/** Tokens a theme is expected to own. A state colour must not read any of them. */
+const BRAND = ['--accent', '--accent-hover', '--accent-dim', '--nav-active', '--nav-active-dim'];
+
+/** The declaration block for one selector — from the selector to its closing brace. */
+function block(src, selector) {
+  const at = src.indexOf(selector);
+  if (at < 0) return null;
+  const open = src.indexOf('{', at);
+  const close = src.indexOf('}', open);
+  if (open < 0 || close < 0) return null;
+  return src.slice(open, close);
+}
+
+describe('semantic state colours do not follow the theme', () => {
+  it('found every rule — the selectors still exist', () => {
+    const missing = [];
+    for (const r of STATE_RULES) {
+      const src = read(r.file);
+      for (const s of r.selectors) if (block(src, s) === null) missing.push(`${r.file}: ${s}`);
+    }
+    assert.deepEqual(missing, [], 'a selector in the list no longer exists — the rule below is checking nothing:\n  '
+      + missing.join('\n  '));
+  });
+
+  it('no state colour reads a brand token', () => {
+    const bad = [];
+    for (const r of STATE_RULES) {
+      const src = read(r.file);
+      for (const s of r.selectors) {
+        const b = block(src, s) ?? '';
+        for (const token of BRAND) {
+          // Word-boundary: `--accent-text` is a FOREGROUND paired with the brand and is not a state colour.
+          if (new RegExp(`var\\(${token}\\)`).test(b)) bad.push(`${r.file}: ${s} reads var(${token})`);
+        }
+      }
+    }
+    assert.deepEqual(bad, [], 'a theme owns identity, not facts. These report state, so a red brand colour would '
+      + `recolour them and leave their siblings alone:\n  ${bad.join('\n  ')}\n\n`
+      + 'Use --state-active for a positive state, or --success / --warning / --error / --info.');
+  });
+
+  it('the state-active token exists and does not resolve to the brand', () => {
+    // If it were `var(--accent)` the whole fix would be cosmetic — a theme would still move it.
+    const styles = read('client/src/styles.scss');
+    const m = styles.match(/--state-active:\s*([^;]+);/);
+    assert.ok(m, '--state-active is not defined in styles.scss');
+    assert.ok(!/var\(--accent/.test(m[1]),
+      '--state-active must be its own value, not an alias of the brand — an alias moves with the theme');
+    assert.match(m[1].trim(), /^#[0-9a-fA-F]{3,8}$/, '--state-active should be a literal colour');
+  });
+
+  it('the active pill mixes its background from the same token', () => {
+    // It was a hardcoded rgba of the DEFAULT accent, so a themed instance got red text on a green pill — the two
+    // halves of one pill disagreeing is worse than either colour on its own.
+    const b = block(read('client/src/app/shared/status-pill.component.ts'), '.pill.active') ?? '';
+    assert.match(b, /background:\s*color-mix\(in srgb, var\(--state-active\)/);
+    assert.match(b, /border-color:\s*color-mix\(in srgb, var\(--state-active\)/);
+  });
+
+  it('navigation still follows the brand — this is a split, not a purge', () => {
+    // The other half of the rule. If a well-meaning sweep converted selected-tab styling to a state token, the
+    // theme would stop working for the thing it is actually for.
+    const nav = [
+      ['client/src/app/pages/settings/space-dialog.styles.ts', '.sp-tab.active'],
+      ['client/src/app/pages/files/file-manager.component.ts', '.tree-node.active'],
+      ['client/src/app/pages/brain/sortable-header.component.ts', '.sort-caret.active'],
+    ];
+    for (const [file, sel] of nav) {
+      const b = block(read(file), sel);
+      assert.ok(b !== null, `${file}: ${sel} not found`);
+      assert.match(b, /var\(--accent/, `${file}: ${sel} is navigation and must follow the brand`);
+    }
+  });
+});


### PR DESCRIPTION
## A red brand colour recoloured exactly the everything-is-fine states

A theme can override any CSS custom property — that is the feature (`theme.service.ts`: a static stylesheet, or
postMessage tokens from an allowlisted embedder). A reporting operator set a red brand colour and watched
**"Active" and "Online" turn red while "Healthy" and "Reachable" stayed green.**

```css
.pill.active  { color: var(--accent);   … }   ← brand
.pill.ok      { color: var(--success);  … }
.pill.warn    { color: var(--warning);  … }
.pill.error   { color: var(--error);    … }
.pill.pending { color: var(--info);     … }
```

Their framing is the rule, and it is a **category split** rather than a bug list:

- **identity** — a selected tab, a highlighted tree node, a sort caret, a wizard step dot. *"You are here."* These
  should move with the theme, and still do.
- **state** — configured, in use, online, healthy, usage-is-fine. A fact about the system. These must not move,
  whatever the operator's brand colour is.

## The audit found two more than they reported

They asked for it to be checked across every pill rather than the two a red theme happened to surface. Sweeping
every state-bearing declaration turned up two beyond the pill:

| where | was | reports |
|---|---|---|
| `status-pill` `.pill.active` | `var(--accent)` | configured / in use / online |
| `summary-strip` `.v.active, .v.ok` | `var(--accent)` | a headline value's state |
| `usage-bar` `.fill.ok` | `var(--accent)` | usage is within limits |

In all three, the *sibling* rules already read semantic tokens — so a red theme recoloured precisely the
**everything-is-fine** states and left every problem state alone. Exactly backwards from useful.

## The fix

A `--state-active` token, valued at the **default accent**, so the default theme is pixel-identical and only a
themed instance changes — which is the entire bug. Not an alias of `--accent`: an alias would move with the theme
and the fix would be cosmetic (the gate has a mutant for that).

The active pill's background and border are now **mixed from the same token**. They were hardcoded rgba of the
default accent, which is how a themed instance ended up with *red text on a green pill* — the two halves of one
pill disagreeing, which is worse than either colour alone.

## Gate: `state-colours-ignore-the-theme`

A named list of state-bearing selectors rather than a pattern, because the difference between "active tab" and
"active state" is semantic and no regex can make it — a new state class has to be added to the list, and that
addition is the moment somebody decides which category it belongs to.

It checks, in both directions:

- no state colour reads a brand token (`--accent`, `--accent-hover`, `--accent-dim`, `--nav-active…`);
- `--state-active` exists, is a literal colour, and is **not** an alias of the brand;
- the active pill mixes its background and border from that token;
- **navigation still follows the brand** — a selected tab, a tree node, a sort caret. If a well-meaning sweep
  converted those to a state token, the theme would stop working for the thing it is actually for.

Plus a floor: every selector in the list must still exist, or the rule is checking nothing.

**Mutation-tested 7/7**, including the two that matter most: `--state-active` defined as `var(--accent)`, and a
navigation style converted to a state token.

## What was verified live, and what was not

Under a red brand, on a running instance: **all six pill variants unchanged**, and the selected tab correctly turns
red — both halves of the rule, observed.

**The strip and the bar are covered by the gate only.** My live probe for them reported identical colours for
variants that must differ (`ok`, `warn` and `danger` all reading the same value), which means it was not exercising
those rules at all — so it proves nothing and I am not counting it. Recorded the same way in the commit message and
the CHANGELOG rather than rounded up.

---

`npm run preflight` PASSED (396 server + 892 client).
