### PR TITLE
test(client): an async write to a rendered field must notify OnPush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **A gate that an async write to a rendered field notifies OnPush** — the deliverable from the last
+  architecture angle, which came back clean. Under OnPush, `this.rows = result.items` in a subscribe
+  callback changes the data and does not tell Angular: the request succeeds, the value is correct in memory,
+  and the screen keeps showing the old one, with nothing thrown and nothing logged.
+  - Measuring found 55 async plain-field writes across 16 files, and three rules account for all of them —
+    a signal written in the same turn (the documented pattern behind every plain edit model, which alone
+    drops 55 to 6), the field being a signal holder, and the field being `private`, which a template cannot
+    read at all under `strictTemplates`.
+  - It ships with **no exemption list**, which is the part worth noting. The instinct was to exempt the four
+    surviving fields by name; `private` is not a model of those four but a fact about what a template can
+    reach, so it stays true of code nobody has written yet. Two gates written just before this one had to be
+    rewritten precisely because they encoded a model drawn from the sample already read.
+
 - **A gate that an env-pinned model setting cannot be rendered as editable** — the deliverable from a third
   architecture angle, on whether adding a provider means editing seven files. The Models settings tab writes
   six provider blocks out by hand, so adding a seventh does mean copying one, and a copied block is where a

