### PR TITLE
fix(files): file metadata embedded from a stale read too, and one copy had already drifted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **File metadata had the same stale-read embedding defect, and a second one on top of it.** `updateFileMeta`
+  and `upsertFileMeta` both computed the vector from the record as they had READ it and spread it into `$set`
+  unconditionally, while every content field was guarded — so two concurrent writes to different fields both
+  landed, lost no field, and left the stored vector describing a record that existed nowhere. It was worse
+  here than in the brain: file-meta records carry no `seq`, so there was no precondition to violate and no
+  counter reporting the rate.
+  - **`upsertFileMeta`'s text had already drifted.** It omitted `excerpt` — a converted document's own
+    opening prose — while `updateFileMeta` included it. So **a re-upload silently dropped that prose out of
+    the file's vector**, and the only symptom was a document that stopped being findable by its own opening
+    words. Three copies of "what goes into a file's embedding" existed and two of them disagreed.
+  - Both now enqueue through the same embed queue as the brain types, so `buildEmbedText` is the only copy
+    and it reads the record as stored. `file` joined `BrainEmbedRecordType` for this; everything downstream
+    of the queue was already file-aware, including the duplicate scanner.
+  - Removes a now-dead second entity-name resolver from `files/file-meta.ts`, which existed only to feed the
+    inline embed and was the spare copy that let the two texts drift apart.
+
 - **A record's search vector could permanently disagree with the record's own fields.** All four update
   functions computed the embedding themselves, from the record as they had READ it plus the caller's patch,
   and wrote it in the same `$set`. Every *content* field in that `$set` was guarded by

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1879,7 +1879,9 @@ Notes:
   conditional write should use the REST route.
 - **File-metadata records are not covered**, and say so: they carry no `seq` to condition a write on, so
   `PATCH /api/brain/spaces/:spaceId/files` **refuses** an `If-Match` with a `400` rather than accepting and
-  dropping it.
+  dropping it. Its search vector is still rebuilt from the record as stored, through the same background
+  queue as everything else, so a concurrent edit cannot leave the record and its vector disagreeing — you
+  simply cannot make *this* write conditional.
 
 The same header, in the same spellings, is honoured on space-meta writes against `meta.version` — see the
 [Spaces API](06-spaces-api.md).

--- a/server/src/brain/embed-record.ts
+++ b/server/src/brain/embed-record.ts
@@ -17,15 +17,15 @@
 
 import { col, asFilter } from '../db/mongo.js';
 import { embed } from './embedding.js';
-import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText } from './embed-text.js';
+import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from './embed-text.js';
 import { resolveEdgeEntityNames } from './edges.js';
 import type {
-  BrainEmbedRecordType, MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry,
+  BrainEmbedRecordType, MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc,
 } from '../config/types.js';
 
 /** Collection suffix per record type — the same mapping recall uses. */
 const COLLECTION: Record<BrainEmbedRecordType, string> = {
-  memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono',
+  memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
 };
 
 /** Resolve entity ids to names, for the two types whose embedding text names their links. */
