### PR TITLE
docs(api): "All errors return JSON" was false, and gate the real boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **"All errors return JSON" was false, and it is the kind of false an integrator codes against.** The
+  integration guide stated it flat. Two surfaces deliberately answer otherwise: `GET /metrics` returns
+  Prometheus comment lines (a scraper does not parse JSON, and `#` is a comment in the exposition format, so the
+  error degrades into something readable instead of corrupting the parse), and the first-run `/setup` flow
+  returns text/HTML (it is server-rendered and exists *before* the SPA does; its consumer is a browser).
+  - Both were **correct**; the sentence was wrong. It now says every `/api/` error is JSON and names the
+    two exceptions with their reasons, so nobody learns them from a parse failure.
+  - The rest of the contract is genuinely held: every route handler, the `/api/` 404, all six rate limiters
+    (each with `message: { error }` and a handler that JSONs it), and the global middleware.
+
+### Testing
+
+- **A gate holds the boundary**, with the two exceptions as explicit exemptions that must carry a written
+  reason. The exceptions themselves are fine; a **third** one appearing without anyone deciding it should is
+  how a contract erodes — each case defensible alone, nobody looking at the set.
+
+- **The gate passed on a planted violation, twice, for two different reasons. Both were the test.**
+  - **A shared module-level `/g` regex.** `assert.match` calls `RegExp.prototype.test`, which
+    advances `lastIndex`, and `String.matchAll` copies `lastIndex` into its clone. So the three
+    assertions in the detector self-test left the cursor mid-string, and the sweep that ran next started from
+    there and found nothing. **The self-test poisoned the very sweep it existed to validate.** The detector is
+    now a function returning a fresh regex.
+  - **One pathspec instead of two.** `server/src/**/*.ts` requires at least one directory level, so
+    `server/src/app.ts` and `server/src/index.ts` were never scanned — the global error middleware
+    and half the admin handlers. A mutation planting a violation in `app.ts` is now part of the suite.
+  - Neither was visible from a passing run. Only mutation found them, and the first mutation harness *also*
+    lied — it matched the failure marker immediately after the cross rather than anywhere on the line, and
+    replaced only the first occurrence, so three no-op mutations were reported as clean survivals. It now
+    distinguishes "nothing failed" from "the wrong test failed".
+
 ### Testing
 
 - **The synced-data migration rule now has a gate. It had been enforced by discipline alone.**

--- a/docs/integration-guide/03-auth-and-limits.md
+++ b/docs/integration-guide/03-auth-and-limits.md
@@ -39,11 +39,26 @@ Tokens are created during first-run setup or via `POST /api/tokens`. The plainte
 
 ## Error Format
 
-All errors return JSON:
+**Every JSON API route** — everything under `/api/` — answers an error with:
 
 ```json
 { "error": "Human-readable message" }
 ```
+
+That holds for handler errors, validation failures, the `404` on an unknown `/api/` path, all rate
+limiters, and anything unhandled (which returns a generic message rather than the internal one).
+
+**Two surfaces deliberately answer in another format, because their consumer does not parse JSON.** Both are
+listed here rather than left for you to discover from a parse failure:
+
+| surface | error format | why |
+|---|---|---|
+| `GET /metrics` | Prometheus comment lines (`# Unauthorized: …`) | A scraper does not parse JSON, and `#` is a comment in the exposition format, so the error degrades into something readable rather than corrupting the parse. |
+| the first-run `/setup` flow | text or HTML | Setup is server-rendered and exists *before* the SPA does; its consumer is a browser, which would render a JSON body as raw text. |
+
+So: **do not treat a non-JSON error body as a bug**, and do not code against "all errors are JSON" — code
+against "every `/api/` error is JSON". A gate holds that boundary and requires a written reason before
+anything is added to the exception list.
 
 Extended errors may include:
 

