### PR TITLE
release: 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-08-04
+
+### Documentation
+
+- **The docs described the previous release's behaviour in five places, and every coverage gate passed.** Found
+  by the owner asking *"does that release gate not make you review docs?"* — it does not, and that was the point:
+  **coverage and accuracy are different axes.** Every gate asserted that a thing is *mentioned*. None could see
+  that what was said had stopped being true.
+  - `POST /memories` and `POST /chrono` **never mentioned `id`** — the parameter added hours
+    earlier in the same session. A *Retry Safety* section at the top of the page described it fully; the endpoints
+    that accept it said nothing, and an integrator reads the endpoint.
+  - `ythril_storage_used_bytes`'s row read *"Storage used in bytes by area"* while the metric's own
+    `help` had gained *"— from a cached measurement, see the age gauge"* when the collector stopped walking
+    the disk. The row described 2.3.0.
+  - Four more rows said strictly less than the help beside them: the help **enumerates** the label values
+    (`success, partial, error`; `memories, entities, edges, files, chrono`) and the row said "by status" / "by
+    type". An operator could not learn the values without scraping first.
+
+### Testing
+
+- **`metric-docs-are-accurate`** closes that axis: a metric's `help` is the **code's own description
+  of itself**, it ships to every scrape, and it is edited in the same commit as the behaviour. So when the help
+  carries a qualifier the docs row must carry that concept. Wording may differ; a whole missing concept fails.
+  - **Rows may defer to a sibling** (three brain totals say "same estimate as above"), and the exemption **names**
+    the row it defers to, so the pointer cannot rot silently.
+  - **The gate’s own self-test caught a real flaw in it.** The first version joined every qualifier into one
+    string; a help like *"…by area (brain, files, total) — from a cached measurement"* has one clause the row
+    legitimately repeats and one it dropped, and joined, the repeat diluted the omission to 50% — under the
+    threshold, on the exact row that shipped stale. Clauses are now scored independently.
+  - A numeric sweep of every documented default against the code came back **clean** — 13 candidates, all
+    heuristic noise, and one doc turned out more precise than the checker. The stale things were never the
+    numbers.
+
 ### Added
 
 - **A retried write no longer duplicates a memory or a chrono entry.** Both creates now accept an optional

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -84,6 +84,7 @@ POST /api/brain/spaces/:spaceId/memories
 
 ```json
 {
+  "id": "3f2b1c9e-7d84-4a51-9e60-1b2c3d4e5f60",
   "fact": "Kubernetes pods are ephemeral by design",
   "type": "note",
   "tags": ["k8s", "architecture"],
@@ -112,7 +113,7 @@ POST /api/brain/spaces/:spaceId/memories
 }
 ```
 
