### PR TITLE
fix(db): a database backup was a world-readable plaintext copy of everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A database backup was a world-readable plaintext copy of everything.** Found by the Privacy audit lens.
+  `02-hosting.md` has a section called **Encryption at Rest**; it is accurately scoped in its own text (four state
+  files) and recommends an encrypted `mongod` for brain data. A backup bypasses the whole arrangement: `dumpDatabase`
+  reads *through* `mongod`, so the NDJSON that lands in `<data-root>/backups/` is **decrypted** — every memory,
+  entity, edge, chrono entry, file-meta record and audit entry, in the clear, on the same volume.
+  `requireEncryptedAtRest` does not touch it, and nothing said so.
+  - **The permissions were inverted with respect to sensitivity.** The four state files have always been written
+    `0600`. The dump directory was created with plain `mkdirSync(dir, { recursive: true })` — default `0755`, files
+    `0644` — as was the offsite copy, which additionally contains **every uploaded file verbatim**. The least
+    sensitive thing on the volume was the best protected.
+  - Now `0700` on every backup directory and `0600` on every NDJSON file, with each `chmod` guarded so a
+    non-POSIX host or a network share that ignores modes cannot turn a hardening into a failed backup.
+  - **Both docs now say what is and is not covered.** The admin endpoint explains that a dump is unencrypted, that
+    the at-rest flag does not cover it, and *why* (it reads through `mongod`). The Encryption at Rest section now
+    scopes itself — uploads, backups and MongoDB brain data are named as exclusions, because a reader who stops at
+    the heading is exactly the reader this is for.
+  - **Whether dumps should be encrypted is parked, not decided.** A backup you cannot restore is not a backup, and
+    encrypting with the master key means a lost key loses the backups too — the trade-off the state files make
+    deliberately, at higher stakes. Recommendation and a middle option are in `_PARKED-DECISIONS.md`.
+  - Gate `backups-are-not-world-readable`, mutation-tested **7/7**, covering both the modes and the documentation.
+
 - **The image shipped with no `NOTICE` and no `LICENSE`.** Confirmed against the published artefact rather than
   inferred: `docker run --rm --entrypoint sh ythril/ythril:2.2.5 -c 'ls /app/NOTICE /app/LICENSE /NOTICE /LICENSE'`
   returned four *No such file or directory*. The Dockerfile never copied them into the production stage.

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -154,6 +154,15 @@ transparently:
   behind. New installs write encrypted from the first save.
 - **Back up the master secret.** Losing it makes the encrypted files unrecoverable — that is the point.
   Deliver it as a Docker/Kubernetes/systemd secret, not baked into an image.
