### PR TITLE
feat(brain): excludeFromVectorSearch — stored, but not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`excludeFromVectorSearch` — a record that stays stored but stops being found** (owner request). Set it
+  on a memory, entity, edge or chrono entry and it drops out of recall, find-similar and duplicate
+  detection; clear it and it comes back. It is not a delete: the record still lists, still exports, still
+  syncs.
+  - **Implemented as the ABSENCE of a vector, not as a query filter.** A filter was the obvious design and
+    does not work — `ne` is not natively pushable to `$vectorSearch` (`brain/filter.ts:74`), so every
+    recall on the space would fall back to an exhaustive scan, and the positive `eq: false` form would
+    need the field backfilled onto every existing record in a **synced** collection, which the
+    synced-data rule forbids. No vector means no vector hit: natively, at zero query cost, with no index
+    change and no migration.
+  - Absent means included, so nothing existing changes.
+  - **Only possible because the embedding queue landed first.** Unsetting a vector is safe precisely
+    because clearing the flag queues a re-embed and the record is back in milliseconds.
+
 - **All four brain creators now queue their embedding instead of waiting for the model.** `upsertEntity`,
   `upsertEdge` and `createChrono` join `remember`: the write returns as soon as the record is durable and a
   worker embeds it moments later, with `waitForEmbedding: true` keeping the inline path for callers who

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -220,7 +220,7 @@ export async function createChrono(
 export async function updateChrono(
   spaceId: string,
   id: string,
-  updates: Partial<Pick<ChronoEntry, 'title' | 'description' | 'type' | 'startsAt' | 'endsAt' | 'status' | 'confidence' | 'tags' | 'entityIds' | 'memoryIds' | 'properties' | 'recurrence'>>,
+  updates: Partial<Pick<ChronoEntry, 'title' | 'description' | 'type' | 'startsAt' | 'endsAt' | 'status' | 'confidence' | 'tags' | 'entityIds' | 'memoryIds' | 'properties' | 'recurrence' | 'excludeFromVectorSearch'>>,
   actor?: WebhookActor,
   ttlDays?: number | null,
 ): Promise<ChronoEntry | null> {
@@ -284,6 +284,10 @@ export async function updateChrono(
   }).inc();
   const updatedChrono = { ...existing, ...($set as Partial<ChronoEntry>) } as ChronoEntry;
   if ('_expireAt' in $unset) delete (updatedChrono as { _expireAt?: unknown })._expireAt;
+  // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
+  // the vector when the flag is on and computes one when it is off. So this path never has to know
+  // which way the toggle went, which is what keeps the rule in one place.
+  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'chrono', updatedChrono._id);
   if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...updatedChrono, embedding: undefined }, ...actor });
   return updatedChrono;
 }

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -238,7 +238,7 @@ export async function getEdgeById(spaceId: string, id: string): Promise<EdgeDoc 
 export async function updateEdgeById(
   spaceId: string,
   id: string,
-  updates: { label?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; weight?: number; type?: string },
+  updates: { label?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; weight?: number; type?: string; excludeFromVectorSearch?: boolean },
   deleteFieldsPaths?: string[],
   actor?: WebhookActor,
   ttlDays?: number | null,
@@ -252,6 +252,7 @@ export async function updateEdgeById(
   const $set: Record<string, unknown> = { updatedAt: now, seq };
   const $unset: Record<string, unknown> = {};
 
+  if (updates.excludeFromVectorSearch !== undefined) $set['excludeFromVectorSearch'] = updates.excludeFromVectorSearch;
   const newLabel = updates.label ?? existing.label;
   let newDesc = updates.description !== undefined ? updates.description : existing.description;
   let newTags = mergeTagsOrKeep(existing.tags, updates.tags);
@@ -351,6 +352,10 @@ export async function updateEdgeById(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
+  // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
+  // the vector when the flag is on and computes one when it is off. So this path never has to know
+  // which way the toggle went, which is what keeps the rule in one place.
+  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'edge', result._id);
   if (actor) emitWebhookEvent({ event: 'edge.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }

--- a/server/src/brain/embed-record.ts
+++ b/server/src/brain/embed-record.ts
@@ -70,8 +70,14 @@ export async function buildEmbedText(
   }
 }
 
-/** What became of an embedding attempt. `gone` is a success: the record was deleted, so there is nothing owed. */
-export type EmbedOutcome = 'embedded' | 'gone';
+/**
+ * What became of an embedding attempt.
+ *
+ * `gone` and `excluded` are both successes — the record was deleted, or its owner asked for it not to be
+ * findable. Neither is owed a vector, so neither may be retried: a retry would keep a job alive forever for
+ * work that must never happen.
+ */
+export type EmbedOutcome = 'embedded' | 'gone' | 'excluded';
 
 /**
  * Load the record, build its text, embed it, store the vector.
@@ -89,6 +95,20 @@ export async function embedStoredRecord(
   const collName = `${spaceId}_${COLLECTION[recordType]}`;
   const doc = await col(collName).findOne(asFilter({ _id: recordId })) as Record<string, unknown> | null;
   if (!doc) return 'gone';
+
+  // `excludeFromVectorSearch` is implemented AS the absence of a vector — there is no query-time filter to
+  // honour, so this is the single place the flag has any effect. Every writer of a vector reaches this
+  // function, which is why one check covers the four creators and sync ingest alike.
+  //
+  // The stale vector is UNSET rather than left behind. Leaving it would keep the record findable by the
+  // exact mechanism the flag exists to switch off, which is the whole bug.
+  if (doc['excludeFromVectorSearch'] === true) {
+    await col(collName).updateOne(
+      asFilter({ _id: recordId }),
+      { $unset: { embedding: '', embeddingModel: '' } },
+    );
+    return 'excluded';
+  }
 
   const text = await buildEmbedText(spaceId, recordType, doc);
   const result = await embed(text);

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -248,7 +248,7 @@ export async function getEntityById(spaceId: string, id: string): Promise<Entity
 export async function updateEntityById(
   spaceId: string,
   id: string,
-  updates: { name?: string; type?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> },
+  updates: { name?: string; type?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; excludeFromVectorSearch?: boolean },
   deleteFieldsPaths?: string[],
   actor?: WebhookActor,
   ttlDays?: number | null,
@@ -295,6 +295,7 @@ export async function updateEntityById(
     }
   }
 
+  if (updates.excludeFromVectorSearch !== undefined) $set['excludeFromVectorSearch'] = updates.excludeFromVectorSearch;
   if (updates.name !== undefined) $set['name'] = newName;
   if (updates.type !== undefined) $set['type'] = newType;
   if (updates.description !== undefined || (deleteFieldsPaths && !$unset['description'])) $set['description'] = newDesc;
@@ -347,6 +348,10 @@ export async function updateEntityById(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
+  // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
+  // the vector when the flag is on and computes one when it is off. So this path never has to know
+  // which way the toggle went, which is what keeps the rule in one place.
+  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'entity', result._id);
   if (actor) emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -201,7 +201,7 @@ export async function remember(
 export async function updateMemory(
   spaceId: string,
   memoryId: string,
-  updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; type?: string },
+  updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; type?: string; excludeFromVectorSearch?: boolean },
   deleteFieldsPaths?: string[],
   actor?: WebhookActor,
   ttlDays?: number | null,
@@ -230,6 +230,10 @@ export async function updateMemory(
   if (updates.description !== undefined) $set['description'] = updates.description;
   if (updates.properties !== undefined) $set['properties'] = mergedUpdateProps;
   if (updates.type !== undefined) $set['type'] = updates.type;
+  // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets the
+  // vector when the flag is on and computes one when it is off. So this path never needs to know which
+  // way the toggle went.
+  if (updates.excludeFromVectorSearch !== undefined) $set['excludeFromVectorSearch'] = updates.excludeFromVectorSearch;
 
   // Apply deleteFields after merge
   if (deleteFieldsPaths && deleteFieldsPaths.length > 0) {
@@ -309,6 +313,10 @@ export async function updateMemory(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
+  // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
+  // the vector when the flag is on and computes one when it is off. So this path never has to know
+  // which way the toggle went, which is what keeps the rule in one place.
+  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'memory', result._id);
   if (actor) emitWebhookEvent({ event: 'memory.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1426,6 +1426,18 @@ export interface AuthorRef {
 }
 
 export interface MemoryDoc {
+  /**
+   * Keep this record stored, but stop it being found by vector search.
+   *
+   * Implemented by having NO embedding rather than by a query filter: a vectorless record cannot be
+   * returned by $vectorSearch at all, at zero query cost, and it also drops out of the lexical channel
+   * because `introduceLexicalOnly` skips what it cannot score. A filter was the obvious design and does
+   * not work — `ne` is not natively pushable (`brain/filter.ts:74`), so it would force every recall onto
+   * an exhaustive scan, and the positive form would need a backfill of a synced collection.
+   *
+   * Absent means included, so no existing record changes. Clearing the flag re-queues an embedding.
+   */
+  excludeFromVectorSearch?: boolean;
   _id: string;
   spaceId: string;
   fact: string;
@@ -1456,6 +1468,18 @@ export interface MemoryDoc {
 }
 
 export interface EntityDoc {
+  /**
+   * Keep this record stored, but stop it being found by vector search.
+   *
+   * Implemented by having NO embedding rather than by a query filter: a vectorless record cannot be
+   * returned by $vectorSearch at all, at zero query cost, and it also drops out of the lexical channel
+   * because `introduceLexicalOnly` skips what it cannot score. A filter was the obvious design and does
+   * not work — `ne` is not natively pushable (`brain/filter.ts:74`), so it would force every recall onto
+   * an exhaustive scan, and the positive form would need a backfill of a synced collection.
+   *
+   * Absent means included, so no existing record changes. Clearing the flag re-queues an embedding.
+   */
+  excludeFromVectorSearch?: boolean;
   _id: string;
   spaceId: string;
   name: string;
@@ -1476,6 +1500,18 @@ export interface EntityDoc {
 }
 
 export interface EdgeDoc {
+  /**
+   * Keep this record stored, but stop it being found by vector search.
+   *
+   * Implemented by having NO embedding rather than by a query filter: a vectorless record cannot be
+   * returned by $vectorSearch at all, at zero query cost, and it also drops out of the lexical channel
+   * because `introduceLexicalOnly` skips what it cannot score. A filter was the obvious design and does
+   * not work — `ne` is not natively pushable (`brain/filter.ts:74`), so it would force every recall onto
+   * an exhaustive scan, and the positive form would need a backfill of a synced collection.
+   *
+   * Absent means included, so no existing record changes. Clearing the flag re-queues an embedding.
+   */
+  excludeFromVectorSearch?: boolean;
   _id: string;
   spaceId: string;
   from: string;
@@ -1504,6 +1540,18 @@ export type ChronoKind = ChronoType;
 export type ChronoStatus = 'upcoming' | 'active' | 'completed' | 'overdue' | 'cancelled';
 
 export interface ChronoEntry {
+  /**
+   * Keep this record stored, but stop it being found by vector search.
+   *
+   * Implemented by having NO embedding rather than by a query filter: a vectorless record cannot be
+   * returned by $vectorSearch at all, at zero query cost, and it also drops out of the lexical channel
+   * because `introduceLexicalOnly` skips what it cannot score. A filter was the obvious design and does
+   * not work — `ne` is not natively pushable (`brain/filter.ts:74`), so it would force every recall onto
+   * an exhaustive scan, and the positive form would need a backfill of a synced collection.
+   *
+   * Absent means included, so no existing record changes. Clearing the flag re-queues an embedding.
+   */
+  excludeFromVectorSearch?: boolean;
   _id: string;
   spaceId: string;
   title: string;

--- a/testing/standalone/embed-queue-drain-db.test.js
+++ b/testing/standalone/embed-queue-drain-db.test.js
@@ -223,6 +223,56 @@ describe('brain embedding queue drains (real MongoDB, real embed() over a stub e
     });
   }
 
+  it('excludeFromVectorSearch: the job UNSETS the vector instead of computing one', async () => {
+    // The flag is implemented AS the absence of a vector, not as a query filter. A filter was the obvious
+    // design and does not work: `ne` is not natively pushable (`brain/filter.ts:74`), so it would force
+    // every recall onto an exhaustive scan, and the positive form would need a backfill of a synced
+    // collection. No vector means no vector hit, natively, at zero query cost.
+    const doc = await memory.remember(SPACE, 'retired fact', [], [], undefined, undefined, undefined,
+      undefined, { waitForEmbedding: true });
+    const coll = mongo.col(`${SPACE}_memories`);
+    assert.ok(Array.isArray((await coll.findOne({ _id: doc._id })).embedding),
+      'precondition: it starts searchable');
+
+    await memory.updateMemory(SPACE, doc._id, { excludeFromVectorSearch: true });
+    assert.equal(await jobs().countDocuments({}), 1, 'the toggle queued a job');
+    assert.equal(await worker.runOneEmbedJob(), true);
+
+    const after = await coll.findOne({ _id: doc._id });
+    assert.equal(after.embedding, undefined, 'the stale vector is UNSET, not left behind');
+    assert.equal(after.embeddingModel, undefined);
+    assert.equal(after.excludeFromVectorSearch, true, 'and the record itself is still there');
+    assert.ok(after.fact, 'excluded is not deleted — an operator must still be able to find it by listing');
+  });
+
+  it('clearing the flag gives the vector back', async () => {
+    // The escape hatch that makes unsetting safe: re-including is one queued job away. That is only true
+    // because the embedding queue exists — this design was not available before it.
+    const doc = await memory.remember(SPACE, 'temporarily retired', [], []);
+    const coll = mongo.col(`${SPACE}_memories`);
+
+    await memory.updateMemory(SPACE, doc._id, { excludeFromVectorSearch: true });
+    await worker.runOneEmbedJob();
+    assert.equal((await coll.findOne({ _id: doc._id })).embedding, undefined);
+
+    await memory.updateMemory(SPACE, doc._id, { excludeFromVectorSearch: false });
+    assert.equal(await worker.runOneEmbedJob(), true);
+    assert.ok(Array.isArray((await coll.findOne({ _id: doc._id })).embedding),
+      'clearing the flag re-embeds — the job handles both directions, so no caller has to know which');
+  });
+
+  it('an excluded record is never given a vector in the first place', async () => {
+    // Not only "unset later": a record created already-excluded must not be embedded at all, or every
+    // creator would burn a model call to produce a vector the next job deletes.
+    const doc = await memory.remember(SPACE, 'born retired', [], []);
+    await mongo.col(`${SPACE}_memories`).updateOne({ _id: doc._id },
+      { $set: { excludeFromVectorSearch: true } });
+
+    assert.equal(await worker.runOneEmbedJob(), true);
+    assert.equal((await mongo.col(`${SPACE}_memories`).findOne({ _id: doc._id })).embedding, undefined);
+    assert.equal(await jobs().countDocuments({}), 0, 'and the job retires rather than retrying forever');
+  });
+
   it('all four creators agree — none embeds inline by default', async () => {
     // Stated as one comparison so a type drifting away fails here even if its own rows above were
     // updated to match it.


### PR DESCRIPTION
feat(brain): excludeFromVectorSearch — stored, but not found

Owner request: a flag marking a record excluded from vector search, generic
rather than tied to 'superseded'. Owner's name for it, adopted.

The obvious design does not work, and finding that out changed the feature into
a much smaller one.

A filter — {excludeFromVectorSearch: {ne: true}} pushed into the vector index —
fails on brain/filter.ts:74: NATIVE_VECTOR_FILTER_OPS is eq/in/gt/gte/lt/lte and
the code says outright that ne and exists make the whole request non-native. So
a filter would drop every recall on the space onto the exhaustive exact:true
scan. The positive form, {eq: false}, IS native but needs the field present on
every record — a backfill of a synced collection, which the synced-data rule
forbids as a boot migration.

So exclusion is implemented as the ABSENCE of a vector. A record with no
embedding cannot be returned by $vectorSearch at all, natively, at zero query
cost, with no index change and no migration. It also drops out of the lexical
channel, because introduceLexicalOnly skips what it cannot score — which is the
right answer once you ask whether the lexical side should resurrect a record the
operator just retired.

That gives ONE choke point: embedStoredRecord. Every writer of a vector reaches
it — four creators, sync ingest, the queue — so one check covers them all, and
there is no per-surface wiring to forget. Setting the flag unsets any stale
vector rather than leaving it, since leaving it would keep the record findable
by the exact mechanism the flag switches off.

This design was not available yesterday. Unsetting a vector is only safe because
clearing the flag queues a re-embed and the record returns in milliseconds — the
queue from #688/#690 is what makes it reversible.

Mutation-verified: inverting the guard turns 3 tests red.

