### PR TITLE
feat(schema-library): PATCH an entry, so one property does not mean resending all of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`PATCH /api/schema-library/:name` — change one property without restating the entry** (an integrator's
+  fourth ask). `PUT` requires `knowledgeType`, `typeName` and the whole `schema`, and replaces `schema`
+  wholesale, so adding one optional property meant resending the type name, the description and **every
+  pre-existing property** — precisely the shape in which a property gets dropped by accident. They had
+  resorted to asserting afterwards that nothing was lost and no enum had narrowed, which is a workaround for a
+  missing merge.
+  - **`schema.propertySchemas` merges by key.** Named properties are added or replaced; unnamed ones survive.
+    A named property is replaced as a whole definition, because deep-merging into it would leave no way to
+    remove a constraint.
+  - `namingPattern` and `tagSuggestions` replace when present and are preserved when absent — one value and
+    one whole list, where merging the list would leave no way to remove a single tag.
+  - `deleteFields` takes dot paths (`propertySchemas.<key>`, `propertySchemas`, `namingPattern`,
+    `tagSuggestions`), reusing the vocabulary the brain record routes already use rather than inventing a
+    second one. Applied **after** the merge, so one request can replace one property and drop another.
+  - **An unrecognised `deleteFields` path is a `400`, not a silent no-op** — a dropped typo would leave the
+    caller believing a property was removed while it is still validating records. A body naming no field at
+    all is also a `400`, so a no-op cannot be mistaken for an applied change.
+  - **`PATCH` does not create:** a missing entry is a `404` that says to use `PUT`. Note the difference from
+    before — an integrator's `PATCH` used to get a `404` from the router itself, which read as "not supported"
+    because it was.
+  - `PUT` is unchanged and remains correct when you hold the whole entry.
+
 - **A duplicate pair now says whether it is the SAME or the OPPOSITE** (an integrator's third ask, and the one
   with the worst failure mode). Two memories meaning opposite things — *"ship the rough version today"* vs
   *"take the extra days and never ship a rough version"* — score ~0.97 and arrived from `/api/duplicates` as a

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -844,6 +844,47 @@ Content-Type: application/json
 
 **Response** `201` (created) or `200` (replaced). Returns `400` for invalid name format or payload.
 
