### PR TITLE
fix(ops): /ready returned the MongoDB driver's error message on a public endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`GET /ready` returned the MongoDB driver's error message verbatim, on a public endpoint.** First finding of the
+  Observability & Operability audit lens. `/health` and `/ready` are registered **before every authentication
+  middleware** — they have to be, an orchestrator cannot carry a token — so both are reachable by anyone who can
+  reach the port, and `checks.mongodb.error` described the infrastructure.
+  - **Measured against the real driver, not assumed.** No credential leaked in any case tried; **internal hostnames
+    did** (`getaddrinfo ENOTFOUND mongo-a.internal`), and other topology failures name internal addresses and ports.
+  - It also made `/ready` the **only** route in the product that answered this way: the global error handler already
+    logs the detail and returns a flat `Internal server error`, the two other public routers echo nothing, and the
+    three admin routers that do echo a raw message sit behind auth, where it is useful.
+  - Now a **stable code** — `unreachable`, `timeout`, `auth_failed`, `not_primary`, `unsupported`, `error` — which is
+    the more useful thing for a probe anyway: it can be alerted on, which a driver message never could.
+  - **The detail now goes to the log, where it was missing entirely.** It used to be handed to whoever probed the
+    endpoint and then discarded, so an operator watching a failing pod saw silence. Logged **once per transition**,
+    with a recovery line, because a Kubernetes probe runs every few seconds and repeating it would bury the log.
+  - The payload and every code are documented in `02-hosting.md`, which never described this response at all.
+  - Gate `public-probes-leak-nothing`, mutation-tested **16/16**. It caught two real defects while being written: a
+    slice that stopped at a `;` inside a comment and hid two of the six codes, and a classifier that read
+    `connection 4 to 10.1.2.3:27017 closed` — the commonest failure of all — as the vague `error`.
+
 - **The audit page's "Export JSON" and "Export CSV" exported only the page on screen.** Up to 100 rows out of a
   `total` that is routinely thousands, with nothing in the label to say so — an operator asked to produce someone's
   activity record could hand over a truncated file believing it complete. They now say **"Export page"**, and

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -282,6 +282,44 @@ and every refusal names the setting that would permit it.
 `/ready` deliberately ignores optional components. Folding a dead render sidecar into it would let a
 degraded feature pull a healthy instance out of the load balancer.
 
+##### What `/ready` returns, and why it says so little
+
+`/ready` and `/health` are registered **before every authentication middleware** — they have to be, an orchestrator
+cannot carry a token — so both are **public**. That is why a failing check reports a **code**, never the underlying
+driver message:
+
+```json
+{
+  "ready": false,
+  "checks": {
+    "mongodb": { "status": "error", "reason": "unreachable" },
+    "vectorSearch": { "status": "ok" }
+  }
+}
+```
+
+| `reason` | Meaning | What to check |
+|---|---|---|
+| `unreachable` | wrong host or port, firewall, DNS failure, connection refused or reset | connectivity to MongoDB |
+| `timeout` | reachable, but did not answer inside 2 s | load on the database |
+| `auth_failed` | credentials rejected | the user/password in `MONGO_URI` |
+| `not_primary` | connected to a secondary, so writes would fail | replica-set state |
+| `unsupported` | the server answered but lacks something required (e.g. no vector search) | MongoDB flavour and version |
+| `error` | nothing more specific matched | **the server log** |
+
+**The full message is in the log**, once per transition — a Kubernetes probe runs every few seconds, so repeating
+it on every failed poll would bury everything else:
+
+```text
+[WARN ] Readiness: mongodb is failing (unreachable) — getaddrinfo ENOTFOUND mongo-a.internal
+[INFO ] Readiness: mongodb recovered
+```
+
+Before this, the driver's message was returned in the response and logged **nowhere** — so the detail went to
+whoever probed the endpoint, including anyone who could reach it, and an operator watching the logs of a failing
+pod saw silence. A code is also the more useful thing for a probe: it is stable enough to alert on, which a driver
+message never was.
+
 #### The single most useful habit: read the posture block
 
 It prints at boot and is live at `GET /api/about/security`. Every line is written to be actionable — a

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -45,7 +45,7 @@ import { clearOidcCache } from './auth/oidc.js';
 import { initSpace, ensureGeneralSpace, wipeSpace, reconcilePendingSpaceOp, WIPE_COLLECTION_TYPES, type WipeCollectionType } from './spaces/lifecycle.js';
 import { col, asFilter, asDoc } from './db/mongo.js';
 import { log } from './util/log.js';
