### PR TITLE
fix(sync): a record from a peer was stored, replicated, and never searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A record replicated from a peer is now embedded on arrival.** It never was, and the consequence was
+  invisible: `embedding` is a DERIVED field excluded from replication (`merkle.ts` `DERIVED_FIELDS`,
+  because two peers may run different models), and sync ingest is a plain `replaceOne` of the incoming
+  document. So a record arriving from a peer had **no vector on the receiving instance and nothing ever
+  gave it one**.
+  - A vectorless record is not ranked lower, it is **absent**: the vector search never returns it, and the
+    lexical channel needs an embedding to compute a real similarity and skips what it cannot score. An
+    instance could hold a peer's entire knowledge base and answer nothing from it, until an operator
+    happened to run a manual whole-space `POST /reindex`.
+  - All twelve ingest write sites now enqueue. A record that arrives *with* a vector is left alone rather
+    than recomputed — an older peer, or a future change of mind about derived fields, should not be undone.
+  - Gated by a coverage check scoped from the **shape** of a write rather than a list of route names, and
+    mutation-verified: deleting one enqueue turns it red.
+
 - **Memory writes no longer wait for the embedding model, and a record that misses its vector now gets one
   later.** A new per-space embedding queue (`<space>_embed_jobs`) takes the work: the write returns as soon as
   the record is durable, a worker embeds it moments later, and a failure retries with jittered backoff instead

--- a/server/src/api/sync/docs.ts
+++ b/server/src/api/sync/docs.ts
@@ -6,6 +6,7 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { col, asFilter, asDoc, asUpdate } from '../../db/mongo.js';
+import { enqueueIngestedRecord } from '../../brain/embed-queue.js';
 import { syncRateLimit } from '../../rate-limit/middleware.js';
 import { getConfig } from '../../config/loader.js';
 import { listTombstones } from '../../brain/tombstones.js';
@@ -120,6 +121,9 @@ syncDocsRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async
     if (!existing) {
       // No local copy â€” insert directly
       await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(incoming));
+      // A peer strips `embedding` before sending — it is derived, and the peer may run a
+      // different model — so this record landed unsearchable. Queue it a vector.
+      await enqueueIngestedRecord(spaceId, 'memory', incoming);
       const peerInst = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string ?? 'unknown';
       checkEntityIdLinkViolations(spaceId, incoming._id, 'memory', incoming.entityIds, peerInst).catch(() => {});
       res.status(200).json({ status: 'inserted' });
@@ -129,6 +133,9 @@ syncDocsRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async
     if (incoming.seq > existing.seq) {
       // Remote is newer â€” overwrite
       await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(asFilter<MemoryDoc>({ _id: incoming._id }), asDoc<MemoryDoc>(incoming));
+      // A peer strips `embedding` before sending — it is derived, and the peer may run a
+      // different model — so this record landed unsearchable. Queue it a vector.
+      await enqueueIngestedRecord(spaceId, 'memory', incoming);
       const peerInst = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string ?? 'unknown';
       checkEntityIdLinkViolations(spaceId, incoming._id, 'memory', incoming.entityIds, peerInst).catch(() => {});
       res.status(200).json({ status: 'updated' });
@@ -159,6 +166,9 @@ syncDocsRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async
         updatedAt: new Date().toISOString(),
       };
       await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(fork));
+      // A peer strips `embedding` before sending — it is derived, and the peer may run a
+      // different model — so this record landed unsearchable. Queue it a vector.
+      await enqueueIngestedRecord(spaceId, 'memory', fork);
       res.status(200).json({ status: 'forked', forkId: fork._id });
       return;
     }
@@ -264,6 +274,9 @@ syncDocsRouter.post('/entities', syncRateLimit, requireAuth, denyReadOnly, async
     const existing = await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: incoming._id })) as EntityDoc;
     if (existing && incoming.seq > existing.seq) {
       await col<EntityDoc>(`${spaceId}_entities`).replaceOne(asFilter<EntityDoc>({ _id: incoming._id }), asDoc<EntityDoc>(incoming));
+      // A peer strips `embedding` before sending — it is derived, and the peer may run a
+      // different model — so this record landed unsearchable. Queue it a vector.
+      await enqueueIngestedRecord(spaceId, 'entity', incoming);
     }
 
     res.status(200).json({ status: 'ok' });
