### PR TITLE
test(sync): gate the synced-data migration rule, which nothing enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Testing
+
+- **The synced-data migration rule now has a gate. It had been enforced by discipline alone.**
+  `docs/contribution-guide.md` states it plainly — *"Synced data → self-healing (lazy), never a one-time boot
+  migration"* — because a per-space collection that replicates (memories, entities, edges, chrono,
+  `{space}_files`) can be **silently reverted by a mixed-version peer**: an older instance rewriting a record
+  with a higher `seq` replaces the whole document and undoes the migration.
+  - **The failure is invisible to every single-instance test.** A boot migration over `{space}_files` runs
+    perfectly on one instance, the field is right, every test passes. It breaks only in a network, only against
+    an older peer, and it breaks by **silently reverting data** — no error, no log line, nothing red. The one
+    place it would surface is a multi-version network, which nobody has in CI.
+  - **The rule is currently held, and this gate is to keep it that way rather than to fix anything.** Every
+    write to a synced collection sits on a user-action path (delete, wipe, the media pipeline, the face
+    embedder), and the one migration-shaped thing at boot — the token `prefix` backfill — is explicitly
+    self-healing on first use.
+  - Two populations checked: functions named `migrate*`, and every function `index.ts` calls in its startup
+    sequence. **Its blind spot is stated rather than implied:** a boot migration that is neither named
+    `migrate*` nor called directly from `index.ts` would slip through.
+  - **The detector is itself tested**, against a synthetic violation and against a synthetic READ that must NOT
+    fire — a gate whose detector is never exercised passes because it finds nothing, which is indistinguishable
+    from passing because there is nothing to find.
+  - **A last test asserts the guide still states the rule**, so a deliberate change to the rule fails here and
+    gets made in one commit instead of leaving a gate nobody can argue with.
+  - 3 mutations, 3 caught: a `migrate*` write, a startup-callee write, and the rule deleted from the guide.
+
 ### Fixed
 
 - **25 HTTP response bodies were read into memory with no size ceiling, while the helper that exists to

