### PR TITLE
fix(ui): a guide's wide tables and code blocks now show a scroll control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Wide tables and code blocks in a rendered guide now show a scroll control.** They already scrolled; on this
+  platform that was invisible, because overlay scrollbars paint only while scrolling and take no layout space —
+  so the content read as **cut off** rather than reachable. Measured on `/settings/help` at 420px: this was the
+  one finding #663 left open.
+  - **Two CSS fixes were tried first and measured as failures**, recorded so nobody repeats them:
+    `scrollbar-width: thin` yields a **2px** bar *and* makes Chromium 121+ ignore `::-webkit-scrollbar`
+    entirely; `::-webkit-scrollbar` with an explicit height did not apply here at all (0px on `table`, 2px on
+    `pre`). Neither shipped — CSS that does not work is worse than a known gap, because it looks like a fix.
+  - The mechanism that works is the **drawn** control, and it could not reach this content for a structural
+    reason: **Angular never instantiates directives inside `[innerHTML]`**. So `attachHscrollTop` was extracted
+    from `HscrollTopDirective` into a plain function taking any element, with the directive becoming a thin
+    wrapper — one implementation of the pointer maths, not two that drift.
+  - `MdScrollersDirective` sits on the container, walks the injected DOM after each render, wraps only the
+    elements that actually overflow, and attaches one control each. Both markdown surfaces benefit: the Help
+    guides and the Files preview share one pipeline.
+  - **The extraction got the characterization tests it never had.** The plan claimed the directive had a spec;
+    it did not — ~150 lines of DOM and pointer arithmetic were covered only by a Playwright sweep needing a
+    running instance. 14 tests now pin insertion position, both hide conditions, the proportional thumb, the
+    28px floor, scroll tracking, track-click, drag maths, pointer-id isolation, teardown, and the
+    unguarded-`ResizeObserver` regression that once took down twelve unrelated specs. **14 mutations killed, 0
+    survived** — after fixing three of my own tests that passed for the wrong reason, including one that
+    asserted the 28px floor while measuring a 0-width track.
+  - Verified against the live bundle, not just by the sweep going 4 → 0: on the integration guide at 420px,
+    **228 overflowing elements produced 228 wrappers and 228 VISIBLE tracks** with real thumb widths — the exact
+    property both CSS attempts failed.
+
 - **Backups can be encrypted, opt-in, on every path.** A backup is a complete **plaintext** copy of the database
   by default — and an encrypted `mongod` does not protect it, because the dump is read *through* mongod and comes
   out decrypted. `encrypt: true` in `backup.json`, or the toggle on **Settings → Data**, wraps every record in the

--- a/client/src/app/pages/settings/help.component.ts
+++ b/client/src/app/pages/settings/help.component.ts
@@ -19,6 +19,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
+import { MdScrollersDirective } from '../../shared/md-scrollers.directive';
 import { MarkdownRenderService } from '../../shared/markdown-render.service';
 import { httpErrorReason } from '../../core/http-error';
 
@@ -75,7 +76,7 @@ export type HelpDocId = typeof HELP_DOCS[number]['id'];
   selector: 'app-help',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TranslocoPipe, PhIconComponent, ErrorStateComponent],
