### PR TITLE
fix(spaces): a deleted schema type was never actually deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A schema type deleted in the settings editor was never actually deleted.** Reported by an integrator
+  whose space had accumulated 21 foreign entity types after a schema file was imported against the wrong
+  space; they deleted every declared type in the UI, re-imported the correct file, and all 21 were still
+  there. No sequence of UI actions could have removed them. Three additive layers stacked: the file import
+  staged into the existing staged schemas, `buildMeta()` omitted a knowledge type from the payload entirely
+  when it held zero types, and the server's PATCH merges per type-name and only touches knowledge types
+  present in the body. So deleting the last entity type meant the `entity` key never left the browser and
+  the server — correctly, by its own documented contract — kept everything it had.
+  - **Save now persists what the editor is showing.** Importing still ADDS, deleting deletes, and Save
+    writes that exact state. No merge behind it.
+  - `PATCH /api/spaces/:id` takes `"typeSchemasMode": "replace"`, which makes the payload authoritative.
+    The default stays `merge` so every existing integration is byte-for-byte unchanged — that behaviour was
+    asked for by an integrator and is not being taken away.
+  - Deliberately not routed through the existing `PUT /:id/schema`, which does replace wholesale but calls
+    `updateSpace()` directly and so bypasses the network vote a meta change on a networked space must go
+    through. That would have traded a silent no-op for a silent consensus bypass.
+
+- **Importing a schema file silently emptied a `$ref` type.** A file declaring
+  `"cross-space-reference": { "$ref": "library:cross-space-reference" }` staged a type with no naming
+  pattern and nothing required, and saved it as `{}` — so records that should have been refused were
+  accepted. The whole-file importer read `namingPattern`, `retention`, `tagSuggestions` and
+  `propertySchemas` and never looked at a type-level `$ref`; the per-type "import as $ref" action always
+  handled it, which is why the same file appeared to give two different results depending on which button
+  was used.
+
 - **The graph's node halo had never been drawn.** The stylesheet set `shadow-blur`, `shadow-color`,
   `shadow-opacity` and `shadow-offset-x/y` across seven selectors. Those are **cytoscape 2** properties;
   cytoscape 3 removed them, and an unknown style property is silently discarded rather than warned about. So

--- a/client/src/app/core/spaces-api.service.ts
+++ b/client/src/app/core/spaces-api.service.ts
@@ -33,7 +33,7 @@ export class SpacesApi {
     return this.http.post<{ space: Space }>('/api/spaces', body);
   }
 
-  updateSpace(id: string, body: { label?: string; description?: string; maxGiB?: number | null; meta?: Partial<SpaceMeta>; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | RecordTtlWindows | null; documentExtraction?: 'off' | 'ocr' | 'vlm' | 'repair' | 'auto' | null; imageAnalysis?: 'off' | 'caption' | 'recognition' | 'auto' | null; audioAnalysis?: 'off' | 'on' | 'auto' | null; videoAnalysis?: 'off' | 'audio' | 'full' | 'auto' | null; textAnalysis?: 'off' | 'embed' | 'chunk' | 'auto' | null }): Observable<UpdateSpaceResult> {
+  updateSpace(id: string, body: { label?: string; description?: string; maxGiB?: number | null; meta?: Partial<SpaceMeta>; typeSchemasMode?: 'merge' | 'replace'; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | RecordTtlWindows | null; documentExtraction?: 'off' | 'ocr' | 'vlm' | 'repair' | 'auto' | null; imageAnalysis?: 'off' | 'caption' | 'recognition' | 'auto' | null; audioAnalysis?: 'off' | 'on' | 'auto' | null; videoAnalysis?: 'off' | 'audio' | 'full' | 'auto' | null; textAnalysis?: 'off' | 'embed' | 'chunk' | 'auto' | null }): Observable<UpdateSpaceResult> {
     return this.http.patch<UpdateSpaceResult>(`/api/spaces/${id}`, body);
   }
 

--- a/client/src/app/pages/settings/space-schema-tab.component.spec.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.spec.ts
@@ -373,3 +373,66 @@ describe('SpaceSchemaTabComponent — validation controls (moved here in U9 pt3)
     expect(state.schStrictLinkage).toBe(false); // view → state
   });
 });
