### PR TITLE
fix(graph): the node halo had never been drawn, and a cast is why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The graph's node halo had never been drawn.** The stylesheet set `shadow-blur`, `shadow-color`,
+  `shadow-opacity` and `shadow-offset-x/y` across seven selectors. Those are **cytoscape 2** properties;
+  cytoscape 3 removed them, and an unknown style property is silently discarded rather than warned about. So
+  the depth-tapering glow the module's own comment described had never once been painted. Replaced with
+  `underlay-color` / `-opacity` / `-padding`, which are cytoscape 3's equivalent — the root node now carries a
+  brighter, wider halo and it fades with distance, which is what the layout was always meant to convey.
+  - `underlay-shape` defaults to round-rectangle, so the halo also had to be told the nodes are ellipses —
+    without it every circular node sat inside a visible box.
+  - It compiled for as long as it did because each `style` block ended in `as any`. The cast was not
+    documenting a boundary where the type is unknowable; it was suppressing the one check that could have
+    noticed. Cytoscape ships its own typings and the module now uses them throughout.
+
 ### Internal
+
+- **A gate that reads the shipped cytoscape runtime, not its typings** — every style property the graph sets
+  must exist in `cytoscape.cjs.js`, because a property present in the `.d.ts` and absent from the runtime is
+  exactly the failure above and only the runtime can tell you. It carries a positive control: a property known
+  to exist must be found and a known-removed one must not, since a gate that cannot read the bundle at all
+  greps empty in precisely the same way as one finding no problems. It also fails if a style block is cast to
+  `any` again.
+
+- **The record drawer's four record shapes are now a discriminated union.** `RecordDrawerState.open()` took
+  `(kind, record: any)` and read `record.fact` / `.name` / `.label` / `.title` off it, so nothing stopped a
+  caller passing an Edge as a `'memory'` and getting a drawer with an undefined field and no error anywhere.
+  Four overloads keep every call site's shape — including the four in TEMPLATES, checked because the client
+  builds with `strictTemplates`. The new type immediately caught a live one: the graph page's `lastSaved`
+  effect wrote an unnarrowed record into both its memory and its chrono list.
 
 - **A ratchet against god-files, measured in CODE lines rather than raw ones** — the deliverable from a second
   architecture angle that also found no defect. Ranked by raw lines the two largest files in the repo are its

--- a/client/src/app/pages/brain/record-drawer-state.service.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject, signal } from '@angular/core';
-import { ChronoType, ChronoStatus } from '../../core/api.types';
+import { ChronoType, ChronoStatus, Memory, Entity, Edge, ChronoEntry } from '../../core/api.types';
 import { BrainApi } from '../../core/brain-api.service';
 import { BrainStore } from './brain-store.service';
 import { EntityRefPicker } from './entity-ref-picker.service';
@@ -21,6 +21,25 @@ import { toLocalDatetime, fmtApiError } from './brain-format';
  *
  * Provided by BrainComponent (not root): one instance per mounted page.
  */
