### PR TITLE
docs(theme): say which tokens a theme must not touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The theme docs now say which tokens a theme must not touch.** Raised by an operator screenshot: a **red** brand
+  palette on 2.2.5 rendered the "Active" pill red.
+  - **Already fixed in code, and not yet released.** In the v2.2.5 tag `.pill.active` reads `var(--accent)` with a
+    hardcoded `rgba(206,255,128,…)` background — red text on a greenish pill, exactly the screenshot — and
+    `--state-active` did not exist. #637 fixed that and swept two more elements; 2.2.5 predates it by 31 commits.
+  - **What was actually left is the theme surface.** Both theming paths — the injected `cssUrl` stylesheet and the
+    `postMessage` token channel — accept **any** `--` custom property, so an embedder can set `--error` or
+    `--state-active` directly. No code can prevent that; the only defence is saying which tokens report facts, and
+    that rule lived in a CSS comment where no operator would read it.
+  - `15-about-and-embedding.md` now has **"What a theme owns — and what it must not touch"**: the five fact tokens
+    and their derived pairs, the brand tokens that *are* the operator's, the line between them (a selected tab
+    follows the accent; a status pill does not), and the concrete failure that motivates it.
+  - Gate `theme-cannot-recolour-facts`: every semantic token declared in `:root` must be named in that list, so a
+    sixth one cannot be added without documenting it. It deliberately does **not** pin `--state-active`'s value —
+    keeping it identical to the default accent is #637's choice, so an unthemed instance stays pixel-identical.
+
 - **`testing/ux-drift-sweep.mjs` — control drift measured from computed styles in the running app.** First tool of
   the UX audit lens, whose brief states that visual consistency is the primary review dimension and that **reading
   CSS does not find drift**: view encapsulation lets two components style "the same" input differently and neither

