### PR TITLE
ci(changelog): enforce the entry rule that memory had been enforcing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history: the CHANGELOG check below diffs `base...HEAD`, which needs a MERGE BASE. The default
+          # shallow clone has none, and the failure mode is the bad one — the diff errors, the check skips, and a
+          # missing entry looks like a passing build.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -29,6 +34,18 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # A change to shipped code needs a CHANGELOG entry under [Unreleased].
+      #
+      # The rule was already the house rule and was being followed — 28 PRs in the batch that added this, every one
+      # with an entry. Nothing enforced it, and a rule kept alive by memory is one distracted afternoon from lapsing,
+      # invisibly: nobody notices the entry that was never written.
+      #
+      # PRs only. On a push to main there is no base to diff against, and the entry was already required of the PR.
+      - name: CHANGELOG entry for shipped changes
+        if: github.event_name == 'pull_request'
+        run: |
+          node scripts/check-changelog.mjs "origin/$GITHUB_BASE_REF"
 
       - name: Lint docs
         run: npm run lint:docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CI now enforces the CHANGELOG rule that memory had been enforcing.** Second finding of the Documentation & DX
+  lens. An `[Unreleased]` entry for every user-facing change is the house rule, and it was being followed — **28 PRs
+  in this batch, every one with an entry** — but nothing checked it. A rule kept alive by memory is one distracted
+  afternoon from lapsing, and the lapse is invisible: nobody notices the entry that was never written.
+  - A diff touching `server/src/`, `client/src/` or `client/public/` must add at least one line **inside the**
+    **`[Unreleased]` section** — not merely touch the file, which a typo fix in a released section would satisfy
+    while the actual change went unrecorded.
+  - **Exempt by path, with no marker-based escape hatch.** Tests, `docs/`, `scripts/`, `todo/`, workflows and any
+    `*.spec.ts` change without changing what a user gets. A `[skip changelog]` in a PR title leaves no record and
+    gets used the moment it is inconvenient; if a source change genuinely has no user-facing effect, one line saying
+    so is cheaper and records that somebody considered the question.
+  - **A check that cannot run must not report success.** `actions/checkout` now uses `fetch-depth: 0`, because
+    `base...HEAD` needs a merge base — and if the diff fails anyway the script **exits 1 in CI** rather than
+    skipping. Verified in both directions against real commits: a scratch branch touching `server/src` with no entry
+    failed; adding the entry passed.
+  - Gate `changelog-entry-is-enforced`, mutation-tested **11/11**, pinning the CI wiring (including the PR-only
+    condition and `fetch-depth: 0`) and every decision inside the script.
+
 - **`docs/decisions/` — the reasoning behind the irreversible calls now ships.** First finding of the Documentation
   & DX lens. The reasoning existed; it just was not in the repository: `todo/` is **gitignored**, so `_REFERENCE.md`
   and `_PARKED-DECISIONS.md` — where the cross-cutting rationale lived — are invisible to anyone who clones.

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * A change to shipped code needs a CHANGELOG entry under `[Unreleased]`.
+ *
+ * ## Why this exists
+ *
+ * The rule was already the house rule, and it was followed — 28 PRs in the batch that added this check, every one
+ * with an entry. Nothing enforced it. A rule kept alive by memory alone is one distracted afternoon from lapsing,
+ * and the lapse is invisible: nobody notices the entry that was never written.
+ *
+ * ## What counts
+ *
+ * A diff that touches `server/src/` or `client/src/` — the code that ships — must also add at least one line inside
+ * the `[Unreleased]` section of `CHANGELOG.md`.
+ *
+ * Deliberately NOT required for: tests, `testing/`, `docs/`, workflows, `scripts/`, `todo/`, or a `*.spec.ts`
+ * anywhere. Those change without changing what a user gets. The exemption is **by path**, with no "skip changelog"
+ * escape hatch: if a source change genuinely has no user-facing effect, saying so in one CHANGELOG line is cheap and
+ * leaves a record, whereas a marker in a PR title leaves nothing and is used the moment it is inconvenient.
+ *
+ * ## Why "inside `[Unreleased]`" rather than "the file changed"
+ *
+ * Touching `CHANGELOG.md` is easy to satisfy accidentally — a released section gets a typo fix and the check passes
+ * while the actual change goes unrecorded. The added line has to land in the section that describes what is not
+ * shipped yet.
+ *
+ * Usage: node scripts/check-changelog.mjs <base-ref>
+ *   e.g. node scripts/check-changelog.mjs origin/main
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const base = process.argv[2] ?? 'origin/main';
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' });
+
+/** Paths whose change never needs a user-facing note. */
+const EXEMPT = [
+  /^testing\//,
+  /^docs\//,
+  /^scripts\//,
+  /^todo\//,
+  /^\.github\//,
+  /\.spec\.ts$/,
+  /\.test\.js$/,
+];
+
+/** Paths that ship to a user, and therefore need one. */
+const SHIPPED = [/^server\/src\//, /^client\/src\//, /^client\/public\//];
+
+let changed;
+try {
+  changed = git('diff', '--name-only', `${base}...HEAD`).split('\n').map(s => s.trim()).filter(Boolean);
+} catch (err) {
+  // A diff that cannot run must NOT look like a pass. In CI that is an environment fault worth stopping for — a
+  // shallow clone with no merge base would otherwise turn this check into a no-op that reports success, which is
+  // precisely the failure mode the check exists to prevent. Locally, skipping is fine.
+  const why = err.message.split('\n')[0];
+  if (process.env['CI']) {
+    console.error(`check-changelog: cannot diff against ${base} (${why}).`);
+    console.error('In CI this is a hard failure: a check that cannot run must not report success. Ensure the base ref');
+    console.error('is fetched — actions/checkout needs `fetch-depth: 0` for a merge base to exist.');
+    process.exit(1);
+  }
+  console.log(`check-changelog: cannot diff against ${base} (${why}) — skipping (not CI).`);
+  process.exit(0);
+}
+
+const shipped = changed.filter(f => SHIPPED.some(re => re.test(f)) && !EXEMPT.some(re => re.test(f)));
+
+if (shipped.length === 0) {
+  console.log(`check-changelog: no shipped-code changes in ${changed.length} changed file(s) — nothing to require.`);
+  process.exit(0);
+}
+
+/** Line numbers added to CHANGELOG.md in this diff. */
+function addedChangelogLines() {
+  let patch;
+  try {
+    patch = git('diff', '-U0', `${base}...HEAD`, '--', 'CHANGELOG.md');
+  } catch {
+    return [];
+  }
+  const lines = [];
+  // Hunk headers look like `@@ -12,0 +13,4 @@` — the `+start,count` is what we need.
+  for (const m of patch.matchAll(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gm)) {
+    const start = Number(m[1]);
+    const count = m[2] === undefined ? 1 : Number(m[2]);
+    for (let i = 0; i < count; i++) lines.push(start + i);
+  }
+  return lines;
+}
+
+/** The line range of the `[Unreleased]` section in the CURRENT file. */
+function unreleasedRange() {
+  const src = readFileSync('CHANGELOG.md', 'utf8').split(/\r?\n/);
+  const start = src.findIndex(l => /^##\s*\[Unreleased\]/i.test(l));
+  if (start < 0) return null;
+  let end = src.length;
+  for (let i = start + 1; i < src.length; i++) {
+    if (/^##\s*\[/.test(src[i])) { end = i; break; }
+  }
+  return { start: start + 1, end };   // 1-based, end exclusive
+}
+
+const range = unreleasedRange();
+if (!range) {
+  console.error('check-changelog: CHANGELOG.md has no "## [Unreleased]" section — add one.');
+  process.exit(1);
+}
+
+const added = addedChangelogLines().filter(n => n > range.start && n <= range.end);
+
+if (added.length === 0) {
+  console.error('check-changelog: FAILED\n');
+  console.error(`These files change what ships, and CHANGELOG.md gained no line under [Unreleased]:\n`);
+  for (const f of shipped.slice(0, 20)) console.error(`  ${f}`);
+  if (shipped.length > 20) console.error(`  … and ${shipped.length - 20} more`);
+  console.error('\nAdd an entry describing the change from a user\'s point of view. If it genuinely has no');
+  console.error('user-facing effect, say that in one line — it is cheap, and it leaves a record that someone');
+  console.error('considered the question.');
+  process.exit(1);
+}
+
+console.log(`check-changelog: OK — ${shipped.length} shipped file(s) changed, `
+  + `${added.length} line(s) added under [Unreleased].`);

--- a/testing/standalone/changelog-entry-is-enforced.test.js
+++ b/testing/standalone/changelog-entry-is-enforced.test.js
@@ -1,0 +1,142 @@
+/**
+ * The CHANGELOG rule is enforced by CI, not by memory.
+ *
+ * ## The finding — Documentation & DX audit lens
+ *
+ * The house rule is an `[Unreleased]` entry for every user-facing change, and it was being followed — **28 PRs in the
+ * batch that added this check, every one with an entry**. Nothing enforced it. A rule kept alive by memory alone is one
+ * distracted afternoon from lapsing, and the lapse is **invisible**: nobody notices the entry that was never written.
+ *
+ * ## What the check does, and the two decisions inside it
+ *
+ * A diff touching `server/src/` or `client/src/` must add at least one line **inside the `[Unreleased]` section**.
+ *
+ * **Inside the section, not merely "the file changed".** Touching `CHANGELOG.md` is easy to satisfy by accident — a
+ * typo fix in a released section would pass while the actual change went unrecorded.
+ *
+ * **Exempt by path, with no "skip changelog" marker.** Tests, `docs/`, `scripts/`, `todo/`, workflows and any
+ * `*.spec.ts` change without changing what a user gets. A marker in a PR title leaves no record and gets used the
+ * moment it is inconvenient; if a source change genuinely has no user-facing effect, one CHANGELOG line saying so is
+ * cheap and records that somebody considered the question.
+ *
+ * ## Why this gate exists on top of the CI step
+ *
+ * The step can be deleted, renamed, or quietly made conditional, and nothing else in the tree would notice. This
+ * pins the wiring — including `fetch-depth: 0`, without which `base...HEAD` has no merge base, the diff errors, and
+ * a check that cannot run reports success. That last part is the failure mode the whole exercise exists to prevent,
+ * so the script itself must fail hard in CI when it cannot diff.
+ *
+ * Run: node --test testing/standalone/changelog-entry-is-enforced.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SCRIPT_PATH = join('scripts', 'check-changelog.mjs');
+const WORKFLOW_PATH = join('.github', 'workflows', 'ci.yml');
+const SCRIPT = existsSync(SCRIPT_PATH) ? readFileSync(SCRIPT_PATH, 'utf8') : '';
+const WORKFLOW = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/**
+ * The script with comments removed.
+ *
+ * Every assertion about behaviour reads THIS, not `SCRIPT`. The script's docstring necessarily quotes the things it
+ * forbids and the paths it exempts, so matching the raw text let two assertions pass on prose: the exemption check
+ * found `testing/` in a sentence, and the no-escape-hatch check fired on the paragraph explaining why there is none.
+ * Sixth time in this batch that a gate read its own documentation as code.
+ */
+const CODE = SCRIPT.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ 	]*\/\/.*$/gm, '');
+
+describe('CI runs the check', () => {
+  it('the script exists', () => {
+    assert.ok(SCRIPT.length > 500, 'scripts/check-changelog.mjs is missing or a stub');
+  });
+
+  it('the workflow invokes it on pull requests', () => {
+    assert.match(WORKFLOW, /node scripts\/check-changelog\.mjs/,
+      'CI does not run the check, so the rule is back to being remembered rather than enforced');
+    const at = WORKFLOW.indexOf('node scripts/check-changelog.mjs');
+    const step = WORKFLOW.slice(WORKFLOW.lastIndexOf('- name:', at), at);
+    assert.match(step, /if:\s*github\.event_name == 'pull_request'/,
+      'the step must be PR-only: a push to main has no base to diff against, and the entry was already required of '
+      + 'the PR that produced it');
+  });
+
+  it('the checkout fetches full history', () => {
+    // Without this the diff has no merge base. It errors, and an unguarded script would treat that as "nothing to
+    // check" — a green build for a missing entry, which is worse than not having the check.
+    const at = WORKFLOW.indexOf('actions/checkout@v4');
+    assert.ok(at > 0, 'the checkout step is gone');
+    const step = WORKFLOW.slice(at, at + 400);
+    assert.match(step, /fetch-depth:\s*0/,
+      'actions/checkout needs fetch-depth: 0, or `base...HEAD` has no merge base and the check silently no-ops');
+  });
+});
+
+describe('the check cannot pass vacuously', () => {
+  it('a diff that fails is a hard failure in CI', () => {
+    assert.match(CODE, /process\.env\['CI'\]/,
+      'the script must distinguish CI from a local run: skipping is fine locally, never in CI');
+    const at = CODE.indexOf("if (process.env['CI'])");
+    assert.ok(at > 0, 'the CI branch is gone');
+    // Bounded by the NEXT statement, not by the first `}` — that one closes a `${...}` inside a template literal, so
+    // the slice ended before `process.exit(1)` and the assertion failed against correct code. Same convenience-slice
+    // mistake this repo has now recorded three times.
+    const end = CODE.indexOf('console.log(`check-changelog: cannot diff', at);
+    assert.ok(end > at, 'could not bound the CI branch');
+    const branch = CODE.slice(at, end);
+    assert.match(branch, /process\.exit\(1\)/, 'in CI, a check that cannot run must fail rather than report success');
+  });
+
+  it('it requires the line to be INSIDE [Unreleased]', () => {
+    // "CHANGELOG.md was touched" is satisfiable by a typo fix in a released section.
+    assert.match(CODE, /\[Unreleased\]/, 'the script must locate the Unreleased section');
+    // The WIRING, not the names. Renaming the declaration while leaving the call site passed a name-only check —
+    // the script would have crashed at runtime and this gate would have stayed green.
+    assert.match(CODE, /const range = unreleasedRange\(\)/, 'the range must be computed');
+    assert.match(CODE, /addedChangelogLines\(\)\s*\.filter\(/,
+      'the added line numbers must be FILTERED by the range — that is what makes it "inside [Unreleased]" rather '
+      + 'than "the file was touched"');
+    assert.match(CODE, /n > range\.start && n <= range\.end/,
+      'the filter must compare against the section bounds');
+    assert.match(CODE, /function unreleasedRange\(\)/, 'the helper must still be declared');
+    assert.match(CODE, /function addedChangelogLines\(\)/, 'the helper must still be declared');
+  });
+
+  it('a missing [Unreleased] section fails rather than passing', () => {
+    const at = CODE.indexOf('if (!range)');
+    assert.ok(at > 0, 'the missing-section branch is gone');
+    assert.match(CODE.slice(at, at + 300), /process\.exit\(1\)/,
+      'no Unreleased section must fail — otherwise deleting the heading disables the check');
+  });
+});
+
+describe('what it exempts, and what it refuses to exempt', () => {
+  it('tests, docs, scripts, workflows and trackers are exempt', () => {
+    const at = CODE.indexOf('const EXEMPT');
+    assert.ok(at > 0, 'the exemption list is gone');
+    const list = CODE.slice(at, CODE.indexOf('];', at));
+    // Scoped to the LIST. Matching the whole file found `testing/` in the docstring, so deleting a real exemption
+    // left this green.
+    for (const p of ['testing', 'docs', 'scripts', 'todo', 'github', 'spec']) {
+      assert.match(list, new RegExp(p, 'i'), `${p} should be in the exemption list`);
+    }
+  });
+
+  it('shipped code is not exempt', () => {
+    const at = CODE.indexOf('const SHIPPED');
+    assert.ok(at > 0, 'the shipped-path list is gone');
+    const list = CODE.slice(at, CODE.indexOf('];', at));
+    assert.match(list, /server\\\/src\\\//, 'server/src must require an entry');
+    assert.match(list, /client\\\/src\\\//, 'client/src must require an entry');
+  });
+
+  it('there is no marker-based escape hatch', () => {
+    // A "[skip changelog]" in a PR title leaves no record and is used the moment it is inconvenient. The exemption
+    // is by PATH so the decision is visible in the diff.
+    assert.doesNotMatch(CODE, /skip[- ]?changelog/i,
+      'no marker-based bypass: if a change truly has no user-facing effect, one CHANGELOG line saying so is cheaper '
+      + 'than a bypass and leaves a record');
+  });
+});


### PR DESCRIPTION
## CI now enforces the CHANGELOG rule that memory had been enforcing

Second finding of audit lens **13 — Documentation & DX**.

An `[Unreleased]` entry for every user-facing change is the house rule, and it was being followed — **28 PRs in this
batch, every one with an entry**. Nothing checked it.

A rule kept alive by memory alone is one distracted afternoon from lapsing, and **the lapse is invisible**: nobody
notices the entry that was never written.

## What it requires

A diff touching `server/src/`, `client/src/` or `client/public/` must add at least one line **inside the
`[Unreleased]` section**.

Not merely *touch* the file — a typo fix in a released section would satisfy that while the actual change went
unrecorded. The script reads the added line numbers from the diff and checks they fall inside the section bounds.

## Two decisions worth stating

**Exempt by path, with no marker-based escape hatch.** Tests, `docs/`, `scripts/`, `todo/`, workflows and any
`*.spec.ts` change without changing what a user gets. A `[skip changelog]` in a PR title leaves no record and gets
used the moment it is inconvenient; if a source change genuinely has no user-facing effect, **one line saying so is
cheaper** and records that somebody considered the question.

**A check that cannot run must not report success.** `actions/checkout` now uses `fetch-depth: 0`, because
`base...HEAD` needs a merge base and the default shallow clone has none — and if the diff fails anyway the script
**exits 1 in CI** rather than skipping.

My first draft skipped on a failed diff. That would have made this a no-op that reports green: precisely the failure
mode the check exists to prevent.

## Verified in both directions, against real commits

```text
$ node scripts/check-changelog.mjs 679affa          # the range that produced #656
check-changelog: OK — 4 shipped file(s) changed, 21 line(s) added under [Unreleased].

$ # scratch branch: one line appended to server/src/ready.ts, no entry
check-changelog: FAILED
  server/src/ready.ts
$ # …then add a line under [Unreleased]
check-changelog: OK — 1 shipped file(s) changed, 2 line(s) added under [Unreleased].
```

Plus the CI-vs-local branch: an unresolvable base exits **1** with `CI=1` and **0** without. The scratch branch was
deleted.

## Gate

`testing/standalone/changelog-entry-is-enforced.test.js`, **mutation-tested 11/11** — the CI wiring (including the
PR-only condition and `fetch-depth: 0`) and every decision inside the script.

**Three of its own assertions were too weak, all caught by mutation:**

1. renaming a helper's *declaration* while leaving the call site passed a **name-only** check — the script would have
   crashed at runtime and the gate stayed green. It now asserts the **wiring**: that the added line numbers are
   filtered by the section bounds;
2. the exemption check matched `testing/` in the script's own **docstring**, so deleting a real exemption stayed
   green. It is scoped to the `EXEMPT` list now;
3. the no-escape-hatch check fired on the paragraph explaining why there is no escape hatch.

Comments are now stripped **once**, at the top, and every behavioural assertion reads that — the **sixth** time in
this batch a gate read its own documentation as code. That pattern is recorded in memory; it earns its place.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
