### PR TITLE
fix(brain): the contradiction sweep judged every pair twice, and the free pass was not free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A gate matches the poll's SHAPE rather than any of its names, and immediately found a **fifth** copy that a
     grep for the others' error message could not: it said `Timed out indexing:` instead.
   - Nothing about the product changed; this is test infrastructure only.
+### Added
+
+- **A contradiction finding says when the judge probably did not read the whole record** (`truncated`, half of
+  a canary ask). Encoder NLI models cap at ~512 tokens, their entity descriptions run to thousands of
+  characters, so a pair is judged on its opening paragraphs — and the confidence comes back looking completely
+  normal. A confident verdict about the first page was indistinguishable from a confident verdict about the
+  record.
+  - **A proxy, and reported as one.** Ythril does not truncate; the model does, invisibly, and we cannot know
+    the configured model's tokenizer. The flag fires on a deliberately conservative character length so it
+    under-reports rather than crying wolf — a flag that fires on ordinary records is one reviewers learn to
+    ignore, which is the same warning this correspondent gave us about a different field.
+  - **Absent, not `false`, when the text is ordinary**, so its absence cannot be read as "the whole text was
+    seen". It never appears on a `structured-field` verdict either: that pass compares whole property values,
+    so a model-window caveat there would describe a mechanism that was never involved.
+  - Carried through to the stored finding and the `/api/contradictions` payload, because the person who needs
+    it is the reviewer deciding whether to act.
+
+- **`POST /api/contradictions/scan` reports `modelCalls` alongside `judgedPairs`** — what the sweep SPENT next
+  to what it SETTLED. The two legitimately differ (a below-threshold answer costs a call and settles nothing;
+  an unreachable judge still received the record text), and only the first can be reconciled against an NLI
+  endpoint's own request log. Reporting one number that was neither is what left an operator unable to explain
+  their bill. `maxJudgedPairsPerRun` now bounds `modelCalls`: gating on useful answers alone let a space full
+  of weak verdicts run indefinitely past a budget whose entire purpose is to bound spend.
 
 ### Fixed
