### PR TITLE
fix(mcp): upsert_edge returned an id for a link that did not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Fixed
+
+- **`upsert_edge` over MCP returned an id for a link that did not exist** (reported by the canary, their
+  top-ranked ask). In a space with `strictLinkage: true`, an edge whose `to` named a **chrono** was
+  accepted: 201, an edge id back, stored fine — and then absent from `traverse` and `recall(traverse: 1)`
+  alike, missing from `nodes` AND `edges`, because both hydrate neighbours out of the entity collection.
+  - **Shape is not existence.** The MCP tool checked `UUID_V4_RE` and stopped; a chrono's `_id` is a
+    perfectly good UUID v4. The REST route has always called `assertRefsResolve`, which asks the database
+    whether the id names an entity. Two surfaces onto one rule, one enforcing a weaker version, each
+    reading as complete on its own.
+  - It cost the reporter a 33-day incident timeline, reassembled by name regex instead of by traversal —
+    and they could not clean up the dead edge, since no `delete_edge` is exposed over MCP; it had to be
+    parked with `ttlDays: 1`.
+  - Gated across **both** write surfaces, not just the one that broke.
+
+
 ### Added
 
 - **`GET /stats` now reports the embedding backlog** as `embedQueue: { pending, processing, failed }`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Added
+
+- **`GET /stats` now reports the embedding backlog** as `embedQueue: { pending, processing, failed }`.
+  Since writes stopped waiting for the model, a record can exist and be absent from recall for a moment —
+  and nothing anywhere said how much of a space was in that state, or whether it was draining.
+  - `getEmbedJobCounts` had existed since the queue landed with **no caller**: the system held the number
+    and never reported it, which is the same shape as the defect the queue itself fixed.
+  - A lasting `failed` count is the signal that an embedding endpoint is unreachable or misconfigured.
+    Rewriting a record requeues it, so there is a way back without touching the queue.
+  - Summed across members for a proxy space, matching the record counts beside it — a zero there would
+    read as "nothing pending" rather than "not counted".
+
+
 ### Fixed
 
 - **`waitForEmbedding` is now reachable over REST for all four brain types.** The option was added to every

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1283,9 +1283,26 @@ GET /api/brain/spaces/:spaceId/stats
   "entities": 156,
   "edges": 89,
   "chrono": 23,
