### PR TITLE
feat(brain): a retried write no longer duplicates a memory or a chrono entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A retried write no longer duplicates a memory or a chrono entry.** Both creates now accept an optional
+  caller-supplied `id` (UUID v4), and a retry that reuses it **converges on the same record** instead of
+  writing a second one. The MCP tools `remember` and `create_chrono` take the same parameter.
+  - **The finding was that three different answers already existed and none was documented.** An entity was
+    idempotent if you supplied an `id`; an edge was always idempotent via its `(from, to, label)`
+    natural key; **memory and chrono duplicated** — and they are the two highest-volume write types and the ones
+    an agent retries most. There is no `Idempotency-Key` support anywhere, so a timed-out request had no safe
+    retry for two of the four types.
+  - **The entity path was real retry safety that was invisible.** The only place the docs mentioned supplying an
+    id was inside a *warning string* about updating an existing entity — never as "this is how you make a write
+    retry-safe".
+  - **Owner chose this over an `Idempotency-Key` header** because it reuses a path already shipped and
+    tested on entities: no new collection, no TTL to expire, and an agent that generates one UUID before its
+    first attempt gets idempotency for free.
+
+### Documentation
+
+- **A `Retry Safety` section on the Brain API page**, documenting all four record types and their three
+  different mechanisms in one table — the thing that did not exist.
+  - It says plainly that **idempotent does not mean no-op**: the second write really happens, `seq` and
+    `updatedAt` advance, it appears in the audit log and in `ythril_brain_write_seq_total`. An integrator who
+    reads "idempotent" as "the second call does nothing" would be confused by their own audit log.
+  - It says to generate the UUID **before the first attempt**, which is the one detail that makes the technique
+    work and the natural thing to get wrong.
+  - It reassures that **omitting `id` is unchanged** — every existing client is unaffected.
+
+### Fixed
+
+- **Convergence emits `*.updated`, not `*.created`.** A webhook subscriber has to be able to tell a converged
+  retry from a new record, or it creates the duplicate downstream that was just prevented upstream.
+- **The new routes validate the supplied id as a UUID v4**; the entity route does **not** — `safeId` there is
+  `typeof id === 'string'`, so an arbitrary string can become the `_id` of a record that replicates across every
+  peer in every network. That is pre-existing and tightening it would be breaking, so it is filed rather than
+  changed here — but it is deliberately not copied onto the new paths.
+
+### Testing
+
+- An integration test proves the record count after a retry (the only thing that can), and an offline gate holds
+  the contract: the docs describe all four types, the routes validate, the MCP schemas advertise it and do not
+  make it required. **8 mutations, 8 caught.**
+- **Three of the first eight survived, and two were my assertions being unscoped.** Both checked that a string
+  existed *anywhere in the file* — and both strings already appear elsewhere in the same file, from the separate
+  update function and from the `entityIds` validation. So a mutation flipping the convergence event to
+  `*.created`, and one replacing the id check with `true`, both passed. Now scoped to the convergence branch and
+  to `UUID_V4_RE.test(rawId)` respectively. The third was a weak mutation rather than a weak test.
+
 ### Documentation
 
 - **The webhook signature-verification example we hand integrators used `===` on the HMAC.** Our own code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An integration test proves the record count after a retry (the only thing that can), and an offline gate holds
   the contract: the docs describe all four types, the routes validate, the MCP schemas advertise it and do not
   make it required. **8 mutations, 8 caught.**
+- **The integration suite failed on its first real run, entirely on my test's plumbing — every feature assertion
+  passed.** The id landed, `seq` advanced, tags merged, a malformed id was refused, the entity path converged.
+  Two faults, and the fix for the first is strictly better than what it replaced:
+  - I counted records through a `POST /memories/query` I had invented; listing is a `GET`. The list
+    came back empty and the assertion announced *"the retry created a second memory (0 records with this fact)"*
+    — **the opposite of the truth.** A count cannot tell "no duplicate" from "I looked in the wrong place". It now
+    compares the ids the API returns, which asserts the same property directly, needs no list endpoint, and cannot
+    be fooled by pagination — a test already in that suite warns that scanning a paginated list gives a false pass
+    past 100 records.
+  - Edge `from`/`to` take entity **IDs**, not names — the API says so in as many words: *"a name is
+    not a reference"*. I passed names and got a 400 that had nothing to do with idempotency.
 - **Three of the first eight survived, and two were my assertions being unscoped.** Both checked that a string
   existed *anywhere in the file* — and both strings already appear elsewhere in the same file, from the separate
   update function and from the `entityIds` validation. So a mutation flipping the convergence event to

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -18,6 +18,64 @@ GET /api/brain/spaces/general/memories
 
 > **Breaking change (2.0):** the old two-segment shape `/api/brain/:spaceId/memories` (e.g. `/api/brain/general/memories`) has been **removed**. It previously duplicated these handlers under a second URL; it now returns `404`. Update any client still using it to the `/spaces/:spaceId/` prefix.
 
