### PR TITLE
fix(models): "works fully offline" was an assertion, and a cache miss downloaded from huggingface.co

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **"Works fully offline" was an assertion, and a cache miss quietly downloaded from `huggingface.co`.** Found by
+  the Privacy audit lens. `env.allowRemoteModels` defaults to **`true`** in `@huggingface/transformers`, and
+  `brain/embedding.ts` set `env.cacheDir` and nothing else — so loading a model that was not in that cache fetched
+  it from the hub: **this instance's IP address and the model id it asked for, to a third party**, with no
+  configuration, no log line, and no mention in any document. The image bakes exactly one model, so every other id
+  — and any id at all on a from-source install with an empty cache — was that request.
+  - **The same failure had already been found once, for the other language.** `docker-compose.yml` sets
+    `HF_HUB_OFFLINE: "1"` on the `unstructured` sidecar with a long comment explaining that `huggingface_hub` calls
+    the hub even for models baked into the image. Nobody connected it to the Node process — which is the one making
+    the offline claim, and which does not read that variable at all, because it belongs to Python.
+  - **The flag is honoured now**: `HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE` or `YTHRIL_MODELS_OFFLINE` maps onto
+    `env.allowRemoteModels`, and **the published image sets it** — after the build-time warm step, which is the one
+    place a download belongs.
+  - **A miss that is still allowed announces itself before it happens**, naming the host, the model and the size,
+    so the egress appears in the log rather than only in a packet capture.
+  - **A blocked miss explains itself in Ythril's terms.** The library's own message names a
+    `node_modules/@huggingface/transformers/models/…` path that has nothing to do with where Ythril keeps models;
+    the loader rewrites it to name `MODEL_CACHE_DIR`, the flag, and how to bake a model in.
+  - **This cannot break the bundled model, and that was measured rather than argued.** `getModelFile` consults its
+    `FileCache` *before* deciding local-versus-remote. Against a real 523 MB cache: the baked model loaded with
+    remote fetching disabled; a model that was not baked failed with the rewritten error; and with the flag unset
+    the warning appeared before the download. All three verified against the compiled loader.
+  - `README.md` and a new **Runtime Model Downloads** section in `02-hosting.md` now state the mechanism, what a
+    miss reveals, and how to populate a cache for a different model without opening the egress.
+  - Gate `no-runtime-model-egress`, mutation-tested **10/10**, including that the warning stays *before* the load
+    and that the image sets the flag *after* the warm step.
+
+### Changed
+
+- **`env-var-docs-coverage` caught its own exemption going stale.** `HF_HUB_OFFLINE` was listed as "a third-party
+  library's env, set in a sidecar image" — true when written, false once the app read it. The fix was a documented
+  setting, not a wider allowlist.
+- **`models-are-attributed` no longer mistakes a source path for a model.** `brain/embedding.ts` matched its
+  detector (`…embed…`) and was reported as unattributed model weights. Source-file extensions are excluded, and
+  both shapes are pinned in the detector's own self-test — a false positive is what costs a gate its credibility.
+
 - **A database backup was a world-readable plaintext copy of everything.** Found by the Privacy audit lens.
   `02-hosting.md` has a section called **Encryption at Rest**; it is accurately scoped in its own text (four state
   files) and recommends an encrypted `mongod` for brain data. A backup bypasses the whole arrangement: `dumpDatabase`

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,24 @@ RUN --mount=type=cache,target=/tmp/hf-model-cache \
     chown -R node:node /app/model-cache && \
     find /app/model-cache -exec touch -h -d '@1' {} +
 
+# No model may be fetched at RUN TIME. Set after the warm step above, which is the one place a download
+# is legitimate — it happens on a build machine, once, and its result is what ships.
+#
+# `env.allowRemoteModels` defaults to TRUE in @huggingface/transformers, so before this a cache MISS
+# silently downloaded from huggingface.co: the instance's IP and the model id it asked for, to a third
+# party, with no configuration, from an image whose README says "works fully offline". Exactly one model
+# is baked in, so every other id — and every id at all on an install with an empty cache — was that request.
+#
+# `HF_HUB_OFFLINE` is the ecosystem's name for this and is already set on the `unstructured` sidecar in
+# docker-compose.yml, for the same reason. transformers.js does not read it (it is Python's), so
+# `brain/embedding.ts` maps it onto `env.allowRemoteModels` itself.
+#
+# This cannot break the bundled model: transformers.js consults its FileCache BEFORE deciding local vs
+# remote, so the baked `/app/model-cache` satisfies the load. Verified against a real populated cache —
+# the default model loads with remote fetching disabled; a model that is NOT baked fails with a message
+# naming this flag. An operator who deliberately wants a different model sets `HF_HUB_OFFLINE=0`.
+ENV HF_HUB_OFFLINE=1
+
 # Copy compiled output from builder
 COPY --from=builder /build/server/dist ./server/dist
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A single semantic query crosses memories, notes, documents, speech, and pictures
 ## Your data, your rules
 
 - **Self-hosted, `docker compose up`.** No accounts, no per-seat pricing, no data leaving your machine.
