### PR TITLE
feat(release): the documentation lens is a release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The gate below reads git history to decide whether HEAD is a tag. A shallow clone with no tags
+          # answers "no", which would silently downgrade the release checks to their mid-cycle form.
+          fetch-depth: 0
+
+      # ── The documentation release gate ────────────────────────────────────
+      #
+      # Owner rule, 2026-08-04: the documentation lens is a release gate. It runs FIRST, before login and before
+      # the build, because the three things it checks are the three a published release can never take back:
+      # an image on two public registries, notes that do not describe it, and an attribution that was owed.
+      #
+      # Two of its checks are only true at release time and therefore cannot be enforced per PR: that the four
+      # manifests agree on one version, and that `[Unreleased]` has been closed into a dated section. The rest
+      # (docs coverage, NOTICE) also runs in CI, and repeating it here costs ~2 minutes against a ~30-minute
+      # multi-arch build — worth it, because it also catches a tag cut from a commit whose CI never ran.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build (the doc gates read server/dist)
+        run: npm run build
+
+      - name: Documentation release gate
+        run: npm run release:gate
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,64 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Documentation
+### Added
 
-- **"All errors return JSON" was false, and it is the kind of false an integrator codes against.** The
-  integration guide stated it flat. Two surfaces deliberately answer otherwise: `GET /metrics` returns
-  Prometheus comment lines (a scraper does not parse JSON, and `#` is a comment in the exposition format, so the
-  error degrades into something readable instead of corrupting the parse), and the first-run `/setup` flow
-  returns text/HTML (it is server-rendered and exists *before* the SPA does; its consumer is a browser).
-  - Both were **correct**; the sentence was wrong. It now says every `/api/` error is JSON and names the
-    two exceptions with their reasons, so nobody learns them from a parse failure.
-  - The rest of the contract is genuinely held: every route handler, the `/api/` 404, all six rate limiters
-    (each with `message: { error }` and a handler that JSONs it), and the global middleware.
+- **The documentation lens is now a release gate** (owner rule): `npm run release:gate`, which also runs
+  inside `publish.yml` **before login and before the build** — so a bad tag fails in ~2 minutes instead of
+  publishing to two registries.
+  - **Three groups, in the terms the rule was given in:** every docs-coverage gate plus markdownlint · the
+    CHANGELOG carries a dated section for this version with real content and `[Unreleased]` emptied into it ·
+    NOTICE attributes every redistributed dependency, ships inside the image, and ffmpeg is accounted for.
+  - **Two of those checks can only exist at release time**, which is why this is not simply more CI: that the
+    four manifests agree on one version (including the lockfile, the one nobody edits by hand), and that
+    `[Unreleased]` was actually closed. No per-PR gate can see either. The rest is repeated at the tag because a
+    tag can be cut from a commit whose CI never ran.
+  - **The gate list is explicit, not globbed**, and a named gate whose file is missing reports as *"this gate
+    stopped running"* rather than as an ordinary assertion failure — a renamed test is exactly the silent shrink
+    the list exists to prevent.
 
-### Testing
-
-- **A gate holds the boundary**, with the two exceptions as explicit exemptions that must carry a written
-  reason. The exceptions themselves are fine; a **third** one appearing without anyone deciding it should is
-  how a contract erodes — each case defensible alone, nobody looking at the set.
-
-- **The gate passed on a planted violation, twice, for two different reasons. Both were the test.**
-  - **A shared module-level `/g` regex.** `assert.match` calls `RegExp.prototype.test`, which
-    advances `lastIndex`, and `String.matchAll` copies `lastIndex` into its clone. So the three
-    assertions in the detector self-test left the cursor mid-string, and the sweep that ran next started from
-    there and found nothing. **The self-test poisoned the very sweep it existed to validate.** The detector is
-    now a function returning a fresh regex.
-  - **One pathspec instead of two.** `server/src/**/*.ts` requires at least one directory level, so
-    `server/src/app.ts` and `server/src/index.ts` were never scanned — the global error middleware
-    and half the admin handlers. A mutation planting a violation in `app.ts` is now part of the suite.
-  - Neither was visible from a passing run. Only mutation found them, and the first mutation harness *also*
-    lied — it matched the failure marker immediately after the cross rather than anywhere on the line, and
-    replaced only the first occurrence, so three no-op mutations were reported as clean survivals. It now
-    distinguishes "nothing failed" from "the wrong test failed".
-
-### Testing
-
-- **The synced-data migration rule now has a gate. It had been enforced by discipline alone.**
-  `docs/contribution-guide.md` states it plainly — *"Synced data → self-healing (lazy), never a one-time boot
-  migration"* — because a per-space collection that replicates (memories, entities, edges, chrono,
-  `{space}_files`) can be **silently reverted by a mixed-version peer**: an older instance rewriting a record
-  with a higher `seq` replaces the whole document and undoes the migration.
-  - **The failure is invisible to every single-instance test.** A boot migration over `{space}_files` runs
-    perfectly on one instance, the field is right, every test passes. It breaks only in a network, only against
-    an older peer, and it breaks by **silently reverting data** — no error, no log line, nothing red. The one
-    place it would surface is a multi-version network, which nobody has in CI.
-  - **The rule is currently held, and this gate is to keep it that way rather than to fix anything.** Every
-    write to a synced collection sits on a user-action path (delete, wipe, the media pipeline, the face
-    embedder), and the one migration-shaped thing at boot — the token `prefix` backfill — is explicitly
-    self-healing on first use.
-  - Two populations checked: functions named `migrate*`, and every function `index.ts` calls in its startup
-    sequence. **Its blind spot is stated rather than implied:** a boot migration that is neither named
-    `migrate*` nor called directly from `index.ts` would slip through.
-  - **The detector is itself tested**, against a synthetic violation and against a synthetic READ that must NOT
-    fire — a gate whose detector is never exercised passes because it finds nothing, which is indistinguishable
-    from passing because there is nothing to find.
-  - **A last test asserts the guide still states the rule**, so a deliberate change to the rule fails here and
-    gets made in one commit instead of leaving a gate nobody can argue with.
-  - 3 mutations, 3 caught: a `migrate*` write, a startup-callee write, and the rule deleted from the guide.
+- **`npm run todo:check`** holds the other rule: `todo/` carries only actionable open items, and
+  `_TODO-ORDERED.md` references every one of them in every other tracker.
+  - **The index half is load-bearing rather than tidy.** The release cadence is *"cut the tag when the ordered
+    list is empty"*, so a tracker holding an item that list never mentions makes "empty" a claim about one file
+    rather than about the work.
+  - **Its first run found two orphans, and both were work that had already shipped and was still marked `[ ]`**
+    — the ordered list had correctly dropped them and the domain tracker never did. Retired after verifying each
+    against the code, because a checkbox is not evidence.
+  - `todo/` is gitignored, so this runs in preflight and exits 0 when the folder is absent. A check that
+    skips in the only place it runs automatically is not a check.
 
 ### Fixed
