### PR TITLE
feat(brain): all four creators queue their embedding, not just remember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **All four brain creators now queue their embedding instead of waiting for the model.** `upsertEntity`,
+  `upsertEdge` and `createChrono` join `remember`: the write returns as soon as the record is durable and a
+  worker embeds it moments later, with `waitForEmbedding: true` keeping the inline path for callers who
+  need the record searchable the instant the call returns.
+  - The three never *failed* without an embedder — they caught the error and stored the record anyway — so
+    what changes is the latency, and that a record which missed its vector is now repaired instead of
+    staying permanently unsearchable.
+  - `upsertEdge` gained an options object rather than a twelfth positional parameter.
+  - The queued edge job resolves its endpoint NAMES itself from the stored edge, so the write path no
+    longer pays two entity reads just to build embedding text it is not going to use.
+  - Pinned as ONE table over all four types, not four tests: the failure mode being guarded against is
+    exactly that the types are wired in four places and nobody compares them.
+
 - **A record replicated from a peer is now embedded on arrival.** It never was, and the consequence was
   invisible: `embedding` is a DERIVED field excluded from replication (`merkle.ts` `DERIVED_FIELDS`,
   because two peers may run different models), and sync ingest is a plain `replaceOne` of the incoming

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -15,6 +15,7 @@ import { deriveChronoStatus } from './chrono-status.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
+import { enqueueEmbedJob } from './embed-queue.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
 
@@ -121,12 +122,13 @@ export async function createChrono(
   const tags = fields.tags ?? [];
 
   // Embed kind + status + title + description + tags + properties (best-effort)
-  let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
-  try {
-    const embedText = chronoEmbedText(fields.title, fields.type, status, fields.description, tags, fields.properties);
+  // Queued by default — see the note in `upsertEntity`. `matchedText` is stored either way.
+  const embedText = chronoEmbedText(fields.title, fields.type, status, fields.description, tags, fields.properties);
+  let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = { matchedText: embedText };
+  if (opts?.waitForEmbedding === true) {
     const embResult = await embed(embedText);
     embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
-  } catch { /* embedding unavailable — chrono stored without vector */ }
+  }
 
   // Opt-in insert-time duplicate / contradiction checks, using the freshly computed vector BEFORE insert so
   // it can never self-match. ONE neighbour search serves both flags. A calendar is where the same thing most
@@ -209,6 +211,7 @@ export async function createChrono(
   // space-wide TTL cannot express.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'chrono', type: doc.type });
   await col<ChronoEntry>(`${spaceId}_chrono`).insertOne(asDoc<ChronoEntry>(doc));
+  if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'chrono', doc._id);
   if (actor) emitWebhookEvent({ event: 'chrono.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   // Advisory only — the entry is stored either way.
   return (similar || contradicts) ? { ...doc, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) } : doc;

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -12,6 +12,7 @@ import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
+import { enqueueEmbedJob } from './embed-queue.js';
 import { getEntityById } from './entities.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EdgeDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
@@ -76,6 +77,11 @@ export async function upsertEdge(
   tags?: string[],
   actor?: WebhookActor,
   ttlDays?: number | null,
+  /**
+   * Write options. An object rather than a twelfth positional — `remember` already carries a note saying
+   * its twelfth was one too many, and this is the same signature growing the same way.
+   */
+  opts?: { waitForEmbedding?: boolean },
 ): Promise<EdgeDoc> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
   const existing = await findEdgeByTriplet(spaceId, from, to, label);
@@ -89,13 +95,15 @@ export async function upsertEdge(
   const effectiveProps = mergePropertiesOrKeep((existing as EdgeDoc | null)?.properties, properties);
 
   // Embed the edge text (best-effort) — resolve entity names so the vector captures semantics
+  // Queued by default — see the note in `upsertEntity`. Resolving the endpoint NAMES is a database read,
+  // so it happens only on the inline path; the queued job resolves them itself from the stored edge.
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
-  try {
+  if (opts?.waitForEmbedding === true) {
     const [fromName, toName] = await resolveEdgeEntityNames(spaceId, from, to);
     const embedText = edgeEmbedText(fromName, label, toName, effectiveTags, effectiveType, effectiveDesc, effectiveProps);
     const embResult = await embed(embedText);
     embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
-  } catch { /* embedding unavailable — edge stored without vector */ }
+  }
 
   if (existing) {
     const $set: Record<string, unknown> = { updatedAt: now, seq, ...embeddingFields };
@@ -127,6 +135,7 @@ export async function upsertEdge(
     };
     if ('_expireAt' in $set) updatedEdge._expireAt = $set['_expireAt'] as Date;
     else if ('_expireAt' in $unset) delete (updatedEdge as { _expireAt?: unknown })._expireAt;
+    if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'edge', updatedEdge._id);
     if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...updatedEdge, embedding: undefined }, ...actor });
     return updatedEdge;
   }