-- **Works fully offline.** Bundled local models for embeddings, vision, and speech — plug in OpenAI/Azure/your own endpoints only if you *want* to.
+- **Works fully offline** — and the image *enforces* it. Bundled local models for embeddings, vision and speech; runtime model downloads are switched off (`HF_HUB_OFFLINE=1`), so a cache miss fails loudly instead of quietly fetching from `huggingface.co`. Plug in OpenAI/Azure/your own endpoints only if you *want* to.
 - **Never trains on your knowledge.** It's a database you run, not a service that mines you.
 - **Enterprise-grade security out of the box** — OIDC/SSO, optional MFA, an immutable audit log, per-token scopes, and aggressive SSRF/injection hardening. [Details ↓](#-under-the-hood)
 

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -90,6 +90,7 @@ DEBUG=1 docker compose up
 | `PORT` | `3200` | HTTP listen port |
 | `CLIENT_DIST` | (resolved from the image layout) | Directory the built Angular client is served from. Set by the Dockerfile; override it only when running the server against a client build in a non-standard location — a local dev checkout, or an image you re-layered. |
 | `MODEL_CACHE_DIR` | `/app/model-cache` in the image, else `<DATA_ROOT>/.model-cache` | Where the bundled in-process embedding model's weights are cached. Baked into the image so a cold start does not download them; the `DATA_ROOT` fallback is for running from source. Point it at a persistent volume if you strip the cache out of your image, or **every** boot re-downloads the model. |
+| `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` / `YTHRIL_MODELS_OFFLINE` | `1` in the image, unset when running from source | Forbid fetching a model at runtime. Any of the three, set to anything other than `0`/`false`/`no`/empty, stops the in-process embedding model from reaching `huggingface.co`: a model that is not in `MODEL_CACHE_DIR` fails to load, with an error naming the cache and this flag, instead of being downloaded. The first two are the names the wider ecosystem uses (Python's `huggingface_hub` reads them, and `docker-compose.yml` already sets `HF_HUB_OFFLINE` on the `unstructured` sidecar); transformers.js reads none of them, so Ythril maps them itself. Set `HF_HUB_OFFLINE=0` in the image if you deliberately want to switch to a model it does not carry. |
 | `DEBUG` | (unset) | Set to `1` for verbose logging |
 | `MONGO_CONNECT_RETRY_MS` | `30000` | How long the **first** MongoDB connection may spend retrying before boot gives up. A container orchestrator's healthcheck can report MongoDB healthy while it is still finishing startup, so the first driver connection can have its socket reset mid-handshake — which used to kill the process outright. Only "not up yet" failures are retried (network errors, server selection, topology closed); bad credentials and a malformed URI fail immediately, because waiting cannot help and retrying would turn a clear error into a boot that appears to hang. Backoff is jittered so several instances starting together do not retry in lockstep. |
 | `SHUTDOWN_DRAIN_MS` | `8000` | How long in-flight HTTP requests get to finish after SIGTERM before their connections are forced shut. On SIGTERM the server stops accepting new connections, waits for the running ones, then flushes config and closes MongoDB. The default is sized for **Docker's 10 s stop grace period** — the whole drain plus the flush has to fit inside it or the container is SIGKILLed mid-write anyway. Kubernetes allows 30 s by default, so raise this if your orchestrator gives you longer. |
@@ -172,6 +173,52 @@ services:
       YTHRIL_MASTER_KEY: "${YTHRIL_MASTER_KEY:?set a 32-byte base64 key}"
       YTHRIL_REQUIRE_ENCRYPTED_AT_REST: "true"
 ```
+
+### Runtime Model Downloads
+
+**The published image never fetches a model at runtime, and that is enforced rather than assumed.**
+
+Ythril's in-process embedding model is baked into the image at `/app/model-cache`, and the image sets
+`HF_HUB_OFFLINE=1`. Only one model is baked in — `nomic-ai/nomic-embed-text-v1.5`, the default — so this
+matters the moment you change it.
+
+Without the flag, the underlying library (`@huggingface/transformers`) allows remote model loading by
+default. A cache **miss** is then a download from `huggingface.co`, which carries **your instance's IP
+address and the model id it asked for** to a third party. Nothing configured it and nothing announced it.
+That is the behaviour the flag turns off.
+
+What each situation does now:
+
+| situation | behaviour |
+|---|---|
+| the image, default model | loads from the baked cache — no network, ever |
+| the image, a model id it does not carry | **fails to load**, with an error naming `MODEL_CACHE_DIR` and this flag |
+| the image with `HF_HUB_OFFLINE=0` | downloads on a miss, and **logs a warning first** naming the host, the model, and the size |
+| from source, empty cache | downloads on first use, with the same warning — this is how you populate a cache |
+
+The flag does **not** disable the bundled model: the library consults its on-disk cache *before* deciding
+local-versus-remote, so a populated `MODEL_CACHE_DIR` satisfies the load with downloads switched off.
+
+To use a different local model on an offline instance, populate the cache rather than opening the egress:
+
+```bash
+# On a machine WITH internet. Same image, same cache layout the offline instance expects,
+# so nothing has to be assembled by hand.
+WARM='import("./server/dist/brain/embedding.js").then(m => m.warmEmbeddingModel())'
+
+docker run --rm -v "$PWD/cache:/cache" -e MODEL_CACHE_DIR=/cache -e HF_HUB_OFFLINE=0 -e EMBEDDING_MODEL=<model-id> ghcr.io/ythril-network/ythril node -e "$WARM"
+
+# Then mount ./cache at MODEL_CACHE_DIR on the offline instance, set EMBEDDING_MODEL to the
+# same id, and leave HF_HUB_OFFLINE=1. The load is a cache hit and never touches the network.
+```
+
+Changing the embedding model **invalidates every existing vector**, so plan the
+[reindex](04-brain-api.md#reindex-space) that has to follow it.
+
+Other model-loading components are separate processes with their own controls: the vision model is pulled
+by **Ollama** when you start it, and the speech model by the **faster-whisper** sidecar. Both are containers
+you run, and both pull at *their* start-up rather than mid-request. The `unstructured` sidecar's layout
+models are baked into its image and it runs with `HF_HUB_OFFLINE=1` on an internal network with no route out.
 
 ### Security Posture Check
 

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { getDataRoot, getEmbeddingConfig } from '../config/loader.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
@@ -77,6 +78,41 @@ type LocalPipeline = (text: string, opts: Record<string, unknown>) => Promise<an
 let _pipelineInit: Promise<LocalPipeline> | null = null;
 let _pipelineModelId: string | null = null;
 
+/**
+ * Is this instance forbidden from fetching a model at runtime?
+ *
+ * Reads the ECOSYSTEM names first on purpose. An operator air-gapping a stack sets `HF_HUB_OFFLINE=1`,
+ * and `docker-compose.yml` already sets exactly that on the `unstructured` sidecar — so an operator has
+ * every reason to believe the convention is honoured stack-wide. It was not: transformers.js does not
+ * read those variables at all (they belong to Python's `huggingface_hub`), so the Node process ignored
+ * them completely. `YTHRIL_MODELS_OFFLINE` is the explicit spelling for anyone who would rather not
+ * borrow another project's variable.
+ */
+function modelsOffline(): boolean {
+  const truthy = (v: string | undefined): boolean =>
+    v !== undefined && v !== '' && v !== '0' && v.toLowerCase() !== 'false' && v.toLowerCase() !== 'no';
+  return truthy(process.env['HF_HUB_OFFLINE'])
+    || truthy(process.env['TRANSFORMERS_OFFLINE'])
+    || truthy(process.env['YTHRIL_MODELS_OFFLINE']);
+}
+
+/**
+ * Is `modelId` already in the on-disk cache, so that loading it needs no network?
+ *
+ * transformers.js keys its `FileCache` as `<cacheDir>/<model-id>/<file>` — verified against the cache the
+ * Dockerfile bakes, which contains `nomic-ai/nomic-embed-text-v1.5/{config.json,tokenizer.json,onnx/…}`.
+ * `config.json` is the first file every load asks for, so its presence is the cheap, accurate test for
+ * "this load will stay local". Deliberately synchronous and best-effort: this only decides whether to
+ * WARN, never whether to load.
+ */
+function isCached(cacheDir: string, modelId: string): boolean {
+  try {
+    return fs.existsSync(path.join(cacheDir, ...modelId.split('/'), 'config.json'));
+  } catch {
+    return false;
+  }
+}
+
 function getLocalPipeline(modelId: string): Promise<LocalPipeline> {
   // Re-init only if the configured model changes (rare: config reload)
   if (_pipelineInit && _pipelineModelId === modelId) return _pipelineInit;
@@ -88,9 +124,54 @@ function getLocalPipeline(modelId: string): Promise<LocalPipeline> {
     const cacheDir = process.env['MODEL_CACHE_DIR'] ??
                      path.join(getDataRoot(), '.model-cache');
     env.cacheDir = cacheDir;
-    log.info(`Loading embedding model ${modelId} (cache: ${cacheDir})`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const pipe = await pipeline('feature-extraction', modelId) as any;
+
+    // A cache MISS reaches out to huggingface.co, and nothing used to say so.
+    //
+    // `env.allowRemoteModels` defaults to `true` in @huggingface/transformers, so `pipeline(…)` on a model
+    // that is not in `cacheDir` silently downloads it: the instance's IP and the model id it asked for,
+    // to a third party, with no configuration, from a product whose README says "works fully offline".
+    // The shipped image bakes exactly ONE model, `nomic-ai/nomic-embed-text-v1.5`, so every other id —
+    // and any id at all on a from-source install with an empty cache — was that request.
+    //
+    // Two changes, and neither of them can break the default:
+    //   1. the offline flag is honoured (see `modelsOffline`), and the published image sets it;
+    //   2. when remote IS allowed and the model is absent, the egress is ANNOUNCED before it happens.
+    //
+    // Measured rather than assumed, because the ordering inside `getModelFile` decides whether this is
+    // safe: the `FileCache` is consulted BEFORE any local-or-remote decision, so a populated `cacheDir`
+    // satisfies a load with remote fetching disabled. Loading the baked model against a real populated
+    // cache with `allowRemoteModels = false` succeeded; a different id under the same conditions failed.
+    const offline = modelsOffline();
+    const cached = isCached(cacheDir, modelId);
+    if (offline) env.allowRemoteModels = false;
+    else if (!cached) {
+      log.warn(
+        `Embedding model '${modelId}' is not in the local cache (${cacheDir}), so loading it will DOWNLOAD it `
+        + 'from huggingface.co — roughly 274 MB, and that request carries this instance\'s IP address and the '
+        + 'model id. Set HF_HUB_OFFLINE=1 (or YTHRIL_MODELS_OFFLINE=1) to forbid it, and bake the model into '
+        + 'your image instead. The published Ythril image already ships with the flag set.',
+      );
+    }
+
+    log.info(`Loading embedding model ${modelId} (cache: ${cacheDir}${offline ? ', offline' : ''})`);
+    let pipe: unknown;
+    try {
+      pipe = await pipeline('feature-extraction', modelId);
+    } catch (err) {
+      // The library's own message on a blocked miss names `node_modules/@huggingface/transformers/models/`,
+      // a path that has nothing to do with where Ythril keeps its models — so an operator would go looking
+      // in the wrong place for a file that was never meant to be there. Say what actually happened.
+      if (offline && !cached) {
+        throw new Error(
+          `Embedding model '${modelId}' is not in the model cache (${cacheDir}) and runtime downloads are `
+          + 'disabled by HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE / YTHRIL_MODELS_OFFLINE. Either bake the model '
+          + 'into the image (see docs/integration-guide/02-hosting.md), point MODEL_CACHE_DIR at a cache that '
+          + 'has it, or unset the flag to allow a one-time download from huggingface.co. '
+          + `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      throw err;
+    }
     log.info(`Embedding model ready: ${modelId}`);
     return pipe as LocalPipeline;
   })();