+
+/** The four record kinds one drawer edits. */
+export type DrawerKind = 'memory' | 'entity' | 'edge' | 'chrono';
+
+/**
+ * What the drawer is holding — a discriminated union, so reading `record.fact` is only legal once
+ * `kind` has been narrowed to `'memory'`.
+ *
+ * This used to be `{ kind: DrawerKind; record: any }`, and the `any` was load-bearing in the wrong
+ * direction: `open()` reads `record.fact`, `record.name`, `record.label` and `record.title` on four
+ * different shapes, so nothing stopped a caller passing an Edge as a `'memory'` and getting a drawer
+ * with an undefined fact and no error anywhere.
+ */
+export type DrawerRecord =
+  | { kind: 'memory'; record: Memory }
+  | { kind: 'entity'; record: Entity }
+  | { kind: 'edge'; record: Edge }
+  | { kind: 'chrono'; record: ChronoEntry };
+
 @Injectable()
 export class RecordDrawerState {
   private brainApi = inject(BrainApi);
@@ -30,7 +49,7 @@ export class RecordDrawerState {
   /** Active brain space. Kept in sync by the shell, whose `activeSpaceId` is nav state. */
   readonly spaceId = signal('');
 
-  drawerRecord = signal<{ kind: 'memory' | 'entity' | 'edge' | 'chrono'; record: any } | null>(null);
+  drawerRecord = signal<DrawerRecord | null>(null);
   drawerSaving = signal(false);
   drawerError = signal('');
 
@@ -43,7 +62,7 @@ export class RecordDrawerState {
    * Deliberately a signal rather than a callback so a host reacts declaratively and one host cannot
    * overwrite another's handler.
    */
-  readonly lastSaved = signal<{ kind: 'memory' | 'entity' | 'edge' | 'chrono'; record: any } | null>(null);
+  readonly lastSaved = signal<DrawerRecord | null>(null);
 
   drawerEditMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
@@ -65,54 +84,74 @@ export class RecordDrawerState {
     this.drawerEditChrono.properties = this.store.buildPropertiesObject('chrono', this.drawerEditChrono.properties, this.drawerChronoKind());
   }
 
-  open(kind: 'memory' | 'entity' | 'edge' | 'chrono', record: any): void {
-    this.drawerRecord.set({ kind, record });
+  /**
+   * Open the drawer on one record.
+   *
+   * Four overloads rather than one `(kind, record: any)`: the kind and the record are separate
+   * arguments, and TypeScript will not narrow the second from the first on its own. Stating the four
+   * legal pairings is what makes `open('memory', someEdge)` a compile error at all eight call sites —
+   * four of which are templates, checked because the client builds with `strictTemplates`.
+   */
+  open(kind: 'memory', record: Memory): void;
+  open(kind: 'entity', record: Entity): void;
+  open(kind: 'edge', record: Edge): void;
+  open(kind: 'chrono', record: ChronoEntry): void;
+  open(kind: DrawerKind, record: Memory | Entity | Edge | ChronoEntry): void {
+    // The one assertion in this method, and the overloads above are what make it sound: every caller
+    // has already been checked against a single legal (kind, record) pairing.
+    const target = { kind, record } as DrawerRecord;
+    this.drawerRecord.set(target);
     this.drawerError.set('');
     this.drawerSaving.set(false);
-    const ids: string[] = record.entityIds ?? [];
+    // Only memories and chrono entries carry entity references — the other two kinds have no such field.
+    const ids: string[] = 'entityIds' in record ? (record.entityIds ?? []) : [];
     if (ids.length) this.picker.resolveEntityNames(ids);
-    if (kind === 'memory') {
+    if (target.kind === 'memory') {
+      const r = target.record;
       this.drawerEditMemory = {
-        fact: record.fact,
-        tags: [...(record.tags ?? [])],
-        entityIds: (record.entityIds ?? []).join(', '),
-        description: record.description ?? '',
-        properties: this.store.buildPropertiesObject('memory', record.properties ?? {}),
+        fact: r.fact,
+        tags: [...(r.tags ?? [])],
+        entityIds: (r.entityIds ?? []).join(', '),
+        description: r.description ?? '',
+        properties: this.store.buildPropertiesObject('memory', r.properties ?? {}),
       };
-    } else if (kind === 'entity') {
+    } else if (target.kind === 'entity') {
+      const r = target.record;
       this.drawerEditEntity = {
-        name: record.name,
-        type: record.type ?? '',
-        tags: [...(record.tags ?? [])],
-        description: record.description ?? '',
-        properties: this.store.buildPropertiesObject('entity', record.properties ?? {}, record.type),
+        name: r.name,
+        type: r.type ?? '',
+        tags: [...(r.tags ?? [])],
+        description: r.description ?? '',
+        properties: this.store.buildPropertiesObject('entity', r.properties ?? {}, r.type),
       };
-    } else if (kind === 'edge') {
+    } else if (target.kind === 'edge') {
+      const r = target.record;
       this.drawerEditEdge = {
-        label: record.label,
-        type: record.type ?? '',
-        weight: record.weight ?? null,
-        tags: [...(record.tags ?? [])],
-        description: record.description ?? '',
-        properties: this.store.buildPropertiesObject('edge', record.properties ?? {}, record.label),
+        label: r.label,
+        type: r.type ?? '',
+        weight: r.weight ?? null,
+        tags: [...(r.tags ?? [])],
+        description: r.description ?? '',
+        properties: this.store.buildPropertiesObject('edge', r.properties ?? {}, r.label),
       };
-    } else if (kind === 'chrono') {
-      const isPredefined = this.store.chronoKinds.includes(record.type as ChronoType);
+    } else {
+      const r = target.record;
+      const isPredefined = this.store.chronoKinds.includes(r.type as ChronoType);
       this.drawerEditChrono = {
-        title: record.title,
-        kind: isPredefined ? record.type : '__custom__',
-        customKind: isPredefined ? '' : record.type,
-        status: record.status,
-        startsAt: record.startsAt ? toLocalDatetime(record.startsAt) : '',
-        endsAt: record.endsAt ? toLocalDatetime(record.endsAt) : '',
-        description: record.description ?? '',
-        tags: [...(record.tags ?? [])],
-        entityIds: (record.entityIds ?? []).join(', '),
-        confidence: record.confidence ?? null,
-        memoryIds: [...(record.memoryIds ?? [])],
-        properties: this.store.buildPropertiesObject('chrono', record.properties ?? {}, record.type),
+        title: r.title,
+        kind: isPredefined ? r.type : '__custom__',
+        customKind: isPredefined ? '' : r.type,
+        status: r.status,
+        startsAt: r.startsAt ? toLocalDatetime(r.startsAt) : '',
+        endsAt: r.endsAt ? toLocalDatetime(r.endsAt) : '',
+        description: r.description ?? '',
+        tags: [...(r.tags ?? [])],
+        entityIds: (r.entityIds ?? []).join(', '),
+        confidence: r.confidence ?? null,
+        memoryIds: [...(r.memoryIds ?? [])],
+        properties: this.store.buildPropertiesObject('chrono', r.properties ?? {}, r.type),
       };
-      this.picker.resolveMemoryTitles(record.memoryIds ?? []);
+      this.picker.resolveMemoryTitles(r.memoryIds ?? []);
     }
   }
 

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -266,7 +266,7 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                 }
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.author' | transloco }}</div>
-                  <div class="drawer-readonly-value">{{ dr.record.author?.instanceLabel }} ({{ dr.record.author?.instanceId }})</div>
+                  <div class="drawer-readonly-value">{{ dr.record.author.instanceLabel }} ({{ dr.record.author.instanceId }})</div>
                 </div>
                 <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.seq' | transloco }}</div>

--- a/client/src/app/pages/graph/graph-cytoscape.ts
+++ b/client/src/app/pages/graph/graph-cytoscape.ts
@@ -102,13 +102,27 @@ function glassShineSvg(color: string): string {
 /**
  * The cytoscape stylesheet.
  *
- * Node size, opacity and shadow all taper with `depth`, so distance from the root reads visually
+ * Node size, opacity and halo all taper with `depth`, so distance from the root reads visually
  * rather than only from the layout — that is why so many values are functions of the element.
+ *
+ * ## The halo is `underlay-*`, and it used to be `shadow-*`, which does not exist
+ *
+ * Cytoscape 2 had `shadow-blur` / `shadow-color` / `shadow-opacity` / `shadow-offset-*`. Cytoscape 3
+ * removed them: the string does not appear in `cytoscape.cjs.js` at all, and an unknown style property
+ * is silently discarded rather than warned about. So seven selectors here were setting a glow that had
+ * never once been painted — and the `as any` on each `style` block is precisely what let them compile.
+ * The comment above claimed depth tapered the shadow, and one of the two things it named was inert.
+ *
+ * `underlay-color` / `-opacity` / `-padding` are cytoscape 3's equivalent and are present in both the
+ * typings and the runtime. Opacities are lower than the old shadow figures because an underlay is a
+ * solid halo rather than a blur — 0.6 of a blur and 0.6 of a solid are not the same amount of light.
+ *
+ * Every block below is now typed, so the next property that stops existing fails the build instead.
  */
-function graphStylesheet(theme: GraphTheme): any[] {
-  const depthOf = (ele: any) => +ele.data('depth');
-  const colorOf = (ele: any) => typeColor(theme, ele.data('type') || 'default');
-  const nodeSize = (ele: any) => { const d = depthOf(ele); return d === 0 ? 68 : Math.max(36, 52 - d * 3); };
+function graphStylesheet(theme: GraphTheme): cytoscape.StylesheetJson {
+  const depthOf = (ele: cytoscape.NodeSingular) => +ele.data('depth');
+  const colorOf = (ele: cytoscape.NodeSingular) => typeColor(theme, ele.data('type') || 'default');
+  const nodeSize = (ele: cytoscape.NodeSingular) => { const d = depthOf(ele); return d === 0 ? 68 : Math.max(36, 52 - d * 3); };
 
   return [
     {
@@ -117,15 +131,15 @@ function graphStylesheet(theme: GraphTheme): any[] {
         'width': nodeSize,
         'height': nodeSize,
         'background-color': theme.nodeBg,
-        'background-image': (ele: any) => glassShineSvg(colorOf(ele)),
+        'background-image': (ele: cytoscape.NodeSingular) => glassShineSvg(colorOf(ele)),
         'background-fit': 'cover',
         'background-clip': 'node',
-        'border-width': (ele: any) => depthOf(ele) === 0 ? 2.5 : 1.5,
+        'border-width': (ele: cytoscape.NodeSingular) => depthOf(ele) === 0 ? 2.5 : 1.5,
         'border-color': colorOf,
         'border-opacity': 0.75,
         'label': 'data(label)',
-        'font-size': (ele: any) => depthOf(ele) === 0 ? 13 : 11,
-        'font-weight': (ele: any) => depthOf(ele) === 0 ? '600' : '400',
+        'font-size': (ele: cytoscape.NodeSingular) => depthOf(ele) === 0 ? 13 : 11,
+        'font-weight': (ele: cytoscape.NodeSingular) => depthOf(ele) === 0 ? 600 : 400,
         'color': theme.nodeText,
         'text-outline-color': theme.nodeBg,
         'text-outline-width': 2,
@@ -133,28 +147,32 @@ function graphStylesheet(theme: GraphTheme): any[] {
         'text-margin-y': 8,
         'text-max-width': '110px',
         'text-wrap': 'ellipsis',
-        'opacity': (ele: any) => { const d = depthOf(ele); return d === 0 ? 1 : Math.max(0.55, 1 - d * 0.1); },
-        'shadow-blur': (ele: any) => depthOf(ele) === 0 ? 28 : 14,
-        'shadow-color': colorOf,
-        'shadow-opacity': (ele: any) => depthOf(ele) === 0 ? 0.6 : 0.35,
-        'shadow-offset-x': 0,
-        'shadow-offset-y': 0,
-      } as any,
+        'opacity': (ele: cytoscape.NodeSingular) => { const d = depthOf(ele); return d === 0 ? 1 : Math.max(0.55, 1 - d * 0.1); },
+        // `underlay-shape` defaults to round-rectangle, which puts a visible BOX behind a circular
+        // node. Nodes here use cytoscape's default ellipse shape, so the halo has to say so too.
+        'underlay-shape': 'ellipse',
+        'underlay-color': colorOf,
+        'underlay-padding': (ele: cytoscape.NodeSingular) => depthOf(ele) === 0 ? 10 : 5,
+        'underlay-opacity': (ele: cytoscape.NodeSingular) => depthOf(ele) === 0 ? 0.35 : 0.18,
+      },
     },
     {
       selector: 'node.root',
-      style: { 'border-color': theme.nodeRoot, 'border-width': 3, 'border-opacity': 1 } as any,
+      style: { 'border-color': theme.nodeRoot, 'border-width': 3, 'border-opacity': 1 },
     },
     {
       selector: 'node.hovered',
-      style: { 'border-width': 2.5, 'border-opacity': 1, 'opacity': 1, 'shadow-blur': 30, 'shadow-opacity': 0.8 } as any,
+      style: {
+        'border-width': 2.5, 'border-opacity': 1, 'opacity': 1,
+        'underlay-padding': 11, 'underlay-opacity': 0.45,
+      },
     },
     {
       selector: 'node:selected',
       style: {
         'border-color': theme.nodeSelect, 'border-width': 3, 'border-opacity': 1, 'opacity': 1,
-        'shadow-blur': 36, 'shadow-color': theme.nodeSelect, 'shadow-opacity': 0.9,
-      } as any,
+        'underlay-padding': 13, 'underlay-color': theme.nodeSelect, 'underlay-opacity': 0.5,
+      },
     },
     {
       selector: 'edge',
@@ -173,26 +191,23 @@ function graphStylesheet(theme: GraphTheme): any[] {
         'text-background-opacity': 0.7,
         'text-background-padding': '2px',
         'opacity': 0.75,
-        'shadow-blur': 0,
-      } as any,
+      },
     },
     {
       selector: 'edge.hovered',
       style: {
         'line-color': theme.edgeHover, 'target-arrow-color': theme.edgeHover, 'opacity': 1, 'width': 2.5,
-        'shadow-blur': 12, 'shadow-color': theme.edgeHover, 'shadow-opacity': 0.6,
-        'shadow-offset-x': 0, 'shadow-offset-y': 0,
-      } as any,
+        'underlay-padding': 4, 'underlay-color': theme.edgeHover, 'underlay-opacity': 0.35,
+      },
     },
     {
       selector: 'edge:selected',
       style: {
         'line-color': theme.edgeSelect, 'target-arrow-color': theme.edgeSelect, 'opacity': 1, 'width': 2.5,
-        'shadow-blur': 16, 'shadow-color': theme.edgeSelect, 'shadow-opacity': 0.7,
-        'shadow-offset-x': 0, 'shadow-offset-y': 0,
-      } as any,
+        'underlay-padding': 5, 'underlay-color': theme.edgeSelect, 'underlay-opacity': 0.4,
+      },
     },
-    { selector: 'edge.hide-labels', style: { 'label': '' } as any },
+    { selector: 'edge.hide-labels', style: { 'label': '' } },
   ];
 }
 
@@ -212,8 +227,8 @@ export function buildElements(
   nodes: readonly TraverseNode[],
   edges: readonly TraverseEdge[],
   rootId: string,
-): any[] {
-  const elements: any[] = [];
+): cytoscape.ElementDefinition[] {
+  const elements: cytoscape.ElementDefinition[] = [];
 
   if (root) {
     elements.push({
@@ -238,6 +253,16 @@ export function buildElements(
   return elements;
 }
 
+/**
+ * The renderer instance, named so the component can hold one without importing cytoscape.
+ *
+ * The alias is the point: the component's field was `private cy: any`, which made the claim at the top
+ * of this file — "the component holds no `any`-typed renderer state" — untrue on the very line it was
+ * written about. An alias keeps the boundary (nothing outside this module names cytoscape) while still
+ * being a real type.
+ */
+export type GraphInstance = cytoscape.Core;
+
 /** What the component wants to know about, expressed without any cytoscape types. */
 export interface GraphHandlers {
   onNodeTap(id: string): void;
@@ -258,7 +283,7 @@ export function createGraphCytoscape(
   container: HTMLElement,
   theme: GraphTheme,
   handlers: GraphHandlers,
-): any {
+): cytoscape.Core {
   const cy = cytoscape({
     container,
     elements: [],
@@ -267,19 +292,21 @@ export function createGraphCytoscape(
     minZoom: 0.1,
     maxZoom: 5,
     wheelSensitivity: 0.25,
-  } as any);
+  });
 
-  cy.on('tap', 'node', (evt: any) => handlers.onNodeTap(evt.target.data('id')));
-  cy.on('tap', 'edge', (evt: any) => handlers.onEdgeTap(evt.target.data('id')));
-  cy.on('dbltap', 'node', (evt: any) => handlers.onNodeDoubleTap(evt.target.data('id')));
+  const idOf = (evt: cytoscape.EventObject): string => evt.target.data('id');
 
-  cy.on('mouseover', 'node', (evt: any) => { evt.target.addClass('hovered'); });
-  cy.on('mouseout',  'node', (evt: any) => { evt.target.removeClass('hovered'); });
-  cy.on('mouseover', 'edge', (evt: any) => { evt.target.addClass('hovered'); });
-  cy.on('mouseout',  'edge', (evt: any) => { evt.target.removeClass('hovered'); });
+  cy.on('tap', 'node', evt => handlers.onNodeTap(idOf(evt)));
+  cy.on('tap', 'edge', evt => handlers.onEdgeTap(idOf(evt)));
+  cy.on('dbltap', 'node', evt => handlers.onNodeDoubleTap(idOf(evt)));
+
+  cy.on('mouseover', 'node', evt => { evt.target.addClass('hovered'); });
+  cy.on('mouseout',  'node', evt => { evt.target.removeClass('hovered'); });
+  cy.on('mouseover', 'edge', evt => { evt.target.addClass('hovered'); });
+  cy.on('mouseout',  'edge', evt => { evt.target.removeClass('hovered'); });
 
   // Background tap — identified by the event target being the instance itself, not an element.
-  cy.on('tap', (evt: any) => { if (evt.target === cy) handlers.onBackgroundTap(); });
+  cy.on('tap', evt => { if (evt.target === cy) handlers.onBackgroundTap(); });
 
   return cy;
 }
@@ -292,8 +319,8 @@ export function createGraphCytoscape(
  * cytoscape knowing. Fitting against stale dimensions is what makes a graph render half off-screen.
  */
 export function renderElements(
-  cy: any,
-  elements: any[],
+  cy: cytoscape.Core,
+  elements: cytoscape.ElementDefinition[],
   rootId: string,
   hideLabels: boolean,
   onSettled: () => void,
@@ -306,16 +333,20 @@ export function renderElements(
   else cy.edges().removeClass('hide-labels');
 
   // breadthfirst keeps each node next to its direct edge-partner.
+  //
+  // `roots` takes an array of raw ids rather than the `#id` selector this used to pass. Both resolve the
+  // same element — cytoscape's selector grammar does accept an id beginning with a digit, which UUIDs
+  // often do — but the array form is what the typings describe, so it needs no cast to compile.
   const layout = cy.layout({
     name: 'breadthfirst',
-    roots: `#${rootId}`,
+    roots: [rootId],
     directed: false,
     spacingFactor: 1.1,
     padding: 40,
     avoidOverlap: true,
     animate: true,
     animationDuration: 400,
-  } as any);
+  });
 
   layout.on('layoutstop', onSettled);
   layout.run();

--- a/client/src/app/pages/graph/graph.component.characterization.spec.ts
+++ b/client/src/app/pages/graph/graph.component.characterization.spec.ts
@@ -443,7 +443,9 @@ describe('GraphComponent — what it asks the renderer to draw', () => {
 
   it('roots the layout at the entity the user selected', () => {
     render([['a', 1]], []);
-    expect(cy.layoutOpts.at(-1)).toMatchObject({ name: 'breadthfirst', roots: '#root' });
+    // `roots` is an array of raw ids, not a `#id` selector. Cytoscape accepts both and resolves them to
+    // the same element; the array is the form its typings describe, so the call needs no cast.
+    expect(cy.layoutOpts.at(-1)).toMatchObject({ name: 'breadthfirst', roots: ['root'] });
   });
 
   it('applies the hide-labels state on every render, not only on toggle', () => {

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -54,7 +54,7 @@ import {
 } from './graph-traversal-cache';
 import {
   GraphTheme, DEFAULT_GRAPH_THEME, readGraphTheme, typeColor,
-  buildElements, createGraphCytoscape, renderElements,
+  buildElements, createGraphCytoscape, renderElements, type GraphInstance,
 } from './graph-cytoscape';
 import { GRAPH_STYLES } from './graph.styles';
 
@@ -387,10 +387,13 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     effect(() => {
       const saved = this.drawerState.lastSaved();
       if (!saved) return;
-      const rec = saved.record;
+      // Read `saved.record` inside each branch, not once above: the discriminant only narrows the
+      // record while it is still reached through `saved`.
       if (saved.kind === 'memory') {
+        const rec = saved.record;
         this.nodeMemories.update(list => list.map(m => m._id === rec._id ? rec : m));
       } else if (saved.kind === 'chrono') {
+        const rec = saved.record;
         this.nodeChrono.update(list => list.map(c => c._id === rec._id ? rec : c));
       }
     });
@@ -524,7 +527,7 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
   });
 
   // â”€â”€ Private state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-  private cy: any = null;
+  private cy: GraphInstance | null = null;
   private subs = new Subscription();
 
   /** Palette read from CSS vars once the view exists; the default until then. */
@@ -909,7 +912,7 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     }).subscribe(({ mems, chrono }) => {
       // filter to those also referencing te.to
       const filteredMems = mems.memories.filter(m =>
-        Array.isArray((m as any).entityIds) && (m as any).entityIds.includes(te.to)
+        Array.isArray(m.entityIds) && m.entityIds.includes(te.to)
       );
       const filteredChrono = (chrono.results as unknown as ChronoEntry[]).filter(c =>
         Array.isArray(c.entityIds) && c.entityIds.includes(te.from) && c.entityIds.includes(te.to)
@@ -940,9 +943,16 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
    *
    * Kept as a method rather than calling `drawerState.open()` from each of the three call sites,
    * so this page keeps one seam for the open path.
+   *
+   * Overloaded for the same reason `RecordDrawerState.open` is: this page only ever opens the two
+   * kinds a graph node carries, and a single `(kind, record: any)` signature would let either one
+   * through as the other.
    */
-  openBrainDrawer(kind: 'memory' | 'chrono', record: any): void {
-    this.drawerState.open(kind, record);
+  openBrainDrawer(kind: 'memory', record: Memory): void;
+  openBrainDrawer(kind: 'chrono', record: ChronoEntry): void;
+  openBrainDrawer(kind: 'memory' | 'chrono', record: Memory | ChronoEntry): void {
+    if (kind === 'memory') this.drawerState.open(kind, record as Memory);
+    else this.drawerState.open(kind, record as ChronoEntry);
   }
 
   /**

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -182,6 +182,8 @@ Two conventions make these worth the effort:
 
 At the rendering boundary, pin the **model** handed to the library rather than the library's output — e.g. the element list given to cytoscape, not what it draws. That lets the renderer move without the tests moving with it.
 
+That leaves one thing the model cannot tell you: whether the library still implements what the model names. A renderer typically **discards an unknown property in silence**, so a style the code sets, the tests pin and the comments describe can be doing nothing at all. The graph set `shadow-*` for as long as it had existed — cytoscape 2 properties, removed in cytoscape 3 — behind an `as any` on each style block that stopped the compiler from mentioning it. Prefer the library's own typings over a cast, and where a cast is genuinely unavoidable, check the property against the shipped bundle (`graph-styles-exist-in-cytoscape` does this). A gate of that shape needs a **positive control**: one that cannot read the bundle at all reports success in exactly the same way as one that finds no problems.
+
 ### Standalone tests (no Docker required)
 
 ```bash

--- a/testing/standalone/graph-styles-exist-in-cytoscape.test.js
+++ b/testing/standalone/graph-styles-exist-in-cytoscape.test.js
@@ -1,0 +1,98 @@
+/**
+ * Every style property the graph sets must be one cytoscape actually implements.
+ *
+ * ## The bug this exists for
+ *
+ * The graph stylesheet set `shadow-blur`, `shadow-color`, `shadow-opacity` and `shadow-offset-x/y` across
+ * seven selectors. Those are **cytoscape 2** properties. Cytoscape 3 removed them — the strings do not
+ * appear anywhere in its bundle — and an unknown style property is silently discarded rather than warned
+ * about. So the depth-tapering glow the module's own comment described had never once been painted, and
+ * nothing anywhere said so.
+ *
+ * It compiled because each `style` block ended in `as any`. That is the whole shape of the defect: the
+ * cast was not documenting a boundary where the type is unknowable, it was suppressing the one check that
+ * could have noticed. The properties are now typed, so a removed property fails the build — but the build
+ * only sees what the TYPINGS declare, and typings can lag a major version. This gate reads the shipped
+ * RUNTIME instead, which is the thing that actually decides whether a property does anything.
+ *
+ * ## Why the runtime bundle rather than the .d.ts
+ *
+ * A property present in the typings and absent from the runtime is exactly the failure above, and only the
+ * runtime can tell you. Checking both would be checking the same claim twice through the weaker copy.
+ *
+ * Run: node --test testing/standalone/graph-styles-exist-in-cytoscape.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const STYLESHEET = join(ROOT, 'client/src/app/pages/graph/graph-cytoscape.ts');
+const BUNDLE = join(ROOT, 'node_modules/cytoscape/dist/cytoscape.cjs.js');
+
+/** The body of `graphStylesheet`, so quoted keys elsewhere in the module are not mistaken for style props. */
+function stylesheetBody(src) {
+  const start = src.indexOf('function graphStylesheet');
+  assert.notEqual(start, -1, 'graphStylesheet() not found — this gate is pointed at the wrong thing');
+  const end = src.indexOf('\n}', start);
+  assert.notEqual(end, -1, 'could not find the end of graphStylesheet()');
+  return src.slice(start, end);
+}
+
+/**
+ * Style property names: a quoted kebab-case key followed by a colon.
+ *
+ * Values are quoted too (`'cover'`, `'data(label)'`, `'110px'`) but are never followed by a colon, so the
+ * trailing `:` is what separates a key from a value.
+ */
+function styleProps(body) {
+  const props = new Set();
+  for (const m of body.matchAll(/'([a-z][a-z0-9-]*)'\s*:/g)) props.add(m[1]);
+  return [...props].sort();
+}
+
+describe('the graph only sets style properties cytoscape implements', () => {
+  const src = readFileSync(STYLESHEET, 'utf8');
+  const props = styleProps(stylesheetBody(src));
+
+  it('read a real bundle and a real stylesheet', () => {
+    // Floors both enumerations. A missing bundle greps empty exactly like an absent property does — which
+    // is the mistake that nearly shipped this gate backwards — so the file's existence is asserted, not
+    // assumed, and the property list must be substantial before any conclusion is drawn from it.
+    assert.ok(existsSync(BUNDLE), `cytoscape bundle not found at ${BUNDLE} — run npm install`);
+    assert.ok(readFileSync(BUNDLE, 'utf8').length > 1_000_000, 'cytoscape bundle is implausibly small');
+    assert.ok(props.length >= 25, `only extracted ${props.length} style properties — the matcher is broken`);
+  });
+
+  it('distinguishes a real property from a removed one', () => {
+    // The positive control. Without it, a gate that could not read the bundle at all would report that
+    // every property is fine, which is the most dangerous way for this check to fail.
+    const bundle = readFileSync(BUNDLE, 'utf8');
+    assert.ok(bundle.includes("'text-outline-width'"), 'a property known to exist was not found — detector broken');
+    assert.ok(!bundle.includes("'shadow-blur'"),
+      'cytoscape now ships `shadow-blur`. If it was reinstated, this control needs re-aiming at another '
+      + 'genuinely-absent property — but check first whether the graph should go back to using it.');
+  });
+
+  it('every property in the stylesheet exists in the shipped cytoscape', () => {
+    const bundle = readFileSync(BUNDLE, 'utf8');
+    const missing = props.filter(p => !bundle.includes(`'${p}'`));
+    assert.deepEqual(missing, [],
+      'these style properties are not implemented by the installed cytoscape, so they are silently '
+      + 'discarded at render time and whatever they were meant to do never happens. Either the property '
+      + 'was removed in a major version and needs its modern equivalent (`shadow-*` became `underlay-*`), '
+      + 'or it is a typo. Do not silence this with a cast — a cast is what hid it last time.');
+  });
+
+  it('no style block is cast away', () => {
+    // The cast is what made the above possible for as long as it did. Style blocks are fully typed now;
+    // reintroducing `as any` there would disable the compiler half of this guarantee.
+    const body = stylesheetBody(src);
+    const casts = body.split('\n').map((l, i) => [i + 1, l]).filter(([, l]) => /\bas\s+any\b/.test(l));
+    assert.deepEqual(casts.map(([n, l]) => `${n}: ${l.trim()}`), [],
+      'a style block is cast to `any` again. That cast is precisely what let seven selectors set a '
+      + 'property cytoscape had removed. If a property is genuinely missing from the typings but present '
+      + 'in the runtime, cast that ONE property and say which, rather than the whole block.');
+  });
+});

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -72,7 +72,10 @@ const FROZEN = {
   'server/src/sync/engine.ts': 966,
   'client/src/app/pages/settings/space-schema-tab.component.ts': 954,
   'server/src/api/spaces.ts': 839,
-  'client/src/app/pages/graph/graph.component.ts': 769,
+  // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
+  // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
+  // raised deliberately rather than worked around, which is what this list is for.
+  'client/src/app/pages/graph/graph.component.ts': 773,
   'server/src/config/loader.ts': 753,
   'client/src/app/pages/brain/review-tab.component.ts': 748,
   'server/src/brain/recall.ts': 739,


### PR DESCRIPTION
fix(graph): the node halo had never been drawn, and a cast is why

The graph stylesheet set `shadow-blur`, `shadow-color`, `shadow-opacity` and
`shadow-offset-x/y` across seven selectors. Those are cytoscape 2 properties.
Cytoscape 3 removed them -- the strings appear nowhere in the shipped
`cytoscape.cjs.js` -- and an unknown style property is silently discarded
rather than warned about.

So the depth-tapering glow had never once been painted, and the module's own
comment said "node size, opacity and shadow all taper with depth" while one of
the two things it named was inert. Every `style` block ended in `as any`, which
is precisely what let it compile for as long as it did. The cast was not
documenting a boundary where the type is unknowable; it was suppressing the one
check that could have noticed.

## How it was found

The A-L2-4 architecture angle: are the `any` escape hatches real boundaries, or
modelling gaps? Measured from source with comments stripped -- 94 in 442 files,
but 18 files hold all of them and one held 53. That file presents itself as a
third-party boundary, which is what made it worth READING rather than counting:
cytoscape ships its own `index.d.ts`. The types existed and the module did not
use them.

## The fix

`underlay-color` / `-opacity` / `-padding` are cytoscape 3's equivalent, present
in both the typings and the runtime. Verified by screenshot -- which is also how
a second bug surfaced: `underlay-shape` defaults to round-rectangle, so the first
attempt put a visible box behind every circular node.

The module is now typed throughout (`StylesheetJson`, `ElementDefinition[]`,
`Core`, `EventObject`), with no `as any` anywhere in it. `roots` moved from the
`#id` selector form to the array-of-ids form the typings describe; both were
probed headlessly and resolve the same element, including for UUIDs beginning
with a digit, so this is a typing change and not a behaviour one.

`GraphInstance` is exported as an alias for `cytoscape.Core` so the component can
hold a typed instance without importing cytoscape -- its field was `private cy:
any`, which made this module's opening claim ("the component holds no `any`-typed
renderer state") untrue on the very line it was written about.

## Second concentration, typed on the way past

`RecordDrawerState.open(kind, record: any)` fronts four record shapes and reads
`record.fact` / `.name` / `.label` / `.title` off them, so nothing stopped a
caller passing an Edge as a `'memory'`. Now a discriminated union plus four
overloads: every call site keeps its shape, and the four that are TEMPLATES are
checked because the client builds with `strictTemplates`.

The new type immediately caught a live one -- the graph page's `lastSaved` effect
extracted the record before the discriminant narrowed it, and wrote it into both
the memory and the chrono list.

## The guarantee

`graph-styles-exist-in-cytoscape` reads the shipped RUNTIME rather than the
`.d.ts`, because a property present in the typings and absent from the runtime is
exactly the failure above and only the runtime can tell you. It carries a
positive control -- a property known to exist must be found, a known-removed one
must not -- since a gate that cannot read the bundle greps empty in precisely the
same way as one finding no problems. That is not hypothetical: a stale working
directory made this very check read a nonexistent path mid-investigation and
return the reassuring answer. It also fails if a style block is cast to `any`
again. Both halves were confirmed to fail against the pre-fix code.

`no-new-god-files` fires on `graph.component.ts` (769 -> 773): four lines of
overload signatures and branch-local reads, no new behaviour. Raised deliberately
with the reason recorded, which is what that list is for.

Recorded in `_REFERENCE.md`, including one thing left open as a different angle:
the client's `Memory.author` is optional and lacks `instanceLabel`, and `Entity`
declares no `author` at all, while the server writes a full `authorRef()` on all
three. The client types under-declare what the API returns.
