### PR TITLE
fix(metrics): a slow collector blinded the whole target, not just its own graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ docs/docker-build-protocol.md
 # publish it before the fixes ship.)
 todo/
 
+# Correspondence with people outside the repo — never commit. Both directions of
+# every conversation with a customer or canary operator, including their
+# deployment details, their findings before the fixes ship, and quoted internals
+# of their own systems. Theirs to share, not ours.
+communication/
+
 # Local-only automation scaffolding — n8n auditor workflow drafts + prompts.
 # Not part of the shipped product; kept out of the repo by design.
 n8n/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A slow `/metrics` collector now degrades one graph instead of blinding the whole target** (canary
+  finding: the scrape hit its 10 s Prometheus timeout twice during an ingest, with `up=0` for both windows).
+  - **The consequence was out of all proportion to the cause**, which is the reason this is a fix and not a
+    performance item. A slow scrape does not lose the slow collector — Prometheus records `up=0` and **drops
+    every series from that target**: HTTP latency, event-loop lag, embed throughput, including the series that
+    would explain the outage. The canary put it exactly right, and it decided the shape of the fix: *"a missing
+    series is a gap in one graph; a failed scrape drops every series from that target."* So a partial scrape,
+    never "make it usually fast enough".
+  - The scrape now has a deadline (`METRICS_SCRAPE_BUDGET_MS`, default **8000** — under the Prometheus
+    default of 10 s with room for serialisation and transfer). A collector that cannot finish inside it is
+    abandoned: **its** series are dropped for that scrape, `ythril_metrics_collect_timeouts_total` counts
+    it by name, `ythril_metrics_scrape_degraded` reads `1`, and everything else is served normally
+    with `up` still 1.
+  - **This half needed none of the canary data the diagnosis needs**, which is why it did not wait for the
+    tag: the guard is collector-agnostic by construction. And the timeout counter turns out to *also* do the
+    diagnosis — it names the slow collector without anyone having to catch a scrape while it is happening,
+    which was otherwise the hard part, since the problem only appears under their load.
+  - **The abandoned collector is dropped rather than left holding its last values.** Stale numbers presented as
+    current are indistinguishable from a healthy flat line — an operator would read "storage steady" off a
+    collector that has not answered in an hour. Same principle as pre-declaring counters at zero: absent must
+    not be confusable with fine. An error, by contrast, keeps the previous values exactly as before — MongoDB
+    briefly unavailable at boot is the normal case, and "momentarily unavailable" is not "unknown".
+  - **One shared deadline is correct only because collection is concurrent.** prom-client 15 collects with
+    `Promise.all`, so the nine collectors run at once and the scrape costs the slowest, not the sum — verified
+    against the library rather than assumed, because a per-collector budget would have to be one-ninth as
+    generous to give the same guarantee.
+  - **A bug found and fixed inside this change, worth recording because the first version shipped it:** the
+    same concurrency that makes the deadline work broke the *reporting* of a timeout. prom-client serialises
+    each metric as soon as its own value is ready, so a counter that another collector increments was written
+    out at 0 before the timeout had happened. The budget worked, the scrape returned fast, and both new metrics
+    read 0 — a guard with no way to tell you it fired. Fixed with a one-microtask barrier, which the mutation
+    run confirms is load-bearing: removing that single `await` fails three tests.
+  - **9 tests, and all 9 mutations caught.** The last one only after a rewrite: the `METRICS_SCRAPE_BUDGET_MS`
+    fallback test asserted an *effect* (a fast collector still completes) that holds whether a malformed value
+    falls back to 8000 or to 0 — so a mutation silently disabling the guard on a typo'd env var passed it. The
+    parsed value is now asserted directly, as a **choice**.
+  - `collectors-are-timed` was **re-pointed, not appeased.** It pinned the mechanism — `collectTimer(` on the
+    first line of each collector and a matching `done()` count — and would now fail against strictly better
+    code, since the wrapper owns both and stops the clock in a `finally` where the old hand-rolled `done()` sat
+    after the try/catch and an early return would have skipped it. It now asserts the guarantee: every async
+    collector routes through the wrapper, and the wrapper times before it awaits and stops on every path.
+
 ## [2.3.0] — 2026-08-04
 
 ### Added

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -99,8 +99,31 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_media_jobs_failed` | gauge | Jobs sitting in the terminal `failed` state by space (a backlog, not a rate) |
 | `ythril_media_job_duration_seconds` | histogram | End-to-end time per job by media type |
 | `ythril_metrics_collect_duration_seconds` | histogram | Time for one async collector to gather its values, by `collector` — one observation per collector per scrape. **This is how a slow `/metrics` names its own cause.** Several gauges here are collected at scrape time and walk every space, so on a many-space instance under write load a scrape can approach the Prometheus timeout; `topk(3, ythril_metrics_collect_duration_seconds_sum / ythril_metrics_collect_duration_seconds_count)` says which collector is responsible. Buckets run to 15 s deliberately — a histogram whose top bucket sits below the failure cannot describe it. |
+| `ythril_metrics_scrape_degraded` | gauge | `1` if the scrape being served had to abandon at least one collector to stay inside its budget, else `0`. **This is the one to alert on**, because the degradation is otherwise invisible: the scrape succeeds, `up` stays 1, and only the abandoned series are missing. It describes the scrape you are reading, not the previous one. |
+| `ythril_metrics_collect_timeouts_total` | counter | Collectors abandoned mid-scrape because the scrape budget ran out, by `collector`. **This names a slow collector without anyone having to catch a scrape while it is happening** — which is otherwise the hard part, since the problem only appears under load. Every collector is pre-declared at `0`, so an absent series never has to be told apart from a healthy one. |
 | `ythril_security_posture_checks` | gauge | This instance's own PASS/WARN/FAIL posture, by `level` — the same findings the boot log prints and `GET /api/about/security` serves, computed per scrape from the same function. **Alert on `level="fail"` > 0**: the checks that matter most produce no runtime symptom at all (`requireEncryptedTransport` on *without* `trustProxy` rejects every request with a 403 that looks like a client problem), and the only other way to notice was somebody reading the boot log of each instance. All three levels report `0` from process start. |
 
+> **A slow scrape degrades one graph, not the whole target.**
+>
+> Several gauges above are collected at scrape time and walk every space, so a many-space instance under
+> write load can push `/metrics` toward the Prometheus timeout. Without a guard the consequence is out of all
+> proportion to the cause: the scrape fails, Prometheus records `up=0`, and **every series from that target
+> disappears** — HTTP latency, event-loop lag, embed throughput, including the ones that would explain the
+> outage.
+>
+> So the scrape has a deadline. A collector that cannot finish inside it is abandoned: **its** series are
+> dropped for that scrape, `ythril_metrics_collect_timeouts_total` counts it by name, and
+> `ythril_metrics_scrape_degraded` reads `1`. Everything else is served normally and `up` stays 1.
+>
+> The abandoned collector is **dropped rather than left holding its last values**, deliberately. Stale numbers
+> presented as current are indistinguishable from a healthy flat line — you would read "storage steady" off a
+> collector that has not answered in an hour. A gap is honest.
+>
+> `METRICS_SCRAPE_BUDGET_MS` sets the deadline. Default **8000**, chosen to sit under the Prometheus
+> default of 10 s with room for serialisation and transfer — if you have raised `scrape_timeout`, raise
+> this with it. Set it to `0` to disable the budget and restore all-or-nothing collection. A malformed
+> value falls back to the default rather than to `0`, so a typo cannot silently switch the guard off.
+>
 > **The stuck-job recipe needs a restart guard.** A counter **resets to zero on restart**, so
 > `rate(ythril_embed_chunks_total[5m])` is 0 for the first five minutes of a new process while jobs are
 > completing normally. A reporting operator built the alert exactly as recommended and it fired two minutes

--- a/server/src/api/metrics.ts
+++ b/server/src/api/metrics.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import crypto from 'node:crypto';
-import { register } from '../metrics/registry.js';
+import { register, beginScrape, endScrape } from '../metrics/registry.js';
 import { requireAdmin } from '../auth/middleware.js';
 
 export const metricsRouter = Router();
@@ -58,7 +58,15 @@ function metricsTokenAuth(req: import('express').Request, res: import('express')
 // This avoids per-request branching and makes the auth path statically clear.
 const metricsAuth = METRICS_TOKEN ? metricsTokenAuth : requireAdmin;
 
+/**
+ * The scrape window exists so a slow collector cannot blind the whole target.
+ *
+ * `beginScrape()` opens the deadline every collector races against; `endScrape()` closes it in a
+ * `finally`, because a deadline left open would be inherited by the next scrape and expire it instantly.
+ * See the budget block in `metrics/registry.ts` for why partial beats all-or-nothing.
+ */
 metricsRouter.get('/', metricsAuth, async (_req, res) => {
+  beginScrape();
   try {
     const metrics = await register.metrics();
     res.setHeader('Content-Type', register.contentType);
@@ -66,5 +74,7 @@ metricsRouter.get('/', metricsAuth, async (_req, res) => {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(500).send(`# Error collecting metrics: ${msg}\n`);
+  } finally {
+    endScrape();
   }
 });

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -63,9 +63,236 @@ const collectDuration = new Histogram({
   registers: [register],
 });
 