@@ -66,6 +66,15 @@ export async function buildEmbedText(
     case 'chrono': {
       const c = doc as unknown as ChronoEntry;
       return chronoEmbedText(c.title, c.type, c.status, c.description, c.tags ?? [], c.properties);
+    }
+    case 'file': {
+      // `_id` IS the normalised path — `toDocId(filePath)` — so the path the vector is built from is the
+      // stored one, not one the caller passed in and that may since have been renamed.
+      const f = doc as unknown as FileMetaDoc & { _id: string };
+      return fileEmbedText(
+        f._id, f.tags ?? [], f.description, f.properties,
+        await entityNames(spaceId, f.entityIds), f.excerpt,
+      );
     }
   }
 }

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1949,7 +1949,20 @@ export interface MediaJobDoc {
  * (`files/media/job-queue.ts`) with a richer job shape — per-page progress, chunking, a provider
  * signature. Folding it in here would replace a working, more capable mechanism with a simpler one.
  */
-export type BrainEmbedRecordType = 'memory' | 'entity' | 'edge' | 'chrono';
+/**
+ * `file` joined the four brain types on 2026-08-07, and for a correctness reason rather than tidiness.
+ *
+ * `updateFileMeta` used to compute the vector itself from the record as it had READ it, while every content
+ * field it wrote was guarded by `opts.X !== undefined` and the embedding was not. Two concurrent writes to
+ * different fields therefore both landed, lost no field, and left the stored vector describing a record that
+ * existed nowhere. The four brain updates had the identical defect and were fixed by handing the work to this
+ * queue, whose `embedStoredRecord` re-reads the document after the write; files needed to be IN the queue
+ * before the same fix could apply to them.
+ *
+ * The alternative — a second re-embed mechanism just for files — is what produced the bug in the first place:
+ * the update path had its own copy of the embed-text builder while the queue had `buildEmbedText`.
+ */
+export type BrainEmbedRecordType = 'memory' | 'entity' | 'edge' | 'chrono' | 'file';
 
 /**
  * One queued embedding job. `_id` is `<recordType>:<recordId>`, so a record rewritten five times has

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -17,25 +17,18 @@ import { toDocId } from '../util/paths.js';
 import { escapeRegex } from '../util/redos.js';
 import { authorRef } from '../config/author.js';
 import { col, asFilter, asDoc, asUpdate } from '../db/mongo.js';
-import { embed } from '../brain/embedding.js';
 import { expiryForCreate } from '../brain/ttl.js';
-import { fileEmbedText } from '../brain/embed-text.js';
+import { enqueueEmbedJob } from '../brain/embed-queue.js';
 import { getConfig } from '../config/loader.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../config/types.js';
 
 
 
 
-/** Resolve entity names from a list of entity IDs in this space. Best-effort — returns [] on error. */
-async function resolveEntityNames(spaceId: string, entityIds: string[]): Promise<string[]> {
-  if (entityIds.length === 0) return [];
-  try {
-    const docs = await col<EntityDoc>(`${spaceId}_entities`)
-      .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
-      .toArray() as Array<{ name: string }>;
-    return docs.map(d => d.name);
-  } catch { return []; }
-}
+// `resolveEntityNames` lived here, used only to build embedding text. That job moved to `buildEmbedText`,
+// which resolves the names itself from the STORED record — so keeping a second resolver here would be a
+// spare copy waiting to be reached for, and the last spare copy in this file is what let its embedding text
+// drift from `updateFileMeta`'s.
 
 /**
  * Create or update the metadata record for a file after a write.
@@ -55,21 +48,15 @@ export async function upsertFileMeta(
     asFilter<FileMetaDoc>({ _id: normalised }),
   );
 
-  // Embed path + entity names + tags + description + property values — best-effort, never blocks write
-  const descForEmbed = opts.description !== undefined ? opts.description : (existing as FileMetaDoc | null)?.description;
-  const tagsForEmbed = opts.tags !== undefined ? opts.tags : ((existing as FileMetaDoc | null)?.tags ?? []);
-  const propsForEmbed = opts.properties !== undefined ? opts.properties : (existing as FileMetaDoc | null)?.properties;
-  const existingEntityIds: string[] = (existing as FileMetaDoc | null)?.entityIds ?? [];
-  const entityNames = await resolveEntityNames(spaceId, existingEntityIds);
-  let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
-  try {
-    const embedText = fileEmbedText(normalised, tagsForEmbed, descForEmbed, propsForEmbed, entityNames);
-    const embResult = await embed(embedText);
-    embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
-  } catch { /* embedding unavailable — file stored without vector */ }
-
+  // The embedding is ENQUEUED after the write, for the same reason as `updateFileMeta` below.
+  //
+  // This path had a second defect on top of the stale read, and it is the one worth naming: the text it
+  // built omitted `excerpt` entirely — a converted document's own opening prose — while `updateFileMeta`
+  // included it. So a re-upload silently dropped that prose out of the file's vector, and the only symptom
+  // was that a document stopped being findable by its own opening words. Three copies of "what goes into a
+  // file's embedding" existed and two of them disagreed; `buildEmbedText` is now the only one.
   if (existing) {
-    const $set: Record<string, unknown> = { updatedAt: now, sizeBytes, ...embeddingFields };
+    const $set: Record<string, unknown> = { updatedAt: now, sizeBytes };
     if (opts.description !== undefined) $set['description'] = opts.description;
     if (opts.tags !== undefined) $set['tags'] = opts.tags;
     if (opts.properties !== undefined) $set['properties'] = opts.properties;
@@ -102,10 +89,13 @@ export async function upsertFileMeta(
       sizeBytes,
       author: authorRef(),
       ...(expireAt ? { _expireAt: expireAt } : {}),
-      ...embeddingFields,
     };
     await col<FileMetaDoc>(`${spaceId}_files`).insertOne(asDoc<FileMetaDoc>(doc));
   }
