### PR TITLE
fix(brain): a properties patch was deleting the keys it did not mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `properties` patch no longer destroys the keys it did not mention** (memories and chrono entries). This is
+  data loss, and it was silent: no error, no warning, nothing in the audit log to distinguish it from an intended
+  overwrite.
+  - `update_memory`'s own tool schema said `properties` were *"to merge"*; `updateMemory` did
+    `$set['properties'] = updates.properties`, a whole-map **replace**. An agent patching one key wiped every
+    other property on the record. `updateChrono` had the same defect through a generic
+    `Object.entries(updates)` loop that treated `properties` like a scalar field.
+  - Three other statements said it should merge and none of them was enforced: the *Retry Safety* section
+    promises "tags union and properties shallow-merge" for all four record types, the `deleteFields` section
+    says deletions are "applied **after** the normal merge" for entities, edges **and memories**, and the
+    entity and edge update paths already merged.
+  - **The REST validation simulation mirrored the replace**, so the schema check could not see the loss either —
+    a `required` property could be dropped by a patch the validator had just approved.
+  - Removing a key remains `deleteFields`' job. An absence never means "delete".
+- **The tag/property merge rule now exists once, not eleven times** (`server/src/brain/merge-fields.ts`). Two
+  lines — a de-duplicated tag union and a shallow property merge — were hand-rolled across six files: the entity,
+  edge, memory and chrono writers, three REST handlers, two MCP tools, and the entity-dedupe merge.
+  - A canonical version already existed (`mergedEntityWrite`) and was already generic — its signature never
+    mentioned an entity. It had **two** call sites. **A helper named and placed for its first caller is invisible
+    to the second:** nobody reaches into `brain/entities.ts` to merge a chrono entry's properties. This is the
+    same shape as `boundedJson` sitting unused in `providers.ts` while 25 upstream reads went unbounded.
+  - Gated by `one-merge-rule.test.js` (source: nobody re-derives the rule) and `merge-rule-db.test.js`
+    (behaviour: all four writers produce the same merged map, against a real MongoDB). **Both halves
+    mutation-verified** — reverting either the memory or the chrono fix turns three tests red.
+  - **One divergence is kept deliberately and is now stated in both places:** `update_memory` documents tags as
+    *"New tags (replaces existing)"* while `update_entity`/`update_edge` document a union. Both halves are
+    written down, so the test pins both rather than letting a later sweep quietly unify them.
 - **The proxy badge now has a spec proving it renders something visible.** It does not replace a screenshot of
   the live space strip, which is still owed — what it closes is the failure this repo has been bitten by twice:
   an **unregistered `ph-icon` name renders a blank SVG with no error and no failing test**. Every

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1544,6 +1544,30 @@ would turn that into a burst of sidecar traffic for a column nobody is reading.
 
 ---
 
+### What a `PATCH` does to `tags` and `properties`
+
+**`properties` MERGE on every record type.** A patch that names one key keeps the others — the stored map with
+your keys laid over it, one level deep. This is the same rule as an upsert and the same rule a converged retry
+follows, so there is one thing to know across memories, entities, edges and chrono entries.
+
+**`tags` differ by type, deliberately:**
+
+| Endpoint / tool | `properties` | `tags` |
+|---|---|---|
+| `PATCH .../entities/:id`, `update_entity` | merge | **union** with the stored tags |
+| `PATCH .../edges/:id`, `update_edge` | merge | **union** with the stored tags |
+| `PATCH .../memories/:id`, `update_memory` | merge | **replaces** the stored tags |
+| `PATCH .../chrono/:id`, `update_chrono` | merge | **replaces** the stored tags |
+
+**Removing a key is `deleteFields`' job, never an absence.** Omitting a property does not delete it, and sending
+an empty `properties: {}` is a no-op rather than a wipe. If you need a key gone, name it:
+`deleteFields: ["properties.oldKey"]`.
+
+> **Changed in 2.4.1.** `PATCH .../memories/:id` and chrono updates previously **replaced** the whole
+> `properties` map, so a patch naming one key silently dropped the rest — while `update_memory`'s own schema
+> described the field as "properties to merge". If you were relying on the replace to clear keys, switch to
+> `deleteFields`.
+
 ### Partial Update with deleteFields
 
 All `PATCH` update endpoints — entities, edges, and memories — accept an optional `deleteFields` array of dot-notation paths. This allows callers to remove specific fields from a document in the same atomic operation as normal property/tag updates.

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -16,6 +16,7 @@ import type { ChronoStatus } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
 import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
+import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const chronoRouter = Router();
 