@@ -364,6 +377,9 @@ syncDocsRouter.post('/edges', syncRateLimit, requireAuth, denyReadOnly, async (r
         asDoc<EdgeDoc>(incoming),
         { upsert: true },
       );
+      // A peer strips `embedding` before sending — it is derived, and the peer may run a
+      // different model — so this record landed unsearchable. Queue it a vector.
+      await enqueueIngestedRecord(spaceId, 'edge', incoming);
     }
 
     // Fire-and-forget: check strict linkage violations after ingest
@@ -473,6 +489,9 @@ syncDocsRouter.post('/chrono', syncRateLimit, requireAuth, denyReadOnly, async (
         asDoc<ChronoEntry>(incoming),
         { upsert: true },
       );
+      // A peer strips `embedding` before sending — it is derived, and the peer may run a
+      // different model — so this record landed unsearchable. Queue it a vector.
+      await enqueueIngestedRecord(spaceId, 'chrono', incoming);
     }
 
     // Fire-and-forget: check strict linkage violations after ingest
@@ -546,9 +565,15 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
         .findOne(asFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
       if (!existing) {
         await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(incoming));
+        // A peer strips `embedding` before sending — it is derived, and the peer may run a
+        // different model — so this record landed unsearchable. Queue it a vector.
+        await enqueueIngestedRecord(spaceId, 'memory', incoming);
         memStats.inserted++;
       } else if (incoming.seq > existing.seq) {
         await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(asFilter<MemoryDoc>({ _id: incoming._id }), asDoc<MemoryDoc>(incoming));
+        // A peer strips `embedding` before sending — it is derived, and the peer may run a
+        // different model — so this record landed unsearchable. Queue it a vector.
+        await enqueueIngestedRecord(spaceId, 'memory', incoming);
         memStats.updated++;
       } else if (incoming.seq === existing.seq && incoming.fact !== existing.fact) {
         // Cap fork chains to prevent unbounded growth
@@ -561,6 +586,9 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
           createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
         };
         await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(fork));
