### PR TITLE
fix(a11y): the other 25 controls announce their state too, so the allowlist is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The other 25 controls now announce their state too, so the allowlist is empty.** Completes the previous entry in
+  one more pass rather than leaving the debt to age.
+  - The attribute was chosen **per group**, not swept in: `aria-selected` (with `role="tablist"`/`role="tab"`) for the
+    two real tab strips — space settings and the schema collection tabs; **`aria-current`** for the Brain space chips
+    and the language buttons, where exactly one of a set is current; **`aria-pressed`** for segmented mode switches,
+    the seven sort selectors and the filter toggles, which are genuinely two-state.
+  - Getting that wrong in the easy direction — `aria-pressed` everywhere — would tell a screen reader that several
+    spaces or languages are simultaneously pressed, which is worse than saying nothing.
+  - `KNOWN_GAPS` in the gate is now `{}`, and the ceiling assertion is an exact **zero** rather than `<= 25`. The gate
+    already refused to let a fixed file linger in the list, so emptying it was forced rather than optional — which is
+    the behaviour that keeps an allowlist from quietly becoming permanent.
+
 - **39 controls showed their selected state and announced nothing; 3 did it properly.** Fourth finding of the
   Accessibility lens. On the Brain page — the product's primary navigation — **none of the eight tabs was marked
   selected**, so which view you were on was visible and unannounced.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -857,6 +857,8 @@
   "spaces.create.strictLinkage": "Strenge Verknüpfung",
   "spaces.create.submitButton": "Erstellen",
   "spaces.popup.tab.settings": "Einstellungen",
+  "spaces.schema.collTabsAriaLabel": "Datensatz-Sammlungen",
+  "spaces.settings.tabsAriaLabel": "Bereiche der Space-Einstellungen",
 
   "spaces.popup.governed": "Verwaltet",
 

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -857,6 +857,8 @@
   "spaces.create.strictLinkage": "Strict linkage",
   "spaces.create.submitButton": "Create",
   "spaces.popup.tab.settings": "Settings",
+  "spaces.schema.collTabsAriaLabel": "Record collections",
+  "spaces.settings.tabsAriaLabel": "Space settings sections",
 
   "spaces.popup.governed": "Governed",
 

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -857,6 +857,8 @@
   "spaces.create.strictLinkage": "Ścisłe powiązanie",
   "spaces.create.submitButton": "Tworzyć",
   "spaces.popup.tab.settings": "Ustawienia",
