### PR TITLE
test(client): fail the build when a component becomes unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The build now fails when a component becomes unreachable.** A component with no route, no importer and no
+  template usage has exactly one reference — its own declaration — and is dead.
+  - The argument for automating it is #662: `pages/settings/schema-library.component.ts` was dead **and had
+    already made four other things wrong** before anyone noticed. A Help anchor written for the URL it implied,
+    so the **live** Schema Library page resolved to no guide section while the anchor table looked complete; a
+    standalone gate pinning it, so that gate had been guarding a file nobody could open; two i18n keys whose
+    only consumer it was; and an hour of work on a component no user can reach.
+  - An unreachable file still reads as documentation. The next reader — or the next gate, or the next anchor
+    table — takes its existence as evidence that its route, its keys and its behaviour are real.
+  - It also forbids **two components exporting the same class name**, which is exactly what let the dead file
+    pass for the live page: a reader could not tell which `SchemaLibraryComponent` was the routed one.
+  - Two scope corrections found while writing it, both the same shape — **a checker narrower than reality
+    reports the gap as a defect**: scanning only `*.component.ts` called `ConfirmDialogComponent` dead (it is
+    instantiated dynamically by a service), and the first local verification was invalid rather than the gate
+    being wrong — an unreachable probe went undetected because `git ls-files` does not see an untracked file.
+
 - **The Overview's last two cards no longer make the page jump on a cold load** (canary B). Four of the six
   self-gating cards already had a skeleton; these two did not, and the framing in the original report — "add
   skeletons" — was wrong because most of them were already there.