-import { getReadiness } from './ready.js';
+import { getReadiness, classifyCheckError } from './ready.js';
 import { isShuttingDown } from './lifecycle.js';
 import {
   httpRequestsTotal,
@@ -177,12 +177,15 @@ export function createApp() {
       const result = await getReadiness();
       res.status(result.ready ? 200 : 503).json(result);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // A code, not the message. This endpoint is public by necessity — an orchestrator cannot carry a token —
+      // and driver messages name internal hosts and addresses (`getaddrinfo ENOTFOUND mongo-a.internal`). The
+      // detail is logged instead, which is also where it was missing entirely before. See `ready.ts`.
+      log.error(`Readiness check itself failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(503).json({
         ready: false,
         checks: {
-          mongodb: { status: 'error', error: message },
-          vectorSearch: { status: 'error', error: 'check skipped' },
+          mongodb: { status: 'error', reason: classifyCheckError(err) },
+          vectorSearch: { status: 'error', reason: 'error' },
         },
       });
     }

--- a/server/src/ready.ts
+++ b/server/src/ready.ts
@@ -10,14 +10,83 @@
  */
 
 import { getMongo } from './db/mongo.js';
+import { log } from './util/log.js';
 
 const TIMEOUT_MS = 2_000;
 const CACHE_TTL_MS = 2_000;
 
+/**
+ * Why a dependency check failed, in terms that say nothing about the deployment.
+ *
+ * `/ready` is registered before every auth middleware — it has to be, an orchestrator cannot hold a token — so it
+ * is a **public** endpoint. It used to return the driver's message verbatim, and those messages describe the
+ * infrastructure: `getaddrinfo ENOTFOUND mongo-a.internal` names an internal host, and a topology error names
+ * internal addresses and ports. Measured against the real driver, not assumed.
+ *
+ * That also made `/ready` the one route that answered differently from everything else: the global error handler
+ * logs the detail and returns a flat `Internal server error`. This brings the probe in line with it.
+ *
+ * A code is more useful to a probe than a sentence anyway — it is stable enough to alert on, which a driver
+ * message never was.
+ */
+export type CheckReason =
+  | 'unreachable'    // wrong host/port, firewall, DNS — the operator checks connectivity
+  | 'timeout'        // reachable but did not answer in time — the operator checks load
+  | 'auth_failed'    // credentials rejected
+  | 'not_primary'    // connected to a secondary; writes would fail
+  | 'unsupported'    // the server answered, but does not support what we need (e.g. no vector search)
+  | 'error';         // classified as nothing more specific; the log has the message
+
 export interface CheckResult {
   status: 'ok' | 'error';
   latencyMs?: number;
-  error?: string;
+  /**
+   * Present only on failure. Deliberately a code, never the underlying message — see {@link CheckReason}.
+   * The full message goes to the log, once per transition.
+   */
+  reason?: CheckReason;
+}
+
+/** Map a driver error onto a {@link CheckReason}. Exported for the `/ready` handler's own catch branch. */
+export function classifyCheckError(err: unknown): CheckReason {
+  const msg = err instanceof Error ? err.message : String(err);
+  // Auth first: "Authentication failed." matches nothing else, and misreading it as `unreachable` would send an
+  // operator to check a firewall that is fine.
+  if (/authentication failed|not authorized|unauthorized|bad auth/i.test(msg)) return 'auth_failed';
+  if (/not primary|notwritableprimary|not master/i.test(msg)) return 'not_primary';
+  // A CONNECT timeout is reported as `Socket 'connect' timed out after …`, and the operator's next step for it is
+  // the same as for a refused connection: check the host, the port, the firewall. `timeout` is reserved for a
+  // server that answered the handshake and then took too long, which is a load problem instead.
+  // `connect` unanchored, deliberately. `\bconnect\b` missed `connection 4 to 10.1.2.3:27017 closed` — the
+  // commonest failure of all, a server that went away mid-session — and classified it as the vague `error`. Caught
+  // by testing the classifier against strings the driver really produces rather than the ones I had in mind.
+  if (/enotfound|eai_again|econnrefused|ehostunreach|enetunreach|econnreset|connect/i.test(msg)) return 'unreachable';
+  if (/timed out|etimedout|timeout|server selection/i.test(msg)) return 'timeout';
+  if (/unrecognized pipeline stage|no such command|not supported|command .* not found|search index/i.test(msg)) {
+    return 'unsupported';
+  }
+  return 'error';
+}
+
+/**
+ * Log a check's failure once per transition, with the full message.
+ *
+ * Two reasons this is not a plain `log.warn` at the failure site. A readiness failure previously logged
+ * **nothing at all** — the detail was returned to whoever asked and then discarded, so an operator watching the
+ * logs of a failing pod saw silence. And a Kubernetes probe runs every few seconds, so logging every failure
+ * would bury the rest of the log in copies of one line. Transitions carry the information; repetitions do not.
+ */
+const _lastState = new Map<string, string>();
+function logTransition(check: string, reason: CheckReason | 'ok', detail?: string): void {
+  const key = reason === 'ok' ? 'ok' : reason;
+  if (_lastState.get(check) === key) return;
+  const was = _lastState.get(check);
+  _lastState.set(check, key);
+  if (reason === 'ok') {
+    if (was !== undefined) log.info(`Readiness: ${check} recovered`);
+    return;
+  }
+  log.warn(`Readiness: ${check} is failing (${reason})${detail ? ` — ${detail}` : ''}`);
 }
 
 export interface ReadinessResult {
@@ -68,15 +137,16 @@ async function checkMongoDB(): Promise<CheckResult> {
     );
     const isWritable = hello['isWritablePrimary'] === true || hello['ismaster'] === true;
     if (!isWritable) {
-      return { status: 'error', error: 'not primary' };
+      logTransition('mongodb', 'not_primary', 'connected node is not a writable primary');
+      return { status: 'error', reason: 'not_primary' };
     }
 
+    logTransition('mongodb', 'ok');
     return { status: 'ok', latencyMs: Date.now() - start };
   } catch (err) {
-    return {
-      status: 'error',
-      error: err instanceof Error ? err.message : String(err),
-    };
+    const reason = classifyCheckError(err);
+    logTransition('mongodb', reason, err instanceof Error ? err.message : String(err));
+    return { status: 'error', reason };
   }
 }
 
@@ -90,12 +160,12 @@ async function checkVectorSearch(): Promise<CheckResult> {
       db.collection('_ready_probe').listSearchIndexes().toArray(),
       TIMEOUT_MS,
     );
+    logTransition('vectorSearch', 'ok');
     return { status: 'ok' };
   } catch (err) {
-    return {
-      status: 'error',
-      error: err instanceof Error ? err.message : String(err),
-    };
+    const reason = classifyCheckError(err);
+    logTransition('vectorSearch', reason, err instanceof Error ? err.message : String(err));
+    return { status: 'error', reason };
   }
 }
 

--- a/testing/standalone/public-probes-leak-nothing.test.js
+++ b/testing/standalone/public-probes-leak-nothing.test.js
@@ -1,0 +1,176 @@
+/**
+ * `/health` and `/ready` are public. They must say whether to send traffic, and nothing about the deployment.
+ *
+ * ## The finding — Observability & Operability audit lens
+ *
+ * Both probes are registered **before every authentication middleware**, and they have to be: an orchestrator
+ * cannot carry a token. `/ready` returned the MongoDB driver's error message verbatim in
+ * `checks.mongodb.error`, and those messages describe the infrastructure. Measured against the real driver, not
+ * assumed:
+ *
+ *     mongodb://appuser:…@mongo-a.internal:27017,mongo-b.internal:27017/ythril?replicaSet=rs0
+ *       → "getaddrinfo ENOTFOUND mongo-a.internal"
+ *
+ * No credential leaked in any case tried — the driver is careful about that. Internal hostnames did, and other
+ * topology failures name internal addresses and ports.
+ *
+ * It also made `/ready` the **only** route in the product that answered this way. The global error handler logs
+ * the detail and returns a flat `Internal server error`; the two other public routers (`setup`, `theme`) echo
+ * nothing. The three admin routers that do echo a raw message are behind auth, where it is useful.
+ *
+ * And the detail was logged **nowhere**: it went to whoever probed the endpoint and was then discarded, so an
+ * operator watching a failing pod's logs saw silence. Classifying it fixed both halves — the response carries a
+ * code, the log carries the message, once per transition.
+ *
+ * Run: node --test testing/standalone/public-probes-leak-nothing.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (p) => readFileSync(p, 'utf8');
+const READY = read('server/src/ready.ts');
+const APP = read('server/src/app.ts');
+
+/** The `/ready` handler, from its registration to the next route registration. */
+function readyHandler() {
+  const at = APP.indexOf("app.get('/ready'");
+  assert.ok(at > 0, 'the /ready route is gone');
+  const end = APP.indexOf("app.use('/metrics'", at);
+  assert.ok(end > at, 'could not bound the /ready handler');
+  return APP.slice(at, end);
+}
+
+describe('the probes are public — that is the premise', () => {
+  it('/health and /ready are registered before any auth middleware', () => {
+    // If this ever stops being true the leak stops mattering, and this whole file should be revisited rather
+    // than left asserting something that no longer describes the code.
+    const health = APP.indexOf("app.get('/health'");
+    const ready = APP.indexOf("app.get('/ready'");
+    const audit = APP.indexOf('app.use(auditMiddleware)');
+    assert.ok(health > 0 && ready > 0, 'the probe routes are gone');
+    assert.ok(health < audit && ready < audit,
+      'the probes are no longer ahead of the middleware stack — re-check whether they are still unauthenticated');
+  });
+
+  it('/health returns a fixed shape with no environment detail', () => {
+    const at = APP.indexOf("app.get('/health'");
+    const body = APP.slice(at, APP.indexOf("app.get('/ready'", at));
+    assert.match(body, /status:\s*'ok'/, 'the liveness probe should stay a constant');
+    assert.doesNotMatch(body, /version|hostname|process\.env|getConfig/,
+      'liveness must not describe the instance: it is the most reachable endpoint there is');
+  });
+});
+
+describe('a failing check reports a code, never the driver message', () => {
+  it('the payload type carries a reason, and no message field', () => {
+    assert.match(READY, /reason\?:\s*CheckReason/, 'CheckResult must carry a classified reason');
+    assert.doesNotMatch(READY, /^\s*error\?:\s*string/m,
+      'CheckResult must not have a free-text error field — that is what leaked internal hostnames');
+  });
+
+  it('no check returns an error message in its result', () => {
+    // The specific shape that leaked: `error: err instanceof Error ? err.message : String(err)`.
+    assert.doesNotMatch(READY, /error:\s*err instanceof Error \? err\.message/,
+      'a check is putting the raw driver message back into the response');
+    assert.doesNotMatch(READY, /error:\s*(msg|message)\b/, 'a check is returning a message field');
+  });
+
+  it("the handler's own catch branch classifies too", () => {
+    // Easy to miss: the route has a second failure path, for `getReadiness()` itself throwing, and it built its
+    // own payload by hand. That was the first place the message came back.
+    const body = readyHandler();
+    assert.match(body, /classifyCheckError\(/, 'the catch branch must classify rather than echo');
+    assert.doesNotMatch(body, /error:\s*message/, 'the catch branch is still echoing the message');
+  });
+
+  it('every reason is a fixed code an alert can key on', () => {
+    const at = READY.indexOf('export type CheckReason');
+    assert.ok(at > 0, 'CheckReason is gone');
+    // Sliced to the next DECLARATION, not to the first `;`. A `;` inside one of the trailing comments
+    // ("connected to a secondary; writes would fail") truncated the slice and hid two of the six codes — the
+    // same convenience-slice mistake as the last two batches, caught the same way.
+    const end = READY.indexOf('export interface CheckResult', at);
+    assert.ok(end > at, 'could not bound the CheckReason declaration');
+    const decl = READY.slice(at, end);
+    for (const code of ['unreachable', 'timeout', 'auth_failed', 'not_primary', 'unsupported', 'error']) {
+      assert.match(decl, new RegExp(`'${code}'`), `the ${code} reason is missing`);
+    }
+  });
+});
+
+describe('the classifier, on the strings the driver actually produces', () => {
+  // Captured from a real `mongodb` driver rather than invented, which is the only reason these are worth pinning.
+  const CASES = [
+    ['getaddrinfo ENOTFOUND mongo-a.internal', 'unreachable'],
+    ["Socket 'connect' timed out after 1211ms (connectTimeoutMS: 1200)", 'unreachable'],
+    ['Authentication failed.', 'auth_failed'],
+    ['connection 4 to 10.1.2.3:27017 closed', 'unreachable'],
+    ['timed out after 2000ms', 'timeout'],
+    ['not primary and secondaryOk=false', 'not_primary'],
+    ['Unrecognized pipeline stage name: $vectorSearch', 'unsupported'],
+    ['something nobody predicted', 'error'],
+  ];
+
+  it('classifies each one as expected', async () => {
+    const { classifyCheckError } = await import('../../server/dist/ready.js');
+    const wrong = [];
+    for (const [msg, expected] of CASES) {
+      const got = classifyCheckError(new Error(msg));
+      if (got !== expected) wrong.push(`${JSON.stringify(msg)} → ${got}, expected ${expected}`);
+    }
+    assert.deepEqual(wrong, [], `misclassified:\n  ${wrong.join('\n  ')}`);
+  });
+
+  it('never returns the input', async () => {
+    // The point of the whole exercise: whatever comes in, what comes out is one of six words.
+    const { classifyCheckError } = await import('../../server/dist/ready.js');
+    const secretish = 'mongodb://appuser:sup3rS3cret@mongo-a.internal:27017 refused the connection';
+    const out = classifyCheckError(new Error(secretish));
+    assert.doesNotMatch(out, /sup3rS3cret|mongo-a\.internal/, 'the classifier is passing input through');
+    assert.ok(['unreachable', 'timeout', 'auth_failed', 'not_primary', 'unsupported', 'error'].includes(out),
+      `unexpected reason: ${out}`);
+  });
+});
+
+describe('the detail goes to the log instead of being discarded', () => {
+  it('a failure is logged with the full message', () => {
+    assert.match(READY, /log\.warn\(/, 'a readiness failure must be logged — it used to be logged nowhere at all');
+    const at = READY.indexOf('function logTransition');
+    assert.ok(at > 0, 'the transition logger is gone');
+    const fn = READY.slice(at, READY.indexOf('\n}', at));
+    assert.match(fn, /\$\{detail\}/, 'the log line must include the underlying message');
+  });
+
+  it('it logs on TRANSITION, not on every poll', () => {
+    // A Kubernetes probe runs every few seconds. Logging each failure would bury the rest of the log in copies
+    // of one line, which is how a well-meant log line becomes a reason to turn logging down.
+    const at = READY.indexOf('function logTransition');
+    const fn = READY.slice(at, READY.indexOf('\n}', at));
+    assert.match(fn, /_lastState\.get\(check\) === key/, 'repeated identical states must be suppressed');
+    assert.match(fn, /recovered/, 'recovery must be logged too, or the log never says the outage ended');
+  });
+
+  it('each check reports its state on success as well as failure', () => {
+    // Without the success call there is no transition to detect, so recovery is silent.
+    for (const check of ['mongodb', 'vectorSearch']) {
+      assert.match(READY, new RegExp(`logTransition\\('${check}', 'ok'\\)`),
+        `${check} never reports success, so a recovery cannot be noticed`);
+    }
+  });
+});
+
+describe('it is documented', () => {
+  it('the hosting guide lists every reason code and says where the detail went', () => {
+    const doc = read('docs/integration-guide/02-hosting.md');
+    const at = doc.indexOf('What `/ready` returns');
+    assert.ok(at > 0, 'the /ready payload section is gone');
+    const section = doc.slice(at, doc.indexOf('\n#### ', at + 10));
+    for (const code of ['unreachable', 'timeout', 'auth_failed', 'not_primary', 'unsupported']) {
+      assert.match(section, new RegExp(`\`${code}\``), `${code} is undocumented, so nobody can alert on it`);
+    }
+    assert.match(section, /before every authentication middleware|public/i,
+      'the section must say why the payload is terse — otherwise it reads as an omission');
+    assert.match(section, /log/i, 'it must say where the full message went');
+  });
+});


