### PR TITLE
fix(ui): the Overview's last two cards no longer make the page jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The Overview's last two cards no longer make the page jump on a cold load** (canary B). Four of the six
+  self-gating cards already had a skeleton; these two did not, and the framing in the original report — "add
+  skeletons" — was wrong because most of them were already there.
+  - **Statistics** is the first card on the tab, and its loading state was a single line of muted text that
+    collapsed into a full stats grid. The largest layout jump on the page, and the one a reader sees first.
+  - **Instance** had **no loading branch at all**: the panel was simply absent, then appeared, shifting whatever
+    the reader was already looking at.
+  - `about` needed a **different lifetime** from the four existing keys, and flattening that would have been a
+    bug: it is fetched once at init and never re-fetched, so raising its flag per space switch would have put a
+    skeleton over data already on screen. It is one-shot — starts pending, clears once — and `selectSpace` now
+    uses `update()` rather than `set()` so it cannot be clobbered.
+  - Both settle on **failure** as well as success. A skeleton that never resolves is worse than a layout that
+    jumps, and #662 was entirely about not letting a failure masquerade as another state.
+  - Verified on a cold load with the overview APIs deliberately delayed, because the pending state is otherwise
+    a race: **8 panels during and after, identical panel heights, 0px document-height shift.** The stable panel
+    count is the direct evidence for the Instance fix — that card was previously not in the DOM at all while
+    loading.
+
 - **Wide tables and code blocks in a rendered guide now show a scroll control.** They already scrolled; on this
   platform that was invisible, because overlay scrollbars paint only while scrolling and take no layout space —
   so the content read as **cut off** rather than reachable. Measured on `/settings/help` at 420px: this was the

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -400,12 +400,16 @@ export class BrainComponent implements OnInit, OnDestroy {
    * the failure handler. It is deliberately not set by the live-event refresh: that has good data on screen, and
    * covering it with a skeleton would be the same defect this exists to remove.
    */
-  overviewPending = signal<Record<'activity' | 'completeness' | 'queue' | 'tokens', boolean>>({
-    activity: false, completeness: false, queue: false, tokens: false,
+  overviewPending = signal<Record<'activity' | 'completeness' | 'queue' | 'tokens' | 'stats' | 'about', boolean>>({
+    activity: false, completeness: false, queue: false, tokens: false, stats: false,
+    // `about` is the one key with a DIFFERENT lifetime: the instance panel is fetched once at init and
+    // never re-fetched, so it starts pending and is cleared exactly once. Raising it per space switch
+    // would put a skeleton over data already on screen.
+    about: true,
   });
 
   /** Clear one panel's pending flag — called from both handlers of each loader, success or failure. */
-  private settled(key: 'activity' | 'completeness' | 'queue' | 'tokens'): void {
+  private settled(key: 'activity' | 'completeness' | 'queue' | 'tokens' | 'stats' | 'about'): void {
     if (!this.overviewPending()[key]) return;
     this.overviewPending.update(p => ({ ...p, [key]: false }));
   }
@@ -443,7 +447,10 @@ export class BrainComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.loadSpaces();
     // Instance identity/health for the Overview's Instance panel — one instance-wide fetch, best-effort.
-    this.adminApi.getAbout().subscribe({ next: a => this.aboutInfo.set(a), error: () => {} });
+    this.adminApi.getAbout().subscribe({
+      next: a => { this.aboutInfo.set(a); this.settled('about'); },
+      error: () => this.settled('about'),
+    });
   }
 
   /** Public so the error state's Retry can re-run it without a page reload. */
@@ -561,7 +568,10 @@ export class BrainComponent implements OnInit, OnDestroy {
     this.completeness.set(null);
     this.spaceActivity.set(null);
     // Blanked and awaiting a first answer — the ONLY place pending is raised. See `overviewPending`.
-    this.overviewPending.set({ activity: true, completeness: true, queue: true, tokens: true });
+    // update(), not set(): `about` is one-shot and must keep whatever it already resolved to.
+    this.overviewPending.update(p => ({
+      ...p, activity: true, completeness: true, queue: true, tokens: true, stats: true,
+    }));
     this.loadStats(id);
     this.loadSpaceMeta(id);
     this.loadEmbeddingQueue(id);
@@ -681,8 +691,11 @@ export class BrainComponent implements OnInit, OnDestroy {
         this.spaces.update(list =>
           list.map(sv => sv.space.id === spaceId ? { ...sv, stats } : sv),
         );
+        this.settled('stats');
       },
-      error: () => {},
+      // Settled on FAILURE too, or the skeleton becomes permanent — a card that never resolves is worse
+      // than one that jumps, and #662 was entirely about a failure not masquerading as another state.
+      error: () => this.settled('stats'),
     });
     this.spacesApi.getReindexStatus(spaceId).subscribe({
       next: ({ needsReindex }) => this.needsReindex.set(needsReindex),

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -211,6 +211,10 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
                 <div class="bar"><span [class.warn]="pct >= 80 && pct < 95" [class.err]="pct >= 95" [style.width.%]="pct"></span></div>
               }
             </div>
+          } @else if (pending().stats) {
+            <!-- Sized to the settled grid, not a one-line placeholder. This is the FIRST card on the tab,
+                 and a single line collapsing into a full stats grid was the largest layout jump on it. -->
+            <app-skeleton-lines [rows]="4" />
           } @else {
             <span class="muted">{{ 'brain.overview.statsLoading' | transloco }}</span>
           }
@@ -519,6 +523,20 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
             </dl>
           </div>
         </section>
+      } @else if (pending().about) {
+        <!-- NO BACKTICKS in a template comment: one ends the template string, and the error points at
+             @Component rather than here.
+             This card had NO else branch at all: the panel was simply absent until its data arrived and then
+             appeared, shifting whatever the reader was already looking at. The about data is fetched once at
+             init, so its pending flag is one-shot — see overviewPending in brain.component. -->
+        <section class="panel" [attr.aria-busy]="true">
+          <header class="panel-h">
+            <span class="ic"><ph-icon name="info" [size]="16"/></span>
+            <div><h3>{{ 'brain.overview.instanceTitle' | transloco }}</h3>
+              <p>{{ 'brain.overview.instanceHint' | transloco }}</p></div>
+          </header>
+          <div class="panel-b"><app-skeleton-lines [rows]="4" /></div>
+        </section>
       }
 
       <!-- ── Token access (admin-only; null for non-admins → hidden) ──── -->
@@ -591,8 +609,8 @@ export class OverviewTabComponent {
    * (the endpoint 403s) and `completeness` is null after a failure, so a skeleton keyed on null alone would sit
    * there forever. The parent raises these only where it blanks, and clears each from both handlers.
    */
-  pending = input<Record<'activity' | 'completeness' | 'queue' | 'tokens', boolean>>({
-    activity: false, completeness: false, queue: false, tokens: false,
+  pending = input<Record<'activity' | 'completeness' | 'queue' | 'tokens' | 'stats' | 'about', boolean>>({
+    activity: false, completeness: false, queue: false, tokens: false, stats: false, about: false,
   });
   /** Emitted (after a confirm) so the shell's existing reindex flow runs — no duplicate API path. */
   /** A collection tile was clicked — the shell switches to that tab. */

--- a/testing/standalone/overview-pending-is-cleared.test.js
+++ b/testing/standalone/overview-pending-is-cleared.test.js
@@ -34,11 +34,21 @@ const PANELS = [
   { key: 'completeness', loader: 'loadCompleteness' },
   { key: 'queue',        loader: 'loadEmbeddingQueue' },
   { key: 'tokens',       loader: 'loadTokenAccess' },
+  // `stats` is per-space like the four above — it is blanked and re-raised on every space switch.
+  { key: 'stats',        loader: 'loadStats', public: true },
+  // `about` is the odd one out and the reason `raisedInSelectSpace` exists as a separate field: the instance
+  // panel is fetched ONCE at init and never re-fetched, so it is one-shot. Raising it on a space switch would
+  // put a skeleton over data already on screen, which is why `selectSpace` must NOT list it.
+  { key: 'about',        loader: 'ngOnInit', public: true, oneShot: true },
 ];
 
 /** The body of one loader method, sliced to its own closing brace rather than a character count. */
 function loaderBody(name) {
-  const start = src.indexOf(`private ${name}(`);
+  // Not every loader is private: `loadStats` is called from four tab components' (mutated) outputs, and
+  // `ngOnInit` is a lifecycle hook. Anchored on either modifier rather than assuming one, because assuming
+  // `private` is what made this helper report "loadStats not found" for a method sitting in plain sight.
+  let start = src.indexOf(`private ${name}(`);
+  if (start < 0) start = src.indexOf(`\n  ${name}(`);
   assert.ok(start > 0, `${name} not found in ${BRAIN}`);
   const end = src.indexOf('\n  }', start);
   assert.ok(end > start, `could not find the end of ${name}`);
@@ -65,18 +75,29 @@ describe('an Overview skeleton can always be dismissed', () => {
 
   it('pending is raised ONLY where the values are blanked', () => {
     // Raising it anywhere else would cover good data with a placeholder — the defect this whole change removes.
-    // `overviewPending.set(` is the raise; `.update(` inside `settled()` is the lower.
-    const raises = [...src.matchAll(/overviewPending\.set\(/g)].length;
+    //
+    // Matched on `...p, activity: true` rather than on `overviewPending.set(`, because the raise legitimately
+    // became an `update()`: `about` has a ONE-SHOT lifetime (fetched once at init, never re-fetched), so a
+    // `set()` here would clobber it back to pending on every space switch and put a skeleton over data
+    // already on screen. The invariant this test protects — raised in exactly ONE place, beside the blanks —
+    // is unchanged; only the method is. Matching the method name made the test about the mechanism instead of
+    // the guarantee.
+    const raises = [...src.matchAll(/\.\.\.p, activity: true/g)].length;
     assert.equal(raises, 1, 'pending must be raised in exactly one place (selectSpace, beside the blanks)');
+
     // Anchored on the METHOD, not the first textual match — `selectSpace(` appears in the template first, and
     // slicing from there measured 19k characters of the wrong thing.
     const at = src.indexOf('  selectSpace(id: string): void {');
     assert.ok(at > 0, 'selectSpace method not found');
     const selectSpace = src.slice(at, src.indexOf('\n  }', at));
-    assert.match(selectSpace, /overviewPending\.set\(\{ activity: true, completeness: true, queue: true, tokens: true \}\)/,
-      'the space switch must raise all four, since it blanks all four');
+    for (const key of ['activity', 'completeness', 'queue', 'tokens', 'stats']) {
+      assert.match(selectSpace, new RegExp(`${key}: true`),
+        `the space switch blanks ${key}, so it must raise its pending flag too`);
+    }
+    // And it must NOT raise `about`, whose data is not blanked by a space switch.
+    assert.doesNotMatch(selectSpace, /about: true/,
+      'about is fetched once at init, so raising it on a space switch would cover data already on screen');
   });
-
   it('`settled` really lowers the flag', () => {
     // The call-site checks above pass whether or not the function does anything, which a mutation test proved:
     // gutting the body left every one of them green.


### PR DESCRIPTION
Queue item 3 (canary B, 2026-08-02).

## The report's framing was wrong, and measuring said so

The item asked for "a skeleton at each card's final size". **Four of the six self-gating cards already had
one.** Working it from the original report would have meant re-adding what was there and missing what was not.
The two actual gaps:

| card | before | why it is the one that matters |
|---|---|---|
| **Statistics** | `@else` rendered a single line of muted text | The **first** card on the tab. One line collapsing into a full stats grid was the largest layout jump on the page. |
| **Instance** | **no `@else` at all** | The panel was simply absent, then appeared — shifting whatever the reader was already looking at. |

## The one design decision, and why flattening it would have been a bug

`pending` had keys for `activity`, `completeness`, `queue`, `tokens` — all per-space, all blanked and re-raised
on a space switch. `stats` joins them unchanged.

**`about` does not.** The instance panel is fetched **once at init** and never re-fetched. Giving it the same
lifetime would have raised its flag on every space switch and **put a skeleton over data already on screen** —
a new bug, in the name of fixing a jump. So it is one-shot: starts pending, clears once, never re-raised. And
`selectSpace` switched from `.set()` to `.update()` so it cannot be clobbered.

A bare `@else` was the cheaper alternative and was rejected: `about()` can fail, and a **permanent** skeleton is
worse than a jumping layout. Both new keys settle on failure as well as success — #662 was entirely about not
letting a failure masquerade as another state.

## Verification

The pending state is a race, so the overview APIs were deliberately delayed to make it observable:

```
DURING : 8 panels, heights [227,135,316,316,316,252,252,252], doc 900px
SETTLED: 8 panels, heights [227,135,316,316,316,252,252,252], doc 900px
                              → 0px document-height shift
```

**The stable panel count is the direct evidence for the Instance fix** — that card was previously not in the DOM
at all while loading, so the count would have gone 7 → 8. The screenshot confirms a skeleton sitting at the
card's own size with the surrounding layout intact.

## Two gates re-pointed, not appeased

- `overview-pending-is-cleared` asserted the raise site by matching `overviewPending.set(`, so a legitimate
  change to `update()` read as **zero** raise sites. It now matches the *guarantee* — raised in exactly one
  place, beside the blanks — rather than the mechanism, and additionally asserts `selectSpace` does **not** raise
  `about`. The one-shot lifetime is now a checked property instead of a comment.
- Its `PANELS` list covers both new keys, and `loaderBody` no longer assumes every loader is `private`:
  `loadStats` is public (four tab components call it on `(mutated)`) and `ngOnInit` is a lifecycle hook, so it
  reported *"loadStats not found"* for a method sitting in plain sight.

`npm run preflight` passes.
