### PR TITLE
fix(docker): the model-warm retry budget was 62 seconds against a failure measured in minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **The model-warm retry loop had a 62-second budget against a failure measured in minutes.** Six attempts
+  backing off 2, 4, 8, 16, 32 seconds — so every attempt landed inside 62.68 s. What it receives is
+  `Error (429)`: HuggingFace rate-limiting the anonymous model download after a day's build volume. A
+  rate-limit window does not clear in a minute, so the loop exhausted itself against an error that could not
+  have succeeded in the time allowed, and took the 2.5.1 release build down with it.
+  - **The loop was never broken.** It logged all five retries and threw on the sixth, exactly as written. It
+    was calibrated for a transient network blip and received a rate limit. Recorded that way on purpose:
+    "the retry loop is broken" is the natural reading of the symptom, and it would send the next person
+    rewriting a working loop while leaving the budget untouched.
+  - **Now two policies, because the two failures want opposite things.** A 429 is waited out — up to nine
+    sleeps rising to a 90-second cap, about 9.5 minutes, against a build that already takes ~45. Anything
+    else fails after three attempts, because a wrong model name or a full disk does not become true by
+    waiting; without that split, raising the budget would have made every misconfiguration take ten minutes
+    to report itself.
+  - Tested by **extracting the script the Dockerfile writes and running it** with `load` and `setTimeout`
+    stubbed, rather than restating the loop in the test — a second copy of a policy is the thing that drifts.
+    The extractor fails loudly if the `printf` block changes shape, so the test cannot pass against a stale
+    copy, and it also syntax-checks the generated script: a mangled shell escape otherwise fails the image
+    build ten minutes in, with an error that points nowhere near the Dockerfile line that caused it.
+  - A neighbouring comment claiming "intermittent 403" is corrected to 429. The two suggest different fixes —
+    a 403 reads as something you cannot wait out, and this is precisely the one you can.
+
 ## [2.5.1] — 2026-08-07
 
 > **Documentation files changed in this release:** `docs/integration-guide/04-brain-api.md`,

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,13 @@ RUN npm ci --workspace=server --omit=dev
 # a layer that is discarded anyway. This costs nothing: `prod-deps` is already built.
 FROM prod-deps AS model-warm
 
-# HF rate-limits anonymous downloads per-IP (shared CI egress → intermittent 403), so the retry/backoff rides
-# through a transient failure, and `--mount=type=cache` keeps a local rebuild from re-fetching ~274 MB.
+# HF rate-limits anonymous downloads per-IP (shared CI egress), so the retry/backoff below rides through it,
+# and `--mount=type=cache` keeps a local rebuild from re-fetching ~274 MB.
+#
+# This said "intermittent 403" until 2026-08-07, when the observed code was **429** on every one of six
+# attempts. Corrected rather than left, because the two suggest different fixes: a 403 reads as an auth or
+# policy problem you cannot wait out, and a 429 is precisely the one you can — which is what the backoff
+# below is now sized for.
 #
 # The mtime stamp here is for THIS stage's own layer, not for the shipped one: it lets CI's `--cache-from
 # type=gha` reuse a warm step across builds. The layer a user pulls is stamped again in the production stage,
@@ -121,18 +126,41 @@ FROM prod-deps AS model-warm
 #
 # `/app`'s mtime moving here is harmless in a way it was not before: this whole stage is discarded, and only
 # `/model-cache` is read out of it.
+#
+# ── The retry policy, and why it is two policies ─────────────────────────────────────────────────────
+#
+# This loop used to be six attempts backing off 2, 4, 8, 16, 32 seconds. It looked like protection and was
+# not: the whole budget is 62 seconds, and the failure it actually receives is `Error (429)` — HuggingFace
+# rate-limiting the anonymous download after a day's build volume. A rate-limit window does not clear in a
+# minute, so the loop exhausted itself against an error that could not have succeeded in the time allowed,
+# and took a release build down with it (2026-08-07).
+#
+# The loop was never broken — it logged all five retries and threw on the sixth, exactly as written. It was
+# CALIBRATED for the wrong failure. That distinction is why the fix is a budget and not a rewrite.
+#
+# So the two failures now get different treatment, because they want opposite things:
+#
+#   - **429 — wait it out.** Up to nine sleeps of 15, 30, 45, 60, 75, 90, 90, 90, 90 seconds: about
+#     9.5 minutes. A build already takes ~45, so spending that to survive a rate limit is cheap next to
+#     spending 45 to discover one.
+#   - **Anything else — fail fast.** A wrong model name, a 404, a full disk: three attempts and out, because
+#     none of them become true by waiting. Without this split, raising the budget would have made every
+#     genuine misconfiguration take ten minutes to report itself.
 RUN --mount=type=cache,target=/tmp/hf-model-cache \
     printf '%s\n' \
     'import { pipeline, env } from "@huggingface/transformers";' \
     'env.cacheDir = "/tmp/hf-model-cache";' \
     'const load = () => pipeline("feature-extraction", "nomic-ai/nomic-embed-text-v1.5", { dtype: "fp32" });' \
