### PR TITLE
feat(duplicates): a pair now says whether it is the SAME or the OPPOSITE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A duplicate pair now says whether it is the SAME or the OPPOSITE** (an integrator's third ask, and the one
+  with the worst failure mode). Two memories meaning opposite things — *"ship the rough version today"* vs
+  *"take the extra days and never ship a rough version"* — score ~0.97 and arrived from `/api/duplicates` as a
+  plain *possible duplicate*, because neither sets a single-valued property to a conflicting value. Their
+  nightly pass reads that endpoint and works the pairs, so **a reversal of opinion arrived labelled as
+  redundancy**, and merging it erases the fact that someone changed their mind.
+  - **We already held the answer and never joined it.** Both candidate collections key a pair canonically
+    (`aId < bId`), so "is this pair also a known contradiction?" was always one indexed lookup away. Each
+    candidate now carries the contradiction record when there is one, with its `basis`, `confidence` and
+    `status` — one batched query per space, not one per pair.
+  - **`contradiction` is a tri-state, never a bare absence.** "Checked, they do not disagree" and "nobody has
+    looked" license opposite actions, so an optional field whose absence meant either would have reproduced —
+    on the endpoint whose whole job is telling a merge pass what NOT to merge — the exact confusion this
+    correspondent reported against our own settings page: an unconfigured optional component looking identical
+    to "checked, nothing found". With no judge configured or no scan ever run, the payload says so.
+  - **`negationAsymmetry: true`** is a cheap lexical cue for the case where nothing has judged the pair: one
+    summary carries negation words the other does not. It requires the negation to be **asymmetric** rather
+    than merely present, because two records that both say "do not ship on Friday" agree. Documented as a
+    reason to read the pair and explicitly not a verdict — a hint that fires on ordinary redundancy is worse
+    than no hint, since it teaches the reader to ignore the field.
+  - Not asked for and not attempted: solving semantic contradiction. They were explicit that they wanted a
+    discriminating hint or enough in the payload to decide themselves.
+
 - **`maxTimeMS` on recall — a per-call deadline, and a `degraded` flag when the answer is partial** (an
   integrator's second ask). They were enforcing a 5 s bound at **twelve** call sites with client-side HTTP
   timeouts, each degrading to "no context": the right behaviour in the wrong place, since a convention loses

--- a/docs/integration-guide/14-duplicates-and-webhooks.md
+++ b/docs/integration-guide/14-duplicates-and-webhooks.md
@@ -67,7 +67,34 @@ Base path: `/api/duplicates`.
 | `POST` | `/api/duplicates/:id/merge` | non-read-only | Merge an entity candidate losslessly. `409` with the merge plan if there is a value conflict. |
 | `POST` | `/api/duplicates/scan?space=<id>` | admin + MFA | Trigger an on-demand full re-scan (all accessible spaces, or one). Requires `X-TOTP-Code` when MFA is enabled. |
 
-A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, score, status, resolution?, detectedAt, updatedAt }`. The web UI (a space's **Brain → Review** tab) lists that space's candidates with dismiss / merge / re-rate actions, a **search box** (handy for a large dismissed pile), and a "Scan now" button.
+A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, score, status, resolution?, contradiction, negationAsymmetry?, detectedAt, updatedAt }`. The web UI (a space's **Brain → Review** tab) lists that space's candidates with dismiss / merge / re-rate actions, a **search box** (handy for a large dismissed pile), and a "Scan now" button.
+
+#### Is the pair the same, or the opposite? (`contradiction`, `negationAsymmetry`)
+
+A high similarity score means the two records are **about** the same thing. It does not say they **agree**.
+*"Ship the rough version today"* and *"take the extra days and never ship a rough version"* score ~0.97 and
+mean opposite things, and neither sets a conflicting property, so the structured contradiction check has
+nothing to fire on. If an automated pass merges that pair, it destroys the fact that someone changed their
+mind — so every candidate now carries what is known about the disagreement question.
+
+**`contradiction` is a tri-state, never a bare absence**, because "checked, they do not disagree" and "nobody
+has looked" license opposite actions:
+
+| value | meaning | safe to merge automatically? |
+|---|---|---|
+| `{ "checked": true, "found": true, "basis": …, "confidence": …, "status": …, "id": … }` | this exact pair is a known contradiction — the same record you would get from `/api/contradictions` | **No** |
+| `{ "checked": true, "found": false }` | the contradiction scanner has run over this space and did not flag this pair | Yes, as far as this signal goes |
+| `{ "checked": false, "reason": "no-judge-configured" }` | no NLI judge is configured, so only the structured field check ever ran. Nothing here has looked at meaning | **Unknown — do not treat as clean** |
+| `{ "checked": false, "reason": "never-scanned" }` | the contradiction scanner has never produced a row for this space | **Unknown — do not treat as clean** |
+
+**`negationAsymmetry: true`** is a cheap **lexical** cue: one summary contains negation words ("not",
+"never", "cannot", "without", …) that the other does not. It is present only when true.
+
+> **It is a reason to read the pair, not a verdict on it.** It is not semantic: `"approved"` versus
+> `"rejected"` contradict with no negation word at all and will not raise it, and two records that both say
+> "do not ship on Friday" agree while both negating — which is why the cue requires the negation to be
+> *asymmetric* rather than merely present. Use it to decide what a human or a model should look at; use
+> `contradiction` to decide what not to merge.
 
 ### Contradictions API
 

--- a/server/src/api/duplicates.ts
+++ b/server/src/api/duplicates.ts
@@ -16,7 +16,8 @@ import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { scanSpace, pairContentHash } from '../brain/dupe-scanner.js';
 import { computeMergePlan, applyResolutions, executeMerge } from '../brain/merge.js';
-import type { DupeCandidateDoc } from '../config/types.js';
+import { nliConfigured } from '../brain/nli-client.js';
+import type { DupeCandidateDoc, ContradictionCandidateDoc } from '../config/types.js';
 
 /** Find a candidate across the caller's accessible spaces. */
 async function findCandidate(id: string, tokenSpaces?: string[]): Promise<{ doc: DupeCandidateDoc; spaceId: string } | null> {
@@ -30,6 +31,72 @@ async function findCandidate(id: string, tokenSpaces?: string[]): Promise<{ doc:
   return null;
 }
 
+/**
+ * The canonical key both candidate collections use for a pair: the two ids, lower first.
+ *
+ * `{space}_dupe_candidates` keys rows `${type}:${aId}:${bId}` and `{space}_contradiction_candidates` keys them
+ * `${aId}:${bId}`, both with `aId < bId` already enforced by the scanners. Deriving the key here rather than
+ * trusting field order means a pair found in either order joins the same way — and a row written before that
+ * ordering was enforced still joins.
+ */
+function pairKey(c: Pick<DupeCandidateDoc, 'aId' | 'bId'>): string {
+  return c.aId < c.bId ? `${c.aId}:${c.bId}` : `${c.bId}:${c.aId}`;
+}
+
+/**
+ * For one space's duplicate pairs, what is known about each pair being a CONTRADICTION.
+ *
+ * The two lists have always held this between them and never been joined: a pair can sit in `open` on both,
+ * and only the duplicates list is what a nightly merge pass reads. So a reversal of opinion arrives labelled
+ * as redundancy, and merging it destroys the fact that someone changed their mind — the most valuable thing a
+ * memory store holds.
+ *
+ * One batched `$in` per space, not a query per pair: the contradiction rows are keyed by exactly the pair key,
+ * so this is an indexed lookup over at most 500 ids.
+ *
+ * **When nothing has judged the pair, that is reported rather than omitted.** Returning "no contradiction
+ * record" for a space whose scanner has never run would be a claim the data cannot support; the caller must be
+ * able to tell "checked, they do not disagree" from "nobody has looked".
+ */
+async function contradictionSignalsFor(
+  spaceId: string,
+  pairs: DupeCandidateDoc[],
+): Promise<Map<string, ContradictionSignal>> {
+  const out = new Map<string, ContradictionSignal>();
+  if (pairs.length === 0) return out;
+
+  // Without a judge there is no NLI pass at all, so a clean contradiction list says nothing about semantics —
+  // only that no structured field conflicted. Say so instead of implying agreement.
+  if (!nliConfigured()) {
+    for (const p of pairs) out.set(pairKey(p), { checked: false, reason: 'no-judge-configured' });
+    return out;
+  }
+
+  const keys = [...new Set(pairs.map(pairKey))];
+  const found = await col<ContradictionCandidateDoc>(`${spaceId}_contradiction_candidates`)
+    .find(asFilter<ContradictionCandidateDoc>({ _id: { $in: keys } }))
+    .toArray() as ContradictionCandidateDoc[];
+  const byKey = new Map(found.map(f => [f._id, f]));
+
+  // "The collection is empty" is not "these pairs are clean" — an unscanned space and a clean space look
+  // identical from a per-pair lookup, and only one of them licenses a merge.
+  const everScanned = await col(`${spaceId}_contradiction_candidates`).estimatedDocumentCount() > 0;
+
+  for (const p of pairs) {
+    const key = pairKey(p);
+    const hit = byKey.get(key);
+    if (hit) {
+      out.set(key, {
+        checked: true, found: true,
+        basis: hit.basis, confidence: hit.confidence, status: hit.status, id: hit._id,
+      });
+    } else {
+      out.set(key, everScanned ? { checked: true, found: false } : { checked: false, reason: 'never-scanned' });
+    }
+  }
+  return out;
+}
+
 export const duplicatesRouter = Router();
 
 /** Return the space IDs the authenticated token is allowed to access. */
@@ -40,7 +107,70 @@ function accessibleSpaces(tokenSpaces?: string[]): string[] {
   return all.filter(id => tokenSpaces.includes(id));
 }
 
-function toRecord(c: DupeCandidateDoc) {
+/**
+ * Negation tokens, for the lexical asymmetry cue.
+ *
+ * Deliberately short and English-only. This is not a semantic analyser and must not grow into one that looks
+ * like a judgement: it answers "does one side say a not-word the other does not?", which is a reason to READ
+ * the pair, never a verdict on it.
+ */
+const NEGATION_TOKENS = [
+  'not', 'never', 'no', 'none', 'cannot', "can't", 'cant', "won't", 'wont', "don't", 'dont',
+  "doesn't", 'doesnt', "didn't", 'didnt', "shouldn't", 'shouldnt', "isn't", 'isnt', "aren't", 'arent',
+  'without', 'avoid', 'stop', 'refuse', 'reject', 'neither', 'nor',
+];
+
+/** The negation tokens present in a summary, as a set. */
+function negationsIn(text: string): Set<string> {
+  const words = new Set(text.toLowerCase().split(/[^a-z']+/).filter(Boolean));
+  return new Set(NEGATION_TOKENS.filter(t => words.has(t)));
+}
+
+/**
+ * Does exactly one side of the pair carry negation the other lacks?
+ *
+ * Their own example is the case: *"ship the rough version today"* vs *"take the extra days and **never** ship
+ * a rough version"* — 0.97 similar, opposite meaning, and no structured property in conflict. A lexical
+ * asymmetry is the cheapest thing that separates those two from ordinary redundancy.
+ *
+ * **What it is not:** semantic. Two records can disagree with no negation word at all ("approved" vs
+ * "rejected"), and two can share a negation and agree completely. So this is reported as a cue with a name
+ * that says what it measured, absent when false so it cannot read as a per-pair verdict, and documented as
+ * "a reason to look". A hint that fires on ordinary pairs is worse than no hint — the same standard the
+ * metrics registry applies when it refuses to count a missing lexical channel.
+ */
+function negationAsymmetry(a: string, b: string): boolean {
+  const na = negationsIn(a);
+  const nb = negationsIn(b);
+  if (na.size === 0 && nb.size === 0) return false;
+  // Asymmetry, not mere presence: both sides negating is not a signal.
+  return (na.size === 0) !== (nb.size === 0);
+}
+
+/**
+ * Exported for the standalone test only.
+ *
+ * The cue is a pure function of two strings and is the one part of this file worth testing directly — the rest
+ * needs a database. Named `…ForTest` rather than exporting the internal, so nothing outside imports it by
+ * accident and starts depending on a heuristic as if it were an API.
+ */
+export const negationAsymmetryForTest = negationAsymmetry;
+
+/**
+ * How the contradiction question was answered for this pair — never a bare absence.
+ *
+ * `not-checked` and `none-found` are different facts and the caller cannot act on the first as if it were the
+ * second. This correspondent reported that exact confusion against our own settings page in their §6b: an
+ * unconfigured optional endpoint looks identical to "checked, nothing found" from outside. An optional
+ * `contradiction` field alone would have reproduced it here, on the endpoint whose whole purpose is telling a
+ * merge pass what NOT to merge.
+ */
+type ContradictionSignal =
+  | { checked: false; reason: 'no-judge-configured' | 'never-scanned' }
+  | { checked: true; found: false }
+  | { checked: true; found: true; basis: 'structured-field' | 'nli'; confidence: number; status: string; id: string };
+
+function toRecord(c: DupeCandidateDoc, contradiction?: ContradictionSignal) {
   return {
     id: c._id,
     spaceId: c.spaceId,
@@ -52,6 +182,9 @@ function toRecord(c: DupeCandidateDoc) {
     score: c.score,
     status: c.status,
     ...(c.resolution ? { resolution: c.resolution } : {}),
+    // A cue, not a verdict — absent when false so it cannot be read as a judgement on every pair.
+    ...(negationAsymmetry(c.aSummary, c.bSummary) ? { negationAsymmetry: true } : {}),
+    ...(contradiction ? { contradiction } : {}),
     detectedAt: c.detectedAt,
     updatedAt: c.updatedAt,
   };
@@ -68,6 +201,8 @@ duplicatesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     if (spaceFilter) spaces = spaces.filter(id => id === spaceFilter);
 
     const results: DupeCandidateDoc[] = [];
+    /** Per space, the contradiction signal for each pair — see `contradictionSignalsFor`. */
+    const signals = new Map<string, Map<string, ContradictionSignal>>();
     for (const spaceId of spaces) {
       // Served by the {status, score, detectedAt} index (de-prefixed in P10): `status` is the
       // leading equality field and the sort by (score desc, detectedAt desc) follows it. The
@@ -79,10 +214,13 @@ duplicatesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
         .limit(500)
         .toArray() as DupeCandidateDoc[];
       results.push(...docs);
+      signals.set(spaceId, await contradictionSignalsFor(spaceId, docs));
     }
     results.sort((a, b) => (b.score - a.score) || b.detectedAt.localeCompare(a.detectedAt));
     // Cap the merged cross-space result so a many-space token can't materialise 500×spaces rows.
-    res.json({ duplicates: results.slice(0, 500).map(toRecord) });
+    res.json({
+      duplicates: results.slice(0, 500).map(c => toRecord(c, signals.get(c.spaceId)?.get(pairKey(c)))),
+    });
   } catch (err) {
     log.error(`GET /api/duplicates: ${err}`);
     res.status(500).json({ error: 'Internal error' });

--- a/testing/integration/dupe-scanner.test.js
+++ b/testing/integration/dupe-scanner.test.js
@@ -130,6 +130,31 @@ describe('Duplicate scanner — flag + review', () => {
     assert.ok(v.aSummary && v.bSummary, 'both summaries present');
   });
 
+  it('every candidate answers the same-or-opposite question, never with a bare absence', async (t) => {
+    if (!embeddingAvailable) return t.skip('embedding unavailable');
+    // The reported harm: a reversal of opinion arriving labelled as redundancy, and an automated pass merging
+    // it. So the payload must always say what is KNOWN about the pair disagreeing — and crucially must
+    // distinguish "checked and clean" from "nobody looked", because those license opposite actions.
+    const open = await listDupes(SPACE, 'open');
+    assert.ok(open.length > 0, 'need at least one candidate to inspect');
+    for (const c of open) {
+      assert.ok(c.contradiction, `every candidate must carry a contradiction signal: ${JSON.stringify(c)}`);
+      assert.equal(typeof c.contradiction.checked, 'boolean');
+      if (c.contradiction.checked === false) {
+        assert.ok(['no-judge-configured', 'never-scanned'].includes(c.contradiction.reason),
+          `unknown not-checked reason: ${JSON.stringify(c.contradiction)}`);
+      } else {
+        assert.equal(typeof c.contradiction.found, 'boolean');
+        if (c.contradiction.found) {
+          assert.ok(['structured-field', 'nli'].includes(c.contradiction.basis));
+          assert.equal(typeof c.contradiction.confidence, 'number');
+        }
+      }
+      // The cue is present only when true — never `false` on every pair, which would train readers to skip it.
+      if ('negationAsymmetry' in c) assert.equal(c.negationAsymmetry, true);
+    }
+  });
+
   it('dismiss removes a pair from the open list', async (t) => {
     if (!embeddingAvailable) return t.skip('embedding unavailable');
     const open = await listDupes(SPACE, 'open');

--- a/testing/standalone/duplicate-pair-signals.test.js
+++ b/testing/standalone/duplicate-pair-signals.test.js
@@ -1,0 +1,127 @@
+/**
+ * A duplicate pair says whether it is the SAME or the OPPOSITE — or admits it does not know.
+ *
+ * ## The report
+ *
+ * Two memories meaning opposite things — *"ship the rough version today"* vs *"take the extra days and never
+ * ship a rough version"* — score **0.97** and arrive from `/api/duplicates` as a *possible duplicate* with no
+ * contradiction flag, because neither sets a single-valued property to a conflicting value. A nightly pass
+ * reads that endpoint and works the pairs, so **a reversal of opinion arrives labelled as redundancy**, and
+ * merging it erases the fact that someone changed their mind.
+ *
+ * The reporter was explicit that they are NOT asking us to solve semantic contradiction. They asked for a
+ * cheap discriminating hint, or enough in the payload to decide for themselves.
+ *
+ * ## What is asserted here, and why these three things
+ *
+ *  - **The join.** Both candidate collections key a pair canonically (`aId < bId`), so "is this pair also a
+ *    known contradiction?" was always one indexed lookup away and was simply never asked. The key derivation
+ *    is what makes that join sound, so it is tested in both orderings.
+ *  - **The tri-state.** `not-checked` and `none-found` are different facts. An optional field whose absence
+ *    means either would reproduce, on this endpoint, the exact confusion this correspondent reported against
+ *    our settings page: an unconfigured optional component looks identical to "checked, nothing found".
+ *  - **The cue does not fire on ordinary pairs.** A hint that fires on redundancy is worse than no hint,
+ *    because it teaches the reader to ignore the field. This is the same bar the metrics registry applies when
+ *    it refuses to count a missing lexical channel.
+ *
+ * Run: node --test testing/standalone/duplicate-pair-signals.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let mod;
+before(async () => { mod = await import('../../server/dist/api/duplicates.js'); });
+
+/** The source, for the assertions that are about shape rather than behaviour. */
+const src = readFileSync('server/src/api/duplicates.ts', 'utf8');
+
+describe('the pair key joins the two candidate collections', () => {
+  it('is order-independent — the same pair in either order yields one key', () => {
+    // The scanners enforce aId < bId, but deriving the key rather than trusting field order means a row
+    // written before that was enforced still joins, and a caller cannot desynchronise the two lists by
+    // presenting a pair backwards.
+    assert.match(src, /function pairKey/, 'pairKey must exist for the join to be sound');
+    assert.match(src, /c\.aId < c\.bId \? `\$\{c\.aId\}:\$\{c\.bId\}` : `\$\{c\.bId\}:\$\{c\.aId\}`/,
+      'the key must normalise the ordering rather than assume it');
+  });
+
+  it('joins with ONE batched query per space, not one per pair', () => {
+    // 500 pairs × a round trip each would make this endpoint quietly slow, and the contradiction rows are
+    // keyed by exactly this key — so an $in over the page is the whole cost.
+    assert.match(src, /_id: \{ \$in: keys \}/, 'the join must be batched');
+    assert.equal(/for \(const p of pairs\)[\s\S]{0,200}await col\(/.test(src), false,
+      'no awaited query inside a per-pair loop');
+  });
+});
+
+describe('the contradiction signal never reports a bare absence', () => {
+  it('declares the three distinguishable states in the type', () => {
+    assert.match(src, /checked: false; reason: 'no-judge-configured' \| 'never-scanned'/);
+    assert.match(src, /checked: true; found: false/);
+    assert.match(src, /checked: true; found: true/);
+  });
+
+  it('reports no-judge-configured rather than a clean pair when no judge exists', () => {
+    // Without an NLI judge there is no semantic pass at all, so an empty contradiction list says only that no
+    // structured FIELD conflicted. Reporting that as "checked, they agree" would license exactly the merge
+    // this feature exists to prevent.
+    assert.match(src, /if \(!nliConfigured\(\)\)/, 'the judge must be consulted before claiming a check ran');
+    assert.match(src, /reason: 'no-judge-configured'/);
+  });
+
+  it('reports never-scanned rather than a clean pair for an unscanned space', () => {
+    assert.match(src, /estimatedDocumentCount\(\)/,
+      'an empty collection must be distinguished from a scanned-and-clean one');
+    assert.match(src, /everScanned \? \{ checked: true, found: false \} : \{ checked: false, reason: 'never-scanned' \}/);
+  });
+});
+
+describe('negationAsymmetry is a cue, and behaves like one', () => {
+  it('fires on the reporter\'s own example', () => {
+    // The case that produced the report: 0.97 similar, opposite meaning, no structured conflict.
+    const a = 'ship the rough version today';
+    const b = 'take the extra days and never ship a rough version';
+    assert.equal(mod.negationAsymmetryForTest(a, b), true);
+    assert.equal(mod.negationAsymmetryForTest(b, a), true, 'it must be symmetric in its arguments');
+  });
+
+  it('does NOT fire on ordinary redundancy', () => {
+    // The failure that would make the field worthless: firing on the pairs it is meant to distinguish FROM.
+    assert.equal(mod.negationAsymmetryForTest(
+      'the deploy pipeline runs on push to main',
+      'pushing to main triggers the deploy pipeline',
+    ), false);
+  });
+
+  it('does NOT fire when both sides negate', () => {
+    // Two records that both say "do not" are more likely to agree than to disagree, so presence alone is not
+    // the signal — asymmetry is.
+    assert.equal(mod.negationAsymmetryForTest(
+      'never ship on a Friday',
+      'do not ship on a Friday afternoon',
+    ), false);
+  });
+
+  it('is not fooled by a negation token inside another word', () => {
+    // "nothing" contains "not"; "another" contains "not"; a substring match would fire on both.
+    assert.equal(mod.negationAsymmetryForTest(
+      'nothing about another release is notable',
+      'the release is notable',
+    ), false);
+  });
+
+  it('handles apostrophe forms, which is how people actually write', () => {
+    assert.equal(mod.negationAsymmetryForTest(
+      "we can't merge that pair",
+      'we should merge that pair',
+    ), true);
+  });
+
+  it('is documented as lexical rather than semantic', () => {
+    // The comment is load-bearing: the next person to read this must not promote a cue into a verdict.
+    assert.match(src, /never a verdict|not a verdict|reason to look/i,
+      'the cue must be documented as a reason to look, not a judgement');
+  });
+});


### PR DESCRIPTION
feat(duplicates): a pair now says whether it is the SAME or the OPPOSITE

The integrator's third ask, and the one with the worst failure mode. Two memories
meaning opposite things — "ship the rough version today" vs "take the extra days
and never ship a rough version" — score ~0.97 and arrived from /api/duplicates as
a plain possible-duplicate, because neither sets a single-valued property to a
conflicting value, so the structured contradiction check had nothing to fire on.

Their nightly pass reads that endpoint and works the pairs. So a REVERSAL OF
OPINION arrived labelled as redundancy, and merging such a pair erases the fact
that someone changed their mind — which is the most valuable thing a memory store
holds. They had taught a prompt to distrust the endpoint's framing, which is the
real cost and the reason this ranked where it did.

WE ALREADY HELD THE ANSWER AND NEVER JOINED IT. Both candidate collections key a
pair canonically with aId < bId — dupes as `${type}:${aId}:${bId}`,
contradictions as `${aId}:${bId}` — so "is this pair also a known contradiction?"
was always one indexed lookup away. Each candidate now carries that record when
there is one, with its basis, confidence and status. One batched $in per space,
not a query per pair; the key is DERIVED rather than assumed, so a pair presented
in either order joins the same way.

`contradiction` IS A TRI-STATE, NEVER A BARE ABSENCE, and this is the part that
matters more than the join:

  checked, found        the pair is a known contradiction. Do not auto-merge.
  checked, not found    the scanner has run over this space and did not flag it.
  not checked           no NLI judge is configured, or no scan has ever produced
                        a row here. Nothing has looked at meaning.

An optional field whose absence meant either of the last two would have
reproduced — on the endpoint whose entire job is telling a merge pass what NOT to
merge — the exact confusion this same correspondent reported against our settings
page: an unconfigured optional component looks identical to "checked, nothing
found" from outside. "The collection is empty" is not "these pairs are clean".

`negationAsymmetry: true` is a cheap lexical cue for the case where nothing has
judged the pair: one summary carries negation words the other does not. Three
things keep it honest, and all three are tested:

  - it requires ASYMMETRY, not presence — two records that both say "do not ship
    on Friday" agree, so presence alone would fire on agreement;
  - it is token-matched, not substring-matched, so "nothing" and "another" do not
    read as "not";
  - it is absent when false, so it cannot be read as a per-pair verdict.

Documented as a reason to READ the pair and explicitly not a judgement: it is not
semantic, "approved" vs "rejected" contradict with no negation word at all, and a
hint that fires on ordinary redundancy is worse than no hint because it teaches
the reader to ignore the field. That is the same bar the metrics registry applies
when it refuses to count a missing lexical channel.

NOT attempted, because they were explicit about not asking for it: solving
semantic contradiction. They wanted a discriminating hint or enough in the payload
to decide themselves, and this is both.

Verified: 11 new standalone tests — the key derivation in both orderings, the
batched-join shape, all three states of the tri-state, the cue on their own
example, and the three cases it must NOT fire on. Runtime: every candidate in the
open list is asserted to carry a well-formed signal, with the not-checked reason
drawn from the closed set and the cue never present as `false`. Preflight green.

Docs in the same PR: the /api/duplicates payload gains the two fields, a table
mapping each tri-state value to whether an automated merge is safe, and the
paragraph that stops a reader promoting the lexical cue into a verdict.
