### PR TITLE
fix(test): a sync wait now re-triggers, and its timeout says what it was waiting for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A gate matches the poll's SHAPE rather than any of its names, and immediately found a **fifth** copy that a
     grep for the others' error message could not: it said `Timed out indexing:` instead.
   - Nothing about the product changed; this is test infrastructure only.
+
+- **A sync wait now re-triggers, and its timeout says what it was waiting for.** `Subscriber-local content
+  survives publisher tombstone` failed CI as a bare `waitFor timed out after 15000ms`, on a branch whose diff
+  could not touch it. The message named neither of that test's two identical waits, nor whether the peer was
+  slow, the trigger was being rejected, or the network id was wrong.
+  - Three defects in one shape (`await triggerSync(...)` then a bare `waitFor`): one trigger races the gossip
+    cycle and is never re-sent; a bare timeout describes a persistently-429'd trigger and a merely-slow peer
+    identically — which is how the notify rate-limit bug hid for weeks; and nothing records what was awaited.
+  - `syncUntil` in the test helpers does all three. `closed-network.test.js` had already worked the pattern out
+    by hand at **one** of its four sites and left the others bare, which is the argument for a helper rather
+    than a comment.
+  - **22 sites still have the bare shape and none has ever been observed failing.** Converting them
+    mechanically would mean inventing 22 "waiting for …" descriptions that no script can write and no
+    measurement justifies — and the description is the point. So the gate freezes the count per file and fails
+    on a new one, while naming exactly what is uncovered: a gate reporting only the fixed case would read as
+    though the class were closed.
+  - Verified against the live four-instance test stack, not just by inspection.
+
 ### Added
 
 - **A contradiction finding says when the judge probably did not read the whole record** (`truncated`, half of
@@ -48,7 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   endpoint's own request log. Reporting one number that was neither is what left an operator unable to explain
   their bill. `maxJudgedPairsPerRun` now bounds `modelCalls`: gating on useful answers alone let a space full
   of weak verdicts run indefinitely past a budget whose entire purpose is to bound spend.
-
 ### Fixed
 
 - **A contradiction sweep judged every pair twice, and the "free" deterministic pass was not free** (the other

--- a/testing/standalone/gates-cannot-pass-vacuously.test.js
+++ b/testing/standalone/gates-cannot-pass-vacuously.test.js
@@ -52,7 +52,19 @@ const EMPTY_ASSERT = [
  */
 const ENUMERATES = /readdirSync|execFileSync\('git', \['ls-files|execSync\('git ls-files|allDocsText\(|docFiles\(/;
 
-/** A lower bound proving the enumeration found something. `> 0` counts — it is the most natural way to write it. */
+/**
+ * A lower bound proving the enumeration found something. `> 0` counts — it is the most natural way to write it.
+ *
+ * **KNOWN FALSE NEGATIVE, found 2026-08-06.** The last pattern accepts any bare numeric comparison, so a floor
+ * on something entirely unrelated satisfies it: `index-lag-wait-is-shared` shipped with an unfloored `git
+ * ls-files` walk and passed this gate on the strength of `assert.ok(ms >= 240_000)`, a bound on a timeout
+ * constant. Both were fixed at the source, and the pattern is kept because its only other user
+ * (`ssrf-allow-private-coverage`) floors a genuine count with it.
+ *
+ * The real rule is "a floor over the SAME enumeration, in the same block", which needs per-`it()` analysis
+ * rather than a file-wide regex. Filed rather than bodged — a tightening that flags a gate whose floor is real
+ * teaches people to widen the allowlist.
+ */
 const HAS_FLOOR = [
   /assert\.ok\([^;]*\.length\s*>\s*0/,
   /assert\.ok\([^;]*\.length\s*>=?\s*[1-9]/,

--- a/testing/standalone/index-lag-wait-is-shared.test.js
+++ b/testing/standalone/index-lag-wait-is-shared.test.js
@@ -69,8 +69,15 @@ describe('the vector-index wait is shared, and its deadline is the measured one'
     // Matched on the SHAPE (a bounded loop that polls recall for ids), not on the name `waitForIndexed` — a fifth
     // copy will be called something else. The two markers together are what a re-implementation cannot avoid:
     // it has to post to a recall route and it has to loop with its own deadline.
+    const files = testFiles();
+    // Floor the enumeration. Without this the check passes while examining nothing — `git ls-files` returning
+    // an empty list (wrong cwd, a partial checkout) would read as a clean tree. This gate shipped in #710
+    // without it and satisfied `gates-cannot-pass-vacuously` only by accident: that meta-gate accepted an
+    // unrelated `assert.ok(ms >= 240_000)` as the floor, which is a floor on a timeout constant, not on the
+    // walk. Both are fixed here.
+    assert.ok(files.length >= 40, `only enumerated ${files.length} test files`);
     const offenders = [];
-    for (const f of testFiles()) {
+    for (const f of files) {
       if (f === HELPERS) continue;
       const src = readFileSync(join(ROOT, f), 'utf8');
       const pollsRecall = /['"`][^'"`\n]*\/recall['"`]|`[^`\n]*\/recall`/.test(src);

--- a/testing/standalone/sync-waits-retrigger-and-diagnose.test.js
+++ b/testing/standalone/sync-waits-retrigger-and-diagnose.test.js
@@ -1,0 +1,133 @@
+/**
+ * A sync wait must re-trigger, and its timeout must explain itself.
+ *
+ * ## The failure
+ *
+ *     not ok — Subscriber-local content survives publisher tombstone
+ *       error: 'waitFor timed out after 15000ms'
+ *
+ * On a feature branch whose diff could not touch it. That message is the whole problem: it does not say which
+ * of the test's two identical waits gave up, nor whether the peer was slow, the trigger was being rejected, or
+ * the network id was wrong. A re-run cleared it, which is the correct immediate action and the wrong permanent
+ * one — a suite that fails environmentally trains everyone to re-run, and the day it fails for a real reason it
+ * gets the same treatment.
+ *
+ * ## Three defects in one shape
+ *
+ * `await triggerSync(...)` followed by a bare `waitFor`:
+ *
+ *   1. **One trigger races the gossip cycle.** The fire is async; if it queues behind other work nothing
+ *      arrives and the poll expires having never asked again.
+ *   2. **A bare timeout cannot tell a stall from a rejection.** A persistently-429'd trigger, a wrong network
+ *      id and a merely-slow peer all print the same sentence. That is exactly how the notify rate-limit bug hid
+ *      for weeks — every trigger was being refused and all anyone saw was a timeout.
+ *   3. **It does not say what it was waiting for.**
+ *
+ * `syncUntil` does all three. `closed-network.test.js` had already worked the pattern out by hand at ONE of its
+ * four sites, which is the argument for a helper over a comment.
+ *
+ * ## Why this is a ratchet and not a clean sweep
+ *
+ * 22 sites still have the bare shape and **none of them has ever been observed failing**. Converting them
+ * mechanically would mean inventing 22 "waiting for …" phrases that no script can write and no measurement
+ * justifies — and the description is the entire value of the change. So this gate freezes the count instead:
+ * the remaining sites are named below, and a NEW one fails the build.
+ *
+ * A negative assertion — "wait a fixed time, then prove it did NOT arrive" — is deliberately not this shape and
+ * must not be converted. See the note in `pubsub-topology.test.js`.
+ *
+ * Run: node --test testing/standalone/sync-waits-retrigger-and-diagnose.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/**
+ * Files still holding the bare shape, with their counts. Lower a number when you convert a site; the gate
+ * fails if any file exceeds its entry, or if a file not listed here acquires one.
+ *
+ * Frozen 2026-08-06 at 22 sites. This list is the honest statement of what is NOT covered — a gate that
+ * reported only "the fixed one is fixed" would read as though the class were closed.
+ */
+const KNOWN_BARE = {
+  'testing/integration/networks.test.js': 2,
+  'testing/sync/braintree-governance.test.js': 4,
+  'testing/sync/braintree.test.js': 2,
+  'testing/sync/closed-network.test.js': 3,
+  'testing/sync/gossip.test.js': 2,
+  'testing/sync/merkle.test.js': 1,
+  'testing/sync/vote-forgery.test.js': 1,
+  'testing/sync/vote-key-rotation.test.js': 2,
+  'testing/sync/vote-propagation.test.js': 5,
+};
+
+function syncTestFiles() {
+  return execFileSync('git', ['ls-files', 'testing/sync', 'testing/integration'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n').filter(f => f.endsWith('.test.js'));
+}
+
+/** Count `triggerSync` immediately followed by a `waitFor` that has no diagnose argument. */
+function bareWaits(src) {
+  const re = /await triggerSync\([^)]*\);(?:[^\n]*\n){0,6}?[^\n]*await waitFor\(/g;
+  let n = 0, m;
+  while ((m = re.exec(src)) !== null) {
+    const seg = src.slice(m.index + m[0].length, m.index + m[0].length + 800);
+    const args = /\}\s*(,[^;]*)?\);/.exec(seg)?.[1] ?? '';
+    if (!/diagnose/.test(args)) n++;
+  }
+  return n;
+}
+
+describe('a sync wait re-triggers and explains its own timeout', () => {
+  it('helpers.js provides the pattern as one function', () => {
+    const src = readFileSync(join(ROOT, 'testing/sync/helpers.js'), 'utf8');
+    assert.match(src, /export async function syncUntil\(/,
+      'the trigger + re-trigger + diagnose pattern must be one helper, not a comment telling people to hand-roll it');
+    // All three defects, so a future "simplification" cannot quietly drop one.
+    assert.match(src, /makeTriggerProbe\(/, 'syncUntil must use the probe, or a rejected trigger is invisible again');
+    assert.match(src, /setInterval\(/, 'syncUntil must re-trigger while polling, or one fire races the gossip cycle');
+    assert.match(src, /waiting for \$\{what\}/, 'the timeout message must name what was awaited');
+    assert.match(src, /clearInterval\(/, 'the re-trigger interval must be cleared, or the test process never exits');
+  });
+
+  it('the test that actually flaked uses it', () => {
+    const src = readFileSync(join(ROOT, 'testing/sync/pubsub-topology.test.js'), 'utf8');
+    assert.match(src, /syncUntil\(/, 'the observed failure must be fixed with the shared helper, not a local copy');
+    assert.equal(bareWaits(src), 0, 'pubsub-topology still holds a bare trigger-then-wait');
+  });
+
+  it('no NEW bare trigger-then-wait appears', () => {
+    const files = syncTestFiles();
+    // An empty enumeration would make the check below pass while examining nothing — the exact failure
+    // `gates-cannot-pass-vacuously` exists to forbid. `git ls-files` returning nothing is a real possibility
+    // (wrong cwd, a submodule checkout), and it would look like a clean tree.
+    assert.ok(files.length >= 20, `only enumerated ${files.length} sync/integration test files`);
+    const grown = [];
+    for (const f of files) {
+      const n = bareWaits(readFileSync(join(ROOT, f), 'utf8'));
+      const allowed = KNOWN_BARE[f.replaceAll('\\', '/')] ?? 0;
+      if (n > allowed) grown.push(`${f}: ${n} bare waits, ${allowed} allowed`);
+    }
+    assert.deepEqual(grown, [],
+      'a new `await triggerSync(...)` + bare `waitFor` — use syncUntil, which re-triggers and says what it '
+      + 'was waiting for when it gives up');
+  });
+
+  it('reports the sites still uncovered, so the class cannot read as closed', () => {
+    // Not an assertion about quality — a statement of scope. If this total ever reaches 0, delete KNOWN_BARE
+    // and make the previous test an absolute check.
+    const remaining = Object.values(KNOWN_BARE).reduce((a, b) => a + b, 0);
+    assert.ok(remaining > 0, 'KNOWN_BARE is empty — tighten the gate to an absolute zero and delete this test');
+    const actual = syncTestFiles()
+      .reduce((sum, f) => sum + bareWaits(readFileSync(join(ROOT, f), 'utf8')), 0);
+    assert.ok(actual <= remaining,
+      `${actual} bare waits in the tree against ${remaining} recorded — the ratchet is out of date`);
+    if (actual < remaining) {
+      console.log(`  note: ${remaining - actual} site(s) have been converted since this was frozen — lower KNOWN_BARE`);
+    }
+  });
+});

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -260,6 +260,38 @@ export function makeTriggerProbe(baseUrl, token, networkId, label = baseUrl) {
   return probe;
 }
 
+/**
+ * Trigger a sync and poll `condition` until it holds, RE-triggering while waiting.
+ *
+ * ## The three-part failure this replaces
+ *
+ * 23 call sites across ten sync/integration files were `await triggerSync(...)` followed by a bare `waitFor`.
+ * Each one has three defects that only show up together, on a slow runner:
+ *
+ *   1. **One trigger races the gossip cycle.** If that single async fire is queued behind other work, nothing
+ *      arrives and the poll expires having waited for something nobody asked for a second time.
+ *   2. **A bare timeout cannot tell a stall from a rejection.** `waitFor timed out after 15000ms` reports a
+ *      persistently-429'd trigger, a misconfigured network id and a merely-slow peer identically. That exact
+ *      message is how the notify rate-limit bug hid for weeks.
+ *   3. **It does not say what it was waiting for.** A test with two identical waits names neither.
+ *
+ * `closed-network.test.js` had already worked this out and hand-rolled it at ONE of its four sites; the other
+ * three, and every other file, kept the bare form. Which is the argument for a helper rather than a comment.
+ *
+ * @param what Human phrase completing "waiting for …". Appears in the timeout message; not optional, because
+ *   the whole point is that the failure explains itself.
+ */
+export async function syncUntil(baseUrl, token, networkId, condition, what, { timeoutMs = 25_000, interval = 500, retriggerMs = 3_000, label } = {}) {
+  await triggerSync(baseUrl, token, networkId);
+  const probe = makeTriggerProbe(baseUrl, token, networkId, label ?? baseUrl);
+  const retrigger = setInterval(() => { void probe(); }, retriggerMs);
+  try {
+    return await waitFor(condition, timeoutMs, interval, () => `waiting for ${what} — ${probe.diagnose()}`);
+  } finally {
+    clearInterval(retrigger);
+  }
+}
+
 /** Create a memory on an instance's general space */
 export async function createMemory(baseUrl, token, fact, tags = []) {
   return post(baseUrl, token, '/api/brain/spaces/general/memories', { fact, tags });

--- a/testing/sync/pubsub-topology.test.js
+++ b/testing/sync/pubsub-topology.test.js
@@ -15,7 +15,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dockerExec,
-  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, waitFor,
+  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, syncUntil,
 } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -32,6 +32,12 @@ let tokenA, tokenB;
 let networkId;
 let testSpaceId;
 let instanceIdA;
+
+/** Wait for a memory to reach (or leave) B, re-triggering A's sync while waiting. See `syncUntil`. */
+const awaitOnB = (memId, expectStatus, what) =>
+  syncUntil(INSTANCES.a, tokenA, networkId,
+    async () => (await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`)).status === expectStatus,
+    `${what} (expected ${expectStatus} for ${memId} on B)`, { label: 'A' });
 
 describe('Pub/Sub topology (A -> B subscriber)', () => {
   before(async () => {
@@ -119,11 +125,7 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     const memId = write.body._id ?? write.body.id;
 
     // A pushes to B
-    await triggerSync(INSTANCES.a, tokenA, networkId);
-    await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
-      return r.status === 200;
-    });
+    await awaitOnB(memId, 200, 'the published fact to appear on B');
     console.log(`  Published fact appeared on B ✓`);
   });
 
@@ -166,25 +168,20 @@ describe('Pub/Sub topology (A -> B subscriber)', () => {
     assert.equal(pubWrite.status, 201);
     const pubMemId = pubWrite.body._id ?? pubWrite.body.id;
 
-    // Push publisher memory to B first
-    await triggerSync(INSTANCES.a, tokenA, networkId);
-    await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${pubMemId}`);
-      return r.status === 200;
-    });
+    // Push publisher memory to B, then push the tombstone — both RE-TRIGGERED while waiting.
+    //
+    // This test failed CI as `waitFor timed out after 15000ms`, with no indication of which of the two waits
+    // gave up or why. Both were a single up-front `triggerSync` followed by a bare 15 s poll, which is the
+    // shape `makeTriggerProbe` exists to replace: a lone trigger races the gossip cycle, and a bare timeout
+    // reports a persistent, actionable failure (a 429, a misconfigured network) identically to a slow one.
+    // `closed-network.test.js` already does it this way — see the comment there.
+    await awaitOnB(pubMemId, 200, 'the publisher memory to arrive on B');
 
     // Now delete on A
     const delR = await del(INSTANCES.a, tokenA, `/api/brain/spaces/${testSpaceId}/memories/${pubMemId}`);
     assert.equal(delR.status, 204, `Delete on A: expected 204, got ${delR.status}`);
 
-    // Push tombstone to B
-    await triggerSync(INSTANCES.a, tokenA, networkId);
-
-    // Wait for tombstone to propagate
-    await waitFor(async () => {
-      const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${pubMemId}`);
-      return r.status === 404;
-    });
+    await awaitOnB(pubMemId, 404, "the publisher's tombstone to reach B");
     console.log(`  Publisher's deleted fact removed from B ✓`);
 
     // Verify subscriber's own memory still exists


### PR DESCRIPTION
fix(test): a sync wait now re-triggers, and its timeout says what it was waiting for

`Subscriber-local content survives publisher tombstone` failed CI as:

    error: 'waitFor timed out after 15000ms'

on a branch whose diff could not touch it. That sentence names neither of the test's two identical
waits, and describes a slow peer, a rejected trigger and a wrong network id in exactly the same words.
A re-run cleared it — the correct immediate action and the wrong permanent one.

`await triggerSync(...)` followed by a bare `waitFor`:

  1. **One trigger races the gossip cycle.** The fire is async; queued behind other work, nothing
     arrives and the poll expires having never asked again.
  2. **A bare timeout cannot tell a stall from a rejection.** This is how the notify rate-limit bug hid
     for weeks: every trigger was being refused with 429 and all anyone ever saw was a timeout.
  3. **It does not record what was awaited.**

`syncUntil` does all three. `closed-network.test.js` had already worked the pattern out by hand at ONE
of its four sites and left the other three bare — which is the argument for a helper over a comment.

22 sites still have the bare shape and **none has ever been observed failing**. Converting them
mechanically means inventing 22 "waiting for …" phrases that no script can write and no measurement
justifies, and the phrase is the entire value. So the gate freezes the count per file, fails on a new
one, and names the remaining sites — a gate reporting only the fixed case would read as though the
class were closed.

A negative assertion (wait a fixed time, prove it did NOT arrive) is deliberately not this shape and
must not be converted; the exemption is commented at the one site that has it.

  - **My new gate had no floor on its enumeration**, so `git ls-files` returning nothing would have
    read as a clean tree. Caught by `gates-cannot-pass-vacuously`, which is exactly its job.
  - **The gate #710 merged an hour ago had the same hole** and passed that meta-gate by ACCIDENT: its
    `HAS_FLOOR` list accepts any bare numeric comparison, and it took `assert.ok(ms >= 240_000)` — a
    bound on a timeout constant — as a floor on a file walk. Floored properly now.
  - The meta-gate's blind spot itself is documented at the regex and filed in the tracker. Not bodged:
    the correct rule is "a floor over the same enumeration, in the same block", which needs per-`it()`
    analysis, and its only other user's floor is genuine. A tightening that flags a real floor is how
    an allowlist gets started.

Full sync suite against the live four-instance stack: **192 tests, 191 passed, 1 skipped, 0 failed**
(129 s). Not inspection — the converted test was run before and after. `npm run preflight` clean.

No product behaviour changes; test infrastructure only.

