### PR TITLE
docs(legal): attribute ffmpeg, and stop claiming it is LGPL when it is not

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,46 @@ jobs:
       # This exists because it once did not: 2.2.5 shipped with neither file. The image is the primary distribution,
       # so it was the one place Apache-2.0 §4(d) and the MIT notice clause actually applied, and the one place they
       # were unmet.
+      # The ffmpeg licence, verified against the BINARY rather than against our own documents.
+      #
+      # `ffmpeg-licensing-is-stated.test.js` asserts the Dockerfile comment and NOTICE agree with each other,
+      # because that check must run without Docker. Two documents agreeing is not the same as either being TRUE:
+      # the original bug was a Dockerfile that claimed LGPL-only while Debian shipped a GPL build, and no
+      # document-level check could ever have caught it.
+      #
+      # So the published image is asked what it actually contains. If Debian ever ships an LGPL build, or if
+      # somebody switches to a custom one, this fails and NOTICE has to be updated in the same change — which is
+      # the whole point: the artefact is what we redistribute, so the artefact is what has to match the notice.
+      - name: Verify ffmpeg is the licence NOTICE claims
+        run: |
+          IMAGE="$(echo '${{ steps.meta.outputs.tags }}' | head -n1)"
+          BUILD="$(docker run --rm --entrypoint ffmpeg "$IMAGE" -buildconf 2>/dev/null || true)"
+          if [ -z "$BUILD" ]; then
+            echo "  FAIL: could not run ffmpeg -buildconf in $IMAGE."
+            echo "  If ffmpeg was deliberately removed, drop this step AND its NOTICE section in the same change."
+            exit 1
+          fi
+          if echo "$BUILD" | grep -q -- "--enable-gpl"; then
+            ACTUAL="GPL-2.0-or-later"
+          else
+            ACTUAL="LGPL-2.1-or-later"
+          fi
+          echo "  ffmpeg as built: $ACTUAL"
+          # NOTICE ships inside the image, so the comparison is image-internal and cannot drift from the tag.
+          if docker run --rm --entrypoint sh "$IMAGE" -c "grep -q 'General Public License v2.0 or later' /app/NOTICE"; then
+            CLAIMED="GPL-2.0-or-later"
+          else
+            CLAIMED="LGPL-2.1-or-later"
+          fi
+          echo "  NOTICE claims:  $CLAIMED"
+          if [ "$ACTUAL" != "$CLAIMED" ]; then
+            echo "  FAIL: the shipped ffmpeg is $ACTUAL but NOTICE documents $CLAIMED."
+            echo "  Update the NOTICE section \"Runtime Dependency: FFmpeg\" and the Dockerfile comment to match"
+            echo "  the binary. This is the exact drift that shipped in 2.2.5 undetected."
+            exit 1
+          fi
+          echo "  ok: the binary and NOTICE agree"
+
       - name: Verify the licence and notices are in the published image
         run: |
           IMAGE="$(echo '${{ steps.meta.outputs.tags }}' | head -n1)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **FFmpeg is now attributed, and the Dockerfile no longer claims the opposite of what ships.** The image
