### PR TITLE
docs(spaces): the TypeSchema block was missing two of its five fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **The `TypeSchema` interface block was missing two of its five fields.**
+  `docs/integration-guide/06-spaces-api.md` documented `namingPattern`, `tagSuggestions` and
+  `propertySchemas`, and omitted **`retention`** (per-type retention, the middle tier of
+  `record > schema > space`) and **`$ref`** (link the type to a schema-library entry). Both are shipped, both
+  have editors in the admin UI, and `retention` is documented in `04-brain-api.md` — in a different file from
+  the one that carries the type. Reported as a question by an integrator who re-ingests the guides on every
+  deploy and could not surface the field by searching the type.
+  - **A prose gap invites the question. An enumeration does not** — it reads as complete, so nobody thinks to
+    ask. That is why this was found from outside rather than by us.
+  - Every docs-coverage gate here asks whether a thing is MENTIONED, and `retention` **was** mentioned, so all
+    of them were satisfied and right to be. An interface block is a second copy of a type declaration, and
+    nothing compared the two.
+
+### Internal
+
+- **A gate that a documented interface block lists what the interface declares**, in both directions and with
+  comments stripped. The reverse direction is the one that matters most to integrators: a documented key the
+  code does not declare produces a `PATCH` that deep-merges to a success code and changes nothing. That is not
+  hypothetical — the integrator who reported the omission above had previously written a `PATCH` against
+  `chronoRetention`, a key the docs described and the implementation never shipped, and was told it worked.
+  Mutation-checked in both directions against the block as it shipped.
+
 ## [2.5.0] — 2026-08-07
 
 ### Added

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -670,7 +670,13 @@ The schema is expressed as a single `typeSchemas` object on the space `meta`. It
 
 ```typescript
 interface TypeSchema {
+  $ref?: string;                                  // "library:<name>" — use a schema-library entry instead
+                                                  //   of the inline fields. When set, inline fields on the
+                                                  //   same object are IGNORED, not merged.
   namingPattern?: string;                         // entity only — regex for name validation
+  retention?: { days?: number; contentDays?: number };  // per-type retention, the middle tier of
+                                                  //   record > schema > space. `contentDays` is chrono-only
+                                                  //   and is rejected elsewhere. See 04-brain-api.md.
   tagSuggestions?: string[];                      // RETIRED — accepted and stored, consumed by nothing
   propertySchemas?: Record<string, PropertySchema>;
 }

--- a/testing/standalone/documented-interfaces-match-code.test.js
+++ b/testing/standalone/documented-interfaces-match-code.test.js
@@ -1,0 +1,127 @@
+/**
+ * An interface block in the docs must list the same fields as the interface it copies.
+ *
+ * ## The failure this catches, reported from outside
+ *
+ * `06-spaces-api.md` documents `TypeSchema` as a TypeScript block. It listed three fields. The real
+ * interface has five public ones — `$ref` and `retention` were missing, and `retention` had been shipped,
+ * built an editor in the admin UI, and documented **in a different file** (`04-brain-api.md`).
+ *
+ * An integrator re-ingesting the guides on every deploy asked whether per-type retention was documented
+ * "anywhere we have not looked", because their recall over `06-spaces-api.md` could not surface a field
+ * that file never named. They were right, and they were careful enough to ask rather than announce it.
+ * The reason it matters to them specifically is the mirror image of this bug: they had once written a
+ * `PATCH` against `chronoRetention`, a key the docs described and the implementation never shipped — and a
+ * deep-merge `PATCH` against a key that does not exist returns success and changes nothing.
+ *
+ * ## Why no existing gate caught it
+ *
+ * Every docs-coverage gate here asks whether a thing is MENTIONED. `retention` **was** mentioned, in
+ * `04-brain-api.md`, so those gates were satisfied and correct to be. What nothing checked was the second
+ * copy: an interface block is a duplicate of a type declaration, and duplicates drift. Drift needs two
+ * copies compared, not one copy counted.
+ *
+ * A prose omission is a gap. An **enumeration** that omits something is worse — it reads as complete, so it
+ * does not invite the question that a gap does. That is the whole reason this gate compares in both
+ * directions: a documented field that no longer exists is the same defect wearing the other hat, and it is
+ * the one that produces a silent no-op `PATCH`.
+ *
+ * Run: node --test testing/standalone/documented-interfaces-match-code.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+
+/**
+ * Each documented block, and the declaration it is a copy of.
+ *
+ * A hardcoded list cannot silently empty — see `gates-cannot-pass-vacuously` for why that exemption
+ * applies — but each entry still asserts it FOUND both blocks, because a renamed interface would otherwise
+ * turn this gate into one that compares nothing.
+ */
+const PAIRS = [
+  { name: 'TypeSchema', doc: 'docs/integration-guide/06-spaces-api.md', src: 'server/src/config/types.ts' },
+  { name: 'PropertySchema', doc: 'docs/integration-guide/06-spaces-api.md', src: 'server/src/config/types.ts' },
+];
+
+/** Strip comments so a field named only in prose about the type cannot satisfy the comparison. */
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/** The body of `interface <name> { … }`, brace-matched so a nested object type does not end it early. */
+function interfaceBody(text, name) {
+  const m = new RegExp(`(?:export\\s+)?interface\\s+${name}\\s*\\{`).exec(text);
+  if (!m) return null;
+  let depth = 1;
+  let i = m.index + m[0].length;
+  const start = i;
+  for (; i < text.length && depth > 0; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}') depth--;
+  }
+  return depth === 0 ? text.slice(start, i - 1) : null;
+}
+
+/**
+ * Field names declared at the TOP level of an interface body.
+ *
+ * Depth-tracked, so `retention?: { days?: number }` contributes `retention` and not `days`. Fields whose
+ * name starts with `_` are skipped: they are marked `@internal` in the source, never appear in stored
+ * config, and documenting them would be wrong rather than merely absent.
+ */
+function fieldNames(body) {
+  const out = [];
+  let depth = 0;
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim();
+    if (depth === 0) {
+      const m = /^([A-Za-z_$][\w$]*)\??\s*:/.exec(trimmed);
+      if (m && !m[1].startsWith('_')) out.push(m[1]);
+    }
+    for (const ch of line) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+    }
+  }
+  return out;
+}
+
+describe('a documented interface block lists what the real interface declares', () => {
+  for (const pair of PAIRS) {
+    it(`${pair.name} — the doc block and the declaration agree`, () => {
+      const srcBody = interfaceBody(withoutComments(read(pair.src)), pair.name);
+      const docBody = interfaceBody(withoutComments(read(pair.doc)), pair.name);
+
+      assert.ok(srcBody !== null,
+        `interface ${pair.name} was not found in ${pair.src} — it was renamed or moved, which makes this `
+        + 'gate compare nothing. Re-point it rather than deleting the entry.');
+      assert.ok(docBody !== null,
+        `no \`interface ${pair.name}\` block in ${pair.doc} — if the block was removed on purpose, remove `
+        + 'this pair too, deliberately.');
+
+      const inCode = fieldNames(srcBody);
+      const inDocs = fieldNames(docBody);
+
+      // The enumeration floor. A brace-matching or regex change that returned an empty body would make
+      // both lists empty and every comparison below pass while examining nothing.
+      assert.ok(inCode.length >= 3,
+        `only parsed ${inCode.length} field(s) out of ${pair.name} in ${pair.src}; the parse broke, not the docs`);
+
+      const missing = inCode.filter(f => !inDocs.includes(f));
+      assert.deepEqual(missing, [],
+        `${pair.doc} documents ${pair.name} without ${missing.join(', ')}. The block is an ENUMERATION, so `
+        + 'it reads as complete and does not invite the question a prose gap would. Being documented in '
+        + 'another file does not fix it: a reader searching this type searches here.');
+
+      const invented = inDocs.filter(f => !inCode.includes(f));
+      assert.deepEqual(invented, [],
+        `${pair.doc} documents ${pair.name}.${invented.join(', ')}, which the code does not declare. This is `
+        + 'the worse direction: a PATCH written against a key that does not exist deep-merges to a success '
+        + 'code and changes nothing, so the integrator is told it worked.');
+    });
+  }
+});


