### PR TITLE
docs(ops): a rollback procedure, because an upgrade is one-way and nothing said so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A documented rollback procedure, because an upgrade is one-way and nothing said so.** Third finding of the
+  Observability & Operability lens. The docs covered upgrading — volumes persist, indexes rebuild, back up first —
+  and said nothing about the direction an operator needs at three in the morning.
+  - The first boot on a new version **rewrites `config.json`**: three migrations run in `loadConfig` and each one
+    persists. Two of them *delete* a field, so an older build cannot see what was there.
+  - **The consequence is now stated, not just the mechanism.** Verified from history: the default for
+    `mediaEmbedding.enabled` before it was removed was **`true`**, so rolling back past that change would
+    **re-enable media embedding on an instance where it had deliberately been switched off** — uploads start
+    reaching the vision and speech models again. Silently, because an absent field reads as "never configured".
+  - The mechanism to go back already existed; it was never named as one. The pre-upgrade copy of `config.json` **is**
+    the rollback, and the section gives the four commands.
+  - Also answered, because they are the next two questions: **brain data needs no rollback** (documents only gain
+    fields, and readers ignore what they do not know) and **vector indexes rebuild on boot**.
+  - Gate `rollback-is-documented`, mutation-tested **11/11**. A migration added to `loadConfig` without a row in the
+    rollback table now fails the build — a one-way door nobody was told about is exactly what this is for.
+    Three of its own assertions were too loose and were caught the same way: a renamed heading still matched, an
+    alternation let the section's own prose satisfy the check for a command, and one surviving `saveConfig` call
+    passed a check meant to cover all three.
+
 - **Export the whole audit log as NDJSON** — `GET /api/admin/audit-log/export`, the same filters as the paged
   endpoint with no row cap. The paged endpoint stops at 1,000 rows because a browser table has to stop somewhere,
   and that ceiling is what made "produce everything you hold about this subject's activity" a paging script: the

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -755,6 +755,46 @@ Named volumes persist across upgrades. The server applies any pending MongoDB in
 
 **Breaking changes**, when they occur, will be listed in `CHANGELOG.md` with migration steps.
 