--- a/testing/standalone/async-writes-notify-onpush.test.js
+++ b/testing/standalone/async-writes-notify-onpush.test.js
@@ -1,0 +1,121 @@
+/**
+ * An async write to a rendered field must be one OnPush can see.
+ *
+ * ## The failure
+ *
+ * Every component here is OnPush. A subscribe callback that assigns to a plain field —
+ * `this.rows = result.items` — changes the data and does not tell Angular, so the request succeeds, the
+ * value is correct in memory, and the screen keeps showing the old one. Nothing throws and nothing logs.
+ * The same assignment to a signal notifies, which is why almost all of this codebase uses signals for
+ * anything rendered.
+ *
+ * ## The three things that make a plain-field write legitimate, and why each is a rule rather than a list
+ *
+ * This came out of the A-L2-6 angle. Measuring the shape found 55 async plain-field writes across 16
+ * files, which sounds like a lot and is almost entirely legitimate:
+ *
+ *  1. **A signal is written in the same turn.** The plain edit models (`entityForm`, `chronoForm`, the
+ *     drawer's four) render under OnPush only because the subscribe body also writes a signal, and that
+ *     coupling is deliberate and documented where it lives. Filtering on it drops 55 to 6.
+ *  2. **The field IS a signal**, and the assignment is a reassignment of the holder.
+ *  3. **The field is `private`.** An Angular template cannot read a private member under
+ *     `strictTemplates`, so a private field is not rendered state by construction.
+ *
+ * All six survivors of (1) turned out to be (3): an EventSource handle, a reconnect timer, a config array
+ * and a re-entrancy guard. So this gate ships with **no exemption list** — every real case is covered by a
+ * rule that stays true of code nobody has written yet.
+ *
+ * That last part is the point. Two gates written just before this one both had to be rewritten because
+ * they encoded a model of the code drawn from the sample already read. `private` is not a model of these
+ * four fields; it is a fact about what a template can reach.
+ *
+ * Run: node --test testing/standalone/async-writes-notify-onpush.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+function sourceFiles() {
+  return execFileSync('git', ['ls-files', 'client/src/app'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n')
+    .filter(f => f.endsWith('.ts') && !f.endsWith('.spec.ts') && !f.endsWith('.d.ts'));
+}
+
+/** The text of each `.subscribe(...)` call, matched by balancing parens from the opening one. */
+function subscribeBodies(src) {
+  const out = [];
+  for (const m of src.matchAll(/\.subscribe\s*\(/g)) {
+    let depth = 0, end = -1;
+    for (let i = src.indexOf('(', m.index); i < src.length; i++) {
+      if (src[i] === '(') depth++;
+      else if (src[i] === ')') { depth--; if (depth === 0) { end = i; break; } }
+    }
+    if (end !== -1) out.push(src.slice(m.index, end));
+  }
+  return out;
+}
+
+/** Async assignments to a field that the template could render and that nothing notifies. */
+function unnotifiedWrites(src) {
+  const found = [];
+  for (const body of subscribeBodies(src)) {
+    // Rule 1 — a signal written in the same turn notifies OnPush, whatever else the body touches.
+    if (/\.(set|update)\s*\(/.test(body)) continue;
+    for (const a of body.matchAll(/this\.([a-zA-Z_$][\w$]*)\s*=(?!=)/g)) {
+      const field = a[1];
+      // Rule 2 — the field is itself a signal holder.
+      if (new RegExp(`\\b${field}\\s*=\\s*(signal|computed|toSignal)\\s*[(<]`).test(src)) continue;
+      if (new RegExp(`\\b${field}\\s*[:!]\\s*(Writable)?Signal\\b`).test(src)) continue;
+      // Rule 3 — private fields cannot be read by a template under strictTemplates.
+      if (new RegExp(`\\bprivate\\s+(readonly\\s+)?${field}\\b`).test(src)) continue;
+      found.push(field);
+    }
+  }
+  return found;
+}
+
+describe('an async write to a rendered field notifies OnPush', () => {
+  const files = sourceFiles();
+
+  it('walked a real tree and found real subscribes', () => {
+    // Floors the enumeration twice over. A glob that matched nothing, or a paren-matcher that returned no
+    // bodies, would both report a clean bill of health over an empty set.
+    assert.ok(files.length >= 100, `only found ${files.length} client source files`);
+    const withSubs = files.filter(f => subscribeBodies(readFileSync(join(ROOT, f), 'utf8')).length > 0);
+    assert.ok(withSubs.length >= 10,
+      `only ${withSubs.length} files yielded a .subscribe() body — the matcher is broken`);
+  });
+
+  it('the detector catches a write nothing notifies', () => {
+    // Positive control. Each of the three rules is an escape hatch, and a bug in any of them turns the
+    // gate into one that always passes — which is indistinguishable from a healthy codebase.
+    const bad = `class C { rows: string[] = []; load() { this.api.get().subscribe(r => { this.rows = r; }); } }`;
+    assert.deepEqual(unnotifiedWrites(bad), ['rows'], 'the detector missed an unnotified write');
+
+    const viaSignal = `class C { rows = signal<string[]>([]); load() { this.api.get().subscribe(r => { this.rows.set(r); }); } }`;
+    assert.deepEqual(unnotifiedWrites(viaSignal), [], 'a signal write must not be reported');
+
+    const sameTurn = `class C { form = {}; open = signal(0); load() { this.api.get().subscribe(r => { this.form = r; this.open.set(1); }); } }`;
+    assert.deepEqual(unnotifiedWrites(sameTurn), [], 'a same-turn signal write must clear the plain write');
+
+    const priv = `class C { private handle?: X; load() { this.api.get().subscribe(r => { this.handle = r; }); } }`;
+    assert.deepEqual(unnotifiedWrites(priv), [], 'a private field is not rendered state');
+  });
+
+  it('no component writes rendered state where nothing notifies', () => {
+    const offenders = [];
+    for (const f of files) {
+      const fields = unnotifiedWrites(readFileSync(join(ROOT, f), 'utf8'));
+      if (fields.length) offenders.push(`${f.replaceAll('\\', '/')}: ${[...new Set(fields)].join(', ')}`);
+    }
+    assert.deepEqual(offenders, [],
+      'this subscribe callback assigns to a field a template can read, and nothing in the same turn tells '
+      + 'Angular. Under OnPush the request succeeds, the value is right in memory, and the view keeps '
+      + 'showing the old one — with nothing thrown and nothing logged. Make the field a signal, or write a '
+      + 'signal in the same callback, or mark it `private` if it is genuinely not rendered.');
+  });
+});


### PR DESCRIPTION
test(client): an async write to a rendered field must notify OnPush

The deliverable from A-L2-6, the last lens-2 angle, which came back clean.

## The failure it prevents

Every component here is OnPush. A subscribe callback that assigns to a plain
field — `this.rows = result.items` — changes the data and does not tell Angular.
The request succeeds, the value is correct in memory, and the screen keeps
showing the old one. Nothing throws and nothing logs.

## The angle's own verify line would have produced a false finding

It counts files under `pages/` using `signal(`/`computed(` — 49 of 70. That
count cannot answer the question: a presentational component with `input()`s and
no state SHOULD have neither, and it is indistinguishable by that measure from a
page holding a fetched list in a mutable field. The 21 without signals are
ref-fields, cards, a search bar and a drawer — exactly the components that
should not have state.

Measured the shape that actually matters instead, by walking each `.subscribe(`
body: 55 async plain-field writes across 16 files. Three rules account for all
of them:

1. A signal is written in the same turn. The plain edit models (`entityForm`,
   `chronoForm`, the drawer's four) render only because the body also writes a
   signal — deliberate, and documented where it lives. This alone drops 55 to 6.
2. The field IS a signal and the assignment reseats the holder.
3. The field is `private`. A template cannot read a private member under
   `strictTemplates`, so a private field is not rendered state by construction.

All six survivors of (1) were (3): an EventSource handle, a reconnect timer, a
config array, and a re-entrancy guard. No page holds rendered server state in a
plain field.

## No exemption list, and that is the point

The instinct was to exempt those four fields by name. `private` is not a model
of those four — it is a fact about what a template can reach, so it stays true
of code nobody has written yet.

The two gates written immediately before this one (#727's sibling and #728) both
had to be rewritten because the measurement encoded a model of the code drawn
from the sample already read. One accused a correctly-guarded field. Asserting
something that needs no model is the fix, and it worked a third time here.

Mutation-checked by removing a single `private` modifier, which turns it red. It
carries a positive control per escape hatch, because a bug in any of the three
turns the gate into one that always passes — indistinguishable from a healthy
codebase.

## Lens 2 is complete

Six angles: A-L2-1 shipped in #687, A-L2-2 and A-L2-3 clean (the latter shipping
the god-file ratchet), A-L2-4 found a real defect — the graph halo that had never
been painted — A-L2-5 found the UI provider seam, A-L2-6 clean. Two of six
produced nothing, which is the ratio the tracker predicts and the reason it says
an angle is a suspicion until a count comes out of the repository.
