### PR TITLE
fix(ux): one pill shape, badge colours follow their tokens, and the date filters are not white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The audit log's two date filters rendered WHITE — a regression from the previous PR, caught by looking.**
+  #659 removed a component override that had been styling `input[type=datetime-local]`, and the global input rule's
+  selector list never covered that type, so both filters fell through to the browser default: white background,
+  black text, in a dark admin UI.
+  - The list now covers every type the product renders — `url`, `tel`, `datetime-local`, `date`, `time`, `month`,
+    `week` — in **both** the base rule and the `:focus` rule, because a type styled but not focus-styled loses its
+    focus ring, which is an accessibility regression rather than a cosmetic one.
+  - **The drift sweep had the same blind spot**, which is why it reported "one signature" while two inputs were
+    white: its selector list was the same four types as the CSS. The measurement and the thing it measures must not
+    share a gap. It now measures every type, and reports the datetime fields at 34px — 2px taller because a native
+    picker has intrinsic content, which is a browser fact rather than drift.
+
+- **One pill shape, and the badge colours follow their tokens.** `.badge` is the class version of
+  `app-status-pill`, and it measured differently: `border-radius: 20px` against `999px`, 11px type against 11.5px,
+  8px padding against 9px — three badges at 22/24/24px beside a 23px pill on the same screens.
+  - Aligned to the component. **20 inline `font-size` declarations** across 10 files were also removed: an inline
+    style beats the class, so every call site had been quietly re-deciding the size of a shared control.
+  - `.badge-green/-yellow/-red/-blue` hardcoded the semantic hexes (`#3fb950`, `#d29922`, …) instead of mixing from
+    `--success`/`--warning`/`--error`/`--info` — the same defect #637 fixed in the pill, where a hardcoded literal
+    stops following its token.
+  - **`.mono` no longer sets a size.** `font-size: 0.85em` made a typeface switch double as a size multiplier, so
+    `.badge.mono` measured **11.05px** — a number nobody chose, produced by the cascade, and winning over `.badge`
+    only because `.mono` is declared later. `1em` was tried first and was worse (it resolves against the parent:
+    13px); removing the declaration is the fix. Both attempts were measured, which is the only reason the second
+    was caught.
+
 - **One input and one small button, everywhere.** The drift the new sweep measured is fixed, on the owner's call.
   - **Inputs: 4 distinct computed signatures → 1.** Every input is now **32px** on `--bg-primary` with
     `var(--radius-sm)` and 13px type, decided in one place — the global rule in `styles.scss`. Three component

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -221,7 +221,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                         <div class="desc-clamp">{{ entry.description || '—' }}</div>
                       </td>
                       <td><span class="badge badge-blue">{{ entry.type }}</span></td>
-                      <td><span class="badge" [class.badge-purple]="entry.status === 'upcoming'" [class.badge-blue]="entry.status === 'active'" style="font-size:11px">{{ entry.status }}</span></td>
+                      <td><span class="badge" [class.badge-purple]="entry.status === 'upcoming'" [class.badge-blue]="entry.status === 'active'">{{ entry.status }}</span></td>
                       <td style="color:var(--text-muted); font-size:12px">{{ entry.startsAt | date:'dd.MM.yyyy HH:mm' }}</td>
                       <td style="color:var(--text-muted); font-size:12px">{{ entry.endsAt ? (entry.endsAt | date:'dd.MM.yyyy HH:mm') : '—' }}</td>
                       <td>

