### PR TITLE
fix(ux): one input and one small button, everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One input and one small button, everywhere.** The drift the new sweep measured is fixed, on the owner's call.
+  - **Inputs: 4 distinct computed signatures → 1.** Every input is now **32px** on `--bg-primary` with
+    `var(--radius-sm)` and 13px type, decided in one place — the global rule in `styles.scss`. Three component
+    overrides were removed, plus **a fourth the re-measurement found**: `pipelines-tab` carried a second, identical
+    copy of `models-tab`'s block, including the same wrong hardcoded `8px` radius, so inputs still reported 38px
+    after the first copy went. Measuring again is what caught it.
+  - **Two real defects inside that**: Models hardcoded `border-radius: 8px` where every other input uses the token,
+    and the Spaces search box was the only input in the product on `--bg-surface` instead of `--bg-primary`.
+  - **Buttons: the one-off is gone.** "Sign out" was the product's only bespoke button (borderless, 13px, 28px tall
+    against the house 27px) and appeared on every page because it lives in the shell — which made a single element
+    look like a second app-wide style. It uses `.btn .btn-sm .btn-secondary` now, as do the audit log's three export
+    buttons, which had **no class at all** and re-created `.btn-sm`'s metrics locally.
+  - **Verified by re-measuring, then by looking.** `testing/ux-drift-sweep.mjs` reports one input signature across
+    all four surfaces; screenshots of Spaces, Audit log, Models and Schema library confirm the layouts are intact
+    and the top bar reads correctly with a real button in it.
+
 - **The other 25 controls now announce their state too, so the allowlist is empty.** Completes the previous entry in
   one more pass rather than leaving the debt to age.
   - The attribute was chosen **per group**, not swept in: `aria-selected` (with `role="tablist"`/`role="tab"`) for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`testing/ux-drift-sweep.mjs` — control drift measured from computed styles in the running app.** First tool of
+  the UX audit lens, whose brief states that visual consistency is the primary review dimension and that **reading
+  CSS does not find drift**: view encapsulation lets two components style "the same" input differently and neither
+  file looks wrong.
+  - Its first run found that **a text input is four different controls** — 28 / 32 / 38 / 39 px tall across Spaces,
+    Audit log, Models and Schema library, on **two different background tokens**, with two radii and two type sizes.
+    That is the #385 search-bar drift pattern, still live on four surfaces.
+  - Buttons show **16 distinct signatures**; the two most-used differ by **1px height and 1px font-size** and appear
+    on 8 and 7 pages respectively — two near-identical styles used interchangeably app-wide. Models also has
+    fractional type (`12.5px`), meaning a rem/em cascade rather than a token.
+  - **The fix is a shared style and lands separately**, because it is a visual change that needs its own
+    before/after pass. The numbers are recorded so it can be done deliberately rather than by eye.
+  - A run that measures **nothing exits non-zero**: an empty report reads exactly like a clean one, and the first
+    draft did that — it passed its arguments to `$$eval` in the wrong order and swallowed the error.
+
 - **CI now enforces the CHANGELOG rule that memory had been enforcing.** Second finding of the Documentation & DX
   lens. An `[Unreleased]` entry for every user-facing change is the house rule, and it was being followed — **28 PRs
   in this batch, every one with an entry** — but nothing checked it. A rule kept alive by memory is one distracted

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -36,16 +36,8 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
       font-size: 12px;
       color: var(--text-secondary);
     }
-    .audit-toolbar input,
-    .audit-toolbar select {
-      font-size: 13px;
-      padding: 5px 8px;
-      border-radius: var(--radius-sm);
-      border: 1px solid var(--border);
-      background: var(--bg-primary);
-      color: var(--text-primary);
-      font-family: var(--font);
-    }
+    /* Geometry comes from the ONE input rule in styles.scss — this block restated it almost exactly, which is
+       precisely how a shared control drifts: every copy is defensible on its own and no two agree. */
     .audit-toolbar button {
       padding: 6px 14px;
       font-size: 13px;
@@ -182,7 +174,8 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
     }
 
     .export-btns { display: flex; gap: 8px; }
