### PR TITLE
fix(docker): the image shipped with no NOTICE and no LICENSE

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,3 +60,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      # The licence obligation, verified against the ARTEFACT rather than the instruction.
+      #
+      # `testing/standalone/notice-ships-in-the-image.test.js` asserts the Dockerfile copies NOTICE and LICENSE in,
+      # because that check has to run without Docker. It cannot see whether the COPY landed where the image serves
+      # from — and a COPY that silently lands in the wrong place passes every unit test there is. So the published
+      # image is asked directly.
+      #
+      # This exists because it once did not: 2.2.5 shipped with neither file. The image is the primary distribution,
+      # so it was the one place Apache-2.0 §4(d) and the MIT notice clause actually applied, and the one place they
+      # were unmet.
+      - name: Verify the licence and notices are in the published image
+        run: |
+          IMAGE="$(echo '${{ steps.meta.outputs.tags }}' | head -n1)"
+          echo "Checking $IMAGE"
+          for f in NOTICE LICENSE; do
+            if docker run --rm --entrypoint sh "$IMAGE" -c "test -s /app/$f"; then
+              echo "  ok: /app/$f present and non-empty"
+            else
+              echo "  FAIL: /app/$f is missing or empty in the published image."
+              echo "  Apache-2.0 4(d) and the MIT notice clause require the notices to travel with the copy."
+              exit 1
+            fi
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The image shipped with no `NOTICE` and no `LICENSE`.** Confirmed against the published artefact rather than
+  inferred: `docker run --rm --entrypoint sh ythril/ythril:2.2.5 -c 'ls /app/NOTICE /app/LICENSE /NOTICE /LICENSE'`
+  returned four *No such file or directory*. The Dockerfile never copied them into the production stage.
+  - **The image is the primary distribution** — most users never see the git repo — so it was the one place the
+    notices were legally required and the one place they were absent. **Apache-2.0 §4(d)** requires a distribution
+    of a work carrying a NOTICE file to "include a readable copy of the attribution notices contained within such
+    NOTICE file", and Ythril redistributes several Apache-2.0 works in that image (`@huggingface/transformers`,
+    `sharp`, and the embedding model weights). **MIT** requires its notice "in all copies or substantial portions".
+    An image is a copy.
+  - This is the one finding from the Legal & Compliance lens that was not merely an unverifiable record: the
+    obligation itself was unmet in the shipped artefact.
+  - `COPY NOTICE LICENSE ./` in the production stage, **after** the dependency install so correcting a copyright
+    line cannot invalidate a 1.07 GB layer. Verified in a real build: 20,479 and 5,082 bytes at `/app/`, readable by
+    the `node` runtime user.
+  - Gated from both ends, because neither half is sufficient alone. `notice-ships-in-the-image` asserts the
+    Dockerfile instruction and the ordering — it must run without Docker, so it can only see the cause. The publish
+    workflow now asks the **built image** whether the files are there and non-empty, because a `COPY` that lands in
+    the wrong directory passes every unit test there is.
+
 - **NOTICE attributed a package that was removed months ago.** `qrcode` was swapped for `uqr` — the MFA component's
   spec documents the swap in its own header, *"CommonJS `qrcode` → ESM `uqr`"* — the dependency went, and the NOTICE
   entry stayed. That claims Ythril redistributes something it does not, which is the small end of a licence problem

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,21 @@ COPY --from=builder /build/server/dist ./server/dist
 # Copy compiled Angular SPA from client-builder
 COPY --from=client-builder /build/client/dist/browser ./client/dist/browser
 
+# The licence and the third-party notices, INSIDE the image.
+#
+# They were not here, and the image is the primary distribution — most users never see the git repo. That made the
+# one place the notices are legally required the one place they were absent:
+#
+#   - Apache-2.0 §4(d): a distribution of a work that carries a NOTICE file "must include a readable copy of the
+#     attribution notices contained within such NOTICE file". Ythril redistributes several Apache-2.0 works in this
+#     image — @huggingface/transformers, sharp, and the embedding model weights themselves.
+#   - MIT: "The above copyright notice and this permission notice shall be included in all copies or substantial
+#     portions of the Software." An image is a copy.
+#
+# A few KB, in the app layer where it belongs. Found by the Legal & Compliance audit lens; asserted by
+# `notice-ships-in-the-image`.
+COPY NOTICE LICENSE ./
+
 ENV NODE_ENV=production
 ENV PORT=3200
 ENV CONFIG_PATH=/config/config.json

