### PR TITLE
feat(brain): infer a space's ER model from its schema AND its records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A space's entity-relationship model, inferred from the schema and from the records** —
+  `GET /api/brain/spaces/:spaceId/er-model`. Entity types with their declared properties and their real
+  record counts, the relationships between those types with real edge counts, and how many memories, chrono
+  entries and files point at each type.
+  - **Both sources, because they disagree and the disagreement is the point.** A type can be declared and
+    used, declared and empty, or — the case that matters — hold records with no declaration at all. A model
+    built from `typeSchemas` alone shows the second and silently omits the third, which is backwards: the
+    undeclared types are the ones nobody knows about. An integrator arrived at this product with a space
+    holding 21 of them, and no view anywhere would have shown it.
+  - **The relationships are type-level.** An edge joins two entity instances; a relationship is the edge set
+    grouped by `(from type, label, to type)`. Derived from two covered index scans and an in-memory join
+    rather than a `$lookup` per edge — `{ name: 1, type: 1 }` carries `_id` as every index does, and the
+    unique `{ from: 1, to: 1, label: 1 }` is exactly the three fields the grouping needs, so neither read
+    fetches a document body.
+  - **Bounded, and it says when it was bounded.** Both reads are capped, and a capped read reports
+    `truncated` naming which scan hit its limit; `totals` is measured before the cap, so a caller can see
+    what share of the space the model covers. A partial diagram is never presented as complete.
+  - `danglingEdges` counts edges whose endpoint does not resolve, rather than inventing a relationship from
+    one. An entity with no `type` is bucketed as `(untyped)` rather than dropped, so the counts add up.
+  - A proxy space reports its members separately. Merging would sum two types that share a name across
+    spaces and show relationships that can never be joined, since an edge cannot cross a space.
+
 ### Internal
 
 - **The model-warm retry loop had a 62-second budget against a failure measured in minutes.** Six attempts

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -1456,6 +1456,67 @@ DELETE /api/brain/spaces/:spaceId/chrono/:id
 
 ---
 
