### PR TITLE
feat(ui): mark proxy spaces wherever a space appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A proxy space is now marked wherever a space appears** (owner UX request). A `globe` badge with a tooltip
+  naming *which* peer spaces it mirrors, on the Brain space strip, the Graph space strip, and the Spaces settings
+  table.
+  - **Why it is not cosmetic:** a proxy space looks identical to a local one, and its records live on a **peer**.
+    The server's metric collectors skip it (`cfg.spaces.filter(s => !s.proxyFor)`), so its storage and
+    record counts are **absent by design, not zero** — someone who cannot tell the two apart reads an absent
+    count as an empty space.
+  - **One shared component, not markup in three templates.** The `space-chip` strip is already duplicated
+    between the Brain and Graph pages, so inlining the badge would have made three copies of one meaning — the
+    exact finding filed as A-L2-1 in the same session. It ships as `app-proxy-space-badge`.
+  - `globe` deliberately: it is **registered** in `ph-icon.component.ts` (an unregistered name renders
+    blank with no error, which has bitten this repo twice), and it is distinct from the `link` icon already
+    on that chip for `networkStatus`. `link` says *participates in a network*; `globe` says *its data is
+    elsewhere*. A chip can carry both.
+
+### Fixed
+
+- **Two mistakes in that change, both caught by existing gates rather than by review:**
+  - the tooltip returned **hardcoded English** while the visible label went through transloco. A tooltip is
+    exactly where an untranslated string hides, and this repo already had that finding once.
+  - the three new keys were added **nested** (`spaces: { badge: { proxy } }`) when en/de/pl store **flat
+    dotted keys** at the top level. The i18n spec does `key in en` with no flattening, so the
+    *"de and pl carry the same keys as en"* test passed — all three were nested identically — while the
+    *"every used key exists"* test failed. **Two gates disagreeing was the signal**; one of them had to be
+    reading something different from what I thought.
+
 ## [2.4.0] — 2026-08-04
 
 ### Documentation

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -609,34 +609,20 @@
   "files.detail.tabsAriaLabel": "Detailansicht",
   "files.detail.previewTab": "Vorschau & Beschreibung",
   "files.detail.metaTab": "Datei-Metadaten",
-
   "files.detail.extractTab": "Extrakt",
-
   "files.extract.loading": "Lese, was die Pipeline erzeugt hat...",
-
   "files.extract.error": "Extraktion konnte nicht geladen werden.",
-
   "files.extract.chunks": "Chunks ({{shown}} von {{total}})",
-
   "files.extract.noChunks": "Keine Chunks. Aus dieser Datei ist noch nichts durchsuchbar.",
-
   "files.extract.images": "Extrahierte Bilder ({{count}})",
-
   "files.extract.noCaption": "Noch keine Bildbeschreibung.",
-
   "files.extract.converted": "Konvertiertes Markdown",
-
   "files.extract.truncated": "Bis 256 KB angezeigt. Den Rest über die konvertierte Datei herunterladen.",
-
   "files.extract.more": "Mehr Chunks anzeigen",
   "files.detail.description": "Beschreibung",
-
   "files.detail.descriptionSource.generated": "generiert",
-
   "files.detail.descriptionSource.generatedHint": "Vom konfigurierten Dokumentmodell aus dem Text der Datei geschrieben. Nicht von einer Person geprüft.",
-
   "files.detail.descriptionSource.extracted": "aus dem Dokument",
-
   "files.detail.descriptionSource.extractedHint": "Der Anfang des Dokumenttexts, wörtlich übernommen — es war kein Modell für Beschreibungen konfiguriert.",
   "files.detail.metaSaved": "Metadaten gespeichert.",
   "files.detail.retryQueued": "Neu-Einbettung eingereiht.",
@@ -869,9 +855,7 @@
   "spaces.popup.tab.settings": "Einstellungen",
   "spaces.schema.collTabsAriaLabel": "Datensatz-Sammlungen",
   "spaces.settings.tabsAriaLabel": "Bereiche der Space-Einstellungen",