-    'const attempts = 6;' \
+    'const rateLimited = (err) => String(err).includes("(429)");' \
+    'const attempts = 10;' \
+    'const FAST_FAIL_AFTER = 3;' \
     'for (let i = 1; i <= attempts; i++) {' \
     '  try { await load(); break; }' \
     '  catch (err) {' \
-    '    if (i === attempts) throw err;' \
-    '    const delay = Math.min(60, 2 ** i);' \
-    '    console.warn(`model download attempt ${i}/${attempts} failed: ${err}; retrying in ${delay}s`);' \
+    '    const limited = rateLimited(err);' \
+    '    if (i === attempts || (!limited && i >= FAST_FAIL_AFTER)) throw err;' \
+    '    const delay = limited ? Math.min(90, 15 * i) : 2 ** i;' \
+    '    console.warn(`model download attempt ${i}/${attempts} failed${limited ? " (rate limited)" : ""}: ${err}; retrying in ${delay}s`);' \
     '    await new Promise(r => setTimeout(r, delay * 1000));' \
     '  }' \
     '}' \

--- a/testing/standalone/model-warm-retry-budget.test.js
+++ b/testing/standalone/model-warm-retry-budget.test.js
@@ -1,0 +1,155 @@
+/**
+ * The model-warm retry policy, driven from the Dockerfile that actually runs it.
+ *
+ * ## The failure this closes
+ *
+ * The loop used to be six attempts backing off 2, 4, 8, 16, 32 seconds. It looked like protection and was
+ * not: the entire budget is 62 seconds, and the failure it actually receives is `Error (429)` — HuggingFace
+ * rate-limiting the anonymous download after a day's build volume. A rate-limit window does not clear in a
+ * minute, so the loop exhausted itself against an error that could not have succeeded in the time allowed,
+ * and took the 2.5.1 release build down with it.
+ *
+ * **The loop was never broken.** It logged all five retries and threw on the sixth, exactly as written. It
+ * was CALIBRATED for the wrong failure. Worth stating in a test, because "the retry loop is broken" is the
+ * natural reading of the symptom and it would send the next person rewriting a loop that works while leaving
+ * the budget — the actual defect — untouched.
+ *
+ * ## Why this test extracts the script instead of copying it
+ *
+ * The policy lives inside a `printf '%s\n' … > /app/warm.mjs` in the Dockerfile. A test that restated the
+ * loop would be a second copy of it, and the two would drift — which is the failure mode this repo keeps
+ * finding, and the reason `buildEmbedText` exists in the first place.
+ *
+ * So the Dockerfile is parsed, the exact script it will write is reconstructed, and THAT is executed with
+ * `load` and `setTimeout` stubbed. If someone edits the Dockerfile, this test runs the edit. If the printf
+ * block moves or changes shape so it can no longer be extracted, the test fails loudly rather than passing
+ * on a stale copy.
+ *
+ * Run: node --test testing/standalone/model-warm-retry-budget.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+/** Reconstruct the exact `warm.mjs` the Dockerfile's printf writes. */
+function extractWarmScript() {
+  const lines = readFileSync(join(ROOT, 'Dockerfile'), 'utf8').split(/\r?\n/);
+  const start = lines.findIndex(l => l.trim().startsWith("printf '%s"));
+  if (start < 0) return null;
+
+  const out = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    let raw = lines[i].trim();
+    if (raw.includes('> /app/warm.mjs')) break;
+    if (raw.endsWith('\\')) raw = raw.slice(0, -1).trim();
+    if (!raw.startsWith("'") || !raw.endsWith("'")) return null;
+    out.push(raw.slice(1, -1));
+  }
+  return out.length > 0 ? out.join('\n') : null;
+}
+
+/**
+ * Run the extracted policy against a stubbed `load`, with time recorded rather than slept.
+ *
+ * `load`, `setTimeout` and `console` are shadowed as local bindings inside the function body, so the script
+ * runs its own control flow unmodified — only its two side effects on the outside world are replaced.
+ */
+async function runPolicy(failWith, { succeedOnAttempt = Infinity } = {}) {
+  const script = extractWarmScript();
+  assert.ok(script, 'could not reconstruct warm.mjs from the Dockerfile — the printf block moved or changed '
+    + 'shape. Re-point the extractor; do NOT paste a copy of the loop into this test.');
+
+  // The first three lines are the import, the cache dir and the real `load`. Everything after them is the
+  // policy, which is what this test is about.
+  const body = script
+    .split('\n')
+    .filter(l => !l.startsWith('import ') && !l.startsWith('env.cacheDir') && !l.startsWith('const load ='))
+    .join('\n');
+
+  const delays = [];
+  let calls = 0;
+  const load = async () => {
+    calls++;
+    if (calls >= succeedOnAttempt) return 'ok';
+    throw new Error(failWith);
+  };
+  const setTimeout = (fn, ms) => { delays.push(ms / 1000); fn(); };
+  const console = { warn() {} };
+
+  const fn = new Function('load', 'setTimeout', 'console',
+    `return (async () => { ${body} })();`);
+
+  let threw = null;
+  try { await fn(load, setTimeout, console); } catch (e) { threw = e; }
+  return { calls, delays, threw, budget: delays.reduce((a, b) => a + b, 0) };
+}
+
+const RATE_LIMIT = 'Error (429) occurred while trying to load file: "https://huggingface.co/x/config.json".';
+const NOT_FOUND = 'Error (404) occurred while trying to load file: "https://huggingface.co/nope/config.json".';
+
+describe('a rate limit is waited out', () => {
+  it('keeps trying for long enough that a 429 window can expire', () => {
+    // The whole point. The old policy spent 62 seconds; a rate limit is measured in minutes, so it lost
+    // every time by construction.
+    return runPolicy(RATE_LIMIT).then(({ budget }) => {
+      assert.ok(budget >= 300,
+        `the rate-limit retry budget is ${budget}s. A HuggingFace 429 does not clear inside that, so the `
+        + 'loop will exhaust itself against an error that could not have succeeded — which is exactly what '
+        + 'took the 2.5.1 release build down.');
+    });
+  });
+
+  it('backs off increasingly, and caps so it does not run away', async () => {
+    const { delays } = await runPolicy(RATE_LIMIT);
+    assert.ok(delays.length >= 5, `only ${delays.length} retries before giving up on a rate limit`);
+    for (let i = 1; i < delays.length; i++) {
+      assert.ok(delays[i] >= delays[i - 1],
+        `backoff went DOWN at retry ${i} (${delays[i - 1]}s then ${delays[i]}s)`);
+    }
+    assert.ok(Math.max(...delays) <= 120,
+      `a single sleep of ${Math.max(...delays)}s is long enough to look like a hung build`);
+  });
+
+  it('stops as soon as the download succeeds', async () => {
+    const { calls, threw } = await runPolicy(RATE_LIMIT, { succeedOnAttempt: 3 });
+    assert.equal(threw, null, 'a download that eventually succeeded still failed the build');
+    assert.equal(calls, 3, 'the loop kept going after a success');
+  });
+});
+
+describe('anything that is not a rate limit fails fast', () => {
+  it('gives up quickly on an error that waiting cannot fix', async () => {
+    // A wrong model name, a 404, a full disk. None of them become true by waiting, and without this split
+    // raising the budget would make every genuine misconfiguration take ten minutes to report itself.
+    const { calls, budget, threw } = await runPolicy(NOT_FOUND);
+    assert.ok(threw, 'a 404 did not fail the build at all');
+    assert.ok(calls <= 4, `a 404 was retried ${calls} times`);
+    assert.ok(budget <= 30,
+      `a 404 spent ${budget}s backing off. Waiting cannot turn a missing model into a present one, and a `
+      + 'build that takes ten minutes to report a typo is worse than one that reports it immediately.');
+  });
+
+  it('the two policies are genuinely different, not the same number twice', async () => {
+    // Guards the case where someone "simplifies" the branch away and both paths get the long budget — the
+    // tests above would each still pass on their own.
+    const limited = await runPolicy(RATE_LIMIT);
+    const other = await runPolicy(NOT_FOUND);
+    assert.ok(limited.budget > other.budget * 5,
+      `rate-limit budget ${limited.budget}s vs other-error budget ${other.budget}s — these are supposed to `
+      + 'be different policies, because they are answers to opposite questions');
+  });
+});
+
+describe('the script the Dockerfile writes is valid', () => {
+  it('reconstructs, and is syntactically valid JavaScript', () => {
+    // A mangled shell escape here fails the image build about ten minutes in, with a syntax error rather
+    // than anything pointing at the Dockerfile line that produced it.
+    const script = extractWarmScript();
+    assert.ok(script, 'the printf block could not be reconstructed');
+    assert.doesNotThrow(() => new Function(`return (async () => { ${script.split('\n').filter(l => !l.startsWith('import ')).join('\n')} })();`),
+      'the script the Dockerfile writes is not valid JavaScript — check the quoting in the printf block');
+  });
+});


