### PR TITLE
fix(metrics): the storage gauge walked the whole files tree on every scrape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The storage gauge walked the entire files tree on every scrape, and it was the whole cause of the canary's
+  `/metrics` timeout.** They answered the diagnostic request from #676 with numbers that name one collector and
+  a count that makes it a cause rather than a correlation:
+
+  | collector | mean seconds |
+  |---|---|
+  | `storage_used_bytes` | **22.150** |
+  | every MongoDB-backed collector | 8.57 – 8.61 |
+
+  Of **20 scrapes, 10 failed** with `scrape_duration_seconds` pinned at exactly `10.0012 s`; of the 19
+  collections the histogram recorded, `storage_used_bytes` exceeded 10 s **exactly 10 times**. The other eight
+  collectors exceeded it 7 times between them, so they are not the determinant. Its distribution was bimodal —
+  6 of 19 under 50 ms, 9 over 15 s — which is a cold-versus-warm filesystem cache rather than "slow". Their
+  four small instances completed every collector in 0.005–0.041 s, so it scales with stored volume.
+
+  - **The cache already existed and this collector was the one caller that opted out of it.** `measureUsage()`
+    takes a `maxAgeMs`, and the comment above that cache listed `metrics` among the callers that
+    deliberately re-measure. That line was the bug. Worse, the argument against exactness was **already written**
+    in the registry for the brain totals — *"the exactness that buys does not survive contact with what a gauge
+    IS"* — and #606 acted on it there, for the collectors costing milliseconds, while leaving the one costing
+    seconds.
+  - The gauge now reads a cache (`peekUsage()`) and **never blocks a scrape on filesystem I/O**. A
+    background walk refreshes it, coalesced so nine scrapes cannot start nine walks — which matters because the
+    canary's array is a degraded RAID1 mid-rebuild, where stacking 22-second walks is actively harmful.
+  - `METRICS_STORAGE_USAGE_MAX_AGE_MS` (default **300000**) governs staleness while the instance is idle.
+    During real activity every write already refreshes the cache as part of its quota check.
+  - **Two new series, and the age one is not optional.** `ythril_storage_usage_age_seconds` publishes how
+    stale the numbers are, because a cached value with no visible age is the failure #676 rejected;
+    `ythril_storage_usage_measurements_total` answers "how often are we doing the expensive thing", which
+    used to be *every scrape*.
+  - **A cold instance reports no storage series at all** rather than a zero. Absent says "not measured yet"; a
+    zero would say "empty".
+
+- **Lost-update detection covered 1 of the 4 brain record types while being named for all of them.** #674
+  shipped `ythril_brain_write_seq_total` — help text *"Brain record writes"* — measuring `memories`
+  alone. `entities`, `edges` and `chrono` have the identical read → nextSeq → updateOne shape
+  and the identical exposure. All four are now instrumented and all four pre-declared.
+  - **The canary spotted it from the outside** and proposed the wrong fix, for the right reason: they saw only
+    `collection="memories"` and reasonably guessed the label set was lazy, so they suggested pre-declaring
+    the others. Pre-declaring an uninstrumented collection would have been worse than omitting it — a permanent
+    `0` on entities reads as "no collisions here" when the truth is "not measured", which is the exact confusion
+    pre-declaring exists to prevent. A gate now fails if a pre-declared collection is not actually counted.
+
+### Documentation
+
+- **Two notes the canary asked for, one of which corrects a query we sent them.**
+  - `ythril_metrics_collect_duration_seconds` is a histogram, so **the bare name is not a series** — only
+    `_bucket`, `_sum` and `_count` exist. An instant query for the bare name returns empty, which reads as "the
+    metric is missing" rather than "wrong series". Our own request for a scrape told them to grep the bare name.
+  - **A collector Prometheus gave up on still finishes and still records its duration**, so a later successful
+    scrape delivers those buckets. That is why timing data exists for the scrapes that failed — and the
+    corollary is that an instance whose scrapes *all* time out looks silent while doing the work.
+
+### Testing
+
+- **9 mutations, 9 caught — but three of the first six survived, and all three were the test rather than the
+  code.** Recorded because the pattern repeats:
+  - the coalescing test asserted *"a refresh is in flight"* before and after nine calls, which is true either
+    way since nine unguarded calls each leave **a** promise in the slot. Now counts completed walks.
+  - the age test read a gauge an earlier test had already set. Adding `reset()` made it **worse** —
+    `reset()` on an unlabelled prom-client gauge re-initialises it to `0` rather than removing it, guaranteeing a
+    value inside the plausible range. A poison sentinel outside that range was the only preparation that fails
+    when nothing writes.
+  - **and that sentinel then found a real bug.** `storageUsageAgeSeconds` was written by the storage
+    collector, and prom-client serialises each metric as soon as **its own** value is ready — so the age was
+    emitted before the collector that set it. Identical to the barrier bug in #676, in the same file, two hours
+    later. It now reads the cache itself; a self-sufficient collector is the only order-independent kind.
+
+### Fixed
+
 - **A slow `/metrics` collector now degrades one graph instead of blinding the whole target** (canary
   finding: the scrape hit its 10 s Prometheus timeout twice during an ingest, with `up=0` for both windows).
   - **The consequence was out of all proportion to the cause**, which is the reason this is a fix and not a

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -98,11 +98,43 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_media_jobs_retried_total` | counter | Attempts that failed and were re-queued, by space and media type — including a job whose claim was recovered while it was still running |
 | `ythril_media_jobs_failed` | gauge | Jobs sitting in the terminal `failed` state by space (a backlog, not a rate) |
 | `ythril_media_job_duration_seconds` | histogram | End-to-end time per job by media type |
-| `ythril_metrics_collect_duration_seconds` | histogram | Time for one async collector to gather its values, by `collector` — one observation per collector per scrape. **This is how a slow `/metrics` names its own cause.** Several gauges here are collected at scrape time and walk every space, so on a many-space instance under write load a scrape can approach the Prometheus timeout; `topk(3, ythril_metrics_collect_duration_seconds_sum / ythril_metrics_collect_duration_seconds_count)` says which collector is responsible. Buckets run to 15 s deliberately — a histogram whose top bucket sits below the failure cannot describe it. |
+| `ythril_metrics_collect_duration_seconds` | histogram | Time for one async collector to gather its values, by `collector` — one observation per collector per scrape. **This is how a slow `/metrics` names its own cause.** Several gauges here are collected at scrape time and walk every space, so on a many-space instance under write load a scrape can approach the Prometheus timeout; `topk(3, ythril_metrics_collect_duration_seconds_sum / ythril_metrics_collect_duration_seconds_count)` says which collector is responsible. **It is a histogram, so the bare metric name is not a series** — only `_bucket`, `_sum` and `_count` exist, and an instant query for `ythril_metrics_collect_duration_seconds` returns empty. That reads as "the metric is missing" rather than "wrong series name", which cost a canary operator a minute and would cost the next person longer. Buckets run to 15 s deliberately — a histogram whose top bucket sits below the failure cannot describe it. |
 | `ythril_metrics_scrape_degraded` | gauge | `1` if the scrape being served had to abandon at least one collector to stay inside its budget, else `0`. **This is the one to alert on**, because the degradation is otherwise invisible: the scrape succeeds, `up` stays 1, and only the abandoned series are missing. It describes the scrape you are reading, not the previous one. |
 | `ythril_metrics_collect_timeouts_total` | counter | Collectors abandoned mid-scrape because the scrape budget ran out, by `collector`. **This names a slow collector without anyone having to catch a scrape while it is happening** — which is otherwise the hard part, since the problem only appears under load. Every collector is pre-declared at `0`, so an absent series never has to be told apart from a healthy one. |
+| `ythril_storage_usage_age_seconds` | gauge | How old the measurement behind `ythril_storage_used_bytes` is. **Those numbers are cached, not re-measured per scrape** — see the note below for why. Absent until the first measurement completes, which is deliberate: a `0` would claim "just measured". |
+| `ythril_storage_usage_measurements_total` | gauge | Completed walks of the files tree since process start. Answers "how often are we doing the expensive thing"; on a large store the answer used to be *every scrape*. |
 | `ythril_security_posture_checks` | gauge | This instance's own PASS/WARN/FAIL posture, by `level` — the same findings the boot log prints and `GET /api/about/security` serves, computed per scrape from the same function. **Alert on `level="fail"` > 0**: the checks that matter most produce no runtime symptom at all (`requireEncryptedTransport` on *without* `trustProxy` rejects every request with a 403 that looks like a client problem), and the only other way to notice was somebody reading the boot log of each instance. All three levels report `0` from process start. |
 
+> **Storage usage is measured out of band, and the age is published with it.**
+>
+> `ythril_storage_used_bytes` used to walk the entire files tree on every scrape. On an instance with a
+> real corpus that took **22 s** against ~8.6 s for every MongoDB-backed collector, and it was the sole cause
+> of half the scrapes on that target failing outright. It is now read from a cache that a **background** walk
+> refreshes; a scrape never blocks on filesystem I/O.
+>
+> `METRICS_SCRAPE_BUDGET_MS`'s sibling `METRICS_STORAGE_USAGE_MAX_AGE_MS` sets how stale the
+> cached value may get before a scrape kicks a refresh. Default **300000** (5 minutes), generous on purpose:
+> stored volume moves slowly, and during real activity every write already refreshes the cache as part of its
+> quota check — so this only governs freshness while the instance is idle, which is when it is least likely to
+> have changed.
+>
+> **Watch `ythril_storage_usage_age_seconds` if you care about freshness.** A cached number with no
+> visible age is worse than a missing one, so the age is a first-class series rather than something you have
+> to infer.
+>
+> **The first scrape after a cold start carries no storage series.** The walk is kicked, not awaited, so the
+> value arrives on the next scrape. An absent series says "not measured yet"; a zero would have said "empty".
+>
+> **A collector Prometheus gave up on still finishes, and still records its duration.**
+>
+> Worth stating because it is useful and not obvious: if a scrape exceeds your `scrape_timeout`,
+> Prometheus discards the *response*, but the server does not abandon the work — the collection completes and
+> its observation lands in the histogram, which a later successful scrape then delivers. That is why timing
+> data exists at all for the scrapes that failed.
+>
+> The corollary matters too: an instance whose scrapes **all** time out looks silent while doing the work. If
+> you see `up=0` with no timing data, the histogram is not empty — nothing has managed to carry it to
+> you yet.
 > **A slow scrape degrades one graph, not the whole target.**
 >
 > Several gauges above are collected at scrape time and walk every space, so a many-space instance under

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { brainWriteSeqTotal } from '../metrics/registry.js';
 import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
@@ -204,10 +205,19 @@ export async function updateChrono(
     { collection: 'chrono', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
-  await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(
+  // Lost-update detection, identical to `updateMemory` and for the same reason: `returnDocument: "before"`
+  // hands back the record as it was at WRITE time, so comparing its seq with the one read at the top of this
+  // function is exactly the test for another writer landing in the window. Observation only — no write that
+  // previously succeeded is now rejected.
+  const beforeWrite = await col<ChronoEntry>(`${spaceId}_chrono`).findOneAndUpdate(
     asFilter<ChronoEntry>({ _id: id }),
     asUpdate<ChronoEntry>(updateOp),
-  );
+    { returnDocument: 'before' },
+  ) as ChronoEntry | null;
+  brainWriteSeqTotal.labels({
+    collection: 'chrono',
+    outcome: beforeWrite && beforeWrite.seq !== existing.seq ? 'collision' : 'clean',
+  }).inc();
   const updatedChrono = { ...existing, ...($set as Partial<ChronoEntry>) } as ChronoEntry;
   if ('_expireAt' in $unset) delete (updatedChrono as { _expireAt?: unknown })._expireAt;
   if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...updatedChrono, embedding: undefined }, ...actor });

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { brainWriteSeqTotal } from '../metrics/registry.js';
 import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
@@ -329,7 +330,19 @@ export async function updateEdgeById(
     { collection: 'edge', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
-  await collection.updateOne(asFilter<EdgeDoc>({ _id: id }), asUpdate<EdgeDoc>(updateOp));
+  // Lost-update detection, identical to `updateMemory` and for the same reason: `returnDocument: "before"`
+  // hands back the record as it was at WRITE time, so comparing its seq with the one read at the top of this
+  // function is exactly the test for another writer landing in the window. Observation only — no write that
+  // previously succeeded is now rejected.
+  const beforeWrite = await collection.findOneAndUpdate(
+    asFilter<EdgeDoc>({ _id: id }),
+    asUpdate<EdgeDoc>(updateOp),
+    { returnDocument: 'before' },
+  ) as EdgeDoc | null;
+  brainWriteSeqTotal.labels({
+    collection: 'edges',
+    outcome: beforeWrite && beforeWrite.seq !== existing.seq ? 'collision' : 'clean',
+  }).inc();
 
   const result = {
     ...existing,

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { brainWriteSeqTotal } from '../metrics/registry.js';
 import { authorRef } from '../config/author.js';
 import { findInsertContradictions, type ContradictionWarning } from './insert-contradictions.js';
 import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
@@ -312,7 +313,19 @@ export async function updateEntityById(
     { collection: 'entity', existing: existing as unknown as Record<string, unknown> }); // F10
   const updateOp: Record<string, unknown> = { $set };
   if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
-  await collection.updateOne(asFilter<EntityDoc>({ _id: id }), asUpdate<EntityDoc>(updateOp));
+  // Lost-update detection, identical to `updateMemory` and for the same reason: `returnDocument: "before"`
+  // hands back the record as it was at WRITE time, so comparing its seq with the one read at the top of this
+  // function is exactly the test for another writer landing in the window. Observation only — no write that
+  // previously succeeded is now rejected.
+  const beforeWrite = await collection.findOneAndUpdate(
+    asFilter<EntityDoc>({ _id: id }),
+    asUpdate<EntityDoc>(updateOp),
+    { returnDocument: 'before' },
+  ) as EntityDoc | null;
+  brainWriteSeqTotal.labels({
+    collection: 'entities',
+    outcome: beforeWrite && beforeWrite.seq !== existing.seq ? 'collision' : 'clean',
+  }).inc();
 
   const result = {
     ...existing,

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -18,7 +18,7 @@ import {
 } from 'prom-client';
 import { col } from '../db/mongo.js';
 import { getConfig, getStorageConfig } from '../config/loader.js';
-import { measureUsage } from '../quota/quota.js';
+import { peekUsage, refreshUsageInBackground, usageMeasurementCount } from '../quota/quota.js';
 
 export const register = new Registry();
 
@@ -441,18 +441,80 @@ export const reindexInProgress = new Gauge({
 
 // ── Storage (collected at scrape time) ──────────────────────────────────────
 
+/**
+ * How stale the storage numbers are, in seconds.
+ *
+ * Shipped **with** the change that made the storage gauge read a cache instead of walking the disk, because a
+ * cached value with no visible age is the failure mode the abandoned-collector decision in #676 was about:
+ * numbers that look current and are not. An operator can alert on this if they care; nobody has to guess.
+ */
+export const storageUsageAgeSeconds = new Gauge({
+  name: 'ythril_storage_usage_age_seconds',
+  help: 'Age of the storage-usage measurement backing ythril_storage_used_bytes (it is cached, not re-walked)',
+  registers: [register],
+  // Reads the cache ITSELF rather than being written by the storage collector, and that is not a style choice.
+  // prom-client serialises each metric as soon as its own value is ready, so a gauge written by a *different*
+  // collector is emitted before that collector runs — the first version of this was set from
+  // `storageUsedBytes.collect()` and a poison-sentinel test caught it reporting the sentinel, not the age. Same
+  // trap as the timeout counter above, walked into a second time in the same file. Self-sufficient collectors are
+  // the only order-independent kind.
+  collect() {
+    const peek = peekUsage();
+    if (peek) this.set(peek.ageMs / 1000);
+  },
+});
+
+/**
+ * How many times the files tree has actually been walked.
+ *
+ * The operator-facing question this answers is "how often are we doing the expensive thing", and on a large
+ * store the answer used to be *every scrape*. It also makes the refresh coalescing testable: the number of walks
+ * is the only observable that distinguishes one guarded refresh from nine unguarded ones.
+ */
+export const storageUsageMeasurementsTotal = new Gauge({
+  name: 'ythril_storage_usage_measurements_total',
+  help: 'Completed walks of the files tree to measure storage usage since process start',
+  registers: [register],
+  collect() { this.set(usageMeasurementCount()); },
+});
+
+/**
+ * Maximum age before a scrape kicks a background re-walk. Default 5 minutes.
+ *
+ * Generous on purpose. Stored volume is a slow-moving quantity, and during actual activity `checkQuota()`
+ * refreshes the cache for free on every write — so this only governs how fresh the number is while the instance
+ * is *idle*, which is exactly when it is least likely to have changed.
+ */
+const STORAGE_USAGE_MAX_AGE_MS = (() => {
+  const raw = process.env['METRICS_STORAGE_USAGE_MAX_AGE_MS']?.trim();
+  if (!raw) return 300_000;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return 300_000;
+  return n;
+})();
+
 export const storageUsedBytes = new Gauge({
   name: 'ythril_storage_used_bytes',
-  help: 'Storage used in bytes by area (brain, files, total)',
+  help: 'Storage used in bytes by area (brain, files, total) — from a cached measurement, see the age gauge',
   labelNames: ['area'] as const,
   registers: [register],
   async collect() {
     await withCollectBudget('storage_used_bytes', async () => {
-      const usage = await measureUsage();
-      const GiB = 1024 ** 3;
-      this.set({ area: 'files' }, usage.files * GiB);
-      this.set({ area: 'brain' }, usage.brain * GiB);
-      this.set({ area: 'total' }, usage.total * GiB);
+      // Deliberately NOT `measureUsage()`. That walks the whole files tree, and the canary measured it at 22.150 s
+      // mean against ~8.6 s for every MongoDB collector, taking down 10 of 20 scrapes on its own. See `peekUsage`
+      // in quota.ts for the full numbers and why exactness is the wrong goal for a sampled gauge.
+      const peek = peekUsage();
+      if (peek) {
+        const GiB = 1024 ** 3;
+        this.set({ area: 'files' }, peek.usage.files * GiB);
+        this.set({ area: 'brain' }, peek.usage.brain * GiB);
+        this.set({ area: 'total' }, peek.usage.total * GiB);
+        // the age gauge reads the cache itself — see its collect()
+      }
+      // Kick the walk, never await it: a scrape must not be able to block on filesystem I/O. On a cold instance
+      // the first scrape carries no storage series and the second one does, which is honest — an absent series
+      // says "not measured yet" where a zero would have claimed "empty".
+      if (!peek || peek.ageMs > STORAGE_USAGE_MAX_AGE_MS) refreshUsageInBackground();
     }, () => this.reset());
   },
 });
@@ -777,7 +839,13 @@ export const brainWriteSeqTotal = new Counter({
   registers: [register],
 });
 // Pre-declared for the same reason as above: absent and zero look identical in a graph and mean opposites.
-for (const collection of ['memories']) {
+//
+// All FOUR record types, because all four are now instrumented. #674 shipped `memories` alone while the
+// metric was named for brain records generally, and the canary spotted the gap from the outside — they saw
+// only `collection="memories"` and reasonably guessed the labels were lazy. Pre-declaring the other three
+// without instrumenting them would have been the worse fix: a permanent 0 on entities reads as "no
+// collisions here", which is the exact confusion pre-declaring exists to prevent.
+for (const collection of ['memories', 'entities', 'edges', 'chrono']) {
   for (const outcome of ['clean', 'collision']) {
     brainWriteSeqTotal.labels({ collection, outcome }).inc(0);
   }

--- a/server/src/quota/quota.ts
+++ b/server/src/quota/quota.ts
@@ -105,6 +105,75 @@ export function invalidateUsageCache(): void {
 }
 
 /**
+ * Read the cached usage WITHOUT measuring. Returns `null` if nothing has been measured yet.
+ *
+ * ## Why a read-only accessor exists
+ *
+ * `measureUsage()` walks the entire files tree. That is correct for a quota check, which must not admit a write
+ * on a stale number, and **wrong for a Prometheus gauge**, which is sampled and already stale by the time it is
+ * graphed. The canary proved the difference with numbers: on their platform instance the storage collector
+ * averaged **22.150 s** against ~8.6 s for every MongoDB-backed collector, its distribution was bimodal (6 of 19
+ * collections under 50 ms, 9 over 15 s — cold cache versus warm), and of 20 scrapes **10 failed** at exactly
+ * `10.0012 s` while this collector exceeded 10 s exactly **10 times**. Same number. Their four small instances
+ * completed every collector in 0.005–0.041 s, so it scales with stored volume, not with anything else.
+ *
+ * The argument against exactness here was already written in `metrics/registry.ts` for the brain totals — *"the
+ * exactness that buys does not survive contact with what a gauge IS"* — and #606 acted on it by switching those
+ * to `estimatedDocumentCount()`. It was simply never carried to the one collector where the cost was seconds
+ * rather than milliseconds. The cache comment above even lists `metrics` among the callers that deliberately
+ * re-measure; that line was the bug.
+ *
+ * So: the gauge reads this, reports what is known, and **never blocks a scrape on filesystem I/O**.
+ */
+export function peekUsage(): { usage: UsageGiB; ageMs: number } | null {
+  if (!usageCache) return null;
+  return { usage: usageCache.usage, ageMs: nowMs() - usageCache.at };
+}
+
+/** In-flight background refresh, so a slow walk cannot be started nine times over by nine scrapes. */
+let backgroundRefresh: Promise<void> | null = null;
+
+/**
+ * Completed background walks since process start.
+ *
+ * Exists because coalescing is only testable by **counting walks**. The first version of the test asserted
+ * "a refresh is in flight" before and after nine calls — which is true whether or not the guard exists, since
+ * nine unguarded calls each leave *a* promise in the slot. The mutation that removed the guard survived it.
+ *
+ * It is also worth exposing: on a large store this is "how often are we walking the disk", which is the number
+ * an operator wants when the answer is "more than you think".
+ */
+let usageMeasurements = 0;
+
+/** Completed background usage walks since process start. Surfaced as a metric; also the coalescing assertion. */
+export function usageMeasurementCount(): number {
+  return usageMeasurements;
+}
+
+/**
+ * Refresh the usage cache off the caller's critical path. Returns immediately.
+ *
+ * Coalesced: while a walk is running, further calls do nothing. That matters precisely because the walk can take
+ * 22 s — without the guard, a 15-second scrape interval would stack walks on a filesystem that is already the
+ * bottleneck, and on the canary's degraded RAID1 mid-rebuild that would be actively harmful.
+ *
+ * Never throws. A failed measurement leaves the previous value in place, which is the same contract every
+ * collector already has for an unreachable dependency.
+ */
+export function refreshUsageInBackground(): void {
+  if (backgroundRefresh) return;
+  backgroundRefresh = measureUsageUncached()
+    .then(usage => { usageCache = { usage, at: nowMs() }; })
+    .catch(() => { /* keep the previous value; an error is not "unknown" */ })
+    .finally(() => { usageMeasurements++; backgroundRefresh = null; });
+}
+
+/** True while a background walk is in flight — for tests, so they need not guess at timing. */
+export function usageRefreshInFlight(): boolean {
+  return backgroundRefresh !== null;
+}
+
+/**
  * Measure current storage usage.
  *
  * @param maxAgeMs  Reuse a cached measurement if it is younger than this many ms.

--- a/testing/standalone/storage-collector-does-not-walk.test.js
+++ b/testing/standalone/storage-collector-does-not-walk.test.js
@@ -1,0 +1,228 @@
+/**
+ * The storage gauge must never walk the disk during a scrape.
+ *
+ * ## The measurement that produced this
+ *
+ * The canary answered the `/metrics` timeout question with numbers, and they name one collector:
+ *
+ * | collector | mean seconds |
+ * |---|---|
+ * | `storage_used_bytes` | **22.150** |
+ * | every MongoDB-backed collector | 8.57 – 8.61 |
+ *
+ * And the count that makes it a cause rather than a correlation: of **20 scrapes, 10 failed** with
+ * `scrape_duration_seconds` pinned at exactly `10.0012 s`, and of the 19 collections the histogram recorded,
+ * `storage_used_bytes` exceeded 10 s **exactly 10 times**. The other eight collectors exceeded 10 s 7 times
+ * between them, so they are not the determinant. Its distribution was bimodal — 6 of 19 under 50 ms, 9 over 15 s
+ * — which is a cold-versus-warm filesystem cache, not "slow". Their four small instances completed every
+ * collector in 0.005–0.041 s.
+ *
+ * Cause, from source: `measureUsage()` recursively `stat`s the whole files tree. It was the only collector doing
+ * filesystem I/O rather than a MongoDB count.
+ *
+ * ## What makes this the interesting kind of bug
+ *
+ * **The cache already existed, and the collector was the one caller that opted out of it.** `measureUsage()`
+ * takes a `maxAgeMs`, and the comment above the cache in `quota.ts` listed `metrics` among the callers that
+ * deliberately re-measure. That line was the bug. Worse, the argument against exactness was *already written* in
+ * `registry.ts` for the brain totals — "the exactness that buys does not survive contact with what a gauge IS" —
+ * and #606 acted on it there, for the collectors costing milliseconds, while leaving the one costing seconds.
+ *
+ * ## What each test defends
+ *
+ *  1. The collector reads the cache and never calls the walking function. Asserted as a **choice** in source,
+ *     because the effect — "the scrape was fast" — is true on a small test tree whatever the code does. That is
+ *     the same trap that made the scrape-budget fallback test vacuous until it asserted the parsed value.
+ *  2. A cold cache yields **no storage series at all**, not a zero. A zero would claim "empty".
+ *  3. A cold scrape kicks a background refresh, so the second scrape has the value.
+ *  4. The refresh is **coalesced** — nine scrapes must not start nine 22-second walks on a filesystem that is
+ *     already the bottleneck. On the canary's degraded RAID1 mid-rebuild that would be actively harmful.
+ *  5. The age is exposed. A cached value with no visible age is the failure mode #676 rejected: numbers that
+ *     look current and are not.
+ *  6. All four brain collections are pre-declared, now that all four are instrumented.
+ *
+ * Run: node --test testing/standalone/storage-collector-does-not-walk.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const REGISTRY_SRC = join(ROOT, 'server/src/metrics/registry.ts');
+const QUOTA_SRC = join(ROOT, 'server/src/quota/quota.ts');
+
+let reg, quota;
+before(async () => {
+  reg = await import('../../server/dist/metrics/registry.js');
+  quota = await import('../../server/dist/quota/quota.js');
+});
+
+const valueOf = (text, series) => {
+  const line = text.split('\n').find(l => l.startsWith(series + ' '));
+  return line ? Number(line.slice(series.length + 1)) : null;
+};
+
+async function scrape() {
+  reg.beginScrape();
+  try {
+    return await reg.register.metrics();
+  } finally {
+    reg.endScrape();
+  }
+}
+
+describe('the storage collector', () => {
+  it('1. reads the cache and never calls the function that walks the disk', () => {
+    const src = readFileSync(REGISTRY_SRC, 'utf8');
+
+    // Strip comments line-first, so this cannot pass on the prose explaining it, and cannot be "fixed" by
+    // deleting that prose.
+    const code = src.split(/\r?\n/).filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+
+    const block = code.match(
+      /name: 'ythril_storage_used_bytes'[\s\S]*?\n {2}\},\n\}\);/,
+    );
+    assert.ok(block, 'could not find the storage_used_bytes collector — re-point this gate, do not delete it');
+
+    assert.match(block[0], /peekUsage\(\)/,
+      'the collector no longer reads the cache; if it went back to measuring, the canary loses half its scrapes');
+    assert.doesNotMatch(block[0], /\bmeasureUsage\s*\(/,
+      'the collector calls measureUsage(), which recursively stats the whole files tree — 22.150 s mean on the '
+      + 'canary instance and the sole cause of 10 failed scrapes out of 20');
+    assert.doesNotMatch(block[0], /await\s+refreshUsageInBackground/,
+      'the background refresh is awaited, which re-introduces the disk walk into the scrape it was moved out of');
+  });
+
+  it('and the whole registry has no other disk-walking collector', () => {
+    const src = readFileSync(REGISTRY_SRC, 'utf8');
+    const code = src.split(/\r?\n/).filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+    assert.doesNotMatch(code, /\bmeasureUsage\s*\(/,
+      'measureUsage() is reachable from the metrics registry again — it walks the files tree and no scrape may');
+  });
+
+  it('2. reports no storage series at all before anything has been measured', async () => {
+    quota.invalidateUsageCache();
+    assert.equal(quota.peekUsage(), null, 'peekUsage must not invent a measurement');
+
+    reg.storageUsedBytes.reset();
+    const text = await scrape();
+    assert.equal(
+      valueOf(text, 'ythril_storage_used_bytes{area="total"}'), null,
+      'a cold instance reported a storage number it had never measured; 0 would read as "empty"',
+    );
+  });
+
+  it('3. a cold scrape kicks a background refresh, so the next scrape has the value', async () => {
+    quota.invalidateUsageCache();
+    reg.storageUsedBytes.reset();
+    await scrape();
+
+    // The walk is real but tiny here — wait for the coalesced promise rather than guessing at a delay.
+    for (let i = 0; i < 200 && quota.usageRefreshInFlight(); i++) {
+      await new Promise(r => setTimeout(r, 10));
+    }
+    assert.notEqual(quota.peekUsage(), null, 'the cold scrape did not start a measurement, so it never arrives');
+
+    const text = await scrape();
+    assert.equal(
+      typeof valueOf(text, 'ythril_storage_used_bytes{area="total"}'), 'number',
+      'the second scrape still has no value, so the refresh never reached the gauge',
+    );
+  });
+
+  it('4. coalesces refreshes — 9 calls must produce exactly 1 walk', async () => {
+    // Counted, not flag-checked. The first version of this test asserted `usageRefreshInFlight()` before and
+    // after the nine calls, which is true either way — nine unguarded calls each leave *a* promise in the slot —
+    // so the mutation that deleted the guard passed it. The number of completed walks is the only observable
+    // that tells one guarded refresh from nine unguarded ones.
+    quota.invalidateUsageCache();
+    const before = quota.usageMeasurementCount();
+
+    for (let i = 0; i < 9; i++) quota.refreshUsageInBackground();
+
+    for (let i = 0; i < 300 && quota.usageRefreshInFlight(); i++) {
+      await new Promise(r => setTimeout(r, 10));
+    }
+    // Let any un-coalesced stragglers land before counting, or an unguarded run could still be in flight and
+    // the test would under-count its way to a pass.
+    await new Promise(r => setTimeout(r, 60));
+
+    assert.equal(
+      quota.usageMeasurementCount() - before, 1,
+      `9 calls produced ${quota.usageMeasurementCount() - before} walks. On a store where one walk is 22 s, a `
+      + '15-second scrape interval would stack them on the filesystem that is already the bottleneck — and on the '
+      + "canary's degraded RAID1 mid-rebuild that is actively harmful.",
+    );
+    assert.equal(quota.usageRefreshInFlight(), false, 'the walk never cleared its in-flight guard — it would '
+      + 'block every future refresh for the life of the process');
+  });
+
+  it('and the coalescing guard is cleared in a finally, not on the success path', () => {
+    const src = readFileSync(QUOTA_SRC, 'utf8');
+    const fn = src.match(/export function refreshUsageInBackground\(\)[\s\S]*?\n\}/);
+    assert.ok(fn, 'refreshUsageInBackground not found');
+    assert.match(fn[0], /\.finally\(/,
+      'the in-flight guard is not cleared in a finally, so one failed measurement wedges the refresh forever and '
+      + 'the gauge silently freezes at its last value');
+  });
+
+  it('5. exposes how stale the numbers are', async () => {
+    quota.invalidateUsageCache();
+    quota.refreshUsageInBackground();
+    for (let i = 0; i < 200 && quota.usageRefreshInFlight(); i++) {
+      await new Promise(r => setTimeout(r, 10));
+    }
+    // POISON the gauge, do not reset it. Two traps here, both hit in sequence:
+    //   1. a prom-client gauge retains its last value, and test 3 already scraped — so with no preparation at all,
+    //      a mutation that stops setting the age still reads a plausible number left behind;
+    //   2. `reset()` on an UNLABELLED gauge re-initialises it to 0 rather than removing it, so resetting made it
+    //      strictly worse — it guaranteed a value inside the plausible range.
+    // A sentinel outside the assertion window is the only preparation that fails when nothing writes.
+    reg.storageUsageAgeSeconds.set(999_999);
+
+    const text = await scrape();
+    const age = valueOf(text, 'ythril_storage_usage_age_seconds');
+    assert.equal(typeof age, 'number', 'the age gauge is absent, so a cached value looks current with no way to '
+      + 'tell — which is the exact failure the abandoned-collector decision rejected');
+    assert.ok(age >= 0 && age < 120, `age ${age}s is not plausible for a measurement taken just now`);
+  });
+});
+
+describe('lost-update detection covers every brain record type', () => {
+  it('6. all four collections are pre-declared at zero', async () => {
+    const text = await reg.register.metrics();
+    for (const collection of ['memories', 'entities', 'edges', 'chrono']) {
+      for (const outcome of ['clean', 'collision']) {
+        assert.notEqual(
+          valueOf(text, `ythril_brain_write_seq_total{collection="${collection}",outcome="${outcome}"}`), null,
+          `${collection}/${outcome} is absent. The canary saw only collection="memories" and reasonably guessed `
+          + 'the labels were lazy; they were not, the other three were simply never instrumented.',
+        );
+      }
+    }
+  });
+
+  it('and every pre-declared collection is actually instrumented somewhere', () => {
+    // The half that matters. Pre-declaring a collection nobody counts is WORSE than omitting it: a permanent 0
+    // reads as "no collisions here" when the truth is "not measured". That is the exact confusion pre-declaring
+    // exists to prevent, so the two must move together.
+    const files = {
+      memories: 'server/src/brain/memory.ts',
+      entities: 'server/src/brain/entities.ts',
+      edges: 'server/src/brain/edges.ts',
+      chrono: 'server/src/brain/chrono.ts',
+    };
+    for (const [collection, file] of Object.entries(files)) {
+      const src = readFileSync(join(ROOT, file), 'utf8');
+      assert.match(src, /brainWriteSeqTotal/,
+        `${collection} is pre-declared in the registry but ${file} never counts a write`);
+      assert.match(src, /returnDocument:\s*'before'/,
+        `${file} increments the counter without reading the pre-write document, so it cannot detect a collision `
+        + 'and would report every write as clean');
+      assert.match(src, new RegExp(`collection:\\s*'${collection}'`),
+        `${file} does not label its writes as collection="${collection}"`);
+    }
+  });
+});


### PR DESCRIPTION
Answers the canary's reply to #676's diagnostic request. They found it in under an hour, with a count rather than a correlation.

## The measurement

| collector | mean seconds |
|---|---|
| `storage_used_bytes` | **22.150** |
| every MongoDB-backed collector | 8.57 – 8.61 |

And the part that makes it a cause: of **20 scrapes, 10 failed** with `scrape_duration_seconds` pinned at exactly `10.0012 s`. Of the 19 collections the histogram recorded, `storage_used_bytes` exceeded 10 s **exactly 10 times**. The other eight collectors exceeded it 7 times between them, so they are not the determinant.

Its distribution was **bimodal** — 6 of 19 under 50 ms, 9 over 15 s — which is a cold-versus-warm filesystem cache, not "slow". Their four small instances completed every collector in 0.005–0.041 s, so it scales with stored volume.

## The interesting part: the cache already existed and this collector opted out of it

`measureUsage()` takes a `maxAgeMs`. The comment above that cache listed `metrics` among the callers that *deliberately re-measure*. **That line was the bug.**

Worse — the argument against exactness was **already written in the registry**, for the brain totals:

> The exactness that buys does not survive contact with what a gauge IS. The value is sampled at scrape time and stored as a point in a series — it is already stale when Prometheus writes it, and stale again before it is graphed.

#606 acted on that reasoning for the collectors costing **milliseconds** and never carried it to the one costing **seconds**.

## The fix

- The gauge reads `peekUsage()` and **never blocks a scrape on filesystem I/O**.
- A background walk refreshes it, **coalesced** — nine scrapes must not start nine walks. Their array is a degraded RAID1 mid-rebuild, where stacking 22-second walks is actively harmful.
- `METRICS_STORAGE_USAGE_MAX_AGE_MS` (default 300000) governs staleness *while idle*. During real activity every write already refreshes the cache as part of its quota check.
- `ythril_storage_usage_age_seconds` — a cached value with no visible age is the exact failure #676 rejected.
- `ythril_storage_usage_measurements_total` — "how often are we doing the expensive thing", which used to be *every scrape*.
- **A cold instance reports no storage series at all.** Absent says "not measured yet"; a zero would say "empty".

## Lost-update detection covered 1 of 4 record types while being named for all of them

#674 shipped `ythril_brain_write_seq_total`, help text *"Brain record writes"*, measuring `memories` alone. `entities`, `edges` and `chrono` have the identical read → `nextSeq` → `updateOne` shape and the identical exposure. All four now instrumented, all four pre-declared.

**The canary spotted it from outside and proposed the wrong fix for the right reason.** They saw only `collection="memories"`, guessed the label set was lazy, and suggested pre-declaring the others. Pre-declaring an *uninstrumented* collection is worse than omitting it: a permanent `0` on entities reads as "no collisions here" when the truth is "not measured" — the exact confusion pre-declaring exists to prevent. A gate now fails if a pre-declared collection is not actually counted.

## Two docs notes they asked for, one correcting a query we sent them

- `ythril_metrics_collect_duration_seconds` is a **histogram**, so the bare name is not a series — only `_bucket`, `_sum`, `_count`. An instant query for the bare name returns **empty**, which reads as "the metric is missing". Our own request for a scrape told them to grep the bare name.
- **A collector Prometheus gave up on still finishes and still records its duration**, so a later successful scrape delivers those buckets. That is why timing data exists for the scrapes that failed — and the corollary is that an instance whose scrapes *all* time out looks silent while doing the work.

## Testing: 9 mutations, 9 caught — and three of the first six were my tests, not the code

| survived first | why | fix |
|---|---|---|
| coalescing | asserted *"a refresh is in flight"* before and after nine calls — true either way, since nine unguarded calls each leave **a** promise in the slot | count completed walks |
| age gauge | read a gauge an earlier test had already set | see below |
| budget fallback (in #676) | asserted an effect true for both branches | assert the parsed value |

The age one is worth the detail: adding `reset()` made it **worse**. `reset()` on an *unlabelled* prom-client gauge re-initialises it to `0` rather than removing it, so it *guaranteed* a value inside the plausible range. A **poison sentinel** outside that range was the only preparation that fails when nothing writes.

**And the sentinel then found a real bug.** `storageUsageAgeSeconds` was written by the storage collector — and prom-client serialises each metric as soon as **its own** value is ready, so the age was emitted before the collector that set it. Identical to the barrier bug in #676, in the same file, two hours later. It now reads the cache itself; a self-sufficient collector is the only order-independent kind.

## Verification

- `npm run preflight` — passes
- `metric-docs-coverage` — both new metrics documented
- `collectors-are-timed`, `scrape-budget` — still green (the storage collector stays inside the budget wrapper)
- `lint:docs` — clean

## What this does not claim

Their collision counter reads **0 on all five instances**, and they said plainly not to lean on it: the counters reset with the pod twelve minutes earlier. That is a statement about twelve quiet minutes. The `If-Match`/412 decision still waits for a week that includes real agent write load — unchanged.
