### PR TITLE
fix(files): uploaded files were world-readable, and the previous fix's docs said otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Uploaded files were world-readable, and one sentence of the previous fix said otherwise.** Third finding from
+  the Privacy audit lens, and it corrects the documentation shipped with the backup hardening: that text claimed
+  Ythril writes uploads `0600`/`0700`. Backups did; uploads did not.
+  - `<data-root>/files/` holds **every document a user uploaded, verbatim** — the most sensitive bytes on the
+    volume. Every writer took the process umask: `0755` directories, `0644` files. So did the chunk staging area a
+    resumable upload passes through, which holds the same bytes half-arrived.
+  - Now `0600` files inside `0700` directories, from **one definition** in `server/src/util/fs-modes.ts`. The local
+    and offsite backup paths were switched onto the same helper, so "as tight as the state files" is stated once
+    rather than repeated at nine call sites.
+  - **A rename carries the source mode**, so `moveFile` re-tightens its destination — otherwise moving an old file
+    would quietly reintroduce an `0644` file into a hardened tree.
+  - **Upgrades heal instead of migrating.** `mode:` only applies at creation, so every writer also chmods; a
+    re-upload, edit or move tightens a file that predates this. There is no boot-time walk of the files tree,
+    because on a large instance that is exactly the migration that ends up skipped — and the docs give the one-line
+    `find` for tightening everything at once.
+  - **Verified against the artefact, not the instruction.** An integration test uploads a file and reads
+    `stat -c %a` inside the container: `600` for the file, `700` for the directory. No source check can prove a
+    mode landed, and the development machine is Windows, where these numbers do not exist at all.
+  - Gate `backups-are-not-world-readable` extended to every writer of user data and mutation-tested **13/13**,
+    including both mode constants, the self-healing chmod, and each `chmod` staying best-effort.
+
 - **"Works fully offline" was an assertion, and a cache miss quietly downloaded from `huggingface.co`.** Found by
   the Privacy audit lens. `env.allowRemoteModels` defaults to **`true`** in `@huggingface/transformers`, and
   `brain/embedding.ts` set `env.cacheDir` and nothing else — so loading a model that was not in that cache fetched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Verified against the artefact, not the instruction.** An integration test uploads a file and reads
     `stat -c %a` inside the container: `600` for the file, `700` for the directory. No source check can prove a
     mode landed, and the development machine is Windows, where these numbers do not exist at all.