-
   "spaces.popup.governed": "Verwaltet",
-
   "spaces.popup.governedHint": "Dieser Space gehört zu {{networks}}. Änderungen an Zweck, Nutzungshinweisen oder Schema starten in jedem Netzwerk eine Abstimmung, statt sofort zu greifen — die Änderung wird eingereicht, nicht angewendet.",
   "spaces.popup.tab.schema": "Schema",
   "spaces.popup.tab.dangerZone": "Gefahrenzone",
@@ -1549,7 +1533,6 @@
   "mediaProcessing.action.test": "Verbindung testen",
   "mediaProcessing.action.testing": "Wird getestet…",
   "mediaProcessing.test.unreachable": "Nicht erreichbar",
-
   "mediaProcessing.test.inProcess": "Modell läuft im Prozess — nichts zu prüfen",
   "mediaProcessing.test.reachable": "Erreichbar",
   "mediaProcessing.test.modelFound": "Erreichbar · Modell gefunden",
@@ -1804,5 +1787,8 @@
   "review.typeFilter.capped": "Es werden die ersten 500 Funde angezeigt — Filter gelten nur für diese.",
   "review.typeFilter.noneOfType": "Keine Funde dieses Typs",
   "review.typeFilter.noneOfTypeBody": "In dieser Liste gibt es Funde, aber keine des gewählten Datensatztyps. Wähle „Alle Typen“, um sie zu sehen.",
-  "about.components.pending": "Komponenten werden geprüft…"
+  "about.components.pending": "Komponenten werden geprüft…",
+  "spaces.badge.proxy": "Proxy-Space",
+  "spaces.badge.proxyTitle": "Proxy-Space — spiegelt {{ids}} auf dem Peer",
+  "spaces.badge.proxyAllTitle": "Proxy-Space — spiegelt alle Spaces auf dem Peer"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -609,34 +609,20 @@
   "files.detail.tabsAriaLabel": "Detail view",
   "files.detail.previewTab": "Preview & description",
   "files.detail.metaTab": "File meta",
-
   "files.detail.extractTab": "Extract",
-
   "files.extract.loading": "Reading what the pipeline produced...",
-
   "files.extract.error": "Could not load the extraction.",
-
   "files.extract.chunks": "Chunks ({{shown}} of {{total}})",
-
   "files.extract.noChunks": "No chunks. Nothing from this file is searchable yet.",
-
   "files.extract.images": "Extracted images ({{count}})",
-
   "files.extract.noCaption": "No caption yet.",
-
   "files.extract.converted": "Converted markdown",
-
   "files.extract.truncated": "Shown up to 256 KB. Download the converted file for the rest.",
-
   "files.extract.more": "Show more chunks",
   "files.detail.description": "Description",
-
   "files.detail.descriptionSource.generated": "generated",
-
   "files.detail.descriptionSource.generatedHint": "Written by the model configured for documents, from the file's own text. It has not been checked by a person.",
-
   "files.detail.descriptionSource.extracted": "from the document",
-
   "files.detail.descriptionSource.extractedHint": "The opening of the document's own text, taken verbatim — no model was configured to write a description.",
   "files.detail.metaSaved": "Metadata saved.",
   "files.detail.retryQueued": "Re-embedding queued.",
@@ -869,9 +855,7 @@
   "spaces.popup.tab.settings": "Settings",
   "spaces.schema.collTabsAriaLabel": "Record collections",
   "spaces.settings.tabsAriaLabel": "Space settings sections",
-
   "spaces.popup.governed": "Governed",
-
   "spaces.popup.governedHint": "This space belongs to {{networks}}. Saving a change to its purpose, usage notes or schema opens a vote in each network instead of applying at once — the change is submitted, not applied.",
   "spaces.popup.tab.schema": "Schema",
   "spaces.popup.tab.dangerZone": "Danger Zone",
@@ -1549,7 +1533,6 @@
   "mediaProcessing.action.test": "Test connection",
   "mediaProcessing.action.testing": "Testing…",
   "mediaProcessing.test.unreachable": "Unreachable",