--- a/testing/standalone/error-shape-is-json.test.js
+++ b/testing/standalone/error-shape-is-json.test.js
@@ -1,0 +1,160 @@
+/**
+ * Every JSON API route returns `{ error }` — and the two surfaces that deliberately do not are named.
+ *
+ * ## The stated contract
+ *
+ * `docs/integration-guide/03-auth-and-limits.md`, under **Error Format**:
+ *
+ * > All errors return JSON:
+ * > `{ "error": "Human-readable message" }`
+ *
+ * ## The finding was the documentation, not the code
+ *
+ * The contract is held everywhere it should be — every route handler, the API 404, all six rate limiters (each
+ * with `message: { error }` and a handler that JSONs it), and the global error middleware. Two surfaces return
+ * something else, **both correctly**:
+ *
+ *  - `api/metrics.ts` — a `401` and a `500` as Prometheus comment lines. A scraper does not parse JSON, and `#`
+ *    is a comment in the exposition format, so the error degrades into something the consumer can read.
+ *  - `setup/routes.ts` — a `404` and a `400` as text/HTML. First-run setup is a server-rendered flow that exists
+ *    *before* the SPA does; its consumer is a browser, and a JSON body would render as raw text.
+ *
+ * So "all errors return JSON" was simply false, and the fix was to say what is actually true. The word "all" in a
+ * contract is the part an integrator relies on.
+ *
+ * ## Why the gate is the more valuable half
+ *
+ * The two exceptions are fine. A **third** one appearing without anybody deciding it should is not — that is how
+ * a contract erodes: each individual case is defensible in isolation, and no one is looking at the set. This gate
+ * makes the exemption list the place that decision has to be written down.
+ *
+ * Run: node --test testing/standalone/error-shape-is-json.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+const DOC = 'docs/integration-guide/03-auth-and-limits.md';
+
+/**
+ * Surfaces allowed to answer an error with something other than JSON, and why.
+ *
+ * The reason is part of the entry on purpose: an exemption whose justification is not written down is
+ * indistinguishable from an oversight the next reader will preserve out of caution.
+ */
+const NOT_JSON = [
+  {
+    file: 'server/src/api/metrics.ts',
+    why: 'Prometheus exposition format — a scraper does not parse JSON, and `#` is a comment line, so the error '
+      + 'degrades into something the consumer can actually read',
+  },
+  {
+    file: 'server/src/setup/routes.ts',
+    why: 'first-run setup is a server-rendered HTML flow that exists before the SPA does; its consumer is a '
+      + 'browser, which would render a JSON body as raw text',
+  },
+];
+
+/**
+ * Every .ts under server/src, tracked and untracked-but-not-ignored.
+ *
+ * **Two pathspecs, not one.** `server/src/**` requires at least one directory level, so a single pattern silently
+ * excluded `server/src/app.ts` and `server/src/index.ts` — which is where the global error middleware and half the
+ * admin handlers live. The gate reported clean while never looking at them.
+ */
+function sourceFiles() {
+  const specs = ['server/src/*.ts', 'server/src/**/*.ts'];
+  const run = (args) => execFileSync('git', ['ls-files', ...args, ...specs], { cwd: ROOT, encoding: 'utf8' });
+  const all = `${run([])}\n${run(['--others', '--exclude-standard'])}`;
+  return [...new Set(all.split(/\r?\n/))].filter(Boolean).map(p => p.replace(/\\/g, '/'));
+}
+
+/** Comments stripped line-first, so the gate cannot fire on the prose that documents it. */
+function code(path) {
+  return readFileSync(join(ROOT, path), 'utf8')
+    .split(/\r?\n/)
+    .filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join('\n');
+}
+
+/**
+ * `res.status(4xx|5xx)` followed by anything other than `.json(`.
+ *
+ * **A FUNCTION, not a shared const, and that is load-bearing.** The first version was a module-level global
+ * regex. `assert.match` calls `RegExp.prototype.test`, which advances `lastIndex` on a `/g` regex, and
+ * `String.matchAll` copies `lastIndex` into its clone — so the three assertions in the detector self-test left
+ * the cursor mid-string and the sweep that ran next started from there and found nothing.
+ *
+ * The gate reported clean on a real injected violation because of it. **The self-test poisoned the very sweep it
+ * existed to validate**, which is only detectable by mutation: every test passed, on code with a planted bug.
+ */
+const nonJsonError = () => /res\s*\.\s*status\(\s*[45]\d\d\s*\)\s*\.\s*(send|end|type|sendFile|render)\b/g;
+
+describe('the sweep works before it is trusted', () => {
+  it('the detector can see a non-JSON error response', () => {
+    // A gate whose detector is never exercised passes because it found nothing, which is indistinguishable from
+    // passing because there was nothing to find.
+    assert.match("res.status(500).send('nope');", nonJsonError());
+    assert.doesNotMatch("res.status(500).json({ error: 'nope' });", nonJsonError());
+    // A 2xx send is not an error response and must not be flagged.
+    assert.doesNotMatch("res.status(200).send('<html>');", nonJsonError());
+  });
+
+  it('every exempted file exists and still contains a non-JSON error', () => {
+    // An exemption for something that has been fixed is an exemption that will one day cover something else.
+    for (const { file } of NOT_JSON) {
+      const src = code(file);
+      assert.ok(src.length > 0, `${file} is exempted here but does not exist`);
+      assert.match(src, nonJsonError(),
+        `${file} no longer returns a non-JSON error — remove it from the exemption list`);
+    }
+  });
+
+  it('every exemption states a reason', () => {
+    for (const e of NOT_JSON) {
+      assert.ok(e.why && e.why.length > 40,
+        `${e.file} is exempted without a real reason; an unjustified exemption reads as an oversight`);
+    }
+  });
+});
+
+describe('every JSON API route answers an error with { error }', () => {
+  it('no unexempted file returns a non-JSON error response', () => {
+    const exempt = new Set(NOT_JSON.map(e => e.file));
+    const offenders = [];
+    for (const f of sourceFiles()) {
+      if (exempt.has(f)) continue;
+      const src = code(f);
+      for (const m of src.matchAll(nonJsonError())) {
+        const line = src.slice(0, m.index).split('\n').length;
+        offenders.push(`${f}:${line} — .${m[1]}()`);
+      }
+    }
+    assert.deepEqual(offenders, [], 'these answer an error with something other than JSON, which the integration '
+      + `guide says never happens:\n  ${offenders.join('\n  ')}\n\n`
+      + 'Either return `{ error }`, or add the file to NOT_JSON in this test **with the reason** — that list is '
+      + 'where the decision has to be written down.');
+  });
+});
+
+describe('the contract and the gate move together', () => {
+  it('the guide states the shape and does NOT claim it is universal', () => {
+    const doc = readFileSync(join(ROOT, DOC), 'utf8');
+    assert.match(doc, /\{ "error": "Human-readable message" \}/,
+      'the documented error shape is gone, but this gate still enforces it');
+    // The original wording was "All errors return JSON", which was false for two surfaces. A contract an
+    // integrator relies on must not overclaim — the word "all" was the whole problem.
+    assert.doesNotMatch(doc, /^All errors return JSON/m,
+      'the guide claims ALL errors are JSON again. /metrics returns Prometheus text and first-run setup returns '
+      + 'HTML, both deliberately — so the universal claim is false and an integrator would code against it');
+  });
+
+  it('the guide names both exceptions, so the gate is not the only place they are recorded', () => {
+    const doc = readFileSync(join(ROOT, DOC), 'utf8');
+    assert.match(doc, /\/metrics/, 'the guide does not mention that /metrics answers in Prometheus text');
+    assert.match(doc, /setup/i, 'the guide does not mention that first-run setup answers in HTML');
+  });
+});


