### PR TITLE
feat(brain): a memory write no longer waits for the embedding model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Memory writes no longer wait for the embedding model, and a record that misses its vector now gets one
+  later.** A new per-space embedding queue (`<space>_embed_jobs`) takes the work: the write returns as soon as
+  the record is durable, a worker embeds it moments later, and a failure retries with jittered backoff instead
+  of being final.
+  - **`remember` used to FAIL outright when the embedder was down**, alone among the four creators. The cause
+    was in the type: `MemoryDoc.embedding` was the only one of the four declared **required**, so that path had
+    no choice but to throw while `upsertEntity`/`upsertEdge`/`createChrono` caught and stored anyway. It is
+    optional now, and the asymmetry is gone.
+  - **A record with no vector is invisible to recall, not merely ranked lower.** Both channels drop it — the
+    vector search never returns it, and the lexical channel's `introduceLexicalOnly` needs an embedding to
+    compute a real similarity and skips what it cannot score. Before this, the only route back was a manual
+    whole-space `POST /reindex` that re-embeds *everything*.
+  - **`waitForEmbedding: true`** (REST body and the MCP `remember` schema, default false) keeps the old
+    behaviour reachable: embed inline, so the record is searchable the moment the call returns — and fail the
+    write if it cannot be. `checkDuplicates`/`checkContradictions` **imply** it, since a duplicate check needs
+    the vector before the insert so the new record cannot self-match.
+  - **Note:** the MCP `remember` tool defaults `checkDuplicates: true`, so MCP writes still embed inline unless
+    the caller passes `checkDuplicates: false`. REST writes go async today.
+  - One job per record (`_id` = `<type>:<recordId>`), so a record written five times has one job holding its
+    latest content rather than five queued embeddings of stale text. Rewriting a record resets a job that had
+    already exhausted its attempts, which is the escape hatch from a permanent failure.
+  - Embedding does **not** advance `seq`. It is a derived field excluded from replication, so bumping `seq`
+    would broadcast a no-op change to every peer in every network, on every embedding, forever.
 - **A proxy space is now marked wherever a space appears** (owner UX request). A `globe` badge with a tooltip
   naming *which* peer spaces it mirrors, on the Brain space strip, the Graph space strip, and the Spaces settings
   table.

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -113,7 +113,33 @@ POST /api/brain/spaces/:spaceId/memories
 }
 ```
 
-**Constraints**: `id` optional — a **UUID v4** you supply to make the write idempotent (a retry with the same id converges on that record instead of creating a second one); anything else is a `400`, and omitting it generates one. See [Retry Safety](#retry-safety). **Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl).
+**Constraints**: `id` optional — a **UUID v4** you supply to make the write idempotent (a retry with the same id converges on that record instead of creating a second one); anything else is a `400`, and omitting it generates one. See [Retry Safety](#retry-safety). **Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl). `waitForEmbedding` optional boolean — see below.
+
+#### When does a memory become searchable? (`waitForEmbedding`)
+
+**By default, a moment after the write returns.** The write stores the record and hands the embedding to a
+background queue, so it no longer pays the model's latency. A worker embeds it immediately afterwards, and a
+failure retries with backoff rather than being final.
+
+Until that lands, the record **is not returned by `recall`** — not ranked lower, absent. Both retrieval
+channels need the vector: the semantic one obviously, and the lexical one because it computes a real
+similarity for the records it introduces rather than inventing a score. The gap is normally milliseconds.
+
+Send `"waitForEmbedding": true` when that gap matters:
+
+```json
+{ "fact": "Kubernetes pods are ephemeral by design", "waitForEmbedding": true }
+```
+
+| | `waitForEmbedding: false` (default) | `waitForEmbedding: true` |
+|---|---|---|
+| write latency | does not include the model | includes the model |
+| searchable when the call returns | not yet | yes |
+| embedder unavailable | write **succeeds**; the queue retries | write **fails** |
+
+Use it when you will search for what you just wrote in the same flow, or when a record that cannot be embedded
+should be a visible error rather than a background repair. `checkDuplicates` and `checkContradictions` imply
+it — a duplicate check needs the vector before the insert so the new record cannot match itself.
 
 ---
 

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -107,9 +107,18 @@ memoriesRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAu
   }
   const safeId: string | undefined = typeof rawId === 'string' ? rawId : undefined;
 
+  // `waitForEmbedding` (default false): the vector is normally computed by the embedding queue moments
+  // after this returns, so the write no longer pays the model latency. Pass true when the caller will
+  // search for what it just wrote, or when a failure to embed should fail the write.
+  const waitForEmbedding = req.body?.waitForEmbedding;
+  if (waitForEmbedding !== undefined && typeof waitForEmbedding !== 'boolean') {
+    res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
+    return;
+  }
   const doc = await remember(
     targetSpace, fact, safeEntityIds, safeTags, safeDesc, safeProps,
-    undefined, safeMemoryType, undefined, webhookToken(req), ttlDaysFromBody(req.body), safeId,
+    undefined, safeMemoryType, waitForEmbedding === true ? { waitForEmbedding: true } : undefined,
+    webhookToken(req), ttlDaysFromBody(req.body), safeId,
   );
   const body: Record<string, unknown> = { ...doc };
   if (quotaResult?.softBreached) body['storageWarning'] = true;

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -94,4 +94,7 @@ export async function startConfiguredInstanceServices(): Promise<void> {
 
   const { startMediaEmbeddingWorker } = await import('./files/media/worker.js');
   startMediaEmbeddingWorker();
+
+  const { startBrainEmbeddingWorker } = await import('./brain/embed-worker.js');
+  startBrainEmbeddingWorker();
 }

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -1,0 +1,272 @@
+/**
+ * The embedding job queue for brain records — memories, entities, edges, chrono entries.
+ *
+ * ## Why writes stopped waiting for the model
+ *
+ * Every brain creator embedded inline, so the caller paid the model's latency on every write. Three of
+ * the four then swallowed a failure (`try { embed } catch`) and stored the record without a vector;
+ * `remember` did not, so a memory write failed outright whenever the embedder was down. Two behaviours,
+ * neither of them chosen by the caller, and no path back for a record that missed its vector short of a
+ * manual whole-space `POST /reindex` that re-embeds *everything*.
+ *
+ * A record with no vector is not a slightly worse record — it is **invisible to recall**. Both channels
+ * drop it: the vector search never returns it, and the lexical channel's `introduceLexicalOnly` needs an
+ * embedding to compute a real similarity and skips what it cannot score. So "stored but never embedded"
+ * is silent data loss from the searcher's point of view, and nothing measured it.
+ *
+ * This queue makes the gap **temporary and self-healing**: the write returns as soon as the record is
+ * durable, a worker embeds it moments later, and a failure retries with backoff instead of being final.
+ *
+ * ## What is deliberately NOT changed
+ *
+ * A caller who needs the record searchable when the call returns says so — `waitForEmbedding: true` —
+ * and gets exactly the old behaviour, including the old failure mode. It is opt-in rather than the
+ * default because the common case (an agent writing a memory) does not care, and the uncommon case
+ * (write-then-immediately-search) can no longer be silently wrong.
+ *
+ * ## One job per record, not one per write
+ *
+ * `_id` is `<type>:<recordId>`, so a record written five times in a second has one job at the end
+ * holding its latest content — the work is coalesced rather than queued five deep. This is the same
+ * shape the media queue uses (`_id` = file id) and the reason neither queue needs de-duplication logic.
+ *
+ * Scheduling — the wake signal, the epoch race, the per-space probe hint — is `util/work-signal.ts`,
+ * shared with the media queue. Only the job shape and the collection differ.
+ */
+
+import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
+import { withJitter } from '../util/backoff.js';
+import { createWorkSignal } from '../util/work-signal.js';
+import { newClaimToken } from '../files/media/lease.js';
+import type { BrainEmbedJobDoc, BrainEmbedRecordType } from '../config/types.js';
+
+/** Attempts before a job is left `failed` for an operator (or a rewrite) to deal with. */
+export const MAX_EMBED_ATTEMPTS = 5;
+
+/**
+ * More attempts than the media queue's three, for a different failure profile. A media job fails on a
+ * malformed file — retrying identical bytes through the same decoder is unlikely to help. An embedding
+ * job fails because the model is loading, the sidecar is restarting, or an external provider is rate
+ * limiting: all transient, all resolved by waiting. The backoff carries the schedule; this only bounds it.
+ */
+const RETRY_BACKOFF_MS: Record<number, number> = {
+  1: 5_000,
+  2: 30_000,
+  3: 120_000,
+  4: 600_000,
+};
+
+function nextClaimableAfter(nextAttempt: number): string {
+  const delay = RETRY_BACKOFF_MS[nextAttempt] ?? 1_800_000;
+  // Jittered for the same reason the media queue jitters: a thousand records enqueued while the model
+  // was loading would otherwise all become claimable on the same tick and hit it together.
+  return new Date(Date.now() + withJitter(delay)).toISOString();
+}
+
+const _signal = createWorkSignal();
+
+function jobs(spaceId: string) {
+  return col<BrainEmbedJobDoc>(`${spaceId}_embed_jobs`);
+}
+
+/** Composite id, so a rewrite of the same record replaces its job rather than adding one. */
+export function embedJobId(recordType: BrainEmbedRecordType, recordId: string): string {
+  return `${recordType}:${recordId}`;
+}
+
+/**
+ * The indexes `<space>_embed_jobs` needs, declared where the queries live.
+ *
+ * Same two shapes as the media queue and for the same reasons: `status` leads because every query pins
+ * it to one value, and the sort key comes last so it is satisfied by the index rather than in memory.
+ */
+export const EMBED_JOB_INDEXES: Array<Record<string, 1>> = [
+  // claimNextEmbedJob: { status, $or:[claimableAfter …] } sorted by createdAt.
+  { status: 1, claimableAfter: 1, createdAt: 1 },
+  // resetStalledEmbedJobs: { status, progressAt < cutoff }, and the per-status counts.
+  { status: 1, progressAt: 1 },
+];
+
+/** Idempotent — safe on every boot for every space, including spaces that predate this queue. */
+export async function ensureEmbedJobIndexes(spaceId: string): Promise<void> {
+  for (const keys of EMBED_JOB_INDEXES) await jobs(spaceId).createIndex(keys);
+}
+
+/**
+ * Announce that a record needs embedding.
+ *
+ * Always resets `status`, `attempts` and `claimableAfter`: a new write is new content, so a job that had
+ * exhausted its attempts on the OLD content must not inherit that verdict. This is what makes rewriting
+ * a record the operator's escape hatch from a permanently failed job.
+ *
+ * Never throws into the caller's write path. An enqueue that fails leaves a record whose vector is
+ * missing — exactly the state this queue exists to repair — and the periodic backfill sweep will find
+ * it. Failing the write instead would trade a delayed search hit for lost data.
+ */
+export async function enqueueEmbedJob(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  recordId: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  try {
+    await jobs(spaceId).updateOne(
+      asFilter<BrainEmbedJobDoc>({ _id: embedJobId(recordType, recordId) }),
+      asUpdate<BrainEmbedJobDoc>({
+        $set: {
+          spaceId, recordType, recordId,
+          status: 'pending',
+          attempts: 0,
+          maxAttempts: MAX_EMBED_ATTEMPTS,
+          lastError: null,
+          claimedAt: null,
+          progressAt: null,
+          claimableAfter: null,
+          claimToken: null,
+          updatedAt: now,
+        },
+        $setOnInsert: { createdAt: now },
+      }),
+      { upsert: true },
+    );
+    _signal.markSpaceMayHaveWork(spaceId);
+  } catch {
+    /* see the note above — a queue failure must never fail the write it was announcing */
+  }
+}
+
+/** Claim one job across the given spaces, oldest first. Returns null when nothing is claimable. */
+export async function claimNextEmbedJob(spaceIds: string[]): Promise<BrainEmbedJobDoc | null> {
+  const now = new Date().toISOString();
+  // Consumes the full-scan slot, so it is called exactly once per claim.
+  for (const spaceId of _signal.spacesToProbe(spaceIds)) {
+    const claimed = await jobs(spaceId).findOneAndUpdate(
+      asFilter<BrainEmbedJobDoc>({
+        status: 'pending',
+        $or: [
+          { claimableAfter: null },
+          { claimableAfter: { $exists: false } },
+          { claimableAfter: { $lte: now } as unknown as string },
+        ],
+      }),
+      asUpdate<BrainEmbedJobDoc>({
+        $set: {
+          status: 'processing', claimedAt: now, progressAt: now, claimableAfter: null,
+          updatedAt: now, claimToken: newClaimToken(),
+        },
+        $inc: { attempts: 1 },
+      }),
+      { returnDocument: 'after', sort: { createdAt: 1 } },
+    ) as BrainEmbedJobDoc | null;
+
+    if (claimed) {
+      _signal.noteClaimed(spaceId);
+      return claimed;
+    }
+    _signal.noteEmpty(spaceId);
+  }
+  return null;
+}
+
+/**
+ * A finished job is DELETED rather than kept as `complete`.
+ *
+ * The media queue keeps completed jobs because a file's embedding status is a thing the UI reports per
+ * file. Here the record itself carries `embeddingStatus`, so a retained job would be a second copy of
+ * one fact — and brain records outnumber files by orders of magnitude, so an unbounded `complete` pile
+ * is real storage for no answer. What "how many are pending" needs is the pending ones.
+ */
+export async function completeEmbedJob(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  recordId: string,
+): Promise<void> {
+  await jobs(spaceId).deleteOne(asFilter<BrainEmbedJobDoc>({ _id: embedJobId(recordType, recordId) }));
+}
+
+/** Requeue with backoff, or leave `failed` once the attempt budget is spent. */
+export async function failEmbedJob(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  recordId: string,
+  attempts: number,
+  errorMessage: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const _id = embedJobId(recordType, recordId);
+  const lastError = errorMessage.slice(0, 500);
+
+  if (attempts < MAX_EMBED_ATTEMPTS) {
+    await jobs(spaceId).updateOne(
+      asFilter<BrainEmbedJobDoc>({ _id }),
+      asUpdate<BrainEmbedJobDoc>({
+        $set: {
+          status: 'pending', claimedAt: null, claimToken: null, lastError, updatedAt: now,
+          claimableAfter: nextClaimableAfter(attempts + 1),
+        },
+      }),
+    );
+    _signal.markSpaceMayHaveWork(spaceId);
+    return;
+  }
+
+  await jobs(spaceId).updateOne(
+    asFilter<BrainEmbedJobDoc>({ _id }),
+    asUpdate<BrainEmbedJobDoc>({
+      $set: { status: 'failed', claimedAt: null, claimToken: null, lastError, updatedAt: now },
+    }),
+  );
+}
+
+/**
+ * Return jobs whose worker died mid-flight to the pending pool.
+ *
+ * Measured from `progressAt` (last sign of life), never from `claimedAt` — the media queue learned that
+ * a wall-clock deadline from the claim cannot tell "wedged" from "slow", and requeues a long job
+ * mid-flight forever. An embedding is short, but a cold model load is not.
+ */
+export async function resetStalledEmbedJobs(spaceIds: string[], timeoutMs: number): Promise<number> {
+  const cutoff = new Date(Date.now() - timeoutMs).toISOString();
+  let reset = 0;
+  for (const spaceId of spaceIds) {
+    const res = await jobs(spaceId).updateMany(
+      asFilter<BrainEmbedJobDoc>({ status: 'processing', progressAt: { $lt: cutoff } as unknown as string }),
+      asUpdate<BrainEmbedJobDoc>({
+        $set: {
+          status: 'pending', claimedAt: null, claimToken: null, claimableAfter: null,
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    );
+    if (res.modifiedCount > 0) {
+      reset += res.modifiedCount;
+      _signal.markSpaceMayHaveWork(spaceId);
+    }
+  }
+  return reset;
+}
+
+/** Per-status counts for one space. A missing collection reports all-zero. */
+export async function getEmbedJobCounts(
+  spaceId: string,
+): Promise<{ pending: number; processing: number; failed: number }> {
+  const rows = await jobs(spaceId)
+    .aggregate([{ $group: { _id: '$status', n: { $sum: 1 } } }])
+    .toArray() as Array<{ _id: string; n: number }>;
+  const out = { pending: 0, processing: 0, failed: 0 };
+  for (const r of rows) {
+    if (r._id === 'pending' || r._id === 'processing' || r._id === 'failed') out[r._id] = r.n;
+  }
+  return out;
+}
+
+// ── Worker wake-up, re-exported so callers do not reach into the signal ──────
+
+export const currentEmbedWorkEpoch = (): number => _signal.currentEpoch();
+export const waitForEmbedWork = (ms: number, since: number): Promise<boolean> => _signal.wait(ms, since);
+export const wakeEmbedWorkers = (): void => _signal.wake();
+/** Test seam: forget the probe hint, forcing the next claim to scan every space. */
+export const resetEmbedPendingHint = (): void => _signal.reset();
+
+/** Exported for the job doc's own sake — see `asDoc` usage in tests that seed jobs directly. */
+export const _asEmbedJobDoc = asDoc<BrainEmbedJobDoc>;

--- a/server/src/brain/embed-record.ts
+++ b/server/src/brain/embed-record.ts
@@ -1,0 +1,104 @@
+/**
+ * Embed one stored brain record, given only its type and id.
+ *
+ * ## Why this is a module rather than a branch inside the worker
+ *
+ * "Rebuild this record's embedding text and store the vector" already existed once, inline in the
+ * `POST /reindex` route — four near-identical blocks, one per type, each re-deriving what the creator
+ * fed the model. The embedding queue needs exactly the same operation, and a second copy would put the
+ * codebase back where `merge-fields.ts` found it: one rule, several implementations, and a promise that
+ * they agree.
+ *
+ * The text MUST match what the creator embedded. If a reindex or a queued job builds it differently, a
+ * record's vector silently stops corresponding to its own content, and the only symptom is worse recall
+ * — no error, nothing to grep for. So the `*EmbedText` builders in `embed-text.ts` are the single
+ * source, and this module's job is only to gather their inputs from the stored document.
+ */
+
+import { col, asFilter } from '../db/mongo.js';
+import { embed } from './embedding.js';
+import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText } from './embed-text.js';
+import { resolveEdgeEntityNames } from './edges.js';
+import type {
+  BrainEmbedRecordType, MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry,
+} from '../config/types.js';
+
+/** Collection suffix per record type — the same mapping recall uses. */
+const COLLECTION: Record<BrainEmbedRecordType, string> = {
+  memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono',
+};
+
+/** Resolve entity ids to names, for the two types whose embedding text names their links. */
+async function entityNames(spaceId: string, ids: unknown): Promise<string[]> {
+  const list = Array.isArray(ids) ? ids.filter((x): x is string => typeof x === 'string') : [];
+  if (list.length === 0) return [];
+  const docs = await col<EntityDoc>(`${spaceId}_entities`)
+    .find(asFilter<EntityDoc>({ _id: { $in: list } }), { projection: { name: 1 } })
+    .toArray() as Array<{ name: string }>;
+  return docs.map(d => d.name);
+}
+
+/**
+ * The exact string this record's vector is built from.
+ *
+ * Exported so a test can assert that a queued job and the creator produce the SAME text for the same
+ * record — the property that makes async embedding invisible to the searcher.
+ */
+export async function buildEmbedText(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  doc: Record<string, unknown>,
+): Promise<string> {
+  switch (recordType) {
+    case 'memory': {
+      const m = doc as unknown as MemoryDoc;
+      return memoryEmbedText(m.fact, m.tags ?? [], await entityNames(spaceId, m.entityIds), m.description, m.properties);
+    }
+    case 'entity': {
+      const e = doc as unknown as EntityDoc;
+      return entityEmbedText(e.name, e.type, e.tags ?? [], e.description, e.properties ?? {});
+    }
+    case 'edge': {
+      const e = doc as unknown as EdgeDoc;
+      const [fromName, toName] = await resolveEdgeEntityNames(spaceId, e.from, e.to);
+      return edgeEmbedText(fromName, e.label, toName, e.tags ?? [], e.type, e.description, e.properties);
+    }
+    case 'chrono': {
+      const c = doc as unknown as ChronoEntry;
+      return chronoEmbedText(c.title, c.type, c.status, c.description, c.tags ?? [], c.properties);
+    }
+  }
+}
+
+/** What became of an embedding attempt. `gone` is a success: the record was deleted, so there is nothing owed. */
+export type EmbedOutcome = 'embedded' | 'gone';
+
+/**
+ * Load the record, build its text, embed it, store the vector.
+ *
+ * Throws if the model is unavailable — the caller decides whether that is a retry (the worker) or a
+ * failed request (`waitForEmbedding: true`). Returns `gone` when the record no longer exists, which is
+ * the ordinary outcome for a record deleted between the enqueue and the claim, and must NOT be a retry:
+ * retrying would keep a job alive for a document that will never come back.
+ */
+export async function embedStoredRecord(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  recordId: string,
+): Promise<EmbedOutcome> {
+  const collName = `${spaceId}_${COLLECTION[recordType]}`;
+  const doc = await col(collName).findOne(asFilter({ _id: recordId })) as Record<string, unknown> | null;
+  if (!doc) return 'gone';
+
+  const text = await buildEmbedText(spaceId, recordType, doc);
+  const result = await embed(text);
+
+  // `seq` is deliberately NOT advanced. An embedding is a DERIVED field — `merkle.ts` excludes it from
+  // replication precisely because each peer computes its own — so bumping `seq` here would broadcast a
+  // no-op change to every peer in every network the space belongs to, on every embedding, forever.
+  await col(collName).updateOne(
+    asFilter({ _id: recordId }),
+    { $set: { embedding: result.vector, embeddingModel: result.model, matchedText: text } },
+  );
+  return 'embedded';
+}

--- a/server/src/brain/embed-worker.ts
+++ b/server/src/brain/embed-worker.ts
@@ -1,0 +1,105 @@
+/**
+ * The worker that drains the brain embedding queue.
+ *
+ * Deliberately much smaller than `files/media/worker.ts`: a media job renders pages, transcribes audio
+ * and reports per-stage progress, so it needs heartbeats and a lease. Embedding one brain record is a
+ * single short call, so the job either finishes or fails — there is nothing to heartbeat *during*.
+ * The stall reset still exists, because a process killed mid-claim leaves a `processing` job that
+ * nothing else would ever pick up.
+ *
+ * Sleeping is event-driven, not polled: `waitForEmbedWork` returns the moment an enqueue announces
+ * work, so a write into an idle instance is embedded in milliseconds rather than waiting out a poll
+ * interval. The epoch sampled before the claim is what closes the race where work arrives between a
+ * failed claim and the start of the sleep.
+ */
+
+import {
+  claimNextEmbedJob, completeEmbedJob, failEmbedJob, resetStalledEmbedJobs,
+  currentEmbedWorkEpoch, waitForEmbedWork, wakeEmbedWorkers,
+} from './embed-queue.js';
+import { embedStoredRecord } from './embed-record.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+
+/** Idle sleep. Work announces itself, so this is only the backstop for a missed announcement. */
+const IDLE_POLL_MS = 30_000;
+/** A claimed job with no sign of life for this long is assumed dead and returned to the pool. */
+const STALL_TIMEOUT_MS = 120_000;
+/** How often to sweep for stalled jobs while running. */
+const STALL_SWEEP_MS = 60_000;
+
+let running = false;
+let stopping = false;
+let stallTimer: NodeJS.Timeout | null = null;
+
+function spaceIds(): string[] {
+  // Proxy spaces hold no records of their own — their members do — so they are never probed.
+  return getConfig().spaces.filter(s => !s.proxyFor).map(s => s.id);
+}
+
+/**
+ * Run one job if there is one. Returns whether anything was claimed, so the loop knows to go straight
+ * round again rather than sleep. Exported for the tests, which drive it directly instead of racing a
+ * background loop — a test that sleeps until a worker happens to have run is a test that flakes.
+ */
+export async function runOneEmbedJob(): Promise<boolean> {
+  const job = await claimNextEmbedJob(spaceIds());
+  if (!job) return false;
+
+  try {
+    // `gone` is a success: the record was deleted between the enqueue and the claim, so nothing is
+    // owed. Retrying would keep a job alive for a document that will never come back.
+    await embedStoredRecord(job.spaceId, job.recordType, job.recordId);
+    await completeEmbedJob(job.spaceId, job.recordType, job.recordId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await failEmbedJob(job.spaceId, job.recordType, job.recordId, job.attempts, msg);
+    // debug, not warn: an embedder that is down produces one of these per queued record, and a
+    // thousand warnings say nothing the first one did not. The failed count is the signal.
+    log.debug(`Embed job ${job._id} in ${job.spaceId} failed (attempt ${job.attempts}): ${msg}`);
+  }
+  return true;
+}
+
+async function loop(): Promise<void> {
+  while (!stopping) {
+    // Sampled BEFORE the claim — this is what makes the wake-up race closed rather than unlikely.
+    const epoch = currentEmbedWorkEpoch();
+    let claimed = false;
+    try {
+      claimed = await runOneEmbedJob();
+    } catch (err) {
+      log.warn(`Brain embedding worker: claim failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (claimed) continue;
+    await waitForEmbedWork(IDLE_POLL_MS, epoch);
+  }
+  running = false;
+}
+
+export function startBrainEmbeddingWorker(): void {
+  if (running) return;
+  running = true;
+  stopping = false;
+
+  // Anything left `processing` by a previous process is dead by definition — nothing survives a
+  // restart holding a claim. Sweeping at startup with a zero timeout returns them immediately rather
+  // than making the first records of the new run wait out the stall window.
+  void resetStalledEmbedJobs(spaceIds(), 0).catch(err =>
+    log.warn(`Brain embedding worker: startup stall sweep failed: ${err}`));
+
+  stallTimer = setInterval(() => {
+    void resetStalledEmbedJobs(spaceIds(), STALL_TIMEOUT_MS).catch(err =>
+      log.warn(`Brain embedding worker: stall sweep failed: ${err}`));
+  }, STALL_SWEEP_MS);
+  if (typeof stallTimer.unref === 'function') stallTimer.unref();
+
+  void loop();
+}
+
+export function stopBrainEmbeddingWorker(): void {
+  stopping = true;
+  if (stallTimer) { clearInterval(stallTimer); stallTimer = null; }
+  // Wake the sleeper so shutdown is not delayed by a full idle interval.
+  wakeEmbedWorkers();
+}

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -19,6 +19,7 @@ import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
+import { enqueueEmbedJob } from './embed-queue.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { MemoryDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
 import { SimilarMatch, DupeCheckOpts, checkDuplicates } from './recall.js';
