### PR TITLE
fix(config): a typo in a numeric setting changed behaviour instead of stopping the boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A typo in any numeric setting silently changed behaviour instead of stopping the boot.** Second finding of the
+  Observability & Operability lens. Fifteen settings were read as `Number(process.env[X])` and exactly **one**
+  checked the result, so `8OOO` (letter O), `30_000`, `5s` or a stray space became `NaN` — and `NaN` does not fail.
+  Measured against real Node:
+
+  | a typo in | did | so |
+  |---|---|---|
+  | `SHUTDOWN_DRAIN_MS` | `setTimeout(fn, NaN)` fires after **0 ms** | the graceful drain did not drain |
+  | `MONGO_CONNECT_RETRY_MS` | `elapsed < NaN` is **false** | zero retries; the mongod boot race returned |
+  | `EMBEDDING_DIMENSIONS` | serialises as **`null`** | a vector index with a null dimension |
+  | `RECALL_BUDGET_MS` | every comparison **false** | the recall budget stopped applying |
+
+  - Two of those are guarantees the hosting guide documents, lost without a word. **`PORT` was already safe** —
+    Node refuses `listen(NaN)` — and that is now the behaviour of all of them.
+  - One helper (`config/env-num.ts`) with a **registry** of every numeric setting, its bounds, and what it does.
+    The boot refuses to start and names **every** offender at once, because an operator with two typos should not
+    need two restarts to find them both.
+  - The reader deliberately **does not throw**: several settings are read at module scope, so a throw would happen
+    during import and hand the operator a stack trace from a module they have never heard of instead of the message.
+  - An **empty** value still means "not set" — the usual way to clear a setting in a compose file — and surrounding
+    whitespace is trimmed, so a YAML block scalar cannot break a value.
+  - Gate `numeric-env-is-validated`, mutation-tested **16/16**, including that the registry stays exhaustive: a new
+    raw `Number(process.env[…])` anywhere in the tree fails the build. It caught four weak assertions of its own
+    while being written — among them one that passed with the boot check **commented out**, and one that passed
+    with the description deleted because the word it matched also appears in the variable name.
+
 - **`GET /ready` returned the MongoDB driver's error message verbatim, on a public endpoint.** First finding of the
   Observability & Operability audit lens. `/health` and `/ready` are registered **before every authentication
   middleware** — they have to be, an orchestrator cannot carry a token — so both are reachable by anyone who can

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -102,6 +102,35 @@ DEBUG=1 docker compose up
 | `SYNC_ALLOW_PRIVATE_PEERS` | `false` | Allow sync **peer URLs** to resolve to private/reserved addresses (RFC-1918, CGNAT, IPv6 ULA) — for same-host or LAN networks (overrides the `allowPrivatePeers` config key). Default `false`: sync connects only to public peers, and any peer that tries to move its URL onto a private address is refused. Even when `true`, crown-jewel addresses (loopback, link-local / cloud IMDS `169.254.169.254`, unspecified) stay blocked. |
 | `MCP_OAUTH_TOKEN_TTL_DAYS` | `90` | Lifetime (in days) of PATs minted by the MCP OAuth browser-connector flow. Tokens expire after this many days, so an abandoned connector leaves no permanent credential behind; the connector re-consents when its token lapses. Each connector holds **one** token that a fresh consent rotates (never accumulates), and the total connector-token count is capped. Set to `0` to disable expiry (tokens never expire) if you need long-lived connector credentials. |
 
+### A Malformed Setting Stops the Boot
+
+Every numeric setting in the table above is **validated at start-up**, before the config file is read. A value
+that is present but not a whole number in range makes the instance refuse to start, naming every offender at once:
+
+```text
+[ERROR] Refusing to start: 2 environment settings are malformed.
+[ERROR]   • SHUTDOWN_DRAIN_MS="8OOO" is not usable — it is not a number. It sets how long in-flight requests
+          get after SIGTERM, and must be a whole number between 0 and 300000.
+[ERROR]   • RECALL_BUDGET_MS="30_000" is not usable — it is not a number. …
+```
+
+An **empty** value means "not set" and uses the documented default, which is the usual way to clear a setting in a
+compose file. Surrounding whitespace is ignored, so a YAML block scalar cannot break a value.
+
+This is deliberately a refusal rather than a fallback, because **a typo is never a preference.** These were read
+with an unchecked `Number()`, so a mistyped value became `NaN` — and `NaN` does not fail, it quietly changes
+behaviour. Measured:
+
+| a typo in | did | so |
+|---|---|---|
+| `SHUTDOWN_DRAIN_MS` | `setTimeout(fn, NaN)` fires after **0 ms** | the graceful drain did not drain: in-flight requests were cut off at SIGTERM |
+| `MONGO_CONNECT_RETRY_MS` | `elapsed < NaN` is **false** | zero retries, so a MongoDB that was still starting killed the boot |
+| `EMBEDDING_DIMENSIONS` | serialises as **`null`** | the vector index was created with a null dimension |
+| `RECALL_BUDGET_MS` | every comparison **false** | the recall budget silently stopped applying |
+
+Two of those are guarantees this guide documents, lost without a word. `PORT` was the one already safe — Node
+refuses `listen(NaN)` outright — and that is now the behaviour of all of them.
+
 ### Data Persistence
 
 All persistent data lives in named Docker volumes:

--- a/server/src/api/local-agent.ts
+++ b/server/src/api/local-agent.ts
@@ -10,6 +10,7 @@ import { globalRateLimit } from '../rate-limit/middleware.js';
 import { requireAdminMfa } from '../auth/middleware.js';
 import { log } from '../util/log.js';
 import { isLoopbackHost, LOCAL_AGENT_DEFAULT_URL } from './local-agent-url.js';