+
+- **A contradiction sweep judged every pair twice, and the "free" deterministic pass was not free** (the other
+  half of that canary ask — reported as `judgedPairs: 6` against their own judge's counter of 12). Two
+  independent mechanisms, each doubling the model calls, each invisible from anywhere except the wire:
+  - **The deterministic pass called the model on every pair and threw the answer away.** It asked for
+    `minConfidence: 2` — an unreachable floor — on the theory that a verdict which can never clear it is a
+    verdict never taken. But a confidence floor is applied to the **response**. The request was made, the
+    record text left the instance, the endpoint served and billed it, and only then was the answer discarded.
+    Worse, the code carried a comment asserting "the structured pass reaches no endpoint", so the mechanism was
+    documented as impossible at the exact site where it happened. There is now an explicit `structuredOnly`
+    flag that returns before anything that could reach the endpoint, and a test that asserts on the CALL rather
+    than the verdict — the old code passes every verdict-shaped assertion.
+  - **A mutually-similar pair was judged from both sides.** Similarity is symmetric, so as the sweep walks by
+    `seq` the pair {A, B} is met once with A as the seed and again with B. Both judgements wrote the *same* row
+    (the pair id is order-independent), so the second only overwrote the first — having paid for another model
+    call and another egress of both records' text. A pair is now judged once per sweep, which also makes the
+    stored row deterministic: the side reached first wins, instead of whichever seed happened to come last.
+  - Net effect on a remote judge: a sweep of the same space costs substantially less than it did, and the
+    number we report is the number their endpoint counted.
+
+- **Half of all structured contradiction findings attributed each value to the wrong record.** A verdict names
+  values by argument position (`aValue` = first argument); the stored row names sides by id order (`aId` = the
+  lower id). Those coincide only when the sweep happened to meet the pair in id order — a coin flip — so for
+  the other half the review card read *"srv-a claims 8080"* about the record claiming 443. The disagreement was
+  genuine and the confidence was 1; only the evidence was inverted, which is the hardest kind of wrong to
+  notice. The values are now re-attributed to the sides as stored, by one pure exported helper with its own
+  enumerated tests (including the plausible near-miss of reversing the list instead of each entry — which
+  looks correct on the single-field findings that are the common case).
 
 - **`GET /api/spaces/:id` returned three fields that `PATCH` then refused** (an integrator's fifth ask, and the
   half of it that had not already shipped). A caller doing the obvious thing — `GET` a space, edit one field of

--- a/docs/integration-guide/14-duplicates-and-webhooks.md
+++ b/docs/integration-guide/14-duplicates-and-webhooks.md
@@ -109,14 +109,35 @@ sticky dismissal — because the Review tab presents both under one vocabulary.
 | `POST` | `/api/contradictions/:id/resolve` | non-read-only | Body `{ "resolution": "edited" \| "linked" }`. Records HOW a human settled it. |
 | `POST` | `/api/contradictions/scan?space=<id>` | admin + MFA | Run the sweep now. Returns `nliStalled: true` if it stopped because the judge was unavailable. |
 
-A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, basis, confidence, fields?, status,
-resolution?, detectedAt, updatedAt }`.
+A candidate is `{ id, spaceId, type, aId, aSummary, bId, bSummary, basis, confidence, fields?, truncated?,
+status, resolution?, detectedAt, updatedAt }`.
+
+**`truncated: true` means the judge probably did not read the whole record.** Encoder NLI models cap at ~512
+tokens; a record whose text runs to thousands of characters is judged on its opening paragraphs, and the
+confidence comes back looking completely normal — so a confident verdict about the first page is otherwise
+indistinguishable from a confident verdict about the record. Treat such a finding as a prompt to read both
+records yourself rather than as a settled answer.
+
+Two things it deliberately is not:
+
+- **It is a proxy, not a measurement.** Ythril does not truncate anything; the model does, invisibly, and we
+  cannot know the configured model's tokenizer. The flag fires on a conservative character length, so it
+  under-reports rather than crying wolf.
+- **Its absence is not a guarantee.** No flag means "not long enough to be worth warning about", not "the
+  whole text was read". It never appears on a `structured-field` verdict, because that pass compares whole
+  property values and no model window is involved.
 
 **`basis` is the important field.** `structured-field` means the two records set the same single-valued
 property to different values — deterministic, `confidence` is 1, and `fields` names the offending keys and
 both values. `nli` means an entailment model judged the free text, and `confidence` is its score. A reviewer
 must be able to tell *"these disagree on `port`"* from *"a model thinks these disagree"*, so do not flatten
 the two into one number.
+
+Within `fields`, **`aValue` belongs to `aId` and `bValue` to `bId`** — the sides are named by the record ids
+on the candidate, never by the order the sweep happened to encounter them in. Earlier releases did not
+re-attribute them when a pair was met the other way round, so roughly half of all `structured-field` findings
+reported each value against the other record; the finding was real, only its evidence was inverted. If you
+have stored or forwarded findings from before this fix, re-scan rather than trusting their `fields`.
 
 **Contradictions are never merged.** Two records that disagree are both real, and which one is wrong is a
 judgement call — so `resolve` records the outcome (`edited`: a record was corrected; `linked`: a
@@ -136,7 +157,7 @@ external endpoint, sends record text off the instance:
     "schedule": "30 3 * * *",       // cron — 03:30 daily (default), half an hour after the dupe sweep
     "structuredThreshold": 0.92,    // similarity floor for the free deterministic pass (default)
     "nliThreshold": 0.92,           // floor for the model pass (default)
-    "maxJudgedPairsPerRun": 0,      // 0 = unlimited (the local default); 2000 for a remote judge
+    "maxJudgedPairsPerRun": 0,      // judge CALLS per run. 0 = unlimited (local default); 2000 for a remote judge
     "batchSize": 200,
     "maxPerRun": 5000
   }
@@ -164,10 +185,28 @@ cap, while a remote endpoint defaults to the strict floor plus a per-run budget.
 > These defaults are **reasoned, not benchmarked** — no NLI sidecar ships with the stack, so there was
 > nothing to time against. That is precisely why they are all configurable.
 
-`POST /scan` reports `judgedPairs` (what a remote judge was actually asked) plus two *distinct* incomplete
-endings: `nliStalled` means the judge was unreachable and **nothing** was settled (the cursor is parked),
-while `budgetExhausted` means the pairs it judged **are** settled and the next run continues from there.
-Neither should be read as a clean result.
+`POST /scan` reports **two** counts, because they answer different questions:
+
+| Field | Means |
+|-------|-------|
+| `modelCalls` | Requests the NLI endpoint actually served. This is what a remote judge bills you for and what its own request log shows — and it is what `maxJudgedPairsPerRun` bounds. |
+| `judgedPairs` | Unique pairs the judge answered *usefully* for. What the sweep **settled**. |
+
+They legitimately differ: a below-threshold answer costs a call and settles nothing, and an unreachable judge
+still received the record text. Compare your endpoint's counter against `modelCalls`, not `judgedPairs`.
+
+> **If you measured a 2× gap against your judge's counter on an earlier release, it was real** — and it was
+> not only a counting difference. Two mechanisms each doubled the calls. The deterministic pass tried to avoid
+> spending the model by demanding an impossible confidence, but a confidence floor is applied to the
+> *response*: the request went out, your text egressed, the endpoint billed it, and only then was the answer
+> discarded. And a mutually-similar pair was judged from both sides as the sweep walked the space, with the
+> second judgement only overwriting the first row. Both are fixed: the deterministic pass now reaches no
+> endpoint at all, and a pair is judged once per sweep. Expect a sweep of the same space to cost
+> substantially less than it used to.
+
+Plus two *distinct* incomplete endings: `nliStalled` means the judge was unreachable and **nothing** was
+settled (the cursor is parked), while `budgetExhausted` means the pairs it judged **are** settled and the next
+run continues from there. Neither should be read as a clean result.
 
 Until it is enabled, contradictions are found **only** when an admin runs `POST /api/contradictions/scan`
 by hand — so the Review tab's Contradictions view stays empty on an instance nobody has scanned manually.

--- a/server/src/api/contradictions.ts
+++ b/server/src/api/contradictions.ts
@@ -51,6 +51,9 @@ function toRecord(c: ContradictionCandidateDoc) {
     // Present only for a structured verdict — this is what lets the UI name the disagreement instead of
     // just asserting one.
     ...(c.fields ? { fields: c.fields } : {}),
+    // A confident verdict on the first page of a long record reads exactly like a confident verdict on the
+    // record, so the reviewer is told which one they are looking at.
+    ...(c.truncated ? { truncated: true } : {}),
     status: c.status,
     ...(c.resolution ? { resolution: c.resolution } : {}),
     detectedAt: c.detectedAt,
@@ -177,18 +180,23 @@ contradictionsRouter.post('/scan', globalRateLimit, requireAdminMfa, denyReadOnl
   try {
     const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
     const spaces = accessibleSpaces(req.authToken?.spaces).filter(id => !spaceFilter || id === spaceFilter);
-    let scanned = 0, found = 0, nliStalled = false, judgedPairs = 0, budgetExhausted = false;
+    let scanned = 0, found = 0, nliStalled = false, judgedPairs = 0, modelCalls = 0, budgetExhausted = false;
     for (const spaceId of spaces) {
       const r = await scanSpace(spaceId);
-      scanned += r.scanned; found += r.found; judgedPairs += r.judgedPairs;
+      scanned += r.scanned; found += r.found; judgedPairs += r.judgedPairs; modelCalls += r.modelCalls;
       nliStalled = nliStalled || r.nliStalled;
       budgetExhausted = budgetExhausted || r.budgetExhausted;
     }
-    // Three different reasons the list may be incomplete, and they are NOT interchangeable:
+    // Two different reasons the list may be incomplete, and they are NOT interchangeable:
     //   nliStalled       the judge was unreachable — nothing was settled, the cursor is parked.
     //   budgetExhausted  the pair budget ran out — what was judged IS settled; the next run continues.
-    // Neither may read as a clean result. `judgedPairs` is what a remote endpoint actually spent.
-    res.json({ scannedSpaces: spaces.length, scanned, found, judgedPairs, nliStalled, budgetExhausted });
+    // Neither may read as a clean result.
+    //
+    // Two counts, because they answer different questions and an operator needs both: `judgedPairs` is what
+    // the sweep SETTLED, `modelCalls` is what it SPENT — the number their endpoint's own request log shows,
+    // and the one `maxJudgedPairsPerRun` bounds. Reporting only the first is what made our report look 2×
+    // short of a judge's own counter.
+    res.json({ scannedSpaces: spaces.length, scanned, found, judgedPairs, modelCalls, nliStalled, budgetExhausted });
   } catch (err) {
     log.error(`POST /api/contradictions/scan: ${err}`);
     res.status(500).json({ error: 'Internal error' });

--- a/server/src/brain/contradiction-candidates.ts
+++ b/server/src/brain/contradiction-candidates.ts
@@ -20,7 +20,7 @@
 import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
 import { pairContentHash, decideDismissed } from './dupe-scanner.js';
 import type { ContradictionCandidateDoc, DupeScanType } from '../config/types.js';
-import type { Verdict } from './contradiction-judge.js';
+import type { Verdict, PropertyDisagreement } from './contradiction-judge.js';
 
 const collectionFor = (spaceId: string) => col<ContradictionCandidateDoc>(`${spaceId}_contradiction_candidates`);
 
@@ -83,6 +83,22 @@ export function decideCandidateAction(
 }
 
 /**
+ * Re-attribute a verdict's per-field values to the sides as they are STORED.
+ *
+ * `findPropertyDisagreements` reports `aValue` for its first argument; the row stores `aId` as the
+ * lexicographically lower of the two ids. Those coincide only when the caller happened to pass them in id
+ * order — a coin flip — so for half of all structured findings the stored row attributed each value to the
+ * wrong record, and the review card read "srv-a claims 8080" about the record claiming 443. Nothing errors,
+ * the finding is real, and only its evidence is inverted, which is the hardest kind of wrong to notice.
+ *
+ * Pure, and exported, so it can be enumerated without a database.
+ */
+export function fieldsInStoredOrder(fields: PropertyDisagreement[], swapped: boolean): PropertyDisagreement[] {
+  if (!swapped) return fields;
+  return fields.map(f => ({ key: f.key, aValue: f.bValue, bValue: f.aValue }));
+}
+
+/**
  * Record (or update) a judged pair.
  *
  * Returns what it did, so a scan can report honestly rather than counting every pair it looked at as a
@@ -97,7 +113,8 @@ export async function recordContradiction(
 ): Promise<RecordOutcome> {
   if (verdict.kind === 'unjudged') return 'skipped-unjudged';   // see the module note
 
-  const [lo, hi] = a.id < b.id ? [a, b] : [b, a];
+  const swapped = a.id >= b.id;
+  const [lo, hi] = swapped ? [b, a] : [a, b];
   const _id = contradictionPairId(a.id, b.id);
   const coll = collectionFor(spaceId);
   const existing = await coll.findOne(asFilter<ContradictionCandidateDoc>({ _id })) as ContradictionCandidateDoc | null;
@@ -122,7 +139,15 @@ export async function recordContradiction(
       ? {
           basis: verdict.basis,
           confidence: verdict.confidence,
-          ...(verdict.basis === 'structured-field' && verdict.fields ? { fields: verdict.fields } : {}),
+          // Re-attributed to the sides as stored — see `fieldsInStoredOrder`. The verdict names values by
+          // ARGUMENT position; `aId` above is the lower id.
+          ...(verdict.basis === 'structured-field' && verdict.fields
+            ? { fields: fieldsInStoredOrder(verdict.fields, swapped) }
+            : {}),
+          // Carried onto the stored finding, because the reviewer who has to act on it is the one who needs
+          // to know the judge may have read only the opening of a long record. Set only when true, so its
+          // absence is not a claim that the whole text fitted the model's window.
+          ...(verdict.truncated ? { truncated: true as const } : {}),
         }
       : {}),
     updatedAt: now,

--- a/server/src/brain/contradiction-judge.ts
+++ b/server/src/brain/contradiction-judge.ts
@@ -41,9 +41,25 @@ export interface PropertyDisagreement {
 
 export type ContradictionBasis = 'structured-field' | 'nli';
 
+/**
+ * Character length past which an encoder NLI model has almost certainly not seen the whole text.
+ *
+ * Reported by an operator running their own judge: encoder cross-encoders cap at **512 tokens**, their entity
+ * descriptions run to several thousand characters, and a pair is therefore judged on its opening paragraphs —
+ * with a completely normal-looking confidence. Nothing errors, so a verdict about the first page is
+ * indistinguishable from a verdict about the record.
+ *
+ * **This is a PROXY and is reported as one.** We cannot know the configured model's tokenizer, so the flag
+ * says "long enough that a 512-token window was probably exceeded", never "we truncated it" — we do not
+ * truncate; the model does, invisibly. 1,800 characters is a deliberately conservative stand-in for 512
+ * tokens at the ~3.5–4 chars/token that English prose runs to: it under-reports rather than cries wolf,
+ * because a flag that fires on ordinary records is one reviewers learn to ignore.
+ */
+export const NLI_LIKELY_TRUNCATED_CHARS = 1_800;
+
 export type Verdict =
-  | { kind: 'contradiction'; basis: ContradictionBasis; confidence: number; fields?: PropertyDisagreement[] }
-  | { kind: 'agree'; basis: ContradictionBasis; confidence: number }
+  | { kind: 'contradiction'; basis: ContradictionBasis; confidence: number; fields?: PropertyDisagreement[]; truncated?: true }
+  | { kind: 'agree'; basis: ContradictionBasis; confidence: number; truncated?: true }
   /** No judgement was possible. NOT "they agree" — the pair must be re-examined on a later scan. */
   /**
    * No judgement was recorded. NOT "they agree".
@@ -54,8 +70,28 @@ export type Verdict =
    *   - `judge-unavailable`  the judge could not answer (unreachable, unreadable). Re-running later may
    *                          well succeed, so the scan must NOT treat this pair as settled.
    *   - `no-judge-configured` / `no-text` — nothing to ask, or nothing to ask about.
+   *   - `model-not-consulted` the caller asked for the deterministic pass ONLY and it found nothing. A
+   *                          judge may well be configured and reachable; we chose not to spend it.
    */
-  | { kind: 'unjudged'; reason: 'no-judge-configured' | 'judge-unavailable' | 'low-confidence' | 'no-text' };
+  | { kind: 'unjudged'; reason: 'no-judge-configured' | 'judge-unavailable' | 'low-confidence' | 'no-text' | 'model-not-consulted' };
+
+/**
+ * Did reaching this verdict cost a call to the NLI endpoint?
+ *
+ * Lives here, next to the code that decides, because it is a statement about `judgePair`'s internals and a
+ * second copy in the scanner would drift the moment a branch moved. The scanner needs it to report what a
+ * sweep actually SPENT — which is not the same as what it settled:
+ *
+ *   - a `low-confidence` answer was paid for in full and then discarded;
+ *   - `judge-unavailable` means the record text left the instance and the response was unusable — egress
+ *     happened, so a caller counting cost must count it;
+ *   - a `structured-field` contradiction, `no-text`, `no-judge-configured` and `model-not-consulted` all
+ *     reach no endpoint at all.
+ */
+export function consultedModel(v: Verdict): boolean {
+  if (v.kind === 'unjudged') return v.reason === 'low-confidence' || v.reason === 'judge-unavailable';
+  return v.basis === 'nli';
+}
 
 /** Multi-valued properties hold a set of facts, so two different values are additive, not contradictory. */
 function isSingleValued(key: string, schemas?: Record<string, TypeSchema>): boolean {
@@ -96,17 +132,26 @@ export function findPropertyDisagreements(
  *
  * @param minConfidence NLI verdicts below this are treated as `unjudged` rather than reported — a
  *   low-confidence contradiction is noise, and noise in a review queue is what makes people stop reading it.
+ * @param structuredOnly Run the deterministic pass and stop. **This is the only way to not spend the model.**
+ *   Passing an unreachable `minConfidence` does NOT work: the threshold is applied to the RESPONSE, so the
+ *   call is made, the text egresses, the endpoint is billed, and only then is the answer thrown away. The
+ *   scanner's structured pass did exactly that, which is where an operator's "judgedPairs: 6 against my
+ *   judge's counter of 12" came from — every pair was judged twice, and the free half was not free.
  */
 export async function judgePair(
   a: JudgeableRecord,
   b: JudgeableRecord,
-  opts: { schemas?: Record<string, TypeSchema>; minConfidence?: number } = {},
+  opts: { schemas?: Record<string, TypeSchema>; minConfidence?: number; structuredOnly?: boolean } = {},
 ): Promise<Verdict> {
   // 1. Deterministic pass first: free, no egress, and not a guess.
   const fields = findPropertyDisagreements(a, b, opts.schemas);
   if (fields.length > 0) {
     return { kind: 'contradiction', basis: 'structured-field', confidence: 1, fields };
   }
+  // Asked for the deterministic answer only, and there isn't one. Return BEFORE anything that could reach
+  // the endpoint — including the checks below, which would otherwise report a judge problem to a caller that
+  // never wanted a judge.
+  if (opts.structuredOnly) return { kind: 'unjudged', reason: 'model-not-consulted' };
 
   // 2. Fall back to the entailment model over the free text.
   if (!a.text?.trim() || !b.text?.trim()) return { kind: 'unjudged', reason: 'no-text' };
@@ -120,7 +165,14 @@ export async function judgePair(
   // A weak answer is still an answer — distinct from an absent one. See the Verdict note.
   if (verdict.score < min) return { kind: 'unjudged', reason: 'low-confidence' };
 
+  // Was either side long enough that the model's window probably cut it? Reported on the verdict rather than
+  // logged, because the person who needs it is the reviewer deciding whether to trust this finding — a
+  // confident verdict on the first page of a long record reads exactly like a confident verdict on the record.
+  // Only set when true, so its absence is not a claim that the text fitted.
+  const likelyTruncated = a.text.length > NLI_LIKELY_TRUNCATED_CHARS || b.text.length > NLI_LIKELY_TRUNCATED_CHARS;
+  const trunc = likelyTruncated ? { truncated: true as const } : {};
+
   return verdict.label === 'contradiction'
-    ? { kind: 'contradiction', basis: 'nli', confidence: verdict.score }
-    : { kind: 'agree', basis: 'nli', confidence: verdict.score };
+    ? { kind: 'contradiction', basis: 'nli', confidence: verdict.score, ...trunc }
+    : { kind: 'agree', basis: 'nli', confidence: verdict.score, ...trunc };
 }

--- a/server/src/brain/contradiction-scanner.ts
+++ b/server/src/brain/contradiction-scanner.ts
@@ -35,9 +35,9 @@ import { getConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
 import { log } from '../util/log.js';
 import { findSimilar, summariseRecall, DEFAULT_DUPE_THRESHOLD, type RecallKnowledgeType, type RecallResult } from './recall.js';
-import { judgePair, type JudgeableRecord } from './contradiction-judge.js';
+import { judgePair, consultedModel, type JudgeableRecord } from './contradiction-judge.js';
 import { extraClaimFields, fetchStructuredClaims, type ClaimMap } from './structured-claims.js';
-import { recordContradiction } from './contradiction-candidates.js';
+import { recordContradiction, contradictionPairId } from './contradiction-candidates.js';
 import { nliConfigured, nliIsLocal } from './nli-client.js';
 import type { ContradictionScannerConfig, DupeScanStateDoc, DupeScanType } from '../config/types.js';
 import { runExclusive } from '../util/single-flight.js';
@@ -113,8 +113,15 @@ export interface RecordOutcomeSummary {
   found: number;
   /** True when at least one pair could not be judged because the judge itself was unavailable. */
   judgeStalled: boolean;
-  /** Pairs the judge actually answered for — what a remote endpoint's budget is spent on. */
+  /** Pairs the judge actually answered usefully for. What the sweep SETTLED. */
   judged: number;
+  /**
+   * Calls the NLI endpoint actually served — what the sweep SPENT.
+   *
+   * Not the same number as `judged`, and the gap is the point: a low-confidence answer was paid for and then
+   * discarded, and an unreachable judge still received the record text. Both cost; neither settles.
+   */
+  modelCalls: number;
 }
 
 /**
@@ -141,17 +148,46 @@ export function toJudgeable(r: RecallResult, claims?: ClaimMap): JudgeableRecord
 }
 
 /**
+ * Neighbours whose pair with the seed this sweep has not settled yet.
+ *
+ * ── Why a pair gets met twice ────────────────────────────────────────────────────────────────────────────
+ *
+ * Similarity is symmetric. As the sweep walks records by `seq`, a mutually-near pair {A, B} is met once with
+ * A as the seed and B among its neighbours, and again with B as the seed and A among its. Both judgements
+ * write the SAME row — `contradictionPairId` is order-independent — so the second one only overwrote the
+ * first, and for the NLI pass it did so at the cost of a second model call and a second egress of both
+ * records' text. An operator measured exactly that: our report said 6 pairs where their judge's own counter
+ * said 12.
+ *
+ * Skipping the repeat is not a loss of evidence. It also makes the stored row deterministic: the side the
+ * sweep reached FIRST wins, rather than whichever seed happened to come last.
+ *
+ * Pure and generic over the hit shape so it can be enumerated without a database.
+ */
+export function unjudgedNeighbours<T extends { _id: string }>(
+  seedId: string, matches: T[], alreadyJudged?: Set<string>,
+): T[] {
+  if (!alreadyJudged) return matches;
+  return matches.filter(m => !alreadyJudged.has(contradictionPairId(seedId, m._id)));
+}
+
+/**
  * Evaluate one seed record against its nearest neighbours.
  *
  * `pass` decides what a pair is allowed to consult: the structured pass never calls the model (so it can
  * run with no NLI configured), the NLI pass is the one that may stall.
+ *
+ * `alreadyJudged` is the sweep's set of pair ids settled earlier in this same pass — see `scanSpace`. Passed
+ * in rather than owned here because a pair spans two seeds and this function only ever sees one of them.
  */
 export async function evalRecord(
   spaceId: string, type: DupeScanType, recordId: string, pass: Pass, threshold: number,
+  alreadyJudged?: Set<string>,
 ): Promise<RecordOutcomeSummary> {
   let found = 0;
   let judgeStalled = false;
   let judged = 0;
+  let modelCalls = 0;
   try {
     const { source, results } = await findSimilar(
       spaceId, recordId, type as RecallKnowledgeType, TOPK, [type as RecallKnowledgeType], threshold);
@@ -168,21 +204,31 @@ export async function evalRecord(
       stored ? stored.get(r._id) : r.properties;
 
     const a = toJudgeable(source, claimsOf(source));
-    for (const match of sameType) {
+    // One pair, one judgement per sweep — see `unjudgedNeighbours`.
+    for (const match of unjudgedNeighbours(source._id, sameType, alreadyJudged)) {
       const b = toJudgeable(match, claimsOf(match));
+      const pairId = contradictionPairId(a.id, b.id);
 
       // The structured pass must not reach the model — it has to stay useful (and cursor-advancing) on an
-      // instance with no NLI endpoint at all. It only records a verdict it can reach deterministically.
+      // instance with no NLI endpoint at all. `structuredOnly` is what enforces that; an unreachable
+      // `minConfidence` (what this used to pass) discards the ANSWER, long after the call was made and paid
+      // for. See `judgePair`.
       const verdict = pass === 'structured'
-        ? await judgePair(a, b, { schemas: undefined, minConfidence: 2 })   // >1 ⇒ any NLI answer is discarded
+        ? await judgePair(a, b, { schemas: undefined, structuredOnly: true })
         : await judgePair(a, b);
+
+      // What the endpoint served, counted before any early exit — an unusable response still egressed the
+      // record text and still costs. This is the number the per-run budget bounds.
+      if (consultedModel(verdict)) modelCalls++;
 
       if (verdict.kind === 'unjudged' && verdict.reason === 'judge-unavailable') {
         judgeStalled = true;
         continue;   // leave the pair unsettled; the NLI cursor will not move past this record
       }
-      // Count only what the MODEL was actually asked. The structured pass reaches no endpoint, and an
-      // unavailable judge answered nothing — neither spends the budget the budget exists to bound.
+      // Settled from here on: a verdict exists (or the pair is deliberately unsettleable in this pass), so
+      // the other side must not re-do it.
+      alreadyJudged?.add(pairId);
+      // Pairs the judge answered USEFULLY for. Deliberately narrower than `modelCalls`.
       if (pass === 'nli' && verdict.kind !== 'unjudged') judged++;
       const outcome = await recordContradiction(spaceId, type,
         { id: a.id, summary: summariseRecall(source), seq: source.seq ?? 0 },
@@ -193,7 +239,7 @@ export async function evalRecord(
   } catch {
     /* no stored vector, record merged away, or search failed — skip the seed, not the sweep */
   }
-  return { found, judgeStalled, judged };
+  return { found, judgeStalled, judged, modelCalls };
 }
 
 export interface ContradictionScanResult {
@@ -201,8 +247,16 @@ export interface ContradictionScanResult {
   found: number;
   /** True when the NLI pass stopped early because the judge was unavailable. Reported, not swallowed. */
   nliStalled: boolean;
-  /** Pairs the NLI judge actually answered for. The number an operator pays for on a remote endpoint. */
+  /** Unique pairs the NLI judge answered usefully for — what the sweep SETTLED. */
   judgedPairs: number;
+  /**
+   * Calls the NLI endpoint served — what the sweep SPENT, and what `maxJudgedPairsPerRun` bounds.
+   *
+   * Reported next to `judgedPairs` rather than instead of it because an operator comparing our number against
+   * their judge's own request counter needs to see the same thing it counts. `judgedPairs` never could:
+   * a low-confidence answer costs a call and settles nothing, so the two legitimately differ.
+   */
+  modelCalls: number;
   /** True when the NLI pass stopped because its per-run budget was spent. An ORDERLY stop, not a stall. */
   budgetExhausted: boolean;
 }
@@ -239,7 +293,7 @@ export function scanTuning(cfg: ContradictionScannerConfig | undefined, judgeIsL
 /** Sweep one space. Incremental per pass; `reset` re-runs both from zero. */
 export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Promise<ContradictionScanResult> {
   const cfg = getConfig();
-  const empty: ContradictionScanResult = { scanned: 0, found: 0, nliStalled: false, judgedPairs: 0, budgetExhausted: false };
+  const empty: ContradictionScanResult = { scanned: 0, found: 0, nliStalled: false, judgedPairs: 0, modelCalls: 0, budgetExhausted: false };
   const space = cfg.spaces.find(s => s.id === spaceId);
   if (!space || space.proxyFor) return empty;
   if (!isVectorSearchAvailable() || needsReindex(spaceId)) return empty;
@@ -249,6 +303,7 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
   let found = 0;
   let nliStalled = false;
   let judgedPairs = 0;
+  let modelCalls = 0;
   let budgetExhausted = false;
 
   // The NLI pass is skipped wholesale when no model is configured — its cursor stays put, so the day one is
@@ -263,6 +318,11 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
       let cursor = opts?.reset ? 0 : await getCursor(spaceId, type, pass);
       const coll = `${spaceId}_${COLLECTION_SUFFIX[type]}`;
       let stopThisType = false;
+      // Pair ids settled during THIS pass over THIS type, so a mutually-near pair is judged from one side
+      // only. Scoped here on purpose: a pair never spans two types, and a structured skip is not an NLI
+      // skip. Bounded by maxPerRun x TOPK ids, which at the 5000-record default is a few tens of thousands
+      // of short strings — the alternative is paying a remote endpoint twice for every pair.
+      const judgedThisPass = new Set<string>();
 
       while (scanned < tune.maxPerRun && !stopThisType) {
         const take = Math.min(tune.batchSize, tune.maxPerRun - scanned);
@@ -274,9 +334,10 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
         if (batch.length === 0) break;
 
         for (const rec of batch) {
-          const out = await evalRecord(spaceId, type, rec._id, pass, threshold);
+          const out = await evalRecord(spaceId, type, rec._id, pass, threshold, judgedThisPass);
           found += out.found;
           judgedPairs += out.judged;
+          modelCalls += out.modelCalls;
           scanned++;
           if (out.judgeStalled) {
             // Stop this pass HERE, without advancing past the record. The pair is not settled, so the
@@ -290,7 +351,11 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
           // Budget spent: an ORDERLY stop. Everything judged so far is settled and the cursor has moved
           // past it, so the next run resumes here rather than re-judging (and re-paying for) the same
           // pairs. This is exactly why it is checked AFTER the cursor advance, unlike a stall.
-          if (pass === 'nli' && tune.maxJudgedPairs > 0 && judgedPairs >= tune.maxJudgedPairs) {
+          //
+          // Gated on `modelCalls`, not on `judgedPairs`: the budget exists to bound what the endpoint is
+          // asked, and a low-confidence answer is a served request that settles nothing. Counting only the
+          // useful answers let a space with weak verdicts run past its budget indefinitely.
+          if (pass === 'nli' && tune.maxJudgedPairs > 0 && modelCalls >= tune.maxJudgedPairs) {
             stopThisType = true;
             budgetExhausted = true;
             break;
@@ -302,8 +367,8 @@ export async function scanSpace(spaceId: string, opts?: { reset?: boolean }): Pr
   }
 
   if (nliStalled) log.warn(`Contradiction scan (${spaceId}): the NLI judge was unavailable — its cursor is parked and will resume where it stopped`);
-  if (budgetExhausted) log.info(`Contradiction scan (${spaceId}): judged ${judgedPairs} pairs and stopped at its per-run budget; the next run resumes from there`);
-  return { scanned, found, nliStalled, judgedPairs, budgetExhausted };
+  if (budgetExhausted) log.info(`Contradiction scan (${spaceId}): spent ${modelCalls} judge calls (${judgedPairs} pairs settled) and stopped at its per-run budget; the next run resumes from there`);
+  return { scanned, found, nliStalled, judgedPairs, modelCalls, budgetExhausted };
 }
 
 /**
@@ -318,17 +383,21 @@ export async function runContradictionScanAllSpaces(): Promise<void> {
   let scanned = 0;
   let found = 0;
   let judgedPairs = 0;
+  let modelCalls = 0;
   let stalled = false;
   let budgetOut = false;
   for (const s of getConfig().spaces) {
     if (s.proxyFor) continue;
     try {
       const r = await scanSpace(s.id);
-      scanned += r.scanned; found += r.found; judgedPairs += r.judgedPairs;
+      scanned += r.scanned; found += r.found; judgedPairs += r.judgedPairs; modelCalls += r.modelCalls;
       stalled ||= r.nliStalled; budgetOut ||= r.budgetExhausted;
     } catch (err) { log.warn(`Contradiction scan failed for ${s.id}: ${err instanceof Error ? err.message : String(err)}`); }
   }
-  if (scanned > 0) log.info(`Contradiction scan: scanned ${scanned}, judged ${judgedPairs} pairs, found ${found}`);
+  // Both numbers, always: the judge-call count is the one that matches an endpoint's own request log, and
+  // the settled-pair count is the one that describes the review queue. Logging only the second is what left
+  // an operator unable to reconcile our report with their bill.
+  if (scanned > 0) log.info(`Contradiction scan: scanned ${scanned}, judge calls ${modelCalls}, pairs settled ${judgedPairs}, found ${found}`);
   // Two different incomplete endings, logged differently on purpose: one means nothing was settled, the
   // other means everything judged WAS settled and the next run picks up from there.
   if (stalled) log.warn('Contradiction scan: the NLI judge was unavailable — its cursor is parked and will resume where it stopped. This sweep did NOT clear the queue.');

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1785,6 +1785,13 @@ export interface ContradictionCandidateDoc {
   confidence: number;
   /** The disagreeing single-valued properties — present only when `basis` is `structured-field`. */
   fields?: { key: string; aValue: string | number | boolean; bValue: string | number | boolean }[];
+  /**
+   * The judged text was long enough that the model's window probably cut it — so this verdict may describe
+   * the OPENING of a record rather than the record. A proxy, never a measurement: we do not truncate, the
+   * encoder does, invisibly and without changing the confidence. Absent means "not long enough to worry
+   * about", not "the whole text was read". See `NLI_LIKELY_TRUNCATED_CHARS`.
+   */
+  truncated?: true;
   status: 'open' | 'dismissed' | 'resolved';
   /** How a resolved candidate was actioned. `edited` = a record was corrected; `linked` = a
    *  contradicts/supersedes edge was drawn instead of changing either record. */

--- a/testing/standalone/contradiction-candidates.test.js
+++ b/testing/standalone/contradiction-candidates.test.js
@@ -22,7 +22,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 
-let decideCandidateAction, contradictionPairId;
+let decideCandidateAction, contradictionPairId, fieldsInStoredOrder;
 
 const CONTRA = { kind: 'contradiction', basis: 'structured-field', confidence: 1, fields: [{ key: 'port', aValue: 1, bValue: 2 }] };
 const NLI = { kind: 'contradiction', basis: 'nli', confidence: 0.91 };
@@ -32,7 +32,7 @@ const row = (status) => ({ status });
 
 describe('contradiction candidates — the decision', () => {
   before(async () => {
-    ({ decideCandidateAction, contradictionPairId } =
+    ({ decideCandidateAction, contradictionPairId, fieldsInStoredOrder } =
       await import('../../server/dist/brain/contradiction-candidates.js'));
   });
 
@@ -97,6 +97,45 @@ describe('contradiction candidates — the decision', () => {
         assert.equal(a.do, 'reopen');
         assert.equal(a.outcome, 'reopened');
       });
+    });
+  });
+
+  /**
+   * The evidence must describe the side it is stored against.
+   *
+   * A verdict names values by ARGUMENT position (`aValue` = first argument), a row names sides by ID order
+   * (`aId` = lower id). Whichever way the scanner met the pair decided which of those two orders applied, so
+   * half of all structured findings stored each value against the other record — a real disagreement,
+   * described backwards. Nothing throws when that happens, which is exactly why it needs a test.
+   */
+  describe('a structured finding attributes each value to the right record', () => {
+    const fields = [{ key: 'port', aValue: 8080, bValue: 443 }, { key: 'env', aValue: 'prod', bValue: 'staging' }];
+
+    it('passes fields through untouched when the sides are already in id order', () => {
+      assert.deepEqual(fieldsInStoredOrder(fields, false), fields);
+    });
+
+    it('mirrors every field when the sides were swapped into id order', () => {
+      assert.deepEqual(fieldsInStoredOrder(fields, true), [
+        { key: 'port', aValue: 443, bValue: 8080 },
+        { key: 'env', aValue: 'staging', bValue: 'prod' },
+      ]);
+    });
+
+    it('keeps the key with its own pair of values — not a wholesale reverse of the list', () => {
+      // A plausible near-miss fix: reversing the array instead of each entry. It looks right on a
+      // single-field finding, which is the common case, and silently mislabels every multi-field one.
+      assert.deepEqual(fieldsInStoredOrder(fields, true).map(f => f.key), ['port', 'env']);
+    });
+
+    it('does not mutate the verdict it was given', () => {
+      const original = JSON.parse(JSON.stringify(fields));
+      fieldsInStoredOrder(fields, true);
+      assert.deepEqual(fields, original, 'the verdict is reused by the caller; mirroring must copy');
+    });
+
+    it('mirroring twice returns the original', () => {
+      assert.deepEqual(fieldsInStoredOrder(fieldsInStoredOrder(fields, true), true), fields);
     });
   });
 });

--- a/testing/standalone/contradiction-judge.test.js
+++ b/testing/standalone/contradiction-judge.test.js
@@ -35,7 +35,7 @@ function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
 }
 
-let judgePair, findPropertyDisagreements, _reloadConfig;
+let judgePair, findPropertyDisagreements, consultedModel, _reloadConfig;
 let cfgPath;
 const rec = (id, text, properties) => ({ id, text, ...(properties ? { properties } : {}) });
 
@@ -56,7 +56,7 @@ describe('contradiction judge', () => {
     fs.writeFileSync(cfgPath, JSON.stringify({ spaces: [], tokens: [], networks: [] }), 'utf8');
     const loader = await import('../../server/dist/config/loader.js');
     _reloadConfig = loader.loadConfig;
-    ({ judgePair, findPropertyDisagreements } = await import('../../server/dist/brain/contradiction-judge.js'));
+    ({ judgePair, findPropertyDisagreements, consultedModel } = await import('../../server/dist/brain/contradiction-judge.js'));
     _reloadConfig();
   });
 
@@ -156,5 +156,138 @@ describe('contradiction judge', () => {
     stubNli({ label: 'contradiction', score: 0.7 });
     assert.equal((await judgePair(rec('a', 'p'), rec('b', 'q'), { minConfidence: 0.9 })).kind, 'unjudged');
     assert.equal((await judgePair(rec('a', 'p'), rec('b', 'q'), { minConfidence: 0.5 })).kind, 'contradiction');
+  });
+});
+
+describe('a verdict says when the judge probably did not see the whole text', () => {
+  // Reported by an operator running their own judge: encoder cross-encoders cap at 512 tokens, their entity
+  // descriptions run to thousands of characters, so a pair is judged on its opening paragraphs — with a
+  // completely normal-looking confidence. Nothing errors, which is what makes it dangerous: a confident
+  // verdict about the first page is indistinguishable from a confident verdict about the record.
+  //
+  // We do not truncate — the model does, invisibly — so the flag is explicitly a PROXY on length. These tests
+  // pin both directions, because a flag that fires on ordinary records is one reviewers learn to ignore.
+  const long = 'x'.repeat(2_000);
+  const short = 'the service runs on 8080';
+
+  beforeEach(() => { configureNli(true); });
+
+  it('flags a contradiction whose text exceeds the likely window', async () => {
+    stubNli({ label: 'contradiction', score: 0.9 });
+    const v = await judgePair(rec('a', long), rec('b', short));
+    assert.equal(v.kind, 'contradiction');
+    assert.equal(v.truncated, true, 'a long side must be reported');
+  });
+
+  it('flags it when the OTHER side is the long one', async () => {
+    stubNli({ label: 'contradiction', score: 0.9 });
+    assert.equal((await judgePair(rec('a', short), rec('b', long))).truncated, true);
+  });
+
+  it('flags an AGREE verdict too — the reason to distrust it is the same', async () => {
+    stubNli({ label: 'entailment', score: 0.9 });
+    const v = await judgePair(rec('a', long), rec('b', short));
+    assert.equal(v.kind, 'agree');
+    assert.equal(v.truncated, true);
+  });
+
+  it('is ABSENT on ordinary-length text, not false', async () => {
+    // Absence must mean "not long enough to worry about". A `truncated: false` on every finding is a field
+    // reviewers stop reading, which is exactly what the operator warned us about with a different flag.
+    stubNli({ label: 'contradiction', score: 0.9 });
+    const v = await judgePair(rec('a', short), rec('b', 'the service does not run on 8080'));
+    assert.equal('truncated' in v, false, `expected no truncated key: ${JSON.stringify(v)}`);
+  });
+
+  it('is not set by the STRUCTURED pass, which reads whole property values', async () => {
+    // The deterministic pass compares single-valued properties; no model, no window, nothing truncated. A
+    // flag there would be a claim about a mechanism that was never involved.
+    const v = await judgePair(
+      rec('a', long, { port: 8080 }),
+      rec('b', long, { port: 9090 }),
+    );
+    assert.equal(v.basis, 'structured-field');
+    assert.equal('truncated' in v, false, 'the structured verdict must not carry a model-window caveat');
+  });
+});
+
+describe('the deterministic pass must not spend the model', () => {
+  /**
+   * The bug this pins, reported as "judgedPairs: 6 against my judge's own counter of 12".
+   *
+   * The scanner's structured pass asked for `minConfidence: 2` — an unreachable floor — on the theory that a
+   * verdict which can never clear it is a verdict never taken. But the floor is applied to the RESPONSE. The
+   * request was still made, the record text still left the instance, the endpoint still served it, and only
+   * then was the answer discarded. Every pair in the sweep was judged twice and only the second was counted.
+   *
+   * So this asserts on the CALL, not on the verdict: a test that only checked the returned kind passed
+   * before the fix and after it.
+   */
+  let saved;
+  before(() => { configureNli(true); });
+  beforeEach(() => { saved = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = saved; });
+
+  const spyFetch = () => {
+    let calls = 0;
+    globalThis.fetch = async () => { calls++; return jsonResponse({ label: 'contradiction', score: 0.99 }); };
+    return () => calls;
+  };
+
+  it('reaches no endpoint at all under structuredOnly', async () => {
+    const calls = spyFetch();
+    const v = await judgePair(rec('a', 'the service runs on 8080'), rec('b', 'the service does not run on 8080'),
+      { structuredOnly: true });
+    assert.equal(calls(), 0, 'structuredOnly made a model call — the free pass is not free');
+    assert.equal(v.kind, 'unjudged');
+    // Deliberately NOT `no-judge-configured`: a judge IS configured here and is answering. We declined to ask.
+    assert.equal(v.reason, 'model-not-consulted');
+  });
+
+  it('an unreachable minConfidence does NOT prevent the call — which is why the flag exists', async () => {
+    const calls = spyFetch();
+    const v = await judgePair(rec('a', 'x is true'), rec('b', 'x is false'), { minConfidence: 2 });
+    assert.equal(calls(), 1, 'the old structured pass paid for this call and threw the answer away');
+    assert.equal(v.kind, 'unjudged');
+  });
+
+  it('still returns the deterministic contradiction it CAN reach', async () => {
+    const calls = spyFetch();
+    const v = await judgePair(rec('a', 'runs on 8080', { port: 8080 }), rec('b', 'runs on 9090', { port: 9090 }),
+      { structuredOnly: true });
+    assert.equal(v.kind, 'contradiction');
+    assert.equal(v.basis, 'structured-field');
+    assert.equal(calls(), 0);
+  });
+
+  it('reports model-not-consulted even for empty text, because nothing was asked', async () => {
+    // The no-text and no-judge-configured checks sit on the model path. Reaching them under structuredOnly
+    // would report a judge problem to a caller that never wanted a judge.
+    const v = await judgePair(rec('a', '  '), rec('b', 'x is false'), { structuredOnly: true });
+    assert.equal(v.reason, 'model-not-consulted');
+  });
+});
+
+describe('consultedModel — what a sweep SPENT, not what it settled', () => {
+  // The scanner's budget bounds egress, so it has to count every served request. Two of these cost a call
+  // and settle nothing, which is exactly why `judgedPairs` could never reconcile with a judge's own counter.
+  it('counts a model verdict', () => {
+    assert.equal(consultedModel({ kind: 'contradiction', basis: 'nli', confidence: 0.9 }), true);
+    assert.equal(consultedModel({ kind: 'agree', basis: 'nli', confidence: 0.9 }), true);
+  });
+
+  it('counts a low-confidence answer — paid for in full, then discarded', () => {
+    assert.equal(consultedModel({ kind: 'unjudged', reason: 'low-confidence' }), true);
+  });
+
+  it('counts an unavailable judge — the record text left the instance regardless', () => {
+    assert.equal(consultedModel({ kind: 'unjudged', reason: 'judge-unavailable' }), true);
+  });
+
+  it('does not count anything that reached no endpoint', () => {
+    assert.equal(consultedModel({ kind: 'contradiction', basis: 'structured-field', confidence: 1, fields: [] }), false);
+    assert.equal(consultedModel({ kind: 'unjudged', reason: 'no-text' }), false);
+    assert.equal(consultedModel({ kind: 'unjudged', reason: 'no-judge-configured' }), false);
+    assert.equal(consultedModel({ kind: 'unjudged', reason: 'model-not-consulted' }), false);
   });
 });

--- a/testing/standalone/contradiction-scanner.test.js
+++ b/testing/standalone/contradiction-scanner.test.js
@@ -21,12 +21,14 @@
  */
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 
-let cursorKey, toJudgeable, DEFAULT_TYPES;
+let cursorKey, toJudgeable, DEFAULT_TYPES, unjudgedNeighbours;
 
 describe('contradiction scanner — cursor separation', () => {
   before(async () => {
-    ({ cursorKey, toJudgeable, DEFAULT_TYPES } = await import('../../server/dist/brain/contradiction-scanner.js'));
+    ({ cursorKey, toJudgeable, DEFAULT_TYPES, unjudgedNeighbours } =
+      await import('../../server/dist/brain/contradiction-scanner.js'));
   });
 
   it('gives the structured and NLI passes DIFFERENT cursors', () => {
@@ -93,5 +95,74 @@ describe('contradiction scanner — swept types', () => {
     // Chrono was in neither scanner's defaults, so a calendar's contradictions were found by nothing.
     assert.ok(DEFAULT_TYPES.includes('chrono'));
     assert.ok(DEFAULT_TYPES.includes('memory') && DEFAULT_TYPES.includes('entity'));
+  });
+});
+
+/**
+ * One pair, one judgement per sweep.
+ *
+ * Reported by an operator: our scan said `judgedPairs: 6` while their own judge's request counter said 12.
+ * Similarity is symmetric, so as the sweep walks by `seq` a mutually-near pair is met from BOTH sides, and
+ * both judgements write the same row — the second one paid for a model call to overwrite the first.
+ */
+describe('contradiction scanner — a pair is judged once per sweep', () => {
+  before(async () => {
+    ({ unjudgedNeighbours } = await import('../../server/dist/brain/contradiction-scanner.js'));
+  });
+  const hit = (id) => ({ _id: id, type: 'memory', score: 0.97 });
+
+  it('drops the neighbour whose pair was settled from the other side', () => {
+    const seen = new Set(['mem-1:mem-2']);
+    const out = unjudgedNeighbours('mem-2', [hit('mem-1'), hit('mem-3')], seen);
+    assert.deepEqual(out.map(m => m._id), ['mem-3']);
+  });
+
+  it('matches regardless of which side seeded it — the id is order-independent', () => {
+    // The pair key is canonical, so `mem-2` as the seed must recognise the row `mem-1:mem-2`. Keying on
+    // `${seed}:${match}` instead would recognise nothing and the dedupe would be a no-op that still passed
+    // a naive test seeded in the same direction.
+    const seen = new Set(['mem-1:mem-2']);
+    assert.equal(unjudgedNeighbours('mem-1', [hit('mem-2')], seen).length, 0);
+    assert.equal(unjudgedNeighbours('mem-2', [hit('mem-1')], seen).length, 0);
+  });
+
+  it('keeps everything on the first visit', () => {
+    const out = unjudgedNeighbours('mem-1', [hit('mem-2'), hit('mem-3')], new Set());
+    assert.equal(out.length, 2);
+  });
+
+  it('is a no-op without a set, so a caller that does not dedupe behaves as before', () => {
+    const matches = [hit('mem-2')];
+    assert.equal(unjudgedNeighbours('mem-1', matches, undefined), matches);
+  });
+});
+
+/**
+ * The structured pass must reach NO endpoint.
+ *
+ * It used to enforce that with `minConfidence: 2` — an unreachable floor. But the floor is applied to the
+ * RESPONSE: the request went out, the record text left the instance, the endpoint served and billed it, and
+ * only then was the answer discarded. That is the other half of the operator's 2×, and it is invisible from
+ * every angle except the call itself. `judgePair`'s own tests pin the behaviour (`structuredOnly` → zero
+ * fetches, `minConfidence: 2` → one); this pins that the scanner is the caller that uses it.
+ */
+describe('contradiction scanner — the free pass is actually free', () => {
+  const src = fs.readFileSync(new URL('../../server/src/brain/contradiction-scanner.ts', import.meta.url), 'utf8');
+  // Comments explain the trap by name, so they must not satisfy the check that guards it.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+
+  it('asks the judge for the deterministic pass only', () => {
+    assert.match(code, /pass === 'structured'[\s\S]{0,160}structuredOnly:\s*true/);
+  });
+
+  it('does not try to buy silence with an unreachable confidence floor', () => {
+    assert.doesNotMatch(code, /minConfidence:\s*2/,
+      'a threshold gates the ANSWER, not the request — the call is made and paid for either way');
+  });
+
+  it('bounds the per-run budget on calls served, not on pairs settled', () => {
+    // A low-confidence answer is a served request that settles nothing. Gating on `judgedPairs` let a space
+    // with weak verdicts run indefinitely past a budget whose whole purpose is to bound spend.
+    assert.match(code, /maxJudgedPairs\s*>\s*0\s*&&\s*modelCalls\s*>=\s*tune\.maxJudgedPairs/);
   });
 });


### PR DESCRIPTION
fix(brain): the contradiction sweep judged every pair twice, and the free pass was not free

An operator running their own NLI judge reported `judgedPairs: 6` against their endpoint's own
request counter of 12, and asked us either to de-duplicate pairs before judging or to document the
ratio so `maxJudgedPairsPerRun` was not out by 2x. It was not one mechanism. It was two, each
doubling the calls, and neither visible from anywhere except the wire.

## 1. The deterministic pass called the model on every pair and threw the answer away

The structured pass is supposed to be the free one: deterministic property conflicts, no model, so it
stays useful on an instance with no NLI endpoint at all. It enforced that with `minConfidence: 2` — an
unreachable floor — on the theory that a verdict which can never clear the bar is a verdict never
taken.

But a confidence floor is applied to the RESPONSE. The request went out, the record text left the
instance, the endpoint served and billed it, and only then was the answer discarded. Every pair in
every sweep was judged twice.

The code carried a comment asserting "The structured pass reaches no endpoint" at the exact site
where it did, which is why this survived: the mechanism was documented as impossible.

`judgePair` now takes `structuredOnly`, which returns before anything that can reach the endpoint —
including the no-text and no-judge-configured checks, which would otherwise report a judge problem to
a caller that never wanted a judge. The test asserts on the CALL, not the verdict: the old code
passes every verdict-shaped assertion, and there is a companion test pinning that `minConfidence: 2`
still makes the call, so the trap stays documented by something executable.

## 2. A mutually-similar pair was judged from both sides

Similarity is symmetric. As the sweep walks records by `seq`, the pair {A, B} is met once with A as
the seed and B among its neighbours, and again with B as the seed and A among its. Both judgements
write the SAME row — the pair id is order-independent — so the second only overwrote the first, having
paid for another model call and another egress of both records' text.

`unjudgedNeighbours` skips the repeat. Nothing is lost: the stored row also becomes deterministic, the
side reached first winning instead of whichever seed happened to come last.

## 3. What the sweep SPENT, reported next to what it SETTLED

`judgedPairs` counts pairs answered usefully. That number can never reconcile with an endpoint's
request log, because a below-threshold answer costs a call and settles nothing, and an unreachable
judge still received the text. `POST /scan` now reports `modelCalls` as well, and
`maxJudgedPairsPerRun` bounds THAT: gating a spend budget on useful answers alone let a space full of
weak verdicts run indefinitely past it.

`consultedModel` lives in the judge, next to the branches it describes, rather than as a second copy
of that knowledge in the scanner.

## 4. Found on the way: half of all structured findings named the wrong record

A verdict names values by argument position (`aValue` = first argument). The stored row names sides by
id order (`aId` = the lower id). Those coincide only when the sweep met the pair in id order — a coin
flip — so for the other half the review card read "srv-a claims 8080" about the record claiming 443.
The disagreement was genuine, `confidence` was 1, and only the evidence was inverted, which is the
hardest kind of wrong to notice.

`fieldsInStoredOrder` re-attributes them, pure and exported so the cases can be enumerated — including
the plausible near-miss of reversing the list instead of each entry, which looks correct on the
single-field findings that are the common case.

## Verification

- 25 judge tests, 16 candidate tests, 16 scanner tests, all green; `npm run preflight` clean.
- The three source-level gates were run against the pre-fix file at HEAD to prove they discriminate:
  no `structuredOnly` (false), `minConfidence: 2` present (true), budget not gated on `modelCalls`
  (false). A gate that cannot fail on the old code is not a gate.

Docs: `14-duplicates-and-webhooks.md` gains the two-count table, the `aValue`/`aId` attribution rule
with a re-scan note for anyone holding older findings, and a boxed explanation for operators who
measured the 2x themselves.

