### PR TITLE
test(tooling): todo:check printed a green tick for a rule it did not enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Testing
+
+- **`npm run todo:check` printed a ✓ for a rule it did not enforce.** Its third line claims
+  *"`_TODO-ORDERED.md` references every open item in every tracker"*. For an item without an `X-LN-N` id the
+  matcher asked `words.some(w => ordered.includes(w))` over the first four long words of the title — so **any
+  single ordinary word was enough**, and the index is a long document containing "client", "search", "probe"
+  and a hundred others somewhere.
+  - Found by experiment rather than by reading: appending `- [ ] **ZZZ deliberately unreferenced probe item.**`
+    to a tracker and running the check produced *"todo/ is consistent — all of them indexed"*. It matched on
+    "probe". A second hole in the same branch skipped any item with fewer than two long words outright.
+  - Load-bearing because the release cadence is *"cut the tag when `_TODO-ORDERED.md` is empty"*: an item the
+    index never mentions makes "the queue is empty" a claim about one file rather than about the work — which
+    is what the script's own header says it exists to prevent.
+  - Reference now means **a contiguous three-word run of the item's own wording**, extracted into
+    `scripts/todo-index-match.mjs` so it can be tested with fixtures. The old matcher lived inside a script
+    that does its work at module scope and exits, so nothing could call it — a matcher nobody can invoke with
+    a fixture is a matcher nobody checks.
+  - **The obvious fallback was cut after being tested rather than reasoned about.** Accepting "every
+    distinctive word appears somewhere" sounds like tolerance for paraphrase; on the real trackers *no* item
+    needed it, and it still admitted the known orphan, because the index now documents that probe and
+    therefore contains every one of its words. Phrase-only can produce a false orphan when an index line is
+    rewritten past recognition — loud, and fixed by quoting three words. The fallback's failure was silent.
+  - Proved in both directions, which the predecessor never was: zero orphans across the real trackers, and a
+    planted orphan now fails the gate and is named in the output.
+
 ### Added
 
 - **"View in graph" on the Entities and Edges tables** (owner request). Next to each row's *View details*

--- a/scripts/todo-consistency.mjs
+++ b/scripts/todo-consistency.mjs
@@ -30,6 +30,7 @@ import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { matchIndexReference } from './todo-index-match.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const TODO = join(ROOT, 'todo');
@@ -127,15 +128,16 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
       if (!ordered.includes(id)) orphans.push(`${f} → ${id}`);
     }
 