+
+- **Two defects in the release gate itself, both found by running it:**
+  - it demanded `[Unreleased]` be empty **unconditionally** and failed on a perfectly healthy mid-cycle tree.
+    Between releases a populated `[Unreleased]` is *correct*; release mode is now derived from
+    `git describe --exact-match --tags HEAD`, with `--releasing` for a pre-tag check. A gate that fires on a
+    healthy tree teaches everyone to ignore it.
+  - `fetch-depth: 0` was needed in `publish.yml`: a shallow clone has no tags, `git describe`
+    fails, that reads as "not releasing", and the release-only rules downgrade silently with nothing looking
+    wrong.
 
 - **25 HTTP response bodies were read into memory with no size ceiling, while the helper that exists to
   prevent exactly that was used at 3 call sites — all inside the file that defines it.** `boundedJson`
@@ -107,22 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     return `err.message` wrap Mongo/config/keypair work no upstream body can reach. So this is log quality and a
     double allocation, not an information leak. The tracker had it filed as possibly either, and guessing would
     have justified a bigger change than the evidence supports.
-
-### Testing
-
-- **7 mutations, 7 caught**, including both directions of the gate (a peer read reverted to raw `.json()`, an
-  error body reverted to hand-rolled).
-- **Six fetch doubles shaped `{ ok, status, json }` became real `Response` objects.** They broke
-  because `boundedJson` reads the content-length header and streams `res.body` — the
-  only things that can actually bound a read. **Making the helper fall back to `res.json()` for objects lacking
-  them was rejected**: that is a silent bypass reachable from anywhere, and the gate would still have reported
-  zero offenders. This entry exists because that shape is the whole bug being fixed.
-- **The gate’s own first run failed on the file it points at.** `git ls-files` cannot see a file added in the
-  same change, so the scan missed `bounded-read.ts`. Now `ls-files` **plus** `--others --exclude-standard`,
-  which adds new files while still honouring .gitignore. Third time this repo has been bitten by treating
-  `git ls-files` as "what files does this project have".
-
-### Fixed
 
 - **The storage gauge walked the entire files tree on every scrape, and it was the whole cause of the canary's
   `/metrics` timeout.** They answered the diagnostic request from #676 with numbers that name one collector and
@@ -167,33 +130,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `0` on entities reads as "no collisions here" when the truth is "not measured", which is the exact confusion
     pre-declaring exists to prevent. A gate now fails if a pre-declared collection is not actually counted.
 
-### Documentation
-
-- **Two notes the canary asked for, one of which corrects a query we sent them.**
-  - `ythril_metrics_collect_duration_seconds` is a histogram, so **the bare name is not a series** — only
-    `_bucket`, `_sum` and `_count` exist. An instant query for the bare name returns empty, which reads as "the
-    metric is missing" rather than "wrong series". Our own request for a scrape told them to grep the bare name.
-  - **A collector Prometheus gave up on still finishes and still records its duration**, so a later successful
-    scrape delivers those buckets. That is why timing data exists for the scrapes that failed — and the
-    corollary is that an instance whose scrapes *all* time out looks silent while doing the work.
-
-### Testing
-
-- **9 mutations, 9 caught — but three of the first six survived, and all three were the test rather than the
-  code.** Recorded because the pattern repeats:
-  - the coalescing test asserted *"a refresh is in flight"* before and after nine calls, which is true either
-    way since nine unguarded calls each leave **a** promise in the slot. Now counts completed walks.
-  - the age test read a gauge an earlier test had already set. Adding `reset()` made it **worse** —
-    `reset()` on an unlabelled prom-client gauge re-initialises it to `0` rather than removing it, guaranteeing a
-    value inside the plausible range. A poison sentinel outside that range was the only preparation that fails
-    when nothing writes.
-  - **and that sentinel then found a real bug.** `storageUsageAgeSeconds` was written by the storage
-    collector, and prom-client serialises each metric as soon as **its own** value is ready — so the age was
-    emitted before the collector that set it. Identical to the barrier bug in #676, in the same file, two hours
-    later. It now reads the cache itself; a self-sufficient collector is the only order-independent kind.
-
-### Fixed
-
 - **A slow `/metrics` collector now degrades one graph instead of blinding the whole target** (canary
   finding: the scrape hit its 10 s Prometheus timeout twice during an ingest, with `up=0` for both windows).
   - **The consequence was out of all proportion to the cause**, which is the reason this is a fix and not a
@@ -235,6 +171,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     code, since the wrapper owns both and stops the clock in a `finally` where the old hand-rolled `done()` sat
     after the try/catch and an early return would have skipped it. It now asserts the guarantee: every async
     collector routes through the wrapper, and the wrapper times before it awaits and stops on every path.
