### PR TITLE
fix(brain): the duplicate check could not see the batch you were writing (#698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The duplicate check could not see the batch you were writing** (reported by two integrators
+  independently). `checkDuplicates` read the vector index, which is eventually consistent — a record
+  committed a moment ago is not in it. So the one check whose entire job is to compare against the
+  neighbourhood of a record being written *now* was the one check guaranteed not to see it: every warning
+  named an older record, and none ever named a sibling from the same batch. That is precisely when
+  duplicates get created.
+  - Diagnosed by the reporter's own measurement: a 0.98-similar record missed at ~14 s and caught at
+    ~2 min on the **same** threshold, which is what proves elapsed time was the variable rather than
+    `dupeThreshold`.
+  - **`exact: true` is not the fix**, though it looks like one. It is an exhaustive scan of the *index*,
+    not of the collection. Measured by inserting a document and polling both paths: ANN first saw it after
+    1088 ms, ENN after 1083 ms — identical. Anything routed through search inherits the lag.
+  - The check now also scores the space's newest records straight from the **collection**, bounded by a
+    time window (`DUPE_FRESH_WINDOW_MS`, default 180 s) and a document cap (`DUPE_FRESH_SCAN_CAP`, default
+    200). Cost tracks how much the space is churning rather than how large it is: ~9 ms with an empty
+    window and ~52 ms with a full one, at 20,000 records and 768 dimensions. A truncated scan logs the cap
+    it hit rather than reading as a complete one.
+  - The mapping from similarity to the score Atlas reports now has one implementation
+    (`atlasScoreFromParts`), reached both by callers holding two vectors and by the aggregation pipeline,
+    which computes only `dot` and the document's norm. Restating the formula in MQL would have been the
+    two-implementations-of-one-rule shape that has cost this repo four bugs.
+  - Reaches the duplicate **and** contradiction checks on memories, entities and chrono entries, since all
+    three write paths already funnelled through this one function. `recall` itself is unchanged — the same
+    lag on the read path is a different cost trade and is tracked separately.
+
+
+### Fixed
+
 - **`excludeFromVectorSearch` was not settable over REST.** It was wired into the four update functions
   and into none of the PATCH handlers, so `PATCH /memories/<id>` with only that field answered *"At least
   one field must be provided"* — the flag shipped unreachable on the surface most integrators use. Found

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -174,12 +174,33 @@ Content-Type: application/json
 
 ### Duplicate Detection on Insert
 
-The `remember`, `upsert_entity` and `create_chrono` tools run a **semantic near-duplicate check** before storing, using the same embedding the new record is stored with — so it costs one extra ANN vector search, not a re-embed. When a highly similar record already exists, the tool's response flags it (id, a short summary, and the cosine score) so an agent can update or merge the existing record instead of accumulating redundant ones:
+The `remember`, `upsert_entity` and `create_chrono` tools run a **semantic near-duplicate check** before storing, using the same embedding the new record is stored with — so it costs a vector search, not a re-embed. When a highly similar record already exists, the tool's response flags it (id, a short summary, and the cosine score) so an agent can update or merge the existing record instead of accumulating redundant ones:
 
 ```text
 Stored memory (seq 1284, ID 7f3c…).
 ⚠️ Possible duplicate — 1 existing memory is highly similar: "The Vault service stores secrets and rotates auth tokens" (ID 9a1b…, 0.97). This memory was still stored; pass checkDuplicates:false to skip this check, or update the existing one instead.
 ```
+
+#### It sees the batch you are writing
+
+The check reads **two** places, and the second one matters if your agent writes several related records in
+one turn. The vector index is eventually consistent — a record committed a second ago is not in it yet — so
+a check that read only the index could never warn you about a sibling from the same batch. Every duplicate
+warning named an older record, and none ever named the one you had just written, which is precisely when
+duplicates get created.
+
+So the check also scores the space's **most recently written records straight from the collection**. Two
+bounds keep that off your latency budget, both settable if your write rate needs different ones:
+
+| variable | default | what it bounds |
+|---|---|---|
+| `DUPE_FRESH_WINDOW_MS` | `180000` | how far back it reads. `0` disables this half — index only, the pre-2.5 behaviour |
+| `DUPE_FRESH_SCAN_CAP` | `200` | the most records one check scores this way, whatever the window says |
+
+The cost is proportional to how much the space is actually churning, not to how large it is: measured on
+20,000 records at 768 dimensions, **~9 ms** when nothing was written recently and **~52 ms** when the window
+is full. A space sustaining more writes than the cap covers logs a warning naming the cap, so a truncated
+scan never quietly reads as a complete one.
 
 #### Contradiction warning on insert
 