--- a/testing/standalone/env-var-docs-coverage.test.js
+++ b/testing/standalone/env-var-docs-coverage.test.js
@@ -93,7 +93,11 @@ const NOT_A_SETTING = new Map([
   ['DOCKERHUB_USERNAME', 'a GitHub Actions secret, not read by the app'],
   ['DOCKERHUB_TOKEN', 'a GitHub Actions secret, not read by the app'],
   ['NUMBA_CACHE_DIR', "a third-party library's env, set in a sidecar image"],
-  ['HF_HUB_OFFLINE', "a third-party library's env, set in a sidecar image"],
+  // `HF_HUB_OFFLINE` used to sit here, exempted as "a third-party library's env, set in a sidecar image".
+  // That was true and became false: the Node process reads it now, because transformers.js does NOT (it is
+  // Python's variable) and an operator who sets it stack-wide has every right to expect the embedding model
+  // to obey. This gate is what noticed — the exemption's stated reason stopped matching the code, and the
+  // fix is a documented setting rather than a wider allowlist.
   ['XDG_CACHE_HOME', "a third-party library's env, set in a sidecar image"],
   // Removed settings the docs still name so an upgrader can find out they are gone.
   ['MEDIA_EMBEDDING_ENABLED', 'removed in 2.0.0; documented as a breaking change'],

--- a/testing/standalone/models-are-attributed.test.js
+++ b/testing/standalone/models-are-attributed.test.js
@@ -58,7 +58,14 @@ function dockerfiles() {
 function bakedModels(src) {
   const found = new Set();
   const RE = /\b([a-zA-Z0-9][\w.-]*)\/([\w.-]*(?:embed|whisper|moondream|clip|bge|gte|minilm|nli|rerank|llama|qwen|mistral|phi)[\w.-]*)\b/gi;
-  for (const m of src.matchAll(RE)) found.add(`${m[1]}/${m[2]}`);
+  // A source path is not a model id. `brain/embedding.ts` matched — a Dockerfile comment naming the file that
+  // loads the model was reported as an unattributed model, which is the false positive that costs a gate its
+  // credibility. No HuggingFace or Ollama id ends in a source-file extension, so this cannot hide a real one.
+  const SOURCE_FILE = /\.(ts|tsx|js|mjs|cjs|json|py|md|yml|yaml|sh|css|scss|html)$/i;
+  for (const m of src.matchAll(RE)) {
+    if (SOURCE_FILE.test(m[2])) continue;
+    found.add(`${m[1]}/${m[2]}`);
+  }
   return [...found];
 }
 
@@ -74,6 +81,10 @@ describe('the model-id detector, before it is trusted to judge anything', () => 
       'FROM node:22-slim@sha256:6c74791e',
       'COPY --from=builder /build/server/dist ./server/dist',
       'RUN npm ci --workspace=server --omit=dev',
+      // A comment naming the file that loads the model. This one got through and reported `brain/embedding.ts`
+      // as an unattributed model, so it is pinned as a case rather than left to the next reader to rediscover.
+      '# `brain/embedding.ts` maps HF_HUB_OFFLINE onto env.allowRemoteModels itself.',
+      'import { embed } from "../brain/embedding.js";',
     ]) assert.deepEqual(bakedModels(line), [], line);
   });
 });