--- a/testing/standalone/notice-ships-in-the-image.test.js
+++ b/testing/standalone/notice-ships-in-the-image.test.js
@@ -1,0 +1,94 @@
+/**
+ * The licence and the third-party notices must be INSIDE the image.
+ *
+ * ## The failure this exists for — Legal & Compliance audit lens, finding 5
+ *
+ * The Dockerfile never copied `NOTICE` or `LICENSE` into the production stage. Confirmed against the published
+ * artefact, not inferred:
+ *
+ *     $ docker run --rm --entrypoint sh ythril/ythril:2.2.5 -c 'ls /app/NOTICE /app/LICENSE /NOTICE /LICENSE'
+ *     ls: cannot access '/app/NOTICE': No such file or directory
+ *     ls: cannot access '/app/LICENSE': No such file or directory
+ *     ls: cannot access '/NOTICE': No such file or directory
+ *     ls: cannot access '/LICENSE': No such file or directory
+ *
+ * **The image is the primary distribution.** Most users never see the git repo, so the one place the notices are
+ * legally required was the one place they were missing:
+ *
+ *   - **Apache-2.0 §4(d)** — a distribution of a work carrying a NOTICE file "must include a readable copy of the
+ *     attribution notices contained within such NOTICE file". Ythril redistributes several Apache-2.0 works in
+ *     this image: `@huggingface/transformers`, `sharp`, and the embedding model weights.
+ *   - **MIT** — "The above copyright notice and this permission notice shall be included in all copies or
+ *     substantial portions of the Software." An image is a copy.
+ *
+ * This one is different from the lens's other findings. Those were records that could not be checked; this was an
+ * obligation the shipped artefact did not meet.
+ *
+ * ## What this checks, and what it cannot
+ *
+ * The Dockerfile instruction, because that runs everywhere and in milliseconds. Verifying a BUILT image needs a
+ * build, which belongs in CI's image job rather than in a unit sweep — so this asserts the cause, and the release
+ * verification script asserts the effect.
+ *
+ * Run: node --test testing/standalone/notice-ships-in-the-image.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/** The production stage: from the last `FROM … AS production` to the end of the file. */
+function productionStage(dockerfile) {
+  const at = dockerfile.lastIndexOf('AS production');
+  assert.ok(at > 0, 'could not find the production stage in the Dockerfile');
+  return dockerfile.slice(at);
+}
+
+describe('the licence and notices ship inside the image', () => {
+  const dockerfile = read('Dockerfile');
+  const stage = productionStage(dockerfile);
+
+  it('both files exist in the repo to begin with', () => {
+    for (const f of ['NOTICE', 'LICENSE']) {
+      assert.ok(existsSync(join(ROOT, f)), `${f} is missing from the repo`);
+      assert.ok(read(f).length > 500, `${f} looks empty`);
+    }
+  });
+
+  it('the production stage copies them in', () => {
+    // Matched in the PRODUCTION stage specifically: a COPY in a builder stage would satisfy a whole-file grep and
+    // ship nothing, since builder layers are discarded.
+    for (const f of ['NOTICE', 'LICENSE']) {
+      assert.match(stage, new RegExp(`^COPY[^\\n]*\\b${f}\\b`, 'm'),
+        `the production stage does not COPY ${f} — the image would ship without it, which is what Apache-2.0 §4(d) `
+        + 'and the MIT notice clause both require it not to do');
+    }
+  });
+
+  it('they are copied AFTER the dependency install, so a licence edit does not rebuild the world', () => {
+    // Ordering is not pedantry here: NOTICE changes on most dependency changes, and putting it above `npm ci`
+    // would invalidate a 1.07 GB layer every time somebody corrected a copyright line.
+    const npmCi = stage.indexOf('npm ci');
+    const copyNotice = stage.search(/^COPY[^\n]*\bNOTICE\b/m);
+    assert.ok(npmCi > 0, 'could not find the dependency install in the production stage');
+    assert.ok(copyNotice > npmCi,
+      'NOTICE is copied before the dependency install, so editing it invalidates the node_modules layer');
+  });
+
+  it('the publish workflow asserts the EFFECT, not just the instruction', () => {
+    // This gate checks the CAUSE, because it must run without Docker. Something has to check the artefact, or a
+    // COPY that silently lands in the wrong directory passes every unit test there is.
+    //
+    // That check lives in the publish workflow, where an image exists to interrogate. Asserted here rather than
+    // left as a convention: the two halves are useless apart, and the workflow is not somewhere a reader of this
+    // file would think to look.
+    const wf = read('.github/workflows/publish.yml');
+    assert.match(wf, /test -s \/app\/\$f|test -s \/app\/NOTICE/,
+      'the publish workflow must ask the built image whether the notices are actually in it');
+    assert.match(wf, /for f in NOTICE LICENSE/,
+      'the artefact check must cover both files');
+  });
+});