--- a/server/src/brain/fresh-writes.ts
+++ b/server/src/brain/fresh-writes.ts
@@ -96,11 +96,17 @@ export async function matchFreshWrites(
 ): Promise<FreshMatch[]> {
   if (queryVector.length === 0) return [];
 
-  const similarity = getEmbeddingConfig().similarity;
-  const queryNorm = norm(queryVector);
-  const cutoff = new Date(now - FRESH_WINDOW_MS).toISOString();
-
+  // Everything, including reading the config, is inside the try.
+  //
+  // `getEmbeddingConfig()` throwing here would propagate into `checkDuplicates`, whose own catch returns
+  // `[]` for the WHOLE check — discarding the index results it had already collected. A best-effort
+  // addition that can take the working half down with it is not best-effort, and the two lines that used
+  // to sit above this were the only way that could happen.
   try {
+    const similarity = getEmbeddingConfig().similarity;
+    const queryNorm = norm(queryVector);
+    const cutoff = new Date(now - FRESH_WINDOW_MS).toISOString();
+
     const rows = await col(collName).aggregate<{ _id: string; dot: number; norm: number }>([
       // Newest first, capped, BEFORE anything expensive. This is the index walk that keeps the cost flat.
       { $sort: { seq: -1 } },

--- a/server/src/brain/fresh-writes.ts
+++ b/server/src/brain/fresh-writes.ts
@@ -1,0 +1,162 @@
+/**
+ * The records the vector index has not seen yet.
+ *
+ * ## The defect this exists for
+ *
+ * `checkDuplicates` asks "is anything already in this space very similar to what I am about to write?" —
+ * and it asked the **vector index**, which is eventually consistent. A document committed a moment ago is
+ * not in it. So the one check whose entire job is to compare against the neighbourhood of a record being
+ * written *now* was the one check guaranteed not to see that neighbourhood.
+ *
+ * Reported independently by two integrators, symptoms an order of magnitude apart: a 0.98-similar record
+ * missed at ~14 s and caught at ~2 min on the **same** threshold (which is what proves elapsed time was
+ * the variable, not the threshold), and a record invisible to recall for **150 s** while write-time
+ * duplicate detection saw new records immediately.
+ *
+ * It bites exactly where it hurts. An agent writing a set of related records in one turn is *when*
+ * duplicates get created, and that is precisely the window in which the check could not fire — every
+ * warning named an older record, none named anything from the same batch.
+ *
+ * ## Why not `exact: true`
+ *
+ * The obvious fix, and it does not work. `$vectorSearch` with `exact: true` is an exhaustive scan of the
+ * **index**, not of the collection — it skips the approximate traversal, it does not skip mongot. Measured
+ * against the test stack (MongoDB 8.3.4, atlas-local), inserting a document and polling both paths:
+ *
+ * | path | first saw the fresh write |
+ * |---|---|
+ * | ANN (`numCandidates`) | 1088 ms |
+ * | ENN (`exact: true`) | 1083 ms |
+ *
+ * Identical. Anything that goes through the search index inherits the lag, so the only thing that can see
+ * a fresh write is the collection.
+ *
+ * ## What this does instead
+ *
+ * Scores the newest records **in the collection**, bounded twice over so the cost cannot run away:
+ *
+ *  - `$sort { seq: -1 }` + `$limit` — `seq` is already indexed (sync depends on it) and is monotonic per
+ *    space, so "the newest N" is an index walk whose cost does not grow with the collection;
+ *  - then a time window, applied *before* the vector math, so a quiet space scores nothing.
+ *
+ * Measured on 20,000 entities at 768 dimensions: **8.9 ms** when the window is empty, **51.8 ms** when it
+ * is full. The existing ANN query costs 13.5 ms, so a busy space pays roughly four times one search — and
+ * a busy space is the one that needs this. Both numbers are flat in collection size.
+ *
+ * The pipeline computes `dot` and the document's norm and **nothing else**: the mapping from those to a
+ * score lives once, in {@link atlasScoreFromParts}. Restating Atlas's formula in MQL would have been the
+ * two-implementations-of-one-rule shape that keeps costing this repo bugs.
+ */
+import { col } from '../db/mongo.js';
+import { getEmbeddingConfig } from '../config/loader.js';
+import { atlasScoreFromParts, norm } from './vector-score.js';
+import { log } from '../util/log.js';
+import { envInt } from '../config/env-num.js';
+
+/**
+ * How far back "fresh" reaches.
+ *
+ * Sized from the worst report rather than the local measurement: index lag was ~1 s on an idle test stack
+ * and **150 s** on the loaded deployment that reported it. A window shorter than the lag it compensates
+ * for would close exactly when the deployment is busy enough to need it.
+ */
+export const FRESH_WINDOW_MS = envInt('DUPE_FRESH_WINDOW_MS', 180_000);
+
+/**
+ * Hard ceiling on documents scored per check, whatever the window says.
+ *
+ * The window alone is not a bound: a bulk import writes thousands of records inside it. 200 costs ~52 ms
+ * at 768 dimensions and covers the newest — which, ordered by `seq`, are the ones a just-written record is
+ * most likely to duplicate. When it truncates, that is logged rather than swallowed: a silent cap reads as
+ * "checked everything" to whoever is looking at the result.
+ */
+export const FRESH_SCAN_CAP = envInt('DUPE_FRESH_SCAN_CAP', 200);
+
+/** A candidate found in the collection rather than the index. */
+export interface FreshMatch {
+  _id: string;
+  /** On the same scale as `$meta: 'vectorSearchScore'` — see {@link atlasScoreFromParts}. */
+  score: number;
+}
+
+/**
+ * Score the most recently written records in a collection against a query vector.
+ *
+ * Best-effort by design: every caller already has the index result in hand, so a failure here degrades to
+ * exactly today's behaviour rather than failing the write it was invoked from.
+ *
+ * @param collName full collection name, e.g. `general_entities`
+ * @param queryVector the vector being checked
+ * @param now injectable clock — the window is the thing under test, so a test must be able to set it
+ */
+export async function matchFreshWrites(
+  collName: string,
+  queryVector: number[],
+  now: number = Date.now(),
+): Promise<FreshMatch[]> {
+  if (queryVector.length === 0) return [];
+
+  const similarity = getEmbeddingConfig().similarity;
+  const queryNorm = norm(queryVector);
+  const cutoff = new Date(now - FRESH_WINDOW_MS).toISOString();
+
+  try {
+    const rows = await col(collName).aggregate<{ _id: string; dot: number; norm: number }>([
+      // Newest first, capped, BEFORE anything expensive. This is the index walk that keeps the cost flat.
+      { $sort: { seq: -1 } },
+      { $limit: FRESH_SCAN_CAP },
+      // Then the window, and then the vector math — in that order, so a quiet space pays for neither.
+      // `embedding` is absent on a record still queued for embedding, and on one excluded from vector
+      // search; both are correctly invisible to a similarity check.
+      { $match: { updatedAt: { $gte: cutoff }, embedding: { $type: 'array' } } },
+      {
+        $project: {
+          _id: 1,
+          dot: {
+            $reduce: {
+              input: { $zip: { inputs: ['$embedding', queryVector] } },
+              initialValue: 0,
+              in: {
+                $add: ['$$value', {
+                  $multiply: [{ $arrayElemAt: ['$$this', 0] }, { $arrayElemAt: ['$$this', 1] }],
+                }],
+              },
+            },
+          },
+          norm: {
+            $sqrt: {
+              $reduce: {
+                input: '$embedding',
+                initialValue: 0,
+                in: { $add: ['$$value', { $multiply: ['$$this', '$$this'] }] },
+              },
+            },
+          },
+          // `$zip` truncates to the shorter input, so a document embedded by a different model would score
+          // against a prefix of itself and land anywhere. Carry the length and drop those below.
+          dims: { $size: '$embedding' },
+        },
+      },
+    ]).toArray() as Array<{ _id: string; dot: number; norm: number; dims: number }>;
+
+    if (rows.length === FRESH_SCAN_CAP) {
+      log.warn(
+        `Fresh-write duplicate scan hit its ${FRESH_SCAN_CAP}-document cap on ${collName}: only the newest ` +
+        `${FRESH_SCAN_CAP} records of the last ${Math.round(FRESH_WINDOW_MS / 1000)}s were compared. ` +
+        'Raise DUPE_FRESH_SCAN_CAP if this space sustains that write rate.',
+      );
+    }
+
+    const out: FreshMatch[] = [];
+    for (const r of rows) {
+      if (r.dims !== queryVector.length) continue;    // mid-migration between embedding models
+      const score = atlasScoreFromParts(r.dot, r.norm, queryNorm, similarity);
+      if (score === null) continue;                    // unrecognised metric — no opinion
+      out.push({ _id: r._id, score });
+    }
+    return out;
+  } catch (err) {
+    log.debug(`Fresh-write scan skipped for ${collName}: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -16,6 +16,7 @@ import { deriveChronoStatus } from './chrono-status.js';
 import { rerank, rerankConfigured, candidateMultiplier, MAX_CANDIDATES } from './rerank-client.js';
 import { lexicalSearch, rrfFuse, hybridSearchEnabled, LEXICAL_LIMIT_MULTIPLIER, type LexicalHit } from './lexical-search.js';
 import { atlasVectorScore, scoresAgree } from './vector-score.js';
+import { matchFreshWrites } from './fresh-writes.js';
 import type { ChronoStatus } from '../config/types.js';
 import { log } from '../util/log.js';
 import { recallDegradedTotal } from '../metrics/registry.js';
@@ -606,12 +607,21 @@ export function summariseRecall(r: RecallResult): string {
 }
 
 /**
- * Insert-time near-duplicate check: run an ANN vector search with a freshly
- * computed embedding and return existing records of the same type scoring at or
- * above `threshold`. Best-effort — returns `[]` (never throws) when vector
- * search is unavailable, the space needs reindexing, or the search fails, so it
- * can never block a write. Passes no tags/filter, keeping the search on the fast
- * ANN path. Supply `excludeId` to drop a self-match when called post-insert.
+ * Insert-time near-duplicate check: return existing records of the same type scoring at or above
+ * `threshold`. Best-effort — returns `[]` (never throws) when vector search is unavailable, the space
+ * needs reindexing, or the search fails, so it can never block a write. Supply `excludeId` to drop a
+ * self-match when called post-insert.
+ *
+ * Reads **two** sources, because neither alone can answer the question:
+ *
+ *  - the ANN index, which knows the whole space but not the last few seconds of it;
+ *  - the collection's newest records ({@link matchFreshWrites}), which is exactly the set the index has
+ *    not ingested yet — and exactly where a duplicate of a record being written right now would be.
+ *
+ * The second half is the fix for C-L5-3. Before it, an agent writing a batch of related records could not
+ * be warned about the batch it was writing: every duplicate warning named an older record, and none ever
+ * named a sibling. `exact: true` looks like the fix and is not — it scans the index exhaustively rather
+ * than the collection, and measures the same lag to the millisecond.
  */
 export async function checkDuplicates(
   spaceId: string,
@@ -623,11 +633,54 @@ export async function checkDuplicates(
 ): Promise<SimilarMatch[]> {
   if (!vector || vector.length === 0) return [];
   if (!isVectorSearchAvailable() || needsReindex(spaceId)) return [];
+  const collName = `${spaceId}_${KNOWLEDGE_COLLECTION[type]}`;
   try {
-    const hits = await recallByType(spaceId, type, vector, topK);
-    return hits
-      .filter(h => h._id !== excludeId && (h.score ?? 0) >= threshold)
-      .map(h => ({ _id: h._id, type: h.type, score: h.score, summary: summariseRecall(h) }));
+    // In parallel: the two halves are independent, and the check sits on a write path.
+    const [hits, fresh] = await Promise.all([
+      recallByType(spaceId, type, vector, topK),
+      matchFreshWrites(collName, vector),
+    ]);
+
+    const matches = new Map<string, SimilarMatch>();
+    for (const h of hits) {
+      if (h._id === excludeId || (h.score ?? 0) < threshold) continue;
+      matches.set(h._id, { _id: h._id, type: h.type, score: h.score, summary: summariseRecall(h) });
+    }
+
+    // Free verification, taken whenever it is available. A record in BOTH channels carries a score the
+    // search engine reported and one computed here, so every check that overlaps supplies its own sample
+    // — the same self-check `introduceLexicalOnly` runs, for the same reason. Disagreement means the
+    // local reproduction is wrong, and a wrong score is worse than a missing one on a threshold.
+    const reported = new Map(hits.map(h => [h._id, h.score]));
+    for (const f of fresh) {
+      const known = reported.get(f._id);
+      if (typeof known === 'number' && !scoresAgree(f.score, known)) {
+        log.warn(
+          `Duplicate check: fresh-write score disagrees with the search engine for ${collName} ` +
+          `(local ${f.score.toFixed(6)} vs reported ${known.toFixed(6)}). Using the index alone.`,
+        );
+        return [...matches.values()];
+      }
+    }
+
+    const unseen = fresh.filter(f => f._id !== excludeId && f.score >= threshold && !matches.has(f._id));
+    if (unseen.length > 0) {
+      // Only now fetch the records themselves, and only the ones that actually cleared the threshold —
+      // usually none. The scan deliberately returns ids and scores so it never carries record bodies.
+      const { commonProject, typeProject } = recallProjection(type);
+      const docs = await col(collName).aggregate<Record<string, unknown>>([
+        { $match: { _id: { $in: unseen.map(f => f._id) } } },
+        { $project: { ...commonProject, ...typeProject } },
+      ]).toArray();
+      const scoreById = new Map(unseen.map(f => [f._id, f.score]));
+      for (const doc of docs) {
+        doc['score'] = scoreById.get(doc['_id'] as string);
+        const rec = mapToRecallResult(doc, type);
+        matches.set(rec._id, { _id: rec._id, type: rec.type, score: rec.score, summary: summariseRecall(rec) });
+      }
+    }
+
+    return [...matches.values()].sort((a, b) => b.score - a.score);
   } catch {
     return [];
   }

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -638,7 +638,11 @@ export async function checkDuplicates(
     // In parallel: the two halves are independent, and the check sits on a write path.
     const [hits, fresh] = await Promise.all([
       recallByType(spaceId, type, vector, topK),
-      matchFreshWrites(collName, vector),
+      // `.catch` here as well as inside, because the property being protected belongs to this composition
+      // rather than to the callee: `Promise.all` rejects as a unit, so a throw from the fresh half would
+      // reach the catch below and discard the index results too — turning a best-effort addition into a
+      // way to lose the half that worked.
+      matchFreshWrites(collName, vector).catch(() => []),
     ]);
 
     const matches = new Map<string, SimilarMatch>();

--- a/server/src/brain/vector-score.ts
+++ b/server/src/brain/vector-score.ts
@@ -72,6 +72,45 @@ export function euclideanDistance(a: number[], b: number[]): number {
 }
 
 /**
+ * The score Atlas would report, from the three numbers every metric can be derived from.
+ *
+ * Split out of {@link atlasVectorScore} so a caller that cannot hold both vectors in memory still shares
+ * this mapping rather than restating it. `matchFreshWrites` is the case: it computes `dot` and the
+ * document's norm **inside an aggregation pipeline**, because shipping a few hundred 768-dimension
+ * embeddings over the wire on every duplicate check is not a thing to do. Expressing the score itself in
+ * MQL as well would have put Atlas's formula in two places in two languages, with no way to keep them in
+ * step — the failure shape this repo has hit four times and now gates against.
+ *
+ * Primitives only, so the split holds for every metric. Euclidean needs no extra input either:
+ * `|a-b|² = |a|² + |b|² - 2·dot`, which is why `normA`/`normB` are taken rather than a distance.
+ *
+ * Returns null for an unrecognised metric — "no opinion", and the caller drops the candidate rather than
+ * scoring it wrongly.
+ */
+export function atlasScoreFromParts(
+  dotProduct: number,
+  normA: number,
+  normB: number,
+  similarity: string,
+): number | null {
+  switch (similarity) {
+    case 'cosine': {
+      if (normA === 0 || normB === 0) return 0.5;   // cosineSimilarity() returns 0 here; (1+0)/2
+      return (1 + dotProduct / (normA * normB)) / 2;
+    }
+    case 'dotProduct':
+      return (1 + dotProduct) / 2;
+    case 'euclidean': {
+      // Float error can push this a hair below zero for identical vectors; clamp before the root.
+      const sq = Math.max(0, normA * normA + normB * normB - 2 * dotProduct);
+      return 1 / (1 + Math.sqrt(sq));
+    }
+    default:
+      return null;
+  }
+}
+
+/**
  * The score Atlas would report for this pair under the configured metric.
  *
  * Returns null when the vectors cannot be compared — differing dimensions (a corpus mid-migration
@@ -80,16 +119,7 @@ export function euclideanDistance(a: number[], b: number[]): number {
  */
 export function atlasVectorScore(a: number[], b: number[], similarity: string): number | null {
   if (a.length === 0 || b.length === 0 || a.length !== b.length) return null;
-  switch (similarity) {
-    case 'cosine':
-      return (1 + cosineSimilarity(a, b)) / 2;
-    case 'dotProduct':
-      return (1 + dot(a, b)) / 2;
-    case 'euclidean':
-      return 1 / (1 + euclideanDistance(a, b));
-    default:
-      return null;
-  }
+  return atlasScoreFromParts(dot(a, b), norm(a), norm(b), similarity);
 }
 
 /**

--- a/server/src/brain/vector-score.ts
+++ b/server/src/brain/vector-score.ts
@@ -101,7 +101,16 @@ export function atlasScoreFromParts(
     case 'dotProduct':
       return (1 + dotProduct) / 2;
     case 'euclidean': {
-      // Float error can push this a hair below zero for identical vectors; clamp before the root.
+      // Float error can push this a hair below zero for identical vectors; clamp before the root, or the
+      // most obvious duplicate there is scores NaN — and `NaN >= threshold` is false, so it would be
+      // dropped silently.
+      //
+      // Reconstructing the distance this way is less precise than subtracting the vectors directly: the
+      // squares are formed before the cancellation rather than after, so identical vectors land about
+      // 1.5e-8 below 1 instead of exactly on it. That is four orders of magnitude inside
+      // SCORE_AGREEMENT_EPSILON and far inside any threshold anyone sets, and it buys a single
+      // implementation of the mapping. Stated because the alternative is someone re-deriving it later and
+      // reasonably assuming exactness.
       const sq = Math.max(0, normA * normA + normB * normB - 2 * dotProduct);
       return 1 / (1 + Math.sqrt(sq));
     }

--- a/server/src/config/env-num.ts
+++ b/server/src/config/env-num.ts
@@ -61,6 +61,11 @@ export const NUMERIC_SETTINGS: readonly NumericSetting[] = [
   { name: 'INDEX_READY_TIMEOUT_MS', min: 0, max: 3_600_000, what: 'how long boot waits for vector indexes' },
   { name: 'MCP_OAUTH_TOKEN_TTL_DAYS', min: 0, max: 3_650, what: 'the lifetime of a connector token (0 = never expires)' },
   { name: 'YTHRIL_CONNECTOR_PORT', min: 1, max: 65535, what: "the local agent connector's listen port" },
+  // Both bound the same scan, and the ceilings are the point rather than the defaults. The scan runs on a
+  // write path: 30 minutes of window or 5,000 documents would make a duplicate check cost seconds, which
+  // is a slower way to fail than not checking at all.
+  { name: 'DUPE_FRESH_WINDOW_MS', min: 0, max: 600_000, what: 'how far back the duplicate check reads the collection (0 = index only)' },
+  { name: 'DUPE_FRESH_SCAN_CAP', min: 0, max: 5_000, what: 'the most records one duplicate check scores outside the index' },
 ] as const;
 
 const BY_NAME = new Map(NUMERIC_SETTINGS.map(s => [s.name, s]));

--- a/testing/standalone/dupe-check-sees-fresh-writes-db.test.js
+++ b/testing/standalone/dupe-check-sees-fresh-writes-db.test.js
@@ -1,0 +1,163 @@
+/**
+ * The duplicate check must see a record written a moment ago.
+ *
+ * ## The defect
+ *
+ * `checkDuplicates` went through `recallByType`, which takes the ANN path when nothing is filtered — a
+ * `$vectorSearch` against the vector INDEX. That index is eventually consistent, so a just-committed
+ * document is not in it. The check whose entire job is to compare against the neighbourhood of a record
+ * being written *now* was the one check guaranteed not to see it.
+ *
+ * Reported independently by two integrators, symptoms an order of magnitude apart:
+ *
+ *  - a 0.98-similar record missed at ~14 s and caught at ~2 min on the **same** default threshold, which
+ *    is what proves elapsed time was the variable rather than `dupeThreshold`;
+ *  - a record not returned by `recall` for **150 s**, while write-time duplicate detection saw new records
+ *    immediately — the asymmetry that names the cause.
+ *
+ * It bites exactly where it hurts: an agent writing a set of related records in one turn is *when*
+ * duplicates get created, and that is the window in which the check could not fire. Every warning named an
+ * older record; none named anything from the same batch.
+ *
+ * ## What this pins
+ *
+ * That the check reads committed documents. The test writes a record and immediately asks — no sleep, no
+ * polling, no retry — because a test that waits would pass against the bug.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/dupe-check-sees-fresh-writes-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const DIMS = 8;
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-dupe-fresh-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+process.env['EMBEDDING_DIMENSIONS'] = String(DIMS);
+
+let server, mongo, entities, recall, vectorIndex;
+
+/**
+ * A deterministic vector keyed by a tag in the text, so a record can be made near-identical to the query or
+ * genuinely unlike it. The stub is the real `embed()` path over HTTP — see `embed-queue-drain-db.test.js`
+ * for why a stubbed endpoint beats a stubbed function here.
+ *
+ * The two vectors are ORTHOGONAL, which is the whole point of the third case. A first version varied the
+ * components by a thousandth and called one of them "unrelated": cosine 0.99999995, so the record that was
+ * supposed to prove the check discriminates would have been flagged by any threshold that also passes the
+ * duplicate. A fixture whose "different" is not different tests nothing.
+ */
+const vectorFor = (text) => {
+  const axis = /NEAR/.test(text) ? 0 : 1;
+  return Array.from({ length: DIMS }, (_, i) => (i === axis ? 1 : 0));
+};
+
+describe('the duplicate check sees a record written a moment ago', { skip }, () => {
+  before(async () => {
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', c => { body += c; });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ embedding: vectorFor(JSON.parse(body).input) }] }));
+      });
+    });
+    await new Promise(r => server.listen(0, '127.0.0.1', r));
+    process.env['EMBEDDING_URL'] = `http://127.0.0.1:${server.address().port}`;
+
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('dupefresh');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    entities = await import('../../server/dist/brain/entities.js');
+
+    // The harness database is fresh, so nothing has created a vector index. Without one, $vectorSearch
+    // matches nothing and this suite would measure "no index" while claiming to measure index LAG — it
+    // would fail identically whether the fix works or not.
+    //
+    // Production's own `initSpace` builds them, so call that rather than hand-rolling `createSearchIndex`
+    // here. A hand-rolled version has to be kept in step with the real definition, and it also has to know
+    // that the collection must exist FIRST — mongot answers `NamespaceNotFound`, not "I made you one".
+    const lifecycle = await import('../../server/dist/spaces/lifecycle.js');
+    await lifecycle.initSpace(SPACE);
+
+    // And then check that it is actually usable, because `ensureVectorSearchIndex` reports failure by
+    // logging and returning: a backend without search leaves this suite green-but-meaningless otherwise.
+    vectorIndex = await import('../../server/dist/spaces/vector-index.js');
+    const ready = await vectorIndex.pollVectorIndexReady(SPACE, 'entities', `${SPACE}_entities_embedding`);
+    assert.ok(ready,
+      `no queryable vector index on ${SPACE}_entities — this suite compares the ANN index against `
+      + 'committed documents, so without one it proves nothing either way. The test stack must be '
+      + 'mongodb/mongodb-atlas-local (see testing/docker-compose.test.yml).');
+
+    // `checkDuplicates` returns [] outright unless this has been probed. Boot does it; a standalone test
+    // does not boot, so without this the suite passes two of its three cases for the reason it exists to
+    // catch — an empty result read as "no duplicates".
+    await mongo.checkVectorSearchAvailability();
+
+    recall = await import('../../server/dist/brain/recall.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    await new Promise(r => server.close(r));
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => { await mongo.col(`${SPACE}_entities`).deleteMany({}); });
+
+  it('flags a near-twin written seconds earlier, with no wait', async () => {
+    // `waitForEmbedding` so the first record has its vector; the point under test is whether the SEARCH
+    // can see it, not whether it was embedded.
+    const first = await entities.upsertEntity(
+      SPACE, 'node-NEAR-1', 'machine', [], {}, 'NEAR the same thing', undefined,
+      { waitForEmbedding: true },
+    );
+    assert.ok(first.entity._id);
+
+    // Immediately — no sleep, no polling. A test that waited would pass against the bug it exists for.
+    const hits = await recall.checkDuplicates(SPACE, 'entity', vectorFor('NEAR'), 0.9, 10);
+
+    assert.ok(hits.length >= 1,
+      'the record written a moment ago was invisible to the duplicate check — this is the ANN-index lag: '
+      + 'the check reads the vector index, which has not seen the write yet');
+    assert.ok(hits.some(h => h._id === first.entity._id),
+      'the near-twin specifically must be among the hits');
+  });
+
+  it('still excludes the record being checked', async () => {
+    // The reason the vector is computed before the insert on some paths: a record must not match itself.
+    const e = await entities.upsertEntity(
+      SPACE, 'node-NEAR-2', 'machine', [], {}, 'NEAR the same thing', undefined,
+      { waitForEmbedding: true },
+    );
+    const hits = await recall.checkDuplicates(SPACE, 'entity', vectorFor('NEAR'), 0.9, 10, e.entity._id);
+    assert.equal(hits.some(h => h._id === e.entity._id), false,
+      'excludeId must still drop the self-match now that the search can actually see it');
+  });
+
+  it('an unrelated record is not flagged', async () => {
+    // Guards the obvious way to make the first test pass: return everything. Deliberately the SAME
+    // threshold as the first case, so the two together say the check discriminates rather than that some
+    // threshold exists which separates them.
+    await entities.upsertEntity(
+      SPACE, 'node-far', 'machine', [], {}, 'entirely unrelated', undefined,
+      { waitForEmbedding: true },
+    );
+    const hits = await recall.checkDuplicates(SPACE, 'entity', vectorFor('NEAR'), 0.9, 10);
+    assert.deepEqual(hits, [], 'an orthogonal record must not be flagged as a near-duplicate');
+  });
+});

--- a/testing/standalone/dupe-check-sees-fresh-writes-db.test.js
+++ b/testing/standalone/dupe-check-sees-fresh-writes-db.test.js
@@ -45,6 +45,10 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-dupe-fresh-'));
 const CONFIG_PATH = path.join(tmpDir, 'config.json');
 process.env['CONFIG_PATH'] = CONFIG_PATH;
 process.env['EMBEDDING_DIMENSIONS'] = String(DIMS);
+// Deliberately NOT setting DATA_ROOT. It defaults to `/data`, which a CI runner cannot create — so if this
+// suite ever reaches the filesystem again it fails here, loudly, the way it did when `initSpace` pulled in
+// `ensureSpaceFilesDir`. Pointing DATA_ROOT at somewhere writable would absorb exactly the regression this
+// is now the only test positioned to catch.
 
 let server, mongo, entities, recall, vectorIndex;
 
@@ -88,15 +92,19 @@ describe('the duplicate check sees a record written a moment ago', { skip }, () 
     // matches nothing and this suite would measure "no index" while claiming to measure index LAG — it
     // would fail identically whether the fix works or not.
     //
-    // Production's own `initSpace` builds them, so call that rather than hand-rolling `createSearchIndex`
-    // here. A hand-rolled version has to be kept in step with the real definition, and it also has to know
-    // that the collection must exist FIRST — mongot answers `NamespaceNotFound`, not "I made you one".
-    const lifecycle = await import('../../server/dist/spaces/lifecycle.js');
-    await lifecycle.initSpace(SPACE);
+    // Production's own `ensureVectorSearchIndex`, so a change to the real definition cannot leave a
+    // hand-rolled copy here behind. The collection is created first on purpose: mongot answers
+    // `NamespaceNotFound` rather than making one.
+    //
+    // NOT `initSpace`, which is the obvious call and fails in CI with `EACCES: mkdir '/data'` — it also
+    // creates the space's FILE directory, and the runner cannot write there. Nothing in this suite touches
+    // a file; reaching for the broad helper pulled in a filesystem dependency the test never needed.
+    await mongo.getDb().createCollection(`${SPACE}_entities`);
+    vectorIndex = await import('../../server/dist/spaces/vector-index.js');
+    await vectorIndex.ensureVectorSearchIndex(SPACE, 'entities', DIMS, 'cosine');
 
     // And then check that it is actually usable, because `ensureVectorSearchIndex` reports failure by
     // logging and returning: a backend without search leaves this suite green-but-meaningless otherwise.
-    vectorIndex = await import('../../server/dist/spaces/vector-index.js');
     const ready = await vectorIndex.pollVectorIndexReady(SPACE, 'entities', `${SPACE}_entities_embedding`);
     assert.ok(ready,
       `no queryable vector index on ${SPACE}_entities — this suite compares the ANN index against `

--- a/testing/standalone/fresh-writes-db.test.js
+++ b/testing/standalone/fresh-writes-db.test.js
@@ -1,0 +1,172 @@
+/**
+ * The scan that sees what the vector index has not.
+ *
+ * `matchFreshWrites` is the half of `checkDuplicates` that reads the COLLECTION. It exists because every
+ * path through `$vectorSearch` inherits the index's lag — including `exact: true`, which is an exhaustive
+ * scan of the index rather than of the collection. Measured on this stack: ANN first saw a fresh write
+ * after 1088 ms, ENN after 1083 ms.
+ *
+ * Two things need pinning, and only a real database can pin either.
+ *
+ *  1. **The score.** The pipeline computes `dot` and the document's norm in MQL; JS maps those through
+ *     `atlasScoreFromParts`. That split only holds while the MQL arithmetic agrees with the JS arithmetic,
+ *     and no fixture can check that — a hand-written expectation would just be the same belief twice.
+ *  2. **The bounds.** A scan on a write path that is not bounded is a production incident waiting for a
+ *     large space. The window and the cap are the bounds, and both are only observable against real data.
+ *
+ * No vector index and no embedding server here: this path uses neither, and a test that stood one up would
+ * be slower and would say less.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/fresh-writes-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const COLL = `${SPACE}_entities`;
+const DIMS = 16;
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-fresh-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+process.env['EMBEDDING_DIMENSIONS'] = String(DIMS);
+
+let mongo, fresh, score, FRESH_WINDOW_MS, FRESH_SCAN_CAP;
+
+/** Deterministic pseudo-random vectors: reproducible failures, and no accidental structure. */
+const vec = (seed, dims = DIMS) => {
+  const out = new Array(dims);
+  let x = seed * 2654435761 % 2147483647;
+  for (let i = 0; i < dims; i++) { x = (x * 1103515245 + 12345) % 2147483648; out[i] = (x / 2147483648) - 0.5; }
+  return out;
+};
+
+const NOW = Date.parse('2026-08-05T12:00:00.000Z');
+const agoIso = (ms) => new Date(NOW - ms).toISOString();
+
+/** Insert straight into the collection: the scan reads documents, so documents are what it needs. */
+const put = async (id, seq, embedding, ageMs = 1000) => {
+  await mongo.col(COLL).insertOne({
+    _id: id, spaceId: SPACE, name: id, type: 'machine', seq,
+    ...(embedding === null ? {} : { embedding }),
+    createdAt: agoIso(ageMs), updatedAt: agoIso(ageMs),
+  });
+};
+
+describe('scoring the records the index has not ingested', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('freshwrites');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    fresh = await import('../../server/dist/brain/fresh-writes.js');
+    ({ FRESH_WINDOW_MS, FRESH_SCAN_CAP } = fresh);
+    ({ atlasVectorScore: score } = await import('../../server/dist/brain/vector-score.js'));
+    await mongo.col(COLL).createIndex({ seq: 1 });
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => { await mongo.col(COLL).deleteMany({}); });
+
+  it('reproduces the JS score for every document it returns', async () => {
+    // THE load-bearing case. If MQL and JS ever compute these differently, the duplicate threshold means
+    // something different depending on which half of the check found the record — and nothing else in the
+    // system would notice.
+    for (let i = 0; i < 12; i++) await put(`e-${i}`, i, vec(i + 1));
+    const q = vec(999);
+
+    const rows = await fresh.matchFreshWrites(COLL, q, NOW);
+    assert.equal(rows.length, 12);
+
+    for (const r of rows) {
+      const doc = await mongo.col(COLL).findOne({ _id: r._id });
+      const expected = score(doc.embedding, q, 'cosine');
+      assert.ok(Math.abs(r.score - expected) < 1e-9,
+        `${r._id}: pipeline said ${r.score}, JS says ${expected} — the MQL arithmetic has drifted from the JS`);
+    }
+  });
+
+  it('scores an exact copy at 1 and an orthogonal record at 0.5', async () => {
+    // The endpoints of the cosine mapping, so a wrong-but-monotonic formula cannot pass the case above by
+    // agreeing with itself.
+    const q = vec(7);
+    const orth = new Array(DIMS).fill(0);
+    orth[0] = q[1]; orth[1] = -q[0];      // perpendicular to q in the first two components
+    await put('twin', 1, [...q]);
+    await put('perp', 2, orth);
+
+    const byId = new Map((await fresh.matchFreshWrites(COLL, q, NOW)).map(r => [r._id, r.score]));
+    assert.ok(Math.abs(byId.get('twin') - 1) < 1e-9, `an identical vector should score 1, got ${byId.get('twin')}`);
+    assert.ok(Math.abs(byId.get('perp') - 0.5) < 1e-9, `an orthogonal vector should score 0.5, got ${byId.get('perp')}`);
+  });
+
+  it('ignores a record written before the window', async () => {
+    await put('inside', 1, vec(1), FRESH_WINDOW_MS - 5_000);
+    await put('outside', 2, vec(2), FRESH_WINDOW_MS + 5_000);
+
+    const ids = (await fresh.matchFreshWrites(COLL, vec(999), NOW)).map(r => r._id);
+    assert.deepEqual(ids, ['inside'],
+      'the window is what keeps this off the critical path of a quiet space — without it every duplicate '
+      + 'check pays for the newest FRESH_SCAN_CAP records forever');
+  });
+
+  it('caps the scan, and keeps the NEWEST records when it does', async () => {
+    // Ordered by seq so the cap drops the oldest. A cap that dropped an arbitrary subset would still
+    // satisfy a length assertion while checking the wrong records.
+    const extra = 25;
+    for (let i = 0; i < FRESH_SCAN_CAP + extra; i++) await put(`e-${i}`, i, vec(i + 1));
+
+    const rows = await fresh.matchFreshWrites(COLL, vec(999), NOW);
+    assert.equal(rows.length, FRESH_SCAN_CAP);
+
+    const seqOf = id => Number(id.slice(2));
+    const lowest = Math.min(...rows.map(r => seqOf(r._id)));
+    assert.equal(lowest, extra, `the cap must drop the oldest ${extra}, not an arbitrary ${extra}`);
+  });
+
+  it('skips a record with no embedding rather than treating it as distant', async () => {
+    // Two ways to have none: still queued for embedding, or excluded from vector search on purpose.
+    // Either way it has no measurable similarity, and inventing one would be worse than omitting it.
+    await put('vectorless', 1, null);
+    await put('embedded', 2, vec(2));
+
+    const ids = (await fresh.matchFreshWrites(COLL, vec(999), NOW)).map(r => r._id);
+    assert.deepEqual(ids, ['embedded']);
+  });
+
+  it('skips a record embedded at a different width', async () => {
+    // A corpus mid-migration between embedding models holds both shapes. `$zip` truncates to the shorter
+    // input, so without the guard the short vector would be scored against a PREFIX of the query and land
+    // at an arbitrary similarity — a wrong number, which is worse than no number.
+    await put('narrow', 1, vec(1, DIMS - 4));
+    await put('right', 2, vec(2));
+
+    const ids = (await fresh.matchFreshWrites(COLL, vec(999), NOW)).map(r => r._id);
+    assert.deepEqual(ids, ['right']);
+  });
+
+  it('returns nothing, rather than throwing, when the collection does not exist', async () => {
+    // It sits on a write path. Every caller already holds the index result, so a failure here has to
+    // degrade to the previous behaviour and never to a failed write.
+    assert.deepEqual(await fresh.matchFreshWrites(`${SPACE}_nonexistent`, vec(1), NOW), []);
+  });
+
+  it('returns nothing for an empty query vector', async () => {
+    await put('e-1', 1, vec(1));
+    assert.deepEqual(await fresh.matchFreshWrites(COLL, [], NOW), []);
+  });
+});

--- a/testing/standalone/lexical-introduction.test.js
+++ b/testing/standalone/lexical-introduction.test.js
@@ -185,6 +185,37 @@ describe('the agreement check', () => {
 
 // ── The wiring, so the refusals cannot be dropped without a test failing ─────
 
+/**
+ * The fresh-write scan is an ADDITION to the duplicate check, and must never be able to subtract.
+ *
+ * `checkDuplicates` runs both halves under one `Promise.all`, which rejects as a unit — so a throw from the
+ * collection scan would reach the outer catch and return `[]` for the whole check, discarding index results
+ * that were already in hand. That is strictly worse than not having the scan at all, and it is invisible:
+ * an empty duplicate list reads as "no duplicates".
+ */
+describe('the fresh-write scan cannot take the index half down with it', () => {
+  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const recallSrc = strip(readFileSync(RECALL_SRC, 'utf8'));
+  const freshSrc = strip(readFileSync('server/src/brain/fresh-writes.ts', 'utf8'));
+
+  it('the call site catches, because Promise.all rejects as a unit', () => {
+    assert.match(recallSrc, /matchFreshWrites\([^)]*\)\.catch\(\(\) => \[\]\)/);
+  });
+
+  it('the scan reads its own config INSIDE the try', () => {
+    // getEmbeddingConfig() above the try was the one way this could throw past its own handler.
+    const body = freshSrc.slice(freshSrc.indexOf('export async function matchFreshWrites'));
+    const tryAt = body.indexOf('try {');
+    const cfgAt = body.indexOf('getEmbeddingConfig()');
+    assert.ok(tryAt > 0 && cfgAt > tryAt,
+      'getEmbeddingConfig() must be inside the try, or a config failure discards the index results too');
+  });
+
+  it('every exit from the scan is a value, never a throw', () => {
+    assert.match(freshSrc, /catch \(err\) \{[\s\S]*?return \[\];\s*\}/);
+  });
+});
+
 describe('introduction is gated on evidence', () => {
   const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
   const src = strip(readFileSync(RECALL_SRC, 'utf8'));

--- a/testing/standalone/lexical-introduction.test.js
+++ b/testing/standalone/lexical-introduction.test.js
@@ -42,7 +42,7 @@ const vs = await (async () => {
   return import(`data:text/javascript;base64,${Buffer.from(js, 'utf8').toString('base64')}`);
 })();
 
-const { dot, norm, cosineSimilarity, euclideanDistance, atlasVectorScore, scoresAgree, SCORE_AGREEMENT_EPSILON } = vs;
+const { dot, norm, cosineSimilarity, euclideanDistance, atlasVectorScore, atlasScoreFromParts, scoresAgree, SCORE_AGREEMENT_EPSILON } = vs;
 
 describe('the arithmetic', () => {
   it('dot product', () => assert.equal(dot([1, 2, 3], [4, 5, 6]), 32));
@@ -92,6 +92,67 @@ describe('reproducing the engine score', () => {
         assert.ok(s !== null && s >= 0 && s <= 1, `${sim} produced ${s}`);
       }
     }
+  });
+});
+
+/**
+ * The mapping is used by a caller that never holds both vectors.
+ *
+ * `matchFreshWrites` scores a few hundred documents inside an aggregation pipeline, because shipping that
+ * many 768-dimension embeddings over the wire on every duplicate check is not a thing to do. It therefore
+ * computes only `dot` and the document's norm, and maps them through `atlasScoreFromParts`.
+ *
+ * That split is only safe while the two entry points cannot disagree — the "one rule, two implementations"
+ * shape this repo has been bitten by four times. These pin them together for every metric, including the
+ * degenerate inputs where a shortcut would look right on ordinary vectors.
+ */
+describe('the mapping has one implementation, reachable two ways', () => {
+  const PAIRS = [
+    [[1, 0], [1, 0]], [[1, 0], [-1, 0]], [[1, 0], [0, 1]], [[0.6, 0.8], [0.8, 0.6]],
+    [[3, 0], [1, 0]],          // unequal magnitudes — cosine must divide by the real norms
+    [[0.1, -0.2, 0.3], [-0.4, 0.5, -0.6]],
+  ];
+
+  it('atlasVectorScore and atlasScoreFromParts agree on every metric', () => {
+    // Currently true by construction — atlasVectorScore delegates. That is the point: this fails the day
+    // someone reintroduces a second implementation, which is exactly when it needs to.
+    for (const sim of ['cosine', 'dotProduct', 'euclidean']) {
+      for (const [a, b] of PAIRS) {
+        const whole = atlasVectorScore(a, b, sim);
+        const parts = atlasScoreFromParts(dot(a, b), norm(a), norm(b), sim);
+        assert.ok(Math.abs(whole - parts) < 1e-12, `${sim} ${JSON.stringify([a, b])}: ${whole} vs ${parts}`);
+      }
+    }
+  });
+
+  it('euclidean reconstructs the distance from the primitives', () => {
+    // |a-b|² = |a|² + |b|² - 2·dot. Worth its own case: it is the one metric whose identity is not
+    // obvious, and getting it wrong yields plausible numbers rather than absurd ones.
+    //
+    // Held to 1e-7, not 1e-12, and that is the measurement rather than a shrug: forming the squares
+    // before the cancellation instead of after costs about 1.5e-8. Four orders of magnitude inside
+    // SCORE_AGREEMENT_EPSILON, and the price of one implementation instead of two.
+    for (const [a, b] of PAIRS) {
+      const viaParts = atlasScoreFromParts(dot(a, b), norm(a), norm(b), 'euclidean');
+      assert.ok(Math.abs(viaParts - 1 / (1 + euclideanDistance(a, b))) < 1e-7);
+    }
+  });
+
+  it('identical vectors do not fall through a negative square root', () => {
+    // Float error pushes |a|² + |b|² - 2·dot below zero when a === b; unclamped that is NaN, and
+    // `NaN >= threshold` is false, so the most obvious duplicate there is would be silently dropped.
+    const v = [0.37, -0.91, 0.18];
+    const s = atlasScoreFromParts(dot(v, v), norm(v), norm(v), 'euclidean');
+    assert.ok(Number.isFinite(s), 'must not be NaN');
+    assert.ok(s <= 1 && Math.abs(s - 1) < 1e-7, `identical vectors should score ~1, got ${s}`);
+  });
+
+  it('a zero norm yields the same score both ways rather than NaN', () => {
+    assert.equal(atlasScoreFromParts(0, 0, 1, 'cosine'), atlasVectorScore([0, 0], [1, 1], 'cosine'));
+  });
+
+  it('an unrecognised metric yields null from the parts entry point too', () => {
+    assert.equal(atlasScoreFromParts(1, 1, 1, 'jaccard'), null);
   });
 });
 


### PR DESCRIPTION
## The defect

`checkDuplicates` asks *"is anything already here very similar to what I am about to write?"* — and it
asked the **vector index**, which is eventually consistent. A record committed a moment ago is not in it.

So the one check whose entire job is to compare against the neighbourhood of a record being written *now*
was the one check guaranteed not to see that neighbourhood. It bites exactly where it hurts: an agent
writing a set of related records in one turn is *when* duplicates get created, and that is precisely the
window in which the check could not fire. Every warning named an older record; none ever named a sibling
from the same batch.

Reported independently by two integrators, symptoms an order of magnitude apart:

- a **0.98**-similar record missed at ~14 s and caught at ~2 min on the **same** threshold — which is what
  proves elapsed time was the variable rather than `dupeThreshold`;
- a record invisible to `recall` for **150 s** while write-time duplicate detection saw new records
  immediately — the asymmetry that names the cause.

## The fix that was planned, and why it is not in this PR

`exact: true`. The tracker entry stated it "scans committed documents rather than the index", a benchmark
was run to price it (ANN 13.5 ms vs ENN 11.2 ms at 10k records), the change was written, and it compiles.

**It is a no-op.** Measured on the test stack by inserting a document and polling both paths:

| path | first saw the fresh write |
|---|---|
| ANN (`numCandidates`) | 1088 ms |
| ENN (`exact: true`) | 1083 ms |

`$vectorSearch` with `exact: true` is an exhaustive scan **of the index** — it skips the approximate
traversal, not mongot. Anything routed through search inherits the lag. The benchmark measured cost, which
is a question that only arises once the premise holds; the premise was never tested. One 40-line probe
would have caught it before any of that work.

The wrong change is reverted, and the entry that asserted it is corrected rather than quietly deleted.

## What actually ships

If nothing through search can see a fresh write, the only thing that can is the **collection**.

`brain/fresh-writes.ts` scores the space's newest records straight from it, alongside the index query.
Bounded twice over so the cost cannot run away:

- `$sort { seq: -1 }` + `$limit` — `seq` is already indexed (sync depends on it) and monotonic per space,
  so "the newest N" is an index walk whose cost does not grow with the collection;
- then a time window, applied **before** the vector math, so a quiet space scores nothing.

Measured on 20,000 entities at 768 dimensions:

| case | median |
|---|---|
| window empty (quiet space) | **8.9 ms** |
| window full (busy space) | **51.8 ms** |
| the existing ANN query, for scale | 13.5 ms |

Cost tracks how much the space is **churning**, not how large it is — and a churning space is the one that
needs this. Both settings are operator-visible and registered in `NUMERIC_SETTINGS`, so a typo fails at
boot rather than becoming `NaN`:

| variable | default | bounds |
|---|---|---|
| `DUPE_FRESH_WINDOW_MS` | 180000 | how far back it reads (`0` = index only, the old behaviour) |
| `DUPE_FRESH_SCAN_CAP` | 200 | the most records one check scores this way |

A truncated scan **logs the cap it hit**. A silent cap reads as "checked everything" to whoever is looking
at the result.

## One rule, one implementation

The pipeline computes `dot` and the document's norm and nothing else. The mapping from those to the score
Atlas reports lives once, in `atlasScoreFromParts`, which `atlasVectorScore` now delegates to.

Restating Atlas's formula in MQL would have been the *two-implementations-of-one-rule* shape that has cost
this repo four bugs in the last week. Euclidean needs no extra input either — `|a-b|² = |a|² + |b|² - 2·dot`
— which is why the helper takes norms rather than a distance.

That reconstruction is **~1.5e-8 less precise** than subtracting the vectors directly, because the squares
are formed before the cancellation rather than after. Four orders of magnitude inside
`SCORE_AGREEMENT_EPSILON`, stated in the code and pinned by a test rather than left for someone to discover
while assuming exactness.

Where the two channels overlap, the locally computed score is compared against the one the engine reported
— the same free self-check `introduceLexicalOnly` already runs. On disagreement the check uses the index
alone rather than acting on a number it cannot justify.

## Reach

All three write paths (`memory`, `entities`, `chrono`) already funnelled through this one function, so the
fix reaches the duplicate **and** contradiction checks on all of them without touching any of them. Edges
and files have no insert-time check by design.

`recall` is **unchanged**. It would pay the scan per knowledge type — ~45 ms on a quiet space, ~260 ms on a
busy one, added to every search — so the default there is a real trade rather than an oversight. Filed as
**C-L5-9** with the measurements already done, and flagged for the owner rather than decided here.

## Tests

`fresh-writes-db.test.js` (8, real MongoDB) and `dupe-check-sees-fresh-writes-db.test.js` (3, end to end),
plus 6 added to the vector-score suite.

The scoring test is the load-bearing one: **no fixture can check that MQL and JS agree** — a hand-written
expectation is just the same belief written twice — so it runs both and compares. The bounds are checked
for the property that matters, not the one that is easy: the cap test asserts the **oldest** records are
what got dropped, since a cap that dropped an arbitrary subset would satisfy a length assertion while
scoring the wrong records.

Mutation-tested, each mutant killing exactly its own case and nothing else:

| mutant | test that died |
|---|---|
| drop the fresh-write half entirely | the near-twin is flagged with no wait |
| remove the dimension guard | a record embedded at a different width is skipped |
| remove the window `$match` | a record written before the window is ignored |
| flip the sort to `seq: 1` | the cap keeps the newest |

Two of my own errors caught on the way, both recorded in the code:

- the first version of the end-to-end test **built no vector index**, so it measured "no index" while
  claiming to measure index lag — it would have failed identically whether the fix worked or not;
- its "unrelated" record had cosine **0.99999995** with the query, so the case guarding against "return
  everything" would have passed no matter what. The vectors are orthogonal now, and both cases use the same
  threshold, so together they say the check *discriminates* rather than that some threshold separates them.