-**Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl).
+**Constraints**: `id` optional — a **UUID v4** you supply to make the write idempotent (a retry with the same id converges on that record instead of creating a second one); anything else is a `400`, and omitting it generates one. See [Retry Safety](#retry-safety). **Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl).
 
 ---
 
@@ -1146,6 +1147,9 @@ POST /api/brain/spaces/:spaceId/chrono
 ```
 
 **Body**:
+
+`id` is optional here too — a **UUID v4** you supply to make the create idempotent, exactly as for a
+memory. See [Retry Safety](#retry-safety).
 
 ```json
 {

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -77,26 +77,26 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_embedding_duration_seconds` | histogram | Time to compute a single embedding |
 | `ythril_embedding_queue_depth` | gauge | Pending embedding operations |
 | `ythril_reindex_in_progress` | gauge | 1 if a reindex is running, 0 otherwise |
-| `ythril_storage_used_bytes` | gauge | Storage used in bytes by area (brain, files, total) |
+| `ythril_storage_used_bytes` | gauge | Storage used in bytes by area (brain, files, total). **From a cached measurement, not re-walked per scrape** — see `ythril_storage_usage_age_seconds` below and the note on why. |
 | `ythril_storage_limit_bytes` | gauge | Configured storage limits by area and tier (soft, hard) |
 | `ythril_auth_attempts_total` | counter | Auth attempts by result (success, invalid) |
 | `ythril_tokens_active` | gauge | Number of active (non-expired) tokens |
 | `ythril_mcp_connections_active` | gauge | Current SSE connections |
 | `ythril_mcp_tool_calls_total` | counter | Tool invocations by tool name and space |
-| `ythril_sync_cycles_total` | counter | Sync cycles by network and status |
-| `ythril_sync_items_pulled_total` | counter | Items received by type |
-| `ythril_sync_items_pushed_total` | counter | Items sent by type |
+| `ythril_sync_cycles_total` | counter | Sync cycles by `network` and `status` — `success`, `partial`, `error`. |
+| `ythril_sync_items_pulled_total` | counter | Items received by `type` — `memories`, `entities`, `edges`, `files`, `chrono`. |
+| `ythril_sync_items_pushed_total` | counter | Items sent by `type` — same set as pulled. |
 | `ythril_sync_duration_seconds` | histogram | Time per sync cycle |
 | `ythril_recall_degraded_total` | counter | Recalls answered with a **weaker pipeline than configured**, by `reason`. `rerank_unavailable` = the cross-encoder is configured but did not answer; `rerank_skipped_budget` = it was not attempted because the end-to-end `RECALL_BUDGET_MS` was already spent upstream. **This is the one to alert on**: these paths return HTTP 200 with a worse ranking, so they raise no error rate and barely move latency — a reranker down for a week is otherwise invisible. Both series report `0` from process start, so absent-vs-zero is never ambiguous. |
-| `ythril_media_jobs_pending` | gauge | Queued media/document embedding jobs by space |
-| `ythril_media_jobs_processing` | gauge | Jobs a worker is currently running, by space. **One long document shows as `1` here for its whole duration** — pair it with `ythril_embed_chunks_total` to tell slow from stuck |
+| `ythril_media_jobs_pending` | gauge | Queued media/document embedding jobs by space, counted **at scrape time** (so it is a sample, not a running total). |
+| `ythril_media_jobs_processing` | gauge | Jobs a worker is currently running, by space. Counted **at scrape time**, so it is a sample. **One long document shows as `1` here for its whole duration** — pair it with `ythril_embed_chunks_total` to tell slow from stuck |
 | `ythril_media_job_phase` | gauge | In-flight jobs by the pipeline step they are in (`render`, `vlm`, `embed`, `describe`, …, or `unknown` for a job that has not reported one). The known step names are **seeded at `0` from the first scrape**, so the series exists before any job has been in them; an unlisted step appears the moment it is seen |
 | `ythril_embed_chunks_total` | counter | Chunks put through the embedder, by space. Motion, not success: `rate(...[5m]) == 0` while `ythril_media_jobs_processing > 0` is a stuck job, a non-zero rate is a slow one — **but see the restart caveat below before alerting on it** |
 | `ythril_brain_write_seq_total` | counter | Brain record writes by whether the record **changed between read and write**, labelled `collection` and `outcome` (`clean` / `collision`). A `collision` is a **lost update**: two clients edited the same record, and because there is no `If-Match` on brain records yet, the second write silently overwrote the first with a `200` and no trace. Note the exposure is narrower than it sounds — a write `$set`s only the fields the caller supplied, so two clients editing *different* fields both succeed and lose nothing; a collision means the same field. **This is a measurement, not a guard.** It exists to answer how often it actually happens on an instance with several MCP agents against one space, before a 412 path is built. Both series report `0` from process start, so absent-vs-zero is never ambiguous, and `clean` is counted so the collision number has a denominator. |
 | `ythril_media_jobs_completed_total` | counter | Jobs that finished, by space and media type |
 | `ythril_media_jobs_failed_total` | counter | Jobs that exhausted their retries, by space and media type |
 | `ythril_media_jobs_retried_total` | counter | Attempts that failed and were re-queued, by space and media type — including a job whose claim was recovered while it was still running |
-| `ythril_media_jobs_failed` | gauge | Jobs sitting in the terminal `failed` state by space (a backlog, not a rate) |
+| `ythril_media_jobs_failed` | gauge | Jobs sitting in the terminal `failed` state by space, counted **at scrape time** (a backlog, not a rate) |
 | `ythril_media_job_duration_seconds` | histogram | End-to-end time per job by media type |
 | `ythril_metrics_collect_duration_seconds` | histogram | Time for one async collector to gather its values, by `collector` — one observation per collector per scrape. **This is how a slow `/metrics` names its own cause.** Several gauges here are collected at scrape time and walk every space, so on a many-space instance under write load a scrape can approach the Prometheus timeout; `topk(3, ythril_metrics_collect_duration_seconds_sum / ythril_metrics_collect_duration_seconds_count)` says which collector is responsible. **It is a histogram, so the bare metric name is not a series** — only `_bucket`, `_sum` and `_count` exist, and an instant query for `ythril_metrics_collect_duration_seconds` returns empty. That reads as "the metric is missing" rather than "wrong series name", which cost a canary operator a minute and would cost the next person longer. Buckets run to 15 s deliberately — a histogram whose top bucket sits below the failure cannot describe it. |
 | `ythril_metrics_scrape_degraded` | gauge | `1` if the scrape being served had to abandon at least one collector to stay inside its budget, else `0`. **This is the one to alert on**, because the degradation is otherwise invisible: the scrape succeeds, `up` stays 1, and only the abandoned series are missing. It describes the scrape you are reading, not the previous one. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -349,7 +349,7 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
@@ -10085,7 +10085,7 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
@@ -11898,7 +11898,7 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
@@ -19070,7 +19070,7 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
@@ -19381,7 +19381,7 @@
       }
     },
     "node_modules/ts-dedent": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
       "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
       "license": "MIT",
@@ -20320,7 +20320,7 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
       "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
       "dev": true,
@@ -20674,7 +20674,7 @@
       }
     },
     "node_modules/why-is-node-running": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -162,6 +162,7 @@ const DOC_GATES = [
   ['env-var-docs-coverage', 'every env var the code reads is documented'],
   ['config-key-docs-coverage', 'every config.json key is documented'],
   ['metric-docs-coverage', 'every metric on /metrics is documented'],
+  ['metric-docs-are-accurate', "every metric row says what the code's help says"],
   ['mcp-tool-docs-coverage', 'every MCP tool is documented'],
   ['route-path-docs-coverage', 'every API route path is documented'],
   ['help-docs-coverage', 'every in-product Help anchor resolves'],

--- a/scripts/todo-consistency.mjs
+++ b/scripts/todo-consistency.mjs
@@ -149,7 +149,52 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
   }
 }
 
-// ── rule 3: the working plan must describe work that is still ahead
+// ── rule 3: every open item states how to verify it is still open
+{
+  /**
+   * The rule that replaces a title-matching check written and deleted in the same session.
+   *
+   * The problem it is really solving: **four of ten open items had already shipped**, none of them marked in any
+   * way — just `- [ ]` entries describing work that was done. No closure word, no checkbox, nothing to grep.
+   *
+   * The first attempt compared each item's title against released CHANGELOG sections. It **survived its own
+   * mutation**: a known-shipped item was restored and the check stayed green. The premise was wrong, not the
+   * implementation — a todo describes the PROBLEM ("Nothing detects an unreachable component") and a CHANGELOG
+   * describes the FIX ("The build now fails when a component becomes unreachable"). They share no phrase, so title
+   * matching could only ever catch coincidences. A green tick that proves nothing is worse than no tick.
+   *
+   * So the item carries its own evidence instead. **Every open item names what to look at to confirm it is still
+   * open** — a file, a symbol, a test name, a route. That turns "is this still open?" from a judgement call into a
+   * one-command answer, and unlike the prose comparison it is mechanically checkable.
+   */
+  const VERIFY = /(?:\*\*)?(?:Verify|Still open because|Evidence)(?:\*\*)?\s*:/i;
+  const OPEN_ITEM = /^[ \t]*[-*][ \t]*\[ \]/;
+  const missing = [];
+  for (const f of files) {
+    if (NOT_A_QUEUE.has(f)) continue;
+    const src = readFileSync(join(TODO, f), 'utf8');
+    // Split on top-level checkboxes so each item is checked together with its own body.
+    const parts = src.split(/(?=^[ \t]*[-*][ \t]*\[ \])/m).filter(p => OPEN_ITEM.test(p));
+    for (const p of parts) {
+      if (VERIFY.test(p)) continue;
+      const title = (p.match(/\*\*(.+?)\*\*/)?.[1] ?? p.split(/\r?\n/)[0]).replace(/[`*[\]]/g, '').trim();
+      missing.push(`${f} — "${title.slice(0, 66)}"`);
+    }
+  }
+  if (missing.length) {
+    fail(`${missing.length} open item(s) do not say how to verify they are still open:\n`
+      + missing.map(x => `      ${x}`).join('\n')
+      + '\n\n      Add a line like "Verify: `grep -c prod-deps Dockerfile` returns 0" — a file, a symbol, a test'
+      + '\n      name, anything runnable. Four of ten items were once found to have already shipped, with nothing'
+      + '\n      in the file to reveal it. This is the cheapest thing that would have.');
+    console.log(`${RED}  ✗${R} an open item does not say how to verify it is still open`);
+  } else {
+    console.log(`${GREEN}  ✓${R} every open item says how to verify it is still open`);
+  }
+}
+
+
+// ── rule 4: the working plan must describe work that is still ahead
 {
   /**
    * `_NEXT-PR-PLAN.md` is exempt from the queue rules because it is a working document — and that exemption is

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {

--- a/testing/standalone/metric-docs-are-accurate.test.js
+++ b/testing/standalone/metric-docs-are-accurate.test.js
@@ -1,0 +1,134 @@
+/**
+ * The docs must describe what the code DOES, not merely mention that it exists.
+ *
+ * ## Why coverage was not enough
+ *
+ * `metric-docs-coverage` asserts that every metric on `/metrics` appears in the docs. It passed for a full release
+ * while `ythril_storage_used_bytes`'s row read *"Storage used in bytes by area"* — after the collector had stopped
+ * walking the disk and its own `help` string had gained *"— from a cached measurement, see the age gauge"*. The
+ * metric was mentioned, so coverage was green, and the documentation described the previous release's behaviour.
+ *
+ * Coverage and accuracy are different axes. That mistake — a guard satisfied on the wrong axis — is the one this
+ * batch kept finding in the product; this is the same mistake in the gates themselves.
+ *
+ * ## What this checks, and why the help string is the right yardstick
+ *
+ * A metric's `help` is the **code's own description of itself**, it ships to every scrape, and it is edited in the
+ * same commit as the behaviour. So when the help carries a qualifier — the clause after an em dash or in
+ * parentheses, the part that says *how* rather than *what* — the docs row must carry that concept too.
+ *
+ * It compares distinctive words rather than exact phrasing, so the docs stay free to word things better than the
+ * help does. What it catches is a whole missing concept: "cached, not per scrape", "collected at scrape time",
+ * "collection metadata, not a scan".
+ *
+ * Run: node --test testing/standalone/metric-docs-are-accurate.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const src = readFileSync(join(ROOT, 'server/src/metrics/registry.ts'), 'utf8');
+const doc = readFileSync(join(ROOT, 'docs/integration-guide/11-setup-api.md'), 'utf8');
+
+/**
+ * Rows allowed to describe themselves by pointing at a sibling, with the row they point at.
+ *
+ * Three of the brain totals say "same estimate as above", which refers to `ythril_memories_total` — and that row
+ * does spell out "read from collection metadata, not counted per scrape". That is accurate **by reference**, and
+ * forcing each row to repeat it would make the table worse to read. The exemption names the referent so the
+ * pointer cannot rot silently.
+ */
+const BY_REFERENCE = new Map([
+  ['ythril_entities_total', 'ythril_memories_total'],
+  ['ythril_edges_total', 'ythril_memories_total'],
+  ['ythril_chrono_entries_total', 'ythril_memories_total'],
+  ['ythril_sync_items_pushed_total', 'ythril_sync_items_pulled_total'],
+]);
+
+/** name -> help, straight from the registry. */
+function registryHelp() {
+  const out = new Map();
+  for (const m of src.matchAll(/name:\s*'(ythril_[a-z0-9_]+)',\s*\r?\n\s*help:\s*'((?:[^'\\]|\\.)*)'/g)) {
+    out.set(m[1], m[2].replace(/\\'/g, "'"));
+  }
+  return out;
+}
+
+const rowOf = (name) => doc.split(/\r?\n/).find(l => l.startsWith(`| \`${name}\``));
+
+/**
+ * The clauses that say HOW — each em-dash tail and each parenthetical, evaluated SEPARATELY.
+ *
+ * Joining them first was wrong, and the self-test caught it. A help like *"Storage used in bytes by area (brain,
+ * files, total) — from a cached measurement"* has one clause the row legitimately repeats (the value list) and one
+ * it had dropped (the cached-ness). Joined, the repeated clause diluted the missing one to 50% and the threshold
+ * let it through — on the exact row that shipped a release out of date. Per clause, the dropped one is 100% absent.
+ */
+function qualifiersOf(help) {
+  const out = [];
+  for (const part of help.split(/—/).slice(1)) out.push(part.replace(/\([^)]*\)/g, '').trim());
+  for (const m of help.matchAll(/\(([^)]{12,})\)/g)) out.push(m[1].trim());
+  return out.filter(q => q.length >= 12);
+}
+
+/** Is this clause essentially absent from the row? */
+function clauseMissing(clause, row) {
+  const words = clause.toLowerCase().match(/[a-z]{5,}/g) ?? [];
+  if (!words.length) return false;
+  const absent = words.filter(w => !row.toLowerCase().includes(w));
+  return absent.length / words.length > 0.6;
+}
+
+describe('the sweep works before it is trusted', () => {
+  it('parses the registry help strings', () => {
+    const helps = registryHelp();
+    assert.ok(helps.size >= 30, `only ${helps.size} metrics parsed from the registry; the enumeration broke`);
+    assert.ok(helps.has('ythril_storage_used_bytes'), 'the metric that motivated this gate is not being parsed');
+  });
+
+  it('the detector would have caught the original bug', () => {
+    // The exact regression: a help with a qualifier, a row without it. Asserted against synthetic text so the gate
+    // cannot pass merely because the tree is currently clean.
+    const help = 'Storage used in bytes by area (brain, files, total) — from a cached measurement, see the age gauge';
+    const staleRow = '| `ythril_storage_used_bytes` | gauge | Storage used in bytes by area (brain, files, total) |';
+    const clauses = qualifiersOf(help);
+    assert.ok(clauses.length >= 2, `expected the value list AND the cached clause, got ${clauses.length}`);
+    assert.ok(clauses.some(q => clauseMissing(q, staleRow)),
+      'the detector no longer flags the row that shipped a release out of date');
+    // And it must NOT flag the clause the row legitimately repeats, or every row in the table becomes an offender.
+    assert.ok(clauses.some(q => !clauseMissing(q, staleRow)),
+      'the detector flags a clause the row DOES carry, which would make it fire on everything');
+  });
+
+  it('every by-reference exemption points at a row that exists and carries the concept', () => {
+    // An exemption whose referent has moved is an exemption covering nothing.
+    for (const [name, referent] of BY_REFERENCE) {
+      assert.ok(rowOf(name), `${name} is exempted but has no docs row`);
+      const target = rowOf(referent);
+      assert.ok(target, `${name} defers to ${referent}, which has no docs row`);
+      assert.ok(target.length > 60,
+        `${name} defers to ${referent}, whose row is too thin to be carrying the explanation`);
+    }
+  });
+});
+
+describe("every metric row says what the code's help says", () => {
+  it('no documented metric omits a concept its help carries', () => {
+    const offenders = [];
+    for (const [name, help] of registryHelp()) {
+      const row = rowOf(name);
+      if (!row) continue;                    // coverage is a different gate's job
+      if (BY_REFERENCE.has(name)) continue;
+      for (const q of qualifiersOf(help)) {
+        if (!clauseMissing(q, row)) continue;
+        offenders.push(`${name}\n      help says:    ${q.slice(0, 84)}\n      row omits it: ${row.slice(0, 84)}`);
+      }
+    }
+    assert.deepEqual(offenders, [], 'these docs rows omit what the code says about the metric. The help string is '
+      + 'edited in the same commit as the behaviour; a row that has fallen behind it is describing an older '
+      + `release:\n\n  ${offenders.join('\n\n  ')}\n\n`
+      + 'Either bring the row up to date, or add it to BY_REFERENCE **naming the row that carries the concept**.');
+  });
+});


