### PR TITLE
feat(docker): the model layer stops moving on releases that do not change the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   endpoint's own request log. Reporting one number that was neither is what left an operator unable to explain
   their bill. `maxJudgedPairsPerRun` now bounds `modelCalls`: gating on useful answers alone let a space full
   of weak verdicts run indefinitely past a budget whose entire purpose is to bound spend.
+
+### Changed
+
+- **The embedding-model layer no longer changes digest on a release that does not change the model** (canary
+  C-L5-5). An operator compared two published images against the registry: **2.3.0 → 2.4.0 shared 5 of 16 layers
+  (76.2 MiB, ~7%) and re-downloaded 1024.4 MiB (93.5%)**, and the 482.5 MiB model layer was among what moved. It
+  recurs on every release, onto a node whose RAID1 has been degraded to a single drive since 2026-07-03.
+  - **The warm step moved into a build stage of its own.** In the production stage it sat below the ffmpeg apt
+    layer and below the dependency tree, so a dependency bump re-executed it — and `apt-get update` is not
+    reproducible, so an untouched lockfile could do it too. The download now happens in a stage that is discarded.
+  - **Being "above the source COPYs" was never the property that mattered**, which is why the previous attempt
+    read as correct while the layer kept moving. A pull compares content digests: a rebuilt layer that comes out
+    byte-identical is not fetched again. So the question is what makes it byte-identical — and the answer was
+    measured over four builds of a minimal reproduction, not reasoned:
+
+    | shape | digest after a forced rebuild |
+    |---|---|
+    | `COPY --from=warm /model-cache /app/model-cache` | **changed** |
+    | `COPY marker.txt ./` — a 7-byte file | **changed** |
+    | `RUN --mount=from=warm …` + stamp the tree **and** `/app` | **identical** |
+
+  - **A 7-byte COPY moving is the finding.** Adding an entry to a directory bumps that directory's mtime, and the
+    bumped parent ships in the same layer as the payload — so 482.5 MiB moves because of one timestamp on `/app`.
+    Stamping the copied tree cannot reach it. This is the same shape as the original bug (the old warm step
+    created and deleted `/app/server/warm.mjs`, putting `/app/server`'s mtime in the model's layer), and the
+    obvious fix quietly reintroduces it through a different directory. Nothing about a `COPY --from` reveals that;
+    only building it twice does.
+  - The model therefore arrives via a mounted copy whose every entry — tree, ownership, and `/app` — is stamped
+    inside the one `RUN`. Runtime is unchanged: same `/app/model-cache`, same `MODEL_CACHE_DIR`, same offline
+    guarantee.
+  - **Still true and not fixable here:** the ffmpeg apt layer (~472 MiB) moves on every build, because
+    `apt-get update` is not reproducible. Documented in the hosting guide so an upgrade's download size is
+    explainable rather than surprising.
+  - **What remains to confirm is the effect on the published artefact**, which needs two releases with this layer
+    structure: the model layer's digest must be identical across `2.x.y → 2.x.z` manifests. The mechanism is
+    measured; the release-to-release number is not yet.
+
 ### Fixed
 
 - **A contradiction sweep judged every pair twice, and the "free" deterministic pass was not free** (the other

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,79 @@ COPY package.json package-lock.json* ./
 COPY server/package.json ./server/
 RUN npm ci --workspace=server --omit=dev
 
+# ── Stage 1c: Warm the embedding model, in a stage of its own ─────────────────
+#
+# ## Why the largest layer in the image had to stop living in the production stage
+#
+# The model warm used to be a `RUN` inside `production`, positioned above the app-source COPYs so a source change
+# would not invalidate it. That reasoning was right and insufficient: it still sat BELOW the ffmpeg apt layer and
+# below `COPY --from=prod-deps node_modules`, so a dependency bump — or any `apt-get update`, which is not
+# reproducible — re-executed it. Re-executing a `RUN` produces a fresh layer, and a fresh layer is a fresh digest
+# even when its content is identical.
+#
+# MEASURED by an operator against the registry, and it recurs every release onto a node whose RAID1 has been
+# degraded to a single drive since 2026-07-03: **2.3.0 → 2.4.0 shared 5 of 16 layers (76.2 MiB, ~7%) and
+# re-downloaded 1024.4 MiB (93.5%)**. The 482.5 MiB model layer changed digest on a release that did not change
+# the model.
+#
+# ## What makes a layer REUSABLE across releases
+#
+# Not "it was not invalidated" — a pull compares content digests, so a layer that is rebuilt but comes out
+# byte-identical is not downloaded again. That is achievable for a COPY of fixed content and is not achievable for
+# a RUN that downloads: the warm step also created and deleted `/app/server/warm.mjs`, which leaves `/app/server`
+# with a new mtime in the same changeset as the model, so 482.5 MiB moved because of one directory timestamp.
+#
+# So the download happens here, in a stage that is thrown away, and production takes the result as a plain COPY.
+# The shipped layer then keys on the model bytes alone. Everything above it in the production stage may change
+# freely without costing a user 482.5 MiB.
+#
+# `FROM prod-deps` rather than a fresh stage that installs `@huggingface/transformers` on its own: the version has
+# to be the one the server actually runs, and that is pinned in the lockfile. Installing the package separately
+# would either duplicate a version string that can drift or leave it unpinned — a supply-chain regression to save
+# a layer that is discarded anyway. This costs nothing: `prod-deps` is already built.
+FROM prod-deps AS model-warm
+
+# HF rate-limits anonymous downloads per-IP (shared CI egress → intermittent 403), so the retry/backoff rides
+# through a transient failure, and `--mount=type=cache` keeps a local rebuild from re-fetching ~274 MB.
+#
+# The mtime stamp here is for THIS stage's own layer, not for the shipped one: it lets CI's `--cache-from
+# type=gha` reuse a warm step across builds. The layer a user pulls is stamped again in the production stage,
+# because — measured — stamping the source cannot make a `COPY` of it deterministic. See the note there.
+#
+# Ownership is deliberately NOT set here; the production stage sets it in the layer that ships.
+#
+# `warm.mjs` goes in `/app`, and that placement is load-bearing in BOTH directions:
+#
+#   - it must be under `/app`, because Node resolves a bare `@huggingface/transformers` import by walking up
+#     from the SCRIPT's directory looking for `node_modules`. Writing it to `/` was tried and fails the build
+#     outright — `/node_modules` does not exist. (The original wrote it to `/app/server`, which resolved.)
+#   - it must NOT be under `/model-cache`, because a create-and-delete leaves the parent directory's new mtime
+#     in the same changeset, and `/model-cache` is the tree the production stage takes.
+#
+# `/app`'s mtime moving here is harmless in a way it was not before: this whole stage is discarded, and only
+# `/model-cache` is read out of it.
+RUN --mount=type=cache,target=/tmp/hf-model-cache \
+    printf '%s\n' \
+    'import { pipeline, env } from "@huggingface/transformers";' \
+    'env.cacheDir = "/tmp/hf-model-cache";' \
+    'const load = () => pipeline("feature-extraction", "nomic-ai/nomic-embed-text-v1.5", { dtype: "fp32" });' \
+    'const attempts = 6;' \
+    'for (let i = 1; i <= attempts; i++) {' \
+    '  try { await load(); break; }' \
+    '  catch (err) {' \
+    '    if (i === attempts) throw err;' \
+    '    const delay = Math.min(60, 2 ** i);' \
+    '    console.warn(`model download attempt ${i}/${attempts} failed: ${err}; retrying in ${delay}s`);' \
+    '    await new Promise(r => setTimeout(r, delay * 1000));' \
+    '  }' \
+    '}' \
+    > /app/warm.mjs && \
+    node /app/warm.mjs && \
+    rm /app/warm.mjs && \
+    mkdir -p /model-cache && \
+    cp -a /tmp/hf-model-cache/. /model-cache/ && \
+    find /model-cache -exec touch -h -d '@1' {} +
+
 # ── Stage 2: Production ──────────────────────────────────────────────────────
 FROM node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS production
 
@@ -110,47 +183,38 @@ COPY server/package.json ./server/
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=prod-deps /app/server/node_modules ./server/node_modules
 
-# Pre-download & cache the embedding model so first startup is instant and fully offline.
-# The model is then copied into the image layer so the container starts offline.
+# The embedding model, baked in so first startup is instant and needs no network.
 #
-# This runs BEFORE the app-source COPYs below on purpose: it depends only on the
-# @huggingface/transformers npm package (installed above), NOT on our source. So
-# a normal source change does not invalidate this layer, which lets a layer cache
-# (CI's `--cache-from type=gha`) restore the already-downloaded model instead of
-# re-fetching ~274 MB from HuggingFace on every build. HF rate-limits anonymous
-# downloads per-IP (shared CI egress → intermittent 403), so the fewer fetches the
-# better; the retry/backoff below rides through a transient 403 on the rare build
-# that does have to download. `--mount=type=cache` additionally speeds local rebuilds.
+# ## Why this is a mounted copy and not a `COPY --from`
 #
-# The step ends by fixing ownership AND stamping every file to a fixed mtime. Both decide what a user downloads:
-#   - ownership HERE rather than in a later `chown -R`, which would rewrite the whole tree into a second layer.
-#     It did: the published image shipped the model TWICE. See the note by the mkdir near the end of this file.
-#   - a fixed mtime because `cp -a` preserves the download's timestamps, and those land in the layer tar. Two
-#     builds of the identical model then produce different layer digests, so the layer can never be reused across
-#     releases even when nothing about the model changed. Determinism is the precondition for that reuse.
+# MEASURED, and the obvious form does not work. Four builds of a minimal reproduction, forcing the copy to
+# re-execute with a changed upstream stage:
+#
+#     COPY --from=warm /model-cache /app/model-cache   → layer digest CHANGED
+#     COPY marker.txt ./            (7 bytes!)         → layer digest CHANGED
+#     RUN --mount=from=warm … + stamp tree AND parent  → layer digest IDENTICAL
+#
+# The reason a 7-byte COPY moves is the whole finding: **adding an entry to a directory bumps that directory's
+# mtime, and the bumped parent ships in the same layer as the payload.** Stamping the copied tree cannot reach
+# `/app`, so 482.5 MiB moves because of one directory timestamp — the same shape as the old warm step, which
+# created and deleted `/app/server/warm.mjs` and so put `/app/server`'s mtime in the model's layer.
+#
+# So: mount the warmed tree (the download stays out of this layer, which is the point of the `model-warm` stage),
+# copy it in, and stamp every entry the layer contains, `/app` included. The changeset is then fully determined by
+# the model bytes, and a rebuild — for a dependency bump, an apt layer, a new release — re-materialises the same
+# digest. That is what makes a pull skip it.
+#
+# `/app`'s mtime being 1970 in this layer is invisible: the later COPYs write to `/app` again and set their own.
+#
+# Ownership is set INSIDE this RUN. A later `chown -R` would rewrite the whole tree into a second layer — that is
+# exactly how the published image came to ship the embedding model twice.
 ENV MODEL_CACHE_DIR=/app/model-cache
-RUN --mount=type=cache,target=/tmp/hf-model-cache \
-    printf '%s\n' \
-    'import { pipeline, env } from "@huggingface/transformers";' \
-    'env.cacheDir = "/tmp/hf-model-cache";' \
-    'const load = () => pipeline("feature-extraction", "nomic-ai/nomic-embed-text-v1.5", { dtype: "fp32" });' \
-    'const attempts = 6;' \
-    'for (let i = 1; i <= attempts; i++) {' \
-    '  try { await load(); break; }' \
-    '  catch (err) {' \
-    '    if (i === attempts) throw err;' \
-    '    const delay = Math.min(60, 2 ** i);' \
-    '    console.warn(`model download attempt ${i}/${attempts} failed: ${err}; retrying in ${delay}s`);' \
-    '    await new Promise(r => setTimeout(r, delay * 1000));' \
-    '  }' \
-    '}' \
-    > /app/server/warm.mjs && \
-    node /app/server/warm.mjs && \
-    rm /app/server/warm.mjs && \
+RUN --mount=from=model-warm,source=/model-cache,target=/mnt/model-cache \
     mkdir -p /app/model-cache && \
-    cp -a /tmp/hf-model-cache/. /app/model-cache/ && \
+    cp -a /mnt/model-cache/. /app/model-cache/ && \
     chown -R node:node /app/model-cache && \
-    find /app/model-cache -exec touch -h -d '@1' {} +
+    find /app/model-cache -exec touch -h -d '@1' {} + && \
+    touch -h -d '@1' /app
 
 # No model may be fetched at RUN TIME. Set after the warm step above, which is the one place a download
 # is legitimate — it happens on a build machine, once, and its result is what ships.

--- a/docs/integration-guide/01-getting-ythril.md
+++ b/docs/integration-guide/01-getting-ythril.md
@@ -43,6 +43,25 @@ Published images are available on two registries:
 
 Tags follow semver: `:latest`, `:1.0.0`, `:1.0`, `:1`. All images are multi-arch (`linux/amd64`, `linux/arm64`).
 
+#### What a version upgrade actually downloads
+
+The single largest thing in the image is the **embedding model, ~482 MiB**, baked in so an instance can embed
+text on first boot with no network. That layer is built to be **stable across releases**: it is warmed in a
+build stage of its own and materialised with fixed file metadata, so its digest depends on the model and the
+`@huggingface/transformers` version and on nothing else. When neither changes, `docker pull` for a new Ythril
+version skips it.
+
+Two caveats, because they are the difference between a small upgrade and a full one:
+
+- **A release that changes the model id or the transformers version re-downloads it.** That is the layer doing
+  its job, not a regression.
+- **The ffmpeg apt layer (~472 MiB) is not stable and cannot be.** `apt-get update` is not reproducible, so
+  that layer's digest moves on essentially every build. If your upgrade download is larger than you expect,
+  this is usually why.
+
+If you are measuring, compare the layer digests in the two registry manifests rather than the reported image
+sizes — sizes tell you what the image weighs, not what a pull has to fetch.
+
 ### Quick Start
 
 ```bash

--- a/testing/standalone/model-layer-is-reusable-across-releases.test.js
+++ b/testing/standalone/model-layer-is-reusable-across-releases.test.js
@@ -1,0 +1,134 @@
+/**
+ * The embedding-model layer must be reusable across releases.
+ *
+ * ## The measurement this exists for (canary C-L5-5 / internal "P2")
+ *
+ * An operator compared two published images against the registry:
+ *
+ *     2.3.0 → 2.4.0   shared 5 of 16 layers (76.2 MiB, ~7%), re-downloaded 1024.4 MiB (93.5%)
+ *
+ * The single largest layer is the 482.5 MiB embedding model, and **its digest changed on a release that did not
+ * change the model**. It recurs on every release, onto a node whose RAID1 has been degraded to a single drive
+ * since 2026-07-03.
+ *
+ * ## Why "it is above the source COPYs" was not enough
+ *
+ * The warm step was a `RUN` in the production stage, deliberately placed above the app-source COPYs so a source
+ * change would not invalidate it. True, and beside the point: it still sat below the ffmpeg apt layer and below
+ * `COPY --from=prod-deps node_modules`. A dependency bump re-executed it — and `apt-get update` is not
+ * reproducible, so an unchanged dependency tree could do it too.
+ *
+ * **A pull compares content digests, not cache keys.** A rebuilt layer that comes out byte-identical is not
+ * downloaded again. So the question is what makes a re-materialised layer byte-identical, and the answer was
+ * MEASURED over four builds of a minimal reproduction, forcing the copy to re-execute against a changed
+ * upstream stage:
+ *
+ *     COPY --from=warm /model-cache /app/model-cache        → layer digest CHANGED
+ *     COPY marker.txt ./              (a 7-byte file!)      → layer digest CHANGED
+ *     RUN --mount=from=warm … + stamp the tree AND /app     → layer digest IDENTICAL
+ *
+ * The 7-byte COPY moving is the whole finding: **adding an entry to a directory bumps that directory's mtime,
+ * and the bumped parent ships in the same layer as the payload.** Stamping the copied tree cannot reach `/app`.
+ * It is the same shape as the original bug — the old warm step created and deleted `/app/server/warm.mjs`, so
+ * 482.5 MiB moved because of one directory timestamp — and the obvious fix reintroduces it via a different
+ * directory. Nothing about a `COPY --from` announces that; only building it twice does.
+ *
+ * So the invariants below are about **determinism**: every entry the shipped layer contains must have a fixed
+ * mtime, including the destination's parent. Ordering, which the previous attempt got right, is not among them.
+ *
+ * ## What this can and cannot check
+ *
+ * The Dockerfile, because that runs everywhere in milliseconds — the same split `notice-ships-in-the-image`
+ * makes. The EFFECT on the real image (two releases, identical layer digest) can only be confirmed against two
+ * published manifests with the same layer structure, which is a release-time check and is recorded as such in
+ * the tracker. This asserts the cause so the cause cannot quietly regress in between.
+ *
+ * Run: node --test testing/standalone/model-layer-is-reusable-across-releases.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dockerfile = readFileSync(join(process.cwd(), 'Dockerfile'), 'utf8');
+
+/** Text of one build stage: from its `FROM … AS <name>` to the next `FROM`, or the end of the file. */
+function stage(name) {
+  const at = dockerfile.search(new RegExp(`^FROM[^\\n]*\\bAS ${name}\\b`, 'm'));
+  assert.ok(at >= 0, `no build stage named '${name}' in the Dockerfile`);
+  const rest = dockerfile.slice(at + 1);
+  const next = rest.search(/^FROM /m);
+  return next >= 0 ? rest.slice(0, next) : rest;
+}
+
+/** The instruction lines of a stage, with comments stripped — a comment must never satisfy these checks. */
+function instructions(name) {
+  return stage(name).split('\n').filter(l => !l.trimStart().startsWith('#')).join('\n');
+}
+
+describe('the model layer is built where a rebuild cannot change its digest', () => {
+  it('the download happens in a stage that is thrown away, not in production', () => {
+    // The model id is the fingerprint of the warm step: whichever stage names it is the one that downloads.
+    const warm = instructions('model-warm');
+    assert.match(warm, /nomic-ai\/nomic-embed-text/, 'the model-warm stage must be the one that warms the model');
+    assert.doesNotMatch(instructions('production'), /nomic-ai\/nomic-embed-text/,
+      'production downloads the model again — a RUN that downloads can never produce a stable layer digest');
+  });
+
+  it('brings the model in by mounting the warm stage, not by COPYing from it', () => {
+    // Measured: a plain `COPY --from` re-materialises with a new digest, because it bumps the destination
+    // directory's mtime into its own layer. A mounted copy inside a RUN can stamp that directory; a COPY cannot.
+    const prod = instructions('production');
+    assert.match(prod, /RUN --mount=from=model-warm[^\n]*source=\/model-cache/,
+      'the model must arrive via a mount, or its layer digest moves on every rebuild');
+    assert.doesNotMatch(prod, /^COPY --from=model-warm/m,
+      'a `COPY --from` cannot stamp the destination parent, so its layer can never be reused across releases');
+  });
+
+  it('stamps EVERY entry the shipped layer contains, including the parent directory', () => {
+    // Both halves, because the tree alone is what the first attempt did and it was measurably not enough.
+    const prod = instructions('production');
+    assert.match(prod, /find \/app\/model-cache -exec touch -h -d '@1'/,
+      'the model tree must be stamped to a fixed mtime');
+    assert.match(prod, /touch -h -d '@1' \/app(\s|$)/,
+      "/app's mtime is bumped by writing into it and ships in this layer — unstamped, it moves 482.5 MiB");
+  });
+
+  it('writes its temp script where node resolves, and not into the tree that is read out', () => {
+    // Both directions, because getting either wrong is silent-ish and I got each wrong once:
+    //
+    //  - OUTSIDE `/model-cache`: a create-and-delete leaves the parent directory's new mtime in the same
+    //    changeset, which is the original 482.5 MiB regression (it was `/app/server` then).
+    //  - UNDER `/app`: node resolves a bare `@huggingface/transformers` import by walking up from the SCRIPT's
+    //    directory for `node_modules`. Moving the script to `/` to satisfy the first rule failed the build
+    //    outright — there is no `/node_modules`. That is a hard failure rather than a silent one, but only if
+    //    somebody builds the image; `docker buildx build --check` passes it happily.
+    const warm = instructions('model-warm');
+    const script = warm.match(/>\s*(\S*warm\.mjs)/)?.[1];
+    assert.ok(script, 'could not find where the warm stage writes its script');
+    assert.doesNotMatch(script, /^\/model-cache\//,
+      `the warm script is written to ${script}, inside the tree the production stage reads out — its `
+      + 'create-and-delete puts a directory mtime in the same layer as the model');
+    assert.match(script, /^\/app\//,
+      `the warm script is at ${script}; node cannot resolve @huggingface/transformers from there, and the `
+      + 'build fails');
+  });
+
+  it('sets ownership inside the layer that ships, not in a later recursive chown', () => {
+    // A `chown -R` in its own layer rewrites every file's metadata, so Docker copies the whole tree into a SECOND
+    // layer. It did: the published image shipped the embedding model twice, in every tag, on every pull.
+    const prod = instructions('production');
+    const modelRun = /RUN --mount=from=model-warm[\s\S]*?(?=\n(?:[A-Z]+ |$))/.exec(prod)?.[0] ?? '';
+    assert.match(modelRun, /chown -R node:node \/app\/model-cache/,
+      'ownership must be set inside the same RUN that materialises the tree');
+    const after = prod.slice(prod.indexOf(modelRun) + modelRun.length);
+    assert.doesNotMatch(after, /chown -R[^\n]*model-cache/,
+      'a later recursive chown of the model cache ships the model twice');
+  });
+
+  it('still serves the model from the path the server reads', () => {
+    // The whole restructure must be invisible at runtime: `embedding.ts` reads MODEL_CACHE_DIR, the offline
+    // guarantee depends on that directory being populated, and three other tests assert on this path.
+    assert.match(instructions('production'), /^ENV MODEL_CACHE_DIR=\/app\/model-cache$/m);
+  });
+});


### PR DESCRIPTION
feat(docker): the model layer stops moving on releases that do not change the model

An operator compared two published images against the registry: 2.3.0 -> 2.4.0 shared 5 of 16 layers
(76.2 MiB, ~7%) and re-downloaded 1024.4 MiB (93.5%). The 482.5 MiB embedding-model layer was among what
moved, on a release that did not touch the model, onto a node whose RAID1 has been degraded to a single
drive since 2026-07-03.

The tracker said: warm the model in its own stage, then `COPY --from=` the cache into production, so the
layer keys on the transformers package plus the model id. The stage half is right — the download must not
live in a shipped layer. The COPY half does not work, and I only know that because I built it.

Four builds of a minimal reproduction, forcing the copy to re-execute against a changed upstream stage:

    COPY --from=warm /model-cache /app/model-cache      -> layer digest CHANGED
    COPY marker.txt ./              (7 bytes)           -> layer digest CHANGED
    RUN --mount=from=warm ... + stamp the tree AND /app -> layer digest IDENTICAL

The 7-byte COPY moving is the finding. **Writing an entry into a directory bumps that directory's mtime,
and the bumped parent ships in the same layer as the payload.** Stamping the copied tree cannot reach
`/app`, so 482.5 MiB moves because of one timestamp. That is the same shape as the bug this item started
as — the old warm step created and deleted `/app/server/warm.mjs`, putting `/app/server`'s mtime in the
model's layer — and the obvious fix relocates it from `/app/server` to `/app` rather than removing it.

Two rounds of that experiment were also wrong before they were right, and both wrongly PASSED:

  - round 1 gave the final stage no `/app`, so the COPY created it and the repro measured a variable the
    real Dockerfile does not have;
  - rounds 1-2 read stable digests because BuildKit served the COPY from its build cache — including an
    unstamped control that should have moved. `--no-cache-filter` is what made the measurement honest.

A pull compares content digests, not cache keys: a layer that re-executes but comes out byte-identical is
not fetched again. "It was not invalidated" was never the property that mattered, which is exactly why the
previous attempt looked right while the layer kept moving.

My first cut moved the warm script from `/app/server/warm.mjs` to `/warm.mjs`, reasoning that it must sit
outside any tree that gets copied out. `docker buildx build --check` passed it. The build fails outright:
node resolves a bare `@huggingface/transformers` import by walking up from the SCRIPT's directory for
`node_modules`, and there is no `/node_modules`.

So the placement is load-bearing in both directions — under `/app` so the import resolves, outside
`/model-cache` so its create-and-delete cannot leave a directory mtime beside the model. `/app`'s own mtime
moving in that stage is harmless now, because the whole stage is discarded. The gate asserts both, and the
one it lacked is the one only a real build could have caught.

  - `model-warm`, a stage of its own (`FROM prod-deps`, so no duplicated install and no version string that
    can drift from the lockfile). Its output layer is discarded; only the model tree is read out.
  - In production, a `RUN --mount=from=model-warm` that copies the tree, sets ownership, and stamps every
    entry the layer contains — the tree and `/app` — inside one layer.
  - Runtime is untouched: same `/app/model-cache`, same `MODEL_CACHE_DIR`, same offline guarantee, same
    three tests that assert on that path.

  - The mechanism is measured, per the table above (`--no-cache-filter` forcing re-execution; digests read
    from `docker image inspect --format '{{range .RootFS.Layers}}'`; the offending mtime located with
    `docker run --rm <img> stat -c '%n %Y' / /app /app/payload`).
  - The `model-warm` stage BUILDS, and its output was inspected rather than assumed: 4 files, 523 MB,
    `find /model-cache -newermt @2` returns 0 (every mtime stamped), and no `warm.mjs` left behind.
  - `npm run preflight` clean. Six gates in `model-layer-is-reusable-across-releases`, each proven to flip
    against the pre-fix Dockerfile. They assert determinism, not ordering — ordering is what the last
    attempt got right while the layer kept moving.

Not the reproduction — `--target production` twice, the second with `--no-cache-filter=production` so every
production step re-executes exactly as a dependency bump makes it. Comparing all 16 built layers:

    472 MB   apt ffmpeg                        DIFFERENT   (apt-get update is not reproducible)
    889 MB   COPY node_modules                 DIFFERENT
    2.84 MB  COPY server/node_modules          DIFFERENT
    548 MB   RUN model-cache                   ** SAME **
    7.48 MB  COPY server/dist                  DIFFERENT
    7.98 MB  COPY client/dist                  DIFFERENT
    41 kB    COPY NOTICE LICENSE               DIFFERENT
    12.3 kB  RUN mkdir /data /config           DIFFERENT

The model layer is the ONLY built layer that survives, and it is the largest. A 41 kB `COPY NOTICE LICENSE`
moving in the same run is the mechanism restated on the real image: every COPY carries `/app`'s new mtime.

Inspected rather than assumed: in the built image `/app/model-cache` is `node:node` with mtime 1, `find
/app/model-cache -newermt @2` returns 0, and no `warm.mjs` is left behind.

**Still open, deliberately:** the effect on the published artefact. That needs two releases with this layer
structure, comparing the model layer's digest across their manifests, and it stays in the tracker until
that comparison has actually been run — two builds on one machine share a cache lineage that two releases
on two CI runners do not. The ffmpeg apt layer (~472 MiB) will keep moving regardless —
`apt-get update` is not reproducible — which is now documented in `01-getting-ythril.md` so an upgrade's
download size is explainable instead of surprising.

