### PR TITLE
fix(brain): an update embedded from its own stale read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A record's search vector could permanently disagree with the record's own fields.** All four update
+  functions computed the embedding themselves, from the record as they had READ it plus the caller's patch,
+  and wrote it in the same `$set`. Every *content* field in that `$set` was guarded by
+  `updates.X !== undefined`; the embedding never was — it went in unconditionally.
+  - So two concurrent `PATCH`es touching **different** fields both landed and lost no field, exactly as the
+    guide promises, while each wrote a whole embedding describing only its own view. The later write won, and
+    the stored vector then described a record that existed nowhere. Not a lost field — a permanent
+    disagreement between a record and its own index, on a record whose every field is correct.
+  - **Nothing could have detected it.** No field was lost, so no `If-Match` precondition would have been
+    violated and `ythril_brain_write_seq_total` would have said `clean`. The only symptom is a search result
+    ranked on `matchedText` the record no longer contains.
+  - **An update now enqueues the re-embed instead**, and `embedStoredRecord` re-reads the document after the
+    write — so the text it embeds is, by construction, the text of the record as it actually stands, whoever
+    else wrote to it in between. This is the contract creates have had since the embed queue shipped;
+    updates were the odd one out.
+  - **What changes for a caller:** an updated record keeps its previous vector for the moment before the
+    worker catches up, so it is briefly ranked on its previous text rather than being absent from `recall`
+    (which is what a *pending create* does). `PATCH` responses no longer carry a freshly computed
+    `embedding`. Write latency drops, because the model is no longer in the `PATCH` path.
+  - It also deletes four inline copies of the embed-text builder. `buildEmbedText` is the one the queue uses,
+    and one copy cannot drift from itself.
+
 ### Documentation
 
 - **The MCP guide now says that a session caches its tool list, so an upgrade needs a reconnect.** MCP

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -180,6 +180,17 @@ Use it when you will search for what you just wrote in the same flow, or when a 
 should be a visible error rather than a background repair. `checkDuplicates` and `checkContradictions` imply
 it — a duplicate check needs the vector before the insert so the new record cannot match itself.
 
+**A `PATCH` re-embeds through the same queue**, and always — you do not have to work out whether the fields
+you sent were the ones the vector is built from. The record keeps its previous vector until the worker
+catches up, which is a moment later; unlike a create, an updated record is never *absent* from `recall` in
+the meantime, it is briefly ranked on its previous text.
+
+That is deliberate and it is the correctness argument, not a convenience: the worker rebuilds the text from
+the record **as stored**, so it sees every concurrent edit. An update that computed the vector itself could
+only build it from the record as that request read it — so two clients editing different fields would both
+succeed, lose nothing, and still leave the stored vector describing a record that exists nowhere. `PATCH`
+does not take `waitForEmbedding`; if you need the new vector before you search, poll the record or re-read it.
+
 ---
 
 ### Record Expiry (TTL)
@@ -1824,7 +1835,9 @@ merges on both, and no other field changes meaning. A `PATCH` that names no reco
 
 Brain-record `PATCH`es are last-write-wins by default. Two clients that read the same record, edit the
 **same field**, and both save produce one silent loser: their value disappears with a `200` and no trace.
-(Editing *different* fields is safe — a `PATCH` only writes the fields you send.)
+(Editing *different* fields is safe — a `PATCH` only writes the fields you send, and the record's search
+vector is rebuilt from the record as **stored**, so a concurrent edit to another field cannot leave the two
+disagreeing.)
 
 To make your write conditional, send back the `seq` you read as an `If-Match` header:
 

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -243,29 +243,10 @@ export async function updateChrono(
   const mergedUpdateProps = mergePropertiesOrKeep(existing.properties, updates.properties);
   if (updates.properties !== undefined) $set['properties'] = mergedUpdateProps;
 
-  // Re-embed if any embedding-relevant field changes
-  if (
-    updates.title !== undefined ||
-    updates.description !== undefined ||
-    updates.type !== undefined ||
-    updates.status !== undefined ||
-    updates.tags !== undefined ||
-    updates.properties !== undefined
-  ) {
-    const newTitle = updates.title ?? existing.title;
-    const newKind = updates.type ?? existing.type;
-    const newStatus = updates.status ?? existing.status;
-    const newDesc = updates.description !== undefined ? updates.description : existing.description;
-    const newTags = updates.tags ?? existing.tags;
-    const newProps = mergedUpdateProps ?? existing.properties;
-    try {
-      const embedText = chronoEmbedText(newTitle, newKind, newStatus, newDesc, newTags, newProps);
-      const embResult = await embed(embedText);
-      $set['embedding'] = embResult.vector;
-      $set['embeddingModel'] = embResult.model;
-      $set['matchedText'] = embedText;
-    } catch { /* embedding unavailable — keep existing embedding */ }
-  }
+  // There is no longer a "did an embedding-relevant field change?" branch here. It existed to decide whether
+  // to pay for an inline embed; the re-embed is now ENQUEUED unconditionally after the write, and
+  // `embedStoredRecord` reads the record as STORED. Deciding here would mean deciding from this function's
+  // stale read — the exact reasoning that made the old inline embedding wrong.
 
   applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
     { collection: 'chrono', existing: existing as unknown as Record<string, unknown> }); // F10