-    .export-btns button { font-size: 12px; padding: 4px 10px; }
+    /* No button geometry here. These three carried NO class and re-created .btn-sm's metrics locally; they use the
+       class now, so the small-button size is defined in one place. */
 
     .error-msg { color: var(--error); margin: 12px 0; }
   `],
@@ -271,9 +264,9 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
     <!-- Export -->
     <div style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:8px; margin-bottom:8px;">
       <div class="export-btns">
-        <button (click)="exportJson()">{{ 'auditLog.exportJson' | transloco }}</button>
-        <button (click)="exportCsv()">{{ 'auditLog.exportCsv' | transloco }}</button>
-        <button (click)="exportAll()" [disabled]="exportingAll()" [attr.title]="'auditLog.exportAllTitle' | transloco">
+        <button class="btn btn-sm btn-secondary" type="button" (click)="exportJson()">{{ 'auditLog.exportJson' | transloco }}</button>
+        <button class="btn btn-sm btn-secondary" type="button" (click)="exportCsv()">{{ 'auditLog.exportCsv' | transloco }}</button>
+        <button class="btn btn-sm btn-primary" type="button" (click)="exportAll()" [disabled]="exportingAll()" [attr.title]="'auditLog.exportAllTitle' | transloco">
           {{ (exportingAll() ? 'auditLog.exportAllBusy' : 'auditLog.exportAll') | transloco }}
         </button>
       </div>

--- a/client/src/app/pages/settings/media-processing/models-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/models-tab.component.ts
@@ -34,9 +34,10 @@ import { TestTarget } from './media-processing.types';
     .field { margin-bottom: 13px; }
     .field:last-child { margin-bottom: 0; }
     .field > label { display: block; font-size: 12px; color: var(--text-secondary); margin-bottom: 5px; font-weight: 500; }
-    .field input, .field select { width: 100%; background: var(--bg-primary); color: var(--text-primary);
-      border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; font-size: 13px; }
-    .field input[data-mono] { font-family: var(--font-mono, monospace); font-size: 12.5px; }
+    /* Geometry comes from the ONE input rule in styles.scss. This used to restate it — and got the radius wrong,
+       hardcoding 8px where every other input uses var(--radius-sm) — which is how the product ended up with four
+       different inputs. */
+    .field input[data-mono] { font-family: var(--font-mono, monospace); }
     .field input:disabled, .field select:disabled { opacity: .6; cursor: not-allowed; }
     .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; }
     /* Each field stacks label / input / hint. Left to themselves the two columns lay those out

--- a/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
@@ -124,8 +124,9 @@ interface Step {
 
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px 16px; margin-top: 14px; }
     .field > label { display: block; font-size: 12px; color: var(--text-secondary); margin-bottom: 5px; font-weight: 500; }
-    .field input { width: 100%; background: var(--bg-primary); color: var(--text-primary);
-      border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; font-size: 13px; }
+    /* Geometry comes from the ONE input rule in styles.scss. This was a second, identical copy of the block that
+       models-tab also had — including the same wrong 8px radius. The re-measurement is what found it: inputs still
+       reported 38px after the first copy was removed, because both tabs render on the Models page. */
     .field input:disabled { opacity: .6; cursor: not-allowed; }
     .warnline { display: flex; align-items: flex-start; gap: 8px; margin-top: 12px; padding: 10px 12px;
       border-radius: 9px; font-size: 12.5px; border: 1px solid var(--warning-border); background: var(--warning-bg); }

--- a/client/src/app/pages/settings/space-dialog.styles.ts
+++ b/client/src/app/pages/settings/space-dialog.styles.ts
@@ -43,7 +43,10 @@ export const SPACE_DIALOG_STYLES = `
 .sort-btn:hover { background:var(--bg-surface); color:var(--text-primary); }
 .sort-btn.active { background:var(--accent-dim); color:var(--accent); font-weight:600; }
 /* search input */
