### PR TITLE
fix(a11y): a full-screen dialog with no focus trap — Tab walked out into the page behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A full-screen dialog with no focus trap: Tab walked out of it into the page behind.** Second finding of the
+  Accessibility lens. `ModalDirective` exists so no dialog hand-rolls this — `role="dialog"`, `aria-modal`, a CDK
+  focus trap, focus restore to the opener, Escape — and the file manager's full-screen preview overlay bypassed it.
+  - The overlay carried `tabindex="0"` and a `#fsOverlay` template ref, and **the ref was never referenced from
+    TypeScript**: focus had been thought about and never wired. So a screen reader announced nothing, the page
+    behind stayed in the accessibility tree, Tab left the dialog for content that is covered and invisible, and
+    focus was lost on close.
+  - **Escape already worked**, via the component's own document keydown listener, which is worth saying because it
+    made the gap narrower than it looked. One `appModal` attribute supplies the rest.
+  - Gate `dialogs-use-the-modal-directive`, mutation-tested **12/12**: every dialog-shaped overlay must carry
+    `appModal`, and the directive must keep providing what its callers rely on. The not-a-dialog allowlist is two
+    entries with stated reasons, and the gate fails if it grows.
+  - **Reduced motion was checked in the same pass and is clean** — recorded in `_REFERENCE.md`. Three components
+    declare a keyframe animation with no local guard, which looked like a finding until `styles.scss` was read: a
+    global `prefers-reduced-motion` block neutralises every animation and transition, exempting `.spinner` on
+    purpose. A per-component sweep was measuring the wrong thing. That global rule is now pinned by the same gate.
+
 - **Four English sentences reached the screen without going through transloco, and one of them already had a
   translation.** First finding of the Accessibility & Internationalization lens.
   - `schemaLib.error.nameRequired` existed in **all three locales** — `"Eintragsname ist erforderlich."` sat in the

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -595,6 +595,7 @@
   "files.preview.modified": "Geändert",
   "files.preview.fullscreen": "Vollbild",
   "files.preview.exitFullscreen": "Vollbild beenden",
+  "files.preview.fullscreenDialog": "Dateivorschau im Vollbild",
   "files.preview.xlsxEmpty": "Diese Tabelle enthält keine Arbeitsblätter zur Vorschau.",
   "files.preview.xlsxTruncated": "Zeige {{rows}} von {{totalRows}} Zeilen und {{cols}} von {{totalCols}} Spalten.",
   "files.detail.tabsAriaLabel": "Detailansicht",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -595,6 +595,7 @@
   "files.preview.modified": "Modified",
   "files.preview.fullscreen": "Full screen",
   "files.preview.exitFullscreen": "Exit full screen",
+  "files.preview.fullscreenDialog": "Full-screen file preview",
   "files.preview.xlsxEmpty": "This spreadsheet has no sheets to preview.",
   "files.preview.xlsxTruncated": "Showing {{rows}} of {{totalRows}} rows and {{cols}} of {{totalCols}} columns.",
   "files.detail.tabsAriaLabel": "Detail view",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -595,6 +595,7 @@
   "files.preview.modified": "Zmodyfikowany",
   "files.preview.fullscreen": "Pełny ekran",
   "files.preview.exitFullscreen": "Zamknij pełny ekran",
+  "files.preview.fullscreenDialog": "Podgląd pliku na pełnym ekranie",
   "files.preview.xlsxEmpty": "Ten arkusz nie zawiera kart do podglądu.",
   "files.preview.xlsxTruncated": "Pokazano {{rows}} z {{totalRows}} wierszy i {{cols}} z {{totalCols}} kolumn.",
   "files.detail.tabsAriaLabel": "Widok szczegółów",

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -38,6 +38,7 @@ import python from 'highlight.js/lib/languages/python';
 import bash from 'highlight.js/lib/languages/bash';
 import plaintext from 'highlight.js/lib/languages/plaintext';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { ModalDirective } from '../../shared/modal.directive';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('typescript', typescript);
