### PR TITLE
fix(server): 25 upstream response bodies were read with no size ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **25 HTTP response bodies were read into memory with no size ceiling, while the helper that exists to
+  prevent exactly that was used at 3 call sites — all inside the file that defines it.** `boundedJson`
+  lived in `files/media/providers.ts` with the risk stated correctly in its own comment: *"
+  `fetch().json()` reads the entire body without limit → a hostile or runaway upstream could exhaust heap."*
+  Nothing about it was media-specific; it was private by accident.
+
+  - **Why nobody noticed, which is the reusable part: every one of those call sites already had a timeout.** An
+    audit sweep asked "is there a provider call with no timeout?", found none, and stopped. A timeout bounds
+    **duration** and says nothing about **size** — a fast upstream streaming gigabytes finishes well inside a
+    120-second budget. A guard on the wrong axis is more dangerous than no guard, because a satisfied check is
+    the strongest possible reason to stop looking.
+  - **The worst path needs no bug and no attacker.** `files/converters/renderer.ts` reads
+    `{ pages: string[] }` — base64 PNGs — and decodes each one, so the JSON string, the parsed strings and
+    the decoded buffers are live at once. `renderDpi` accepts up to **600** and `maxPages` up to
+    **2000** through the UI, both supported operator actions.
+  - `boundedJson` and a new `boundedErrorText` now live in `server/src/util/bounded-read.ts`
+    and every read goes through them. `YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES` (default **256 MiB**) sets the
+    ceiling; the error names the upstream **and** the override, because "response too large" with neither is an
+    unactionable log line. A malformed value falls back to the default rather than removing the bound.
+  - **A gate fails the build on any `Response.json()` outside the helper**, with a floor assertion so a pattern
+    that stopped matching cannot pass by reporting zero offenders.
+
+- **The count in the original finding was 12. The real count was 25, and the miss is the more useful half.**
+  I scoped the sweep by grepping `await res.json()`, `await response.json()` and
+  `await r.json()` — variable names I had already seen — instead of `await <anything>.json()`. The
+  gate, written from the general shape, immediately found 13 more.
+  - **And they were the ones that mattered most.** All 13 were in `sync/engine.ts` and the network-join
+    handshake: paged record batches, file manifests, member lists and vote rounds read from **another operator’s
+    Ythril instance**, not from a sidecar the local operator runs. A checker whose scope comes from the code it
+    audits shares that code’s blind spot — the same failure as a drift sweep that reused the selector list of
+    the CSS it was auditing.
+
+- **Upstream error bodies were truncated at 3 of 5 sites and interpolated whole at the other 2**
+  (`unstructured.ts`, `embedding.ts`). One `boundedErrorText` now serves all five. The 200-char
+  limit was already the de-facto standard — three sites chose it independently — so the outliers were drift, not
+  a decision.
+  - **Checked rather than assumed: these do NOT reach an API client.** The global error middleware returns a
+    literal `'Internal server error'` and never `err.message`, and the four route handlers that do
+    return `err.message` wrap Mongo/config/keypair work no upstream body can reach. So this is log quality and a
+    double allocation, not an information leak. The tracker had it filed as possibly either, and guessing would
+    have justified a bigger change than the evidence supports.
+
+### Testing
+
+- **7 mutations, 7 caught**, including both directions of the gate (a peer read reverted to raw `.json()`, an
+  error body reverted to hand-rolled).
+- **Six fetch doubles shaped `{ ok, status, json }` became real `Response` objects.** They broke
+  because `boundedJson` reads the content-length header and streams `res.body` — the
+  only things that can actually bound a read. **Making the helper fall back to `res.json()` for objects lacking
+  them was rejected**: that is a silent bypass reachable from anywhere, and the gate would still have reported
+  zero offenders. This entry exists because that shape is the whole bug being fixed.
+- **The gate’s own first run failed on the file it points at.** `git ls-files` cannot see a file added in the
+  same change, so the scan missed `bounded-read.ts`. Now `ls-files` **plus** `--others --exclude-standard`,
+  which adds new files while still honouring .gitignore. Third time this repo has been bitten by treating
+  `git ls-files` as "what files does this project have".
+
+### Fixed
+
 - **The storage gauge walked the entire files tree on every scrape, and it was the whole cause of the canary's
   `/metrics` timeout.** They answered the diagnostic request from #676 with numbers that name one collector and
   a count that makes it a cause rather than a correlation:

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -734,7 +734,23 @@ see the egress table above. You can optionally point a **bigger, external model*
 > target, the address it resolved to, and the setting that would permit it — so a blocked endpoint is
 > diagnosable from the container log, not only from whatever a dialog happened to show. The line is
 > redacted like any other, so a key in a query string is not echoed into the log.
-
+>
+> **`YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES` — how large a response any of these providers may return.**
+>
+> Default **268435456** (256 MiB). Every response body from a sidecar, model endpoint or sync peer is read
+> with this ceiling; a body that exceeds it is refused rather than buffered, and the error names which
+> upstream and this variable.
+>
+> **Raise it if you have raised render quality.** The one path that can legitimately approach the default is
+> document rendering: `renderDpi` accepts up to 600 and `maxPages` up to 2000, and the sidecar
+> returns each page as a base64 image in one JSON body. 50 pages at 600 DPI sits comfortably under 256 MiB;
+> 2000 does not.
+>
+> **A malformed value falls back to the default rather than removing the ceiling**, so a typo cannot silently
+> unbound these reads.
+>
+> Note what this is *not*: the per-provider timeouts bound how **long** a call may take and say nothing about
+> how **much** it may return. A fast endpoint streaming gigabytes finishes well inside any timeout.
 ⚠️ **This is the only setting that sends document content off the instance.** When a task is assigned, the
 external model receives OCR-extracted text and draft transcriptions (and, for future image-based tasks,
 rendered page images). Settings → Media Processing surfaces an **acknowledgment dialog** on save that states exactly