-
   "mediaProcessing.test.inProcess": "In-process model — nothing to probe",
   "mediaProcessing.test.reachable": "Reachable",
   "mediaProcessing.test.modelFound": "Reachable · model found",
@@ -1804,5 +1787,8 @@
   "review.typeFilter.capped": "Showing the first 500 findings — filters apply to those only.",
   "review.typeFilter.noneOfType": "No findings of this type",
   "review.typeFilter.noneOfTypeBody": "There are findings in this queue, but none of the selected record type. Choose All types to see them.",
-  "about.components.pending": "Checking components…"
+  "about.components.pending": "Checking components…",
+  "spaces.badge.proxy": "Proxy space",
+  "spaces.badge.proxyTitle": "Proxy space — mirrors {{ids}} on the peer",
+  "spaces.badge.proxyAllTitle": "Proxy space — mirrors every space on the peer"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -609,34 +609,20 @@
   "files.detail.tabsAriaLabel": "Widok szczegółów",
   "files.detail.previewTab": "Podgląd i opis",
   "files.detail.metaTab": "Metadane pliku",
-
   "files.detail.extractTab": "Ekstrakt",
-
   "files.extract.loading": "Czytanie tego, co wytworzył potok...",
-
   "files.extract.error": "Nie udało się wczytać ekstrakcji.",
-
   "files.extract.chunks": "Fragmenty ({{shown}} z {{total}})",
-
   "files.extract.noChunks": "Brak fragmentów. Nic z tego pliku nie jest jeszcze wyszukiwalne.",
-
   "files.extract.images": "Wyodrębnione obrazy ({{count}})",
-
   "files.extract.noCaption": "Brak opisu obrazu.",
-
   "files.extract.converted": "Przekonwertowany markdown",
-
   "files.extract.truncated": "Pokazano do 256 KB. Pobierz przekonwertowany plik, aby zobaczyć resztę.",
-
   "files.extract.more": "Pokaż więcej fragmentów",
   "files.detail.description": "Opis",
-
   "files.detail.descriptionSource.generated": "wygenerowany",
-
   "files.detail.descriptionSource.generatedHint": "Napisany przez model skonfigurowany dla dokumentów, na podstawie tekstu pliku. Nie został sprawdzony przez człowieka.",
-
   "files.detail.descriptionSource.extracted": "z dokumentu",
-
   "files.detail.descriptionSource.extractedHint": "Początek tekstu dokumentu, przepisany dosłownie — nie skonfigurowano modelu do pisania opisów.",
   "files.detail.metaSaved": "Zapisano metadane.",
   "files.detail.retryQueued": "Ponowne osadzanie w kolejce.",
@@ -869,9 +855,7 @@
   "spaces.popup.tab.settings": "Ustawienia",
   "spaces.schema.collTabsAriaLabel": "Kolekcje rekordów",
   "spaces.settings.tabsAriaLabel": "Sekcje ustawień przestrzeni",
-
   "spaces.popup.governed": "Zarządzany",
-
   "spaces.popup.governedHint": "Ta przestrzeń należy do {{networks}}. Zapisanie zmiany celu, wskazówek lub schematu otwiera głosowanie w każdej sieci, zamiast zastosować ją od razu — zmiana zostaje zgłoszona, nie zastosowana.",
   "spaces.popup.tab.schema": "Schemat",
   "spaces.popup.tab.dangerZone": "Strefa zagrożenia",
@@ -1549,7 +1533,6 @@
   "mediaProcessing.action.test": "Testuj połączenie",
   "mediaProcessing.action.testing": "Testowanie…",
   "mediaProcessing.test.unreachable": "Nieosiągalny",
-
   "mediaProcessing.test.inProcess": "Model działa w procesie — nie ma czego sprawdzać",
   "mediaProcessing.test.reachable": "Osiągalny",
   "mediaProcessing.test.modelFound": "Osiągalny · model znaleziony",
