### PR TITLE
ci(cla): enforce the CLA, and pin the action to a version that exists

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,78 @@
+# Contributor License Agreement check.
+#
+# Enforces CLA.md (shipped in #664): a contributor keeps their copyright and grants the project a licence broad
+# enough to redistribute and relicense. Without something enforcing it, the document is stated policy only.
+#
+# ## Why pull_request_target, and why that is safe HERE
+#
+# `pull_request_target` runs in the context of the BASE repository, so it can see repository secrets even for a
+# pull request from a fork — which is why it is normally a footgun. It is safe in this workflow because this job
+# **never checks out or executes pull-request code**: there is no `actions/checkout`, no build, no test. It reads
+# pull-request metadata, writes a comment, and appends to a signatures file. That is the documented pattern for
+# a CLA check and the reason it is the only trigger that can work for forks.
+#
+# If anyone ever adds a checkout or a build step to this file, that reasoning stops holding — do not.
+#
+# ## Why an exact version rather than a floating major
+#
+# `ci.yml` and `publish.yml` pin actions by major tag (`@v4`). This action publishes no `v2` tag — verified,
+# `git/ref/tags/v2` is a 404 — so a major pin would silently fail on the first run. An exact version is also the
+# better choice for something holding a signature record: it cannot change under us.
+#
+# ## The token
+#
+# `GITHUB_TOKEN` is not sufficient: a run triggered from a fork gets a read-only one, and the action has to
+# commit the signature. `CLA_SIGNATURES_TOKEN` is a fine-grained PAT (Contents RW + Pull requests RW, this repo
+# only). It EXPIRES — an expired token makes this check fail closed, which is the safe direction, but the
+# failure will read as a mysterious red check, so the message here names the cause.
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read # the PAT does the writing, not this token
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    # Act on a signing comment, or on a pull-request event — not on every issue comment in the repository.
+    if: >
+      (github.event.issue.pull_request != null
+        && contains(github.event.comment.body, 'I have read the CLA Document'))
+      || github.event_name == 'pull_request_target'
+    steps:
+      - name: Fail with a readable reason if the PAT is missing or expired
+        if: ${{ secrets.CLA_SIGNATURES_TOKEN == '' }}
+        run: |
+          echo "::error::CLA_SIGNATURES_TOKEN is not set. This check cannot record a signature without it."
+          echo "Create a fine-grained PAT (Contents: RW, Pull requests: RW, this repo only) and add it as a"
+          echo "repository secret named CLA_SIGNATURES_TOKEN. See todo/_CLA-BOT-SETUP.md."
+          exit 1
+
+      - name: Check the CLA
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/ythril-network/Ythril/blob/main/CLA.md
+          branch: cla-signatures
+          # The owner and the bots never get asked. `Copilot` authors commits on the owner's behalf here.
+          allowlist: MetalMMagic,Copilot,dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: >
+            Thanks for the contribution. Before this can be merged, please sign the
+            [Contributor License Agreement](https://github.com/ythril-network/Ythril/blob/main/CLA.md).
+            **You keep the copyright in your work** — the CLA grants the licence the project needs to
+            redistribute it and to license it under other terms in future. It is one comment, once, and it
+            covers every contribution you make afterwards. Reply to this pull request with:
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA.
+          suggest-recheck: Post a new comment with **recheck** if the status has not updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The CLA is now enforced, not just stated.** #664 shipped `CLA.md`; a document nothing checks is policy on
+  paper. `.github/workflows/cla.yml` asks a first-time contributor to sign, records the signature in
+  `signatures/cla.json` on a `cla-signatures` branch, and passes silently for everyone who already has.
+  - **Self-hosted deliberately.** The hosted alternative keeps the record of who signed in a Gist under a
+    third-party account and wants the CLA text as a second copy that can drift from `CLA.md`. For a project that
+    ships air-gapped and may be licensed commercially, "who holds the signature record" is not a thing to
+    outsource.
+  - **Pinned to `v2.6.1`, and that pin is the interesting part:** the action publishes **no floating `v2` tag**
+    (`git/ref/tags/v2` is a 404), so the `@v2` a first draft used would have failed on the very first run —
+    caught by checking rather than assuming. Every input name was verified against the action's own `action.yml`.
+  - **`pull_request_target` is normally a footgun** because it exposes repository secrets to a fork's pull
+    request. It is safe here for one specific reason, recorded in the file so it is not lost: the job **never
+    checks out or executes pull-request code** — no checkout, no build, no test. If anyone adds a checkout step,
+    that reasoning stops holding.
+  - A guard step fails with the cause named if `CLA_SIGNATURES_TOKEN` is missing or expired. An expired PAT fails
+    the check closed, which is the safe direction, but would otherwise read as a mysterious red check.
+
 - **Contributor licensing: a Contributor License Agreement, because the old wording quietly closed a door.**
   `docs/contribution-guide.md` had 400+ lines on architecture, security and test discipline and one sentence on
   licensing: *"By contributing, you agree that your contributions are licensed under the same terms."*


### PR DESCRIPTION
Step 3 of `todo/_CLA-BOT-SETUP.md`. The owner completed steps 1–2 (fine-grained PAT → `CLA_SIGNATURES_TOKEN`
repository secret), so the enforcement half can land. #664 shipped `CLA.md`; a document nothing checks is
policy on paper.

## What this does

A first-time contributor is asked to sign, the signature is recorded in `signatures/cla.json` on a
`cla-signatures` branch, and anyone who has already signed passes silently. The owner and the bots are
allowlisted, so existing PRs are never interrupted.

## Self-hosted deliberately

The hosted alternative keeps the record of **who signed** in a Gist under a third-party account, and wants the
CLA text as a second copy that can drift from `CLA.md`. For a project that ships air-gapped and may be licensed
commercially, "who holds the signature record" is not a thing to outsource. Both options and their trade-offs
are written up in `todo/_CLA-BOT-SETUP.md`.

## Three things verified rather than assumed

- **The action publishes no floating `v2` tag** — `git/ref/tags/v2` returns 404. The `@v2` my first draft used
  **would have failed on the very first run.** Pinned to `v2.6.1`, the current release. An exact pin is also the
  right call for something holding a signature record: it cannot change under us. (`ci.yml` and `publish.yml`
  pin by major tag, so this deviates from convention for a stated reason.)
- **Every input name** was checked against the action's own `action.yml`.
- **`CLA_SIGNATURES_TOKEN` exists** in the repository secrets — confirmed by name via the API, not by value.

## The `pull_request_target` question, before a reviewer asks it

That trigger is normally a footgun: it runs in the base repo's context, so a fork's pull request can reach
repository secrets. It is safe **in this workflow** for one specific reason, and the reason is recorded in the
file rather than left to be rediscovered:

> This job never checks out or executes pull-request code. There is no `actions/checkout`, no build, no test. It
> reads pull-request metadata, writes a comment, and appends to a signatures file.

**If anyone ever adds a checkout or build step to that file, the reasoning stops holding.** It is the only
trigger that can work for forks at all, which is why the CLA-bot pattern uses it.

## The expiry failure mode

The PAT expires. That makes this check **fail closed**, which is the safe direction — but it would read as a
mysterious red check a year from now. So there is a guard step that names the cause and points back at the
setup doc.

## Verification

`npm run preflight` passes; the workflow parses as YAML with one job, two steps, and exactly one pinned action.
A workflow is code, so this waits for green CI before merging — the docs-only shortcut does not apply.

One thing this PR cannot prove: the bot's behaviour against a real outside contributor, since there isn't one.
The first genuine external PR is the real test, and the guard step plus the allowlist are what keep a
misconfiguration from blocking the owner's own work in the meantime.