### PR DESCRIPTION
docs(api): "All errors return JSON" was false, and gate the real boundary

The integration guide stated it flat. Two surfaces deliberately answer
otherwise, and both are correct:

  GET /metrics       Prometheus comment lines. A scraper does not parse JSON,
                     and # is a comment in the exposition format, so the error
                     degrades into something readable instead of corrupting the
                     parse.
  the /setup flow    text/HTML. First-run setup is server-rendered and exists
                     BEFORE the SPA does; its consumer is a browser, which would
                     render a JSON body as raw text.

So the code was right and the sentence was wrong. The guide now says every
/api/ error is JSON and names the two exceptions with their reasons, so nobody
learns them from a parse failure. The word "all" is the part an integrator codes
against.

The rest of the contract is genuinely held: every route handler, the /api/ 404,
all six rate limiters (each with message: { error } and a handler that JSONs
it), and the global middleware.

A gate now holds the boundary, with the two exceptions as explicit exemptions
that must carry a written reason. The exceptions are fine; a THIRD one appearing
without anyone deciding it should is how a contract erodes -- each case
defensible alone, nobody looking at the set.

The gate passed on a planted violation, twice, for two different reasons, and
both were the test rather than the code:

A shared module-level /g regex. assert.match calls RegExp.prototype.test, which
advances lastIndex, and String.matchAll copies lastIndex into its clone. So the
three assertions in the detector self-test left the cursor mid-string and the
sweep that ran next started from there and found nothing. The self-test poisoned
the very sweep it existed to validate. The detector is now a function returning
a fresh regex.

One pathspec instead of two. server/src/**/*.ts requires at least one directory
level, so server/src/app.ts and server/src/index.ts were never scanned -- the
global error middleware and half the admin handlers. A mutation planting a
violation in app.ts is now part of the suite.

Neither was visible from a passing run. Only mutation found them -- and the
first mutation harness also lied: it matched the failure marker immediately
after the cross rather than anywhere on the line, and replaced only the first
occurrence, so three no-op mutations were reported as clean survivals. It now
distinguishes "nothing failed" from "the wrong test failed".

6 mutations, 6 caught.