### PR DESCRIPTION
docs(spaces): the TypeSchema block was missing two of its five fields

Reported from outside, as a question rather than a defect report, by an
integrator who re-ingests the guides on every deploy at the deployed tag.

`06-spaces-api.md` documented `TypeSchema` as `namingPattern`, `tagSuggestions`
and `propertySchemas`. The real interface also has:

  - `retention` -- per-type retention, the middle tier of record > schema >
    space. Shipped, has an editor in the admin UI, and IS documented -- in
    `04-brain-api.md`, a different file from the one that carries the type. So a
    reader searching the type could not find it, which is exactly what happened.
  - `$ref` -- link the type to a schema-library entry. Also shipped, also with
    an editor, and it is the mechanism behind a defect this same integrator hit
    last week.

A prose gap invites the question. An ENUMERATION does not: it reads as complete,
so nobody thinks to ask. That is why this was found from outside instead of by
us, and it is the reason the fix is a gate and not just a paragraph.

Why no existing gate caught it
------------------------------

Every docs-coverage gate here asks whether a thing is MENTIONED. `retention`
WAS mentioned, so all of them were satisfied and correct to be. What nothing
checked was the second copy -- an interface block in the docs is a duplicate of
a type declaration, and duplicates drift. Drift needs two copies compared, not
one copy counted.

The gate
--------

`documented-interfaces-match-code.test.js` brace-matches both blocks, strips
comments (a field named only in prose about the type must not satisfy it), and
compares in BOTH directions. It carries an enumeration floor, so a parse that
returned an empty body fails loudly instead of passing while examining nothing.

The reverse direction is the one that matters most to integrators, and it is not
hypothetical: this integrator had previously written a PATCH against
`chronoRetention`, a key the docs described and the implementation never
shipped. A deep-merge PATCH against a key that does not exist returns a success
code and changes nothing, so they were told it worked.

Mutation-checked both ways against the block as it shipped -- removing
`retention` fails by name, and adding a `chronoRetention` that the code does not
declare fails with the message quoted above.

`PropertySchema` was already correct and is now pinned by the same gate.

preflight green.
