### PR TITLE
test(ux): measure control drift from computed styles in the running app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`testing/ux-drift-sweep.mjs` — control drift measured from computed styles in the running app.** First tool of
+  the UX audit lens, whose brief states that visual consistency is the primary review dimension and that **reading
+  CSS does not find drift**: view encapsulation lets two components style "the same" input differently and neither
+  file looks wrong.
+  - Its first run found that **a text input is four different controls** — 28 / 32 / 38 / 39 px tall across Spaces,
+    Audit log, Models and Schema library, on **two different background tokens**, with two radii and two type sizes.
+    That is the #385 search-bar drift pattern, still live on four surfaces.
+  - Buttons show **16 distinct signatures**; the two most-used differ by **1px height and 1px font-size** and appear
+    on 8 and 7 pages respectively — two near-identical styles used interchangeably app-wide. Models also has
+    fractional type (`12.5px`), meaning a rem/em cascade rather than a token.
+  - **The fix is a shared style and lands separately**, because it is a visual change that needs its own
+    before/after pass. The numbers are recorded so it can be done deliberately rather than by eye.
+  - A run that measures **nothing exits non-zero**: an empty report reads exactly like a clean one, and the first
+    draft did that — it passed its arguments to `$$eval` in the wrong order and swallowed the error.
+
 - **CI now enforces the CHANGELOG rule that memory had been enforcing.** Second finding of the Documentation & DX
   lens. An `[Unreleased]` entry for every user-facing change is the house rule, and it was being followed — **28 PRs
   in this batch, every one with an entry** — but nothing checked it. A rule kept alive by memory is one distracted

