### PR TITLE
feat(brain): expose the insert-time duplicate/contradiction check over REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The insert-time near-duplicate / contradiction check is now reachable over REST** (`checkDuplicates`,
+  `checkContradictions`, `dupeThreshold` on `POST …/memories`, `…/entities` and `…/chrono`). It had existed
+  only on the MCP write tools, so the best knowledge-hygiene feature in the product was invisible to any
+  client that speaks HTTP — which an integrator pointed out is *every* record their thirty-flow fleet writes.
+  - Same shared implementation, same options object, same advisory contract: the record is written either way
+    and the warning rides on the `201` as `similar` / `contradicts`. An agent correcting an outdated fact must
+    be able to contradict the record it supersedes.
+  - **`recall` cannot stand in for it**, measured by the reporter: the same pair scores 0.94 on this check and
+    0.896 on recall, with unrelated topical neighbours at 0.845 — no recall threshold separates the true
+    near-duplicate from the coincidences, and the two scales are not interchangeable.
+  - **The flags are opt-in on REST and default ON over MCP**, which is a deliberate asymmetry rather than an
+    oversight: the check implies `waitForEmbedding`, so defaulting it on would make every existing REST
+    integration — including bulk importers — start paying the embedding model synchronously without asking.
+    Documented rather than left to be discovered from a latency graph.
+  - One shared reader for all three routes, because three hand-written copies of "read, validate, default" is
+    how the surfaces drifted apart to begin with.
+
 ### Fixed
 
 - **Creating a space with a broken schema-library `$ref` succeeded silently, while every route that EDITS the

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -115,6 +115,45 @@ POST /api/brain/spaces/:spaceId/memories
 
 **Constraints**: `id` optional — a **UUID v4** you supply to make the write idempotent (a retry with the same id converges on that record instead of creating a second one); anything else is a `400`, and omitting it generates one. See [Retry Safety](#retry-safety). **Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl). `waitForEmbedding` optional boolean — see below.
 
+#### Catching a near-duplicate at write time (`checkDuplicates`, `checkContradictions`)
+
+A write can tell you it looks like something you already have, before you have two of them:
+
+```json
+{ "fact": "Deploys are frozen on Fridays after 14:00 UTC", "checkDuplicates": true }
+```
+
+```json
+{ "_id": "…", "fact": "…",
+  "similar": [ { "_id": "…", "type": "memory", "score": 0.94, "summary": "Deploys freeze Friday 14:00 UTC" } ] }
+```
+
+Available on `POST …/memories`, `POST …/entities` and `POST …/chrono`, with the same meaning the MCP tools
+have always had.
+
+| field | default on REST | effect |
+|---|---|---|
+| `checkDuplicates` | `false` | Report existing records that are semantically near-identical, as `similar` (`_id`, `type`, `score`, `summary`). |
+| `checkContradictions` | `false` | Report near-neighbours that set the same single-valued property to a DIFFERENT value, as `contradicts`. A different question from redundancy, so it is a separate flag. |
+| `dupeThreshold` | `0.92` | Score at or above which a neighbour is reported. Must be between 0 and 1. |
+
+- **It never blocks the write.** The record is stored either way and the warning rides on the `201`. An agent
+  correcting an outdated fact must be able to contradict the record it supersedes — the point is that it is
+  told, not that it is stopped.
+- **The flags are opt-in here, and default ON over MCP.** That asymmetry is deliberate: the check implies
+  `waitForEmbedding`, because it needs the vector before the insert so the new record cannot match itself. On
+  REST — which is also how a fleet imports thousands of records — defaulting it on would make every existing
+  integration pay the embedding model synchronously without asking. A REST write that sends none of these
+  behaves exactly as it did before.
+- **`recall` is not a substitute**, and an integrator measured why: the same pair scores **0.94** on this
+  check and **0.896** on recall, while unrelated topical neighbours sit at 0.845. No recall threshold
+  separates the true near-duplicate from the coincidences, and the two scales are not interchangeable.
+- `GET /api/duplicates` is the background scanner's review queue, not an on-demand similarity search — it
+  lists what a scheduled sweep has already found.
+
+A non-boolean flag (or a `dupeThreshold` outside 0–1) is a `400`, never a coercion: `"false"` is truthy, and
+a hygiene check that silently turns itself off is worse than one that was never asked for.
+
 #### When does a memory become searchable? (`waitForEmbedding`)
 
 **By default, a moment after the write returns.** The write stores the record and hands the embedding to a

--- a/server/src/api/brain/_shared.ts
+++ b/server/src/api/brain/_shared.ts
@@ -11,6 +11,7 @@ import type express from 'express';
 import { getConfig } from '../../config/loader.js';
 import { resolveMetaRefs, type SchemaViolation } from '../../spaces/schema-validation.js';
 import type { SpaceMeta } from '../../config/types.js';
+import type { DupeCheckOpts } from '../../brain/recall.js';
 
 /** Regex that matches a UUID v4 (case-insensitive). */
 // Re-exported from the canonical definition so there is exactly one copy in the codebase.
@@ -85,4 +86,66 @@ export function buildMemoryFilter(query: Record<string, unknown>): Record<string
   const or = textSearchOr(search, SEARCHABLE_FIELDS.memories);
   if (or) Object.assign(filter, or);
   return filter;
+}
+
+/**
+ * Read the insert-time duplicate / contradiction flags from a REST write body.
+ *
+ * ## Why this exists
+ *
+ * The check itself is the same code MCP has always used — `upsertEntity`, `createMemory` and `createChrono`
+ * all take a `DupeCheckOpts`, and the MCP tools fill it. REST simply never did, so the single best
+ * knowledge-hygiene feature in the product was invisible to any client that speaks HTTP.
+ *
+ * An integrator reported it with the measurement that makes the case: their fleet is thirty n8n flows, n8n
+ * speaks HTTP, so **every record they create is written over REST**. They also showed that recall cannot
+ * stand in for it — the same pair scores 0.94 on the dedup check and 0.896 on recall, with unrelated topical
+ * neighbours at 0.845, so no recall threshold separates a true near-duplicate from a coincidence.
+ *
+ * ## Why one reader rather than three
+ *
+ * Three record types take these flags, and three hand-written copies of "read, validate, default" is how the
+ * surfaces drifted apart in the first place. One function means a fourth type is a one-line change and
+ * cannot disagree with the others about what `dupeThreshold: "0.9"` means.
+ *
+ * ## Both flags are OPT-IN here, and that differs from MCP on purpose
+ *
+ * MCP's `remember` and `upsert_entity` default `checkDuplicates` ON. Copying that default to REST would be a
+ * silent latency regression for every integration that exists today, because **the check implies
+ * `waitForEmbedding`** — it needs the vector before the insert so the new record cannot match itself. Every
+ * REST write would start paying the embedding model synchronously, including bulk loaders, without anyone
+ * asking for it.
+ *
+ * The surfaces are asymmetric for a reason that survives stating: an MCP caller is an agent writing one
+ * record and reading the answer, and REST is also how a fleet imports thousands. So the CAPABILITY is now
+ * identical and the DEFAULT is not, which is documented rather than left to be discovered from a latency
+ * graph.
+ *
+ * A REST caller that sends none of these gets today's behaviour, byte for byte.
+ *
+ * Returns an error string when a flag is present but the wrong type — never a coercion. `"false"` is truthy,
+ * and a hygiene check that silently turns itself off is worse than one that was never asked for.
+ */
+export function dupeCheckOptsFromBody(body: unknown): { opts: DupeCheckOpts } | { error: string } {
+  const b = (body ?? {}) as Record<string, unknown>;
+  const opts: DupeCheckOpts = {};
+
+  for (const key of ['checkDuplicates', 'checkContradictions'] as const) {
+    const v = b[key];
+    if (v === undefined) continue;
+    if (typeof v !== 'boolean') return { error: `\`${key}\` must be a boolean` };
+    opts[key] = v;
+  }
+
+  if (b['dupeThreshold'] !== undefined) {
+    const t = b['dupeThreshold'];
+    // Bounded to the same 0..1 the score itself lives in. An out-of-range threshold is not a preference,
+    // it is a caller who has misunderstood the scale — and 1.5 would silently mean "never warn".
+    if (typeof t !== 'number' || !Number.isFinite(t) || t < 0 || t > 1) {
+      return { error: '`dupeThreshold` must be a number between 0 and 1' };
+    }
+    opts.dupeThreshold = t;
+  }
+
+  return { opts };
 }

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -13,7 +13,7 @@ import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
 import type { ChronoStatus } from '../../config/types.js';