--- a/client/src/app/pages/brain/query-tab.component.ts
+++ b/client/src/app/pages/brain/query-tab.component.ts
@@ -220,13 +220,13 @@ import { BrainStore } from './brain-store.service';
                     @if (g.file; as f) {
                       <!-- A grouped document: name the FILE once, then say where inside it matched. -->
                       <div style="display:flex; gap:8px; margin-bottom:4px; align-items:center; flex-wrap:wrap;">
-                        <span class="badge badge-purple" style="font-size:10px;">file</span>
+                        <span class="badge badge-purple">file</span>
                         <strong style="font-size:12px; word-break:break-all;">{{ f.path }}</strong>
                         @if (g.score != null) {
                           <span style="font-size:11px; color:var(--text-muted);">{{ 'common.score' | transloco }}: {{ g.score.toFixed(3) }}</span>
                         }
                         @if (g.hitCount > 1) {
-                          <span class="badge" style="font-size:10px;">{{ 'brain.query.passages' | transloco: { count: g.hitCount } }}</span>
+                          <span class="badge">{{ 'brain.query.passages' | transloco: { count: g.hitCount } }}</span>
                         }
                       </div>
                       @if (f.description) {
@@ -251,7 +251,7 @@ import { BrainStore } from './brain-store.service';
                       </ul>
                     } @else {
                       <div style="display:flex; gap:8px; margin-bottom:4px; align-items:center;">
-                        <span class="badge badge-purple" style="font-size:10px;">{{ g.hits[0].type }}</span>
+                        <span class="badge badge-purple">{{ g.hits[0].type }}</span>
                         @if (g.score != null) {
                           <span style="font-size:11px; color:var(--text-muted);">{{ 'common.score' | transloco }}: {{ g.score.toFixed(3) }}</span>
                         }

--- a/client/src/app/pages/settings/network-create-dialog.component.ts
+++ b/client/src/app/pages/settings/network-create-dialog.component.ts
@@ -101,7 +101,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                           <input type="checkbox" [checked]="isNetworkSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleNetworkSpace(s.id)" />
                         </td>
                         <td>{{ s.label }}</td>
-                        <td><span class="badge badge-gray mono" style="font-size:11px;">{{ s.id }}</span></td>
+                        <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
                       </tr>
                     }
                   </tbody>

--- a/client/src/app/pages/settings/networks.component.ts
+++ b/client/src/app/pages/settings/networks.component.ts
@@ -284,7 +284,7 @@ import { NetworkEnableWizardComponent } from './network-enable-wizard.component'
                 <div class="member-row">
                   <span class="mono badge badge-gray" style="font-size:11px;">{{ m.instanceId.slice(0, 8) }}</span>
                   <span style="font-weight:500; flex:1;">{{ m.label }}</span>
-                  <span class="badge badge-gray" style="font-size:11px;">{{ m.syncDirection ?? 'both' }}</span>
+                  <span class="badge badge-gray">{{ m.syncDirection ?? 'both' }}</span>
                   <!-- Sync health at a glance: last successful sync + a failing badge when a run streak is failing. -->
                   @if (m.consecutiveFailures) {
                     <span class="member-failing" [attr.title]="'networks.member.failingTitle' | transloco: { count: m.consecutiveFailures }">

--- a/client/src/app/pages/settings/space-create-dialog.component.ts
+++ b/client/src/app/pages/settings/space-create-dialog.component.ts
@@ -65,7 +65,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                     <tr style="cursor:pointer;" [class.text-muted]="proxyForAll" (click)="!proxyForAll && toggleProxyFor(s.id)">
                       <td style="text-align:center;"><input type="checkbox" [checked]="proxyForAll || isProxyForSelected(s.id)" [disabled]="proxyForAll" (click)="$event.stopPropagation()" (change)="!proxyForAll && toggleProxyFor(s.id)" /></td>
                       <td>{{ s.label }}</td>
-                      <td><span class="badge badge-gray mono" style="font-size:11px;">{{ s.id }}</span></td>
+                      <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
                     </tr>
                   }
                 </tbody>

--- a/client/src/app/pages/settings/space-danger-tab.component.ts
+++ b/client/src/app/pages/settings/space-danger-tab.component.ts
@@ -134,7 +134,7 @@ import { TranslocoService } from '@jsverse/transloco';
       <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border);">
         <div>
           <span style="font-weight:500;">{{ n.label }}</span>
-          <span class="badge badge-gray" style="margin-left:8px;font-size:11px;">{{ n.id }}</span>
+          <span class="badge badge-gray" style="margin-left:8px">{{ n.id }}</span>
         </div>
         <button class="btn btn-secondary btn-sm" type="button" (click)="leaveNetworkDanger(n.id)">{{ 'spaces.dangerZone.leaveButton' | transloco }}</button>
       </div>