@@ -1804,5 +1787,8 @@
   "review.typeFilter.capped": "Pokazano pierwsze 500 wyników — filtry dotyczą tylko ich.",
   "review.typeFilter.noneOfType": "Brak wyników tego typu",
   "review.typeFilter.noneOfTypeBody": "W tej kolejce są wyniki, ale żaden nie jest wybranego typu rekordu. Wybierz „Wszystkie typy”, aby je zobaczyć.",
-  "about.components.pending": "Sprawdzanie komponentów…"
+  "about.components.pending": "Sprawdzanie komponentów…",
+  "spaces.badge.proxy": "Przestrzeń proxy",
+  "spaces.badge.proxyTitle": "Przestrzeń proxy — odzwierciedla {{ids}} na peerze",
+  "spaces.badge.proxyAllTitle": "Przestrzeń proxy — odzwierciedla wszystkie przestrzenie na peerze"
 }

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -1,5 +1,6 @@
 ﻿import { ChangeDetectionStrategy, Component, inject, signal, computed, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ProxySpaceBadgeComponent } from '../../shared/proxy-space-badge.component';
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
 import { RecordDrawerState } from './record-drawer-state.service';
@@ -46,7 +47,7 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, ReviewTabComponent, ErrorStateComponent, TranslocoPipe],
+  imports: [ProxySpaceBadgeComponent, CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, ReviewTabComponent, ErrorStateComponent, TranslocoPipe],
   providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
   styles: [`
     .space-tabs {
@@ -192,6 +193,9 @@ interface SpaceView {
           >
             <span class="space-chip-label">{{ sv.space.label }}</span>
             <span class="space-chip-id">{{ sv.space.id }}</span>
+            @if (sv.space.proxyFor?.length) {
+              <app-proxy-space-badge [proxyFor]="sv.space.proxyFor" [size]="12" />
+            }
             @if (sv.space.networkStatus) {
               <span class="space-chip-net" [class]="'net-' + sv.space.networkStatus" [title]="networkChipTitle(sv.space)">
                 <ph-icon name="link" [size]="12"/>

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -13,6 +13,7 @@
   ElementRef,
 } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
+import { ProxySpaceBadgeComponent } from '../../shared/proxy-space-badge.component';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription, forkJoin, of } from 'rxjs';
@@ -70,7 +71,7 @@ import { GRAPH_STYLES } from './graph.styles';
   // `openBrainDrawer` alongside the `drawerRecord` signal that guards the drawer's `@if`, the same
   // load-bearing coupling pinned by the brain spec.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, RecordDrawerComponent, GraphLinkedRecordsComponent],
+  imports: [ProxySpaceBadgeComponent, CommonModule, FormsModule, EntryPopupComponent, EntitySearchComponent, PropertiesViewComponent, PhIconComponent, ErrorStateComponent, TranslocoPipe, RecordDrawerComponent, GraphLinkedRecordsComponent],
   // Its own drawer collaborators, so the standalone `/graph` route works with nothing above it. When
   // this page is embedded as Brain's Graph tab these SHADOW Brain's instances, which is deliberate:
   // the drawer then patches this page's per-node lists, exactly as the forked drawer did. The cost is
@@ -83,7 +84,7 @@ import { GRAPH_STYLES } from './graph.styles';
     @if (!isEmbedded() && spaces().length > 0) {
       <div class="space-tabs">
         @for (s of spaces(); track s.id) {
-          <button class="space-chip" type="button" [class.active]="activeSpaceId() === s.id" [attr.aria-current]="activeSpaceId() === s.id ? 'true' : null" (click)="onSpaceChange(s.id)">{{ s.label }}</button>
+          <button class="space-chip" type="button" [class.active]="activeSpaceId() === s.id" [attr.aria-current]="activeSpaceId() === s.id ? 'true' : null" (click)="onSpaceChange(s.id)">{{ s.label }}@if (s.proxyFor?.length) { <app-proxy-space-badge [proxyFor]="s.proxyFor" [size]="12" /> }</button>
         }
       </div>
     }

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -1,5 +1,6 @@
 ﻿import { ChangeDetectionStrategy, Component, HostListener, inject, signal, computed, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ProxySpaceBadgeComponent } from '../../shared/proxy-space-badge.component';
 import { FormsModule } from '@angular/forms';
 import { finalize, timeout, TimeoutError } from 'rxjs';
 import {
@@ -32,7 +33,7 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
 @Component({
   selector: 'app-spaces',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslocoPipe, DragDropModule, PhIconComponent, SummaryStripComponent,
+  imports: [ProxySpaceBadgeComponent, CommonModule, FormsModule, TranslocoPipe, DragDropModule, PhIconComponent, SummaryStripComponent,
     SpaceSettingsTabComponent, SpaceDuplicatesTabComponent, SpaceDangerTabComponent, SpaceSchemaTabComponent,
     SpaceCreateDialogComponent, ModalDirective, HscrollTopDirective, StatusPillComponent],
   // Provided here (not root) so each mount gets its own settings state, with a lifetime tied to
@@ -226,8 +227,10 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
                   </td>
                   <td>
                     @if (s.proxyFor?.[0]==='*') {
-                      <span class="badge badge-blue" style="font-style:italic;">{{ 'spaces.badge.allSpaces' | transloco }}</span>
+                      <app-proxy-space-badge [proxyFor]="s.proxyFor" [size]="14" [showLabel]="true" />
+                      <span class="badge badge-blue" style="font-style:italic;margin-left:4px;">{{ 'spaces.badge.allSpaces' | transloco }}</span>
                     } @else if (s.proxyFor?.length) {
+                      <app-proxy-space-badge [proxyFor]="s.proxyFor" [size]="14" style="margin-right:4px" />
                       @for (pid of s.proxyFor; track pid) {
                         <span class="badge badge-blue" style="margin-right:4px">{{ pid }}</span>
                       }

--- a/client/src/app/shared/proxy-space-badge.component.ts
+++ b/client/src/app/shared/proxy-space-badge.component.ts
@@ -1,0 +1,90 @@
+import { Component, ChangeDetectionStrategy, input, inject } from '@angular/core';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from './ph-icon.component';
+
+/**
+ * Marks a space as a PROXY — a view onto another instance's space, reached over a network, rather than data this
+ * instance holds.
+ *
+ * ## Why this is a shared component and not markup in two templates
+ *
+ * The space-chip strip is duplicated: `pages/brain/brain.component.ts` and `pages/graph/graph.component.ts` each
+ * carry their own copy of `class="space-chip"`. Adding the marker inline would have made three copies of one
+ * meaning, which is the finding filed as A-L2-1 in the same session — a rule written eleven times because the
+ * shared helper was named for its first caller and nobody found it. So this ships as a shared primitive with an
+ * obvious name, which is the whole point of the lens-2 red flag *"shared UI primitives instead of every page
+ * re-rolling pills"*.
+ *
+ * ## Why a proxy space needs marking at all
+ *
+ * A proxy space looks exactly like a local one in every list, and the difference is not cosmetic:
+ *
+ *  - its records live on a **peer**, so what you see depends on that peer being reachable;
+ *  - the server's own metric collectors skip it (`cfg.spaces.filter(s => !s.proxyFor)`), so storage and record
+ *    counts for it are **absent by design**, not zero;
+ *  - a write intent that makes sense locally may not make sense against someone else's space.
+ *
+ * Someone who cannot tell the two apart reads an absent count as an empty space.
+ *
+ * ## `globe`, deliberately
+ *
+ * It is registered in `ph-icon.component.ts` — an unregistered name renders **blank** with no error, which has
+ * bitten this repo twice. And it is visually distinct from the `link` icon already used on the same chip for
+ * `networkStatus`: `link` says *this space participates in a network*, `globe` says *this space's data is
+ * elsewhere*. Those are different facts and a chip can carry both.
+ */
+@Component({
+  selector: 'app-proxy-space-badge',
+  standalone: true,
+  imports: [TranslocoModule, PhIconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span
+      class="badge badge-blue proxy-space-badge"
+      [attr.title]="titleText()"
+      [attr.aria-label]="titleText()"
+    >
+      <ph-icon name="globe" [size]="size()" />
+      @if (showLabel()) {
+        <span class="proxy-space-badge-text">{{ 'spaces.badge.proxy' | transloco }}</span>
+      }
+    </span>
+  `,
+  styles: [`
+    .proxy-space-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      /* Vertical rhythm with the sibling network chip on the same row, which sets its own line-height. */
+      line-height: 1;
+    }
+    .proxy-space-badge-text { font-size: 0.85em; }
+  `],
+})
+export class ProxySpaceBadgeComponent {
+  /** The space ids this space proxies. `['*']` means every space on the peer. */
+  readonly proxyFor = input<readonly string[] | null | undefined>(null);
+
+  /** Icon size. 12 matches the network chip in the space strip; 14 suits a table cell. */
+  readonly size = input<number>(12);
+
+  /** Off in a dense chip strip where the icon plus its tooltip is enough. */
+  readonly showLabel = input<boolean>(false);
+
+  private readonly i18n = inject(TranslocoService);
+
+  /**
+   * The tooltip names WHICH spaces are proxied, because "this is a proxy" without "of what" is half an answer —
+   * and `['*']` is the case a reader is most likely to misread as a wildcard typo.
+   *
+   * Translated, not interpolated in English. The first draft of this returned hardcoded strings while the visible
+   * label went through transloco — which is precisely the untranslated-string class an earlier accessibility lens
+   * already found in this codebase, and a tooltip is exactly where it hides.
+   */
+  titleText(): string {
+    const ids = this.proxyFor() ?? [];
+    if (ids[0] === '*') return this.i18n.translate('spaces.badge.proxyAllTitle');
+    if (ids.length) return this.i18n.translate('spaces.badge.proxyTitle', { ids: ids.join(', ') });
+    return this.i18n.translate('spaces.badge.proxy');
+  }
+}