-import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError, dupeCheckOptsFromBody } from './_shared.js';
 import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
@@ -124,7 +124,12 @@ chronoRouter.post('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, 
     res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
     return;
   }
-  const embedOpts = waitForEmbedding === true ? { waitForEmbedding: true } : undefined;
+  // Same insert-time check as the other two write paths, and the same shared reader — `createChrono`
+  // already merges `similar` and `contradicts` into what it returns, so the spread below reports them.
+  const dupe = dupeCheckOptsFromBody(req.body);
+  if ('error' in dupe) { res.status(400).json({ error: dupe.error }); return; }
+  const writeOpts = { ...dupe.opts, ...(waitForEmbedding === true ? { waitForEmbedding: true } : {}) };
+  const embedOpts = Object.keys(writeOpts).length > 0 ? writeOpts : undefined;
   const entry = await createChrono(wt.target, {
     title: title.trim(), type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -16,7 +16,7 @@ import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEntity } from '../../spaces/schema-validation.js';
-import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError, dupeCheckOptsFromBody } from './_shared.js';
 import { classifyEntityUpsert, classifyUpdateViolations } from '../../brain/write-validation.js';
 import { tagContains, textContains, propertiesValueContains } from '../../brain/tag-filter.js';
 import { mergePropertiesOrKeep, mergeTagsOrKeep } from '../../brain/merge-fields.js';