+import { envInt } from '../config/env-num.js';
 
 export const localAgentRouter = Router();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -366,7 +367,7 @@ localAgentRouter.post('/enable-networks/execute', globalRateLimit, requireAdminM
     // correct origin into cloudflared config.yml regardless of what port Ythril runs on.
     // YTHRIL_LOCAL_AGENT_ORIGIN overrides this — needed in Docker workstation mode where
     // the container's internal PORT (3200) differs from the host-exposed port (e.g. 3210).
-    const serverPort = Number(process.env['PORT'] ?? 3200);
+    const serverPort = envInt('PORT', 3200);
     const defaultOrigin = process.env['YTHRIL_LOCAL_AGENT_ORIGIN']?.trim()
       || `http://localhost:${serverPort}`;
     const bodyWithOrigin = {

--- a/server/src/api/model-verify.ts
+++ b/server/src/api/model-verify.ts
@@ -41,6 +41,7 @@ import { createMediaProviders } from '../files/media/providers.js';
 import { embed } from '../brain/embedding.js';
 import { repairMarkdownExternal } from '../files/converters/vlm-client.js';
 import { log } from '../util/log.js';
+import { envInt } from '../config/env-num.js';
 
 export const modelVerifyRouter = Router();
 
@@ -51,7 +52,7 @@ export const modelVerifyRouter = Router();
  * swapping in on a shared GPU took 34.7s in the field; 180s leaves room for a larger model on a busier
  * host without ever making the operator wonder whether the button did anything.
  */
-const VERIFY_TIMEOUT_MS = Number(process.env['MODEL_VERIFY_TIMEOUT_MS'] ?? 180_000);
+const VERIFY_TIMEOUT_MS = envInt('MODEL_VERIFY_TIMEOUT_MS', 180_000);
 
 /**
  * A 1×1 transparent PNG.

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -19,6 +19,7 @@ import { atlasVectorScore, scoresAgree } from './vector-score.js';
 import type { ChronoStatus } from '../config/types.js';
 import { log } from '../util/log.js';
 import { recallDegradedTotal } from '../metrics/registry.js';
+import { envInt } from '../config/env-num.js';
 
 /**
  * End-to-end budget for one recall call.
@@ -32,7 +33,7 @@ import { recallDegradedTotal } from '../metrics/registry.js';
  * hop it can cancel is the reranker, because that is the only optional one. Raise it if your clients are
  * patient and your corpus is slow; lower it if you would rather degrade sooner.
  */
-export const RECALL_BUDGET_MS = Number(process.env['RECALL_BUDGET_MS'] ?? 25_000);
+export const RECALL_BUDGET_MS = envInt('RECALL_BUDGET_MS', 25_000);
 
 /**
  * Below this much remaining budget the reranker is skipped entirely rather than started.
@@ -42,7 +43,7 @@ export const RECALL_BUDGET_MS = Number(process.env['RECALL_BUDGET_MS'] ?? 25_000
  * order — a slightly worse ranking, delivered — which is the trade the whole pipeline already makes when
  * a reranker is unreachable.
  */
-export const RERANK_MIN_BUDGET_MS = Number(process.env['RERANK_MIN_BUDGET_MS'] ?? 3_000);
+export const RERANK_MIN_BUDGET_MS = envInt('RERANK_MIN_BUDGET_MS', 3_000);
 
 export type RecallKnowledgeType = 'memory' | 'entity' | 'edge' | 'chrono' | 'file';
 

--- a/server/src/config/env-num.ts
+++ b/server/src/config/env-num.ts
@@ -1,0 +1,137 @@
+/**
+ * Numeric environment variables, validated once, at boot, out loud.
+ *
+ * ## The finding — Observability & Operability audit lens
+ *
+ * Fifteen numeric settings were read as `Number(process.env[X])` and exactly **one** of them checked the result.
+ * A typo — `8OOO` with letter O, `30_000`, `5s`, a trailing space in a YAML block — yields `NaN`, and `NaN` does
+ * not fail. It silently changes behaviour. Measured, not assumed:
+ *
+ * | setting | typo'd value does | consequence |
+ * |---|---|---|
+ * | `SHUTDOWN_DRAIN_MS` | `setTimeout(fn, NaN)` fires after **0 ms** | the graceful drain does not drain: in-flight requests are cut off at SIGTERM, which is the exact guarantee the drain was added to provide |
+ * | `MONGO_CONNECT_RETRY_MS` | `elapsed < NaN` is **false** | zero retries, reintroducing the boot race where the first connection is reset while mongod is still starting |
+ * | `EMBEDDING_DIMENSIONS` | serialises as **`null`** | the vector index is created with a null dimension |
+ * | `RECALL_BUDGET_MS` | every budget comparison is **false** | the budget silently stops applying |
+ *
+ * `PORT` is the one that was already safe, and worth recording because I expected otherwise: Node throws
+ * `ERR_SOCKET_BAD_PORT` from `listen(NaN)`, so a typo there fails loudly at boot. That is the behaviour every
+ * other setting now has.
+ *
+ * ## Why fail fast rather than fall back to the default
+ *
+ * Because a typo is never a preference. Falling back gives an operator an instance that runs with settings they did
+ * not choose and cannot see — and for the three above, one that has quietly lost a documented guarantee. Refusing
+ * to start is the same choice the at-rest encryption already makes: a wrong key stops the boot rather than
+ * continuing without it.
+ *
+ * Every malformed value is reported in ONE message, not the first one only, so an operator with two typos learns
+ * about both.
+ */
+import { log } from '../util/log.js';
+
+/** A numeric setting: its name, its bounds, and what it means, for the error message. */
+interface NumericSetting {
+  name: string;
+  min: number;
+  max: number;
+  /** Named in the failure message so an operator knows what they have broken. */
+  what: string;
+}
+
+/**
+ * Every numeric environment variable Ythril reads.
+ *
+ * Exhaustive by design, and asserted to be: a new `Number(process.env[…])` anywhere in the tree without an entry
+ * here is a setting nobody validates, which is how this class of bug returns. See
+ * `testing/standalone/numeric-env-is-validated.test.js`.
+ */
+export const NUMERIC_SETTINGS: readonly NumericSetting[] = [
+  { name: 'PORT', min: 1, max: 65535, what: 'the HTTP listen port' },
+  { name: 'MONGO_CONNECT_RETRY_MS', min: 0, max: 600_000, what: 'how long the first MongoDB connection may retry' },
+  { name: 'SHUTDOWN_DRAIN_MS', min: 0, max: 300_000, what: 'how long in-flight requests get after SIGTERM' },
+  { name: 'SHUTDOWN_READY_GRACE_MS', min: 0, max: 300_000, what: 'how long to keep serving after /ready turns 503' },
+  { name: 'RECALL_BUDGET_MS', min: 1_000, max: 600_000, what: 'the end-to-end budget for one recall' },
+  { name: 'RERANK_MIN_BUDGET_MS', min: 0, max: 600_000, what: 'the remaining budget below which reranking is skipped' },
+  { name: 'EMBEDDING_DIMENSIONS', min: 1, max: 8_192, what: 'the embedding vector width' },
+  { name: 'EMBEDDING_CONCURRENCY', min: 1, max: 256, what: 'how many embeds run at once' },
+  { name: 'MODEL_VERIFY_TIMEOUT_MS', min: 1_000, max: 1_800_000, what: 'how long a model verification may take' },
+  { name: 'DOC_OCR_TIMEOUT_MS', min: 1_000, max: 3_600_000, what: 'how long an OCR extraction may take' },
+  { name: 'DOC_DESCRIBE_TIMEOUT_MS', min: 1_000, max: 3_600_000, what: 'how long a document description may take' },
+  { name: 'INDEX_READY_TIMEOUT_MS', min: 0, max: 3_600_000, what: 'how long boot waits for vector indexes' },
+  { name: 'MCP_OAUTH_TOKEN_TTL_DAYS', min: 0, max: 3_650, what: 'the lifetime of a connector token (0 = never expires)' },
+  { name: 'YTHRIL_CONNECTOR_PORT', min: 1, max: 65535, what: "the local agent connector's listen port" },
+] as const;
+
+const BY_NAME = new Map(NUMERIC_SETTINGS.map(s => [s.name, s]));
+
+/** Why a value was rejected, phrased for an operator rather than a developer. */
+function reject(name: string, raw: string, why: string): string {
+  const s = BY_NAME.get(name);
+  return `${name}=${JSON.stringify(raw)} is not usable — ${why}.${s ? ` It sets ${s.what}` : ''}`
+    + (s ? `, and must be a whole number between ${s.min} and ${s.max}.` : '');
+}
+
+/**
+ * Strict parse. `null` when unset; a string when the value is present and unusable.
+ *
+ * The single definition of "usable", so the reader and the boot-time check can never disagree about a value —
+ * which would be the worst outcome available: an instance that starts because the check passed and then behaves as
+ * if the setting were absent.
+ */
+function parse(name: string): { value: number | null } | { problem: string } {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return { value: null };
+  const s = BY_NAME.get(name);
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n)) return { problem: reject(name, raw, 'it is not a number') };
+  if (!Number.isInteger(n)) return { problem: reject(name, raw, 'it is not a whole number') };
+  if (s && (n < s.min || n > s.max)) return { problem: reject(name, raw, `${n} is out of range`) };
+  return { value: n };
+}
+
+/**
+ * Parse one numeric env var, or `undefined` when it is unset or unusable.
+ *
+ * **Does not throw, deliberately.** Several of these are read at module scope, so a throw would happen during
+ * import — before any of `index.ts` runs, producing a stack trace instead of the message an operator needs, and
+ * from a module they have never heard of. Instead the problem is remembered, and
+ * {@link assertNumericEnvOrExit} refuses to start the process. Nothing is served with a value nobody chose.
+ */
+export function envIntOpt(name: string): number | undefined {
+  const r = parse(name);
+  if ('problem' in r) return undefined;
+  return r.value ?? undefined;
+}
+
+/** Parse one numeric env var, falling back to `fallback` when it is unset (or unusable — see above). */
+export function envInt(name: string, fallback: number): number {
+  return envIntOpt(name) ?? fallback;
+}
+
+/**
+ * Check every numeric setting and report ALL problems.
+ *
+ * Returns rather than exits so it is testable: a test can assert the reporting without killing its own process.
+ * Every offender is listed, not just the first — an operator with two typos should learn about both.
+ */
+export function validateNumericEnv(): { ok: boolean; problems: string[] } {
+  const problems: string[] = [];
+  for (const s of NUMERIC_SETTINGS) {
+    const r = parse(s.name);
+    if ('problem' in r) problems.push(r.problem);
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+/** Report and exit, or return. The one place the process is allowed to die over a setting. */
+export function assertNumericEnvOrExit(): void {
+  const { ok, problems } = validateNumericEnv();
+  if (ok) return;
+  log.error(`Refusing to start: ${problems.length} environment setting${problems.length === 1 ? ' is' : 's are'} malformed.`);
+  for (const p of problems) log.error(`  • ${p}`);
+  log.error('A typo is never a preference: continuing would run this instance with settings you did not choose, '
+    + 'and for the shutdown drain and the MongoDB connect retry it would silently drop a guarantee. '
+    + 'Fix the value(s) above, or unset them to use the documented defaults.');
+  process.exit(1);
+}

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -4,6 +4,7 @@ import { log } from '../util/log.js';
 import type { Config, SecretsFile, SchemaLibraryEntry, SchemaCatalog } from './types.js';
 import { normalizeDocExtractionMode } from './types.js';
 import { resolveMasterSecret, isEnvelope, encryptEnvelope, decryptEnvelope } from './secretbox.js';
+import { envIntOpt } from './env-num.js';
 
 const CONFIG_PATH = process.env['CONFIG_PATH'] ?? '/config/config.json';
 const SECRETS_PATH = path.join(path.dirname(CONFIG_PATH), 'secrets.json');
@@ -791,11 +792,10 @@ export function getEmbeddingConfig() {
   return {
     baseUrl: process.env['EMBEDDING_URL'] ?? base.baseUrl,
     model: process.env['EMBEDDING_MODEL'] ?? base.model ?? 'nomic-ai/nomic-embed-text-v1.5',
-    dimensions: process.env['EMBEDDING_DIMENSIONS'] ? Number(process.env['EMBEDDING_DIMENSIONS']) : (base.dimensions ?? 768),
+    dimensions: envIntOpt('EMBEDDING_DIMENSIONS') ?? base.dimensions ?? 768,
     // Left `undefined` when unset on purpose: `embedConcurrency()` picks a different default per embedder,
     // so a number here would flatten that distinction. Clamping happens there, in one place.
-    embedConcurrency: process.env['EMBEDDING_CONCURRENCY']
-      ? Number(process.env['EMBEDDING_CONCURRENCY']) : base.embedConcurrency,
+    embedConcurrency: envIntOpt('EMBEDDING_CONCURRENCY') ?? base.embedConcurrency,
     similarity: base.similarity ?? ('cosine' as const),
     provider: (process.env['EMBEDDING_PROVIDER'] as 'local' | 'external' | undefined) ?? base.provider ?? 'local',
     // 'auto' resolves to the pre-existing behaviour (see resolvePrefixScheme in brain/embedding.ts), so an
@@ -1160,11 +1160,11 @@ export function getDocumentProcessingConfig(): Required<DocumentProcessingConfig
     maxTotalPages: base.maxTotalPages ?? d.maxTotalPages,
     pageTimeoutMs: base.pageTimeoutMs ?? d.pageTimeoutMs,
     concurrency: base.concurrency ?? d.concurrency,
-    ocrTimeoutMs: process.env['DOC_OCR_TIMEOUT_MS'] ? Number(process.env['DOC_OCR_TIMEOUT_MS']) : (base.ocrTimeoutMs ?? d.ocrTimeoutMs),
+    ocrTimeoutMs: envIntOpt('DOC_OCR_TIMEOUT_MS') ?? base.ocrTimeoutMs ?? d.ocrTimeoutMs,
     // A single-GPU backend that swaps models per request spends the first part of this call LOADING one,
     // which is why it is tunable at all: at 30 s such a host times out on every document and silently keeps
     // extractive text instead.
-    describeTimeoutMs: process.env['DOC_DESCRIBE_TIMEOUT_MS'] ? Number(process.env['DOC_DESCRIBE_TIMEOUT_MS']) : (base.describeTimeoutMs ?? d.describeTimeoutMs),
+    describeTimeoutMs: envIntOpt('DOC_DESCRIBE_TIMEOUT_MS') ?? base.describeTimeoutMs ?? d.describeTimeoutMs,
     vlmModel: process.env['DOC_VLM_MODEL'] ?? base.vlmModel ?? d.vlmModel,
     vlmBaseUrl: process.env['DOC_VLM_URL'] ?? base.vlmBaseUrl ?? d.vlmBaseUrl,
     repairModel: process.env['DOC_REPAIR_MODEL'] ?? base.repairModel ?? d.repairModel,

--- a/server/src/db/mongo.ts
+++ b/server/src/db/mongo.ts
@@ -3,6 +3,7 @@ import { getMongoUri } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { dbNameFromUri } from './db-name.js';
 import { withJitter } from '../util/backoff.js';
+import { envInt } from '../config/env-num.js';
 
 let _client: MongoClient | null = null;
 let _dbName = 'ythril';
@@ -12,7 +13,7 @@ let _vectorSearchAvailable: boolean | null = null;
 let _vectorSearchDetails = '';
 
 /** Total time the first connection may spend retrying before boot gives up. */
-const CONNECT_RETRY_BUDGET_MS = Number(process.env['MONGO_CONNECT_RETRY_MS'] ?? 30_000);
+const CONNECT_RETRY_BUDGET_MS = envInt('MONGO_CONNECT_RETRY_MS', 30_000);
 
 /**
  * Errors worth retrying: the database is there but not yet able to hold a connection.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,13 +9,14 @@ import { stopBackupScheduler } from './db/backup-scheduler.js';
 import { stopDupeScanner } from './brain/dupe-scanner.js';
 import { cleanupStaleChunks } from './files/chunks.js';
 import { log, redactSecrets } from './util/log.js';
+import { envInt, assertNumericEnvOrExit } from './config/env-num.js';
 
 // Enable debug logging when --debug flag is passed or DEBUG env is already set.
 if (process.argv.includes('--debug')) {
   process.env['DEBUG'] = '1';
 }
 
-const PORT = Number(process.env['PORT'] ?? 3200);
+const PORT = envInt('PORT', 3200);
 
 // ANSI helpers — no-op when stdout is not a TTY (e.g. piped logs)
 const isTTY = process.stdout.isTTY;
@@ -26,6 +27,15 @@ const YELLOW = isTTY ? '\x1b[33m'          : '';
 const RESET  = isTTY ? '\x1b[0m'           : '';
 
 async function main(): Promise<void> {
+  // Before anything else, including reading the config file: a malformed numeric setting stops the boot.
+  //
+  // These used to be `Number(process.env[X])` with no check, so a typo (`8OOO` with letter O, `30_000`, `5s`)
+  // became NaN — and NaN does not fail, it silently changes behaviour. Measured: a NaN `SHUTDOWN_DRAIN_MS` makes
+  // `setTimeout` fire after 0 ms, so the graceful drain does not drain; a NaN `MONGO_CONNECT_RETRY_MS` makes the
+  // retry budget comparison false, so there are zero retries. Both are documented guarantees, lost in silence.
+  // Same choice the at-rest encryption already makes: refuse to start rather than continue wrongly.
+  assertNumericEnvOrExit();
+
   const isFirstRun = !configExists();
 
   if (!isFirstRun) {
@@ -154,7 +164,7 @@ async function main(): Promise<void> {
    * config flush and the Mongo close that follow. Kubernetes' default is 30 s, so this is the tighter
    * of the two constraints; raise `SHUTDOWN_DRAIN_MS` if your orchestrator gives you longer.
    */
-  const DRAIN_MS = Number(process.env['SHUTDOWN_DRAIN_MS'] ?? 8_000);
+  const DRAIN_MS = envInt('SHUTDOWN_DRAIN_MS', 8_000);
 
   /**
    * How long to keep serving after readiness starts reporting false, before the drain begins.
@@ -166,7 +176,7 @@ async function main(): Promise<void> {
    *
    * Comes out of the same budget as DRAIN_MS: both must fit inside the orchestrator's stop grace.
    */
-  const READY_GRACE_MS = Number(process.env['SHUTDOWN_READY_GRACE_MS'] ?? 2_000);
+  const READY_GRACE_MS = envInt('SHUTDOWN_READY_GRACE_MS', 2_000);
 
   let shuttingDown = false;
 

--- a/server/src/local-agent-connector/index.ts
+++ b/server/src/local-agent-connector/index.ts
@@ -8,8 +8,9 @@ import os from 'node:os';
 import { redactSecrets } from '../util/log.js';
 import { spawn } from 'node:child_process';
 import { z } from 'zod';
+import { envInt } from '../config/env-num.js';
 
-const PORT = Number(process.env['YTHRIL_CONNECTOR_PORT'] ?? 38123);
+const PORT = envInt('YTHRIL_CONNECTOR_PORT', 38123);
 const HOST = process.env['YTHRIL_CONNECTOR_BIND_HOST'] ?? '0.0.0.0';
 const TOKEN_FILE = process.env['YTHRIL_CONNECTOR_TOKEN_FILE'] ?? path.join(os.homedir(), '.ythril-local-connector', 'token');
 // On Windows workstations, service install is the correct default so the tunnel survives reboots

--- a/server/src/mcp/oauth.ts
+++ b/server/src/mcp/oauth.ts
@@ -42,6 +42,7 @@ import { getPublicBaseUrl } from '../config/public-url.js';
 import { createOAuthToken, findMatchingToken } from '../auth/tokens.js';
 import { authRateLimit } from '../rate-limit/middleware.js';
 import { log } from '../util/log.js';
+import { envInt } from '../config/env-num.js';
 
 // ── Public base URL / resource identifiers ──────────────────────────────────
 
@@ -72,10 +73,9 @@ const MAX_OAUTH_CLIENTS = 50;
 // abandoned connectors don't leave permanent credentials behind, and the total
 // count is capped as a backstop. Both are overridable via env; a TTL of 0 opts
 // out of expiry (tokens never expire) for operators who need long-lived ones.
-const OAUTH_TOKEN_TTL_DAYS = (() => {
-  const raw = Number(process.env['MCP_OAUTH_TOKEN_TTL_DAYS']);
-  return Number.isFinite(raw) && raw >= 0 ? raw : 90;
-})();
+// Was the ONE numeric setting that validated its own input. It now shares the boot-time check with the other
+// thirteen, so a typo is reported alongside them instead of quietly becoming 90.
+const OAUTH_TOKEN_TTL_DAYS = envInt('MCP_OAUTH_TOKEN_TTL_DAYS', 90);
 const OAUTH_TOKEN_TTL_MS: number | null = OAUTH_TOKEN_TTL_DAYS === 0 ? null : OAUTH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
 const MAX_OAUTH_TOKENS = 50;
 

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -17,6 +17,7 @@ import { VECTOR_INDEXED_COLLECTIONS, buildSpaceVectorIndexes, finalizeSpaceIndex
 import { SPACE_COLLECTIONS, repairStaleSpaceIds, dropLegacyPrefixedIndexes, pendingOpConflictMessage , setReindexNeeded, beginSpaceOp, endSpaceOp, spaceOpInFlight } from './_shared.js';
 import { moveSpaceData, applySpaceRenameToConfig } from './rename.js';
 import { ensureMediaJobIndexes } from '../files/media/job-queue.js';
+import { envInt } from '../config/env-num.js';
 
 export async function initSpace(
   spaceId: string,
@@ -176,7 +177,7 @@ export async function initSpace(
  * and reported `failed` for indexes that were building perfectly well. Off the boot path nothing is
  * waiting on this but a status label, so it can afford to be long enough to be TRUE.
  */
-const STARTUP_INDEX_READY_TIMEOUT_MS = Number(process.env['INDEX_READY_TIMEOUT_MS'] ?? 10 * 60_000);
+const STARTUP_INDEX_READY_TIMEOUT_MS = envInt('INDEX_READY_TIMEOUT_MS', 10 * 60_000);
 
 /** How many spaces confirm their index builds at once, once boot has already finished. */
 const FINALIZE_CONCURRENCY = 3;

--- a/testing/standalone/model-verify.test.js
+++ b/testing/standalone/model-verify.test.js
@@ -81,12 +81,17 @@ describe('a cold start is reported as its own outcome', () => {
   it('the budget is generous enough for a swapping backend', () => {
     // The field measurement was 34.7s for a model being swapped in on a shared GPU. A tight budget here
     // recreates the false negative this endpoint removes.
-    const ms = Number(/MODEL_VERIFY_TIMEOUT_MS'\] \?\? (\d+_?\d*)/.exec(SRC)?.[1].replace('_', ''));
+    // Matches either idiom: the read moved to the validated `envInt` helper so a typo stops the boot instead of
+    // becoming NaN. This assertion is about the BUDGET, not about how it is read, so it accepts both shapes.
+    const raw = /MODEL_VERIFY_TIMEOUT_MS'\] \?\? (\d+_?\d*)/.exec(SRC)?.[1]
+      ?? /envInt\('MODEL_VERIFY_TIMEOUT_MS',\s*(\d+_?\d*)\)/.exec(SRC)?.[1];
+    const ms = Number(String(raw).replaceAll('_', ''));
     assert.ok(ms >= 60_000, `budget is ${ms}ms — a cold model load has been measured at ~35s`);
   });
 
   it('the budget is tunable without a rebuild', () => {
-    assert.match(SRC, /process\.env\['MODEL_VERIFY_TIMEOUT_MS'\]/);
+    assert.match(SRC, /process\.env\['MODEL_VERIFY_TIMEOUT_MS'\]|envInt\('MODEL_VERIFY_TIMEOUT_MS'/,
+      'the budget must stay env-overridable, however it is read');
   });
 });
 

--- a/testing/standalone/mongo-connect-retry.test.js
+++ b/testing/standalone/mongo-connect-retry.test.js
@@ -80,7 +80,13 @@ describe('the retry loop itself', () => {
   it('is bounded by a budget, not by an attempt count alone', () => {
     // An attempt count with growing backoff has no predictable ceiling; a deadline does, which is what
     // an orchestrator's startup budget has to be sized against.
-    assert.match(SRC, /CONNECT_RETRY_BUDGET_MS = Number\(process\.env\['MONGO_CONNECT_RETRY_MS'\] \?\? 30_000\)/);
+    // Either idiom. The read moved to the validated `envInt` helper because a typo used to become NaN, and
+    // `elapsed < NaN` is false — which silently reduced this budget to ZERO retries, the exact boot race the
+    // retry loop exists to survive. This assertion is about the budget's shape, not about how it is read.
+    assert.match(
+      SRC,
+      /CONNECT_RETRY_BUDGET_MS = (?:Number\(process\.env\['MONGO_CONNECT_RETRY_MS'\] \?\? 30_000\)|envInt\('MONGO_CONNECT_RETRY_MS', 30_000\))/,
+    );
     assert.match(SRC, /Date\.now\(\) >= deadline/);
   });
 

--- a/testing/standalone/numeric-env-is-validated.test.js
+++ b/testing/standalone/numeric-env-is-validated.test.js
@@ -1,0 +1,239 @@
+/**
+ * A typo in a numeric setting must stop the boot, not silently change behaviour.
+ *
+ * ## The finding — Observability & Operability audit lens
+ *
+ * Fifteen numeric settings were read as `Number(process.env[X])`, and exactly **one** checked the result. A typo —
+ * `8OOO` with letter O, `30_000`, `5s`, a stray space in a YAML block — yields `NaN`, and `NaN` does not fail.
+ * Measured against real Node, not assumed:
+ *
+ * | setting | what NaN does | consequence |
+ * |---|---|---|
+ * | `SHUTDOWN_DRAIN_MS` | `setTimeout(fn, NaN)` fires after **0 ms** | the graceful drain does not drain |
+ * | `MONGO_CONNECT_RETRY_MS` | `elapsed < NaN` is **false** | zero retries; the mongod boot race returns |
+ * | `EMBEDDING_DIMENSIONS` | serialises as **`null`** | a vector index with a null dimension |
+ * | `RECALL_BUDGET_MS` | every budget comparison **false** | the budget stops applying |
+ *
+ * `PORT` was already safe and is recorded here because the expectation was wrong: `listen(NaN)` throws
+ * `ERR_SOCKET_BAD_PORT`, so a typo there fails loudly. That is the behaviour every setting now has.
+ *
+ * ## What this gate holds
+ *
+ * That the registry stays **exhaustive** — a new unvalidated read is the way this class of bug returns — that the
+ * boot actually refuses, and that the refusal names every offender rather than the first.
+ *
+ * Run: node --test testing/standalone/numeric-env-is-validated.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p) => readFileSync(p, 'utf8');
+
+/** Every .ts file under server/src. */
+function sources(dir = 'server/src') {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...sources(p));
+    else if (entry.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+const FILES = sources();
+const HELPER = read('server/src/config/env-num.ts');
+
+describe('the sweep itself works', () => {
+  it('found the server sources', () => {
+    // Without this, a rename would reduce the sweep to zero files and the coverage assertion below would pass by
+    // examining nothing — the failure mode every coverage gate in this repo has had at least once.
+    assert.ok(FILES.length > 100, `expected the server tree, found ${FILES.length} files`);
+    assert.ok(FILES.includes(join('server', 'src', 'index.ts')), 'index.ts was not found');
+  });
+});
+
+describe('every numeric env read goes through the validated helper', () => {
+  it('no raw Number()/parseInt() on process.env outside the helper', () => {
+    const RAW = /(?:Number|parseInt|parseFloat)\(\s*(?:process\.env\[|process\.env\.)/;
+    const offenders = [];
+    for (const f of FILES) {
+      if (f.endsWith(join('config', 'env-num.ts'))) continue;   // the helper is allowed to parse
+      const src = read(f);
+      src.split(/\r?\n/).forEach((line, i) => {
+        // Comment lines are skipped. This is the THIRD gate this session to fire on its own documentation — the
+        // comment explaining a fix quotes the pattern it warns against, every time. A gate that reads prose as
+        // code gets appeased by deleting the explanation, which is precisely backwards.
+        const code = line.replace(/\/\*.*?\*\//g, '').trim();
+        if (code.startsWith('//') || code.startsWith('*') || code.startsWith('/*')) return;
+        if (RAW.test(code)) offenders.push(`${f}:${i + 1}  ${code}`);
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'these read a numeric setting without validating it, so a typo becomes NaN and silently changes behaviour '
+      + 'instead of stopping the boot. Use envInt / envIntOpt and add the variable to NUMERIC_SETTINGS:\n  '
+      + offenders.join('\n  '));
+  });
+
+  it('the registry covers every setting the helper is asked for', () => {
+    // A call site that passes a name the registry does not know still gets parsed, but with no bounds and no entry
+    // in the boot-time sweep — half-validated, which is the worst of both.
+    const names = new Set([...HELPER.matchAll(/name:\s*'([A-Z0-9_]+)'/g)].map(m => m[1]));
+    assert.ok(names.size >= 12, `the registry looks empty: ${names.size} entries`);
+
+    const missing = [];
+    for (const f of FILES) {
+      if (f.endsWith(join('config', 'env-num.ts'))) continue;
+      for (const m of read(f).matchAll(/envInt(?:Opt)?\(\s*'([A-Z0-9_]+)'/g)) {
+        if (!names.has(m[1])) missing.push(`${f}: ${m[1]}`);
+      }
+    }
+    assert.deepEqual(missing, [], 'these are read through the helper but have no registry entry, so they are '
+      + `unbounded and invisible to the boot check:\n  ${missing.join('\n  ')}`);
+  });
+});
+
+describe('the boot refuses to start on a malformed value', () => {
+  it('index.ts checks before it does anything else', () => {
+    // Comments stripped FIRST. Commenting the call out left `indexOf` finding it inside the comment, so the gate
+    // passed with the check disabled — the fourth time this session a gate read prose as code.
+    const src = read('server/src/index.ts')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ 	]*\/\/.*$/gm, '');
+    const at = src.indexOf('assertNumericEnvOrExit()');
+    assert.ok(at > 0, 'nothing calls assertNumericEnvOrExit, so a malformed setting still starts the instance');
+    // Ordering is the whole value: after `loadConfig()` it would be reported behind whatever the config loader
+    // does with a NaN, and after `listen()` it would be reported to an instance already serving traffic.
+    const loadConfig = src.indexOf('loadConfig()');
+    const listen = src.indexOf('.listen(');
+    assert.ok(loadConfig < 0 || at < loadConfig, 'the check must run before the config is loaded');
+    assert.ok(listen < 0 || at < listen, 'the check must run before the server starts listening');
+  });
+
+  it('the process actually exits', () => {
+    const at = HELPER.indexOf('export function assertNumericEnvOrExit');
+    assert.ok(at > 0, 'assertNumericEnvOrExit is gone');
+    const fn = HELPER.slice(at, HELPER.indexOf('\n}', at));
+    assert.match(fn, /process\.exit\(1\)/, 'a malformed setting must stop the boot, not warn and continue');
+    // The ENUMERATION, not just any log.error: the summary line ("2 settings are malformed") survived deleting
+    // the loop that actually names them, and a count without names is not actionable.
+    assert.match(fn, /for \(const p of problems\)/,
+      'every offender must be logged by name, not summarised as a count');
+    assert.match(fn, /log\.error/, 'the reason must be logged, or an operator sees an exit with no explanation');
+  });
+
+  it('the reader does NOT throw, so a module-scope read cannot pre-empt the message', () => {
+    // Several settings are read at module scope. A throw there happens during import, before any of index.ts
+    // runs — the operator would get a stack trace from a module they have never heard of instead of the message.
+    const at = HELPER.indexOf('export function envIntOpt');
+    const fn = HELPER.slice(at, HELPER.indexOf('\n}', at));
+    assert.doesNotMatch(fn, /throw /, 'envIntOpt must not throw — see the note in the helper');
+  });
+});
+
+describe('it is documented', () => {
+  it('the hosting guide says the boot refuses, and what a typo used to do', () => {
+    const doc = read('docs/integration-guide/02-hosting.md');
+    const at = doc.indexOf('### A Malformed Setting Stops the Boot');
+    assert.ok(at > 0, 'the section is gone');
+    const section = doc.slice(at, doc.indexOf('\n### ', at + 10));
+    assert.match(section, /refuse to start/i, 'it must say the instance refuses to start');
+    assert.match(section, /empty/i, 'it must say that an empty value means "not set" — the usual way to clear one');
+    assert.match(section, /NaN/, 'it must say what a typo used to do, or the refusal reads as pedantry');
+    assert.match(section, /every offender|all/i, 'it must say every offender is reported at once');
+  });
+});
+
+describe('the helper, against values an operator really types', () => {
+  const CASES = [
+    ['8000', 'accepted'],
+    ['0', 'accepted'],
+    ['8OOO', 'refused'],      // letter O
+    ['30_000', 'refused'],    // JS numeric separator, not shell
+    ['5s', 'refused'],        // a duration
+    ['8000ms', 'refused'],
+    ['', 'unset'],            // empty is "not set", not an error — a common way to clear a value
+    ['  8000  ', 'accepted'], // whitespace from a YAML block scalar
+    ['8000.5', 'refused'],    // milliseconds are whole
+    ['-1', 'refused'],        // below the floor
+    ['999999999', 'refused'], // above the ceiling
+  ];
+
+  it('classifies each one as expected', async () => {
+    const { validateNumericEnv, envIntOpt } = await import('../../server/dist/config/env-num.js');
+    const wrong = [];
+    const before = process.env['SHUTDOWN_DRAIN_MS'];
+    try {
+      for (const [raw, expected] of CASES) {
+        process.env['SHUTDOWN_DRAIN_MS'] = raw;
+        const { ok, problems } = validateNumericEnv();
+        const got = !ok ? 'refused' : envIntOpt('SHUTDOWN_DRAIN_MS') === undefined ? 'unset' : 'accepted';
+        if (got !== expected) {
+          wrong.push(`${JSON.stringify(raw)} → ${got}, expected ${expected}${problems[0] ? ` (${problems[0]})` : ''}`);
+        }
+      }
+    } finally {
+      if (before === undefined) delete process.env['SHUTDOWN_DRAIN_MS'];
+      else process.env['SHUTDOWN_DRAIN_MS'] = before;
+    }
+    assert.deepEqual(wrong, [], `misjudged:\n  ${wrong.join('\n  ')}`);
+  });
+
+  it('reports EVERY offender, not just the first', async () => {
+    // An operator with two typos should learn about both. Reporting one at a time turns a five-second fix into
+    // as many restarts as they made mistakes.
+    const { validateNumericEnv } = await import('../../server/dist/config/env-num.js');
+    const saved = { d: process.env['SHUTDOWN_DRAIN_MS'], r: process.env['RECALL_BUDGET_MS'] };
+    try {
+      process.env['SHUTDOWN_DRAIN_MS'] = 'nope';
+      process.env['RECALL_BUDGET_MS'] = 'also-nope';
+      const { ok, problems } = validateNumericEnv();
+      assert.equal(ok, false);
+      assert.equal(problems.length, 2, `expected both to be reported, got ${problems.length}`);
+      assert.ok(problems.some(p => p.includes('SHUTDOWN_DRAIN_MS')), 'the first offender is missing');
+      assert.ok(problems.some(p => p.includes('RECALL_BUDGET_MS')), 'the second offender is missing');
+    } finally {
+      for (const [k, v] of [['SHUTDOWN_DRAIN_MS', saved.d], ['RECALL_BUDGET_MS', saved.r]]) {
+        if (v === undefined) delete process.env[k]; else process.env[k] = v;
+      }
+    }
+  });
+
+  it('the message says what the setting DOES, not just that it is wrong', async () => {
+    // "SHUTDOWN_DRAIN_MS is invalid" makes an operator go and look it up. Naming the effect and the range makes
+    // the fix obvious from the log line alone.
+    const { validateNumericEnv } = await import('../../server/dist/config/env-num.js');
+    const before = process.env['MONGO_CONNECT_RETRY_MS'];
+    try {
+      process.env['MONGO_CONNECT_RETRY_MS'] = 'oops';
+      const { problems } = validateNumericEnv();
+      assert.equal(problems.length, 1);
+      assert.match(problems[0], /MONGO_CONNECT_RETRY_MS/, 'the message must name the variable');
+      assert.match(problems[0], /"oops"/, 'it must quote the value, so a trailing space is visible');
+      // Deliberately checked on SHUTDOWN_DRAIN_MS below rather than here: "retry" also appears in the variable
+      // name MONGO_CONNECT_RETRY_MS, so this assertion passed with the description removed entirely.
+      assert.match(problems[0], /between 0 and \d+/, 'it must state the accepted range');
+    } finally {
+      if (before === undefined) delete process.env['MONGO_CONNECT_RETRY_MS'];
+      else process.env['MONGO_CONNECT_RETRY_MS'] = before;
+    }
+  });
+
+  it('the message describes the setting in words the NAME does not already contain', async () => {
+    // The point of `what`: an operator should not have to look the variable up. Checked on a setting whose
+    // description shares no words with its name, so the assertion cannot pass on the name alone.
+    const { validateNumericEnv } = await import('../../server/dist/config/env-num.js');
+    const before = process.env['SHUTDOWN_DRAIN_MS'];
+    try {
+      process.env['SHUTDOWN_DRAIN_MS'] = 'oops';
+      const { problems } = validateNumericEnv();
+      assert.equal(problems.length, 1);
+      assert.match(problems[0], /in-flight requests/i,
+        'the message must say what the setting does, in words the variable name does not already give away');
+    } finally {
+      if (before === undefined) delete process.env['MONGO_CONNECT_RETRY_MS'];
+      else process.env['MONGO_CONNECT_RETRY_MS'] = before;
+    }
+  });
+});

--- a/testing/standalone/startup-index-wait.test.js
+++ b/testing/standalone/startup-index-wait.test.js
@@ -113,9 +113,14 @@ describe('the readiness timeout is a parameter, and generous off the boot path',
   it('startup waits far longer than 60s, because nothing is blocked on it', () => {
     // The old ceiling was short BECAUSE boot was blocked on it — and being short is exactly why it
     // always expired on a real migration and reported `failed` for indexes that were building fine.
-    const m = /STARTUP_INDEX_READY_TIMEOUT_MS = Number\(process\.env\['INDEX_READY_TIMEOUT_MS'\] \?\? ([^)]+)\)/
+    // Matches either idiom on purpose. The reading moved from a raw `Number(process.env[…])` to the validated
+    // `envInt(…)` helper, so that a typo stops the boot instead of becoming NaN — and this assertion, which is
+    // about the CEILING rather than how it is read, caught the refactor. Keeping both shapes means the next
+    // refactor of the same kind does not have to touch a test whose subject has not changed.
+    const m = /STARTUP_INDEX_READY_TIMEOUT_MS = (?:Number\(process\.env\['INDEX_READY_TIMEOUT_MS'\] \?\? ([^)]+)\)|envInt\('INDEX_READY_TIMEOUT_MS',\s*([^)]+)\))/
       .exec(LIFECYCLE);
     assert.ok(m, 'startup timeout should be defined and env-overridable');
+    m[1] = m[1] ?? m[2];
     // eslint-disable-next-line no-eval
     const ms = eval(m[1].replaceAll('_', ''));
     assert.ok(ms >= 5 * 60_000, `expected a multi-minute ceiling, got ${ms}ms`);


### PR DESCRIPTION
## A typo in a numeric setting changed behaviour instead of stopping the boot

Second finding of audit lens **9 — Observability & Operability**, whose brief asks for *"boot-time config validation
that fails fast on a bad setting"*.

Fifteen numeric settings were read as `Number(process.env[X])`, and exactly **one** checked the result. So `8OOO`
(letter O), `30_000` (a JS separator, not shell), `5s`, or a stray space in a YAML block became `NaN` — and `NaN` does
not fail. It silently changes behaviour.

## Measured against real Node, not assumed

| a typo in | what NaN does | consequence |
|---|---|---|
| `SHUTDOWN_DRAIN_MS` | `setTimeout(fn, NaN)` fires after **0 ms** | the graceful drain **did not drain** — in-flight requests cut off at SIGTERM, the exact guarantee it exists to provide |
| `MONGO_CONNECT_RETRY_MS` | `elapsed < NaN` is **false** | **zero retries**, reintroducing the boot race where the first connection is reset while mongod is still starting |
| `EMBEDDING_DIMENSIONS` | serialises as **`null`** | a vector index created with a null dimension |
| `RECALL_BUDGET_MS` | every comparison **false** | the recall budget silently stopped applying |

Two of those are guarantees the hosting guide documents, lost without a word.

**`PORT` was the one already safe**, and it is recorded because I expected otherwise: Node throws
`ERR_SOCKET_BAD_PORT` from `listen(NaN)`, so a typo there fails loudly at boot. That is now the behaviour of all of
them.

## What it does now

```text
[ERROR] Refusing to start: 2 environment settings are malformed.
[ERROR]   • SHUTDOWN_DRAIN_MS="8OOO" is not usable — it is not a number. It sets how long in-flight requests
          get after SIGTERM, and must be a whole number between 0 and 300000.
[ERROR]   • RECALL_BUDGET_MS="30_000" is not usable — it is not a number. …
```

One helper (`config/env-num.ts`) with a **registry** of every numeric setting, its bounds, and what it does. The
message quotes the value (so a trailing space is visible), says what the setting *does*, and states the range — so
the fix is obvious from the log line alone. **Every** offender is named at once: an operator with two typos should
not need two restarts to find both.

Refusal rather than fallback, because **a typo is never a preference.** Same choice the at-rest encryption already
makes: a wrong key stops the boot rather than continuing without it.

## Two design points worth stating

**The reader deliberately does not throw.** Several settings are read at module scope, so a throw happens during
*import* — before any of `index.ts` runs — handing the operator a stack trace from a module they have never heard of
instead of the message. Problems are collected; the boot check refuses.

**An empty value still means "not set"** and uses the documented default, which is the usual way to clear a setting in
a compose file. Surrounding whitespace is trimmed, so a YAML block scalar cannot break a value.

## Three pre-existing gates caught the refactor, which is what they are for

`startup-index-wait`, `model-verify` and `mongo-connect-retry` each pinned the old expression. Each now accepts
either idiom, because each is about the **value** — a multi-minute index ceiling, a 60 s+ verify budget, a
deadline-bounded retry loop — and not about how it is read.

## Gate

`testing/standalone/numeric-env-is-validated.test.js`, **mutation-tested 16/16**, including that the registry stays
**exhaustive**: a new raw `Number(process.env[…])` anywhere in the server tree fails the build, which is the way this
class of bug would otherwise return.

**It caught four weak assertions of its own while being written, none by reading:**

1. One passed with the boot check **commented out** — `indexOf` found the call inside the comment. The *fourth* time
   this session a gate read prose as code; comments are stripped first now.
2. One passed with the per-offender logging deleted, because the summary count (`2 settings are malformed`) survived.
   A count without names is not actionable.
3. One passed with the description removed, because the word it matched (`retry`) also appears in the variable name
   `MONGO_CONNECT_RETRY_MS`. Re-anchored on a setting whose description shares no words with its name.
4. One mutation never applied at all: `env-num.ts` is LF while the rest of `server/src` is CRLF, and a wrong line
   ending applies nothing — which reads exactly like a passing gate.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