-  "files": 31
+  "files": 31,
+  "embedQueue": { "pending": 0, "processing": 0, "failed": 0 }
 }
 ```
+
+**`embedQueue` — how much of this space is not searchable yet.** Writes do not wait for the embedding
+model; a background worker embeds each record moments later. Until it does, the record exists but is
+**absent from recall** rather than ranked lower, because both retrieval channels need the vector.
+
+| field | meaning |
+|---|---|
+| `pending` | queued, not started. Normally 0, briefly non-zero after a burst of writes or a sync pull |
+| `processing` | in flight right now |
+| `failed` | gave up after retrying with backoff. **A non-zero value that does not clear is the signal that something is wrong** — usually an unreachable or misconfigured embedding endpoint |
+
+Use it to answer "is this space ready to search". A steady `pending` that never drains, or any lasting
+`failed`, means recall is quietly returning less than the space contains. Rewriting a record requeues it,
+which is the way back from `failed` without an operator touching the queue.
+
+For a proxy space the numbers are its **members'**, summed — matching the record counts above.
 
 ---
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -9,6 +9,7 @@ import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
+import { getEmbedJobCounts } from '../../brain/embed-queue.js';
 import { queryBrain } from '../../brain/query.js';
 import { findSimilar, recall, rankOf, type RecallKnowledgeType } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
@@ -46,13 +47,25 @@ searchRouter.get('/spaces/:spaceId/stats', globalRateLimit, requireSpaceAuth, as
     chrono: await col(`${mid}_chrono`).countDocuments(),
     // Exclude chunk records (parentFileId set) — count only top-level file records
     files: await col(`${mid}_files`).countDocuments({ parentFileId: { $exists: false } }),
+    // How much of the above is not searchable YET. Writes no longer wait for the embedding model, so a
+    // record can exist and be absent from recall for a moment — and a caller asking "is this space ready"
+    // could not tell that from "the model is down and nothing has embedded for an hour". Same shape as the
+    // defect the queue fixed: a state the system knew about and never reported.
+    embedQueue: await getEmbedJobCounts(mid),
   })));
   const memories = counts.reduce((s, c) => s + c.memories, 0);
   const entities = counts.reduce((s, c) => s + c.entities, 0);
   const edges = counts.reduce((s, c) => s + c.edges, 0);
   const chrono = counts.reduce((s, c) => s + c.chrono, 0);
   const files = counts.reduce((s, c) => s + c.files, 0);
-  res.json({ spaceId, memories, entities, edges, chrono, files });
+  // Summed across members like everything else here, so a proxy space reports its members' backlog rather
+  // than a zero that would read as "nothing pending".
+  const embedQueue = {
+    pending: counts.reduce((s, c) => s + c.embedQueue.pending, 0),
+    processing: counts.reduce((s, c) => s + c.embedQueue.processing, 0),
+    failed: counts.reduce((s, c) => s + c.embedQueue.failed, 0),
+  };
+  res.json({ spaceId, memories, entities, edges, chrono, files, embedQueue });
 });
 
 

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -6,6 +6,7 @@ import { getEdgeById, traverseGraph, updateEdgeById, upsertEdge } from '../../br
 import { assertUpdateAllowed, classifyEdgeUpsert, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
+import { assertRefsResolve } from '../../brain/entity-refs.js';
 import { resolveMetaRefs, validateEdge } from '../../spaces/schema-validation.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
@@ -56,6 +57,15 @@ export const upsert_edgeTool: ToolHandler = {
     if (isStrictLinkage(wt.target)) {
       if (!UUID_V4_RE.test(from)) throw new Error('from must be a valid UUID v4 (entity ID), not a name');
       if (!UUID_V4_RE.test(to)) throw new Error('to must be a valid UUID v4 (entity ID), not a name');
+      // Shape is not existence. A UUID v4 that names a CHRONO passes both checks above, and the edge then
+      // stores fine and is invisible to every graph query — `traverse` and `recall(traverse:1)` hydrate
+      // neighbours from the entity collection, so a non-entity endpoint yields no node and no edge. The
+      // caller gets an id back for a link that does not exist.
+      //
+      // Reported by the canary, who lost a 33-day incident timeline to it. The REST route has always
+      // called this; only the MCP surface checked the shape and stopped there.
+      await assertRefsResolve(wt.target, 'from', 'entity', [from]);
+      await assertRefsResolve(wt.target, 'to', 'entity', [to]);
     }
 
     // Schema validation of the record this upsert will PRODUCE. An edge's identity is (from, to, label)

--- a/testing/standalone/strict-linkage-checks-both-surfaces.test.js
+++ b/testing/standalone/strict-linkage-checks-both-surfaces.test.js
@@ -1,0 +1,80 @@
+/**
+ * Strict linkage means the endpoint EXISTS, not that it is UUID-shaped — on every write surface.
+ *
+ * ## The defect, reported by the canary
+ *
+ * `upsert_edge` over MCP, in a space with `strictLinkage: true`, with `to:` a **chrono** uuid: it returned
+ * 201 and an edge id. The edge stored fine and was then absent from `traverse` and from
+ * `recall(traverse: 1)` alike — missing from `nodes` AND from `edges`, because both hydrate neighbours out
+ * of the entity collection and a non-entity endpoint yields nothing.
+ *
+ * So the caller got **an id for a link that does not exist**, which is worse than an error. They could not
+ * clean it up either — no `delete_edge` on the MCP surface — and parked the dead edge with `ttlDays: 1`.
+ * It cost them a 33-day incident timeline that had to be reassembled by name regex instead of by traversal.
+ *
+ * ## Why it was invisible
+ *
+ * The REST route has always called `assertRefsResolve`, which asks the database whether the id names an
+ * entity. The MCP tool checked `UUID_V4_RE` and stopped — and a chrono's `_id` is a perfectly good UUID v4.
+ * Two surfaces onto one rule, one of them enforcing a weaker version of it, and each reads as complete on
+ * its own. Same shape as `waitForEmbedding` reaching one route of four.
+ *
+ * This gate is written against BOTH surfaces for that reason. Pinning only the MCP tool would leave the
+ * next surface free to reintroduce it.
+ *
+ * Run: node --test testing/standalone/strict-linkage-checks-both-surfaces.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** Comments stripped, so the gate cannot pass on the prose that documents it. */
+const code = (p) => readFileSync(join(ROOT, p), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n');
+
+/** Every surface that writes an edge and therefore owes the same linkage guarantee. */
+const EDGE_WRITE_SURFACES = {
+  rest: 'server/src/api/brain/edges.ts',
+  mcp: 'server/src/mcp/tools/edge.ts',
+};
+
+describe('strict linkage is enforced by existence on every edge write surface', () => {
+  it('the detector distinguishes a shape check from an existence check', () => {
+    // Mutation-check the matcher: the whole finding is that one surface had the first and not the second,
+    // so a gate that cannot tell them apart would have passed on the bug.
+    const shapeOnly = "if (!UUID_V4_RE.test(to)) throw new Error('bad');";
+    const existence = "await assertRefsResolve(wt.target, 'to', 'entity', [to]);";
+    assert.equal(/assertRefsResolve\([^)]*'to'/.test(shapeOnly), false);
+    assert.ok(/assertRefsResolve\([^)]*'to'/.test(existence));
+  });
+
+  it('both surfaces check that `from` AND `to` resolve to an entity', () => {
+    const missing = [];
+    for (const [surface, file] of Object.entries(EDGE_WRITE_SURFACES)) {
+      const src = code(file);
+      for (const side of ['from', 'to']) {
+        const re = new RegExp(`assertRefsResolve\\([^)]*'${side}'[^)]*'entity'`);
+        if (!re.test(src)) missing.push(`${surface}.${side}`);
+      }
+    }
+    assert.deepEqual(missing, [],
+      'A UUID v4 that names a chrono passes a shape check and stores an edge that every graph query '
+      + 'ignores — the caller gets an id for a link that does not exist. Shape is not existence: use '
+      + 'assertRefsResolve on BOTH endpoints, as the REST route always has.');
+  });
+
+  it('a shape check alone is never the whole guard', () => {
+    // The specific regression to prevent: someone removes the existence call and leaves the UUID test,
+    // which still looks like validation at a glance.
+    for (const [surface, file] of Object.entries(EDGE_WRITE_SURFACES)) {
+      const src = code(file);
+      if (!/UUID_V4_RE\.test\((from|to)\)/.test(src)) continue;
+      assert.match(src, /assertRefsResolve/,
+        `${surface} shape-checks an edge endpoint but never asks whether it exists`);
+    }
+  });
+});


### PR DESCRIPTION
fix(mcp): upsert_edge returned an id for a link that did not exist

The canary's top-ranked ask, and they were right to rank it first: it reports
success and does nothing, which is worse than an error.

In a space with strictLinkage: true, upsert_edge over MCP with `to` naming a
CHRONO was accepted — 201, an edge id returned, stored fine. The edge was then
absent from traverse and from recall(traverse: 1) alike, missing from `nodes`
AND from `edges`, because both hydrate neighbours out of the entity collection
and a non-entity endpoint yields nothing.

Shape is not existence. The MCP tool checked UUID_V4_RE and stopped, and a
chrono's _id is a perfectly good UUID v4. The REST route has always called
assertRefsResolve, which asks the database whether the id names an entity. Two
surfaces onto one rule, one of them enforcing a weaker version of it, and each
reads as complete on its own — the same shape as waitForEmbedding reaching one
route of four earlier today.

What it cost them: a 33-day hardware-RMA timeline that had to be reassembled
from four query() calls and two repo greps, and the first pass still missed the
carrier ticket because it had to be found by name regex instead of by traversal
from the incident. They could not clean up the dead edge either — no delete_edge
is exposed over MCP — so it was parked with ttlDays: 1.

Gated across BOTH edge write surfaces rather than the one that broke, because
pinning only the MCP tool leaves the next surface free to reintroduce it. The
gate's matcher is mutation-checked against a shape-check-only sample, since the
entire finding is that one surface had a shape check and not an existence check
— a detector that cannot tell those apart would have passed on the bug.

Their other seven asks are filed as C-L5-2..C-L5-8 in their ranking, each with a
verify line. Not shipped here, and not silently narrowed: this is the one they
called the smallest change with the largest correctness gain.