--- a/docs/integration-guide/15-about-and-embedding.md
+++ b/docs/integration-guide/15-about-and-embedding.md
@@ -130,6 +130,34 @@ Only `--`-prefixed CSS custom properties are accepted. Standard CSS properties (
 
 The `postMessage` handler validates `event.origin`. **Same-origin messages are always accepted. A cross-origin embedder — which is what portal-style embedding actually is — is accepted only if the operator has explicitly allowlisted its origin** (see below). Without that opt-in, a cross-origin `postMessage` is ignored *and* the browser will refuse to frame Ythril at all.
 
+### What a theme owns — and what it must not touch
+
+**A theme owns identity. It does not own facts.**
+
+Both paths above can set any `--` custom property, so both can reach tokens that are not brand colours. One class
+of token reports **what the system is**, and recolouring it makes the product lie:
+
+| do not override | it means |
+|---|---|
+| `--state-active` | a feature is configured and running — "Active", "Online", "In use" |
+| `--success` | a check passed — "Healthy", "Reachable", "Complete" |
+| `--warning` | degraded, still working — a fallback is in use |
+| `--error` | failed |
+| `--info` | in progress, nothing wrong |
+| `--status-*-bg` / `--status-*-fg`, `--success-*`, `--warning-*`, `--error-*` | derived from the five above |
+
+This is not a style preference. A brand palette built on red made **"Active" and "Online" render red** while
+"Healthy" and "Reachable" stayed green — the same instance reporting the same good news in two colours, one of which
+reads as an alarm. Fixed in the code for the tokens that were mixing the two, but a theme can still override these
+directly, and nothing in the browser can stop it.
+
+**Brand tokens are yours**: `--accent`, `--accent-hover`, `--accent-text`, `--nav-active`, the backgrounds, the text
+greys, the borders, the radii. Anything that says *"you are here"* — a selected tab, a highlighted row, a sort caret
+— is navigation and correctly follows `--accent`.
+
+One caveat if you do restyle the text greys: they are chosen to clear **WCAG AA (4.5:1)** against all three
+background tokens, and that is computed on every build (`text-contrast-meets-aa`). A theme is outside that check.
+
 ### Enabling cross-origin embedding (opt-in)
 
 By default Ythril may only be framed and themed by its own origin. To embed it in a portal on a **different** origin, list that origin in `config.json`:

--- a/testing/standalone/theme-cannot-recolour-facts.test.js
+++ b/testing/standalone/theme-cannot-recolour-facts.test.js
@@ -1,0 +1,113 @@
+/**
+ * A theme owns identity. It must not own facts — and the docs have to say so, because nothing else can stop it.
+ *
+ * ## The finding — UX audit lens
+ *
+ * An operator running a **red** brand palette on 2.2.5 sent a screenshot of an "Active" pill rendered in red. In the
+ * v2.2.5 tag, `.pill.active` reads:
+ *
+ *     color: var(--accent);  background: rgba(206,255,128,.12);  border-color: rgba(206,255,128,.28);
+ *
+ * Red text from the themed brand token, greenish background from a hardcoded rgba of the *default* green — which is
+ * exactly what the screenshot shows. `--state-active` did not exist in that tag at all.
+ *
+ * **#637 already fixed the code**: `.pill.active` now reads `--state-active`, and a sweep at the time found two more
+ * elements doing the same thing. It simply is not released yet — 2.2.5 predates it.
+ *
+ * ## So what was actually left to do
+ *
+ * The residual risk is not in the CSS, it is in the theme SURFACE. Both theming paths — the injected `cssUrl`
+ * stylesheet and the `postMessage` token channel — accept **any** `--` custom property, so an embedder can set
+ * `--error`, `--success` or `--state-active` directly. No code can prevent that; the only defence is telling the
+ * operator which tokens report facts. The rule existed in a CSS comment and nowhere an operator would read.
+ *
+ * ## What this gate holds
+ *
+ * That every semantic state token declared in `:root` is named in the theme documentation's do-not-override list. Add
+ * a new one and the docs must mention it, or a future palette recolours a fact and nothing warns anybody.
+ *
+ * It deliberately does NOT assert `--state-active`'s value. Keeping it byte-identical to the default accent is a
+ * choice from #637 — an unthemed instance stays pixel-identical, and only a themed one changes.
+ *
+ * Run: node --test testing/standalone/theme-cannot-recolour-facts.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CSS = readFileSync(join('client', 'src', 'styles.scss'), 'utf8');
+const DOC = readFileSync(join('docs', 'integration-guide', '15-about-and-embedding.md'), 'utf8');
+
+/** The five tokens that report what the system IS. Derived tokens mix from these. */
+const FACT_TOKENS = ['--state-active', '--success', '--warning', '--error', '--info'];
+
+describe('the semantic tokens exist and are grouped as such', () => {
+  it('all five are declared', () => {
+    for (const t of FACT_TOKENS) {
+      assert.match(CSS, new RegExp(`${t}:\\s*#[0-9a-fA-F]{3,6}`), `${t} is missing or no longer a literal colour`);
+    }
+  });
+
+  it('the block still explains the rule at the point of declaration', () => {
+    // The comment is what stops the next person "tidying up" by pointing a pill at --accent again.
+    const at = CSS.indexOf('--state-active:');
+    const around = CSS.slice(Math.max(0, at - 1400), at);
+    assert.match(around, /theme/i, 'the declaration should carry the identity-vs-facts note');
+    assert.match(around, /SEMANTIC STATE NEVER DOES|must not move|does not own facts/i,
+      'the rule must be stated where the tokens are declared');
+  });
+});
+
+describe('no fact-reporting element reads the brand token', () => {
+  it('the pill variants use semantic tokens, not --accent', () => {
+    // The regression #637 fixed, pinned. `.pill.active` read `var(--accent)` in v2.2.5, which is why a red brand
+    // palette turned "Active" red while "Healthy" stayed green.
+    const pill = readFileSync(join('client', 'src', 'app', 'shared', 'status-pill.component.ts'), 'utf8');
+    const at = pill.indexOf('.pill.active');
+    assert.ok(at > 0, 'the active pill variant is gone — re-anchor this gate');
+    const rule = pill.slice(at, pill.indexOf('}', at));
+    assert.match(rule, /var\(--state-active\)/, 'the active pill must read --state-active');
+    assert.doesNotMatch(rule, /var\(--accent\)/, 'a pill reports a fact; it must never follow the brand colour');
+    assert.doesNotMatch(rule, /rgba\(206,\s*255,\s*128/,
+      'the background must mix from the same token, not hardcode the default green — that mismatch is what produced '
+      + 'red text on a green pill');
+  });
+});
+
+describe('the theme surface documents what it must not touch', () => {
+  it('there is a section saying a theme does not own facts', () => {
+    const at = DOC.indexOf('What a theme owns');
+    assert.ok(at > 0, 'the theme docs no longer say which tokens are off limits — and nothing in the browser can '
+      + 'stop an embedder from setting them');
+    const section = DOC.slice(at, DOC.indexOf('\n### ', at + 10));
+    assert.match(section, /does not own facts|must not/i, 'the rule must be stated plainly');
+    return section;
+  });
+
+  it('every fact token is named in that section', () => {
+    // The point of the gate: adding a sixth semantic token without documenting it would leave a fact a theme can
+    // recolour with nothing to warn the operator.
+    const at = DOC.indexOf('What a theme owns');
+    const section = DOC.slice(at, DOC.indexOf('\n### ', at + 10));
+    const missing = FACT_TOKENS.filter(t => !section.includes(t));
+    assert.deepEqual(missing, [], 'these report facts but the theme docs do not list them as off limits:\n  '
+      + missing.join('\n  '));
+  });
+
+  it('it says which tokens ARE the theme\'s, so the guidance is usable', () => {
+    // A list of prohibitions with no permissions reads as "do not theme", which nobody will follow.
+    const at = DOC.indexOf('What a theme owns');
+    const section = DOC.slice(at, DOC.indexOf('\n### ', at + 10));
+    assert.match(section, /--accent/, 'it must say the brand tokens are the operator\'s');
+    assert.match(section, /you are here|navigation/i,
+      'it must explain the line: a selected tab follows the accent, a status pill does not');
+  });
+
+  it('it gives the concrete failure, not just a rule', () => {
+    const at = DOC.indexOf('What a theme owns');
+    const section = DOC.slice(at, DOC.indexOf('\n### ', at + 10));
+    assert.match(section, /red/i,
+      'the example is what makes the rule land: "Active" and "Online" rendered red while "Healthy" stayed green');
+  });
+});


### PR DESCRIPTION
## Say which tokens a theme must not touch

Raised by an operator screenshot: a **red** brand palette on 2.2.5 rendered the "Active" pill red — an alarm colour for
a healthy state.

## First, the correction: this is already fixed, and not yet released

From the **v2.2.5 tag itself**:

```
.pill.active { color: var(--accent);
               background: rgba(206,255,128,.12);
               border-color: rgba(206,255,128,.28); }
```

Red text from the themed brand token, greenish background from a **hardcoded rgba of the default green** — exactly what
the screenshot shows. `--state-active` did not exist in that tag at all.

**#637** replaced the accent reference and swept two more elements doing the same thing. 2.2.5 predates it by **31
commits**.

I had begun changing `--state-active` to a distinct literal before checking the tag. **Reverted** — the reported bug is
fixed, and keeping that token byte-identical to the default accent is a deliberate choice from #637: an unthemed
instance stays pixel-identical, and only a themed one changes.

The operator also corrected a second thing I was about to change: the accent-bordered "Embed" box marking the path that
runs is **emphasis, not a state claim**, and correctly follows the theme. Left alone.

## What was actually left: the theme surface, not the CSS

Both theming paths accept **any** `--`-prefixed custom property:

- the injected `cssUrl` stylesheet;
- the `postMessage` token channel.

So an embedder can set `--error`, `--success` or `--state-active` directly. **No code can prevent that.** The only
defence is telling the operator which tokens report facts — and that rule lived in a CSS comment, where no operator
would ever read it.

`15-about-and-embedding.md` now has **"What a theme owns — and what it must not touch"**:

- the five fact tokens and their derived pairs, tabulated with what each one means;
- the brand tokens that **are** the operator's, so the guidance is usable rather than a wall of prohibitions;
- the line between them: a selected tab, a highlighted row and a sort caret say *"you are here"* and correctly follow
  the accent; a status pill reports a fact and never does;
- the concrete failure, because the rule does not land without it — "Active" and "Online" red while "Healthy" and
  "Reachable" stayed green, one instance reporting the same good news in two colours;
- a note that a theme sits outside the WCAG AA contrast computation, since the text greys are chosen against all three
  background tokens.

## Gate

`testing/standalone/theme-cannot-recolour-facts.test.js` — 7 assertions.

Every semantic token declared in `:root` must be named in that do-not-override list, so a sixth cannot be added
without documenting it. It also pins the **#637 regression itself**: `.pill.active` must read `--state-active`, must
not read `--accent`, and must not hardcode the default green in its background — that mismatch is what produced red
text on a green pill.

It deliberately does **not** assert `--state-active`'s value, for the reason above.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