+## Retry Safety
+
+**A request that times out has not necessarily failed.** If you retry a create, whether you get one record or
+two depends on the record type — so this is the first thing to read if anything you write is retried, and
+anything an agent writes is retried.
+
+| type | retried create | how |
+|---|---|---|
+| **memory** | idempotent **if you supply `id`** | a UUID v4 you generate; the retry converges on that record |
+| **chrono** | idempotent **if you supply `id`** | same |
+| **entity** | idempotent **if you supply `id`** | same |
+| **edge** | **always idempotent** | the natural key `(from, to, label)` — no id needed |
+
+### How to make a write retry-safe
+
+Generate the UUID **before your first attempt** and reuse it on every retry. That is the whole technique:
+
+```js
+const id = crypto.randomUUID();          // once, before the first attempt
+
+async function writeWithRetry(fact) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await post('/api/brain/spaces/general/memories', { id, fact });
+    } catch (err) {
+      // A timeout here may mean the write SUCCEEDED and the response was lost. Retrying with the same `id`
+      // converges on the same record instead of writing a second one.
+      if (attempt === 2) throw err;
+    }
+  }
+}
+```
+
+### What "idempotent" means here, precisely
+
+**It is not a no-op.** The second write really happens — it just lands on the same record:
+
+- `seq` and `updatedAt` advance, so the retry is a real write and appears in the audit log and in
+  `ythril_brain_write_seq_total`;
+- **tags union and properties shallow-merge**, they do not replace. A retry sends the identical payload so this
+  makes no difference to it, but reusing an id later with different content behaves as a merge;
+- the webhook event is `memory.updated` / `chrono.updated` / `entity.updated`, **not**
+  `*.created`, so a subscriber can tell a converged retry from a new record.
+
+What you get is the guarantee that matters: **the same content, in one record, however many times you send it.**
+
+### Rules
+
+- `id` must be a **UUID v4**. Anything else is a `400` — it becomes the record's identity across
+  every peer in every network the space belongs to, so it is held to a shape.
+- **Omitting `id` is unchanged**: every call creates a new record. Existing clients are unaffected.
+- An id that names nothing yet simply becomes the new record's id, so your *first* attempt does not need to know
+  whether it is the first.
+- The MCP tools `remember` and `create_chrono` take the same optional `id`, with the same
+  meaning.
+
+---
+
 ### Write a Memory
 
 ```http

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -169,6 +169,7 @@ const DOC_GATES = [
   ['error-shape-is-json', 'the documented error shape holds'],
   ['rollback-is-documented', 'every boot migration has a documented way back'],
   ['webhook-docs-are-safe', 'the webhook verification example is safe to copy'],
+  ['idempotent-writes-contract', 'retry safety is documented for all four record types'],
 ];
 
 const NOTICE_GATES = [

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -105,9 +105,20 @@ chronoRouter.post('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, 
   const ttlErr = ttlDaysError(req.body);
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
 
+  // A caller-supplied id becomes the sync identity of a record that replicates across networks, so it is held
+  // to the same shape the rest of the API uses. (The entity route accepts any string here — pre-existing, and
+  // tightening it would be a breaking change, so it is filed rather than copied.)
+  const rawId: unknown = req.body?.['id'];
+  if (rawId !== undefined && (typeof rawId !== 'string' || !UUID_V4_RE.test(rawId))) {
+    res.status(400).json({ error: '`id` must be a UUID v4 when supplied. Omit it to have one generated, or reuse the same value to make a retry idempotent.' });
+    return;
+  }
+  const safeId: string | undefined = typeof rawId === 'string' ? rawId : undefined;
+
   const entry = await createChrono(wt.target, {
     title: title.trim(), type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
+    id: safeId,
   }, webhookToken(req), ttlDaysFromBody(req.body));
   const result: Record<string, unknown> = { ...entry };
   if (validation.warnings.length > 0) result['warnings'] = validation.warnings;

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -96,9 +96,19 @@ memoriesRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAu
   const ttlErr = ttlDaysError(req.body);
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
 
+  // A caller-supplied id becomes the sync identity of a record that replicates across networks, so it is held
+  // to the same shape the rest of the API uses. (The entity route accepts any string here — pre-existing, and
+  // tightening it would be a breaking change, so it is filed rather than copied.)
+  const rawId: unknown = req.body?.['id'];
+  if (rawId !== undefined && (typeof rawId !== 'string' || !UUID_V4_RE.test(rawId))) {
+    res.status(400).json({ error: '`id` must be a UUID v4 when supplied. Omit it to have one generated, or reuse the same value to make a retry idempotent.' });
+    return;
+  }
+  const safeId: string | undefined = typeof rawId === 'string' ? rawId : undefined;
+
   const doc = await remember(
     targetSpace, fact, safeEntityIds, safeTags, safeDesc, safeProps,
-    undefined, safeMemoryType, undefined, webhookToken(req), ttlDaysFromBody(req.body),
+    undefined, safeMemoryType, undefined, webhookToken(req), ttlDaysFromBody(req.body), safeId,
   );
   const body: Record<string, unknown> = { ...doc };
   if (quotaResult?.softBreached) body['storageWarning'] = true;

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -94,11 +94,26 @@ export async function createChrono(
     memoryIds?: string[];
     properties?: Record<string, string | number | boolean>;
     recurrence?: ChronoEntry['recurrence'];
+    /**
+     * A caller-supplied UUID v4, which makes this write idempotent — see `remember()` for the full reasoning.
+     *
+     * A retried create that names an existing entry CONVERGES on the same content instead of producing a
+     * second calendar entry. Chrono is the type where the same thing most often gets logged twice even
+     * without a retry, which is why the opt-in duplicate check below exists; this closes the mechanical case.
+     */
+    id?: string;
   },
   actor?: WebhookActor,
   ttlDays?: number | null,
   opts?: DupeCheckOpts,
 ): Promise<ChronoEntry & { similar?: SimilarMatch[]; contradicts?: ContradictionWarning[] }> {
+  // When an id is supplied, look for the entry it names first — the same shape as `upsertEntity` and
+  // `remember`.
+  const existing: ChronoEntry | null = fields.id
+    ? (await col<ChronoEntry>(`${spaceId}_chrono`).findOne(
+      asFilter<ChronoEntry>({ _id: fields.id, spaceId })) as ChronoEntry | null)
+    : null;
+
   const seq = await nextSeq(spaceId);
   const now = new Date().toISOString();
   const status = fields.status ?? 'upcoming';
@@ -127,8 +142,47 @@ export async function createChrono(
     }
   }
 
+  // ── The idempotent branch: a supplied id that already names an entry converges rather than duplicating.
+  if (existing) {
+    const mergedTags = [...new Set([...(existing.tags ?? []), ...tags])];
+    const mergedProps = { ...(existing.properties ?? {}), ...(fields.properties ?? {}) };
+    const $set: Record<string, unknown> = {
+      title: fields.title,
+      type: fields.type,
+      startsAt: fields.startsAt,
+      status,
+      tags: mergedTags,
+      updatedAt: now,
+      seq,
+      ...embeddingFields,
+    };
+    if (fields.endsAt !== undefined) $set['endsAt'] = fields.endsAt;
+    if (fields.description !== undefined) $set['description'] = fields.description;
+    if (fields.confidence !== undefined) $set['confidence'] = fields.confidence;
+    if (fields.entityIds !== undefined) $set['entityIds'] = fields.entityIds;
+    if (fields.memoryIds !== undefined) $set['memoryIds'] = fields.memoryIds;
+    if (fields.properties !== undefined) $set['properties'] = mergedProps;
+    if (fields.recurrence !== undefined) $set['recurrence'] = fields.recurrence;
+    const $unset: Record<string, unknown> = {};
+    applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+      { collection: 'chrono', existing: existing as unknown as Record<string, unknown> });
+    const updateOp: Record<string, unknown> = { $set };
+    if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
+    await col<ChronoEntry>(`${spaceId}_chrono`).updateOne(
+      asFilter<ChronoEntry>({ _id: existing._id }), asUpdate<ChronoEntry>(updateOp),
+    );
+    const converged = { ...existing, ...($set as Partial<ChronoEntry>) } as ChronoEntry;
+    if ('_expireAt' in $unset) delete (converged as { _expireAt?: unknown })._expireAt;
+    // `chrono.updated`, not `created` — a subscriber must be able to tell a converged retry from a new entry.
+    if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...converged, embedding: undefined }, ...actor });
+    return (similar || contradicts)
+      ? { ...converged, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) }
+      : converged;
+  }
+
   const doc: ChronoEntry = {
-    _id: uuidv4(),
+    // A supplied id that named nothing becomes the entry's identity, so the caller's retry finds it next time.
+    _id: fields.id ?? uuidv4(),
     spaceId,
     title: fields.title,
     type: fields.type,

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -45,7 +45,41 @@ export async function remember(
   opts?: DupeCheckOpts,
   actor?: WebhookActor,
   ttlDays?: number | null,
+  /**
+   * A caller-supplied UUID v4, which makes this write **idempotent**.
+   *
+   * ## Why it exists
+   *
+   * An MCP agent or an integrator whose request times out will retry — and before this, a retried memory create
+   * produced a **second memory**, silently. Entities already had this: a supplied `id` makes `upsertEntity` find
+   * by `_id` and update. Edges get it free from their `(from, to, label)` natural key. Memories and chrono had
+   * neither, and they are the two highest-volume write types.
+   *
+   * The owner chose this mechanism over an `Idempotency-Key` header specifically because it reuses a path already
+   * shipped and tested on entities: no new storage, no TTL to expire, and an agent that generates one UUID before
+   * its first attempt gets idempotency for free.
+   *
+   * ## What a retry actually does, stated precisely
+   *
+   * It is **not** a no-op. The record converges on the same content, but `updatedAt` and `seq` move, and tags and
+   * properties **merge** rather than replace — matching `upsertEntity` exactly, because one mental model across
+   * four record types is worth more than a marginally different rule per type. Converging on the same content is
+   * what retry safety means here; claiming "no effect" would be false, and it would also be visible as a `clean`
+   * write in `ythril_brain_write_seq_total`.
+   *
+   * The route validates the shape. An arbitrary string must never reach `_id`: it becomes the sync identity of a
+   * record that replicates across networks.
+   *
+   * NOTE: this is the twelfth positional parameter, which is one too many. The next addition should convert the
+   * tail to an options object rather than continue the pattern.
+   */
+  id?: string,
 ): Promise<MemoryDoc & { similar?: SimilarMatch[]; contradicts?: ContradictionWarning[] }> {
+  // When an id is supplied, look for the record it names first — the same shape as `upsertEntity`.
+  const existing: MemoryDoc | null = id
+    ? (await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: id })) as MemoryDoc | null)
+    : null;
+
   const names = entityNames ?? await resolveEntityNames(spaceId, entityIds);
   const embedText = memoryEmbedText(fact, tags, names, description, properties);
   const embResult = await embed(embedText);
@@ -66,8 +100,49 @@ export async function remember(
 
   const seq = await nextSeq(spaceId);
   const now = new Date().toISOString();
+
+  // ── The idempotent branch: a supplied id that already names a record CONVERGES rather than duplicating.
+  //
+  // Merge semantics match `upsertEntity` deliberately — tags union, properties shallow-merge — so a caller has one
+  // rule to learn across all four record types. A retry sends the identical payload, so merge and replace are
+  // indistinguishable for the case this exists for; the difference only shows when the id is reused with different
+  // content, which is a deliberate update and behaves like the entity path does.
+  if (existing) {
+    const mergedTags = [...new Set([...(existing.tags ?? []), ...tags])];
+    const mergedProps = { ...(existing.properties ?? {}), ...(properties ?? {}) };
+    const $set: Record<string, unknown> = {
+      fact,
+      tags: mergedTags,
+      entityIds,
+      matchedText: embedText,
+      updatedAt: now,
+      seq,
+      embedding: embResult.vector,
+      embeddingModel: embResult.model,
+    };
+    if (type !== undefined) $set['type'] = type;
+    if (description !== undefined) $set['description'] = description;
+    if (properties !== undefined) $set['properties'] = mergedProps;
+    const $unset: Record<string, unknown> = {};
+    applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
+      { collection: 'memory', existing: existing as unknown as Record<string, unknown> });
+    const updateOp: Record<string, unknown> = { $set };
+    if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;
+    await col<MemoryDoc>(`${spaceId}_memories`).updateOne(
+      asFilter<MemoryDoc>({ _id: existing._id }), asUpdate<MemoryDoc>(updateOp),
+    );
+    const converged = { ...existing, ...($set as Partial<MemoryDoc>) } as MemoryDoc;
+    if ('_expireAt' in $unset) delete (converged as { _expireAt?: unknown })._expireAt;
+    // `memory.updated`, not `created` — a subscriber must be able to tell a converged retry from a new record.
+    if (actor) emitWebhookEvent({ event: 'memory.updated', spaceId, entry: { ...converged, embedding: undefined }, ...actor });
+    return (similar || contradicts)
+      ? { ...converged, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) }
+      : converged;
+  }
+
   const doc: MemoryDoc = {
-    _id: uuidv4(),
+    // A supplied id that named nothing becomes the record's identity, so the caller's retry finds it next time.
+    _id: id ?? uuidv4(),
     spaceId,
     fact,
     embedding: embResult.vector,

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -17,6 +17,7 @@ export const create_chronoTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
+            id: { type: 'string', description: 'Optional UUID v4. Supply one to make this call IDEMPOTENT: retrying with the same id converges on the same entry instead of creating a second one. Generate it before your first attempt and reuse it on every retry. Omit it and each call creates a new entry.' },
             title: { type: 'string', minLength: 1, description: 'Entry title.' },
             type: { type: 'string', minLength: 1, description: 'Entry type. Rejected unless it is one of the space\'s allowed chrono types: the defaults are event, deadline, plan, prediction, milestone, or the custom set declared in the space\'s typeSchemas.chrono.' },
             startsAt: { type: 'string', minLength: 1, description: 'ISO 8601 start date/time.' },
@@ -106,6 +107,7 @@ export const create_chronoTool: ToolHandler = {
     if (!rec.ok) throw new Error(rec.error);
 
     const entry = await createChrono(wt.target, {
+      id: typeof a['id'] === 'string' ? a['id'] : undefined,
       title,
       type: chronoType,
       startsAt,

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -28,6 +28,10 @@ export const rememberTool: ToolHandler = {
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {
+            id: {
+              type: 'string',
+              description: 'Optional UUID v4. Supply one to make this call IDEMPOTENT: retrying with the same id converges on the same record instead of creating a second one. Generate it before your first attempt and reuse it on every retry. Omit it and each call creates a new record.',
+            },
             space: s.requiredSpace,
             fact: { type: 'string', minLength: 1, maxLength: 50000, description: 'The fact, observation, or memory to store (1–50 000 characters).' },
             entityIds: {
@@ -112,7 +116,8 @@ export const rememberTool: ToolHandler = {
     const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
     const remTtlDays = ttlDaysFromArgs(a);
     const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames, memType,
-      { checkDuplicates: remDupeCheck, checkContradictions: remContraCheck, dupeThreshold: remDupeThreshold }, ctx.actor, remTtlDays);
+      { checkDuplicates: remDupeCheck, checkContradictions: remContraCheck, dupeThreshold: remDupeThreshold }, ctx.actor, remTtlDays,
+      typeof a['id'] === 'string' ? a['id'] : undefined);
     const warnings: string[] = [];
     if (mem.similar && mem.similar.length > 0) {
       warnings.push(`⚠️ Possible duplicate — ${mem.similar.length} existing memor${mem.similar.length === 1 ? 'y is' : 'ies are'} highly similar: ${mem.similar.map(s => `"${s.summary}" (ID ${s._id}, ${s.score.toFixed(2)})`).join('; ')}. This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.`);

--- a/testing/integration/idempotent-writes.test.js
+++ b/testing/integration/idempotent-writes.test.js
@@ -20,10 +20,10 @@
  *
  * ## Why these tests need a real instance
  *
- * The whole behaviour is "what is in the collection after the second call", which is a database question. The
+ * The whole behaviour is "which record the second call landed on", which is a database question. The
  * offline gate (`idempotent-writes-contract.test.js`) holds the parts that can be checked from source — that the
  * routes validate the shape, that the MCP tools advertise it, that the docs describe all four behaviours. Only
- * this file can prove the record count.
+ * this file can prove where the second write actually went.
  *
  * Run: node --test testing/integration/idempotent-writes.test.js
  * (needs the Docker test stack: `npm run test:up`)
@@ -44,10 +44,19 @@ before(() => { tok = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8
 /** A fresh UUID v4 per test, so one test's id can never make another's assertion pass. */
 const uuid = () => crypto.randomUUID();
 
-const listMemories = async () => {
-  const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories/query', {});
-  return r.body?.memories ?? r.body?.results ?? [];
-};
+/**
+ * Identity, not count.
+ *
+ * The first version of these tests counted records through a list endpoint. It came back empty — the endpoint
+ * was a POST /memories/query I had invented; listing is a GET — and the assertion then reported "the retry
+ * created a second memory (0 records with this fact)", which is the opposite of the truth.
+ *
+ * **A count cannot tell "no duplicate" from "I looked in the wrong place."** Comparing the ids the API returns
+ * is the same property asserted directly: same id means one record, different ids mean two. It needs no list
+ * endpoint and cannot be fooled by pagination, which an existing test in this suite already warns about past
+ * 100 records.
+ */
+const idOf = (r) => r.body?._id ?? r.body?.entity?._id ?? r.body?.edge?._id;
 
 describe('memories: a retry with the same id converges', () => {
   it('two identical creates with one id produce ONE record', async () => {
@@ -63,10 +72,9 @@ describe('memories: a retry with the same id converges', () => {
     assert.equal(second.status, 201, `retry failed: ${JSON.stringify(second.body)}`);
     assert.equal(second.body._id, id, 'the retry produced a different id');
 
-    const mine = (await listMemories()).filter(m => m.fact === fact);
-    assert.equal(mine.length, 1,
-      `the retry created a second memory (${mine.length} records with this fact). This is the bug: an agent whose `
-      + 'request timed out and retried used to double every record it wrote.');
+    assert.equal(idOf(second), idOf(first),
+      `the retry produced a DIFFERENT record (${idOf(first)} then ${idOf(second)}). This is the bug: an agent `
+      + 'whose request timed out and retried used to double every record it wrote.');
   });
 
   it('the retry moves seq and updatedAt — it converges, it is not a no-op', async () => {
@@ -98,10 +106,11 @@ describe('memories: a retry with the same id converges', () => {
   it('omitting the id still creates a new record every time', async () => {
     // The default must not change. Every existing client omits the id and relies on this.
     const fact = `no-id probe ${uuid()}`;
-    await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
-    await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
-    const mine = (await listMemories()).filter(m => m.fact === fact);
-    assert.equal(mine.length, 2, 'omitting the id silently deduplicated, which would break every existing caller');
+    const a = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
+    const b = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
+    assert.ok(idOf(a) && idOf(b), `both creates must return an id (${idOf(a)}, ${idOf(b)})`);
+    assert.notEqual(idOf(b), idOf(a),
+      'omitting the id silently deduplicated, which would break every existing caller');
   });
 
   it('a malformed id is refused with 400, not stored', async () => {
@@ -127,10 +136,8 @@ describe('chrono: the same contract', () => {
     const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono', body);
     assert.equal(second.status, 201, `retry failed: ${JSON.stringify(second.body)}`);
 
-    const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono/query', {});
-    const entries = r.body?.entries ?? r.body?.chrono ?? r.body?.results ?? [];
-    const mine = entries.filter(e => e.title === title);
-    assert.equal(mine.length, 1, `the retry created a second chrono entry (${mine.length} with this title)`);
+    assert.equal(idOf(second), idOf(first),
+      `the retry produced a different chrono entry (${idOf(first)} then ${idOf(second)})`);
   });
 
   it('a malformed id is refused with 400', async () => {
@@ -150,24 +157,26 @@ describe('entities and edges: the behaviour that already existed still holds', (
     assert.equal(first.status, 201, `entity create failed: ${JSON.stringify(first.body)}`);
     const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { id, name, type: 'person' });
     assert.ok(second.status === 200 || second.status === 201, `entity retry failed: ${second.status}`);
-    assert.equal(second.body.entity?._id ?? second.body._id, id, 'the entity retry did not converge on the same id');
+    assert.equal(idOf(second), id, 'the entity retry did not converge on the same id');
   });
 
   it('an edge retry converges on its natural key without any id', async () => {
+    // `from`/`to` are entity IDs, not names — the API says so explicitly: "a name is not a reference". The first
+    // version passed names and got a 400 that had nothing to do with idempotency.
     const suffix = uuid().slice(0, 8);
-    const from = `edge-from-${suffix}`;
-    const to = `edge-to-${suffix}`;
-    for (const n of [from, to]) {
-      await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { name: n, type: 'person' });
+    const ids = [];
+    for (const n of [`edge-from-${suffix}`, `edge-to-${suffix}`]) {
+      const e = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { name: n, type: 'person' });
+      assert.ok(idOf(e), `entity ${n} was not created: ${JSON.stringify(e.body)}`);
+      ids.push(idOf(e));
     }
-    const body = { from, to, label: 'knows' };
+    const body = { from: ids[0], to: ids[1], label: 'knows' };
     const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/edges', body);
     assert.ok(first.status === 200 || first.status === 201, `edge create failed: ${JSON.stringify(first.body)}`);
     const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/edges', body);
     assert.ok(second.status === 200 || second.status === 201, `edge retry failed: ${second.status}`);
-    const firstId = first.body.edge?._id ?? first.body._id;
-    const secondId = second.body.edge?._id ?? second.body._id;
-    assert.equal(secondId, firstId,
+    assert.ok(idOf(first), `the edge create returned no id: ${JSON.stringify(first.body)}`);
+    assert.equal(idOf(second), idOf(first),
       'the edge retry created a second edge — the (from, to, label) natural key stopped being idempotent');
   });
 });

--- a/testing/integration/idempotent-writes.test.js
+++ b/testing/integration/idempotent-writes.test.js
@@ -1,0 +1,173 @@
+/**
+ * A retried write must converge, not duplicate.
+ *
+ * ## The finding this closes
+ *
+ * An MCP agent or an integrator whose request times out will retry. Before this, what happened next differed per
+ * record type by three different mechanisms, and none of it was documented:
+ *
+ * | type | a retried create | mechanism |
+ * |---|---|---|
+ * | entity | idempotent | a caller-supplied `id` makes it an upsert |
+ * | edge | idempotent | natural key `(from, to, label)` |
+ * | memory | **DUPLICATED** | no id parameter, no natural key |
+ * | chrono | **DUPLICATED** | no id parameter, no natural key |
+ *
+ * Memory is the highest-volume write type and the one an agent retries most, so it had the worst of it. The owner
+ * chose the caller-supplied id over an `Idempotency-Key` header because it reuses a path already shipped and
+ * tested on entities: no new storage, no TTL to expire, and an agent that generates one UUID before its first
+ * attempt gets idempotency for free.
+ *
+ * ## Why these tests need a real instance
+ *
+ * The whole behaviour is "what is in the collection after the second call", which is a database question. The
+ * offline gate (`idempotent-writes-contract.test.js`) holds the parts that can be checked from source — that the
+ * routes validate the shape, that the MCP tools advertise it, that the docs describe all four behaviours. Only
+ * this file can prove the record count.
+ *
+ * Run: node --test testing/integration/idempotent-writes.test.js
+ * (needs the Docker test stack: `npm run test:up`)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+
+let tok;
+before(() => { tok = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
+
+/** A fresh UUID v4 per test, so one test's id can never make another's assertion pass. */
+const uuid = () => crypto.randomUUID();
+
+const listMemories = async () => {
+  const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories/query', {});
+  return r.body?.memories ?? r.body?.results ?? [];
+};
+
+describe('memories: a retry with the same id converges', () => {
+  it('two identical creates with one id produce ONE record', async () => {
+    const id = uuid();
+    const fact = `idempotency probe ${id}`;
+
+    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
+    assert.equal(first.status, 201, `first create failed: ${JSON.stringify(first.body)}`);
+    assert.equal(first.body._id, id, 'the supplied id did not become the record id, so a retry cannot find it');
+
+    // The retry. Byte-identical payload, which is what a client resending after a timeout actually sends.
+    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
+    assert.equal(second.status, 201, `retry failed: ${JSON.stringify(second.body)}`);
+    assert.equal(second.body._id, id, 'the retry produced a different id');
+
+    const mine = (await listMemories()).filter(m => m.fact === fact);
+    assert.equal(mine.length, 1,
+      `the retry created a second memory (${mine.length} records with this fact). This is the bug: an agent whose `
+      + 'request timed out and retried used to double every record it wrote.');
+  });
+
+  it('the retry moves seq and updatedAt — it converges, it is not a no-op', async () => {
+    // Stated in the docs and asserted here, because "idempotent" is often read as "no effect" and that would be
+    // wrong: the second write really happens, it just lands on the same record.
+    const id = uuid();
+    const fact = `seq probe ${id}`;
+    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
+    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
+
+    assert.ok(second.body.seq > first.body.seq,
+      `seq did not advance (${first.body.seq} -> ${second.body.seq}); the second write did not happen at all, which `
+      + 'is a different behaviour from the one documented');
+  });
+
+  it('tags and properties MERGE on convergence, matching the entity path', async () => {
+    const id = uuid();
+    const fact = `merge probe ${id}`;
+    await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories',
+      { id, fact, tags: ['first'], properties: { a: '1' } });
+    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories',
+      { id, fact, tags: ['second'], properties: { b: '2' } });
+
+    assert.deepEqual([...second.body.tags].sort(), ['first', 'second'],
+      'tags replaced rather than merged — entities merge, and one rule across four record types is the point');
+    assert.deepEqual(second.body.properties, { a: '1', b: '2' }, 'properties did not shallow-merge');
+  });
+
+  it('omitting the id still creates a new record every time', async () => {
+    // The default must not change. Every existing client omits the id and relies on this.
+    const fact = `no-id probe ${uuid()}`;
+    await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
+    await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
+    const mine = (await listMemories()).filter(m => m.fact === fact);
+    assert.equal(mine.length, 2, 'omitting the id silently deduplicated, which would break every existing caller');
+  });
+
+  it('a malformed id is refused with 400, not stored', async () => {
+    // A caller-supplied id becomes the sync identity of a record that replicates across networks.
+    for (const bad of ['not-a-uuid', '', '../../etc/passwd', '12345']) {
+      const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories',
+        { id: bad, fact: `bad id ${bad}` });
+      assert.equal(r.status, 400, `id "${bad}" was accepted (status ${r.status}) and became a record identity`);
+    }
+  });
+});
+
+describe('chrono: the same contract', () => {
+  it('two identical creates with one id produce ONE entry', async () => {
+    const id = uuid();
+    const title = `chrono idempotency ${id}`;
+    const body = { id, title, type: 'event', startsAt: '2026-01-01T00:00:00.000Z' };
+
+    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono', body);
+    assert.equal(first.status, 201, `first create failed: ${JSON.stringify(first.body)}`);
+    assert.equal(first.body._id, id, 'the supplied id did not become the entry id');
+
+    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono', body);
+    assert.equal(second.status, 201, `retry failed: ${JSON.stringify(second.body)}`);
+
+    const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono/query', {});
+    const entries = r.body?.entries ?? r.body?.chrono ?? r.body?.results ?? [];
+    const mine = entries.filter(e => e.title === title);
+    assert.equal(mine.length, 1, `the retry created a second chrono entry (${mine.length} with this title)`);
+  });
+
+  it('a malformed id is refused with 400', async () => {
+    const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono',
+      { id: 'nope', title: 'bad', type: 'event', startsAt: '2026-01-01T00:00:00.000Z' });
+    assert.equal(r.status, 400, `a malformed chrono id was accepted (status ${r.status})`);
+  });
+});
+
+describe('entities and edges: the behaviour that already existed still holds', () => {
+  it('an entity retry with the same id converges', async () => {
+    // Regression cover for the path the new ones were modelled on — if this changes, the "one rule across four
+    // types" claim in the docs stops being true and nothing else would notice.
+    const id = uuid();
+    const name = `idem entity ${id}`;
+    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { id, name, type: 'person' });
+    assert.equal(first.status, 201, `entity create failed: ${JSON.stringify(first.body)}`);
+    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { id, name, type: 'person' });
+    assert.ok(second.status === 200 || second.status === 201, `entity retry failed: ${second.status}`);
+    assert.equal(second.body.entity?._id ?? second.body._id, id, 'the entity retry did not converge on the same id');
+  });
+
+  it('an edge retry converges on its natural key without any id', async () => {
+    const suffix = uuid().slice(0, 8);
+    const from = `edge-from-${suffix}`;
+    const to = `edge-to-${suffix}`;
+    for (const n of [from, to]) {
+      await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { name: n, type: 'person' });
+    }
+    const body = { from, to, label: 'knows' };
+    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/edges', body);
+    assert.ok(first.status === 200 || first.status === 201, `edge create failed: ${JSON.stringify(first.body)}`);
+    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/edges', body);
+    assert.ok(second.status === 200 || second.status === 201, `edge retry failed: ${second.status}`);
+    const firstId = first.body.edge?._id ?? first.body._id;
+    const secondId = second.body.edge?._id ?? second.body._id;
+    assert.equal(secondId, firstId,
+      'the edge retry created a second edge — the (from, to, label) natural key stopped being idempotent');
+  });
+});

--- a/testing/standalone/idempotent-writes-contract.test.js
+++ b/testing/standalone/idempotent-writes-contract.test.js
@@ -1,0 +1,151 @@
+/**
+ * The retry-safety contract, in the parts that can be checked without a database.
+ *
+ * The behaviour itself — "how many records are in the collection after the second call" — is a database question
+ * and lives in `testing/integration/idempotent-writes.test.js`. This file holds everything else, because the
+ * integration suite needs Docker and therefore only runs in CI, while the contract is the part somebody breaks
+ * accidentally while editing a route.
+ *
+ * ## What it defends
+ *
+ *  1. **All four record types are documented**, with their different mechanisms. Two of them (entity by id, edge
+ *     by natural key) were already idempotent and nobody was told — the only mention of supplying an id was inside
+ *     a *warning string* about updating an existing entity. Documented capability is the whole point of this work.
+ *  2. **A caller-supplied id is validated as a UUID v4** on the new paths. It becomes the `_id` of a record that
+ *     replicates across every peer in every network the space belongs to, so an arbitrary string must not reach it.
+ *  3. **The MCP tools advertise it.** An MCP agent is precisely the "external caller that retries" this exists for;
+ *     leaving it REST-only would have fixed the case that matters least.
+ *  4. **The convergence emits `*.updated`, not `*.created`.** A subscriber has to be able to tell a converged
+ *     retry from a new record, and getting this backwards would be invisible to any count-based test.
+ *
+ * Run: node --test testing/standalone/idempotent-writes-contract.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const DOC = 'docs/integration-guide/04-brain-api.md';
+const doc = readFileSync(join(ROOT, DOC), 'utf8');
+
+const src = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/** The two writers that gained the path, and the one it was modelled on. */
+const WRITERS = [
+  { label: 'memory', impl: 'server/src/brain/memory.ts', route: 'server/src/api/brain/memories.ts', event: 'memory.updated' },
+  { label: 'chrono', impl: 'server/src/brain/chrono.ts', route: 'server/src/api/brain/chrono.ts', event: 'chrono.updated' },
+];
+
+describe('the contract is documented', () => {
+  it('a Retry Safety section exists and names all four record types', () => {
+    assert.match(doc, /## Retry Safety/,
+      'the Retry Safety section is gone. Two of these four types were already idempotent and nobody knew, which is '
+      + 'the failure this section exists to prevent.');
+    const region = doc.slice(doc.indexOf('## Retry Safety'), doc.indexOf('## Retry Safety') + 4000);
+    for (const t of ['memory', 'chrono', 'entity', 'edge']) {
+      assert.ok(region.includes(t), `the Retry Safety section does not mention ${t}`);
+    }
+  });
+
+  it("says plainly that idempotent does NOT mean no-op", () => {
+    // "Idempotent" is routinely read as "the second call does nothing". Here the second write really happens and
+    // moves seq — an integrator who believes otherwise will be confused by their own audit log.
+    assert.match(doc, /not a no-op/i,
+      'the doc does not warn that the retry is a real write; seq and updatedAt advance and it appears in the audit '
+      + 'log, which contradicts the usual reading of "idempotent"');
+    assert.match(doc, /\bseq\b/, 'the doc does not mention that seq advances');
+  });
+
+  it('states the UUID v4 requirement and that omitting the id is unchanged', () => {
+    assert.match(doc, /UUID v4/, 'the id format is not stated');
+    assert.match(doc, /Omitting .{0,6}id.{0,6} is unchanged|every call creates a new record/i,
+      'the doc does not reassure that existing clients which omit the id are unaffected — the first question any '
+      + 'reader of a new write parameter has');
+  });
+
+  it('tells the reader to generate the id BEFORE the first attempt', () => {
+    // The technique is worthless if the id is generated per attempt, and that is the natural mistake.
+    assert.match(doc, /before your first attempt|before the first attempt/i,
+      'the doc does not say to generate the id before the first attempt, which is the one detail that makes the '
+      + 'technique work');
+  });
+});
+
+describe('the routes validate a caller-supplied id', () => {
+  for (const w of WRITERS) {
+    it(`${w.label}: refuses anything that is not a UUID v4`, () => {
+      // Asserts the id is tested against the pattern, not merely that the pattern is imported. The first version
+      // matched `UUID_V4_RE` anywhere in the file — and both routes already use it for `entityIds` — so a mutation
+      // replacing the id check with `true` passed while nothing validated the id at all.
+      const s = src(w.route);
+      assert.match(s, /UUID_V4_RE\.test\(rawId\)/,
+        `${w.route} does not test the supplied id against UUID_V4_RE. It becomes the _id of a record that replicates `
+        + 'across every peer in every network the space belongs to, so an arbitrary string must not reach it.');
+      assert.match(s, /rawId !== undefined/,
+        `${w.route} does not let the id be omitted, which every existing client relies on`);
+      assert.match(s, /status\(400\)/, `${w.route} has no 400 path for a malformed id`);
+    });
+  }
+});
+
+describe('the implementation converges rather than duplicating', () => {
+  for (const w of WRITERS) {
+    it(`${w.label}: looks the record up by the supplied id before inserting`, () => {
+      const s = src(w.impl);
+      assert.match(s, /const existing/,
+        `${w.impl} never looks for an existing record, so a supplied id cannot converge on anything`);
+      assert.match(s, /_id: (id|fields\.id|existing\._id)/,
+        `${w.impl} does not query by the supplied id`);
+    });
+
+    it(`${w.label}: a supplied id becomes the new record's identity`, () => {
+      // Without this the FIRST call generates its own id, the caller's id names nothing, and the retry inserts a
+      // second record — the bug, with a lookup in front of it that never matches.
+      const s = src(w.impl);
+      assert.match(s, /_id: (id|fields\.id) \?\? uuidv4\(\)/,
+        `${w.impl} ignores the supplied id when inserting, so the caller's retry can never find the record`);
+    });
+
+    it(`${w.label}: emits ${w.event} on convergence, not *.created`, () => {
+      // SCOPED to the converge branch, not the whole file. The first version asserted the file merely CONTAINED
+      // `${w.event}` — which it does anyway, from the separate update function — so a mutation flipping the
+      // converge branch to `*.created` passed. Scoping is the difference between checking the branch and checking
+      // that the string exists somewhere.
+      const s = src(w.impl);
+      const branchAt = s.indexOf('if (existing) {');
+      assert.ok(branchAt > 0, `${w.impl} has no convergence branch at all`);
+      const branch = s.slice(branchAt, s.indexOf('\n  }', branchAt));
+      assert.ok(branch.includes(`'${w.event}'`),
+        `the convergence branch in ${w.impl} does not emit ${w.event}. A webhook subscriber cannot tell a converged `
+        + 'retry from a new record, and no count-based test would catch it.');
+      assert.ok(!branch.includes(`'${w.label}.created'`),
+        `the convergence branch emits ${w.label}.created — it is an update to an existing record, and a subscriber `
+        + 'would create a duplicate downstream from it');
+    });
+  }
+});
+
+describe('the MCP tools advertise it', () => {
+  let ALL_TOOLS;
+  before(async () => { ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js')); });
+
+  const schemas = {
+    requiredSpace: { type: 'string', description: 'Space ID.' },
+    optionalSpace: { type: 'string', description: 'Optional space ID.' },
+  };
+
+  for (const name of ['remember', 'create_chrono']) {
+    it(`${name} takes an optional id, and says what it is for`, () => {
+      const tool = ALL_TOOLS.find(t => t.name === name);
+      assert.ok(tool, `the ${name} tool is gone`);
+      const schema = tool.inputSchema(schemas);
+      assert.ok(schema.properties.id, `${name} does not advertise an id — an MCP agent is exactly the caller that `
+        + 'retries, so leaving this REST-only would fix the case that matters least');
+      assert.match(schema.properties.id.description, /idempotent/i,
+        `${name}'s id has no description explaining what it is for; an agent reads the schema and nothing else`);
+      assert.ok(!(schema.required ?? []).includes('id'),
+        `${name} made id REQUIRED, which breaks every existing agent call`);
+    });
+  }
+});


### PR DESCRIPTION
feat(brain): a retried write no longer duplicates a memory or a chrono entry

Memory and chrono creates now accept an optional caller-supplied id (UUID v4),
and a retry that reuses it converges on the same record instead of writing a
second one. The MCP tools remember and create_chrono take the same parameter.

The finding was that three different answers already existed and none of them was
documented:

  entity   idempotent if you supplied an id
  edge     always idempotent, via its (from, to, label) natural key
  memory   DUPLICATED -- no id parameter, no natural key
  chrono   DUPLICATED -- no id parameter, no natural key

There is no Idempotency-Key support anywhere, so a timed-out request had no safe
retry for two of the four types -- and they are the two highest-volume write
types and the ones an agent retries most.

The entity path was real retry safety that was invisible. The only place the docs
mentioned supplying an id was inside a warning string about updating an existing
entity, never as "this is how you make a write retry-safe".

The owner chose this over an Idempotency-Key header because it reuses a path
already shipped and tested on entities: no new collection, no TTL to expire, and
an agent that generates one UUID before its first attempt gets idempotency for
free.

A Retry Safety section on the Brain API page documents all four types and their
three mechanisms in one table. It says plainly that idempotent does NOT mean
no-op -- the second write really happens, seq and updatedAt advance, it appears
in the audit log and in ythril_brain_write_seq_total. It says to generate the
UUID before the first attempt, which is the one detail that makes the technique
work. And it reassures that omitting the id is unchanged, so every existing
client is unaffected.

Convergence emits *.updated, not *.created: a webhook subscriber has to be able
to tell a converged retry from a new record, or it creates downstream the
duplicate that was just prevented upstream.

The new routes validate the supplied id as a UUID v4. The entity route does not
-- safeId there is `typeof id === 'string'`, so an arbitrary string can become
the _id of a record that replicates across every peer in every network. That is
pre-existing and tightening it would be breaking, so it is filed rather than
changed here, and deliberately not copied onto the new paths.

Testing: an integration test proves the record count after a retry (the only
thing that can), and an offline gate holds the contract. 8 mutations, 8 caught.

Three of the first eight survived and two were my assertions being unscoped: both
checked that a string existed anywhere in the file, and both strings already
appear elsewhere in the same file -- from the separate update function, and from
the entityIds validation. So a mutation flipping the convergence event to
*.created, and one replacing the id check with `true`, both passed. Now scoped to
the convergence branch and to UUID_V4_RE.test(rawId) respectively. The third was
a weak mutation rather than a weak test.
