### PR TITLE
fix(release-gate): a green line claimed something it had not checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **The release gate printed a green line for a check it had skipped.** Its CHANGELOG section ended in
+  `✓ [2.4.0] is dated, has content, and [Unreleased] is empty` on every successful run — including mid-cycle
+  ones, five lines below its own `mid-cycle — [Unreleased] may hold entries` banner, and while `checkChangelog`
+  only tests emptiness under `RELEASING`. So mid-cycle it asserted, in green, something it had not looked at
+  and that was usually false; the run that found it printed the claim against an `[Unreleased]` holding eight
+  entries. A gate that overstates its coverage is worse than one that covers less — the value of a green line
+  is that someone can stop worrying about the thing it names. Mid-cycle now reads
+  `✓ [2.4.0] is dated and has content ([Unreleased] not checked mid-cycle)`; releasing mode is unchanged.
+  - Locked by a test asserting the claim is downstream of the mode branch and that the mid-cycle line names
+    what it skipped. Its first draft **passed against the pre-fix code**, because the comment written to
+    explain the fix mentions `RELEASING` — so the test strips comments before reading the source. An
+    assertion satisfiable by prose rewards deleting the prose.
+
 - **A gate that an async write to a rendered field notifies OnPush** — the deliverable from the last
   architecture angle, which came back clean. Under OnPush, `this.rows = result.items` in a subscribe
   callback changes the data and does not tell Angular: the request succeeds, the value is correct in memory,

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -234,7 +234,16 @@ console.log(`  version: ${version ?? '(inconsistent)'}   mode: ${mode}\n`);
 console.log(`${YELLOW}CHANGELOG carries the release${R}`);
 checkChangelog(version);
 if (!failures.some(f => f.gate === 'changelog')) {
-  console.log(`${GREEN}  ✓${R} [${version}] is dated, has content, and [Unreleased] is empty\n`);
+  // Say what was CHECKED, which is not the same in both modes. This line used to claim "[Unreleased] is
+  // empty" unconditionally — five lines after printing "mid-cycle — [Unreleased] may hold entries", and
+  // while `checkChangelog` only tests emptiness under RELEASING. So on every mid-cycle run the gate
+  // asserted, in green, something it had not looked at and that was usually false.
+  //
+  // A gate that overstates its coverage is worse than one that covers less: the whole value of a green
+  // line is that someone can stop worrying about the thing it names.
+  console.log(RELEASING
+    ? `${GREEN}  ✓${R} [${version}] is dated, has content, and [Unreleased] is empty\n`
+    : `${GREEN}  ✓${R} [${version}] is dated and has content ${DIM}([Unreleased] not checked mid-cycle)${R}\n`);
 } else {
   console.log('');
 }

--- a/testing/standalone/release-gate-works.test.js
+++ b/testing/standalone/release-gate-works.test.js
@@ -34,6 +34,14 @@ const ROOT = process.cwd();
 const GATE = 'scripts/release-gate.mjs';
 const src = readFileSync(join(ROOT, GATE), 'utf8');
 
