### PR TITLE
test(embed): stop racing the vector index — read matchedText off the record

### DIFF
--- a/testing/integration/embed-properties.test.js
+++ b/testing/integration/embed-properties.test.js
@@ -6,8 +6,9 @@
  * values lost their field context. All builders now fold `key value` pairs into the
  * embedded text via the shared propsEmbedText helper.
  *
- * These tests assert the stored embedding text (`matchedText`, returned by recall)
- * contains the property KEY for a memory, an entity, an edge, and a chrono entry — the edge
+ * These tests assert the stored embedding text (`matchedText`, read back from the RECORD — see the helper
+ * below for why not from recall) contains the property KEY for a memory, an entity, an edge, and a chrono
+ * entry — the edge
  * and chrono cases embedded no property data at all before the original fix, and the REST
  * memory-create path had *regressed* to values-only (it inlined its own embed-text derivation
  * instead of calling the shared `remember()` — fixed by routing it through the shared function).
@@ -20,7 +21,7 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post } from '../sync/helpers.js';
+import { INSTANCES, post, get } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -30,16 +31,38 @@ const SPACE = `b4-embed-props-${RUN}`;
 let token;
 let embeddingAvailable = false;
 
-/** Poll recall until the doc with `id` appears, then return its result row. */
-async function recallMatch(id, query, types, timeoutMs = 30_000) {
+/**
+ * Poll the RECORD by id until its `matchedText` is populated, then return it.
+ *
+ * ## Why this does not use recall, having previously used it
+ *
+ * These tests assert one thing: that a property KEY reaches the stored embed text. `matchedText` lives on the
+ * document, written by the embed job moments after the write. Recall was never necessary to see it — it was
+ * incidental, and it was the only reason this suite was flaky.
+ *
+ * The old helper polled `POST /recall` for **30 seconds** waiting for the record to become findable. Recall
+ * reads the **eventually-consistent vector index**, and the worst case for that lag was MEASURED by an
+ * operator at **150 seconds** (tracked separately: `recall` cannot see a record written two minutes ago). So
+ * the deadline was five times too short and the suite failed whenever the index was slow — four times in one
+ * evening, twice on `main` where no PR was in flight, each time reading like a mysterious infrastructure
+ * flake on a diff that could not touch it.
+ *
+ * **Raising the timeout was the tempting fix and the wrong one:** it would trade a flaky test for a
+ * two-and-a-half-minute one, and it would still be measuring index latency rather than the thing under test.
+ * Reading the document waits only for the embed job — about a second — and it cannot be affected by index lag
+ * at all.
+ *
+ * The `matchedText != null` condition matters: an immediate read can arrive before the embed job has run, and
+ * asserting on an absent value would turn this back into a race with a different clock.
+ */
+const COLLECTION_PATH = { memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono' };
+
+async function embedTextOf(kind, id, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/recall`, { query, types, topK: 50 });
-    if (r.status === 200) {
-      const hit = r.body.results?.find(x => x._id === id);
-      if (hit) return hit;
-    }
-    await new Promise(res => setTimeout(res, 500));
+    const r = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/${COLLECTION_PATH[kind]}/${id}`);
+    if (r.status === 200 && r.body?.matchedText != null) return r.body;
+    await new Promise(res => setTimeout(res, 250));
   }
   return null;
 }
@@ -72,8 +95,8 @@ describe('Property keys are embedded (B4)', () => {
     // before the fix the REST create set no matchedText and embedded values only ("pilot").
     assert.match(r.body.matchedText ?? '', /occupation pilot/,
       `memory create must fold "key value" into matchedText: ${r.body.matchedText}`);
-    const hit = await recallMatch(r.body._id, `MemPropKey-${RUN}`, ['memory']);
-    assert.ok(hit, 'memory should be recallable once indexed');
+    const hit = await embedTextOf('memory', r.body._id);
+    assert.ok(hit, 'memory should have its embed text stored');
     assert.match(hit.matchedText ?? '', /occupation/,
       `memory embed text must include the property key: ${hit.matchedText}`);
   });
@@ -83,8 +106,8 @@ describe('Property keys are embedded (B4)', () => {
     const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`,
       { name: `EntPropKey-${RUN}`, type: 'concept', properties: { occupation: 'engineer' } });
     assert.equal(r.status, 201, JSON.stringify(r.body));
-    const hit = await recallMatch(r.body._id, `EntPropKey-${RUN}`, ['entity']);
-    assert.ok(hit, 'entity should be recallable once indexed');
+    const hit = await embedTextOf('entity', r.body._id);
+    assert.ok(hit, 'entity should have its embed text stored');
     assert.match(hit.matchedText ?? '', /occupation/,
       `entity embed text must include the property key: ${hit.matchedText}`);
   });
@@ -96,8 +119,8 @@ describe('Property keys are embedded (B4)', () => {
       properties: { venue: 'stadium' },
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
-    const hit = await recallMatch(r.body._id, `ChronoPropKey-${RUN}`, ['chrono']);
-    assert.ok(hit, 'chrono should be recallable once indexed');
+    const hit = await embedTextOf('chrono', r.body._id);
+    assert.ok(hit, 'chrono should have its embed text stored');
     assert.match(hit.matchedText ?? '', /venue/,
       `chrono embed text must include the property key: ${hit.matchedText}`);
   });
@@ -112,8 +135,8 @@ describe('Property keys are embedded (B4)', () => {
       from, to, label: `edgePropKey${RUN}`, properties: { medium: 'email' },
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
-    const hit = await recallMatch(r.body._id, `edgePropKey${RUN}`, ['edge']);
-    assert.ok(hit, 'edge should be recallable once indexed');
+    const hit = await embedTextOf('edge', r.body._id);
+    assert.ok(hit, 'edge should have its embed text stored');
     assert.match(hit.matchedText ?? '', /medium/,
       `edge embed text must include the property key: ${hit.matchedText}`);
   });


### PR DESCRIPTION
test(embed): stop racing the vector index — read matchedText off the record

`Property keys are embedded (B4)` failed four times in one evening, TWICE ON MAIN
where no PR was in flight, always on diffs that could not touch it. It read like
infrastructure flakiness and it was not.

Its helper polled `POST /recall` for 30 seconds waiting for the new record to
become findable. Recall reads the EVENTUALLY-CONSISTENT vector index, and an
operator measured that lag at up to 150 SECONDS — the defect this repo already
tracks as "recall cannot see a record written two minutes ago". So the deadline
was five times shorter than the known worst case, and the suite failed whenever
the index happened to be slow.

The tests never needed recall. They assert one thing: that a property KEY reaches
the stored embed text. `matchedText` lives on the DOCUMENT, written by the embed
job moments after the write, and is returned by a plain read by id. Recall was
incidental to the assertion and was the only reason the suite was flaky.

RAISING THE TIMEOUT WAS THE TEMPTING FIX AND THE WRONG ONE. It trades a flaky test
for a two-and-a-half-minute one, and it still measures index latency rather than
the thing under test. Reading the record waits only for the embed job — about a
second — and cannot be affected by index lag at all.

The helper keeps polling, on `matchedText != null`: an immediate read can arrive
before the embed job has run, and asserting on an absent value would just swap one
race for another with a different clock. The reasoning is in the helper's own
header, because the next person to see a slow embed test will reach for the
timeout.

Four call sites converted, no `recallMatch` left, and the file header no longer
claims matchedText comes back "from recall". This does not fix the 150-second lag
itself — that stays filed — it stops a test that is about embed text from
depending on it.