+
+  // Both branches, unconditionally. A create enqueues for the reason every brain create does — the write
+  // should not pay the model's latency — and an update for the correctness reason above.
+  await enqueueEmbedJob(spaceId, 'file', normalised);
 }
 
 /**
@@ -147,24 +137,17 @@ export async function updateFileMeta(
   if (!existing) return null;
 
   const now = new Date().toISOString();
-  const descForEmbed = opts.description !== undefined ? opts.description : existing.description;
-  const tagsForEmbed = opts.tags !== undefined ? opts.tags : existing.tags;
-  const propsForEmbed = opts.properties !== undefined ? opts.properties : existing.properties;
-  // Falls back to the stored value like every other embedding input: an unrelated edit — a tag, a link —
-  // re-embeds the record, and reading the excerpt only from `opts` would silently drop the document's own
-  // text out of the embedding on the first tag change after conversion.
-  const excerptForEmbed = opts.excerpt !== undefined ? opts.excerpt : existing.excerpt;
-  // Use the incoming entityIds if being updated, otherwise fall back to existing
-  const entityIdsForEmbed: string[] = opts.entityIds !== undefined ? opts.entityIds : (existing.entityIds ?? []);
-  const entityNames = await resolveEntityNames(spaceId, entityIdsForEmbed);
-  let embeddingFields: { embedding?: number[]; embeddingModel?: string; matchedText?: string } = {};
-  try {
-    const embedText = fileEmbedText(normalised, tagsForEmbed, descForEmbed, propsForEmbed, entityNames, excerptForEmbed);
-    const embResult = await embed(embedText);
-    embeddingFields = { embedding: embResult.vector, embeddingModel: embResult.model, matchedText: embedText };
-  } catch { /* best-effort */ }
 
-  const $set: Record<string, unknown> = { updatedAt: now, ...embeddingFields };
+  // The re-embed is ENQUEUED after the write — see `embedStoredRecord`, and the note on
+  // `BrainEmbedRecordType` for why `file` is in that union at all.
+  //
+  // This function used to build the text here, from `existing` plus `opts`, and spread the result into
+  // `$set` UNCONDITIONALLY while every content field below is guarded by `opts.X !== undefined`. So two
+  // concurrent writes to different fields both landed and lost no field — and each wrote a whole embedding
+  // describing only its own view, leaving the stored vector describing a record that existed nowhere. There
+  // was nothing to notice it with: file-meta records carry no `seq`, so there is no precondition to violate
+  // and no lost-update counter, unlike the four brain types that had the identical defect.
+  const $set: Record<string, unknown> = { updatedAt: now };
   if (opts.description !== undefined) $set['description'] = opts.description;
   if (opts.descriptionSource !== undefined) $set['descriptionSource'] = opts.descriptionSource;
   if (opts.excerpt !== undefined) $set['excerpt'] = opts.excerpt;
@@ -185,6 +168,10 @@ export async function updateFileMeta(
     asFilter<FileMetaDoc>({ _id: normalised }),
     asUpdate<FileMetaDoc>(Object.keys($unset).length > 0 ? { $set, $unset } : { $set }),
   );
+
+  // ONE enqueue, unconditionally, after the write. Not gated on which fields moved: any such condition
+  // could only be computed from the read above, which is the stale value this change exists to stop using.
+  await enqueueEmbedJob(spaceId, 'file', normalised);
 
   // Face recognition side-effects when entity links change.
   //