--- a/client/src/app/testing/components-are-reachable.spec.ts
+++ b/client/src/app/testing/components-are-reachable.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Every component must be reachable — routed, or imported by another component.
+ *
+ * ## The bug this exists for
+ *
+ * `pages/settings/schema-library.component.ts` had **no route and no importer**, and a class name that collided
+ * with the live Schema Library page. It was deleted in #662 — but not before it had made **four other things
+ * wrong**, which is the argument for detecting this automatically rather than trusting a reader to notice:
+ *
+ *  1. A Help anchor had been written for the URL that dead file *implied* (`/settings/schema-library`, which
+ *     nothing routes to), so the **live** page — a top-level nav item — resolved to no guide section at all,
+ *     while the anchor table looked complete.
+ *  2. A standalone gate pinned it, so that gate had been guarding a file nobody could open.
+ *  3. Two i18n keys existed in all three locales with the dead file as their only consumer.
+ *  4. An hour of work fixing a component no user can reach.
+ *
+ * An unreachable file still reads as documentation. The next person — or the next gate, or the next anchor
+ * table — takes its existence as evidence that its route, its keys and its behaviour are real.
+ *
+ * ## What "reachable" means here
+ *
+ * A component is reachable if its exported class is named by `app.routes.ts` (directly or in a `loadComponent`),
+ * or appears in another component's `imports` array, or is used as a selector in another component's template.
+ * Anything else has exactly one reference — its own declaration — and is dead.
+ *
+ * Comments are stripped first. Seven gates in this repo have now fired on the comment explaining their own
+ * subject, and the comment above literally names a deleted component.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** vitest runs with cwd = client/, and `git ls-files` output is relative to it. */
+const CLIENT = resolve(__dirname, '../../..');
+
+/**
+ * Components that are legitimately not referenced from another component or a route.
+ *
+ * Each is asserted below to still exist and still be unreferenced, so a component that gains a caller cannot
+ * linger here — an allowlist is a ceiling, not a licence.
+ */
+const EXEMPT: Record<string, string> = {
+  'app.component.ts':
+    'The application root. Bootstrapped by main.ts rather than routed or imported, which is exactly why it has '
+    + 'no referrer — and why every other component having none is a defect.',
+};
+
+const strip = (src: string): string => src
+  // Only block comments that START a line: a `/*` inside a string literal (a glob, a cron expression) opens a
+  // fake comment that runs to the next `*​/` and eats real code. That mistake produced a false PASS in a sibling
+  // gate — it reported a file as having no call it was asserting on.
+  .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, ' ')
+  .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ');
+
+interface Comp {
+  /** Repo-relative path. */
+  path: string;
+  /** File name only, for the EXEMPT map. */
+  base: string;
+  /** Exported class names declared in the file. */
+  classes: string[];
+  /** `selector: '…'` values declared in the file. */
+  selectors: string[];
+}
+
+/** Every tracked source file. `git ls-files`, not readdir — a gitignored or generated file is not the app. */
+function allSources(): string[] {
+  return execFileSync('git', ['ls-files', 'src/app'], { cwd: CLIENT, encoding: 'utf8' })
+    .split('\n').map(l => l.trim().replace(/\\/g, '/'))
+    .filter(p => p.endsWith('.ts') && !p.endsWith('.spec.ts'));
+}
+
+function tracked(): string[] {
+  return allSources().filter(p => p.endsWith('.component.ts'));
+}
+
+function parse(path: string): Comp {
+  const code = strip(readFileSync(resolve(CLIENT, path), 'utf8'));
+  return {
+    path,
+    base: path.split('/').pop()!,
+    classes: [...code.matchAll(/export class (\w+)/g)].map(m => m[1]),
+    selectors: [...code.matchAll(/selector:\s*'([^']+)'/g)].map(m => m[1]),
+  };
+}
+
+describe('every component is reachable', () => {
+  const comps = tracked().map(parse);
+  const routes = strip(readFileSync(resolve(CLIENT, 'src/app/app.routes.ts'), 'utf8'));
+  /**
+   * Every source file’s stripped text, so "who references X" is one pass rather than N reads.
+   *
+   * ALL sources, not just components — the first version scanned `*.component.ts` only and reported
+   * `ConfirmDialogComponent` as dead. It is instantiated dynamically by `ConfirmDialogService`, which is a
+   * perfectly good reachability path that a component-only scan cannot see. A checker whose scope is narrower
+   * than reality reports the gap as a defect.
+   */
+  const sources = new Map(allSources().map(p => [p, strip(readFileSync(resolve(CLIENT, p), 'utf8'))]));
+
+  it('found the components and the router (guards against a vacuous pass)', () => {
+    expect(comps.length).toBeGreaterThan(40);
+    expect(comps.every(c => c.classes.length > 0)).toBe(true);
+    expect(routes).toContain('loadComponent');
+  });
+
+  /** Is `c` named by the router, or by any component other than itself? */
+  const referrers = (c: Comp): string[] => {
+    const out: string[] = [];
+    if (c.classes.some(cls => routes.includes(cls))) out.push('app.routes.ts');
+    for (const [path, src] of sources) {
+      if (path === c.path) continue;
+      const byClass = c.classes.some(cls => new RegExp(`\\b${cls}\\b`).test(src));
+      // A selector counts as a reference only as an ELEMENT — matching the bare string would let a CSS rule
+      // or a stray mention keep a dead component alive.
+      const bySelector = c.selectors.some(sel => src.includes(`<${sel}`));
+      if (byClass || bySelector) out.push(path);
+    }
+    return out;
+  };
+
+  it('no component has only its own declaration referring to it', () => {
+    const dead = comps
+      .filter(c => !(c.base in EXEMPT))
+      .filter(c => referrers(c).length === 0)
+      .map(c => `${c.path}  (class ${c.classes.join(', ')})`);
+
+    expect(
+      dead,
+      'These components are unreachable — no route, no importer, no template usage. An unreachable file still '
+      + 'reads as documentation: #662 found one that had already caused a stale Help anchor, a gate guarding a '
+      + 'file nobody could open, and two orphaned i18n keys.\n'
+      + dead.map(d => `  - ${d}`).join('\n')
+      + '\n\nDelete it, or wire it up. If it is genuinely meant to be unreferenced, add it to EXEMPT with the reason.',
+    ).toEqual([]);
+  });
+
+  it('no exemption outlives its reason', () => {
+    for (const [base, reason] of Object.entries(EXEMPT)) {
+      const c = comps.find(x => x.base === base);
+      expect(c, `EXEMPT lists ${base}, which is not a tracked component — renamed or deleted?`).toBeDefined();
+      expect(
+        referrers(c!),
+        `${base} now HAS a referrer, so its exemption is stale — delete the entry. Reason given: ${reason}`,
+      ).toEqual([]);
+      expect(reason.length, `EXEMPT ${base} needs a real reason, not a placeholder.`).toBeGreaterThan(40);
+    }
+  });
+
+  it('no two components share an exported class name', () => {
+    // The collision that made #662's dead file look real: two `SchemaLibraryComponent`s, one routed and one
+    // not, so a reader (and an anchor table) could not tell which was the live page.
+    const byName = new Map<string, string[]>();
+    for (const c of comps) for (const cls of c.classes) {
+      byName.set(cls, [...(byName.get(cls) ?? []), c.path]);
+    }
+    const clashes = [...byName.entries()].filter(([, paths]) => paths.length > 1)
+      .map(([cls, paths]) => `${cls}: ${paths.join(' + ')}`);
+    expect(clashes, `two components exporting one class name is how a dead file passes for a live one:\n  ${clashes.join('\n  ')}`)
+      .toEqual([]);
+  });
+});


