### PR TITLE
fix(ci): the CLA workflow never ran — an invalid if: made every run a startup failure

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -48,13 +48,27 @@ jobs:
         && contains(github.event.comment.body, 'I have read the CLA Document'))
       || github.event_name == 'pull_request_target'
     steps:
+      # The secret is read through `env`, and the emptiness test happens in the SHELL.
+      #
+      # This step previously used `if: ${{ secrets.CLA_SIGNATURES_TOKEN == '' }}`. The `secrets` context is not
+      # available in an `if:` conditional — only in `env:` and `with:` — so the whole workflow was an invalid
+      # expression and every run was a STARTUP FAILURE: zero jobs, conclusion "failure", one per push, and an
+      # email each time. The workflow therefore never ran at all from the day it was added, so the CLA was not
+      # being enforced despite the check appearing to exist.
+      #
+      # That is a nastier shape than a broken step: a workflow that fails to start looks, in the runs list, much
+      # like a workflow that ran and failed. The tell is "No jobs were run".
       - name: Fail with a readable reason if the PAT is missing or expired
-        if: ${{ secrets.CLA_SIGNATURES_TOKEN == '' }}
+        env:
+          CLA_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         run: |
-          echo "::error::CLA_SIGNATURES_TOKEN is not set. This check cannot record a signature without it."
-          echo "Create a fine-grained PAT (Contents: RW, Pull requests: RW, this repo only) and add it as a"
-          echo "repository secret named CLA_SIGNATURES_TOKEN. See todo/_CLA-BOT-SETUP.md."
-          exit 1
+          if [ -z "$CLA_TOKEN" ]; then
+            echo "::error::CLA_SIGNATURES_TOKEN is not set. This check cannot record a signature without it."
+            echo "Create a fine-grained PAT (Contents: RW, Pull requests: RW, this repo only) and add it as a"
+            echo "repository secret named CLA_SIGNATURES_TOKEN. See todo/_CLA-BOT-SETUP.md."
+            exit 1
+          fi
+          echo "CLA_SIGNATURES_TOKEN is present."
 
       - name: Check the CLA
         uses: contributor-assistant/github-action@v2.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The CLA check had never run once.** An invalid `if:` expression made every run a *startup* failure — zero
+  jobs, conclusion `failure`, one per push. The owner noticed because of the emails; the real cost was that the
+  CLA was not being enforced at all from the day #665 added it, while the repository looked guarded.
+  - The expression was `if: ${{ secrets.CLA_SIGNATURES_TOKEN == '' }}`. **The `secrets` context is not available
+    in `if:`** — only in `env:` and `with:` — and GitHub rejects the whole workflow rather than the one line. The
+    secret is now read through `env:` and tested in the shell, which keeps the actionable error message.
+  - **Diagnosed by measuring, not guessing:** `gh run list --workflow=cla.yml` showed 12 runs, all
+    `event: push`, all `failure` — on a workflow whose `on:` block has no push trigger. That mismatch, plus "No
+    jobs were run", is the signature of a startup failure, which in the runs list looks almost exactly like a
+    check that ran and failed. That resemblance is why nothing here caught it.
+  - Gate `workflows-are-valid`: every workflow parses, declares a trigger and a job with `runs-on` or `uses`, and
+    **no `if:` anywhere reads the `secrets` context**. It cannot replace GitHub's own validation; it closes the
+    class of error whose cost is a silent outage rather than a red X.
+
 - **An embedded iframe narrower than 768px had no navigation at all.** Below that width the sidebar is an
   off-canvas drawer and the hamburger is the only thing that opens it — and the hamburger lived in the topbar,
   which `?embedded=1` removes because it duplicates the host portal's chrome. So a portal embedding Ythril in a

