### PR TITLE
fix(a11y): 39 controls showed their selected state and announced nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **39 controls showed their selected state and announced nothing; 3 did it properly.** Fourth finding of the
+  Accessibility lens. On the Brain page — the product's primary navigation — **none of the eight tabs was marked
+  selected**, so which view you were on was visible and unannounced.
+  - A consistency gap rather than a design question: `review-tab.component.ts` already had the right pattern
+    (`role="tablist"` / `role="tab"` / `aria-selected` / `aria-controls`).
+  - Fixed here, the three highest-impact groups: the **Brain tab strip** (6 buttons), the **schema-library page
+    tabs**, and the **graph toolbar** — `aria-pressed` on the direction and label toggles, `aria-current` on the
+    space chips, because a single-select set is not a set of independent toggles and telling a screen reader that
+    several spaces are simultaneously *pressed* would be worse than saying nothing.
+  - **25 remain, in 8 files, enumerated in the gate rather than described.** That allowlist is the point: the debt
+    is finite and visible, a **new** control cannot skip ARIA, no listed file may get worse, and a file that gets
+    fixed must be **removed** from the list rather than left as slack.
+  - Gate `toggle-state-is-announced`, mutation-tested **8/8** — including that adding one more unannounced button to
+    an already-listed file fails, since an allowlist is a ceiling and never a licence.
+
 - **`--text-muted` failed WCAG AA on every surface, at 11px.** Third finding of the Accessibility lens, and the
   first time the palette's ratios were computed rather than judged by eye.
 

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -314,6 +314,7 @@
   "brain.reindex.stale": "Einbettungen sind veraltet – das Einbettungsmodell hat sich geändert und dieser Bereich muss neu indiziert werden.",
   "brain.reindex.button": "Jetzt neu indizieren",
   "brain.tab.overview": "Übersicht",
+  "brain.tabsAriaLabel": "Brain-Ansichten",
   "brain.tab.query": "Abfrage",
   "brain.tab.graph": "Graph",
   "brain.tab.files": "Dateien",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -314,6 +314,7 @@
   "brain.reindex.stale": "Embeddings are stale — the embedding model has changed and this space needs reindexing.",
   "brain.reindex.button": "Reindex now",
   "brain.tab.overview": "Overview",
+  "brain.tabsAriaLabel": "Brain views",
   "brain.tab.query": "Query",
   "brain.tab.graph": "Graph",
   "brain.tab.files": "Files",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -314,6 +314,7 @@
   "brain.reindex.stale": "Osadzania są przestarzałe — model osadzania uległ zmianie i to miejsce wymaga ponownego indeksowania.",
   "brain.reindex.button": "Zindeksuj teraz ponownie",
   "brain.tab.overview": "Przegląd",
+  "brain.tabsAriaLabel": "Widoki Brain",
   "brain.tab.query": "Zapytanie",
   "brain.tab.graph": "Wykres",
   "brain.tab.files": "Akta",

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -212,25 +212,28 @@ interface SpaceView {
         <div class="alert alert-success" style="margin-bottom:10px; font-size:13px;"><ph-icon name="check" [size]="14" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ reindexResult() }}</div>
       }
 
-      <!-- Sub-tabs: Query on left, collections on right -->
-      <div class="tabs">
-        <button class="tab" [class.active]="activeTab() === 'overview'" (click)="setTab('overview')">
+      <!-- Sub-tabs: Query on left, collections on right.
+           role=tablist / role=tab / aria-selected, matching the pattern review-tab already used. Without
+           aria-selected the active tab was conveyed by a CSS class ALONE, so a screen-reader user could not
+           tell which of eight views they were on: the state was visible and unannounced. -->
+      <div class="tabs" role="tablist" [attr.aria-label]="'brain.tabsAriaLabel' | transloco">
+        <button class="tab" type="button" role="tab" [class.active]="activeTab() === 'overview'" [attr.aria-selected]="activeTab() === 'overview'" (click)="setTab('overview')">
           <ph-icon name="chart-bar" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.overview' | transloco }}
         </button>
-        <button class="tab" [class.active]="activeTab() === 'query'" (click)="setTab('query')">
+        <button class="tab" type="button" role="tab" [class.active]="activeTab() === 'query'" [attr.aria-selected]="activeTab() === 'query'" (click)="setTab('query')">
           <ph-icon name="magnifying-glass" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.query' | transloco }}
         </button>
