### PR TITLE
test(arch): an env-pinned model setting cannot be rendered as editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **A gate that an env-pinned model setting cannot be rendered as editable** — the deliverable from a third
+  architecture angle, on whether adding a provider means editing seven files. The Models settings tab writes
+  six provider blocks out by hand, so adding a seventh does mean copying one, and a copied block is where a
+  field loses its lock. When that happens nothing errors: the operator types a value, saves, and the
+  environment silently wins, which reads as a broken save rather than a field that was never theirs to set.
+  - The invariant is that an `ngModel`-bound control on that tab has a `[disabled]` binding — no provider
+    taxonomy at all. Two earlier drafts encoded one and both were wrong: discovering providers by
+    `Configured()` swept up internal predicates, and demanding a matching `<prefix>Locked()` reported a
+    correctly-guarded field as unguarded because its key belongs to a neighbouring block. The guards are not
+    uniform in shape either — six blocks use a helper, two call `isLocked(path)` directly, and both are
+    fine. A gate that knew about providers would have had to know that too.
+  - Also recorded: on the SERVER the seam is real and improved when the reranker arrived, which extracted a
+    shared endpoint predicate out of the NLI client rather than copying it. The finding is the UI only.
+
 - **A gate that reads the shipped cytoscape runtime, not its typings** — every style property the graph sets
   must exist in `cytoscape.cjs.js`, because a property present in the `.d.ts` and absent from the runtime is
   exactly the failure above and only the runtime can tell you. It carries a positive control: a property known

--- a/testing/standalone/model-config-controls-can-lock.test.js
+++ b/testing/standalone/model-config-controls-can-lock.test.js
@@ -1,0 +1,83 @@
+/**
+ * Every editable control on the Models settings tab can disable itself.
+ *
+ * ## The failure this prevents
+ *
+ * Instance model configuration can be pinned by environment variables. When a field is pinned the UI must
+ * render its input disabled, because the alternative is silent: the operator types a value, presses Save,
+ * and the environment wins. Nothing errors. The field simply shows the old value again on reload, and the
+ * obvious conclusion is that the save failed rather than that the field was never theirs to set.
+ *
+ * ## Why the invariant is "has a `[disabled]` binding" and not something cleverer
+ *
+ * This came out of the A-L2-5 angle — adding a seventh model provider should not mean copying a block and
+ * hoping. The tab has six provider blocks written out by hand, so copying is exactly what it does mean, and
+ * a copied block is where a new field loses its guard.
+ *
+ * The first two attempts at this gate encoded a model of the providers, and both were wrong:
+ *
+ *   - Discovering providers by `<prefix>Configured()` swept up `assistConfigured`, `vlmConfigured` and
+ *     `faceExternalConfigured`, which are internal predicates, not editable blocks.
+ *   - Discovering by `<prefix>Locked()` and then demanding that exact lock on each field reported
+ *     `faceApiKeyInput` as unguarded. It is guarded — by `faceExternalLocked()`, because the key belongs to
+ *     the external-face block. The heuristic was wrong, not the code.
+ *
+ * And the guards are not even uniform in shape: six providers use a `<prefix>Locked()` helper while the
+ * vision and speech blocks call `isLocked('vision.apiKey')` directly. Both are correct. A gate that knew
+ * about providers would have had to encode that too, and would have been wrong a third time.
+ *
+ * So it asserts the thing that is actually true of all of them and needs no taxonomy: an `ngModel`-bound
+ * control on this tab has a `[disabled]` binding. What it binds to is the author's business.
+ *
+ * Run: node --test testing/standalone/model-config-controls-can-lock.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const TAB = 'client/src/app/pages/settings/media-processing/models-tab.component.ts';
+
+/** Each `<input>`/`<select>` as its own chunk, since an element's attributes span several lines. */
+function formElements(src) {
+  return src.split(/<(?=input\b|select\b)/).slice(1)
+    .map(s => { const i = s.indexOf('>'); return i === -1 ? s : s.slice(0, i + 1); });
+}
+
+describe('an env-pinnable model setting cannot be rendered as editable', () => {
+  const src = readFileSync(join(ROOT, TAB), 'utf8');
+  const bound = formElements(src).filter(el => el.includes('[(ngModel)]'));
+
+  it('found the tab and its controls', () => {
+    // Floors the enumeration. A regex that stopped matching would leave `bound` empty, and an empty
+    // "everything passed" is indistinguishable from a real pass — which is how the earlier version of
+    // this gate nearly shipped inverted.
+    assert.ok(src.includes('models-tab') || src.length > 10_000, 'the tab source looks wrong');
+    assert.ok(bound.length >= 25,
+      `only found ${bound.length} ngModel-bound controls on the Models tab — the element split is broken`);
+  });
+
+  it('every bound control has a [disabled] binding', () => {
+    const naked = bound
+      .filter(el => !el.includes('[disabled]'))
+      .map(el => el.replace(/\s+/g, ' ').slice(0, 120));
+    assert.deepEqual(naked, [],
+      'this control edits instance model configuration but can never disable itself. If an environment '
+      + 'variable pins the value, the operator edits the field, saves, and the environment silently wins — '
+      + 'which reads as a broken save rather than a field that was never theirs to set. Add '
+      + '`[disabled]="s.<provider>Locked(\'<field>\')"`, or `s.isLocked(\'<path>\')` for a block with no '
+      + 'per-provider helper. Both shapes are in use and both are fine.');
+  });
+
+  it('the detector can tell a guarded control from an unguarded one', () => {
+    // Positive control. Without it, a change that made `formElements` return whole-file blobs would find
+    // `[disabled]` somewhere in every "element" and report perfect health.
+    const guarded = '<input [(ngModel)]="s.x" [disabled]="s.xLocked(\'y\')" />';
+    const unguarded = '<input [(ngModel)]="s.x" />';
+    const found = formElements(`${guarded}${unguarded}`).filter(el => el.includes('[(ngModel)]'));
+    assert.equal(found.length, 2, 'the element split did not separate two adjacent controls');
+    assert.equal(found.filter(el => !el.includes('[disabled]')).length, 1,
+      'the detector cannot distinguish a guarded control from an unguarded one');
+  });
+});