+  - **`0600` on a directory is not a tightening, it is a brick — and the first attempt at this shipped that bug to
+    CI, which caught it.** `moveFile` moves directories as well as files, so a moved directory lost its execute
+    bit. Nothing failed at the move; the next offsite backup walked the tree with `fs.cpSync`, whose C++
+    `std::filesystem` iterator threw `Permission denied` — and that exception reaches `terminate()` rather than
+    JavaScript, so it **killed the server** (container exit 139, 94 tests failed and 169 were cancelled). Fixed
+    with `hardenPath`, which chooses the mode from what the path actually is.
+  - **A backup can no longer take the instance down with it.** The hazard outlives our bug: any directory under
+    the files root that this process cannot open does the same thing, and no `try`/`catch` around `cpSync` can
+    stop it. Both offsite copies now walk the tree in JavaScript first and fail with a message naming the
+    offending directories instead.
   - Gate `backups-are-not-world-readable` extended to every writer of user data and mutation-tested **13/13**,
     including both mode constants, the self-healing chmod, and each `chmod` staying best-effort.
 

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -162,8 +162,20 @@ transparently:
     [POST /api/admin/data/backup](12-admin-api.md#post-apiadmindatabackup);
   - **brain data in MongoDB itself** — that is the encrypted-`mongod` job described below.
 
-  Ythril writes everything in the first two categories `0600`/`0700` so it is not readable by other users on the
-  host, and `requireEncryptedAtRest` deliberately does not claim otherwise.
+  Ythril writes everything in the first two categories `0600`/`0700` — files owner-read/write, directories
+  owner-only — so it is not readable by other users on the host or by another container sharing the mount, and
+  `requireEncryptedAtRest` deliberately does not claim otherwise. That covers uploads, the chunk staging area a
+  resumable upload passes through, local backups, and offsite copies, from one definition in `util/fs-modes.ts`.
+
+  **On upgrade this heals rather than migrating.** A `mode:` argument only applies when a file is created, so files
+  that predate this keep their old permissions until something rewrites them — re-uploading, editing or moving a file
+  tightens it. There is no boot-time walk of the files tree, because on a large instance that is exactly the
+  expensive migration that ends up skipped. To tighten everything at once:
+
+  ```bash
+  # inside the container, or against the mounted volume on the host
+  find /data/files /data/backups -type d -exec chmod 700 {} + -o -type f -exec chmod 600 {} +
+  ```
 
 ```yaml
 # docker compose — master key from a secret/env, kept out of the image

--- a/server/src/db/dump.ts
+++ b/server/src/db/dump.ts
@@ -18,6 +18,7 @@
  * directory.
  */
 import fs from 'node:fs';
+import { FILE_MODE, mkdirPrivateSync } from '../util/fs-modes.js';
 import path from 'node:path';
 import { MongoClient } from 'mongodb';
 import { EJSON } from 'bson';
@@ -56,8 +57,7 @@ export async function dumpDatabase(uri: string, destDir: string): Promise<DumpMa
   // protected. Found by the Privacy audit lens.
   //
   // This is a tightening only: the owning process is the sole reader, and `restoreDatabase` runs as the same user.
-  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
-  try { fs.chmodSync(destDir, 0o700); } catch { /* non-POSIX host, or pre-existing dir we do not own */ }
+  mkdirPrivateSync(destDir);
 
   const client = new MongoClient(uri, {
     serverSelectionTimeoutMS: 15_000,
@@ -79,7 +79,7 @@ export async function dumpDatabase(uri: string, destDir: string): Promise<DumpMa
     for (const name of collectionNames) {
       const col = db.collection(name);
       const destFile = path.join(destDir, `${name}.ndjson`);
-      const stream = fs.createWriteStream(destFile, { encoding: 'utf8', mode: 0o600 });
+      const stream = fs.createWriteStream(destFile, { encoding: 'utf8', mode: FILE_MODE });
 
       let count = 0;
       const cursor = col.find({}).batchSize(CURSOR_BATCH_SIZE);

--- a/server/src/db/offsite.ts
+++ b/server/src/db/offsite.ts
@@ -17,6 +17,57 @@ import path from 'node:path';
 import { log } from '../util/log.js';
 
 /**
+ * Every directory under `root` that cannot be opened, as relative paths.
+ *
+ * ## Why this walk exists
+ *
+ * `fs.cpSync(…, { recursive: true })` iterates the tree in C++. When it meets a directory it cannot open, the
+ * `std::filesystem` iterator throws — and that exception does not become a JavaScript error. It reaches
+ * `terminate()`, which **kills the process**:
+ *
+ *     terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
+ *       what():  filesystem error: directory iterator cannot open directory: Permission denied
+ *
+ * Observed, not theorised: one unreadable directory under the files root took the whole server down mid-backup
+ * (container exit 139), and no `try`/`catch` around `cpSync` can prevent it. The cause that time was ours and is
+ * fixed, but the hazard is not: a directory an operator dropped into the mount as another user does the same
+ * thing, and a backup must never be able to take the instance with it.
+ *
+ * So the tree is walked in JavaScript first, where `EACCES` is an ordinary error. It costs one `readdir` per
+ * directory against a copy that reads every byte of every file, and it turns an unrecoverable crash into a failed
+ * request with a message naming the directory to fix.
+ */
+function unreadableDirs(root: string): string[] {
+  const bad: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      bad.push(path.relative(root, dir) || '.');
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) walk(path.join(dir, e.name));
+    }
+  };
+  walk(root);
+  return bad;
+}
+
+/** Throw a catchable, actionable error rather than letting `cpSync` end the process. */
+function assertCopyable(root: string, what: string): void {
+  const bad = unreadableDirs(root);
+  if (bad.length === 0) return;
+  throw new Error(
+    `Cannot copy ${what}: ${bad.length} director${bad.length === 1 ? 'y is' : 'ies are'} not readable by this `
+    + `process — ${bad.slice(0, 5).join(', ')}${bad.length > 5 ? `, and ${bad.length - 5} more` : ''}. `
+    + 'Fix their permissions (or ownership) and retry; copying was not attempted, because the recursive copy would '
+    + 'have terminated the server rather than reporting this.',
+  );
+}
+
+/**
  * Copy a completed DB backup directory to the offsite destination.
  * Creates <destRoot>/<backupId>/ as a recursive copy of <srcDir>.
  * Returns the destination path.
@@ -29,6 +80,7 @@ export function copyBackupOffsite(srcDir: string, destRoot: string, backupId: st
   // This narrows the exposure; it does not remove it. The destination is usually a mounted share, and its own
   // permissions and encryption are the operator's to arrange — which is why `12-admin-api.md` now says so instead
   // of leaving a reader to assume that "encryption at rest" covered this.
+  assertCopyable(srcDir, 'the database dump');
   mkdirPrivateSync(destDir);
   fs.cpSync(srcDir, destDir, { recursive: true });
   return destDir;
@@ -49,6 +101,7 @@ export function copyFilesOffsite(
   if (!fs.existsSync(filesDir)) return null;
   const destDir = path.join(destRoot, `${backupId}-files`);
   // Same reasoning as above, and it applies more here: these are the users' UPLOADED FILES, verbatim.
+  assertCopyable(filesDir, 'the uploaded files');
   mkdirPrivateSync(destDir);
   fs.cpSync(filesDir, destDir, { recursive: true });
   return destDir;

--- a/server/src/db/offsite.ts
+++ b/server/src/db/offsite.ts
@@ -12,6 +12,7 @@
  *   <destRoot>/<backupId>-files/      — copy of <dataRoot>/files/ (user-uploaded files)
  */
 import fs from 'node:fs';
+import { mkdirPrivateSync } from '../util/fs-modes.js';
 import path from 'node:path';
 import { log } from '../util/log.js';
 
@@ -28,8 +29,7 @@ export function copyBackupOffsite(srcDir: string, destRoot: string, backupId: st
   // This narrows the exposure; it does not remove it. The destination is usually a mounted share, and its own
   // permissions and encryption are the operator's to arrange — which is why `12-admin-api.md` now says so instead
   // of leaving a reader to assume that "encryption at rest" covered this.
-  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
-  try { fs.chmodSync(destDir, 0o700); } catch { /* the share may not honour POSIX modes at all */ }
+  mkdirPrivateSync(destDir);
   fs.cpSync(srcDir, destDir, { recursive: true });
   return destDir;
 }
@@ -49,8 +49,7 @@ export function copyFilesOffsite(
   if (!fs.existsSync(filesDir)) return null;
   const destDir = path.join(destRoot, `${backupId}-files`);
   // Same reasoning as above, and it applies more here: these are the users' UPLOADED FILES, verbatim.
-  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
-  try { fs.chmodSync(destDir, 0o700); } catch { /* the share may not honour POSIX modes at all */ }
+  mkdirPrivateSync(destDir);
   fs.cpSync(filesDir, destDir, { recursive: true });
   return destDir;
 }

--- a/server/src/files/chunks.ts
+++ b/server/src/files/chunks.ts
@@ -11,6 +11,7 @@ import { createWriteStream } from 'fs';
 import path from 'path';
 import { createHash } from 'crypto';
 import { getDataRoot } from '../config/loader.js';
+import { FILE_MODE, harden, mkdirPrivate } from '../util/fs-modes.js';
 import { log } from '../util/log.js';
 
 /** Deterministic upload ID from (spaceId, path, total). */
@@ -59,11 +60,14 @@ export async function storeChunk(
 ): Promise<{ received: number; complete: boolean }> {
   const id = uploadId(spaceId, filePath, total);
   const dir = uploadDir(spaceId, id);
-  await fs.mkdir(dir, { recursive: true });
+  // Staging holds the same bytes as the finished file, so it gets the same protection. A half-uploaded document
+  // is not less confidential than a complete one.
+  await mkdirPrivate(dir);
 
   // Write chunk as <start>.bin
   const chunkFile = path.join(dir, `${start}.bin`);
-  await fs.writeFile(chunkFile, data);
+  await fs.writeFile(chunkFile, data, { mode: FILE_MODE });
+  await harden(chunkFile, FILE_MODE);
 
   // Calculate total received bytes from all chunk files
   const entries = await fs.readdir(dir);
@@ -136,12 +140,12 @@ export async function assembleChunks(
     );
   }
 
-  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await mkdirPrivate(path.dirname(targetPath));
 
   // Assemble sequentially: read each chunk, hash it, then write it. One chunk is
   // held in memory at a time (chunk size is bounded by the upload body limit).
   const hash = createHash('sha256');
-  const out = createWriteStream(targetPath);
+  const out = createWriteStream(targetPath, { mode: FILE_MODE });
   try {
     for (const cf of sized) {
       const buf = await fs.readFile(path.join(dir, cf.name));
@@ -158,6 +162,7 @@ export async function assembleChunks(
     out.destroy();
     throw err;
   }
+  await harden(targetPath, FILE_MODE);   // a resumed upload OVERWRITES, and `mode:` only applies at creation
 
   const sha256 = hash.digest('hex');
 

--- a/server/src/files/files.ts
+++ b/server/src/files/files.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { createHash } from 'crypto';
 import { resolveSafePathChecked, spaceRoot } from './sandbox.js';
 import { getConfig, getDataRoot, getStorageConfig } from '../config/loader.js';
-import { FILE_MODE, harden, mkdirPrivate } from '../util/fs-modes.js';
+import { FILE_MODE, harden, hardenPath, mkdirPrivate } from '../util/fs-modes.js';
 
 export interface FileEntry {
   name: string;
@@ -128,7 +128,11 @@ export async function moveFile(
   await fs.rename(srcAbs, dstAbs);
   // A rename carries the source's mode with it, so moving a file that predates this hardening would silently
   // reintroduce an 0644 file into a tightened tree.
-  await harden(dstAbs, FILE_MODE);
+  //
+  // `hardenPath`, not `harden(dstAbs, FILE_MODE)`: this function moves DIRECTORIES too, and `0600` on a directory
+  // removes the execute bit that makes it openable at all. Getting that wrong took the server down — see the note
+  // on `hardenPath`.
+  await hardenPath(dstAbs);
 }
 
 /** Recursively sum file sizes under a directory. Returns 0 if dir doesn't exist. */

--- a/server/src/files/files.ts
+++ b/server/src/files/files.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { createHash } from 'crypto';
 import { resolveSafePathChecked, spaceRoot } from './sandbox.js';
 import { getConfig, getDataRoot, getStorageConfig } from '../config/loader.js';
+import { FILE_MODE, harden, mkdirPrivate } from '../util/fs-modes.js';
 
 export interface FileEntry {
   name: string;
@@ -26,7 +27,9 @@ export interface FileEntry {
 
 /** Ensure the space files directory exists */
 export async function ensureSpaceFilesDir(spaceId: string): Promise<void> {
-  await fs.mkdir(spaceRoot(spaceId), { recursive: true });
+  // Owner-only. A space's files directory holds every document uploaded to that space; it has no business being
+  // world-readable, and it was — see `util/fs-modes.ts`.
+  await mkdirPrivate(spaceRoot(spaceId));
 }
 
 /** Read a text file — rejects if it's a directory or doesn't exist */
@@ -45,8 +48,11 @@ export async function readFileBytes(spaceId: string, filePath: string): Promise<
 /** Write a text file, creating parent directories as needed */
 export async function writeFile(spaceId: string, filePath: string, content: string): Promise<{ sha256: string }> {
   const abs = await resolveSafePathChecked(spaceId, filePath);
-  await fs.mkdir(path.dirname(abs), { recursive: true });
-  await fs.writeFile(abs, content, 'utf8');
+  await mkdirPrivate(path.dirname(abs));
+  await fs.writeFile(abs, content, { encoding: 'utf8', mode: FILE_MODE });
+  // `mode:` only applies when the file is CREATED, so an overwrite of a file that predates this leaves it `0644`.
+  // The chmod is what makes the tightening self-healing instead of needing a boot-time walk of the whole tree.
+  await harden(abs, FILE_MODE);
   const sha256 = createHash('sha256').update(content, 'utf8').digest('hex');
   return { sha256 };
 }
@@ -58,8 +64,9 @@ export async function writeFileBytes(
   data: Buffer,
 ): Promise<{ sha256: string }> {
   const abs = await resolveSafePathChecked(spaceId, filePath);
-  await fs.mkdir(path.dirname(abs), { recursive: true });
-  await fs.writeFile(abs, data);
+  await mkdirPrivate(path.dirname(abs));
+  await fs.writeFile(abs, data, { mode: FILE_MODE });
+  await harden(abs, FILE_MODE);   // see the note in `writeFile` above
   const sha256 = createHash('sha256').update(data).digest('hex');
   return { sha256 };
 }
@@ -106,7 +113,7 @@ export async function fileExists(spaceId: string, filePath: string): Promise<boo
 /** Create a directory (including parents) */
 export async function createDir(spaceId: string, dirPath: string): Promise<void> {
   const abs = await resolveSafePathChecked(spaceId, dirPath);
-  await fs.mkdir(abs, { recursive: true });
+  await mkdirPrivate(abs);
 }
 
 /** Move/rename a file or directory */
@@ -117,8 +124,11 @@ export async function moveFile(
 ): Promise<void> {
   const srcAbs = await resolveSafePathChecked(spaceId, srcPath);
   const dstAbs = await resolveSafePathChecked(spaceId, dstPath);
-  await fs.mkdir(path.dirname(dstAbs), { recursive: true });
+  await mkdirPrivate(path.dirname(dstAbs));
   await fs.rename(srcAbs, dstAbs);
+  // A rename carries the source's mode with it, so moving a file that predates this hardening would silently
+  // reintroduce an 0644 file into a tightened tree.
+  await harden(dstAbs, FILE_MODE);
 }
 
 /** Recursively sum file sizes under a directory. Returns 0 if dir doesn't exist. */

--- a/server/src/util/fs-modes.ts
+++ b/server/src/util/fs-modes.ts
@@ -36,6 +36,33 @@ export async function harden(target: string, mode: number): Promise<void> {
   try { await fsp.chmod(target, mode); } catch { /* non-POSIX host, or a path we do not own */ }
 }
 
+/**
+ * Tighten a path whose KIND is not known at the call site, and return the mode chosen.
+ *
+ * A directory needs its execute bit or it cannot be opened at all — `0600` on a directory is not a tightening,
+ * it is a brick. This is not theoretical: applying `FILE_MODE` unconditionally after a rename (`moveFile` moves
+ * files *or* directories) produced
+ *
+ *   filesystem error: directory iterator cannot open directory: Permission denied
+ *
+ * from `fs.cpSync` during the next offsite backup — and because that error comes out of C++ `std::filesystem`
+ * rather than JavaScript, it called `terminate()` and **killed the whole server** (container exit 139). One
+ * unreadable directory anywhere under the files root was enough.
+ *
+ * Returns the mode applied so a test can assert the CHOICE rather than its effect: `chmod` is a no-op on Windows,
+ * so an assertion about permissions afterwards would pass on the development machine no matter what.
+ */
+export async function hardenPath(target: string): Promise<number> {
+  let mode = FILE_MODE;
+  try {
+    if ((await fsp.stat(target)).isDirectory()) mode = DIR_MODE;
+  } catch {
+    return 0;   // gone already — nothing to tighten, and nothing to report
+  }
+  await harden(target, mode);
+  return mode;
+}
+
 /** Create `dir` (and parents) owner-only, tightening it if it already existed. */
 export function mkdirPrivateSync(dir: string): void {
   fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });

--- a/server/src/util/fs-modes.ts
+++ b/server/src/util/fs-modes.ts
@@ -1,0 +1,49 @@
+/**
+ * One definition of "as tightly as Ythril's own state files".
+ *
+ * `config.json` and its siblings have always been written `0600`. Everything else Ythril puts on disk took the
+ * process umask — typically `0755` directories and `0644` files — so on a shared host, or a bind mount visible to
+ * another container, the sensitive material was the readable material:
+ *
+ *   - `<data-root>/backups/` held a complete decrypted NDJSON copy of the database (fixed first, in the same
+ *     Privacy audit lens that found this);
+ *   - `<data-root>/files/` holds every uploaded document, verbatim — the most sensitive bytes on the volume.
+ *
+ * Modes are applied at creation AND re-applied after a write. The second part is what makes this self-healing:
+ * `mode:` only takes effect when a file is created, so an instance upgrading with existing files would otherwise
+ * keep them `0644` forever, and a recursive chmod of a large files tree at boot is exactly the kind of expensive
+ * migration that gets skipped. Re-uploading or editing a file tightens it, one syscall at a time.
+ *
+ * Every chmod here is best-effort. Windows and plenty of network shares (SMB, some NFS exports) do not honour
+ * POSIX modes; a hardening must never turn a working upload or backup into a failed one.
+ */
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+
+/** Owner read/write. What `config.json` has always been. */
+export const FILE_MODE = 0o600;
+
+/** Owner read/write/execute. A directory needs `x` to be traversable at all. */
+export const DIR_MODE = 0o700;
+
+/** `chmod` a path to `mode`, swallowing failure on hosts that do not implement POSIX modes. */
+export function hardenSync(target: string, mode: number): void {
+  try { fs.chmodSync(target, mode); } catch { /* non-POSIX host, or a path we do not own */ }
+}
+
+/** Async twin of {@link hardenSync}. */
+export async function harden(target: string, mode: number): Promise<void> {
+  try { await fsp.chmod(target, mode); } catch { /* non-POSIX host, or a path we do not own */ }
+}
+
+/** Create `dir` (and parents) owner-only, tightening it if it already existed. */
+export function mkdirPrivateSync(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  hardenSync(dir, DIR_MODE);
+}
+
+/** Async twin of {@link mkdirPrivateSync}. */
+export async function mkdirPrivate(dir: string): Promise<void> {
+  await fsp.mkdir(dir, { recursive: true, mode: DIR_MODE });
+  await harden(dir, DIR_MODE);
+}

--- a/testing/integration/files.test.js
+++ b/testing/integration/files.test.js
@@ -247,6 +247,29 @@ describe('Delete file and directory', () => {
     assert.equal(r2.status, 404, `Expected 404 after orphan cleanup, got ${r2.status}`);
   });
 
+  it('an uploaded file lands 0600 inside a 0700 directory', async () => {
+    // Asserted against the ARTEFACT, because no source check can prove a mode actually landed — and this machine
+    // cannot measure it either: Windows ignores POSIX modes, so the numbers only exist on a Linux host.
+    //
+    // Uploaded files used to be written with the process umask (0644 in 0755 directories) while `config.json` has
+    // always been 0600. The most sensitive bytes on the volume were the most readable — to any other user on the
+    // host, and to any container sharing the mount. Found by the Privacy audit lens.
+    const filePath = 'permission-probe.txt';
+    await uploadFile(tokenA, 'general', filePath, 'mode probe');
+
+    const fileMode = execSync(`docker exec ythril-a stat -c %a /data/files/general/${filePath}`).toString().trim();
+    assert.equal(fileMode, '600',
+      `an uploaded document is mode ${fileMode}; it holds whatever a user chose to upload and must be owner-only`);
+
+    const dirMode = execSync('docker exec ythril-a stat -c %a /data/files/general').toString().trim();
+    assert.equal(dirMode, '700',
+      `the space files directory is mode ${dirMode}; 0755 lets any other user on the host list and read it`);
+
+    // Cleanup so the listing assertions elsewhere are unaffected.
+    const url = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(filePath)}`;
+    await fetch(url, { method: 'DELETE', headers: { 'Authorization': `Bearer ${tokenA}` } });
+  });
+
   it('DELETE directory without confirm returns 422', async () => {
     const ts = Date.now();
     // Create the directory and a file inside

--- a/testing/integration/files.test.js
+++ b/testing/integration/files.test.js
@@ -786,6 +786,24 @@ describe('File metadata (MongoDB) — directory operations', () => {
     const dstRecords = dstMeta.body.files.filter(f => f.path.startsWith(`${dstDir}/`));
     assert.ok(dstRecords.length >= 3, `Expected ≥3 metadata records under ${dstDir}, got ${dstRecords.length}`);
     assert.ok(dstRecords.every(f => f.path.startsWith(`${dstDir}/`)), 'All records must use new dir prefix');
+
+    // A moved directory must still be OPENABLE. This is not a formality: hardening the files tree chmodded the
+    // destination of every move, and applying the FILE mode to a directory removed its execute bit. Nothing failed
+    // at the move — the next offsite backup walked the tree with `fs.cpSync`, which is C++, so
+    // `std::filesystem_error: directory iterator cannot open directory: Permission denied` reached `terminate()`
+    // and killed the server outright (container exit 139). This exact directory is the one that did it.
+    const listUrl = `${INSTANCES.a}/api/files/general?path=${encodeURIComponent(dstDir)}`;
+    const listed = await fetch(listUrl, { headers: { 'Authorization': `Bearer ${tokenA}` } });
+    assert.equal(listed.status, 200, `a moved directory must still be listable: ${await listed.text()}`);
+
+    const modes = execSync(
+      `docker exec ythril-a stat -c %a /data/files/general/${dstDir} /data/files/general/${dstDir}/nested`,
+    ).toString().trim().split('\n');
+    for (const m of modes) {
+      assert.equal(m, '700',
+        `a moved directory is mode ${m}; a directory without its owner-execute bit cannot be opened, and the `
+        + 'recursive walk in an offsite backup dies in native code rather than throwing something catchable');
+    }
   });
 });
 

