### PR TITLE
feat(api): the embedding backlog was a number nobody could see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Added
+
+- **`GET /stats` now reports the embedding backlog** as `embedQueue: { pending, processing, failed }`.
+  Since writes stopped waiting for the model, a record can exist and be absent from recall for a moment —
+  and nothing anywhere said how much of a space was in that state, or whether it was draining.
+  - `getEmbedJobCounts` had existed since the queue landed with **no caller**: the system held the number
+    and never reported it, which is the same shape as the defect the queue itself fixed.
+  - A lasting `failed` count is the signal that an embedding endpoint is unreachable or misconfigured.
+    Rewriting a record requeues it, so there is a way back without touching the queue.
+  - Summed across members for a proxy space, matching the record counts beside it — a zero there would
+    read as "nothing pending" rather than "not counted".
+
+
 ### Fixed
 
 - **`waitForEmbedding` is now reachable over REST for all four brain types.** The option was added to every

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1283,9 +1283,26 @@ GET /api/brain/spaces/:spaceId/stats
   "entities": 156,
   "edges": 89,
   "chrono": 23,
-  "files": 31
+  "files": 31,
+  "embedQueue": { "pending": 0, "processing": 0, "failed": 0 }
 }
 ```
+
+**`embedQueue` — how much of this space is not searchable yet.** Writes do not wait for the embedding
+model; a background worker embeds each record moments later. Until it does, the record exists but is
+**absent from recall** rather than ranked lower, because both retrieval channels need the vector.
+
+| field | meaning |
+|---|---|
+| `pending` | queued, not started. Normally 0, briefly non-zero after a burst of writes or a sync pull |
+| `processing` | in flight right now |
+| `failed` | gave up after retrying with backoff. **A non-zero value that does not clear is the signal that something is wrong** — usually an unreachable or misconfigured embedding endpoint |
+
+Use it to answer "is this space ready to search". A steady `pending` that never drains, or any lasting
+`failed`, means recall is quietly returning less than the space contains. Rewriting a record requeues it,
+which is the way back from `failed` without an operator touching the queue.
+
+For a proxy space the numbers are its **members'**, summed — matching the record counts above.
 
 ---
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -9,6 +9,7 @@ import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
+import { getEmbedJobCounts } from '../../brain/embed-queue.js';
 import { queryBrain } from '../../brain/query.js';
 import { findSimilar, recall, rankOf, type RecallKnowledgeType } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
@@ -46,13 +47,25 @@ searchRouter.get('/spaces/:spaceId/stats', globalRateLimit, requireSpaceAuth, as
     chrono: await col(`${mid}_chrono`).countDocuments(),
     // Exclude chunk records (parentFileId set) — count only top-level file records
     files: await col(`${mid}_files`).countDocuments({ parentFileId: { $exists: false } }),
+    // How much of the above is not searchable YET. Writes no longer wait for the embedding model, so a
+    // record can exist and be absent from recall for a moment — and a caller asking "is this space ready"
+    // could not tell that from "the model is down and nothing has embedded for an hour". Same shape as the
+    // defect the queue fixed: a state the system knew about and never reported.
+    embedQueue: await getEmbedJobCounts(mid),
   })));
   const memories = counts.reduce((s, c) => s + c.memories, 0);
   const entities = counts.reduce((s, c) => s + c.entities, 0);
   const edges = counts.reduce((s, c) => s + c.edges, 0);
   const chrono = counts.reduce((s, c) => s + c.chrono, 0);
   const files = counts.reduce((s, c) => s + c.files, 0);
-  res.json({ spaceId, memories, entities, edges, chrono, files });
+  // Summed across members like everything else here, so a proxy space reports its members' backlog rather
+  // than a zero that would read as "nothing pending".
+  const embedQueue = {
+    pending: counts.reduce((s, c) => s + c.embedQueue.pending, 0),
+    processing: counts.reduce((s, c) => s + c.embedQueue.processing, 0),
+    failed: counts.reduce((s, c) => s + c.embedQueue.failed, 0),
+  };
+  res.json({ spaceId, memories, entities, edges, chrono, files, embedQueue });
 });
 
 


### PR DESCRIPTION
feat(api): the embedding backlog was a number nobody could see

GET /stats now returns embedQueue: { pending, processing, failed }.

Since writes stopped waiting for the embedding model, a record can exist and be
absent from recall for a moment — absent, not ranked lower, because both
retrieval channels need the vector. Nothing anywhere reported how much of a space
was in that state or whether it was draining, so "recall returned less than I
expected" had no diagnosis short of querying Mongo by hand.

getEmbedJobCounts has existed since the queue landed and had NO caller. The
system held the number and never reported it, which is precisely the shape of the
defect the queue itself was built to fix: a record could be unsearchable with
nothing anywhere saying so.

On /stats rather than a new endpoint, because /stats is already "what is in this
space", it is already proxy-aware, and someone asking whether a space is ready to
search should not have to learn a second route. Summed across members for the
same reason the record counts are: a zero on a proxy space would read as "nothing
pending" rather than "not counted".

The field worth acting on is `failed`. Pending and processing are transient by
design; a `failed` count that does not clear means an embedding endpoint is
unreachable or misconfigured and recall is quietly returning less than the space
contains. Documented with that reading, plus the way back — rewriting a record
requeues it, so an operator never has to touch the queue directly.