+
+### Documentation
+
+- **"All errors return JSON" was false, and it is the kind of false an integrator codes against.** The
+  integration guide stated it flat. Two surfaces deliberately answer otherwise: `GET /metrics` returns
+  Prometheus comment lines (a scraper does not parse JSON, and `#` is a comment in the exposition format, so the
+  error degrades into something readable instead of corrupting the parse), and the first-run `/setup` flow
+  returns text/HTML (it is server-rendered and exists *before* the SPA does; its consumer is a browser).
+  - Both were **correct**; the sentence was wrong. It now says every `/api/` error is JSON and names the
+    two exceptions with their reasons, so nobody learns them from a parse failure.
+  - The rest of the contract is genuinely held: every route handler, the `/api/` 404, all six rate limiters
+    (each with `message: { error }` and a handler that JSONs it), and the global middleware.
+
+- **Two notes the canary asked for, one of which corrects a query we sent them.**
+  - `ythril_metrics_collect_duration_seconds` is a histogram, so **the bare name is not a series** — only
+    `_bucket`, `_sum` and `_count` exist. An instant query for the bare name returns empty, which reads as "the
+    metric is missing" rather than "wrong series". Our own request for a scrape told them to grep the bare name.
+  - **A collector Prometheus gave up on still finishes and still records its duration**, so a later successful
+    scrape delivers those buckets. That is why timing data exists for the scrapes that failed — and the
+    corollary is that an instance whose scrapes *all* time out looks silent while doing the work.
+
+### Testing
+
+- **A gate holds the boundary**, with the two exceptions as explicit exemptions that must carry a written
+  reason. The exceptions themselves are fine; a **third** one appearing without anyone deciding it should is
+  how a contract erodes — each case defensible alone, nobody looking at the set.
+
+- **The gate passed on a planted violation, twice, for two different reasons. Both were the test.**
+  - **A shared module-level `/g` regex.** `assert.match` calls `RegExp.prototype.test`, which
+    advances `lastIndex`, and `String.matchAll` copies `lastIndex` into its clone. So the three
+    assertions in the detector self-test left the cursor mid-string, and the sweep that ran next started from
+    there and found nothing. **The self-test poisoned the very sweep it existed to validate.** The detector is
+    now a function returning a fresh regex.
+  - **One pathspec instead of two.** `server/src/**/*.ts` requires at least one directory level, so
+    `server/src/app.ts` and `server/src/index.ts` were never scanned — the global error middleware
+    and half the admin handlers. A mutation planting a violation in `app.ts` is now part of the suite.
+  - Neither was visible from a passing run. Only mutation found them, and the first mutation harness *also*
+    lied — it matched the failure marker immediately after the cross rather than anywhere on the line, and
+    replaced only the first occurrence, so three no-op mutations were reported as clean survivals. It now
+    distinguishes "nothing failed" from "the wrong test failed".
+
+- **The synced-data migration rule now has a gate. It had been enforced by discipline alone.**
+  `docs/contribution-guide.md` states it plainly — *"Synced data → self-healing (lazy), never a one-time boot
+  migration"* — because a per-space collection that replicates (memories, entities, edges, chrono,
+  `{space}_files`) can be **silently reverted by a mixed-version peer**: an older instance rewriting a record
+  with a higher `seq` replaces the whole document and undoes the migration.
+  - **The failure is invisible to every single-instance test.** A boot migration over `{space}_files` runs
+    perfectly on one instance, the field is right, every test passes. It breaks only in a network, only against
+    an older peer, and it breaks by **silently reverting data** — no error, no log line, nothing red. The one
+    place it would surface is a multi-version network, which nobody has in CI.
+  - **The rule is currently held, and this gate is to keep it that way rather than to fix anything.** Every
+    write to a synced collection sits on a user-action path (delete, wipe, the media pipeline, the face
+    embedder), and the one migration-shaped thing at boot — the token `prefix` backfill — is explicitly
+    self-healing on first use.
+  - Two populations checked: functions named `migrate*`, and every function `index.ts` calls in its startup
+    sequence. **Its blind spot is stated rather than implied:** a boot migration that is neither named
+    `migrate*` nor called directly from `index.ts` would slip through.
+  - **The detector is itself tested**, against a synthetic violation and against a synthetic READ that must NOT
+    fire — a gate whose detector is never exercised passes because it finds nothing, which is indistinguishable
+    from passing because there is nothing to find.
+  - **A last test asserts the guide still states the rule**, so a deliberate change to the rule fails here and
+    gets made in one commit instead of leaving a gate nobody can argue with.
+  - 3 mutations, 3 caught: a `migrate*` write, a startup-callee write, and the rule deleted from the guide.
+
+- **7 mutations, 7 caught**, including both directions of the gate (a peer read reverted to raw `.json()`, an
+  error body reverted to hand-rolled).
+- **Six fetch doubles shaped `{ ok, status, json }` became real `Response` objects.** They broke
+  because `boundedJson` reads the content-length header and streams `res.body` — the
+  only things that can actually bound a read. **Making the helper fall back to `res.json()` for objects lacking
+  them was rejected**: that is a silent bypass reachable from anywhere, and the gate would still have reported
+  zero offenders. This entry exists because that shape is the whole bug being fixed.
+- **The gate’s own first run failed on the file it points at.** `git ls-files` cannot see a file added in the
+  same change, so the scan missed `bounded-read.ts`. Now `ls-files` **plus** `--others --exclude-standard`,
+  which adds new files while still honouring .gitignore. Third time this repo has been bitten by treating
+  `git ls-files` as "what files does this project have".
+
+- **9 mutations, 9 caught — but three of the first six survived, and all three were the test rather than the
+  code.** Recorded because the pattern repeats:
+  - the coalescing test asserted *"a refresh is in flight"* before and after nine calls, which is true either
+    way since nine unguarded calls each leave **a** promise in the slot. Now counts completed walks.
+  - the age test read a gauge an earlier test had already set. Adding `reset()` made it **worse** —
+    `reset()` on an unlabelled prom-client gauge re-initialises it to `0` rather than removing it, guaranteeing a
+    value inside the plausible range. A poison sentinel outside that range was the only preparation that fails
+    when nothing writes.
+  - **and that sentinel then found a real bug.** `storageUsageAgeSeconds` was written by the storage
+    collector, and prom-client serialises each metric as soon as **its own** value is ready — so the age was
+    emitted before the collector that set it. Identical to the barrier bug in #676, in the same file, two hours
+    later. It now reads the cache itself; a self-sufficient collector is the only order-independent kind.
 
 ## [2.3.0] — 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     stopped running"* rather than as an ordinary assertion failure — a renamed test is exactly the silent shrink
     the list exists to prevent.
 
+- **`todo:check` gained two rules after its first version missed three real problems**, all of which it
+  now catches:
+  - **closure announced in a HEADING**, not with a checkbox. Section 1 still listed an item shipped in #678, and
+    P1 sat in section 1b with `CLOSED` in its own heading — a checkbox-only check called the queue clean.
+    `SHIPPED|CLOSED|RESOLVED|DONE` in any heading of a queue file now fails, as does a struck-through open
+    item (I had left one myself as a breadcrumb when the CLA went green).
+  - **`_NEXT-PR-PLAN.md` must not name a PR already merged into main.** It is exempt from the queue rules
+    because it is a working document, and that exemption is precisely why it rotted unnoticed until the owner
+    opened it. A plan is about work ahead; a merged number in it means the file describes the past. Checkable
+    locally with no network, which matters for a gitignored folder.
+  - Both were **my own** leftovers from closing items earlier the same day, which is the argument for the check
+    rather than for more care.
 - **`npm run todo:check`** holds the other rule: `todo/` carries only actionable open items, and
   `_TODO-ORDERED.md` references every one of them in every other tracker.
   - **The index half is load-bearing rather than tidy.** The release cadence is *"cut the tag when the ordered

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "test:all:core": "npm run test:integration && npm run test:sync && npm run test:redteam && npm run test:standalone",
     "test:all:keep": "npm run test:all:core",
     "test:all": "node testing/_init/run-test-all-with-cleanup.mjs",
