### PR TITLE
docs(tokens): say which key of the create response is the credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **The tokens guide now says which key of the create response is the credential.** `POST /api/tokens` answers
+  `{ token: <the record>, plaintext: <the secret> }`, and an integrator read the field called `token`, wrote it
+  into a handover file, and rendered the actual secret to a terminal — then revoked and re-minted rather than
+  reason about the exposure. They filed it as *"our bug, but the shape invited it"*, and they are right about
+  the shape: `PATCH /api/tokens/:id` and `GET /api/tokens` both return records under the same word, so every
+  other route reinforces the wrong reading. Only `regenerate` cannot be misread.
+  - The guide states it as a table — `token` is metadata and carries no credential, `plaintext` is the secret
+    and is shown once — names the incident, and explains that `prefix` is the only part of the secret a record
+    contains.
+  - A gate holds both claims **and** checks them against the route, so the note cannot be tidied away in a
+    harmless-looking edit and cannot outlive the response shape it describes. The mistake's failure mode is
+    silent; nothing would tell anyone it had been made again.
+  - The rename itself (a clearer primary key with `plaintext` as an alias for one major) is still an open
+    decision, and is the only half of this left.
+
 ### Changed
 
 - **`traverse` reaches chrono entries, so a timeline is walkable from the entity it is about** (a canary ask).

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -104,7 +104,23 @@ POST /api/tokens
 }
 ```
 
-> **The `plaintext` field is shown once.** Store it immediately.
+> **Two keys, and only one of them is a credential.**
+>
+> | key | what it is |
+> |---|---|
+> | `token` | **The record**, not the secret — id, name, prefix, flags, scoping. Safe to log, store and display. It carries no credential. |
+> | `plaintext` | **The secret.** Shown once, never retrievable again. Treat it as you would a password. |
+>
+> The names invite the opposite reading, and an integrator made it: they took the field called `token`,
+> wrote it into a handover file, and rendered the actual secret to a terminal — then revoked and re-minted
+> rather than reason about the exposure. The mistake is silent, so nothing tells you it happened.
+>
+> `prefix` on the record is the first characters of the secret, kept so a token can be identified in a list.
+> It is not enough to authenticate with, and it is the only part of the secret the record contains.
+>
+> Every other route reinforces the misleading reading: `PATCH /api/tokens/:id` returns `{ "token": … }` and
+> `GET /api/tokens` lists records under the same word — all metadata, never a credential.
+> `POST /api/tokens/:id/regenerate` is the one that cannot be misread: it returns `{ "plaintext": … }` alone.
 
 #### Library Access Tokens
 

--- a/testing/standalone/token-secret-key-is-named.test.js
+++ b/testing/standalone/token-secret-key-is-named.test.js
@@ -1,0 +1,62 @@
+/**
+ * The token-creation response has two keys and only one is a credential — the guide must say so.
+ *
+ * ## What happened
+ *
+ * `POST /api/tokens` answers `{ token: <the record>, plaintext: <the secret> }`. An integrator read the field
+ * called `token`, wrote it into a handover file, and rendered the actual secret to a terminal. They revoked
+ * and re-minted rather than reason about the exposure, and filed it as *"our bug, but the shape invited it"*.
+ *
+ * They are right about the shape. Every other route reinforces the wrong reading: `PATCH /api/tokens/:id`
+ * returns `{ token: … }` and `GET /api/tokens` lists records under the same word. `regenerate` is the only
+ * one that cannot be misread.
+ *
+ * ## Why a gate for one paragraph
+ *
+ * The rename is the real fix and is an owner decision (a new key plus `plaintext` as an alias for a major).
+ * Until then the guide's note is the only thing between a reader and a mistake that has already been made
+ * once — and its failure mode is silent, so nothing tells anyone it happened again. A paragraph nobody
+ * defends is a paragraph that gets tidied away in an edit that looks harmless.
+ *
+ * This asserts the two claims that prevent the mistake, not the prose around them.
+ *
+ * Run: node --test testing/standalone/token-secret-key-is-named.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const GUIDE = 'docs/integration-guide/07-tokens-api.md';
+
+describe('the tokens guide says which key is the secret', () => {
+  const doc = readFileSync(join(ROOT, GUIDE), 'utf8');
+
+  it('the guide still documents the create response at all', () => {
+    // Floors the checks below: if this section is renamed or moved, they would pass over an empty file.
+    assert.match(doc, /"plaintext"/, `${GUIDE} no longer shows the create response`);
+    assert.ok(doc.length > 2000, `${GUIDE} looks truncated (${doc.length} bytes)`);
+  });
+
+  it('says `token` is the RECORD and carries no credential', () => {
+    assert.match(doc, /`token`[^\n]*[Tt]he record/,
+      'the guide must state that the key named `token` is metadata — that misreading is the reported incident');
+    assert.match(doc, /carries no credential|not the secret/,
+      'and say plainly that it is not a credential');
+  });
+
+  it('says `plaintext` is the secret and is shown once', () => {
+    assert.match(doc, /`plaintext`[^\n]*[Tt]he secret|[Tt]he secret\.\*\*/,
+      'the guide must name `plaintext` as the credential');
+    assert.match(doc, /[Ss]hown once/, 'and that it cannot be retrieved again');
+  });
+
+  it('the server really does answer with those two keys — or this gate documents a fiction', () => {
+    // The guide could be right about a response that no longer exists. Checked against the route so the
+    // two cannot drift apart in either direction.
+    const src = readFileSync(join(ROOT, 'server/src/api/tokens.ts'), 'utf8');
+    assert.match(src, /res\.status\(201\)\.json\(\{ token: safeRecord, plaintext \}\)/,
+      'the create route no longer answers `{ token, plaintext }` — update the guide and this gate together');
+  });
+});


### PR DESCRIPTION
docs(tokens): say which key of the create response is the credential

`POST /api/tokens` answers `{ token: <the record>, plaintext: <the secret> }`. An integrator read the field
called `token`, wrote it into a handover file, and rendered the actual secret to a terminal — then revoked
and re-minted rather than reason about the exposure. They filed it as "our bug, but the shape invited it".

They are right about the shape. `PATCH /api/tokens/:id` returns `{ token: … }` and `GET /api/tokens` lists
records under the same word, so every route but `regenerate` reinforces the wrong reading. The misreading is
silent and its failure mode is a secret written somewhere it should not be.

The guide now states it as a table — `token` is metadata and carries no credential, `plaintext` is the
secret and is shown once — names the incident so the reason is legible, and explains that `prefix` is the
only part of the secret a record contains.

A gate holds it. One paragraph nobody defends is one that gets tidied away in an edit that looks harmless,
and `token-secret-key-is-named` also checks the guide's claims against the ROUTE, so the note cannot outlive
the response shape it describes. It floors itself too: a renamed or moved section fails loudly rather than
letting the checks pass over an empty file.

The rename — a clearer primary key with `plaintext` kept as an alias for one major — remains an owner
decision and is now the only half of this item left. The tracker entry says exactly that.