### PR DESCRIPTION
## `GET /ready` returned the MongoDB driver's error message, on a public endpoint

First finding of audit lens **9 — Observability & Operability**, whose brief includes *"the actual ops endpoints
exist, are correct, and **leak nothing**"*.

`/health` and `/ready` are registered **before every authentication middleware**. They have to be — an orchestrator
cannot carry a token — so both are reachable by anyone who can reach the port. And `checks.mongodb.error` carried the
driver's message verbatim:

```json
{ "ready": false, "checks": { "mongodb": { "status": "error", "error": "getaddrinfo ENOTFOUND mongo-a.internal" } } }
```

## Measured against the real driver, not assumed

| URI under test | message returned | secret? | topology? |
|---|---|---|---|
| unreachable host, credentials in the URI | `Socket 'connect' timed out after 1211ms` | no | no |
| unreachable replica set, two internal hosts | **`getaddrinfo ENOTFOUND mongo-a.internal`** | no | **yes** |
| reachable mongod, wrong credentials | `Authentication failed.` | no | no |

**No credential leaked in any case tried** — the driver is careful about that, and I would have reported it the other
way round if it had. **Internal hostnames did**, and other topology failures name internal addresses and ports
(`connection 4 to 10.1.2.3:27017 closed`).

## It was also the only route in the product that answered this way

