### PR TITLE
fix(test): the CI index-lag deadline was shorter than the lag it waited for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **The CI vector-index wait had a deadline shorter than the lag it waited for.** Five integration files had each
+  grown their own copy of "poll recall until these ids appear", every one with a **30 s** timeout that had never
+  been measured against anything. The Atlas Local index lag has been observed at **150 s** on the runner, so when
+  it ran long the poll threw from a `before` hook — which cancels every test in that suite and reads exactly like
+  a real regression (`hookFailed: Timed out waiting for indexing of: <uuid>`). That failed CI four separate times
+  on four different tests, and each occurrence was individually dismissible as a flake. It was not a flake; it was
+  an unmeasured number.
+  - One shared poll now, with the deadline as a named constant well beyond the worst observation. This costs
+    nothing when the index is quick — the poll returns on the first hit — so a larger number buys not failing and a
+    smaller one buys only failing sooner.
+  - **The copies had already drifted in a way that mattered:** four matched `result._id` and one matched
+    `result.record?._id ?? result._id`. A copy that guesses the wrong shape matches nothing and times out in full,
+    so the drift was invisible until it wasn't. The shared version accepts both.
+  - A gate matches the poll's SHAPE rather than any of its names, and immediately found a **fifth** copy that a
+    grep for the others' error message could not: it said `Timed out indexing:` instead.
+  - Nothing about the product changed; this is test infrastructure only.
+
 ### Fixed
 
 - **`GET /api/spaces/:id` returned three fields that `PATCH` then refused** (an integrator's fifth ask, and the

--- a/testing/integration/dupe-detection.test.js
+++ b/testing/integration/dupe-detection.test.js
@@ -22,7 +22,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get } from '../sync/helpers.js';
+import { INSTANCES, post, get, waitForIndexed as waitForIndexedShared } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -106,17 +106,14 @@ async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_
   });
 }
 
-/** Poll $vectorSearch until every id appears in unfiltered recall for `types`. */
-async function waitForIndexed(ids, types, timeoutMs = 30_000) {
-  const pending = new Set(ids);
-  const deadline = Date.now() + timeoutMs;
-  while (pending.size > 0 && Date.now() < deadline) {
-    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, { query: 'indexing probe query', types, topK: 100 });
-    if (r.status === 200 && Array.isArray(r.body.results)) for (const x of r.body.results) pending.delete(x._id);
-    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
-  }
-  if (pending.size > 0) throw new Error(`Timed out waiting for indexing of: ${[...pending].join(', ')}`);
-}
+/**
+ * Poll $vectorSearch until every id appears in unfiltered recall for `types`.
+ *
+ * The poll and its deadline are shared — this file used to carry its own copy with a 30 s timeout, under the
+ * 150 s index lag seen on CI.
+ */
+const waitForIndexed = (ids, types, timeoutMs) =>
+  waitForIndexedShared(INSTANCES.a, token(), SPACE, ids, types, timeoutMs);
 
 let session;
 

--- a/testing/integration/dupe-scanner.test.js
+++ b/testing/integration/dupe-scanner.test.js
@@ -23,7 +23,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get } from '../sync/helpers.js';
+import { INSTANCES, post, get, waitForIndexed as waitForIndexedShared } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -61,16 +61,15 @@ async function createEntity(space, name, description) {
   return r.status === 201 ? r.body._id : null;
 }
 