-/** Start timing one collector. The returned function records the elapsed time; call it on every exit path. */
-function collectTimer(collector: string): () => void {
-  return collectDuration.startTimer({ collector });
+/**
+ * Every collector that gathers asynchronously and is therefore subject to the budget below.
+ *
+ * Named in one place so the timeout counter can be pre-declared at zero for each of them — an absent series
+ * and a zero one look identical on a graph and mean opposite things — and so a test can assert that no
+ * `withCollectBudget` call site uses a name that is not on this list. A collector that timed out under a
+ * name nobody enumerated would be invisible in exactly the situation this exists to make visible.
+ */
+export const TIMED_COLLECTORS = [
+  'memories_total', 'entities_total', 'edges_total', 'chrono_entries_total', 'storage_used_bytes',
+  'media_jobs_pending', 'media_jobs_processing', 'media_jobs_failed', 'media_job_phase',
+] as const;
+
+/**
+ * ## Why these two carry a `collect()` that gathers nothing
+ *
+ * The same concurrency that makes one shared deadline correct breaks the *reporting* of a timeout, and it does
+ * so silently. prom-client serialises each metric as soon as **its own** value is ready — one synchronous pass
+ * starts every collector, then each is written out independently. So a counter that some *other* collector
+ * increments is serialised at 0, before the timeout it is meant to record has even happened. The first version
+ * of this change shipped that bug: the budget worked, the scrape returned fast, and both of these read 0.
+ *
+ * The fix is a barrier. `scrapeSettled()` holds these two until every budgeted collector in this scrape has
+ * finished or been abandoned — bounded, because each of them is bounded by the budget.
+ *
+ * **This is why the two are not simply set from `endScrape()`.** That runs after serialisation, so the flag
+ * would describe the *previous* scrape: an alert permanently one scrape behind, firing after recovery and
+ * silent during the incident.
+ */
+export const collectTimeoutsTotal = new Counter({
+  name: 'ythril_metrics_collect_timeouts_total',
+  help: 'Collectors abandoned mid-scrape because the scrape budget ran out, by collector',
+  labelNames: ['collector'] as const,
+  registers: [register],
+  async collect() { await scrapeSettled(); },
+});
+for (const name of TIMED_COLLECTORS) collectTimeoutsTotal.labels({ collector: name }).inc(0);
+
+/**
+ * Whether the scrape being served right now had to abandon anything.
+ *
+ * It exists because the degradation must be alertable: an operator who cannot tell a complete scrape from a
+ * partial one has traded a loud failure for a quiet wrong answer, which is worse.
+ */
+export const metricsScrapeDegraded = new Gauge({
+  name: 'ythril_metrics_scrape_degraded',
+  help: '1 if this scrape abandoned at least one collector to stay inside its budget, else 0',
+  registers: [register],
+  async collect() { await scrapeSettled(); },
+});
+metricsScrapeDegraded.set(0);
+
+/**
+ * ## The scrape budget
+ *
+ * The canary measured `/metrics` exceeding its **10 s Prometheus timeout** during an ingest, and the
+ * consequence is out of proportion to the cause: a slow scrape does not lose the slow collector, it sets
+ * `up=0` and **drops every series from the target** — HTTP latency, event-loop lag, embed throughput, all of
+ * it, including the series that would explain the outage. Their framing, and it is correct.
+ *
+ * So the scrape gets a deadline it is guaranteed to return inside. A collector that cannot finish in time is
+ * abandoned: its series are dropped for that scrape, the timeout is counted against its name, and
+ * `ythril_metrics_scrape_degraded` goes to 1. Everything else is served normally, and `up` stays 1.
+ *
+ * **Why the collector is abandoned rather than left holding its last values.** Stale numbers presented as
+ * current are indistinguishable from a healthy flat line — the operator would read "storage is steady" from a
+ * collector that has not answered in an hour. A gap is honest and a gap is what the canary explicitly asked
+ * for. Same reason the counters here are pre-declared at zero: absent must not be confusable with fine.
+ *
+ * **8 seconds by default**, under the Prometheus default of 10 with room for serialisation and transfer. Set
+ * `METRICS_SCRAPE_BUDGET_MS` to change it, or to `0` to disable the budget and restore the old
+ * all-or-nothing behaviour.
+ *
+ * **Concurrency is what makes one shared deadline correct.** prom-client 15 collects with `Promise.all`, so
+ * the nine collectors run at once and the scrape costs the slowest one, not the sum. A per-collector budget
+ * would have to be one-ninth as generous to give the same guarantee.
+ */
+export const DEFAULT_SCRAPE_BUDGET_MS = 8000;
+
+const SCRAPE_BUDGET_MS = (() => {
+  const raw = process.env['METRICS_SCRAPE_BUDGET_MS']?.trim();
+  if (!raw) return DEFAULT_SCRAPE_BUDGET_MS;
+  const n = Number(raw);
+  // A malformed value must not silently disable the guard, so it falls back rather than becoming 0.
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_SCRAPE_BUDGET_MS;
+  return n;
+})();
+
+/**
+ * The budget this process resolved at load, in ms. `0` means disabled.
+ *
+ * Exported because the fallback is only testable as a **choice**, not as an effect: a malformed value falling
+ * back to 8000 and a malformed value becoming 0 both let a fast collector finish, so every effect-based
+ * assertion passes either way. A mutation that turned the fallback into `0` — silently disabling the guard on a
+ * typo'd env var — survived the first version of that test for exactly this reason.
+ */
+export function scrapeBudgetMs(): number {
+  return SCRAPE_BUDGET_MS;
+}
+
+/** Monotonic — `performance.now()` rather than `Date.now()`, so an NTP correction cannot expire a budget. */
+let scrapeDeadline = 0;
+let scrapesInFlight = 0;
+
+/**
+ * One entry per budgeted collector in the scrape being served, resolving when it finishes or is abandoned.
+ *
+ * `scrapeSettled()` waits on these so the two reporting metrics describe *this* scrape. Never rejects — each
+ * entry is resolved from a `finally`.
+ */
+let collectorsThisScrape: Array<Promise<void>> = [];
+
+/**
+ * Open a scrape window. Called by the `/metrics` handler; safe to nest.
+ *
+ * Overlapping scrapes are not what Prometheus does with one target, but a second Prometheus or a curl by hand
+ * can produce them. A later window therefore **extends** the deadline and never shortens it: a scrape already
+ * running must not have its budget cut by one that started after it.
+ *
+ * The window bookkeeping runs even when the budget is disabled, so the collector list cannot accumulate.
+ */
+export function beginScrape(): void {
+  if (scrapesInFlight === 0) {
+    metricsScrapeDegraded.set(0);
+    collectorsThisScrape = [];
+  }
+  scrapesInFlight++;
+  if (SCRAPE_BUDGET_MS === 0) return;
+  const deadline = performance.now() + SCRAPE_BUDGET_MS;
+  if (deadline > scrapeDeadline) scrapeDeadline = deadline;
+}
+
+/** Close a scrape window. Must run on the failure path too, or the deadline leaks into the next scrape. */
+export function endScrape(): void {
+  scrapesInFlight = Math.max(0, scrapesInFlight - 1);
+  if (scrapesInFlight === 0) {
+    scrapeDeadline = 0;
+    collectorsThisScrape = [];
+  }
+}
+
+/**
+ * Resolve once every budgeted collector in this scrape has finished or been abandoned.
+ *
+ * The single `await` before reading the list is load-bearing, not defensive. prom-client starts every metric's
+ * `collect()` in one synchronous pass, so yielding exactly one microtask is both necessary — the list is still
+ * being filled — and sufficient: the pass cannot still be running once microtasks get to run.
+ *
+ * `allSettled` rather than `all`: a reporting metric that rejects would turn a partial scrape into a 500, which
+ * is the failure this whole change exists to prevent.
+ */
+async function scrapeSettled(): Promise<void> {
+  await Promise.resolve();
+  await Promise.allSettled(collectorsThisScrape);
+}
+
+/** Milliseconds left in the current scrape, or Infinity when no budget applies. */
+function budgetRemaining(): number {
+  return scrapeDeadline === 0 ? Infinity : scrapeDeadline - performance.now();
+}
+
+const EXPIRED = Symbol('collector-budget-expired');
+
+/**
+ * Time one collector and hold it to the scrape budget.
+ *
+ * `work` keeps its own error handling contract: a collector that throws (MongoDB not ready at startup is the
+ * normal case) keeps its previous values, exactly as before this change. Only a **timeout** abandons them,
+ * because only a timeout means the value is unknown rather than momentarily unavailable.
+ *
+ * A query that lands after its budget still completes and still writes; those values simply belong to
+ * whichever scrape is serialising when they arrive. That is not worth machinery to prevent — late-but-real is
+ * a better outcome than dropped-and-refetched.
+ *
+ * **Every async collector in this file must go through this**, and `scrape-budget.test.js` fails the build if one
+ * does not. A collector that awaits outside the budget re-creates the exact `up=0` the canary reported, and it
+ * would do so silently — the scrape would simply get slow again with nothing naming the cause.
+ *
+ * Exported for that test, which needs a collector it can make arbitrarily slow. The nine real ones finish
+ * instantly without a database, so the mechanism is not otherwise reachable offline.
+ */
+export async function withCollectBudget(
+  collector: string,
+  work: () => Promise<void>,
+  abandon: () => void,
+): Promise<void> {
+  const done = collectDuration.startTimer({ collector });
+
+  // Register with this scrape SYNCHRONOUSLY, before the first await. The Promise executor runs immediately, so
+  // `release` is assigned during prom-client's synchronous collect() pass — which is what makes the one-microtask
+  // barrier in scrapeSettled() sound.
+  let release!: () => void;
+  collectorsThisScrape.push(new Promise<void>(resolve => { release = resolve; }));
+
+  try {
+    const remaining = budgetRemaining();
+    if (remaining === Infinity) {
+      await work().catch(() => { /* collector failure keeps last values, as before */ });
+      return;
+    }
+    if (remaining <= 0) {
+      // The budget was gone before this collector even started — still a timeout, still its own fault to own.
+      overBudget(collector, abandon);
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expiry = new Promise<typeof EXPIRED>(resolve => {
+      timer = setTimeout(() => resolve(EXPIRED), remaining);
+      // Never let a metrics budget hold the process open on shutdown.
+      timer.unref?.();
+    });
+    try {
+      const outcome = await Promise.race([
+        work().then(() => null, () => null),
+        expiry,
+      ]);
+      if (outcome === EXPIRED) overBudget(collector, abandon);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  } finally {
+    done();
+    release();
+  }
+}
+
+function overBudget(collector: string, abandon: () => void): void {
+  collectTimeoutsTotal.labels({ collector }).inc();
+  metricsScrapeDegraded.set(1);
+  abandon();
 }
 
 // ── HTTP ────────────────────────────────────────────────────────────────────
@@ -121,15 +348,13 @@ export const memoriesTotal = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('memories_total');
-    try {
+    await withCollectBudget('memories_total', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_memories`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
-    } catch { /* MongoDB may not be ready at startup */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -139,15 +364,13 @@ export const entitiesTotal = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('entities_total');
-    try {
+    await withCollectBudget('entities_total', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_entities`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
-    } catch { /* ignore */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -157,15 +380,13 @@ export const edgesTotal = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('edges_total');
-    try {
+    await withCollectBudget('edges_total', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_edges`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
-    } catch { /* ignore */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -175,15 +396,13 @@ export const chronoEntriesTotal = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('chrono_entries_total');
-    try {
+    await withCollectBudget('chrono_entries_total', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_chrono`).estimatedDocumentCount();
         this.set({ space: space.id }, count);
       }
-    } catch { /* ignore */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -228,15 +447,13 @@ export const storageUsedBytes = new Gauge({
   labelNames: ['area'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('storage_used_bytes');
-    try {
+    await withCollectBudget('storage_used_bytes', async () => {
       const usage = await measureUsage();
       const GiB = 1024 ** 3;
       this.set({ area: 'files' }, usage.files * GiB);
       this.set({ area: 'brain' }, usage.brain * GiB);
       this.set({ area: 'total' }, usage.total * GiB);
-    } catch { /* ignore */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -377,15 +594,13 @@ export const mediaJobsPending = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('media_jobs_pending');
-    try {
+    await withCollectBudget('media_jobs_pending', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_media_jobs`).countDocuments({ status: 'pending' });
         this.set({ space: space.id }, count);
       }
-    } catch { /* MongoDB may not be ready */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -395,15 +610,13 @@ export const mediaJobsProcessing = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('media_jobs_processing');
-    try {
+    await withCollectBudget('media_jobs_processing', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_media_jobs`).countDocuments({ status: 'processing' });
         this.set({ space: space.id }, count);
       }
-    } catch { /* ignore */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -413,15 +626,13 @@ export const mediaJobsFailed = new Gauge({
   labelNames: ['space'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('media_jobs_failed');
-    try {
+    await withCollectBudget('media_jobs_failed', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const count = await col(`${space.id}_media_jobs`).countDocuments({ status: 'failed' });
         this.set({ space: space.id }, count);
       }
-    } catch { /* ignore */ }
-    done();
+    }, () => this.reset());
   },
 });
 
@@ -467,8 +678,7 @@ export const mediaJobPhase = new Gauge({
   labelNames: ['space', 'step'] as const,
   registers: [register],
   async collect() {
-    const done = collectTimer('media_job_phase');
-    try {
+    await withCollectBudget('media_job_phase', async () => {
       const cfg = getConfig();
       for (const space of cfg.spaces.filter(s => !s.proxyFor)) {
         const rows = await col(`${space.id}_media_jobs`)
@@ -484,8 +694,7 @@ export const mediaJobPhase = new Gauge({
         for (const step of counts.keys()) _seenJobSteps.add(step);
         for (const step of _seenJobSteps) this.set({ space: space.id, step }, counts.get(step) ?? 0);
       }
-    } catch { /* MongoDB may not be ready */ }
-    done();
+    }, () => this.reset());
   },
 });
 

--- a/testing/standalone/collectors-are-timed.test.js
+++ b/testing/standalone/collectors-are-timed.test.js
@@ -1,5 +1,6 @@
 /**
- * Every async metric collector must be timed — because an untimed one is the one that will own the ten seconds.
+ * Every async metric collector must be timed AND bounded — because an untimed one is the one that will own the
+ * ten seconds, and an unbounded one will blind the whole target while doing it.
  *
  * ## The failure this exists for
  *
@@ -9,15 +10,23 @@
  * awaiting, not hogging — and the candidates are the gauges that gather at scrape time, each walking every
  * space, several of them querying the collection the embedding worker writes to continuously.
  *
- * We cannot reproduce their load, so the instance has to report it. `ythril_metrics_collect_duration_seconds`
- * does that — but only for collectors that actually call the timer, and the next collector somebody adds is the
- * one that will silently not.
+ * We cannot reproduce their load, so the instance has to report it.
  *
- * ## Why this gate is not just "grep for collectTimer"
+ * ## Why this file changed shape
  *
- * It enumerates the `async collect()` blocks from the source and requires each to have one, so the check scales
- * with the file instead of with a list somebody maintains. The floor matters as much: if the pattern stops
- * matching, an empty offender list would pass while checking nothing.
+ * It used to assert the **mechanism**: `collectTimer(` on the first line of each collector, and a `done()` count
+ * that matched. Both were hand-rolled per collector, and the timer stop sat *after* the try/catch rather than in
+ * a `finally` — so an early `return` would have silently skipped it.
+ *
+ * `withCollectBudget()` now owns both, plus the scrape budget. That makes the guarantee structural instead of
+ * remembered, so this gate asserts the guarantee:
+ *
+ *   1. every async collector routes through the wrapper;
+ *   2. the wrapper starts its timer before anything can await;
+ *   3. the wrapper stops it in a `finally`, so no path escapes measurement.
+ *
+ * The old assertions would now FAIL against strictly better code, which is the signature of a gate pinned to an
+ * implementation. Re-pointed rather than appeased.
  *
  * Run: node --test testing/standalone/collectors-are-timed.test.js
  */
@@ -31,44 +40,101 @@ const SRC = 'server/src/metrics/registry.ts';
 const src = readFileSync(join(ROOT, SRC), 'utf8');
 const lines = src.split(/\r?\n/);
 
-/** `{ line, metric, timed }` for every async collector in the registry. */
+/**
+ * Collectors that gather nothing and so are exempt from the budget wrapper, with the reason.
+ *
+ * These two report on the scrape itself and wait for the budgeted collectors to settle. Routing them through the
+ * wrapper would make them wait on themselves.
+ */
+const REPORTING_COLLECTORS = ['ythril_metrics_collect_timeouts_total', 'ythril_metrics_scrape_degraded'];
+
+/** `{ line, metric, body }` for every async collector in the registry, reporting ones excluded. */
 function collectors() {
   const found = [];
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() !== 'async collect() {') continue;
+    if (!/^\s*async collect\(\)\s*\{/.test(lines[i])) continue;
+
     let metric = null;
-    for (let j = i; j >= 0 && j > i - 12; j--) {
+    for (let j = i; j >= 0 && j > i - 14; j--) {
       const m = lines[j].match(/name: '(ythril_[a-z_]+)'/);
       if (m) { metric = m[1]; break; }
     }
-    // The timer must be the FIRST statement: a collector that starts timing after its first await measures the
-    // wrong thing, and measuring the wrong thing is worse here than not measuring.
-    found.push({ line: i + 1, metric, timed: lines[i + 1]?.includes('collectTimer(') === true });
+    if (metric !== null && REPORTING_COLLECTORS.includes(metric)) continue;
+
+    // Body runs to the closing brace at the collector's own indent.
+    const indent = lines[i].match(/^\s*/)[0];
+    let end = i + 1;
+    while (end < lines.length && !new RegExp(`^${indent}\\},?$`).test(lines[end])) end++;
+    found.push({ line: i + 1, metric, body: lines.slice(i, end + 1).join('\n') });
   }
   return found;
 }
 
-describe('every async metric collector is timed', () => {
+describe('every async metric collector is timed and bounded', () => {
   it('found the collectors — the pattern still matches', () => {
     const all = collectors();
+    // The floor matters as much as the check: if the pattern stopped matching, an empty offender list would pass
+    // while verifying nothing.
     assert.ok(all.length >= 8, `only found ${all.length} async collectors in ${SRC}`);
     assert.ok(all.every(c => c.metric !== null), 'a collector has no metric name above it');
   });
 
-  it('each one starts a timer as its first statement', () => {
-    const untimed = collectors().filter(c => !c.timed).map(c => `${SRC}:${c.line} (${c.metric})`);
-    assert.deepEqual(untimed, [], 'these gather at scrape time without recording how long they took, so a slow '
-      + `scrape cannot name them:\n  ${untimed.join('\n  ')}\n\n`
-      + "Add `const done = collectTimer('<name>');` as the first line and `done();` before the closing brace.");
+  it('every reporting collector named exempt actually exists', () => {
+    // An exemption for something that is gone is an exemption that will one day cover something else. The old
+    // version of this gate had no exemptions and the new metrics would have silently widened its scope.
+    for (const name of REPORTING_COLLECTORS) {
+      assert.match(src, new RegExp(`name: '${name}'`), `${name} is exempted here but not in the registry`);
+    }
   });
 
-  it('each one records the elapsed time before returning', () => {
-    // A started timer that is never stopped observes nothing — the histogram would stay empty and look like a
-    // collector that is instantly fast.
-    const starts = (src.match(/collectTimer\(/g) ?? []).length;
-    const stops = (src.match(/^\s*done\(\);$/gm) ?? []).length;
-    assert.equal(stops, starts - 1, `${starts - 1} timer start(s) in collectors but ${stops} done() call(s) `
-      + '(one collectTimer occurrence is the helper definition itself)');
+  it('each one routes through withCollectBudget, which times it and bounds it', () => {
+    const loose = collectors()
+      .filter(c => !c.body.includes('withCollectBudget('))
+      .map(c => `${SRC}:${c.line} (${c.metric})`);
+    assert.deepEqual(loose, [], 'these gather at scrape time outside the budget wrapper, so they are neither '
+      + `timed nor bounded — a slow scrape cannot name them and cannot survive them:\n  ${loose.join('\n  ')}\n\n`
+      + "Wrap the body: `await withCollectBudget('<name>', async () => { ... }, () => this.reset());`");
+  });
+
+  it('the wrapper starts its timer before it can await', () => {
+    // A timer started after the first await measures the wrong thing, and measuring the wrong thing is worse
+    // here than not measuring.
+    const m = src.match(/export async function withCollectBudget\([\s\S]*?\n\) *: *Promise<void> *\{([\s\S]*?)\n\}/);
+    assert.ok(m, 'withCollectBudget not found — this gate needs re-pointing, not deleting');
+    const body = m[1];
+
+    const firstTimer = body.indexOf('collectDuration.startTimer(');
+    const firstAwait = body.indexOf('await ');
+    assert.ok(firstTimer >= 0, 'withCollectBudget no longer starts a timer');
+    assert.ok(
+      firstAwait === -1 || firstTimer < firstAwait,
+      'withCollectBudget awaits before it starts timing, so every collector under-reports its own duration',
+    );
+  });
+
+  it('the wrapper stops its timer in a finally, so no path escapes measurement', () => {
+    const m = src.match(/export async function withCollectBudget\([\s\S]*?\n\) *: *Promise<void> *\{([\s\S]*?)\n\}/);
+    const body = m[1];
+
+    // Strip comments line-first, so this cannot pass on the prose that explains it — and cannot be "fixed" by
+    // deleting that prose.
+    const code = body.split('\n').filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+
+    // The wrapper has two finally blocks — the inner one clears the expiry timer, the outer one stops the clock.
+    // Anchor on the LAST, because a non-greedy match finds the inner one and then stops at the outer finally's
+    // own opening brace, capturing a region that never contains the stop. (It did exactly that on first run.)
+    const lastFinally = code.lastIndexOf('finally {');
+    assert.ok(lastFinally >= 0, 'the timer stop is not in a finally — an early return would skip it, which is the '
+      + 'exact hole the previous per-collector `done()` had');
+    assert.match(
+      code.slice(lastFinally), /done\(\);/,
+      'the last finally does not stop the timer; a started timer that never stops observes nothing, so the '
+      + 'histogram stays empty and reads as a collector that is instantly fast',
+    );
+    assert.equal(
+      (code.match(/\bdone\(\);/g) ?? []).length, 1,
+      'more than one done() call: if one of them is outside the finally, that is the path that escapes measurement',
+    );
   });
 
   it('the histogram can describe a scrape that timed out', () => {
@@ -84,5 +150,8 @@ describe('every async metric collector is timed', () => {
   it('is documented, like every other metric family', () => {
     const docs = readFileSync(join(ROOT, 'docs/integration-guide/11-setup-api.md'), 'utf8');
     assert.match(docs, /ythril_metrics_collect_duration_seconds/);
+    // The budget is operator-facing configuration: an undocumented knob is one nobody can turn.
+    assert.match(docs, /METRICS_SCRAPE_BUDGET_MS/,
+      'the scrape budget env var is not documented, so an operator whose scrape_timeout differs cannot adjust it');
   });
 });

--- a/testing/standalone/scrape-budget.test.js
+++ b/testing/standalone/scrape-budget.test.js
@@ -1,0 +1,275 @@
+/**
+ * A slow collector must degrade one graph, not blind the whole target.
+ *
+ * ## Why this exists
+ *
+ * The canary measured `/metrics` exceeding its 10 s Prometheus timeout during an embedding run, twice, with
+ * `up=0` for both windows. The consequence is out of proportion to the cause: a slow scrape does not lose the
+ * slow collector's series, it drops **every** series from that target — HTTP latency, event-loop lag, embed
+ * throughput, including the ones that would explain the outage. Their words, and they are right:
+ *
+ *     "A missing series is a gap in one graph; a failed scrape drops every series from that target."
+ *
+ * So the guarantee under test is not "collection is fast". It is: **the scrape returns inside its budget, says
+ * so when it had to give something up, and names what.**
+ *
+ * ## What each test is defending against, and how it fails if the guard is gone
+ *
+ *  1. **The scrape returns inside the budget.** Without the race, this test blocks for the collector's full
+ *     sleep and the deadline assertion fails. This is the whole point of the change.
+ *  2. **The abandoned collector's series are DROPPED, not left stale.** Stale numbers presented as current are
+ *     indistinguishable from a healthy flat line — an operator reads "storage steady" off a collector that has
+ *     not answered in an hour. Remove the `abandon()` call and this fails.
+ *  3. **The timeout is counted against the collector's own name.** This is the half that also does the
+ *     diagnosis: the counter names the slow collector without anyone having to catch a scrape mid-ingest.
+ *  4. **`ythril_metrics_scrape_degraded` is 1 for the scrape it describes**, not the one after. Set it from
+ *     `endScrape()` instead of from the timeout and this fails — it would always be one scrape behind.
+ *  5. **A clean scrape reports 0**, so the flag is usable in an alert rather than latching forever.
+ *  6. **A collector that THROWS keeps its previous values.** This is the no-behaviour-change guard: an error is
+ *     "momentarily unavailable" (MongoDB not ready at boot, the normal case), a timeout is "unknown". Only the
+ *     second may drop data. Make the wrapper abandon on error too and this fails.
+ *  7. **`METRICS_SCRAPE_BUDGET_MS=0` restores the old all-or-nothing behaviour**, because an escape hatch that
+ *     does not work is worse than none.
+ *  8. **A malformed budget falls back to the default rather than to 0.** A typo in a deployment env var must not
+ *     silently switch the guard off.
+ *  9. **No async collector bypasses the wrapper.** The gate. One that awaits outside the budget re-creates the
+ *     original bug silently: the scrape just gets slow again with nothing naming the cause.
+ *
+ * Each scenario imports a **fresh** registry via a cache-busting query string, because the budget is read from
+ * the environment once at module load — which is correct for a server and inconvenient for a test.
+ *
+ * Run: node --test testing/standalone/scrape-budget.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { Gauge } from 'prom-client';
+
+const REGISTRY = '../../server/dist/metrics/registry.js';
+const SOURCE = 'server/src/metrics/registry.js'.replace('/dist/', '/src/');
+
+let bust = 0;
+/** Load a fresh registry module with a chosen budget. */
+async function loadRegistry(budgetMs) {
+  if (budgetMs === null) delete process.env.METRICS_SCRAPE_BUDGET_MS;
+  else process.env.METRICS_SCRAPE_BUDGET_MS = String(budgetMs);
+  return import(`${REGISTRY}?budget=${budgetMs}-${bust++}`);
+}
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Register a collector that takes `workMs` and reports one value.
+ * `mode: 'throw'` makes it fail instead, which must NOT drop its values.
+ */
+function slowCollector(mod, { name, workMs, mode = 'ok' }) {
+  const gauge = new Gauge({
+    name: `test_slow_${name}`,
+    help: 'test collector',
+    labelNames: ['space'],
+    registers: [mod.register],
+    async collect() {
+      await mod.withCollectBudget(name, async () => {
+        await sleep(workMs);
+        if (mode === 'throw') throw new Error('collector failed');
+        this.set({ space: 'alpha' }, 42);
+      }, () => this.reset());
+    },
+  });
+  return gauge;
+}
+
+/** One full scrape through the same begin/end window the route uses. */
+async function scrape(mod) {
+  mod.beginScrape();
+  try {
+    return await mod.register.metrics();
+  } finally {
+    mod.endScrape();
+  }
+}
+
+const valueOf = (text, series) => {
+  const line = text.split('\n').find(l => l.startsWith(series + ' '));
+  return line ? Number(line.slice(series.length + 1)) : null;
+};
+
+describe('the scrape budget', () => {
+  it('1. returns inside the budget even when a collector runs long past it', async () => {
+    const mod = await loadRegistry(120);
+    slowCollector(mod, { name: 'media_job_phase', workMs: 3000 });
+
+    const started = performance.now();
+    const text = await scrape(mod);
+    const elapsed = performance.now() - started;
+
+    // Generous headroom over the 120 ms budget — the assertion that matters is "not the 3000 ms sleep".
+    assert.ok(elapsed < 1500, `scrape took ${Math.round(elapsed)}ms; the budget was 120ms`);
+    // And it is a real scrape, not an error page: unrelated series are still served.
+    assert.match(text, /ythril_metrics_scrape_degraded/);
+  });
+
+  it('2. drops the abandoned collector\'s series rather than serving stale values', async () => {
+    const mod = await loadRegistry(2000);
+    const g = slowCollector(mod, { name: 'storage_used_bytes', workMs: 10 });
+
+    // First scrape is comfortably inside the budget, so the value lands.
+    const first = await scrape(mod);
+    assert.equal(valueOf(first, 'test_slow_storage_used_bytes{space="alpha"}'), 42);
+
+    // Now the same collector cannot finish. Its previous value must NOT be re-served.
+    g.remove({ space: 'alpha' });
+    const mod2 = await loadRegistry(100);
+    const g2 = slowCollector(mod2, { name: 'storage_used_bytes', workMs: 10 });
+    await scrape(mod2);                       // populate
+    g2.collect = async function () {          // then make it slow
+      await mod2.withCollectBudget('storage_used_bytes', async () => {
+        await sleep(3000);
+        this.set({ space: 'alpha' }, 99);
+      }, () => this.reset());
+    };
+    const second = await scrape(mod2);
+    assert.equal(
+      valueOf(second, 'test_slow_storage_used_bytes{space="alpha"}'), null,
+      'a timed-out collector served its previous value — an operator cannot tell that from a healthy flat line',
+    );
+  });
+
+  it('3. counts the timeout against the collector\'s own name', async () => {
+    const mod = await loadRegistry(100);
+    slowCollector(mod, { name: 'media_jobs_pending', workMs: 3000 });
+    const text = await scrape(mod);
+
+    assert.equal(
+      valueOf(text, 'ythril_metrics_collect_timeouts_total{collector="media_jobs_pending"}'), 1,
+      'the timeout counter is what names the slow collector without catching a scrape mid-ingest',
+    );
+    // Every other collector must still read 0 — a counter that blames everything blames nothing.
+    assert.equal(valueOf(text, 'ythril_metrics_collect_timeouts_total{collector="media_job_phase"}'), 0);
+  });
+
+  it('4. reports degraded=1 on the scrape it describes, not the next one', async () => {
+    const mod = await loadRegistry(100);
+    slowCollector(mod, { name: 'edges_total', workMs: 3000 });
+    const text = await scrape(mod);
+    assert.equal(
+      valueOf(text, 'ythril_metrics_scrape_degraded'), 1,
+      'set from endScrape() this would be 0 here and 1 next time — an alert one scrape behind',
+    );
+  });
+
+  it('5. reports degraded=0 for a clean scrape, so the flag does not latch', async () => {
+    const mod = await loadRegistry(2000);
+    slowCollector(mod, { name: 'entities_total', workMs: 5 });
+    const first = await scrape(mod);
+    assert.equal(valueOf(first, 'ythril_metrics_scrape_degraded'), 0);
+
+    // And it clears after a degraded one rather than staying stuck at 1.
+    const mod2 = await loadRegistry(80);
+    slowCollector(mod2, { name: 'entities_total', workMs: 3000 });
+    assert.equal(valueOf(await scrape(mod2), 'ythril_metrics_scrape_degraded'), 1);
+    // Same module, but now nothing is slow: a second window must reset the flag.
+    mod2.register.removeSingleMetric('test_slow_entities_total');
+    slowCollector(mod2, { name: 'entities_total', workMs: 5 });
+    assert.equal(
+      valueOf(await scrape(mod2), 'ythril_metrics_scrape_degraded'), 0,
+      'degraded latched at 1 — an operator would see a permanent alert and start ignoring it',
+    );
+  });
+
+  it('6. keeps previous values when a collector THROWS, because that is not the same as unknown', async () => {
+    const mod = await loadRegistry(2000);
+    const g = slowCollector(mod, { name: 'chrono_entries_total', workMs: 5 });
+    assert.equal(valueOf(await scrape(mod), 'test_slow_chrono_entries_total{space="alpha"}'), 42);
+
+    g.collect = async function () {
+      await mod.withCollectBudget('chrono_entries_total', async () => {
+        throw new Error('MongoDB not ready');
+      }, () => this.reset());
+    };
+    const text = await scrape(mod);
+    assert.equal(
+      valueOf(text, 'test_slow_chrono_entries_total{space="alpha"}'), 42,
+      'an error dropped the values; MongoDB briefly unavailable at boot is the normal case and pre-dates this change',
+    );
+    assert.equal(
+      valueOf(text, 'ythril_metrics_scrape_degraded'), 0,
+      'an error is not a budget failure and must not raise the degraded flag',
+    );
+  });
+
+  it('7. honours METRICS_SCRAPE_BUDGET_MS=0 as "no budget", restoring all-or-nothing', async () => {
+    const mod = await loadRegistry(0);
+    slowCollector(mod, { name: 'memories_total', workMs: 250 });
+
+    const started = performance.now();
+    const text = await scrape(mod);
+    const elapsed = performance.now() - started;
+
+    assert.ok(elapsed >= 200, `budget 0 should not interrupt anything, but the scrape returned in ${Math.round(elapsed)}ms`);
+    assert.equal(valueOf(text, 'test_slow_memories_total{space="alpha"}'), 42, 'the collector must complete');
+    assert.equal(valueOf(text, 'ythril_metrics_collect_timeouts_total{collector="memories_total"}'), 0);
+  });
+
+  it('8. falls back to the default when the budget is malformed, rather than to no budget', async () => {
+    // Asserted as a CHOICE, not an effect. The first version of this test set a malformed budget and checked
+    // that a fast collector still completed — which is true whether the fallback is 8000 or 0, so a mutation
+    // turning it into 0 (silently disabling the guard on a typo'd env var) passed the test. The parsed value is
+    // the only thing that distinguishes the two.
+    for (const bad of ['not-a-number', '-1', 'NaN', '']) {
+      const mod = await loadRegistry(bad);
+      assert.equal(
+        mod.scrapeBudgetMs(), mod.DEFAULT_SCRAPE_BUDGET_MS,
+        `METRICS_SCRAPE_BUDGET_MS='${bad}' resolved to ${mod.scrapeBudgetMs()}; a typo must not disable the guard`,
+      );
+    }
+    // And the escape hatch must still be reachable deliberately, or the fallback has swallowed it.
+    assert.equal((await loadRegistry(0)).scrapeBudgetMs(), 0);
+    assert.equal((await loadRegistry(250)).scrapeBudgetMs(), 250);
+  });
+});
+
+describe('the gate: no async collector may bypass the budget', () => {
+  it('9. every async collect() in registry.ts goes through withCollectBudget', () => {
+    const src = readFileSync(SOURCE.replace('.js', '.ts'), 'utf8');
+
+    // Strip comments first, anchored to line starts so a `/*` inside a string literal cannot eat live code —
+    // and so this gate cannot fire on the comment block that explains it.
+    const code = src
+      .split(/\r?\n/)
+      .filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      .join('\n');
+
+    const asyncCollectors = [...code.matchAll(/async collect\(\)\s*\{([\s\S]*?)\n {2}\},/g)];
+    assert.ok(
+      asyncCollectors.length >= 9,
+      `expected at least 9 async collectors, found ${asyncCollectors.length} — if this dropped, the ` +
+      'enumeration broke, not the code',
+    );
+
+    const bypassing = asyncCollectors
+      .filter(m => !m[1].includes('withCollectBudget'))
+      .map(m => m[1].split('\n').find(l => l.trim())?.trim() ?? '(empty)');
+
+    assert.deepEqual(
+      bypassing, [],
+      'an async collector awaits outside the scrape budget. That re-creates the up=0 the canary reported, and ' +
+      'silently: the scrape simply gets slow again with nothing naming the cause.',
+    );
+  });
+
+  it('every name passed to withCollectBudget is in TIMED_COLLECTORS', async () => {
+    const mod = await loadRegistry(null);
+    const src = readFileSync(SOURCE.replace('.js', '.ts'), 'utf8');
+    const used = [...src.matchAll(/withCollectBudget\('([a-z_]+)'/g)].map(m => m[1]);
+
+    assert.ok(used.length >= 9, `found only ${used.length} withCollectBudget call sites`);
+    const unlisted = used.filter(n => !mod.TIMED_COLLECTORS.includes(n));
+    assert.deepEqual(
+      unlisted, [],
+      'a collector times out under a name that is never pre-declared at 0, so its series is absent until the ' +
+      'first timeout — invisible in exactly the case this exists to make visible',
+    );
+  });
+});


### PR DESCRIPTION
## The bug

The canary measured `/metrics` exceeding its 10 s Prometheus timeout twice during an ingest, with `up=0` for both windows.

**The consequence is out of all proportion to the cause**, which is why this is a fix rather than a performance item. A slow scrape does not lose the slow collector — Prometheus records `up=0` and **drops every series from that target**: HTTP latency, event-loop lag, embed throughput, including the series that would explain the outage.

Their framing decided the shape of the fix, and it is right:

> A missing series is a gap in one graph; a failed scrape drops every series from that target.

So: a partial scrape, never "make it usually fast enough".

## The fix

The scrape gets a deadline — `METRICS_SCRAPE_BUDGET_MS`, default **8000**, under the Prometheus default of 10 s with room for serialisation and transfer. A collector that cannot finish inside it is abandoned:

| | |
|---|---|
| its series | dropped for that scrape |
| `ythril_metrics_collect_timeouts_total{collector}` | counts it **by name** |
| `ythril_metrics_scrape_degraded` | reads `1` |
| everything else | served normally, `up` stays 1 |

`0` disables the budget and restores all-or-nothing collection. A malformed value falls back to the default rather than to `0`, so a typo cannot silently switch the guard off.

## Why this did not wait for the tag

The `/metrics` item sat behind the release because *diagnosing which collector is slow* needs a scrape taken during the canary's ingest, and 2.3.0 is the first build that can produce one.

**This half needs none of that** — the guard is collector-agnostic by construction. And the timeout counter turns out to *also* do the diagnosis: it names the slow collector without anyone having to catch a scrape while it is happening, which was otherwise the hard part, since the problem only appears under their load.

## Three decisions worth the review time

**1. The abandoned collector is dropped, not left holding its last values.** Stale numbers presented as current are indistinguishable from a healthy flat line — an operator would read "storage steady" off a collector that has not answered in an hour. Same principle as pre-declaring counters at zero: absent must not be confusable with fine.

An **error**, by contrast, keeps the previous values exactly as before this change. MongoDB briefly unavailable at boot is the normal case, and "momentarily unavailable" is not "unknown". Only a timeout means the value is unknown.

**2. One shared deadline, not one per collector.** Correct *only* because collection is concurrent: prom-client 15 collects with `Promise.all`, so the nine collectors run at once and the scrape costs the slowest, not the sum. Verified by reading the library, not assumed — a per-collector budget would have to be one-ninth as generous to give the same guarantee.

**3. A bug found inside this change, recorded because the first version shipped it.** The same concurrency that makes the deadline work broke the *reporting* of a timeout. prom-client serialises each metric as soon as **its own** value is ready, so a counter that another collector increments was written out at 0 before the timeout had happened.

The budget worked, the scrape returned fast, and both new metrics read 0 — a guard with no way to tell you it had fired. Fixed with a one-microtask barrier (`scrapeSettled()`), which the mutation run confirms is load-bearing: removing that single `await` fails three tests.

## Tests

**9 tests, all 9 mutations caught.**

| mutation | caught by |
|---|---|
| no race, just await the work | 1 |
| timeout no longer abandons values | 2 |
| timeout not counted | 3 |
| degraded flag never raised | 4, 5 |
| barrier loses its microtask yield | 3, 4, 5 |
| an error abandons values too | 6 |
| budget `0` still enforced | 7 |
| malformed budget becomes `0` | 8 |
| a collector bypasses the wrapper | 9 |

The last one only after a rewrite. Test 8 originally asserted an **effect** — a fast collector still completes — which holds whether a malformed value falls back to 8000 *or* to 0, so the mutation that silently disables the guard on a typo'd env var **survived**. The parsed value is now asserted directly, as a *choice*. Same lesson as asserting a file mode by return value rather than by `stat`.

## `collectors-are-timed` was re-pointed, not appeased

It pinned the **mechanism**: `collectTimer(` on the first line of each collector, plus a `done()` count that had to match. Both were hand-rolled per collector, and the stop sat *after* the try/catch rather than in a `finally` — an early `return` would have skipped it.

The wrapper now owns both, so the guarantee is structural instead of remembered. The old assertions would **fail against strictly better code**, which is the signature of a gate pinned to an implementation. It now asserts the guarantee: every async collector routes through the wrapper, and the wrapper times before it awaits and stops on every path.

It also gained an exemption list for the two new reporting collectors (they wait for the budgeted ones to settle, so routing them through the wrapper would make them wait on themselves) — plus a test that every exempted name still exists, because an exemption for something that is gone will one day cover something else.

## Also here, unrelated to the code

Correspondence moves out of `todo/` into a gitignored `communication/<correspondent>/`, with direction in every filename — `Y2B-` outgoing, `B2Y-` incoming. The previous neutral `_CUSTOMER-MESSAGE-NEXT.md` sat beside a working file called `undated.md` and three received messages, and nothing in any filename said which way it travelled, so "which file do I forward?" was a question that had to be asked.

## Verification

- `npm run preflight` — passes
- `audit-route-coverage` — 5/5 (the `/metrics` change is a read-only GET)
- `metric-docs-coverage` — both new metrics documented, and the env var with them
- `lint:docs` — clean