@@ -152,6 +161,7 @@ export async function upsertEdge(
   // Passing `type` here would look right and read a schema that is never there.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'edge', type: doc.label });
   await collection.insertOne(asDoc<EdgeDoc>(doc));
+  if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'edge', doc._id);
   if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   return doc;
 }

--- a/server/src/brain/embed-worker.ts
+++ b/server/src/brain/embed-worker.ts
@@ -51,6 +51,15 @@ export async function runOneEmbedJob(): Promise<boolean> {
     // owed. Retrying would keep a job alive for a document that will never come back.
     await embedStoredRecord(job.spaceId, job.recordType, job.recordId);
     await completeEmbedJob(job.spaceId, job.recordType, job.recordId);
+
+    // The space-level insert rule runs HERE, not at the write, because it evaluates the STORED record
+    // against its neighbours and a stored record has no vector until this job gives it one. Firing it at
+    // insert time would compare nothing and find nothing, silently. It is internally gated on
+    // `dupeRulesOnInsert`, so this is a no-op for every space that has not enabled it, and it writes
+    // candidates to the Review surface rather than returning them — no caller is waiting on it.
+    void import('./dupe-scanner.js')
+      .then(m => m.evaluateRecordForDuplicates(job.spaceId, job.recordType, job.recordId))
+      .catch(() => { /* best-effort, exactly as it was on the write path */ });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     await failEmbedJob(job.spaceId, job.recordType, job.recordId, job.attempts, msg);

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -12,6 +12,7 @@ import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { mergeTagsAndProperties, mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
+import { enqueueEmbedJob } from './embed-queue.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './recall.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import { log } from '../util/log.js';
@@ -111,14 +112,19 @@ export async function upsertEntity(
   const now = new Date().toISOString();
 
   // Embed the entity text (best-effort — if embedding fails we still store the entity)
-  let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
-  try {
-    const { tags: mergedTags, properties: mergedProps } = mergeTagsAndProperties(existing, { tags, properties });
-    const effectiveDesc = description ?? existing?.description;
-    const embedText = entityEmbedText(name, type, mergedTags, effectiveDesc, mergedProps);
+  //
+  // Queued by default, so the write does not pay the model's latency. `matchedText` is stored either
+  // way: it is a pure string, it is exactly what the queued job will embed, and recording it now is what
+  // lets the stored vector be checked against the text it came from.
+  const forEmbed = mergeTagsAndProperties(existing, { tags, properties });
+  const embedText = entityEmbedText(name, type, forEmbed.tags, description ?? existing?.description, forEmbed.properties);
+  let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = { matchedText: embedText };
+  if (opts?.waitForEmbedding === true) {
+    // Unguarded on purpose: the caller asked for a record searchable when this returns, so falling back
+    // to "stored, not searchable" would answer a different question than the one asked.
     const embResult = await embed(embedText);
     embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
-  } catch { /* embedding unavailable — entity stored without vector */ }
+  }
 
   if (existing) {
     const { tags: updatedTags, properties: mergedProps } = mergeTagsAndProperties(existing, { tags, properties });
@@ -136,6 +142,8 @@ export async function upsertEntity(
     const entity: EntityDoc = { ...existing, name, type, tags: updatedTags, properties: mergedProps, updatedAt: now, seq, ...embeddingFields, ...(description !== undefined ? { description } : {}) };
     if ('_expireAt' in $set) entity._expireAt = $set['_expireAt'] as Date;
     else if ('_expireAt' in $unset) delete (entity as { _expireAt?: unknown })._expireAt;
+    // After the write, never before: a job for a record that failed to store would be a job for nothing.
+    if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'entity', entity._id);
     if (actor) emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...entity, embedding: undefined }, ...actor });
     return { entity };
   }