--- a/testing/standalone/no-boot-migration-on-synced-data.test.js
+++ b/testing/standalone/no-boot-migration-on-synced-data.test.js
@@ -1,0 +1,181 @@
+/**
+ * No boot migration may write to a collection that replicates across a network.
+ *
+ * ## The rule, which is already written down and enforced by nothing
+ *
+ * `docs/contribution-guide.md`:
+ *
+ * > **Synced data → self-healing (lazy), never a one-time boot migration.** The per-space MongoDB record
+ * > collections that replicate across networks — memories, entities, edges, chrono, `{space}_files`, and their
+ * > fields — can be silently reverted by a **mixed-version peer**: an older-version instance that rewrites a
+ * > record with a higher `seq` replaces the *whole* document and undoes any boot migration. So don't migrate
+ * > these on boot — **repair or derive the field on access**, so it re-heals after any cross-version clobber.
+ *
+ * ## Why it needs a gate rather than discipline
+ *
+ * **The failure is invisible to every single-instance test.** A boot migration over `{space}_files` works
+ * perfectly on one instance: it runs, the field is right, every test passes. It only breaks in a network, only
+ * when a peer is on an older build, and it breaks by *silently reverting data* — no error, no log line, no
+ * failing assertion. The one place it would be caught is a multi-version network, which nobody has in CI.
+ *
+ * The canary operates **five instances off one manifest**. They upgrade together today, which is exactly why
+ * nobody would notice this rule being broken until a network spans two organisations that do not.
+ *
+ * The rule is currently **held**: every write to a synced collection sits on a user-action path (delete, wipe,
+ * the media pipeline, the face embedder), and the one migration-shaped thing at boot — token `prefix` backfill —
+ * is explicitly self-healing on first use, with a comment in `index.ts` saying so. This gate exists to keep that
+ * true, not to fix it.
+ *
+ * ## What it can and cannot see, stated rather than implied
+ *
+ * It checks two populations: functions **named** `migrate*`, and the functions `index.ts` calls in its startup
+ * sequence. A boot migration that is neither named `migrate*` nor called directly from `index.ts` would slip
+ * through. That is a real limit, not a covered case — the mitigation is that the naming convention is the one
+ * contributors already follow (four of four current migrations use it) and that the startup sequence is short
+ * enough to enumerate.
+ *
+ * Run: node --test testing/standalone/no-boot-migration-on-synced-data.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+
+/** The collections that replicate. Named in the contribution guide; this list must match it. */
+const SYNCED = ['memories', 'entities', 'edges', 'chrono', 'files'];
+
+/** Mutating Mongo operations. A read never reverts anything, so a boot-time read is fine. */
+const WRITES = ['updateMany', 'updateOne', 'bulkWrite', 'deleteMany', 'deleteOne', 'insertMany', 'insertOne',
+  'replaceOne', 'findOneAndUpdate', 'findOneAndReplace', 'findOneAndDelete'];
+
+function sourceFiles() {
+  const tracked = execFileSync('git', ['ls-files', 'server/src/**/*.ts'], { cwd: ROOT, encoding: 'utf8' });
+  const fresh = execFileSync('git', ['ls-files', '--others', '--exclude-standard', 'server/src/**/*.ts'],
+    { cwd: ROOT, encoding: 'utf8' });
+  return [...new Set(`${tracked}\n${fresh}`.split(/\r?\n/))].filter(Boolean).map(p => p.replace(/\\/g, '/'));
+}
+
+/** Comments stripped line-first, so the gate cannot fire on the prose that documents it. */
+function code(path) {
+  return readFileSync(join(ROOT, path), 'utf8')
+    .split(/\r?\n/)
+    .filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join('\n');
+}
+
+/** Extract `name -> body` for every top-level function in a file, by brace matching. */
+function functions(src) {
+  const out = new Map();
+  for (const m of src.matchAll(/^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)[^{]*\{/gm)) {
+    let depth = 0;
+    let i = m.index + m[0].length - 1;
+    const start = i;
+    for (; i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}') { depth--; if (depth === 0) break; }
+    }
+    out.set(m[1], src.slice(start, i + 1));
+  }
+  return out;
+}
+
+/** Does this function body write to a synced collection? Returns the offending fragment, or null. */
+function writesSynced(body) {
+  for (const coll of SYNCED) {
+    // `col(...)` / `col<T>(...)` naming a synced collection, followed by a mutating call.
+    const re = new RegExp(`_${coll}\`\\s*\\)?\\s*[\\s\\S]{0,80}?\\.(${WRITES.join('|')})\\b`);
+    const m = re.exec(body);
+    if (m) return `${coll}: .${m[1]}()`;
+  }
+  return null;
+}
+
+/** Functions index.ts invokes in its startup sequence, before the server begins serving. */
+function bootCallees() {
+  const src = code('server/src/index.ts');
+  const listen = src.search(/\.listen\(|startServer\(/);
+  const startup = listen > 0 ? src.slice(0, listen) : src;
+  const names = new Set();
+  for (const m of startup.matchAll(/(?:await\s+)?([a-z][\w$]*)\s*\(\s*\)/g)) names.add(m[1]);
+  return names;
+}
+
+describe('the sweep works before it is trusted', () => {
+  it('finds the migrate* functions', () => {
+    const found = [];
+    for (const f of sourceFiles()) {
+      for (const name of functions(code(f)).keys()) if (/^migrate/.test(name)) found.push(name);
+    }
+    // Four exist today. A floor of 3 leaves room for one to be retired without the gate going quiet.
+    assert.ok(found.length >= 3, `expected the migrate* functions, found ${JSON.stringify(found)}`);
+    assert.ok(found.includes('migrateStateFilesAtRest'),
+      'the known migration set is not being found, so this gate is checking nothing');
+  });
+
+  it('finds the startup call sequence', () => {
+    const callees = bootCallees();
+    assert.ok(callees.size >= 4, `only ${callees.size} startup calls found; the enumeration broke`);
+    assert.ok(callees.has('loadConfig'), 'loadConfig is not in the startup sequence — the parse is wrong');
+  });
+
+  it('and it can actually detect a violation — the detector is tested, not assumed', () => {
+    // A gate whose detector is never exercised is a gate that passes because it finds nothing, which is
+    // indistinguishable from passing because there is nothing to find.
+    const fake = 'function migrateSomething() {\n'
+      + '  await col(`${space.id}_files`).updateMany({}, { $set: { x: 1 } });\n}';
+    assert.ok(writesSynced(fake), 'the detector cannot see a plain updateMany on a synced collection');
+    const safeRead = 'function migrateSomething() {\n'
+      + '  const n = await col(`${space.id}_files`).countDocuments({});\n}';
+    assert.equal(writesSynced(safeRead), null, 'the detector flags a READ, which reverts nothing');
+  });
+});
+
+describe('no boot migration writes to a synced collection', () => {
+  it('no migrate* function does', () => {
+    const offenders = [];
+    for (const f of sourceFiles()) {
+      for (const [name, body] of functions(code(f))) {
+        if (!/^migrate/.test(name)) continue;
+        const hit = writesSynced(body);
+        if (hit) offenders.push(`${f} → ${name}() writes ${hit}`);
+      }
+    }
+    assert.deepEqual(offenders, [], 'a boot migration writes to a collection that replicates across networks. An '
+      + 'older peer rewriting one of those records replaces the WHOLE document and silently undoes the '
+      + 'migration — with no error, no log line, and every single-instance test still green.\n  '
+      + offenders.join('\n  ')
+      + '\n\nRepair or derive the field ON ACCESS instead, so it re-heals after a cross-version clobber. See '
+      + 'the token `prefix` backfill in index.ts for the shape.');
+  });
+
+  it('nor does anything index.ts calls during startup', () => {
+    const callees = bootCallees();
+    const offenders = [];
+    for (const f of sourceFiles()) {
+      for (const [name, body] of functions(code(f))) {
+        if (!callees.has(name)) continue;
+        const hit = writesSynced(body);
+        if (hit) offenders.push(`${f} → ${name}() writes ${hit}`);
+      }
+    }
+    assert.deepEqual(offenders, [], 'a function called during startup writes to a synced collection:\n  '
+      + offenders.join('\n  '));
+  });
+});
+
+describe('the rule and the gate move together', () => {
+  it('the contribution guide still states the rule this gate enforces', () => {
+    // A gate outliving its documented rule is a gate nobody can argue with. If the rule is deliberately
+    // changed, this failing is the prompt to change the gate in the same commit — not to delete this assertion.
+    const doc = readFileSync(join(ROOT, 'docs/contribution-guide.md'), 'utf8');
+    assert.match(doc, /never a one-time boot migration/i,
+      'the synced-data migration rule is gone from the contribution guide, but this gate still enforces it');
+    for (const coll of SYNCED) {
+      assert.ok(doc.includes(coll),
+        `the guide no longer names \`${coll}\` as a synced collection, so this gate's list may be out of date`);
+    }
+  });
+});


### PR DESCRIPTION
## The rule, which was enforced by nothing

`docs/contribution-guide.md` states it plainly:

> **Synced data → self-healing (lazy), never a one-time boot migration.** The per-space MongoDB record collections that replicate across networks — memories, entities, edges, chrono, `{space}_files`, and their fields — can be silently reverted by a **mixed-version peer**: an older-version instance that rewrites a record with a higher `seq` replaces the *whole* document and undoes any boot migration.

Nothing checked it.

## Why discipline is not enough here

**The failure is invisible to every single-instance test.** A boot migration over `{space}_files` runs perfectly on one instance: it executes, the field is correct, every test passes. It breaks only in a network, only against a peer on an older build, and it breaks by **silently reverting data** — no error, no log line, nothing red.

The one place it would surface is a multi-version network, which nobody has in CI.

**And the canary is exactly the operator who would not catch it.** They run five instances off one manifest and upgrade them together — which is precisely why nobody would notice this rule being broken until a network spans two organisations that don't.

## The rule is currently HELD

This gate keeps it that way; it fixes nothing. Verified from source: every write to a synced collection sits on a user-action path — delete, wipe, the media pipeline, the face embedder — and the one migration-shaped thing at boot, the token `prefix` backfill, is explicitly self-healing on first use with a comment in `index.ts` saying so.

## What it checks, and what it cannot see

Two populations:

1. functions **named** `migrate*` (four of four current migrations use the convention);
2. every function `index.ts` calls in its startup sequence, up to the point it begins serving.

**Blind spot, stated rather than implied:** a boot migration that is neither named `migrate*` nor called directly from `index.ts` slips through. The mitigation is that the naming convention is the one contributors already follow and the startup sequence is short enough to enumerate — not that the case is covered.

It flags **writes only**. A boot-time read reverts nothing, and the detector is tested against a synthetic read to prove it does not fire on one.

## Two things worth the review time

**The detector is itself tested.** A gate whose detector is never exercised passes because it found nothing, which is indistinguishable from passing because there was nothing to find. So there is a synthetic violation it must catch and a synthetic read it must ignore.

**A final test asserts the guide still states the rule.** If the rule is deliberately changed, this fails — which is the prompt to change the gate in the same commit, rather than leaving a gate nobody can argue with. It also checks the guide still names all five synced collections, so the gate's list cannot drift from the documented one.

## Mutations

| mutation | caught by |
|---|---|
| a `migrate*` function gains an `updateMany` on `{space}_files` | "no migrate* function does" |
| a real startup callee (`loadSchemaLibrary`) gains a `deleteMany` on `{space}_entities` | "nor does anything index.ts calls during startup" |
| the rule deleted from the contribution guide | "the guide still states the rule" |

3 of 3.

## Verification

- `npm run preflight` — passes
- the gate itself — 6/6