@@ -85,11 +85,24 @@ entitiesRouter.post('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAu
       res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
       return;
     }
-    const embedOpts = waitForEmbedding === true ? { waitForEmbedding: true } : undefined;
-    const { entity, warning } = await upsertEntity(wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId, embedOpts, webhookToken(req), ttlDaysFromBody(req.body));
+    // The insert-time near-duplicate / contradiction check, which MCP has always had and REST never
+    // exposed. Same options object, same shared implementation — the only thing that was missing here was
+    // reading the flags off the body and reporting what came back.
+    const dupe = dupeCheckOptsFromBody(req.body);
+    if ('error' in dupe) { res.status(400).json({ error: dupe.error }); return; }
+
+    const writeOpts = { ...dupe.opts, ...(waitForEmbedding === true ? { waitForEmbedding: true } : {}) };
+    const { entity, warning, similar, contradicts } = await upsertEntity(
+      wt.target, name.trim(), type.trim(), tags, properties, safeDesc, safeId,
+      Object.keys(writeOpts).length > 0 ? writeOpts : undefined,
+      webhookToken(req), ttlDaysFromBody(req.body));
     const result: Record<string, unknown> = { ...entity };
     if (warning) result['warning'] = warning;
     if (check.warnings.length > 0) result['warnings'] = check.warnings;
+    // Advisory, never blocking: the write already happened. An agent correcting an outdated fact must be
+    // able to contradict the record it supersedes — the point is that it is TOLD, not that it is stopped.
+    if (similar && similar.length > 0) result['similar'] = similar;
+    if (contradicts && contradicts.length > 0) result['contradicts'] = contradicts;
     res.status(201).json(result);
   } catch (err) {
     res.status(500).json({ error: 'Internal server error' });

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -17,7 +17,7 @@ import { checkQuota, QuotaError } from '../../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateMemory } from '../../spaces/schema-validation.js';
 import type { MemoryDoc } from '../../config/types.js';
-import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, buildMemoryFilter, ttlDaysFromBody, ttlDaysError } from './_shared.js';
+import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, buildMemoryFilter, ttlDaysFromBody, ttlDaysError, dupeCheckOptsFromBody } from './_shared.js';
 import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
