### PR TITLE
test(ui): prove the proxy badge renders something visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The proxy badge now has a spec proving it renders something visible.** It does not replace a screenshot of
+  the live space strip, which is still owed — what it closes is the failure this repo has been bitten by twice:
+  an **unregistered `ph-icon` name renders a blank SVG with no error and no failing test**. Every
+  measurement passes, the markup is present, and the user sees nothing.
+  - Asserts the icon path is non-empty, the tooltip came through transloco with interpolation applied (not the
+    raw key, not `{{ids}}`), the wildcard case reads "every space" rather than `*`, and
+    `aria-label` mirrors the tooltip so the marker is not sighted-only.
+  - **Mutation-verified:** pointing the icon at an unregistered name fails the spec.
 - **Two mistakes in that change, both caught by existing gates rather than by review:**
   - the tooltip returned **hardcoded English** while the visible label went through transloco. A tooltip is
     exactly where an untranslated string hides, and this repo already had that finding once.

--- a/client/src/app/shared/proxy-space-badge.component.spec.ts
+++ b/client/src/app/shared/proxy-space-badge.component.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideTransloco, TranslocoService } from '@jsverse/transloco';
+import { ProxySpaceBadgeComponent } from './proxy-space-badge.component';
+
+/**
+ * The badge renders something a human can actually see.
+ *
+ * ## Why this exists rather than only a screenshot
+ *
+ * A screenshot is still owed for layout inside the live space strip, and this does not replace it. What it *does*
+ * close is the specific failure this repo has been bitten by twice: **an unregistered `ph-icon` name renders a
+ * blank SVG with no error and no failing test.** Every measurement passes, the markup is present, and the user sees
+ * nothing. `globe` is registered today; nothing stopped someone renaming it.
+ *
+ * The second thing it pins is the tooltip, because a tooltip is where an untranslated string hides — the first
+ * draft of this component returned hardcoded English from `titleText()` while the visible label went through
+ * transloco, and no gate would have noticed a *tooltip* in the wrong language.
+ */
+describe('ProxySpaceBadgeComponent', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ProxySpaceBadgeComponent],
+      providers: [
+        provideTransloco({
+          config: { availableLangs: ['en'], defaultLang: 'en', reRenderOnLangChange: false, prodMode: true },
+        }),
+      ],
+    });
+    // Real strings, so an assertion cannot pass on a key echoed back as its own translation.
+    TestBed.inject(TranslocoService).setTranslation({
+      'spaces.badge.proxy': 'Proxy space',
+      'spaces.badge.proxyTitle': 'Proxy space — mirrors {{ids}} on the peer',
+      'spaces.badge.proxyAllTitle': 'Proxy space — mirrors every space on the peer',
+    }, 'en');
+  });
+
+  const render = (proxyFor: string[] | null, showLabel = false) => {
+    const f = TestBed.createComponent(ProxySpaceBadgeComponent);
+    f.componentRef.setInput('proxyFor', proxyFor);
+    f.componentRef.setInput('showLabel', showLabel);
+    f.detectChanges();
+    return f;
+  };
+
+  it('draws a NON-EMPTY icon — an unregistered name renders blank with no error', () => {
+    const el: HTMLElement = render(['other-space']).nativeElement;
+    const path = el.querySelector('svg path');
+    expect(path, 'no <path> in the badge svg — the icon name is not in the registry').not.toBeNull();
+    const d = path?.getAttribute('d') ?? '';
+    expect(d.length, `the icon path is empty (d="${d}"), so the badge renders as blank space`).toBeGreaterThan(10);
+  });
+
+  it('puts a translated tooltip on the badge, naming which spaces are mirrored', () => {
+    const el: HTMLElement = render(['alpha', 'beta']).nativeElement;
+    const title = el.querySelector('.proxy-space-badge')?.getAttribute('title') ?? '';
+    expect(title).toContain('alpha, beta');
+    // Not the raw key, and not English-by-accident: it came through transloco with interpolation applied.
+    expect(title).not.toContain('spaces.badge');
+    expect(title).not.toContain('{{ids}}');
+  });
+
+  it('says "every space" for the wildcard, which is the case most likely to be misread as a typo', () => {
+    const el: HTMLElement = render(['*']).nativeElement;
+    const title = el.querySelector('.proxy-space-badge')?.getAttribute('title') ?? '';
+    expect(title).toContain('every space');
+    expect(title).not.toContain('*');
+  });
+
+  it('mirrors the tooltip into aria-label, so the marker is not sighted-only', () => {
+    const el: HTMLElement = render(['alpha']).nativeElement;
+    const badge = el.querySelector('.proxy-space-badge');
+    expect(badge?.getAttribute('aria-label')).toBe(badge?.getAttribute('title'));
+    expect(badge?.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  it('shows a text label only when asked, so a dense chip strip stays dense', () => {
+    expect(render(['alpha'], false).nativeElement.textContent?.trim()).toBe('');
+    expect(render(['alpha'], true).nativeElement.textContent).toContain('Proxy space');
+  });
+});


### PR DESCRIPTION
test(ui): prove the proxy badge renders something visible

I told the owner a look at the badge was worth their 30 seconds. That was wrong:
verifying my own work is my job, not theirs.

This does not replace a screenshot of the live space strip, which is still owed.
What it closes is the failure this repo has been bitten by twice: an unregistered
ph-icon name renders a blank SVG with no error and no failing test. Every
measurement passes, the markup is present, and the user sees nothing.

Five assertions:

  the icon path is non-empty -- the blank-icon scar, closed
  the tooltip came through transloco with interpolation applied: not the raw key,
    not {{ids}}
  the wildcard case reads "every space" rather than a bare *, which is the case a
    reader is most likely to misread as a typo
  aria-label mirrors the tooltip, so the marker is not sighted-only
  the text label appears only when asked, so a dense chip strip stays dense

The tooltip assertions matter because the first draft of this component returned
hardcoded English from titleText() while the visible label went through transloco.
No gate would have noticed a TOOLTIP in the wrong language.

Mutation-verified: pointing the icon at an unregistered name fails the spec.

Still genuinely unverified: layout inside the live space strip next to the
existing network chip. A screenshot is the only thing that settles that, and it
remains open.