+### Rolling Back
+
+**The first boot on a new version rewrites `config.json`, and some of those rewrites drop a field an older
+build reads.** So a rollback is not simply "run the previous image": that path exists, but it needs the copy of
+`config.json` you took *before* upgrading.
+
+The rewrites are one-time and idempotent, they are logged when they happen, and each one exists because a setting
+moved. They are listed here so the consequence of going back is not a surprise:
+
+| the boot migrates | dropping | so an older build |
+|---|---|---|
+| `mediaEmbedding.enabled` → per-class `levels` | `enabled` | defaults it back to **`true`**: an instance where media embedding was deliberately **off** starts sending uploads to the vision and speech models again |
+| a space's `description` → `meta.purpose` | `description` | reads no space instructions, because the field it serves to MCP clients is gone |
+| `mediaEmbedding.faceRecognition.enabled` → the image ladder | `faceRecognition.enabled` | applies its own default for face recognition rather than the choice that was recorded |
+
+Each of those is silent in the old build — the field is simply absent, which reads as "never configured" rather
+than "removed".
+
+#### The procedure
+
+```bash
+# BEFORE upgrading — this file is the rollback, and it is 4 KB
+docker compose cp ythril:/config/config.json ./config.json.pre-upgrade
+
+# ... upgrade, and if it goes wrong:
+docker compose down
+docker compose cp ./config.json.pre-upgrade ythril:/config/config.json
+# pin the previous tag in compose (or .env), then:
+docker compose up -d
+```
+
+**Brain data in MongoDB needs no rollback of its own.** Documents only ever gain fields, and both the API and the
+UI ignore ones they do not know, so an older build reads newer records — it simply does not show the newer fields.
+The exception is anything created by a feature the old version lacks: a record whose `type` has no schema in the
+old build is still stored and still returned, just unvalidated.
+
+**Vector indexes are rebuilt on boot**, so a rollback that changes the embedding model or its dimensions costs a
+reindex, not data. Check `GET /ready` before sending traffic — see [Runtime Model Downloads](#runtime-model-downloads)
+if you also pinned a different model.
+
 **Backup before upgrading:**
 
 ```bash

--- a/testing/standalone/rollback-is-documented.test.js
+++ b/testing/standalone/rollback-is-documented.test.js
@@ -1,0 +1,145 @@
+/**
+ * The first boot on a new version rewrites `config.json`. Every rewrite that drops a field must be documented,
+ * because it decides whether a rollback is possible.
+ *
+ * ## The finding — Observability & Operability audit lens
+ *
+ * The lens asks about "the upgrade path (does a new version read old config/data?)". The docs covered that
+ * direction — named volumes persist, indexes rebuild, back up first — and said **nothing at all** about the
+ * direction an operator needs at three in the morning.
+ *
+ * `loadConfig()` runs three migrations and **persists** each one. Two of them `delete` a field:
+ *
+ *   - `mediaEmbedding.enabled` — verified from history, the default before it was removed was **`true`**, so an
+ *     instance where media embedding had been deliberately switched **off** would start sending uploads to the
+ *     vision and speech models again after a rollback;
+ *   - a space's `description` — the field an older build serves to MCP clients as space instructions.
+ *
+ * Neither failure announces itself: the field is simply absent, which an old build reads as "never configured"
+ * rather than "removed".
+ *
+ * The mechanism to go back already existed — the docs tell you to back up before upgrading — it just was never
+ * named as the rollback, and the specific consequences were never stated.
+ *
+ * ## What this gate holds
+ *
+ * That the documented list stays complete. A migration added to `loadConfig` without a row in the rollback table
+ * is a one-way door nobody was told about, and this is the only thing that would notice.
+ *
+ * Run: node --test testing/standalone/rollback-is-documented.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (p) => readFileSync(p, 'utf8');
+const LOADER = read('server/src/config/loader.ts');
+const DOC = read('docs/integration-guide/02-hosting.md');
+
+/** Strip comments, so a migration named only in prose is not mistaken for a call. */
+const CODE = LOADER.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+/** The body of `loadConfig`, where a persisted migration has to be invoked to run at boot. */
+function loadConfigBody() {
+  const at = CODE.indexOf('export function loadConfig()');
+  assert.ok(at > 0, 'loadConfig is gone — re-anchor this gate');
+  const end = CODE.indexOf('\n}', at);
+  assert.ok(end > at, 'could not bound loadConfig');
+  return CODE.slice(at, end);
+}
+
+/** Every `migrateX(...)` invoked from loadConfig, i.e. every rewrite an upgrade performs. */
+function bootMigrations() {
+  return [...new Set([...loadConfigBody().matchAll(/\b(migrate[A-Za-z0-9_]+)\s*\(/g)].map(m => m[1]))];
+}
+
+/** The rollback section of the hosting guide. */
+function rollbackSection() {
+  // Matched as a WHOLE heading line. `indexOf('### Rolling Back')` also matched "### Rolling Back Someday",
+  // so renaming the section away left the gate green.
+  const m = /^### Rolling Back$/m.exec(DOC);
+  assert.ok(m, 'the Rolling Back section is gone — a one-way upgrade with no documented way back');
+  const at = m.index;
+  const end = DOC.indexOf('\n### ', at + 10);
+  return DOC.slice(at, end < 0 ? DOC.length : end);
+}
+
+describe('the sweep works before it is trusted', () => {
+  it('finds the boot migrations', () => {
+    const found = bootMigrations();
+    assert.ok(found.length >= 3, `expected the boot migrations, found ${JSON.stringify(found)}`);
+    assert.ok(found.includes('migrateMediaEmbeddingMasterSwitch'), 'the known migration set is not being found');
+  });
+
+  it('each one actually persists, which is what makes it one-way', () => {
+    // A migration that only adjusts the in-memory config is harmless to a rollback. It is `saveConfig` that
+    // rewrites the file on disk, and that is what an older build then has to read.
+    const body = loadConfigBody();
+    const saves = [...body.matchAll(/saveConfig\(_config\)/g)].length;
+    const migrations = bootMigrations().length;
+    // One save is not enough: a single `saveConfig` left behind while the others were removed satisfied a bare
+    // `assert.match`, so the gate would have kept describing a hazard that only partly existed.
+    assert.ok(saves >= migrations,
+      `${migrations} boot migration(s) but only ${saves} saveConfig call(s) — if a migration no longer persists, `
+      + 'the rollback section should be simplified rather than left describing a hazard that is gone');
+  });
+});
+
+describe('every rewrite an upgrade performs is documented as one-way', () => {
+  it('the rollback section names each dropped field', () => {
+    // Matched on the FIELD rather than the function name: an operator reads config.json, not our source. The
+    // mapping is stated here so a new migration fails this test until its field is added to the table.
+    const FIELD_BY_MIGRATION = {
+      migrateMediaEmbeddingMasterSwitch: 'mediaEmbedding.enabled',
+      migrateSpaceDescriptionToPurpose: 'description',
+      migrateFaceRecognitionSwitch: 'faceRecognition.enabled',
+    };
+    const section = rollbackSection();
+    const undocumented = [];
+    for (const fn of bootMigrations()) {
+      const field = FIELD_BY_MIGRATION[fn];
+      if (field === undefined) {
+        undocumented.push(`${fn} — no entry in this gate's field map, so nobody has said what it drops`);
+        continue;
+      }
+      if (!section.includes(field)) undocumented.push(`${fn} → \`${field}\` is missing from the rollback table`);
+    }
+    assert.deepEqual(undocumented, [], 'a boot migration rewrites config.json and the rollback section does not '
+      + `mention it, so rolling back would lose the setting in silence:\n  ${undocumented.join('\n  ')}`);
+  });
+
+  it('it says what an older build DOES, not merely that a field changed', () => {
+    // "The field moved" is not the information. "Media embedding turns back on" is.
+    const section = rollbackSection();
+    assert.match(section, /defaults it back to \*\*`true`\*\*|starts sending uploads/i,
+      'the media-embedding row must state the consequence: the old default was true, so a rollback re-enables it');
+    assert.match(section, /silent/i,
+      'it must say the loss is silent — an absent field reads as "never configured", not "removed"');
+  });
+
+  it('it gives the procedure, and names the pre-upgrade config copy as the mechanism', () => {
+    const section = rollbackSection();
+    // No alternation with prose: "before upgrading" appears in the section's own explanation, so an assertion
+    // that accepted either passed with the actual command deleted.
+    assert.match(section, /config\.json\.pre-upgrade/,
+      'the section must name the pre-upgrade copy of config.json — it is the mechanism, not a suggestion');
+    assert.match(section, /docker compose cp \S*config\.json\.pre-upgrade ythril:/,
+      'it must show the command that puts the old config BACK, which is the step that makes a rollback work');
+    assert.match(section, /docker compose up -d/, 'it must show how to start the pinned previous version');
+  });
+
+  it('it covers brain data and vector indexes, not just config', () => {
+    // The two questions an operator asks next. Leaving them out invites the assumption that a rollback loses data.
+    const section = rollbackSection();
+    assert.match(section, /MongoDB|brain data/i, 'it must say what happens to brain data');
+    assert.match(section, /[Vv]ector index/, 'it must say what happens to the vector indexes');
+  });
+});
+
+describe('the upgrade direction still says what it said', () => {
+  it('backing up before an upgrade is still documented', () => {
+    // The rollback procedure depends on it, so this is now load-bearing rather than advice.
+    assert.match(DOC, /Backup before upgrading/i, 'the pre-upgrade backup instruction is gone, and the rollback '
+      + 'procedure depends on it');
+  });
+});