+- **What this does NOT cover**, stated here because the section title invites the wider reading:
+  - **uploaded files** under `<data-root>/files/` are stored as they arrived;
+  - **database backups** under `<data-root>/backups/` are plaintext NDJSON — a dump reads *through* `mongod`, so an
+    encrypted `mongod` does not protect it either. See
+    [POST /api/admin/data/backup](12-admin-api.md#post-apiadmindatabackup);
+  - **brain data in MongoDB itself** — that is the encrypted-`mongod` job described below.
+
+  Ythril writes everything in the first two categories `0600`/`0700` so it is not readable by other users on the
+  host, and `requireEncryptedAtRest` deliberately does not claim otherwise.
 
 ```yaml
 # docker compose — master key from a secret/env, kept out of the image

--- a/docs/integration-guide/12-admin-api.md
+++ b/docs/integration-guide/12-admin-api.md
@@ -309,6 +309,28 @@ Content-Type: application/json
 
 Trigger an immediate point-in-time dump of the entire MongoDB database. The backup is written to `<data-root>/backups/<ISO-timestamp>/` and contains a `manifest.json` plus one NDJSON file per collection.
 
+> **A backup is an unencrypted copy of everything, and `requireEncryptedAtRest` does not cover it.**
+>
+> The dump is written by reading *through* `mongod`, so it comes out **decrypted**: every memory, entity, edge,
+> chrono entry, file-meta record and audit entry, as plaintext NDJSON on the data volume. If you followed
+> [Encryption at Rest](02-hosting.md#encryption-at-rest) and gave the instance a master key, that covers the app's
+> four state files — `config.json`, `secrets.json`, `schema-library.json`, `schema-catalogs.json`. It does not
+> cover this, and neither does running against an encrypted `mongod`.
+>
+> Ythril writes the dump directory `0700` and each NDJSON file `0600`, so it is not readable by other users on the
+> host. Beyond that the protection is yours to arrange:
+>
+> - treat `<data-root>/backups/` as sensitive as the database itself — it *is* the database;
+> - the **offsite** copy is usually a mounted share, and `<destRoot>/<backupId>-files/` additionally contains every
+>   uploaded file verbatim. Ythril creates those directories `0700` too, but a network filesystem may not honour
+>   POSIX modes at all — encrypt the volume or the transport;
+> - a dump you download is plaintext from the moment it leaves the instance.
+>
+> This is stated rather than fixed because whether Ythril should *encrypt* dumps with the master key is a real
+> trade-off: it would make a backup unrestorable without that key, which is either the point or a foot-gun
+> depending on why you are taking it. Until that is decided, the honest thing is to say what the current behaviour
+> is.
+
 When `YTHRIL_DB_MIGRATION_ENABLED=true` and a `backup.json` config file is present, this endpoint also:
 
 - Copies the backup (plus `<data-root>/files/`) to the configured `offsite.destPath`

--- a/server/src/db/dump.ts
+++ b/server/src/db/dump.ts
@@ -45,7 +45,19 @@ function redactUri(uri: string): string {
  * Returns the manifest describing the dump.
  */
 export async function dumpDatabase(uri: string, destDir: string): Promise<DumpManifest> {
-  fs.mkdirSync(destDir, { recursive: true });
+  // 0700, and 0600 on every file below.
+  //
+  // A dump is a COMPLETE PLAINTEXT COPY of the database — every memory, entity, edge, chrono entry, file-meta
+  // record and audit entry, as NDJSON. It is written by reading THROUGH mongod, so an encrypted `mongod` (the
+  // mitigation `02-hosting.md` recommends for brain data) protects nothing here: the dump comes out decrypted.
+  //
+  // These directories were created with default permissions — typically 0755, with 0644 files — while the app's
+  // own state files have always been written 0600. So the least sensitive thing on the volume was the best
+  // protected. Found by the Privacy audit lens.
+  //
+  // This is a tightening only: the owning process is the sole reader, and `restoreDatabase` runs as the same user.
+  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(destDir, 0o700); } catch { /* non-POSIX host, or pre-existing dir we do not own */ }
 
   const client = new MongoClient(uri, {
     serverSelectionTimeoutMS: 15_000,
@@ -67,7 +79,7 @@ export async function dumpDatabase(uri: string, destDir: string): Promise<DumpMa
     for (const name of collectionNames) {
       const col = db.collection(name);
       const destFile = path.join(destDir, `${name}.ndjson`);
-      const stream = fs.createWriteStream(destFile, { encoding: 'utf8' });
+      const stream = fs.createWriteStream(destFile, { encoding: 'utf8', mode: 0o600 });
 
       let count = 0;
       const cursor = col.find({}).batchSize(CURSOR_BATCH_SIZE);

--- a/server/src/db/offsite.ts
+++ b/server/src/db/offsite.ts
@@ -22,7 +22,14 @@ import { log } from '../util/log.js';
  */
 export function copyBackupOffsite(srcDir: string, destRoot: string, backupId: string): string {
   const destDir = path.join(destRoot, backupId);
-  fs.mkdirSync(destDir, { recursive: true });
+  // 0700, matching the source dump. `cpSync` preserves the source file modes, so the 0600 NDJSON files stay 0600 —
+  // it is the DIRECTORY that would otherwise be created world-readable.
+  //
+  // This narrows the exposure; it does not remove it. The destination is usually a mounted share, and its own
+  // permissions and encryption are the operator's to arrange — which is why `12-admin-api.md` now says so instead
+  // of leaving a reader to assume that "encryption at rest" covered this.
+  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(destDir, 0o700); } catch { /* the share may not honour POSIX modes at all */ }
   fs.cpSync(srcDir, destDir, { recursive: true });
   return destDir;
 }
@@ -41,7 +48,9 @@ export function copyFilesOffsite(
 ): string | null {
   if (!fs.existsSync(filesDir)) return null;
   const destDir = path.join(destRoot, `${backupId}-files`);
-  fs.mkdirSync(destDir, { recursive: true });
+  // Same reasoning as above, and it applies more here: these are the users' UPLOADED FILES, verbatim.
+  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
+  try { fs.chmodSync(destDir, 0o700); } catch { /* the share may not honour POSIX modes at all */ }
   fs.cpSync(filesDir, destDir, { recursive: true });
   return destDir;
 }

--- a/testing/standalone/backups-are-not-world-readable.test.js
+++ b/testing/standalone/backups-are-not-world-readable.test.js
@@ -1,0 +1,106 @@
+/**
+ * A database dump is the whole database in plaintext. Treat it that way, and say so.
+ *
+ * ## The finding — Privacy audit lens
+ *
+ * `02-hosting.md` has a section titled **Encryption at Rest**. It is scoped correctly in its own text — four state
+ * files — and it recommends an encrypted `mongod` for brain data. An operator who does all of that has, reasonably,
+ * concluded their data at rest is protected.
+ *
+ * A backup bypasses the whole arrangement. `dumpDatabase` reads **through** `mongod`, so the NDJSON that lands in
+ * `<data-root>/backups/` is **decrypted**: every memory, entity, edge, chrono entry, file-meta record and audit
+ * entry, in the clear, on the same volume. `requireEncryptedAtRest` does not touch it. Nothing said so.
+ *
+ * And the permissions were inverted with respect to sensitivity: the four state files have always been written
+ * `0600`, while the dump directory was created with `mkdirSync(dir, { recursive: true })` — default `0755`, files
+ * `0644`. **The least sensitive thing on the volume was the best protected.** The offsite copy, which additionally
+ * contains every uploaded file verbatim, was the same.
+ *
+ * ## What this gate holds
+ *
+ * The modes, and the fact that the docs admit the gap. It cannot check the deeper question — whether dumps should be
+ * *encrypted* — because that is a live trade-off parked for the owner: encrypting them with the master key makes a
+ * backup unrestorable without that key, which is either the point or a foot-gun depending on why it was taken.
+ *
+ * Run: node --test testing/standalone/backups-are-not-world-readable.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/** Every `mkdirSync` in a file, with its options text — so a missing `mode` is visible. */
+function mkdirs(src) {
+  return [...src.matchAll(/fs\.mkdirSync\(([^;]*?)\);/gs)].map(m => m[1].replace(/\s+/g, ' ').trim());
+}
+
+describe('a dump is written as tightly as the state files it sits beside', () => {
+  const dump = read('server/src/db/dump.ts');
+  const offsite = read('server/src/db/offsite.ts');
+
+  it('found the writers — the parse still matches', () => {
+    assert.ok(mkdirs(dump).length >= 1, 'no mkdirSync found in dump.ts');
+    assert.ok(mkdirs(offsite).length >= 2, `expected both offsite copies, found ${mkdirs(offsite).length}`);
+  });
+
+  it('every backup directory is created 0700', () => {
+    const loose = [];
+    for (const [file, src] of [['dump.ts', dump], ['offsite.ts', offsite]]) {
+      for (const call of mkdirs(src)) {
+        if (!/mode:\s*0o700/.test(call)) loose.push(`${file}: fs.mkdirSync(${call})`);
+      }
+    }
+    assert.deepEqual(loose, [], 'these create a directory holding a plaintext copy of the database — or of every '
+      + `uploaded file — with default permissions, typically 0755:\n  ${loose.join('\n  ')}`);
+  });
+
+  it('the NDJSON files themselves are written 0600', () => {
+    // The directory mode is not enough on a host where an existing directory is reused, and `cpSync` preserves
+    // source file modes — so the FILE mode is what actually travels offsite.
+    const streams = [...dump.matchAll(/createWriteStream\(([^;]*?)\);/gs)].map(m => m[1].replace(/\s+/g, ' '));
+    assert.ok(streams.length >= 1, 'no createWriteStream found in dump.ts');
+    for (const s of streams) {
+      assert.match(s, /mode:\s*0o600/,
+        `a collection dump is written without a restrictive mode: createWriteStream(${s})`);
+    }
+  });
+
+  it('a non-POSIX host cannot make the chmod fatal', () => {
+    // Windows and some network shares do not honour POSIX modes. Hardening must not turn a working backup into a
+    // failed one — the mode is a tightening, not a precondition.
+    for (const [file, src] of [['dump.ts', dump], ['offsite.ts', offsite]]) {
+      for (const m of src.matchAll(/fs\.chmodSync\([^)]*\)/g)) {
+        const around = src.slice(Math.max(0, src.indexOf(m[0]) - 120), src.indexOf(m[0]) + m[0].length + 80);
+        assert.match(around, /try\s*\{/, `${file}: ${m[0]} is not guarded — a non-POSIX host would fail the backup`);
+      }
+    }
+  });
+});
+
+describe('the docs admit what encryption at rest does not cover', () => {
+  it('the admin API says a dump is unencrypted and not covered by the flag', () => {
+    const doc = read('docs/integration-guide/12-admin-api.md');
+    assert.match(doc, /unencrypted copy of everything/i,
+      'the backup endpoint must say the dump is unencrypted');
+    assert.match(doc, /requireEncryptedAtRest.{0,40}does not cover it/i,
+      'it must say explicitly that the at-rest flag does not cover a dump — that is the assumption being corrected');
+    assert.match(doc, /decrypted/i,
+      'it must explain WHY: the dump reads through mongod, so an encrypted mongod does not help');
+  });
+
+  it('the Encryption at Rest section scopes itself', () => {
+    // The section was accurate and its TITLE was broader than its content. A reader who stops at the heading is the
+    // one this is for.
+    const doc = read('docs/integration-guide/02-hosting.md');
+    const at = doc.indexOf('### Encryption at Rest');
+    assert.ok(at > 0, 'the Encryption at Rest section is gone');
+    const section = doc.slice(at, doc.indexOf('\n### ', at + 10));
+    assert.match(section, /does NOT cover/,
+      'the section must state what it does not cover — uploads, backups, and brain data in MongoDB');
+    assert.match(section, /backups/i, 'backups must be named among the exclusions');
+    assert.match(section, /files/i, 'uploaded files must be named among the exclusions');
+  });
+});


### PR DESCRIPTION
## A database backup was a world-readable plaintext copy of everything

First finding from audit lens **12 — Privacy**.

`02-hosting.md` has a section titled **Encryption at Rest**. It is accurate and correctly scoped *in its own text* —
four state files, `config.json`, `secrets.json`, and the two schema catalogs — and it recommends an encrypted `mongod`
for brain data. An operator who does both concludes, reasonably, that their data at rest is protected.

A backup bypasses the whole arrangement.

`dumpDatabase` reads **through** `mongod`. That is the only way it can work — it uses the driver, so what comes back
is already decrypted. The NDJSON that lands in `<data-root>/backups/` is therefore **the entire database in the
clear**: every memory, every entity, every edge, every chrono entry, every file-meta record, and the audit log.
`requireEncryptedAtRest` does not touch it. An encrypted `mongod` does not help, because the dump is on the far side
of the decryption. **Nothing in any document said so.**

### The permissions were inverted with respect to sensitivity

| written by | mode | contains |
|---|---|---|
| the four state files | `0600` (always has been) | config, secrets, schema catalogs |
| `<data-root>/backups/` | `0755` / files `0644` | **the whole database, decrypted** |
| the offsite destination | `0755` / files `0644` | the dump **plus every uploaded file verbatim** |

Both backup paths used a plain `fs.mkdirSync(dir, { recursive: true })` and a plain `createWriteStream(file)`, so they
took the process umask — typically world-readable. On a multi-tenant host, or a bind mount shared with another
container, that is readable by anything with a shell on the box. **The least sensitive thing on the volume was the
best protected, and the most sensitive thing was the least.**

Now `0700` on every backup directory and `0600` on every NDJSON file, in both `dump.ts` and `offsite.ts`.

The file mode matters independently of the directory mode, which is why both are set: an operator may point
`backupDir` at a directory that already exists (so the `mkdir` mode never applies), and `cpSync` preserves **source**
file modes, so the file mode is what actually travels offsite.

Every `chmod` is guarded:

```ts
fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
try { fs.chmodSync(destDir, 0o700); } catch { /* non-POSIX host, or pre-existing dir we do not own */ }
```

Windows and plenty of network shares — SMB, some NFS exports — do not honour POSIX modes. A hardening must not turn a
working backup into a failed one, so the mode is a tightening, never a precondition. The gate asserts the guard, not
just the mode.

## Both docs now say what is and is not covered

Permissions are the smaller half. The larger half is that a reader could not have known.

- **`12-admin-api.md`**, under `POST /api/admin/data/backup`: a dump is an unencrypted copy of everything,
  `requireEncryptedAtRest` does not cover it, and **why** — it reads through `mongod`, so the data comes out
  decrypted. Without the *why*, the natural response is to turn the flag on and assume it is handled.
- **`02-hosting.md`**, in the Encryption at Rest section: an explicit **what this does NOT cover** list — uploaded
  files, backups, and brain data in MongoDB. The section's title was always broader than its content, and a reader
  who stops at the heading is exactly the reader this is for.

## What is deliberately NOT decided here

**Whether dumps should be encrypted with the master key.** Parked in `todo/_PARKED-DECISIONS.md` with a
recommendation, because it genuinely goes both ways:

- *for* — the envelope helpers already exist and already protect the state files, so this is consistency rather than
  new machinery, and an operator who sets `YTHRIL_REQUIRE_ENCRYPTED_AT_REST=true` is asking for precisely this;
- *against* — **a backup you cannot restore is not a backup.** Losing the master key would lose the backups too, and
  disaster recovery onto a fresh instance would need the old key present *before* the restore: a new ordering
  constraint on the most stressful operation an operator ever performs.

The middle option in the note — encrypt by default when a master secret is set, with an explicit, audit-logged
`plaintext` opt-out — is what I would build. It is one call in `dumpDatabase`, its mirror in `restoreDatabase`, and a
line of documentation, so nothing here forecloses it.

## Gate

`testing/standalone/backups-are-not-world-readable.test.js`, **mutation-tested 7/7**:

| mutation | caught |
|---|---|
| the dump dir goes back to default permissions | ✅ |
| the NDJSON files go back to default permissions | ✅ |
| an offsite copy goes back to default permissions | ✅ |
| a `chmod` is left unguarded, so a non-POSIX host fails the backup | ✅ |
| the admin doc drops the unencrypted warning | ✅ |
| the admin doc stops saying the flag does not cover it | ✅ |
| the hosting section stops scoping itself | ✅ |

It parses both writers and asserts it found them before asserting anything about them — the vacuous-pass guard every
coverage gate in this repo now carries. The `doc-links-resolve` gate from #638 validated the new cross-reference on
its first firing.

Also verified in this pass and **clean**: `STATE_FILES` is exactly the four files `02-hosting.md` claims are
encrypted, so that half of the documentation was never wrong.

---

`npm run preflight` PASSED — 892 tests, 77 files.