### PR DESCRIPTION
test(arch): an env-pinned model setting cannot be rendered as editable

The deliverable from A-L2-5, the architecture angle on whether adding a
provider means editing seven files.

## The measurement

The reranker (#519) touched 10 non-config files; the NLI provider (#450)
touched 4. The verify line's "more than three is the finding" is met, but the
diff splits into two halves that deserve opposite verdicts.

The SERVER seam is real and it got better when it was exercised: each provider
is its own client module, and when the reranker arrived it EXTRACTED the shared
endpoint predicate out of `nli-client.ts` into `model-egress-policy.ts` rather
than copying it, with the comment "two copies of a security predicate is how
they drift". Editing a sibling to remove a duplicate is not coupling.

The UI has no seam. Six provider blocks are written out by hand in
`models-tab.component.ts` — 105 provider mentions in one 678-line component —
so adding a seventh means copying one, and a copied block is where a field
loses its guard.

Every existing block is correct, checked field by field. This is a seam
finding, not a live defect, and the gate ships green.

## Three drafts, two of them wrong, both for the same reason

Each of the first two encoded a model of "what a provider looks like" drawn
from the two blocks I had read:

1. Discovering providers by `<prefix>Configured()` swept up `assistConfigured`,
   `vlmConfigured` and `faceExternalConfigured` — internal predicates ("is a URL
   set?"), not editable blocks.
2. Discovering by `<prefix>Locked()` and demanding that exact lock per field
   reported `faceApiKeyInput` as unguarded. It is guarded, by
   `faceExternalLocked()`, because the key belongs to the external-face block.
   The heuristic was wrong, not the code. A bare `[a-z]+Locked` also matches the
   unrelated `isLocked`.

The accessors are legitimately non-uniform, which is why no model of them
survives contact: `IsExternal` exists only for `nli` and `rerank`, the two that
can point either on-box or off. `embedding` and `face` are local and `assist` is
external by definition. The guards differ in SHAPE too — six blocks use a
`<prefix>Locked()` helper, the vision and speech blocks call
`isLocked('vision.apiKey')` directly, and both are correct.

## What it asserts instead

An `ngModel`-bound control on that tab has a `[disabled]` binding. That is all.
No provider list, no prefix matching, no families. It is the one property true
of all 30 controls today, it needs no taxonomy to stay true of the 31st, and
what a control binds its `[disabled]` to is the author's business.

The failure it prevents is silent: an env-pinned field rendered editable means
the operator types a value, presses Save, and the environment wins with nothing
anywhere to say so — which reads as a broken save rather than a field that was
never theirs to set.

Mutation-checked: removing the `[disabled]` from one control turns it red. It
carries a positive control too, because a change that made the element splitter
return whole-file blobs would find `[disabled]` somewhere in every "element" and
report perfect health.

The lesson is recorded in `_REFERENCE.md`: two gates in a row failed because the
measurement encoded a model drawn from the sample already read — the same shape
as `measurement-must-not-share-the-blind-spot`. The fix both times was to assert
something that needs no model at all.
