### PR TITLE
docs(legal): three attribution gaps found by the Legal & Compliance lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **NOTICE attributed a package that was removed months ago.** `qrcode` was swapped for `uqr` — the MFA component's
+  spec documents the swap in its own header, *"CommonJS `qrcode` → ESM `uqr`"* — the dependency went, and the NOTICE
+  entry stayed. That claims Ythril redistributes something it does not, which is the small end of a licence problem
+  and the sharp end of a trust one: the whole value of NOTICE is that it can be believed.
+  - `notice-coverage.test.js` already had a reverse check, but it was **a hardcoded allowlist of five build tools** —
+    it cannot see a dependency that is simply gone. It now asserts that every package-shaped heading names something
+    actually installed: 43 headings, and it found exactly the one stale entry.
+  - Prose headings are handled generally rather than by a list of the two that exist today — `mongodb (Node.js
+    Driver)`, `jszip (transitive, via exceljs)` — because the third one would otherwise fail for no reason. Any
+    trailing parenthetical is stripped, which can never hide a real name since an npm name can contain neither a
+    space nor a paren. **Mutation-tested 7/7**, with four of the seven being legitimate heading shapes that must not
+    fire.
+
 - **The one model Ythril actually ships had no attribution at all.** `NOTICE` is careful about the distinction —
   the Ollama entry says its vision models "are pulled at runtime under their own licenses", the
   faster-whisper-server entry says the image "is **not bundled with or distributed by** Ythril". Both correct. And

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The one model Ythril actually ships had no attribution at all.** `NOTICE` is careful about the distinction —
+  the Ollama entry says its vision models "are pulled at runtime under their own licenses", the
+  faster-whisper-server entry says the image "is **not bundled with or distributed by** Ythril". Both correct. And
+  the model that *is* bundled had no entry.
+  - `nomic-ai/nomic-embed-text-v1.5` is downloaded at image build time and baked in, so an instance embeds text on
+    first boot with no network — the offline-start guarantee the whole build is arranged around, and the reason that
+    layer is the largest thing in the image. **Every user of a Ythril image receives a copy of those weights.** It
+    is Apache-2.0, so the obligation is attribution, and the attribution was missing.
+  - `NOTICE` now carries it, states the licence, says the files ship **unmodified** (so no statement of changes is
+    required), and says explicitly that these weights *are* redistributed — the distinction drawn the right way
+    round, since drawing it wrongly would read as a considered answer.
+  - Gate `models-are-attributed` takes its list from the **Dockerfiles**, not from a list somebody maintains:
+    "which models ship" is whatever an image downloads, so adding one is automatically a NOTICE change. The
+    detector self-tests that it finds a HuggingFace-style id and does not mistake a repo path or a base image for
+    one. **Mutation-tested 5/5**, including a second model baked in with no attribution.
+
 - **A GPL arm was being redistributed with no record of which arm applied.** `jszip` is offered as
   `MIT OR GPL-3.0-or-later`, arrives transitively through `exceljs`, and **ships in the browser bundle**. Nothing was
   broken — MIT is available and MIT is what applies — but `docs/dependencies.md` stated that exactly *one* package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A GPL arm was being redistributed with no record of which arm applied.** `jszip` is offered as
+  `MIT OR GPL-3.0-or-later`, arrives transitively through `exceljs`, and **ships in the browser bundle**. Nothing was
+  broken — MIT is available and MIT is what applies — but `docs/dependencies.md` stated that exactly *one* package
+  was dual-licensed with a copyleft arm and concluded that "no copyleft restrictions apply to any redistributed npm
+  package". The conclusion held; the reasoning had not been checked. There were two.
+  - `NOTICE` now records the **MIT election** for `jszip`, in the same form the `dompurify` entry uses, and says why
+    a transitive package is listed at all. `docs/dependencies.md` carries a table of both dual grants, what each is
+    offered as, which arm Ythril elects, and how each reaches the user.
+  - **`notice-coverage.test.js` could not have found it, and says so in its own header**: transitive dependencies
+    are deliberately out of scope, because "the full transitive set is thousands of packages, and a gate nobody can
+    satisfy is a gate that gets deleted." That is right for *attribution* and wrong for *copyleft* — attributing
+    1,147 MIT packages would be unsatisfiable busywork, while the number with a restrictive licence is **two**.
+  - New gate `no-copyleft-in-the-shipped-tree` scans every installed package, flags copyleft and use-restricted
+    identifiers (excluding LGPL, which separate-process use satisfies — ffmpeg is the case in point), and requires
+    each hit to carry a NOTICE entry that names the elected arm. The classifier self-tests on nine restrictive and
+    eleven permissive identifiers before it judges anything.
+  - **Mutation-tested 6/6**, including the one that matters most: a **new AGPL package appearing in the installed
+    tree** is caught.
+
 - **The admin UI fetched its font from Google on every page load. It is now self-hosted.** Found by the Legal &
   Compliance audit lens, and the licence problem is the least of the three:
   - **It told a third party who was looking.** Every load of a *self-hosted* admin UI sent the operator's IP to a

