### PR TITLE
docs(legal): a licence CLA, because "the same terms" closed the door it looked like it opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Contributor licensing: a Contributor License Agreement, because the old wording quietly closed a door.**
+  `docs/contribution-guide.md` had 400+ lines on architecture, security and test discipline and one sentence on
+  licensing: *"By contributing, you agree that your contributions are licensed under the same terms."*
+  - That reads as reassuring and was the problem. A contribution arriving under **PolyForm Small Business** does
+    **not** carry the right to sublicense or relicense it — so the one sentence that looked like it settled the
+    question was the sentence that would have made a future relicence require the individual agreement of every
+    past contributor.
+  - `CLA.md` is a **licence, not an assignment** — adapted from the Apache ICLA v2.0, the established reference,
+    so nothing here is freshly drafted. **A contributor keeps the copyright in everything they write.** What
+    they grant is a perpetual, irrevocable licence that explicitly includes **sublicensing and relicensing under
+    any terms**, which is the operative clause and the whole reason to have one.
+  - Signing is one click on a first pull request via a bot, covering every later contribution. Nothing to print,
+    nothing to repeat.
+  - Owner decision, 2026-08-03, from three options (licence CLA / assignment CLA / DCO-only). Worth recording
+    why it was not urgent and was still worth doing now: **every commit in the repo is the owner or Copilot, so
+    the owner holds 100% of the copyright today and could already relicense unilaterally.** The CLA is pure
+    prevention — and its entire value is being in place *before* the first outside pull request, because
+    retrofitting one means chasing people down.
+
 - **A failed load no longer reads as "there is nothing here".** Eight surfaces cleared their spinner on failure and
   fell through to the empty state, so a request that never succeeded and a result set that is genuinely empty rendered
   the same words.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,107 @@