+  "spaces.schema.collTabsAriaLabel": "Kolekcje rekordów",
+  "spaces.settings.tabsAriaLabel": "Sekcje ustawień przestrzeni",
 
   "spaces.popup.governed": "Zarządzany",
 

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -180,7 +180,7 @@ interface SpaceView {
         @for (sv of spaces(); track sv.space.id) {
           <button
             class="space-chip"
-            [class.active]="activeSpaceId() === sv.space.id"
+            [class.active]="activeSpaceId() === sv.space.id" [attr.aria-current]="activeSpaceId() === sv.space.id ? 'true' : null"
             [title]="sv.space.label + ' (' + sv.space.id + ')'"
             (click)="selectSpace(sv.space.id)"
           >

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -262,10 +262,10 @@ export function entriesFromTypeSchemas(
     @if (pageTab() === 'library' && entries().length) {
       <div class="type-filters">
         @for (kt of ['entity','memory','edge','chrono']; track kt) {
-          <button class="type-filter-btn" [class.active]="typeFilter() === kt" type="button" (click)="typeFilter.set(typeFilter() === kt ? null : $any(kt))">{{ kt }}</button>
+          <button class="type-filter-btn" [class.active]="typeFilter() === kt" [attr.aria-pressed]="typeFilter() === kt" type="button" (click)="typeFilter.set(typeFilter() === kt ? null : $any(kt))">{{ kt }}</button>
         }
         @for (g of availableGroups(); track g) {
-          <button class="group-filter-btn" [class.active]="groupFilter() === g" type="button" (click)="groupFilter.set(groupFilter() === g ? null : g)"><ph-icon name="tag" [size]="11" style="margin-right:3px;vertical-align:-1px;"/>{{ g }}</button>
+          <button class="group-filter-btn" [class.active]="groupFilter() === g" [attr.aria-pressed]="groupFilter() === g" type="button" (click)="groupFilter.set(groupFilter() === g ? null : g)"><ph-icon name="tag" [size]="11" style="margin-right:3px;vertical-align:-1px;"/>{{ g }}</button>
         }
       </div>
     }

--- a/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
@@ -186,7 +186,7 @@ interface Step {
         <div class="knobs-h">{{ 'mediaProcessing.pipelines.extractionMode' | transloco }}</div>
         <div class="modeseg" role="group" [attr.aria-label]="'mediaProcessing.pipelines.extractionMode' | transloco">
           @for (m of s.MODES; track m) {
-            <button type="button" [class.on]="s.docMode() === m" (click)="s.setMode(m)" [disabled]="s.managed">
+            <button type="button" [class.on]="s.docMode() === m" [attr.aria-pressed]="s.docMode() === m" (click)="s.setMode(m)" [disabled]="s.managed">
               {{ 'mediaProcessing.mode.' + m | transloco }}
             </button>
           }
@@ -275,7 +275,7 @@ interface Step {
                    document extraction mode — one control vocabulary across all of them. -->
               <div class="modeseg" role="group" [attr.aria-label]="'mediaProcessing.class.' + c.cls | transloco">
                 @for (rung of c.ladder; track rung) {
-                  <button type="button" [class.on]="ceilingOf(c.cls) === rung" (click)="setCeiling(c.cls, rung)"
+                  <button type="button" [class.on]="ceilingOf(c.cls) === rung" [attr.aria-pressed]="ceilingOf(c.cls) === rung" (click)="setCeiling(c.cls, rung)"
                     [disabled]="rungDisabled(c.cls, rung, p.steps)">
                     {{ 'mediaProcessing.level.' + rung | transloco }}
                   </button>

--- a/client/src/app/pages/settings/preferences.component.ts
+++ b/client/src/app/pages/settings/preferences.component.ts
@@ -44,7 +44,7 @@ import { SettingsCardComponent } from '../../shared/settings-card.component';
           @for (lang of languages; track lang.code) {
             <button
               class="lang-btn"
-              [class.active]="activeLang() === lang.code"
+              [class.active]="activeLang() === lang.code" [attr.aria-current]="activeLang() === lang.code ? 'true' : null"
               (click)="setLang(lang.code)">
               {{ lang.label }}
             </button>

--- a/client/src/app/pages/settings/space-schema-tab.component.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.ts
@@ -154,20 +154,20 @@ const SCHEMA_MD_STYLES = `
   <span style="font-size:11px;color:var(--text-muted);margin-left:4px;">{{ 'spaces.schema.autoSyncHint' | transloco }}</span>
 </div>
 <!-- collection tabs -->
-<div class="sch-coll-tabs">
-  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='entity'" (click)="state.schemaCollTab.set('entity');schImportError.set('');schImportInfo.set('')">
+<div class="sch-coll-tabs" role="tablist" [attr.aria-label]="'spaces.schema.collTabsAriaLabel' | transloco">
+  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='entity'" [attr.aria-selected]="state.schemaCollTab()==='entity'" role="tab" (click)="state.schemaCollTab.set('entity');schImportError.set('');schImportInfo.set('')">
     {{ 'spaces.schema.tab.entities' | transloco }}
     @if (state.typeCount('entity')) { <span class="sch-cnt-badge">{{ state.typeCount('entity') }}</span> }
   </button>
-  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='edge'" (click)="state.schemaCollTab.set('edge');schImportError.set('');schImportInfo.set('')">
+  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='edge'" [attr.aria-selected]="state.schemaCollTab()==='edge'" role="tab" (click)="state.schemaCollTab.set('edge');schImportError.set('');schImportInfo.set('')">
     {{ 'spaces.schema.tab.edges' | transloco }}
     @if (state.typeCount('edge')) { <span class="sch-cnt-badge">{{ state.typeCount('edge') }}</span> }
   </button>
-  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='memory'" (click)="state.schemaCollTab.set('memory');schImportError.set('');schImportInfo.set('')">
+  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='memory'" [attr.aria-selected]="state.schemaCollTab()==='memory'" role="tab" (click)="state.schemaCollTab.set('memory');schImportError.set('');schImportInfo.set('')">
     {{ 'spaces.schema.tab.memories' | transloco }}
     @if (state.typeCount('memory')) { <span class="sch-cnt-badge">{{ state.typeCount('memory') }}</span> }
   </button>
-  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='chrono'" (click)="state.schemaCollTab.set('chrono');schImportError.set('');schImportInfo.set('')">
+  <button class="sch-coll-tab" [class.active]="state.schemaCollTab()==='chrono'" [attr.aria-selected]="state.schemaCollTab()==='chrono'" role="tab" (click)="state.schemaCollTab.set('chrono');schImportError.set('');schImportInfo.set('')">
     {{ 'spaces.schema.tab.chrono' | transloco }}
     @if (state.typeCount('chrono')) { <span class="sch-cnt-badge">{{ state.typeCount('chrono') }}</span> }
   </button>

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -71,11 +71,11 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
             }
             <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="attemptClose()"><ph-icon name="x" [size]="14"/></button>
           </div>
-          <div class="sp-tabs">
-            <button class="sp-tab" [class.active]="state.settingsTab()==='settings'" (click)="state.settingsTab.set('settings')">{{ 'spaces.popup.tab.settings' | transloco }}</button>
-            <button class="sp-tab" [class.active]="state.settingsTab()==='schema'"   (click)="state.settingsTab.set('schema')">{{ 'spaces.popup.tab.schema' | transloco }}</button>
-            <button class="sp-tab" [class.active]="state.settingsTab()==='duplicates'" (click)="state.settingsTab.set('duplicates')">{{ 'spaces.popup.tab.duplicates' | transloco }}</button>
-            <button class="sp-tab danger-tab" [class.active]="state.settingsTab()==='danger'" (click)="state.settingsTab.set('danger')">{{ 'spaces.popup.tab.dangerZone' | transloco }}</button>
+          <div class="sp-tabs" role="tablist" [attr.aria-label]="'spaces.settings.tabsAriaLabel' | transloco">
+            <button class="sp-tab" [class.active]="state.settingsTab()==='settings'" [attr.aria-selected]="state.settingsTab()==='settings'" role="tab" (click)="state.settingsTab.set('settings')">{{ 'spaces.popup.tab.settings' | transloco }}</button>
+            <button class="sp-tab" [class.active]="state.settingsTab()==='schema'" [attr.aria-selected]="state.settingsTab()==='schema'" role="tab"   (click)="state.settingsTab.set('schema')">{{ 'spaces.popup.tab.schema' | transloco }}</button>
+            <button class="sp-tab" [class.active]="state.settingsTab()==='duplicates'" [attr.aria-selected]="state.settingsTab()==='duplicates'" role="tab" (click)="state.settingsTab.set('duplicates')">{{ 'spaces.popup.tab.duplicates' | transloco }}</button>
+            <button class="sp-tab danger-tab" [class.active]="state.settingsTab()==='danger'" [attr.aria-selected]="state.settingsTab()==='danger'" role="tab" (click)="state.settingsTab.set('danger')">{{ 'spaces.popup.tab.dangerZone' | transloco }}</button>
           </div>
           <div class="sp-body">
 
@@ -148,16 +148,16 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
             class="space-search-input"
             [placeholder]="'spaces.table.search.placeholder' | transloco" />
           <div class="sort-group" [attr.aria-label]="'spaces.table.sortLabel' | transloco">
-            <button class="sort-btn" [class.active]="sortMode()==='custom'" (click)="sortMode.set('custom')" [attr.title]="'spaces.table.sort.custom' | transloco">⠿</button>
-            <button class="sort-btn" [class.active]="sortMode()==='az'" (click)="sortMode.set('az')" [attr.title]="'spaces.table.sort.az' | transloco">A→Z</button>
-            <button class="sort-btn" [class.active]="sortMode()==='za'" (click)="sortMode.set('za')" [attr.title]="'spaces.table.sort.za' | transloco">Z→A</button>
-            <button class="sort-btn" [class.active]="sortMode()==='usage-desc'" (click)="sortMode.set('usage-desc')" [attr.title]="'spaces.table.sort.usageDesc' | transloco">↓ GiB</button>
-            <button class="sort-btn" [class.active]="sortMode()==='usage-asc'" (click)="sortMode.set('usage-asc')" [attr.title]="'spaces.table.sort.usageAsc' | transloco">↑ GiB</button>
+            <button class="sort-btn" [class.active]="sortMode()==='custom'" [attr.aria-pressed]="sortMode()==='custom'" (click)="sortMode.set('custom')" [attr.title]="'spaces.table.sort.custom' | transloco">⠿</button>
+            <button class="sort-btn" [class.active]="sortMode()==='az'" [attr.aria-pressed]="sortMode()==='az'" (click)="sortMode.set('az')" [attr.title]="'spaces.table.sort.az' | transloco">A→Z</button>
+            <button class="sort-btn" [class.active]="sortMode()==='za'" [attr.aria-pressed]="sortMode()==='za'" (click)="sortMode.set('za')" [attr.title]="'spaces.table.sort.za' | transloco">Z→A</button>
+            <button class="sort-btn" [class.active]="sortMode()==='usage-desc'" [attr.aria-pressed]="sortMode()==='usage-desc'" (click)="sortMode.set('usage-desc')" [attr.title]="'spaces.table.sort.usageDesc' | transloco">↓ GiB</button>
+            <button class="sort-btn" [class.active]="sortMode()==='usage-asc'" [attr.aria-pressed]="sortMode()==='usage-asc'" (click)="sortMode.set('usage-asc')" [attr.title]="'spaces.table.sort.usageAsc' | transloco">↑ GiB</button>
             <!-- Two orderings, because "useful" has two halves. Busiest finds the load; worst-answered finds
                  the content gap — a space fielding questions and returning nothing, which is invisible in
                  every other column on this page. -->
-            <button class="sort-btn" [class.active]="sortMode()==='calls-desc'" (click)="sortMode.set('calls-desc')" [attr.title]="'spaces.table.sort.callsDesc' | transloco">↓ {{ 'spaces.table.sort.callsShort' | transloco }}</button>
-            <button class="sort-btn" [class.active]="sortMode()==='answers-asc'" (click)="sortMode.set('answers-asc')" [attr.title]="'spaces.table.sort.answersAsc' | transloco">↑ {{ 'spaces.table.sort.answersShort' | transloco }}</button>
+            <button class="sort-btn" [class.active]="sortMode()==='calls-desc'" [attr.aria-pressed]="sortMode()==='calls-desc'" (click)="sortMode.set('calls-desc')" [attr.title]="'spaces.table.sort.callsDesc' | transloco">↓ {{ 'spaces.table.sort.callsShort' | transloco }}</button>
+            <button class="sort-btn" [class.active]="sortMode()==='answers-asc'" [attr.aria-pressed]="sortMode()==='answers-asc'" (click)="sortMode.set('answers-asc')" [attr.title]="'spaces.table.sort.answersAsc' | transloco">↑ {{ 'spaces.table.sort.answersShort' | transloco }}</button>
           </div>
           <button class="btn-primary btn btn-sm" (click)="showCreateDialog.set(true)">{{ 'spaces.table.createButton' | transloco }}</button>
           <button class="btn-secondary btn btn-sm" (click)="store.load()">{{ 'spaces.table.refreshButton' | transloco }}</button>

--- a/client/src/app/shared/entity-search.component.ts
+++ b/client/src/app/shared/entity-search.component.ts
@@ -207,8 +207,8 @@ import { TranslocoPipe } from '@jsverse/transloco';
       />
       @if (mode !== 'bar' || showModeToggle) {
         <div class="pill-group" [attr.title]="'common.searchMode.tooltip' | transloco">
-          <button type="button" [class.active]="searchMode() === 'name'"     (click)="setMode('name')">{{ 'common.sortAZ' | transloco }}</button>
-          <button type="button" [class.active]="searchMode() === 'semantic'" (click)="setMode('semantic')">{{ 'entitySearch.semantic' | transloco }}</button>
+          <button type="button" [class.active]="searchMode() === 'name'" [attr.aria-pressed]="searchMode() === 'name'"     (click)="setMode('name')">{{ 'common.sortAZ' | transloco }}</button>
+          <button type="button" [class.active]="searchMode() === 'semantic'" [attr.aria-pressed]="searchMode() === 'semantic'" (click)="setMode('semantic')">{{ 'entitySearch.semantic' | transloco }}</button>
         </div>
       }
       @if (mode === 'bar' && displayValue()) {

--- a/client/src/app/shared/properties-view.component.ts
+++ b/client/src/app/shared/properties-view.component.ts
@@ -90,8 +90,8 @@ import { TranslocoPipe } from '@jsverse/transloco';
     } @else {
       <div class="props-wrap">
         <div class="props-toggle">
-          <button [class.active]="mode() === 'table'" (click)="mode.set('table')">{{ 'propertiesView.tableButton' | transloco }}</button>
-          <button [class.active]="mode() === 'json'" (click)="mode.set('json')">{{ 'propertiesView.jsonButton' | transloco }}</button>
+          <button [class.active]="mode() === 'table'" [attr.aria-pressed]="mode() === 'table'" (click)="mode.set('table')">{{ 'propertiesView.tableButton' | transloco }}</button>
+          <button [class.active]="mode() === 'json'" [attr.aria-pressed]="mode() === 'json'" (click)="mode.set('json')">{{ 'propertiesView.jsonButton' | transloco }}</button>
         </div>
         @if (mode() === 'table') {
           <table class="props-table">

--- a/testing/standalone/toggle-state-is-announced.test.js
+++ b/testing/standalone/toggle-state-is-announced.test.js
@@ -33,18 +33,16 @@ import { join } from 'node:path';
 /**
  * Known gaps, by path, with the exact number of buttons still missing an ARIA state.
  *
+ * **Empty, and it should stay that way.** The 25 entries this list was created with are all fixed, so the debt
+ * existed for exactly one PR — which is what an allowlist is for. Every assertion below now runs with nothing to
+ * forgive: a new state-bearing button anywhere in the client must announce itself or the build fails.
+ *
+ * If an entry is ever added back it needs a reason in the PR that adds it and a plan to remove it. A permanent entry
+ * is indistinguishable from the gate not existing.
+ *
  * Keyed on the full path, not the basename: two different components are called `schema-library.component.ts`.
  */
-const KNOWN_GAPS = {
-  'client/src/app/pages/settings/spaces.component.ts': 11,
-  'client/src/app/pages/settings/space-schema-tab.component.ts': 4,
-  'client/src/app/pages/schema-library/schema-library.component.ts': 2,
-  'client/src/app/pages/settings/media-processing/pipelines-tab.component.ts': 2,
-  'client/src/app/shared/entity-search.component.ts': 2,
-  'client/src/app/shared/properties-view.component.ts': 2,
-  'client/src/app/pages/brain/brain.component.ts': 1,
-  'client/src/app/pages/settings/preferences.component.ts': 1,
-};
+const KNOWN_GAPS = {};
 
 function clientSources(dir = join('client', 'src', 'app'), out = []) {
   for (const entry of readdirSync(dir)) {
@@ -106,10 +104,12 @@ describe('no NEW control conveys its state by CSS alone', () => {
       + `says:\n  ${stale.join('\n  ')}`);
   });
 
-  it('the remaining debt is going DOWN', () => {
-    // A single number, checked, so "we will get to it" cannot drift upward unnoticed.
-    const total = Object.values(gaps()).reduce((a, b) => a + b, 0);
-    assert.ok(total <= 25, `${total} controls still convey state by CSS alone; the recorded ceiling is 25`);
+  it('there is no remaining debt at all', () => {
+    // Was `<= 25` for exactly one PR. Now zero: every state-bearing control in the client announces its state.
+    const now = gaps();
+    const total = Object.values(now).reduce((a, b) => a + b, 0);
+    const detail = Object.entries(now).map(([f, n]) => `${f}: ${n}`).join('\n  ');
+    assert.equal(total, 0, `${total} control(s) convey state by CSS alone:\n  ${detail}`);
   });
 });
 


### PR DESCRIPTION
## The other 25 controls announce their state too, so the allowlist is empty

Finishes #654 in one more pass rather than letting the debt age. **`KNOWN_GAPS` is now `{}`**, and the ceiling
assertion is an exact **zero** instead of `<= 25`.

## The attribute was chosen per group, not swept in

| attribute | where | why |
|---|---|---|
| `aria-selected` + `role="tab"` | space-settings tabs (4), schema collection tabs (4) | real tab strips with a panel behind them; both containers became a named `role="tablist"` |
| **`aria-current`** | Brain space chips, language buttons | exactly **one** item of a set is current |
| `aria-pressed` | segmented mode switches (entity-search, properties-view, 2× pipelines-tab), 7 sort selectors, 2 filter toggles | genuinely two-state — and a filter you can click off really is a toggle |

Getting this wrong in the easy direction — `aria-pressed` everywhere — would tell a screen reader that **several
spaces, or several languages, are simultaneously pressed**. That is worse than saying nothing, which is why the
grouping was done by hand rather than with one regex.

## Emptying the allowlist was forced, not optional

The gate from #654 already asserted that a **fixed file must be removed** from `KNOWN_GAPS` rather than left as
slack. So finishing the work made the previous list fail, and the list had to go to `{}`.

That is the behaviour worth keeping: it stops an allowlist from quietly becoming permanent, and a permanent entry is
indistinguishable from the gate not existing. The docstring now says an entry added back needs a reason and a plan.

Two i18n keys added in all three locales for the new tablist labels.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone. Client bundle builds clean.
