### PR TITLE
fix(ux): a narrow embedded iframe had no navigation at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An embedded iframe narrower than 768px had no navigation at all.** Below that width the sidebar is an
+  off-canvas drawer and the hamburger is the only thing that opens it — and the hamburger lived in the topbar,
+  which `?embedded=1` removes because it duplicates the host portal's chrome. So a portal embedding Ythril in a
+  narrow frame got whatever page it landed on and no way to leave it. Measured on a real browser at 420px:
+  sidebar at `left: -280px`, and **no control anywhere on the page able to reach it**.
+  - Embedded mode now renders a nav-only bar holding just the drawer opener — no logo, no Sign out, so both
+    reasons the topbar was hidden still hold — and only below the breakpoint, where the sidebar is off-canvas.
+    Above it the sidebar is inline and a bar holding a no-op hamburger would just cost the host 56px.
+  - Pinned by four assertions in `shell.component.spec.ts`, including the overcorrection (bringing the whole
+    topbar back) and the CSS media query, which jsdom cannot evaluate. **6 mutations killed, 0 survived.**
+
+- **Two pages slid sideways at phone width, and four scrollers were invisible.** Found by running
+  `testing/responsive-sweep.mjs` at 600px and 420px — the first run since the pages this batch touched:
+  **19 findings, now 0.**
+  - `/settings/spaces` and `/settings/audit-log` violated the sweep's rule 1 — the whole page pane scrolled
+    sideways, filter bars and headings and all. Named precisely rather than guessed: the spaces search input's
+    364px pushed the pane 48px past its box, and the audit log's 195px "Export all matching (NDJSON)" button
+    pushed it 72px. Both were flex rows that could not wrap. `.card-header` now wraps globally, which is the
+    correct behaviour for a title-plus-controls row at any width, and `.export-btns` wraps too.
+  - The Help page's table of contents was one `overflow-x: auto` row of nowrap buttons: **976px of hidden
+    content past a 388px box, with no visible affordance**, so ten of the sixteen guides were simply not there.
+    A table of contents is a list, and a list may take two lines — it wraps below 900px now, and is still the
+    sticky vertical column above it.
+  - Media Processing's two pipeline chain diagrams and the Tools tab's table scroll legitimately, so they get
+    the drawn `hscrollTop` control that already exists for exactly this — up to 488px of the pipeline was past
+    the edge with nothing to say so.
+  - The eight error states added in #662 were measured at both widths too: the pane does not overflow, the long
+    server reason wraps, and Retry stays reachable.
+
 - **The Schema Library page had no Help link, and a dead copy of the page is why.** `pages/settings/schema-library.component.ts`
   was unreachable — no route, no importer, and a class name that collided with the live page — and the Help table had
   been written against the URL that dead file implied (`/settings/schema-library`), which nothing routes to. So the
@@ -814,6 +843,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "everything" was not true. The precedence is now stated once, at the top, where the section is described; the
   per-type part is a pointer line rather than a heading that promises a control it does not have; and no copy
   refers to "the number above" any more.
+
+### Known gaps
+
+- **Wide tables and code blocks inside a rendered guide still scroll invisibly** (`/settings/help` at 420px,
+  4 occurrences). Recorded in the component with both failed attempts measured, so nobody repeats them:
+  `scrollbar-width: thin` yields a **2px** bar *and* makes Chromium 121+ ignore `::-webkit-scrollbar`
+  entirely, and `::-webkit-scrollbar` with an explicit height did not apply here at all (measured 0px on
+  `table`, 2px on `pre`, with and without `:is()`). The mechanism that does work in this app is the drawn
+  control, and it needs a host element in the template — this content arrives as sanitized `innerHTML`, so
+  closing the gap means wrapping `pre`/`table` during render. Tracked rather than bodged.
 
 ## [2.2.5] — 2026-08-02
 

--- a/client/src/app/pages/settings/audit-log.component.ts
+++ b/client/src/app/pages/settings/audit-log.component.ts
@@ -173,7 +173,9 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
       font-family: var(--font);
     }
 
-    .export-btns { display: flex; gap: 8px; }
+    /* flex-wrap because "Export all matching (NDJSON)" is 195px and cannot shrink: at 420px these three
+       pushed the page pane 72px past its box, so the whole audit log slid sideways. */
+    .export-btns { display: flex; gap: 8px; flex-wrap: wrap; }
     /* No button geometry here. These three carried NO class and re-created .btn-sm's metrics locally; they use the
        class now, so the small-button size is defined in one place. */
 