@@ -142,7 +143,7 @@ function xlsxCellText(v: unknown): string {
   // regardless of zone. Text fields (`newFolderName`, `renameValue`) are ngModel two-way bindings
   // whose input events mark the view dirty. So OnPush re-checks exactly when state changes.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent, HscrollTopDirective],
+  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent, HscrollTopDirective, ModalDirective],
   styles: [`
     /* A background refresh, as a 2px indeterminate hairline above the table. Deliberately NOT a spinner and
        deliberately not an overlay: the whole point is that nothing on screen moves or disappears while a poll
@@ -982,9 +983,16 @@ function xlsxCellText(v: unknown): string {
       }
     </ng-template>
 
-    <!-- Full-screen preview overlay (the one intentional fixed overlay — for the full-screen button). -->
+    <!-- Full-screen preview overlay (the one intentional fixed overlay — for the full-screen button).
+         NO BACKTICKS IN THIS TEMPLATE: one ends the string and the error points at @Component, never at the comment.
+         appModal supplies role=dialog, aria-modal, a CDK focus trap and focus restore on close. Escape was already
+         handled by this component's document keydown listener (full-screen collapses first, then the pane closes),
+         but the TRAP was not: Tab walked out of a full-screen overlay into the page behind it, which is covered and
+         invisible. The fsOverlay template ref that used to sit here was never referenced from TypeScript —
+         evidence that focus had been thought about and never wired.
+         No backdrop dismissal: this overlay IS the backdrop, and Escape or the close button already dismiss it. -->
     @if (previewFullscreen() && previewFile(); as pf) {
-      <div class="preview-fs-overlay" tabindex="0" #fsOverlay>
+      <div class="preview-fs-overlay" tabindex="0" [appModal]="'files.preview.fullscreenDialog' | transloco">
         <div class="preview-fs-bar">
           <span class="file-title" [title]="pf.name">{{ pf.name }}</span>
           <button class="icon-btn" (click)="previewFullscreen.set(false)" [attr.aria-label]="'files.preview.exitFullscreen' | transloco"><ph-icon name="x" [size]="18"/></button>

--- a/testing/standalone/dialogs-use-the-modal-directive.test.js
+++ b/testing/standalone/dialogs-use-the-modal-directive.test.js
@@ -1,0 +1,148 @@
+/**
+ * Every dialog surface goes through `ModalDirective`, so none of them hand-rolls accessibility.
+ *
+ * ## The finding — Accessibility & Internationalization audit lens
+ *
+ * `ModalDirective` is thorough: `role="dialog"`, `aria-modal`, an `aria-label`, a CDK focus trap that captures focus
+ * on open and **restores it to the opener** on close, Escape, and opt-in backdrop dismissal. Its own docstring says
+ * it exists so that no dialog hand-rolls this.
+ *
+ * One did. The file manager's full-screen preview overlay — a surface that covers the entire viewport — carried
+ * `tabindex="0"` and a `#fsOverlay` template ref, and **the ref was never referenced from TypeScript**: focus had
+ * been thought about and never wired. So:
+ *
+ *   - no `role="dialog"` / `aria-modal`, so a screen reader announced nothing and the page behind stayed in the
+ *     accessibility tree;
+ *   - **no focus trap** — Tab walked out of a full-screen overlay into a page that is covered and invisible;
+ *   - no focus restore on close.
+ *
+ * Escape *was* handled, by the component's own document keydown listener, and that is worth stating because it means
+ * the gap was narrower than it first looked. The rest is what `appModal` supplies in one attribute.
+ *
+ * ## Checked and CLEAN in the same pass, recorded so it is not re-derived
+ *
+ * - **Reduced motion.** Three components declare a keyframe animation with no local guard, which looked like a
+ *   finding until `styles.scss` was read: a global `@media (prefers-reduced-motion: reduce)` block neutralises
+ *   *every* animation and transition (`*:not(.spinner)`), exempting `.spinner` deliberately so loading indicators
+ *   keep turning. A per-component sweep was measuring the wrong thing.
+ * - **The shell's mobile drawer backdrop** is a `<button>` with an `aria-label`, dismissible by click — correct for
+ *   a navigation drawer, which is not a modal dialog.
+ * - **`loading-overlay`** is a spinner scrim, not a dialog, and is excluded below by name rather than by accident.
+ *
+ * Run: node --test testing/standalone/dialogs-use-the-modal-directive.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+function clientSources(dir = join('client', 'src', 'app'), out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) clientSources(p, out);
+    else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts')) out.push(p);
+  }
+  return out;
+}
+
+const FILES = clientSources();
+const read = (p) => readFileSync(p, 'utf8');
+
+/**
+ * Overlay classes that are NOT dialogs, excluded by name and with a reason.
+ *
+ * An allowlist rather than a heuristic: "does this overlay contain a form?" is exactly the kind of guess that makes
+ * a gate wrong in both directions.
+ */
+const NOT_A_DIALOG = {
+  'loading-overlay': 'a spinner scrim, no focusable content',
+  'drawer-backdrop': 'the dismiss button for a navigation drawer, which is not a modal dialog',
+};
+
+/** Every `class="…overlay…"` / `class="…backdrop…"` in a file, minus the allowlisted ones. */
+function dialogSurfaces(src) {
+  const found = new Set();
+  for (const m of src.matchAll(/class="([^"]*(?:overlay|backdrop)[^"]*)"/g)) {
+    for (const cls of m[1].split(/\s+/)) {
+      if (!/overlay|backdrop/.test(cls)) continue;
+      // BEM modifiers count as their base class: `loading-overlay--float` is the same spinner scrim as
+      // `loading-overlay`, and an exact-match allowlist reported it as an unguarded dialog.
+      const base = cls.split('--')[0];
+      if (cls in NOT_A_DIALOG || base in NOT_A_DIALOG) continue;
+      found.add(cls);
+    }
+  }
+  return [...found];
+}
+
+describe('the sweep works before it is trusted', () => {
+  it('sees the client, and finds the surface it is meant to police', () => {
+    assert.ok(FILES.length > 100, `expected the client tree, found ${FILES.length} files`);
+    const fm = read(join('client', 'src', 'app', 'pages', 'files', 'file-manager.component.ts'));
+    assert.deepEqual(dialogSurfaces(fm), ['preview-fs-overlay'],
+      'the file manager should expose exactly one dialog surface — if this changed, re-check the new one by hand');
+  });
+
+  it('the allowlist is small and reasoned', () => {
+    // A growing allowlist is how this gate would quietly stop meaning anything.
+    assert.ok(Object.keys(NOT_A_DIALOG).length <= 4, 'the not-a-dialog list is growing; re-justify each entry');
+    for (const [cls, why] of Object.entries(NOT_A_DIALOG)) {
+      assert.ok(why.length > 20, `${cls} is excluded without a real reason`);
+    }
+  });
+});
+
+describe('every dialog surface uses ModalDirective', () => {
+  it('no component hand-rolls one', () => {
+    const offenders = [];
+    for (const f of FILES) {
+      const src = read(f);
+      const surfaces = dialogSurfaces(src);
+      if (surfaces.length === 0) continue;
+      if (!src.includes('appModal')) offenders.push(`${f}  →  ${surfaces.join(', ')}`);
+    }
+    assert.deepEqual(offenders, [],
+      'these render a dialog-shaped overlay without appModal, so they have no focus trap, no role="dialog", and no '
+      + 'focus restore on close — Tab walks out of the dialog into the page behind it:\n  ' + offenders.join('\n  '));
+  });
+
+  it('the full-screen preview specifically is a labelled dialog', () => {
+    const fm = read(join('client', 'src', 'app', 'pages', 'files', 'file-manager.component.ts'));
+    const at = fm.indexOf('class="preview-fs-overlay"');
+    assert.ok(at > 0, 'the full-screen preview overlay is gone — re-anchor this gate');
+    const tag = fm.slice(fm.lastIndexOf('<', at), fm.indexOf('>', at) + 1);
+    assert.match(tag, /\[appModal\]/, 'the full-screen overlay must be a modal dialog');
+    assert.match(tag, /transloco/, 'its aria-label must be translated, not an English literal');
+    assert.doesNotMatch(tag, /#fsOverlay/,
+      'the dangling template ref should be gone — it was never referenced from TypeScript, and leaving it suggests '
+      + 'focus is handled somewhere it is not');
+  });
+
+  it('the directive still provides what the callers rely on', () => {
+    // The gate above is only worth having while `appModal` actually means all of this.
+    const dir = read(join('client', 'src', 'app', 'shared', 'modal.directive.ts'));
+    assert.match(dir, /'role':\s*'dialog'/, 'role=dialog');
+    assert.match(dir, /'aria-modal':\s*'true'/, 'aria-modal');
+    assert.match(dir, /focusInitialElementWhenReady\(\)/, 'the focus trap must actually be entered');
+    assert.match(dir, /this\.previouslyFocused\?\.focus\?\.\(\)/,
+      'focus must be restored to the opener on close, or a keyboard user is dumped at the top of the page');
+    assert.match(dir, /keydown\.escape/, 'Escape must dismiss');
+  });
+});
+
+describe('reduced motion is handled globally, which is why per-component guards are not required', () => {
+  it('the global rule exists and neutralises animation AND transition', () => {
+    // Pinned because three components look unguarded and are not. Deleting this rule would make those three, and
+    // everything else, animate for a user who asked for no motion — with nothing else in the tree to notice.
+    const css = read(join('client', 'src', 'styles.scss'));
+    const at = css.indexOf('@media (prefers-reduced-motion: reduce)');
+    assert.ok(at > 0, 'the global reduced-motion rule is gone; every component would now need its own guard');
+    const block = css.slice(at, css.indexOf('\n}', at));
+    assert.match(block, /animation-duration:\s*0\.01ms\s*!important/, 'animations must be neutralised');
+    assert.match(block, /transition-duration:\s*0\.01ms\s*!important/, 'transitions must be neutralised');
+    assert.match(block, /animation-iteration-count:\s*1\s*!important/, 'infinite animations must be stopped');
+    assert.match(block, /\*:not\(\.spinner\)/,
+      'the spinner exemption is deliberate — loading indicators keep turning; state it explicitly so it is not '
+      + 'mistaken for an oversight');
+  });
+});