--- a/testing/standalone/no-runtime-model-egress.test.js
+++ b/testing/standalone/no-runtime-model-egress.test.js
@@ -1,0 +1,158 @@
+/**
+ * "Works fully offline" must be enforced, not asserted.
+ *
+ * ## The finding — Privacy audit lens
+ *
+ * `README.md` says **works fully offline** and `userguide.md` says "it needs no internet connection, which is the
+ * point: the installs that most need [it]". The in-process embedding model made that untrue in a way nobody could
+ * see.
+ *
+ * `env.allowRemoteModels` defaults to **`true`** in `@huggingface/transformers` (confirmed in the installed
+ * `types/env.d.ts` at 3.8.1). `brain/embedding.ts` set `env.cacheDir` and nothing else, so `pipeline(…)` on a model
+ * that was not in that cache **silently downloaded it from `huggingface.co`** — the instance's IP address and the
+ * model id it asked for, to a third party, with no configuration and no log line. The image bakes exactly one model,
+ * so every other id — and any id at all on a from-source install with an empty cache — was that request.
+ *
+ * The repo had already found this exact failure once. `docker-compose.yml` sets `HF_HUB_OFFLINE: "1"` on the
+ * `unstructured` sidecar with a long comment explaining that `huggingface_hub` calls the hub even for models baked
+ * into the image. Nobody connected it to the Node process, which is the one making the offline claim — and
+ * transformers.js does not read that variable, so setting it stack-wide did nothing here.
+ *
+ * ## Why disabling remote loading is safe, and how that was established
+ *
+ * Not by reading — by loading. `getModelFile` consults its `FileCache` **before** it decides local-versus-remote, so
+ * a populated `cacheDir` satisfies a load with remote fetching off. Against a real 523 MB cache:
+ *
+ *   - the baked model, `env.allowRemoteModels = false`  → **loaded**, no network;
+ *   - a different model id, same conditions             → failed, naming a `node_modules/…/models/` path that has
+ *                                                         nothing to do with Ythril's cache.
+ *
+ * The second result is why the loader rewrites that error: an operator would otherwise go looking in the wrong
+ * place for a file that was never meant to be there.
+ *
+ * ## What this gate holds
+ *
+ * That the three levers stay in place — the flag is honoured, the miss is announced before it happens, and the image
+ * sets the flag *after* the build-time warm step that legitimately downloads. It cannot prove no packet leaves the
+ * host; it pins the decisions that made one leave.
+ *
+ * Run: node --test testing/standalone/no-runtime-model-egress.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+const EMBEDDING = read('server/src/brain/embedding.ts');
+const DOCKERFILE = read('Dockerfile');
+
+/** The body of `getLocalPipeline`, from its signature to the closing of its IIFE. */
+function loaderBody() {
+  const at = EMBEDDING.indexOf('function getLocalPipeline(');
+  assert.ok(at > 0, 'getLocalPipeline is gone — this gate is pinned to it');
+  const end = EMBEDDING.indexOf('\n}', at);
+  assert.ok(end > at, 'could not find the end of getLocalPipeline');
+  return EMBEDDING.slice(at, end);
+}
+
+describe('the offline flag is honoured by the process that claims to be offline', () => {
+  it('found the loader (the parse still works)', () => {
+    // Without this the slices below could silently be empty and every assertion would pass by examining nothing.
+    const body = loaderBody();
+    assert.ok(body.includes('pipeline('), 'the loader no longer calls pipeline() — re-anchor this gate');
+    assert.ok(body.length > 200, `the loader body sliced to ${body.length} chars, which cannot be right`);
+  });
+
+  it('maps the ecosystem offline variables onto allowRemoteModels', () => {
+    // transformers.js reads NONE of these — they are Python's. That is exactly why the mapping has to exist here:
+    // an operator air-gapping a stack sets HF_HUB_OFFLINE and reasonably expects the whole stack to obey.
+    for (const v of ['HF_HUB_OFFLINE', 'TRANSFORMERS_OFFLINE', 'YTHRIL_MODELS_OFFLINE']) {
+      assert.match(EMBEDDING, new RegExp(`['"\`]${v}['"\`]`),
+        `${v} is not read — a stack-wide offline flag would silently not apply to the embedding model`);
+    }
+    assert.match(EMBEDDING, /env\.allowRemoteModels\s*=\s*false/,
+      'nothing sets env.allowRemoteModels = false, so the library default (true) still allows a runtime download');
+  });
+
+  it('announces the egress BEFORE it happens, naming the host', () => {
+    // The order is the whole point. A warning after the fact is a log line about 274 MB that already left.
+    const body = loaderBody();
+    const warnAt = body.search(/log\.warn\(/);
+    const loadAt = body.search(/await pipeline\(/);
+    assert.ok(warnAt > 0, 'a cache miss with remote loading allowed must warn — otherwise the egress is silent');
+    assert.ok(loadAt > 0, 'could not find the pipeline() load');
+    assert.ok(warnAt < loadAt,
+      'the warning must come BEFORE the load, or it reports a download that has already happened');
+    assert.match(body.slice(warnAt, loadAt), /huggingface\.co/,
+      'the warning must name the host the data goes to — "downloading the model" does not tell an operator '
+      + 'that their IP reaches a third party');
+  });
+
+  it('a blocked miss explains itself in terms of Ythril, not node_modules', () => {
+    // Measured: the library's own message points at `node_modules/@huggingface/transformers/models/…`, so an
+    // operator goes looking in the wrong place for a file that was never meant to be there.
+    //
+    // Sliced to the CATCH BLOCK, not the whole loader. Asserting `cacheDir` and `HF_HUB_OFFLINE` anywhere in
+    // the function passed with the entire rewrite deleted — both strings also occur in the warning above it.
+    // Caught by mutating the block away, not by reading this file.
+    const body = loaderBody();
+    const at = body.indexOf('catch (err) {');
+    assert.ok(at > 0, 'the load is unguarded, so the library\'s misleading message reaches the operator verbatim');
+    const end = body.indexOf('throw err;', at);
+    assert.ok(end > at, 'the catch block does not rethrow — a load failure would be swallowed');
+    const handler = body.slice(at, end);
+
+    assert.match(handler, /throw new Error\(/,
+      'the handler must rethrow a rewritten error; the library\'s own message names a node_modules path that '
+      + 'has nothing to do with where Ythril keeps its models');
+    assert.match(handler, /MODEL_CACHE_DIR|cacheDir/, 'the rewritten error must name the cache the operator controls');
+    assert.match(handler, /HF_HUB_OFFLINE/, 'the rewritten error must name the flag that blocked the load');
+  });
+});
+
+describe('the published image enforces it', () => {
+  it('sets the offline flag', () => {
+    assert.match(DOCKERFILE, /^ENV HF_HUB_OFFLINE=1$/m,
+      'the image must set HF_HUB_OFFLINE — the README promises an offline product and the image is the product');
+  });
+
+  it('sets it AFTER the build-time warm step, which must still be able to download', () => {
+    // Ordering is load-bearing in both directions: before the warm RUN, the image cannot bake a model at all;
+    // after it, the running container cannot fetch one. A gate that only checked presence would let a
+    // well-meaning reorder break the build in a way no unit test sees.
+    const warm = DOCKERFILE.indexOf('nomic-ai/nomic-embed-text-v1.5');
+    const flag = DOCKERFILE.search(/^ENV HF_HUB_OFFLINE=1$/m);
+    assert.ok(warm > 0, 'the model warm step is gone — re-anchor this gate');
+    assert.ok(flag > warm,
+      'HF_HUB_OFFLINE is set BEFORE the model download that bakes the cache, so the build cannot fetch it');
+  });
+});
+
+describe('the claim and its enforcement are documented together', () => {
+  it('the README says how offline operation is enforced', () => {
+    // The bare claim was accurate about intent and wrong about mechanism. A reader deciding whether to put this
+     // on an air-gapped network needs the mechanism.
+    const readme = read('README.md');
+    const at = readme.indexOf('Works fully offline');
+    assert.ok(at > 0, 'the offline claim is gone from the README');
+    assert.match(readme.slice(at, at + 400), /HF_HUB_OFFLINE/,
+      'the claim must say what enforces it, or it is back to being an assertion');
+  });
+
+  it('the hosting guide documents the flag and what a miss does', () => {
+    const doc = read('docs/integration-guide/02-hosting.md');
+    const at = doc.indexOf('### Runtime Model Downloads');
+    assert.ok(at > 0, 'the Runtime Model Downloads section is gone');
+    const section = doc.slice(at, doc.indexOf('\n### ', at + 10));
+    assert.match(section, /huggingface\.co/, 'the section must name the host a miss would reach');
+    // `\s+` rather than a literal space: the sentence wraps, and a gate that fails on a line break is a gate
+    // that gets appeased by reflowing a paragraph rather than by keeping the fact.
+    assert.match(section, /IP\s+address/i, 'it must say what the request reveals, not just that one happens');
+    assert.match(section, /HF_HUB_OFFLINE/, 'it must name the flag');
+    assert.match(section, /before deciding\s+local-versus-remote|cache \*before\*/,
+      'it must explain why the flag does not break the bundled model, or an operator will not dare set it');
+  });
+});


### PR DESCRIPTION
## "Works fully offline" was an assertion, and a cache miss downloaded from `huggingface.co`

Second finding from audit lens **12 — Privacy**.

`README.md` says **works fully offline**. `userguide.md` says *"it needs no internet connection, which is the point:
the installs that most need [it]"*. The in-process embedding model made that untrue in a way nobody could see.

`env.allowRemoteModels` defaults to **`true`** in `@huggingface/transformers` (3.8.1, confirmed in the installed
`types/env.d.ts`). `brain/embedding.ts` set `env.cacheDir` and nothing else:

```ts
env.cacheDir = cacheDir;
log.info(`Loading embedding model ${modelId} (cache: ${cacheDir})`);
const pipe = await pipeline('feature-extraction', modelId);   // ← a miss here goes to the hub
```

So loading a model that was not in that cache **fetched it from `huggingface.co`** — this instance's **IP address**
and the **model id it asked for**, to a third party, with no configuration, no log line, and no mention in any
document. The image bakes exactly **one** model, so every other id — and *any* id at all on a from-source install
with an empty cache — was that request. The model id is settable from Settings → Models, `config.json`, or
`EMBEDDING_MODEL`; nothing about changing it hinted that it reached the internet.

### The same failure had already been found once, for the other language

`docker-compose.yml`, on the `unstructured` sidecar:

```yaml
# NOT a hardening flag — this fixes hi_res extraction outright. The layout and table models … ARE
# baked into the image, but huggingface_hub still calls the hub to resolve them …
HF_HUB_OFFLINE: "1"
```

Diagnosed in detail, fixed, and commented. Nobody connected it to the **Node** process — which is the one making the
offline claim, and which **does not read that variable at all**, because it belongs to Python's `huggingface_hub`. An
operator air-gapping this stack sets `HF_HUB_OFFLINE` and has every reason to think the whole stack obeys.

## What changes

1. **The flag is honoured.** `HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE` or `YTHRIL_MODELS_OFFLINE` maps onto
   `env.allowRemoteModels`. Ecosystem names first, deliberately — the operator has probably already set one.
2. **The published image sets it**, *after* the build-time warm step, which is the one place a download belongs.
3. **A miss that is still allowed announces itself before it happens** — host, model and size, so the egress appears
   in the log rather than only in a packet capture.
4. **A blocked miss explains itself in Ythril's terms.** The library's own message names
   `node_modules/@huggingface/transformers/models/…`, a path that has nothing to do with where Ythril keeps models,
   so an operator would go looking in the wrong place for a file that was never meant to be there.

## This cannot break the bundled model, and that was measured rather than argued

`getModelFile` consults its `FileCache` **before** it decides local-versus-remote, so a populated `cacheDir` satisfies
a load with remote fetching off. Driving the **compiled** loader against a real 523 MB cache:

| condition | result |
|---|---|
| baked model, `HF_HUB_OFFLINE=1` | `Loading embedding model … (cache: …, offline)` → **ready in 0.6 s**, no network |
| a model not baked, `HF_HUB_OFFLINE=1` | fails with the rewritten error, naming the cache, the three flags, and the docs |
| flag unset, model not baked | **warning first**, naming `huggingface.co` and the IP exposure — then the download |

The third row is the old behaviour minus the silence.

## Documentation

- **`README.md`** — the claim now says what enforces it, rather than asking to be believed.
- **`02-hosting.md`** — a new **Runtime Model Downloads** section: what a miss reveals, the flag, a table of what each
  situation does, why the flag does not break the bundled model (an operator who does not know that will not dare set
  it), and how to populate a cache for a different model on a machine that *does* have internet, so an air-gapped
  instance can change models without ever opening the egress.
- The env-var table documents all three names and what a miss does.

## Two gates were corrected, both by their own failures

Neither was noticed by reading — `npm run preflight` failed and was right both times.

- **`env-var-docs-coverage`** caught its own exemption going stale. `HF_HUB_OFFLINE` was listed as *"a third-party
  library's env, set in a sidecar image"* — accurate when written, false the moment the app read it. The fix is a
  **documented setting**, not a wider allowlist. This is the gate doing exactly the job it was built for.
- **`models-are-attributed`** mistook a source path for model weights: `brain/embedding.ts` matched its detector
  (`…embed…`) and was reported as an unattributed model baked into the image. Source-file extensions are now excluded
  — no HuggingFace or Ollama id ends in `.ts` — and both shapes are pinned in the detector's own self-test. A false
  positive is what costs a gate its credibility.

## Gate

`testing/standalone/no-runtime-model-egress.test.js`, **mutation-tested 10/10**:

| mutation | caught |
|---|---|
| the offline flag is no longer read | ✅ |
| `allowRemoteModels` is never set to `false` | ✅ |
| the warning moves *after* the load | ✅ |
| the warning stops naming `huggingface.co` | ✅ |
| the blocked-miss error is not rewritten | ✅ |
| the image stops setting the flag | ✅ |
| the image sets the flag *before* the warm step, breaking the build | ✅ |
| the README claim goes back to a bare assertion | ✅ |
| the hosting section drops what the request reveals | ✅ |
| the hosting section stops explaining why the flag is safe | ✅ |

Both orderings are load-bearing in **opposite** directions — before the warm step the image cannot bake a model at
all, after it the container cannot fetch one — so presence alone would have let a well-meaning reorder break the
build in a way no unit test sees.

The blocked-miss mutation initially **passed**: the assertion looked for `cacheDir` and `HF_HUB_OFFLINE` anywhere in
the loader, and both also occur in the warning above it. Re-anchored to the catch block. Same lesson as last batch —
slice to a syntactic boundary.

## Checked in the same pass and clean

- **Every other outbound call in the server is to an operator-configured destination** — sidecars, the local agent,
  external provider endpoints, sync peers. There is no telemetry, no update check, and no phone-home.
- **The embedding model is the only in-process `pipeline()` call.** Vision goes to Ollama and speech to
  faster-whisper — separate containers the operator runs, which pull at *their* start-up, not mid-request.
- The audit log is already scoped for privacy: a per-entry TTL (90 days by default), a separate shorter retention for
  captured field changes, and indexes on `oidcSubject` / `tokenId` / `ip` so a subject's activity is actually
  queryable.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