--- a/client/src/app/pages/settings/help.component.ts
+++ b/client/src/app/pages/settings/help.component.ts
@@ -83,7 +83,13 @@ export type HelpDocId = typeof HELP_DOCS[number]['id'];
        chip row above the document, which keeps every guide one tap away on a phone. */
     @media (min-width: 900px) { .help { grid-template-columns: 232px minmax(0, 1fr); align-items: start; } }
 
-    .index { display: flex; gap: 6px; overflow-x: auto; padding-bottom: 4px; }
+    /* NO BACKTICKS in this block — one ends the styles template string, and the error points at @Component.
+       Wraps rather than scrolls below 900px. It used to be a single overflow-x:auto row of nowrap buttons,
+       which measured 976px of hidden content past a 388px box with no visible affordance — on this platform
+       an overlay scrollbar paints nothing, so ten of the sixteen guides were simply not there. A table of
+       contents is a list, and a list may take two lines; scrolling it was the wrong shape for the content.
+       Above 900px it is still the sticky vertical column. */
+    .index { display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 4px; }
     @media (min-width: 900px) {
       .index { flex-direction: column; overflow-x: visible; position: sticky; top: 12px; }
     }
@@ -111,7 +117,22 @@ export type HelpDocId = typeof HELP_DOCS[number]['id'];
      */
     .doc ::ng-deep :is(p, li, blockquote) { max-width: 78ch; }
 