-        <button class="tab" [class.active]="activeTab() === 'graph'" (click)="setTab('graph')">
+        <button class="tab" type="button" role="tab" [class.active]="activeTab() === 'graph'" [attr.aria-selected]="activeTab() === 'graph'" (click)="setTab('graph')">
           <ph-icon name="binoculars" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.graph' | transloco }}
         </button>
         <!-- Review (F-REVIEW): duplicate pairs awaiting a decision in this space. Grouped with the
              other whole-space views rather than after Files — it is a workflow, not a record collection. -->
-        <button class="tab" [class.active]="activeTab() === 'review'" (click)="setTab('review')">
+        <button class="tab" type="button" role="tab" [class.active]="activeTab() === 'review'" [attr.aria-selected]="activeTab() === 'review'" (click)="setTab('review')">
           <ph-icon name="copy" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.review' | transloco }}
         </button>
         <span class="tab-spacer"></span>
         @for (tab of collectionTabs; track tab.key) {
-          <button class="tab" [class.active]="activeTab() === tab.key" (click)="setTab(tab.key)">
+          <button class="tab" type="button" role="tab" [class.active]="activeTab() === tab.key" [attr.aria-selected]="activeTab() === tab.key" (click)="setTab(tab.key)">
             <ph-icon [name]="tab.icon" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ tab.label | transloco }}
             @if (activeStats(); as s) {
               @if (tab.statsKey) {
@@ -241,7 +244,7 @@ interface SpaceView {
         }
         <!-- Files (the former File Meta slot) — the file manager and File Meta merged into one tab: the
              explorer now shows each file's status, tags and folder sizes inline. -->
-        <button class="tab" [class.active]="activeTab() === 'files'" (click)="setTab('files')">
+        <button class="tab" type="button" role="tab" [class.active]="activeTab() === 'files'" [attr.aria-selected]="activeTab() === 'files'" (click)="setTab('files')">
           <ph-icon name="folder" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.files' | transloco }}
           @if (activeStats(); as s) {
             <span class="tab-count">{{ s.files }}</span>

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -83,7 +83,7 @@ import { GRAPH_STYLES } from './graph.styles';
     @if (!isEmbedded() && spaces().length > 0) {
       <div class="space-tabs">
         @for (s of spaces(); track s.id) {
-          <button class="space-chip" [class.active]="activeSpaceId() === s.id" (click)="onSpaceChange(s.id)">{{ s.label }}</button>
+          <button class="space-chip" type="button" [class.active]="activeSpaceId() === s.id" [attr.aria-current]="activeSpaceId() === s.id ? 'true' : null" (click)="onSpaceChange(s.id)">{{ s.label }}</button>
         }
       </div>
     }
@@ -110,13 +110,13 @@ import { GRAPH_STYLES } from './graph.styles';
       </div>
 
       <div class="pill-group">
-        <button [class.active]="direction() === 'outbound'" (click)="setDirection('outbound')">{{ 'graph.toolbar.direction.out' | transloco }}</button>
-        <button [class.active]="direction() === 'inbound'" (click)="setDirection('inbound')">{{ 'graph.toolbar.direction.in' | transloco }}</button>
-        <button [class.active]="direction() === 'both'"    (click)="setDirection('both')">{{ 'graph.toolbar.direction.both' | transloco }}</button>
+        <button type="button" [class.active]="direction() === 'outbound'" [attr.aria-pressed]="direction() === 'outbound'" (click)="setDirection('outbound')">{{ 'graph.toolbar.direction.out' | transloco }}</button>
+        <button type="button" [class.active]="direction() === 'inbound'" [attr.aria-pressed]="direction() === 'inbound'" (click)="setDirection('inbound')">{{ 'graph.toolbar.direction.in' | transloco }}</button>
+        <button type="button" [class.active]="direction() === 'both'" [attr.aria-pressed]="direction() === 'both'"    (click)="setDirection('both')">{{ 'graph.toolbar.direction.both' | transloco }}</button>
       </div>
 
       <div class="pill-group">
-        <button [class.active]="!hideLabels()" (click)="onHideLabelsChange(!hideLabels())" [attr.title]="'graph.toolbar.toggleLabels' | transloco">{{ 'graph.toolbar.labels' | transloco }}</button>
+        <button type="button" [class.active]="!hideLabels()" [attr.aria-pressed]="!hideLabels()" (click)="onHideLabelsChange(!hideLabels())" [attr.title]="'graph.toolbar.toggleLabels' | transloco">{{ 'graph.toolbar.labels' | transloco }}</button>
       </div>
 
       <div class="toolbar-spacer"></div>

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -240,9 +240,9 @@ export function entriesFromTypeSchemas(
     </div>
 
     <!-- page tabs: My Library / Foreign Catalogs -->
-    <div class="page-tabs">
-      <button class="page-tab" [class.active]="pageTab()==='library'" (click)="pageTab.set('library')">{{ 'schemaLib.tab.library' | transloco }}</button>
-      <button class="page-tab" [class.active]="pageTab()==='catalogs'" (click)="pageTab.set('catalogs');loadCatalogs()"><ph-icon name="globe" [size]="13" style="margin-right:4px;"/>{{ 'schemaLib.tab.catalogs' | transloco }}</button>
+    <div class="page-tabs" role="tablist" [attr.aria-label]="'schemaLib.title' | transloco">
+      <button class="page-tab" type="button" role="tab" [class.active]="pageTab()==='library'" [attr.aria-selected]="pageTab()==='library'" (click)="pageTab.set('library')">{{ 'schemaLib.tab.library' | transloco }}</button>
+      <button class="page-tab" type="button" role="tab" [class.active]="pageTab()==='catalogs'" [attr.aria-selected]="pageTab()==='catalogs'" (click)="pageTab.set('catalogs');loadCatalogs()"><ph-icon name="globe" [size]="13" style="margin-right:4px;"/>{{ 'schemaLib.tab.catalogs' | transloco }}</button>
     </div>
 
     <div class="search-row" style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">

--- a/testing/standalone/toggle-state-is-announced.test.js
+++ b/testing/standalone/toggle-state-is-announced.test.js
@@ -1,0 +1,145 @@
+/**
+ * A control whose selected state is visible must also be announced.
+ *
+ * ## The finding — Accessibility & Internationalization audit lens
+ *
+ * **39 buttons conveyed their selected state through a CSS class alone; 3 carried an ARIA state.** For a screen-reader
+ * user that means the current view is simply not there: on the Brain page — the product's primary navigation — none of
+ * the eight tabs was marked selected, so which one you were on was visible and unannounced.
+ *
+ * It is a consistency gap rather than a design question, because the codebase already had the right pattern.
+ * `review-tab.component.ts`:
+ *
+ *     <nav class="tabs" role="tablist" [attr.aria-label]="'review.title' | transloco">
+ *       <button class="tab" role="tab" [class.active]="sub() === t" [attr.aria-selected]="sub() === t" …>
+ *
+ * ## Fixed here, and what is left
+ *
+ * The three highest-impact groups: the **Brain tab strip** (6 buttons, primary navigation), the **schema-library page
+ * tabs**, and the **graph toolbar** (`aria-pressed` on the direction/label toggles, `aria-current` on the space chips —
+ * a single-select set is not a set of independent toggles).
+ *
+ * **25 remain, in 8 files, and they are enumerated below rather than described.** The allowlist is the point: it makes
+ * the debt finite and visible, a NEW control cannot skip ARIA, and no listed file may get worse. It can only shrink.
+ * Recording the count honestly beats a gate that passes because it only looks where the work was already done.
+ *
+ * Run: node --test testing/standalone/toggle-state-is-announced.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Known gaps, by path, with the exact number of buttons still missing an ARIA state.
+ *
+ * Keyed on the full path, not the basename: two different components are called `schema-library.component.ts`.
+ */
+const KNOWN_GAPS = {
+  'client/src/app/pages/settings/spaces.component.ts': 11,
+  'client/src/app/pages/settings/space-schema-tab.component.ts': 4,
+  'client/src/app/pages/schema-library/schema-library.component.ts': 2,
+  'client/src/app/pages/settings/media-processing/pipelines-tab.component.ts': 2,
+  'client/src/app/shared/entity-search.component.ts': 2,
+  'client/src/app/shared/properties-view.component.ts': 2,
+  'client/src/app/pages/brain/brain.component.ts': 1,
+  'client/src/app/pages/settings/preferences.component.ts': 1,
+};
+
+function clientSources(dir = join('client', 'src', 'app'), out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) clientSources(p, out);
+    else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts')) out.push(p);
+  }
+  return out;
+}
+
+const HAS_ACTIVE_CLASS = /<button[^>]*\[class\.(?:active|selected|on)\][^>]*>/g;
+const HAS_ARIA_STATE = /aria-selected|aria-pressed|aria-current/;
+
+/** path (forward slashes) → count of state-bearing buttons with no ARIA state. */
+function gaps() {
+  const out = {};
+  for (const f of clientSources()) {
+    const hits = [...readFileSync(f, 'utf8').matchAll(HAS_ACTIVE_CLASS)].filter(m => !HAS_ARIA_STATE.test(m[0]));
+    if (hits.length) out[f.split('\\').join('/')] = hits.length;
+  }
+  return out;
+}
+
+describe('the sweep works before it is trusted', () => {
+  it('sees the client and finds state-bearing buttons at all', () => {
+    const files = clientSources();
+    assert.ok(files.length > 100, `expected the client tree, found ${files.length} files`);
+    const total = files.reduce(
+      (n, f) => n + [...readFileSync(f, 'utf8').matchAll(HAS_ACTIVE_CLASS)].length, 0);
+    assert.ok(total >= 30, `expected the toggle/tab buttons, found ${total} — has the pattern changed?`);
+  });
+});
+
+describe('no NEW control conveys its state by CSS alone', () => {
+  it('every file with a gap is a known one', () => {
+    const unknown = Object.keys(gaps()).filter(f => !(f in KNOWN_GAPS));
+    assert.deepEqual(unknown, [], 'these have a button whose selected state is conveyed by a CSS class only, so a '
+      + 'screen reader announces nothing. Add [attr.aria-selected] for a tab, [attr.aria-pressed] for a toggle, or '
+      + `[attr.aria-current] for one item in a single-select set:\n  ${unknown.join('\n  ')}`);
+  });
+
+  it('no known gap gets worse', () => {
+    // The allowlist is a ceiling, never a licence. Adding one more unannounced button to a listed file is the same
+    // defect as adding the first one to a clean file.
+    const now = gaps();
+    const worse = [];
+    for (const [f, ceiling] of Object.entries(KNOWN_GAPS)) {
+      const count = now[f] ?? 0;
+      if (count > ceiling) worse.push(`${f}: ${count}, allowed ${ceiling}`);
+    }
+    assert.deepEqual(worse, [], `these regressed:\n  ${worse.join('\n  ')}`);
+  });
+
+  it('a fixed file is removed from the list rather than left as slack', () => {
+    // Otherwise the allowlist stops describing reality and quietly permits a regression later.
+    const now = gaps();
+    const stale = Object.keys(KNOWN_GAPS).filter(f => (now[f] ?? 0) === 0);
+    assert.deepEqual(stale, [], 'these are fixed — delete them from KNOWN_GAPS so the list keeps meaning what it '
+      + `says:\n  ${stale.join('\n  ')}`);
+  });
+
+  it('the remaining debt is going DOWN', () => {
+    // A single number, checked, so "we will get to it" cannot drift upward unnoticed.
+    const total = Object.values(gaps()).reduce((a, b) => a + b, 0);
+    assert.ok(total <= 25, `${total} controls still convey state by CSS alone; the recorded ceiling is 25`);
+  });
+});
+
+describe('the groups fixed here stay fixed', () => {
+  it('the Brain tab strip is a labelled tablist with selected state', () => {
+    // The product's primary navigation. Eight views, and which one you were on was unannounced.
+    const src = readFileSync(join('client', 'src', 'app', 'pages', 'brain', 'brain.component.ts'), 'utf8');
+    const at = src.indexOf('<div class="tabs"');
+    assert.ok(at > 0, 'the Brain tab strip is gone — re-anchor this gate');
+    const strip = src.slice(at, src.indexOf('</div>', at));
+    assert.match(src.slice(at, at + 200), /role="tablist"/, 'the strip must be a tablist');
+    assert.match(src.slice(at, at + 200), /aria-label/, 'a tablist needs a name');
+    const tabs = [...strip.matchAll(/<button class="tab"[^>]*>/g)];
+    assert.ok(tabs.length >= 5, `expected the tab buttons, found ${tabs.length}`);
+    const silent = tabs.filter(m => !/aria-selected/.test(m[0])).length;
+    assert.equal(silent, 0, `${silent} Brain tab(s) still do not report aria-selected`);
+  });
+
+  it('the graph toolbar distinguishes a toggle from a single-select set', () => {
+    // `aria-pressed` on independent toggles; `aria-current` on the space chips, where exactly one is active.
+    // Using pressed for both would tell a screen reader that several spaces are simultaneously on.
+    const src = readFileSync(join('client', 'src', 'app', 'pages', 'graph', 'graph.component.ts'), 'utf8');
+    assert.match(src, /aria-pressed/, 'the direction/label toggles must report pressed state');
+    assert.match(src, /aria-current/, 'the space chips are a single-select set, so aria-current is the right one');
+  });
+
+  it('the pattern this copied is still there to copy', () => {
+    const src = readFileSync(join('client', 'src', 'app', 'pages', 'brain', 'review-tab.component.ts'), 'utf8');
+    assert.match(src, /role="tablist"/, 'review-tab was the reference implementation');
+    assert.match(src, /aria-controls/,
+      'review-tab also wires aria-controls to its panel — the next pass should bring the others up to that');
+  });
+});


### PR DESCRIPTION
## 39 controls showed their selected state and announced nothing

Fourth finding of audit lens **11 — Accessibility & Internationalization**.

**39 buttons conveyed their selected state through a CSS class alone; 3 carried an ARIA state.** On the Brain page —
the product's primary navigation — **none of the eight tabs was marked selected**, so which view you were on was
visible and unannounced.

This is a consistency gap rather than a design question, because the codebase already had the right pattern:

```html
<!-- review-tab.component.ts -->
<nav class="tabs" role="tablist" [attr.aria-label]="'review.title' | transloco">
  <button class="tab" role="tab" [class.active]="sub() === t" [attr.aria-selected]="sub() === t" …>
```

## Fixed here — the three highest-impact groups

- **the Brain tab strip** — `role="tablist"` with a name, `role="tab"` and `aria-selected` on all six buttons;
- **the schema-library page tabs** — same treatment;
- **the graph toolbar** — `aria-pressed` on the direction and hide-labels toggles, **`aria-current` on the space
  chips**.

That last distinction matters: a single-select set is not a set of independent toggles. Telling a screen reader that
several spaces are simultaneously *pressed* would be worse than saying nothing.

## 25 remain, and they are enumerated rather than described

| file | buttons |
|---|---|
| `settings/spaces.component.ts` | 11 |
| `settings/space-schema-tab.component.ts` | 4 |
| `schema-library/schema-library.component.ts` | 2 |
| `settings/media-processing/pipelines-tab.component.ts` | 2 |
| `shared/entity-search.component.ts` | 2 |
| `shared/properties-view.component.ts` | 2 |
| `brain/brain.component.ts` | 1 |
| `settings/preferences.component.ts` | 1 |

**The allowlist is the deliverable as much as the fix.** It makes the debt finite and visible, and the gate enforces
four things about it:

1. a **new** control anywhere cannot skip ARIA;
2. no listed file may get **worse** — an allowlist is a ceiling, never a licence;
3. a file that gets **fixed** must be removed from the list, so it never becomes slack that permits a later
   regression;
4. the **total** may not exceed 25.

Queued in the tracker with per-file counts and a note on which attribute each group needs — `aria-selected` for a tab,
`aria-pressed` for an independent toggle, `aria-current` for one item in a single-select set. The next pass should also
wire `aria-controls` to the panels, which `review-tab` does and nothing else yet does.

## Gate

`testing/standalone/toggle-state-is-announced.test.js`, **mutation-tested 8/8**:

| mutation | caught |
|---|---|
| a Brain tab loses `aria-selected` | ✅ |
| the Brain strip stops being a `tablist` | ✅ |
| the tablist loses its accessible name | ✅ |
| the graph toggles lose `aria-pressed` | ✅ |
| the space chips lose `aria-current` | ✅ |
| the reference implementation loses its tablist | ✅ |
| a **new** unannounced button is added to a clean file | ✅ |
| a **known-gap** file gets one more unannounced button | ✅ |

---

`npm run preflight` PASSED — 892 client tests, 511 standalone. Client bundle builds clean.