### PR DESCRIPTION
## The image shipped with no `NOTICE` and no `LICENSE`

Fifth finding from audit lens **1 — Legal & Compliance**, and the only one so far where the obligation itself was
unmet rather than merely unrecorded.

Confirmed against the published artefact, not inferred:

```console
$ docker run --rm --entrypoint sh ythril/ythril:2.2.5 -c 'ls /app/NOTICE /app/LICENSE /NOTICE /LICENSE'
ls: cannot access '/app/NOTICE': No such file or directory
ls: cannot access '/app/LICENSE': No such file or directory
ls: cannot access '/NOTICE': No such file or directory
ls: cannot access '/LICENSE': No such file or directory
```

The Dockerfile never copied them into the production stage.

## Why it matters more than it looks

**The image is the primary distribution.** Most users never see the git repo — they pull a tag. So the image was
the one place the notices were legally required, and the one place they were absent.

- **Apache-2.0 §4(d)** — a distribution of a work carrying a NOTICE file "must include a readable copy of the
  attribution notices contained within such NOTICE file". Ythril redistributes several Apache-2.0 works in that
  image: `@huggingface/transformers`, `sharp`, and — since the layer fix in #636 made it explicit — the **embedding
  model weights**.
- **MIT** — "The above copyright notice and this permission notice shall be included in all copies or substantial
  portions of the Software." An image is a copy.

The repo has had a thorough `NOTICE` all along. It just never travelled with the thing being distributed.

## The fix

`COPY NOTICE LICENSE ./` in the production stage — **after** the dependency install, so that correcting a copyright
line cannot invalidate a 1.07 GB `node_modules` layer. A few KB, in the app layer where it belongs.

Verified in a real build rather than assumed:

```
ok: /app/NOTICE  20479 bytes
ok: /app/LICENSE  5082 bytes
readable as the runtime user (node): yes
```

## Gated from both ends, because neither half is sufficient

| gate | checks | blind to |
|---|---|---|
| `notice-ships-in-the-image` | the Dockerfile `COPY` exists **in the production stage**, and sits after the dependency install | whether the files actually land where the image serves from |
| the publish workflow | asks the **built image** whether both files are present and non-empty, and fails the publish if not | nothing — but it needs an image, so it cannot run in the unit sweep |

A `COPY` that silently lands in the wrong directory passes every unit test there is, which is why the artefact-side
check exists. And the unit gate asserts that the workflow half **exists**, because the two are useless apart and a
reader of one would not think to look for the other.

The production-stage scoping is deliberate too: a `COPY` in a builder stage would satisfy a whole-file grep and ship
nothing, since builder layers are discarded.

---

`npm run preflight` PASSED. The artefact check ran locally against a full image build; the workflow step will run it
on the next publish.