+
+/**
+ * Two defects reported together by an integrator whose space had accumulated 21 foreign entity types
+ * after a schema file was imported against the wrong space, and which no UI action could remove.
+ *
+ * Both are client-side halves of "Save persists the state the editor is showing".
+ */
+describe('SpaceSchemaTabComponent — a file import must not silently empty a $ref type', () => {
+  it('reads a type-level $ref and keeps it as a library reference', () => {
+    const { c } = setup();
+    // `{ "$ref": "library:x" }` carries no namingPattern, no propertySchemas and no retention, so the
+    // importer used to read every field as absent and stage an EMPTY type — which then saved as `{}`:
+    // no naming rule, nothing required, every new record accepted. Same file, and the per-type
+    // "import as $ref" button handled it correctly, which is why it looked non-deterministic.
+    const staged = (c as unknown as {
+      mapImportedTypeSchema(raw: Record<string, unknown>): TypeSchemaState;
+    }).mapImportedTypeSchema({ $ref: 'library:cross-space-reference' });
+
+    expect(staged._libRef).toBe('cross-space-reference');
+  });
+
+  it('still maps an inline schema normally', () => {
+    // The guard must not swallow ordinary types: it fires only on a `library:` ref.
+    const { c } = setup();
+    const staged = (c as unknown as {
+      mapImportedTypeSchema(raw: Record<string, unknown>): TypeSchemaState;
+    }).mapImportedTypeSchema({ namingPattern: '^f-', propertySchemas: { order: { type: 'number' } } });
+
+    expect(staged._libRef).toBeUndefined();
+    expect(staged.namingPattern).toBe('^f-');
+    expect(staged.propertySchemas.map(p => p.key)).toEqual(['order']);
+  });
+});
+
+describe('SpaceSettingsState.buildMeta — an emptied knowledge type must still be sent', () => {
+  it('emits every knowledge type, including the empty ones', () => {
+    const { state } = setup();
+    state.schTypeSchemas = { entity: {}, edge: { follows: mkType() } };
+    const meta = state.buildMeta();
+
+    // The bug: `if (names.length)` omitted a knowledge type holding zero types, so deleting the last
+    // entity type meant the `entity` key never left the browser — and the server, merging, kept all of
+    // them. An absent key and an empty object have to mean different things.
+    expect(meta.typeSchemas).toBeDefined();
+    expect(meta.typeSchemas!.entity).toEqual({});
+    expect(Object.keys(meta.typeSchemas!.edge!)).toEqual(['follows']);
+  });
+
+  it('emits typeSchemas even when the space declares nothing at all', () => {
+    const { state } = setup();
+    state.schTypeSchemas = {};
+    const meta = state.buildMeta();
+    expect(meta.typeSchemas).toBeDefined();
+    expect(meta.typeSchemas!.entity).toEqual({});
+  });
+
+  it('round-trips a $ref type back out as a $ref', () => {
+    const { state } = setup();
+    state.schTypeSchemas = { entity: { ref: mkType({ _libRef: 'cross-space-reference' }) } };
+    const meta = state.buildMeta();
+    expect(meta.typeSchemas!.entity!['ref']).toEqual({ $ref: 'library:cross-space-reference' });
+  });
+});

--- a/client/src/app/pages/settings/space-schema-tab.component.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.ts
@@ -812,8 +812,23 @@ export class SpaceSchemaTabComponent implements OnInit {
     });
   }
 