-    "test:client": "npm run test --workspace=client"
+    "test:client": "npm run test --workspace=client",
+    "release:gate": "node ./scripts/release-gate.mjs",
+    "todo:check": "node ./scripts/todo-consistency.mjs"
   },
   "overrides": {
     "protobufjs": "^7.5.5"

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -142,6 +142,15 @@ if (standaloneFailed) {
 console.log('\n── docs lint ──');
 try { run('npm run lint:docs'); } catch { failures.push({ name: 'lint:docs', why: 'markdown that will fail CI' }); }
 
+// The owner reads todo/ directly, and the release cadence is "cut the tag when _TODO-ORDERED.md is empty" — so a
+// domain tracker holding an item the ordered list never mentions makes "empty" a claim about one file rather than
+// about the work. todo/ is gitignored, so this can only ever run here; the script exits 0 when the folder is
+// absent, which is what makes it safe in a clean checkout.
+console.log('\n── todo/ is open items only, all indexed ──');
+try { run('npm run todo:check'); } catch {
+  failures.push({ name: 'todo:check', why: 'a tracker holds closed work, or an open item the ordered list never references' });
+}
+
 console.log('\n── client unit tests (includes i18n key coverage) ──');
 try { run('npm run test:client'); } catch {
   failures.push({ name: 'test:client', why: 'component behaviour, and translation keys missing from de/pl' });

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * The documentation release gate.
+ *
+ * Owner rule, 2026-08-04: *"i want the documentation lens to be a release gate from now on. docs/ MUST match code
+ * and changelog must be carrying and notice MUST contain all attribution."*
+ *
+ * ## Why this is a RELEASE gate and not just more CI
+ *
+ * The individual coverage gates already run per PR. What nothing checked was **the tag itself**. A tag push goes
+ * straight to `publish.yml`, so the sequence "cut the tag → build → push to two registries" had no documentation
+ * precondition at all. Every one of these three failures could have shipped:
+ *
+ *  - a version tagged with `[Unreleased]` still holding the entries, so the released CHANGELOG section is empty
+ *    and every change in the release is filed under a heading that does not exist yet;
+ *  - a version tagged where the four manifests disagree, so the image reports one number and the notes another;
+ *  - a dependency added and attributed nowhere, published to two public registries under a licence that requires
+ *    attribution.
+ *
+ * The per-PR gates catch the second and third *eventually*. A release is the moment they stop being recoverable:
+ * an image on GHCR and Docker Hub cannot be un-published, and a missing attribution in a shipped artefact is a
+ * licence problem rather than a tidiness one.
+ *
+ * ## What it enforces, in the owner's three terms
+ *
+ *  1. **docs/ MUST match code** — every documentation-coverage gate, plus markdownlint.
+ *  2. **CHANGELOG must be carrying** — this version has a dated section, that section has real content, and
+ *     `[Unreleased]` has been emptied into it.
+ *  3. **NOTICE MUST contain all attribution** — every direct dependency of the redistributed trees.
+ *
+ * Run: `npm run release:gate`
+ * Also runs in `publish.yml` BEFORE the build, so a bad tag fails in seconds instead of publishing.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const R = '\x1b[0m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const DIM = '\x1b[2m';
+
+const RELEASING = detectReleasing();
+const failures = [];
+const fail = (gate, why) => failures.push({ gate, why });
+
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+// ─────────────────────────────────────────────────── 1. the version, everywhere
+/**
+ * One version, in every manifest.
+ *
+ * Not pedantry: the image reports `package.json`'s version from inside itself (that is how a release is verified
+ * after publish), while the CHANGELOG heading and the git tag come from elsewhere. A disagreement means the
+ * artefact and its notes describe different releases, and the pull that proves the release is fine passes anyway.
+ */
+function checkVersion() {
+  const manifests = ['package.json', 'server/package.json', 'client/package.json'];
+  const versions = new Map();
+  for (const m of manifests) versions.set(m, JSON.parse(read(m)).version);
+
+  const distinct = [...new Set(versions.values())];
+  if (distinct.length !== 1) {
+    fail('version', `manifests disagree: ${[...versions].map(([f, v]) => `${f}=${v}`).join(', ')}`);
+    return null;
+  }
+  const version = distinct[0];
+
+  // The lockfile carries the workspace versions too, and it is the one that gets forgotten because nobody edits
+  // it by hand.
+  const lock = read('package-lock.json');
+  const lockHits = (lock.match(new RegExp(`"version": "${version.replace(/\./g, '\\.')}"`, 'g')) ?? []).length;
+  if (lockHits < manifests.length) {
+    fail('version', `package-lock.json names ${version} ${lockHits} time(s), expected at least ${manifests.length}`
+      + ' — run `npm install` after a version bump so the lockfile follows');
+  }
+  return version;
+}
+
+// ─────────────────────────────────────────────────── 2. the CHANGELOG carries the release
+/**
+ * "Carrying" means three separate things, and only the first is obvious.
+ */
+function checkChangelog(version) {
+  if (!version) return;
+  const eolSplit = read('CHANGELOG.md').split(/\r?\n/);
+  const text = eolSplit.join('\n');
+
+  // (a) a dated section for THIS version
+  const heading = new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]\\s+[—-]\\s+(\\d{4}-\\d{2}-\\d{2})`, 'm');
+  const m = heading.exec(text);
+  if (!m) {
+    fail('changelog', `no dated section for ${version}. Expected a line like "## [${version}] — YYYY-MM-DD". `
+      + 'The version was bumped without closing [Unreleased] into it, so every change in this release is filed '
+      + 'under a heading that does not exist.');
+    return;
+  }
+
+  // (b) that section has real content — a version can be tagged with an empty one, and an empty release section
+  //     is worse than none: it asserts that nothing changed.
+  const start = m.index;
+  const nextHeading = text.slice(start + 1).search(/^## \[/m);
+  const body = nextHeading < 0 ? text.slice(start) : text.slice(start, start + 1 + nextHeading);
+  const contentLines = body.split('\n').slice(1).filter(l => l.trim() && !/^#{1,3} /.test(l.trim()));
+  if (contentLines.length < 3) {
+    fail('changelog', `the ${version} section has ${contentLines.length} content line(s). An empty release section `
+      + 'claims nothing changed, which is a stronger and falser statement than saying nothing at all.');
+  }
+
+  // (c) [Unreleased] has been emptied into it — but ONLY at release time.
+  //
+  // Between releases `[Unreleased]` is supposed to be full; that is what it is for. The first version of this
+  // check demanded it be empty unconditionally and failed on a perfectly healthy mid-cycle tree, which would have
+  // taught everyone to ignore the gate. So the question is not "is it empty" but "are we cutting a release right
+  // now", and that has an answer in git rather than in a flag somebody remembers to pass.
+  const unrel = /^## \[Unreleased\]/m.exec(text);
+  if (!unrel) {
+    fail('changelog', 'the [Unreleased] heading is gone. It must exist so the next change has somewhere to go.');
+    return;
+  }
+  if (!RELEASING) return;
+
+  const after = text.slice(unrel.index + unrel[0].length);
+  const nextSec = after.search(/^## \[/m);
+  const region = nextSec < 0 ? after : after.slice(0, nextSec);
+  const leftovers = region.split('\n').filter(l => l.trim() && !/^#{1,3} /.test(l.trim()));
+  if (leftovers.length > 0) {
+    fail('changelog', `[Unreleased] still holds ${leftovers.length} line(s) at release time. Those changes are `
+      + `IN ${version} but documented as unreleased.\n      first: ${leftovers[0].trim().slice(0, 90)}`);
+  }
+}
+
+/**
+ * Are we cutting a release right now?
+ *
+ * `true` when HEAD is exactly a tag (which is the state `publish.yml` runs in, since a tag push is what triggers
+ * it) or when `--releasing` is passed by hand for a pre-tag check. Everything else is mid-cycle, where a populated
+ * `[Unreleased]` is correct and demanding otherwise would just train people to ignore this.
+ */
+function detectReleasing() {
+  if (process.argv.includes('--releasing')) return true;
+  try {
+    execFileSync('git', ['describe', '--exact-match', '--tags', 'HEAD'],
+      { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─────────────────────────────────────────────────── 3+4. the gates that already exist
+/**
+ * The documentation and attribution gates, run as one group.
+ *
+ * Listed explicitly rather than globbed. A glob would silently shrink if a file were renamed, and this gate's
+ * whole job is to not silently shrink — the same reason every enumeration gate in this repo asserts a floor.
+ */
+const DOC_GATES = [
+  ['env-var-docs-coverage', 'every env var the code reads is documented'],
+  ['config-key-docs-coverage', 'every config.json key is documented'],
+  ['metric-docs-coverage', 'every metric on /metrics is documented'],
+  ['mcp-tool-docs-coverage', 'every MCP tool is documented'],
+  ['route-path-docs-coverage', 'every API route path is documented'],
+  ['help-docs-coverage', 'every in-product Help anchor resolves'],
+  ['docs-tables-render', 'no docs table is malformed'],
+  ['error-shape-is-json', 'the documented error shape holds'],
+  ['rollback-is-documented', 'every boot migration has a documented way back'],
+];
+
+const NOTICE_GATES = [
+  ['notice-coverage', 'every redistributed dependency is attributed in NOTICE'],
+  ['notice-ships-in-the-image', 'NOTICE and LICENSE are inside the published image'],
+  ['ffmpeg-licensing-is-stated', 'ffmpeg runs as a separate process and is attributed'],
+];
+
+function runTest(name) {
+  const path = `testing/standalone/${name}.test.js`;
+  // A missing gate file must read as "this gate is gone", not as an ordinary assertion failure. A renamed or
+  // deleted gate is exactly the silent shrink this list exists to prevent, so it gets its own message.
+  if (!existsSync(join(ROOT, path))) {
+    return `MISSING — ${path} does not exist. A gate named here and absent from the tree is a gate that stopped `
+      + 'running; restore it or remove the entry deliberately.';
+  }
+  try {
+    execFileSync('node', ['--test', path], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' });
+    return null;
+  } catch (e) {
+    const out = (e.stdout ?? '') + (e.stderr ?? '');
+    const first = out.split('\n').find(l => l.includes('AssertionError') || l.includes('Error:'));
+    return first ? first.trim().slice(0, 200) : 'failed (see the full run)';
+  }
+}
+
+function checkGroup(label, gates) {
+  for (const [name, what] of gates) {
+    process.stdout.write(`${DIM}  · ${what}…${R}`);
+    const err = runTest(name);
+    if (err) {
+      process.stdout.write(`\r${RED}  ✗ ${what}${R}${' '.repeat(20)}\n`);
+      fail(label, `${name}: ${err}`);
+    } else {
+      process.stdout.write(`\r${GREEN}  ✓${R} ${what}${' '.repeat(20)}\n`);
+    }
+  }
+}
+
+function checkMarkdownLint() {
+  process.stdout.write(`${DIM}  · markdown in docs/ lints clean…${R}`);
+  try {
+    execFileSync('npm', ['run', 'lint:docs'], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe', shell: true });
+    process.stdout.write(`\r${GREEN}  ✓${R} markdown in docs/ lints clean${' '.repeat(20)}\n`);
+  } catch (e) {
+    process.stdout.write(`\r${RED}  ✗ markdown in docs/ lints clean${R}${' '.repeat(20)}\n`);
+    const out = (e.stdout ?? '') + (e.stderr ?? '');
+    fail('docs', out.split('\n').filter(l => l.includes('error')).slice(0, 3).join(' | ') || 'markdownlint failed');
+  }
+}
+
+// ─────────────────────────────────────────────────── run
+console.log(`\n${YELLOW}Documentation release gate${R}  ${DIM}(owner rule 2026-08-04)${R}\n`);
+
+const version = checkVersion();
+const mode = RELEASING
+  ? 'RELEASING — [Unreleased] must be empty'
+  : 'mid-cycle — [Unreleased] may hold entries';
+console.log(`  version: ${version ?? '(inconsistent)'}   mode: ${mode}\n`);
+
+console.log(`${YELLOW}CHANGELOG carries the release${R}`);
+checkChangelog(version);
+if (!failures.some(f => f.gate === 'changelog')) {
+  console.log(`${GREEN}  ✓${R} [${version}] is dated, has content, and [Unreleased] is empty\n`);
+} else {
+  console.log('');
+}
+
+console.log(`${YELLOW}docs/ matches code${R}`);
+checkGroup('docs', DOC_GATES);
+checkMarkdownLint();
+
+console.log(`\n${YELLOW}NOTICE carries all attribution${R}`);
+checkGroup('notice', NOTICE_GATES);
+
+console.log(`\n${'='.repeat(78)}`);
+if (failures.length === 0) {
+  console.log(`${GREEN}Release gate PASSED${R} — docs match code, the CHANGELOG carries ${version}, NOTICE is complete.\n`);
+  process.exit(0);
+}
+console.log(`${RED}Release gate FAILED${R} — ${failures.length} problem(s). A tag must not go out with these:\n`);
+for (const f of failures) console.log(`  ${RED}[${f.gate}]${R} ${f.why}\n`);
+console.log(`${DIM}These are the three things a published release can never take back: an image on two public${R}`);
+console.log(`${DIM}registries, notes that do not describe it, and an attribution that was owed and not given.${R}\n`);
+process.exit(1);

--- a/scripts/todo-consistency.mjs
+++ b/scripts/todo-consistency.mjs
@@ -27,6 +27,7 @@
  * Run: `npm run todo:check`
  */
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -57,7 +58,6 @@ const NOT_A_QUEUE = new Map([
   ['_THE_LOOP.md', 'the process description itself'],
   ['_CRYPTO-INVENTORY.md', 'a fact sheet kept for reference; its subject is closed'],
   ['_PARKED-DECISIONS.md', 'owner decisions, indexed by outcome rather than queued'],
-  ['_REFERENCE-ARCHIVE.md', 'archive'],
   ['_DEPRECATIONS.md', 'a removal checklist keyed to a future major, not the current queue'],
   ['_CLA-BOT-SETUP.md', 'setup instructions'],
   ['_NEXT-PR-PLAN.md', 'the working plan for the PR in flight; cleared on push'],
@@ -80,10 +80,16 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
 {
   // A completed marker anywhere in todo/ means shipped work is being tracked twice — here and in the CHANGELOG —
   // and the two will disagree. Two survivors labelled OPEN had already shipped when this rule was made.
+  //
+  // The heading patterns were added after the first three missed all of this: section 1 still listed an item
+  // shipped in #678, and P1 sat in section 1b with "CLOSED" in its own heading. Both announced their closure in a
+  // *heading* rather than with a checkbox, so a checkbox-only check reported the queue clean. The rule is about
+  // closed work being tracked as work, not about one syntax for saying so.
   const CLOSED = [
     [/^\s*[-*]\s*\[x\]/im, 'a checked `[x]` item'],
     [/^\s*[-*]?\s*\*\*?SHIPPED/im, 'a SHIPPED marker'],
-    [/^\s*#{1,4}\s+.*\bSHIPPED\b/im, 'a SHIPPED heading'],
+    [/^\s*#{1,4}\s+.*\b(SHIPPED|CLOSED|RESOLVED|DONE)\b/im, 'a heading announcing the item is finished'],
+    [/^\s*[-*]\s*\[ \]\s*~~/im, 'a struck-through open item — delete it rather than crossing it out'],
   ];
   let clean = true;
   for (const f of files) {
@@ -140,6 +146,38 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
     console.log(`${RED}  ✗${R} ${ORDERED} does not index every open item`);
   } else {
     console.log(`${GREEN}  ✓${R} ${ORDERED} references every open item in every tracker`);
+  }
+}
+
+// ── rule 3: the working plan must describe work that is still ahead
+{
+  /**
+   * `_NEXT-PR-PLAN.md` is exempt from the queue rules because it is a working document — and that exemption is
+   * exactly why it rotted unnoticed until the owner opened it and said "outdated again". It described the
+   * pre-2.3.0 world: an item that had shipped, a release that had happened, and layer figures I later corrected.
+   *
+   * The check that catches it without needing network: **it must not name a PR that is already merged into main.**
+   * A plan is about work ahead; a merged PR number in it is a plan describing the past. Context references belong
+   * in `_REFERENCE.md`, which is exempt from this for that reason.
+   */
+  const PLAN = '_NEXT-PR-PLAN.md';
+  if (files.includes(PLAN)) {
+    const src = readFileSync(join(TODO, PLAN), 'utf8');
+    const claimed = [...new Set([...src.matchAll(/#(\d{3,5})\b/g)].map(m => m[1]))];
+    let log = '';
+    try {
+      log = execFileSync('git', ['log', '--oneline', '-400'], { cwd: ROOT, encoding: 'utf8' });
+    } catch { /* no git history available — skip rather than guess */ }
+
+    const merged = log ? claimed.filter(n => log.includes(`(#${n})`)) : [];
+    if (merged.length) {
+      fail(`${PLAN} names PR(s) already merged into main: ${merged.map(n => `#${n}`).join(', ')}. A plan is about `
+        + 'work ahead — a merged number in it means the file describes the past. Rewrite it to the current state, '
+        + 'or move the context to `_REFERENCE.md`.');
+      console.log(`${RED}  ✗${R} ${PLAN} describes work that has already shipped`);
+    } else {
+      console.log(`${GREEN}  ✓${R} ${PLAN} describes work that is still ahead`);
+    }
   }
 }
 

--- a/scripts/todo-consistency.mjs
+++ b/scripts/todo-consistency.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * The `todo/` folder holds only actionable open work, and `_TODO-ORDERED.md` indexes all of it.
+ *
+ * Owner rules:
+ *  - 2026-08-02: *"todos must be only actionable open items"* — no `[x]`, no SHIPPED, no standing rules. Shipped
+ *    work lives in the CHANGELOG; rationale lives in `_REFERENCE.md`.
+ *  - 2026-08-04: *"ordered has to reference all todos in all other todo files"* — `_TODO-ORDERED.md` is the single
+ *    index. An item that exists in a domain tracker and is not referenced from the ordered list is invisible to
+ *    the thing that decides what gets built next.
+ *
+ * ## Why this is a script and not a test
+ *
+ * `todo/` is **gitignored**. It never reaches CI, so a standalone test would either fail there for lack of the
+ * folder or have to skip — and a check that skips in the only place it runs automatically is not a check. This is
+ * a local pre-push tool instead, and it exits 0 with a clear note when `todo/` is absent, so it can be wired into
+ * preflight without breaking a clean checkout.
+ *
+ * ## Why the second rule matters more than it sounds
+ *
+ * The release cadence is *"cut the tag when `_TODO-ORDERED.md` is EMPTY"*. If a domain tracker can hold an item
+ * the ordered list never mentions, then "the queue is empty" is a statement about one file rather than about the
+ * work — and the release gate fires on a queue that only looks drained. That already happened once: a
+ * reconciliation on 2026-08-03 found five real items (2 FEATURES, 2 UX, 1 PERFORMANCE) missing from a list that
+ * claimed to order all of them.
+ *
+ * Run: `npm run todo:check`
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TODO = join(ROOT, 'todo');
+const R = '\x1b[0m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const DIM = '\x1b[2m';
+
+if (!existsSync(TODO)) {
+  console.log(`${DIM}todo/ is not present (it is gitignored) — nothing to check.${R}`);
+  process.exit(0);
+}
+
+const ORDERED = '_TODO-ORDERED.md';
+
+/**
+ * Files that are reference material rather than queues, so an unindexed heading in them is not an orphan.
+ *
+ * Each carries its reason. `_REFERENCE.md` is where resolved rationale goes *by* the rules above, and
+ * `_AUDIT-LENSES.md` is a catalogue of methods, not of work.
+ */
+const NOT_A_QUEUE = new Map([
+  ['_REFERENCE.md', 'resolved rationale — where closed work is supposed to end up'],
+  ['_AUDIT-LENSES.md', 'a catalogue of review methods, not a list of work'],
+  ['_THE_LOOP.md', 'the process description itself'],
+  ['_CRYPTO-INVENTORY.md', 'a fact sheet kept for reference; its subject is closed'],
+  ['_PARKED-DECISIONS.md', 'owner decisions, indexed by outcome rather than queued'],
+  ['_REFERENCE-ARCHIVE.md', 'archive'],
+  ['_DEPRECATIONS.md', 'a removal checklist keyed to a future major, not the current queue'],
+  ['_CLA-BOT-SETUP.md', 'setup instructions'],
+  ['_NEXT-PR-PLAN.md', 'the working plan for the PR in flight; cleared on push'],
+]);
+
+const failures = [];
+const fail = (why) => failures.push(why);
+
+const files = readdirSync(TODO).filter(f => f.endsWith('.md'));
+if (!files.includes(ORDERED)) {
+  console.log(`${RED}${ORDERED} is missing — there is no index.${R}`);
+  process.exit(1);
+}
+
+const ordered = readFileSync(join(TODO, ORDERED), 'utf8');
+
+console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and 2026-08-04)${R}\n`);
+
+// ── rule 1: only actionable OPEN items
+{
+  // A completed marker anywhere in todo/ means shipped work is being tracked twice — here and in the CHANGELOG —
+  // and the two will disagree. Two survivors labelled OPEN had already shipped when this rule was made.
+  const CLOSED = [
+    [/^\s*[-*]\s*\[x\]/im, 'a checked `[x]` item'],
+    [/^\s*[-*]?\s*\*\*?SHIPPED/im, 'a SHIPPED marker'],
+    [/^\s*#{1,4}\s+.*\bSHIPPED\b/im, 'a SHIPPED heading'],
+  ];
+  let clean = true;
+  for (const f of files) {
+    if (NOT_A_QUEUE.has(f)) continue;
+    const src = readFileSync(join(TODO, f), 'utf8');
+    for (const [re, what] of CLOSED) {
+      const m = re.exec(src);
+      if (m) {
+        const line = src.slice(0, m.index).split(/\r?\n/).length;
+        fail(`${f}:${line} holds ${what}. Shipped work goes in the CHANGELOG; the reasoning goes in `
+          + '`_REFERENCE.md`. A checkbox is not evidence — verify a survivor against the code before keeping it.');
+        clean = false;
+      }
+    }
+  }
+  console.log(clean
+    ? `${GREEN}  ✓${R} every queue file holds only open items`
+    : `${RED}  ✗${R} a queue file tracks closed work`);
+}
+
+// ── rule 2: the ordered list references every item in every other tracker
+{
+  /**
+   * An item is a `### N. Title` heading or a `- [ ]` checkbox. Reference is by ID token or by a distinctive title
+   * fragment, because the ordered list legitimately paraphrases rather than copying a heading verbatim.
+   */
+  const orphans = [];
+  for (const f of files) {
+    if (f === ORDERED || NOT_A_QUEUE.has(f)) continue;
+    const src = readFileSync(join(TODO, f), 'utf8');
+
+    // IDs like S-L5-1 are the strongest handle; fall back to the first few words of an open checkbox.
+    const ids = [...src.matchAll(/^\s*[-*]\s*\[ \]\s*\**([A-Z]+-[A-Z0-9-]+)\**\.?/gim)].map(m => m[1]);
+    for (const id of new Set(ids)) {
+      if (!ordered.includes(id)) orphans.push(`${f} → ${id}`);
+    }
+
+    // Checkboxes with no ID: match on a distinctive phrase (the longest run of words in the first 12).
+    const plain = [...src.matchAll(/^\s*[-*]\s*\[ \]\s*(.{16,120})$/gim)]
+      .map(m => m[1].replace(/[*`_]/g, '').trim())
+      .filter(t => !/^[A-Z]+-[A-Z0-9-]+/.test(t));
+    for (const t of plain) {
+      const words = t.split(/\s+/).filter(w => w.length > 4).slice(0, 4);
+      if (words.length < 2) continue;
+      const referenced = words.some(w => ordered.toLowerCase().includes(w.toLowerCase()));
+      if (!referenced) orphans.push(`${f} → "${t.slice(0, 70)}"`);
+    }
+  }
+  if (orphans.length) {
+    fail(`${orphans.length} open item(s) exist in a domain tracker and are not referenced from ${ORDERED}:\n`
+      + orphans.map(o => `      ${o}`).join('\n')
+      + `\n\n      The release cadence is "cut the tag when ${ORDERED} is empty". An item it never mentions makes`
+      + '\n      "empty" a statement about one file rather than about the work.');
+    console.log(`${RED}  ✗${R} ${ORDERED} does not index every open item`);
+  } else {
+    console.log(`${GREEN}  ✓${R} ${ORDERED} references every open item in every tracker`);
+  }
+}
+
+// ── the exemption list must not rot
+{
+  const stale = [...NOT_A_QUEUE.keys()].filter(f => !files.includes(f));
+  if (stale.length) {
+    console.log(`${YELLOW}  !${R} exempt but absent: ${stale.join(', ')} ${DIM}(harmless, but tidy it)${R}`);
+  }
+}
+
+console.log(`\n${'='.repeat(78)}`);
+if (!failures.length) {
+  console.log(`${GREEN}todo/ is consistent${R} — open items only, all of them indexed.\n`);
+  process.exit(0);
+}
+console.log(`${RED}todo/ is inconsistent${R} — ${failures.length} problem(s):\n`);
+for (const f of failures) console.log(`  ${RED}·${R} ${f}\n`);
+process.exit(1);

--- a/testing/standalone/release-gate-works.test.js
+++ b/testing/standalone/release-gate-works.test.js
@@ -1,0 +1,160 @@
+/**
+ * The release gate is itself testable, because a gate that cannot fail is worse than no gate.
+ *
+ * Owner rule, 2026-08-04: *"i want the documentation lens to be a release gate from now on. docs/ MUST match code
+ * and changelog must be carrying and notice MUST contain all attribution."*
+ *
+ * `scripts/release-gate.mjs` runs at tag time — in `publish.yml`, before login and before the build. The three
+ * things it protects are the three a published release can never take back: an image on two public registries,
+ * notes that do not describe it, and an attribution that was owed and not given. So the gate has to be right, and
+ * "it printed PASSED once" is not evidence of that.
+ *
+ * ## What these tests are for
+ *
+ * The gate's own logic is what nothing else covers. The coverage gates it *invokes* have their own tests; the
+ * parts unique to a release do not:
+ *
+ *  1. **The gate list cannot silently shrink.** Every gate it names must exist as a file. A renamed test would
+ *     otherwise turn into a gate that quietly stopped running — the exact failure the list exists to prevent.
+ *  2. **Mode detection is real.** `[Unreleased]` is *supposed* to be full between releases. The first version of
+ *     the gate demanded it be empty unconditionally and failed on a healthy tree, which is how a gate teaches
+ *     people to ignore it. So the release-only rules must be gated on actually releasing.
+ *  3. **Every release-specific rule fires.** Version disagreement, a missing dated section, an empty one, and
+ *     `[Unreleased]` left populated at release time — each asserted against a synthetic CHANGELOG rather than by
+ *     trusting the prose.
+ *
+ * Run: node --test testing/standalone/release-gate-works.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const GATE = 'scripts/release-gate.mjs';
+const src = readFileSync(join(ROOT, GATE), 'utf8');
+
+/** The gate names its checks in two arrays; pull them out rather than duplicating the list here. */
+function namedGates() {
+  const out = [];
+  for (const m of src.matchAll(/^\s*\['([a-z0-9-]+)',\s*'/gim)) out.push(m[1]);
+  return out;
+}
+
+describe('the release gate names real gates', () => {
+  it('finds the gate list — the parse still works', () => {
+    const names = namedGates();
+    assert.ok(names.length >= 10,
+      `only ${names.length} gates parsed out of ${GATE}; the enumeration broke, not the gate`);
+  });
+
+  it('every named gate exists as a test file', () => {
+    // A gate listed here and absent from the tree is a gate that stopped running. The script reports that
+    // distinctly at runtime; this makes it a build failure rather than something noticed at the next release.
+    const missing = namedGates()
+      .map(n => `testing/standalone/${n}.test.js`)
+      .filter(p => !existsSync(join(ROOT, p)));
+    assert.deepEqual(missing, [], `the release gate names test files that do not exist:\n  ${missing.join('\n  ')}`);
+  });
+
+  it("covers all three of the owner's terms", () => {
+    // The rule was stated as three things. If a future edit drops one of the groups, the gate would still pass
+    // while enforcing less than was asked for.
+    assert.match(src, /notice-coverage/, 'NOTICE attribution is not checked');
+    assert.match(src, /env-var-docs-coverage/, 'docs/-matches-code is not checked');
+    assert.match(src, /checkChangelog/, 'the CHANGELOG is not checked');
+    assert.match(src, /lint:docs/, 'markdown in docs/ is not linted');
+  });
+});
+
+describe('mode detection', () => {
+  it('gates the [Unreleased]-must-be-empty rule on actually releasing', () => {
+    // Between releases a populated [Unreleased] is correct. Asserted structurally because the alternative — run
+    // the gate and see — depends on whether HEAD happens to be a tag when the suite runs.
+    assert.match(src, /if \(!RELEASING\) return;/,
+      'the [Unreleased] emptiness check is not gated on release mode, so it fails on every healthy mid-cycle tree '
+      + 'and teaches everyone to ignore this gate');
+  });
+
+  it('detects release mode from git rather than from a flag alone', () => {
+    // A flag somebody has to remember is not a gate. `publish.yml` runs with HEAD at the tag, so git can answer.
+    assert.match(src, /describe.*--exact-match.*--tags/s,
+      'release mode is not derived from git, so publish.yml would run the mid-cycle rules');
+    assert.match(src, /--releasing/, 'there is no way to run the release rules before cutting the tag');
+  });
+});
+
+describe('every release-specific rule actually fires', () => {
+  /**
+   * The gate reads real files, so its rules are exercised here against synthetic text using the same patterns.
+   * That is a deliberate trade: it does not prove the gate's file I/O, and it does prove the rules are not
+   * vacuous. The file I/O is covered by the gate having run green on this repo.
+   */
+  const version = '9.9.9';
+  const dated = `## [${version}] — 2026-01-01`;
+
+  it('a dated section for the version is required', () => {
+    const heading = new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]\\s+[—-]\\s+(\\d{4}-\\d{2}-\\d{2})`, 'm');
+    assert.ok(heading.test(`# Changelog\n\n${dated}\n\n- something\n`), 'the pattern rejects a valid heading');
+    assert.ok(!heading.test(`# Changelog\n\n## [${version}]\n\n- something\n`),
+      'an undated section passes, so a version could ship with no release date');
+    assert.ok(!heading.test('# Changelog\n\n## [Unreleased]\n\n- something\n'),
+      'a version with no section at all passes');
+  });
+
+  it('an em dash and a hyphen are both accepted as the date separator', () => {
+    // The repo uses an em dash; a contributor typing a hyphen should not be told the section is missing, because
+    // that error message points at the wrong problem entirely.
+    const heading = new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]\\s+[—-]\\s+(\\d{4}-\\d{2}-\\d{2})`, 'm');
+    assert.ok(heading.test(`## [${version}] — 2026-01-01`), 'em dash rejected');
+    assert.ok(heading.test(`## [${version}] - 2026-01-01`), 'hyphen rejected');
+  });
+
+  it('an empty release section is caught', () => {
+    // An empty section is a stronger and falser claim than no section: it asserts that nothing changed.
+    const countContent = (body) => body.split('\n').slice(1)
+      .filter(l => l.trim() && !/^#{1,3} /.test(l.trim())).length;
+    assert.ok(countContent(`${dated}\n\n### Added\n\n`) < 3, 'a section with only a subheading counts as content');
+    assert.ok(countContent(`${dated}\n\n### Added\n\n- a\n- b\n- c\n`) >= 3, 'real content is miscounted as empty');
+  });
+
+  it('leftovers under [Unreleased] are counted, and subheadings are not mistaken for them', () => {
+    // `### Fixed` alone under [Unreleased] is the residue of a template, not an unreleased change. Counting it
+    // would block every release until someone deleted a heading, which is how a gate gets bypassed.
+    const leftovers = (region) => region.split('\n').filter(l => l.trim() && !/^#{1,3} /.test(l.trim())).length;
+    assert.equal(leftovers('\n\n### Fixed\n\n'), 0, 'a bare subheading is counted as an unreleased change');
+    assert.equal(leftovers('\n\n### Fixed\n\n- a real change\n'), 1, 'a real leftover is not counted');
+  });
+
+  it('the version check looks at the lockfile too', () => {
+    // The lockfile is the manifest nobody edits by hand, so it is the one that gets left behind on a bump.
+    assert.match(src, /package-lock\.json/,
+      'the lockfile is not checked, so a version bump can leave it naming the previous release');
+  });
+});
+
+describe('it is wired into the release path, not merely available', () => {
+  it('publish.yml runs the gate BEFORE the build', () => {
+    const wf = readFileSync(join(ROOT, '.github/workflows/publish.yml'), 'utf8');
+    const gateAt = wf.indexOf('release:gate');
+    const buildAt = wf.indexOf('Build and push');
+    assert.ok(gateAt > 0, 'publish.yml does not run the release gate, so a tag can publish with stale docs');
+    assert.ok(buildAt > 0, 'the Build and push step is gone — this assertion needs re-pointing');
+    assert.ok(gateAt < buildAt,
+      'the gate runs after the build, so a bad tag pays for a full multi-arch build before failing');
+  });
+
+  it('publish.yml fetches enough history for mode detection to work', () => {
+    // A shallow clone with no tags makes `git describe --exact-match` fail, which reads as "not releasing" and
+    // silently downgrades the release checks to their mid-cycle form. Nothing would look wrong.
+    const wf = readFileSync(join(ROOT, '.github/workflows/publish.yml'), 'utf8');
+    assert.match(wf, /fetch-depth:\s*0/,
+      'publish.yml checks out shallow, so the gate cannot tell it is at a tag and would skip the release rules');
+  });
+
+  it('npm exposes both scripts', () => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+    assert.ok(pkg.scripts['release:gate'], 'npm run release:gate is missing');
+    assert.ok(pkg.scripts['todo:check'], 'npm run todo:check is missing');
+  });
+});


### PR DESCRIPTION
Two owner rules, both enforced rather than written down.

> "i want the documentation lens to be a release gate from now on. docs/ MUST match code and changelog must be carrying and notice MUST contain all attribution."

> "todos must be only actionable open items and ordered has to reference all todos in all other todo files."

## `npm run release:gate`

Runs before a tag, and again inside `publish.yml` **before login and before the build** — so a bad tag fails in about two minutes instead of publishing to two registries. The three things it protects are the three a published release can never take back: an image on GHCR and Docker Hub, notes that do not describe it, and an attribution that was owed and not given.

| your term | what runs |
|---|---|
| **docs/ matches code** | every `*-docs-coverage` gate · `docs-tables-render` · `error-shape-is-json` · `rollback-is-documented` · `lint:docs` |
| **CHANGELOG carries** | a dated `## [version] — date` section, with real content, and `[Unreleased]` emptied into it |
| **NOTICE holds all attribution** | `notice-coverage` · `notice-ships-in-the-image` · `ffmpeg-licensing-is-stated` |

Plus **one version across all three manifests and the lockfile** — the lockfile is the one nobody edits by hand, so it is the one left behind on a bump.

### Why this is not just more CI

**Two of the checks can only be true at release time**: that the manifests agree, and that `[Unreleased]` was actually closed. No per-PR gate can see either. The rest is repeated at the tag because a tag can be cut from a commit whose CI never ran.

The gate list is **explicit rather than globbed**, and a named gate whose file is missing reports as *"this gate stopped running"* rather than as an ordinary assertion failure — a renamed test is exactly the silent shrink the list exists to prevent. (That message earned itself during this PR: the list named a gate that only landed in #680.)

## Two defects in the gate, both found by running it

**It demanded `[Unreleased]` be empty unconditionally** and failed on a perfectly healthy mid-cycle tree. Between releases a populated `[Unreleased]` is *correct* — that is what it is for. Release mode now comes from `git describe --exact-match --tags HEAD`, the state `publish.yml` runs in, with `--releasing` for a pre-tag check.

**A gate that fires on a healthy tree teaches everyone to ignore it**, which would have cost more than the gate was worth.

**`fetch-depth: 0` is load-bearing in the workflow.** A shallow clone has no tags, `git describe` fails, that reads as "not releasing", and the release-only rules downgrade **silently** with nothing looking wrong.

Verified both directions on this branch: mid-cycle → PASSED; `--releasing` → FAILED on the populated `[Unreleased]`, which is exactly what should stop a tag today.

## `npm run todo:check`

The second rule, wired into preflight.

**The index half is load-bearing, not tidiness.** The release cadence is *"cut the tag when `_TODO-ORDERED.md` is empty"* — so a domain tracker holding an item the ordered list never mentions makes "empty" a claim about one file rather than about the work.

**Its first run found two orphans, and both were work that had already shipped and was still marked `[ ]`.** The ordered list had correctly dropped them; the domain tracker never did. So an orphan is usually not a missing index entry — it is a closed item wearing an open checkbox, which is why the two rules belong in one check. Retired after verifying each against the code, because a checkbox is not evidence.

`todo/` is gitignored, so this can only run locally and exits 0 when the folder is absent. A check that skips in the only place it runs automatically is not a check.

Reference files are exempt **with a written reason each** — an exemption without a stated reason is indistinguishable from an oversight the next reader preserves out of caution.

## The gate is itself tested

`release-gate-works.test.js`, 13 assertions, because a gate that cannot fail is worse than no gate:

- every gate it names must exist as a file;
- mode detection must be real, and derived from git rather than a flag somebody remembers;
- each release-specific rule must fire against synthetic input — em dash *and* hyphen date separators, a bare `### Fixed` not counted as an unreleased change, an empty release section caught;
- `publish.yml` must run it **before** the build, and must fetch enough history for mode detection to work.

## Verification

- `npm run preflight` — passes
- `npm run release:gate` — PASSED (mid-cycle)
- `npm run release:gate -- --releasing` — FAILED on the populated `[Unreleased]`, as it should
- `npm run todo:check` — clean on both rules