### PR DESCRIPTION
Queue item 1 (was item 5). The gate #662 argued for.

## Why automate it rather than trust a reader

`pages/settings/schema-library.component.ts` had no route, no importer, and a class name that collided with the
live Schema Library page. It was dead — **and it had already made four other things wrong** before anyone
noticed:

1. A Help anchor had been written for the URL that dead file *implied* (`/settings/schema-library`, which
   nothing routes to). So the **live** page — a top-level nav item — resolved to **no guide section at all**,
   while the anchor table looked complete.
2. A standalone gate pinned it, so that gate had been guarding a file nobody could open.
3. Two i18n keys existed in all three locales with the dead file as their only consumer.
4. An hour of my work fixing a component no user can reach.

**An unreachable file still reads as documentation.** The next reader — or the next gate, or the next anchor
table — takes its existence as evidence that its route, its keys and its behaviour are real. That is the cost,
and it is why one file being dead was not a tidy-up item.

## The four checks

- **Nothing is unreferenced.** Reachable = named by `app.routes.ts`, or by any other source file's class
  reference, or used as an element (`<app-foo`) in a template.
- **No exemption outlives its reason.** One entry today (`app.component.ts`, bootstrapped by `main.ts`), asserted
  to still exist and still be unreferenced — an allowlist is a ceiling, not a licence.
- **No two components export the same class name.** This is the check aimed squarely at how #662 happened: with
  two `SchemaLibraryComponent`s, a reader could not tell which one was routed.
- **A vacuous-pass guard** on the component count and the router parse.

## Two scope corrections it forced, both the same shape

**A checker narrower than reality reports the gap as a defect.**

- Scanning only `*.component.ts` reported **`ConfirmDialogComponent` as dead.** It is instantiated dynamically
  by `ConfirmDialogService` — a perfectly good reachability path a component-only scan cannot see. The referrer
  corpus is now every tracked source file.
- **My first verification was invalid, not the gate.** I dropped an unreachable probe component in and the gate
  passed — because `git ls-files` does not see an untracked file. Staged it and the gate named it immediately,
  then went green when it was removed. `git ls-files` stays (it is the right answer for "what files does this
  repo have", and `readdirSync` has burned this repo before), but a local verification has to stage first, which
  is now written down.

Comments are stripped before matching — the file's own header names a deleted component, and this is the eighth
gate here that would otherwise fire on the prose explaining its subject.

`npm run preflight` passes.