### PR DESCRIPTION
feat(ui): mark proxy spaces wherever a space appears

Owner UX request. A `globe` badge with a tooltip naming which peer spaces it
mirrors, on the Brain space strip, the Graph space strip, and the Spaces settings
table.

Why it is not cosmetic: a proxy space looks identical to a local one, and its
records live on a PEER. The server's own metric collectors skip it
(cfg.spaces.filter(s => !s.proxyFor)), so its storage and record counts are
absent BY DESIGN, not zero -- and someone who cannot tell the two apart reads an
absent count as an empty space.

One shared component, not markup in three templates. The space-chip strip is
already duplicated between the Brain and Graph pages, so inlining the badge would
have made three copies of one meaning -- the exact finding filed as A-L2-1 in this
same session (one merge rule, eleven implementations, because the shared helper
was named for its first caller and nobody found it). It ships as
app-proxy-space-badge with an obvious name in shared/.

globe deliberately: it is REGISTERED in ph-icon.component.ts -- an unregistered
name renders blank with no error, which has bitten this repo twice -- and it is
visually distinct from the `link` icon already on that chip for networkStatus.
`link` says participates in a network; `globe` says its data is elsewhere. Those
are different facts and a chip can carry both.

Two mistakes in this change, both caught by existing gates rather than by review:

The tooltip returned hardcoded English while the visible label went through
transloco. A tooltip is exactly where an untranslated string hides, and this repo
already had that finding once.

The three new keys were added NESTED (spaces: { badge: { proxy } }) when en/de/pl
store flat dotted keys at the top level. The i18n spec does `key in en` with no
flattening, so the "de and pl carry the same keys as en" test PASSED -- all three
were nested identically -- while the "every used key exists" test FAILED. Two
gates disagreeing was the signal: one of them had to be reading something
different from what I thought, and guessing at it twice would have been the wrong
move.

NOT verified visually against a running instance with a real proxy space
configured -- 80 client test files pass and the AOT build is clean, but nobody has
looked at the rendered badge. Worth one screenshot before it is called done.
