### PR TITLE
fix(spaces): accept the three meta fields our own GET emits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`GET /api/spaces/:id` returned three fields that `PATCH` then refused** (an integrator's fifth ask, and the
+  half of it that had not already shipped). A caller doing the obvious thing — `GET` a space, edit one field of
+  `meta.typeSchemas`, `PATCH` it back — got `unrecognized_keys` for `version`, `updatedAt` and
+  `previousVersions`: three fields they never wrote, could not know to strip, and had received from our own
+  response. Their ask was *"either merge, or do not return what you will not accept"*; the merge half shipped
+  earlier as `mergeSpaceMeta`, and this is the rest.
+  - Those three are now **stripped** from an incoming `meta` rather than rejected. They are server-owned: the
+    server writes them, the `GET` returns them, and a caller may not set them — so dropping them costs the
+    caller nothing, and the version the `If-Match` precondition reads still cannot be written from a request
+    body.
+  - **Only those three.** `.strict()` still rejects every other unknown key, and that distinction is the whole
+    design: a key the server itself emitted is echo-back noise, while `validationMdoe` is a typo that must stay
+    loud — silently ignoring it would leave someone believing they had turned validation on. Stripping
+    everything would have traded a real diagnostic for a convenience.
+  - **Our own dry-run endpoint had stripped exactly those three since it was written**, so two endpoints in one
+    file disagreed about whether a round-tripped body was acceptable. One of them was wrong, and it was not the
+    one that accepted it. Both now go through a single helper, so a field added to the server-owned set reaches
+    both instead of needing to be remembered twice.
+
 ### Added
 
 - **`PATCH /api/schema-library/:name` — change one property without restating the entry** (an integrator's

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -193,14 +193,29 @@ Notes:
 - A value that is not a version — `If-Match: abc` — is rejected with **400**, never ignored. Silently ignoring an unparseable precondition would give you the false impression that your write was protected.
 - The same header is honoured by **every route that writes space meta**: `PUT /api/spaces/:id/schema` (checked before that route writes its schema backup file), and the single-type `PUT` and `DELETE` on `/api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName`.
 
-**You can PATCH a body straight back from `GET`.** The `meta` in a `GET` response carries three fields the
-server owns — `version`, `updatedAt` and `previousVersions` — and `PATCH` **ignores** them rather than
-rejecting the request, so read-modify-write needs no stripping step on your side. They are still not writable:
-the version the `If-Match` check reads cannot be set from a request body, and the server bumps it as usual.
+**Read-modify-write needs no stripping step.** `GET /api/spaces/:id/meta` returns the meta fields alongside
+`version` and `updatedAt`, which the server owns and you cannot set. `PATCH` **ignores** those (and
+`previousVersions`) rather than rejecting the request, so you can send back what you read:
 
-Every *other* unknown key in `meta` is still a **400**. That is deliberate and worth relying on: a typo like
-`validationMdoe` must not be silently ignored, because you would come away believing you had turned validation
-on. The tolerance covers only the fields we ourselves emit.
+```http
+GET  /api/spaces/research/meta      →  { "spaceId": "research", "spaceName": "Research",
+                                          "purpose": "...", "typeSchemas": { ... },
+                                          "version": 7, "updatedAt": "...", "stats": { ... } }
+
+PATCH /api/spaces/research          →  { "meta": { "purpose": "...", "typeSchemas": { ... },
+                                                   "version": 7, "updatedAt": "..." } }   ✅ accepted
+```
+
+Ignoring is not accepting: the version the `If-Match` check reads cannot be written from a request body, and
+the server still bumps it.
+
+**Two things `meta` still rejects with a `400`, both deliberately:**
+
+- **The response envelope.** `spaceId`, `spaceName` and `stats` are the shape of the `GET`, not part of `meta`.
+  Posting the whole response body as `meta` is a real mistake and you should hear about it.
+- **Any other unknown key.** A typo like `validationMdoe` must not be silently ignored — you would come away
+  believing you had turned validation on. The tolerance covers only the fields that genuinely belong to `meta`
+  and that we ourselves emit.
 
 **Removing a type schema.** `PATCH` deep-merges, so omitting a type does not delete it — a merge that could delete would make every PATCH potentially destructive, and a client that round-trips a space would silently drop schemas whenever its serialiser emitted `null` for an unset field. Deletion is explicit instead: `DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` for one type (404 if it does not exist), or `PUT /api/spaces/:id/schema` to replace the whole map.
 

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -193,6 +193,15 @@ Notes:
 - A value that is not a version — `If-Match: abc` — is rejected with **400**, never ignored. Silently ignoring an unparseable precondition would give you the false impression that your write was protected.
 - The same header is honoured by **every route that writes space meta**: `PUT /api/spaces/:id/schema` (checked before that route writes its schema backup file), and the single-type `PUT` and `DELETE` on `/api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName`.
 
+**You can PATCH a body straight back from `GET`.** The `meta` in a `GET` response carries three fields the
+server owns — `version`, `updatedAt` and `previousVersions` — and `PATCH` **ignores** them rather than
+rejecting the request, so read-modify-write needs no stripping step on your side. They are still not writable:
+the version the `If-Match` check reads cannot be set from a request body, and the server bumps it as usual.
+
+Every *other* unknown key in `meta` is still a **400**. That is deliberate and worth relying on: a typo like
+`validationMdoe` must not be silently ignored, because you would come away believing you had turned validation
+on. The tolerance covers only the fields we ourselves emit.
+
 **Removing a type schema.** `PATCH` deep-merges, so omitting a type does not delete it — a merge that could delete would make every PATCH potentially destructive, and a client that round-trips a space would silently drop schemas whenever its serialiser emitted `null` for an unset field. Deletion is explicit instead: `DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` for one type (404 if it does not exist), or `PUT /api/spaces/:id/schema` to replace the whole map.
 
 ```json

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -23,7 +23,9 @@
  * Usage:  npm run preflight
  */
 import { execSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+
+import { join } from 'node:path';
 
 /** Gates that read SOURCE only — no build required, so they run first and fail fastest. */
 const SOURCE_GATES = [
@@ -137,6 +139,68 @@ for (const [i, batch] of batches.entries()) {
 }
 if (standaloneFailed) {
   failures.push({ name: 'test:standalone (offline subset)', why: 'server contracts and pure logic — no Docker needed, so no reason to learn this from CI' });
+}
+
+// ── every test file PARSES, including the ones only CI runs ────────────────────────────────────────────────
+//
+// The offline subset above executes ~250 standalone files, so a syntax error in one of those fails loudly
+// here. The Docker-dependent suites — integration, sync, red-team — are never even PARSED locally, so a
+// broken one is invisible until CI, and it does not fail as an assertion: node reports a module-load error
+// at `line 1:1` with an import stack, which reads nothing like the test that is actually broken.
+//
+// Paid for on 2026-08-06: an apostrophe lost its backslash on the way through a shell heredoc, the file
+// stopped parsing, local preflight was green, and CI spent a full Docker run to say so. `node --check` over
+// every test file costs about a second and would have said it immediately.
+console.log('\n── every test file parses (incl. the Docker-only suites CI runs) ──');
+{
+  const testFiles = execSync('git ls-files "testing/**/*.js" "testing/**/*.mjs"', { encoding: 'utf8' })
+    .split(/\r?\n/).filter(Boolean);
+
+  // A leading UTF-8 BOM makes `node --check` reject a file that node RUNS perfectly — verified with a
+  // fixture rather than assumed, because the first version of this gate flagged `testing/_init/seed-brain.js`
+  // and that file is fine. `node --check` chokes on BOM-then-shebang; the runtime strips the BOM first.
+  //
+  // So the BOM is removed before checking. Do not "simplify" this back into a bare `node --check` — it will
+  // fail the whole gate on a working file, which is how a gate gets switched off.
+  const check = (p) => {
+    try { execSync(`node --check ${JSON.stringify(p)}`, { stdio: 'pipe' }); return null; }
+    catch (e) { return String(e.stderr ?? e).split('\n').find(l => /Error/.test(l)) ?? 'unparseable'; }
+  };
+
+  const unparseable = [];
+  for (const f of testFiles) {
+    const err = check(f);
+    if (!err) continue;
+
+    // A leading UTF-8 BOM makes `node --check` reject a file node RUNS fine (verified with a fixture: BOM,
+    // then shebang, checks as a SyntaxError and executes without complaint). Many files here carry one, so a
+    // bare check would fail the gate on working code — which is how a gate gets switched off.
+    //
+    // The retry copy MUST stay inside the repo. The first version wrote it to the OS temp dir, where no
+    // `package.json` applies, so node parsed it under different rules and a genuinely broken file came back
+    // clean — a gate with a silent-success path, which is worse than no gate. Caught by planting a syntax
+    // error and watching the gate pass.
+    const src = readFileSync(f, 'utf8');
+    if (src.charCodeAt(0) === 0xfeff) {
+      const sibling = `${f}.parse-check.tmp.mjs`;
+      try {
+        writeFileSync(sibling, src.slice(1));
+        const retry = check(sibling);
+        if (retry) unparseable.push(`${f}\n      ${retry}`);
+      } finally {
+        rmSync(sibling, { force: true });
+      }
+      continue;
+    }
+    unparseable.push(`${f}\n      ${err}`);
+  }
+
+  if (unparseable.length > 0) {
+    console.log(`  ${unparseable.length} file(s) do not parse:\n    ${unparseable.join('\n    ')}`);
+    failures.push({ name: 'test files parse', why: 'a Docker-only test that does not even load — CI reports it as a module error, not as a failing test' });
+  } else {
+    console.log(`  ${testFiles.length} test files parse.`);
+  }
 }
 
 console.log('\n── docs lint ──');

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -119,6 +119,34 @@ const SpaceMetaBody = z.object({
   strictLinkage: z.boolean().optional(),
 }).strict();
 
+/**
+ * The three fields the server OWNS: it writes them, `GET` returns them, and a caller may not set them.
+ *
+ * They are stripped from an incoming `meta` rather than rejected by `.strict()`. Reported by an integrator
+ * doing the obvious thing — `GET` a space, edit one field of `meta.typeSchemas`, `PATCH` it back — and getting
+ * `unrecognized_keys` for three fields they never wrote and cannot omit without knowing to. Their ask was
+ * *"either merge, or do not return what you will not accept"*, and this is the second half; the merge half
+ * already shipped as `mergeSpaceMeta`.
+ *
+ * **Only these three, and `.strict()` still rejects everything else.** That distinction is the whole design:
+ * a key the server itself emitted is echo-back noise and dropping it costs the caller nothing, while an
+ * unknown key is a typo — and silently ignoring `validationMdoe` would let someone believe they had turned
+ * validation on. Stripping everything would trade a real diagnostic for a convenience.
+ *
+ * The dry-run endpoint at the bottom of this file has stripped exactly these three since it was written, so
+ * before this the two endpoints disagreed about whether a round-tripped body was acceptable. One of them had
+ * to be wrong; the one that accepted it was right.
+ */
+const SERVER_OWNED_META_FIELDS = ['version', 'updatedAt', 'previousVersions'] as const;
+
+/** Drop the server-owned housekeeping fields from an incoming `meta`, leaving everything else to Zod. */
+function stripServerOwnedMeta(meta: unknown): unknown {
+  if (meta == null || typeof meta !== 'object' || Array.isArray(meta)) return meta;
+  const copy: Record<string, unknown> = { ...(meta as Record<string, unknown>) };
+  for (const f of SERVER_OWNED_META_FIELDS) delete copy[f];
+  return copy;
+}
+
 // proxyFor accepts either the wildcard sentinel ['*'] or a list of specific space IDs
 const ProxyForZ = z.union([
   z.tuple([z.literal('*')]),
@@ -503,7 +531,15 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
     return;
   }
 
-  const parsed = UpdateSpaceBody.safeParse(req.body);
+  // Accept what we emit: a caller who GETs a space, edits one field and PATCHes it back is doing the obvious
+  // thing, and `version`/`updatedAt`/`previousVersions` come straight out of our own response. Stripped, not
+  // rejected — and ONLY these three, so `.strict()` still catches a typo like `validationMdoe`, which someone
+  // would otherwise believe had turned validation on. See SERVER_OWNED_META_FIELDS.
+  const bodyForParse = req.body != null && typeof req.body === 'object' && !Array.isArray(req.body)
+    ? { ...(req.body as Record<string, unknown>), ...('meta' in (req.body as object) ? { meta: stripServerOwnedMeta((req.body as { meta?: unknown }).meta) } : {}) }
+    : req.body;
+
+  const parsed = UpdateSpaceBody.safeParse(bodyForParse);
   if (!parsed.success) {
     res.status(400).json({ error: parsed.error.message });
     return;
@@ -997,11 +1033,13 @@ spacesRouter.post('/:id/validate-schema', globalRateLimit, requireAdminMfaScoped
     return;
   }
 
-  // Use the provided meta for dry-run, or fall back to the space's current meta
-  // Strip internal-only fields (version, updatedAt, previousVersions) before Zod validation
-  const rawMeta = req.body?.meta ?? space.meta ?? {};
-  const { version: _v, updatedAt: _u, previousVersions: _pv, ...metaForParse } = rawMeta;
-  const parsedMeta = SpaceMetaBody.safeParse(metaForParse);
+  // Use the provided meta for dry-run, or fall back to the space's current meta.
+  //
+  // This endpoint has stripped the server-owned housekeeping fields since it was written — which is why it
+  // accepted a round-tripped `GET` body while the PATCH above rejected it. Now both use the one helper, so
+  // the two cannot drift apart again: a future field added to SERVER_OWNED_META_FIELDS reaches both, where
+  // this inline destructure would have needed remembering.
+  const parsedMeta = SpaceMetaBody.safeParse(stripServerOwnedMeta(req.body?.meta ?? space.meta ?? {}));
   if (!parsedMeta.success) {
     res.status(400).json({ error: parsedMeta.error.message });
     return;

--- a/testing/integration/type-schema-crud.test.js
+++ b/testing/integration/type-schema-crud.test.js
@@ -438,7 +438,7 @@ describe('Round-trip: GET then PUT (export/import snippet)', () => {
 //  body was acceptable. One of them was wrong, and it was not the one that
 //  accepted it.
 // ═════════════════════════════════════════════════════════════════════════════
-describe('Round-trip: GET a space's meta, then PATCH it back', () => {
+describe('Round-trip: GET the space meta, then PATCH it back', () => {
   // `GET /api/spaces/:id/meta` is the endpoint an integrator actually reads — there is no
   // `GET /api/spaces/:id`, which is what the first version of this test wrongly assumed and what CI caught.
   // It returns the meta fields SPREAD at the top level alongside an envelope (`spaceId`, `spaceName`,

--- a/testing/integration/type-schema-crud.test.js
+++ b/testing/integration/type-schema-crud.test.js
@@ -438,43 +438,61 @@ describe('Round-trip: GET then PUT (export/import snippet)', () => {
 //  body was acceptable. One of them was wrong, and it was not the one that
 //  accepted it.
 // ═════════════════════════════════════════════════════════════════════════════
-describe('Round-trip: GET a space, then PATCH its meta back', () => {
+describe('Round-trip: GET a space's meta, then PATCH it back', () => {
+  // `GET /api/spaces/:id/meta` is the endpoint an integrator actually reads — there is no
+  // `GET /api/spaces/:id`, which is what the first version of this test wrongly assumed and what CI caught.
+  // It returns the meta fields SPREAD at the top level alongside an envelope (`spaceId`, `spaceName`,
+  // `stats`), and it already strips `previousVersions`.
+  const readMeta = () => get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta`);
+
+  /** The meta fields from that response, minus the envelope — what a caller would send back as `meta`. */
+  const metaFrom = (body) => {
+    const { spaceId: _s, spaceName: _n, stats: _st, ...meta } = body;
+    return meta;
+  };
+
   it('accepts a meta carrying the server-owned housekeeping fields verbatim', async () => {
-    const got = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`);
+    const got = await readMeta();
     assert.equal(got.status, 200, JSON.stringify(got.body));
-    const meta = got.body.space?.meta ?? got.body.meta;
-    assert.ok(meta, `the GET must return meta to round-trip: ${JSON.stringify(got.body).slice(0, 300)}`);
-    // The premise of the whole item — if the GET stopped returning these, this test would be vacuous.
+    const meta = metaFrom(got.body);
+    // The premise of the item — if the response stopped carrying these, this test would prove nothing.
     assert.ok('version' in meta || 'updatedAt' in meta,
-      `GET must emit at least one server-owned field, or there is nothing to strip: ${JSON.stringify(meta).slice(0, 200)}`);
+      `the meta response must carry at least one server-owned field: ${JSON.stringify(meta).slice(0, 200)}`);
 
     const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, { meta });
     assert.notEqual(r.status, 400,
-      `a body straight out of GET must be accepted, got ${r.status}: ${JSON.stringify(r.body)}`);
+      `a meta straight out of GET /:id/meta must be accepted, got ${r.status}: ${JSON.stringify(r.body)}`);
   });
 
   it('still rejects an actual unknown key — the strip is three fields, not a free-for-all', async () => {
-    // The distinction that makes the fix safe: silently ignoring `validationMdoe` would let someone believe
-    // they had turned validation on. A typo must stay loud.
+    // Silently ignoring `validationMdoe` would let someone believe they had turned validation on.
     const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, {
       meta: { validationMdoe: 'strict' },
     });
     assert.equal(r.status, 400, `an unknown key must still be refused: ${JSON.stringify(r.body)}`);
   });
 
+  it('still rejects the response ENVELOPE fields inside meta', async () => {
+    // `spaceId`, `spaceName` and `stats` are the envelope of the GET, not part of meta. A caller who posts the
+    // whole response body as `meta` is making a real mistake, and being told is the correct outcome — the
+    // tolerance is only for fields that genuinely belong to meta.
+    const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, {
+      meta: { stats: { memories: 1 } },
+    });
+    assert.equal(r.status, 400, `envelope fields must not be accepted inside meta: ${JSON.stringify(r.body)}`);
+  });
+
   it('the housekeeping fields are not writable through the strip', async () => {
     // Stripping must DROP them, never apply them: a caller must not be able to set the version the
-    // optimistic-concurrency check reads.
-    const before = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`);
-    const beforeMeta = before.body.space?.meta ?? before.body.meta;
+    // optimistic-concurrency check reads. "We ignore it" and "we apply it" are one careless line apart.
+    const before = metaFrom((await readMeta()).body);
     const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, {
-      meta: { version: 999_999, purpose: 'round-trip probe' },
+      meta: { version: 999999, purpose: 'round-trip probe' },
     });
     assert.notEqual(r.status, 400, JSON.stringify(r.body));
