### PR TITLE
fix(api): excludeFromVectorSearch shipped unreachable over REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`excludeFromVectorSearch` was not settable over REST.** It was wired into the four update functions
+  and into none of the PATCH handlers, so `PATCH /memories/<id>` with only that field answered *"At least
+  one field must be provided"* — the flag shipped unreachable on the surface most integrators use. Found
+  by an integrator probing the feature rather than trusting the changelog.
+  - Each handler builds its own allowlisted `updates` object with its own inline type, so an addition to
+    the writer beneath them is invisible from where the request is parsed.
+  - It may be the **only** field in a request: retiring a record from vector search is a complete edit in
+    itself, not a modifier on some other change.
+
+
+### Fixed
+
 - **A wrong-shaped NLI model no longer impersonates a dead endpoint** (canary report). A 2-class head —
   `{entailment, not_entailment}`, which most *zeroshot* variants are — emits a label `parseVerdict` maps
   to nothing, so every pair was recorded `judge-unavailable` and the scanner parked its cursor: **exactly**

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -197,7 +197,7 @@ edgesRouter.patch('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAut
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
   const ttlDaysProvided = !!req.body && typeof req.body === 'object' && 'ttlDays' in req.body;
   const dfPaths: string[] | undefined = Array.isArray(deleteFields) && deleteFields.length > 0 ? deleteFields : undefined;
-  const updates: { label?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; weight?: number; type?: string } = {};
+  const updates: { label?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; weight?: number; type?: string; excludeFromVectorSearch?: boolean } = {};
   if (label !== undefined) {
     if (typeof label !== 'string' || !label.trim()) { res.status(400).json({ error: '`label` must be a non-empty string' }); return; }
     updates.label = label.trim();
@@ -221,6 +221,16 @@ edgesRouter.patch('/spaces/:spaceId/edges/:id', globalRateLimit, requireSpaceAut
   if (type !== undefined) {
     if (typeof type !== 'string') { res.status(400).json({ error: '`type` must be a string' }); return; }
     updates.type = type.trim();
+  }
+  // A boolean, and the ONLY field a caller may send on its own — retiring a record from vector search is a
+  // complete edit in itself. It was wired into the update functions and into no PATCH handler, so it
+  // shipped unreachable over REST; a caller sending it alone was told they had sent no fields at all.
+  if (req.body?.excludeFromVectorSearch !== undefined) {
+    if (typeof req.body.excludeFromVectorSearch !== 'boolean') {
+      res.status(400).json({ error: '`excludeFromVectorSearch` must be a boolean' });
+      return;
+    }
+    updates.excludeFromVectorSearch = req.body.excludeFromVectorSearch;
   }
   if (Object.keys(updates).length === 0 && !dfPaths && !ttlDaysProvided) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
   const memberIds = resolveMemberSpaces(wt.target);

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -229,7 +229,7 @@ entitiesRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSp
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
   const ttlDaysProvided = !!req.body && typeof req.body === 'object' && 'ttlDays' in req.body;
   const dfPaths: string[] | undefined = Array.isArray(deleteFields) && deleteFields.length > 0 ? deleteFields : undefined;
-  const updates: { name?: string; type?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean> } = {};
+  const updates: { name?: string; type?: string; description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; excludeFromVectorSearch?: boolean } = {};
   if (name !== undefined) {
     if (typeof name !== 'string' || !name.trim()) { res.status(400).json({ error: '`name` must be a non-empty string' }); return; }
     updates.name = name.trim();
@@ -249,6 +249,16 @@ entitiesRouter.patch('/spaces/:spaceId/entities/:id', globalRateLimit, requireSp
   if (properties !== undefined) {
     if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) { res.status(400).json({ error: '`properties` must be a plain object' }); return; }
     updates.properties = properties as Record<string, string | number | boolean>;
+  }
+  // A boolean, and the ONLY field a caller may send on its own — retiring a record from vector search is a
+  // complete edit in itself. It was wired into the update functions and into no PATCH handler, so it
+  // shipped unreachable over REST; a caller sending it alone was told they had sent no fields at all.
+  if (req.body?.excludeFromVectorSearch !== undefined) {
+    if (typeof req.body.excludeFromVectorSearch !== 'boolean') {
+      res.status(400).json({ error: '`excludeFromVectorSearch` must be a boolean' });
+      return;
+    }
+    updates.excludeFromVectorSearch = req.body.excludeFromVectorSearch;
   }
   if (Object.keys(updates).length === 0 && !dfPaths && !ttlDaysProvided) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
   const memberIds = resolveMemberSpaces(wt.target);

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -201,7 +201,7 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
   const ttlDaysProvided = !!req.body && typeof req.body === 'object' && 'ttlDays' in req.body;
   const dfPaths: string[] | undefined = Array.isArray(deleteFields) && deleteFields.length > 0 ? deleteFields : undefined;
-  const updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean> } = {};
+  const updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; excludeFromVectorSearch?: boolean } = {};
   if (fact !== undefined) {
     if (typeof fact !== 'string' || !fact.trim()) { res.status(400).json({ error: '`fact` must be a non-empty string' }); return; }
     updates.fact = fact;
@@ -225,6 +225,16 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
   if (properties !== undefined) {
     if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) { res.status(400).json({ error: '`properties` must be a plain object' }); return; }
     updates.properties = properties as Record<string, string | number | boolean>;
+  }
+  // A boolean, and the ONLY field a caller may send on its own — retiring a record from vector search is a
+  // complete edit in itself. It was wired into the update functions and into no PATCH handler, so it
+  // shipped unreachable over REST; a caller sending it alone was told they had sent no fields at all.
+  if (req.body?.excludeFromVectorSearch !== undefined) {
+    if (typeof req.body.excludeFromVectorSearch !== 'boolean') {
+      res.status(400).json({ error: '`excludeFromVectorSearch` must be a boolean' });
+      return;
+    }
+    updates.excludeFromVectorSearch = req.body.excludeFromVectorSearch;
   }
   if (Object.keys(updates).length === 0 && !dfPaths && !ttlDaysProvided) { res.status(400).json({ error: 'At least one field must be provided' }); return; }
   const memberIds = resolveMemberSpaces(wt.target);

--- a/testing/standalone/wait-for-embedding-on-every-create-route.test.js
+++ b/testing/standalone/wait-for-embedding-on-every-create-route.test.js
@@ -61,6 +61,25 @@ describe('waitForEmbedding is reachable on every brain create route', () => {
       + 'seven duplicate-scanner failures. Add it to the rest, or remove it from all four deliberately.');
   });
 
+  it('excludeFromVectorSearch is reachable on every PATCH handler that has one, or none', () => {
+    // Same rule, same gate. It shipped wired into the four update FUNCTIONS and into no PATCH handler at
+    // all, so a caller sending it alone was told they had sent no fields — reported by an integrator
+    // against a live instance. Fourth time in one session that one rule reached some surfaces and not
+    // others, so it is gated the same way: consistency, not presence.
+    const has = {};
+    for (const [type, file] of Object.entries(ROUTES)) {
+      const src = code(file);
+      if (!/At least one field must be provided/.test(src)) continue;   // no PATCH handler here
+      has[type] = /excludeFromVectorSearch/.test(src);
+    }
+    const yes = Object.entries(has).filter(([, v]) => v).map(([k]) => k);
+    const no = Object.entries(has).filter(([, v]) => !v).map(([k]) => k);
+    assert.ok(yes.length === 0 || no.length === 0,
+      `excludeFromVectorSearch is settable over REST for [${yes.join(', ')}] but not [${no.join(', ')}]. `
+      + 'A flag wired into the update function and not into the handler ships UNREACHABLE on the surface '
+      + 'most integrators use.');
+  });
+
   it('each route VALIDATES it rather than trusting the body', () => {
     // A boolean read straight out of a request body and passed to a writer is how a string "false" turns
     // into a truthy synchronous embed. Every route that reads it must also reject a non-boolean.


### PR DESCRIPTION
fix(api): excludeFromVectorSearch shipped unreachable over REST

Reported by aigents against a live instance, probing the feature rather than
trusting the changelog: PATCH /memories/<id> with only excludeFromVectorSearch
returns "At least one field must be provided". The validator did not count it as
a field, so the flag could not be set on its own — on the surface they use
exclusively.

They are right, and the cause is that the flag was wired into the four update
FUNCTIONS and into none of the PATCH handlers. Each handler builds its own
allowlisted `updates` object with its own inline type, so an addition to the
writer beneath them is invisible from where the request is parsed.

That is the FOURTH occurrence of one shape today: a rule reaching some surfaces
and not others, each file reading as complete on its own. checkDuplicates
implying the wait (memories, not entities). waitForEmbedding (one route of four).
upsert_edge (REST checked existence, MCP checked shape). Now this. So it is swept
across all three PATCH handlers that carry the validator, not fixed on the one
that was reported, and folded into the existing consistency gate rather than
given a new one.

It is also allowed to be the ONLY field in a request, which the validator's
wording made a decision worth stating: retiring a record from vector search is a
complete edit in itself, not a modifier on some other change.

Two further things from the same letter, verified and NOT changed:

  the changelog placement     They read the entry as shipped in 2.4.0. It sits
                              under [Unreleased] (line 98; [2.4.0] begins at
                              223), so the feature is post-2.4.0 and their build
                              correctly lacks it. No defect, but two readers in
                              two letters have now spent real effort on the
                              question of what is in their build.

  their §0 retraction         They withdrew the "POST to a memory id returns 200"
                              report, having found their probe never checked the
                              status code. That matches the 404 measured here
                              independently, and the asymmetry underneath it was
                              documented separately.