-.space-search-input { height:28px; padding:0 8px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-surface); color:var(--text-primary); font-size:13px; min-width:160px; }
+/* Only what the global input rule does not decide. This used to set its own height (28px), its own padding, and --
+   the real defect -- background:var(--bg-surface), which made it the one input in the product sitting on a different
+   surface token from every other. */
+.space-search-input { min-width:160px; }
 /* create dialog */
 .dialog-backdrop { position:fixed; inset:0; background:var(--bg-scrim); display:flex; align-items:center; justify-content:center; z-index:100; }
 .dialog { background:var(--bg-primary); border:1px solid var(--border); border-radius:var(--radius-lg); padding:24px; width:90%; max-width:960px; max-height:90vh; overflow-y:auto; }

--- a/client/src/app/pages/shell/shell.component.ts
+++ b/client/src/app/pages/shell/shell.component.ts
@@ -60,18 +60,10 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
     }
     .menu-btn:hover { color: var(--text-primary); background: var(--bg-elevated); }
 
-    .topbar-logout {
-      background: none;
-      border: none;
-      color: var(--text-secondary);
-      font-size: 13px;
-      cursor: pointer;
-      padding: 5px 10px;
-      border-radius: var(--radius-sm);
-      transition: color var(--transition), background var(--transition);
-      font-family: var(--font);
-    }
-    .topbar-logout:hover { color: var(--text-primary); background: var(--bg-elevated); }
+    /* Sign out was the product's only bespoke button: borderless, 13px, 5px/10px padding — 28px tall where the
+       house small button is 27px. It appeared on every page because it lives here, which made a one-off look like a
+       second app-wide style in the drift measurement. It uses .btn .btn-sm .btn-secondary now, so there is one small
+       button and this block is gone. */
 
     .layout {
       display: flex;
@@ -226,7 +218,7 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
           <app-brand-logo [size]="21" />
         </a>
         <span class="topbar-spacer"></span>
-        <button class="topbar-logout" (click)="logout()">{{ 'nav.signOut' | transloco }}</button>
+        <button class="btn btn-sm btn-secondary" type="button" (click)="logout()">{{ 'nav.signOut' | transloco }}</button>
       </header>
     }
 

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -229,14 +229,26 @@ input[type="number"],
 input[type="search"],
 textarea,
 select {
+  /*
+   * ONE input, everywhere — 32px tall, measured rather than eyeballed.
+   *
+   * The same element used to be four different controls: 28px on Spaces, 32px on the audit log, 38px on Models,
+   * 39px from this rule — across two background tokens, two radii and two type sizes. Encapsulation hid it, because
+   * each component's CSS looked reasonable on its own; only computed styles in the running app showed the spread
+   * (`testing/ux-drift-sweep.mjs`).
+   *
+   * 13px type with 5px vertical padding lands on 32px, which is where three of the four surfaces already sat.
+   * 14px/8px was the outlier, and 39px is tall for a dense admin UI. The component overrides that produced the other
+   * three are gone, so this is now the only place an input's geometry is decided.
+   */
   width: 100%;
-  padding: 8px 12px;
+  padding: 5px 10px;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
   font-family: var(--font);
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   transition: border-color var(--transition), box-shadow var(--transition);
   outline: none;

--- a/testing/ux-drift-sweep.mjs
+++ b/testing/ux-drift-sweep.mjs
@@ -1,0 +1,127 @@
+/**
+ * Sibling-surface drift pass — the same control across every page, measured from COMPUTED styles.
+ *
+ * ## Why this cannot be a unit test
+ *
+ * Visual consistency is the owner's primary review dimension, and the audit lens is explicit that reading CSS does
+ * not find drift: Angular's view encapsulation means two components can style "the same" input differently and
+ * neither file looks wrong. The search-bar drift (#385) is the cautionary tale. Only the running app knows what a
+ * control actually measures, so this drives the real bundle and groups every control by its computed signature.
+ *
+ * Drift then shows up as a NUMBER — "4 distinct signatures for a text input" — instead of an impression.
+ *
+ * ## Running it
+ *
+ *   1. Boot an isolated instance (never the operator's own on :3210):
+ *
+ *        cd server
+ *        PORT=3260 TRUST_PROXY=1 \
+ *        CONFIG_PATH=<scratch>/config/config.json DATA_ROOT=<scratch>/data \
+ *        MONGO_URI=mongodb://127.0.0.1:27017/ythril_ux_audit \
+ *        npx tsx src/index.ts
+ *
+ *   2. `npm run build:client` once, so the server serves the bundle that ships.
+ *   3. Complete first-run setup and put the admin token in `token.txt` beside this script. The token is shown ONCE,
+ *      in the setup page's TEXT (`ythril_…`) — not in an `input#token`.
+ *   4. `node testing/ux-drift-sweep.mjs`
+ *
+ * Needs `playwright` available and Edge installed (`channel: 'msedge'` avoids a browser download).
+ *
+ * ## What it will not do
+ *
+ * It reports; it does not judge. Some variation is real design — an icon button is not a primary button. The signal
+ * is *near-identical* signatures (a 1px height difference across eight pages) and the same control appearing on
+ * different background tokens, which is drift by definition rather than intent.
+ *
+ * A run that measures NOTHING exits non-zero. An empty report reads exactly like a clean one, and the first draft of
+ * this script did precisely that: it passed its arguments to `$$eval` in the wrong order and swallowed the error.
+ */
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+
+const BASE = process.env['UX_BASE'] ?? 'http://localhost:3260';
+const TOKEN_FILE = process.env['UX_TOKEN_FILE'] ?? 'token.txt';
+
+const PAGES = [
+  ['/brain', 'Brain'],
+  ['/settings/spaces', 'Spaces'],
+  ['/settings/tokens', 'Tokens'],
+  ['/settings/storage', 'Storage'],
+  ['/settings/models', 'Models'],
+  ['/settings/audit-log', 'Audit log'],
+  ['/settings/preferences', 'Preferences'],
+  ['/schema-library', 'Schema library'],
+];
+
+/** The concretes the UX lens names: control height, padding, background token, radius, type size. */
+const INPUT_PROPS = ['height', 'padding-top', 'padding-bottom', 'padding-left', 'background-color', 'border-radius', 'font-size'];
+const BUTTON_PROPS = ['height', 'padding-left', 'padding-right', 'font-size', 'border-radius'];
+const PILL_PROPS = ['height', 'padding-left', 'border-radius', 'font-size', 'text-transform'];
+
+const browser = await chromium.launch({ channel: 'msedge' });
+const page = await browser.newPage({ viewportSize: { width: 1440, height: 900 } });
+const consoleErrors = [];
+page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text().slice(0, 160)); });
+
+const token = readFileSync(TOKEN_FILE, 'utf8').trim();
+await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('#token', { timeout: 30_000 });
+await page.fill('#token', token);
+await page.press('#token', 'Enter');
+await page.waitForURL(u => !/\/(setup|login)/.test(u.toString()), { timeout: 30_000 });
+console.log(`signed in, landed on ${page.url()}`);
+
+/**
+ * Every visible instance of `selector`, grouped by computed signature.
+ *
+ * Argument order matters: `$$eval(selector, fn, arg)`. Passing `[selector, props]` as the selector throws, and
+ * catching that would turn a broken measurement into a clean-looking report.
+ */
+async function measure(selector, props) {
+  return page.$$eval(selector, (els, ps) => {
+    const out = {};
+    for (const el of els) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) continue;      // invisible: not part of the visual language
+      const cs = getComputedStyle(el);
+      const sig = ps.map(p => (p === 'height' ? `${Math.round(r.height)}px` : cs.getPropertyValue(p))).join(' | ');
+      out[sig] = (out[sig] ?? 0) + 1;
+    }
+    return out;
+  }, props);
+}
+
+const groups = {
+  'TEXT INPUTS': { sel: 'input[type=text], input:not([type]), input[type=search], input[type=number]', props: INPUT_PROPS, map: {} },
+  'BUTTONS': { sel: 'button', props: BUTTON_PROPS, map: {} },
+  'PILLS / BADGES': { sel: '[class*=pill], [class*=badge], [class*=chip]', props: PILL_PROPS, map: {} },
+};
+
+for (const [path, name] of PAGES) {
+  await page.goto(BASE + path, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(1200);          // let the first data load settle; skeletons are not the final state
+  for (const g of Object.values(groups)) {
+    for (const [sig, n] of Object.entries(await measure(g.sel, g.props))) {
+      (g.map[sig] ??= []).push(`${name}×${n}`);
+    }
+  }
+}
+
+let measured = 0;
+for (const [label, g] of Object.entries(groups)) {
+  const entries = Object.entries(g.map).sort((a, b) => b[1].length - a[1].length);
+  measured += entries.length;
+  console.log(`\n=== ${label}: ${entries.length} distinct signature(s) across ${PAGES.length} pages`);
+  console.log(`    (${g.props.join(' | ')})`);
+  for (const [sig, where] of entries) console.log(`  ${sig}\n      ${where.join(', ')}`);
+}
+
+console.log(`\nconsole errors: ${consoleErrors.length}`);
+consoleErrors.slice(0, 8).forEach(e => console.log(`  ${e}`));
+
+await browser.close();
+
+if (measured === 0) {
+  console.error('\nMEASURED NOTHING. The sign-in or the selectors failed — this is not a clean result.');
+  process.exit(1);
+}


### PR DESCRIPTION
## One input and one small button, everywhere

The drift the new sweep measured, fixed — on the owner's call (4.1–4.3).

## Inputs: 4 distinct computed signatures → 1

| | before | after |
|---|---|---|
| Spaces | 28px, `--bg-surface` | **32px, `--bg-primary`** |
| Audit log | 32px | **32px** |
| Models ×5 | 38px, `border-radius: 8px` | **32px, `var(--radius-sm)`** |
| Schema library | 39px, 14px type | **32px, 13px type** |

Decided in **one place** now — the global rule in `styles.scss`. 13px type with 5px vertical padding lands on 32px,
which is where three of the four surfaces already sat; 14px/8px was the outlier, and 39px is tall for a dense admin UI.

**Three component overrides removed — and a fourth that only re-measuring found.** `pipelines-tab` carried a second,
identical copy of `models-tab`'s block, including the same wrong hardcoded `8px` radius. Inputs still reported 38px
after the first copy went, because both tabs render on the Models page. Reading would not have caught that; measuring
again did.

**Two real defects inside it:**

- Models hardcoded `border-radius: 8px` where every other input uses the token;
- the Spaces search box was **the only input in the product on `--bg-surface`** instead of `--bg-primary`.

## Buttons: the one-off is gone

"Sign out" was the product's only bespoke button — borderless, 13px, 28px tall against the house 27px — and it appeared
on all eight pages **because it lives in the shell**. That single element is what made my first reading of the data
say "two competing app-wide styles"; it wasn't.

It uses `.btn .btn-sm .btn-secondary` now, as do the audit log's three export buttons, which carried **no class** and
re-created `.btn-sm`'s metrics locally.

## Verified by re-measuring, then by looking

```text
=== TEXT INPUTS: 1 distinct signature(s) across 8 pages
  32px | 5px | 5px | 10px | rgb(13, 17, 23) | 4px | 13px
      Spaces×1, Models×5, Audit log×1, Schema library×1
```

Screenshots of Spaces, Audit log, Models and Schema library confirm the layouts are intact and the top bar reads
correctly with a real button in it. A colour or geometry change is a visual change, so the numbers alone were not
enough.

## One thing left alone deliberately

The Spaces search input is full-width above its sort row, which looks odd — but that predates this change: it comes
from the global `width: 100%`, not from the geometry that was removed. Changing it is a layout decision, not a drift
fix, so it is not smuggled in here.

## Footnote

`scripts/check-changelog.mjs`, merged an hour ago in #657, validated this PR on its own diff: *6 shipped file(s)
changed, 31 line(s) added under `[Unreleased]`*.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone. Client bundle builds clean.