That is what makes this an inconsistency rather than a judgement call:

- the **global error handler** already logs the detail and returns a flat `Internal server error`;
- the two other **public** routers (`setup`, `theme`) echo nothing — checked, not assumed;
- the three admin routers that *do* echo a raw message sit **behind auth**, where it is useful.

`/ready` was the single exception, and the sweep for others came back empty.

## What it returns now

A stable code, which is the more useful thing for a probe anyway — it can be **alerted on**, which a driver message
never could:

| `reason` | meaning | what the operator checks |
|---|---|---|
| `unreachable` | wrong host/port, firewall, DNS, refused or reset | connectivity |
| `timeout` | reachable, no answer within 2 s | database load |
| `auth_failed` | credentials rejected | the user/password in `MONGO_URI` |
| `not_primary` | connected to a secondary, so writes would fail | replica-set state |
| `unsupported` | answered, but lacks something required (e.g. no vector search) | MongoDB flavour/version |
| `error` | nothing more specific matched | **the log** |

## The detail now goes to the log, where it was missing entirely

This is the half that makes the change an *improvement* rather than a trade: the message used to be handed to
whoever probed the endpoint and then **discarded**. An operator watching the logs of a failing pod saw silence.

```text
[WARN ] Readiness: mongodb is failing (unreachable) — getaddrinfo ENOTFOUND mongo-a.internal
[INFO ] Readiness: mongodb recovered
```

Logged **once per transition**, with a recovery line. A Kubernetes probe runs every few seconds; repeating one line
on every poll is how a well-meant log line becomes a reason to turn logging down.

`02-hosting.md` documents the payload, every code, what to check for each, and where the message went — it never
described this response at all.

## Gate

`testing/standalone/public-probes-leak-nothing.test.js`, **mutation-tested 16/16** (two of those caught by the
typecheck rather than the gate, which the run reports honestly rather than counting as a win). It pins that the
probes stay ahead of the middleware stack — because if they ever stop being public, this whole file should be
revisited rather than left asserting something that no longer describes the code.

**It found two real defects while being written, neither by reading:**

1. The slice for the reason-code union stopped at the first `;` — which appears inside a **trailing comment**
   (`connected to a secondary; writes would fail`) — so two of the six codes were never checked. The same
   convenience-slice mistake as the last two batches, caught the same way, and now anchored on the next declaration.
2. The classifier read `connection 4 to 10.1.2.3:27017 closed` as the vague `error`. That is the **commonest failure
   of all** — a server that went away mid-session — and `\bconnect\b` does not match `connection`. Found by testing
   the classifier against strings the driver really produces instead of the ones I had in mind.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