### PR DESCRIPTION
## A rollback procedure, because an upgrade is one-way and nothing said so

Third finding of audit lens **9 — Observability & Operability**, whose brief asks about *"the upgrade path (does a new
version read old config/data?)"*.

The docs answered that direction — named volumes persist, indexes rebuild, back up first — and said **nothing at all**
about the direction an operator needs at three in the morning.

## The first boot on a new version rewrites `config.json`

Three migrations run in `loadConfig()` and **each one persists**. Two of them `delete` a field, so an older build
cannot see what was there:

| the boot migrates | dropping | so an older build |
|---|---|---|
| `mediaEmbedding.enabled` → per-class `levels` | `enabled` | defaults it back to **`true`** |
| a space's `description` → `meta.purpose` | `description` | reads no space instructions for MCP clients |
| `faceRecognition.enabled` → the image ladder | `faceRecognition.enabled` | applies its own default |

**The consequence is now stated, not just the mechanism.** Verified from git history — the default for
`mediaEmbedding.enabled` before it was removed was `enabled: true`:

```text
5826007 feat(models)!: remove media-embedding master switch — always on, per-class levels (#416)
-  enabled: true,
```

So rolling back past that change **re-enables media embedding on an instance where it had deliberately been switched
off**: uploads start reaching the vision and speech models again. Silently, because an absent field reads as "never
configured" rather than "removed".

## The mechanism already existed; it was never named as one

The docs told operators to back up before upgrading. That copy of `config.json` **is** the rollback — 4 KB — and the
section now gives the four commands rather than leaving someone to work it out under pressure.

Two questions an operator asks next are answered in the same place, because omitting them invites the assumption that
a rollback loses data:

- **brain data needs no rollback of its own** — documents only ever gain fields, and both the API and the UI ignore
  ones they do not know, so an older build reads newer records and simply does not display the newer fields;
- **vector indexes rebuild on boot**, so a rollback that changes the embedding model costs a reindex, not data.

## Gate

`testing/standalone/rollback-is-documented.test.js`, **mutation-tested 11/11**.

A migration added to `loadConfig` without a row in the rollback table now **fails the build** — a one-way door nobody
was told about is exactly what this exists to catch. It also asserts the migrations still *persist*, so if that ever
stops being true the section gets simplified rather than left describing a hazard that is gone.

**Three of its own assertions were too loose**, each caught by mutation rather than by reading:

1. renaming the heading to `### Rolling Back Someday` still matched an `indexOf` prefix — anchored on the whole
   heading line now;
2. an alternation let the section's own prose (`before upgrading`) satisfy the check for the **restore command**, so
   deleting the command left the gate green;
3. one surviving `saveConfig` call passed a check that was meant to cover all three — it counts them against the
   number of migrations now.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
