### PR TITLE
fix(spaces): refuse a broken library $ref on space CREATE, as every edit route already does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Creating a space with a broken schema-library `$ref` succeeded silently, while every route that EDITS the
+  same field answered 422.** Reported by an operator setting up a new space: a type declared
+  `{"$ref": "library:…"}` came back as an empty schema and the create reported success.
+  - The asymmetry was narrower than it looked from outside — `PATCH /:id`, `PUT /:id/schema` and the
+    single-type `PUT` all refused already. Only `POST /` did not, so the identical mistake was loud on every
+    path except the one people make it on: the one where a space and its schema arrive together.
+  - It matters most in a `strict` space, and `POST /` is the handler that SEEDS `strict`. One mistyped ref
+    left that type with no constraints while the schema looked authored.
+  - The check runs before the space is created, so a refusal leaves nothing behind to clean up.
+  - A gate now derives the requirement — every handler taking `typeSchemas` (or a `meta` that contains it)
+    must consult the ref checker. Keyed on `meta` as well as the literal field name, because the route that
+    had the defect never mentioned `typeSchemas` at all: a narrower detector would have reported the tree
+    clean on the day the bug was live.
+  - The guide said unresolvable refs "silently degrade to an empty schema" without qualifying when. Corrected:
+    they cannot be STORED, and the degrade applies to a ref that becomes unresolvable later — a library entry
+    deleted out from under a space that referenced it, which must not make that space unwritable.
+
+### Fixed
+
 - **The space settings form silently truncated `usageNotes` at 2 000 characters while the API accepts 50 000.**
   Reported by an operator who authored 2,377 characters, imported them, and read the field back to find it
   ending mid-word — two rules after that sentence gone, no error and no warning on either side. The cause was

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -970,7 +970,19 @@ A space type definition can reference a library entry instead of embedding the s
 }
 ```
 
-`resolveMetaRefs()` resolves all `$ref` pointers from the library before validation runs. Unresolvable refs (entry not found, or unknown `$ref` format) silently degrade to an empty schema — no constraints are applied, which is identical to the behaviour for an undefined type.
+`resolveMetaRefs()` resolves all `$ref` pointers from the library before validation runs.
+
+**You cannot store an unresolvable ref.** Every route that accepts `typeSchemas` — `POST /api/spaces`,
+`PATCH /api/spaces/:id`, `PUT /api/spaces/:id/schema`, and the single-type
+`PUT /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` — answers **422** naming the missing library
+entry, before anything is written. Creation used to be the one exception, which meant the identical mistake
+was loud on every path except the one where a space and its schema arrive together.
+
+If a ref does become unresolvable later — the library entry is deleted out from under a space that referenced
+it — resolution degrades to an empty schema: no constraints are applied, identical to the behaviour for an
+undefined type. That is a deliberate degrade rather than a hard failure, because a deleted library entry must
+not make an existing space unwritable. In a `strict` space it does mean that type accepts anything, so treat
+deleting a referenced library entry as a change to every space that points at it.
 
 `$ref` and inline fields are mutually exclusive: a `TypeSchema` that contains `$ref` must not also contain `namingPattern`, `propertySchemas`, etc.
 

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -494,6 +494,26 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
   // incoming off-schema federated records on ingest. With no typeSchemas yet defined, 'strict' still
   // accepts every type/label (nothing to violate), so this never blocks a brand-new empty space.
   const requestMeta = meta as SpaceMeta | undefined;
+
+  // Same broken-`$ref` refusal the three UPDATE routes make, which this one did not.
+  //
+  // Reported by an operator setting up a NEW space: a type declared `{"$ref": "library:…"}` came back as an
+  // empty schema, and the create reported success. Every path that EDITS meta — `PATCH /:id`,
+  // `PUT /:id/schema`, `PUT /:id/meta/typeSchemas/…` — already answers 422 here; only creation did not, so
+  // the identical mistake was loud on one route and silent on another.
+  //
+  // It matters most in a `strict` space, which is the default this very handler seeds two lines below: one
+  // mistyped ref leaves that type with no constraints at all, and the space then accepts anything for it
+  // while its schema looks authored. A refusal naming the missing entry costs one call to fix; a silent
+  // empty schema costs however long it takes someone to notice their rules are not being applied.
+  if (requestMeta?.typeSchemas) {
+    const brokenRefs = findBrokenLibraryRefs(requestMeta.typeSchemas as z.infer<typeof TypeSchemasZ>);
+    if (brokenRefs.length > 0) {
+      res.status(422).json({ error: `Schema library ${brokenRefs.length === 1 ? 'entry' : 'entries'} not found: ${brokenRefs.join(', ')}. Create ${brokenRefs.length === 1 ? 'it' : 'them'} via POST /api/schema-library before referencing.` });
+      return;
+    }
+  }
+
   const seededMeta: SpaceMeta | undefined = proxyFor
     ? requestMeta
     : { validationMode: 'strict', strictLinkage: true, ...(requestMeta ?? {}) };

--- a/testing/standalone/broken-library-ref-refused-everywhere.test.js
+++ b/testing/standalone/broken-library-ref-refused-everywhere.test.js
@@ -1,0 +1,97 @@
+/**
+ * Every route that accepts `typeSchemas` refuses a broken library `$ref`.
+ *
+ * ## The report
+ *
+ * An operator setting up a NEW space declared a type as `{"$ref": "library:cross-space-reference"}` and it
+ * came back as `{}` — while the create reported success. Their words: *"in a `strict` space, one mistyped ref
+ * removes every constraint from a type and reports success"*, and they noted the behaviour is inconsistent
+ * with the full-replace route, which returns 422.
+ *
+ * They were right, and the asymmetry was narrower than they could see from outside: the three routes that
+ * EDIT meta — `PATCH /:id`, `PUT /:id/schema`, `PUT /:id/meta/typeSchemas/:kt/:name` — all answered 422
+ * already. Only `POST /` did not, so the identical mistake was loud on every path except the one people make
+ * it on, which is the one where the space and its schema arrive together.
+ *
+ * It matters most in a `strict` space, and `POST /` is the handler that SEEDS `validationMode: 'strict'`: one
+ * mistyped ref leaves that type with no constraints, and the space then accepts anything for it while its
+ * schema looks authored.
+ *
+ * ## Why this is derived rather than a list of four routes
+ *
+ * A list would have been written against the routes that existed and agreed with itself. This finds every
+ * route handler that takes `typeSchemas` from a request and requires each one to consult the checker — so a
+ * fifth route added later is covered on the day it is written, which is the only time it is cheap.
+ *
+ * Run: node --test testing/standalone/broken-library-ref-refused-everywhere.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC = 'server/src/api/spaces.ts';
+const src = readFileSync(join(ROOT, SRC), 'utf8');
+
+/** Split the file into route handlers: from one `spacesRouter.<verb>(` to the next. */
+function routes() {
+  const starts = [];
+  const re = /spacesRouter\.(get|post|put|patch|delete)\(\s*'([^']+)'/g;
+  let m;
+  while ((m = re.exec(src)) !== null) starts.push({ verb: m[1], path: m[2], at: m.index });
+  return starts.map((s, i) => ({
+    ...s,
+    body: src.slice(s.at, i + 1 < starts.length ? starts[i + 1].at : src.length),
+  }));
+}
+
+describe('a broken schema-library $ref is refused on every route that accepts one', () => {
+  const all = routes();
+
+  it('found the routes to check', () => {
+    // Floors the enumeration — a changed router name would otherwise make every check below vacuous.
+    assert.ok(all.length >= 10, `only found ${all.length} route handlers in ${SRC}`);
+    assert.ok(all.some(r => r.verb === 'post' && r.path === '/'), 'the space-create route must be among them');
+  });
+
+  it('every handler that reads typeSchemas from the request consults the ref checker', () => {
+    const offenders = [];
+    for (const r of all) {
+      // Only mutating handlers that take schemas from the CALLER. A read route returning them is not
+      // accepting a ref and has nothing to reject.
+      if (!['post', 'put', 'patch'].includes(r.verb)) continue;
+      // `meta` counts, not just a literal `typeSchemas`. The route that had the defect destructured `meta`
+      // from the body and never named `typeSchemas` at all — a detector keyed on that word would have
+      // reported the tree clean on the day the bug was live, which is the one day it needed to speak.
+      const takesSchemas = /typeSchemas/.test(r.body)
+        || /const \{[^}]*\bmeta\b[^}]*\} = parsed\.data/.test(r.body);
+      if (!takesSchemas) continue;
+      if (!/findBrokenLibraryRefs\(/.test(r.body)) offenders.push(`${r.verb.toUpperCase()} ${r.path}`);
+    }
+    assert.deepEqual(offenders, [],
+      'these accept `typeSchemas` from a request without checking its library refs. An unresolvable ref '
+      + 'degrades to an empty schema, so in a strict space the type silently loses every constraint while '
+      + 'the call reports success — and the other routes answer 422 for the same input.');
+  });
+
+  it('the create route refuses BEFORE the space exists', () => {
+    // Ordering is the guarantee: a check after `createSpace` would leave a space behind whose schema is the
+    // thing being rejected, and the caller would have to clean it up.
+    const create = all.find(r => r.verb === 'post' && r.path === '/');
+    const check = create.body.indexOf('findBrokenLibraryRefs(');
+    const write = create.body.indexOf('await createSpace(');
+    assert.ok(check > 0, 'the create route must call the checker');
+    assert.ok(write > check, 'the ref check must run before the space is created');
+  });
+
+  it('all four answer with the same status and a message naming what is missing', () => {
+    const checking = all.filter(r => /findBrokenLibraryRefs\(/.test(r.body));
+    assert.ok(checking.length >= 4, `only ${checking.length} routes check refs; expected the create route plus three editors`);
+    for (const r of checking) {
+      assert.match(r.body, /res\.status\(422\)/, `${r.verb.toUpperCase()} ${r.path} must answer 422`);
+      assert.match(r.body, /Schema library[^\n]*not found/,
+        `${r.verb.toUpperCase()} ${r.path} must name the missing entry — "invalid schema" sends the caller looking in the wrong place`);
+    }
+  });
+});


### PR DESCRIPTION
fix(spaces): refuse a broken library $ref on space CREATE, as every edit route already does

Reported by an operator setting up a new space: a type declared `{"$ref": "library:cross-space-reference"}`
came back as an empty schema and the create reported success. Their framing — "in a strict space, one
mistyped ref removes every constraint from a type and reports success" — is exactly right.

The asymmetry was narrower than they could see from outside. `PATCH /:id`, `PUT /:id/schema` and the
single-type `PUT /:id/meta/typeSchemas/:kt/:name` all answered 422 already. Only `POST /` did not — so the
identical mistake was loud on every path except the one people actually make it on, which is the one where
a space and its schema arrive together.

It matters most in a `strict` space, and `POST /` is the handler that SEEDS `validationMode: 'strict'` two
lines further down. One mistyped ref left that type with no constraints at all while its schema looked
authored, and the space then accepted anything for it.

The check runs before `createSpace`, so a refusal leaves nothing behind for the caller to clean up.

## The gate is derived, and its detector was wrong the first time

It requires every mutating handler that accepts `typeSchemas` to consult the ref checker, found from the
router rather than from a list of four routes — a list would have been written against what existed.

My first detector keyed on the word `typeSchemas`, and the route that HAD the defect destructures `meta`
from the body and never names `typeSchemas` at all. Proven by running it against the pre-fix file: the main
check passed. So it now also matches a handler taking `meta`, and all three checks fail without the fix.

## Docs

The guide said unresolvable refs "silently degrade to an empty schema" with no qualification, which is what
made the create behaviour look intended. Corrected: a ref that cannot resolve cannot be STORED on any route;
the degrade applies to one that becomes unresolvable LATER — a library entry deleted out from under a space
that referenced it — which is a deliberate choice, because a deleted entry must not make an existing space
unwritable. With the note that deleting a referenced entry is therefore a change to every space pointing at
it.