@@ -291,7 +272,10 @@ export async function updateChrono(
   // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
   // the vector when the flag is on and computes one when it is off. So this path never has to know
   // which way the toggle went, which is what keeps the rule in one place.
-  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'chrono', updatedChrono._id);
+  // ONE enqueue, unconditionally, for every successful update: recompute the text from the record as
+  // STORED, and honour excludeFromVectorSearch in whichever direction it moved. See the entity update and
+  // `embedStoredRecord` for why this replaced an inline embed built from a stale read.
+  await enqueueEmbedJob(spaceId, 'chrono', updatedChrono._id);
   if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...updatedChrono, embedding: undefined }, ...actor });
   return updatedChrono;
 }

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -316,15 +316,9 @@ export async function updateEdgeById(
   if (updates.type !== undefined) $set['type'] = newType;
   if (updates.weight !== undefined || (deleteFieldsPaths && !$unset['weight'])) $set['weight'] = newWeight;
 
-  // Re-embed whenever any content field changes — resolve entity names for semantic signal
-  try {
-    const [fromName, toName] = await resolveEdgeEntityNames(spaceId, existing.from, existing.to);
-    const embedText = edgeEmbedText(fromName, newLabel, toName, newTags, newType, newDesc, newProps);
-    const embResult = await embed(embedText);
-    $set['embedding'] = embResult.vector;
-    $set['embeddingModel'] = embResult.model;
-    $set['matchedText'] = embedText;
-  } catch { /* embedding unavailable — keep existing embedding */ }
+  // The re-embed is ENQUEUED after the write — see `embedStoredRecord`. Computing it here would build the
+  // text from this function's stale read, which is how a record's vector ends up describing a record that
+  // no longer exists anywhere.
 
   applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
     { collection: 'edge', existing: existing as unknown as Record<string, unknown> }); // F10
@@ -356,7 +350,6 @@ export async function updateEdgeById(
     ...(updates.properties !== undefined || (deleteFieldsPaths && !$unset['properties']) ? { properties: newProps } : {}),
     ...(updates.type !== undefined ? { type: newType } : {}),
     ...(updates.weight !== undefined ? { weight: newWeight } : {}),
-    ...('embedding' in $set ? { embedding: $set['embedding'] as number[], embeddingModel: $set['embeddingModel'] as string } : {}),
   } as EdgeDoc;
   if ('_expireAt' in $set) result._expireAt = $set['_expireAt'] as Date;
   else if ('_expireAt' in $unset) delete (result as { _expireAt?: unknown })._expireAt;