--- a/server/src/api/local-agent.ts
+++ b/server/src/api/local-agent.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { boundedJson } from '../util/bounded-read.js';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -329,7 +330,7 @@ localAgentRouter.get('/status', globalRateLimit, requireAdminMfa, async (_req, r
       return;
     }
 
-    const body = await r.json().catch(() => ({}));
+    const body = await boundedJson<Record<string, unknown>>(r, 'local agent').catch(() => ({} as Record<string, unknown>));
     res.json({
       configured: true,
       reachable: true,
@@ -380,8 +381,9 @@ localAgentRouter.post('/enable-networks/execute', globalRateLimit, requireAdminM
       body: JSON.stringify(bodyWithOrigin),
     }, 5 * 60 * 1_000);
 
-    const raw = await response.text();
-    const body = raw ? JSON.parse(raw) : {};
+    // Bounded like every other upstream read. The local agent is operator-run, so this is the runaway
+    // case rather than the hostile one — but a runaway agent should not be able to take the server with it.
+    const body = await boundedJson<Record<string, unknown>>(response, 'local agent').catch(() => ({} as Record<string, unknown>));
 
     if (!response.ok) {
       res.status(502).json({

--- a/server/src/api/media-config.ts
+++ b/server/src/api/media-config.ts
@@ -9,6 +9,7 @@
  */
 
 import { Router } from 'express';
+import { boundedJson } from '../util/bounded-read.js';
 import { z } from 'zod';
 import { getConfig, saveConfig, getMediaEmbeddingConfig, getSecrets, saveSecrets, getDocAssistApiKey, getNliApiKey, getEmbeddingConfig, getEmbeddingApiKey, getRerankApiKey } from '../config/loader.js';
 import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
@@ -766,7 +767,7 @@ export async function probeModelEndpoint(
     try {
       const res = await doFetch(a.url, { method: 'GET', headers, signal: AbortSignal.timeout(5_000) });
       if (res.ok) {
-        const json = await res.json().catch(() => ({}));
+        const json = await boundedJson<Record<string, unknown>>(res, 'model provider').catch(() => ({}));
         const models = a.parse(json);
         // Ollama tags carry a `:tag` suffix (e.g. `moondream:latest`); match exact or `<model>:*`.
         const modelEnumerated = opts.model

--- a/server/src/api/networks/join.ts
+++ b/server/src/api/networks/join.ts
@@ -4,6 +4,7 @@
  * Split out of the api/networks.ts monolith (A17.5); handlers are unchanged.
  */
 import { Router } from 'express';
+import { boundedJson } from '../../util/bounded-read.js';
 import { v4 as uuidv4 } from 'uuid';
 import bcrypt from 'bcrypt';
 import { z } from 'zod';
@@ -98,12 +99,12 @@ joinRouter.post('/join-remote', globalRateLimit, requireAdmin, async (req, res) 
     }
 
     if (!applyRes.ok) {
-      const errBody = await applyRes.json().catch(() => ({}));
+      const errBody = await boundedJson<unknown>(applyRes, 'network peer').catch(() => ({}));
       res.status(applyRes.status).json(errBody);
       return;
     }
 
-    const applyData = await applyRes.json() as {
+    const applyData = await boundedJson<{
       encryptedTokenForB: string;
       rsaPublicKeyPem: string;
       instanceId: string;
@@ -112,7 +113,7 @@ joinRouter.post('/join-remote', globalRateLimit, requireAdmin, async (req, res) 
       networkLabel: string;
       networkType: string;
       spaces: string[];
-    };
+    }>(applyRes, 'network peer');
 
     // Decrypt tokenForB — the PAT Brain A created on its own server for Brain B to use
     let tokenForB: string;
@@ -194,12 +195,12 @@ joinRouter.post('/join-remote', globalRateLimit, requireAdmin, async (req, res) 
 
     if (!finalizeRes.ok) {
       await revokeToken(tokenForARecord.id);
-      const errBody = await finalizeRes.json().catch(() => ({}));
+      const errBody = await boundedJson<unknown>(finalizeRes, 'network peer').catch(() => ({}));
       res.status(finalizeRes.status).json(errBody);
       return;
     }
 
-    const finalizeData = await finalizeRes.json() as { status: string };
+    const finalizeData = await boundedJson<{ status: string }>(finalizeRes, 'network peer');
 
     // ── Register network and peer locally ────────────────────────────────────
     // Store tokenForB so this brain can call Brain A's sync endpoints.

--- a/server/src/api/schema-library.ts
+++ b/server/src/api/schema-library.ts
@@ -28,6 +28,7 @@
  */
 
 import { Router } from 'express';
+import { boundedJson } from '../util/bounded-read.js';
 import { requireAuth, requireAdminMfa, acceptSchemaLibraryToken } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getSchemaLibrary, saveSchemaLibrary, getConfig, getSchemaCatalogs, saveSchemaCatalogs } from '../config/loader.js';
@@ -637,7 +638,7 @@ async function proxyCatalogFetch(url: string, accessToken?: string): Promise<{ o
     // External catalogs must never reach private space, so allowPrivate stays false (the default).
     const resp = await ssrfSafeFetch(url, { headers, signal: controller.signal });
     clearTimeout(timer);
-    const body = await resp.json().catch(() => null);
+    const body = await boundedJson<unknown>(resp, 'schema library peer').catch(() => null);
     return { ok: resp.ok, status: resp.status, body };
   } catch (err: unknown) {
     clearTimeout(timer);

--- a/server/src/auth/oidc.ts
+++ b/server/src/auth/oidc.ts
@@ -12,6 +12,7 @@
  */
 
 import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
+import { boundedJson } from '../util/bounded-read.js';
 import type { JWTPayload } from 'jose';
 import { getConfig } from '../config/loader.js';
 import { allowPrivateOidcIssuer } from '../config/oidc-egress-policy.js';
@@ -254,7 +255,7 @@ export async function getDiscoveryDoc(issuerUrl: string): Promise<DiscoveryDoc> 
   if (!res.ok) {
     throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText} for ${url}`);
   }
-  const doc = await res.json() as DiscoveryDoc;
+  const doc = await boundedJson<DiscoveryDoc>(res, 'OIDC discovery');
 
   validateDiscoveryDocument(doc, issuerUrl, endpointsMayBePrivate);
 

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { boundedJson, boundedErrorText } from '../util/bounded-read.js';
 import path from 'node:path';
 import { getDataRoot, getEmbeddingConfig } from '../config/loader.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
@@ -220,13 +221,13 @@ async function embedViaHttp(
     );
   }
   if (!response.ok) {
-    const body = await response.text().catch(() => '');
+    const body = await boundedErrorText(response);
     throw new Error(`Embedding request failed (HTTP ${response.status}): ${body}`);
   }
-  const json = await response.json() as {
+  const json = await boundedJson<{
     data?: { embedding?: number[] }[];
     error?: { message?: string };
-  };
+  }>(response, 'embedding provider');
   if (json.error) throw new Error(`Embedding API error: ${json.error.message ?? JSON.stringify(json.error)}`);
   const vector = json.data?.[0]?.embedding;
   if (!vector || vector.length === 0) throw new Error('Embedding API returned empty vector');

--- a/server/src/brain/nli-client.ts
+++ b/server/src/brain/nli-client.ts
@@ -16,6 +16,7 @@
  * attacker-supplied endpoint cannot be used to reach cluster-internal services.
  */
 import { getMediaEmbeddingConfig } from '../config/loader.js';
+import { boundedJson } from '../util/bounded-read.js';
 import { allowPrivateForSlot, isLocalModelEndpoint as isLocalEndpoint } from '../config/model-egress-policy.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
@@ -103,7 +104,7 @@ export async function classify(premise: string, hypothesis: string): Promise<Nli
       log.warn(`NLI classify: ${res.status} from the judge endpoint — treating as no verdict`);
       return null;
     }
-    return parseVerdict(await res.json());
+    return parseVerdict(await boundedJson(res, 'NLI'));
   } catch (err) {
     // Deliberately does not include the pair text: it is record content, and this line goes to the log.
     log.warn(`NLI classify failed — treating as no verdict: ${err instanceof Error ? err.message : String(err)}`);

--- a/server/src/brain/rerank-client.ts
+++ b/server/src/brain/rerank-client.ts
@@ -18,6 +18,7 @@
  * vector order. A reranker that is down must degrade search quality, never break search.
  */
 import { getMediaEmbeddingConfig } from '../config/loader.js';
+import { boundedJson } from '../util/bounded-read.js';
 import { allowPrivateForSlot, isLocalModelEndpoint } from '../config/model-egress-policy.js';
 import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
@@ -163,7 +164,7 @@ export async function rerank(
       log.warn(`Rerank: HTTP ${res.status} from the reranker — keeping the vector order`);
       return null;
     }
-    const scores = parseScores(await res.json(), passages.length);
+    const scores = parseScores(await boundedJson(res, 'reranker'), passages.length);
     if (!scores) {
       log.warn('Rerank: unreadable response shape — keeping the vector order');
       return null;

--- a/server/src/files/converters/renderer.ts
+++ b/server/src/files/converters/renderer.ts
@@ -12,6 +12,7 @@
  * guard is for operator-supplied *external* model endpoints).
  */
 import { log } from '../../util/log.js';
+import { boundedJson, boundedErrorText } from '../../util/bounded-read.js';
 
 const RENDER_URL = (process.env['RENDER_SIDECAR_URL'] ?? 'http://localhost:8100').replace(/\/$/, '');
 const OFFICE_URL = (process.env['RENDER_OFFICE_SIDECAR_URL'] ?? 'http://localhost:8101').replace(/\/$/, '');
@@ -106,11 +107,14 @@ export async function renderDocumentPages(
     throw new Error(`${which} sidecar unreachable at ${base}: ${err instanceof Error ? err.message : String(err)}`);
   }
   if (!res.ok) {
-    const detail = await res.text().catch(() => '');
-    throw new Error(`${which} sidecar error ${res.status}: ${detail.slice(0, 200)}`);
+    const detail = await boundedErrorText(res);
+    throw new Error(`${which} sidecar error ${res.status}: ${detail}`);
   }
 
-  const body = await res.json() as { pages?: string[]; total?: number; truncated?: boolean; startPage?: number };
+  // The largest JSON body in the server: `pages` is an array of base64 PNGs, and every one of them is
+  // decoded below. Bounded because renderDpi accepts up to 600 and maxPages up to 2000 from the UI.
+  const body = await boundedJson<{ pages?: string[]; total?: number; truncated?: boolean; startPage?: number }>(
+    res, `${which} sidecar`);
   const pages = (body.pages ?? []).map(b64 => Buffer.from(b64, 'base64'));
   if (body.truncated) log.debug(`render: pages ${startPage}–${startPage + pages.length} of ${body.total}; more follow`);
   // `startPage` falls back to what we asked for: an older sidecar that does not echo it still windows

--- a/server/src/files/converters/unstructured.ts
+++ b/server/src/files/converters/unstructured.ts
@@ -11,6 +11,7 @@
  */
 
 import type { FileConverter } from './types.js';
+import { boundedJson, boundedErrorText } from '../../util/bounded-read.js';
 import { ConversionUnavailableError } from './types.js';
 import { getDocumentProcessingConfig } from '../../config/loader.js';
 
@@ -152,14 +153,16 @@ export class UnstructuredConverter implements FileConverter {
     }
 
     if (!response.ok) {
-      const body = await response.text().catch(() => '');
+      // Truncated like the other four sites. Untruncated, a multi-megabyte upstream body lands in a log
+      // line and buries the error it was supposed to explain.
+      const body = await boundedErrorText(response);
       throw new ConversionUnavailableError(
         'sidecar_error',
         `Unstructured sidecar returned HTTP ${response.status}: ${body}`,
       );
     }
 
-    const partitions = await response.json() as Partition[];
+    const partitions = await boundedJson<Partition[]>(response, 'Unstructured sidecar');
     if (!Array.isArray(partitions) || partitions.length === 0) {
       throw new ConversionUnavailableError('no_content', 'Unstructured returned no partitions');
     }

--- a/server/src/files/converters/vlm-client.ts
+++ b/server/src/files/converters/vlm-client.ts
@@ -12,6 +12,7 @@
  * acknowledgment (enforced at config-save time).
  */
 import { ssrfSafeFetch } from '../../util/ssrf.js';
+import { boundedJson, boundedErrorText } from '../../util/bounded-read.js';
 import { allowPrivateForSlot, type EgressSlot } from '../../config/model-egress-policy.js';
 import { chatUrlFor, type VlmWire } from './vlm-endpoint.js';
 
@@ -102,18 +103,19 @@ async function postChat(
     throw new Error(`VLM unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
   }
   if (!res.ok) {
-    const body2 = await res.text().catch(() => '');
-    throw new Error(`VLM HTTP ${res.status}: ${body2.slice(0, 200)}`);
+    const body2 = await boundedErrorText(res);
+    throw new Error(`VLM HTTP ${res.status}: ${body2}`);
   }
 
   if (endpoint.wire === 'ollama') {
-    const json = await res.json() as { message?: { content?: string }; done_reason?: string; error?: string };
+    const json = await boundedJson<{ message?: { content?: string }; done_reason?: string; error?: string }>(
+      res, 'VLM');
     if (json.error) throw new Error(`VLM error: ${json.error}`);
     return { text: json.message?.content ?? '', truncated: json.done_reason === 'length' };
   }
-  const json = await res.json() as {
+  const json = await boundedJson<{
     choices?: Array<{ message?: { content?: string }; finish_reason?: string }>; error?: unknown;
-  };
+  }>(res, 'VLM');
   if (json.error) throw new Error(`VLM error: ${typeof json.error === 'string' ? json.error : JSON.stringify(json.error).slice(0, 200)}`);
   const choice = json.choices?.[0];
   return { text: choice?.message?.content ?? '', truncated: choice?.finish_reason === 'length' };
@@ -270,10 +272,11 @@ export async function repairMarkdownExternal(
     throw new Error(`assist model unreachable (${url}): ${err instanceof Error ? err.message : String(err)}`);
   }
   if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`assist model HTTP ${res.status}: ${body.slice(0, 200)}`);
+    const body = await boundedErrorText(res);
+    throw new Error(`assist model HTTP ${res.status}: ${body}`);
   }
-  const json = await res.json() as { choices?: Array<{ message?: { content?: string }; finish_reason?: string }>; error?: unknown };
+  const json = await boundedJson<{ choices?: Array<{ message?: { content?: string }; finish_reason?: string }>; error?: unknown }>(
+    res, 'assist model');
   if (json.error) throw new Error(`assist model error: ${typeof json.error === 'string' ? json.error : JSON.stringify(json.error).slice(0, 200)}`);
   const choice = json.choices?.[0];
   return { text: choice?.message?.content ?? '', truncated: choice?.finish_reason === 'length' };

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -1,4 +1,5 @@
 import { ssrfSafeFetch } from '../../util/ssrf.js';
+import { boundedJson } from '../../util/bounded-read.js';
 import { getConfig, getSecrets } from '../../config/loader.js';
 import { allowPrivateForSlot } from '../../config/model-egress-policy.js';
 import { log } from '../../util/log.js';
@@ -88,7 +89,7 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
       log.warn(`External face model: HTTP ${res.status} — falling back to in-process recognition`);
       return null;
     }
-    const body = await res.json() as ExternalFaceResponse;
+    const body = await boundedJson<ExternalFaceResponse>(res, 'external face provider');
     const raw = Array.isArray(body?.faces) ? body.faces.slice(0, MAX_FACES) : [];
 
     const faces: ExternalFace[] = [];

--- a/server/src/files/media/providers.ts
+++ b/server/src/files/media/providers.ts
@@ -13,6 +13,7 @@
  */
 
 import type { MediaProviderConfig } from '../../config/types.js';
+import { boundedJson, boundedErrorText } from '../../util/bounded-read.js';
 import { log } from '../../util/log.js';
 import { ssrfSafeFetch } from '../../util/ssrf.js';
 import { allowPrivateForSlot, type EgressSlot } from '../../config/model-egress-policy.js';
@@ -57,46 +58,6 @@ const egressFetch = (external: boolean, slot: EgressSlot): typeof fetch => {
   return ((url: string, init?: RequestInit) =>
     ssrfSafeFetch(url, init ?? {}, { allowPrivate })) as unknown as typeof fetch;
 };
-
-// ── Bounded JSON response reader ──────────────────────────────────────────────────────
-//
-// fetch().json() reads the entire body without limit → a hostile or runaway
-// upstream could exhaust heap. We cap by streaming the body and aborting once
-// `maxBytes` is exceeded.
-//
-// Defaults are generous (100 MiB STT response, 50 MiB caption response) but
-// finite — enough headroom for legitimate Whisper verbose_json responses on
-// hour-long recordings, far below an OOM threshold.
-async function boundedJson<T>(res: Response, maxBytes: number, label: string): Promise<T> {
-  const declared = res.headers.get('content-length');
-  if (declared && Number(declared) > maxBytes) {
-    throw new Error(`${label} response too large: ${declared} bytes (max ${maxBytes})`);
-  }
-  if (!res.body) {
-    // Some runtimes buffer bodies; fall back to text() with a post-hoc size check.
-    const text = await res.text();
-    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
-      throw new Error(`${label} response exceeded ${maxBytes} bytes`);
-    }
-    return JSON.parse(text) as T;
-  }
-  const reader = res.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      try { await reader.cancel(); } catch { /* ignore */ }
-      throw new Error(`${label} response exceeded ${maxBytes} bytes`);
-    }
-    chunks.push(value);
-  }
-  const merged = Buffer.concat(chunks.map(c => Buffer.from(c.buffer, c.byteOffset, c.byteLength)));
-  return JSON.parse(merged.toString('utf8')) as T;
-}
 
 const MAX_VISION_RESPONSE_BYTES = 50 * 1024 * 1024;  // 50 MiB — caption JSON is small
 const MAX_STT_RESPONSE_BYTES    = 100 * 1024 * 1024; // 100 MiB — verbose_json with many segments
@@ -168,13 +129,11 @@ export class OllamaVisionProvider implements VisionProvider {
     }
 
     if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new Error(`Ollama vision HTTP ${res.status}: ${body.slice(0, 200)}`);
+      const body = await boundedErrorText(res);
+      throw new Error(`Ollama vision HTTP ${res.status}: ${body}`);
     }
 
-    const json = await boundedJson<{ message?: { content?: string }; error?: string }>(
-      res, MAX_VISION_RESPONSE_BYTES, 'Ollama vision',
-    );
+    const json = await boundedJson<{ message?: { content?: string }; error?: string }>(res, 'Ollama vision', MAX_VISION_RESPONSE_BYTES);
     if (json.error) throw new Error(`Ollama vision error: ${json.error}`);
     const caption = json.message?.content?.trim();
     if (!caption) throw new Error('Ollama vision returned empty caption');
@@ -236,14 +195,14 @@ export class ExternalVisionProvider implements VisionProvider {
     }
 
     if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new Error(`External vision HTTP ${res.status}: ${body.slice(0, 200)}`);
+      const body = await boundedErrorText(res);
+      throw new Error(`External vision HTTP ${res.status}: ${body}`);
     }
 
     const json = await boundedJson<{
       choices?: { message?: { content?: string } }[];
       error?: { message?: string };
-    }>(res, MAX_VISION_RESPONSE_BYTES, 'External vision');
+    }>(res, 'External vision', MAX_VISION_RESPONSE_BYTES);
     if (json.error) throw new Error(`External vision error: ${json.error.message}`);
     const caption = json.choices?.[0]?.message?.content?.trim();
     if (!caption) throw new Error('External vision returned empty caption');
