### PR TITLE
feat(brain): traverse reaches chrono entries, so a timeline is walkable from its entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`traverse` reaches chrono entries, so a timeline is walkable from the entity it is about** (a canary ask).
+  `chrono.entityIds` was the only thing linking a chrono to the graph, legible to `query()` and invisible to
+  `traverse` — the retrieval path an agent reaches for first. The reporter measured the cost: reconstructing a
+  **33-day hardware-RMA timeline took four `query()` calls plus two repository greps**, and the first pass
+  still missed the carrier ticket, which had to be found by a name regex rather than by traversal from the
+  incident. No schema change and no migration: the link already existed and had no reader here.
+  - **On by default, because the defect was discoverability.** A flag defaulting to off leaves the graph
+    looking the same to everyone who does not already know the answer. What it costs is a response that can
+    contain a node from another collection — so **a chrono node carries `kind: "chrono"` and an entity node
+    carries no `kind` at all**, leaving every response you were already parsing unchanged. `includeChrono:
+    false` restores the entity-only shape, on both REST and MCP.
+  - The synthetic edge is labelled **`chrono.entityIds`** and its `_id` is the chrono's own, so looking it up
+    resolves rather than 404ing on an invented edge. Being a real label, `edgeLabels` filters it like any
+    other: a filter that does not name it excludes chrono entries — a filter that cannot exclude something is
+    not a filter.
+  - A chrono is a leaf: traversal does not expand outward from one, because a chrono links to entities and
+    would only walk back to entities already visited.
+  - **The first version returned nothing for the commonest case in the report** — an entity whose only link is
+    a timeline. The BFS breaks out when a frontier yields no entity neighbours, and the chrono lookup sat after
+    that break. Nothing about the source read wrong and the source-level gate passed; only running it against a
+    server found it. That case is now the first assertion in the integration test.
+
 ### Added
 
 - **MCP can delete an entity, an edge and a chrono entry** (`delete_entity`, `delete_edge`, `delete_chrono` — a

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1209,6 +1209,7 @@ POST /api/brain/spaces/:spaceId/traverse
 | `edgeLabels` | — | all labels | Filter traversal to specific edge labels only |
 | `maxDepth` | — | `3` | Maximum hops from `startId`; hard-capped at `10` |
 | `limit` | — | `100` | Maximum total nodes returned |
+| `includeChrono` | — | `true` | Also reach chrono entries whose `entityIds` reference a traversed node. Set `false` for entity-only results. A non-boolean is a `400`, never coerced |
 
 **Response** `200`:
 
@@ -1216,20 +1217,43 @@ POST /api/brain/spaces/:spaceId/traverse
 {
   "nodes": [
     { "_id": "...", "name": "auth-service", "type": "service", "depth": 1 },
-    { "_id": "...", "name": "user-service",  "type": "service", "depth": 2 }
+    { "_id": "...", "name": "user-service",  "type": "service", "depth": 2 },
+    { "_id": "...", "name": "Unit collected by carrier", "type": "event", "depth": 1, "kind": "chrono" }
   ],
   "edges": [
-    { "_id": "...", "from": "...", "to": "...", "label": "depends_on" }
+    { "_id": "...", "from": "...", "to": "...", "label": "depends_on" },
+    { "_id": "...", "from": "...", "to": "...", "label": "chrono.entityIds" }
   ],
   "truncated": false
 }
 ```
 
-- `nodes` — entities discovered during traversal, excluding the start entity itself; each node includes a `depth` field indicating the hop count from `startId`
+- `nodes` — records discovered during traversal, excluding the start entity itself; each node includes a `depth` field indicating the hop count from `startId`
 - `edges` — only the edges actually traversed (not all edges of the returned nodes)
 - `truncated: true` if `limit` was reached before exhausting the graph
 
-Server-side cycle detection ensures each entity is visited at most once, so cyclic graphs are handled safely.
+Server-side cycle detection ensures each record is visited at most once, so cyclic graphs are handled safely.
+
+#### Chrono entries are nodes
+
+`chrono.entityIds` is the link between a timeline and the graph, and traversal follows it — a chrono entry
+that references a traversed node is returned as though joined by an **inbound** edge, which is what that
+field is. No schema change was needed; the link already existed and simply had no reader here.
+
+- **A chrono node carries `kind: "chrono"`. An entity node carries no `kind` at all**, so every response you
+  were already parsing is unchanged. Read `kind` before following an `_id`: the two live in different
+  collections, and `type` cannot tell you which (a chrono's is `event`/`deadline`/…, an entity's is whatever
+  the space calls it).
+- **The synthetic edge is labelled `chrono.entityIds`** and its `_id` is the chrono's own, so looking it up
+  resolves to the chrono rather than 404ing on an invented edge. Because it is a real label, `edgeLabels`
+  filters it like any other: an explicit filter that does not name it **excludes** chrono entries.
+- **A chrono is a leaf.** Traversal does not expand outward from one — a chrono links to entities, not to
+  other chrono entries, so expanding would only walk back to entities already visited.
+- Set `includeChrono: false` for the previous entity-only behaviour.
+
+This closes a gap an integrator measured: reconstructing a 33-day hardware-RMA timeline took four `query()`
+calls plus two repository greps, and the first pass still missed the carrier ticket — it had to be found by a
+name regex instead of by traversal from the incident.
 
 ---
 

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -136,7 +136,7 @@ Content-Type: application/json
 | `upsert_edge` | Create or update a directed relationship |
 | `update_edge` | Update an existing edge by ID (label, type, weight, description, tags, properties, `excludeFromVectorSearch`); supports `deleteFields` for field removal |
 | `delete_edge` | Delete an edge by ID |
-| `traverse` | BFS graph traversal — follow edges from a starting entity up to `maxDepth` hops |
+| `traverse` | BFS graph traversal — follow edges from a starting entity up to `maxDepth` hops. Chrono entries referencing a reached node come back too, marked `kind: "chrono"` (`includeChrono: false` for entity-only) |
 | `create_chrono` | Create a chrono entry (event, deadline, plan, prediction, milestone) |
 | `update_chrono` | Update an existing chrono entry, including `excludeFromVectorSearch`. Requires at least one field beyond `id` |
 | `delete_chrono` | Delete a chrono entry by ID |

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -130,8 +130,17 @@ searchRouter.post('/spaces/:spaceId/traverse', globalRateLimit, requireSpaceAuth
   const rawLimit = typeof limit === 'number' ? limit : 100;
   const effectiveLimit = Math.min(Math.max(1, rawLimit), 1000);
 
+  // Chrono entries are reachable by default; a client that assumed every node is an entity opts out.
+  // Rejected rather than coerced, so `includeChrono: "false"` cannot silently mean true.
+  const includeChronoRaw = (req.body as { includeChrono?: unknown }).includeChrono;
+  if (includeChronoRaw !== undefined && typeof includeChronoRaw !== 'boolean') {
+    res.status(400).json({ error: '`includeChrono` must be a boolean' });
+    return;
+  }
+
   const memberIds = resolveMemberSpaces(spaceId);
-  const result = await traverseGraph(memberIds, startId.trim(), effectiveDirection, effectiveEdgeLabels, effectiveDepth, effectiveLimit);
+  const result = await traverseGraph(memberIds, startId.trim(), effectiveDirection, effectiveEdgeLabels, effectiveDepth, effectiveLimit,
+    includeChronoRaw !== false);
   res.json(result);
 });
 

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -15,7 +15,7 @@ import { mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
 import { enqueueEmbedJob } from './embed-queue.js';
 import { getEntityById } from './entities.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
-import type { EdgeDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
+import type { EdgeDoc, EntityDoc, TombstoneDoc, ChronoEntry } from '../config/types.js';
 import { tagContains, textContains, propertiesValueContains, PROPERTIES_SCAN_MAX_MS } from './tag-filter.js';
 
 export interface TraverseNode {
@@ -23,6 +23,16 @@ export interface TraverseNode {
   name: string;
   type: string;
   depth: number;
+  /**
+   * WHICH collection this node lives in.
+   *
+   * Absent on an entity — every node was one until chrono entries became reachable, so absence keeps every
+   * existing response byte-identical. Present and `'chrono'` on a chrono entry, because the two are looked
+   * up in different collections and a caller that follows `_id` needs to know where to look. Guessing from
+   * `type` does not work: a chrono's `type` is `event`/`deadline`/…, and an entity's is whatever the space
+   * calls it.
+   */
+  kind?: 'chrono';
 }
 
 export interface TraverseEdge {
@@ -398,12 +408,42 @@ export async function bulkDeleteEdges(spaceId: string): Promise<number> {
 }
 
 /**
+ * The label the synthetic chrono link carries.
+ *
+ * A real value rather than an empty string so `edgeLabels` can include or exclude it like any other, and so a
+ * reader of a traverse result can tell a modelled relationship from a derived one.
+ */
+export const CHRONO_LINK_LABEL = 'chrono.entityIds';
+
+/**
  * BFS graph traversal from a starting entity.
+ *
+ * ── Chrono entries are nodes ──────────────────────────────────────────────────────────────────────────────
+ *
+ * `chrono.entityIds` is the only thing linking a chrono to the graph, and until now it was legible to
+ * `query()` and invisible to `traverse` — which is the retrieval path an agent reaches for first. An
+ * integrator measured the cost: reconstructing a 33-day hardware-RMA timeline took four `query()` calls plus
+ * two repo greps, and the first pass still missed the actual carrier ticket, which had to be found by a name
+ * regex instead of by traversal from the incident.
+ *
+ * So a chrono whose `entityIds` contains a frontier node is reached as though it were joined by an INBOUND
+ * edge — which is what that field is. No schema change and no migration: the link already exists, it simply
+ * had no reader here.
+ *
+ * **On by default, because the defect was discoverability.** A flag defaulting to off leaves the graph
+ * looking the same to everyone who does not already know the answer. What that costs is a response that can
+ * now contain a node from another collection, so every chrono node carries `kind: 'chrono'` and entity nodes
+ * are unchanged down to the byte. `includeChrono: false` restores the old shape for a client that assumed
+ * one collection.
+ *
+ * The synthetic edge is labelled `chrono.entityIds` and its `_id` is the chrono's, so nothing has to invent
+ * an edge id that does not exist — a caller looking it up finds the chrono, not a 404.
  *
  * @param memberIds  Space IDs to search for edges and entities (supports proxy spaces).
  * @param startId    UUID of the starting entity.
  * @param direction  Follow edges from the node (outbound), to the node (inbound), or both.
- * @param edgeLabels If provided, only traverse edges with one of these labels.
+ * @param edgeLabels If provided, only traverse edges with one of these labels. Also filters the synthetic
+ *                   chrono link, which is labelled `chrono.entityIds`.
  * @param maxDepth   Maximum hop count from startId (hard cap enforced by caller).
  * @param limit      Maximum total nodes to return.
  */
@@ -414,6 +454,11 @@ export async function traverseGraph(
   edgeLabels?: string[],
   maxDepth = 3,
   limit = 100,
+  /**
+   * Follow `chrono.entityIds` as inbound links, so a chrono entry is reachable from the entities it is
+   * about. Default ON — see the note above the function.
+   */
+  includeChrono = true,
 ): Promise<TraverseResult> {
   const visited = new Set<string>([startId]);
   // frontier: nodes whose outgoing edges we need to explore at the current depth
@@ -426,6 +471,9 @@ export async function traverseGraph(
   const labelFilter = edgeLabels && edgeLabels.length > 0
     ? { label: { $in: edgeLabels } }
     : {};
+  // An explicit label filter excludes the chrono link unless it names it — otherwise asking for `depends_on`
+  // would quietly return chrono entries too, and a filter that cannot exclude something is not a filter.
+  const wantsChronoLabel = !edgeLabels || edgeLabels.length === 0 || edgeLabels.includes(CHRONO_LINK_LABEL);
 
   while (frontier.length > 0 && currentDepth < maxDepth) {
     // Batch-fetch all edges for the current frontier across all member spaces
@@ -463,7 +511,31 @@ export async function traverseGraph(
       edgesForNewNeighbors.push(edge);
     }
 
-    if (newNeighborIds.length === 0) break;
+    // Chrono entries that point AT the current frontier. `entityIds` is an inbound link in everything but
+    // name, so this reads it as one — see the note above the function.
+    //
+    // Collected BEFORE the early break, and counted by it. Keying the break on entity neighbours alone meant
+    // an entity whose only link is a timeline returned nothing at all — which is the reported scenario, not
+    // an edge case: an incident with ten chrono entries and no edges is exactly what someone traverses from.
+    // Verified against a running server; the source-level gate passed happily either way.
+    const chronoHere: { doc: ChronoEntry; via: string }[] = [];
+    if (includeChrono && wantsChronoLabel) {
+      for (const mid of memberIds) {
+        const linked = await col<ChronoEntry>(`${mid}_chrono`)
+          .find(asFilter<ChronoEntry>({ spaceId: mid, entityIds: { $in: frontier } }),
+                { projection: { title: 1, type: 1, entityIds: 1 } })
+          .toArray() as ChronoEntry[];
+        for (const c of linked) {
+          if (visited.has(c._id)) continue;
+          visited.add(c._id);
+          // The frontier entity it hangs off — the `from` of the synthetic edge.
+          const via = c.entityIds.find(id => frontierSet.has(id)) ?? frontier[0];
+          chronoHere.push({ doc: c, via });
+        }
+      }
+    }
+
+    if (newNeighborIds.length === 0 && chronoHere.length === 0) break;
 
     // Batch-fetch entity docs for all new neighbors
     const entityMap = new Map<string, EntityDoc>();
@@ -473,6 +545,7 @@ export async function traverseGraph(
         .toArray() as EntityDoc[];
       for (const e of entities) entityMap.set(e._id, e);
     }
+
 
     // Build results for this depth level
     const nextFrontier: string[] = [];
@@ -490,6 +563,16 @@ export async function traverseGraph(
       }
 
       nextFrontier.push(neighborId);
+    }
+
+    // Chrono nodes are emitted at this depth but do NOT join the next frontier: a chrono links to entities,
+    // not to other chrono entries, so expanding from one would only walk back to entities already visited.
+    for (const { doc, via } of chronoHere) {
+      resultEdges.push({ _id: doc._id, from: via, to: doc._id, label: CHRONO_LINK_LABEL });
+      resultNodes.push({ _id: doc._id, name: doc.title, type: doc.type, depth: currentDepth + 1, kind: 'chrono' });
+      if (resultNodes.length >= limit) {
+        return { nodes: resultNodes, edges: resultEdges, truncated: true };
+      }
     }
 
     frontier = nextFrontier;

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -179,7 +179,7 @@ export const update_edgeTool: ToolHandler = {
 
 export const traverseTool: ToolHandler = {
   name: 'traverse',
-  description: 'Follow edges from a starting entity and return reachable nodes up to maxDepth hops. Useful for dependency analysis, impact assessment, and lineage queries.',
+  description: 'Follow edges from a starting entity and return reachable nodes up to maxDepth hops. Chrono entries that reference a reached node come back too (kind:"chrono"), so a timeline can be walked from the entity it is about. Useful for dependency analysis, impact assessment, and lineage queries.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
@@ -199,6 +199,7 @@ export const traverseTool: ToolHandler = {
             },
             maxDepth: { type: 'number', minimum: 1, maximum: 10, default: 3, description: 'Maximum hops from startId (clamped to 1–10). Default 3.' },
             limit: { type: 'number', minimum: 1, maximum: 1000, default: 100, description: 'Maximum total nodes returned (clamped to 1–1000). Default 100.' },
+            includeChrono: { type: 'boolean', default: true, description: 'Follow chrono.entityIds as inbound links, so chrono entries about a node are reached too. Chrono nodes carry kind:"chrono"; entity nodes are unchanged. Set false for entity-only results.' },
           },
           required: ['space', 'startId'],
           additionalProperties: false,
@@ -219,7 +220,10 @@ export const traverseTool: ToolHandler = {
     const limit = typeof a['limit'] === 'number' ? Math.min(Math.max(1, a['limit']), 1000) : 100;
 
     const memberIds = resolveMemberSpaces(callSpace);
-    const result = await traverseGraph(memberIds, startId, direction, edgeLabels, maxDepth, limit);
+    // Same default and same opt-out as REST — a rule that reaches one door and not the other is the defect
+    // four brain-API fixes were about.
+    const result = await traverseGraph(memberIds, startId, direction, edgeLabels, maxDepth, limit,
+      a['includeChrono'] !== false);
     return {
       content: [{
         type: 'text' as const,

--- a/testing/integration/traverse-chrono.test.js
+++ b/testing/integration/traverse-chrono.test.js
@@ -1,0 +1,138 @@
+/**
+ * Integration: `traverse` reaches a chrono entry through `chrono.entityIds`.
+ *
+ * ## The reported cost
+ *
+ * `chrono.entityIds` was the only thing linking a chrono to the graph, legible to `query()` and invisible to
+ * `traverse` — the retrieval path an agent reaches for first. An integrator measured it: reconstructing a
+ * **33-day hardware-RMA timeline took four `query()` calls plus two repo greps**, and the first pass still
+ * missed the actual carrier ticket, which had to be found by a name regex rather than by traversal from the
+ * incident.
+ *
+ * ## Why this is an integration test and not only a unit one
+ *
+ * The source-level gate (`traverse-reaches-chrono`) passed on a version that returned **nothing** for the
+ * commonest case in the report: an entity whose only link is a timeline. The BFS breaks out early when a
+ * frontier yields no entity neighbours, and the chrono lookup sat after that break — so an incident with ten
+ * chrono entries and no edges traversed to an empty result. Nothing about the source reads wrong; only running
+ * it does.
+ *
+ * That case is the first test below, deliberately.
+ *
+ * Run: node --test testing/integration/traverse-chrono.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `traverse-chrono-${RUN}`;
+
+let tokenA;
+const ids = {};
+const token = () => tokenA;
+const P = (p, body) => post(INSTANCES.a, token(), p, body);
+const traverse = (body) => P(`/api/brain/spaces/${SPACE}/traverse`, body);
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const sp = await P('/api/spaces', { id: SPACE, label: `Traverse Chrono ${RUN}` });
+  assert.equal(sp.status, 201, `create space: ${JSON.stringify(sp.body)}`);
+
+  // A lone entity whose ONLY link is a timeline — the case that returned nothing.
+  const lone = await P(`/api/brain/spaces/${SPACE}/entities`, { name: `Lone Incident ${RUN}`, type: 'incident' });
+  ids.lone = lone.body?._id;
+
+  // And an incident with a real edge AND a chrono, so both kinds of node appear in one result.
+  const inc = await P(`/api/brain/spaces/${SPACE}/entities`, { name: `RMA Incident ${RUN}`, type: 'incident' });
+  const car = await P(`/api/brain/spaces/${SPACE}/entities`, { name: `Carrier Ticket ${RUN}`, type: 'ticket' });
+  ids.inc = inc.body?._id;
+  ids.car = car.body?._id;
+  await P(`/api/brain/spaces/${SPACE}/edges`, { from: ids.inc, to: ids.car, label: 'depends_on' });
+
+  const c1 = await P(`/api/brain/spaces/${SPACE}/chrono`, {
+    title: 'Unit collected by carrier', type: 'event',
+    startsAt: '2026-07-04T09:00:00.000Z', entityIds: [ids.inc],
+  });
+  const c2 = await P(`/api/brain/spaces/${SPACE}/chrono`, {
+    title: 'Replacement promised', type: 'event',
+    startsAt: '2026-07-06T09:00:00.000Z', entityIds: [ids.lone],
+  });
+  ids.chrono = c1.body?._id;
+  ids.loneChrono = c2.body?._id;
+});
+
+after(async () => {
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true }),
+  }).catch(() => {});
+});
+
+describe('traverse reaches chrono entries', () => {
+  it('an entity whose ONLY link is a timeline is not a dead end', async () => {
+    // The regression the unit gate could not see: the BFS used to break out before looking for chrono.
+    const r = await traverse({ startId: ids.lone, direction: 'both', maxDepth: 2 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const node = (r.body.nodes ?? []).find(n => n._id === ids.loneChrono);
+    assert.ok(node, `the chrono must be reachable with no edges present: ${JSON.stringify(r.body)}`);
+    assert.equal(node.kind, 'chrono');
+    assert.equal(node.name, 'Replacement promised', 'the node name is the chrono title');
+  });
+
+  it('returns entity and chrono nodes together, and marks only the chrono', async () => {
+    const r = await traverse({ startId: ids.inc, direction: 'both', maxDepth: 2 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const nodes = r.body.nodes ?? [];
+
+    const chrono = nodes.find(n => n._id === ids.chrono);
+    assert.ok(chrono, `the chrono must be reachable: ${JSON.stringify(nodes)}`);
+    assert.equal(chrono.kind, 'chrono');
+
+    const entity = nodes.find(n => n._id === ids.car);
+    assert.ok(entity, 'the entity reached by a real edge is still returned');
+    assert.ok(!('kind' in entity),
+      'an entity node must be unchanged — absence of `kind` is what keeps every existing response identical');
+
+    const link = (r.body.edges ?? []).find(e => e.to === ids.chrono);
+    assert.ok(link, 'the synthetic link must be reported like any other edge');
+    assert.equal(link.label, 'chrono.entityIds');
+    assert.equal(link.from, ids.inc, 'it hangs off the entity the chrono references');
+    assert.equal(link._id, ids.chrono, 'the edge id is the chrono id — never an invented id that 404s');
+  });
+
+  it('includeChrono:false restores the entity-only shape', async () => {
+    const r = await traverse({ startId: ids.inc, direction: 'both', maxDepth: 2, includeChrono: false });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const nodes = r.body.nodes ?? [];
+    assert.ok(!nodes.some(n => n._id === ids.chrono), 'no chrono node');
+    assert.ok(nodes.some(n => n._id === ids.car), 'the entity is still reached');
+  });
+
+  it('an explicit edgeLabels filter excludes chrono unless it names the label', async () => {
+    // A filter that cannot exclude something is not a filter: asking for `depends_on` must not quietly
+    // return timeline entries.
+    const filtered = await traverse({ startId: ids.inc, direction: 'both', maxDepth: 2, edgeLabels: ['depends_on'] });
+    assert.ok(!(filtered.body.nodes ?? []).some(n => n._id === ids.chrono),
+      `depends_on must not return chrono: ${JSON.stringify(filtered.body.nodes)}`);
+
+    const named = await traverse({ startId: ids.inc, direction: 'both', maxDepth: 2, edgeLabels: ['chrono.entityIds'] });
+    assert.ok((named.body.nodes ?? []).some(n => n._id === ids.chrono),
+      `naming the label must return it: ${JSON.stringify(named.body.nodes)}`);
+  });
+
+  it('refuses a non-boolean includeChrono rather than coercing it', async () => {
+    // `includeChrono: "false"` is truthy in JavaScript. Coercing it would mean the opt-out silently did the
+    // opposite of what the caller asked.
+    const r = await traverse({ startId: ids.inc, includeChrono: 'false' });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /includeChrono/);
+  });
+});

--- a/testing/standalone/traverse-reaches-chrono.test.js
+++ b/testing/standalone/traverse-reaches-chrono.test.js
@@ -1,0 +1,132 @@
+/**
+ * A chrono entry is reachable by `traverse`.
+ *
+ * ## The reported cost, which is why this is not cosmetic
+ *
+ * `chrono.entityIds` was the only thing linking a chrono to the graph, and it was legible to `query()` and
+ * invisible to `traverse` — the retrieval path an agent reaches for first. An integrator measured what that
+ * costs: reconstructing a **33-day hardware-RMA timeline took four `query()` calls plus two repo greps**, and
+ * the first pass still missed the actual carrier ticket, which had to be found by a name regex rather than by
+ * traversal from the incident.
+ *
+ * Their framing is the right one: the natural reading of "knowledge graph" is that a chrono is a node.
+ *
+ * ## What is pinned here
+ *
+ * The traversal itself needs MongoDB, so the behaviour is proven in the Docker suite. What this file pins is
+ * the part that is pure and the part that is a promise to callers:
+ *
+ *  - the synthetic link has a REAL label, so `edgeLabels` can include or exclude it like any other;
+ *  - an explicit `edgeLabels` filter that does not name it EXCLUDES chrono — a filter that cannot exclude
+ *    something is not a filter, and asking for `depends_on` must not quietly return timeline entries;
+ *  - chrono nodes are marked `kind`, and entity nodes are not — so a response is byte-identical for every
+ *    caller that was already using this, and a caller following `_id` knows which collection to look in;
+ *  - the chrono node does NOT join the next frontier, or a depth-2 walk would bounce back through every
+ *    entity the chrono mentions;
+ *  - **both surfaces take the same flag with the same default.** A rule that reaches one door and not the
+ *    other is the defect four brain-API fixes were about.
+ *
+ * Run: node --test testing/standalone/traverse-reaches-chrono.test.js
+ * (requires a prior `npm run build` in server/ so server/dist exists)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+let CHRONO_LINK_LABEL;
+
+describe('the chrono link is a first-class edge label', () => {
+  before(async () => {
+    ({ CHRONO_LINK_LABEL } = await import('../../server/dist/brain/edges.js'));
+  });
+
+  it('is exported and non-empty, so callers can name it', () => {
+    assert.equal(typeof CHRONO_LINK_LABEL, 'string');
+    assert.ok(CHRONO_LINK_LABEL.length > 0);
+    // Named for the field it derives from: a reader of a traverse result can tell a modelled relationship
+    // from a derived one without consulting the docs.
+    assert.match(CHRONO_LINK_LABEL, /chrono/);
+  });
+});
+
+describe('traverse follows chrono.entityIds', () => {
+  const src = read('server/src/brain/edges.ts');
+  // Comments explain the mechanism by name, so they must not satisfy the checks that guard it.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+
+  it('queries the chrono collection for entries pointing at the frontier', () => {
+    assert.match(code, /_chrono`\)/, 'the traversal must read the chrono collection');
+    assert.match(code, /entityIds: \{ \$in: frontier \}/,
+      'the link is `entityIds` containing a frontier node — that is the inbound edge this ask is about');
+  });
+
+  it('an explicit edgeLabels filter excludes chrono unless it names the label', () => {
+    assert.match(code, /wantsChronoLabel/,
+      'without this, asking for one label would quietly return chrono entries as well');
+    assert.match(code, /edgeLabels\.includes\(CHRONO_LINK_LABEL\)/);
+  });
+
+  it('marks the chrono node and leaves entity nodes untouched', () => {
+    assert.match(code, /kind: 'chrono'/, 'a caller following `_id` must know which collection to look in');
+    // The entity push must NOT carry a kind — absence is what keeps existing responses identical.
+    const entityPush = /resultNodes\.push\(\{ _id: entity\._id[^)]*\)/.exec(code)?.[0] ?? '';
+    assert.ok(entityPush, 'could not find the entity node push');
+    assert.doesNotMatch(entityPush, /kind:/,
+      'an entity node must stay exactly as it was, so no existing response changes shape');
+  });
+
+  it('collects chrono BEFORE the early break', () => {
+    // The defect this gate did not catch on its own: the BFS breaks out when a frontier yields no entity
+    // neighbours, and the chrono lookup originally sat after that break — so an entity whose only link is a
+    // timeline traversed to nothing, which is the reported scenario rather than an edge case. Behaviour
+    // proved it; this pins the ordering that fixed it.
+    const chronoAt = code.indexOf('const chronoHere');
+    const breakAt = code.indexOf('length === 0 && chronoHere.length === 0) break');
+    assert.ok(chronoAt > 0, 'could not find the chrono lookup');
+    assert.ok(breakAt > chronoAt,
+      'the chrono lookup must run before the early break, and the break must count what it found');
+  });
+
+  it('does not expand FROM a chrono node', () => {
+    // A chrono links to entities, not to other chrono entries, so expanding one would only walk back to
+    // entities already visited — spending depth to return nothing.
+    const chronoBlock = code.slice(code.indexOf('for (const { doc, via } of chronoHere)'));
+    const block = chronoBlock.slice(0, chronoBlock.indexOf('frontier = nextFrontier'));
+    assert.doesNotMatch(block, /nextFrontier\.push/, 'a chrono node must not join the next frontier');
+  });
+
+  it('honours the node limit like any other node', () => {
+    const chronoBlock = code.slice(code.indexOf('for (const { doc, via } of chronoHere)'));
+    assert.match(chronoBlock.slice(0, 600), /resultNodes\.length >= limit/,
+      'chrono nodes must count toward `limit`, or a timeline-heavy space blows past it');
+  });
+
+  it('reuses the chrono id for the synthetic edge rather than inventing one', () => {
+    // An invented edge id would 404 for anyone who looked it up. The chrono's own id resolves.
+    assert.match(code, /resultEdges\.push\(\{ _id: doc\._id/);
+  });
+});
+
+describe('both surfaces take the same flag with the same default', () => {
+  const rest = read('server/src/api/brain/search.ts');
+  const mcp = read('server/src/mcp/tools/edge.ts');
+
+  it('REST accepts includeChrono and validates its type', () => {
+    assert.match(rest, /includeChrono/);
+    assert.match(rest, /`includeChrono` must be a boolean/,
+      'coercing a string would make includeChrono:"false" silently mean true');
+  });
+
+  it('MCP advertises it in the tool schema, so an agent can discover it', () => {
+    assert.match(mcp, /includeChrono: \{ type: 'boolean', default: true/);
+  });
+
+  it('both default to ON — the defect was discoverability, not the absence of a flag', () => {
+    for (const [name, src] of [['REST', rest], ['MCP', mcp]]) {
+      assert.match(src, /includeChrono[^\n]*!== false|!== false/, `${name} must treat only an explicit false as opt-out`);
+    }
+  });
+});


### PR DESCRIPTION
feat(brain): traverse reaches chrono entries, so a timeline is walkable from its entity

A canary ask. `chrono.entityIds` was the only thing linking a chrono to the graph, and it was legible to
`query()` and invisible to `traverse` — the retrieval path an agent reaches for first. They measured the
cost: reconstructing a 33-day hardware-RMA timeline took four `query()` calls plus two repository greps,
and the first pass still missed the carrier ticket, which had to be found by a name regex rather than by
traversal from the incident.

No schema change and no migration. The link already existed; it had no reader here.

The defect is discoverability, so a flag defaulting to off fixes it only for people who already know the
answer. What "on" costs is a response that can contain a node from another collection — so a chrono node
carries `kind: "chrono"` and an entity node carries no `kind` at all. Every response that parsed before
parses identically now. `includeChrono: false` restores the entity-only shape, on REST and MCP alike, with
the same default on both: a rule that reaches one door and not the other is the defect four brain-API fixes
were about.

`includeChrono: "false"` is a 400 rather than a coercion — the string is truthy, so coercing it would make
the opt-out do the opposite of what the caller asked.

Labelled `chrono.entityIds`, with the chrono's own `_id`, so a caller who looks it up resolves to the chrono
instead of 404ing on an invented id. Being a real label, `edgeLabels` filters it like any other: an explicit
filter that does not name it excludes chrono entries. A filter that cannot exclude something is not a filter.

A chrono is a leaf — traversal does not expand outward from one, because a chrono links to entities and
would only walk back to entities already visited, spending depth to return nothing.

My first version returned NOTHING for the commonest case in the report: an entity whose only link is a
timeline. The BFS breaks out when a frontier yields no entity neighbours, and the chrono lookup sat after
that break — so an incident with ten chrono entries and no edges traversed to an empty result. Nothing about
the source reads wrong, and all ten gate assertions passed. Running it against a server found it in one call.

Fixed by collecting chrono before the break and counting it in the break condition. That case is now the
FIRST assertion in the integration test, and the ordering is pinned by the unit gate.

  - 16 checks against a from-source server on 3260: default reachability, the `kind` marker present on
    chrono and absent on entities, the labelled link and its `from`, the opt-out, the label filter in both
    directions, and the 400. All pass; the label-filter check is the one that caught the bug above.
  - 11 unit assertions on the mechanism and the cross-surface contract, plus an integration test CI runs.
  - `npm run preflight` clean.