--- a/testing/ux-drift-sweep.mjs
+++ b/testing/ux-drift-sweep.mjs
@@ -1,0 +1,127 @@
+/**
+ * Sibling-surface drift pass — the same control across every page, measured from COMPUTED styles.
+ *
+ * ## Why this cannot be a unit test
+ *
+ * Visual consistency is the owner's primary review dimension, and the audit lens is explicit that reading CSS does
+ * not find drift: Angular's view encapsulation means two components can style "the same" input differently and
+ * neither file looks wrong. The search-bar drift (#385) is the cautionary tale. Only the running app knows what a
+ * control actually measures, so this drives the real bundle and groups every control by its computed signature.
+ *
+ * Drift then shows up as a NUMBER — "4 distinct signatures for a text input" — instead of an impression.
+ *
+ * ## Running it
+ *
+ *   1. Boot an isolated instance (never the operator's own on :3210):
+ *
+ *        cd server
+ *        PORT=3260 TRUST_PROXY=1 \
+ *        CONFIG_PATH=<scratch>/config/config.json DATA_ROOT=<scratch>/data \
+ *        MONGO_URI=mongodb://127.0.0.1:27017/ythril_ux_audit \
+ *        npx tsx src/index.ts
+ *
+ *   2. `npm run build:client` once, so the server serves the bundle that ships.
+ *   3. Complete first-run setup and put the admin token in `token.txt` beside this script. The token is shown ONCE,
+ *      in the setup page's TEXT (`ythril_…`) — not in an `input#token`.
+ *   4. `node testing/ux-drift-sweep.mjs`
+ *
+ * Needs `playwright` available and Edge installed (`channel: 'msedge'` avoids a browser download).
+ *
+ * ## What it will not do
+ *
+ * It reports; it does not judge. Some variation is real design — an icon button is not a primary button. The signal
+ * is *near-identical* signatures (a 1px height difference across eight pages) and the same control appearing on
+ * different background tokens, which is drift by definition rather than intent.
+ *
+ * A run that measures NOTHING exits non-zero. An empty report reads exactly like a clean one, and the first draft of
+ * this script did precisely that: it passed its arguments to `$$eval` in the wrong order and swallowed the error.
+ */
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+
+const BASE = process.env['UX_BASE'] ?? 'http://localhost:3260';
+const TOKEN_FILE = process.env['UX_TOKEN_FILE'] ?? 'token.txt';
+
+const PAGES = [
+  ['/brain', 'Brain'],
+  ['/settings/spaces', 'Spaces'],
+  ['/settings/tokens', 'Tokens'],
+  ['/settings/storage', 'Storage'],
+  ['/settings/models', 'Models'],
+  ['/settings/audit-log', 'Audit log'],
+  ['/settings/preferences', 'Preferences'],
+  ['/schema-library', 'Schema library'],
+];
+
+/** The concretes the UX lens names: control height, padding, background token, radius, type size. */
+const INPUT_PROPS = ['height', 'padding-top', 'padding-bottom', 'padding-left', 'background-color', 'border-radius', 'font-size'];
+const BUTTON_PROPS = ['height', 'padding-left', 'padding-right', 'font-size', 'border-radius'];
+const PILL_PROPS = ['height', 'padding-left', 'border-radius', 'font-size', 'text-transform'];
+
+const browser = await chromium.launch({ channel: 'msedge' });
+const page = await browser.newPage({ viewportSize: { width: 1440, height: 900 } });
+const consoleErrors = [];
+page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text().slice(0, 160)); });
+
+const token = readFileSync(TOKEN_FILE, 'utf8').trim();
+await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('#token', { timeout: 30_000 });
+await page.fill('#token', token);
+await page.press('#token', 'Enter');
+await page.waitForURL(u => !/\/(setup|login)/.test(u.toString()), { timeout: 30_000 });
+console.log(`signed in, landed on ${page.url()}`);
+
+/**
+ * Every visible instance of `selector`, grouped by computed signature.
+ *
+ * Argument order matters: `$$eval(selector, fn, arg)`. Passing `[selector, props]` as the selector throws, and
+ * catching that would turn a broken measurement into a clean-looking report.
+ */
+async function measure(selector, props) {
+  return page.$$eval(selector, (els, ps) => {
+    const out = {};
+    for (const el of els) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) continue;      // invisible: not part of the visual language
+      const cs = getComputedStyle(el);
+      const sig = ps.map(p => (p === 'height' ? `${Math.round(r.height)}px` : cs.getPropertyValue(p))).join(' | ');
+      out[sig] = (out[sig] ?? 0) + 1;
+    }
+    return out;
+  }, props);
+}
+
+const groups = {
+  'TEXT INPUTS': { sel: 'input[type=text], input:not([type]), input[type=search], input[type=number]', props: INPUT_PROPS, map: {} },
+  'BUTTONS': { sel: 'button', props: BUTTON_PROPS, map: {} },
+  'PILLS / BADGES': { sel: '[class*=pill], [class*=badge], [class*=chip]', props: PILL_PROPS, map: {} },
+};
+
+for (const [path, name] of PAGES) {
+  await page.goto(BASE + path, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(1200);          // let the first data load settle; skeletons are not the final state
+  for (const g of Object.values(groups)) {
+    for (const [sig, n] of Object.entries(await measure(g.sel, g.props))) {
+      (g.map[sig] ??= []).push(`${name}×${n}`);
+    }
+  }
+}
+
+let measured = 0;
+for (const [label, g] of Object.entries(groups)) {
+  const entries = Object.entries(g.map).sort((a, b) => b[1].length - a[1].length);
+  measured += entries.length;
+  console.log(`\n=== ${label}: ${entries.length} distinct signature(s) across ${PAGES.length} pages`);
+  console.log(`    (${g.props.join(' | ')})`);
+  for (const [sig, where] of entries) console.log(`  ${sig}\n      ${where.join(', ')}`);
+}
+
+console.log(`\nconsole errors: ${consoleErrors.length}`);
+consoleErrors.slice(0, 8).forEach(e => console.log(`  ${e}`));
+
+await browser.close();
+
+if (measured === 0) {
+  console.error('\nMEASURED NOTHING. The sign-in or the selectors failed — this is not a clean result.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Control drift, measured from computed styles in the running app

First tool of audit lens **6 — UX**, whose brief is explicit on two points: visual consistency is the owner's
**primary** review dimension, and **reading CSS will not find drift** — view encapsulation lets two components style
"the same" input differently and neither file looks wrong. The search-bar drift (#385) is the cautionary tale.

So this drives the real bundle on an isolated instance and groups every control by its **computed signature**, which
turns drift into a number instead of an impression.

## What its first run found, across eight pages

### A text input is four different controls

| page | height | background | radius | font | padding-left |
|---|---|---|---|---|---|
| Spaces | **28px** | `#161b22` (bg-surface) | 4px | 13px | 8px |
| Models ×5 | **38px** | `#0d1117` (bg-primary) | **8px** | 13px | 10px |
| Audit log | **32px** | `#0d1117` | 4px | 13px | 8px |
| Schema library | **39px** | `#0d1117` | 4px | **14px** | 12px |

Two background tokens, two radii, two type sizes, and an **11px height spread** — for the same element.

### Buttons: 16 distinct signatures

Some of that is legitimate; an icon button is not a primary button. The drift is:

- the **two most-used signatures differ by 1px height and 1px font-size** — `28px/13px` on 8 pages, `27px/12px` on 7 —
  two near-identical styles used interchangeably app-wide;
- Models has **fractional type** (`12.5px`, `10.5px`), which means a rem/em cascade rather than a token.

Zero console errors across all eight pages, so nothing else is wrong on them.

## The fix lands separately, deliberately

It is one shared style plus a decision about which of the two near-identical button sizes survives. That is a **visual
change**, and it deserves its own before/after pass rather than being bolted onto the measurement PR — the numbers are
recorded in the tracker so it can be done from evidence instead of by eye.

## Two things about the tool worth keeping

1. **A run that measures nothing exits non-zero.** An empty report reads exactly like a clean one — and the first
   draft did precisely that: it passed its arguments to `$$eval` in the wrong order and swallowed the error with a
   `.catch`. The same vacuous-pass trap this batch has spent its time closing in other people's code, written by me.
2. **The setup token is shown once in the setup page's *text*, not in an `input#token`.** The note that said otherwise
   cost a run; the script's header now records the real flow, along with the full isolated-instance recipe.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