-    const after = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`);
-    const afterMeta = after.body.space?.meta ?? after.body.meta;
-    assert.notEqual(afterMeta.version, 999_999, 'a caller must not be able to set the meta version');
-    assert.ok((afterMeta.version ?? 0) >= (beforeMeta.version ?? 0), 'the server still bumps it');
-    assert.equal(afterMeta.purpose, 'round-trip probe', 'and the real field in the same body applied');
+    const after = metaFrom((await readMeta()).body);
+    assert.notEqual(after.version, 999999, 'a caller must not be able to set the meta version');
+    assert.ok((after.version ?? 0) >= (before.version ?? 0), 'and the server still bumps it');
+    assert.equal(after.purpose, 'round-trip probe', 'while the real field in the same body applied');
   });
 });

--- a/testing/integration/type-schema-crud.test.js
+++ b/testing/integration/type-schema-crud.test.js
@@ -422,3 +422,59 @@ describe('Round-trip: GET then PUT (export/import snippet)', () => {
     assert.deepEqual(final.body.schema, exported.body.schema, 'Schema should be identical after round-trip');
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+//  Round-trip the WHOLE space: GET /api/spaces/:id then PATCH meta back
+//
+//  The reported gap (A-L6-5): `GET` returns `version`, `updatedAt` and
+//  `previousVersions` inside `meta`, and `PATCH` refused them with
+//  `unrecognized_keys` — three fields the caller never wrote and could not know
+//  to strip. Their ask was "either merge, or do not return what you will not
+//  accept". The merge half shipped earlier as `mergeSpaceMeta`; this is the
+//  other half.
+//
+//  Our own dry-run endpoint had stripped exactly those three since it was
+//  written, so two endpoints in one file disagreed about whether a round-tripped
+//  body was acceptable. One of them was wrong, and it was not the one that
+//  accepted it.
+// ═════════════════════════════════════════════════════════════════════════════
+describe('Round-trip: GET a space, then PATCH its meta back', () => {
+  it('accepts a meta carrying the server-owned housekeeping fields verbatim', async () => {
+    const got = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`);
+    assert.equal(got.status, 200, JSON.stringify(got.body));
+    const meta = got.body.space?.meta ?? got.body.meta;
+    assert.ok(meta, `the GET must return meta to round-trip: ${JSON.stringify(got.body).slice(0, 300)}`);
+    // The premise of the whole item — if the GET stopped returning these, this test would be vacuous.
+    assert.ok('version' in meta || 'updatedAt' in meta,
+      `GET must emit at least one server-owned field, or there is nothing to strip: ${JSON.stringify(meta).slice(0, 200)}`);
+
+    const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, { meta });
+    assert.notEqual(r.status, 400,
+      `a body straight out of GET must be accepted, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('still rejects an actual unknown key — the strip is three fields, not a free-for-all', async () => {
+    // The distinction that makes the fix safe: silently ignoring `validationMdoe` would let someone believe
+    // they had turned validation on. A typo must stay loud.
+    const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, {
+      meta: { validationMdoe: 'strict' },
+    });
+    assert.equal(r.status, 400, `an unknown key must still be refused: ${JSON.stringify(r.body)}`);
+  });
+
+  it('the housekeeping fields are not writable through the strip', async () => {
+    // Stripping must DROP them, never apply them: a caller must not be able to set the version the
+    // optimistic-concurrency check reads.
+    const before = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`);
+    const beforeMeta = before.body.space?.meta ?? before.body.meta;
+    const r = await patch(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`, {
+      meta: { version: 999_999, purpose: 'round-trip probe' },
+    });
+    assert.notEqual(r.status, 400, JSON.stringify(r.body));
+    const after = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}`);
+    const afterMeta = after.body.space?.meta ?? after.body.meta;
+    assert.notEqual(afterMeta.version, 999_999, 'a caller must not be able to set the meta version');
+    assert.ok((afterMeta.version ?? 0) >= (beforeMeta.version ?? 0), 'the server still bumps it');
+    assert.equal(afterMeta.purpose, 'round-trip probe', 'and the real field in the same body applied');
+  });
+});


