### PR TITLE
release: 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-08-07
+
 ### Added
 
 - **Optimistic concurrency on brain records — `If-Match` and a 412.** Two clients that read the same record,

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
release: 2.5.0

The queue drained, so the tag is due -- the gate is "cut it when `_TODO-ORDERED.md`
section 1 is empty, before the next audit round", and what is left there is one
item that cannot be worked until a second release exists with the current image
layer structure, plus four watch items that are not work by definition.

Four manifests moved to 2.5.0 (package.json, server, client, and the lockfile via
`npm install --package-lock-only`), and `[Unreleased]` is closed into a dated
`## [2.5.0] — 2026-08-07`.

`node scripts/release-gate.mjs --releasing` is green on all three of the owner's
terms: the CHANGELOG carries 2.5.0 with `[Unreleased]` emptied, thirteen
docs-coverage gates plus markdownlint, and NOTICE attributes every redistributed
dependency including ffmpeg. It runs again inside publish.yml before the build,
so a bad tag fails in about two minutes rather than publishing.

What is in it
-------------

The headline is **optimistic concurrency on brain records** -- `If-Match` on the
PATCH of all four record types, 412 on a mismatch, no header means no
precondition so every existing client is unaffected. It closes the lost-update
exposure the collision counter was measuring, and it matters most for the case
that produced the counter: several MCP agents writing one space.

Also in it: the schema-editor delete that never deleted, a `$ref` type silently
emptied on whole-file import, the graph halo that had never once been painted,
REST `includeContent` on recall, the insert-time duplicate/contradiction check
reachable over REST, and a row of gates -- OnPush notification, env-pinned model
settings, cytoscape runtime style properties, runtime import cycles, and a
god-file ratchet measured in code lines.

Minor rather than patch: `If-Match` is new API surface. Nothing in this release
removes or renames anything a client depends on.

One behaviour change worth reading before upgrading
---------------------------------------------------

A brain-record PATCH used to build its response from the record as READ and
return it whether or not the write matched anything -- so a record deleted inside
the read-to-write window produced a fabricated 200 describing changes that were
never made, counted as a `clean` write in the metrics. That path now returns 404
(or 412 when a precondition was in play) and counts as `collision`. The race is
narrow, but any client that was relying on that 200 was relying on a lie.

`ythril_brain_write_seq_total` also gains a third `outcome`: `refused`, for a
write an `If-Match` stopped. Deliberately not folded into `collision` -- one is a
lost update that happened, the other one that did not, and folding them would
have changed the meaning of the `collision` series halfway through its own
history.

preflight green. After merge: annotated tag, GitHub Release from this CHANGELOG
section, verify both registries on both architectures, then the canary exercise
-- which from 2.2.2 on IS the release gate, since automated suites gate a PR and
do not gate a release.