@@ -369,7 +362,10 @@ export async function updateEdgeById(
   // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
   // the vector when the flag is on and computes one when it is off. So this path never has to know
   // which way the toggle went, which is what keeps the rule in one place.
-  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'edge', result._id);
+  // ONE enqueue, unconditionally, for every successful update: recompute the text from the record as
+  // STORED, and honour excludeFromVectorSearch in whichever direction it moved. See the entity update and
+  // `embedStoredRecord` for why this replaced an inline embed built from a stale read.
+  await enqueueEmbedJob(spaceId, 'edge', result._id);
   if (actor) emitWebhookEvent({ event: 'edge.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }

--- a/server/src/brain/embed-record.ts
+++ b/server/src/brain/embed-record.ts
@@ -80,7 +80,30 @@ export async function buildEmbedText(
 export type EmbedOutcome = 'embedded' | 'gone' | 'excluded';
 
 /**
- * Load the record, build its text, embed it, store the vector.
+ * ## Why an UPDATE enqueues this instead of embedding inline
+ *
+ * Until 2026-08-07 all four update functions computed the vector themselves, from the record as they had
+ * READ it plus the caller's patch, and wrote it in the same `$set`. Every content field in that `$set` was
+ * guarded by `updates.X !== undefined`, but the embedding never was — it went in unconditionally.
+ *
+ * So two concurrent patches touching DIFFERENT fields both landed and lost no field, exactly as documented,
+ * while each wrote a whole embedding describing only its own view of the record. The later write won, and
+ * the stored vector then described a record that no longer existed anywhere: not a lost field, a permanent
+ * disagreement between a record and its own index. Nothing could detect it, because every field was
+ * correct — no counter fires, and no `If-Match` precondition would have been violated.
+ *
+ * `embedStoredRecord` cannot have that bug. It re-reads the document AFTER the write, so the text it embeds
+ * is by construction the text of the record as it actually stands, whoever else wrote to it in between.
+ *
+ * Two things fall out of the change that are worth knowing before "simplifying" it back:
+ *
+ *  - **It is the contract creates already have.** `upsertEntity` and `remember` have queued by default since
+ *    the embed queue shipped, and `waitForEmbedding` is the documented opt-out. Updates were the odd one out.
+ *  - **It deletes four copies of the embed-text builder.** Each update function had its own inline call to
+ *    `entityEmbedText` / `memoryEmbedText` / …; `buildEmbedText` above is the one the queue uses, and one
+ *    copy cannot drift from itself.
+ *
+ * ## Load the record, build its text, embed it, store the vector.
  *
  * Throws if the model is unavailable — the caller decides whether that is a retry (the worker) or a
  * failed request (`waitForEmbedding: true`). Returns `gone` when the record no longer exists, which is

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -311,14 +311,8 @@ export async function updateEntityById(
   if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
   if (updates.properties !== undefined || (deleteFieldsPaths && !$unset['properties'])) $set['properties'] = newProps;
 
-  // Re-embed whenever any content field changes
-  try {
-    const embedText = entityEmbedText(newName, newType, newTags, newDesc, newProps);
-    const embResult = await embed(embedText);
-    $set['embedding'] = embResult.vector;
-    $set['embeddingModel'] = embResult.model;
-    $set['matchedText'] = embedText;
-  } catch { /* embedding unavailable — keep existing embedding */ }
+  // The re-embed is ENQUEUED after the write, not computed here. See `embedStoredRecord` for why computing
+  // it inline was wrong rather than merely slow: the text would come from this function's stale read.
 
   applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
     { collection: 'entity', existing: existing as unknown as Record<string, unknown> }); // F10
@@ -351,7 +345,6 @@ export async function updateEntityById(
     updatedAt: now,
     seq,
     ...(updates.description !== undefined ? { description: newDesc } : {}),
-    ...('embedding' in $set ? { embedding: $set['embedding'] as number[], embeddingModel: $set['embeddingModel'] as string } : {}),
   } as EntityDoc;
   if ('_expireAt' in $set) result._expireAt = $set['_expireAt'] as Date;
   else if ('_expireAt' in $unset) delete (result as { _expireAt?: unknown })._expireAt;
@@ -361,10 +354,14 @@ export async function updateEntityById(
     applyDeleteFields(result as unknown as Record<string, unknown>, deleteFieldsPaths);
   }
 
-  // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
-  // the vector when the flag is on and computes one when it is off. So this path never has to know
-  // which way the toggle went, which is what keeps the rule in one place.
-  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'entity', result._id);
+  // ONE enqueue, unconditionally, for every successful update.
+  //
+  // It used to be conditional on `excludeFromVectorSearch` being present, because every other path embedded
+  // inline. Now that the vector always comes from the queue, the same call covers both jobs: recompute the
+  // text from the record as STORED, and honour the exclusion flag in whichever direction it was moved —
+  // `embedStoredRecord` unsets the vector when the flag is on and computes one when it is off, so this path
+  // still never has to know which way the toggle went.
+  await enqueueEmbedJob(spaceId, 'entity', result._id);
   if (actor) emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -261,28 +261,10 @@ export async function updateMemory(
   }
 
   // Re-embed whenever any content field changes