+        // A peer strips `embedding` before sending — it is derived, and the peer may run a
+        // different model — so this record landed unsearchable. Queue it a vector.
+        await enqueueIngestedRecord(spaceId, 'memory', fork);
         memStats.forked++;
       } else {
         memStats.skipped++;
@@ -581,6 +609,9 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
         await col<EntityDoc>(`${spaceId}_entities`).replaceOne(
           asFilter<EntityDoc>({ _id: incoming._id }), asDoc<EntityDoc>(incoming), { upsert: true },
         );
+        // A peer strips `embedding` before sending — it is derived, and the peer may run a
+        // different model — so this record landed unsearchable. Queue it a vector.
+        await enqueueIngestedRecord(spaceId, 'entity', incoming);
         entStats.upserted++;
       } else {
         entStats.skipped++;
@@ -601,6 +632,9 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
         await col<EdgeDoc>(`${spaceId}_edges`).replaceOne(
           asFilter<EdgeDoc>({ _id: incoming._id }), asDoc<EdgeDoc>(incoming), { upsert: true },
         );
+        // A peer strips `embedding` before sending — it is derived, and the peer may run a
+        // different model — so this record landed unsearchable. Queue it a vector.
+        await enqueueIngestedRecord(spaceId, 'edge', incoming);
         edgeStats.upserted++;
       } else {
         edgeStats.skipped++;
@@ -621,6 +655,9 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
         await col<ChronoEntry>(`${spaceId}_chrono`).replaceOne(
           asFilter<ChronoEntry>({ _id: incoming._id }), asDoc<ChronoEntry>(incoming), { upsert: true },
         );
+        // A peer strips `embedding` before sending — it is derived, and the peer may run a
+        // different model — so this record landed unsearchable. Queue it a vector.
+        await enqueueIngestedRecord(spaceId, 'chrono', incoming);
         chronoStats.upserted++;
       } else {
         chronoStats.skipped++;

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -270,3 +270,32 @@ export const resetEmbedPendingHint = (): void => _signal.reset();
 
 /** Exported for the job doc's own sake — see `asDoc` usage in tests that seed jobs directly. */
 export const _asEmbedJobDoc = asDoc<BrainEmbedJobDoc>;
+
+/**
+ * Enqueue a record that arrived from a peer, if it needs a vector.
+ *
+ * ## The bug this closes
+ *
+ * `embedding` is a DERIVED field, deliberately excluded from replication (`merkle.ts` `DERIVED_FIELDS`)
+ * because two peers may run different models. Sync ingest is a plain `replaceOne` of the incoming
+ * document. Put those together and a record replicated from a peer arrives with **no vector on the
+ * receiving instance** — and nothing ever gave it one.
+ *
+ * A vectorless record is invisible to recall on that instance: the vector search never returns it, and
+ * the lexical channel needs an embedding to compute a real similarity and skips what it cannot score. So
+ * an instance could hold a peer's entire knowledge base and answer nothing from it, silently, until an
+ * operator happened to run a manual whole-space `POST /reindex`. Nothing measured it and nothing
+ * reported it.
+ *
+ * Guarded on the vector rather than enqueued unconditionally: a peer that DOES send one (an older build,
+ * or a future change of mind about derived fields) should not have it thrown away and recomputed.
+ */
+export async function enqueueIngestedRecord(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  doc: { _id: string; embedding?: number[] },
+): Promise<void> {
+  const vec = doc.embedding;
+  if (Array.isArray(vec) && vec.length > 0) return;
+  await enqueueEmbedJob(spaceId, recordType, doc._id);
+}

--- a/testing/standalone/sync-ingest-embeds-db.test.js
+++ b/testing/standalone/sync-ingest-embeds-db.test.js
@@ -1,0 +1,102 @@
+/**
+ * A record replicated from a peer gets a vector on THIS instance.
+ *
+ * ## The bug
+ *
+ * `embedding` is a derived field, deliberately excluded from replication (`merkle.ts` `DERIVED_FIELDS`)
+ * because two peers may run different models. Sync ingest is a plain `replaceOne` of the incoming
+ * document. Put those together and a record arriving from a peer had **no vector on the receiving
+ * instance, and nothing ever gave it one**.
+ *
+ * A vectorless record is invisible to recall — the vector search never returns it, and the lexical channel
+ * needs an embedding to compute a real similarity and skips what it cannot score. So an instance could
+ * hold a peer's entire knowledge base and answer nothing from it, silently, until an operator happened to
+ * run a manual whole-space `POST /reindex`. Nothing measured it and nothing reported it.
+ *
+ * ## What this pins
+ *
+ * The decision, not the route. `enqueueIngestedRecord` is what every ingest write site calls, so this
+ * tests the thing all twelve of them share: an unembedded arrival is queued, an arrival that already
+ * carries a vector is left alone, and the job names the right record.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/sync-ingest-embeds-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-sync-embed-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let mongo, queue;
+const jobs = () => mongo.col(`${SPACE}_embed_jobs`);
+
+describe('a synced-in record is queued for embedding', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('syncembed');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    queue = await import('../../server/dist/brain/embed-queue.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => { await jobs().deleteMany({}); });
+
+  it('an arrival with no vector is queued', async () => {
+    await queue.enqueueIngestedRecord(SPACE, 'memory', { _id: 'm-1' });
+    const job = await jobs().findOne({ _id: 'memory:m-1' });
+    assert.ok(job, 'the peer stripped the embedding, so this instance must compute one');
+    assert.equal(job.status, 'pending');
+    assert.equal(job.recordType, 'memory');
+    assert.equal(job.recordId, 'm-1');
+  });
+
+  it('an arrival that already carries a vector is left alone', async () => {
+    // A peer that DOES send one — an older build, or a future change of mind about derived fields —
+    // should not have it thrown away and recomputed.
+    await queue.enqueueIngestedRecord(SPACE, 'entity', { _id: 'e-1', embedding: [0.1, 0.2, 0.3] });
+    assert.equal(await jobs().countDocuments({}), 0);
+  });
+
+  it('an empty vector counts as no vector', async () => {
+    await queue.enqueueIngestedRecord(SPACE, 'edge', { _id: 'g-1', embedding: [] });
+    assert.ok(await jobs().findOne({ _id: 'edge:g-1' }), 'an empty array is not an embedding');
+  });
+
+  it('every sync-ingest write site enqueues', () => {
+    // Scoped from the SHAPE of a write, not a list of route names — a name list is how the merge-rule
+    // sweep missed its twelfth copy. Every `.replaceOne(`/`.insertOne(` into a synced brain collection
+    // must be followed by an enqueue, or a record can still arrive and never be embedded.
+    const src = execFileSync('git', ['show', 'HEAD:server/src/api/sync/docs.ts'], { encoding: 'utf8' }).length
+      ? fs.readFileSync('server/src/api/sync/docs.ts', 'utf8')
+      : '';
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').split(/\r?\n/).filter(l => !/^\s*\/\//.test(l));
+
+    const writes = code.filter(l =>
+      /col<\w+>\(`\$\{spaceId\}_(memories|entities|edges|chrono)`\)\.(replaceOne|insertOne)\(/.test(l)).length;
+    const enqueues = code.filter(l => /enqueueIngestedRecord\(/.test(l)).length;
+
+    assert.ok(writes > 0, 'the detector must actually find the writes it is gating');
+    assert.equal(enqueues, writes,
+      `${writes} sync-ingest write(s) into a synced brain collection, but ${enqueues} enqueue(s). `
+      + 'A write without one leaves a record that is stored, replicated, and permanently unsearchable '
+      + 'on this instance.');
+  });
+});


### PR DESCRIPTION
fix(sync): a record from a peer was stored, replicated, and never searchable

`embedding` is a DERIVED field, deliberately excluded from replication
(merkle.ts DERIVED_FIELDS) because two peers may run different models. Sync
ingest is a plain replaceOne of the incoming document.

Put those together: a record arriving from a peer had no vector on the
receiving instance, and nothing ever gave it one. Not one route — all twelve
ingest write sites, across memories, entities, edges and chrono, single-doc and
batch.

The consequence is worse than it sounds, because a vectorless record is not
ranked lower, it is ABSENT. The vector search never returns it, and the lexical
channel needs an embedding to compute a real similarity so it skips what it
cannot score. An instance could hold a peer's entire knowledge base and answer
nothing from it — silently, with no error, no metric and no log line — until an
operator happened to run a manual whole-space POST /reindex that re-embeds
everything.

Nothing measured it either. The only query anywhere for a record missing an
embedding is completeness.ts, which REPORTS it, for files only.

Every ingest site now calls enqueueIngestedRecord. A record that arrives WITH a
vector is left alone rather than recomputed: an older peer, or a future change
of mind about derived fields, should not be undone by this.

Gated by a coverage check scoped from the SHAPE of a write — every
`.replaceOne(`/`.insertOne(` into a synced brain collection — rather than from a
list of route names. A name list is exactly how the merge-rule sweep missed its
twelfth copy. Mutation-verified: deleting one enqueue turns it red, which it
then did for real when a `git checkout --` during that very mutation check
reverted the uncommitted wiring. The gate caught its own author.

The three remaining creators (upsertEntity, upsertEdge, createChrono) still
embed inline. They tolerate a failed embed and store anyway, so they never
break — they only pay the latency. Split out rather than half-wired here: an
enqueue-less creator that also skips the inline embed would produce records that
never get a vector at all, which is the bug this commit fixes.