### PR DESCRIPTION
fix(docker): the model-warm retry budget was 62 seconds against a failure measured in minutes

This took the 2.5.1 release build down yesterday.

The loop retried the HuggingFace model download six times, backing off 2, 4, 8,
16, 32 seconds. Every attempt landed inside 62.68 s -- that is the entire
budget. What it receives is `Error (429)`: HF rate-limiting the anonymous
download after a day's build volume. A rate-limit window does not clear in a
minute, so the loop exhausted itself against an error that could not possibly
have succeeded in the time it allowed, and failed the image build.

The loop was never broken
-------------------------

It logged all five retries and threw on the sixth, exactly as written. This is a
CALIBRATION defect, not a dead guard, and the commit says so deliberately: "the
retry loop is broken" is the natural reading of the symptom, and acting on it
would mean rewriting a loop that works while leaving the budget -- the actual
defect -- untouched.

(My own first check misread it too. I grepped for the retry warnings, found
none, and briefly believed the loop had never run. The pattern was wrong, not
the code.)

Two policies, because the two failures want opposite things
-----------------------------------------------------------

  - 429 -- wait it out. Up to nine sleeps of 15, 30, 45, 60, 75, 90, 90, 90, 90
    seconds: about 9.5 minutes. A build already takes ~45, so spending that to
    survive a rate limit is cheap next to spending 45 to discover one.
  - anything else -- fail after three attempts. A wrong model name, a 404, a
    full disk: none of them become true by waiting. Without this split, raising
    the budget would have made every genuine misconfiguration take ten minutes
    to report itself, which is a worse build than the one we started with.

The test runs the Dockerfile, not a copy of it
-----------------------------------------------

The policy lives inside a `printf '%s\n' ... > /app/warm.mjs`. A test that
restated the loop would be a second copy, and the two would drift -- which is
the exact failure this repo keeps finding, and what the embedding work fixed
two commits ago.

So the test parses the Dockerfile, reconstructs the script it will write, and
executes THAT with `load` and `setTimeout` stubbed as local bindings, leaving
the script's own control flow untouched. Edit the Dockerfile and the test runs
the edit. If the printf block moves or changes shape so it can no longer be
extracted, the test fails loudly rather than passing against a stale copy.

It also syntax-checks the generated script. A mangled shell escape in that block
otherwise fails the image build about ten minutes in, with a JavaScript syntax
error that points nowhere near the Dockerfile line that produced it.

Mutation-checked both ways: restoring `attempts = 6` fails on the budget
assertion with the measured number, and collapsing the two branches into one
fails both the fast-fail assertion and the one that exists specifically to catch
the two policies becoming the same number twice.

Also corrects a neighbouring comment that claimed "intermittent 403". The
observed code was 429 on all six attempts. The two suggest different fixes -- a
403 reads as auth or policy, something you cannot wait out, and this is
precisely the one you can.

preflight green.