-async function waitForIndexed(space, ids, timeoutMs = 30_000) {
-  const pending = new Set(ids);
-  const deadline = Date.now() + timeoutMs;
-  while (pending.size > 0 && Date.now() < deadline) {
-    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${space}/recall`, { query: 'probe', types: ['entity'], topK: 100 });
-    if (r.status === 200 && Array.isArray(r.body.results)) for (const x of r.body.results) pending.delete(x._id);
-    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
-  }
-  if (pending.size > 0) throw new Error(`Timed out indexing: ${[...pending].join(', ')}`);
-}
+/**
+ * Wait for $vectorSearch to see these entities. Shared poll, shared deadline.
+ *
+ * This was the FIFTH copy, and the one a grep for the others' error message could never find — it said
+ * "Timed out indexing:" instead of "Timed out waiting for indexing of:". It was caught by a gate that matches the
+ * SHAPE of the poll rather than any of its names.
+ */
+const waitForIndexed = (space, ids, timeoutMs) =>
+  waitForIndexedShared(INSTANCES.a, token(), space, ids, ['entity'], timeoutMs);
 
 async function scan(space) {
   return raw('POST', `/api/duplicates/scan?space=${space}`);

--- a/testing/integration/recall-filter.test.js
+++ b/testing/integration/recall-filter.test.js
@@ -20,7 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get } from '../sync/helpers.js';
+import { INSTANCES, post, get, waitForIndexed as waitForIndexedShared } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -181,32 +181,13 @@ after(async () => {
 });
 
 /**
- * Poll $vectorSearch until all given IDs appear in unfiltered recall results.
- * Atlas Local has indexing latency — a document written with a 201 is not
- * immediately visible to $vectorSearch. We must wait for mongot to catch up.
+ * Wait for $vectorSearch to see the given ids in THIS suite's space.
+ *
+ * The poll and its deadline live in `helpers.js` — this file used to carry its own copy with a 30 s timeout,
+ * which is well under the 150 s index lag observed on CI and failed the whole suite from a `before` hook.
  */
-async function waitForIndexed(ids, types = ['entity', 'memory'], timeoutMs = 30_000) {
-  const pending = new Set(ids);
-  const deadline = Date.now() + timeoutMs;
-  while (pending.size > 0 && Date.now() < deadline) {
-    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`, {
-      query: 'indexing probe query',
-      types,
-      topK: 100,
-    });
-    if (r.status === 200 && Array.isArray(r.body.results)) {
-      for (const result of r.body.results) {
-        pending.delete(result._id);
-      }
-    }
-    if (pending.size > 0) {
-      await new Promise(res => setTimeout(res, 500));
-    }
-  }
-  if (pending.size > 0) {
-    throw new Error(`Timed out waiting for indexing of: ${[...pending].join(', ')}`);
-  }
-}
+const waitForIndexed = (ids, types = ['entity', 'memory'], timeoutMs) =>
+  waitForIndexedIn(SPACE, ids, types, timeoutMs);
 
 // ── Validation tests (no embedding required) ─────────────────────────────
 
@@ -663,21 +644,10 @@ describe('Recall filter — exists operator', () => {
   });
 });
 