@@ -83,14 +84,29 @@ export async function remember(
 
   const names = entityNames ?? await resolveEntityNames(spaceId, entityIds);
   const embedText = memoryEmbedText(fact, tags, names, description, properties);
-  const embResult = await embed(embedText);
+
+  // ── Embed now, or hand it to the queue?
+  //
+  // An insert-time duplicate/contradiction check needs the vector BEFORE the insert — that is the whole
+  // reason it is computed here rather than after, so the new record cannot self-match. So those flags
+  // IMPLY waiting. Implied rather than rejected as an invalid combination: a caller asking "is this a
+  // duplicate?" is asking a question that cannot be answered later, so refusing it would be a puzzle
+  // where an answer was available.
+  const needsVectorNow = opts?.waitForEmbedding === true || opts?.checkDuplicates === true || opts?.checkContradictions === true;
+
+  let embResult: { vector: number[]; model: string } | null = null;
+  if (needsVectorNow) {
+    // Unguarded on purpose: the caller asked for a record that is searchable when this returns. A
+    // silent fallback to "stored, not searchable" would answer a different question than the one asked.
+    embResult = await embed(embedText);
+  }
 
   // Opt-in insert-time duplicate / contradiction checks, using the freshly computed vector BEFORE insert
   // so it can never self-match. ONE neighbour search serves both flags — the second question is free once
   // the first has paid for the vector search.
   let similar: SimilarMatch[] | undefined;
   let contradicts: ContradictionWarning[] | undefined;
-  if (opts?.checkDuplicates || opts?.checkContradictions) {
+  if (embResult && (opts?.checkDuplicates || opts?.checkContradictions)) {
     const hits = await checkDuplicates(spaceId, 'memory', embResult.vector, opts.dupeThreshold, opts.dupeTopK);
     if (opts.checkDuplicates && hits.length > 0) similar = hits;
     if (opts.checkContradictions && hits.length > 0) {
@@ -118,9 +134,14 @@ export async function remember(
       matchedText: embedText,
       updatedAt: now,
       seq,
-      embedding: embResult.vector,
-      embeddingModel: embResult.model,
     };
+    // Only when a vector was actually computed. When it was not, the PREVIOUS vector stays: it
+    // describes the record as it was a moment ago, which is a better answer than none while the
+    // queued job catches up. `matchedText` above is always current, so the two can be compared.
+    if (embResult) {
+      $set['embedding'] = embResult.vector;
+      $set['embeddingModel'] = embResult.model;
+    }
     if (type !== undefined) $set['type'] = type;
     if (description !== undefined) $set['description'] = description;
     if (properties !== undefined) $set['properties'] = mergedProps;
@@ -134,6 +155,10 @@ export async function remember(
     );
     const converged = { ...existing, ...($set as Partial<MemoryDoc>) } as MemoryDoc;
     if ('_expireAt' in $unset) delete (converged as { _expireAt?: unknown })._expireAt;
+    // After the write, never before: a job for a record that failed to store would be a job for
+    // nothing. Enqueued even when the vector is already current — the content just changed, so the
+    // stored vector is now stale, and the queue is what makes it catch up.
+    if (!embResult) await enqueueEmbedJob(spaceId, 'memory', converged._id);
     // `memory.updated`, not `created` — a subscriber must be able to tell a converged retry from a new record.
     if (actor) emitWebhookEvent({ event: 'memory.updated', spaceId, entry: { ...converged, embedding: undefined }, ...actor });
     return (similar || contradicts)
@@ -146,7 +171,6 @@ export async function remember(
     _id: id ?? uuidv4(),
     spaceId,
     fact,
-    embedding: embResult.vector,
     tags,
     entityIds,
     matchedText: embedText,
@@ -154,7 +178,7 @@ export async function remember(
     createdAt: now,
     updatedAt: now,
     seq,
-    embeddingModel: embResult.model,
+    ...(embResult ? { embedding: embResult.vector, embeddingModel: embResult.model } : {}),
   };
   if (type !== undefined) doc.type = type;
   if (description !== undefined) doc.description = description;
@@ -162,6 +186,7 @@ export async function remember(
   // See entities.ts: without `typed` the schema tier is unreachable and the space default applies instead.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'memory', type: doc.type });
   await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(doc));
+  if (!embResult) await enqueueEmbedJob(spaceId, 'memory', doc._id);
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
   if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -857,7 +857,7 @@ async function getEntryEmbedding(
   spaceId: string,
   entryId: string,
   entryType: RecallKnowledgeType,
-): Promise<{ vector: number[]; doc: Record<string, unknown> } | null> {
+): Promise<{ vector: number[]; doc: Record<string, unknown> } | 'no-embedding' | null> {
   const collSuffix = KNOWLEDGE_COLLECTION[entryType];
   const collName = `${spaceId}_${collSuffix}`;
   const doc = await col(collName).findOne(
@@ -866,7 +866,10 @@ async function getEntryEmbedding(
   ) as Record<string, unknown> | null;
   if (!doc) return null;
   const vector = doc['embedding'] as number[] | undefined;
-  if (!vector || !Array.isArray(vector) || vector.length === 0) return null;
+  // Told apart from `null` deliberately. Since writes stopped waiting for the embedding model, "exists but
+  // has no vector yet" is a routine state lasting milliseconds — not an anomaly — and reporting it as "not
+  // found" sends an operator hunting for a record that is sitting right there.
+  if (!vector || !Array.isArray(vector) || vector.length === 0) return 'no-embedding';
   return { vector, doc };
 }
 
@@ -897,8 +900,15 @@ export async function findSimilar(
 
   // Fetch the source entry's stored embedding
   const entry = await getEntryEmbedding(spaceId, entryId, entryType);
+  if (entry === 'no-embedding') {
+    throw new NotFoundError(
+      `Entry '${entryId}' exists in space '${spaceId}' (type: ${entryType}) but is not embedded yet, so ` +
+      'there is nothing to compare it against. Embedding is queued and normally completes in milliseconds — ' +
+      'retry, or write with waitForEmbedding: true when you need the record searchable the moment the write returns.',
+    );
+  }
   if (!entry) {
-    throw new NotFoundError(`Entry '${entryId}' not found in space '${spaceId}' (type: ${entryType}), or has no embedding.`);
+    throw new NotFoundError(`Entry '${entryId}' not found in space '${spaceId}' (type: ${entryType}).`);
   }
 
   const activeTypes: RecallKnowledgeType[] = (targetTypes && targetTypes.length > 0)

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -572,6 +572,26 @@ export interface DupeCheckOpts {
   checkContradictions?: boolean;
   dupeThreshold?: number;
   dupeTopK?: number;
+  /**
+   * Block the write until this record is embedded, so it is searchable the moment the call returns.
+   *
+   * Default false: the vector is computed by the embedding queue moments later, and the write no longer
+   * pays the model's latency. Set true when the caller will search for what it just wrote, or when a
+   * failure to embed should fail the write rather than be repaired in the background.
+   *
+   * Two consequences worth stating rather than discovering. With this true, a write **fails** when the
+   * embedder is unavailable — that was `remember`'s unconditional behaviour before the queue, now named
+   * and opt-in. With it false, the write **succeeds** and the record is briefly unrecallable: a vectorless
+   * record is invisible to BOTH recall channels, since the lexical one needs an embedding to compute a
+   * real similarity and skips what it cannot score.
+   *
+   * `checkDuplicates` and `checkContradictions` IMPLY this — they need the vector before the insert so the
+   * new record cannot self-match, and that is a question which cannot be answered later.
+   *
+   * It lives here, in the options object the write paths already take, rather than as another positional
+   * parameter: `remember` carries a note saying its twelfth was one too many.
+   */
+  waitForEmbedding?: boolean;
 }
 
 /** One-line human summary of a recall result, for duplicate feedback. */

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1431,7 +1431,13 @@ export interface MemoryDoc {
   fact: string;
   /** Optional memory type — used to look up typeSchemas.memory for schema validation. */
   type?: string;
-  embedding: number[];
+  /**
+   * Optional since the embedding queue landed — and it is the reason `remember` used to be the one
+   * creator of four whose write FAILED when the embedder was down. `EntityDoc`, `EdgeDoc` and
+   * `ChronoEntry` have always declared this optional and stored the record regardless; only this type
+   * demanded a vector, so only this path had no choice but to throw. The asymmetry was in the type.
+   */
+  embedding?: number[];
   tags: string[];
   entityIds: string[];
   description?: string;
@@ -1442,7 +1448,7 @@ export interface MemoryDoc {
   createdAt: string;
   updatedAt: string;
   seq: number;
-  embeddingModel: string;
+  embeddingModel?: string;
   forkOf?: string;
   /** Absolute expiry (F10). Set when a per-record `ttlDays` or the space's `recordTtlDays` applies;
    *  the TTL sweep deletes the record (through the normal delete path) once it passes. */
@@ -1838,3 +1844,45 @@ export interface MediaJobDoc {
   updatedAt: string;          // ISO8601
 }
 
+
+/**
+ * The brain record types that carry their own embedding and therefore their own embedding job.
+ *
+ * `file` is deliberately absent: file and media embedding already has its own queue
+ * (`files/media/job-queue.ts`) with a richer job shape — per-page progress, chunking, a provider
+ * signature. Folding it in here would replace a working, more capable mechanism with a simpler one.
+ */
+export type BrainEmbedRecordType = 'memory' | 'entity' | 'edge' | 'chrono';
+
+/**
+ * One queued embedding job. `_id` is `<recordType>:<recordId>`, so a record rewritten five times has
+ * ONE job holding its latest content rather than five queued deep.
+ *
+ * A completed job is deleted rather than kept — the record itself carries `embeddingStatus`, so a
+ * retained job would be a second copy of one fact, and brain records outnumber files by orders of
+ * magnitude.
+ */
+export interface BrainEmbedJobDoc {
+  /** `<recordType>:<recordId>` — see `embedJobId`. */
+  _id: string;
+  spaceId: string;
+  recordType: BrainEmbedRecordType;
+  recordId: string;
+  status: 'pending' | 'processing' | 'failed';
+  attempts: number;
+  maxAttempts: number;
+  lastError: string | null;
+  /** ISO8601 — set when a worker claims this job. */
+  claimedAt: string | null;
+  /**
+   * ISO8601 — last sign of life. Stall detection reads THIS, not `claimedAt`: a deadline measured from
+   * the claim cannot tell "wedged" from "slow", and a cold model load is slow.
+   */
+  progressAt?: string | null;
+  /** ISO8601 — retry backoff; the job is `pending` but not claimable until this passes. */
+  claimableAfter?: string | null;
+  /** Identifies THIS run of THIS job, so a recovered job's old holder learns it was replaced. */
+  claimToken?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/server/src/files/media/job-queue.ts
+++ b/server/src/files/media/job-queue.ts
@@ -13,6 +13,7 @@ import type { MediaJobDoc, FileMetaDoc } from '../../config/types.js';
 import { log } from '../../util/log.js';
 import { withJitter } from '../../util/backoff.js';
 import { newClaimToken, stalledJobWarning } from './lease.js';
+import { createWorkSignal } from '../../util/work-signal.js';
 
 const MAX_ATTEMPTS = 3;
 
@@ -307,9 +308,11 @@ export async function enqueueTextJob(
 // backoff (`claimableAfter`) has not yet elapsed is `pending` but not claimable, so the claim
 // returns null and the hint is dropped — and when the backoff DOES elapse, nothing would
 // re-add it. The full scan bounds how long such a job can sit unnoticed.
-const _pendingHint = new Set<string>();
-let _lastFullScan = 0;
-const FULL_SCAN_INTERVAL_MS = 30_000;
+//
+// Both concerns now live in `util/work-signal.ts` — they are properties of "a per-space queue with a
+// sleeping worker", not of media, and the brain embedding queue needs the identical answer. This module
+// keeps its own instance, so a brain enqueue never wakes the media worker.
+const _signal = createWorkSignal();
 
 // ── Worker wake-up ──────────────────────────────────────────────────────────
 //
@@ -323,12 +326,9 @@ const FULL_SCAN_INTERVAL_MS = 30_000;
 // *between* the worker's failed claim and the start of its sleep would otherwise be missed and
 // wait out the full backoff anyway. The worker samples the epoch BEFORE claiming and passes it
 // to waitForWork(), which returns immediately if it has since moved.
-let _workEpoch = 0;
-let _wakeWaiters: Array<() => void> = [];
-
 /** Monotonic counter bumped every time claimable work is announced. */
 export function currentWorkEpoch(): number {
-  return _workEpoch;
+  return _signal.currentEpoch();
 }
 
 /**
@@ -338,43 +338,22 @@ export function currentWorkEpoch(): number {
  * `sinceEpoch` must be sampled BEFORE the caller's claim attempt.
  */
 export function waitForWork(ms: number, sinceEpoch: number): Promise<boolean> {
-  // Work already arrived while the caller was claiming — do not sleep at all.
-  if (_workEpoch !== sinceEpoch) return Promise.resolve(true);
-
-  return new Promise<boolean>(resolve => {
-    let settled = false;
-    const finish = (woken: boolean) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      _wakeWaiters = _wakeWaiters.filter(w => w !== wake);
-      resolve(woken);
-    };
-    const wake = () => finish(true);
-    const timer = setTimeout(() => finish(false), ms);
-    if (typeof timer.unref === 'function') timer.unref();
-    _wakeWaiters.push(wake);
-  });
+  return _signal.wait(ms, sinceEpoch);
 }
 
 /** Wake every waiter — used on announcement, and on shutdown so stopping is not delayed. */
 export function wakeWorkers(): void {
-  const waiters = _wakeWaiters;
-  _wakeWaiters = [];
-  for (const w of waiters) w();
+  _signal.wake();
 }
 
 /** Record that a space may have claimable work (enqueue, requeue-on-failure, stall reset). */
 export function markSpaceMayHaveWork(spaceId: string): void {
-  _pendingHint.add(spaceId);
-  _workEpoch++;
-  wakeWorkers();
+  _signal.markSpaceMayHaveWork(spaceId);
 }
 
 /** Test seam: forget everything the hint knows, forcing the next claim to do a full scan. */
 export function resetPendingHint(): void {
-  _pendingHint.clear();
-  _lastFullScan = 0;
+  _signal.reset();
 }
 
 export async function claimNextJob(
@@ -382,12 +361,10 @@ export async function claimNextJob(
 ): Promise<MediaJobDoc | null> {
   const now = new Date().toISOString();
 
-  const dueFullScan = Date.now() - _lastFullScan >= FULL_SCAN_INTERVAL_MS;
-  if (dueFullScan) _lastFullScan = Date.now();
-
   // On a full scan, probe every space (authoritative). Otherwise probe only the spaces the
-  // hint says are worth probing — which, on an idle queue, is none.
-  const candidates = dueFullScan ? spaceIds : spaceIds.filter(s => _pendingHint.has(s));
+  // hint says are worth probing — which, on an idle queue, is none. Consumes the full-scan slot,
+  // so it is called exactly once per claim.
+  const candidates = _signal.spacesToProbe(spaceIds);
 
   for (const spaceId of candidates) {
     const claimed = await jobCollection(spaceId).findOneAndUpdate(
@@ -414,12 +391,12 @@ export async function claimNextJob(
 
     if (claimed) {
       // There may be MORE work in this space — keep probing it on the next claim.
-      _pendingHint.add(spaceId);
+      _signal.noteClaimed(spaceId);
       return claimed;
     }
     // Nothing claimable here right now. Drop the hint; a future enqueue, a requeue, or the
     // periodic full scan will put it back.
-    _pendingHint.delete(spaceId);
+    _signal.noteEmpty(spaceId);
   }
   return null;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -215,6 +215,10 @@ async function main(): Promise<void> {
     // `processing` with a live token, so the next boot waited out the full stall timeout before re-queuing it.
     const { stopMediaEmbeddingWorker } = await import('./files/media/worker.js');
     stopMediaEmbeddingWorker();
+    // Same reasoning for the brain embedding worker: a job claimed while the process drains dies
+    // `processing`, and the next boot waits out a stall timeout to rediscover it.
+    const { stopBrainEmbeddingWorker } = await import('./brain/embed-worker.js');
+    stopBrainEmbeddingWorker();
     const { stopRetryWorker } = await import('./webhooks/dispatcher.js');
     stopRetryWorker();
 

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -54,6 +54,7 @@ export const rememberTool: ToolHandler = {
             },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             checkDuplicates: { type: 'boolean', default: true, description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar memory already exists, the response flags it (id + summary + score) so you can update it instead of creating a redundant one. The memory is still stored regardless. Set false to skip the check.' },
+            waitForEmbedding: { type: 'boolean', default: false, description: 'Block until this memory is embedded, so it is searchable the moment this returns (default false). Normally the vector is computed moments later by the embedding queue and the write does not pay the model latency. Set true when you will immediately search for what you just wrote, or when a failure to embed should fail the write rather than be repaired in the background. Note: checkDuplicates (default true) already requires the vector up front, so it implies this.' },
             checkContradictions: { type: 'boolean', default: false, description: 'Also flag existing memories that CONTRADICT this one — a near-neighbour that sets the same single-valued property to a different value (e.g. status="active" vs status="retired"). Different question from checkDuplicates: "is this redundant?" vs "does this conflict with what we already believe?". Deterministic only (no model call, no added latency). The memory is still stored regardless — if you are correcting an outdated fact, that is expected; consider updating or superseding the record named in the warning.' },
             dupeThreshold: unitScoreSchema('Cosine-similarity threshold for the duplicate check (0-1, default ~0.92). Lower to flag looser matches.'),
             ttlDays: TTL_DAYS_SCHEMA,
@@ -112,12 +113,19 @@ export const rememberTool: ToolHandler = {
     // are now derived FROM the ids rather than being the input.
     const resolvedNames = (await findEntitiesByIds(ts, entityIds)).map(e => e.name);
     // Insert-time duplicate check defaults ON for the interactive remember tool.
+    // NOTE: `checkDuplicates` defaults to TRUE on this tool, and a duplicate check needs the vector
+    // before the insert — so an MCP remember still embeds inline unless the caller passes
+    // `checkDuplicates: false`. The queue's latency win therefore reaches REST today and MCP only on
+    // request. Whether that default should flip is a product call, not one to make inside this change.
     const remDupeCheck = a['checkDuplicates'] !== false;
     const remContraCheck = a['checkContradictions'] === true;
     const remDupeThreshold = typeof a['dupeThreshold'] === 'number' ? a['dupeThreshold'] : undefined;
     const remTtlDays = ttlDaysFromArgs(a);
     const mem = await remember(ts, fact, entityIds, tags, description, props, resolvedNames, memType,
-      { checkDuplicates: remDupeCheck, checkContradictions: remContraCheck, dupeThreshold: remDupeThreshold }, ctx.actor, remTtlDays,
+      {
+        checkDuplicates: remDupeCheck, checkContradictions: remContraCheck, dupeThreshold: remDupeThreshold,
+        ...(a['waitForEmbedding'] === true ? { waitForEmbedding: true } : {}),
+      }, ctx.actor, remTtlDays,
       typeof a['id'] === 'string' ? a['id'] : undefined);
     const warnings: string[] = [];
     if (mem.similar && mem.similar.length > 0) {

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -17,6 +17,7 @@ import { VECTOR_INDEXED_COLLECTIONS, buildSpaceVectorIndexes, finalizeSpaceIndex
 import { SPACE_COLLECTIONS, repairStaleSpaceIds, dropLegacyPrefixedIndexes, pendingOpConflictMessage , setReindexNeeded, beginSpaceOp, endSpaceOp, spaceOpInFlight } from './_shared.js';
 import { moveSpaceData, applySpaceRenameToConfig } from './rename.js';
 import { ensureMediaJobIndexes } from '../files/media/job-queue.js';
+import { ensureEmbedJobIndexes } from '../brain/embed-queue.js';
 import { envInt } from '../config/env-num.js';
 
 export async function initSpace(
@@ -122,6 +123,7 @@ export async function initSpace(
   // The key patterns are declared next to the queries they serve, in job-queue.ts, and created by its own
   // function — so this cannot drift from them and the database-level test exercises the same call.
   await ensureMediaJobIndexes(spaceId);
+  await ensureEmbedJobIndexes(spaceId);
 
   // Lexical retrieval index — the BM25-family half of hybrid search (`brain/lexical-search.ts`).
   //

--- a/server/src/util/work-signal.ts
+++ b/server/src/util/work-signal.ts
@@ -1,0 +1,127 @@
+/**
+ * The wake-up and space-probing machinery a per-space job queue needs, with no job type in it.
+ *
+ * ## Why this is a module and not two copies
+ *
+ * `files/media/job-queue.ts` grew a careful answer to two problems that have nothing to do with media:
+ *
+ *  - **latency on an idle queue.** A worker that backs its poll off to 30 s is right for CPU and wrong
+ *    for latency — work enqueued into an idle system waits up to the full interval before anything
+ *    starts. The fix is an announcement that wakes the sleeper, plus an epoch counter to close the race
+ *    where work arrives *between* a failed claim and the start of the sleep.
+ *  - **the empty-queue walk.** Per-space collections mean claiming walks the spaces one
+ *    `findOneAndUpdate` at a time. On an idle 100-space instance that is ~300 useless round trips per
+ *    tick. A hint records which spaces might hold claimable work; a periodic full scan re-seeds it, which
+ *    is what stops a job whose retry backoff has not yet elapsed from sitting unnoticed forever.
+ *
+ * Both are properties of "a queue with per-space collections and a sleeping worker". The brain embedding
+ * queue is exactly that, and re-deriving forty lines of race-closing logic for it is how a codebase ends
+ * up with two subtly different answers to one question — the same finding as `merge-fields.ts`.
+ *
+ * ## Why a factory rather than module-level state
+ *
+ * The media queue held `_workEpoch` and `_wakeWaiters` as module globals, which is correct while there
+ * is one queue. With two, shared globals would mean a brain enqueue wakes the media worker: harmless
+ * (it claims nothing and sleeps again) but it turns an idle instance into one that wakes on every write
+ * and makes "why did this worker wake" unanswerable. Each queue gets its own signal.
+ */
+
+/** How long a queue may go without re-probing every space, however quiet the hint says it is. */
+export const DEFAULT_FULL_SCAN_INTERVAL_MS = 30_000;
+
+/** A monotonic clock, injectable so the tests do not sleep. Defaults to `Date.now`. */
+export type NowFn = () => number;
+
+export interface WorkSignal {
+  /** Monotonic counter, bumped every time claimable work is announced. */
+  currentEpoch(): number;
+  /**
+   * Sleep up to `ms`, returning early if work is announced. Resolves true if woken, false on timeout.
+   *
+   * `sinceEpoch` must be sampled BEFORE the caller's claim attempt — that is what makes the race
+   * closed rather than merely unlikely.
+   */
+  wait(ms: number, sinceEpoch: number): Promise<boolean>;
+  /** Wake every waiter. Used on announcement, and on shutdown so stopping is not delayed. */
+  wake(): void;
+  /** Record that a space may have claimable work (enqueue, requeue-on-failure, stall reset). */
+  markSpaceMayHaveWork(spaceId: string): void;
+  /**
+   * The spaces worth probing on this claim: every space when a full scan is due, otherwise only the
+   * hinted ones. Calling this CONSUMES the full-scan slot, so call it once per claim.
+   */
+  spacesToProbe(spaceIds: string[]): string[];
+  /** A space that just yielded a job — keep probing it next time. */
+  noteClaimed(spaceId: string): void;
+  /** A space with nothing claimable right now. A future announcement or full scan puts it back. */
+  noteEmpty(spaceId: string): void;
+  /** Test seam: forget everything the hint knows, forcing the next claim to do a full scan. */
+  reset(): void;
+}
+
+export function createWorkSignal(opts: {
+  fullScanIntervalMs?: number;
+  now?: NowFn;
+} = {}): WorkSignal {
+  const fullScanIntervalMs = opts.fullScanIntervalMs ?? DEFAULT_FULL_SCAN_INTERVAL_MS;
+  const now = opts.now ?? Date.now;
+
+  const pendingHint = new Set<string>();
+  let lastFullScan = 0;
+  let epoch = 0;
+  let waiters: Array<() => void> = [];
+
+  return {
+    currentEpoch: () => epoch,
+
+    wait(ms, sinceEpoch) {
+      // Work already arrived while the caller was claiming — do not sleep at all.
+      if (epoch !== sinceEpoch) return Promise.resolve(true);
+
+      return new Promise<boolean>(resolve => {
+        let settled = false;
+        const finish = (woken: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          waiters = waiters.filter(w => w !== wake);
+          resolve(woken);
+        };
+        const wake = () => finish(true);
+        const timer = setTimeout(() => finish(false), ms);
+        // Unref'd: a sleeping worker must never be the reason the process will not exit.
+        if (typeof timer.unref === 'function') timer.unref();
+        waiters.push(wake);
+      });
+    },
+
+    wake() {
+      const current = waiters;
+      waiters = [];
+      for (const w of current) w();
+    },
+
+    markSpaceMayHaveWork(spaceId) {
+      pendingHint.add(spaceId);
+      epoch++;
+      this.wake();
+    },
+
+    spacesToProbe(spaceIds) {
+      const due = now() - lastFullScan >= fullScanIntervalMs;
+      if (due) {
+        lastFullScan = now();
+        return spaceIds;
+      }
+      return spaceIds.filter(s => pendingHint.has(s));
+    },
+
+    noteClaimed(spaceId) { pendingHint.add(spaceId); },
+    noteEmpty(spaceId) { pendingHint.delete(spaceId); },
+
+    reset() {
+      pendingHint.clear();
+      lastFullScan = 0;
+    },
+  };
+}

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -2389,10 +2389,16 @@ describe('Brain — find-similar', () => {
     // Write two similar memories
     const w1 = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `FindSimilar test: authentication and authorization ${RUN}`,
+      // find-similar compares VECTORS, so the source must be embedded before it is searched.
+      // Without this the test races the embedding worker — it lost that race on CI once already.
+      waitForEmbedding: true,
       tags: ['find-similar-test'],
     });
     const w2 = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `FindSimilar test: auth and authz security ${RUN}`,
+      // find-similar compares VECTORS, so the source must be embedded before it is searched.
+      // Without this the test races the embedding worker — it lost that race on CI once already.
+      waitForEmbedding: true,
       tags: ['find-similar-test'],
     });
     assert.equal(w1.status, 201, JSON.stringify(w1.body));
@@ -2419,6 +2425,9 @@ describe('Brain — find-similar', () => {
   it('POST /find-similar respects targetTypes filter', async () => {
     const w = await post(INSTANCES.a, token(), '/api/brain/spaces/general/memories', {
       fact: `FindSimilar targetTypes test ${RUN}`,
+      // find-similar compares VECTORS, so the source must be embedded before it is searched.
+      // Without this the test races the embedding worker — it lost that race on CI once already.
+      waitForEmbedding: true,
     });
     const sourceId = w.body._id ?? w.body.id;
 

--- a/testing/standalone/embed-queue-db.test.js
+++ b/testing/standalone/embed-queue-db.test.js
@@ -1,0 +1,207 @@
+/**
+ * A write no longer waits for the embedding model, and a record that missed its vector gets one later.
+ *
+ * ## The defect
+ *
+ * Every brain creator embedded inline. Three of the four swallowed a failure and stored the record
+ * without a vector; `remember` did not — `MemoryDoc.embedding` was the only one of the four declared
+ * REQUIRED, so that path had no choice but to throw. Two behaviours, neither chosen by the caller.
+ *
+ * And a record with no vector is not slightly worse, it is **invisible to recall**. Both channels drop
+ * it: the vector search never returns it, and `introduceLexicalOnly` needs an embedding to compute a
+ * real similarity and skips what it cannot score. Nothing repaired it either — the only route back was
+ * a manual whole-space `POST /reindex` that re-embeds everything.
+ *
+ * ## What this pins
+ *
+ * The loop, end to end, against a real MongoDB and with the model deliberately unreachable — which is
+ * the condition the whole feature exists for, and the one a machine with a warm cache cannot reproduce
+ * by accident:
+ *
+ *  1. a write with no embedder available SUCCEEDS and enqueues (it used to throw);
+ *  2. the queued job carries the record, and draining it stores the vector;
+ *  3. a failure retries with backoff rather than being final, and stops at the attempt budget;
+ *  4. `waitForEmbedding: true` still fails loudly — the old behaviour, kept reachable on request;
+ *  5. rewriting a record resets a job that had already failed, so a rewrite is the escape hatch;
+ *  6. a record deleted before its job runs retires the job instead of retrying forever.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/embed-queue-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-embed-queue-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+// The model is made UNREACHABLE, not merely absent: offline plus an empty cache directory. This is the
+// condition the queue exists for, and asserting it here is what stops the suite from quietly measuring
+// a machine that happens to hold 274 MB of weights.
+const EMPTY_CACHE = path.join(tmpDir, 'empty-model-cache');
+fs.mkdirSync(EMPTY_CACHE, { recursive: true });
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
+process.env['MODEL_CACHE_DIR'] = EMPTY_CACHE;
+
+let mongo, memory, queue, worker;
+
+const jobs = () => mongo.col(`${SPACE}_embed_jobs`);
+const memories = () => mongo.col(`${SPACE}_memories`);
+
+describe('brain embedding queue (real MongoDB, no reachable model)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('embedqueue');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    memory = await import('../../server/dist/brain/memory.js');
+    queue = await import('../../server/dist/brain/embed-queue.js');
+    worker = await import('../../server/dist/brain/embed-worker.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    await jobs().deleteMany({});
+    await memories().deleteMany({});
+    queue.resetEmbedPendingHint();
+  });
+
+  it('the model really is unreachable (the precondition, not an assumption)', async () => {
+    const { embed } = await import('../../server/dist/brain/embedding.js');
+    await assert.rejects(() => embed('anything'),
+      'this suite proves behaviour WITHOUT an embedder; if one is reachable it proves nothing');
+  });
+
+  it('a write succeeds with no embedder and leaves a job behind', async () => {
+    // This is the regression: `remember` used to throw here, because MemoryDoc.embedding was required.
+    const doc = await memory.remember(SPACE, 'node-7 runs the platform apps', [], ['prod']);
+    assert.ok(doc._id, 'the write returned a record');
+
+    const stored = await memories().findOne({ _id: doc._id });
+    assert.equal(stored.embedding, undefined, 'no vector yet — that is the point');
+    assert.equal(stored.matchedText, 'node-7 runs the platform apps'.length ? stored.matchedText : null);
+    assert.ok(stored.matchedText, 'the exact text the vector will be built from is stored at write time');
+
+    const job = await jobs().findOne({ _id: `memory:${doc._id}` });
+    assert.ok(job, 'a job was enqueued');
+    assert.equal(job.status, 'pending');
+    assert.equal(job.recordType, 'memory');
+    assert.equal(job.recordId, doc._id);
+    assert.equal(job.attempts, 0);
+  });
+
+  it('waitForEmbedding: true still fails loudly', async () => {
+    // The old behaviour, kept reachable on request rather than removed. A caller who needs the record
+    // searchable when the call returns must hear that it is not.
+    await assert.rejects(
+      () => memory.remember(SPACE, 'must be searchable now', [], [], undefined, undefined, undefined,
+        undefined, { waitForEmbedding: true }),
+      'an explicit wait must surface the embedder failure, not swallow it',
+    );
+  });
+
+  it('an insert-time duplicate check implies the wait', async () => {
+    // It needs the vector BEFORE the insert so the new record cannot self-match — a question that
+    // cannot be answered later. So it must fail here rather than silently skip the check.
+    await assert.rejects(
+      () => memory.remember(SPACE, 'is this a duplicate', [], [], undefined, undefined, undefined,
+        undefined, { checkDuplicates: true }),
+      'checkDuplicates cannot be honoured without a vector, so it must not report "no duplicates"',
+    );
+  });
+
+  it('draining retries with backoff, then gives up at the budget', async () => {
+    const doc = await memory.remember(SPACE, 'retry me', [], []);
+    const id = `memory:${doc._id}`;
+
+    // Attempt 1: the embedder is down, so the job goes back to pending with a backoff.
+    assert.equal(await worker.runOneEmbedJob(), true, 'a job was claimed');
+    let job = await jobs().findOne({ _id: id });
+    assert.equal(job.status, 'pending', 'a failure requeues rather than being final');
+    assert.equal(job.attempts, 1);
+    assert.ok(job.claimableAfter, 'and is not immediately claimable again');
+    assert.ok(job.lastError, 'the reason is recorded');
+
+    // The backoff is real: nothing is claimable until it elapses.
+    queue.resetEmbedPendingHint();
+    assert.equal(await worker.runOneEmbedJob(), false, 'the backoff holds the job back');
+
+    // Walk it to the attempt budget, clearing the backoff each time as the passage of time would.
+    for (let i = 2; i <= queue.MAX_EMBED_ATTEMPTS; i++) {
+      await jobs().updateOne({ _id: id }, { $set: { claimableAfter: null } });
+      queue.resetEmbedPendingHint();
+      assert.equal(await worker.runOneEmbedJob(), true, `attempt ${i} was claimable`);
+    }
+    job = await jobs().findOne({ _id: id });
+    assert.equal(job.status, 'failed', 'the budget is finite');
+    assert.equal(job.attempts, queue.MAX_EMBED_ATTEMPTS);
+
+    queue.resetEmbedPendingHint();
+    assert.equal(await worker.runOneEmbedJob(), false, 'a failed job is not claimed again');
+  });
+
+  it('rewriting the record revives a failed job', async () => {
+    // The operator's escape hatch: new content deserves a fresh attempt budget, so a job that gave up
+    // on the OLD content must not pass that verdict on.
+    const doc = await memory.remember(SPACE, 'first version', [], []);
+    const id = `memory:${doc._id}`;
+    await jobs().updateOne({ _id: id }, { $set: { status: 'failed', attempts: 99, lastError: 'old' } });
+
+    await memory.remember(SPACE, 'second version', [], [], undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, doc._id);
+
+    const job = await jobs().findOne({ _id: id });
+    assert.equal(job.status, 'pending', 'a rewrite requeues');
+    assert.equal(job.attempts, 0, 'with a fresh budget');
+    assert.equal(job.lastError, null);
+  });
+
+  it('one job per record, however many times it is written', async () => {
+    const doc = await memory.remember(SPACE, 'v1', [], []);
+    for (const fact of ['v2', 'v3', 'v4']) {
+      await memory.remember(SPACE, fact, [], [], undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, doc._id);
+    }
+    assert.equal(await jobs().countDocuments({}), 1,
+      'work coalesces on the record — four writes must not queue four embeddings of stale content');
+  });
+
+  it('a record deleted before its job runs retires the job', async () => {
+    const doc = await memory.remember(SPACE, 'short lived', [], []);
+    await memories().deleteOne({ _id: doc._id });
+
+    queue.resetEmbedPendingHint();
+    assert.equal(await worker.runOneEmbedJob(), true, 'the job was claimed');
+    assert.equal(await jobs().countDocuments({}), 0,
+      'a job for a record that no longer exists is done, not retried — retrying would keep it alive forever');
+  });
+
+  it('a stalled job returns to the pool', async () => {
+    const doc = await memory.remember(SPACE, 'stalled', [], []);
+    const id = `memory:${doc._id}`;
+    // A process killed mid-claim leaves exactly this: processing, with an old sign of life.
+    await jobs().updateOne({ _id: id }, {
+      $set: { status: 'processing', progressAt: new Date(Date.now() - 600_000).toISOString() },
+    });
+
+    assert.equal(await queue.resetStalledEmbedJobs([SPACE], 120_000), 1);
+    const job = await jobs().findOne({ _id: id });
+    assert.equal(job.status, 'pending');
+    assert.equal(job.claimableAfter, null, 'and is claimable at once — it already waited long enough');
+  });
+});

--- a/testing/standalone/embed-queue-drain-db.test.js
+++ b/testing/standalone/embed-queue-drain-db.test.js
@@ -1,0 +1,181 @@
+/**
+ * The queue actually stores a vector — the happy path, end to end, with nothing faked.
+ *
+ * ## Why a stub HTTP endpoint rather than a stubbed `embed()`
+ *
+ * The subject here is the QUEUE, not the model. But a test that monkey-patches `embed()` proves the
+ * worker calls a function, not that a record becomes searchable: it would pass with a broken provider
+ * path, a broken config resolution, or a vector written to the wrong field.
+ *
+ * Ythril already supports an OpenAI-compatible HTTP embedder (`EMBEDDING_URL`), so this stands one up on
+ * localhost and lets the REAL `embed()` — real config resolution, real provider selection, real response
+ * parsing and dimension check — talk to it. Nothing in the path under test is replaced, and it needs no
+ * 274 MB model download, which is what made the sibling suite fail in CI while passing locally.
+ *
+ * `provider` is left at its default `local`, so the plain `fetch` is used rather than the SSRF-guarded
+ * one — correct for a loopback address, and the same choice the product makes for an on-cluster embedder.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/embed-queue-drain-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const DIMS = 8;
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-embed-drain-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+process.env['EMBEDDING_DIMENSIONS'] = String(DIMS);
+
+/** Requests the stub served, so a test can assert WHAT was embedded, not merely that something was. */
+let seen = [];
+/** Flip to make the endpoint fail, without tearing the server down. */
+let failNext = false;
+
+let server, mongo, memory, entities, queue, worker;
+
+const jobs = () => mongo.col(`${SPACE}_embed_jobs`);
+const memories = () => mongo.col(`${SPACE}_memories`);
+
+/** A deterministic pseudo-vector, so an assertion can name the expected numbers. */
+const vectorFor = (text) => Array.from({ length: DIMS }, (_, i) => ((text.length + i) % 10) / 10);
+
+describe('brain embedding queue drains (real MongoDB, real embed() over a stub endpoint)', { skip }, () => {
+  before(async () => {
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', c => { body += c; });
+      req.on('end', () => {
+        if (failNext) {
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: { message: 'stub is down' } }));
+          return;
+        }
+        const input = JSON.parse(body).input;
+        seen.push(input);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ embedding: vectorFor(input) }] }));
+      });
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    process.env['EMBEDDING_URL'] = `http://127.0.0.1:${server.address().port}`;
+
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('embeddrain');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    memory = await import('../../server/dist/brain/memory.js');
+    entities = await import('../../server/dist/brain/entities.js');
+    queue = await import('../../server/dist/brain/embed-queue.js');
+    worker = await import('../../server/dist/brain/embed-worker.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    await new Promise(resolve => server.close(resolve));
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    await jobs().deleteMany({});
+    await memories().deleteMany({});
+    await mongo.col(`${SPACE}_entities`).deleteMany({});
+    seen = [];
+    failNext = false;
+    queue.resetEmbedPendingHint();
+  });
+
+  it('a queued memory gets its vector, and the job is gone', async () => {
+    const doc = await memory.remember(SPACE, 'node-7 runs the platform apps', [], ['prod']);
+    assert.equal((await memories().findOne({ _id: doc._id })).embedding, undefined,
+      'precondition: the write did not embed');
+
+    assert.equal(await worker.runOneEmbedJob(), true);
+
+    const stored = await memories().findOne({ _id: doc._id });
+    assert.ok(Array.isArray(stored.embedding), 'the record now has a vector');
+    assert.equal(stored.embedding.length, DIMS);
+    assert.ok(stored.embeddingModel, 'and the model that produced it');
+    assert.equal(await jobs().countDocuments({}), 0, 'a finished job is deleted, not left as a tombstone');
+  });
+
+  it('the queued job embeds the SAME text the inline path would have', async () => {
+    // The property that makes async embedding invisible to the searcher. If the worker built the text
+    // differently, a record's vector would silently stop corresponding to its own content — no error,
+    // nothing to grep for, only worse recall.
+    const doc = await memory.remember(SPACE, 'shared text check', ['e-missing'], ['a', 'b'], 'a description');
+    const storedBefore = await memories().findOne({ _id: doc._id });
+
+    await worker.runOneEmbedJob();
+
+    assert.equal(seen.length, 1, 'exactly one embedding call');
+    assert.equal(seen[0], storedBefore.matchedText,
+      'the worker embedded exactly the matchedText the write recorded');
+    const after = await memories().findOne({ _id: doc._id });
+    assert.deepEqual(after.embedding, vectorFor(storedBefore.matchedText));
+  });
+
+  it('the vector is stored WITHOUT advancing seq', async () => {
+    // An embedding is a derived field, excluded from replication because each peer computes its own.
+    // Bumping seq would broadcast a no-op change to every peer in every network, on every embedding.
+    const doc = await memory.remember(SPACE, 'seq must not move', [], []);
+    const before = await memories().findOne({ _id: doc._id });
+
+    await worker.runOneEmbedJob();
+
+    const after = await memories().findOne({ _id: doc._id });
+    assert.equal(after.seq, before.seq, 'embedding is not a content change');
+    assert.equal(after.updatedAt, before.updatedAt, 'and does not look like one to a peer either');
+  });
+
+  it('a transient endpoint failure is retried and then succeeds', async () => {
+    const doc = await memory.remember(SPACE, 'flaky endpoint', [], []);
+    const id = `memory:${doc._id}`;
+
+    failNext = true;
+    assert.equal(await worker.runOneEmbedJob(), true);
+    assert.equal((await jobs().findOne({ _id: id })).status, 'pending', 'requeued, not failed');
+
+    failNext = false;
+    await jobs().updateOne({ _id: id }, { $set: { claimableAfter: null } });
+    queue.resetEmbedPendingHint();
+    assert.equal(await worker.runOneEmbedJob(), true);
+
+    assert.ok(Array.isArray((await memories().findOne({ _id: doc._id })).embedding),
+      'the record recovered on its own — no operator, no whole-space reindex');
+    assert.equal(await jobs().countDocuments({}), 0);
+  });
+
+  it('waitForEmbedding: true embeds inline and queues nothing', async () => {
+    const doc = await memory.remember(SPACE, 'searchable right now', [], [], undefined, undefined,
+      undefined, undefined, { waitForEmbedding: true });
+
+    assert.ok(Array.isArray((await memories().findOne({ _id: doc._id })).embedding),
+      'the record is searchable the moment the call returns');
+    assert.equal(await jobs().countDocuments({}), 0,
+      'nothing to queue — there is no work left to do');
+    assert.equal(seen.length, 1);
+  });
+
+  it('an entity written inline still embeds, and queues nothing', async () => {
+    // upsertEntity has always embedded inline and tolerated failure. This pins that the queue's arrival
+    // did not change it — the other three creators are wired in a follow-up, and until then their
+    // behaviour must be exactly what it was.
+    const { entity } = await entities.upsertEntity(SPACE, 'node-7', 'machine', ['prod'], { rack: 'B12' });
+    const stored = await mongo.col(`${SPACE}_entities`).findOne({ _id: entity._id });
+    assert.ok(Array.isArray(stored.embedding), 'entities still embed on the write path');
+    assert.equal(await jobs().countDocuments({}), 0);
+  });
+});


### PR DESCRIPTION
Owner asked why embedding could not be async on the creators with a lazy retry, and for an opt-in param
for callers who still want to wait. Both are here, plus the answer to why `remember` was the odd one out.

## Why `remember` alone hard-failed

`MemoryDoc.embedding` was the **only one of the four record types declared required**. That is the whole
asymmetry: `upsertEntity`, `upsertEdge` and `createChrono` wrap `embed()` in a `try/catch` and store the
record without a vector, while `remember` could not — the type forbade it, so it threw. It was in the type,
not the logic.

## Why this is more than write latency

A record with no vector is **invisible to recall**, not ranked lower. Both channels drop it:

- the vector search never returns it;
- `introduceLexicalOnly` computes a *real* similarity for the records it introduces rather than inventing a
  score, so it skips what it cannot score — `if (!doc || !Array.isArray(vec)) continue;`

So "stored but never embedded" was silent data loss from the searcher's side, and the only route back was a
manual whole-space `POST /reindex` that re-embeds everything.

## What's here

| module | what it is |
|---|---|
| `util/work-signal.ts` | the wake/epoch/probe-hint machinery **extracted** from the media queue, which now uses it |
| `brain/embed-queue.ts` | per-space `<space>_embed_jobs`: atomic claim, jittered backoff, stall reset, attempt budget |
| `brain/embed-record.ts` | "rebuild this record's text and store its vector", **once** |
| `brain/embed-worker.ts` | event-driven drain, startup + periodic stall sweeps, stopped on shutdown |

**Extracted, not copied.** The media queue's 50 existing tests pass unchanged — that is the proof it is the
same machinery and not a lookalike. It is a factory rather than module globals so a brain enqueue does not
wake the media worker and make "why did this worker wake" unanswerable.

**`embed-record.ts` exists because `POST /reindex` already had four inline copies** of "rebuild the text and
store the vector". A fifth would be A-L2-1 again — and if the queue built the text differently from the
creator, a record's vector would silently stop corresponding to its own content. No error, nothing to grep
for, only worse recall.

**One job per record** (`_id` = `<type>:<recordId>`), so five writes leave one job holding the latest content
rather than five embeddings of stale text. Rewriting a record resets a job that had exhausted its attempts —
the escape hatch from a permanent failure.

**A finished job is deleted**, not kept as `complete` like the media queue does. The record's own `embedding`
field already answers "is it embedded"; a retained job would be a second copy of one fact, across millions of
records rather than thousands of files.

**Stall detection reads `progressAt`, not `claimedAt`** — the media queue learned that a deadline measured
from the claim cannot tell "wedged" from "slow", and a cold model load is slow.

**Embedding does not advance `seq`.** It is a derived field excluded from replication, so bumping `seq` would
broadcast a no-op change to every peer in every network, on every embedding, forever.

## `waitForEmbedding` (the opt-in)

Lives on the options object the write paths already take — **not** a thirteenth positional parameter, because
`remember` carries a note saying its twelfth was one too many. Surfaced on the REST body and the MCP
`remember` schema, default false.

| | default | `waitForEmbedding: true` |
|---|---|---|
| write latency | excludes the model | includes it |
| searchable on return | not yet | yes |
| embedder down | write succeeds, queue retries | write **fails** |

`checkDuplicates`/`checkContradictions` **imply** it: they need the vector before the insert so the record
cannot self-match, and that question cannot be answered later. Implied rather than rejected as an invalid
combination — refusing it would be a puzzle where an answer was available.

## Tests — twice, and deliberately without a model

`embed-queue-db.test.js` runs with the model made **unreachable** (offline + an empty cache dir), and asserts
that as a *precondition* rather than assuming it. Covers: a write succeeds and enqueues (it used to throw);
retries back off and stop at the budget; a rewrite revives a failed job; a deleted record retires its job
instead of retrying forever; `waitForEmbedding: true` still fails loudly; a stalled job returns to the pool.

`embed-queue-drain-db.test.js` proves the happy path over a **stub OpenAI-compatible endpoint on localhost**,
so the real `embed()` runs — real config resolution, real provider selection, real response parsing — with no
274 MB download. Monkey-patching `embed()` would have proven the worker calls a function, not that a record
becomes searchable.

That shape is a direct response to this branch's earlier CI failure, where a suite passed locally only
because a model cache happened to be warm.

## Known, and documented rather than worked around

The MCP `remember` tool defaults `checkDuplicates: true`, and a duplicate check needs the vector up front —
so **MCP writes still embed inline** unless the caller passes `checkDuplicates: false`. REST goes async today.
Whether that default should flip is a product call and is not made here; the tradeoff is written into the code
and into `_NEXT-PR-PLAN.md`.

## Follow-ups (filed as F-EMB-2 / F-EMB-3, with verify lines)

The other three creators still embed inline, and **sync ingest does not enqueue** — that one is a real bug:
`embedding` is excluded from replication (`merkle.ts` `DERIVED_FIELDS`) and sync ingest is a plain
`replaceOne`, so a record arriving from a peer is invisible to that instance's recall until someone runs a
manual reindex. `grep 'embed('` over `api/sync/docs.ts` and `sync/engine.ts` returns nothing.

## Verification

- `npm run preflight` — PASSED
- 54 pass / 0 fail across the new suites plus every media-queue suite the extraction touches