-  const contentChanged =
-    updates.fact !== undefined ||
-    updates.tags !== undefined ||
-    updates.entityIds !== undefined ||
-    updates.description !== undefined ||
-    updates.properties !== undefined ||
-    (deleteFieldsPaths && deleteFieldsPaths.length > 0);
-  if (contentChanged) {
-    const newFact = ($set['fact'] as string) ?? existing.fact;
-    const newTags = ($set['tags'] as string[]) ?? existing.tags;
-    const newEntityIds = ($set['entityIds'] as string[]) ?? existing.entityIds;
-    const newDesc = 'description' in $set ? ($set['description'] as string | undefined) : existing.description;
-    const newProps = ($set['properties'] as Record<string, string | number | boolean>) ?? existing.properties;
-    const entityNames = await resolveEntityNames(spaceId, newEntityIds);
-    try {
-      const embedText = memoryEmbedText(newFact, newTags, entityNames, newDesc, newProps);
-      const embResult = await embed(embedText);
-      $set['embedding'] = embResult.vector;
-      $set['embeddingModel'] = embResult.model;
-      $set['matchedText'] = embedText;
-    } catch { /* embedding unavailable — keep existing embedding */ }
-  }
+  // There is no longer a "did the content change?" branch here. It existed to decide whether to pay for an
+  // inline embed; the re-embed is now ENQUEUED unconditionally after the write, and `embedStoredRecord`
+  // reads the record as STORED. Deciding here would mean deciding from this function's stale read — the
+  // exact reasoning that made the old inline embedding wrong.
 
   applyExpiryToUpdate(spaceId, ttlDays, existing._expireAt != null, $set, $unset,
     { collection: 'memory', existing: existing as unknown as Record<string, unknown> }); // F10
@@ -325,7 +307,10 @@ export async function updateMemory(
   // Toggling exclusion always ends in an embed job, and the job handles BOTH directions — it unsets
   // the vector when the flag is on and computes one when it is off. So this path never has to know
   // which way the toggle went, which is what keeps the rule in one place.
-  if (updates.excludeFromVectorSearch !== undefined) await enqueueEmbedJob(spaceId, 'memory', result._id);
+  // ONE enqueue, unconditionally, for every successful update: recompute the text from the record as
+  // STORED, and honour excludeFromVectorSearch in whichever direction it moved. See the entity update and
+  // `embedStoredRecord` for why this replaced an inline embed built from a stale read.
+  await enqueueEmbedJob(spaceId, 'memory', result._id);
   if (actor) emitWebhookEvent({ event: 'memory.updated', spaceId, entry: { ...result, embedding: undefined }, ...actor });
   return result;
 }