+# Ythril Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Ythril.
+
+This agreement clarifies the terms under which You contribute, so that both You and the project know where
+things stand. **You keep the copyright in everything You write.** What You grant is a licence broad enough
+that the project can be maintained, redistributed, and licensed to others — including under terms different
+from the one it ships under today.
+
+This document is adapted from the [Apache Software Foundation Individual Contributor License Agreement
+v2.0](https://www.apache.org/licenses/icla.pdf), which is the widely-used reference for this kind of
+agreement. It is a **licence**, not an assignment: nothing here transfers ownership of Your work.
+
+You accept it by signing once — a bot will ask on Your first pull request, and one click covers every
+contribution You make afterwards.
+
+---
+
+## 1. Definitions
+
+**"You"** means the individual who accepts this agreement, or the legal entity on whose behalf it is
+accepted. For a legal entity, "You" includes any entity that controls, is controlled by, or is under common
+control with that entity.
+
+**"Contribution"** means any work of authorship, including any modification of or addition to an existing
+work, that is intentionally submitted by You to the project for inclusion in, or documentation of, any of the
+products owned or managed by the project. "Submitted" means any form of electronic, verbal, or written
+communication sent to the project or its representatives — including but not limited to pull requests, issues,
+patches, and communication on electronic mailing lists, source code control systems, and issue tracking
+systems — excluding communication that is conspicuously marked or otherwise designated in writing by You as
+"Not a Contribution".
+
+**"Project Owner"** means the copyright holder of Ythril, as identified in the `LICENSE` and `NOTICE` files.
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this agreement, **You retain all right, title, and interest in and to Your
+Contributions**, and You hereby grant to the Project Owner a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to:
+
+- reproduce, prepare derivative works of, publicly display, publicly perform, and distribute Your
+  Contributions and such derivative works; and
+- **sublicense and relicense** Your Contributions and derivative works thereof, under any license terms,
+  including terms different from those under which Ythril is distributed at the time of Your Contribution.
+
+This sublicensing right is the operative clause. Ythril ships under the PolyForm Small Business License, and
+the Project Owner may in future offer it under other terms — commercial licences, a different open licence, or
+both. Without this grant, every such change would require the individual agreement of every contributor.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this agreement, You hereby grant to the Project Owner and to recipients of software
+distributed by the Project Owner a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer Your Contribution — where such license applies only to those patent claims licensable by
+You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the
+work to which it was submitted.
+
+If any entity institutes patent litigation against You or any other entity alleging that Your Contribution, or
+the work to which You contributed, constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this agreement for that Contribution or work shall terminate as of the
+date such litigation is filed.
+
+## 4. Your Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each of Your Contributions is Your original creation, **or** You have identified the source and any
+   license terms of any third-party material it contains (see section 5).
+3. If Your employer has rights to intellectual property that You create — including anything You write as part
+   of Your employment — You have either received permission to make the Contributions on behalf of that
+   employer, or that employer has waived such rights, or that employer has executed a separate corporate
+   agreement with the Project Owner.
+
+## 5. Third-Party Material
+
+Should You wish to submit work that is not Your original creation, You may submit it separately from any
+Contribution, identifying the complete details of its source and of any license or other restriction of which
+You are personally aware, and conspicuously marking the work as "Submitted on behalf of a third party:
+[named here]".
+
+## 6. No Obligation, No Warranty
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to do so. You
+provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+The Project Owner is under no obligation to accept or include any Contribution.
+
+## 7. Notification
+
+You agree to notify the Project Owner of any facts or circumstances of which You become aware that would make
+these representations inaccurate in any respect.
+
+---
+
+## Signing
+
+Sign once, via the CLA bot on Your first pull request. A single signature covers every Contribution You make
+afterwards; there is nothing to repeat and nothing to print.
+
+## Questions
+
+Open an issue. If a term here is a blocker for You, say so — it is better to hear that than to lose the
+contribution.

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -20,7 +20,7 @@ Audience: developers and maintainers working on Ythril source code.
 10. [Code Style](#code-style)
 11. [Commit Conventions](#commit-conventions)
 12. [Pull Request Checklist](#pull-request-checklist)
-13. [License](#license)
+13. [License and contributor agreement](#license-and-contributor-agreement)
 
 ---
 
@@ -505,6 +505,14 @@ Use conventional-commit-style prefixes:
 
 ---
 
-## License
+## License and contributor agreement
 
-Ythril is licensed under the **PolyForm Small Business License 1.0.0**. By contributing, you agree that your contributions are licensed under the same terms. See [LICENSE](../LICENSE) for the full text.
+Ythril is distributed under the **PolyForm Small Business License 1.0.0**. See [LICENSE](../LICENSE) for the full text.
+
+**Contributing requires signing the [Contributor License Agreement](../CLA.md).** It is a licence, not an assignment: **you keep the copyright in everything you write.** What you grant is a licence broad enough for the project to be maintained, redistributed, and — this is the operative part — **licensed to others under different terms in future**, whether commercial, a different open licence, or both.
+
+Signing is one click on your first pull request, via a bot, and it covers every contribution you make afterwards. There is nothing to print and nothing to repeat.
+
+**Why this replaced the previous wording.** This section used to say only that "your contributions are licensed under the same terms". That reads as reassuring and was in fact the problem: a contribution arriving under PolyForm Small Business does **not** carry the right to sublicense or relicense it, so the one sentence that looked like it settled the question was the sentence that would have made a future relicence require the individual agreement of every past contributor. The CLA grants that right explicitly and up front, which is the whole point of having one.
+
+If a term in the CLA is a blocker for you, open an issue and say so.


### PR DESCRIPTION
Owner decision, 2026-08-03: **licence CLA**, from three options (licence CLA / assignment CLA / DCO-only).

## The finding this actually fixes

`docs/contribution-guide.md` had 400+ lines on architecture, security and test discipline, and one sentence on
licensing:

> By contributing, you agree that your contributions are licensed under the same terms.

That reads as reassuring and it was the problem. A contribution arriving under **PolyForm Small Business** does
**not** carry the right to sublicense or relicense it — so **the one sentence that looked like it settled the
question was the sentence that would have blocked a future relicence**, which would then have needed the
individual agreement of every past contributor.

## What was chosen, and why it is the light option

`CLA.md` is a **licence, not an assignment**, adapted from the [Apache ICLA
v2.0](https://www.apache.org/licenses/icla.pdf) — the established reference, so nothing here is freshly drafted.

- **The contributor keeps the copyright in everything they write.** That is why almost nobody objects to this
  shape, and it is what distinguishes it from an assignment CLA.
- What they grant is a perpetual, worldwide, irrevocable licence that **explicitly includes sublicensing and
  relicensing under any terms**. §2 is the operative clause and the whole reason to have the document.
- Signing is **one click on a first pull request** via a bot; it covers every later contribution.

## Context worth recording, because it explains why this was not urgent and was still worth doing now

**Every commit in this repository is the owner (two identities) or GitHub Copilot.** There is no outside human
contributor, so the owner holds 100% of the copyright today and could already relicense unilaterally.

This is therefore **pure prevention**, and its entire value is being in place **before the first outside pull
request** — retrofitting one means chasing people down for signatures.

## Two smaller things in the diff

- The `## License` heading became `## License and contributor agreement`, which broke the table-of-contents
  anchor at line 23. Fixed in the same commit — a dead in-guide link is the same class of bug as #583.
- `CLA.md` sits at the **repo root**, not in `docs/`: that is the conventional location beside `LICENSE` and
  `NOTICE`, and the CLA bot needs a stable URL. It is deliberately **not** added to the in-product Help, which
  is an operator surface — the contribution guide links to it for the audience that needs it.

## What is left, and it is not mine

**Installing the CLA bot is an account action on the GitHub org**, so it is the owner's:
[cla-assistant.io](https://cla-assistant.io) — free GitHub App, point it at `CLA.md`, and it comments on a
first-time PR and stores the signature. Until it is installed the document is stated policy without
enforcement, which is still strictly better than the previous wording but is not the finished state.

## Verification

`npm run preflight` passes. Docs-only diff (three markdown files), so per the standing rule this merges after
preflight rather than waiting on CI — no `.ts`, test or workflow is touched.