-    // Checkboxes with no ID: match on a distinctive phrase (the longest run of words in the first 12).
+    // Checkboxes with no ID: match on a contiguous phrase from the item's own wording.
+    //
+    // This used to be `words.some(w => ordered.includes(w))` over the first four long words, which any ONE
+    // ordinary word satisfied — so this check reported a rule it did not enforce, and said "✓" while doing it.
+    // See `todo-index-match.mjs` for what replaced it and for the two fixtures that prove it discriminates.
     const plain = [...src.matchAll(/^\s*[-*]\s*\[ \]\s*(.{16,120})$/gim)]
       .map(m => m[1].replace(/[*`_]/g, '').trim())
       .filter(t => !/^[A-Z]+-[A-Z0-9-]+/.test(t));
     for (const t of plain) {
-      const words = t.split(/\s+/).filter(w => w.length > 4).slice(0, 4);
-      if (words.length < 2) continue;
-      const referenced = words.some(w => ordered.toLowerCase().includes(w.toLowerCase()));
-      if (!referenced) orphans.push(`${f} → "${t.slice(0, 70)}"`);
+      if (!matchIndexReference(t, ordered).referenced) orphans.push(`${f} → "${t.slice(0, 70)}"`);
     }
   }
   if (orphans.length) {

--- a/scripts/todo-index-match.mjs
+++ b/scripts/todo-index-match.mjs
@@ -1,0 +1,94 @@
+/**
+ * Is an open todo item referenced from `_TODO-ORDERED.md`?
+ *
+ * ## Why this is its own module
+ *
+ * It was four lines inside `todo-consistency.mjs` and it was WRONG in a way the check itself reported as
+ * "✓ _TODO-ORDERED.md references every open item in every tracker". For an item with no `X-LN-N` id it asked:
+ *
+ *     const words = title.split(/\s+/).filter(w => w.length > 4).slice(0, 4);
+ *     const referenced = words.some(w => ordered.toLowerCase().includes(w.toLowerCase()));
+ *
+ * `.some()` over four ordinary words means **any single one is enough**. `_TODO-ORDERED.md` is a long file
+ * about this repository, so it contains "client", "search", "probe", "response" and a hundred other words
+ * somewhere — and an item whose title merely contains one of them passed. Proved by appending
+ * `- [ ] **ZZZ deliberately unreferenced probe item.**` to a tracker and watching the check pass: it matched
+ * on "probe".
+ *
+ * That is load-bearing rather than cosmetic. The release cadence is "cut the tag when `_TODO-ORDERED.md` is
+ * EMPTY", so an item the index never mentions turns "the queue is empty" into a statement about one file
+ * rather than about the work — which is the exact failure the surrounding script's own header describes.
+ *
+ * Extracted so it can be tested directly. The script it came from does its work at module scope and exits,
+ * so nothing could import it, and a matcher nobody can call with a fixture is a matcher nobody checks.
+ *
+ * ## The rule: a contiguous phrase, and why the obvious fallback was cut
+ *
+ * A reference means **three consecutive words of the item's own wording appear in the index**. That is what a
+ * real reference looks like, because whoever wrote the index line was reading the item.
+ *
+ * The first version of this fix also accepted "every distinctive word appears somewhere", as tolerance for the
+ * old comment's point that the index "legitimately paraphrases rather than copying a heading verbatim". It was
+ * removed after being tested rather than reasoned about:
+ *
+ *  - On the real trackers, **all** ID-less items matched by phrase and **none** needed the fallback. It
+ *    protected nothing.
+ *  - It admitted a known orphan. The `ZZZ deliberately unreferenced probe item` used to prove the original bug
+ *    passed the fallback, because the index now DOCUMENTS that probe and therefore contains every one of its
+ *    words. Word-presence cannot distinguish "referenced" from "written about elsewhere in the same file".
+ *
+ * So the two failure modes were weighed rather than split. Phrase-only can produce a **false orphan** when an
+ * index line is rewritten past recognition — loud, and fixed by quoting three of the item's words. The
+ * fallback produced a **false green** — silent, and indistinguishable from a healthy queue. Loud beats silent
+ * for a gate whose whole job is to be believed.
+ *
+ * Accuracy over speed here is not a trade: the whole match is substring work over ten small markdown files,
+ * single-digit milliseconds against ~95 ms of node startup for the script that calls it. There was nothing to
+ * weigh and nothing worth moving off the path the owner waits on.
+ *
+ * Accuracy over speed here is not a trade: the whole match is substring work over ten small markdown files,
+ * single-digit milliseconds against ~95 ms of node startup for the script that calls it. There was nothing to
+ * weigh and nothing worth moving off the path the owner waits on.
+ */
+
+/** Lowercase, drop markdown noise, and collapse everything non-alphanumeric to single spaces. */
+export function normalize(text) {
+  return text
+    .toLowerCase()
+    .replace(/[`*_~]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/** Words worth matching on: long enough that a coincidental hit is unlikely. */
+export function distinctiveWords(title, limit = 4) {
+  return [...new Set(normalize(title).split(' ').filter(w => w.length > 4))].slice(0, limit);
+}
+
+/**
+ * @param {string} title  the item's text, as written in the tracker
+ * @param {string} ordered  the whole `_TODO-ORDERED.md` source
+ * @returns {{referenced: boolean, how: 'phrase'|'full-title'|'none'}}
+ */
+export function matchIndexReference(title, ordered) {
+  const t = normalize(title);
+  const o = normalize(ordered);
+  if (!t) return { referenced: false, how: 'none' };
+
+  const words = t.split(' ');
+
+  // A contiguous three-word run from the first part of the title. Beyond ~12 words a title has stopped being
+  // a name and started being prose, and prose is where an index line legitimately diverges.
+  const head = words.slice(0, 12);
+  for (let i = 0; i + 3 <= head.length; i++) {
+    if (o.includes(head.slice(i, i + 3).join(' '))) return { referenced: true, how: 'phrase' };
+  }
+
+  // A title too short to have a three-word run is not silently exempt — the old code `continue`d past
+  // anything with fewer than two long words, a second hole in the same check. Require the whole thing.
+  if (words.length < 3) {
+    return o.includes(t) ? { referenced: true, how: 'full-title' } : { referenced: false, how: 'none' };
+  }
+
+  return { referenced: false, how: 'none' };
+}

--- a/testing/standalone/todo-index-match.test.js
+++ b/testing/standalone/todo-index-match.test.js
@@ -1,0 +1,108 @@
+/**
+ * The tracker index check can actually FAIL.
+ *
+ * ## Why this test exists
+ *
+ * `npm run todo:check` printed *"✓ `_TODO-ORDERED.md` references every open item in every tracker"* while not
+ * enforcing it. For an item with no `X-LN-N` id it asked `words.some(w => ordered.includes(w))` over the first
+ * four long words of the title, so **any single ordinary word was enough** — and `_TODO-ORDERED.md` is a long
+ * document about this repository, so it contains "client", "search", "probe" and a hundred others somewhere.
+ *
+ * Found by experiment, not by reading: appending `- [ ] **ZZZ deliberately unreferenced probe item.**` to a
+ * tracker and running the check produced "todo/ is consistent — open items only, all of them indexed". It
+ * matched on "probe".
+ *
+ * That is load-bearing. The release cadence is "cut the tag when `_TODO-ORDERED.md` is EMPTY", so an item the
+ * index never mentions makes "the queue is empty" a claim about one file rather than about the work — which is
+ * what `todo-consistency.mjs`'s own header says the check is for.
+ *
+ * ## What this test refuses to let happen again
+ *
+ * A gate that cannot fail. Every case below is a fixture, so `todo/` being gitignored (and absent in CI) does
+ * not make this test vacuous — it tests the MATCHER, not the folder.
+ *
+ * Run: node --test testing/standalone/todo-index-match.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { matchIndexReference, normalize, distinctiveWords } from '../../scripts/todo-index-match.mjs';
+
+/** A stand-in for `_TODO-ORDERED.md`: real index lines, plus prose that mentions ordinary words. */
+const ORDERED = `
+# Ordered queue
+
+## 1 · Open work, in shipping order
+
+1. **A-L6-1** — maxPerType on recall, a ceiling to match minPerType's floor
+2. **C-L5-5** — a stable layer for the embedding model
+3. The client suite fails on a cold vitest cache, with NG0950
+
+### Watch items
+
+- The unreproduced preflight flake — capture the full tail if it recurs.
+
+Notes: a probe that asserted success by checking a string was absent; every search response is deliberately
+unreferenced from this list unless it names the item.
+`;
+
+describe('the tracker index matcher discriminates a reference from a coincidence', () => {
+  it('a genuine index line is a reference', () => {
+    for (const title of [
+      'A stable layer for the embedding model.',
+      'The client suite fails on a cold vitest cache, with NG0950',
+      'Unreproduced preflight flake',
+    ]) {
+      const r = matchIndexReference(title, ORDERED);
+      assert.equal(r.referenced, true, `"${title}" should be referenced, got ${r.how}`);
+    }
+  });
+
+  it('THE regression: a single common word is NOT a reference', () => {
+    // The exact fixture that passed the old rule, and the exact reason it passed: every one of its long words
+    // occurs somewhere in the index prose, just never together and never about this item.
+    const probe = 'ZZZ deliberately unreferenced probe item.';
+    for (const w of distinctiveWords(probe)) {
+      assert.ok(normalize(ORDERED).includes(w),
+        `fixture is wrong: "${w}" must appear in the index prose, or this test proves nothing`);
+    }
+    // The old rule, reconstructed, to show the fixture really did fool it.
+    const oldRule = distinctiveWords(probe).some(w => normalize(ORDERED).includes(w));
+    assert.equal(oldRule, true, 'the predecessor called this referenced — that is the bug');
+
+    assert.equal(matchIndexReference(probe, ORDERED).referenced, false,
+      'a title whose words merely occur in the index is an ORPHAN — the index never mentions the item');
+  });
+
+  it('a title made only of words the index happens to contain is an orphan', () => {
+    assert.equal(matchIndexReference('A client search response for the user.', ORDERED).referenced, false);
+  });
+
+  it('paraphrase is tolerated as long as three words survive', () => {
+    // The tolerance the old comment was reaching for. The index says "a stable layer for the embedding model";
+    // an item written the other way round still shares a three-word run.
+    assert.equal(matchIndexReference('Give the embedding model a stable layer, measured', ORDERED).referenced, true);
+  });
+
+  it('a rewritten index line fails LOUDLY rather than passing quietly', () => {
+    // The accepted cost of dropping the every-word fallback: an index line rewritten past any shared
+    // three-word run reports an orphan. That is the intended direction — it is fixed by quoting three of the
+    // item's words in the index, and it is visible, where the old failure was not.
+    assert.equal(matchIndexReference('Ceiling per type so one long chunk cannot crowd out the distilled tier', ORDERED).referenced, false);
+  });
+
+  it('a two-word item must appear in full, rather than being skipped', () => {
+    // The second hole in the old code: it `continue`d past anything with fewer than two long words, exempting
+    // it silently.
+    assert.equal(matchIndexReference('Vitest cache', ORDERED).referenced, true);
+    assert.equal(matchIndexReference('Nonexistent thing', ORDERED).referenced, false);
+  });
+
+  it('markdown emphasis and punctuation do not decide the answer', () => {
+    assert.equal(matchIndexReference('**A stable layer** for the `embedding model`!', ORDERED).referenced, true);
+  });
+
+  it('an empty or whitespace title is an orphan, not a pass', () => {
+    assert.equal(matchIndexReference('   ', ORDERED).referenced, false);
+    assert.equal(matchIndexReference('', ORDERED).referenced, false);
+  });
+});


### PR DESCRIPTION
`npm run todo:check` printed **✓ `_TODO-ORDERED.md` references every open item in every tracker** while not enforcing it.

For an item without an `X-LN-N` id, the matcher asked — over the first four long words of the title:

```js
words.some(w => ordered.toLowerCase().includes(w.toLowerCase()))
```

**Any one ordinary word was enough.** The index is a long document about this repository, so it contains "client", "search", "probe" and a hundred others somewhere. A second hole in the same branch skipped any item with fewer than two long words outright.

Found by experiment rather than by reading. Appending this to a tracker:

```markdown
- [ ] **ZZZ deliberately unreferenced probe item.**
```

produced *"todo/ is consistent — open items only, all of them indexed"*. It matched on "probe".

## Why it is not cosmetic

The release cadence is **"cut the tag when `_TODO-ORDERED.md` is EMPTY"**. An item the index never mentions makes "the queue is empty" a claim about one file rather than about the work — which is exactly what `todo-consistency.mjs`'s own header says the check exists to prevent. The owner's rule of 2026-08-04 ("ordered has to reference all todos in all other todo files") was unenforced for every ID-less item.

## The fix

Reference now means a **contiguous three-word run** of the item's own wording, in `scripts/todo-index-match.mjs`.

Extracted into its own module rather than fixed in place, because the old matcher lived inside a script that does its work at module scope and calls `process.exit` — nothing could import it. A matcher nobody can call with a fixture is a matcher nobody checks, which is the structural reason this bug survived as long as it did.

## The fallback I wrote first, and why it is gone

Accepting *"every distinctive word appears somewhere"* reads as reasonable tolerance for the old comment's point that the index "legitimately paraphrases rather than copying a heading verbatim". Testing it killed it twice:

- On the real trackers, **all seven** ID-less items matched by phrase and **none** needed the fallback. It protected nothing.
- It still admitted the known orphan. The index now **documents** that probe, so it contains every one of its words. Word presence cannot distinguish "referenced" from "written about elsewhere in the same file".

So the two failure modes were weighed rather than split:

| | failure | cost |
|---|---|---|
| phrase-only | a rewritten index line reads as a false orphan | **loud**, fixed by quoting three of the item's words |
| every-word fallback | a genuine orphan passes | **silent**, indistinguishable from a healthy queue |

Loud beats silent for a gate whose entire value is being believed.

## Performance vs accuracy

The owner's rule is: if it makes them wait, performance; if it is background, accuracy; and push to the background where possible. Applied to a measurement rather than a guess — `todo:check` is **~95 ms, essentially all node startup**, and the matcher is substring work over ten small markdown files. There is no trade to make, so accuracy inline. Backgrounding would also be strictly worse here: a gate that answers later cannot gate a release that happens now.

## Verified

- **run** — zero orphans across the real trackers; a planted orphan (`Wombat telemetry sharding for quokka batches`) now fails the gate and is **named** in the output; 8 fixture tests; `npm run preflight` green.
- The regression test asserts the *old* rule would have passed the probe, so the fixture cannot rot into something that proves nothing.

Filed last night as needing sign-off because `scripts/` is shipped tooling; the owner gave the decision rule, so it is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