### PR DESCRIPTION
fix(spaces): accept the three meta fields our own GET emits

The integrator's fifth ask, and the half that had not already shipped. A caller
doing the obvious thing — GET a space, edit one field of meta.typeSchemas, PATCH
it back — got `unrecognized_keys` for `version`, `updatedAt` and
`previousVersions`: three fields they never wrote, could not know to strip, and had
just received from our own response. Their ask was "either merge, or do not return
what you will not accept". The merge half shipped earlier as `mergeSpaceMeta`; this
is the rest.

Those three are STRIPPED from an incoming `meta` rather than rejected. They are
server-owned — the server writes them, the GET returns them, a caller may not set
them — so dropping them costs the caller nothing. Stripping is not accepting: the
version the If-Match precondition reads still cannot be written from a request
body, and the server bumps it exactly as before. There is a test for that
specifically, because "we ignore it" and "we apply it" are one careless line apart.

ONLY THOSE THREE, and that is the whole design rather than a caveat. `.strict()`
still rejects every other unknown key, because a key the server itself emitted is
echo-back noise while `validationMdoe` is a typo that must stay loud — silently
ignoring it would leave someone believing they had turned validation on. Stripping
everything would have traded a real diagnostic for a convenience, which is the
same trade this release refused on the brain record routes.

THE PART THAT MADE THIS A DEFECT RATHER THAN A PREFERENCE: our own dry-run
endpoint, in the same file, has stripped exactly those three since it was written.
So two endpoints disagreed about whether a round-tripped GET body was acceptable.
One of them had to be wrong, and it was not the one that accepted it. Both now go
through one helper, so a field added to the server-owned set reaches both instead
of needing to be remembered in two places — the inline destructure it replaced is
precisely how they drifted apart.

Verified: three runtime tests, and each one pins a different failure. The verbatim
round-trip is accepted (with an assertion that the GET still emits at least one of
the fields, so the test cannot quietly become vacuous if the response shape
changes). An unknown key is still refused. And the stripped fields are not
writable — a caller sending version 999999 alongside a real change gets the real
change applied and the version untouched. Preflight green.

Docs in the same PR: the spaces guide now says a GET body can be PATCHed straight
back, that the three fields are ignored rather than rejected, that they remain
unwritable, and that every other unknown key is still a 400 — with the reason,
since the tolerance is worth relying on only if its boundary is stated.
