### PR TITLE
docs(mcp): a session caches its tool list, so an upgrade needs a reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **The MCP guide now says that a session caches its tool list, so an upgrade needs a reconnect.** MCP
+  negotiates the tool list once at session start; a session held open across an instance upgrade keeps
+  reporting the old surface, and tools the new version added are absent from the client's view while the
+  server offers them normally. An operator upgrading five instances 2.4.0 → 2.5.0 came close to reporting
+  that three tools had not shipped — every piece of evidence in front of them pointed that way, because the
+  tools really were missing from their client and the instance really was on the new version. `help()` is the
+  check: it is generated server-side per token at call time, so it describes what the instance offers now.
+  Nothing to fix in the server — the protocol permits the client to cache — which is exactly why it needed
+  writing down instead.
+
 - **The `TypeSchema` interface block was missing two of its five fields.**
   `docs/integration-guide/06-spaces-api.md` documented `namingPattern`, `tagSuggestions` and
   `propertySchemas`, and omitted **`retention`** (per-type retention, the middle tier of

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -116,6 +116,21 @@ Content-Type: application/json
 
 ### Available Tools
 
+> **After an instance upgrade, reconnect before concluding a tool is missing.** MCP negotiates the tool list
+> **once, at session start**, and clients cache it. A session held open across an upgrade keeps reporting the
+> tool surface of the version it connected to — so tools added by the new version are absent from the client's
+> view while the server offers them normally. Nothing is wrong and nothing needs fixing; the session is stale,
+> not the server.
+>
+> This is easy to misread, because every piece of evidence in front of you points the other way: the tool is
+> genuinely not in your client's list, and the instance is genuinely on the new version. An operator running
+> five instances hit exactly this on a 2.4.0 → 2.5.0 upgrade and came close to reporting that three tools had
+> not shipped.
+>
+> **`help()` is the check.** It is generated server-side, per token, at call time — so it always describes what
+> the instance offers *right now*, scoped to what your token may call. If `help()` lists a tool your client
+> does not, the answer is to reconnect.
+
 | Tool | Description |
 |---|---|
 | `help` | Self-documenting system guide — the knowledge model, how to choose between `query` / `recall` / filtered recall, schema authoring, and the tools available to the calling token. Read-only, no `space` needed; scoped to the token so it never lists tools the token can't call |


### PR DESCRIPTION
docs(mcp): a session caches its tool list, so an upgrade needs a reconnect

Reported by an operator running five instances, during the 2.5.0 canary
exercise. After the upgrade, three tools the server offers were still absent
from their MCP client's view, and they came close to filing "the tools did not
ship".

They were looking at the client. MCP negotiates the tool list ONCE at session
start and the client caches it, so a session held open across an upgrade keeps
reporting the surface of the version it connected to.

Nothing to fix in the server -- the protocol permits the client to cache -- and
that is exactly why it needed writing down instead. The wrong conclusion is the
one the evidence supports: the tool really is missing from your list, and the
instance really is on the new version. Every fact in front of you agrees, and
they are all consistent with a stale session.

`help()` is the check, and the note says so. It is generated server-side, per
token, at call time, so it describes what the instance offers right now rather
than what some earlier session was told.

Placed at the head of the tool table, which is where someone goes when they
cannot find a tool.

Docs only -- no code, no test, no workflow in this diff. preflight green.