@@ -180,6 +188,7 @@ export async function upsertEntity(
   // space default, so a window set on `typeSchemas.entity.<type>.retention` does nothing at all.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'entity', type: doc.type });
   await collection.insertOne(asDoc<EntityDoc>(doc));
+  if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'entity', doc._id);
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
   if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -118,8 +118,16 @@ export async function upsertEntity(
   // lets the stored vector be checked against the text it came from.
   const forEmbed = mergeTagsAndProperties(existing, { tags, properties });
   const embedText = entityEmbedText(name, type, forEmbed.tags, description ?? existing?.description, forEmbed.properties);
+  //
+  // The duplicate/contradiction checks below compare THIS record's vector against its neighbours, so they
+  // cannot run without one — and unlike the embedding itself, that question cannot be deferred and
+  // answered later in a response that has already been sent. So they imply the wait, exactly as they do
+  // in `remember`. Implied rather than rejected as an invalid combination: a caller asking "is this a
+  // duplicate?" would otherwise get a silent "no".
+  const needsVectorNow = opts?.waitForEmbedding === true
+    || opts?.checkDuplicates === true || opts?.checkContradictions === true;
   let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = { matchedText: embedText };
-  if (opts?.waitForEmbedding === true) {
+  if (needsVectorNow) {
     // Unguarded on purpose: the caller asked for a record searchable when this returns, so falling back
     // to "stored, not searchable" would answer a different question than the one asked.
     const embResult = await embed(embedText);
@@ -191,7 +199,14 @@ export async function upsertEntity(
   if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'entity', doc._id);
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the
   // dynamic import avoids a static cycle with dupe-scanner.js.
-  if (getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {
+  //
+  // Behind the embedding, not beside it. This evaluates the STORED record against its neighbours, and a
+  // stored record has no vector until the queue gets to it — firing here would compare nothing and find
+  // nothing, silently. Nothing is lost by the wait: this path is fire-and-forget and writes candidates to
+  // the Review surface rather than returning them, so no caller is holding a response open for it.
+  // Only when we embedded INLINE — otherwise the embed worker runs it once the vector exists, so this
+  // guard is what stops it running twice rather than what stops it running at all.
+  if (embeddingFields.embedding && getConfig().spaces.find(s => s.id === spaceId)?.dupeRulesOnInsert) {
     import('./dupe-scanner.js').then(m => m.evaluateRecordForDuplicates(spaceId, 'entity', doc._id)).catch(() => { /* best-effort */ });
   }
   if (actor) emitWebhookEvent({ event: 'entity.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });

--- a/testing/standalone/embed-queue-drain-db.test.js
+++ b/testing/standalone/embed-queue-drain-db.test.js
@@ -42,7 +42,7 @@ let seen = [];
 /** Flip to make the endpoint fail, without tearing the server down. */
 let failNext = false;
 
-let server, mongo, memory, entities, queue, worker;
+let server, mongo, memory, entities, edges, chrono, queue, worker;
 
 const jobs = () => mongo.col(`${SPACE}_embed_jobs`);
 const memories = () => mongo.col(`${SPACE}_memories`);
@@ -78,6 +78,8 @@ describe('brain embedding queue drains (real MongoDB, real embed() over a stub e
     loader.loadConfig();
     memory = await import('../../server/dist/brain/memory.js');
     entities = await import('../../server/dist/brain/entities.js');
+    edges = await import('../../server/dist/brain/edges.js');
+    chrono = await import('../../server/dist/brain/chrono.js');
     queue = await import('../../server/dist/brain/embed-queue.js');
     worker = await import('../../server/dist/brain/embed-worker.js');
   });
@@ -92,6 +94,8 @@ describe('brain embedding queue drains (real MongoDB, real embed() over a stub e
     await jobs().deleteMany({});
     await memories().deleteMany({});
     await mongo.col(`${SPACE}_entities`).deleteMany({});
+    await mongo.col(`${SPACE}_edges`).deleteMany({});
+    await mongo.col(`${SPACE}_chrono`).deleteMany({});
     seen = [];
     failNext = false;
     queue.resetEmbedPendingHint();
@@ -169,13 +173,65 @@ describe('brain embedding queue drains (real MongoDB, real embed() over a stub e
     assert.equal(seen.length, 1);
   });
 
-  it('an entity written inline still embeds, and queues nothing', async () => {
-    // upsertEntity has always embedded inline and tolerated failure. This pins that the queue's arrival
-    // did not change it — the other three creators are wired in a follow-up, and until then their
-    // behaviour must be exactly what it was.
-    const { entity } = await entities.upsertEntity(SPACE, 'node-7', 'machine', ['prod'], { rack: 'B12' });
-    const stored = await mongo.col(`${SPACE}_entities`).findOne({ _id: entity._id });
-    assert.ok(Array.isArray(stored.embedding), 'entities still embed on the write path');
-    assert.equal(await jobs().countDocuments({}), 0);
+  // ── All four creators, as one table ─────────────────────────────────────────
+  //
+  // One table rather than four tests, for the reason the merge-rule suite is one table: the failure mode
+  // being guarded against is precisely that the four types are wired in four places and nobody compares
+  // them. A per-type test can be updated to match whatever that type does.
+  const CREATORS = [
+    {
+      name: 'memory', collection: 'memories',
+      create: (opts) => memory.remember(SPACE, 'creator table memory', [], ['prod'], undefined, undefined,
+        undefined, undefined, opts),
+    },
+    {
+      name: 'entity', collection: 'entities',
+      create: async (opts) => (await entities.upsertEntity(SPACE, 'node-9', 'machine', ['prod'],
+        { rack: 'B12' }, undefined, undefined, opts)).entity,
+    },
+    {
+      name: 'edge', collection: 'edges',
+      create: (opts) => edges.upsertEdge(SPACE, 'a-9', 'b-9', 'runs-on', undefined, undefined, undefined,
+        { since: '2026' }, ['prod'], undefined, undefined, opts),
+    },
+    {
+      name: 'chrono', collection: 'chrono',
+      create: (opts) => chrono.createChrono(SPACE, {
+        title: 'creator table chrono', type: 'event', startsAt: '2026-08-05T09:00:00Z', tags: ['prod'],
+      }, undefined, undefined, opts),
+    },
+  ];
+
+  for (const c of CREATORS) {
+    it(`${c.name}: the write queues, the worker embeds`, async () => {
+      const doc = await c.create(undefined);
+      const stored = await mongo.col(`${SPACE}_${c.collection}`).findOne({ _id: doc._id });
+      assert.equal(stored.embedding, undefined, `${c.name} must not embed on the write path by default`);
+      assert.equal(await jobs().countDocuments({}), 1, `${c.name} enqueued exactly one job`);
+
+      assert.equal(await worker.runOneEmbedJob(), true);
+      const after = await mongo.col(`${SPACE}_${c.collection}`).findOne({ _id: doc._id });
+      assert.ok(Array.isArray(after.embedding), `${c.name} got its vector from the queue`);
+      assert.equal(await jobs().countDocuments({}), 0);
+    });
+
+    it(`${c.name}: waitForEmbedding embeds inline and queues nothing`, async () => {
+      const doc = await c.create({ waitForEmbedding: true });
+      const stored = await mongo.col(`${SPACE}_${c.collection}`).findOne({ _id: doc._id });
+      assert.ok(Array.isArray(stored.embedding), `${c.name} is searchable the moment the call returns`);
+      assert.equal(await jobs().countDocuments({}), 0, `${c.name} has no work left to queue`);
+    });
+  }
+
+  it('all four creators agree — none embeds inline by default', async () => {
+    // Stated as one comparison so a type drifting away fails here even if its own rows above were
+    // updated to match it.
+    const inline = {};
+    for (const c of CREATORS) {
+      const doc = await c.create(undefined);
+      const stored = await mongo.col(`${SPACE}_${c.collection}`).findOne({ _id: doc._id });
+      inline[c.name] = stored.embedding !== undefined;
+    }
+    assert.deepEqual(inline, { memory: false, entity: false, edge: false, chrono: false });
   });
 });


### PR DESCRIPTION
feat(brain): all four creators queue their embedding, not just remember

Completes what #688 started. upsertEntity, upsertEdge and createChrono now
enqueue by default and accept waitForEmbedding: true for the inline path.

Unlike remember, these three never FAILED without an embedder — each wrapped
embed() in a try/catch and stored the record anyway. So what changes for them is
the latency, plus the thing that was actually broken: a record that missed its
vector stayed permanently unsearchable, because nothing ever came back for it.
Now the queue does.

upsertEdge gained an options object rather than a twelfth positional parameter.
remember already carries a note saying its twelfth was one too many, and this
signature was growing exactly the same way.

One incidental win on the edge path: building edge embedding text needs the
endpoint entity NAMES, which is two database reads. The queued job resolves them
itself from the stored edge, so the default write path no longer pays for text
it is not going to embed.

Wired as PAIRS — skip the inline embed AND enqueue after the write — because a
first attempt at this did only the first half and had to be reverted. A creator
that skips the embed without enqueueing produces records that never get a vector
at all, which is the bug this whole line of work exists to fix.

The drain suite now covers all four creators as ONE table rather than four
tests, for the same reason the merge-rule suite is one table: the failure mode
being guarded against is precisely that the four types are wired in four places
and nobody compares them. A per-type test can always be updated to match
whatever that type happens to do. It also carries a single cross-type assertion
so a type drifting away fails even if its own rows were updated to match it.

The placeholder that pinned "an entity still embeds inline" is gone — it existed
to hold that behaviour until this change, and said so.

  14 pass, 0 fail  (was 6)
