### PR TITLE
docs(legal): NOTICE named the wrong licence for the Whisper models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     workflow now asks the **built image** whether the files are there and non-empty, because a `COPY` that lands in
     the wrong directory passes every unit test there is.
 
+- **NOTICE named the wrong licence for the Whisper models an operator actually pulls.** It said they "are Apache 2.0
+  licensed", which is the licence of **OpenAI's upstream Whisper weights** — not of the artefacts that get fetched. What
+  `faster-whisper-server` downloads are the **Systran `faster-whisper-*` CTranslate2 conversions, published under MIT**
+  (Ythril's default is `base`, so `Systran/faster-whisper-base`). Both are permissive, so nothing an operator may do
+  changes — but a stated licence should name the thing it describes. The Kubernetes manifest carried the same error in a
+  comment and is corrected too.
+  - Worth recording how nearly this went the other way: I first assumed Whisper was MIT upstream and the conversions
+    Apache-2.0. It is the reverse. Both were checked against the model API rather than recalled.
+
 - **NOTICE attributed a package that was removed months ago.** `qrcode` was swapped for `uqr` — the MFA component's
   spec documents the swap in its own header, *"CommonJS `qrcode` → ESM `uqr`"* — the dependency went, and the NOTICE
   entry stayed. That claims Ythril redistributes something it does not, which is the small end of a licence problem

--- a/NOTICE
+++ b/NOTICE
@@ -311,8 +311,14 @@ Ythril** - it is pulled independently at deployment time.
 Role: speech-to-text - transcribes uploaded / segmented audio via an OpenAI-compatible endpoint.
 
 License: MIT (the server). The full MIT text, with its copyright notice, ships in the image's bundled
-`LICENSE`; Ythril does not redistribute the image. Whisper models are pulled separately at runtime and
-are Apache 2.0 licensed.
+`LICENSE`; Ythril does not redistribute the image.
+
+The MODELS are pulled separately at runtime, and there are two licences in play rather than one. What the server
+actually downloads are the **Systran `faster-whisper-*` CTranslate2 conversions, published under MIT** — Ythril's
+default is `base`, so `Systran/faster-whisper-base`. Those are conversions of **OpenAI's Whisper weights, which are
+Apache 2.0**. This entry previously named only Apache 2.0, which is the licence of the upstream weights and not of
+the artefacts that are fetched. Both are permissive, so nothing an operator may do changes — but a stated licence
+should name the thing it is describing.
 
 Ythril communicates with the sidecar only over an HTTP socket on an isolated internal media network; no
 faster-whisper-server code is linked into or incorporated into the Ythril application.

--- a/kubernetes/manifests/whisper-deploy.yaml
+++ b/kubernetes/manifests/whisper-deploy.yaml
@@ -3,7 +3,8 @@
 # Exposes an OpenAI-compatible POST /v1/audio/transcriptions endpoint with
 # response_format=verbose_json for per-segment timing data.
 #
-# Image: fedirz/faster-whisper-server (MIT licence, Apache 2.0 models).
+# Image: fedirz/faster-whisper-server (MIT). Models: the Systran faster-whisper CTranslate2 conversions
+# (MIT), which are conversions of OpenAI Whisper (Apache 2.0). See NOTICE.
 # Default model: base — adequate for most speech; upgrade to medium/large-v3
 # for noisy recordings or non-English audio.
 #


### PR DESCRIPTION
## NOTICE named the wrong licence for the Whisper models

Sixth and smallest finding from audit lens **1 — Legal & Compliance**, and the last item in its sweep.

`NOTICE` said:

> Whisper models are pulled separately at runtime and are Apache 2.0 licensed.

That is the licence of **OpenAI's upstream Whisper weights**. It is not the licence of the artefacts that actually
get fetched.

`faster-whisper-server` downloads the **Systran `faster-whisper-*` CTranslate2 conversions, which are published
under MIT**. Ythril's default STT model is `base`, so `Systran/faster-whisper-base`.

Both are permissive, so **nothing an operator may do changes**. But a stated licence should name the thing it is
describing, and the whole of this lens has been about claims that could not be checked. The Kubernetes manifest
carried the same error in a comment — `(MIT licence, Apache 2.0 models)` — and is corrected too.

## Worth recording how nearly this went the other way

My first instinct was the reverse: Whisper MIT upstream, the conversions Apache-2.0. Both were verified against the
model API rather than recalled:

```text
Systran/faster-whisper-base -> mit
openai/whisper-base         -> apache-2.0
```

Had I written that from memory I would have replaced one wrong licence with another, and it would have looked more
authoritative than what was there before.

Checked in the same pass and **clean**: `moondream2` is Apache-2.0, exactly as `NOTICE` already says. Neither model
carries an acceptable-use restriction — both are plain permissive licences — so there is no AUP an operator needs
surfaced.

## This closes the lens

Six findings, all fixed or parked:

| # | finding | where |
|---|---|---|
| 1 | the UI fetched its font from a CDN on every page load | #640 |
| 2 | a GPL arm (`jszip`) redistributed with no recorded election | #641 |
| 3 | the one model Ythril ships had no attribution | #641 |
| 4 | a NOTICE entry outlived its dependency (`qrcode`) | #641 |
| 5 | **the image shipped with no NOTICE and no LICENSE** | #642 |
| 6 | the Whisper models' licence was misnamed | this PR |

Five produced a gate. Findings 1–4 and 6 were records that could not be checked; **5 was the only one where the
obligation itself was unmet** in the shipped artefact.

Two questions were deliberately **parked rather than answered** (`todo/_PARKED-DECISIONS.md`): contributor licensing
— there is no DCO, no CLA and no sign-off, and which instrument to adopt is an owner call with real consequences for
relicensing — and whether an export/encryption notice applies at all, where a confident paragraph from me would be
exactly the unverified claim this lens spent its time removing.

Everything it confirmed clean is recorded in the tracker so it is not re-derived: no AGPL/SSPL/BUSL across 1,147
packages, the sidecar images are built by the operator and in no registry, and nothing licensable is fetched at
runtime.

---

`npm run preflight` PASSED.