+  installs Debian’s `ffmpeg`, and **Debian builds it with `--enable-gpl`** — so the redistributed binary is
+  GPL-2.0-or-later, not the LGPL-2.1+ that FFmpeg’s core alone would be.
+  - The Dockerfile asserted *"LGPL-2.1+ core only (no GPL codecs)"* and told the reader to verify that
+    `--enable-gpl` must be absent. Running that one command disproves it — on a fresh build **and** on the
+    released 2.2.5 image, so the stated verification cannot ever have been run. Two documents that could not
+    both be true, with the comment naming the command that settles it.
+  - **The sharper half: FFmpeg appeared in `NOTICE` zero times.** Every optional sidecar had a careful
+    runtime-dependency entry — including LibreOffice’s MPL/LGPL with a corresponding-source offer — while the
+    one GPL binary, shipping in the *main* image, had no attribution at all.
+  - `NOTICE` gains a **Runtime Dependency: FFmpeg** section naming GPL-2.0-or-later as Debian builds it, recording
+    that the executable is invoked as a **separate process** and never linked (the same argument `NOTICE`
+    already makes for LibreOffice), and offering corresponding source from ffmpeg.org and the Debian source
+    packages. The separate-process argument covers Ythril’s own code; it does not cover redistributing the
+    binary, which is what the attribution and source offer are for.
+  - Gate `ffmpeg-licensing-is-stated`: FFmpeg must be attributed, the licence named must be the one Debian
+    builds, the source offer must point somewhere real, and **the two documents must agree**. It cannot strip
+    comments — the comment *is* the claim under test — so it distinguishes asserting the false claim from
+    quoting it, which the ninth-in-a-row gate-fires-on-its-own-explanation incident forced it to learn.
+  - **And the artefact is checked, not just the documents.**  now runs  in the
+    published image, derives the licence from whether  is present, and compares it against the
+     that ships *inside that same image*. Two documents agreeing is not the same as either being true —
+    the original bug was precisely a pair of self-consistent documents that both described a different binary,
+    and no document-level check could ever have caught it. If Debian switches builds, or somebody supplies a
+    custom ffmpeg, the publish fails until NOTICE is updated in the same change.
+  - Not asserted, deliberately: whether this attribution is legally *sufficient*, or how it interacts with
+    offering commercial terms later. That needs a qualified answer, alongside the export-notice question. What
+    is fixed here is two documents telling the truth about what is in the image.
+
 - **The shipped image no longer carries a C++ toolchain.** The production stage installed `python3 make g++`
   purely so `npm ci --omit=dev` could compile the bcrypt native addon — a compiler in the image that nothing at
   runtime uses. A `prod-deps` stage now installs the production tree with the toolchain and production copies the

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,22 @@ LABEL org.opencontainers.image.licenses="PolyForm-Small-Business-1.0.0"
 # on every release for no reason anyone wanted: `apt-get update` is not reproducible, so it was re-downloaded on
 # every pull even when nothing about it had changed.
 #
-# ffmpeg: LGPL-2.1+ core only (no GPL codecs); used for audio/video media embedding pipeline.
-# Verify at build time: ffmpeg -buildconf | grep enable-gpl must be absent.
+# ffmpeg, for the audio/video media embedding pipeline.
+#
+# LICENSING, corrected 2026-08-04 — this comment used to claim "LGPL-2.1+ core only (no GPL codecs)" and told
+# the reader to verify that `--enable-gpl` was absent. Running that check disproves it: **Debian builds ffmpeg
+# WITH `--enable-gpl`**, so the binary shipped here is GPL-2.0-or-later. It reported the same in the released
+# 2.2.5 image, so the stated verification cannot ever have been run — the comment asserted the opposite of the
+# artefact while naming the command that would have caught it.
+#
+# Why it is still fine to ship, and it is the same argument NOTICE already makes for LibreOffice in the
+# doc-office sidecar: the executable is invoked as a SEPARATE PROCESS (`spawn('ffmpeg', …)` in
+# files/media/{audio,video}-embedder.ts), never linked into Ythril. What that argument does NOT cover is
+# redistribution of the binary itself, which needs attribution and a corresponding-source offer — now present
+# in NOTICE under "Bundled Binary: FFmpeg". It had been missing entirely.
+#
+# Asserted by `testing/standalone/ffmpeg-licensing-is-stated.test.js` so the claim and the artefact cannot drift
+# apart again in either direction.
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/NOTICE
+++ b/NOTICE
@@ -207,6 +207,33 @@ Copyright (c) 2018 Filip Skokan
 License: Apache License 2.0
 Copyright (c) 2015 Simon Nyberg
 
