### PR TITLE
release: 2.3.0

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -50,9 +50,14 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     # Act on a signing comment, or on a pull-request event — not on every issue comment in the repository.
+    # Both comment paths, not just the signing one. The action is configured with a `suggest-recheck` message
+    # telling contributors to comment "recheck" if the status has not updated — and this condition used to
+    # exclude exactly that comment, so the documented recovery path silently did nothing. Found by using the
+    # feature as its own message describes.
     if: >
       (github.event.issue.pull_request != null
-        && contains(github.event.comment.body, 'I have read the CLA Document'))
+        && (contains(github.event.comment.body, 'I have read the CLA Document')
+            || contains(github.event.comment.body, 'recheck')))
       || github.event_name == 'pull_request_target'
     steps:
       # The secret is read through `env`, and the emptiness test happens in the SHELL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - It deliberately does **not** assert that the NOTICE paragraph still exists or still says the right words.
     Prose does not drift on its own, nothing regenerates that section, and a check earns its place by catching
     something that can change — not by restating a file back to itself.
-  - **And the artefact is checked, not just the documents.**  now runs  in the
-    published image, derives the licence from whether  is present, and compares it against the
-     that ships *inside that same image*. Two documents agreeing is not the same as either being true —
+  - **And the artefact is checked, not just the documents.** `publish.yml` now runs `ffmpeg -buildconf` in the
+    published image, derives the licence from whether `--enable-gpl` is present, and compares it against the
+    `NOTICE` that ships *inside that same image*. Two documents agreeing is not the same as either being true —
     the original bug was precisely a pair of self-consistent documents that both described a different binary,
     and no document-level check could ever have caught it. If Debian switches builds, or somebody supplies a
     custom ffmpeg, the publish fails until NOTICE is updated in the same change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] — 2026-08-04
+
 ### Added
 
 - **Lost updates on brain records are now counted**, ahead of building the `If-Match` path — the owner's

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.2.5",
+      "version": "2.3.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.2.5",
+      "version": "2.3.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.2.5",
+      "version": "2.3.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**48 commits since v2.2.5.** The queue that gated this release is drained — see the note at the end on why the
three remaining items could not be done before it.

## Why minor, not patch

Backward-compatible features: **opt-in backup encryption**, the **audit-log NDJSON export**, new metrics. No
`[Unreleased]` entry is marked BREAKING — checked, zero matches.

## What is in it

Six audit lenses finished: **1 Legal · 12 Privacy · 9 Operability · 11 a11y/i18n · 13 Docs · 6 UX.**

**Every finding had the same shape: a stated guarantee that something else quietly bypassed.** Never undocumented
behaviour — always two documents, or a document and a build, that could not both be true. The four worth
remembering:

- **A failed load rendered as an empty list on eight surfaces.** `/files/conflicts` answered a 500 with a green
  check-circle and *"No conflicts — all synced files are in agreement."* `/brain` told a user with a full brain to
  create their first space.
- **A narrow embedded iframe had no navigation at all.** The topbar's hide-condition was *correct* about the logo
  and Sign out, and silently took the hamburger with it — the only control that can open an off-canvas sidebar.
- **The Dockerfile asserted ffmpeg was LGPL-only while naming the command that disproves it**, and ffmpeg appeared
  in `NOTICE` zero times — the one GPL binary, in the main image, was the only component with no attribution.
- **The CLA workflow had never executed once.** An invalid `if:` made every run a startup failure, so the check
  existed and enforced nothing.

Twenty-plus gates were added, and about ten existing ones were **re-pointed rather than appeased** — each because
it asserted a *mechanism* instead of the guarantee it existed to protect.

## What this PR is, and is not

Version roll across the three manifests plus the lockfile, and the `[Unreleased]` section closed as `2.3.0`.

**Remaining, in order:** the annotated tag · the publish workflow run · verifying all four tags on **both** GHCR
and Docker Hub with the pulled image reporting `2.3.0` from its own `package.json` · then the canary hand-off.

## The canary hand-off matters more than usual this time

Per the standing gate, **breituai's exercise is the release gate**, not a per-PR check. Two things go in the one
outgoing document:

1. **A request for one `/metrics` scrape taken during an ingest.** This tag carries #628's collector timing to
   them for the first time, which is the only thing that can name which collector owns the 10 s in their
   `up=0` windows. That finding has been unactionable purely because the instrument never reached them.
2. **A note that canary I — the governed-save "Done" button — is confirmed already shipped.** It had been sitting
   in the tracker labelled open while the code had the fix.

## Why three items sit behind this release rather than before it

Each one's *next step* is impossible until a build reaches the canary, so doing them first was not an option:

- **`/metrics` timeout** — the collector-timing instrument shipped after 2.2.5, so their build cannot measure it.
- **Image layer split** — the next step is a real two-tag pull, which needs two published tags with the current
  layer shape. The original "96% re-downloaded" predates both the duplicate-model fix and #670.
- **Optimistic concurrency** — the owner's own sequencing was *"ship the counter first, it says in a week whether
  the collision is common or theoretical."* The counter shipped in #674 and has been live for minutes on a dev
  machine with no MCP agents.

`npm run preflight` passes.