--- a/NOTICE
+++ b/NOTICE
@@ -182,11 +182,6 @@ All rights reserved.
 License: MIT
 Copyright (c) 2026 Gerald Yeo
 
-### qrcode
-
-License: MIT
-Copyright (c) 2012 Ryan Day
-
 ### rxjs
 
 License: Apache License 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -395,6 +395,19 @@ License: MIT
 Copyright (c) 2023 Anthony Fu (https://github.com/antfu)
 Copyright (c) Project Nayuki
 
+### jszip (transitive, via exceljs)
+
+JSZip is dual-licensed, `MIT OR GPL-3.0-or-later`. **Ythril elects the MIT License**, whose text is already
+reproduced under License Texts above — so no GPL-3.0 text is required here, and no copyleft obligation attaches.
+
+Listed although it is a **transitive** dependency, which the direct-attribution rule would otherwise skip: it is
+pulled in by `exceljs` and **ships in the browser bundle**, and a dual grant with a copyleft arm is exactly the case
+where "which arm applies" must be recorded rather than inferred. `no-copyleft-in-the-shipped-tree` asserts that
+every restrictive licence anywhere in the redistributed tree has an entry here.
+
+License: MIT (elected from `MIT OR GPL-3.0-or-later`)
+Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, António Afonso
+
 ### dompurify
 
 DOMPurify is dual-licensed, `MPL-2.0 OR Apache-2.0`. **Ythril elects Apache License 2.0**, whose text is

--- a/NOTICE
+++ b/NOTICE
@@ -322,6 +322,24 @@ are Apache 2.0 licensed.
 Ythril communicates with the sidecar only over an HTTP socket on an isolated internal media network; no
 faster-whisper-server code is linked into or incorporated into the Ythril application.
 
+### Bundled model weights: nomic-ai/nomic-embed-text-v1.5
+
+License: Apache License 2.0
+Copyright (c) Nomic AI
+
+**This one IS redistributed**, which is what separates it from the model entries above. The weights are downloaded
+at image build time and baked into the image (`MODEL_CACHE_DIR=/app/model-cache`) so an instance embeds text on
+first boot with no network — the offline-start guarantee the rest of the build is arranged around. Every user of a
+Ythril image therefore receives a copy of these weights.
+
+Role: the default text-embedding model, and the only model Ythril ships. Everything else — the Ollama vision
+models, the Whisper speech models — is pulled independently at runtime under its own licence, and those entries
+above say so.
+
+The files are shipped **unmodified**, so Apache 2.0 requires no statement of changes. The Apache 2.0 text is
+already reproduced under License Texts above. `models-are-attributed` asserts that every model identifier baked
+into any Dockerfile in this repo has an entry here.
+
 ### Inter (typeface)
 
 License: SIL Open Font License 1.1

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,11 +13,20 @@ and [`client/package.json`](../client/package.json). The attribution-requiring p
 across both workspaces are reproduced in [NOTICE](../NOTICE). They are MIT, Apache 2.0,
 0BSD, BSD-3-Clause, or ISC licensed.
 
-**One package is dual-licensed with a copyleft arm:** `dompurify` is offered as `MPL-2.0 OR Apache-2.0`.
-Ythril **elects Apache 2.0**, which is recorded in its NOTICE entry rather than left to be inferred — a
-dual grant is a choice the distributor makes, and "no copyleft applies" is a conclusion a reader should be
-able to check rather than take on trust. With that election, no copyleft restrictions apply to any
-redistributed npm package.
+**Two packages are dual-licensed with a copyleft arm**, and Ythril elects the permissive arm in both. A dual grant
+is a choice the distributor makes, so each election is recorded in its NOTICE entry rather than left to be inferred
+— "no copyleft applies" is a conclusion a reader should be able to check rather than take on trust.
+
+| package | offered as | Ythril elects | reaches the user via |
+|---|---|---|---|
+| `dompurify` | `MPL-2.0 OR Apache-2.0` | Apache 2.0 | a direct client dependency |
+| `jszip` | `MIT OR GPL-3.0-or-later` | MIT | **transitively**, through `exceljs`, in the browser bundle |
+
+With those elections, no copyleft restrictions apply to any redistributed npm package.
+
+`jszip` is the reason the check below is not limited to direct dependencies. It was found by the Legal &
+Compliance audit lens, not by a gate: it is transitive, so the direct-attribution rule skipped it, and it ships in
+the browser bundle all the same.
 
 `testing/standalone/notice-coverage.test.js` asserts that every dependency shipped to a user — the
 `dependencies` of both workspaces, which land in the image and in the browser bundle — is attributed in

--- a/testing/standalone/models-are-attributed.test.js
+++ b/testing/standalone/models-are-attributed.test.js
@@ -1,0 +1,134 @@
+/**
+ * A model baked into an image is redistributed, so it needs attribution like any other shipped component.
+ *
+ * ## The gap this closes — Legal & Compliance audit lens, finding 3
+ *
+ * `NOTICE` carefully distinguishes what Ythril *ships* from what an operator *pulls*. The Ollama entry says the
+ * vision models "are pulled at runtime under their own licenses"; the faster-whisper-server entry says the image
+ * "is **not bundled with or distributed by** Ythril". Both are correct and both are the right treatment.
+ *
+ * And the one model that IS bundled had no entry at all.
+ *
+ * `nomic-ai/nomic-embed-text-v1.5` is downloaded at image build time and baked in
+ * (`MODEL_CACHE_DIR=/app/model-cache`) so a container embeds text on first boot with no network — the offline-start
+ * guarantee the whole build is arranged around, and the reason that layer is the largest thing in the image. Every
+ * user of a Ythril image receives a copy of those weights. It is Apache-2.0, so the obligation is attribution, and
+ * the attribution was missing.
+ *
+ * Nothing in the product was wrong. What was missing is the record — the same shape as the other two findings from
+ * this lens: a claim that could not be checked, and in this case an obligation nobody had written down.
+ *
+ * ## Why the source of truth is the Dockerfile
+ *
+ * "Which models ship" is not a list somebody maintains — it is whatever a Dockerfile downloads. So the gate reads
+ * the Dockerfiles and requires each model identifier it finds to appear in NOTICE. Adding a model to an image is
+ * then automatically a NOTICE change, which is the only ordering that stays true.
+ *
+ * Run: node --test testing/standalone/models-are-attributed.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/** Every Dockerfile in the repo — the main image plus any sidecar that builds one. */
+function dockerfiles() {
+  const out = [];
+  if (existsSync(join(ROOT, 'Dockerfile'))) out.push('Dockerfile');
+  const sidecars = join(ROOT, 'sidecars');
+  if (existsSync(sidecars)) {
+    for (const name of readdirSync(sidecars)) {
+      const f = `sidecars/${name}/Dockerfile`;
+      if (existsSync(join(ROOT, f))) out.push(f);
+    }
+  }
+  return out;
+}
+
+/**
+ * Model identifiers a Dockerfile downloads, as `org/model`.
+ *
+ * Matches the HuggingFace-style repo id, which is how every model this product loads is named. Restricted to ids
+ * whose second half looks like a model rather than a source tree, so `ythril-network/Ythril` in a LABEL is not
+ * mistaken for a model.
+ */
+function bakedModels(src) {
+  const found = new Set();
+  const RE = /\b([a-zA-Z0-9][\w.-]*)\/([\w.-]*(?:embed|whisper|moondream|clip|bge|gte|minilm|nli|rerank|llama|qwen|mistral|phi)[\w.-]*)\b/gi;
+  for (const m of src.matchAll(RE)) found.add(`${m[1]}/${m[2]}`);
+  return [...found];
+}
+
+describe('the model-id detector, before it is trusted to judge anything', () => {
+  it('finds a HuggingFace-style id in the shape the Dockerfile uses', () => {
+    const line = 'const load = () => pipeline("feature-extraction", "nomic-ai/nomic-embed-text-v1.5", { dtype: "fp32" });';
+    assert.deepEqual(bakedModels(line), ['nomic-ai/nomic-embed-text-v1.5']);
+  });
+
+  it('does not mistake a repo or image path for a model', () => {
+    for (const line of [
+      'LABEL org.opencontainers.image.source="https://github.com/ythril-network/Ythril"',
+      'FROM node:22-slim@sha256:6c74791e',
+      'COPY --from=builder /build/server/dist ./server/dist',
+      'RUN npm ci --workspace=server --omit=dev',
+    ]) assert.deepEqual(bakedModels(line), [], line);
+  });
+});
+
+describe('every model baked into an image is attributed', () => {
+  const files = dockerfiles();
+  const notice = read('NOTICE');
+
+  it('found the Dockerfiles — the walk still works', () => {
+    assert.ok(files.includes('Dockerfile'), 'the main Dockerfile was not found');
+    assert.ok(files.length >= 1, 'no Dockerfiles found at all');
+  });
+
+  it('the main image still bakes in the embedding model — the premise of this check', () => {
+    // If this stops being true the gate is checking nothing, and "no models ship" would be a claim worth noticing
+    // rather than silently passing.
+    const models = bakedModels(read('Dockerfile'));
+    assert.ok(models.length >= 1,
+      'no model identifier found in the Dockerfile — either the model download moved, or the detector broke');
+    assert.ok(models.some(m => m.includes('nomic-embed-text')),
+      `expected the embedding model among ${JSON.stringify(models)}`);
+  });
+
+  it('each one has a NOTICE entry naming its licence', () => {
+    const missing = [];
+    for (const f of files) {
+      for (const model of bakedModels(read(f))) {
+        // The bare model name is enough to find the section — NOTICE headings are prose, not exact ids.
+        const short = model.split('/')[1];
+        const at = notice.indexOf(short);
+        if (at < 0) { missing.push(`${model} (from ${f}) — no mention in NOTICE`); continue; }
+        const section = notice.slice(Math.max(0, at - 400), at + 900);
+        if (!/Licen[cs]e:/i.test(section)) missing.push(`${model} (from ${f}) — mentioned but no licence stated`);
+      }
+    }
+    assert.deepEqual(missing, [], 'these model weights are baked into an image, so every user of that image '
+      + `receives a copy — which is redistribution, whatever the licence:\n  ${missing.join('\n  ')}`);
+  });
+
+  it("the bundled model's entry says it is redistributed, not merely used", () => {
+    // The distinction NOTICE already draws for Ollama and faster-whisper-server ("pulled independently", "not
+    // bundled with or distributed by Ythril"). Drawing it the wrong way round for a model that DOES ship would be
+    // worse than saying nothing, because it would read as a considered answer.
+    // Scoped to THIS entry — from its heading to the next one — not to a character window around the name. A
+    // ±(400,1200) window passed against a deliberate break because the neighbouring faster-whisper-server entry
+    // says "Ythril does not redistribute the image", and `/redistribut/i` found that instead. Third time this
+    // session that a loose slice let an assertion be satisfied by text it was not looking at.
+    const heading = '### Bundled model weights: nomic-ai/nomic-embed-text-v1.5';
+    const at = notice.indexOf(heading);
+    assert.ok(at >= 0, 'the bundled embedding model has no NOTICE entry');
+    const rest = notice.slice(at + heading.length);
+    const next = rest.indexOf('\n### ');
+    const section = next < 0 ? rest : rest.slice(0, next);
+    assert.match(section, /Apache License 2\.0|Apache-2\.0/, "the bundled model's licence is not named");
+    assert.match(section, /redistribut/i,
+      'the entry must say the weights are redistributed — that is what separates it from the pulled models');
+  });
+});

--- a/testing/standalone/no-copyleft-in-the-shipped-tree.test.js
+++ b/testing/standalone/no-copyleft-in-the-shipped-tree.test.js
@@ -1,0 +1,168 @@
+/**
+ * No copyleft licence anywhere in the redistributed tree — direct or transitive — without a recorded election.
+ *
+ * ## The gap this closes, and why it was a reasonable gap
+ *
+ * `notice-coverage.test.js` checks that every **direct** dependency of both workspaces is attributed, and it says
+ * plainly why it stops there:
+ *
+ *   > Transitive dependencies are also out of scope here. That is a deliberate limit, not an oversight: the full
+ *   > transitive set is thousands of packages, and a gate nobody can satisfy is a gate that gets deleted.
+ *
+ * That is correct for **attribution**. It is not correct for **copyleft**, and the difference is the whole point of
+ * this file: attributing 1,147 MIT packages individually would be unsatisfiable busywork, but the number of
+ * packages in that tree with a restrictive licence is *two*. That set is small, it is checkable in seconds, and it
+ * is the one that carries legal consequence.
+ *
+ * ## What the audit lens found
+ *
+ * `jszip` is offered as `MIT OR GPL-3.0-or-later`. It is pulled in transitively by `exceljs` and **ships in the
+ * browser bundle** — so a GPL arm was being redistributed to every user with no record of which arm applied.
+ * `docs/dependencies.md` meanwhile stated that exactly *one* package was dual-licensed with a copyleft arm and
+ * concluded that "no copyleft restrictions apply to any redistributed npm package". The conclusion held, because
+ * MIT is available; the reasoning did not, because nobody had looked.
+ *
+ * Nothing was wrong in the product. What was wrong is that the claim could not be checked.
+ *
+ * ## Scope
+ *
+ * Everything present in `node_modules` after an install, which is a superset of what ships. A `devDependency` with
+ * a copyleft licence is not a redistribution problem — so a hit that is build-time only can be recorded as such in
+ * `DEV_ONLY` rather than needing a NOTICE entry it does not deserve.
+ *
+ * Run: `npm ci` first, then
+ *      node --test testing/standalone/no-copyleft-in-the-shipped-tree.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/**
+ * Licence identifiers that impose source-disclosure or use restrictions on a distributor.
+ *
+ * LGPL is deliberately excluded from the `GPL` match: it is a weak copyleft that dynamic linking satisfies, and
+ * Ythril links no LGPL code into its own binary (ffmpeg is LGPL and runs as a separate process — see NOTICE).
+ * Anything matching here needs either a recorded permissive election or a documented reason it is safe.
+ */
+const RESTRICTIVE = /\b(AGPL|GPL-[23](\.0)?(-only|-or-later)?|SSPL|BUSL|CC-BY-NC|Commons Clause|EUPL|OSL|CDDL)\b/i;
+const NOT_RESTRICTIVE = /\bLGPL\b/i;
+
+/** Packages whose restrictive arm is fine because they never reach a user. Each needs a reason, not just a name. */
+const DEV_ONLY = {
+  // (empty today — every hit so far is redistributed. Kept so the exemption is a decision, not an edit.)
+};
+
+/** Every package installed under node_modules, with its declared licence. */
+function installed() {
+  const out = new Map();
+  const read = (dir) => {
+    try {
+      const p = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+      const license = typeof p.license === 'string'
+        ? p.license
+        : (p.license && p.license.type)
+          || (Array.isArray(p.licenses) ? p.licenses.map(l => l.type).join(' OR ') : 'UNKNOWN');
+      if (p.name) out.set(p.name, { version: p.version, license });
+    } catch { /* not a package dir */ }
+  };
+  const scan = (root) => {
+    if (!existsSync(root)) return;
+    for (const entry of readdirSync(root)) {
+      if (entry.startsWith('.')) continue;
+      const dir = join(root, entry);
+      if (!statSync(dir).isDirectory()) continue;
+      if (entry.startsWith('@')) for (const s of readdirSync(dir)) read(join(dir, s));
+      else read(dir);
+    }
+  };
+  scan(join(ROOT, 'node_modules'));
+  for (const ws of ['server', 'client']) scan(join(ROOT, ws, 'node_modules'));
+  return out;
+}
+
+describe('the licence classifier, before it is trusted to judge anything', () => {
+  it('flags the licences that constrain a distributor', () => {
+    for (const l of ['AGPL-3.0', 'GPL-3.0-or-later', 'GPL-2.0-only', 'SSPL-1.0', 'BUSL-1.1',
+      'CC-BY-NC-4.0', 'MIT OR GPL-3.0-or-later', 'EUPL-1.2', 'CDDL-1.0']) {
+      assert.ok(RESTRICTIVE.test(l) && !NOT_RESTRICTIVE.test(l), `${l} should be flagged`);
+    }
+  });
+
+  it('does not flag the permissive ones, or LGPL', () => {
+    for (const l of ['MIT', 'Apache-2.0', 'ISC', '0BSD', 'BSD-3-Clause', 'BSD-2-Clause', 'Unlicense',
+      'MPL-2.0 OR Apache-2.0', 'CC0-1.0', 'Python-2.0', 'BlueOak-1.0.0']) {
+      assert.ok(!RESTRICTIVE.test(l) || NOT_RESTRICTIVE.test(l), `${l} should NOT be flagged`);
+    }
+    // LGPL is weak copyleft satisfied by separate-process use; ffmpeg is the case in point and is not linked in.
+    for (const l of ['LGPL-2.1-or-later', 'LGPL-3.0']) {
+      assert.ok(NOT_RESTRICTIVE.test(l), `${l} must be excluded as LGPL`);
+    }
+  });
+});
+
+describe('nothing copyleft is redistributed without a recorded election', () => {
+  const pkgs = installed();
+  const notice = readFileSync(join(ROOT, 'NOTICE'), 'utf8');
+
+  it('the install is present — otherwise this checks nothing', () => {
+    // A gate that silently passes on an empty node_modules is worse than no gate: it reads as "clean".
+    assert.ok(pkgs.size >= 300, `only found ${pkgs.size} installed packages — run \`npm ci\` before this test`);
+  });
+
+  it('every restrictive licence in the tree is recorded in NOTICE with its election', () => {
+    const hits = [...pkgs.entries()]
+      .filter(([, v]) => RESTRICTIVE.test(v.license ?? '') && !NOT_RESTRICTIVE.test(v.license ?? ''))
+      .filter(([name]) => !(name in DEV_ONLY));
+
+    const unrecorded = [];
+    for (const [name, v] of hits) {
+      const section = notice.match(new RegExp(`### ${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b[\\s\\S]{0,900}`));
+      if (!section) { unrecorded.push(`${name}@${v.version} (${v.license}) — no NOTICE entry`); continue; }
+      // An entry that just names the dual grant is not an election. It has to say which arm Ythril takes.
+      if (!/elects/i.test(section[0])) {
+        unrecorded.push(`${name}@${v.version} (${v.license}) — NOTICE entry does not record which arm is elected`);
+      }
+    }
+
+    assert.deepEqual(unrecorded, [], 'a licence with a copyleft or use-restricted arm is being redistributed '
+      + 'without a recorded election. Whether it is safe may well be yes — but "no copyleft applies" has to be a '
+      + `conclusion a reader can CHECK, not one they take on trust:\n  ${unrecorded.join('\n  ')}\n\n`
+      + 'Add a NOTICE entry stating which arm Ythril elects, or add the package to DEV_ONLY with the reason it '
+      + 'never reaches a user.');
+  });
+
+  it('the two known dual grants are still elected the permissive way', () => {
+    // Named explicitly so a NOTICE rewrite cannot quietly drop an election and leave the generic check satisfied
+    // by some other package's wording.
+    for (const [name, arm] of [['dompurify', /elects Apache License 2\.0/], ['jszip', /elects the MIT License/]]) {
+      const section = notice.match(new RegExp(`### ${name}[\\s\\S]{0,900}`));
+      assert.ok(section, `NOTICE has no entry for ${name}`);
+      assert.match(section[0], arm, `${name}'s election is not recorded as expected`);
+    }
+  });
+
+  it('the docs state the same count the tree does', () => {
+    // The claim that drifted: dependencies.md said ONE package was dual-licensed with a copyleft arm. There were
+    // two, and the second shipped in the browser bundle.
+    const deps = readFileSync(join(ROOT, 'docs/dependencies.md'), 'utf8');
+    assert.match(deps, /Two packages are dual-licensed with a copyleft arm/,
+      'docs/dependencies.md must state the actual number of dual-licensed packages');
+    // The TABLE ROW, not merely the name somewhere on the page. A first version matched `/jszip/` and stayed green
+    // when the row was deleted, because the prose underneath still mentions it — the same fault as an assertion
+    // satisfied by its own explanation.
+    assert.match(deps, /\|\s*`jszip`\s*\|[^|]*GPL[^|]*\|\s*MIT\s*\|/,
+      'the dual-grant table must carry a jszip row naming its offered licences and the elected arm');
+    assert.match(deps, /\|\s*`dompurify`\s*\|[^|]*MPL[^|]*\|\s*Apache 2\.0\s*\|/,
+      'the dual-grant table must carry a dompurify row');
+  });
+
+  it('every DEV_ONLY exemption names a real package and gives a reason', () => {
+    for (const [name, reason] of Object.entries(DEV_ONLY)) {
+      assert.ok(pkgs.has(name), `DEV_ONLY lists ${name}, which is not installed — drop the entry`);
+      assert.ok(typeof reason === 'string' && reason.length > 30, `${name}'s exemption needs a real reason`);
+    }
+  });
+});

--- a/testing/standalone/notice-coverage.test.js
+++ b/testing/standalone/notice-coverage.test.js
@@ -33,10 +33,35 @@
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 
 const NOTICE = readFileSync('NOTICE', 'utf8');
 const NOTICE_LC = NOTICE.toLowerCase();
+
+/**
+ * Every package name present after an install, across the root and both workspaces.
+ *
+ * Used only by the stale-entry check at the bottom: "is this thing still here at all?" needs the installed set,
+ * not the declared one, because a heading may legitimately name a transitive package (`jszip`).
+ */
+const INSTALLED = (() => {
+  const out = new Set();
+  const scan = (root) => {
+    if (!existsSync(root)) return;
+    for (const entry of readdirSync(root)) {
+      if (entry.startsWith('.')) continue;              // .bin, .package-lock.json, … npm internals
+      const dir = join(root, entry);
+      if (!statSync(dir).isDirectory()) continue;
+      if (entry.startsWith('@')) for (const s of readdirSync(dir)) out.add(`${entry}/${s}`);
+      else out.add(entry);
+    }
+  };
+  scan('node_modules');
+  scan('server/node_modules');
+  scan('client/node_modules');
+  return out;
+})();
 
 const MANIFESTS = [
   ['server', 'server/package.json'],
@@ -131,5 +156,35 @@ describe('NOTICE covers everything we redistribute', () => {
     const overclaimed = BUILD_ONLY.filter(n => NOTICE_LC.includes(`### ${n.toLowerCase()}\n`));
     assert.deepEqual(overclaimed, [],
       'NOTICE lists build tooling that is never redistributed — that overstates what ships');
+  });
+
+  it('does not attribute a package that is no longer here at all', () => {
+    // The allowlist above catches build tooling. It cannot catch a dependency that was REMOVED and whose entry
+    // was left behind — which is what happened: `qrcode` was swapped for `uqr` (the mfa spec documents the swap
+    // in its own header), the dependency went, and the NOTICE entry stayed. Found by the Legal & Compliance audit
+    // lens, not by this file.
+    //
+    // Generalisable and satisfiable, unlike a full transitive audit: every package-shaped heading must name
+    // something actually installed. 43 headings, and it found exactly one stale entry.
+    const stale = [];
+    for (const heading of [...NOTICE.matchAll(/^### (.+)$/gm)].map(m => m[1].trim())) {
+      // Headings that are not packages: licence texts, pulled images, model weights, the typeface, Ythril itself.
+      if (/^(MIT|Apache License|BSD-|ISC|0BSD|Runtime Dependency|Bundled model|Inter |Ythril|SIL |Mozilla|Eclipse|GNU)/i.test(heading)) continue;
+      // One heading may list several packages, and several carry a parenthetical gloss —
+      // `mongodb (Node.js Driver)`, `jszip (transitive, via exceljs)`. ANY trailing parenthetical is stripped
+      // rather than a hardcoded list of the two that exist today: the third one would otherwise fail the gate for
+      // no reason, and an npm name can contain neither a space nor a paren, so this can never hide a real name.
+      const names = heading
+        .replace(/\s*\([^)]*\)\s*$/, '')
+        .split(',').map(s => s.trim()).filter(Boolean);
+      for (const name of names) {
+        if (!INSTALLED.has(name) && !INSTALLED.has(name.toLowerCase())) {
+          stale.push(`${name}  (heading: "${heading}")`);
+        }
+      }
+    }
+    assert.deepEqual(stale, [], 'NOTICE attributes packages that are not installed. Either they were removed and '
+      + 'the entry was left behind — which claims we redistribute something we do not — or a heading is spelled '
+      + `differently from the package name:\n  ${stale.join('\n  ')}`);
   });
 });


### PR DESCRIPTION
## Three attribution gaps, from audit lens 1 — Legal & Compliance

None of these is a product defect. In all three the code was fine and the **record** was not: a conclusion in the
docs had never been verified, a licence obligation had never been written down, and an entry outlived the dependency
it described.

That is the pattern every finding from this lens shares — including the font leak in #640 — and it is why each
one ships with a gate rather than just a correction.

---

## 1. A GPL arm was being redistributed with no record of which arm applied

`jszip` is offered as **`MIT OR GPL-3.0-or-later`**. It arrives transitively through `exceljs` and **ships in the
browser bundle** (`chunk-…js`, the 944 KB `exceljs-min` chunk).

Meanwhile `docs/dependencies.md` said:

> **One package is dual-licensed with a copyleft arm:** `dompurify` … With that election, no copyleft restrictions
> apply to any redistributed npm package.

The **conclusion held** — MIT is available, MIT is what applies. The reasoning did not, because nobody had looked.
There were two.

- `NOTICE` now records the **MIT election** in the same form the `dompurify` entry uses, and says why a transitive
  package is listed at all.
- `docs/dependencies.md` carries a table of both grants: what each is offered as, which arm Ythril elects, and how
  each reaches the user.

### Why the existing gate could not find it

`notice-coverage.test.js` scopes transitive dependencies out, and explains itself in its own header:

> Transitive dependencies are also out of scope here. That is a deliberate limit, not an oversight: the full
> transitive set is thousands of packages, and a gate nobody can satisfy is a gate that gets deleted.

**Right for attribution. Wrong for copyleft.** Attributing 1,147 MIT packages individually is unsatisfiable
busywork; the number in that tree with a restrictive licence is **two**. So the new gate is scoped to exactly the
set that carries legal consequence.

`no-copyleft-in-the-shipped-tree` scans every installed package, flags copyleft and use-restricted identifiers —
**excluding LGPL**, which separate-process use satisfies and ffmpeg is the case in point — and requires each hit to
carry a NOTICE entry that *names the elected arm*. The classifier self-tests on nine restrictive and eleven
permissive identifiers before it judges anything.

**Mutation-tested 6/6**, including the one that matters most: **a new AGPL package appearing in the installed tree**
is caught.

Also confirmed and worth recording: across those 1,147 packages there is **no AGPL, SSPL or BUSL at all**. The
AGPL §13 network-use question therefore has no npm-side answer to worry about.

---

## 2. The one model Ythril actually ships had no attribution

`NOTICE` is careful about this distinction, and correct everywhere it draws it:

- Ollama's vision models "are pulled at runtime under their own licenses";
- `fedirz/faster-whisper-server` "is **not bundled with or distributed by** Ythril — it is pulled independently at
  deployment time".

And the model that **is** bundled had no entry at all.

`nomic-ai/nomic-embed-text-v1.5` is downloaded at image build time and baked in (`MODEL_CACHE_DIR=/app/model-cache`)
so an instance embeds text on first boot with no network — the offline-start guarantee the whole build is arranged
around, and the reason that layer is the largest single thing in the image. **Every user of a Ythril image receives
a copy of those weights.** That is redistribution. It is Apache-2.0, so the obligation is attribution, and the
attribution was missing.

`NOTICE` now carries it: the licence, that the files ship **unmodified** (so no statement of changes is required),
and explicitly that these weights **are** redistributed — the distinction drawn the right way round, because
drawing it wrongly would read as a considered answer rather than an omission.

### The gate reads the Dockerfiles, not a list

"Which models ship" is not something a human maintains — it is whatever an image downloads. So
`models-are-attributed` extracts model identifiers from every Dockerfile in the repo and requires each to appear in
`NOTICE` with a licence. Adding a model to an image is then **automatically** a NOTICE change, which is the only
ordering that stays true.

The detector self-tests both ways: it finds a HuggingFace-style id in the shape the Dockerfile actually uses, and it
does not mistake `ythril-network/Ythril` in a LABEL, a `node:22-slim` base image, or a `COPY --from=builder` path
for a model.

**Mutation-tested 5/5**, including a second model baked in with no attribution, and the model download disappearing
from the Dockerfile entirely.

---

## 3. NOTICE attributed a package that was removed months ago

The reverse of the usual direction. `qrcode` was swapped for `uqr` — the MFA component's spec documents the swap in
its own header, *"CommonJS `qrcode` → ESM `uqr`"* — the dependency was removed, and the NOTICE entry stayed.

That claims Ythril redistributes something it does not: the small end of a licence problem, and the sharp end of a
trust one, because the whole value of NOTICE is that it can be believed.

`notice-coverage.test.js` already had a reverse check — but it was **a hardcoded allowlist of five build tools**
(`typescript`, `eslint`, …). That catches *"we listed build tooling"* and cannot catch *"we listed something that is
gone"*.

It now asserts that every package-shaped heading names something **actually installed**: 43 headings, and it found
exactly the one stale entry. Satisfiable rather than aspirational — the same reasoning the file already gives for
scoping transitive attribution out.

Prose headings are handled **generally** rather than by a list of the two that exist today (`mongodb (Node.js
Driver)`, `jszip (transitive, via exceljs)`), because the third one would otherwise fail the gate for no reason.
Any trailing parenthetical is stripped, which can never hide a real name: an npm name can contain neither a space
nor a paren.

**Mutation-tested 7/7**, and four of the seven are the false-positive direction — the multi-package Angular
heading, a prose name with a parenthetical, a licence-*text* heading, and a pulled-image heading must all stay
green. The parenthetical case is the one that caught my first version, which hardcoded the two known glosses.

---

## One fault of my own, found the same way

The "says it is redistributed" assertion used a character window around the model name — and passed against a
deliberate break, because the **neighbouring** faster-whisper entry says *"Ythril does not redistribute the image"*.
It is scoped to the entry's own heading-to-next-heading span now.

That is the fourth time in this batch that a slice taken by convenience rather than by syntax let an assertion be
satisfied by text it was not looking at. It is recorded in the tracker as a rule, not just fixed here.

---

`npm run preflight` PASSED (892 client; all three gates are pure standalone and run locally).
