### PR TITLE
feat(brain): REST recall takes includeContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **REST `recall` takes `includeContent`, closing the last two-surfaces gap from that letter** (owner-approved
+  new surface). MCP `recall` and `find_similar` have had it since they shipped: ask for file-chunk locations
+  and metadata WITHOUT the passage bodies. A REST caller had no way to ask, which an integrator pointed out —
+  the same shape as the four two-surfaces-one-rule defects fixed on 2026-08-05.
+  - A passage body is by far the largest field a result carries, and every field is paid for `topK` times.
+    `includeContent: false` turns one expensive call into a cheap two-phase flow: recall to find WHERE
+    something is, then read only the chunk you chose.
+  - **It drops `content` and nothing else, on file results and nothing else** — the flag is about the passage
+    body, not about thinning a result. Verified against a live instance: the same chunk comes back with its
+    `path`, `score` and `_id` intact, and a memory result in the same response is untouched.
+  - Default `true`, so no existing caller changes; a non-boolean is a `400` rather than a coercion, because
+    `"false"` is truthy and an opt-out that silently does nothing is worse than one that errors.
+  - **The traverse path honours it too.** A caller who asked not to be sent passage bodies did not stop
+    meaning it because they also asked for graph expansion — an option that lapses on one code path is the
+    same defect one level down.
+  - Held by a cross-surface gate, as the item asked: the check is not "REST has a flag" but "the two surfaces
+    agree", which is the property that was violated.
+
 ### Documentation
 
 - **The tokens guide now says which key of the create response is the credential.** `POST /api/tokens` answers

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -418,6 +418,7 @@ Available as both:
 | `maxTimeMS` | — | the instance budget | Deadline for this recall, in ms. **Can only lower the instance's `RECALL_BUDGET_MS`, never raise it** — a larger value is clamped to it, and a very small one is clamped up to a 250 ms floor. On expiry you get a **partial** answer with a `degraded` field, not an error and not a hang |
 | `traverse` | — | `0` | Graph-expansion depth (integer 0–5). `0` = classic recall; > 0 follows edges from each match (see [Graph-Augmented Recall](#graph-augmented-recall-traverse-parameter)) |
 | `includeFreshWrites` | — | `false` | Also scan the newest records straight from each collection, so a record written seconds ago is findable before the vector index has ingested it. See below. A non-boolean is a `400`, never coerced |
+| `includeContent` | — | `true` | Whether file-chunk results carry `content` — the passage body. `false` returns locations and metadata only (path, heading, chunk index, tags, properties). A non-boolean is a `400`, never coerced |
 
 **Response** `200`:
 
@@ -736,6 +737,23 @@ Per-result annotations:
 - Only **entities** are returned by traversal (edges connect entities); memories, chrono entries, and files still appear as seeds when they match semantically.
 
 **Performance:** traversal issues roughly two batched (`$in`) MongoDB queries per hop, not one query per node. Even so, `traverse > 2` on a densely-connected graph can fan out quickly — pair it with `filter`, `tags`, or a low `topK` to keep the seed set (and therefore the traversal frontier) tight.
+
+#### Recall without passage bodies (`includeContent`)
+
+A file result's `content` is the passage body, and it is by far the largest field a result carries — paid for
+`topK` times, in tokens. `includeContent: false` omits it and returns everything needed to decide *which*
+passage you want: path, heading, chunk index, tags, properties.
+
+```json
+{ "query": "retention policy", "types": ["file"], "includeContent": false }
+```
+
+That turns one expensive call into a cheap two-phase flow — recall to find **where** something is, then read
+only the chunk you chose (`GET /api/files/:spaceId/…`). MCP `recall` and `find_similar` have taken the same
+flag with the same meaning since they shipped; REST had no way to ask, which an integrator pointed out.
+
+It drops `content` and nothing else, on file results and nothing else — the flag is about the passage body,
+not about thinning a result. The default is `true`, so no existing caller changes.
 
 #### Searching for something you just wrote (`includeFreshWrites`)
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -11,7 +11,7 @@ import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
 import { getEmbedJobCounts } from '../../brain/embed-queue.js';
 import { queryBrain } from '../../brain/query.js';
-import { findSimilar, recall, rankOf, mergeRecallResults, type RecallKnowledgeType } from '../../brain/recall.js';
+import { findSimilar, recall, rankOf, mergeRecallResults, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
 import { traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE, resolveEdgeEntityNames } from '../../brain/edges.js';
 import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from '../../brain/embed-text.js';
@@ -98,6 +98,26 @@ searchRouter.get('/spaces/:spaceId/activity', globalRateLimit, requireSpaceAuth,
   res.json({ spaceId, hours, spaces: rows });
 });
 
+
+/**
+ * Drop the passage body from file chunks when the caller asked not to receive it.
+ *
+ * A file result's `content` is the largest field a recall returns, and it is returned `topK` times. Omitting
+ * it leaves everything a caller needs to decide WHICH passage to fetch — path, heading, chunk index, tags —
+ * which is the two-phase flow MCP callers have had all along.
+ *
+ * Only `content`, and only on file results: the flag is about the passage body, not about thinning a result.
+ * Copies rather than mutating, because `seeds` is also handed to the traverse builder and to the audit
+ * outcome — deleting a field in place would change what those saw.
+ */
+function stripContentIfAsked(results: RecallResult[], includeContent: boolean): RecallResult[] {
+  if (includeContent) return results;
+  return results.map(r => {
+    if (r.type !== 'file' || r.content === undefined) return r;
+    const { content: _dropped, ...rest } = r;
+    return rest as RecallResult;
+  });
+}
 
 // POST /api/brain/spaces/:spaceId/traverse — graph traversal (BFS)
 searchRouter.post('/spaces/:spaceId/traverse', globalRateLimit, requireSpaceAuth, async (req, res) => {
@@ -342,6 +362,21 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     }
     const safeIncludeFresh = includeFreshRaw === true;
 
+    // `includeContent: false` drops the passage BODY from file chunks, leaving where they are and what they
+    // are about. MCP `recall` has had this since it shipped; REST had no way to ask for it, and an integrator
+    // pointed out the asymmetry — the same two-surfaces-one-rule shape as four defects fixed the day before.
+    //
+    // Why it is worth a flag: a passage body is by far the largest field a result carries, and every field is
+    // paid for `topK` times. Dropping it turns one expensive call into a cheap two-phase flow — recall to
+    // find WHERE something is, then read only the chunk you chose. Default true, so no existing caller
+    // changes; only an explicit `false` opts out, and a non-boolean is refused rather than coerced.
+    const includeContentRaw = (req.body as { includeContent?: unknown }).includeContent;
+    if (includeContentRaw !== undefined && typeof includeContentRaw !== 'boolean') {
+      res.status(400).json({ error: '`includeContent` must be a boolean' });
+      return;
+    }
+    const safeIncludeContent = includeContentRaw !== false;
+
     const degraded: string[] = [];
     const all = (await Promise.all(
       memberIds.map(mid => recall(mid, query.trim(), safeTopK, safeTags, safeTypes, safeMinPerType, safeMinScore, safeFilter, { maxPerType: safeMaxPerType, maxTimeMS: safeMaxTimeMS, degraded, includeFreshWrites: safeIncludeFresh })),
@@ -379,7 +414,7 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
       // noise, and a field that is almost always empty is a field readers learn to skip — which is exactly
       // when it needs to be noticed. The requester asked for the flag in the BODY rather than only a status,
       // because a 200 that is quietly short is indistinguishable from a 200 that found everything.
-      res.json({ results: seeds, count: seeds.length, ...(degraded.length > 0 ? { degraded } : {}) });
+      res.json({ results: stripContentIfAsked(seeds, safeIncludeContent), count: seeds.length, ...(degraded.length > 0 ? { degraded } : {}) });
       return;
     }
 
@@ -392,7 +427,10 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
       Math.max(0, totalCap - seeds.length),
     );
     const results: RecallTraverseItem[] = [
-      ...seeds.map(s => ({ score: s.score, source: 'recall' as const, hops: 0, path: [], spaceId: s.spaceId, type: s.type, record: s })),
+      // The flag applies here too. A caller who asked not to be sent passage bodies did not stop meaning it
+      // because they also asked for graph expansion — and an option that silently lapses on one code path is
+      // the same shape of defect as one that reaches only one surface.
+      ...stripContentIfAsked(seeds, safeIncludeContent).map(s => ({ score: s.score, source: 'recall' as const, hops: 0, path: [], spaceId: s.spaceId, type: s.type, record: s })),
       ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity' as const, record: n.record })),
     ];
     // The traverse shape carries the flag too — the seeds it expanded may already have been partial, and a

--- a/testing/standalone/recall-include-content-both-surfaces.test.js
+++ b/testing/standalone/recall-include-content-both-surfaces.test.js
@@ -1,0 +1,87 @@
+/**
+ * `includeContent` reaches BOTH doors.
+ *
+ * ## The asymmetry
+ *
+ * MCP `recall` has had `includeContent` since it shipped: a caller can ask for file-chunk locations and
+ * metadata WITHOUT the passage bodies, which is the difference between one expensive call and a cheap
+ * two-phase flow — recall to find where something is, then read only the chunk you chose. A passage body is
+ * by far the largest field a result carries, and every field is paid for `topK` times.
+ *
+ * REST had no way to ask. An integrator pointed it out, and it is the same shape as the four
+ * two-surfaces-one-rule defects fixed on 2026-08-05 (`upsert_edge` existence checks,
+ * `excludeFromVectorSearch` over REST and then over MCP, the recall ceiling): a capability that reaches one
+ * door and not the other.
+ *
+ * ## Why the gate is written as a comparison
+ *
+ * The item was filed asking for exactly this — *"if it is wanted, it belongs behind the same cross-surface
+ * gate as the others so it cannot regress on one side"*. So the check is not "REST has a flag"; it is "the
+ * two surfaces agree", which is the property that was violated and the only one worth holding.
+ *
+ * Run: node --test testing/standalone/recall-include-content-both-surfaces.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const REST = 'server/src/api/brain/search.ts';
+const MCP = 'server/src/mcp/tools/search.ts';
+
+describe('recall exposes includeContent on both surfaces', () => {
+  const rest = read(REST);
+  const mcp = read(MCP);
+
+  it('MCP still has it — otherwise this gate is comparing REST to nothing', () => {
+    assert.match(mcp, /includeContent/, `${MCP} no longer mentions includeContent`);
+    assert.match(mcp, /includeContent: \{/, 'the MCP tool must still ADVERTISE it in its schema');
+  });
+
+  it('REST accepts it', () => {
+    assert.match(rest, /includeContent/, `${REST} does not accept includeContent — the asymmetry is back`);
+  });
+
+  it('both default to TRUE, so neither surface silently thins an existing caller’s results', () => {
+    // The default is the compatibility guarantee: only an explicit `false` opts out.
+    assert.match(mcp, /a\['includeContent'\] !== false/, 'MCP must treat only an explicit false as opt-out');
+    assert.match(rest, /includeContentRaw !== false/, 'REST must treat only an explicit false as opt-out');
+  });
+
+  it('REST refuses a non-boolean rather than coercing it', () => {
+    // `"false"` is truthy. An opt-out that silently does nothing is worse than one that errors — and this is
+    // the flag whose whole purpose is to make a response smaller.
+    assert.match(rest, /`includeContent` must be a boolean/);
+  });
+
+  it('drops only `content`, and only on file results', () => {
+    // The flag is about the passage body. Thinning anything else would make it a different feature with the
+    // same name on the two surfaces — which is the defect class this gate exists for, one level in.
+    assert.match(rest, /r\.type !== 'file'/, 'the strip must be scoped to file results');
+    assert.match(rest, /const \{ content: _dropped, \.\.\.rest \} = r/, 'and drop `content` alone');
+  });
+
+  it('the traverse path honours it too', () => {
+    // A caller who asked not to be sent passage bodies did not stop meaning it because they also asked for
+    // graph expansion. An option that lapses on one code path is the same defect one level down.
+    const traverseBuild = rest.slice(rest.indexOf('const results: RecallTraverseItem[]'));
+    assert.match(traverseBuild.slice(0, 600), /stripContentIfAsked\(seeds, safeIncludeContent\)/,
+      'the traverse response must apply the same strip as the plain one');
+  });
+
+  it('does not mutate the results it was given', () => {
+    // `seeds` is also handed to the traverse builder and to the audit outcome; deleting a field in place
+    // would change what those saw.
+    assert.match(rest, /return results\.map\(/, 'the strip must copy rather than delete in place');
+  });
+
+  it('both surfaces document it', () => {
+    const restDoc = read('docs/integration-guide/04-brain-api.md');
+    const mcpDoc = read('docs/integration-guide/16-mcp.md');
+    for (const [name, doc] of [['brain-api', restDoc], ['mcp', mcpDoc]]) {
+      assert.match(doc, /includeContent/, `${name} guide does not mention includeContent`);
+    }
+  });
+});


### PR DESCRIPTION
feat(brain): REST recall takes includeContent

Owner-approved (2026-08-06). MCP `recall` and `find_similar` have had `includeContent` since they shipped —
ask for file-chunk locations and metadata WITHOUT the passage bodies. A REST caller had no way to ask, and
an integrator pointed it out: the same two-surfaces-one-rule shape as the four defects fixed on 2026-08-05,
where a capability reaches one door and not the other.

## Why it is worth a flag

A passage body is by far the largest field a result carries, and every field is paid for `topK` times in
tokens. `includeContent: false` turns one expensive call into a cheap two-phase flow — recall to find WHERE
something is, then read only the chunk you chose.

## Scope, deliberately narrow

It drops `content`, on file results, and nothing else. The flag is about the passage body, not about
thinning a result — a version that also dropped, say, `description` would be a different feature wearing the
same name on the two surfaces, which is the defect class this closes, one level in.

Default `true`, so no existing caller changes. A non-boolean is a 400 rather than a coercion: `"false"` is
truthy, and an opt-out that silently does nothing is worse than one that errors.

The strip copies rather than deleting in place, because `seeds` is also handed to the traverse builder and
to the audit outcome — mutating would change what those saw.

**The traverse path honours it too.** A caller who asked not to be sent passage bodies did not stop meaning
it because they also asked for graph expansion; an option that lapses on one code path is the same defect
one level down.

## Verification

Ten checks against a from-source instance backed by a real Atlas Local index: by default a file result
carries `content`; with the flag the SAME chunk comes back with `content` gone and `path`, `score` and `_id`
intact; a memory result in the same response is untouched; and the string `"false"` is refused.

The gate is written as a comparison, as the tracker entry asked — not "REST has a flag" but "the two
surfaces agree", including that both default to true and both document it. That is the property that was
violated, and the only one worth holding.