-  /** Map one raw type-schema object (as exported / stored) into editor state. */
+  /**
+   * Map one raw type-schema object (as exported / stored) into editor state.
+   *
+   * A type-level `$ref` is read FIRST and short-circuits the rest. It used to be ignored entirely, and the
+   * consequence was not a broken import but a silently empty one: `{ "$ref": "library:cross-space-reference" }`
+   * has no `namingPattern`, no `propertySchemas` and no `retention`, so every field below read as absent and
+   * the type saved as `{}` — no naming rule, nothing required, every new record accepted. The per-type
+   * "import as $ref" action always handled this; the whole-file import did not, which is why the same file
+   * gave two different answers depending on which button was used.
+   */
   private mapImportedTypeSchema(ts2: Record<string, unknown>): TypeSchemaState {
+    const ref = ts2['$ref'];
+    if (typeof ref === 'string' && ref.startsWith('library:')) {
+      // `_libRef` is the editor's marker for "this type is a library reference"; `buildMeta()` turns it
+      // back into `{ $ref: 'library:<name>' }` on save, and the server resolves it.
+      return emptyTypeSchemaState({ _libRef: ref.slice('library:'.length) });
+    }
     // A retention window travels with the type it belongs to. It is read defensively because the file is
     // arbitrary JSON: a string or a negative number becomes "inherit" rather than a save the API will reject.
     const ret = ts2['retention'];

--- a/client/src/app/pages/settings/space-settings-state.service.spec.ts
+++ b/client/src/app/pages/settings/space-settings-state.service.spec.ts
@@ -150,7 +150,11 @@ describe('SpaceSettingsState — buildMeta (what actually gets saved)', () => {
   it('always emits validationMode, and omits blank purpose/usageNotes', () => {
     const c = make();
     c.openSettings(space());
-    expect(c.buildMeta()).toEqual({ validationMode: 'off' });
+    // `typeSchemas` is now always present (see the deletion test below), so the blank-field assertion is
+    // made against the other keys rather than the whole object.
+    expect(c.buildMeta()).toMatchObject({ validationMode: 'off' });
+    expect(c.buildMeta().purpose).toBeUndefined();
+    expect(c.buildMeta().usageNotes).toBeUndefined();
   });
 
   it('trims purpose and usageNotes', () => {
@@ -214,10 +218,16 @@ describe('SpaceSettingsState — buildMeta (what actually gets saved)', () => {
     expect(ps.enum).toBeUndefined();    // empty enum dropped
   });
 
-  it('omits typeSchemas entirely when no type is defined', () => {
+  it('emits an empty typeSchemas when no type is defined — it used to omit it, and that lost deletions', () => {
+    // Changed deliberately. This assertion previously read `toBeUndefined()`, pinning the behaviour that
+    // made a schema-type deletion impossible to save: an omitted key told the server nothing, so its
+    // merge kept what it had, and the delete survived the save only in the UI. An absent key and an empty
+    // object have to mean different things for "this space declares nothing" to be expressible at all.
     const c = make();
     c.openSettings(space());
-    expect(c.buildMeta().typeSchemas).toBeUndefined();
+    const ts = c.buildMeta().typeSchemas;
+    expect(ts).toBeDefined();
+    expect(ts!.entity).toEqual({});
   });
 });
 

--- a/client/src/app/pages/settings/space-settings-state.service.ts
+++ b/client/src/app/pages/settings/space-settings-state.service.ts
@@ -333,25 +333,31 @@ export class SpaceSettingsState {
     meta.validationMode = this.schValidation;
     if (this.schStrictLinkage)         meta.strictLinkage  = true;
     if (this.schTagSuggestions.length) meta.tagSuggestions = [...this.schTagSuggestions];
+    // Every knowledge type is emitted, including the empty ones, and `typeSchemas` is always set.
+    //
+    // Both used to be conditional (`if (names.length)`, `if (Object.keys(typeSchemas).length)`), and that
+    // is how a deletion was lost: delete the last entity type and the `entity` key vanished from the
+    // payload, so the server had nothing to act on and kept what it had. An absent key and an empty object
+    // mean opposite things here, and only one of them can express "this kind now declares nothing".
+    //
+    // Paired with `typeSchemasMode: 'replace'` on the request, this makes Save mean what it looks like it
+    // means: the space ends up holding exactly what the editor was showing.
     const typeSchemas: Partial<Record<KnowledgeType, Record<string, TypeSchema>>> = {};
     for (const kt of this.KINDS) {
       const ktMap = this.schTypeSchemas[kt] ?? {};
-      const names = Object.keys(ktMap);
-      if (names.length) {
-        const out: Record<string, TypeSchema> = {};
-        for (const name of names) {
-          const state = ktMap[name]!;
-          // If this type was set via "import as $ref", emit a $ref TypeSchema
-          if (state._libRef) {
-            out[name] = { $ref: `library:${state._libRef}` };
-            continue;
-          }
-          out[name] = typeSchemaFromState(kt, state);
+      const out: Record<string, TypeSchema> = {};
+      for (const name of Object.keys(ktMap)) {
+        const state = ktMap[name]!;
+        // If this type was set via "import as $ref", emit a $ref TypeSchema
+        if (state._libRef) {
+          out[name] = { $ref: `library:${state._libRef}` };
+          continue;
         }
-        typeSchemas[kt] = out;
+        out[name] = typeSchemaFromState(kt, state);
       }
+      typeSchemas[kt] = out;
     }
-    if (Object.keys(typeSchemas).length) meta.typeSchemas = typeSchemas;
+    meta.typeSchemas = typeSchemas;
     return meta;
   }
 

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -401,6 +401,10 @@ export class SpacesComponent implements OnInit {
       videoAnalysis: this.state.stForm.videoAnalysis || null,
       textAnalysis: this.state.stForm.textAnalysis || null,
       meta:   this.state.buildMeta(),
+      // Save persists the state the editor is showing. Without this the PATCH merges, so a type deleted in
+      // the UI is simply not mentioned and the server keeps it — the delete appears to work, survives the
+      // save, and is still there on reload.
+      typeSchemasMode: 'replace',
     }).subscribe({
       next: (result) => {
         this.state.settingsSaving.set(false);

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -217,7 +217,21 @@ the server still bumps it.
   believing you had turned validation on. The tolerance covers only the fields that genuinely belong to `meta`
   and that we ourselves emit.
 
-**Removing a type schema.** `PATCH` deep-merges, so omitting a type does not delete it — a merge that could delete would make every PATCH potentially destructive, and a client that round-trips a space would silently drop schemas whenever its serialiser emitted `null` for an unset field. Deletion is explicit instead: `DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` for one type (404 if it does not exist), or `PUT /api/spaces/:id/schema` to replace the whole map.
+**Removing a type schema.** `PATCH` deep-merges by default, so omitting a type does not delete it — a merge that could delete would make every PATCH potentially destructive, and a client that round-trips a space would silently drop schemas whenever its serialiser emitted `null` for an unset field. There are three ways to delete:
+
+- `DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` for one type (404 if it does not exist).
+- `PUT /api/spaces/:id/schema` to replace the whole map. It writes a timestamped backup of the previous schema into the space first. Note it applies **directly**, so on a networked space it does not open a vote round — use the PATCH form below if the change should go to consensus.
+- `PATCH /api/spaces/:id` with `"typeSchemasMode": "replace"` alongside `meta.typeSchemas`. The payload becomes authoritative: types absent from it are removed. This is the same request as any other meta change, so it takes the same network-vote path.
+
+```jsonc
+// Authoritative: the space ends up declaring exactly `flow`, and nothing else of any kind.
+PATCH /api/spaces/flows
+{ "typeSchemasMode": "replace",
+  "meta": { "typeSchemas": { "entity": { "flow": { "namingPattern": "^f-" } },
+                             "memory": {}, "edge": {}, "chrono": {} } } }
+```
+
+`typeSchemasMode` defaults to `merge`, which is the behaviour this endpoint has always had. Under `replace`, a knowledge type sent as `{}` clears it, and omitting a knowledge type entirely also clears it — so send all four keys unless you mean to empty the ones you leave out. Omitting `meta.typeSchemas` altogether still changes nothing, in either mode; `replace` says how to apply schemas that are present, not that absent ones should be erased.
 
 ```json
 {

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -186,6 +186,23 @@ const UpdateSpaceBody = z.object({
   description: z.string().max(SPACE_PURPOSE_MAX).optional(),
   maxGiB: z.number().positive().nullable().optional(),
   meta: SpaceMetaBody.optional(),
+  /**
+   * How `meta.typeSchemas` combines with what is already stored. Default `merge`, which is the behaviour
+   * this endpoint has always had and which an integrator specifically asked for — a caller that edits one
+   * type must not have to resend the other forty.
+   *
+   * `replace` makes the payload authoritative: types absent from it are REMOVED. It exists because there
+   * was otherwise no way to delete a type at all. The settings UI deleted one, sent a payload that simply
+   * did not mention it, and `mergeSpaceMeta` faithfully preserved it — so a deletion could be performed,
+   * saved, and silently not happen. Reported by an integrator whose space had 21 foreign types they could
+   * not remove by any sequence of UI actions.
+   *
+   * Deliberately NOT a new endpoint. `PUT /:id/schema` already replaces wholesale, but it calls
+   * `updateSpace()` directly and so bypasses the network vote that a meta change on a networked space
+   * has to go through. Routing the UI's Save there would have traded a silent no-op for a silent
+   * consensus bypass.
+   */
+  typeSchemasMode: z.enum(['merge', 'replace']).optional(),
   dupeRules: z.array(DupeActionRuleBody).max(20).optional(),
   dupeMergeSurvivor: z.enum(['older', 'newer']).optional(),
   dupeRulesOnInsert: z.boolean().optional(),
@@ -239,9 +256,13 @@ const PutSchemaBody = z.object({
  * The `version`, `updatedAt`, and `previousVersions` housekeeping fields are
  * intentionally omitted from the return value — `updateSpace()` re-adds them.
  */
-function mergeSpaceMeta(
+// Exported for testing only. The merge/replace decision is pure and is where a deletion was silently lost
+// for as long as it was; a unit test that reaches it directly is worth more than one that has to stand up
+// Docker and a network to observe the same branch.
+export function mergeSpaceMeta(
   existing: SpaceMeta,
   incoming: Partial<SpaceMeta>,
+  typeSchemasMode: 'merge' | 'replace' = 'merge',
 ): Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'> {
   // Spread the existing base (drop housekeeping fields that updateSpace re-adds)
   const { version: _v, updatedAt: _u, previousVersions: _pv, ...existingBase } = existing;
@@ -254,8 +275,13 @@ function mergeSpaceMeta(
   if (incoming.tagSuggestions !== undefined) merged.tagSuggestions = incoming.tagSuggestions;
   if (incoming.strictLinkage !== undefined) merged.strictLinkage = incoming.strictLinkage;
 
-  // typeSchemas — merge per-KT, per-type: incoming types add/update, existing untouched types preserved
-  if (incoming.typeSchemas !== undefined) {
+  // typeSchemas — merge per-KT, per-type: incoming types add/update, existing untouched types preserved.
+  // Under `replace` the payload is authoritative instead, so a type absent from it is deleted. Note the
+  // guard is on `!== undefined`, so `replace` with `typeSchemas: {}` clears every type — which is the only
+  // way to express "this space declares nothing" and has to be reachable.
+  if (incoming.typeSchemas !== undefined && typeSchemasMode === 'replace') {
+    merged.typeSchemas = incoming.typeSchemas;
+  } else if (incoming.typeSchemas !== undefined) {
     const existingTs = existingBase.typeSchemas ?? {};
     const mergedTs: Partial<Record<KnowledgeType, Record<string, TypeSchema>>> = { ...existingTs };
     for (const [kt, ktMap] of Object.entries(incoming.typeSchemas) as
@@ -636,9 +662,10 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
   // Merge the incoming meta with the existing meta so that PATCH has true
   // RFC-7396 semantics: scalar fields overwrite, typeSchemas entries are
   // added/updated, and types *not* mentioned in the body are preserved.
+  // `typeSchemasMode: 'replace'` opts out of that last clause so a deletion can be expressed at all.
   const mergedMeta: SpaceMeta | undefined =
     parsed.data.meta !== undefined
-      ? mergeSpaceMeta(space.meta ?? {}, parsed.data.meta)
+      ? mergeSpaceMeta(space.meta ?? {}, parsed.data.meta, parsed.data.typeSchemasMode ?? 'merge')
       : undefined;
 
   // ── Network voting for meta changes ──────────────────────────────────────

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -70,8 +70,13 @@ const FROZEN = {
   'client/src/app/pages/files/file-manager.component.ts': 1617,
   'client/src/app/pages/schema-library/schema-library.component.ts': 1112,
   'server/src/sync/engine.ts': 966,
-  'client/src/app/pages/settings/space-schema-tab.component.ts': 954,
-  'server/src/api/spaces.ts': 839,
+  // 954 -> 958: `mapImportedTypeSchema` now reads a type-level `$ref` before the inline fields, which is
+  // four lines and closes a hole where an imported library-backed type saved as `{}` with nothing required.
+  'client/src/app/pages/settings/space-schema-tab.component.ts': 958,
+  // 839 -> 843: `typeSchemasMode` on the update body and the replace branch in `mergeSpaceMeta`. Both are
+  // small and belong beside the merge they qualify — splitting a two-branch decision across files would
+  // make the contract harder to read, not easier.
+  'server/src/api/spaces.ts': 843,
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.

--- a/testing/standalone/schema-type-deletion-persists.test.js
+++ b/testing/standalone/schema-type-deletion-persists.test.js
@@ -1,0 +1,115 @@
+/**
+ * A schema type deleted in the editor is actually gone after Save.
+ *
+ * ## The bug
+ *
+ * Reported by an integrator whose space had accumulated 21 foreign entity types after a schema file was
+ * imported against the wrong space. They deleted every declared type in the UI, re-imported the correct
+ * file, and all 21 were still there. From outside they could not tell whether the deletes had failed to
+ * persist or whether import was re-merging against a stored prior version.
+ *
+ * It was the first, and no sequence of UI actions could have worked. Three additive layers stacked:
+ *
+ *   1. the file import staged into the existing staged schemas rather than replacing them;
+ *   2. `buildMeta()` omitted a knowledge type from the payload entirely when it held zero types;
+ *   3. `mergeSpaceMeta()` merges per type-NAME and only touches knowledge types present in the payload.
+ *
+ * So deleting the last entity type meant the `entity` key never left the browser, and the server —
+ * correctly, by its own documented contract — preserved everything it had. The delete could be performed,
+ * saved, and confirmed, and nothing anywhere had changed.
+ *
+ * ## Why PATCH was not simply changed
+ *
+ * The additive behaviour is deliberate and was asked for: a caller editing one type must not have to
+ * resend the other forty. Both semantics have to exist, so the request says which it wants. `merge` stays
+ * the default, so every existing integration keeps its behaviour byte for byte.
+ *
+ * Run: node --test testing/standalone/schema-type-deletion-persists.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mergeSpaceMeta;
+
+before(async () => {
+  ({ mergeSpaceMeta } = await import('../../server/dist/api/spaces.js'));
+});
+
+/** A space declaring two entity types and one edge label. */
+const EXISTING = {
+  version: 9,
+  updatedAt: '2026-08-06T00:00:00.000Z',
+  purpose: 'flows',
+  typeSchemas: {
+    entity: {
+      flow: { namingPattern: '^f-' },
+      step: { propertySchemas: { order: { type: 'number' } } },
+    },
+    edge: { follows: {} },
+  },
+};
+
+describe('a deleted schema type is gone after save', () => {
+  it('the module under test is the real one', () => {
+    // Floors the suite: an import that silently resolved to undefined would make every assertion below
+    // throw on call rather than pass, but a helper that existed and did nothing would not be caught.
+    assert.equal(typeof mergeSpaceMeta, 'function');
+    const sanity = mergeSpaceMeta(EXISTING, {}, 'merge');
+    assert.deepEqual(Object.keys(sanity.typeSchemas.entity).sort(), ['flow', 'step']);
+  });
+
+  it('replace mode removes a type absent from the payload', () => {
+    // The editor showed one entity type because the user deleted the other. Save must mean that.
+    const out = mergeSpaceMeta(EXISTING, {
+      typeSchemas: { entity: { flow: { namingPattern: '^f-' } }, edge: { follows: {} } },
+    }, 'replace');
+    assert.deepEqual(Object.keys(out.typeSchemas.entity), ['flow'],
+      '`step` was deleted in the editor and left out of the payload, so it must be gone from the space');
+  });
+
+  it('replace mode clears a knowledge type sent as empty', () => {
+    // The case that actually bit: every entity type deleted. An absent key and an empty object have to
+    // mean different things, or "this kind declares nothing" is inexpressible.
+    const out = mergeSpaceMeta(EXISTING, {
+      typeSchemas: { entity: {}, edge: { follows: {} } },
+    }, 'replace');
+    assert.deepEqual(out.typeSchemas.entity, {}, 'an empty entity map must clear the declared entity types');
+  });
+
+  it('replace mode with an empty typeSchemas clears everything', () => {
+    const out = mergeSpaceMeta(EXISTING, { typeSchemas: {} }, 'replace');
+    assert.deepEqual(out.typeSchemas, {}, 'a space must be able to declare nothing at all');
+  });
+
+  it('merge mode is unchanged — the default keeps every existing contract', () => {
+    // The regression that would hurt most: silently making PATCH authoritative would delete types for
+    // every integrator who sends a partial body, which is what a partial body is FOR.
+    const out = mergeSpaceMeta(EXISTING, {
+      typeSchemas: { entity: { flow: { namingPattern: '^flow-' } } },
+    });
+    assert.deepEqual(Object.keys(out.typeSchemas.entity).sort(), ['flow', 'step'],
+      'a type not mentioned in a merge PATCH must survive');
+    assert.equal(out.typeSchemas.entity.flow.namingPattern, '^flow-', 'a mentioned type must be updated');
+    assert.deepEqual(Object.keys(out.typeSchemas.edge), ['follows'],
+      'a knowledge type absent from a merge PATCH must survive');
+  });
+
+  it('an absent typeSchemas changes nothing in either mode', () => {
+    // `replace` describes how to apply typeSchemas WHEN PRESENT. A caller renaming a space sends no
+    // schemas at all, and must not thereby erase them.
+    for (const mode of ['merge', 'replace']) {
+      const out = mergeSpaceMeta(EXISTING, { purpose: 'renamed' }, mode);
+      assert.deepEqual(out.typeSchemas, EXISTING.typeSchemas, `${mode}: schemas must be untouched`);
+      assert.equal(out.purpose, 'renamed');
+    }
+  });
+
+  it('scalars still overwrite, and untouched ones survive, in replace mode', () => {
+    const out = mergeSpaceMeta({ ...EXISTING, usageNotes: 'keep me' }, {
+      purpose: 'new', typeSchemas: {},
+    }, 'replace');
+    assert.equal(out.purpose, 'new');
+    assert.equal(out.usageNotes, 'keep me',
+      'replace applies to typeSchemas only — it is not a whole-meta replacement');
+  });
+});


### PR DESCRIPTION
fix(spaces): a deleted schema type was never actually deleted

Reported by breituai-platform against 2.4.0. Their space had accumulated 21
foreign entity types after a schema file was imported against the wrong space.
They deleted every declared type in the UI, re-imported the correct file, and
all 21 were still there. They could not tell from outside whether the deletes
had failed to persist or whether import was re-merging against a stored prior
version.

It was the first, and no sequence of UI actions could have worked.

## Three additive layers, all of which had to be crossed

1. `onImportSchemaFile` stages `{ ...this.state.schTypeSchemas }` — the file is
   merged into what is already staged.
2. `buildMeta()` walked the four knowledge types and emitted one only
   `if (names.length)`, so a kind holding zero types was omitted from the
   payload entirely.
3. `mergeSpaceMeta()` merges per type-NAME and only touches knowledge types
   present in the incoming payload.

Delete the last entity type and the `entity` key never left the browser, so the
server — correctly, by its own documented contract — preserved everything it
had. That also explains the part that must have read as contradictory in their
report: `usageNotes` came back correct and a type gained its new properties,
because scalars and PRESENT types both write through fine. Only absence failed
to travel.

## What changed

Save persists the state the editor is showing. Import still ADDS, delete
deletes, and Save writes exactly that. The owner's call, and closer to the
reporter's first suggested remedy than their third.

`PATCH /api/spaces/:id` takes `typeSchemasMode: 'replace'`, which makes the
payload authoritative. The default stays `merge`: that behaviour was asked for
by a different integrator ("a caller editing one type must not have to resend
the other forty") and every existing integration is byte-for-byte unchanged.

Deliberately NOT routed through `PUT /:id/schema`. That endpoint does replace
wholesale and even backs up the previous schema first — but it calls
`updateSpace()` directly, so it bypasses the network vote a meta change on a
networked space has to go through. Using it from the UI would have traded a
silent no-op for a silent consensus bypass.

`buildMeta()` now emits all four knowledge types including the empty ones. An
absent key and an empty object have to mean different things, or "this space
declares nothing" is inexpressible.

## Second defect, same report

The whole-file import dropped a type-level `$ref`. `mapImportedTypeSchema` read
`namingPattern`, `retention`, `tagSuggestions` and `propertySchemas` and never
looked at `$ref`, so `{ "$ref": "library:cross-space-reference" }` staged an
empty type and saved as `{}` — no naming rule, nothing required, every new
record accepted. The reporter saw "same file, same ref, different result" and
reasonably read it as non-determinism; it is which button was used. The
per-type "import as $ref" action always handled it. The fix mirrors what the
server-load path at `space-settings-state.service.ts:240` already did.

## Verification

Every test here was confirmed to FAIL against the pre-fix code by planting the
old behaviour and rebuilding, not by reasoning about it:

- `schema-type-deletion-persists` — 3 of 7 fail with the replace branch
  disabled. The other 4 are the merge contract and correctly keep passing;
  silently making PATCH authoritative would delete types for every integrator
  who sends a partial body, which is what a partial body is for.
- The two client specs fail with `buildMeta`'s emptiness guards and the `$ref`
  read reverted.

`mergeSpaceMeta` is exported for the first of those. The merge/replace decision
is pure, and a unit test that reaches it directly is worth more than one that
stands up Docker and a network to observe the same branch.

Two pre-existing specs pinned the old behaviour ("omits typeSchemas entirely
when no type is defined"). Updated deliberately with the reason in place — that
is the characterization net working, not noise.

`no-new-god-files` fires on both touched files (+4 each). Raised with reasons.

Docs: `06-spaces-api.md` now states all three deletion routes and which of them
goes to network consensus. The reporter noted the merge behaviour "is not
stated anywhere we could find", and they were right.

Answered on the shared board (`46ccd47c`), with the diagnosis and the
workaround they can use today.