### PR DESCRIPTION
## A full-screen dialog with no focus trap — Tab walked out into the page behind it

Second finding of audit lens **11 — Accessibility & Internationalization**.

`ModalDirective` exists precisely so no dialog hand-rolls accessibility. Its own docstring says so, and it supplies —
in one attribute — `role="dialog"`, `aria-modal`, an `aria-label`, a CDK focus trap that captures focus on open **and
restores it to the opener** on close, Escape, and opt-in backdrop dismissal.

The file manager's **full-screen preview overlay** bypassed it. That surface covers the entire viewport, and it carried
`tabindex="0"` plus a `#fsOverlay` template ref:

```html
<div class="preview-fs-overlay" tabindex="0" #fsOverlay>
```

**The ref was never referenced from TypeScript.** Focus had been thought about and never wired. So:

- no `role="dialog"` / `aria-modal` — a screen reader announced nothing, and the page behind stayed in the
  accessibility tree;
- **no focus trap** — Tab left the dialog for content that is covered and invisible;
- no focus restore, so closing dumped a keyboard user at the top of the page.

**Escape already worked**, through the component's own document keydown listener (full-screen collapses first, then the
pane closes). Worth stating, because it made the gap narrower than it first looked.

## Reduced motion was checked in the same pass and is clean

Three components declare a keyframe animation with **no local guard** — `drawer-in`, `graph-spin`, `spin` — which
looked like a second finding until `styles.scss` was read:

```scss
@media (prefers-reduced-motion: reduce) {
  *:not(.spinner), *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
```

A global rule neutralises **every** animation and transition, exempting `.spinner` on purpose so loading indicators
keep turning. A per-component sweep measures the wrong thing here, and the eight components that *do* carry their own
guard are refining that rule rather than supplying a missing one.

Recorded in `_REFERENCE.md` so it is not re-derived — and the global rule is now **pinned by this gate**, so deleting
it fails the build.

Also clean: the shell's mobile drawer backdrop is a `<button>` with an `aria-label`, which is right for a navigation
drawer — not a modal dialog.

## Gate

`testing/standalone/dialogs-use-the-modal-directive.test.js`, **mutation-tested 12/12**:

| mutation | caught |
|---|---|
| the overlay goes back to a hand-rolled div | ✅ |
| it keeps `appModal` but its label becomes an English literal | ✅ |
| a **new** dialog overlay is added with no `appModal` | ✅ |
| the directive drops `role="dialog"` | ✅ |
| the directive drops `aria-modal` | ✅ |
| the focus trap is created but never entered | ✅ |
| focus is no longer restored to the opener | ✅ |
| Escape no longer dismisses | ✅ |
| the global reduced-motion rule is removed | ✅ |
| it stops neutralising transitions | ✅ |
| it stops stopping infinite animations | ✅ |
| the `.spinner` exemption disappears, making it implicit again | ✅ |

The not-a-dialog allowlist is **two entries with stated reasons**, and the gate fails if it grows past four — a growing
allowlist is how a gate stops meaning anything.

## Two of my own mistakes, for the record

1. A **backtick** in the comment I added to the inline template ended the template string. The error pointed at
   `@Component`, never at the comment — exactly as this repo's own note about it warns. The comment now says
   `NO BACKTICKS IN THIS TEMPLATE` where the next person will read it.
2. The gate first reported `loading-overlay--float` as an unguarded dialog, because the allowlist matched exact class
   names and not **BEM modifiers**.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone. Client bundle builds clean.