+**`PUT` replaces the `schema` wholesale**, and requires `knowledgeType`, `typeName` and `schema` every time.
+That is the right verb when you are holding the whole entry — and the wrong one for changing a single
+property, because it means resending every pre-existing property, which is how one gets dropped by accident.
+Use `PATCH` for that.
+
+#### Change part of an entry (merge)
+
+```http
+PATCH /api/schema-library/:name
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+  "schema": { "propertySchemas": { "region": { "type": "string" } } }
+}
+```
+
+Every field is optional and **`schema.propertySchemas` merges by key**: the properties you name are added or
+replaced, and the ones you do not name survive untouched. So the request above adds `region` without
+restating `tier`, `owner`, the `namingPattern`, the description or the type name.
+
+| field | behaviour |
+|---|---|
+| `schema.propertySchemas` | **merged per key.** A named property is REPLACED as a whole definition — naming it is how you change it, and deep-merging into it would make removing a constraint impossible |
+| `schema.namingPattern`, `schema.tagSuggestions` | replaced when present, preserved when absent. One value and one whole list; merging a list would leave no way to remove a single tag |
+| `knowledgeType`, `typeName`, `published` | replaced when present |
+| `description`, `schemaGroup`, `sourceUrl`, `sourceCatalog` | `null` clears, a value sets, absent preserves — the same three-way contract `PUT` honours |
+| `deleteFields` | dot paths to remove: `propertySchemas.<key>`, `propertySchemas`, `namingPattern`, `tagSuggestions`. Applied **after** the merge, so one request can replace one property and drop another |
+
+**Response** `200 { "entry": { ... } }`.
+
+- `404` if the entry does not exist — **`PATCH` does not create**; use `PUT` for that. (Before this endpoint
+  existed, a `PATCH` here returned a `404` from the router itself, which read as "not supported" because it
+  was.)
+- `400` if the body names no field at all, so a no-op cannot be mistaken for an applied change.
+- `400` for an unrecognised `deleteFields` path, rather than ignoring it — a silently dropped typo would leave
+  you believing a property was removed while it is still validating records.
+
+Editing a library entry changes what **every space that `$ref`s it** validates against; use
+`GET /api/schema-library/:name/usages` first if you need to know who that is.
+
 #### Delete an entry
 
 ```http

--- a/server/src/api/schema-library.ts
+++ b/server/src/api/schema-library.ts
@@ -125,6 +125,32 @@ const LibraryEntryPutBodyZ = z.object({
   sourceCatalog: z.string().max(200).nullable().optional(),
 });
 
+/**
+ * Body for `PATCH /:name` — every field optional, and `schema` MERGES.
+ *
+ * The gap this closes, reported by an integrator: `PUT` requires `knowledgeType`, `typeName` and the whole
+ * `schema`, and replaces `schema` wholesale. So adding one optional property meant resending the type name,
+ * the description and **every pre-existing property** — precisely the shape in which a property gets dropped
+ * by accident. They had resorted to asserting afterwards that nothing was lost and no enum had narrowed,
+ * which is a workaround for a missing merge.
+ *
+ * `deleteFields` rather than a new convention: the brain record routes already use dot-notation paths for
+ * removal, so an integrator who has used `PATCH .../memories/:id` already knows this. Two vocabularies for
+ * one operation is how they diverge.
+ */
+const LibraryEntryPatchBodyZ = z.object({
+  knowledgeType: z.enum(['entity', 'memory', 'edge', 'chrono']).optional(),
+  typeName: z.string().min(1).max(200).optional(),
+  schema: LibraryTypeSchemaZ.optional(),
+  description: z.string().max(1000).nullable().optional(),
+  schemaGroup: z.string().min(1).max(200).nullable().optional(),
+  published: z.boolean().optional(),
+  sourceUrl: z.string().url().max(2048).nullable().optional(),
+  sourceCatalog: z.string().max(200).nullable().optional(),
+  /** Dot paths inside `schema`: `propertySchemas.<key>`, `namingPattern`, `tagSuggestions`, `propertySchemas`. */
+  deleteFields: z.array(z.string().min(1).max(300)).max(100).optional(),
+}).strict();
+
 /** Body for PATCH /:name/publish */
 const PublishPatchZ = z.object({
   published: z.boolean(),
@@ -505,6 +531,104 @@ schemaLibraryRouter.put('/:name', globalRateLimit, requireAdminMfa, (req, res) =
     req.auditSnapshots = { before: existing, after: updatedEntry };
     res.json({ entry: updatedEntry });
   }
+});
+
+// ── PATCH /:name — merge into an existing entry ───────────────────────────────
+//
+// `PUT` remains the full replace, and is still the right verb when you hold the whole entry. This is for the
+// case that produced the report: change one thing without restating everything else.
+//
+// It does NOT create. A `404` here means "no such entry", which is a different fact from the `404` an
+// integrator used to get — that one was Express refusing an unrouted method, and it read as "PATCH is not
+// supported" because it was.
+
+schemaLibraryRouter.patch('/:name', globalRateLimit, requireAdminMfa, (req, res) => {
+  const name = req.params['name'] as string;
+
+  if (!LIBRARY_NAME_RE.test(name)) {
+    res.status(400).json({ error: 'Invalid library entry name. Must be lowercase alphanumeric with optional dashes/underscores.' });
+    return;
+  }
+
+  const parsed = LibraryEntryPatchBodyZ.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.message });
+    return;
+  }
+  const patch = parsed.data;
+
+  // A patch that names nothing is a request that cannot be carried out, and answering 200 to it would make a
+  // no-op indistinguishable from an applied change — the same trap the brain PATCH handlers now refuse.
+  const named = Object.keys(patch).filter(k => patch[k as keyof typeof patch] !== undefined);
+  if (named.length === 0) {
+    res.status(400).json({ error: 'At least one field must be provided' });
+    return;
+  }
+
+  const library = getSchemaLibrary();
+  const idx = library.findIndex(e => e.name === name);
+  if (idx === -1) {
+    res.status(404).json({ error: `Library entry '${name}' not found. Use PUT to create one.` });
+    return;
+  }
+  const existing = library[idx]!;
+
+  // Merge the schema: named properties are added or replaced, unnamed ones survive. `namingPattern` and
+  // `tagSuggestions` replace when present — they are a single value and a whole list, and merging a list
+  // would make removing one tag impossible without a second mechanism.
+  const mergedSchema: SchemaLibraryEntry['schema'] = { ...(existing.schema ?? {}) };
+  if (patch.schema) {
+    if (patch.schema.namingPattern !== undefined) mergedSchema.namingPattern = patch.schema.namingPattern;
+    if (patch.schema.tagSuggestions !== undefined) mergedSchema.tagSuggestions = patch.schema.tagSuggestions;
+    if (patch.schema.propertySchemas !== undefined) {
+      mergedSchema.propertySchemas = { ...(existing.schema?.propertySchemas ?? {}), ...patch.schema.propertySchemas };
+    }
+  }
+
+  // Removals, applied AFTER the merge so a single request can replace one property and drop another without
+  // the order mattering to the caller.
+  const unknownPaths: string[] = [];
+  for (const path of patch.deleteFields ?? []) {
+    if (path === 'namingPattern') { delete mergedSchema.namingPattern; continue; }
+    if (path === 'tagSuggestions') { delete mergedSchema.tagSuggestions; continue; }
+    if (path === 'propertySchemas') { delete mergedSchema.propertySchemas; continue; }
+    const prop = /^propertySchemas\.(.+)$/.exec(path);
+    if (prop && mergedSchema.propertySchemas) { delete mergedSchema.propertySchemas[prop[1]!]; continue; }
+    if (prop) continue;   // nothing to delete from, but the path is valid
+    unknownPaths.push(path);
+  }
+  if (unknownPaths.length > 0) {
+    // Refused rather than ignored: a typo'd path that is silently dropped leaves the caller believing a
+    // property was removed when it is still validating records.
+    res.status(400).json({
+      error: `deleteFields paths must be 'namingPattern', 'tagSuggestions', 'propertySchemas', or 'propertySchemas.<key>' — unrecognised: ${unknownPaths.join(', ')}`,
+    });
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const updated: SchemaLibraryEntry = {
+    ...existing,
+    ...(patch.knowledgeType !== undefined ? { knowledgeType: patch.knowledgeType } : {}),
+    ...(patch.typeName !== undefined ? { typeName: patch.typeName } : {}),
+    schema: mergedSchema,
+    // null clears, a value sets, absent preserves — the same three-way contract PUT already honours for these.
+    ...(patch.description === null ? { description: undefined } : patch.description !== undefined ? { description: patch.description } : {}),
+    ...(patch.schemaGroup === null ? { schemaGroup: undefined } : patch.schemaGroup !== undefined ? { schemaGroup: patch.schemaGroup } : {}),
+    ...(patch.published !== undefined ? { published: patch.published } : {}),
+    ...(patch.sourceUrl === null ? { sourceUrl: undefined } : patch.sourceUrl !== undefined ? { sourceUrl: patch.sourceUrl } : {}),
+    ...(patch.sourceCatalog === null ? { sourceCatalog: undefined } : patch.sourceCatalog !== undefined ? { sourceCatalog: patch.sourceCatalog } : {}),
+    updatedAt: now,
+  };
+
+  const next = [...library];
+  next[idx] = updated;
+  saveSchemaLibrary(next);
+  // Same reasoning as PUT: this entry is `$ref`d from any number of spaces, so editing it changes what all of
+  // them validate against. The audit layer records the scalar metadata and which property KEYS changed, never
+  // the property schemas themselves, which can carry example values.
+  req.auditSnapshots = { before: existing, after: updated };
+  res.json({ entry: updated });
 });
 
 // ── GET /:name/usages — list all spaces that $ref this library entry ─────────

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -188,6 +188,14 @@ const ROUTE_RULES: RouteRule[] = [
   { method: 'POST',   pattern: /^\/api\/schema-library$/,                           operation: 'schema_library.create' },
   { method: 'PUT',    pattern: /^\/api\/schema-library\/([^/]+)$/,                  operation: 'schema_library.update' },
   { method: 'DELETE', pattern: /^\/api\/schema-library\/([^/]+)$/,                  operation: 'schema_library.delete' },
+  // The merge verb shares `schema_library.update` with PUT: both change what every space that `$ref`s the
+  // entry validates against, which is the fact an auditor is looking for, and a reader filtering the log for
+  // "who changed this schema" must not have to know which verb the caller happened to use. The change list
+  // records what actually moved either way.
+  //
+  // `/publish` stays a separate operation because it changes visibility rather than content. The two patterns
+  // cannot collide — `([^/]+)$` excludes a slash — so their order here is not load-bearing.
+  { method: 'PATCH',  pattern: /^\/api\/schema-library\/([^/]+)$/,                  operation: 'schema_library.update' },
   { method: 'PATCH',  pattern: /^\/api\/schema-library\/([^/]+)\/publish$/,         operation: 'schema_library.publish' },
   { method: 'POST',   pattern: /^\/api\/schema-library\/catalogs$/,                 operation: 'schema_library.catalog.add' },
   { method: 'DELETE', pattern: /^\/api\/schema-library\/catalogs\/([^/]+)$/,        operation: 'schema_library.catalog.remove' },

--- a/testing/integration/schema-library.test.js
+++ b/testing/integration/schema-library.test.js
@@ -262,6 +262,109 @@ describe('PUT /api/schema-library/:name — create-or-replace', () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════════════
+//  PATCH /:name — merge into an existing entry
+//
+//  The reported gap: PUT requires knowledgeType, typeName and the whole schema, and REPLACES the schema. So
+//  adding one optional property meant resending the type name, the description and every pre-existing
+//  property — the shape in which a property gets dropped by accident. The integrator had resorted to
+//  asserting afterwards that nothing was lost and no enum had narrowed.
+//
+//  So the assertion that matters here is not "the patch applied" — it is WHAT SURVIVED it.
+// ═════════════════════════════════════════════════════════════════════════════
+describe('PATCH /api/schema-library/:name — merge', () => {
+  const patchName = `lib-test-${RUN}-patch`;
+  const patchEntry = (name, body) => patch(INSTANCES.a, token(), `/api/schema-library/${encodeURIComponent(name)}`, body);
+
+  before(async () => {
+    const r = await putEntry(patchName, {
+      knowledgeType: 'entity',
+      typeName: 'service',
+      description: 'the original description',
+      schema: {
+        namingPattern: '^svc-',
+        tagSuggestions: ['infra', 'owned'],
+        propertySchemas: {
+          tier: { type: 'string', enum: ['gold', 'silver'] },
+          owner: { type: 'string' },
+        },
+      },
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+  });
+  after(async () => { await deleteEntry(patchName).catch(() => {}); });
+
+  it('adds ONE property without resending the others — the whole point', async () => {
+    const r = await patchEntry(patchName, {
+      schema: { propertySchemas: { region: { type: 'string' } } },
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const ps = r.body.entry.schema.propertySchemas;
+    assert.ok(ps.region, 'the new property must be added');
+    assert.ok(ps.tier, 'a property not mentioned must SURVIVE — this is the bug being fixed');
+    assert.ok(ps.owner, 'and so must the other one');
+    // Nothing else may be collateral damage either.
+    assert.equal(r.body.entry.typeName, 'service', 'typeName must survive a schema-only patch');
+    assert.equal(r.body.entry.description, 'the original description');
+    assert.equal(r.body.entry.schema.namingPattern, '^svc-');
+    assert.deepEqual(r.body.entry.schema.tagSuggestions, ['infra', 'owned']);
+  });
+
+  it('does not narrow an enum it was not asked to touch', async () => {
+    // Their exact after-the-fact assertion, made unnecessary: they were checking that a round-tripped PUT
+    // had not silently dropped enum members.
+    const r = await getEntry(patchName);
+    assert.deepEqual(r.body.entry.schema.propertySchemas.tier.enum, ['gold', 'silver']);
+  });
+
+  it('replaces a named property rather than deep-merging it', async () => {
+    // A property schema is one definition, so naming it means replacing it. Merging INTO it would make
+    // removing a constraint impossible without a second mechanism.
+    const r = await patchEntry(patchName, {
+      schema: { propertySchemas: { tier: { type: 'string' } } },
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.entry.schema.propertySchemas.tier.enum, undefined,
+      'naming a property replaces its definition');
+    assert.ok(r.body.entry.schema.propertySchemas.region, 'other properties still survive');
+  });
+
+  it('deleteFields removes one property and leaves the rest', async () => {
+    const r = await patchEntry(patchName, { deleteFields: ['propertySchemas.region'] });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.entry.schema.propertySchemas.region, undefined);
+    assert.ok(r.body.entry.schema.propertySchemas.owner, 'the others survive the removal');
+  });
+
+  it('refuses an unrecognised deleteFields path instead of ignoring it', async () => {
+    // A silently dropped typo leaves the caller believing a property was removed while it is still
+    // validating records.
+    const r = await patchEntry(patchName, { deleteFields: ['propertySchemasss.owner'] });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /unrecognised/i);
+  });
+
+  it('a patch naming nothing is a 400, not a 200 no-op', async () => {
+    const r = await patchEntry(patchName, {});
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /At least one field/);
+  });
+
+  it('PATCH does not create — a missing entry is 404 and says to use PUT', async () => {
+    const r = await patchEntry(`lib-test-${RUN}-does-not-exist`, { typeName: 'x' });
+    assert.equal(r.status, 404, JSON.stringify(r.body));
+    assert.match(r.body.error, /PUT/, 'the 404 should say how to create one');
+  });
+
+  it('null clears a scalar, absent preserves it', async () => {
+    const cleared = await patchEntry(patchName, { description: null });
+    assert.equal(cleared.status, 200, JSON.stringify(cleared.body));
+    assert.equal(cleared.body.entry.description, undefined, 'null must clear');
+    const after = await patchEntry(patchName, { typeName: 'service' });
+    assert.equal(after.body.entry.description, undefined, 'and absent must not resurrect it');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
 //  DELETE — remove an entry
 // ═════════════════════════════════════════════════════════════════════════════
 describe('DELETE /api/schema-library/:name — remove', () => {


### PR DESCRIPTION
feat(schema-library): PATCH an entry, so one property does not mean resending all of them

The integrator's fourth ask. `PUT` requires knowledgeType, typeName and the whole
`schema`, and replaces `schema` wholesale — so adding one optional property meant
resending the type name, the description and EVERY pre-existing property. That is
precisely the shape in which a property gets dropped by accident, and they were
already asserting after every write that nothing had been lost and no enum had
narrowed. An assertion like that is a workaround for a missing merge, and it only
catches the mistake after it has been made.

WHAT MERGES, AND WHY EACH ONE WORKS THAT WAY:

  propertySchemas     merged BY KEY. Named properties are added or replaced,
                      unnamed ones survive. A named property is replaced as a
                      whole definition rather than deep-merged, because merging
                      into it would leave no way to remove a constraint.

  namingPattern       replaced when present, preserved when absent. One value and
  tagSuggestions      one whole list — merging the list would leave no way to
                      remove a single tag.

  the scalars         null clears, a value sets, absent preserves. The same
                      three-way contract PUT already honoured, kept identical so
                      the two verbs cannot disagree about what null means.

  deleteFields        dot paths: propertySchemas.<key>, propertySchemas,
                      namingPattern, tagSuggestions. Reuses the vocabulary the
                      brain record routes already use rather than inventing a
                      second one for the same operation — two vocabularies is how
                      they diverge. Applied AFTER the merge, so one request can
                      replace one property and drop another without the caller
                      reasoning about order.

TWO REFUSALS, both for the reason this release keeps returning to:

  an unrecognised deleteFields path is a 400, not a silent skip. A dropped typo
  would leave the caller believing a property was removed while it is still
  validating records.

  a body naming no field at all is a 400. A no-op that answers 200 is
  indistinguishable from an applied change, which is the trap the brain PATCH
  handlers now refuse as well.

PATCH DOES NOT CREATE: a missing entry is a 404 that names PUT. Worth stating
because the 404 an integrator used to get here came from the router refusing an
unrouted method — it read as "PATCH is not supported", because it was.

Two gates caught this on the way past, which is the system working:

  audit-route-coverage   The new mutating route produced no audit entry. It now
                         shares `schema_library.update` with PUT: both change what
                         every space that `$ref`s the entry validates against,
                         which is the fact an auditor wants, and someone filtering
                         the log for "who changed this schema" should not have to
                         know which verb the caller used. `/publish` stays separate
                         because it changes visibility rather than content.

  a comment I got wrong  My first version of that rule claimed the pattern order
                         was load-bearing. It is not — `([^/]+)$` cannot match a
                         path with a slash, so the two PATCH patterns are mutually
                         exclusive. Corrected rather than left: a comment that
                         invents a constraint is a trap for whoever reorders the
                         list later.

Verified: 8 runtime tests, and the ones that matter assert what SURVIVED the patch
— that adding `region` leaves `tier`, `owner`, the namingPattern, the tagSuggestions,
the typeName and the description untouched, and that an enum nobody mentioned is
not narrowed (their own after-the-fact check, made unnecessary). Plus: naming a
property replaces its definition, deleteFields removes one and keeps the rest, a
typo'd path is refused, an empty body is refused, a missing entry 404s toward PUT,
and null-clears-then-absent-preserves. Preflight green.

Docs in the same PR: a new "Change part of an entry (merge)" section in the spaces
guide with a per-field behaviour table, both refusals, the 404-does-not-create
note, and a pointer to `/usages` since editing an entry changes what every
referencing space validates against.
