### PR TITLE
docs(brain): recall's traverse parameter and the /traverse endpoint are different tools

### DIFF
--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -667,6 +667,18 @@ By default `recall` returns matches in isolation — the knowledge-graph edges b
 
 `traverse: 0` (the default) is behaviourally identical to classic recall and returns the classic response shape above. When `traverse > 0` the response shape changes: each result is annotated, and a `traverseDepth` field is added.
 
+> **This parameter and the [`/traverse` endpoint](#traverse-graph) are different tools that share a name.**
+> The difference is where the walk STARTS, and it decides which one you want:
+>
+> | | starts from | use it when |
+> |---|---|---|
+> | `recall` with `traverse: n` | whatever the query matched semantically | you can *describe* the starting point but do not know its id |
+> | `POST /traverse` | one entity id you supply (`startId`) | you already *have* the node and want its neighbourhood |
+>
+> Both walk edges in both directions, so neither is "the directional one". An integrator read this section,
+> concluded that graph expansion only ever radiates outward from semantic matches, and hand-walked the edge
+> list in two flows — the endpoint below does exactly what they were building by hand.
+
 ```json
 {
   "query": "authentication token scoping",
@@ -1168,6 +1180,11 @@ DELETE /api/brain/spaces/:spaceId/edges/:id
 ### Traverse Graph
 
 BFS traversal from a starting entity, following edges up to `maxDepth` hops.
+
+> **Not to be confused with `recall`'s `traverse` parameter**, which shares the name and does a different
+> job: it expands outward from whatever a *semantic query* matched, while this endpoint starts from an
+> **entity id you already hold**. Use this one when you have the node; use
+> [`recall` with `traverse`](#graph-augmented-recall-traverse-parameter) when you can only describe it.
 
 ```http
 POST /api/brain/spaces/:spaceId/traverse


### PR DESCRIPTION
The third of the three doc gaps in an integrator's list, and the only one whose
premise survived checking. They read the graph-augmented-recall section,
concluded that graph expansion only ever radiates outward from semantic matches,
and hand-walked the edge list in two flows — while the endpoint below in the same
document does exactly what they were building by hand.

Neither section mentioned the other. Both are called "traverse". So the fix is a
cross-reference in both directions that names the ACTUAL difference, which is
where the walk starts:

  recall with traverse: n   starts from whatever the query matched semantically —
                            for when you can DESCRIBE the starting point but do
                            not know its id.

  POST /traverse            starts from an entity id you supply — for when you
                            already HAVE the node and want its neighbourhood.

And one thing stated because the wording invited the wrong guess: both walk edges
in both directions, so neither is "the directional one".

The other two gaps in that list did NOT survive checking and are deliberately not
touched here: `includeContent` is MCP-only, so adding it to the REST parameter
table would document a parameter the REST route does not read (the REST/MCP parity
question is filed separately as a feature), and `meta.purpose`'s 4000-char limit is
already documented three times — the "otherwise-complete limits table" the report
refers to does not exist in docs/. Both are recorded in the tracker with what was
checked, so the next reader does not re-derive it.