--- a/client/src/app/pages/settings/space-schema-tab.component.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.ts
@@ -403,14 +403,14 @@ const SCHEMA_MD_STYLES = `
                         </label>
                       </div>
                     </td>
-                    <td><span class="badge badge-gray" style="font-size:11px;">{{ p.s.type ?? 'any' }}</span></td>
+                    <td><span class="badge badge-gray">{{ p.s.type ?? 'any' }}</span></td>
                     <td style="font-size:11px;color:var(--text-muted);">
-                      @if (p.s.enum?.length) { <span class="badge badge-gray" style="font-size:10px;margin-right:3px;">enum {{ p.s.enum!.length }}</span> }
+                      @if (p.s.enum?.length) { <span class="badge badge-gray" style="margin-right:3px">enum {{ p.s.enum!.length }}</span> }
                       @if (p.s.minimum!==undefined) { <span style="margin-right:4px;">min:{{ p.s.minimum }}</span> }
                       @if (p.s.maximum!==undefined) { <span style="margin-right:4px;">max:{{ p.s.maximum }}</span> }
                       @if (p.s.pattern) { <span style="margin-right:4px;">pattern</span> }
                       @if (p.s.default!==undefined) { <span style="margin-right:4px;">default:{{ p.s.default }}</span> }
-                      @if (p.s.mergeFn) { <span class="badge badge-blue" style="font-size:10px;">{{ p.s.mergeFn }}</span> }
+                      @if (p.s.mergeFn) { <span class="badge badge-blue">{{ p.s.mergeFn }}</span> }
                     </td>
                     <td (click)="$event.stopPropagation()">
                       <button class="icon-btn danger" type="button" (click)="state.removeProp(kt,name,p.key)" [attr.title]="'common.remove' | transloco"><ph-icon name="x" [size]="14"/></button>

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -183,9 +183,9 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
                   <td><span class="drag-handle" cdkDragHandle [class.drag-handle-disabled]="sortMode() !== 'custom'" [attr.title]="'spaces.table.dragHandleTitle' | transloco"><ph-icon name="dots-three-vertical" [size]="16"/></span></td>
                   <td style="font-weight:500;">{{ s.label }}
                     @if (s.indexStatus === 'building') {
-                      <span class="badge badge-blue" style="font-size:10px;margin-left:6px;font-weight:normal;" [attr.title]="'spaces.indexBuildingTitle' | transloco"><span class="spinner" style="width:8px;height:8px;border-width:1.5px;display:inline-block;vertical-align:middle;margin-right:3px;"></span>{{ 'spaces.indexBuilding' | transloco }}</span>
+                      <span class="badge badge-blue" style="margin-left:6px;font-weight:normal" [attr.title]="'spaces.indexBuildingTitle' | transloco"><span class="spinner" style="width:8px;height:8px;border-width:1.5px;display:inline-block;vertical-align:middle;margin-right:3px;"></span>{{ 'spaces.indexBuilding' | transloco }}</span>
                     } @else if (s.indexStatus === 'failed') {
-                      <span class="badge badge-red" style="font-size:10px;margin-left:6px;font-weight:normal;" [attr.title]="'spaces.indexFailedTitle' | transloco">{{ 'spaces.indexFailed' | transloco }}</span>
+                      <span class="badge badge-red" style="margin-left:6px;font-weight:normal" [attr.title]="'spaces.indexFailedTitle' | transloco">{{ 'spaces.indexFailed' | transloco }}</span>
                     }
                   </td>
                   <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
@@ -205,12 +205,12 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
                     @if (use) {
                       <span class="mono" style="font-size:12px;">{{ use.calls }}</span>
                       @if (answerRate(use); as rate) {
-                        <span class="badge" style="margin-left:6px;font-size:10px;"
+                        <span class="badge" style="margin-left:6px"
                               [class.badge-green]="rate >= 50" [class.badge-yellow]="rate < 50 && rate >= 20"
                               [class.badge-red]="rate < 20"
                               [attr.title]="('spaces.table.usageAnsweredTitle' | transloco) + ' ' + use.answered + '/' + use.recall">{{ rate }}%</span>
                       } @else if (use.recall > 0) {
-                        <span class="badge badge-red" style="margin-left:6px;font-size:10px;">0%</span>
+                        <span class="badge badge-red" style="margin-left:6px">0%</span>
                       }
                     } @else {
                       <span style="color:var(--text-muted)">—</span>
@@ -229,7 +229,7 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
                       <span class="badge badge-blue" style="font-style:italic;">{{ 'spaces.badge.allSpaces' | transloco }}</span>
                     } @else if (s.proxyFor?.length) {
                       @for (pid of s.proxyFor; track pid) {
-                        <span class="badge badge-blue" style="margin-right:4px;font-size:11px;">{{ pid }}</span>
+                        <span class="badge badge-blue" style="margin-right:4px">{{ pid }}</span>
                       }
                     } @else { <span style="color:var(--text-muted)">—</span> }
                   </td>

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -304,7 +304,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                             <input type="checkbox" [checked]="isSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleSpace(s.id)" />
                           </td>
                           <td>{{ s.label }}</td>
-                          <td><span class="badge badge-gray mono" style="font-size:11px;">{{ s.id }}</span></td>
+                          <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
                         </tr>
                       }
                     </tbody>

--- a/client/src/app/shared/prop-schema-table.component.ts
+++ b/client/src/app/shared/prop-schema-table.component.ts
@@ -56,14 +56,14 @@ export interface PropSchemaRow {
                   </label>
                 </div>
               </td>
-              <td><span class="badge badge-gray" style="font-size:11px;">{{ p.s.type ?? 'any' }}</span></td>
+              <td><span class="badge badge-gray">{{ p.s.type ?? 'any' }}</span></td>
               <td style="font-size:11px;color:var(--text-muted);">
-                @if (p.s.enum?.length) { <span class="badge badge-gray" style="font-size:10px;margin-right:3px;">enum {{ p.s.enum!.length }}</span> }
+                @if (p.s.enum?.length) { <span class="badge badge-gray" style="margin-right:3px">enum {{ p.s.enum!.length }}</span> }
                 @if (p.s.minimum !== undefined) { <span style="margin-right:4px;">min:{{ p.s.minimum }}</span> }
                 @if (p.s.maximum !== undefined) { <span style="margin-right:4px;">max:{{ p.s.maximum }}</span> }
                 @if (p.s.pattern) { <span style="margin-right:4px;">pattern</span> }
                 @if (p.s.default !== undefined) { <span style="margin-right:4px;">default:{{ p.s.default }}</span> }
-                @if (p.s.mergeFn) { <span class="badge badge-blue" style="font-size:10px;">{{ p.s.mergeFn }}</span> }
+                @if (p.s.mergeFn) { <span class="badge badge-blue">{{ p.s.mergeFn }}</span> }
               </td>
               <td>
                 <div style="display:flex;gap:4px;justify-content:flex-end;">

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -222,11 +222,25 @@ code, pre {
 .field-hint.error { color: var(--error); }
 .field-hint.success { color: var(--success); }
 
+/* Every input type this product renders, not just the common five.
+ *
+ * `datetime-local` was missing, so the audit log's two date filters fell through to the BROWSER DEFAULT — white
+ * background, black text — the moment the component override that had been styling them was removed in #659. A
+ * selector list is a promise about which controls look like the product; an incomplete one fails silently, and this
+ * one was only visible in a screenshot. The drift sweep could not see it either, because its selector list had the
+ * same gap: the tool and the CSS shared one blind spot. */
 input[type="text"],
 input[type="password"],
 input[type="email"],
 input[type="number"],
 input[type="search"],
+input[type="url"],
+input[type="tel"],
+input[type="datetime-local"],
+input[type="date"],
+input[type="time"],
+input[type="month"],
+input[type="week"],
 textarea,
 select {
   /*
@@ -255,11 +269,20 @@ select {
   appearance: none;
 }
 
+/* Same list as the base rule above — a type styled but not focus-styled loses its focus ring, which is an
+   accessibility regression rather than a cosmetic one. */
 input[type="text"]:focus,
 input[type="password"]:focus,
 input[type="email"]:focus,
 input[type="number"]:focus,
 input[type="search"]:focus,
+input[type="url"]:focus,
+input[type="tel"]:focus,
+input[type="datetime-local"]:focus,
+input[type="date"]:focus,
+input[type="time"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
 textarea:focus,
 select:focus {
   border-color: var(--accent);
@@ -518,22 +541,38 @@ tr:last-child td { border-bottom: none; }
 tbody tr:hover td { background: var(--bg-elevated); }
 
 /* ── Badges ──────────────────────────────────────────────────────────────── */
+/*
+ * ONE pill shape. `.badge` is the class version of `app-status-pill`, so it has to measure the same.
+ *
+ * It did not: `border-radius: 20px` against the component's `999px`, 11px type against 11.5px, 8px padding against
+ * 9px — three badges rendering at 22/24/24px beside a 23px pill, on the same screens. Measured, not read
+ * (`testing/ux-drift-sweep.mjs`); encapsulation meant neither file looked wrong on its own.
+ *
+ * The two are kept in step deliberately rather than merged: markup that cannot reach the component still gets the
+ * house shape from the class. If they ever need to differ, that is a decision, not a drift.
+ */
 .badge {
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
-  border-radius: 20px;
-  font-size: 11px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 11.5px;
   font-weight: 500;
   letter-spacing: 0.02em;
   border: 1px solid transparent;
 }
 
 .badge-purple { background: rgba(124, 106, 247, 0.15); color: #9580ff; border-color: rgba(124, 106, 247, 0.3); }
-.badge-green  { background: rgba(63, 185, 80,  0.15); color: #3fb950; border-color: rgba(63, 185, 80,  0.3); }
-.badge-yellow { background: rgba(210, 153, 34,  0.15); color: #d29922; border-color: rgba(210, 153, 34,  0.3); }
-.badge-red    { background: rgba(248, 81, 73,   0.1);  color: #f85149; border-color: rgba(248, 81, 73,   0.3); }
-.badge-blue   { background: rgba(88, 166, 255,  0.1);  color: #58a6ff; border-color: rgba(88, 166, 255,  0.3); }
+/* Mixed from the tokens, not hardcoded. Each of these repeated a semantic colour as a literal, so it could not
+   follow its token -- exactly what made a themed pill show red text on a green background before #637. */
+.badge-green  { background: color-mix(in srgb, var(--success) 15%, transparent); color: var(--success);
+                border-color: color-mix(in srgb, var(--success) 30%, transparent); }
+.badge-yellow { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning);
+                border-color: color-mix(in srgb, var(--warning) 30%, transparent); }
+.badge-red    { background: color-mix(in srgb, var(--error) 12%, transparent); color: var(--error);
+                border-color: color-mix(in srgb, var(--error) 30%, transparent); }
+.badge-blue   { background: color-mix(in srgb, var(--info) 12%, transparent); color: var(--info);
+                border-color: color-mix(in srgb, var(--info) 30%, transparent); }
 .badge-orange { background: rgba(227, 134, 37,  0.15); color: #e38625; border-color: rgba(227, 134, 37,  0.3); }
 .badge-gray   { background: var(--bg-elevated); color: var(--text-secondary); border-color: var(--border); }
 
@@ -631,9 +670,20 @@ hr, .divider {
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
 /* ── Monospace text ──────────────────────────────────────────────────────── */
+/*
+ * Typeface only — no size.
+ *
+ * This used to say `font-size: 0.85em`, which made a typeface switch double as a size multiplier: `.badge.mono`
+ * measured **11.05px** against every other badge's 11.5px. Nobody chose 11.05px; the cascade did. And because
+ * `.mono` and `.badge` have equal specificity, source order decided it — `.mono` is declared later, so it won.
+ *
+ * `1em` was tried first and was worse: it resolves against the PARENT, so the same badge went to 13px. Removing the
+ * declaration is the fix — with no size of its own, `.mono` cannot outrank the element it is applied to, and a badge
+ * stays a badge whether or not its text is monospace. Both attempts were measured, which is the only reason the
+ * second one was caught.
+ */
 .mono {
   font-family: var(--font-mono);
-  font-size: 0.85em;
 }
 
 /* ── Tag pills ───────────────────────────────────────────────────────────── */

--- a/testing/ux-drift-sweep.mjs
+++ b/testing/ux-drift-sweep.mjs
@@ -92,7 +92,16 @@ async function measure(selector, props) {
 }
 
 const groups = {
-  'TEXT INPUTS': { sel: 'input[type=text], input:not([type]), input[type=search], input[type=number]', props: INPUT_PROPS, map: {} },
+  // Every type the product renders. The first version listed four, which is the SAME gap the global CSS rule had
+  // — so when a component override was removed and the audit log's `datetime-local` filters fell back to the
+  // browser default (white on white), this tool could not see it. The measurement and the thing it measures must
+  // not share a blind spot.
+  'TEXT INPUTS': {
+    sel: 'input[type=text], input:not([type]), input[type=search], input[type=number], input[type=url],'
+       + ' input[type=tel], input[type=datetime-local], input[type=date], input[type=time], input[type=month],'
+       + ' input[type=week], input[type=password], input[type=email], textarea, select',
+    props: INPUT_PROPS, map: {},
+  },
   'BUTTONS': { sel: 'button', props: BUTTON_PROPS, map: {} },
   'PILLS / BADGES': { sel: '[class*=pill], [class*=badge], [class*=chip]', props: PILL_PROPS, map: {} },
 };


### PR DESCRIPTION
## One pill shape, badge colours that follow their tokens — and a regression I shipped in #659

Two things, both found by measuring and then **looking**.

## 1. The audit log's date filters rendered white — my regression, from #659

White background, black text, in a dark admin UI. #659 removed a component override that had been styling
`input[type=datetime-local]`, and the **global input rule's selector list never covered that type**, so both filters
fell through to the browser default.

The list now covers every type the product renders — `url`, `tel`, `datetime-local`, `date`, `time`, `month`, `week` —
in **both** the base rule and the `:focus` rule. A type styled but not focus-styled loses its focus ring, which is an
accessibility regression rather than a cosmetic one.

**The drift sweep had the same blind spot.** It reported "1 signature" while two inputs were white, because its
selector list was the same four types as the CSS. *A measurement must not share a gap with the thing it measures.* It
now covers every type, and reports the datetime fields at **34px** — 2px taller because a native picker has intrinsic
content, which is a browser fact, not drift.

Only the screenshot caught this. The numbers said clean.

## 2. One pill shape

`.badge` is the class version of `app-status-pill` and measured differently: `border-radius: 20px` against `999px`,
11px type against 11.5px, 8px padding against 9px — **three badges at 22/24/24px beside a 23px pill**, on the same
screens.

| | before | after |
|---|---|---|
| Spaces "Preparing indexes…" | 22px, r=20px, 10px | **24px, r=999px, 11.5px** |
| Spaces "general" (mono) | 24px, r=20px, **11.05px** | **24px, r=999px, 11.5px** |
| Tokens "All spaces" | 24px, r=20px, 11px | **24px, r=999px, 11.5px** |

- **20 inline `font-size` declarations removed across 10 files.** An inline style beats the class, so every call site
  had been quietly re-deciding the size of a shared control.
- **`.badge-green/-yellow/-red/-blue` hardcoded the semantic hexes** instead of mixing from
  `--success`/`--warning`/`--error`/`--info`. The same defect #637 fixed in the pill: a hardcoded literal stops
  following its token, which is how a themed instance got red text on a green background.
- **`.mono` no longer sets a size.** `font-size: 0.85em` made a typeface switch double as a size multiplier, so
  `.badge.mono` measured **11.05px** — a number nobody chose, produced by the cascade, winning over `.badge` only
  because `.mono` is declared later. `1em` was tried first and was **worse** (it resolves against the parent: 13px).
  Removing the declaration is the fix. Both attempts were measured, which is the only reason the second was caught.

## Verified

Re-measured after every step, and screenshotted Spaces, Audit log, Models and Schema library. Pills and badges are one
shape (`999px / 9px / 11.5px`); the date filters match the input family.

`scripts/check-changelog.mjs` on this diff: *11 shipped file(s) changed, 26 line(s) added under `[Unreleased]`*.

---

`npm run preflight` PASSED — 892 client tests, 511 standalone.