+  imports: [TranslocoPipe, PhIconComponent, ErrorStateComponent, MdScrollersDirective],
   styles: [`
     :host { display: block; }
     .help { display: grid; grid-template-columns: 1fr; gap: 16px; }
@@ -178,7 +179,7 @@ export type HelpDocId = typeof HELP_DOCS[number]['id'];
           <!-- Links inside a rendered guide are handled in onDocClick rather than by the browser: a
                bare hash link would otherwise navigate the router, and a cross-doc link like
                integration-guide.md would leave the app for a URL that does not exist. -->
-          <article #doc [innerHTML]="html()" (click)="onDocClick($event)"></article>
+          <article #doc [innerHTML]="html()" [mdScrollers]="html()" (click)="onDocClick($event)"></article>
           <p class="loading" style="margin-top:22px;">
             <ph-icon name="info" [size]="14"/>{{ 'help.shippedNote' | transloco }}
           </p>

--- a/client/src/app/shared/hscroll-top.control.spec.ts
+++ b/client/src/app/shared/hscroll-top.control.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Characterization tests for the drawn scroll control.
+ *
+ * Written **because the refactor found there were none.** The plan for extracting this out of
+ * `HscrollTopDirective` said "proven against the existing behaviour first — the directive has a spec"; it did
+ * not. ~150 lines of DOM insertion and pointer-drag arithmetic were covered only by a Playwright sweep that
+ * needs a running instance, so nothing offline would have caught the extraction breaking it.
+ *
+ * jsdom computes no layout, so `scrollWidth`/`clientWidth` are 0 and the geometry has to be supplied. That is
+ * not a weakness here: the arithmetic *is* the thing worth pinning, and feeding it known geometry tests it more
+ * precisely than a real browser would. What jsdom cannot check — that the control is VISIBLE — is exactly what
+ * `testing/responsive-sweep.mjs` exists for, and why that sweep is not replaced by this file.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { attachHscrollTop } from './hscroll-top.control';
+
+/** Give an element the layout jsdom will not compute. */
+function geometry(el: HTMLElement, { client, scroll }: { client: number; scroll: number }): void {
+  Object.defineProperty(el, 'clientWidth', { value: client, configurable: true });
+  Object.defineProperty(el, 'scrollWidth', { value: scroll, configurable: true });
+}
+
+function setup({ client = 400, scroll = 1000 } = {}) {
+  const parent = document.createElement('div');
+  const host = document.createElement('div');
+  parent.appendChild(host);
+  document.body.appendChild(parent);
+  geometry(host, { client, scroll });
+  const detach = attachHscrollTop(host);
+  const track = parent.querySelector('.hscroll-top') as HTMLDivElement | null;
+  const thumb = track?.querySelector('.hscroll-top-thumb') as HTMLDivElement | null;
+  if (track) {
+    // The track only exists after attach, so its width has to be supplied afterwards — and then the control
+    // has to render AGAIN, or every assertion reads geometry from a 0-width track.
+    //
+    // This is not a nitpick: with trackW = 0 the thumb maths yields max(28, 0) = 28, so the "floors at 28px"
+    // test passed for entirely the wrong reason until this line existed. A test that agrees with the code by
+    // accident is worse than no test.
+    geometry(track, { client, scroll: client });
+    host.dispatchEvent(new Event('scroll'));
+  }
+  return { parent, host, track, thumb, detach };
+}
+
+describe('attachHscrollTop', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('inserts a track with a thumb immediately BEFORE the host', () => {
+    // Position is the entire point of this control — a native bar sits ~2800px below the fold on a tall table.
+    const { parent, host, track, thumb } = setup();
+    expect(track).toBeTruthy();
+    expect(thumb).toBeTruthy();
+    expect(parent.firstElementChild).toBe(track);
+    expect(track!.nextElementSibling).toBe(host);
+  });
+
+  it('marks the track aria-hidden — it is a decorative twin of the host', () => {
+    // The host is already scrollable by keyboard and exposed to assistive tech; announcing a second control
+    // would be noise.
+    const { track } = setup();
+    expect(track!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('does nothing at all when the host has no parent to insert into', () => {
+    const orphan = document.createElement('div');
+    geometry(orphan, { client: 400, scroll: 1000 });
+    const detach = attachHscrollTop(orphan);
+    // Asserted on the ORPHAN, not on `document`: a mutation that wrapped the host in a detached parent still
+    // left `document.querySelector` empty, so that check passed while the guard was gone. What the guard
+    // actually promises is that the host is not re-parented and nothing is built.
+    expect(orphan.parentElement).toBeNull();
+    expect(orphan.previousElementSibling).toBeNull();
+    expect(document.querySelector('.hscroll-top')).toBeNull();
+    expect(() => detach()).not.toThrow();   // the teardown must still be safe to call
+  });
+
+  it('hides itself when the content fits', () => {
+    const { track } = setup({ client: 400, scroll: 400 });
+    expect(track!.style.display).toBe('none');
+  });
+
+  it('hides itself when the host has no width yet (a tab not on screen)', () => {
+    // clientWidth 0 with a non-zero scrollWidth is what a display:none ancestor looks like. Without this the
+    // thumb maths divides by a zero-width track and produces NaN transforms.
+    const { track } = setup({ client: 0, scroll: 1000 });
+    expect(track!.style.display).toBe('none');
+  });
+
+  it('sizes the thumb in proportion to how much is visible', () => {
+    // 400 of 1000 visible → 40% of a 400px track → 160px.
+    const { thumb } = setup({ client: 400, scroll: 1000 });
+    expect(thumb!.style.width).toBe('160px');
+  });
+
+  it('floors the thumb at 28px, so a very wide table stays aimable', () => {
+    // 400 of 40000 visible is 1% — a 4px thumb nobody can grab.
+    const { thumb } = setup({ client: 400, scroll: 40000 });
+    expect(parseInt(thumb!.style.width, 10)).toBe(28);
+  });
+
+  it('places the thumb from the host scroll position, and tracks scrolling', () => {
+    const { host, thumb } = setup({ client: 400, scroll: 1000 });
+    expect(thumb!.style.transform).toBe('translateX(0px)');
+
+    // Halfway through a 600px range → halfway along the 240px of thumb travel.
+    host.scrollLeft = 300;
+    host.dispatchEvent(new Event('scroll'));
+    expect(thumb!.style.transform).toBe('translateX(120px)');
+
+    host.scrollLeft = 600;
+    host.dispatchEvent(new Event('scroll'));
+    expect(thumb!.style.transform).toBe('translateX(240px)');
+  });
+
+  it('a track click centres the thumb there and scrolls the host to match', () => {
+    const { host, track, thumb } = setup({ client: 400, scroll: 1000 });
+    geometry(thumb!, { client: 160, scroll: 160 });
+    vi.spyOn(track!, 'getBoundingClientRect').mockReturnValue({ left: 0, width: 400 } as DOMRect);
+
+    // Click at 200: target left = 200 - 80 = 120 of 240 max → half the 600px range.
+    track!.dispatchEvent(new PointerEvent('pointerdown', { clientX: 200, bubbles: true }));
+    expect(host.scrollLeft).toBe(300);
+  });
+
+  it('dragging the thumb converts thumb travel into host travel', () => {
+    const { host, track, thumb } = setup({ client: 400, scroll: 1000 });
+    geometry(thumb!, { client: 160, scroll: 160 });
+    geometry(track!, { client: 400, scroll: 400 });
+
+    thumb!.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, clientX: 0, bubbles: true }));
+    expect(thumb!.classList.contains('is-dragging')).toBe(true);
+
+    // 120px of thumb travel out of 240 available → half of the 600px range.
+    window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: 120 }));
+    expect(host.scrollLeft).toBe(300);
+
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1 }));
+    expect(thumb!.classList.contains('is-dragging')).toBe(false);
+
+    // After release, a move must no longer scroll.
+    window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: 240 }));
+    expect(host.scrollLeft).toBe(300);
+  });
+
+  it('ignores pointermove from a different pointer than the one that started the drag', () => {
+    // A second finger on a touch screen must not hijack the drag.
+    const { host, thumb, track } = setup({ client: 400, scroll: 1000 });
+    geometry(thumb!, { client: 160, scroll: 160 });
+    geometry(track!, { client: 400, scroll: 400 });
+
+    thumb!.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, clientX: 0, bubbles: true }));
+    window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 99, clientX: 120 }));
+    expect(host.scrollLeft).toBe(0);
+  });
+
+  it('a thumb pointerdown does not also trigger the track jump', () => {
+    // Both listen for pointerdown on overlapping boxes; without stopPropagation a grab would jump first.
+    const { host, thumb } = setup({ client: 400, scroll: 1000 });
+    geometry(thumb!, { client: 160, scroll: 160 });
+    thumb!.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, clientX: 200, bubbles: true }));
+    expect(host.scrollLeft).toBe(0);
+  });
+
+  it('teardown removes the track AND detaches the scroll listener', () => {
+    const { parent, host, thumb, detach } = setup({ client: 400, scroll: 1000 });
+    const before = thumb!.style.transform;
+    detach();
+    expect(parent.querySelector('.hscroll-top')).toBeNull();
+
+    // The listener half needs its own assertion. "Does not throw" was not enough: a leaked listener still
+    // renders happily against the detached track, so removing the removeEventListener call survived. Keeping
+    // the thumb reference and checking it does NOT move is what detects the leak.
+    host.scrollLeft = 600;
+    host.dispatchEvent(new Event('scroll'));
+    expect(thumb!.style.transform).toBe(before);
+
+    expect(() => detach()).not.toThrow();
+  });
+
+  it('survives a jsdom-like environment with no ResizeObserver', () => {
+    // Feature-detected rather than assumed: constructing one unguarded previously threw and took down twelve
+    // unrelated specs that merely rendered a table.
+    expect(typeof ResizeObserver).toBe('undefined');
+    expect(() => setup()).not.toThrow();
+  });
+});

--- a/client/src/app/shared/hscroll-top.control.ts
+++ b/client/src/app/shared/hscroll-top.control.ts
@@ -1,0 +1,149 @@
+/**
+ * The drawn horizontal-scroll control, as a plain class that takes any element.
+ *
+ * ## Why this is not just the directive's body
+ *
+ * `HscrollTopDirective` gets its element from `inject(ElementRef)`, which means it can only ever attach to an
+ * element Angular itself created. **Angular does not instantiate directives inside `[innerHTML]`** — so a
+ * `hscrollTop` attribute in rendered markdown does precisely nothing, and the guides' wide tables and code
+ * blocks scroll with no visible affordance at all (measured: 4 occurrences on `/settings/help` at 420px).
+ *
+ * So the behaviour lives here, taking an element rather than injecting one. The directive is now a thin wrapper
+ * that calls `attachHscrollTop(this.host)`; a second caller can walk sanitized HTML and attach one per wrapper.
+ * One implementation either way — two copies of pointer-drag maths would drift, and the reason this control is
+ * drawn rather than borrowed is subtle enough that a second copy would lose it.
+ *
+ * ## Why it is drawn rather than borrowed (kept from the directive, because it is the whole point)
+ *
+ * A scroll container puts its scrollbar at the bottom of its own box. For a tall data table that is the worst
+ * possible place — measured ~2800px below the fold on Brain → Entities at a 900px viewport, so the table was
+ * scrollable the entire time and nobody could tell. A mirrored *native* scroller placed above it was tried and
+ * was invisible: this platform uses **overlay** scrollbars, which paint only while scrolling and take no layout
+ * space (`offsetHeight - clientHeight === 0`). An affordance you cannot see until you have already used it is
+ * not an affordance. Hence a track and a proportional thumb, always visible while the host overflows.
+ *
+ * The host keeps its own `overflow-x: auto`, so wheel, trackpad, touch and keyboard scrolling are untouched —
+ * this adds a visible, draggable handle for them rather than replacing the mechanism.
+ */
+
+/** Tear down everything {@link attachHscrollTop} added. Safe to call twice. */
+export type DetachHscrollTop = () => void;
+
+/**
+ * Insert a drawn scroll control immediately before `host` and keep it in sync.
+ *
+ * @param host the scroll container — must already have `overflow-x: auto` and a parent element
+ * @param runOutside optional scheduler for the listeners. Angular callers pass `NgZone.runOutsideAngular`,
+ *   because scrolling and dragging fire continuously and change no state the framework needs to hear about.
+ *   A non-Angular caller omits it.
+ * @returns a teardown function, or a no-op when `host` has no parent to insert into
+ */
+export function attachHscrollTop(host: HTMLElement, runOutside: (fn: () => void) => void = fn => fn()): DetachHscrollTop {
+  if (!host.parentElement) return () => { /* nothing was attached */ };
+
+  const track = document.createElement('div');
+  track.className = 'hscroll-top';
+  // Decorative twin of a control the host already exposes to assistive tech and the keyboard.
+  track.setAttribute('aria-hidden', 'true');
+  const thumb = document.createElement('div');
+  thumb.className = 'hscroll-top-thumb';
+  track.appendChild(thumb);
+  host.parentElement.insertBefore(track, host);
+
+  let ro: ResizeObserver | undefined;
+  let mo: MutationObserver | undefined;
+  /** Pointer id + geometry captured at drag start, so a drag survives the pointer leaving the thumb. */
+  let drag: { pointerId: number; startX: number; startScroll: number } | null = null;
+
+  /** How far the host can scroll. Zero means it fits, and the control hides itself. */
+  const range = (): number => host.scrollWidth - host.clientWidth;
+
+  /** Size and place the thumb from the host's current geometry. */
+  const render = (): void => {
+    if (range() <= 1 || host.clientWidth === 0) {
+      track.style.display = 'none';
+      return;
+    }
+    track.style.display = '';
+
+    const trackW = track.clientWidth;
+    const ratio = host.clientWidth / host.scrollWidth;
+    // A floor, or a very wide table produces a thumb too small to aim at.
+    const thumbW = Math.max(28, Math.round(trackW * ratio));
+    const maxLeft = trackW - thumbW;
+    const left = Math.round((host.scrollLeft / range()) * maxLeft);
+
+    thumb.style.width = `${thumbW}px`;
+    thumb.style.transform = `translateX(${left}px)`;
+  };
+
+  const onPointerDown = (e: PointerEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();   // do not also fire the track's jump-to-position
+    drag = { pointerId: e.pointerId, startX: e.clientX, startScroll: host.scrollLeft };
+    thumb.classList.add('is-dragging');
+  };
+
+  const onPointerMove = (e: PointerEvent): void => {
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    const maxLeft = track.clientWidth - thumb.clientWidth;
+    if (maxLeft <= 0) return;
+    // Convert thumb travel back into host travel: the thumb crosses `maxLeft` px while the host crosses its
+    // whole range, so the two are related by that ratio and nothing else.
+    host.scrollLeft = drag.startScroll + ((e.clientX - drag.startX) / maxLeft) * range();
+  };
+
+  const onPointerUp = (): void => {
+    if (!drag) return;
+    drag = null;
+    thumb.classList.remove('is-dragging');
+  };
+
+  /** Click anywhere on the track: centre the thumb there. */
+  const onTrackClick = (e: PointerEvent): void => {
+    if (range() <= 1) return;
+    const rect = track.getBoundingClientRect();
+    const maxLeft = track.clientWidth - thumb.clientWidth;
+    if (maxLeft <= 0) return;
+    const target = e.clientX - rect.left - thumb.clientWidth / 2;
+    host.scrollLeft = (Math.min(Math.max(target, 0), maxLeft) / maxLeft) * range();
+  };
+
+  runOutside(() => {
+    host.addEventListener('scroll', render, { passive: true });
+    thumb.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+    window.addEventListener('pointerup', onPointerUp, { passive: true });
+    track.addEventListener('pointerdown', onTrackClick);
+
+    // The content's width changes without the host resizing — a column filter narrows the data, a row expands.
+    // Observe both the box and the subtree, or the thumb goes stale and lies about the range.
+    //
+    // Feature-detected, not assumed: jsdom has MutationObserver and no ResizeObserver, so constructing one
+    // unguarded threw inside `runOutsideAngular` and took down every spec that rendered a table — a decorative
+    // scrollbar breaking twelve unrelated tests.
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(render);
+      ro.observe(host);
+      const table = host.querySelector('table');
+      if (table) ro.observe(table);
+    }
+    if (typeof MutationObserver !== 'undefined') {
+      mo = new MutationObserver(render);
+      mo.observe(host, { childList: true, subtree: true });
+    }
+  });
+
+  render();
+
+  return () => {
+    host.removeEventListener('scroll', render);
+    thumb.removeEventListener('pointerdown', onPointerDown);
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    track.removeEventListener('pointerdown', onTrackClick);
+    ro?.disconnect();
+    mo?.disconnect();
+    track.remove();
+  };
+}

--- a/client/src/app/shared/hscroll-top.directive.ts
+++ b/client/src/app/shared/hscroll-top.directive.ts
@@ -1,32 +1,20 @@
 import { Directive, ElementRef, OnDestroy, AfterViewInit, inject, NgZone } from '@angular/core';
+import { attachHscrollTop, type DetachHscrollTop } from './hscroll-top.control';
 
 /**
  * Draw a horizontal scroll control ABOVE the element it scrolls.
  *
- * ## Why this exists
+ * **The behaviour lives in `hscroll-top.control.ts`** — including why the control is *drawn* rather than
+ * borrowed from the platform, and the three approaches tried before it. This file is only the Angular binding.
  *
- * A scroll container puts its horizontal scrollbar at the bottom of its own box. For a data table that
- * is the worst possible place: the table is the tallest thing on the page, so the only hint that there
- * is more to the right sits below everything, and the box moves as the page scrolls. Measured on
- * Brain → Entities at a 900px viewport, the bar was roughly **2800px** below the fold — the table was
- * scrollable the whole time and nobody could tell.
+ * ## Why the behaviour moved out
  *
- * Three approaches were tried before this one. Recording them because each looked correct:
- *
- *  1. **A blanket `min-width` on `table`.** Stopped the column collapse, and forced a horizontal
- *     scrollbar onto every narrow three-column settings table that previously fit.
- *  2. **Bounding the wrapper's height** so the bar could not be far away. It shortened the distance,
- *     added a second vertical scrollbar nested in a page that already scrolls — rejected on sight — and
- *     the bar still moved with the page, because height was never the problem. *Position* was.
- *  3. **A mirrored native scroller above the table.** Right position, invisible: this platform uses
- *     OVERLAY scrollbars, which paint only while scrolling and occupy no layout space. Measured
- *     `offsetHeight - clientHeight === 0`, and a screenshot showed nothing at all. An affordance you
- *     cannot see until you have already used it is not an affordance.
- *
- * So the control is **drawn**, not borrowed: a track and a proportional thumb, always visible while the
- * host overflows, positioned immediately above it. The host keeps its own `overflow-x: auto`, so wheel,
- * trackpad, touch and keyboard scrolling all still work untouched — this adds a visible, draggable
- * handle for them rather than replacing the mechanism.
+ * A directive takes its element from `inject(ElementRef)`, so it can only attach to an element Angular created.
+ * **Angular does not instantiate directives inside `[innerHTML]`** — so this control could never reach the
+ * rendered guides on `/settings/help`, where wide tables and code blocks scroll with no visible affordance at
+ * all, because this platform's overlay scrollbars paint nothing. Extracting it lets a second caller walk
+ * sanitized HTML and attach one per wrapper, with **one** implementation of the pointer maths rather than two
+ * copies that drift.
  */
 @Directive({
   selector: '[hscrollTop]',
@@ -36,126 +24,15 @@ export class HscrollTopDirective implements AfterViewInit, OnDestroy {
   private readonly host = inject(ElementRef<HTMLElement>).nativeElement as HTMLElement;
   private readonly zone = inject(NgZone);
 
-  private track?: HTMLDivElement;
-  private thumb?: HTMLDivElement;
-  private ro?: ResizeObserver;
-  private mo?: MutationObserver;
-
-  /** Pointer id + geometry captured at drag start, so a drag survives the pointer leaving the thumb. */
-  private drag: { pointerId: number; startX: number; startScroll: number } | null = null;
+  private detach?: DetachHscrollTop;
 
   ngAfterViewInit(): void {
-    if (!this.host.parentElement) return;
-
-    const track = document.createElement('div');
-    track.className = 'hscroll-top';
-    // Decorative twin of a control the host already exposes to assistive tech and the keyboard.
-    track.setAttribute('aria-hidden', 'true');
-    const thumb = document.createElement('div');
-    thumb.className = 'hscroll-top-thumb';
-    track.appendChild(thumb);
-    this.host.parentElement.insertBefore(track, this.host);
-    this.track = track;
-    this.thumb = thumb;
-
-    // Outside Angular: scrolling and dragging fire continuously and change no state the framework
-    // needs to hear about.
-    this.zone.runOutsideAngular(() => {
-      this.host.addEventListener('scroll', this.render, { passive: true });
-      thumb.addEventListener('pointerdown', this.onPointerDown);
-      window.addEventListener('pointermove', this.onPointerMove, { passive: true });
-      window.addEventListener('pointerup', this.onPointerUp, { passive: true });
-      track.addEventListener('pointerdown', this.onTrackClick);
-
-      // The table's width changes without the host resizing — a column filter narrows the data, a row
-      // expands. Observe both the box and the subtree, or the thumb goes stale and lies about the range.
-      //
-      // Feature-detected, not assumed: jsdom has MutationObserver and no ResizeObserver, so
-      // constructing one unguarded threw inside `runOutsideAngular` and took down every spec that
-      // rendered a table — a decorative scrollbar breaking twelve unrelated tests.
-      if (typeof ResizeObserver !== 'undefined') {
-        this.ro = new ResizeObserver(this.render);
-        this.ro.observe(this.host);
-        const table = this.host.querySelector('table');
-        if (table) this.ro.observe(table);
-      }
-      if (typeof MutationObserver !== 'undefined') {
-        this.mo = new MutationObserver(this.render);
-        this.mo.observe(this.host, { childList: true, subtree: true });
-      }
-    });
-
-    this.render();
+    // Outside Angular: scrolling and dragging fire continuously and change no state the framework needs to
+    // hear about. Passed in as a scheduler rather than imported, so the control stays framework-free.
+    this.detach = attachHscrollTop(this.host, fn => this.zone.runOutsideAngular(fn));
   }
 
   ngOnDestroy(): void {
-    this.host.removeEventListener('scroll', this.render);
-    this.thumb?.removeEventListener('pointerdown', this.onPointerDown);
-    window.removeEventListener('pointermove', this.onPointerMove);
-    window.removeEventListener('pointerup', this.onPointerUp);
-    this.track?.removeEventListener('pointerdown', this.onTrackClick);
-    this.ro?.disconnect();
-    this.mo?.disconnect();
-    this.track?.remove();
+    this.detach?.();
   }
-
-  /** How far the host can scroll. Zero means it fits, and the control hides itself. */
-  private get range(): number { return this.host.scrollWidth - this.host.clientWidth; }
-
-  /** Size and place the thumb from the host's current geometry. */
-  private render = (): void => {
-    const track = this.track, thumb = this.thumb;
-    if (!track || !thumb) return;
-
-    if (this.range <= 1 || this.host.clientWidth === 0) {
-      track.style.display = 'none';
-      return;
-    }
-    track.style.display = '';
-
-    const trackW = track.clientWidth;
-    const ratio = this.host.clientWidth / this.host.scrollWidth;
-    // A floor, or a very wide table produces a thumb too small to aim at.
-    const thumbW = Math.max(28, Math.round(trackW * ratio));
-    const maxLeft = trackW - thumbW;
-    const left = Math.round((this.host.scrollLeft / this.range) * maxLeft);
-
-    thumb.style.width = `${thumbW}px`;
-    thumb.style.transform = `translateX(${left}px)`;
-  };
-
-  private onPointerDown = (e: PointerEvent): void => {
-    if (!this.thumb) return;
-    e.preventDefault();
-    e.stopPropagation();   // do not also fire the track's jump-to-position
-    this.drag = { pointerId: e.pointerId, startX: e.clientX, startScroll: this.host.scrollLeft };
-    this.thumb.classList.add('is-dragging');
-  };
-
-  private onPointerMove = (e: PointerEvent): void => {
-    const drag = this.drag, track = this.track, thumb = this.thumb;
-    if (!drag || drag.pointerId !== e.pointerId || !track || !thumb) return;
-    const maxLeft = track.clientWidth - thumb.clientWidth;
-    if (maxLeft <= 0) return;
-    // Convert thumb travel back into host travel: the thumb crosses `maxLeft` px while the host
-    // crosses its whole range, so the two are related by that ratio and nothing else.
-    this.host.scrollLeft = drag.startScroll + ((e.clientX - drag.startX) / maxLeft) * this.range;
-  };
-
-  private onPointerUp = (): void => {
-    if (!this.drag) return;
-    this.drag = null;
-    this.thumb?.classList.remove('is-dragging');
-  };
-
-  /** Click anywhere on the track: centre the thumb there. */
-  private onTrackClick = (e: PointerEvent): void => {
-    const track = this.track, thumb = this.thumb;
-    if (!track || !thumb || this.range <= 1) return;
-    const rect = track.getBoundingClientRect();
-    const maxLeft = track.clientWidth - thumb.clientWidth;
-    if (maxLeft <= 0) return;
-    const target = e.clientX - rect.left - thumb.clientWidth / 2;
-    this.host.scrollLeft = (Math.min(Math.max(target, 0), maxLeft) / maxLeft) * this.range;
-  };
 }

--- a/client/src/app/shared/md-scrollers.directive.ts
+++ b/client/src/app/shared/md-scrollers.directive.ts
@@ -1,0 +1,89 @@
+import { Directive, ElementRef, OnDestroy, inject, NgZone, effect, input } from '@angular/core';
+import { attachHscrollTop, type DetachHscrollTop } from './hscroll-top.control';
+
+/**
+ * Give every wide table and code block inside rendered markdown a VISIBLE scroll control.
+ *
+ * ## The gap this closes
+ *
+ * A wide `<table>` or `<pre>` in a rendered guide already scrolls — `help.component` sets
+ * `overflow-x: auto` on both. On this platform that is invisible: overlay scrollbars paint only while
+ * scrolling and take no layout space (`offsetHeight - clientHeight === 0`), so the content reads as having
+ * been **cut off** rather than as something you can reach. Measured on `/settings/help` at 420px: four
+ * occurrences, the widest 50px past a 338px box.
+ *
+ * Two CSS fixes were tried first and **measured as failures** — recorded so nobody repeats them:
+ *
+ *  - `scrollbar-width: thin` + `scrollbar-color` yields a **2px** bar AND makes Chromium 121+ ignore
+ *    `::-webkit-scrollbar` entirely.
+ *  - `::-webkit-scrollbar` with an explicit height did not apply at all here (0px on `table`, 2px on `pre`).
+ *
+ * ## Why a directive on the container rather than on each element
+ *
+ * The mechanism that *does* work in this app is the drawn control. It could not reach this content because
+ * **Angular never instantiates directives inside `[innerHTML]`** — so a `hscrollTop` attribute in rendered
+ * markdown does nothing. This sits on the container instead, and after each render walks the injected DOM,
+ * wraps each overflowing element in a positioned parent, and attaches `attachHscrollTop` to it.
+ *
+ * The wrapping happens here, in the DOM, rather than in `MarkdownRenderService`: the control needs a parent it
+ * can insert a sibling into, and doing it here keeps the render service's output a pure function of the
+ * markdown. (An attempt to emit the wrapper from a `table` renderer override recursed — the override calls the
+ * parser, which calls the override.)
+ *
+ * Re-run on every `mdScrollers` change, because the Help page swaps documents without recreating the article.
+ */
+@Directive({
+  selector: '[mdScrollers]',
+  standalone: true,
+})
+export class MdScrollersDirective implements OnDestroy {
+  /** Bind to whatever changes when the rendered HTML changes — the value itself is not read. */
+  readonly mdScrollers = input<unknown>();
+
+  private readonly host = inject(ElementRef<HTMLElement>).nativeElement as HTMLElement;
+  private readonly zone = inject(NgZone);
+
+  private detachers: DetachHscrollTop[] = [];
+
+  constructor() {
+    effect(() => {
+      this.mdScrollers();          // the dependency; its value is irrelevant
+      // After the browser has laid the new HTML out — scrollWidth is 0 until then, so attaching earlier would
+      // measure every element as fitting and hide every control.
+      requestAnimationFrame(() => this.attachAll());
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.teardown();
+  }
+
+  private teardown(): void {
+    for (const d of this.detachers) d();
+    this.detachers = [];
+    // Unwrap, so a re-render does not accumulate a wrapper per pass.
+    for (const w of Array.from(this.host.querySelectorAll('.md-scroll'))) {
+      const el = w.firstElementChild;
+      if (el) w.replaceWith(el);
+      else w.remove();
+    }
+  }
+
+  private attachAll(): void {
+    this.teardown();
+
+    for (const el of Array.from(this.host.querySelectorAll<HTMLElement>('table, pre'))) {
+      // Only what actually overflows. Wrapping a table that fits would add a hidden track to most documents
+      // and make the DOM harder to read for no gain.
+      if (el.scrollWidth <= el.clientWidth + 2) continue;
+      if (el.closest('.md-scroll')) continue;          // already wrapped (defensive)
+
+      const wrap = document.createElement('div');
+      wrap.className = 'md-scroll';
+      el.replaceWith(wrap);
+      wrap.appendChild(el);
+
+      this.detachers.push(attachHscrollTop(el, fn => this.zone.runOutsideAngular(fn)));
+    }
+  }
+}

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -479,6 +479,16 @@ button:disabled, .btn:disabled {
  * did not bring it back. So the track and thumb are ordinary elements the directive positions — always
  * visible while the table overflows, and themable like everything else.
  */
+/*
+ * Wrapper that `MdScrollersDirective` puts around a wide table or code block inside rendered markdown.
+ *
+ * It exists only to give the drawn control a parent to insert its track into — the control is a SIBLING placed
+ * before its host, so the host needs a parent that is not the article itself (inserting into the article would
+ * put a track between two paragraphs). `display: block` and no padding, so it is invisible in the layout: the
+ * only thing it changes is that a track can appear above the element it scrolls.
+ */
+.md-scroll { display: block; }
+
 .hscroll-top {
   position: relative;
   height: 10px;

--- a/testing/standalone/innerhtml-css-reach.test.js
+++ b/testing/standalone/innerhtml-css-reach.test.js
@@ -70,8 +70,26 @@ function stylesBlock(src) {
   return raw.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
+/**
+ * Detect the BINDING, not a mention of it.
+ *
+ * This used to test the raw file, so any file whose comments discussed `[innerHTML]` was classified as
+ * rendering it — and the map then had to list a directive that renders nothing, which would have made the map
+ * a lie about the very thing it exists to enumerate. `md-scrollers.directive.ts` tripped it by explaining *why*
+ * Angular directives cannot reach `[innerHTML]` content.
+ *
+ * Comments are stripped first, which is what `stylesBlock` above already does for the same reason: prose about
+ * a thing is not the thing. Six gates in this repo have now fired on the comment explaining their own subject.
+ */
+function rendersInnerHtml(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+    .includes('[innerHTML]');
+}
+
 describe('CSS for [innerHTML] content can reach it', () => {
-  const usesInnerHtml = sources().filter(f => readFileSync(f, 'utf8').includes('[innerHTML]'));
+  const usesInnerHtml = sources().filter(f => rendersInnerHtml(readFileSync(f, 'utf8')));
 
   it('finds the components that render innerHTML (the check itself works)', () => {
     // A refactor that reduced this to zero would make every assertion below pass by examining nothing.


### PR DESCRIPTION
Queue item 2 — the one finding PR #663 left open.

## The bug

`/settings/help` at 420px had four wide tables and code blocks past the pane edge. They **already scrolled**;
on this platform that is invisible, because overlay scrollbars paint only while scrolling and take no layout
space. So the content read as **cut off** rather than as something you could reach.

## Two CSS fixes were tried and measured as failures — neither shipped

| attempt | measured |
|---|---|
| `scrollbar-width: thin` + `scrollbar-color` | **2px** bar, *and* it makes Chromium 121+ ignore `::-webkit-scrollbar` entirely |
| `::-webkit-scrollbar` with an explicit height | did not apply at all — 0px on `table`, 2px on `pre`, with and without `:is()` |

Both were reverted rather than left in. **CSS that does not work is worse than a known gap, because it looks
like a fix** — and the next person would have had to re-derive that these two are dead ends.

## The structural reason it needed a refactor

The mechanism that works in this app is the **drawn** control. It could not reach this content, and not because
of a missing attribute: **Angular never instantiates directives inside `[innerHTML]`.** So `hscrollTop` in
rendered markdown does nothing at all.

**Commit 1** extracts `attachHscrollTop(el, runOutside?)` out of `HscrollTopDirective`, which becomes a thin
wrapper. One implementation of the pointer-drag maths, not two that drift — and the reason the control is drawn
rather than borrowed is subtle enough that a second copy would lose it. **No behaviour change**, deliberately
its own commit: extraction plus new behaviour together would make a regression in today's tables
indistinguishable from a bug in the new wrapping.

**Commit 2** adds `MdScrollersDirective` on the container. After each render it walks the injected DOM, wraps
**only** what actually overflows, and attaches one control each — unwrapping first, so a re-render does not
accumulate wrappers. Both markdown surfaces benefit: the Help guides and the Files preview share one pipeline.

Wrapping happens in the DOM, not in `MarkdownRenderService`. An attempt to emit the wrapper from a `table`
renderer override **recursed** (the override calls the parser, which calls the override), and doing it in the
directive keeps the render service's output a pure function of its markdown.

## The extraction got the tests it never had

My plan said *"proven against the existing behaviour first — the directive has a spec."* **It did not.** ~150
lines of DOM and pointer arithmetic were covered only by a Playwright sweep that needs a running instance, so
nothing offline would have caught the extraction breaking it.

14 characterization tests now pin: insertion position (the entire point — a native bar measured ~2800px below
the fold on a tall table), `aria-hidden`, the no-parent guard, both hide conditions, the proportional thumb, the
28px floor, scroll tracking, track-click, drag maths, pointer-id isolation, `stopPropagation`, teardown, and the
unguarded-`ResizeObserver` regression that once took down twelve unrelated specs.

**14 mutations killed, 0 survived** — after mutation testing caught **three of my own tests passing for the
wrong reason**:

- Setting the track width *after* attach meant the first render saw a 0-width track, so `max(28, 0)` made the
  **"floors at 28px" test pass vacuously**.
- The orphan test asserted on `document`, so a mutation that re-parented the host into a detached div survived.
- The teardown test only asserted "does not throw", so **a leaked scroll listener survived** — a removed track
  still renders happily.

## Verification — because 0 findings and 0 measurements look identical

The sweep goes **4 → 0** on `/settings/help`. That alone would not be evidence, so it was checked directly
against the live bundle at 420px on the integration guide:

```
overflowing elements : 228
wrappers created     : 228
VISIBLE tracks       : 228     thumb widths 263 / 309 / 290 / 217 / 194 / 189 px
```

**Visible** is the exact property both CSS attempts failed. The screenshot also confirms #663's wrapped table of
contents working — all 11 guides reachable at phone width.

## One pre-existing gate needed fixing, not appeasing

`innerhtml-css-reach` detected `[innerHTML]` in the **raw** file, so it classified this directive — whose doc
comment explains *why directives cannot reach `[innerHTML]` content* — as rendering it. Its map would then have
had to list a directive that renders nothing, making the map a lie about the very thing it enumerates.

It now strips comments first, which the same gate already did for its styles check. Verified in both directions:
it passes now, and it still fails when a real `[innerHTML]` binding is added. That is the seventh gate in this
repo to fire on the comment explaining its own subject.

`npm run preflight` passes.