--- a/testing/standalone/update-embeds-from-stored-record.test.js
+++ b/testing/standalone/update-embeds-from-stored-record.test.js
@@ -1,0 +1,131 @@
+/**
+ * A record's vector must describe the record as STORED, never as the writer read it.
+ *
+ * ## The defect this closes
+ *
+ * All four update functions used to compute the embedding themselves — from the record they had read, plus
+ * the caller's patch — and write it in the same `$set`. Every CONTENT field in that `$set` was guarded by
+ * `updates.X !== undefined`. The embedding never was: it went in unconditionally.
+ *
+ * So two concurrent patches touching DIFFERENT fields both landed and lost no field, exactly as the guide
+ * promises — while each wrote a whole embedding describing only its own view. The later write won, and the
+ * stored vector then described a record that existed nowhere. Not a lost field: a permanent disagreement
+ * between a record and its own index, on a record whose every field is correct.
+ *
+ * **Nothing could have detected it.** No field was lost, so no `If-Match` precondition would have been
+ * violated and the lost-update counter would have said `clean`. Recall would rank the record on a
+ * `matchedText` it no longer contains, and the only symptom is a slightly wrong search result.
+ *
+ * ## Why this is asserted on the source
+ *
+ * The property is "the text came from the stored document", and the only way to observe it at runtime is to
+ * lose a race against an embedding round trip on purpose. That is not a test, it is a coin flip. What CAN be
+ * pinned is the mechanism: the update path must not build embed text at all, and must hand the record to the
+ * queue, whose `embedStoredRecord` re-reads the document after the write and is correct by construction.
+ *
+ * Comments are stripped first. Every one of these functions now carries a comment explaining why the inline
+ * embed is gone, and those comments name the very builders being searched for — an assertion that reads them
+ * would pass on the explanation and go green if someone put the inline embed back.
+ *
+ * Run: node --test testing/standalone/update-embeds-from-stored-record.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/** The four update functions, and the embed-text builder each one used to call inline. */
+const UPDATES = [
+  { type: 'entity', file: 'server/src/brain/entities.ts', fn: 'updateEntityById', builder: 'entityEmbedText' },
+  { type: 'memory', file: 'server/src/brain/memory.ts', fn: 'updateMemory', builder: 'memoryEmbedText' },
+  { type: 'edge', file: 'server/src/brain/edges.ts', fn: 'updateEdgeById', builder: 'edgeEmbedText' },
+  { type: 'chrono', file: 'server/src/brain/chrono.ts', fn: 'updateChrono', builder: 'chronoEmbedText' },
+];
+
+/**
+ * The body of an exported async function.
+ *
+ * The parameter list has to be walked with paren depth before looking for the body brace. Every one of
+ * these signatures declares an inline object type — `updates: { name?: string; … }` — so taking the first
+ * `{` after the name lands inside the parameters and returns ~160 characters of type declaration. That is
+ * not hypothetical: the first version of this file did exactly that, and the enumeration floor below is
+ * what caught it rather than four assertions passing against a body they never saw.
+ */
+function functionBody(text, name) {
+  const m = new RegExp(`export async function ${name}\\s*\\(`).exec(text);
+  if (!m) return null;
+
+  let i = m.index + m[0].length;
+  let parens = 1;
+  for (; i < text.length && parens > 0; i++) {
+    if (text[i] === '(') parens++;
+    else if (text[i] === ')') parens--;
+  }
+  if (parens !== 0) return null;
+
+  const open = text.indexOf('{', i);
+  if (open < 0) return null;
+  let depth = 1;
+  let j = open + 1;
+  for (; j < text.length && depth > 0; j++) {
+    if (text[j] === '{') depth++;
+    else if (text[j] === '}') depth--;
+  }
+  return depth === 0 ? text.slice(open + 1, j - 1) : null;
+}
+
+describe('an update never embeds from its own read', () => {
+  for (const u of UPDATES) {
+    it(`${u.fn} builds no embed text and enqueues instead`, () => {
+      const body = functionBody(withoutComments(read(u.file)), u.fn);
+      assert.ok(body !== null,
+        `${u.fn} was not found in ${u.file} — it was renamed or moved, which makes this gate examine `
+        + 'nothing. Re-point it rather than deleting the entry.');
+      assert.ok(body.length > 400,
+        `only parsed ${body.length} chars of ${u.fn}; the brace match broke, not the code`);
+
+      assert.doesNotMatch(body, new RegExp(`${u.builder}\\s*\\(`),
+        `${u.fn} builds its own embed text with ${u.builder}(). Whatever it builds comes from the record as `
+        + 'this function READ it, so a concurrent write to another field leaves the stored vector describing '
+        + 'a record that exists nowhere. Hand the record to the queue instead — embedStoredRecord re-reads it '
+        + 'after the write.');
+
+      assert.doesNotMatch(body, /await embed\(/,
+        `${u.fn} calls embed() directly. Same reason: the only text available here is stale.`);
+
+      assert.match(body, new RegExp(`enqueueEmbedJob\\(spaceId, '${u.type}'`),
+        `${u.fn} does not enqueue a re-embed, so an edit would leave the previous vector in place forever`);
+    });
+  }
+
+  it('the enqueue is unconditional, not gated on which fields changed', () => {
+    // It used to fire only when `excludeFromVectorSearch` was present, because every other path embedded
+    // inline. A condition here would have to be evaluated against this function's stale read — the exact
+    // reasoning that made the inline embedding wrong, reintroduced one level up.
+    for (const u of UPDATES) {
+      const body = withoutComments(functionBody(withoutComments(read(u.file)), u.fn));
+      const line = body.split('\n').find(l => l.includes('enqueueEmbedJob'));
+      assert.ok(line, `${u.fn}: no enqueue line found`);
+      assert.doesNotMatch(line, /^\s*if\s*\(/,
+        `${u.fn} enqueues conditionally (${line.trim()}). The condition can only be computed from the stale `
+        + 'read; an unconditional enqueue costs one queue write and cannot be wrong.');
+    }
+  });
+
+  it('embedStoredRecord — the thing that makes this correct — reads the record back', () => {
+    // The floor under the whole design. If this ever stopped re-reading and took the text from its caller,
+    // every assertion above would still pass while the bug returned.
+    const body = functionBody(withoutComments(read('server/src/brain/embed-record.ts')), 'embedStoredRecord');
+    assert.ok(body !== null, 'embedStoredRecord not found — the queue path this gate assumes is gone');
+    assert.match(body, /findOne\(/,
+      'embedStoredRecord no longer loads the record, so the text it embeds no longer comes from what is '
+      + 'stored — which is the single property the update path relies on');
+    assert.match(body, /buildEmbedText\(/,
+      'embedStoredRecord no longer uses the shared builder, so the queued text can drift from the creators');
+  });
+});


### PR DESCRIPTION
fix(brain): an update embedded from its own stale read, so a vector could describe a record that existed nowhere

Q-L8-1, the first finding of the Lens 8 (Data Integrity) pass.

All four update functions computed the embedding themselves -- from the record
as they had READ it plus the caller's patch -- and wrote it in the same `$set`.
Every CONTENT field in that `$set` was guarded by `updates.X !== undefined`. The
embedding never was. It went in unconditionally.

So two concurrent PATCHes touching DIFFERENT fields both landed and lost no
field, exactly as the guide promises, while each wrote a whole embedding
describing only its own view of the record. The later write won. The stored
vector then described a record that existed nowhere -- not a lost field, a
permanent disagreement between a record and its own index.

Nothing could have detected it. No field was lost, so no If-Match precondition
would have been violated and `ythril_brain_write_seq_total` would have said
`clean`. The only symptom is a search result ranked on `matchedText` the record
no longer contains, which nobody attributes to a write that happened last week.

I was wrong about the cost of fixing it
---------------------------------------

The tracker entry I wrote this morning said the repairs were all expensive: an
unbounded re-read-and-retry loop, or a second round trip on every write, and it
recommended measuring before designing.

That missed the mechanism already in the tree. `embedStoredRecord` loads the
record by id, builds its text with the shared `buildEmbedText`, embeds, and
stores the vector -- it CANNOT read stale, because it re-reads after the write.
The queue that calls it has been the default path for CREATES since it shipped.
Updates were the odd one out, still paying the model's latency inline and
getting a worse answer for it.

So the fix is to enqueue, which is one queue write, and correct by construction.

What changes for a caller
-------------------------

  - An updated record keeps its PREVIOUS vector for the moment before the worker
    catches up, so it is briefly ranked on its previous text. Note this is
    weaker than what a pending CREATE does, where the record is absent from
    recall entirely.
  - PATCH responses no longer carry a freshly computed `embedding`.
  - PATCH latency drops -- the model is no longer in the write path.

Documented in `04-brain-api.md`, including the correction to a sentence shipped
in 2.5.0 this morning. It told integrators that editing different fields is
safe; the FIELDS were safe and the vector was not, which is precisely the case
the sentence was reassuring people about.

The gate
--------

Asserted on the source, because the property is "the text came from the stored
document" and the only way to observe it at runtime is to deliberately lose a
race against an embedding round trip. That is a coin flip, not a test. What is
pinned instead is the mechanism: no update may build embed text or call embed(),
each must enqueue, the enqueue must be unconditional, and `embedStoredRecord`
must still re-read.

That last one is the floor. Without it every other assertion would keep passing
while the bug returned through the queue.

Comments stripped before matching -- each of these functions now carries a
comment explaining why the inline embed is gone, and those comments NAME the
builders being searched for. Mutation-checked: restoring the inline embed in
`updateChrono` fails by name.

The parser needed the same care. Its first version took the first `{` after the
function name, which lands inside `updates: { name?: string; ... }` and returned
160 characters of type declaration. Four assertions passed against a body they
had never seen; the enumeration floor caught it, which is the entire reason that
floor is there.

Also removes the two dead "did the content change?" branches. They existed to
decide whether to pay for an inline embed -- and any condition there would have
had to be computed from the stale read, which is the same defect one level up.

preflight green.