@@ -249,7 +250,10 @@ chronoRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceA
     const check = classifyUpdateViolations(
       meta,
       validateChrono(meta ?? {}, { type: prior.type, properties: priorProps }),
-      validateChrono(meta ?? {}, { type: type ?? prior.type, properties: safeProps ?? priorProps }),
+      validateChrono(meta ?? {}, {
+        type: type ?? prior.type,
+        properties: mergePropertiesOrKeep(prior.properties, safeProps) ?? {},
+      }),
     );
     if (check.blocked) {
       res.status(422).json({

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -18,6 +18,7 @@ import { validateEdge } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError } from './_shared.js';
 import { classifyEdgeUpsert, classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
+import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const edgesRouter = Router();
 
@@ -222,9 +223,7 @@ edgesRouter.patch('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAut
     const existing = await getEdgeById(mid, id);
     if (!existing) continue;
     {
-      const resultProps = updates.properties !== undefined
-        ? { ...(existing.properties ?? {}), ...updates.properties }
-        : { ...(existing.properties ?? {}) };
+      const resultProps = mergePropertiesOrKeep(existing.properties, updates.properties) ?? {};
       const sim: Record<string, unknown> = { properties: resultProps };
       if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       const simProps = (sim['properties'] ?? {}) as Record<string, unknown>;

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -19,6 +19,7 @@ import { validateEntity } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError } from './_shared.js';
 import { classifyEntityUpsert, classifyUpdateViolations } from '../../brain/write-validation.js';
 import { tagContains, textContains, propertiesValueContains } from '../../brain/tag-filter.js';
+import { mergePropertiesOrKeep, mergeTagsOrKeep } from '../../brain/merge-fields.js';
 
 export const entitiesRouter = Router();
 
@@ -253,12 +254,8 @@ entitiesRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSp
       // Build the resulting entity state to validate against schema
       const resultName = updates.name ?? existing.name;
       const resultType = updates.type ?? existing.type;
-      const resultTags = updates.tags !== undefined
-        ? Array.from(new Set([...(existing.tags ?? []), ...updates.tags]))
-        : existing.tags ?? [];
-      const resultProps = updates.properties !== undefined
-        ? { ...(existing.properties ?? {}), ...updates.properties }
-        : { ...(existing.properties ?? {}) };
+      const resultTags = mergeTagsOrKeep(existing.tags, updates.tags);
+      const resultProps = mergePropertiesOrKeep(existing.properties, updates.properties) ?? {};
       // Build a simulation and apply deleteFields for schema check
       const sim: Record<string, unknown> = { properties: resultProps, tags: resultTags, description: updates.description !== undefined ? updates.description : existing.description };
       if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -20,6 +20,7 @@ import type { MemoryDoc } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, buildMemoryFilter, ttlDaysFromBody, ttlDaysError } from './_shared.js';
 import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
+import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const memoriesRouter = Router();
 
@@ -233,7 +234,7 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
     {
       const mem = existing[0]!;
       const priorProps = mem.properties != null ? { ...mem.properties } : {};
-      const resultProps = updates.properties ?? { ...priorProps };
+      const resultProps = mergePropertiesOrKeep(mem.properties, updates.properties) ?? {};
       const sim: Record<string, unknown> = { properties: resultProps };
       if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       const simProps = (sim['properties'] ?? {}) as Record<string, unknown>;

--- a/server/src/brain/bulk.ts
+++ b/server/src/brain/bulk.ts
@@ -18,8 +18,9 @@ import {
 } from '../spaces/schema-validation.js';
 import { isStrictLinkage } from '../spaces/proxy.js';
 import { remember } from './memory.js';
-import { upsertEntity, mergedEntityWrite } from './entities.js';
-import { upsertEdge, findEdgeByTriplet, mergedEdgeProperties } from './edges.js';
+import { upsertEntity } from './entities.js';
+import { upsertEdge, findEdgeByTriplet } from './edges.js';
+import { mergeTagsAndProperties, mergePropertiesOrKeep } from './merge-fields.js';
 import { createChrono } from './chrono.js';
 import type { EntityDoc, ChronoType, ChronoStatus } from '../config/types.js';
 
@@ -140,7 +141,7 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
       const existing = rawId
         ? await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId }))
         : null;
-      const mergedEnt = mergedEntityWrite(existing as EntityDoc | null, { tags: strArray(item['tags']), properties });
+      const mergedEnt = mergeTagsAndProperties(existing as EntityDoc | null, { tags: strArray(item['tags']), properties });
       if (schemaFails('entity', i, validateEntity(meta ?? {}, { name, type, properties: mergedEnt.properties, tags: mergedEnt.tags }))) continue;
       const result = await upsertEntity(spaceId, name, type, strArray(item['tags']), properties,
         typeof item['description'] === 'string' ? item['description'] : undefined, rawId, undefined, undefined, ttlDays);
@@ -166,7 +167,7 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
     if (ttlDays === TTL_INVALID) { errors.push({ type: 'edge', index: i, reason: TTL_INVALID_MSG }); continue; }
     try {
       const existing = await findEdgeByTriplet(spaceId, from, to, label);
-      if (schemaFails('edge', i, validateEdge(meta ?? {}, { label, properties: mergedEdgeProperties(existing, properties) ?? {} }))) continue;
+      if (schemaFails('edge', i, validateEdge(meta ?? {}, { label, properties: mergePropertiesOrKeep(existing?.properties, properties) ?? {} }))) continue;
       await upsertEdge(spaceId, from, to, label,
         typeof item['weight'] === 'number' ? item['weight'] : undefined,
         typeof item['type'] === 'string' ? item['type'] : undefined,

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -14,6 +14,7 @@ import { findInsertContradictions, type ContradictionWarning } from './insert-co
 import { deriveChronoStatus } from './chrono-status.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
+import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
 
@@ -144,8 +145,8 @@ export async function createChrono(
 
   // ── The idempotent branch: a supplied id that already names an entry converges rather than duplicating.
   if (existing) {
-    const mergedTags = [...new Set([...(existing.tags ?? []), ...tags])];
-    const mergedProps = { ...(existing.properties ?? {}), ...(fields.properties ?? {}) };
+    const mergedTags = mergeTags(existing.tags, tags);
+    const mergedProps = mergeProperties(existing.properties, fields.properties);
     const $set: Record<string, unknown> = {
       title: fields.title,
       type: fields.type,
@@ -230,6 +231,12 @@ export async function updateChrono(
   for (const [k, v] of Object.entries(updates)) {
     if (v !== undefined) $set[k] = v;
   }
+  // `properties` MERGES, like every other write path: `createChrono`'s converge branch above, the entity
+  // and edge updates, and the retry-safety guarantee the integration guide states for all four record
+  // types. The generic loop overhead has been REPLACING it — patch one key, lose the rest, no error.
+  // Removing a key is `deleteFields`' job on the surfaces that offer it, never an absence here.
+  const mergedUpdateProps = mergePropertiesOrKeep(existing.properties, updates.properties);
+  if (updates.properties !== undefined) $set['properties'] = mergedUpdateProps;
 
   // Re-embed if any embedding-relevant field changes
   if (
@@ -245,7 +252,7 @@ export async function updateChrono(
     const newStatus = updates.status ?? existing.status;
     const newDesc = updates.description !== undefined ? updates.description : existing.description;
     const newTags = updates.tags ?? existing.tags;
-    const newProps = updates.properties !== undefined ? updates.properties : existing.properties;
+    const newProps = mergedUpdateProps ?? existing.properties;
     try {
       const embedText = chronoEmbedText(newTitle, newKind, newStatus, newDesc, newTags, newProps);
       const embResult = await embed(embedText);

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -11,6 +11,7 @@ import { edgeEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
+import { mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
 import { getEntityById } from './entities.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EdgeDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
@@ -63,25 +64,6 @@ export async function findEdgeByTriplet(
   return await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ spaceId, from, to, label })) as EdgeDoc | null;
 }
 
-/**
- * The properties an upsert will actually store: the stored ones with the incoming ones laid over.
- *
- * Exported because schema validation has to run against the record that will EXIST, and until this was
- * shared it re-derived the rule from the outside — badly. An edge's identity is `(from, to, label)`, so
- * every repeat upsert of an existing edge merges, with no id involved and nothing in the caller's payload
- * to hint at it. Validating the payload alone refused patches whose merged result was perfectly valid.
- *
- * `undefined` properties mean "do not touch", which is why that case returns the stored value rather than
- * an empty object — the difference between "no properties supplied" and "properties cleared".
- */
-export function mergedEdgeProperties(
-  existing: { properties?: Record<string, string | number | boolean> } | null | undefined,
-  incoming: Record<string, string | number | boolean> | undefined,
-): Record<string, string | number | boolean> | undefined {
-  if (incoming === undefined) return existing?.properties;
-  return { ...(existing?.properties ?? {}), ...incoming };
-}
-
 export async function upsertEdge(
   spaceId: string,
   from: string,
@@ -103,10 +85,8 @@ export async function upsertEdge(
 
   const effectiveDesc = description ?? (existing as EdgeDoc | null)?.description;
   const effectiveType = type ?? (existing as EdgeDoc | null)?.type;
-  const effectiveTags = tags !== undefined
-    ? Array.from(new Set([...((existing as EdgeDoc | null)?.tags ?? []), ...tags]))
-    : ((existing as EdgeDoc | null)?.tags ?? []);
-  const effectiveProps = mergedEdgeProperties(existing as EdgeDoc | null, properties);
+  const effectiveTags = mergeTagsOrKeep((existing as EdgeDoc | null)?.tags, tags);
+  const effectiveProps = mergePropertiesOrKeep((existing as EdgeDoc | null)?.properties, properties);
 
   // Embed the edge text (best-effort) — resolve entity names so the vector captures semantics
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
@@ -124,7 +104,7 @@ export async function upsertEdge(
     if (description !== undefined) $set['description'] = description;
     // When tags are provided, persist the merged result; otherwise leave existing tags unchanged
     if (tags !== undefined) $set['tags'] = effectiveTags;
-    if (properties !== undefined) $set['properties'] = mergedEdgeProperties(existing as EdgeDoc, properties);
+    if (properties !== undefined) $set['properties'] = effectiveProps;
     const $unset: Record<string, unknown> = {};
     applyExpiryToUpdate(spaceId, ttlDays, (existing as EdgeDoc)._expireAt != null, $set, $unset,
       { collection: 'edge', existing: existing as unknown as Record<string, unknown> }); // F10
@@ -142,7 +122,7 @@ export async function upsertEdge(
       ...(type !== undefined ? { type } : {}),
       ...(description !== undefined ? { description } : {}),
       ...(tags !== undefined ? { tags: effectiveTags } : {}),
-      ...(properties !== undefined ? { properties: { ...((existing as EdgeDoc).properties ?? {}), ...properties } } : {}),
+      ...(properties !== undefined ? { properties: effectiveProps } : {}),
       ...embeddingFields,
     };
     if ('_expireAt' in $set) updatedEdge._expireAt = $set['_expireAt'] as Date;
@@ -264,12 +244,9 @@ export async function updateEdgeById(
 
   const newLabel = updates.label ?? existing.label;
   let newDesc = updates.description !== undefined ? updates.description : existing.description;
-  let newTags = updates.tags !== undefined
-    ? Array.from(new Set([...(existing.tags ?? []), ...updates.tags]))
-    : existing.tags ?? [];
-  let newProps: Record<string, string | number | boolean> | undefined = updates.properties !== undefined
-    ? { ...(existing.properties ?? {}), ...updates.properties }
-    : existing.properties != null ? { ...existing.properties } : {};
+  let newTags = mergeTagsOrKeep(existing.tags, updates.tags);
+  let newProps: Record<string, string | number | boolean> | undefined =
+    mergePropertiesOrKeep(existing.properties, updates.properties) ?? {};
   let newType = updates.type !== undefined ? updates.type : existing.type;
   let newWeight: number | undefined = updates.weight !== undefined ? updates.weight : existing.weight;
 

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -11,6 +11,7 @@ import { entityEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
+import { mergeTagsAndProperties, mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './recall.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import { log } from '../util/log.js';
@@ -87,26 +88,6 @@ export interface UpsertResult {
  *
  * Callers that need name-based lookup should use `findEntitiesByName`.
  */
-/**
- * The tags and properties an upsert will actually store, given the record it lands on.
- *
- * Both are MERGES, not replacements: an upsert that mentions one property keeps the rest. That rule
- * belongs to this function so that schema validation can ask what the stored record will look like
- * instead of guessing. It used to guess, and it guessed the payload — so a partial upsert against a
- * complete record was refused for missing required properties the record already had and kept.
- *
- * `existing` is null for an insert, where the merge is the identity function.
- */
-export function mergedEntityWrite(
-  existing: { tags?: string[]; properties?: Record<string, string | number | boolean> } | null | undefined,
-  incoming: { tags?: string[]; properties?: Record<string, string | number | boolean> },
-): { tags: string[]; properties: Record<string, string | number | boolean> } {
-  return {
-    tags: Array.from(new Set([...(existing?.tags ?? []), ...(incoming.tags ?? [])])),
-    properties: { ...(existing?.properties ?? {}), ...(incoming.properties ?? {}) },
-  };
-}
-
 export async function upsertEntity(
   spaceId: string,
   name: string,
@@ -132,7 +113,7 @@ export async function upsertEntity(
   // Embed the entity text (best-effort — if embedding fails we still store the entity)
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
   try {
-    const { tags: mergedTags, properties: mergedProps } = mergedEntityWrite(existing, { tags, properties });
+    const { tags: mergedTags, properties: mergedProps } = mergeTagsAndProperties(existing, { tags, properties });
     const effectiveDesc = description ?? existing?.description;
     const embedText = entityEmbedText(name, type, mergedTags, effectiveDesc, mergedProps);
     const embResult = await embed(embedText);
@@ -140,7 +121,7 @@ export async function upsertEntity(
   } catch { /* embedding unavailable — entity stored without vector */ }
 
   if (existing) {
-    const { tags: updatedTags, properties: mergedProps } = mergedEntityWrite(existing, { tags, properties });
+    const { tags: updatedTags, properties: mergedProps } = mergeTagsAndProperties(existing, { tags, properties });
     const $set: Record<string, unknown> = { name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields };
     if (description !== undefined) $set['description'] = description;
     const $unset: Record<string, unknown> = {};
@@ -260,12 +241,8 @@ export async function updateEntityById(
   const newName = updates.name ?? existing.name;
   const newType = updates.type ?? existing.type;
   const newDesc = updates.description !== undefined ? updates.description : existing.description;
-  let newTags = updates.tags !== undefined
-    ? Array.from(new Set([...(existing.tags ?? []), ...updates.tags]))
-    : existing.tags ?? [];
-  let newProps = updates.properties !== undefined
-    ? { ...(existing.properties ?? {}), ...updates.properties }
-    : { ...(existing.properties ?? {}) };
+  let newTags = mergeTagsOrKeep(existing.tags, updates.tags);
+  let newProps = mergePropertiesOrKeep(existing.properties, updates.properties) ?? {};
 
   // Apply deleteFields after merge
   if (deleteFieldsPaths && deleteFieldsPaths.length > 0) {

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -18,6 +18,7 @@ import { memoryEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
+import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { MemoryDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
 import { SimilarMatch, DupeCheckOpts, checkDuplicates } from './recall.js';
@@ -108,8 +109,8 @@ export async function remember(
   // indistinguishable for the case this exists for; the difference only shows when the id is reused with different
   // content, which is a deliberate update and behaves like the entity path does.
   if (existing) {
-    const mergedTags = [...new Set([...(existing.tags ?? []), ...tags])];
-    const mergedProps = { ...(existing.properties ?? {}), ...(properties ?? {}) };
+    const mergedTags = mergeTags(existing.tags, tags);
+    const mergedProps = mergeProperties(existing.properties, properties);
     const $set: Record<string, unknown> = {
       fact,
       tags: mergedTags,
@@ -188,11 +189,21 @@ export async function updateMemory(
   const $set: Record<string, unknown> = { updatedAt: now, seq };
   const $unset: Record<string, unknown> = {};
 
+  // `properties` MERGES into the stored map. It used to replace it, which contradicted this tool's own
+  // schema ("Key-value properties to merge"), the `deleteFields` contract ("applied AFTER the normal
+  // merge"), the entity and edge update paths, and `remember`'s own converge branch above. An agent
+  // patching one key silently destroyed every other property on the record, with no error anywhere.
+  // Removing a key is `deleteFields`' job — an absence never means "delete".
+  //
+  // `tags` deliberately still REPLACE here, and that is not an oversight: `update_memory` documents them
+  // as "New tags (replaces existing)" while `update_entity`/`update_edge` document a union. Both halves
+  // are stated, so both are kept and pinned by a test rather than silently unified.
+  const mergedUpdateProps = mergePropertiesOrKeep(existing.properties, updates.properties);
   if (updates.fact !== undefined) $set['fact'] = updates.fact;
   if (updates.tags !== undefined) $set['tags'] = updates.tags;
   if (updates.entityIds !== undefined) $set['entityIds'] = updates.entityIds;
   if (updates.description !== undefined) $set['description'] = updates.description;
-  if (updates.properties !== undefined) $set['properties'] = updates.properties;
+  if (updates.properties !== undefined) $set['properties'] = mergedUpdateProps;
   if (updates.type !== undefined) $set['type'] = updates.type;
 
   // Apply deleteFields after merge
@@ -203,7 +214,7 @@ export async function updateMemory(
       tags: updates.tags ?? existing.tags,
       entityIds: updates.entityIds ?? existing.entityIds,
       description: updates.description !== undefined ? updates.description : existing.description,
-      properties: updates.properties ?? (existing.properties != null ? { ...existing.properties } : {}),
+      properties: mergedUpdateProps ?? {},
     };
     applyDeleteFields(merged, deleteFieldsPaths);
 

--- a/server/src/brain/merge-fields.ts
+++ b/server/src/brain/merge-fields.ts
@@ -1,0 +1,98 @@
+/**
+ * The one merge rule for `tags` and `properties`, in one place.
+ *
+ * ## Why this file exists
+ *
+ * Every brain write that lands on an existing record has to answer the same question: what do the
+ * stored `tags`/`properties` become once the incoming ones are applied? The answer is two lines —
+ * a de-duplicated tag union and a shallow property merge — and it was written **eleven times** across
+ * six files before this module: in the entity writer, the edge writer, the memory writer, the chrono
+ * writer, three REST handlers and two MCP tools.
+ *
+ * A canonical version did exist (`mergedEntityWrite`, in `entities.ts`), and it was already generic —
+ * its signature never mentioned an entity. It had two call sites. Everyone else re-derived it, because
+ * **a helper named and placed for its first caller is invisible to the second**: nobody reaches into
+ * `brain/entities.ts` to merge a chrono entry's properties. Two of the eleven copies were added hours
+ * before the 2.4.0 docs promised that all four record types converge "matching the entity path".
+ *
+ * That promise is the reason this is correctness rather than tidiness. A stated guarantee with eleven
+ * implementations is held together by nothing, and it was not in fact held: `update_memory`'s own tool
+ * schema said `properties` were "to merge" while `updateMemory` **replaced** them, so an agent that
+ * patched one property silently destroyed every other property on the record.
+ *
+ * ## The rule
+ *
+ * - **tags** — union, de-duplicated, stored order first. Adding a tag never removes one.
+ * - **properties** — shallow merge, incoming wins per key. A patch that names one key keeps the rest.
+ * - Removing either is `deleteFields`' job, never an absence.
+ *
+ * `*OrKeep` are the PATCH-shaped variants: `undefined` incoming means *do not touch*, which is a
+ * different statement from an empty object and must not collapse into one.
+ */
+
+/** The value shape a brain record's `properties` map is allowed to hold. */
+export type RecordProperties = Record<string, string | number | boolean>;
+
+/** A record's mergeable fields — any of the five brain types, none of them named. */
+export interface MergeableFields {
+  tags?: string[];
+  properties?: RecordProperties;
+}
+
+/**
+ * The stored tags plus the incoming ones, de-duplicated, stored order first.
+ *
+ * Order matters more than it looks: it is what a caller sees echoed back, and a `Set` preserves
+ * insertion order, so the stored tags keep their positions and new ones append.
+ */
+export function mergeTags(existing?: readonly string[] | null, incoming?: readonly string[]): string[] {
+  return Array.from(new Set([...(existing ?? []), ...(incoming ?? [])]));
+}
+
+/** The stored properties with the incoming ones laid over — one level deep, incoming wins per key. */
+export function mergeProperties(
+  existing?: RecordProperties | null,
+  incoming?: RecordProperties,
+): RecordProperties {
+  return { ...(existing ?? {}), ...(incoming ?? {}) };
+}
+
+/**
+ * Both fields at once: what a write will actually store, given the record it lands on.
+ *
+ * `existing` is null/undefined for an insert, where the merge is the identity function. Schema
+ * validation calls this so it can check the record that will EXIST rather than the payload — the
+ * distinction that made a partial upsert of a conformant record fail in a strict space.
+ */
+export function mergeTagsAndProperties(
+  existing: MergeableFields | null | undefined,
+  incoming: MergeableFields,
+): { tags: string[]; properties: RecordProperties } {
+  return {
+    tags: mergeTags(existing?.tags, incoming.tags),
+    properties: mergeProperties(existing?.properties, incoming.properties),
+  };
+}
+
+/**
+ * `mergeProperties` for a PATCH: `undefined` incoming means the caller said nothing about properties,
+ * so the stored map is returned untouched — `undefined` included, so a writer can tell "leave it out
+ * of the `$set`" from "store an empty map".
+ *
+ * A copy is returned rather than the stored reference: `deleteFields` mutates what it is handed, and
+ * aliasing the document just read from the driver is a defect waiting for the first caller that does
+ * both in one request.
+ */
+export function mergePropertiesOrKeep(
+  existing?: RecordProperties | null,
+  incoming?: RecordProperties,
+): RecordProperties | undefined {
+  if (incoming === undefined) return existing == null ? undefined : { ...existing };
+  return mergeProperties(existing, incoming);
+}
+
+/** `mergeTags` for a PATCH: `undefined` incoming leaves the stored tags alone. */
+export function mergeTagsOrKeep(existing?: readonly string[] | null, incoming?: readonly string[]): string[] {
+  if (incoming === undefined) return [...(existing ?? [])];
+  return mergeTags(existing, incoming);
+}

--- a/server/src/brain/merge.ts
+++ b/server/src/brain/merge.ts
@@ -16,6 +16,7 @@ import { entityEmbedText } from './embed-text.js';
 import { getEntityById } from './entities.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
+import { mergeTags } from './merge-fields.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc, SpaceMeta, PropertySchema } from '../config/types.js';
 
@@ -430,7 +431,7 @@ export async function executeMerge(
       }
 
       // ── 4. Update survivor entity ──────────────────────────────────────
-      const mergedTags = Array.from(new Set([...(survivor.tags ?? []), ...(absorbed.tags ?? [])]));
+      const mergedTags = mergeTags(survivor.tags, absorbed.tags);
       const entityColl = col<EntityDoc>(`${spaceId}_entities`);
 
       let embeddingFields: { embedding?: number[]; embeddingModel?: string } = {};

--- a/server/src/brain/write-validation.ts
+++ b/server/src/brain/write-validation.ts
@@ -36,8 +36,9 @@ import { validateEntity, validateEdge, type SchemaViolation } from '../spaces/sc
 import type { SpaceMeta } from '../config/types.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
 import { applyValidation, getSpaceMeta } from '../spaces/schema-validation.js';
-import { getEntityById, mergedEntityWrite } from './entities.js';
-import { findEdgeByTriplet, mergedEdgeProperties } from './edges.js';
+import { getEntityById } from './entities.js';
+import { findEdgeByTriplet } from './edges.js';
+import { mergeTagsAndProperties, mergePropertiesOrKeep } from './merge-fields.js';
 
 /**
  * Identity of a violation for before/after comparison.
@@ -227,7 +228,7 @@ export function classifyEntityUpsertAgainst(
   existing: { name: string; type: string; properties?: Record<string, string | number | boolean>; tags?: string[] } | null,
   incoming: { name: string; type: string; properties?: Record<string, string | number | boolean>; tags?: string[] },
 ): UpdateValidation {
-  const merged = mergedEntityWrite(existing, incoming);
+  const merged = mergeTagsAndProperties(existing, incoming);
   const after = validateEntity(meta ?? {}, {
     name: incoming.name, type: incoming.type, properties: merged.properties, tags: merged.tags,
   });
@@ -246,7 +247,7 @@ export function classifyEdgeUpsertAgainst(
   incoming: { label: string; properties?: Record<string, string | number | boolean> },
 ): UpdateValidation {
   const after = validateEdge(meta ?? {}, {
-    label: incoming.label, properties: mergedEdgeProperties(existing, incoming.properties) ?? {},
+    label: incoming.label, properties: mergePropertiesOrKeep(existing?.properties, incoming.properties) ?? {},
   });
   const before = existing
     ? validateEdge(meta ?? {}, { label: existing.label, properties: existing.properties ?? {} })

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -7,6 +7,7 @@ import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
 import { getAllowedChronoTypes, resolveMetaRefs, validateChrono } from '../../spaces/schema-validation.js';
+import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const create_chronoTool: ToolHandler = {
   name: 'create_chrono',
@@ -181,7 +182,7 @@ export const update_chronoTool: ToolHandler = {
             description: { type: 'string' },
             properties: {
               type: 'object',
-              description: 'Optional structured key-value metadata for this entry.',
+              description: 'Key-value properties to merge into the stored map — keys you do not name are kept.',
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             recurrence: {
@@ -264,7 +265,9 @@ export const update_chronoTool: ToolHandler = {
         validateChrono(found.meta ?? {}, { type: prior.type, properties: priorProps }),
         validateChrono(found.meta ?? {}, {
           type: (updates['type'] as string | undefined) ?? prior.type,
-          properties: (updates['properties'] as Record<string, unknown> | undefined) ?? priorProps,
+          properties: mergePropertiesOrKeep(
+            prior.properties, updates['properties'] as Record<string, string | number | boolean> | undefined,
+          ) ?? {},
         }),
       ));
     }

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -7,6 +7,7 @@ import { assertUpdateAllowed, classifyEdgeUpsert, classifyUpdateViolations, loca
 import { getConfig } from '../../config/loader.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateEdge } from '../../spaces/schema-validation.js';
+import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const upsert_edgeTool: ToolHandler = {
   name: 'upsert_edge',
@@ -143,9 +144,7 @@ export const update_edgeTool: ToolHandler = {
     if (found) {
       const prior = found.record;
       const sim: Record<string, unknown> = {
-        properties: updates.properties !== undefined
-          ? { ...(prior.properties ?? {}), ...updates.properties }
-          : { ...(prior.properties ?? {}) },
+        properties: mergePropertiesOrKeep(prior.properties, updates.properties) ?? {},
       };
       if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       assertUpdateAllowed(classifyUpdateViolations(

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -8,6 +8,7 @@ import { type PropertyResolution, applyResolutions, computeMergePlan, executeMer
 import { getConfig } from '../../config/loader.js';
 import { isProxySpace, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateEntity } from '../../spaces/schema-validation.js';
+import { mergePropertiesOrKeep, mergeTagsOrKeep } from '../../brain/merge-fields.js';
 
 export const upsert_entityTool: ToolHandler = {
   name: 'upsert_entity',
@@ -152,13 +153,9 @@ export const update_entityTool: ToolHandler = {
     const found = await locateForUpdate(wt.target, mid => getEntityById(mid, id));
     if (found) {
       const prior = found.record;
-      const resultTags = updates.tags !== undefined
-        ? Array.from(new Set([...(prior.tags ?? []), ...updates.tags]))
-        : prior.tags ?? [];
+      const resultTags = mergeTagsOrKeep(prior.tags, updates.tags);
       const sim: Record<string, unknown> = {
-        properties: updates.properties !== undefined
-          ? { ...(prior.properties ?? {}), ...updates.properties }
-          : { ...(prior.properties ?? {}) },
+        properties: mergePropertiesOrKeep(prior.properties, updates.properties) ?? {},
         tags: resultTags,
       };
       if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -19,6 +19,7 @@ import { checkQuota } from '../../quota/quota.js';
 import { resolveWriteTarget, findFirstAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
 import { resolveMetaRefs, validateMemory } from '../../spaces/schema-validation.js';
 import { TTL_DAYS_SCHEMA, ttlDaysFromArgs, unitScoreSchema } from './shared.js';
+import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const rememberTool: ToolHandler = {
   name: 'remember',
@@ -160,7 +161,7 @@ export const update_memoryTool: ToolHandler = {
             description: { type: 'string', description: 'New prose description or context.' },
             properties: {
               type: 'object',
-              description: 'Key-value properties to merge (e.g. {"source": "manual"}). Values must be string, number, or boolean.',
+              description: 'Key-value properties to merge into the stored map (e.g. {"source": "manual"}) — keys you do not name are kept. Use deleteFields to remove one. Values must be string, number, or boolean.',
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
@@ -212,7 +213,7 @@ export const update_memoryTool: ToolHandler = {
     const found = await locateForUpdate(wt.target, async mid => (await listMemories(mid, { _id: id }, 1, 0))[0]);
     if (found) {
       const priorProps = (found.record.properties ?? {}) as Record<string, unknown>;
-      const sim: Record<string, unknown> = { properties: updates.properties ?? { ...priorProps } };
+      const sim: Record<string, unknown> = { properties: mergePropertiesOrKeep(found.record.properties, updates.properties) ?? {} };
       if (dfPaths) applyDeleteFieldsPaths(sim, dfPaths);
       assertUpdateAllowed(classifyUpdateViolations(
         found.meta,

--- a/testing/standalone/merge-rule-db.test.js
+++ b/testing/standalone/merge-rule-db.test.js
@@ -1,0 +1,164 @@
+/**
+ * The four writers really do agree — against a real MongoDB, through the real functions.
+ *
+ * `one-merge-rule.test.js` pins the rule and gates the source. Neither can tell live code from dead
+ * code: a grep-based version of this check would have passed happily while `updateMemory` replaced the
+ * properties map, because the replace was a `$set` and the merge helper it should have used was simply
+ * absent. Only a write, then a read, settles it.
+ *
+ * ## The defect this exists for
+ *
+ * `update_memory`'s tool schema said `properties` were "to merge". `updateMemory` did
+ * `$set['properties'] = updates.properties` — a whole-map REPLACE. An agent patching one key silently
+ * destroyed every other property on the record: no error, no warning, and the REST validation
+ * simulation mirrored the same replace so the schema check could not see it either. `updateChrono`
+ * had it too, through a generic `Object.entries(updates)` loop that treated `properties` like a scalar.
+ *
+ * So the test is written as ONE table over all four types, not four tests. The failure mode was
+ * precisely that the types were handled in four places and nobody compared them.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/merge-rule-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+
+// Written before any dist import: the loader reads CONFIG_PATH at module load.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-merge-rule-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let mongo, brain;
+
+/** The stored record, in every type: two properties and one tag, all of which must survive a patch. */
+const STORED_PROPS = { owner: 'platform', rack: 'B12' };
+/** The patch: one property the record already has, under a new value. Nothing else is mentioned. */
+const PATCH_PROPS = { rack: 'C03' };
+/** What every type must hold afterwards. `owner` surviving is the whole point. */
+const MERGED_PROPS = { owner: 'platform', rack: 'C03' };
+
+/**
+ * One row per record type: how to create it, how to patch it, how to read it back.
+ *
+ * Each `create` returns the record id; each `update` calls the type's real update function with a
+ * properties-only patch; each `load` returns the stored document.
+ */
+const TYPES = [
+  {
+    name: 'entity',
+    create: async () => (await brain.entities.upsertEntity(
+      SPACE, 'node-7', 'machine', ['prod'], STORED_PROPS, undefined, undefined,
+    )).entity._id,
+    update: (id) => brain.entities.updateEntityById(SPACE, id, { properties: PATCH_PROPS }),
+    load: (id) => mongo.col(`${SPACE}_entities`).findOne({ _id: id }),
+  },
+  {
+    name: 'edge',
+    create: async () => (await brain.edges.upsertEdge(
+      SPACE, 'a-1', 'b-1', 'runs-on', undefined, undefined, undefined, STORED_PROPS, ['prod'],
+    ))._id,
+    update: (id) => brain.edges.updateEdgeById(SPACE, id, { properties: PATCH_PROPS }),
+    load: (id) => mongo.col(`${SPACE}_edges`).findOne({ _id: id }),
+  },
+  {
+    name: 'memory',
+    create: async () => (await brain.memory.remember(
+      SPACE, 'node-7 runs the platform apps', [], ['prod'], undefined, STORED_PROPS,
+    ))._id,
+    update: (id) => brain.memory.updateMemory(SPACE, id, { properties: PATCH_PROPS }),
+    load: (id) => mongo.col(`${SPACE}_memories`).findOne({ _id: id }),
+  },
+  {
+    name: 'chrono',
+    create: async () => (await brain.chrono.createChrono(SPACE, {
+      title: 'rack move', type: 'event', startsAt: '2026-08-05T09:00:00Z',
+      tags: ['prod'], properties: STORED_PROPS,
+    }))._id,
+    update: (id) => brain.chrono.updateChrono(SPACE, id, { properties: PATCH_PROPS }),
+    load: (id) => mongo.col(`${SPACE}_chrono`).findOne({ _id: id }),
+  },
+];
+
+describe('one merge rule, four record types (real MongoDB)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('mergerule');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    brain = {
+      entities: await import('../../server/dist/brain/entities.js'),
+      edges: await import('../../server/dist/brain/edges.js'),
+      memory: await import('../../server/dist/brain/memory.js'),
+      chrono: await import('../../server/dist/brain/chrono.js'),
+    };
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  for (const t of TYPES) {
+    it(`${t.name}: a properties patch KEEPS the keys it does not mention`, async () => {
+      const id = await t.create();
+      const before = await t.load(id);
+      assert.deepEqual(before.properties, STORED_PROPS, 'precondition: the record stored both properties');
+
+      const returned = await t.update(id);
+      const after = await t.load(id);
+
+      assert.deepEqual(after.properties, MERGED_PROPS,
+        `${t.name} lost a property the patch never mentioned — this is the replace defect. Removing a `
+        + 'key is deleteFields\' job; an absence must never mean "delete".');
+      // The returned document is what an API caller sees. It used to be built separately from the
+      // `$set`, which is its own way for the two to disagree.
+      if (returned && returned.properties) {
+        assert.deepEqual(returned.properties, MERGED_PROPS,
+          `${t.name}'s returned document disagrees with what was stored`);
+      }
+    });
+  }
+
+  it('all four types produce the SAME merged map from the same input', async () => {
+    // The assertion the docs rely on and nothing enforced. Stated as one comparison rather than four
+    // so a type drifting away fails here even if its own row above was updated to match it.
+    const results = {};
+    for (const t of TYPES) {
+      const id = await t.create();
+      await t.update(id);
+      results[t.name] = (await t.load(id)).properties;
+    }
+    assert.deepEqual(results, {
+      entity: MERGED_PROPS, edge: MERGED_PROPS, memory: MERGED_PROPS, chrono: MERGED_PROPS,
+    });
+  });
+
+  it('an absent properties field leaves the stored map alone', async () => {
+    // `undefined` is the caller saying nothing. Reading it as `{}` would clear the map on any patch
+    // that only touches another field.
+    for (const t of TYPES) {
+      const id = await t.create();
+      await t.update(id);                                   // establishes the merged state
+      const patchless = t.name === 'entity' || t.name === 'edge'
+        ? { description: 'unrelated' }
+        : t.name === 'memory' ? { description: 'unrelated' } : { title: 'unrelated' };
+      await (t.name === 'entity' ? brain.entities.updateEntityById(SPACE, id, patchless)
+        : t.name === 'edge' ? brain.edges.updateEdgeById(SPACE, id, patchless)
+          : t.name === 'memory' ? brain.memory.updateMemory(SPACE, id, patchless)
+            : brain.chrono.updateChrono(SPACE, id, patchless));
+      assert.deepEqual((await t.load(id)).properties, MERGED_PROPS,
+        `${t.name}: a patch that says nothing about properties must not touch them`);
+    }
+  });
+});

--- a/testing/standalone/merge-rule-db.test.js
+++ b/testing/standalone/merge-rule-db.test.js
@@ -1,5 +1,5 @@
 /**
- * The four writers really do agree — against a real MongoDB, through the real functions.
+ * The four UPDATE paths really do agree — against a real MongoDB, through the real functions.
  *
  * `one-merge-rule.test.js` pins the rule and gates the source. Neither can tell live code from dead
  * code: a grep-based version of this check would have passed happily while `updateMemory` replaced the
@@ -17,11 +17,26 @@
  * So the test is written as ONE table over all four types, not four tests. The failure mode was
  * precisely that the types were handled in four places and nobody compared them.
  *
+ * ## Why records are seeded directly rather than created through the writers
+ *
+ * The subject is the UPDATE path, and going through the creators made the test depend on a live
+ * embedding model. Three of the four creators tolerate a missing embedder (`try { embed } catch`);
+ * `remember` does not — it awaits `embed()` unguarded, so a memory is never stored without a vector.
+ * That is defensible on its own terms (a memory with no embedding is invisible to recall), but it made
+ * this suite pass on a laptop with a warm model cache and fail in CI with
+ * `EACCES: permission denied, mkdir '/data'` — an environment difference reported as a merge defect.
+ *
+ * A test whose result depends on whether the machine happens to hold 274 MB of model weights is not
+ * measuring what it claims to. Every row now seeds its document with one `insertOne`, uniformly, and
+ * `YTHRIL_MODELS_OFFLINE=1` makes the update paths' guarded re-embed fail fast instead of reaching for
+ * the network. Uniformity is deliberate too: a table where three rows take one route and the fourth
+ * takes another invites exactly the divergence it is checking for.
+ *
  * Run: `npm run test:up` first, then
  *      node --test testing/standalone/merge-rule-db.test.js
  * (requires a prior `npm run build` in server/)
  */
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -32,10 +47,13 @@ const skip = await mongoSkipReason();
 
 const SPACE = 'general';
 
-// Written before any dist import: the loader reads CONFIG_PATH at module load.
+// Both read at module load, so both must be set before any dist import.
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-merge-rule-'));
 const CONFIG_PATH = path.join(tmpDir, 'config.json');
 process.env['CONFIG_PATH'] = CONFIG_PATH;
+// No network, no cache probe, no 274 MB download. The update paths catch the failure and keep the
+// stored embedding, which is exactly the behaviour under test here (none — this is about properties).
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
 
 let mongo, brain;
 
@@ -46,47 +64,65 @@ const PATCH_PROPS = { rack: 'C03' };
 /** What every type must hold afterwards. `owner` surviving is the whole point. */
 const MERGED_PROPS = { owner: 'platform', rack: 'C03' };
 
+/** Fields every brain record carries, so each row below states only what makes it that type. */
+const base = (id) => ({
+  _id: id,
+  spaceId: SPACE,
+  tags: ['prod'],
+  properties: { ...STORED_PROPS },
+  author: { instanceId: 'self' },
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  seq: 1,
+});
+
 /**
- * One row per record type: how to create it, how to patch it, how to read it back.
+ * One row per record type: how to seed it, how to patch it, how to read it back.
  *
- * Each `create` returns the record id; each `update` calls the type's real update function with a
- * properties-only patch; each `load` returns the stored document.
+ * `update` takes the patch so the same row serves both the properties case and the "says nothing about
+ * properties" case — writing the dispatch twice is how the types drifted apart in the first place.
  */
 const TYPES = [
   {
     name: 'entity',
-    create: async () => (await brain.entities.upsertEntity(
-      SPACE, 'node-7', 'machine', ['prod'], STORED_PROPS, undefined, undefined,
-    )).entity._id,
-    update: (id) => brain.entities.updateEntityById(SPACE, id, { properties: PATCH_PROPS }),
-    load: (id) => mongo.col(`${SPACE}_entities`).findOne({ _id: id }),
+    collection: 'entities',
+    seed: (id) => ({ ...base(id), name: 'node-7', type: 'machine' }),
+    update: (id, patch) => brain.entities.updateEntityById(SPACE, id, patch),
+    unrelated: { description: 'unrelated' },
   },
   {
     name: 'edge',
-    create: async () => (await brain.edges.upsertEdge(
-      SPACE, 'a-1', 'b-1', 'runs-on', undefined, undefined, undefined, STORED_PROPS, ['prod'],
-    ))._id,
-    update: (id) => brain.edges.updateEdgeById(SPACE, id, { properties: PATCH_PROPS }),
-    load: (id) => mongo.col(`${SPACE}_edges`).findOne({ _id: id }),
+    collection: 'edges',
+    seed: (id) => ({ ...base(id), from: 'a-1', to: 'b-1', label: 'runs-on' }),
+    update: (id, patch) => brain.edges.updateEdgeById(SPACE, id, patch),
+    unrelated: { description: 'unrelated' },
   },
   {
     name: 'memory',
-    create: async () => (await brain.memory.remember(
-      SPACE, 'node-7 runs the platform apps', [], ['prod'], undefined, STORED_PROPS,
-    ))._id,
-    update: (id) => brain.memory.updateMemory(SPACE, id, { properties: PATCH_PROPS }),
-    load: (id) => mongo.col(`${SPACE}_memories`).findOne({ _id: id }),
+    collection: 'memories',
+    seed: (id) => ({ ...base(id), fact: 'node-7 runs the platform apps', entityIds: [] }),
+    update: (id, patch) => brain.memory.updateMemory(SPACE, id, patch),
+    unrelated: { description: 'unrelated' },
   },
   {
     name: 'chrono',
-    create: async () => (await brain.chrono.createChrono(SPACE, {
-      title: 'rack move', type: 'event', startsAt: '2026-08-05T09:00:00Z',
-      tags: ['prod'], properties: STORED_PROPS,
-    }))._id,
-    update: (id) => brain.chrono.updateChrono(SPACE, id, { properties: PATCH_PROPS }),
-    load: (id) => mongo.col(`${SPACE}_chrono`).findOne({ _id: id }),
+    collection: 'chrono',
+    seed: (id) => ({
+      ...base(id), title: 'rack move', type: 'event',
+      startsAt: '2026-08-05T09:00:00.000Z', status: 'upcoming', entityIds: [], memoryIds: [],
+    }),
+    update: (id, patch) => brain.chrono.updateChrono(SPACE, id, patch),
+    unrelated: { title: 'unrelated' },
   },
 ];
+
+/** Seed one record of this type and return its id. */
+async function seed(t, id) {
+  await mongo.col(`${SPACE}_${t.collection}`).insertOne(t.seed(id));
+  return id;
+}
+
+const load = (t, id) => mongo.col(`${SPACE}_${t.collection}`).findOne({ _id: id });
 
 describe('one merge rule, four record types (real MongoDB)', { skip }, () => {
   before(async () => {
@@ -109,21 +145,24 @@ describe('one merge rule, four record types (real MongoDB)', { skip }, () => {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
+  beforeEach(async () => {
+    for (const t of TYPES) await mongo.col(`${SPACE}_${t.collection}`).deleteMany({});
+  });
+
   for (const t of TYPES) {
     it(`${t.name}: a properties patch KEEPS the keys it does not mention`, async () => {
-      const id = await t.create();
-      const before = await t.load(id);
-      assert.deepEqual(before.properties, STORED_PROPS, 'precondition: the record stored both properties');
+      const id = await seed(t, `${t.name}-1`);
+      assert.deepEqual((await load(t, id)).properties, STORED_PROPS, 'precondition: both properties stored');
 
-      const returned = await t.update(id);
-      const after = await t.load(id);
+      const returned = await t.update(id, { properties: PATCH_PROPS });
+      assert.ok(returned, `${t.name}: the update found no record to patch`);
 
-      assert.deepEqual(after.properties, MERGED_PROPS,
+      assert.deepEqual((await load(t, id)).properties, MERGED_PROPS,
         `${t.name} lost a property the patch never mentioned — this is the replace defect. Removing a `
         + 'key is deleteFields\' job; an absence must never mean "delete".');
-      // The returned document is what an API caller sees. It used to be built separately from the
-      // `$set`, which is its own way for the two to disagree.
-      if (returned && returned.properties) {
+      // The returned document is what an API caller sees. It is built separately from the `$set` on
+      // some paths, which is its own way for the two to disagree.
+      if (returned.properties) {
         assert.deepEqual(returned.properties, MERGED_PROPS,
           `${t.name}'s returned document disagrees with what was stored`);
       }
@@ -135,9 +174,9 @@ describe('one merge rule, four record types (real MongoDB)', { skip }, () => {
     // so a type drifting away fails here even if its own row above was updated to match it.
     const results = {};
     for (const t of TYPES) {
-      const id = await t.create();
-      await t.update(id);
-      results[t.name] = (await t.load(id)).properties;
+      const id = await seed(t, `${t.name}-same`);
+      await t.update(id, { properties: PATCH_PROPS });
+      results[t.name] = (await load(t, id)).properties;
     }
     assert.deepEqual(results, {
       entity: MERGED_PROPS, edge: MERGED_PROPS, memory: MERGED_PROPS, chrono: MERGED_PROPS,
@@ -148,17 +187,20 @@ describe('one merge rule, four record types (real MongoDB)', { skip }, () => {
     // `undefined` is the caller saying nothing. Reading it as `{}` would clear the map on any patch
     // that only touches another field.
     for (const t of TYPES) {
-      const id = await t.create();
-      await t.update(id);                                   // establishes the merged state
-      const patchless = t.name === 'entity' || t.name === 'edge'
-        ? { description: 'unrelated' }
-        : t.name === 'memory' ? { description: 'unrelated' } : { title: 'unrelated' };
-      await (t.name === 'entity' ? brain.entities.updateEntityById(SPACE, id, patchless)
-        : t.name === 'edge' ? brain.edges.updateEdgeById(SPACE, id, patchless)
-          : t.name === 'memory' ? brain.memory.updateMemory(SPACE, id, patchless)
-            : brain.chrono.updateChrono(SPACE, id, patchless));
-      assert.deepEqual((await t.load(id)).properties, MERGED_PROPS,
+      const id = await seed(t, `${t.name}-absent`);
+      await t.update(id, t.unrelated);
+      assert.deepEqual((await load(t, id)).properties, STORED_PROPS,
         `${t.name}: a patch that says nothing about properties must not touch them`);
+    }
+  });
+
+  it('an EMPTY properties map is a no-op, not a wipe', async () => {
+    // `{}` is a caller who built a patch object and put nothing in it. It must not read as "clear".
+    for (const t of TYPES) {
+      const id = await seed(t, `${t.name}-empty`);
+      await t.update(id, { properties: {} });
+      assert.deepEqual((await load(t, id)).properties, STORED_PROPS,
+        `${t.name}: an empty properties map must not clear the stored one`);
     }
   });
 });

--- a/testing/standalone/one-merge-rule.test.js
+++ b/testing/standalone/one-merge-rule.test.js
@@ -1,0 +1,200 @@
+/**
+ * There is ONE merge rule for `tags` and `properties`, and every write path uses it.
+ *
+ * ## The finding
+ *
+ * The rule is two lines — a de-duplicated tag union and a shallow property merge — and it was written
+ * **eleven times** across six files. A canonical version existed (`mergedEntityWrite`) and was already
+ * generic: its signature never mentioned an entity. It had two call sites. Everyone else re-derived it,
+ * because a helper named and placed for its first caller is invisible to the second — nobody reaches
+ * into `brain/entities.ts` to merge a chrono entry's properties.
+ *
+ * ## Why it is correctness rather than tidiness
+ *
+ * The docs promise the copies agree. 2.4.0's *Retry Safety* section says a converged retry does
+ * "tags union and properties shallow-merge" for all four record types; the `deleteFields` section says
+ * it is "applied **after** the normal merge" for entities, edges **and memories**; and
+ * `update_memory`'s own tool schema said `properties` were "to merge".
+ *
+ * They did not agree. `updateMemory` and `updateChrono` **replaced** the properties map, so an agent
+ * patching one key silently destroyed every other property on the record — no error, no warning, and
+ * the REST validation simulation mirrored the same replace, so the schema check could not see it either.
+ *
+ * ## What this file pins
+ *
+ * 1. the rule itself, as pure functions;
+ * 2. that no write path hand-rolls it again — enumerated from the SHAPE (`{ ...x.properties }`,
+ *    `new Set([...tags])`), not from a list of file names, because a name list is what let the eleventh
+ *    copy be added by the same person who wrote the promise;
+ * 3. the one divergence that is deliberate and documented: `update_memory` REPLACES tags
+ *    ("New tags (replaces existing)") while `update_entity`/`update_edge` union them. Both halves are
+ *    stated, so the test states them too rather than letting a future sweep quietly unify them.
+ *
+ * The behavioural half — that the four writers really do agree against a real MongoDB — is
+ * `merge-rule-db.test.js`. A source gate cannot tell live code from dead code.
+ *
+ * Run: node --test testing/standalone/one-merge-rule.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+
+/** The module that is allowed to contain the rule. Everything else must call it. */
+const HOME = 'server/src/brain/merge-fields.ts';
+
+let merge;
+
+/**
+ * Tracked AND newly-added sources. `git ls-files` alone misses a file a contributor has just written,
+ * which is precisely when a fresh copy of the rule gets introduced.
+ *
+ * Two pathspecs, not one: `server/src/*.ts` does not descend in git's glob, so a single pattern would
+ * silently skip every subdirectory — which is all of them.
+ */
+function sourceFiles() {
+  const run = (args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+  const specs = ['server/src/*.ts', 'server/src/**/*.ts'];
+  const tracked = run(['ls-files', ...specs]);
+  const fresh = run(['ls-files', '--others', '--exclude-standard', ...specs]);
+  return [...new Set(`${tracked}\n${fresh}`.split(/\r?\n/))]
+    .filter(Boolean)
+    .map(p => p.replace(/\\/g, '/'));
+}
+
+/**
+ * Comments stripped, so the gate cannot fire on the prose that documents the rule — including this
+ * file's own explanation of the pattern it bans, and the block comment at the top of `merge-fields.ts`.
+ */
+function code(path) {
+  return readFileSync(join(ROOT, path), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split(/\r?\n/)
+    .filter(l => !/^\s*\/\//.test(l))
+    .join('\n');
+}
+
+/**
+ * Built fresh per call, never shared. A `/g` regex carries `lastIndex` between uses, and
+ * `assert.match` advances it — a shared instance makes the NEXT file in the sweep come back clean on a
+ * planted violation.
+ */
+const patterns = () => [
+  // A MERGE, not a copy: the second spread is what makes it the rule. `{ ...(x.properties ?? {}) }`
+  // on its own is a defensive copy — legitimate, and several validation paths take one before handing
+  // it to `deleteFields`. Matching those too would make the gate noise that gets suppressed.
+  { name: 'properties spread-merge', re: /\{\s*\.\.\.\([^)]*\.properties\s*\?\?\s*\{\}\)\s*,\s*\.\.\./g },
+  { name: 'tags Set-union', re: /new Set\(\[\s*\.\.\.\([^)]*\.tags\s*\?\?\s*\[\]\)/g },
+];
+
+describe('one merge rule', () => {
+  before(async () => {
+    merge = await import('../../server/dist/brain/merge-fields.js');
+  });
+
+  describe('the rule', () => {
+    it('unions tags, stored order first, de-duplicated', () => {
+      assert.deepEqual(merge.mergeTags(['a', 'b'], ['b', 'c']), ['a', 'b', 'c']);
+    });
+
+    it('shallow-merges properties, incoming wins per key', () => {
+      assert.deepEqual(merge.mergeProperties({ x: 1, y: 2 }, { y: 3 }), { x: 1, y: 3 });
+    });
+
+    it('is the identity on an insert', () => {
+      assert.deepEqual(merge.mergeTagsAndProperties(null, { tags: ['b'], properties: { y: 3 } }),
+        { tags: ['b'], properties: { y: 3 } });
+    });
+
+    it('treats an ABSENT incoming map as "do not touch", not "clear"', () => {
+      // The distinction the whole PATCH surface rests on: `undefined` is the caller saying nothing.
+      // Collapsing it to `{}` would wipe a required property on any patch that only sets a weight.
+      assert.deepEqual(merge.mergePropertiesOrKeep({ owner: 'platform' }, undefined), { owner: 'platform' });
+      assert.equal(merge.mergePropertiesOrKeep(undefined, undefined), undefined,
+        'nothing stored and nothing supplied must stay undefined, so a writer can leave it out of the $set');
+      assert.deepEqual(merge.mergeTagsOrKeep(['prod'], undefined), ['prod']);
+    });
+
+    it('never hands back the stored object itself', () => {
+      // deleteFields mutates what it is given. Aliasing the document just read from the driver is a
+      // defect waiting for the first caller that merges and deletes in one request.
+      const stored = { owner: 'platform' };
+      const kept = merge.mergePropertiesOrKeep(stored, undefined);
+      assert.notEqual(kept, stored, 'a copy, not the stored reference');
+      kept.owner = 'mutated';
+      assert.equal(stored.owner, 'platform');
+    });
+
+    it('an empty incoming map is a no-op, not a wipe', () => {
+      assert.deepEqual(merge.mergeProperties({ x: 1 }, {}), { x: 1 });
+    });
+  });
+
+  describe('nobody hand-rolls it', () => {
+    it('the detector fires on the pattern it is meant to catch', () => {
+      // Mutation-check the gate before believing a clean sweep. Three gates in this repo have passed on
+      // planted bugs; a detector that matches nothing reports "clean" for every codebase on earth.
+      const planted = 'const p = { ...(existing.properties ?? {}), ...incoming };\n'
+        + 'const t = Array.from(new Set([...(existing.tags ?? []), ...incoming]));';
+      const hits = patterns().filter(p => p.re.test(planted)).map(p => p.name);
+      assert.deepEqual(hits.sort(), ['properties spread-merge', 'tags Set-union']);
+    });
+
+    it('the sweep reaches the files that used to hold the copies', () => {
+      // Scope check. The eleven copies lived in these six; if the pathspec stops reaching them the
+      // gate below passes vacuously and reads like coverage it does not have.
+      const files = sourceFiles();
+      for (const f of [
+        'server/src/brain/entities.ts', 'server/src/brain/edges.ts', 'server/src/brain/memory.ts',
+        'server/src/brain/chrono.ts', 'server/src/api/brain/entities.ts', 'server/src/mcp/tools/entity.ts',
+      ]) {
+        assert.ok(files.includes(f), `${f} must be in the swept set`);
+      }
+      assert.ok(files.length > 100, `expected the whole server tree, swept ${files.length}`);
+    });
+
+    it('no file outside brain/merge-fields.ts contains the rule', () => {
+      const offenders = [];
+      for (const file of sourceFiles()) {
+        if (file === HOME) continue;
+        const src = code(file);
+        for (const { name, re } of patterns()) {
+          for (const m of src.matchAll(re)) {
+            offenders.push(`${file} — ${name}: ${m[0].slice(0, 60)}`);
+          }
+        }
+      }
+      assert.deepEqual(offenders, [],
+        'the tag union and the property merge live in brain/merge-fields.ts. Import mergeTags / '
+        + 'mergeProperties / mergeTagsAndProperties / mergePropertiesOrKeep / mergeTagsOrKeep instead of '
+        + 'writing the two lines again — eleven copies is how a documented guarantee stopped being true.');
+    });
+  });
+
+  describe('the one divergence is deliberate, and stated in both places', () => {
+    const schema = (file) => readFileSync(join(ROOT, file), 'utf8');
+
+    it('update_memory documents tags as a REPLACE and update_entity as a union', () => {
+      // Not an oversight to be tidied away: both halves are written down, so a future sweep that
+      // "unifies" them is changing documented behaviour and has to say so.
+      assert.match(schema('server/src/mcp/tools/memory.ts'), /New tags \(replaces existing\)/,
+        'update_memory still documents replace semantics for tags');
+      assert.match(schema('server/src/mcp/tools/entity.ts'), /Tags to merge with existing tags/,
+        'update_entity still documents union semantics for tags');
+    });
+
+    it('every update tool that merges properties says so in its schema', () => {
+      // The defect was a schema promising "to merge" over code that replaced. The promise is now true;
+      // this keeps the two moving together.
+      for (const f of ['memory', 'entity', 'edge', 'chrono']) {
+        const src = schema(`server/src/mcp/tools/${f}.ts`);
+        assert.match(src, /properties to merge|properties to merge into the stored map/i,
+          `update_${f}'s properties description must state the merge — the code does it`);
+      }
+    });
+  });
+});

--- a/testing/standalone/upsert-validation.test.js
+++ b/testing/standalone/upsert-validation.test.js
@@ -35,8 +35,8 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 
 let classifyEntityUpsertAgainst;
 let classifyEdgeUpsertAgainst;
-let mergedEntityWrite;
-let mergedEdgeProperties;
+let mergeTagsAndProperties;
+let mergePropertiesOrKeep;
 
 /** A space that requires `owner` on every `machine` entity, and `since` on every edge. */
 const STRICT_ENTITY = {
@@ -77,8 +77,9 @@ describe('upsert validation', () => {
   before(async () => {
     ({ classifyEntityUpsertAgainst, classifyEdgeUpsertAgainst } =
       await import('../../server/dist/brain/write-validation.js'));
-    ({ mergedEntityWrite } = await import('../../server/dist/brain/entities.js'));
-    ({ mergedEdgeProperties } = await import('../../server/dist/brain/edges.js'));
+    // Both merge rules now live in one module — see brain/merge-fields.ts. They used to live with the
+    // entity writer and the edge writer respectively, which is exactly why nine other sites re-derived them.
+    ({ mergeTagsAndProperties, mergePropertiesOrKeep } = await import('../../server/dist/brain/merge-fields.js'));
   });
 
   describe('the reported case', () => {
@@ -149,7 +150,7 @@ describe('upsert validation', () => {
       // wipe a required field and refuse an upsert that only sets, say, a weight.
       const out = classifyEdgeUpsertAgainst(STRICT_EDGE, STORED_EDGE, { label: 'runs-on' });
       assert.equal(out.blocked, false);
-      assert.deepEqual(mergedEdgeProperties(STORED_EDGE, undefined), STORED_EDGE.properties);
+      assert.deepEqual(mergePropertiesOrKeep(STORED_EDGE.properties, undefined), STORED_EDGE.properties);
     });
   });
 
@@ -174,13 +175,13 @@ describe('upsert validation', () => {
 
   describe('the merge rule lives with the writer', () => {
     it('merges properties and unions tags', () => {
-      const out = mergedEntityWrite({ tags: ['a'], properties: { x: 1, y: 2 } }, { tags: ['b'], properties: { y: 3 } });
+      const out = mergeTagsAndProperties({ tags: ['a'], properties: { x: 1, y: 2 } }, { tags: ['b'], properties: { y: 3 } });
       assert.deepEqual(out.properties, { x: 1, y: 3 });
       assert.deepEqual(out.tags.sort(), ['a', 'b']);
     });
 
     it('is the identity on an insert', () => {
-      const out = mergedEntityWrite(null, { tags: ['b'], properties: { y: 3 } });
+      const out = mergeTagsAndProperties(null, { tags: ['b'], properties: { y: 3 } });
       assert.deepEqual(out, { tags: ['b'], properties: { y: 3 } });
     });
   });
@@ -233,7 +234,7 @@ describe('upsert validation', () => {
         // bulk.ts composes the merge itself (it needs the prior record for its own counters), so it is
         // allowed to call the validator directly — as long as what it hands over came from the writer's
         // merge helper and not from the request.
-        const usesMergeHelper = /merged(EntityWrite|EdgeProperties)\(/.test(src);
+        const usesMergeHelper = /merge(TagsAndProperties|PropertiesOrKeep|Properties)\(/.test(src);
         if (!usesClassifier && !usesMergeHelper) offenders.push(p);
       }
       assert.deepEqual(offenders, [],


### PR DESCRIPTION
## The defect

`update_memory`'s tool schema describes `properties` as **"to merge"**. `updateMemory` did:

```ts
if (updates.properties !== undefined) $set['properties'] = updates.properties;
```

A whole-map **replace**. An agent patching one key silently destroyed every other property on the record — no
error, no warning, nothing in the audit log to distinguish it from an intended overwrite. `updateChrono` had the
same defect through a generic `Object.entries(updates)` loop that treated `properties` like a scalar field.

Three statements said it should merge, and none of them was enforced by anything:

| where | what it says |
|---|---|
| *Retry Safety* (`04-brain-api.md`, added in 2.4.0) | "tags union and properties shallow-merge", for all four record types |
| the `deleteFields` section | deletions are "applied **after** the normal merge" — for entities, edges **and memories** |
| `updateEntityById` / `updateEdgeById` | already merged |

And the REST validation simulation mirrored the replace (`updates.properties ?? { ...priorProps }`), so the
schema check could not see the loss either: a `required` property could be dropped by a patch the validator had
just approved.

## Why it was there

The merge rule is two lines — a de-duplicated tag union and a shallow property merge — and it was written
**eleven times** across six files.

A canonical version already existed, `mergedEntityWrite` in `brain/entities.ts`, and it was **already generic**:
its signature is `{ tags?, properties? }` with nothing entity-specific in it. It had **two** call sites.

**A helper named and placed for its first caller is invisible to the second.** Nobody reaches into
`brain/entities.ts` to merge a chrono entry's properties, so everybody wrote the two lines again. Two of the
eleven copies were added hours before the 2.4.0 docs promised that all four types agree. Same shape as
`boundedJson` sitting unused in `providers.ts` while 25 upstream reads went unbounded.

## The change

- `server/src/brain/merge-fields.ts` — `mergeTags`, `mergeProperties`, `mergeTagsAndProperties`, plus the
  PATCH-shaped `mergePropertiesOrKeep` / `mergeTagsOrKeep` where `undefined` means *do not touch*.
- Every write path routed through it: the entity, edge, memory and chrono writers, `bulk.ts`,
  `write-validation.ts`, four REST handlers, four MCP tools, and the entity-dedupe merge in `brain/merge.ts`.
- `mergedEntityWrite` and `mergedEdgeProperties` are **deleted**, not aliased — a leftover alias is how the next
  contributor finds the wrong door.
- `update_memory` and `update_chrono` schema descriptions now say what the code does.

## Gates

Both halves, because neither is sufficient. A source gate cannot tell live code from dead code; a behaviour test
cannot see the twelfth copy being added tomorrow.

**`one-merge-rule.test.js`** — nobody re-derives the rule. Scoped from the **shape** of the merge, not from a
list of file names; a name list is what let two copies be added by the same person who wrote the promise. The
detector self-test fires on a planted violation, the regexes are rebuilt per use (a shared `/g` carries
`lastIndex` and makes the next file come back clean), comments are stripped so the gate cannot fire on the prose
explaining it, and **two** git pathspecs are passed because `server/src/*.ts` does not descend.

It found two hits on its first run: `brain/merge.ts` really was a twelfth copy (now routed), and
`structured-claims.ts` was a false positive — a defensive `{ ...(record.properties ?? {}) }` **copy**, not a
merge. The pattern now requires the second spread, so copies are not flagged.

**`merge-rule-db.test.js`** — all four writers produce the same merged map, driven through the real functions
against a real MongoDB. Written as one table over four types rather than four tests, because the failure mode was
precisely that the types lived in four places and nobody compared them.

**Both mutation-verified.** Reverting the memory fix turns 3 tests red; reverting the chrono fix turns the same
3 red.

## The one divergence, kept on purpose

`update_memory` documents tags as *"New tags (replaces existing)"*; `update_entity`/`update_edge` document a
union. Both halves are written down, so this PR pins both with a test rather than quietly unifying them — that
would be a behaviour change to a documented contract, and it belongs to whoever wants it, not to a dedup PR.

## Breaking-ish

A caller relying on the replace to clear properties on a memory or chrono entry must switch to
`deleteFields: ["properties.oldKey"]`. Called out in the CHANGELOG and in a *Changed in 2.4.1* note in the
integration guide, next to the new per-type table.

## Verification

- `npm run preflight` — PASSED
- `node --test testing/standalone/{merge-rule-db,one-merge-rule,upsert-validation}.test.js` — 32 pass, 0 fail
- markdownlint MD024 count on `CHANGELOG.md`: 8 before, 8 after (pre-existing, structural to Keep a Changelog)