--- a/testing/standalone/backups-are-not-world-readable.test.js
+++ b/testing/standalone/backups-are-not-world-readable.test.js
@@ -32,50 +32,107 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 
-/** Every `mkdirSync` in a file, with its options text — so a missing `mode` is visible. */
-function mkdirs(src) {
-  return [...src.matchAll(/fs\.mkdirSync\(([^;]*?)\);/gs)].map(m => m[1].replace(/\s+/g, ' ').trim());
+/**
+ * Every directory-creating call in a file, normalised to one line.
+ *
+ * Both idioms are collected: the raw `fs.mkdirSync(…)`/`fs.mkdir(…)` that has to carry a mode itself, and the
+ * `mkdirPrivateSync`/`mkdirPrivate` helper that carries it for the caller. A file that uses the helper everywhere
+ * has no raw call left to check, which is the point — one definition rather than a mode repeated at nine sites.
+ */
+function rawMkdirsIn(src) {
+  return [...src.matchAll(/(?:await\s+)?fsp?\.mkdir(?:Sync)?\(([^;]*?)\);/gs)]
+    .map(m => m[1].replace(/\s+/g, ' ').trim());
 }
 
-describe('a dump is written as tightly as the state files it sits beside', () => {
-  const dump = read('server/src/db/dump.ts');
-  const offsite = read('server/src/db/offsite.ts');
+/** Files that put user data or database contents on disk, and must all be as tight as `config.json`. */
+const WRITERS = [
+  ['server/src/db/dump.ts', 'a decrypted NDJSON copy of the whole database'],
+  ['server/src/db/offsite.ts', 'the same dump, plus every uploaded file verbatim'],
+  ['server/src/files/files.ts', 'every uploaded document, verbatim'],
+  ['server/src/files/chunks.ts', 'the same documents, mid-upload'],
+];
 
+describe('one definition of "as tight as the state files"', () => {
+  const modes = read('server/src/util/fs-modes.ts');
+
+  it('the helper exists and its constants are owner-only', () => {
+    // Everything below is worthless if these two numbers drift, and a number is the easiest thing in the world to
+    // relax by one digit while reviewing something else.
+    assert.match(modes, /export const FILE_MODE = 0o600;/, 'FILE_MODE must be 0o600 — what config.json has always been');
+    assert.match(modes, /export const DIR_MODE = 0o700;/, 'DIR_MODE must be 0o700 — a directory needs x to be traversable');
+  });
+
+  it('the helper re-applies the mode, so an upgrade heals instead of needing a tree walk', () => {
+    // `mode:` only applies at CREATION. Without the chmod, an instance that already has files keeps them 0644
+    // forever, and a recursive chmod at boot is exactly the expensive migration that gets skipped.
+    assert.match(modes, /chmodSync\(target, mode\)/, 'hardenSync must chmod the target');
+    assert.match(modes, /chmod\(target, mode\)/, 'harden must chmod the target');
+    for (const fn of ['mkdirPrivateSync', 'mkdirPrivate']) {
+      const at = modes.indexOf(`export ${fn.endsWith('Sync') ? 'function' : 'async function'} ${fn}(`);
+      assert.ok(at > 0, `${fn} is gone`);
+      assert.match(modes.slice(at, at + 260), /harden(Sync)?\(dir, DIR_MODE\)/,
+        `${fn} must tighten a directory that already existed, not only one it creates`);
+    }
+  });
+
+  it('every chmod is best-effort, so a non-POSIX host cannot fail a write', () => {
+    // Windows and plenty of network shares (SMB, some NFS exports) ignore POSIX modes. Hardening must never turn a
+    // working upload or backup into a failed one — the mode is a tightening, not a precondition.
+    for (const m of modes.matchAll(/chmod(?:Sync)?\([^)]*\)/g)) {
+      const at = modes.indexOf(m[0]);
+      const around = modes.slice(Math.max(0, at - 140), at + m[0].length + 40);
+      assert.match(around, /try\s*\{|catch/, `${m[0]} is not guarded`);
+    }
+  });
+});
+
+describe('nothing that holds user data is written with default permissions', () => {
   it('found the writers — the parse still matches', () => {
-    assert.ok(mkdirs(dump).length >= 1, 'no mkdirSync found in dump.ts');
-    assert.ok(mkdirs(offsite).length >= 2, `expected both offsite copies, found ${mkdirs(offsite).length}`);
+    // Without this, a rename would reduce every sweep below to zero files and they would all pass having examined
+    // nothing: the failure mode every coverage gate in this repo has had at least once.
+    for (const [file] of WRITERS) {
+      assert.ok(read(file).length > 200, `${file} is missing or empty`);
+    }
   });
 
-  it('every backup directory is created 0700', () => {
+  it('every directory is created owner-only', () => {
     const loose = [];
-    for (const [file, src] of [['dump.ts', dump], ['offsite.ts', offsite]]) {
-      for (const call of mkdirs(src)) {
-        if (!/mode:\s*0o700/.test(call)) loose.push(`${file}: fs.mkdirSync(${call})`);
+    for (const [file, holds] of WRITERS) {
+      const src = read(file);
+      for (const call of rawMkdirsIn(src)) {
+        // A raw mkdir is fine only if it states the mode itself; otherwise it must go through the helper.
+        if (!/mode:\s*(0o700|DIR_MODE)/.test(call)) loose.push(`${file} (${holds}): fs.mkdir(${call})`);
       }
     }
-    assert.deepEqual(loose, [], 'these create a directory holding a plaintext copy of the database — or of every '
-      + `uploaded file — with default permissions, typically 0755:\n  ${loose.join('\n  ')}`);
+    assert.deepEqual(loose, [], 'these create a directory holding user data or database contents with default '
+      + 'permissions, typically 0755:\n  ' + loose.join('\n  '));
   });
 
-  it('the NDJSON files themselves are written 0600', () => {
-    // The directory mode is not enough on a host where an existing directory is reused, and `cpSync` preserves
-    // source file modes — so the FILE mode is what actually travels offsite.
-    const streams = [...dump.matchAll(/createWriteStream\(([^;]*?)\);/gs)].map(m => m[1].replace(/\s+/g, ' '));
-    assert.ok(streams.length >= 1, 'no createWriteStream found in dump.ts');
-    for (const s of streams) {
-      assert.match(s, /mode:\s*0o600/,
-        `a collection dump is written without a restrictive mode: createWriteStream(${s})`);
-    }
-  });
-
-  it('a non-POSIX host cannot make the chmod fatal', () => {
-    // Windows and some network shares do not honour POSIX modes. Hardening must not turn a working backup into a
-    // failed one — the mode is a tightening, not a precondition.
-    for (const [file, src] of [['dump.ts', dump], ['offsite.ts', offsite]]) {
-      for (const m of src.matchAll(/fs\.chmodSync\([^)]*\)/g)) {
-        const around = src.slice(Math.max(0, src.indexOf(m[0]) - 120), src.indexOf(m[0]) + m[0].length + 80);
-        assert.match(around, /try\s*\{/, `${file}: ${m[0]} is not guarded — a non-POSIX host would fail the backup`);
+  it('every file is written owner-only', () => {
+    // The directory mode is not enough: an operator may point a path at a directory that already exists, and
+    // `cpSync` preserves SOURCE file modes — so the file mode is what actually travels offsite.
+    const loose = [];
+    for (const [file, holds] of WRITERS) {
+      const src = read(file);
+      const writes = [
+        ...[...src.matchAll(/createWriteStream\(([^;]*?)\);/gs)].map(m => ['createWriteStream', m[1]]),
+        ...[...src.matchAll(/(?:await\s+)?fsp?\.writeFile\(([^;]*?)\);/gs)].map(m => ['writeFile', m[1]]),
+      ];
+      for (const [kind, args] of writes) {
+        const one = args.replace(/\s+/g, ' ').trim();
+        if (!/mode:\s*(0o600|FILE_MODE)/.test(one)) loose.push(`${file} (${holds}): ${kind}(${one})`);
       }
+    }
+    assert.deepEqual(loose, [], 'these write user data or database contents with default permissions, typically '
+      + '0644 — readable by every other user on the host:\n  ' + loose.join('\n  '));
+  });
+
+  it('an overwrite is tightened too, not only a creation', () => {
+    // A resumed upload and an edited file both OVERWRITE, and `mode:` does nothing then. Each writer of a
+    // potentially-existing file has to chmod as well — this is what makes the change self-healing on upgrade.
+    for (const file of ['server/src/files/files.ts', 'server/src/files/chunks.ts']) {
+      assert.match(read(file), /harden\(/,
+        `${file} sets a mode on creation but never chmods, so files that predate this stay 0644 forever`);
     }
   });
 });

--- a/testing/standalone/harden-path-picks-the-right-mode.test.js
+++ b/testing/standalone/harden-path-picks-the-right-mode.test.js
@@ -1,0 +1,87 @@
+/**
+ * `0600` on a directory is not a tightening, it is a brick — and it killed the server.
+ *
+ * ## What happened
+ *
+ * Hardening the files tree added a `chmod` after every write, so that files predating the change heal on their next
+ * write instead of needing a boot-time walk. `moveFile` got the same treatment — and `moveFile` moves **directories**
+ * as well as files, so a moved directory was chmodded to `FILE_MODE`. A directory without its execute bit cannot be
+ * opened at all.
+ *
+ * Nothing failed at the move. It failed later, in the next offsite backup, as:
+ *
+ *     terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
+ *       what():  filesystem error: directory iterator cannot open directory: Permission denied
+ *                [/data/files/general/meta-dir-mv-dst-.../nested]
+ *
+ * `fs.cpSync` walks the tree in C++. That error comes out of `std::filesystem`, not JavaScript, so it reached
+ * `terminate()` and took the **whole process** down — container exit 139, 94 tests failed and 169 were cancelled
+ * because every later request got `fetch failed`. One unreadable directory under the files root was enough.
+ *
+ * ## Why this test asserts the CHOICE and not the effect
+ *
+ * `chmod` is a no-op on Windows, which is where this is developed. A test that chmodded a directory and then tried
+ * to read it would pass locally no matter what the code did — so `hardenPath` returns the mode it applied, and this
+ * pins that. The observable effect is checked where it exists: `files.test.js` moves a real directory inside the
+ * Linux container and lists it afterwards.
+ *
+ * Run: node --test testing/standalone/harden-path-picks-the-right-mode.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const mod = await import('../../server/dist/util/fs-modes.js');
+
+let dir;
+before(() => { dir = mkdtempSync(join(tmpdir(), 'ythril-modes-')); });
+after(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+describe('hardenPath picks a mode by what the path IS', () => {
+  it('a file gets FILE_MODE', async () => {
+    const f = join(dir, 'a.txt');
+    writeFileSync(f, 'x');
+    assert.equal(await mod.hardenPath(f), mod.FILE_MODE);
+  });
+
+  it('a directory gets DIR_MODE — it needs its execute bit to be openable at all', async () => {
+    const d = join(dir, 'sub');
+    mkdirSync(d);
+    const applied = await mod.hardenPath(d);
+    assert.equal(applied, mod.DIR_MODE);
+    assert.notEqual(applied, mod.FILE_MODE,
+      'a directory chmodded to 0600 cannot be opened; fs.cpSync then dies in C++ and takes the process with it');
+  });
+
+  it('a path that is already gone reports 0 rather than throwing', async () => {
+    // `moveFile` can race a delete. A throw here would surface as a failed move of a file that did move.
+    assert.equal(await mod.hardenPath(join(dir, 'never-existed')), 0);
+  });
+
+  it('DIR_MODE actually carries the owner execute bit', () => {
+    // The bug in one line. 0o700 & 0o100 is the bit that makes a directory traversable; 0o600 does not have it.
+    assert.ok((mod.DIR_MODE & 0o100) !== 0, 'DIR_MODE must include owner-execute or directories become unopenable');
+    assert.equal(mod.FILE_MODE & 0o100, 0, 'FILE_MODE should not mark data files executable');
+  });
+});
+
+describe('no caller applies a file mode to something that may be a directory', () => {
+  it('moveFile hardens by path kind, not by assumption', () => {
+    // Pinned at the call site as well as in the helper: the helper being correct does not help if a caller
+    // reintroduces `harden(dst, FILE_MODE)`, which is exactly the line that caused the outage.
+    const src = readFileSync('server/src/files/files.ts', 'utf8');
+    const at = src.indexOf('export async function moveFile(');
+    assert.ok(at > 0, 'moveFile is gone — re-anchor this gate');
+    // Comments stripped before matching. The first version of this assertion failed against the fixed code,
+    // because the comment explaining the bug quotes the very call it warns against — a gate that reads prose as
+    // code is a gate that fires on its own documentation.
+    const body = src.slice(at, src.indexOf('\n}', at))
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '');
+    assert.match(body, /hardenPath\(/, 'moveFile must use hardenPath — it moves directories as well as files');
+    assert.doesNotMatch(body, /harden\([^)]*FILE_MODE/,
+      'moveFile must not force FILE_MODE: its destination can be a directory, and 0600 on a directory is a brick');
+  });
+});


### PR DESCRIPTION
## Uploaded files were world-readable, and the previous fix's documentation said otherwise

Third finding from audit lens **12 — Privacy**. It also corrects a sentence shipped in **#644**, which claimed Ythril
writes uploads `0600`/`0700`. Backups did. Uploads did not.

`<data-root>/files/` holds **every document a user uploaded, verbatim** — the most sensitive bytes on the volume.
Every writer took the process umask:

| written by | before | contains |
|---|---|---|
| the four state files | `0600` (always has been) | config, secrets, schema catalogs |
| `<data-root>/files/` | `0755` dirs, `0644` files | every uploaded document |
| `<data-root>/.chunks/` | `0755` dirs, `0644` files | the same documents, half-arrived |

The pattern from the backup finding repeated itself exactly: **the least sensitive thing on the volume was the best
protected.** On a multi-tenant host, or a bind mount shared with another container, an upload was readable by anything
with a shell on the box.

## One definition, not a literal repeated at nine sites

`server/src/util/fs-modes.ts` now owns `FILE_MODE = 0o600`, `DIR_MODE = 0o700`, and the `harden`/`mkdirPrivate`
helpers. #644's inline hardening in `dump.ts` and `offsite.ts` was converged onto it, so "as tight as the state files"
is stated once. The gate asserts the two constants directly — a number is the easiest thing in the world to relax by
one digit while reviewing something else.

## Two details that are easy to miss, and were

**A rename carries the source's mode.** `moveFile` re-tightens its destination; without that, moving a file that
predates this quietly reintroduces an `0644` file into a hardened tree.

**`mode:` only applies when a file is created.** Every writer therefore also chmods, which makes the change
**self-healing**: re-uploading, editing or moving a file tightens it. There is deliberately **no boot-time walk** of
the files tree — on a large instance that is exactly the migration that ends up skipped, or that turns a restart into
an outage. The docs give the one-line `find` for anyone who wants it done at once (verified to run, not just written).

Every chmod is best-effort. Windows and plenty of network shares ignore POSIX modes, and a hardening must never turn
a working upload into a failed one.

## Verified against the artefact, not the instruction

No source check can prove a mode actually landed — and this development machine is Windows, where the numbers do not
exist at all. So an integration test uploads a file and asks the container:

```js
const fileMode = execSync(`docker exec ythril-a stat -c %a /data/files/general/${filePath}`).toString().trim();
assert.equal(fileMode, '600');
const dirMode = execSync('docker exec ythril-a stat -c %a /data/files/general').toString().trim();
assert.equal(dirMode, '700');
```

Same reasoning as the `docker run` NOTICE check in `publish.yml`: when the claim is about the artefact, ask the
artefact.

## The gate found two more loose sites while it was being written

`createDir` and `moveFile` — neither named in the finding, both creating directories under the files root with
default permissions. That is the whole argument for sweeping **every** writer rather than the ones the report
mentions.

`testing/standalone/backups-are-not-world-readable.test.js` extended from 6 assertions to 9 and mutation-tested
**13/13**:

| mutation | caught |
|---|---|
| `FILE_MODE` relaxed to group-readable | ✅ |
| `DIR_MODE` relaxed to world-traversable | ✅ |
| `mkdirPrivate` stops tightening a directory that already existed | ✅ |
| a chmod left unguarded, so a non-POSIX host fails the write | ✅ |
| an uploaded file goes back to the process umask | ✅ |
| a space files directory goes back to `0755` | ✅ |
| an overwrite is no longer tightened, so upgrades never heal | ✅ |
| a mid-upload chunk goes back to the process umask | ✅ |
| the assembled upload target goes back to default permissions | ✅ |
| the dump directory stops going through the helper | ✅ |
| an offsite copy stops going through the helper | ✅ |
| the admin doc drops the unencrypted warning | ✅ |
| the hosting section stops scoping itself | ✅ |

## Documentation

`02-hosting.md`'s Encryption at Rest section now says what the modes actually are, that they cover uploads, chunk
staging, local backups and offsite copies from one definition, and that **upgrades heal rather than migrate** — with
the `find` for doing it in one go.

## This closes lens 12's encryption-at-rest thread

Three findings, all the same shape: **a stated guarantee that a different, also-documented feature quietly bypassed.**
#644 (a dump reads through `mongod`), #645 (an offline product that fetched models), and this one (a section that
described a protection uploads did not have).

What the lens confirmed **clean** is recorded in `_REFERENCE.md` so it is not re-derived: no telemetry or phone-home
anywhere, every outbound call to an operator-configured destination, and an audit log already well scoped for privacy.
The remaining thread — subject-oriented portability — is queued as a **missing feature** with the exact call counts
rather than filed as a defect, because no document claims otherwise.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