-    /* Long tables and code blocks scroll inside the document rather than widening the page. */
+    /* Long tables and code blocks scroll inside the document rather than widening the page.
+
+       NO BACKTICKS in this block.
+
+       KNOWN GAP, measured rather than assumed: on this platform that scroll is INVISIBLE. Overlay
+       scrollbars paint only while scrolling and take no layout space, so a table or code block wider than
+       the pane looks like a complete one that was cut. Two attempts are recorded so nobody repeats them:
+
+         - scrollbar-width:thin + scrollbar-color yields a 2px bar (offsetHeight - clientHeight === 2) AND
+           makes Chromium 121+ ignore ::-webkit-scrollbar entirely.
+         - ::-webkit-scrollbar with an explicit height did not apply here at all, with or without :is(),
+           measured at 0px on table and 2px on pre.
+
+       The mechanism that does work in this app is the DRAWN control (hscrollTop, see its own file), and it
+       needs a host element in the template. This content arrives as sanitized innerHTML, so there is none.
+       Closing this means wrapping pre/table during render so a host exists — tracked, not bodged here. */
     .doc ::ng-deep :is(pre, table) { max-width: 100%; overflow-x: auto; }
     .doc ::ng-deep table { display: block; border-collapse: collapse; font-variant-numeric: tabular-nums; }
     .doc ::ng-deep :is(th, td) { border: 1px solid var(--border-muted); padding: 6px 10px; font-size: 13px; text-align: left;

--- a/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/pipelines-tab.component.ts
@@ -24,6 +24,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
 import { PhIconComponent } from '../../../shared/ph-icon.component';
 import { StatusPillComponent } from '../../../shared/status-pill.component';
 import { HealthDotComponent } from './health-dot.component';
+import { HscrollTopDirective } from '../../../shared/hscroll-top.directive';
 import { MediaProcessingStateService, PipeId } from './media-processing-state.service';
 import { PipelineStatusService } from './pipeline-status.service';
 import { HealthState, MODE_STAGES, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, MediaClass } from './media-processing.types';
@@ -45,7 +46,7 @@ interface Step {
   selector: 'app-pipelines-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgTemplateOutlet, FormsModule, TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent],
+  imports: [NgTemplateOutlet, FormsModule, TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent, HscrollTopDirective],
   styles: [`
     :host { display: block; }
     .pipe-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px;
@@ -165,7 +166,7 @@ interface Step {
         <app-status-pill [variant]="s.docVariant()" [dot]="true">{{ s.docPillLabelKey() | transloco }}</app-status-pill>
       </header>
 
-      <div class="chain">
+      <div class="chain" hscrollTop>
         @for (st of documentSteps(); track st.key) {
           <div class="step" [class.cond]="st.conditional" [class.dim]="stepDim(st.key)" [class.active]="stepActive(st.key)">
             <div class="box">
@@ -245,7 +246,7 @@ interface Step {
           </div>
         </header>
 
-        <div class="chain">
+        <div class="chain" hscrollTop>
           @for (st of p.steps; track st.key) {
             <!-- dim/active, same as the document pipeline. Without these the four media pipelines showed
                  availability only: green dots everywhere and no indication of which steps the chosen

--- a/client/src/app/pages/settings/media-processing/tools-tab.component.ts
+++ b/client/src/app/pages/settings/media-processing/tools-tab.component.ts
@@ -24,6 +24,7 @@ import { PhIconComponent } from '../../../shared/ph-icon.component';
 import { StatusPillComponent, StatusVariant } from '../../../shared/status-pill.component';
 import { HealthDotComponent } from './health-dot.component';
 import { ModelProviderCardComponent } from './model-provider-card.component';
+import { HscrollTopDirective } from '../../../shared/hscroll-top.directive';
 import { PipelineStatusService } from './pipeline-status.service';
 import { SpaceIndexStatus } from './media-processing.types';
 import { SpacesApi } from '../../../core/spaces-api.service';
@@ -34,7 +35,7 @@ import { ConfirmDialogService } from '../../../core/confirm-dialog.service';
   selector: 'app-tools-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent, ModelProviderCardComponent],
+  imports: [TranslocoPipe, PhIconComponent, StatusPillComponent, HealthDotComponent, ModelProviderCardComponent, HscrollTopDirective],
   styles: [`
     :host { display: block; }
     /* Splitter + chunker sit side by side as model-style cards, matching the Models tab grid. */
@@ -126,7 +127,7 @@ import { ConfirmDialogService } from '../../../core/confirm-dialog.service';
         } @else if (!spaces().length) {
           <div class="empty">{{ 'mediaProcessing.tools.indexEmpty' | transloco }}</div>
         } @else {
-          <div class="tablewrap">
+          <div class="tablewrap" hscrollTop>
             <table>
               <thead>
                 <tr>

--- a/client/src/app/pages/shell/shell.component.spec.ts
+++ b/client/src/app/pages/shell/shell.component.spec.ts
@@ -9,6 +9,8 @@
  */
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { Subject } from 'rxjs';
 import { provideRouter, Router, NavigationEnd } from '@angular/router';
 import { of } from 'rxjs';
@@ -18,7 +20,7 @@ import { EmbedService } from '../../core/embed.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { ShellComponent } from './shell.component';
 
-function make() {
+function make(embedded = false) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     imports: [ShellComponent, getTranslocoModule()],
@@ -26,7 +28,7 @@ function make() {
       provideRouter([]),
       { provide: FilesApi, useValue: { listConflicts: () => of({ conflicts: [] }) } as any },
       { provide: AuthService, useValue: { logout: () => {}, logoutOidc: async () => false } as unknown as AuthService },
-      { provide: EmbedService, useValue: { embedded: () => false } as unknown as EmbedService },
+      { provide: EmbedService, useValue: { embedded: () => embedded } as unknown as EmbedService },
     ],
   });
   const fixture = TestBed.createComponent(ShellComponent);
@@ -77,6 +79,62 @@ describe('ShellComponent — drawer', () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
     cmp.onResize();
     expect(cmp.drawerOpen()).toBe(false); // crossed to desktop → closed
+  });
+
+  /**
+   * Embedded mode (`?embedded=1`) hides the topbar because it duplicates the host portal's chrome. The
+   * hamburger lived in that topbar — and below 768px the hamburger is the ONLY way to open the sidebar,
+   * which is an off-canvas drawer there. So an embedded narrow iframe rendered whatever page it landed on
+   * and no navigation at all: measured on a real browser at 420px, sidebar at `left: -280px`, no control
+   * anywhere able to reach it.
+   */
+  describe('embedded mode', () => {
+    const opener = (fixture: ReturnType<typeof make>['fixture']) =>
+      fixture.nativeElement.querySelector('[aria-controls="app-sidebar"]');
+
+    it('still renders a drawer opener — without one, narrow embeds have no navigation', () => {
+      const { fixture } = make(true);
+      fixture.detectChanges();
+      expect(opener(fixture), 'no control targets app-sidebar, so the off-canvas drawer cannot be opened').toBeTruthy();
+    });
+
+    it('renders no host chrome — the reason the topbar was hidden still holds', () => {
+      // Guards the fix against overcorrection: bringing the whole topbar back would restore the logo and a
+      // Sign out that ends only the Ythril session, which is what embedded mode exists to avoid.
+      const { fixture } = make(true);
+      fixture.detectChanges();
+      const host: HTMLElement = fixture.nativeElement;
+      expect(host.querySelector('app-brand-logo'), 'embedded mode must not duplicate the host portal logo').toBeNull();
+      expect(host.querySelector('.topbar-logo')).toBeNull();
+      expect(
+        [...host.querySelectorAll('button')].some(b => /sign ?out|abmelden|wyloguj/i.test(b.textContent ?? '')),
+        'embedded mode must not offer Sign out — it would end only the Ythril session',
+      ).toBe(false);
+      // And the opener from the previous test is still there, so "no chrome" did not become "no nav".
+      expect(opener(fixture)).toBeTruthy();
+    });
+
+    it('normal mode keeps its full topbar', () => {
+      const { fixture } = make(false);
+      fixture.detectChanges();
+      const host: HTMLElement = fixture.nativeElement;
+      expect(host.querySelector('.topbar')).toBeTruthy();
+      expect(host.querySelector('app-brand-logo')).toBeTruthy();
+      expect(opener(fixture)).toBeTruthy();
+    });
+
+    it('the embedded bar is shown only below the breakpoint (asserted on the CSS — jsdom has no layout)', () => {
+      // jsdom evaluates no media queries and computes no layout, so the rule itself is the only thing that
+      // can be checked here. Without the media-query half, embedded desktop users would get 56px of bar
+      // holding a hamburger that does nothing, because the sidebar is already inline at that width.
+      // vitest runs with cwd = client/, and `new URL(..., import.meta.url)` throws at collection time here.
+      const src = readFileSync(resolve('src/app/pages/shell/shell.component.ts'), 'utf8');
+      expect(src, 'the embedded bar must default to hidden').toMatch(/\.topbar-embedded\s*\{\s*display:\s*none;?\s*\}/);
+      const mq = src.slice(src.indexOf('@media (max-width: 768px)'));
+      const block = mq.slice(0, mq.indexOf('\n    }'));
+      expect(block, 'the 768px block must reveal the embedded bar').toMatch(/\.topbar-embedded\s*\{\s*display:\s*flex/);
+      expect(block, 'the 768px block must also reveal the hamburger').toMatch(/\.menu-btn\s*\{\s*display:\s*inline-flex/);
+    });
   });
 
   it('navigation closes the drawer (NavigationEnd subscription)', () => {

--- a/client/src/app/pages/shell/shell.component.ts
+++ b/client/src/app/pages/shell/shell.component.ts
@@ -45,6 +45,10 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
     .topbar-spacer { flex: 1; }
 
+    /* The embedded nav bar exists only below the breakpoint. Above it the sidebar is inline, so a bar
+       holding nothing but a drawer opener would be 56px of host-portal space spent on a no-op. */
+    .topbar-embedded { display: none; }
+
     /* Hamburger — hidden on desktop, shown below the breakpoint. */
     .menu-btn {
       display: none;
@@ -177,6 +181,7 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
     @media (max-width: 768px) {
       .menu-btn { display: inline-flex; }
+      .topbar-embedded { display: flex; }
       .main { padding: 20px 16px; }
 
       /* The sidebar becomes an off-canvas overlay drawer. It stays in the DOM
@@ -202,7 +207,25 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
   template: `
     <!-- Top bar — hidden in embedded mode (?embedded=1): it duplicates the host
          portal's chrome, and its Sign out would end only the Ythril session. -->
-    @if (!embed.embedded()) {
+    @if (embed.embedded()) {
+      <!-- …but the hamburger is not chrome, it is the ONLY way to open the sidebar below 768px, where the
+           sidebar is an off-canvas drawer. Without this an embedded narrow iframe rendered whatever page it
+           landed on and no navigation at all: measured at 420px, sidebar at left:-280 and no control able to
+           reach it. This bar is nav-only (no logo, no Sign out, so neither objection above applies) and is
+           display:none above the breakpoint, where the sidebar is inline and needs no opener. -->
+      <header class="topbar topbar-embedded">
+        <button
+          class="menu-btn"
+          type="button"
+          [attr.aria-label]="'nav.menu' | transloco"
+          [attr.aria-expanded]="drawerOpen()"
+          aria-controls="app-sidebar"
+          (click)="toggleDrawer()"
+        >
+          <ph-icon [name]="drawerOpen() ? 'x' : 'list'" [size]="20"/>
+        </button>
+      </header>
+    } @else {
       <header class="topbar">
         <button
           class="menu-btn"

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -412,6 +412,11 @@ button:disabled, .btn:disabled {
   justify-content: space-between;
   margin-bottom: 16px;
   gap: 12px;
+  /* A card header is a title plus however many controls that card needs, and at a narrow width they do not
+     fit on one line. Without this the header simply grew past the page pane and `.main` slid sideways —
+     filter bars, headings and all — which is what the responsive sweep calls rule 1. Measured on
+     /settings/spaces at 420px: the search input's 364px pushed the pane 48px past its box. */
+  flex-wrap: wrap;
 }
 
 .card-title {


### PR DESCRIPTION
Audit lens 6 (UX)'s last thread: **mobile width, and inside an iframe.** Both were asked for explicitly and
neither had been run since the pages this batch touched.

## The iframe half: a narrow embed had no navigation at all

Below 768px the sidebar becomes an off-canvas drawer, and the hamburger is the only thing that opens it. The
hamburger lived inside the topbar — which `?embedded=1` removes, for good reasons that still hold:

> Top bar — hidden in embedded mode: it duplicates the host portal's chrome, and its Sign out would end only
> the Ythril session.

Both statements are true. The hamburger is neither of those things, and it went with them. So a portal
embedding Ythril in a narrow frame got whatever page it landed on and **no way to leave it**.

Measured before touching anything:

```
--- embedded=true 420px
  topbar present : false
  menu button    : present=false visible=false
  sidebar        : left=-280 width=280 offscreen=true
  other nav ctrls: (none)
  => NAVIGATION REACHABLE: false
```

Embedded mode now renders a **nav-only bar** — just the drawer opener, no logo, no Sign out, so neither
objection above applies — and only below the breakpoint. Above it the sidebar is inline, and a bar holding a
hamburger that does nothing would cost the host portal 56px for no reason.

Pinned by four assertions in `shell.component.spec.ts`: the opener exists in embedded mode; the chrome does
*not* (guarding against the obvious overcorrection of restoring the whole topbar); normal mode is unchanged;
and the media query, asserted against the source because jsdom evaluates none and computes no layout.
**6 mutations killed, 0 survived** — including "the bar is never revealed" and "the bar defaults to visible".

## The mobile half: 19 findings from the sweep, now 0

`testing/responsive-sweep.mjs` at 600px and 420px.

**Two pages violated its rule 1 — the whole page pane scrolled sideways**, filter bars and headings and all.
Both culprits were named by measurement rather than guessed at (my first probe blamed table cells, which
legitimately stick out of a `.table-wrapper`; excluding scroller descendants left exactly one element each):

| page | culprit | pushed the pane |
|---|---|---|
| `/settings/spaces` | the 364px search input | 48px past its box |
| `/settings/audit-log` | the 195px "Export all matching (NDJSON)" button | 72px past its box |

Both were flex rows that could not wrap. `.card-header` now wraps globally — correct for a
title-plus-controls row at any width — and `.export-btns` wraps too.

**The Help page's table of contents was the worst single finding**: one `overflow-x: auto` row of nowrap
buttons holding **976px of content past a 388px box, with no visible affordance**. On this platform overlay
scrollbars paint nothing, so ten of the sixteen guides were simply not there. A table of contents is a list,
and a list may take two lines — it wraps below 900px now, and above it is still the sticky vertical column.

**Media Processing's two pipeline chain diagrams and the Tools tab's table** scroll legitimately, so they get
the drawn `hscrollTop` control that exists for exactly this case. Up to 488px of a pipeline was past the edge
with nothing saying so.

**The eight error states from #662** were measured at both widths as well, since they were new: the pane does
not overflow, a deliberately long server reason wraps instead of widening it, and Retry stays reachable.

## One gap left open, with its measurements

Wide tables and code blocks **inside a rendered guide** still scroll invisibly (`/settings/help` at 420px, 4
occurrences). I tried twice and both attempts are recorded in the component so nobody repeats them:

- `scrollbar-width: thin` + `scrollbar-color` yields a **2px** bar (`offsetHeight - clientHeight === 2`) *and*
  makes Chromium 121+ ignore `::-webkit-scrollbar` entirely.
- `::-webkit-scrollbar` with an explicit height **did not apply here at all** — measured 0px on `table`, 2px on
  `pre`, with and without `:is()`.

The mechanism that does work in this app is the drawn control, and it needs a host element in the template.
This content arrives as sanitized `innerHTML`, so closing the gap means wrapping `pre`/`table` during render.
That is a change to the markdown pipeline, not a CSS tweak, so it is tracked rather than bodged in — and the
CSS that did not work is not shipped pretending to be a fix.

## Verification

Isolated instance on :3260 driving the built bundle. The sweep, the embedded probe, and the error-state
measurement were each read as screenshots, not just as numbers. `npm run preflight` passes.