-// Space-parameterized variant of waitForIndexed (the schema test uses a second space).
-async function waitForIndexedIn(spaceId, ids, types = ['entity', 'memory'], timeoutMs = 30_000) {
-  const pending = new Set(ids);
-  const deadline = Date.now() + timeoutMs;
-  while (pending.size > 0 && Date.now() < deadline) {
-    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${spaceId}/recall`, {
-      query: 'indexing probe query', types, topK: 100,
-    });
-    if (r.status === 200 && Array.isArray(r.body.results)) {
-      for (const result of r.body.results) pending.delete(result.record?._id ?? result._id);
-    }
-    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
-  }
-  if (pending.size > 0) throw new Error(`Timed out waiting for indexing of: ${[...pending].join(', ')}`);
-}
+// Space-parameterized variant (the schema test uses a second space). Thin wrapper over the shared poll so both
+// spaces get the same measured deadline and the same diagnosis on failure.
+const waitForIndexedIn = (spaceId, ids, types = ['entity', 'memory'], timeoutMs) =>
+  waitForIndexedShared(INSTANCES.a, token(), spaceId, ids, types, timeoutMs);
 
 // ── P6: tags param uses ALL-of semantics on the native filter fast path ────────
 describe('Recall filter — tags param (must contain ALL; native fast path)', () => {

--- a/testing/integration/recall-traverse.test.js
+++ b/testing/integration/recall-traverse.test.js
@@ -28,7 +28,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
 import { fileURLToPath } from 'url';
-import { INSTANCES, post, get } from '../sync/helpers.js';
+import { INSTANCES, post, get, waitForIndexed as waitForIndexedShared } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -150,19 +150,14 @@ async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_
   });
 }
 
-/** Poll $vectorSearch on `space` until every id in `ids` appears in unfiltered recall. */
-async function waitForIndexed(space, ids, timeoutMs = 30_000) {
-  const pending = new Set(ids);
-  const deadline = Date.now() + timeoutMs;
-  while (pending.size > 0 && Date.now() < deadline) {
-    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${space}/recall`, { query: 'indexing probe query', types: ['entity'], topK: 100 });
-    if (r.status === 200 && Array.isArray(r.body.results)) {
-      for (const result of r.body.results) pending.delete(result._id);
-    }
-    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
-  }
-  if (pending.size > 0) throw new Error(`Timed out waiting for indexing of: ${[...pending].join(', ')}`);
-}
+/**
+ * Poll $vectorSearch on `space` until every id in `ids` appears in unfiltered recall.
+ *
+ * The poll and its deadline are shared — this file used to carry its own copy with a 30 s timeout, under the
+ * 150 s index lag seen on CI.
+ */
+const waitForIndexed = (space, ids, timeoutMs) =>
+  waitForIndexedShared(INSTANCES.a, token(), space, ids, ['entity'], timeoutMs);
 
 async function syncEntity(space, id, name, seq) {
   const { post: syncPost } = await import('../sync/helpers.js');

--- a/testing/standalone/index-lag-wait-is-shared.test.js
+++ b/testing/standalone/index-lag-wait-is-shared.test.js
@@ -1,0 +1,85 @@
+/**
+ * One index-lag poll, with one measured deadline.
+ *
+ * ## The failure this exists for
+ *
+ * The Atlas Local vector index is eventually consistent, and the lag has been observed at up to **150 s** on the
+ * CI runner. Four integration files had each grown their own copy of "poll recall until these ids appear", every
+ * one with a **30 s** deadline that had never been measured against anything. When the lag exceeded it the poll
+ * threw from a `before` hook, which cancels every test in that suite and reads exactly like a real regression:
+ *
+ *     not ok 129 - Recall filter — tags in (any-of)
+ *       failureType: 'hookFailed'
+ *       error: 'Timed out waiting for indexing of: 527a9f04-…'
+ *
+ * That failed CI four separate times, on four different tests, and each occurrence was individually dismissible
+ * as a flake. It is not a flake: it is a deadline shorter than the thing it waits for.
+ *
+ * ## Why a gate and not just a fix
+ *
+ * The four copies had already drifted in a way that matters: three matched `result._id` and one matched
+ * `result.record?._id ?? result._id`. A copy that guesses the wrong shape matches nothing and times out in full,
+ * so the drift was invisible until it wasn't. Consolidating without a gate just resets the clock on the next
+ * copy — and the next copy will be written by whoever adds the fifth suite that needs to wait for the index.
+ *
+ * Run: node --test testing/standalone/index-lag-wait-is-shared.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** Test files, from git rather than the filesystem — gitignored scratch must not count as repo content. */
+function testFiles() {
+  return execFileSync('git', ['ls-files', 'testing'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n').filter(f => f.endsWith('.js') || f.endsWith('.mjs'));
+}
+
+const HELPERS = 'testing/sync/helpers.js';
+
+describe('the vector-index wait is shared, and its deadline is the measured one', () => {
+  it('helpers.js owns the poll and names the deadline as a constant', () => {
+    const src = readFileSync(join(ROOT, HELPERS), 'utf8');
+    assert.match(src, /export async function waitForIndexed\(/,
+      'the shared poll must live in helpers.js, where every integration file already imports from');
+    assert.match(src, /export const INDEX_LAG_TIMEOUT_MS = /,
+      'the deadline must be a named constant, not a magic number repeated per call site');
+  });
+
+  it('the deadline comfortably exceeds the worst observed lag', () => {
+    const src = readFileSync(join(ROOT, HELPERS), 'utf8');
+    const ms = Number(/INDEX_LAG_TIMEOUT_MS = ([0-9_]+)/.exec(src)?.[1]?.replaceAll('_', ''));
+    assert.ok(Number.isFinite(ms), 'could not read INDEX_LAG_TIMEOUT_MS');
+    // 150 s observed. A margin, not a coin flip: the poll returns the moment the index catches up, so a larger
+    // number costs nothing on a healthy runner and a smaller one buys nothing but earlier failure on a slow one.
+    assert.ok(ms >= 240_000,
+      `the index-lag deadline is ${ms}ms, but the lag has been measured at 150s — this is the bug, not a tuning knob`);
+  });
+
+  it('accepts both result shapes, because the old copies disagreed', () => {
+    const src = readFileSync(join(ROOT, HELPERS), 'utf8');
+    assert.match(src, /result\.record\?\._id \?\? result\._id/,
+      'a poll that matches only one of the two recall result shapes never matches and always times out');
+  });
+
+  it('no test file re-implements the poll', () => {
+    // Matched on the SHAPE (a bounded loop that polls recall for ids), not on the name `waitForIndexed` — a fifth
+    // copy will be called something else. The two markers together are what a re-implementation cannot avoid:
+    // it has to post to a recall route and it has to loop with its own deadline.
+    const offenders = [];
+    for (const f of testFiles()) {
+      if (f === HELPERS) continue;
+      const src = readFileSync(join(ROOT, f), 'utf8');
+      const pollsRecall = /['"`][^'"`\n]*\/recall['"`]|`[^`\n]*\/recall`/.test(src);
+      const hasOwnDeadline = /Date\.now\(\)\s*\+\s*timeoutMs|deadline\s*=\s*Date\.now\(\)/.test(src);
+      const waitsForIds = /pending\s*=\s*new Set\(/.test(src);
+      if (pollsRecall && hasOwnDeadline && waitsForIds) offenders.push(f);
+    }
+    assert.deepEqual(offenders, [],
+      'these files poll a recall route on their own deadline waiting for ids to appear — import waitForIndexed '
+      + `from ${HELPERS} instead, or the next index-lag stall fails a suite from a before hook again`);
+  });
+});

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -164,6 +164,63 @@ export async function waitFor(condition, timeout = 15_000, interval = 500, diagn
   throw new Error(`waitFor timed out after ${timeout}ms${detail ? ` — ${detail}` : ''}`);
 }
 
+/**
+ * Wait until every id is visible to `$vectorSearch`, then return how long it took.
+ *
+ * ## Why this is one helper and not four copies of a 30-second timeout
+ *
+ * The Atlas Local vector index is **eventually consistent**: a record that came back 201 is not yet visible to
+ * `$vectorSearch`, and nothing in the write path tells you when it will be. Four test files each grew their own
+ * copy of this poll, each with a 30 s deadline that nobody had measured against anything.
+ *
+ * The lag has been observed at up to **150 s** on the CI runner. So the deadline was not conservative, it was
+ * simply wrong, and its failure — `Timed out waiting for indexing of: <uuid>` inside a `before` hook — cancels
+ * every test in the suite and reads exactly like a real regression. That has now failed CI four separate times.
+ *
+ * `INDEX_LAG_TIMEOUT_MS` is deliberately well beyond the worst observation rather than just past it. **This costs
+ * nothing when the index is quick** — the poll returns on the first hit — so the only thing a bigger number buys
+ * is not failing, and the only thing a smaller one buys is failing sooner on a slow runner.
+ *
+ * A test that does NOT need the index should not call this at all; prefer asserting on what the record itself
+ * returns. `embed-properties` was rewritten that way and stopped flaking entirely.
+ *
+ * @param types Record types to poll. Narrow it — polling for types you did not write cannot succeed.
+ */
+export const INDEX_LAG_TIMEOUT_MS = 300_000;
+
+export async function waitForIndexed(baseUrl, token, spaceId, ids, types, timeoutMs = INDEX_LAG_TIMEOUT_MS) {
+  const pending = new Set(ids);
+  const started = Date.now();
+  const deadline = started + timeoutMs;
+  let lastStatus = null;
+  let polls = 0;
+  while (pending.size > 0 && Date.now() < deadline) {
+    const r = await post(baseUrl, token, `/api/brain/spaces/${spaceId}/recall`,
+      { query: 'indexing probe query', types, topK: 100 });
+    polls++;
+    lastStatus = r.status;
+    if (r.status === 200 && Array.isArray(r.body?.results)) {
+      // Both shapes, because the four copies of this poll did not agree on one: most read `result._id`, one read
+      // `result.record?._id ?? result._id`. A copy that guesses wrong never matches anything and times out in
+      // full — a hard failure that looks exactly like index lag. Accepting both is the only version that cannot
+      // be silently wrong.
+      for (const result of r.body.results) pending.delete(result.record?._id ?? result._id);
+    }
+    if (pending.size > 0) await new Promise(res => setTimeout(res, 500));
+  }
+  if (pending.size > 0) {
+    // Say which of the two failures this is. A recall that never returned 200 is a broken instance and has
+    // nothing to do with index lag, but the old message described both as "timed out waiting for indexing".
+    const how = lastStatus === 200
+      ? `recall answered 200 every time and never listed them, over ${polls} polls`
+      : `the last recall returned ${lastStatus} — this is not index lag, recall itself is failing`;
+    throw new Error(
+      `Timed out after ${Math.round((Date.now() - started) / 1000)}s waiting for $vectorSearch to see `
+      + `${[...pending].join(', ')} in space ${spaceId} (types: ${types.join(',')}): ${how}`);
+  }
+  return Date.now() - started;
+}
+
 /** Trigger a sync run on an instance for a given networkId. Throws on any non-200. */
 export async function triggerSync(baseUrl, token, networkId) {
   const r = await post(baseUrl, token, '/api/notify/trigger', { networkId });


### PR DESCRIPTION
fix(test): the CI index-lag deadline was shorter than the lag it waited for

`not ok 129 - Recall filter — tags in (any-of)`
`  failureType: 'hookFailed'`
`  error: 'Timed out waiting for indexing of: 527a9f04-c485-4013-842b-699496c794f4'`

That is the fourth time this has failed CI, on the fourth different test, and it blocked #709. Each
occurrence was individually dismissible as a flake. It is not a flake.

## The number was never measured

Five integration files had each grown their own copy of "poll recall until these ids appear", every one
with a 30 second deadline. The Atlas Local vector index is eventually consistent and the lag has been
observed at 150 seconds on the runner. So the deadline was not optimistic, it was simply wrong — and
because these polls run in `before` hooks, exceeding it cancels every test in the suite and reports as
`hookFailed`, which reads exactly like a real regression.

One shared poll now, with the deadline as a named constant well beyond the worst observation. This is
free when the index is quick: the poll returns on the first hit, so a bigger number buys not failing
and a smaller one buys nothing but failing sooner on a slow runner.

## The copies had already drifted, invisibly

Four matched `result._id`; one matched `result.record?._id ?? result._id`. A copy that guesses the
wrong shape matches nothing and times out in full — a hard failure indistinguishable from index lag.
The shared version accepts both, because that is the only version that cannot be silently wrong.

The failure message now also separates the two cases it used to merge: a recall that never returned 200
is a broken instance, not index lag, and it said "timed out waiting for indexing" for both.

## The gate found a copy the grep could not

`index-lag-wait-is-shared` matches the SHAPE of the poll — posts to a recall route, own deadline, waits
on a set of ids — rather than any of its names. Run against the tree it immediately reported a FIFTH
copy in `dupe-scanner.test.js`, which my grep for the others' error message had missed because it said
`Timed out indexing:` instead. Scoping a sweep by name would have left it in place.

## Verification

- `npm run preflight` clean; the new gate passes and its shape-match was proven by the copy it found.
- Every edited file `node --check`ed. Not by importing them: importing a test file RUNS it, which I did
  by accident against the Docker test instance on :3200 — the `after` hooks cleaned up after themselves
  (only `general` remains) but that is not a verification method, it is a side effect.

No product behaviour changes; this is test infrastructure only.