+### Runtime Dependency: FFmpeg (Debian `ffmpeg`, inside the Ythril image)
+
+The Ythril production image installs Debian’s `ffmpeg` package. It is used by the audio and video embedding
+pipeline (`files/media/audio-embedder.ts`, `files/media/video-embedder.ts`), which invokes the `ffmpeg`
+executable as a **separate process** via `spawn()` — it is not linked into, or distributed as part of, Ythril’s
+own program. This is the same relationship Ythril has with LibreOffice in the optional `doc-office` sidecar,
+described below.
+
+**Debian builds FFmpeg with `--enable-gpl`**, so the binary Ythril redistributes is licensed under the GNU
+General Public License v2.0 or later, not the LGPL-2.1+ that FFmpeg’s core alone would be. Verify on any
+image with `ffmpeg -buildconf`.
+
+- FFmpeg (Debian `ffmpeg` and its dependencies) — GNU General Public License v2.0 or later, as built by
+  Debian. Copyright the FFmpeg developers. Invoked as a separate process; not linked. **Corresponding source
+  is available** from the FFmpeg project (https://ffmpeg.org/download.html, and
+  https://git.ffmpeg.org/ffmpeg.git) and from the Debian source packages for the exact versions shipped
+  (`apt-get source ffmpeg` against the image’s `bookworm` sources, or
+  https://sources.debian.org/src/ffmpeg/).
+
+The GPL-2.0-or-later license text ships inside the image at `/usr/share/doc/ffmpeg/copyright`, together with
+the per-component copyright records Debian installs for every package.
+
+> This entry was added on 2026-08-04. FFmpeg had been absent from this file while every optional sidecar was
+> documented — so the most restrictively-licensed binary in the product was the only one with no attribution,
+> and it ships in the main image rather than an opt-in one. The Dockerfile had also asserted the opposite
+> (“LGPL-2.1+ core only”) while naming the command that disproves it.
+
 ### Runtime Dependency: mongodb/mongodb-atlas-local (Docker image)
 
 Ythril's `docker-compose.yml` references the `mongodb/mongodb-atlas-local` container

--- a/testing/standalone/ffmpeg-licensing-is-stated.test.js
+++ b/testing/standalone/ffmpeg-licensing-is-stated.test.js
@@ -1,0 +1,105 @@
+/**
+ * The ffmpeg licensing claim and the shipped artefact must not drift apart — in EITHER direction.
+ *
+ * ## The failure this exists for
+ *
+ * The Dockerfile asserted *"ffmpeg: LGPL-2.1+ core only (no GPL codecs)"* and instructed the reader to verify
+ * that `--enable-gpl` must be absent. Running that one command disproves it: Debian builds ffmpeg **with**
+ * `--enable-gpl`, so the shipped binary is GPL-2.0-or-later. It reported the same on the released 2.2.5 image,
+ * so the stated verification cannot ever have been run.
+ *
+ * Two documents that could not both be true, with the comment naming the command that settles it. The same
+ * shape as every other finding in this audit round — and worse than most, because it was a **licensing** claim
+ * on the primary distribution, and because ffmpeg was simultaneously the one bundled binary with **no NOTICE
+ * entry at all** while every optional sidecar had a careful one.
+ *
+ * ## Why this gate is about the CLAIM, not the codecs
+ *
+ * It cannot run ffmpeg — no Docker in the offline suite. What it can do is stop the two files from disagreeing:
+ * if someone later builds an LGPL-only ffmpeg (a legitimate option), they must update NOTICE in the same
+ * change, and if someone re-adds a "no GPL" claim without doing that work, this fails.
+ *
+ * Comments are NOT stripped here, unusually: the Dockerfile comment IS the claim under test.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const dockerfile = readFileSync(join(ROOT, 'Dockerfile'), 'utf8');
+const notice = readFileSync(join(ROOT, 'NOTICE'), 'utf8');
+
+describe('the ffmpeg licensing claim matches what ships', () => {
+  it('found both documents (guards against a vacuous pass)', () => {
+    assert.match(dockerfile, /install[^\n]*ffmpeg/, 'the Dockerfile no longer installs ffmpeg — retire this gate');
+    assert.ok(notice.length > 5000, 'NOTICE looks truncated');
+  });
+
+  it('ffmpeg is attributed in NOTICE at all', () => {
+    // It was not, for the entire life of the feature. Every optional sidecar had an entry; the one GPL binary,
+    // in the MAIN image, had none.
+    assert.match(notice, /FFmpeg/i, 'ffmpeg ships in the image and must appear in NOTICE');
+  });
+
+  it('NOTICE names the licence Debian actually builds, not the one ffmpeg could have been', () => {
+    const at = notice.search(/###[^\n]*FFmpeg/i);
+    assert.ok(at > 0, 'no FFmpeg section heading in NOTICE');
+    const section = notice.slice(at, notice.indexOf('\n### ', at + 5));
+    assert.match(section, /General Public License v2\.0 or later|GPL-2\.0-or-later/,
+      'Debian builds ffmpeg with --enable-gpl, so the shipped binary is GPL-2.0-or-later');
+    assert.match(section, /--enable-gpl/, 'the section should name the flag, so a reader can verify it themselves');
+  });
+
+  it('NOTICE offers corresponding source for the binary', () => {
+    // The separate-process argument covers Ythril's own code. It does not cover redistributing the binary.
+    const at = notice.search(/###[^\n]*FFmpeg/i);
+    const section = notice.slice(at, notice.indexOf('\n### ', at + 5));
+    assert.match(section, /[Cc]orresponding source/, 'a GPL binary needs a corresponding-source offer');
+    assert.match(section, /ffmpeg\.org|git\.ffmpeg\.org|sources\.debian\.org/,
+      'the source offer must point somewhere real');
+  });
+
+  it('NOTICE records that it is a separate process, not linked', () => {
+    const at = notice.search(/###[^\n]*FFmpeg/i);
+    const section = notice.slice(at, notice.indexOf('\n### ', at + 5));
+    assert.match(section, /separate process/i);
+    assert.match(section, /not linked/i);
+  });
+
+  it('the Dockerfile does not claim ffmpeg is LGPL-only', () => {
+    // The precise regression to prevent: re-asserting the comforting version without doing the work that would
+    // make it true. Scoped to the ffmpeg RUN's own comment block, since NOTICE-adjacent text elsewhere in the
+    // file legitimately discusses LGPL for other components.
+    const at = dockerfile.search(/# ffmpeg, for the|# ffmpeg:/);
+    assert.ok(at > 0, 'could not find the ffmpeg comment block — re-anchor this gate');
+    const block = dockerfile.slice(at, dockerfile.indexOf('RUN apt-get', at));
+
+    // QUOTED spans are removed before matching, and this gate had to learn it the hard way: the corrected
+    // comment necessarily *quotes* the false claim in order to record that it was false, and the first version
+    // of this assertion fired on that quotation. Stripping comments is not an option here — the comment IS the
+    // claim under test — so the distinction has to be assertion vs. quotation instead.
+    //
+    // Ninth gate in this repo to fire on the prose explaining its own subject. The tempting "fix" every time is
+    // to delete the explanation, which is precisely the wrong move.
+    const unquoted = block.replace(/"[^"]*"|“[^”]*”/g, ' ');
+
+    assert.doesNotMatch(unquoted, /LGPL-2\.1\+ core only|no GPL codecs/,
+      'this claim is false for Debian ffmpeg. If an LGPL-only build is introduced, update NOTICE in the same '
+      + 'change and then this assertion can be inverted. (Quoting the old claim to explain it is fine — put it '
+      + 'in quotes.)');
+    assert.match(block, /GPL-2\.0-or-later|General Public License/,
+      'the comment must state the licence that actually ships');
+  });
+
+  it('the two documents agree', () => {
+    // The invariant, stated once: whatever the Dockerfile says about ffmpeg's licence, NOTICE says the same.
+    const claimsGpl = /GPL-2\.0-or-later|General Public License/.test(dockerfile.slice(
+      dockerfile.search(/# ffmpeg, for the|# ffmpeg:/),
+      dockerfile.indexOf('RUN apt-get', dockerfile.search(/# ffmpeg, for the|# ffmpeg:/)),
+    ));
+    const noticeGpl = /General Public License v2\.0 or later|GPL-2\.0-or-later/.test(notice);
+    assert.equal(claimsGpl, noticeGpl,
+      'the Dockerfile and NOTICE disagree about ffmpeg\'s licence — that disagreement is the original bug');
+  });
+});


### PR DESCRIPTION
Owner-approved (2026-08-04). Documentation and verification only — **no licence change**, and it deliberately
does not attempt to resolve the deeper legal question.

## The facts

The image installs Debian's `ffmpeg`, and **Debian builds it with `--enable-gpl`**. So the binary Ythril
redistributes is **GPL-2.0-or-later**, not the LGPL-2.1+ that FFmpeg's core alone would be.

The Dockerfile asserted *"LGPL-2.1+ core only (no GPL codecs)"* — and told the reader to verify that
`--enable-gpl` **must be absent**. Running that one command disproves it, on a fresh build *and* on released
`2.2.5`. **The stated verification cannot ever have been run.** Two documents that could not both be true, with
the comment naming the command that settles it.

## The sharper half, found by looking rather than by reasoning

**FFmpeg appeared in `NOTICE` zero times.** Every optional sidecar had a careful runtime-dependency entry —
including LibreOffice's MPL/LGPL with a corresponding-source offer — while the one **GPL** binary, shipping in
the **main** image rather than an opt-in one, had no attribution at all.

That reframed the whole thing. The open obligation was never about Ythril's source; it was attribution and a
source offer for a binary we redistribute.

## What this does

`NOTICE` gains a **Runtime Dependency: FFmpeg** section, mirroring the LibreOffice precedent exactly:

- names **GPL-2.0-or-later as Debian builds it**, and names `ffmpeg -buildconf` so a reader can check;
- records that the executable is invoked as a **separate process** (`spawn('ffmpeg', …)` in
  `files/media/{audio,video}-embedder.ts`) and **never linked** — the same argument `NOTICE` already makes for
  LibreOffice via `soffice`;
- offers **corresponding source** from ffmpeg.org, `git.ffmpeg.org`, and the Debian source packages for the exact
  version shipped;
- points at the licence text Debian installs at `/usr/share/doc/ffmpeg/copyright`, the way the sidecar sections
  handle theirs.

The Dockerfile comment now states what actually ships, and explains why it is still fine to ship it.

## Two checks, at two levels — because one of them could never have caught this

| | |
|---|---|
| **`ffmpeg-licensing-is-stated`** (offline) | FFmpeg must be attributed; the licence named must be the one Debian builds; the source offer must point somewhere real; the Dockerfile and `NOTICE` must **agree**. |
| **`publish.yml`** (artefact) | Runs `ffmpeg -buildconf` in the **published image**, derives the licence from `--enable-gpl`, and compares it against the `NOTICE` shipping *inside that same image*. |

**The second is the owner's suggestion and it is the leg that matters.** Two documents agreeing is not the same
as either being *true* — the original bug was a self-consistent pair that both described a different binary, and
no document-level check could ever have caught it. If Debian switches builds, or somebody supplies a custom
ffmpeg, the publish now fails until `NOTICE` is updated in the same change.

One implementation note worth recording: the offline gate **cannot strip comments**, because the Dockerfile
comment *is* the claim under test. So it distinguishes **asserting** the false claim from **quoting** it — which
the ninth gate-fires-on-its-own-explanation incident in this repo forced it to learn. Verified by mutation:
re-asserting "LGPL-2.1+ core only" unquoted turns it red.

## What is explicitly not resolved

Whether this attribution is legally **sufficient**, and how it interacts with offering commercial terms later.
That needs a qualified answer, alongside the export-notice question already queued in `_PARKED-DECISIONS.md`.
The contingency options — an LGPL-only ffmpeg build, or dropping ffmpeg from the image — remain open and are
recorded there.

What is fixed here is two documents telling the truth about what is in the image, and a check that keeps them
honest.

`npm run preflight` passes.