+/**
+ * Code only. Assertions about what a gate CHECKS must not be satisfiable by the comment that explains the
+ * check — that reads as coverage and makes deleting the explanation look like a fix.
+ */
+function withoutComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
 /** The gate names its checks in two arrays; pull them out rather than duplicating the list here. */
 function namedGates() {
   const out = [];
@@ -74,6 +82,34 @@ describe('mode detection', () => {
     assert.match(src, /if \(!RELEASING\) return;/,
       'the [Unreleased] emptiness check is not gated on release mode, so it fails on every healthy mid-cycle tree '
       + 'and teaches everyone to ignore this gate');
+  });
+
+  it('the green CHANGELOG line does not claim a check that mid-cycle skips', () => {
+    // `checkChangelog` returns early on the [Unreleased] rule unless RELEASING. So a success line naming that
+    // rule unconditionally reports, in green, a check that did not run — and green is the colour people stop
+    // reading after. It did exactly that for two releases, five lines below its own
+    // "mid-cycle — [Unreleased] may hold entries" banner.
+    //
+    // Asserted structurally for the same reason as the test above: running the gate and reading its output
+    // depends on whether HEAD happens to be a tag when the suite runs. Shape-agnostic on purpose — an
+    // if/else satisfies it as readily as the ternary that is there now.
+    const start = src.indexOf('checkChangelog(version);');
+    assert.ok(start > 0, 'the CHANGELOG section moved — this test needs re-pointing, not deleting');
+    // Comments stripped, and not as a formality: the first draft of this test PASSED against the pre-fix
+    // code, because the comment written to explain the fix mentions RELEASING. A gate that reads prose
+    // rewards deleting the prose.
+    const region = withoutComments(src.slice(start, src.indexOf('\n}', start)));
+
+    const claim = region.indexOf('[Unreleased] is empty');
+    assert.ok(claim > 0,
+      'the releasing-mode line no longer states that it checked [Unreleased]; if that claim was dropped on '
+      + 'purpose, re-point this test at whatever states the coverage now');
+    const branch = region.indexOf('RELEASING');
+    assert.ok(branch > 0 && branch < claim,
+      'the CHANGELOG success line is not gated on release mode, so a mid-cycle run claims [Unreleased] was '
+      + 'checked while checkChangelog skipped it');
+    assert.match(region, /not checked mid-cycle/,
+      'the mid-cycle line does not say which check it skipped, so its silence reads as coverage');
   });
 
   it('detects release mode from git rather than from a flag alone', () => {


### PR DESCRIPTION
## The defect

`npm run release:gate` ended its CHANGELOG section with

```text
  ✓ [2.4.0] is dated, has content, and [Unreleased] is empty
```

on **every** successful run. Including mid-cycle ones — five lines below its own banner saying
`mid-cycle — [Unreleased] may hold entries`, and while `checkChangelog` returns early on that rule
unless `RELEASING`:

```js
  if (!RELEASING) return;   // scripts/release-gate.mjs, inside checkChangelog
```

So on every mid-cycle run the gate asserted, in green, something it had not looked at and that was
usually false. The run that found it printed the claim against an `[Unreleased]` holding eight entries.

A gate that overstates its coverage is worse than one that covers less. The whole value of a green line
is that someone can stop worrying about the thing it names, and this one invited exactly that about a
check it had skipped — in the one place where the cost of a wrong assumption is a published artefact.

## The fix

The line now says what was checked, which is not the same in both modes:

```text
mid-cycle:  ✓ [2.4.0] is dated and has content ([Unreleased] not checked mid-cycle)
releasing:  ✓ [2.4.0] is dated, has content, and [Unreleased] is empty
```

Releasing mode is unchanged. Both branches were verified by running the gate each way rather than by
reasoning about the conditional.

## The test, and the trap it fell into first

The invariant: the emptiness claim must sit downstream of the mode branch, and the mid-cycle line must
name the check it skipped. Asserted on the source, for the reason the neighbouring mode-detection test
in the same file already documents — running the gate and reading its output depends on whether HEAD
happens to be a tag when the suite runs. It is shape-agnostic, so an `if`/`else` satisfies it as
readily as the ternary that is there now.

**The first draft passed against the pre-fix code.** The comment written to explain the fix mentions
`RELEASING`, and the assertion was reading the comment rather than the code. So the test strips
comments before searching.

That direction of the failure is the dangerous one. This repo has hit comment-matching three times
before, and every one of those was a gate hunting a *forbidden* pattern — it fired on the explanation
and went red, which gets noticed immediately. A gate requiring a *required* pattern that matches the
comment instead goes **green**, covering nothing, and looks exactly like a gate that works.

Proved in both directions, and against a second mutant: a ternary whose mid-cycle branch repeats the
emptiness claim is caught by the third assertion.

## Notes

- `check-changelog` does not require an entry here — `scripts/` is not shipped code. One is included
  anyway under `### Internal`, following #701, which did the same for a tooling gate defect.
- No `docs/` change: the release gate is not documented under `docs/`, checked before pushing.

preflight green. `release:gate` green mid-cycle, printing the new line.