@@ -115,9 +115,16 @@ memoriesRouter.post('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAu
     res.status(400).json({ error: '`waitForEmbedding` must be a boolean' });
     return;
   }
+  // The insert-time near-duplicate / contradiction check MCP's `remember` has always taken. `remember`
+  // already merges `similar` and `contradicts` into what it returns, so the spread below reports them with
+  // no further work — the only thing missing on this surface was reading the flags off the body.
+  const dupe = dupeCheckOptsFromBody(req.body);
+  if ('error' in dupe) { res.status(400).json({ error: dupe.error }); return; }
+  const writeOpts = { ...dupe.opts, ...(waitForEmbedding === true ? { waitForEmbedding: true } : {}) };
+
   const doc = await remember(
     targetSpace, fact, safeEntityIds, safeTags, safeDesc, safeProps,
-    undefined, safeMemoryType, waitForEmbedding === true ? { waitForEmbedding: true } : undefined,
+    undefined, safeMemoryType, Object.keys(writeOpts).length > 0 ? writeOpts : undefined,
     webhookToken(req), ttlDaysFromBody(req.body), safeId,
   );
   const body: Record<string, unknown> = { ...doc };


### PR DESCRIPTION
feat(brain): expose the insert-time duplicate/contradiction check over REST

Asked for by an integrator whose fleet is thirty n8n flows: n8n speaks HTTP, so every record they create is
written over REST — and the check existed only on the MCP write tools. The best knowledge-hygiene feature in
the product was invisible to the system generating almost all of their records.

Their measurement is the part that settles it. `recall` cannot stand in: the same pair scores **0.94** on
this check and **0.896** on recall, while unrelated topical neighbours sit at **0.845**. A threshold safe
against those false positives would sit above 0.85 and is a coin-flip against the true match — and the two
scales are not interchangeable, so the proven 0.92 default cannot be ported to a recall approximation.

## Almost all of this already existed

`upsertEntity`, `remember` and `createChrono` all take a `DupeCheckOpts` and already return `similar` /
`contradicts`. The MCP tools filled it; the REST routes did not. So this reads the flags off the body,
passes the same object, and reports what comes back — one shared reader for all three routes, because three
hand-written copies of "read, validate, default" is how the surfaces drifted apart to begin with.

## The flags are OPT-IN here, and default ON over MCP

A deliberate asymmetry, not an oversight. The check implies `waitForEmbedding` — it needs the vector before
the insert so the new record cannot self-match — so copying MCP's default would make every existing REST
integration, bulk importers included, start paying the embedding model synchronously without asking for it.
An MCP caller is an agent writing one record and reading the answer; REST is also how a fleet imports
thousands. A REST write that sends none of these behaves exactly as it did before.

## What verification caught

I wrote the helper's doc claiming `checkDuplicates` defaults ON, then verified against a live instance: the
`contradicts` warning came back and `similar` did not. The default lives in the MCP tool, not in
`DupeCheckOpts`, so the comment and the behaviour disagreed. Corrected in both directions — the code is now
explicitly opt-in and the comment says why.

A second apparent failure was my probe, not the product: a top hit at score 1.0 looked like a record matching
itself, and was the identical record left behind by an earlier run against the same space. On a clean space
all 15 checks pass. The check does run before the insert, exactly as the comment beside it claims.

Verified end to end against a real Atlas Local index: warnings reported on entities and memories, the write
still succeeding, `checkDuplicates:false` suppressing it, a no-flags write unchanged, and `"false"` / `1` /
`1.5` each refused with a 400 rather than coerced.

