### PR TITLE
release: 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.6.0] — 2026-08-07
+## [2.5.1] — 2026-08-07
 
 > **Documentation files changed in this release:** `docs/integration-guide/04-brain-api.md`,
 > `docs/integration-guide/06-spaces-api.md`, `docs/integration-guide/16-mcp.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-08-07
+
+> **Documentation files changed in this release:** `docs/integration-guide/04-brain-api.md`,
+> `docs/integration-guide/06-spaces-api.md`, `docs/integration-guide/16-mcp.md`.
+>
+> Listed because an operator who re-ingests the guides on every deploy asked for it: their refresh is
+> size-idempotent and silently skips a file whose byte size has not changed, so a same-size edit would leave
+> their readers answering confidently from a stale copy. Naming the files means they know when to force.
+
 ### Fixed
 
 - **File metadata had the same stale-read embedding defect, and a second one on top of it.** `updateFileMeta`

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.6.0",
+  "version": "2.5.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.6.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.6.0",
+      "version": "2.5.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.6.0",
+      "version": "2.5.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.6.0",
+      "version": "2.5.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.6.0",
+  "version": "2.5.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.6.0",
+  "version": "2.5.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
release: 2.5.1

The queue drained again, so the tag is due. What is left in section 1 is one
item that cannot be worked from this side -- the model-layer measurement, owed
by the operator from a 2.5.0 -> 2.5.1 comparison -- plus four watch items that
are not work by definition.

PATCH, and the first draft of this had it wrong
-----------------------------------------------

This was cut as 2.6.0 on the argument that an update no longer computes the
record's embedding inline, so a PATCH returns before the new vector exists --
"an observable behaviour change, so minor".

That is not what minor means. Semver's minor is backwards-compatible NEW
FUNCTIONALITY, and there is none here: no new endpoint, parameter, field, status
code, config key or tool. Every entry in this release is a bug fix or a
documentation correction.

The behaviour change is the fix, not a feature. The old behaviour wrote a vector
that could permanently describe a record that existed nowhere; the new one
trades that for a brief lag while the queue catches up. A fix that changes
behaviour because the old behaviour was WRONG is still a patch, and calling it
minor tells operators to look for something new when the honest signal is
"this only fixes things".

What is in it
-------------

Both halves of the Lens 8 data-integrity finding.

All four brain update functions, and both file-metadata write paths, computed
the record's embedding from the record as they had READ it and wrote it
unconditionally, while every content field was guarded. Two concurrent writes to
DIFFERENT fields therefore both landed, lost no field, and left the stored
vector describing a record that existed nowhere. Nothing could detect it: no
field was lost, so no If-Match precondition would have been violated and the
lost-update counter said `clean`.

They now enqueue through the embed queue, whose `embedStoredRecord` re-reads the
document after the write and so cannot read stale. That deletes five inline
copies of the embed-text builder in the process.

`upsertFileMeta` had a second defect underneath the first: its embed text
omitted `excerpt`, a converted document's own opening prose, while its sibling
included it. A re-upload therefore silently dropped that prose out of the file's
vector, and the only symptom is a document that stops being findable by its own
opening words.

Two documentation fixes, both reported from outside: the `TypeSchema` interface
block listed three of its five fields, and the MCP guide never said that a
session caches its tool list so an upgrade needs a reconnect.

Docs changed, named on purpose
------------------------------

`04-brain-api.md`, `06-spaces-api.md`, `16-mcp.md`.

Named because an operator who re-ingests the guides on every deploy asked for
it: their refresh is size-idempotent and silently skips a file whose byte size
has not changed, so a same-size edit would leave their readers answering
confidently from a stale copy. This is the first release owing that line.

This tag is also a measurement
------------------------------

2.5.0 -> 2.5.1 is the first release pair where BOTH sides carry the reworked
model layer. The operator measured 2.4.0 -> 2.5.0 and saw the 482.5 MiB layer
move again; that comparison spans the fix itself, so it was always going to.
This pair is the one that answers the question.

`node scripts/release-gate.mjs --releasing` green on all three of the owner's
terms. preflight green.
