### PR TITLE
docs(api): the one POST-as-update route was documented nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Documentation
+
+- **The one POST-as-update route is now documented as legacy, and gated.** A chrono entry can be updated by
+  posting to its id; no other type can, and posting to a memory id is a 404. Nothing said so, which reads as
+  a bug from either direction depending on which type you met first.
+  - **Resolved by documenting, not by adding the missing route.** Adding it to memories would spread a
+    deprecated shape to a second type to make it look symmetrical. The supported idempotent create is a
+    client-supplied UUID v4 in the COLLECTION post, which already covers every type — the chrono route
+    predates that design and duplicates it. Listed for removal in `_DEPRECATIONS.md`.
+  - Investigated after a report that posting to a memory id returned **200 and changed nothing**. That did
+    not reproduce: both the current and the legacy path shapes answer 404. The asymmetry underneath it was
+    real, so that is what got fixed.
+
 ### Added
 
 - **`excludeFromVectorSearch` — a record that stays stored but stops being found** (owner request). Set it

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1594,6 +1594,24 @@ an empty `properties: {}` is a no-op rather than a wipe. If you need a key gone,
 > described the field as "properties to merge". If you were relying on the replace to clear keys, switch to
 > `deleteFields`.
 
+### Updating by id: use PATCH
+
+`PATCH` is the update verb for every brain record type. There is **one exception, and it is a legacy one**:
+a POST to a chrono **id** also updates (`.../chrono/:id`). No other type has an equivalent: posting
+to a memory id is a **404**, not an update.
+
+| type | update by id | POST-as-update |
+|---|---|---|
+| memory | `PATCH .../memories/:id` | **no** (404) |
+| entity | `PATCH .../entities/:id` | no — but a collection POST with a matching `id` upserts |
+| edge | `PATCH .../edges/:id` | no — a collection POST upserts on `(from, to, label)` |
+| chrono | `PATCH .../chrono/:id` | **yes**, legacy |
+
+**Do not build on the chrono form.** It predates the retry-safety design and duplicates it: the supported way
+to make a create idempotent is a client-supplied UUID v4 in the **collection** POST body, which converges on
+the same record for every type (see [Retry Safety](#retry-safety)). The chrono route is kept for existing
+callers and is listed for removal in a future major.
+
 ### Partial Update with deleteFields
 
 All `PATCH` update endpoints — entities, edges, and memories — accept an optional `deleteFields` array of dot-notation paths. This allows callers to remove specific fields from a document in the same atomic operation as normal property/tag updates.

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -77,7 +77,16 @@ entitiesRouter.post('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAu
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
 
   try {
-    const { entity, warning } = await upsertEntity(wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId, undefined, webhookToken(req), ttlDaysFromBody(req.body));
+    // `waitForEmbedding` (default false): the vector is normally computed by the embedding queue moments
+    // after this returns. Pass true when the caller will search for, scan, or compare what it just wrote —
+    // a duplicate scan cannot pair records that have no vector yet.
+    const waitForEmbedding = req.body?.waitForEmbedding;
+    if (waitForEmbedding !== undefined && typeof waitForEmbedding !== 'boolean') {
+      res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
+      return;
+    }
+    const embedOpts = waitForEmbedding === true ? { waitForEmbedding: true } : undefined;
+    const { entity, warning } = await upsertEntity(wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId, embedOpts, webhookToken(req), ttlDaysFromBody(req.body));
     const result: Record<string, unknown> = { ...entity };
     if (warning) result['warning'] = warning;
     if (check.warnings.length > 0) result['warnings'] = check.warnings;

--- a/testing/integration/dupe-scanner.test.js
+++ b/testing/integration/dupe-scanner.test.js
@@ -57,7 +57,7 @@ async function raw(method, urlPath, body) {
 }
 
 async function createEntity(space, name, description) {
-  const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${space}/entities`, { name, type: 'service', description, tags: [] });
+  const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${space}/entities`, { name, type: 'service', description, tags: [], waitForEmbedding: true });
   return r.status === 201 ? r.body._id : null;
 }
 

--- a/testing/standalone/post-as-update-is-chrono-only.test.js
+++ b/testing/standalone/post-as-update-is-chrono-only.test.js
@@ -1,0 +1,66 @@
+/**
+ * `POST /:id` as an update exists for chrono and for nothing else — and the docs now say so.
+ *
+ * ## Why this needed a gate rather than a note
+ *
+ * The asymmetry was reported as a bug ("POST to a memory id returns 200 and changes nothing"). The 200 did
+ * not reproduce — both the current and the legacy path shapes answer **404** — but the asymmetry underneath
+ * it is real, and it was documented nowhere. It reads as a bug from either direction depending on which
+ * type you met first, which is exactly the kind of thing a reader discovers at the wrong moment.
+ *
+ * The resolution was NOT to add `POST /memories/:id` for symmetry. That would spread a deprecated shape to a
+ * second type to make it look tidy. The chrono route predates the retry-safety design and duplicates it —
+ * a client-supplied UUID v4 in the COLLECTION POST already makes a create idempotent for every type — so it
+ * is documented as legacy and listed for removal.
+ *
+ * This gate holds the two halves together: the route set stays as it is, and the guide keeps saying so. A
+ * doc that describes a route table nobody re-checks is how the previous drift happened.
+ *
+ * Run: node --test testing/standalone/post-as-update-is-chrono-only.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** Comments stripped, so the gate cannot pass on the prose that documents it. */
+const code = (p) => readFileSync(join(ROOT, p), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n');
+
+/** A `POST /…/<collection>/:id` route — the update-by-id shape, as opposed to the collection POST. */
+const postById = (src, router, collection) =>
+  new RegExp(`${router}\\.post\\('/spaces/:spaceId/${collection}/:id'`).test(src);
+
+describe('POST-as-update is chrono-only, and documented', () => {
+  it('chrono has it and the other three do not', () => {
+    const found = {
+      memory: postById(code('server/src/api/brain/memories.ts'), 'memoriesRouter', 'memories'),
+      entity: postById(code('server/src/api/brain/entities.ts'), 'entitiesRouter', 'entities'),
+      edge: postById(code('server/src/api/brain/edges.ts'), 'edgesRouter', 'edges'),
+      chrono: postById(code('server/src/api/brain/chrono.ts'), 'chronoRouter', 'chrono'),
+    };
+    assert.deepEqual(found, { memory: false, entity: false, edge: false, chrono: true },
+      'Adding POST-as-update to another type spreads a DEPRECATED shape to make things look symmetrical. '
+      + 'The supported idempotent create is a client-supplied UUID v4 in the collection POST. If chrono\'s '
+      + 'route has finally been removed, delete this gate and its deprecation entry together.');
+  });
+
+  it('the detector can actually see a route of that shape', () => {
+    // Mutation-check the matcher before trusting a negative. A regex that matches nothing reports every
+    // codebase clean, and three gates in this repo have passed on planted bugs.
+    assert.equal(postById("chronoRouter.post('/spaces/:spaceId/chrono/:id', handler)", 'chronoRouter', 'chrono'), true);
+    assert.equal(postById("memoriesRouter.post('/spaces/:spaceId/memories', handler)", 'memoriesRouter', 'memories'), false,
+      'a COLLECTION post must not be mistaken for an update-by-id route');
+  });
+
+  it('the guide states the asymmetry rather than leaving it to be discovered', () => {
+    const guide = readFileSync(join(ROOT, 'docs/integration-guide/04-brain-api.md'), 'utf8');
+    assert.match(guide, /Updating by id: use PATCH/, 'the section exists');
+    assert.match(guide, /memories\/:id`? is \*\*404\*\*|`no` \(404\)|\*\*no\*\* \(404\)/,
+      'the guide says plainly that POST to a memory id is a 404, not an update');
+    assert.match(guide, /legacy/i, 'and marks the chrono form as legacy rather than as an option');
+  });
+});


### PR DESCRIPTION
docs(api): the one POST-as-update route was documented nowhere

Reported as a bug: posting to a memory id returns 200 and changes nothing. That
did NOT reproduce — driven against a live stack, both the current and the legacy
path shapes answer 404, and the source agrees, because no such route exists.

The asymmetry underneath the report is real though, and was documented nowhere:
a chrono entry CAN be updated by posting to its id, and no other type can. That
reads as a bug from either direction depending on which type you met first.

Resolved by documenting rather than by adding the missing route. Adding
POST-as-update to memories would spread a deprecated shape to a second type to
make it look symmetrical, which is the wrong direction: the supported idempotent
create is a client-supplied UUID v4 in the COLLECTION post, and that already
covers all four types. The chrono route predates that design and duplicates it,
so it is marked legacy in the guide and listed for removal in _DEPRECATIONS.md.

Gated, because a doc describing a route table nobody re-checks is how the drift
happened in the first place. The gate holds both halves together: the route set
stays as it is, and the guide keeps saying so. Its matcher is mutation-checked,
since a regex that matches nothing reports every codebase clean.

One thing worth recording. The first version of the doc wrote the non-existent
route in full "POST /api/..." form in order to say it does not exist, and
route-path-docs-coverage caught it: a doc that names a route to DENY it is
indistinguishable from one that promises it. Reworded to prose.