+### Data Model (inferred ER)
+
+```http
+GET /api/brain/spaces/:spaceId/er-model
+```
+
+The space's entity-relationship model, derived from the schema **and** from what is stored. Read-only,
+nothing cached, every number a real count of records.
+
+```json
+{
+  "spaceId": "ops",
+  "entityTypes": [
+    {
+      "type": "service",
+      "count": 128,
+      "declared": true,
+      "namingPattern": "^[a-z-]+$",
+      "properties": [
+        { "name": "tier", "type": "string", "required": true, "enumValues": ["gold", "silver"] }
+      ],
+      "linkedFrom": { "memories": 412, "chrono": 0, "files": 89 }
+    }
+  ],
+  "relationships": [
+    { "from": "deployment", "to": "service", "label": "targets", "count": 1204 }
+  ],
+  "danglingEdges": 0,
+  "truncated": null,
+  "totals": { "entities": 1771, "edges": 1929 }
+}
+```
+
+**Both sources, because they disagree and the disagreement is the point.** Three cases, and a caller should
+handle all three:
+
+| `declared` | `count` | what it means |
+|---|---|---|
+| `true` | `> 0` | the ordinary case |
+| `true` | `0` | a type nobody writes — the schema is aspirational, or the writers do not know it exists |
+| `false` | `> 0` | **records outside the declared vocabulary.** Under `validationMode: "strict"` these can no longer be written, so they are history; under `warn` they are still arriving |
+
+A model built from `typeSchemas` alone would show the second case and silently omit the third — which is
+backwards, because the third is the one nobody knows about.
+
+Notes:
+
+- **`relationships` are type-level.** An edge joins two entity *instances*; a relationship is the edge set
+  grouped by `(from type, label, to type)`, with `count` being how many real edges back it.
+- **`danglingEdges`** counts edges whose endpoint does not resolve to an entity. Normally `0`; a non-zero
+  value on a space with `strictLinkage` on is worth investigating.
+- **`truncated`** is `null` or `{ scan, limit }`. Both reads are capped, and a capped read says so rather
+  than presenting a partial diagram as complete. `totals` is measured **before** the cap, so you can see
+  what share of the space the model covers.
+- **An entity with no `type` is bucketed as `(untyped)`** rather than dropped, so the per-type counts add up.
+- **`properties` lists what the schema declares**, not what records happen to carry. An undeclared type
+  reports `[]` — the model does not infer a schema from data it has not been asked to validate.
+- **On a proxy space the members are reported separately**, as `{ spaceId, members: [ …model per member… ] }`.
+  They are not merged: two spaces can use one type name for different things, and an edge cannot cross a
+  space, so a merged model would show relationships that can never be joined.
+
 ### Space Stats
 
 ```http

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -24,11 +24,40 @@ import { resolveMemberSpaces, collectAcrossMembers } from '../../spaces/proxy.js
 import type { MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc } from '../../config/types.js';
 import { reindexInProgress } from '../../metrics/registry.js';
 import { UUID_V4_RE } from './_shared.js';
+import { buildErModel } from '../../brain/er-model.js';
 
 export const searchRouter = Router();
 
 /** Guard so only one reindex job runs at a time per process. */
 let reindexJobRunning = false;
+
+
+/**
+ * GET /api/brain/spaces/:spaceId/er-model
+ *
+ * The space's entity-relationship model, inferred from the schema AND from what is stored — see
+ * `brain/er-model.ts` for why both, and why a type with zero records is a result rather than an omission.
+ *
+ * Read-only and derived: no state, nothing cached, and every number is a real count.
+ *
+ * **On a proxy space this reports the member spaces separately rather than merged.** Merging would add up
+ * counts for two types that share a name and mean different things in different spaces, and produce
+ * relationships between types that can never actually be joined, since an edge cannot cross a space. A
+ * union here would look richer and be false.
+ */
+searchRouter.get('/spaces/:spaceId/er-model', globalRateLimit, requireSpaceAuth, async (req, res) => {
+  const spaceId = req.params['spaceId'] as string;
+  const cfg = getConfig();
+  if (!cfg.spaces.some(s => s.id === spaceId)) {
+    res.status(404).json({ error: `Space '${spaceId}' not found` });
+    return;
+  }
+  const memberIds = resolveMemberSpaces(spaceId);
+  const models = await Promise.all(memberIds.map(mid => buildErModel(mid)));
+  res.json(memberIds.length === 1 && memberIds[0] === spaceId
+    ? models[0]
+    : { spaceId, members: models });
+});
 
 
 // GET /api/brain/spaces/:spaceId/stats

--- a/server/src/brain/er-model.ts
+++ b/server/src/brain/er-model.ts
@@ -1,0 +1,249 @@
+/**
+ * The entity-relationship model of a space, inferred from its schema AND from what is actually stored.
+ *
+ * ## Why it is inferred from both, and not just from the schema
+ *
+ * A space's `typeSchemas` declares what SHOULD be there. The records say what IS. Those two disagree
+ * constantly and the disagreement is the interesting part — an operator arrived at this product with a
+ * space holding 21 entity types nobody had declared, imported from the wrong schema file, and no view
+ * anywhere would have shown them that. So every type reports which side it came from:
+ *
+ *   - `declared` and used  — the ordinary case.
+ *   - `declared` and empty — a type nobody writes. Either the schema is aspirational or the writers do
+ *     not know it exists; both are worth seeing, and a count of 0 is the only way to see it.
+ *   - used but NOT declared — records outside the agreed vocabulary. Under `strict` validation these
+ *     cannot be written any more, so they are history; under `warn` they are still arriving.
+ *
+ * A diagram drawn from the schema alone would show the second case and silently omit the third, which is
+ * exactly backwards: the undeclared types are the ones nobody knows about.
+ *
+ * ## How the relationships are derived
+ *
+ * An edge joins two entity INSTANCES. A relationship joins two TYPES. So the type-level model is the
+ * edge set grouped by `(fromType, label, toType)`, which needs every edge's endpoints resolved to their
+ * types.
+ *
+ * Done with two COVERED index scans and an in-memory join, rather than a `$lookup` per edge:
+ *
+ *   - entities are read through `{ name: 1, type: 1 }`, which carries `_id` as every index does, so the
+ *     id→type map comes off the index without touching a document;
+ *   - edges are read through the unique `{ from: 1, to: 1, label: 1 }`, which is exactly the three
+ *     fields the grouping needs.
+ *
+ * Neither scan fetches a document body, and a `$lookup` per edge is avoided entirely. That matters
+ * because this feeds a page an operator is WAITING on: the trade documented in `perf-vs-accuracy` says
+ * performance wins when someone is watching, and the honesty below is how the accuracy half is paid.
+ *
+ * ## Bounded, and it says when it was bounded
+ *
+ * Both scans are capped. A space large enough to exceed the cap gets a model built from what was read
+ * and `truncated: true` naming which scan hit its limit — never a quietly partial diagram presented as
+ * complete. "Absent" and "not looked at" are different answers and this endpoint is required to say
+ * which one it is giving.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { getSpaceMeta } from '../spaces/schema-validation.js';
+import type { EntityDoc, EdgeDoc, PropertySchema } from '../config/types.js';
+
+/** Read caps. Generous enough that no real space hits them, low enough that a runaway one cannot hang a page. */
+export const ER_ENTITY_SCAN_LIMIT = 200_000;
+export const ER_EDGE_SCAN_LIMIT = 200_000;
+/** A property is only listed if the schema declares it; observed property keys are counted, not enumerated. */
+export interface ErProperty {
+  name: string;
+  type?: PropertySchema['type'];
+  required: boolean;
+  /** Present only when the schema constrains the value set — the diagram shows this as a badge. */
+  enumValues?: (string | number | boolean)[];
+}
+
+export interface ErEntityType {
+  type: string;
+  /** How many records of this type the space actually holds. `0` is a real and interesting answer. */
+  count: number;
+  /** Whether the space's `typeSchemas.entity` declares it. `false` means records outside the vocabulary. */
+  declared: boolean;
+  /** Declared naming constraint, if any — shown as the type's key format. */
+  namingPattern?: string;
+  properties: ErProperty[];
+  /** Records of the other three kinds that point AT this type through their `entityIds`. */
+  linkedFrom: { memories: number; chrono: number; files: number };
+}
+
+export interface ErRelationship {
+  from: string;
+  to: string;
+  label: string;
+  count: number;
+}
+
+export interface ErModel {
+  spaceId: string;
+  entityTypes: ErEntityType[];
+  relationships: ErRelationship[];
+  /** Edges whose endpoint no longer resolves to an entity — dangling, and worth surfacing rather than dropping. */
+  danglingEdges: number;
+  truncated: null | { scan: 'entities' | 'edges' | 'links'; limit: number };
+  /** Totals BEFORE any cap, so the caller can see what share of the space the diagram represents. */
+  totals: { entities: number; edges: number };
+}
+
+/** The bucket an entity with no `type` falls into. Named rather than dropped: untyped records are real. */
+export const UNTYPED = '(untyped)';
+
+/** The declared half of the model — `typeSchemas.entity`, narrowed to what a diagram uses. */
+export type DeclaredTypes = Record<string, {
+  namingPattern?: string;
+  propertySchemas?: Record<string, PropertySchema>;
+}>;
+
+/** Everything the assembly needs, already read. Separated so the logic can be tested without a database. */
+export interface ErInputs {
+  spaceId: string;
+  entities: Array<{ _id: string; type?: string }>;
+  edges: Array<{ from: string; to: string; label: string }>;
+  /** `entityIds` arrays from the three linking collections. */
+  links: { memories: string[][]; chrono: string[][]; files: string[][] };
+  declared: DeclaredTypes;
+  totals: { entities: number; edges: number };
+  truncated: ErModel['truncated'];
+}
+
+/**
+ * Turn what was read into the model. Pure — no I/O, no clock, no config.
+ *
+ * Split out because everything that can be WRONG here is arithmetic and set logic: which type a record
+ * counts toward, whether a memory linking two services counts once or twice, what an unresolvable edge
+ * endpoint means. Those deserve a test that runs in milliseconds against hand-built rows, not one that
+ * needs a container and a seeded space.
+ */
+export function assembleErModel(input: ErInputs): ErModel {
+  const typeOf = new Map<string, string>();
+  const observed = new Map<string, number>();
+  for (const row of input.entities) {
+    const t = (row.type ?? '').trim() || UNTYPED;
+    typeOf.set(row._id, t);
+    observed.set(t, (observed.get(t) ?? 0) + 1);
+  }
+
+  const rel = new Map<string, ErRelationship>();
+  let danglingEdges = 0;
+  for (const e of input.edges) {
+    const from = typeOf.get(e.from);
+    const to = typeOf.get(e.to);
+    // An endpoint we cannot resolve is either genuinely dangling or beyond the entity cap. Counted
+    // separately either way: it keeps a truncated read from inventing a relationship, and it surfaces real
+    // dangling edges — which `strictLinkage` exists to prevent and which matter where it is off.
+    if (from === undefined || to === undefined) { danglingEdges++; continue; }
+    const key = JSON.stringify([from, e.label, to]);
+    const hit = rel.get(key);
+    if (hit) hit.count++;
+    else rel.set(key, { from, to, label: e.label, count: 1 });
+  }
+
+  const byType = new Map<string, { memories: number; chrono: number; files: number }>();
+  for (const [kind, rows] of Object.entries(input.links) as Array<['memories' | 'chrono' | 'files', string[][]]>) {
+    for (const ids of rows) {
+      // A record linking three entities of the SAME type counts ONCE for that type. "How many memories
+      // mention a service" must not double because one memory mentions two services.
+      const seen = new Set<string>();
+      for (const id of ids) {
+        const t = typeOf.get(id);
+        if (t !== undefined) seen.add(t);
+      }
+      for (const t of seen) {
+        const hit = byType.get(t) ?? { memories: 0, chrono: 0, files: 0 };
+        hit[kind]++;
+        byType.set(t, hit);
+      }
+    }
+  }
+
+  const names = new Set<string>([...observed.keys(), ...Object.keys(input.declared)]);
+  const entityTypes: ErEntityType[] = [...names].map(type => {
+    const schema = input.declared[type];
+    const props = schema?.propertySchemas ?? {};
+    return {
+      type,
+      count: observed.get(type) ?? 0,
+      declared: schema !== undefined,
+      ...(schema?.namingPattern ? { namingPattern: schema.namingPattern } : {}),
+      properties: Object.entries(props).map(([name, p]) => ({
+        name,
+        ...(p.type ? { type: p.type } : {}),
+        required: p.required === true,
+        ...(p.enum ? { enumValues: p.enum } : {}),
+      })),
+      linkedFrom: byType.get(type) ?? { memories: 0, chrono: 0, files: 0 },
+    };
+  });
+
+  // Biggest first: someone opening this wants the SHAPE of the space, and the shape is carried by the types
+  // that hold records. An undeclared type with records outranks a declared empty one, deliberately — the
+  // undeclared ones are the ones nobody knows about.
+  entityTypes.sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+
+  return {
+    spaceId: input.spaceId,
+    entityTypes,
+    relationships: [...rel.values()].sort((a, b) => b.count - a.count || a.from.localeCompare(b.from)),
+    danglingEdges,
+    truncated: input.truncated,
+    totals: input.totals,
+  };
+}
+
+/**
+ * Build the ER model for one space.
+ *
+ * Every count is a real count of stored records. Nothing here is estimated, and nothing is hidden — a
+ * capped read reports itself in `truncated`.
+ */
+export async function buildErModel(spaceId: string): Promise<ErModel> {
+  const entities = col<EntityDoc>(`${spaceId}_entities`);
+  const edges = col<EdgeDoc>(`${spaceId}_edges`);
+
+  const [totalEntities, totalEdges] = await Promise.all([
+    entities.countDocuments({}),
+    edges.countDocuments({}),
+  ]);
+
+  // Read through the covering indexes: `{ name: 1, type: 1 }` carries `_id`, as every index does, and the
+  // unique `{ from: 1, to: 1, label: 1 }` is exactly the three fields the grouping needs. No document
+  // bodies are fetched, and there is no `$lookup` per edge.
+  const [entityRows, edgeRows] = await Promise.all([
+    entities.find({}, { projection: { type: 1 }, limit: ER_ENTITY_SCAN_LIMIT })
+      .toArray() as Promise<Array<{ _id: string; type?: string }>>,
+    edges.find({}, { projection: { from: 1, to: 1, label: 1 }, limit: ER_EDGE_SCAN_LIMIT })
+      .toArray() as Promise<Array<{ from: string; to: string; label: string }>>,
+  ]);
+
+  const links: ErInputs['links'] = { memories: [], chrono: [], files: [] };
+  let linksTruncated = false;
+  for (const kind of ['memories', 'chrono', 'files'] as const) {
+    const rows = await col(`${spaceId}_${kind}`)
+      .find(asFilter({ entityIds: { $exists: true, $ne: [] } }),
+        { projection: { entityIds: 1 }, limit: ER_ENTITY_SCAN_LIMIT })
+      .toArray() as Array<{ entityIds?: string[] }>;
+    if (rows.length >= ER_ENTITY_SCAN_LIMIT) linksTruncated = true;
+    links[kind] = rows.map(r => r.entityIds ?? []);
+  }
+
+  // The first cap hit wins the report. One name is enough to tell a reader the diagram is partial; listing
+  // all three would suggest they are independently interesting, and they are not.
+  const truncated: ErModel['truncated'] =
+    entityRows.length >= ER_ENTITY_SCAN_LIMIT ? { scan: 'entities', limit: ER_ENTITY_SCAN_LIMIT }
+      : edgeRows.length >= ER_EDGE_SCAN_LIMIT ? { scan: 'edges', limit: ER_EDGE_SCAN_LIMIT }
+        : linksTruncated ? { scan: 'links', limit: ER_ENTITY_SCAN_LIMIT }
+          : null;
+
+  return assembleErModel({
+    spaceId,
+    entities: entityRows,
+    edges: edgeRows,
+    links,
+    declared: (getSpaceMeta(spaceId)?.typeSchemas?.entity ?? {}) as DeclaredTypes,
+    totals: { entities: totalEntities, edges: totalEdges },
+    truncated,
+  });
+}

--- a/testing/standalone/er-model.test.js
+++ b/testing/standalone/er-model.test.js
@@ -1,0 +1,240 @@
+/**
+ * The inferred ER model — the counting and set logic, tested against hand-built rows.
+ *
+ * ## Why this is a unit test and not an integration one
+ *
+ * Everything that can be WRONG in this feature is arithmetic: which type a record counts toward, whether a
+ * memory linking two entities of one type counts once or twice, what an edge with an unresolvable endpoint
+ * means. None of that needs a container or a seeded space — and a test that needed one would run rarely
+ * enough that the arithmetic would go unchecked between releases.
+ *
+ * `assembleErModel` is pure for exactly this reason: `buildErModel` does the reads, this does the thinking.
+ *
+ * ## The three cases the feature exists for
+ *
+ * A diagram drawn from `typeSchemas` alone would show a declared-but-empty type and silently omit a type
+ * that has records and no declaration. That is backwards — the undeclared ones are the ones nobody knows
+ * about, and an operator arrived at this product with 21 of them. All three cases are asserted below,
+ * because "it renders" would pass with any two of them.
+ *
+ * Run: node --test testing/standalone/er-model.test.js
+ * (requires a prior `npm run build:server`)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let assembleErModel, UNTYPED;
+
+before(async () => {
+  ({ assembleErModel, UNTYPED } = await import('../../server/dist/brain/er-model.js'));
+});
+
+/** Minimal well-formed input; each test overrides only what it is about. */
+const inputs = (over = {}) => ({
+  spaceId: 'test',
+  entities: [],
+  edges: [],
+  links: { memories: [], chrono: [], files: [] },
+  declared: {},
+  totals: { entities: 0, edges: 0 },
+  truncated: null,
+  ...over,
+});
+
+const typeNamed = (model, name) => model.entityTypes.find(t => t.type === name);
+
+describe('the schema and the records are BOTH sources', () => {
+  it('a declared type with records reports its count and its properties', () => {
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'a', type: 'service' }, { _id: 'b', type: 'service' }],
+      declared: {
+        service: {
+          namingPattern: '^[a-z-]+$',
+          propertySchemas: {
+            tier: { type: 'string', enum: ['gold', 'silver'], required: true },
+            repo: { type: 'string' },
+          },
+        },
+      },
+    }));
+    const t = typeNamed(m, 'service');
+    assert.equal(t.count, 2);
+    assert.equal(t.declared, true);
+    assert.equal(t.namingPattern, '^[a-z-]+$');
+    assert.deepEqual(t.properties.find(p => p.name === 'tier'),
+      { name: 'tier', type: 'string', required: true, enumValues: ['gold', 'silver'] });
+    assert.equal(t.properties.find(p => p.name === 'repo').required, false);
+  });
+
+  it('a declared type with ZERO records is still reported', () => {
+    // The whole point of reading the schema as well. A type nobody writes is either aspirational or unknown
+    // to the writers, and a count of 0 is the only way anyone sees it.
+    const m = assembleErModel(inputs({ declared: { runbook: { propertySchemas: {} } } }));
+    const t = typeNamed(m, 'runbook');
+    assert.ok(t, 'a declared type with no records vanished from the model');
+    assert.equal(t.count, 0);
+    assert.equal(t.declared, true);
+  });
+
+  it('a type with records and NO declaration is reported, and marked as such', () => {
+    // The case a schema-only diagram would silently omit — and the one that actually cost an operator time.
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'a', type: 'document' }, { _id: 'b', type: 'document' }],
+    }));
+    const t = typeNamed(m, 'document');
+    assert.ok(t, 'records outside the declared vocabulary are invisible in the model');
+    assert.equal(t.count, 2);
+    assert.equal(t.declared, false,
+      'an undeclared type is reported as declared, so the diagram cannot distinguish it from an agreed one');
+    assert.deepEqual(t.properties, [], 'properties were invented for a type that declares none');
+  });
+
+  it('an entity with no type at all lands in a named bucket rather than vanishing', () => {
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'a' }, { _id: 'b', type: '   ' }],
+    }));
+    const t = typeNamed(m, UNTYPED);
+    assert.ok(t, 'untyped records were dropped — they are real records and the count would not add up');
+    assert.equal(t.count, 2, 'a blank-string type and a missing type are the same case and must share a bucket');
+  });
+});
+
+describe('relationships are the edge set grouped by TYPE', () => {
+  const entities = [
+    { _id: 'p1', type: 'person' }, { _id: 'p2', type: 'person' },
+    { _id: 's1', type: 'service' }, { _id: 's2', type: 'service' },
+  ];
+
+  it('edges between the same pair of types collapse into one relationship with a count', () => {
+    const m = assembleErModel(inputs({
+      entities,
+      edges: [
+        { from: 'p1', to: 's1', label: 'owns' },
+        { from: 'p2', to: 's2', label: 'owns' },
+      ],
+    }));
+    assert.equal(m.relationships.length, 1);
+    assert.deepEqual(m.relationships[0], { from: 'person', to: 'service', label: 'owns', count: 2 });
+  });
+
+  it('direction matters — A→B and B→A are different relationships', () => {
+    const m = assembleErModel(inputs({
+      entities,
+      edges: [{ from: 'p1', to: 's1', label: 'x' }, { from: 's1', to: 'p1', label: 'x' }],
+    }));
+    assert.equal(m.relationships.length, 2, 'opposite directions were merged, which reverses what the diagram claims');
+  });
+
+  it('a type related to itself is one relationship, not two nodes', () => {
+    const m = assembleErModel(inputs({
+      entities,
+      edges: [{ from: 's1', to: 's2', label: 'depends_on' }],
+    }));
+    assert.deepEqual(m.relationships[0], { from: 'service', to: 'service', label: 'depends_on', count: 1 });
+  });
+
+  it('an edge whose endpoint does not resolve is counted as dangling, never as a relationship', () => {
+    // Two ways to get here: a genuinely dangling edge where `strictLinkage` is off, or an entity beyond the
+    // read cap. Either way, inventing a relationship from it would put a line in the diagram for a join
+    // that cannot be shown to exist.
+    const m = assembleErModel(inputs({
+      entities,
+      edges: [{ from: 'p1', to: 'GONE', label: 'owns' }, { from: 'MISSING', to: 's1', label: 'owns' }],
+    }));
+    assert.equal(m.danglingEdges, 2);
+    assert.deepEqual(m.relationships, []);
+  });
+
+  it('labels containing spaces cannot collide into one relationship', () => {
+    // Regression. The grouping key was built by joining the triple with a separator; with a plain space,
+    // (from "a b", label "c") and (from "a", label "b c") produce the same key and two distinct
+    // relationships silently merge into one with a doubled count.
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'x', type: 'a b' }, { _id: 'y', type: 'a' }, { _id: 'z', type: 'z' }],
+      edges: [
+        { from: 'x', to: 'z', label: 'c' },
+        { from: 'y', to: 'z', label: 'b c' },
+      ],
+    }));
+    assert.equal(m.relationships.length, 2,
+      'two different relationships merged — the grouping key is ambiguous for values containing its separator');
+    assert.ok(m.relationships.every(r => r.count === 1), 'a merged key produced a doubled count');
+  });
+});
+
+describe('links from the other three record kinds', () => {
+  const entities = [
+    { _id: 's1', type: 'service' }, { _id: 's2', type: 'service' }, { _id: 'p1', type: 'person' },
+  ];
+
+  it('one record linking TWO entities of the same type counts once for that type', () => {
+    // "How many memories mention a service" must not double because one memory mentions two services.
+    const m = assembleErModel(inputs({
+      entities,
+      links: { memories: [['s1', 's2']], chrono: [], files: [] },
+    }));
+    assert.equal(typeNamed(m, 'service').linkedFrom.memories, 1);
+  });
+
+  it('one record spanning two types counts once for EACH', () => {
+    const m = assembleErModel(inputs({
+      entities,
+      links: { memories: [['s1', 'p1']], chrono: [], files: [] },
+    }));
+    assert.equal(typeNamed(m, 'service').linkedFrom.memories, 1);
+    assert.equal(typeNamed(m, 'person').linkedFrom.memories, 1);
+  });
+
+  it('the three kinds are counted separately', () => {
+    const m = assembleErModel(inputs({
+      entities,
+      links: { memories: [['s1']], chrono: [['s1'], ['s2']], files: [] },
+    }));
+    assert.deepEqual(typeNamed(m, 'service').linkedFrom, { memories: 1, chrono: 2, files: 0 });
+  });
+
+  it('a link to an entity that does not resolve is ignored rather than counted', () => {
+    const m = assembleErModel(inputs({ entities, links: { memories: [['GONE']], chrono: [], files: [] } }));
+    assert.equal(typeNamed(m, 'service').linkedFrom.memories, 0);
+  });
+});
+
+describe('ordering puts the shape of the space first', () => {
+  it('types are sorted by record count, so an undeclared type with records outranks a declared empty one', () => {
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'a', type: 'loud' }, { _id: 'b', type: 'loud' }, { _id: 'c', type: 'quiet' }],
+      declared: { empty: { propertySchemas: {} }, quiet: { propertySchemas: {} } },
+    }));
+    assert.deepEqual(m.entityTypes.map(t => t.type), ['loud', 'quiet', 'empty']);
+  });
+
+  it('relationships are sorted by count', () => {
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'a', type: 'A' }, { _id: 'b', type: 'B' }, { _id: 'c', type: 'C' }],
+      edges: [
+        { from: 'a', to: 'b', label: 'rare' },
+        { from: 'a', to: 'c', label: 'common' },
+        { from: 'a', to: 'c', label: 'common' },
+      ],
+    }));
+    assert.equal(m.relationships[0].label, 'common');
+  });
+});
+
+describe('a bounded read says so', () => {
+  it('truncation is carried through rather than dropped', () => {
+    // The diagram must never present a partial read as complete: "absent" and "not looked at" are different
+    // answers, and only one of them is a fact about the space.
+    const m = assembleErModel(inputs({ truncated: { scan: 'edges', limit: 200000 } }));
+    assert.deepEqual(m.truncated, { scan: 'edges', limit: 200000 });
+  });
+
+  it('the pre-cap totals survive, so the caller can see what share it is looking at', () => {
+    const m = assembleErModel(inputs({
+      entities: [{ _id: 'a', type: 'x' }],
+      totals: { entities: 999999, edges: 12345 },
+    }));
+    assert.deepEqual(m.totals, { entities: 999999, edges: 12345 });
+    assert.equal(typeNamed(m, 'x').count, 1, 'the per-type count must be what was READ, not the pre-cap total');
+  });
+});


### PR DESCRIPTION
First of four slices for the inferred ER diagram. This one is the endpoint and
nothing else — it is what the other three sit on, and it is useful on its own to
anyone integrating.

`GET /api/brain/spaces/:spaceId/er-model` returns the type-level model of a
space: entity types with their declared properties and their real record counts,
the relationships between those types with real edge counts, and how many
memories, chrono entries and files point at each type.

Why it reads BOTH the schema and the records
--------------------------------------------

`typeSchemas` says what SHOULD be there. The records say what IS. They disagree
constantly, and the disagreement is the interesting part:

  - declared and used     -- the ordinary case
  - declared and empty    -- a type nobody writes; the schema is aspirational,
    or the writers do not know it exists
  - records, NOT declared -- outside the agreed vocabulary

A model built from the schema alone shows the second and silently omits the
third. That is backwards: the undeclared types are the ones nobody knows about.
This is not hypothetical — an integrator arrived here with a space holding 21
undeclared entity types after importing the wrong schema file, and no view in
the product would have shown them.

How the relationships are derived
----------------------------------

An edge joins two entity INSTANCES; a relationship joins two TYPES. So the model
is the edge set grouped by (fromType, label, toType), which needs every edge's
endpoints resolved.

Two COVERED index scans and an in-memory join, not a `$lookup` per edge:

  - `{ name: 1, type: 1 }` carries `_id` as every index does, so the id->type
    map comes off the index without touching a document;
  - the unique `{ from: 1, to: 1, label: 1 }` is exactly the three fields the
    grouping needs.

Neither read fetches a document body. That matters because this feeds a page
someone is WAITING on.

Bounded, and it says so
------------------------

Both reads are capped. A capped read reports `truncated` naming which scan hit
its limit, and `totals` is measured BEFORE the cap so a caller can see what share
of the space the model covers. A partial diagram is never presented as complete
— "absent" and "not looked at" are different answers.

`danglingEdges` counts an edge whose endpoint does not resolve rather than
inventing a relationship from it. An entity with no `type` goes to `(untyped)`
rather than being dropped, so the per-type counts add up to the total.

A proxy space reports its members separately rather than merged: two spaces can
use one type name for different things, and an edge cannot cross a space, so a
merged model would draw relationships that can never be joined.

Shape and tests
---------------

`assembleErModel` is pure and takes rows; `buildErModel` is the thin I/O shell.
Everything that can be WRONG here is arithmetic and set logic, and that deserves
a test running in milliseconds against hand-built rows rather than one needing a
container and a seeded space.

17 cases, including all three declared/undeclared cases (a test asserting only
two of them would pass on a model that omits the important one), direction
mattering on relationships, dangling endpoints, and per-record link dedup — one
memory linking two entities of the SAME type counts once, because "how many
memories mention a service" must not double for a memory that mentions two.

One regression is worth naming. The grouping key was a template literal whose
separators came out as literal NUL bytes, which made git treat the source as
binary. It is now `JSON.stringify([from, label, to])` — which also fixes a real
ambiguity a space separator would have had: (from "a b", label "c") and
(from "a", label "b c") produce the same key, and two distinct relationships
merge into one with a doubled count. Mutation-checked: restoring the space-joined
key fails that test by name.

Docs in `04-brain-api.md`, including the three-case table, because a caller has
to handle all three.

What is NOT in this PR
-----------------------

The Overview panel, the count -> filtered-tab link, and the schema-dialog
extraction. The dialog is the real work of the next slice: "the same popup as
space settings" means lifting the per-type editor OUT of
`space-schema-tab.component.ts` into a shared standalone dialog both places
open, because two editors for one schema would drift.

preflight green.