--- a/testing/standalone/workflows-are-valid.test.js
+++ b/testing/standalone/workflows-are-valid.test.js
@@ -1,0 +1,82 @@
+/**
+ * A workflow that fails to START looks almost exactly like a workflow that ran and failed.
+ *
+ * ## The failure this exists for
+ *
+ * `cla.yml` shipped in #665 with `if: ${{ secrets.CLA_SIGNATURES_TOKEN == '' }}` on a step. The `secrets` context
+ * is **not available in an `if:` conditional** — only in `env:` and `with:`. So the expression was invalid, and
+ * GitHub responded the way it does to any invalid workflow: it created a run for every push, concluded it
+ * **failure**, ran **zero jobs**, and emailed about each one.
+ *
+ * The consequence was not the email. It was that **the CLA was never enforced at all** — from the day the check
+ * was added, it had never once executed, while the runs list showed activity and the repository looked guarded.
+ * The owner noticed because of the noise; nothing in this repo would have.
+ *
+ * The tell, in the runs list, is `event: push` on a workflow that has no `push` trigger, plus "No jobs were run".
+ *
+ * ## What this checks
+ *
+ * The static half of what GitHub's validator would have caught, offline: every workflow parses as YAML, declares
+ * a trigger and at least one job, and — the specific trap — never reads `secrets` from a place where the context
+ * does not exist.
+ *
+ * It cannot replace GitHub's own validation. It closes the class of error that costs a silent, invisible outage.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'js-yaml';
+
+const DIR = join(process.cwd(), '.github', 'workflows');
+const files = readdirSync(DIR).filter(f => f.endsWith('.yml') || f.endsWith('.yaml'));
+
+describe('every workflow would start', () => {
+  it('found the workflows (guards against a vacuous pass)', () => {
+    assert.ok(files.length >= 3, `expected several workflows, found ${files.length}`);
+  });
+
+  it('each one parses, and declares a trigger and a job', () => {
+    for (const f of files) {
+      const doc = load(readFileSync(join(DIR, f), 'utf8'));
+      assert.ok(doc && typeof doc === 'object', `${f}: does not parse to a mapping`);
+      // `on:` is YAML 1.1 truthy, so js-yaml gives the key back as boolean true. Accept either.
+      const triggers = doc.on ?? doc[true];
+      assert.ok(triggers, `${f}: no 'on:' trigger`);
+      assert.ok(doc.jobs && Object.keys(doc.jobs).length > 0, `${f}: no jobs`);
+      for (const [name, job] of Object.entries(doc.jobs)) {
+        assert.ok(job['runs-on'] || job.uses, `${f}: job '${name}' has neither runs-on nor uses`);
+      }
+    }
+  });
+
+  it('no `if:` reads the secrets context — the exact trap that silently disabled cla.yml', () => {
+    // GitHub rejects the whole workflow rather than the one expression, so the blast radius is every job in the
+    // file. Read the secret through `env:` and test it in the shell instead.
+    const bad = [];
+    for (const f of files) {
+      const raw = readFileSync(join(DIR, f), 'utf8');
+      raw.split('\n').forEach((line, i) => {
+        // `if:` at any nesting, containing `secrets.` anywhere in the expression.
+        if (/^\s*if:\s/.test(line) && /\bsecrets\s*\./.test(line)) {
+          bad.push(`${f}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    assert.deepEqual(bad, [],
+      'the `secrets` context is unavailable in `if:`; GitHub treats this as an invalid workflow, so every run '
+      + 'becomes a startup failure with zero jobs — which reads as a failing check rather than a check that '
+      + 'never ran:\n  ' + bad.join('\n  '));
+  });
+
+  it('a job that needs a PAT does not silently fall back to GITHUB_TOKEN', () => {
+    // Adjacent trap: `pull_request_target` from a fork gets a read-only GITHUB_TOKEN, so a job that must write
+    // has to be handed a PAT explicitly. If a workflow names a PAT-ish secret it should actually pass it.
+    for (const f of files) {
+      const raw = readFileSync(join(DIR, f), 'utf8');
+      if (!/PERSONAL_ACCESS_TOKEN|_TOKEN:\s*\$\{\{\s*secrets\./.test(raw)) continue;
+      assert.match(raw, /\$\{\{\s*secrets\.[A-Z_]+\s*\}\}/,
+        `${f}: references a token but never interpolates a secret`);
+    }
+  });
+});


### PR DESCRIPTION
The owner reported a stream of `.github/workflows/cla.yml: No jobs were run` emails.

**The noise was the symptom. The cause is worse: that workflow has never executed once since #665 added it** — so
the CLA has not been enforced at all, while the repository looked guarded.

## The bug is mine, and it is the step I was pleased about

```yaml
if: ${{ secrets.CLA_SIGNATURES_TOKEN == '' }}
```

The `secrets` context **is not available in an `if:` conditional** — only in `env:` and `with:`. GitHub rejects
the *whole workflow* rather than the one expression, so every push produced a run with zero jobs, conclusion
`failure`, and an email.

## Diagnosed by measuring, not by guessing at the trigger

My first instinct was that `issue_comment` fires repo-wide and the job was being skipped. That would have been a
plausible story and it was wrong. One command:

```
gh run list --workflow=cla.yml   ->   12 runs, all `event: push`, all `failure`
```

**`event: push` on a workflow whose `on:` block has no push trigger.** That mismatch, plus "No jobs were run", is
the signature of a *startup* failure — and in the runs list a startup failure looks almost exactly like a check
that ran and failed. That resemblance is precisely why nothing in this repo caught it and the owner's inbox did.

## The fix

The secret is read through `env:` and the emptiness test happens in the shell — the supported pattern, and it
keeps the actionable error message about creating the PAT.

## The gate

`workflows-are-valid.test.js` — the static half of what GitHub's validator would have caught, offline:

- every workflow parses as YAML;
- each declares a trigger and at least one job, and every job has `runs-on` or `uses`;
- **no `if:` anywhere reads the `secrets` context** — the specific trap;
- a token-shaped secret is actually interpolated somewhere, since a `pull_request_target` job from a fork gets a
  read-only `GITHUB_TOKEN` and has to be handed a PAT explicitly.

Mutation-verified: reintroducing the exact expression fails and names the file and line.

It cannot replace GitHub's own validation. It closes the class of error whose cost is a **silent** outage rather
than a red X — which is the only reason this one survived as long as it did.

## Worth stating plainly

I told you in #665 that the CLA was "enforced rather than stated". It was not. The document shipped, the
enforcement did not, and I had no evidence for the claim beyond the file existing — the same shape as the ffmpeg
comment that asserted a verification nobody had run.

`npm run preflight` passes. After this merges, the next push should produce a CLA run that actually executes and
passes via the allowlist rather than one that never starts.
