### PR TITLE
fix(api): finish the waitForEmbedding sweep instead of the instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Fixed
+
+- **`waitForEmbedding` is now reachable over REST for all four brain types.** The option was added to every
+  creator function in one change while only ONE of the four routes forwarded it, so an HTTP caller writing
+  an entity, edge or chrono entry could not ask for a synchronous embedding at all — a write-then-search or
+  write-then-scan flow had no correct form for those types.
+  - Invisible from the code, because each route looks complete on its own. It surfaced as seven
+    duplicate-scanner failures: those tests create entities and then scan, and a scan cannot pair records
+    that have no vector yet.
+  - **Gated on CONSISTENCY, not on presence** — the check fails when the four routes disagree, so it holds
+    whichever way a future change moves, and it also requires each route to validate the flag rather than
+    trust the body. Mutation-verified.
+
+
 ### Documentation
 
 - **The one POST-as-update route is now documented as legacy, and gated.** A chrono entry can be updated by

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -116,11 +116,20 @@ chronoRouter.post('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, 
   }
   const safeId: string | undefined = typeof rawId === 'string' ? rawId : undefined;
 
+  // `waitForEmbedding` (default false): the vector is normally computed by the embedding queue
+  // moments after this returns. Pass true when the caller will search for, scan, or compare what it
+  // just wrote — none of those can see a record that has no vector yet.
+  const waitForEmbedding = req.body?.waitForEmbedding;
+  if (waitForEmbedding !== undefined && typeof waitForEmbedding !== 'boolean') {
+    res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
+    return;
+  }
+  const embedOpts = waitForEmbedding === true ? { waitForEmbedding: true } : undefined;
   const entry = await createChrono(wt.target, {
     title: title.trim(), type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
     id: safeId,
-  }, webhookToken(req), ttlDaysFromBody(req.body));
+  }, webhookToken(req), ttlDaysFromBody(req.body), embedOpts);
   const result: Record<string, unknown> = { ...entry };
   if (validation.warnings.length > 0) result['warnings'] = validation.warnings;
   res.status(201).json(result);

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -89,10 +89,19 @@ edgesRouter.post('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, de
   const ttlErr = ttlDaysError(req.body);
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
 
+  // `waitForEmbedding` (default false): the vector is normally computed by the embedding queue
+  // moments after this returns. Pass true when the caller will search for, scan, or compare what it
+  // just wrote — none of those can see a record that has no vector yet.
+  const waitForEmbedding = req.body?.waitForEmbedding;
+  if (waitForEmbedding !== undefined && typeof waitForEmbedding !== 'boolean') {
+    res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
+    return;
+  }
+  const embedOpts = waitForEmbedding === true ? { waitForEmbedding: true } : undefined;
   const edge = await upsertEdge(
     wt.target, from.trim(), to.trim(), label.trim(), weight, type?.trim(),
     typeof description === 'string' ? description : undefined, safeProps, safeTags,
-    webhookToken(req), ttlDaysFromBody(req.body),
+    webhookToken(req), ttlDaysFromBody(req.body), embedOpts,
   );
   const result: Record<string, unknown> = { ...edge };
   if (check.warnings.length > 0) result['warnings'] = check.warnings;

--- a/testing/standalone/wait-for-embedding-on-every-create-route.test.js
+++ b/testing/standalone/wait-for-embedding-on-every-create-route.test.js
@@ -1,0 +1,76 @@
+/**
+ * Every brain create route accepts `waitForEmbedding`, or none of them should.
+ *
+ * ## Why this gate exists rather than a note
+ *
+ * Writes stopped waiting for the embedding model, which means a caller who will search for, scan, or
+ * compare what it just wrote needs a way to say so. `waitForEmbedding` is that way — and it was added to
+ * all four creator FUNCTIONS in one change while only ONE of the four ROUTES forwarded it.
+ *
+ * That gap was invisible from the code (each route looks complete on its own) and cost seven CI failures in
+ * the duplicate-scanner suite, which creates entities and then scans: a scan cannot pair records that have
+ * no vector yet. It was then fixed one route at a time, twice.
+ *
+ * Three times in one session the same shape recurred — a rule established for memories and not carried to
+ * the types the mechanism was extended to. The individual misses are cheap. The pattern is what this gate
+ * is for: it fails when the set is INCONSISTENT, not when any particular route is missing, so it holds
+ * whichever way a future change moves.
+ *
+ * Run: node --test testing/standalone/wait-for-embedding-on-every-create-route.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** The four brain record types that carry their own embedding, and the route file for each. */
+const ROUTES = {
+  memory: 'server/src/api/brain/memories.ts',
+  entity: 'server/src/api/brain/entities.ts',
+  edge: 'server/src/api/brain/edges.ts',
+  chrono: 'server/src/api/brain/chrono.ts',
+};
+
+/** Comments stripped, so the gate cannot pass on the prose that documents it. */
+const code = (p) => readFileSync(join(ROOT, p), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n');
+
+describe('waitForEmbedding is reachable on every brain create route', () => {
+  it('the detector sees the pattern it is gating', () => {
+    // Mutation-check before trusting a positive: a matcher that matches everything is as useless as one
+    // that matches nothing, and this gate's whole value is telling the four routes apart.
+    assert.ok(/req\.body\?\.waitForEmbedding/.test('const x = req.body?.waitForEmbedding;'));
+    assert.equal(/req\.body\?\.waitForEmbedding/.test('const x = req.body?.somethingElse;'), false);
+  });
+
+  it('all four routes read it, or none do', () => {
+    const reads = {};
+    for (const [type, file] of Object.entries(ROUTES)) {
+      reads[type] = /req\.body\?\.waitForEmbedding/.test(code(file));
+    }
+    const yes = Object.entries(reads).filter(([, v]) => v).map(([k]) => k);
+    const no = Object.entries(reads).filter(([, v]) => !v).map(([k]) => k);
+
+    assert.ok(yes.length === 4 || no.length === 4,
+      `waitForEmbedding is reachable over REST for [${yes.join(', ')}] but not [${no.join(', ')}]. `
+      + 'A caller writing one of the second group cannot ask for a synchronous embedding at all, so a '
+      + 'write-then-search or write-then-scan flow has no correct form for that type. This exact gap cost '
+      + 'seven duplicate-scanner failures. Add it to the rest, or remove it from all four deliberately.');
+  });
+
+  it('each route VALIDATES it rather than trusting the body', () => {
+    // A boolean read straight out of a request body and passed to a writer is how a string "false" turns
+    // into a truthy synchronous embed. Every route that reads it must also reject a non-boolean.
+    const offenders = [];
+    for (const [type, file] of Object.entries(ROUTES)) {
+      const src = code(file);
+      if (!/req\.body\?\.waitForEmbedding/.test(src)) continue;
+      if (!/typeof waitForEmbedding !== 'boolean'/.test(src)) offenders.push(type);
+    }
+    assert.deepEqual(offenders, [],
+      'these routes read waitForEmbedding but never check it is a boolean');
+  });
+});


### PR DESCRIPTION
fix(api): finish the waitForEmbedding sweep instead of the instance

Edges and chrono can now be created with waitForEmbedding over REST. All four
brain types accept it; until now only memories and entities did.

This is the third time in one session that the same shape appeared: a rule
established for memories and not carried to the types the mechanism was extended
to. First it was checkDuplicates implying the wait (two CI failures). Then it was
the entity route not forwarding the flag (seven). Fixing the third instance
one-at-a-time again would have been the same mistake with a different line
number, so this closes the set and gates it.

The gate fails on INCONSISTENCY, not on absence: it asserts that all four routes
accept the flag or none do. That holds whichever way a future change moves —
adding a fifth record type, or deciding the flag was a bad idea and removing it —
where a presence check would only hold one of those directions. It also requires
each route that reads the flag to VALIDATE it, since a boolean taken straight
from a request body is how the string "false" becomes a truthy synchronous embed.

Mutation-verified: blanking the flag on one route turns it red, and the detector
is checked against a near-miss so a matcher that matches everything cannot pass
for one that discriminates.

Why this was invisible: each route reads fine on its own. Nothing in
edges.ts suggested that memories.ts had grown an option it lacked, which is
exactly the class of defect a per-file review cannot catch and a cross-file
assertion can.