--- a/testing/standalone/update-embeds-from-stored-record.test.js
+++ b/testing/standalone/update-embeds-from-stored-record.test.js
@@ -39,12 +39,22 @@ const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 const withoutComments = (text) =>
   text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-/** The four update functions, and the embed-text builder each one used to call inline. */
+/**
+ * Every write path that stores a vector, and the embed-text builder each one used to call inline.
+ *
+ * `file` is here twice on purpose. `updateFileMeta` had the defect this file is named for; `upsertFileMeta`
+ * had it too AND had already drifted — its text omitted `excerpt`, so a re-upload silently dropped a
+ * converted document's opening prose out of the vector while the sibling function kept it. Three copies of
+ * "what goes into a file's embedding" existed and two disagreed. Listing both is what stops a fix to one
+ * leaving the other behind, which is exactly how they came to disagree.
+ */
 const UPDATES = [
   { type: 'entity', file: 'server/src/brain/entities.ts', fn: 'updateEntityById', builder: 'entityEmbedText' },
   { type: 'memory', file: 'server/src/brain/memory.ts', fn: 'updateMemory', builder: 'memoryEmbedText' },
   { type: 'edge', file: 'server/src/brain/edges.ts', fn: 'updateEdgeById', builder: 'edgeEmbedText' },
   { type: 'chrono', file: 'server/src/brain/chrono.ts', fn: 'updateChrono', builder: 'chronoEmbedText' },
+  { type: 'file', file: 'server/src/files/file-meta.ts', fn: 'updateFileMeta', builder: 'fileEmbedText' },
+  { type: 'file', file: 'server/src/files/file-meta.ts', fn: 'upsertFileMeta', builder: 'fileEmbedText' },
 ];
 
 /**


### PR DESCRIPTION
fix(files): file metadata embedded from a stale read too, and one copy had already drifted

Q-L8-1b -- the half of the Lens 8 finding that the brain fix left behind.

`updateFileMeta` and `upsertFileMeta` both computed the vector from the record
as they had READ it, and spread it into `$set` UNCONDITIONALLY while every
content field was guarded by `opts.X !== undefined`. Two concurrent writes to
different fields therefore both landed, lost no field, and left the stored
vector describing a record that existed nowhere.

Worse here than in the brain, and that is not rhetoric: file-meta records carry
no `seq`. There is no precondition to violate, and no
`ythril_brain_write_seq_total` series counting the rate. The brain types at
least had a number to look at.

The second defect, which is the one I did not expect
----------------------------------------------------

`upsertFileMeta` built its embed text WITHOUT `excerpt` -- a converted
document's own opening prose -- while `updateFileMeta` included it.

So a re-upload silently dropped that prose out of the file's vector. The only
symptom is a document that stops being findable by its own opening words, some
time after someone re-uploaded it, which is not a symptom anyone traces back to
a write.

Three copies of "what goes into a file's embedding" existed. Two of them
disagreed. Nothing compared them.

The fix
-------

Both paths now enqueue through the same embed queue as the four brain types, so
`buildEmbedText` is the only copy and it reads the record as STORED.

`file` joined `BrainEmbedRecordType` for this. That turned out to be the whole
cost: everything downstream of the queue was already file-aware -- the worker
dispatches generically, and `DupeScanType` already listed `file`, so the
insert-time duplicate rule works for files without a line of change. No metric
carries a `recordType` label, so no docs gate is affected.

Also deletes a now-dead second entity-name resolver from `files/file-meta.ts`.
It existed only to feed the inline embed, and a spare copy of exactly that
helper is what let the two texts drift apart in the first place.

The gate
--------

The `update-embeds-from-stored-record` gate grows from four entries to six.
`upsertFileMeta` is listed alongside `updateFileMeta` deliberately: the two
already disagreed, so listing only the one that was reported is precisely how
the other gets left behind. Mutation-checked -- dropping either enqueue fails by
function name.

Docs: `04-brain-api.md` now says the file record's vector is rebuilt from the
stored record through the same background queue, so a concurrent edit cannot
leave the two disagreeing -- you simply cannot make that particular write
conditional. `05-files-api.md` already described file embedding as background
work, so this brings the code into line with what it said.

preflight green.