### PR DESCRIPTION
release: 2.4.0

MINOR: [Unreleased] carried two Added sections -- the caller-supplied id that
makes memory and chrono writes idempotent (a new, additive REST and MCP
parameter), and the documentation release gate. Both backward-compatible;
omitting the id is unchanged and every existing client is unaffected. The one
"breaking" in the section is prose describing something deliberately NOT done.

Also in this tag: five places where the docs described the PREVIOUS release's
behaviour, and every coverage gate passed the whole time.

Found because the owner asked "does that release gate not make you review docs?"
It does not, and that is the finding: coverage and accuracy are different axes.
Every gate asserted a thing is MENTIONED. None could see that what was said had
stopped being true.

  POST /memories and POST /chrono never mentioned `id` -- the parameter added
  hours earlier in this same session. A Retry Safety section at the top of the
  page described it fully; the endpoints that accept it said nothing, and an
  integrator reads the endpoint.

  ythril_storage_used_bytes's row read "Storage used in bytes by area" while the
  metric's own help had gained "-- from a cached measurement, see the age gauge"
  when the collector stopped walking the disk. The row described 2.3.0.

  Four more rows said strictly less than the help beside them: the help
  ENUMERATES the label values and the row said "by status" / "by type".

metric-docs-are-accurate closes that axis. A metric's help is the code's own
description of itself, it ships to every scrape, and it is edited in the same
commit as the behaviour -- so when the help carries a qualifier, the docs row must
carry that concept. Wording may differ; a whole missing concept fails. Rows may
defer to a sibling, and the exemption names the row it defers to so the pointer
cannot rot silently.

The gate's own self-test caught a real flaw in it: the first version joined every
qualifier into one string, and a help like "...by area (brain, files, total) --
from a cached measurement" has one clause the row legitimately repeats and one it
dropped. Joined, the repeat diluted the omission to 50% -- under the threshold, on
the exact row that shipped stale. Clauses are now scored independently.

A numeric sweep of every documented default against the code came back clean: 13
candidates, all heuristic noise, and one doc more precise than the checker. The
stale things were never the numbers.

Queue state: section 1 holds no work. Cross-space subject collect was REJECTED by
the owner -- while every schema is operator-defined, only the operator can define
what counts as "about" a person, and the tools (audit-log NDJSON export,
textSearchOr, indexed entityIds) are already there. Recorded in _REFERENCE.md
with the one condition that would revive it: a governed schema for person.