@@ -302,15 +261,15 @@ export class WhisperProvider implements SttProvider {
     }
 
     if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new Error(`Whisper HTTP ${res.status}: ${body.slice(0, 200)}`);
+      const body = await boundedErrorText(res);
+      throw new Error(`Whisper HTTP ${res.status}: ${body}`);
     }
 
     const json = await boundedJson<{
       text?: string;
       segments?: { start?: number; end?: number; text?: string }[];
       error?: { message?: string };
-    }>(res, MAX_STT_RESPONSE_BYTES, 'Whisper');
+    }>(res, 'Whisper', MAX_STT_RESPONSE_BYTES);
     if (json.error) throw new Error(`Whisper error: ${json.error.message}`);
 
     const text = json.text?.trim() ?? '';

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -16,6 +16,7 @@
  */
 
 import { getConfig, saveConfig, saveConfigSoon, getSecrets, getFaceRecognitionConfig } from '../config/loader.js';
+import { boundedJson } from '../util/bounded-read.js';
 import { toSafeRelPath } from '../util/paths.js';
 import { col, asFilter, asDoc, asBulk } from '../db/mongo.js';
 import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
@@ -593,7 +594,7 @@ async function gossipWithPeer(
     if (resp.ok) {
       // Peer may piggyback its own self-record in the response so we can update our entry for it
       try {
-        const body = await resp.json() as { status: string; self?: Partial<NetworkMember> & { signingKeyRotation?: import('../util/signing.js').SigningKeyRotation } };
+        const body = await boundedJson<{ status: string; self?: Partial<NetworkMember> & { signingKeyRotation?: import('../util/signing.js').SigningKeyRotation } }>(resp, 'sync peer');
         const peerSelf = body.self;
         if (peerSelf?.instanceId === member.instanceId) {
           const freshCfg = getConfig();
@@ -630,7 +631,7 @@ async function gossipWithPeer(
       log.warn(`Gossip pull from ${member.label}: HTTP ${resp.status}`);
       return;
     }
-    const { members: peerView } = await resp.json() as { members: Partial<NetworkMember>[] };
+    const { members: peerView } = await boundedJson<{ members: Partial<NetworkMember>[] }>(resp, 'sync peer');
     if (!Array.isArray(peerView)) return;
 
     const fresh = getConfig();
@@ -701,7 +702,7 @@ async function propagateVotesWithPeer(
       log.warn(`Vote pull from ${member.label}: HTTP ${resp.status}`);
       return;
     }
-    const { rounds: peerRounds } = await resp.json() as { rounds: (Omit<VoteRound, 'concluded'>)[] };
+    const { rounds: peerRounds } = await boundedJson<{ rounds: (Omit<VoteRound, 'concluded'>)[] }>(resp, 'sync peer');
     if (!Array.isArray(peerRounds)) return;
 
     const fresh = getConfig();
@@ -860,7 +861,7 @@ async function pullFromPeer(
     const tombsUrl = `${member.url}/api/sync/tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}&sinceSeq=${sinceSeq}`;
     const resp = await peerSafeFetch(tombsUrl, opts());
     if (resp.ok) {
-      const data = await resp.json() as { memories?: TombstoneDoc[]; entities?: TombstoneDoc[]; edges?: TombstoneDoc[]; chrono?: TombstoneDoc[] };
+      const data = await boundedJson<{ memories?: TombstoneDoc[]; entities?: TombstoneDoc[]; edges?: TombstoneDoc[]; chrono?: TombstoneDoc[] }>(resp, 'sync peer');
       const all = [...(data.memories ?? []), ...(data.entities ?? []), ...(data.edges ?? []), ...(data.chrono ?? [])];
       // The peer we pulled from is the authenticated source. Its own tombstones
       // (issuer === member) are authorised; a tombstone it relays on behalf of a
@@ -891,9 +892,9 @@ async function pullFromPeer(
       });
       const resp = await peerSafeFetch(`${member.url}/api/sync/${urlSuffix}?${params}`, batchOpts());
       if (!resp.ok) { log.warn(`Pull ${urlSuffix} from ${member.label} returned ${resp.status}`); break; }
-      const { items, nextCursor } = await resp.json() as {
+      const { items, nextCursor } = await boundedJson<{
         items: (T | { _id: string; seq: number; deletedAt: string })[]; nextCursor: string | null;
-      };
+      }>(resp, 'sync peer');
       // Collect the applyable docs for this page, then upsert them in one batch (P3).
       const pageDocs: T[] = [];
       for (const item of items) {
@@ -1100,7 +1101,7 @@ async function syncFiles(
         opts(),
       );
       if (tsResp.ok) {
-        const { tombstones } = await tsResp.json() as { tombstones: { path: string }[] };
+        const { tombstones } = await boundedJson<{ tombstones: { path: string }[] }>(tsResp, 'sync peer');
         const spaceDataRoot = getDataRoot();
         const spaceFiles = path.resolve(spaceDataRoot, 'files', spaceId);
         for (const ts of tombstones) {
@@ -1160,7 +1161,7 @@ async function syncFiles(
     if (!doPull && !doPush) return { pulledFiles, pushedFiles, pulledPaths };
     const resp = await peerSafeFetch(`${member.url}/api/sync/manifest?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}`, opts());
     if (!resp.ok) { log.warn(`File manifest from ${member.label}: ${resp.status}`); return { pulledFiles, pushedFiles, pulledPaths }; }
-    const { manifest } = await resp.json() as { manifest: { path: string; sha256: string; size: number; modifiedAt: string }[] };
+    const { manifest } = await boundedJson<{ manifest: { path: string; sha256: string; size: number; modifiedAt: string }[] }>(resp, 'sync peer');
 
     // Build our manifest for comparison
     const ours = await buildFileManifest(spaceId);
@@ -1346,7 +1347,7 @@ async function checkMerkleWithPeer(
       return;
     }
 
-    const peerResult = await peerResp.json() as { root?: string; leafCount?: number };
+    const peerResult = await boundedJson<{ root?: string; leafCount?: number }>(peerResp, 'sync peer');
     const peerRoot = peerResult.root;
 
     if (!peerRoot) {

--- a/server/src/util/bounded-read.ts
+++ b/server/src/util/bounded-read.ts
@@ -1,0 +1,149 @@
+/**
+ * Bounded readers for HTTP responses from operator-configured upstreams.
+ *
+ * ## Why this is a shared module and not a private helper
+ *
+ * `boundedJson` was written in `files/media/providers.ts`, with the risk stated correctly in a comment:
+ *
+ * > `fetch().json()` reads the entire body without limit → a hostile or runaway upstream could exhaust heap.
+ * > We cap by streaming the body and aborting once `maxBytes` is exceeded.
+ *
+ * It was then used at three call sites, **all inside that same file**, while twelve other `Response.json()` reads
+ * across eight files went unbounded — including `files/converters/renderer.ts`, which reads rendered page images
+ * as base64 strings and is the largest JSON body the server ever handles. Nothing about the reader is
+ * media-specific; it was private by accident.
+ *
+ * ## Why nobody noticed, which is the part worth remembering
+ *
+ * **Every one of those call sites already had a timeout.** An audit sweep asked "is there a provider call with no
+ * timeout?", found none, and moved on. A timeout bounds **duration**; it says nothing about **size**. A fast
+ * upstream streaming gigabytes finishes well inside a 120-second budget. A guard on the wrong axis is more
+ * dangerous than no guard, because a satisfied check is the strongest possible reason to stop looking.
+ *
+ * ## The realistic failure is runaway, not hostile
+ *
+ * Every upstream here is operator-configured — a sidecar, a local model server, an OpenAI-compatible endpoint.
+ * None is attacker-supplied, so this is not remotely exploitable. What it is: a sidecar bug, or an operator
+ * turning render quality up. `renderDpi` accepts up to **600** and `maxPages` up to **2000** through the UI, and
+ * `renderer.ts` decodes every returned page with `Buffer.from(b64, 'base64')` — so the JSON string, the parsed
+ * strings and the decoded buffers are all live at once. That path needs no bug and no attacker to hurt.
+ */
+
+/**
+ * Default ceiling for one upstream response body.
+ *
+ * 256 MiB: comfortably above a legitimate 50-page render at 600 DPI (the shipped `maxPages` default at the
+ * schema's maximum quality), and far below anything that threatens the heap. Deliberately one generous number
+ * rather than a per-caller guess — a cap tuned so tightly that it rejects real work would be reverted, and a
+ * reverted cap protects nothing.
+ *
+ * `YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES` raises or lowers it. An operator who has set `maxPages: 2000` at 600 DPI
+ * genuinely needs more than this, and the error message says so rather than leaving them to guess.
+ */
+export const DEFAULT_MAX_UPSTREAM_RESPONSE_BYTES = 256 * 1024 * 1024;
+
+export function maxUpstreamResponseBytes(): number {
+  const raw = process.env['YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES']?.trim();
+  if (!raw) return DEFAULT_MAX_UPSTREAM_RESPONSE_BYTES;
+  const n = Number(raw);
+  // A malformed value must not silently remove the bound, so it falls back rather than becoming 0 or NaN.
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_MAX_UPSTREAM_RESPONSE_BYTES;
+  return n;
+}
+
+/** How much of an upstream error body is worth keeping. Three call sites chose 200 independently; that is the standard. */
+export const ERROR_BODY_CHARS = 200;
+
+/**
+ * Read a JSON response with a hard size ceiling.
+ *
+ * Checks `content-length` first — a declared oversize body is refused without reading a byte — then streams and
+ * aborts the moment the cap is passed. The `content-length` check is an optimisation, not the guard: it is
+ * advisory and an upstream may omit or lie about it, which is why the streaming check exists regardless.
+ *
+ * @param label  Named in the error, because "response too large" without a source is an unactionable log line.
+ */
+export async function boundedJson<T>(
+  res: Response,
+  label: string,
+  maxBytes: number = maxUpstreamResponseBytes(),
+): Promise<T> {
+  const tooBig = (detail: string): Error => new Error(
+    `${label} response ${detail} (max ${maxBytes} bytes). If this is legitimate, raise `
+    + 'YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES.',
+  );
+
+  const declared = res.headers.get('content-length');
+  if (declared && Number(declared) > maxBytes) {
+    throw tooBig(`too large: ${declared} bytes`);
+  }
+
+  if (!res.body) {
+    // Some runtimes buffer bodies and expose no stream. Fall back to text() with a post-hoc check — weaker,
+    // because the allocation has already happened, but it is the only option and it still refuses to PARSE.
+    const text = await res.text();
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) throw tooBig(`exceeded ${maxBytes} bytes`);
+    return JSON.parse(text) as T;
+  }
+
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      // Cancel rather than drain: the point is to stop paying for bytes we have already decided to refuse.
+      try { await reader.cancel(); } catch { /* the connection is going away anyway */ }
+      throw tooBig(`exceeded ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+  const merged = Buffer.concat(chunks.map(c => Buffer.from(c.buffer, c.byteOffset, c.byteLength)));
+  return JSON.parse(merged.toString('utf8')) as T;
+}
+
+/**
+ * Read an upstream ERROR body, bounded and truncated, for use in a message.
+ *
+ * Five sites did this by hand and three of them truncated at 200 characters while two interpolated the whole
+ * body into an `Error`. The untruncated pair are not an information leak — the global error middleware returns a
+ * generic message and never `err.message`, which was checked rather than assumed — but they are a second full
+ * copy of an already unbounded read, landing in a log line where a multi-megabyte body destroys the surrounding
+ * context and buries the actual error.
+ *
+ * Never throws. An error path that can itself fail replaces a diagnosable failure with a confusing one, which is
+ * the opposite of what an error body is for.
+ */
+export async function boundedErrorText(res: Response, maxChars: number = ERROR_BODY_CHARS): Promise<string> {
+  try {
+    // 1 MiB is plenty for any error body; nothing legitimate needs more, and it caps the read before truncation
+    // rather than after — truncating a string you have already allocated is not a bound.
+    const text = await boundedJsonSafeText(res, 1024 * 1024);
+    return text.length > maxChars ? `${text.slice(0, maxChars)}… (truncated)` : text;
+  } catch {
+    return '';
+  }
+}
+
+/** Streaming text read with a byte ceiling. Returns what it got if the cap is hit rather than throwing. */
+async function boundedJsonSafeText(res: Response, maxBytes: number): Promise<string> {
+  if (!res.body) return (await res.text()).slice(0, maxBytes);
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    chunks.push(value);
+    total += value.byteLength;
+    if (total >= maxBytes) {
+      try { await reader.cancel(); } catch { /* ignore */ }
+      break;
+    }
+  }
+  return Buffer.concat(chunks.map(c => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
+}

--- a/testing/standalone/contradiction-judge.test.js
+++ b/testing/standalone/contradiction-judge.test.js
@@ -23,6 +23,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+/**
+ * A REAL Response, not a { ok, status, json } shape.
+ *
+ * The client under test reads its body through boundedJson, which bounds a read by inspecting content-length
+ * and streaming res.body — neither of which a hand-rolled double has. Making the helper fall back to res.json()
+ * for objects lacking them was rejected: that is a silent bypass reachable from anywhere, and a guard with a
+ * silent bypass is worse than none. Using the real thing also means these tests exercise the production path.
+ */
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
 let judgePair, findPropertyDisagreements, _reloadConfig;
 let cfgPath;
 const rec = (id, text, properties) => ({ id, text, ...(properties ? { properties } : {}) });
@@ -34,7 +46,7 @@ function configureNli(on) {
   }), 'utf8');
   _reloadConfig();
 }
-const stubNli = (body, ok = true) => { globalThis.fetch = async () => ({ ok, status: ok ? 200 : 503, json: async () => body }); };
+const stubNli = (body, ok = true) => { globalThis.fetch = async () => jsonResponse(body, ok ? 200 : 503); };
 
 describe('contradiction judge', () => {
   before(async () => {
@@ -69,7 +81,7 @@ describe('contradiction judge', () => {
     it('beats the NLI pass — a deterministic answer is preferred and costs nothing', async () => {
       configureNli(true);
       let called = false;
-      globalThis.fetch = async () => { called = true; return { ok: true, status: 200, json: async () => ({ label: 'entailment', score: 0.99 }) }; };
+      globalThis.fetch = async () => { called = true; return jsonResponse({ label: 'entailment', score: 0.99 }); };
       const v = await judgePair(rec('a', 'runs on 8080', { port: 8080 }), rec('b', 'runs on 9090', { port: 9090 }));
       assert.equal(v.kind, 'contradiction');
       assert.equal(v.basis, 'structured-field');

--- a/testing/standalone/nli-client.test.js
+++ b/testing/standalone/nli-client.test.js
@@ -21,6 +21,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+/**
+ * A REAL Response, not a { ok, status, json } shape.
+ *
+ * The client under test reads its body through boundedJson, which bounds a read by inspecting content-length
+ * and streaming res.body — neither of which a hand-rolled double has. Making the helper fall back to res.json()
+ * for objects lacking them was rejected: that is a silent bypass reachable from anywhere, and a guard with a
+ * silent bypass is worse than none. Using the real thing also means these tests exercise the production path.
+ */
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
 let classify, nliConfigured, _reloadConfig;
 let dir, cfgPath;
 const savedEnv = {};
@@ -69,7 +81,7 @@ describe('NLI client — the contradiction judge', () => {
     writeConfig({ nli: { baseUrl: 'http://nli:8080', model: 'm' } });
     globalThis.__realFetch ??= globalThis.fetch;
 
-    globalThis.fetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+    globalThis.fetch = async () => jsonResponse({}, 503);
     assert.equal(await classify('a', 'b'), null, 'a 503 is not "these records agree"');
 
     globalThis.fetch = async () => { throw new Error('ECONNREFUSED'); };
@@ -90,7 +102,7 @@ describe('NLI client — the contradiction judge', () => {
       [{ label: 'LABEL_2', score: 0.7 }, 'entailment'],
     ];
     for (const [body, expected] of cases) {
-      globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => body });
+      globalThis.fetch = async () => jsonResponse(body);
       const v = await classify('p', 'h');
       assert.equal(v?.label, expected, `${body.label} must normalise to ${expected}`);
       assert.equal(v?.score, body.score);
@@ -100,7 +112,7 @@ describe('NLI client — the contradiction judge', () => {
   it('accepts the HF array shape as well as a bare object', async () => {
     writeConfig({ nli: { baseUrl: 'http://nli:8080', model: 'm' } });
     globalThis.__realFetch ??= globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => [[{ label: 'contradiction', score: 0.95 }]] });
+    globalThis.fetch = async () => jsonResponse([[{ label: 'contradiction', score: 0.95 }]]);
     assert.deepEqual(await classify('p', 'h'), { label: 'contradiction', score: 0.95 });
   });
 
@@ -108,7 +120,7 @@ describe('NLI client — the contradiction judge', () => {
     writeConfig({ nli: { baseUrl: 'http://nli:8080', model: 'm' } });
     globalThis.__realFetch ??= globalThis.fetch;
     for (const body of [{}, { label: 'wat', score: 0.9 }, { label: 'neutral' }, null]) {
-      globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => body });
+      globalThis.fetch = async () => jsonResponse(body);
       assert.equal(await classify('p', 'h'), null, `unreadable body ${JSON.stringify(body)} must yield no verdict`);
     }
   });

--- a/testing/standalone/upstream-reads-are-bounded.test.js
+++ b/testing/standalone/upstream-reads-are-bounded.test.js
@@ -1,0 +1,206 @@
+/**
+ * No upstream response body may be read without a size ceiling.
+ *
+ * ## The finding
+ *
+ * `boundedJson` was written in `files/media/providers.ts` with the risk stated correctly in a comment —
+ * *"`fetch().json()` reads the entire body without limit → a hostile or runaway upstream could exhaust heap"* —
+ * and then used at **three call sites, all inside that same file**. Twelve other `Response.json()` reads across
+ * eight files were unbounded, including `files/converters/renderer.ts`, which reads rendered page images as
+ * base64 strings and decodes each one, making it the largest JSON body the server handles.
+ *
+ * ## Why nobody noticed, which is the part this gate is really for
+ *
+ * **Every one of those call sites already had a timeout.** An audit sweep asked "is there a provider call with no
+ * timeout?", found none, and moved on. A timeout bounds **duration**; it says nothing about **size**. A fast
+ * upstream streaming gigabytes finishes well inside a 120-second budget.
+ *
+ * The realistic failure is **runaway, not hostile** — every upstream is operator-configured. `renderDpi` accepts
+ * up to 600 and `maxPages` up to 2000 through the UI, so no bug and no attacker is needed.
+ *
+ * ## Sizing, checked rather than assumed
+ *
+ * The two untruncated error bodies do **not** reach an API client: the global error middleware in `app.ts`
+ * returns a literal `'Internal server error'` and never `err.message`, and the four route handlers that do return
+ * `err.message` wrap Mongo/config/keypair work that no upstream body can reach. So that half is a log-quality and
+ * double-allocation problem, not an information leak — stated because the tracker entry had it filed as possibly
+ * either, and guessing would have justified a larger change than the evidence supports.
+ *
+ * Run: node --test testing/standalone/upstream-reads-are-bounded.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+const HELPER = 'server/src/util/bounded-read.ts';
+
+let mod;
+before(async () => { mod = await import('../../server/dist/util/bounded-read.js'); });
+
+/**
+ * Every .ts under server/src that is part of the repo — tracked **and** untracked-but-not-ignored.
+ *
+ * `git ls-files` alone cannot see a file added in the same change as the gate, so on its first run this scan
+ * missed the very helper it points at. That is exactly how it failed the first time it was run, and it is the
+ * third time this repo has been bitten by treating `git ls-files` as "what files does this project have".
+ * `--others --exclude-standard` adds new files while still honouring .gitignore, which is the property that
+ * matters: a gitignored generated file must not enter the scan.
+ */
+function sourceFiles() {
+  const tracked = execFileSync('git', ['ls-files', 'server/src/**/*.ts'], { cwd: ROOT, encoding: 'utf8' });
+  const fresh = execFileSync('git', ['ls-files', '--others', '--exclude-standard', 'server/src/**/*.ts'],
+    { cwd: ROOT, encoding: 'utf8' });
+  return [...new Set(`${tracked}\n${fresh}`.split(/\r?\n/))]
+    .filter(Boolean).map(p => p.replace(/\\/g, '/'));
+}
+
+/** Strip comments line-first so the gate cannot fire on the prose explaining it. */
+function code(path) {
+  return readFileSync(join(ROOT, path), 'utf8')
+    .split(/\r?\n/)
+    .filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join('\n');
+}
+
+describe('the gate: every upstream read goes through a bounded reader', () => {
+  it('found a plausible number of files — the scan itself still works', () => {
+    const files = sourceFiles();
+    assert.ok(files.length > 50, `only ${files.length} source files found; the enumeration broke, not the code`);
+    assert.ok(files.includes(HELPER), `${HELPER} is not tracked, so the helper this gate points at is missing`);
+  });
+
+  it('no Response.json() is called outside the helper', () => {
+    const offenders = [];
+    for (const f of sourceFiles()) {
+      if (f === HELPER) continue;
+      const src = code(f);
+      // `.json()` on a fetch Response. Mongo/Express have no such method, so this pattern is specific.
+      for (const m of src.matchAll(/\bawait\s+\w+\.json\(\)/g)) {
+        offenders.push(`${f}: ${m[0]}`);
+      }
+    }
+    assert.deepEqual(offenders, [], 'these read an entire upstream body into memory with no ceiling. A timeout '
+      + 'does not help — it bounds duration, not size.\n  ' + offenders.join('\n  ')
+      + "\n\nUse `boundedJson<T>(res, 'label')` from util/bounded-read.js.");
+  });
+
+  it('no error body is read by hand', () => {
+    const offenders = [];
+    for (const f of sourceFiles()) {
+      if (f === HELPER) continue;
+      const src = code(f);
+      for (const m of src.matchAll(/\.text\(\)\s*\.catch\(/g)) offenders.push(`${f}: ${m[0]}`);
+    }
+    assert.deepEqual(offenders, [], 'these read an upstream error body unbounded. Five sites did this by hand and '
+      + 'three truncated at 200 chars while two did not, so the truncation was drift rather than a decision.\n  '
+      + offenders.join('\n  ') + '\n\nUse `boundedErrorText(res)`.');
+  });
+
+  it('and the helper is actually used, so the two checks above are not vacuous', () => {
+    // A pattern that stopped matching would report zero offenders and pass while verifying nothing. The floor is
+    // the other half of every enumeration gate in this repo.
+    let jsonSites = 0;
+    let textSites = 0;
+    for (const f of sourceFiles()) {
+      if (f === HELPER) continue;
+      const src = code(f);
+      jsonSites += (src.match(/boundedJson[<(]/g) ?? []).length;
+      textSites += (src.match(/boundedErrorText\(/g) ?? []).length;
+    }
+    assert.ok(jsonSites >= 12, `only ${jsonSites} boundedJson call sites; 12 were routed, so some regressed`);
+    assert.ok(textSites >= 5, `only ${textSites} boundedErrorText call sites; 5 were routed`);
+  });
+});
+
+describe('the bounded JSON reader', () => {
+  const jsonRes = (body, headers = {}) => new Response(body, {
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+
+  it('reads a normal body', async () => {
+    const out = await mod.boundedJson(jsonRes(JSON.stringify({ ok: 1 })), 'test');
+    assert.deepEqual(out, { ok: 1 });
+  });
+
+  it('refuses a declared-oversize body without reading it', async () => {
+    const res = jsonRes('{}', { 'content-length': String(50 * 1024 * 1024) });
+    await assert.rejects(
+      () => mod.boundedJson(res, 'test', 1024),
+      /too large: 52428800 bytes/,
+      'content-length is the cheap check: an upstream that declares 50 MiB against a 1 KiB cap must be refused '
+      + 'before a byte is read',
+    );
+  });
+
+  it('aborts a body that exceeds the cap while streaming, even with no content-length', async () => {
+    // The declared length is advisory and an upstream may omit or lie about it, so the streaming check is the
+    // actual guard. Removing it leaves a hole that content-length alone cannot cover.
+    const big = 'x'.repeat(4096);
+    const stream = new ReadableStream({
+      start(c) {
+        for (let i = 0; i < 8; i++) c.enqueue(new TextEncoder().encode(big));
+        c.close();
+      },
+    });
+    await assert.rejects(
+      () => mod.boundedJson(new Response(stream), 'test', 1024),
+      /exceeded 1024 bytes/,
+    );
+  });
+
+  it('names the source and the escape hatch in the error', async () => {
+    // "response too large" with no source is an unactionable log line, and a cap with no documented override is
+    // one an operator has to read our source to discover.
+    await assert.rejects(
+      () => mod.boundedJson(jsonRes('x'.repeat(5000)), 'doc-render sidecar', 100),
+      (err) => {
+        assert.match(err.message, /doc-render sidecar/, 'the error does not name which upstream');
+        assert.match(err.message, /YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES/, 'the error does not name the override');
+        return true;
+      },
+    );
+  });
+
+  it('falls back to the default when the cap env var is malformed, never to unbounded', () => {
+    const saved = process.env.YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES;
+    try {
+      // Asserted as a CHOICE, not an effect: a malformed value becoming Infinity and becoming 256 MiB both let a
+      // small body through, so every effect-based assertion here passes either way.
+      for (const bad of ['nonsense', '0', '-1', 'NaN', '']) {
+        process.env.YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES = bad;
+        assert.equal(
+          mod.maxUpstreamResponseBytes(), mod.DEFAULT_MAX_UPSTREAM_RESPONSE_BYTES,
+          `'${bad}' resolved to ${mod.maxUpstreamResponseBytes()} — a typo must not remove the bound`,
+        );
+      }
+      process.env.YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES = '4096';
+      assert.equal(mod.maxUpstreamResponseBytes(), 4096, 'a deliberate override must still work');
+    } finally {
+      if (saved === undefined) delete process.env.YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES;
+      else process.env.YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES = saved;
+    }
+  });
+});
+
+describe('the bounded error-body reader', () => {
+  it('truncates and says so', async () => {
+    const out = await mod.boundedErrorText(new Response('e'.repeat(5000)), 50);
+    assert.equal(out.length, 50 + '… (truncated)'.length);
+    assert.match(out, /truncated/, 'a silently truncated error body reads as a complete one');
+  });
+
+  it('returns a short body unchanged', async () => {
+    assert.equal(await mod.boundedErrorText(new Response('upstream said no')), 'upstream said no');
+  });
+
+  it('never throws, because an error path that can fail replaces a diagnosable failure with a confusing one', async () => {
+    const broken = new Response(new ReadableStream({
+      start(c) { c.error(new Error('connection reset mid-error-body')); },
+    }));
+    assert.equal(await mod.boundedErrorText(broken), '', 'it threw, so the real upstream status is now lost');
+  });
+});


### PR DESCRIPTION
## The finding

`boundedJson` lived in `files/media/providers.ts` with the risk stated correctly in its own comment:

> `fetch().json()` reads the entire body without limit → a hostile or runaway upstream could exhaust heap. We cap by streaming the body and aborting once `maxBytes` is exceeded.

It was used at **three call sites, all inside that same file.** Nothing about it was media-specific — it was private by accident.

## Why nobody noticed, which is the reusable part

**Every one of those call sites already had a timeout.** An audit sweep asked *"is there a provider call with no timeout?"*, found none, and stopped.

A timeout bounds **duration**. It says nothing about **size** — a fast upstream streaming gigabytes finishes well inside a 120-second budget. **A guard on the wrong axis is more dangerous than no guard**, because a satisfied check is the strongest possible reason to stop looking.

## The worst path needs no bug and no attacker

`files/converters/renderer.ts` reads `{ pages: string[] }` — base64 PNGs — and decodes each one, so the JSON string, the parsed strings and the decoded buffers are all live at once.

| knob | default | schema max, settable in the UI |
|---|---|---|
| `renderDpi` | 150 | **600** |
| `maxPages` | 50 | **2000** |

Both are supported operator actions. Raising render quality on a large document is the realistic path — runaway, not hostile.

## The count was 12. It was actually 25, and the miss is the more useful half

I scoped the original sweep by grepping `await res.json()`, `await response.json()` and `await r.json()` — **variable names I had already seen** — instead of `await <anything>.json()`. The gate, written from the general shape, immediately found 13 more.

**And they were the ones that mattered most.** All 13 were in `sync/engine.ts` and the network-join handshake: paged record batches, file manifests, member lists and vote rounds read from **another operator's Ythril instance**, not from a sidecar the local operator runs.

A checker whose scope comes from the code it audits shares that code's blind spot.

## The fix

`boundedJson` and a new `boundedErrorText` in `server/src/util/bounded-read.ts`; all 25 reads and all 5 error-body reads go through them.

- `YTHRIL_MAX_UPSTREAM_RESPONSE_BYTES`, default **256 MiB**. Comfortably above a 50-page render at 600 DPI, far below anything threatening the heap. A cap tuned so tight it rejects real work gets reverted, and a reverted cap protects nothing.
- The error names **the upstream and the override** — "response too large" with neither is an unactionable log line.
- A malformed value **falls back to the default**, never to unbounded.
- `content-length` is checked first as an optimisation; the streaming check is the actual guard, since the header is advisory and an upstream may omit or lie about it.
- **A gate fails the build on any `Response.json()` outside the helper**, with a floor assertion so a pattern that stopped matching cannot pass by reporting zero offenders.

## Error bodies: 3 of 5 truncated, 2 interpolated whole — and checked, not assumed

`unstructured.ts` and `embedding.ts` put the entire upstream body into an `Error` message. One `boundedErrorText` now serves all five; 200 chars was already the de-facto standard, three sites having chosen it independently, so the outliers were drift rather than a decision.

**These do not reach an API client.** The global error middleware returns a literal `'Internal server error'` and never `err.message`; the four route handlers that *do* return `err.message` wrap Mongo/config/keypair work no upstream body can reach. So this is log quality and a double allocation, **not** an information leak.

The tracker had it filed as possibly either, and guessing would have justified a bigger change than the evidence supports.

## Testing

**7 mutations, 7 caught** — including both directions of the gate (a peer read reverted to raw `.json()`, an error body reverted to hand-rolled).

**Six fetch doubles shaped `{ ok, status, json }` became real `Response` objects.** They broke because `boundedJson` reads the content-length header and streams `res.body` — the only things that can actually bound a read.

**Making the helper fall back to `res.json()` for objects lacking them was rejected.** That is a silent bypass reachable from anywhere, and the gate would still have reported zero offenders. That shape is the whole bug being fixed.

**The gate's own first run failed on the file it points at.** `git ls-files` cannot see a file added in the same change, so the scan missed `bounded-read.ts`. Now `ls-files` **plus** `--others --exclude-standard`, which adds new files while still honouring `.gitignore`. Third time this repo has been bitten by treating `git ls-files` as "what files does this project have".

## Verification

- `npm run preflight` — passes
- `env-var-docs-coverage` — the new setting is documented (this gate caught it)
- `lint:docs` — clean
