### PR TITLE
refactor(settings): the per-type schema edits become pure, so a second host can use them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     spaces and show relationships that can never be joined, since an edge cannot cross a space.
 
 ### Internal
+- **The per-type schema edits are pure functions now, so a second host can use them.** `addProp`,
+  `removeProp`, `addEnumVal` and `removeEnumVal` lived on `SpaceSettingsState` and reached into its own
+  map, which made them unusable anywhere else. The Brain Overview needs the same editor in place, and that
+  service is page-scoped — root-providing it would turn per-space editing state into a cross-page
+  singleton. They operate on a state object they are handed now; the service delegates. No behaviour
+  change, proven by the existing characterization spec and the full client suite.
+
 
 - **The model-warm retry loop had a 62-second budget against a failure measured in minutes.** Six attempts
   backing off 2, 4, 8, 16, 32 seconds — so every attempt landed inside 62.68 s. What it receives is

--- a/client/src/app/pages/settings/space-settings-state.service.ts
+++ b/client/src/app/pages/settings/space-settings-state.service.ts
@@ -5,6 +5,12 @@ import {
 } from '../../core/api.types';
 import { TranslocoService } from '@jsverse/transloco';
 import { SpacesApi } from '../../core/spaces-api.service';
+import {
+  addProp as addPropTo,
+  removeProp as removePropFrom,
+  addEnumVal as addEnumValTo,
+  removeEnumVal as removeEnumValFrom,
+} from './type-schema-edits';
 
 /**
  * Editable form state for one type schema.
@@ -427,18 +433,21 @@ export class SpaceSettingsState {
     else this.schExpandedProps.add(k);
   }
 
+  // ── The per-type edits live in `type-schema-edits.ts` and are delegated to from here.
+  //
+  // They moved so the Brain Overview's data-model panel can open the same editor in place rather than
+  // sending an operator to Space Settings for a one-field change. This service is page-scoped and cannot be
+  // injected there; the edits are now plain functions over a state object, so both callers share one
+  // implementation. What stays HERE is the expansion set, because which rows are open is a property of this
+  // view and a modal editing a single type has no use for it.
+
   addProp(kt: KnowledgeType, typeName: string): void {
-    const state = this.typeState(kt, typeName);
-    const key = (state._newPropInput ?? '').trim();
-    if (!key || state.propertySchemas.some(e => e.key === key)) { state._newPropInput = ''; return; }
-    state.propertySchemas = [...state.propertySchemas, { key, s: {}, _enumInput: '' }];
-    state._newPropInput   = '';
-    this.schExpandedProps.add(this.propKey(kt, typeName, key));
+    const key = addPropTo(this.typeState(kt, typeName));
+    if (key !== null) this.schExpandedProps.add(this.propKey(kt, typeName, key));
   }
 
   removeProp(kt: KnowledgeType, typeName: string, propKey: string): void {
-    const state = this.typeState(kt, typeName);
-    state.propertySchemas = state.propertySchemas.filter(e => e.key !== propKey);
+    removePropFrom(this.typeState(kt, typeName), propKey);
     this.schExpandedProps.delete(this.propKey(kt, typeName, propKey));
   }
 
@@ -452,19 +461,11 @@ export class SpaceSettingsState {
   }
 
   addEnumVal(kt: KnowledgeType, typeName: string, propKey: string): void {
-    const entry = this.typeState(kt, typeName).propertySchemas.find(e => e.key === propKey);
-    if (!entry) return;
-    const val = (entry._enumInput ?? '').trim();
-    if (!val) return;
-    const curr = entry.s.enum ?? [];
-    if (!curr.some(v => String(v) === val)) entry.s = { ...entry.s, enum: [...curr, val] };
-    entry._enumInput = '';
+    addEnumValTo(this.typeState(kt, typeName), propKey);
   }
 
   removeEnumVal(kt: KnowledgeType, typeName: string, propKey: string, val: string | number | boolean): void {
-    const entry = this.typeState(kt, typeName).propertySchemas.find(e => e.key === propKey);
-    if (!entry) return;
-    entry.s = { ...entry.s, enum: (entry.s.enum ?? []).filter(v => v !== val) };
+    removeEnumValFrom(this.typeState(kt, typeName), propKey, val);
   }
 
   wipeStatCols(): { label: string; value: number }[] {

--- a/client/src/app/pages/settings/type-schema-edits.spec.ts
+++ b/client/src/app/pages/settings/type-schema-edits.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * The per-type schema edits, tested directly now that they are pure.
+ *
+ * These operations used to live on `SpaceSettingsState` and reach into its own map, so the only way to
+ * exercise them was through the service — which meant the settings page's `TestBed` had to be stood up to
+ * assert that a duplicate property key is refused. They are plain functions over a state object now, and
+ * this file is what that buys.
+ *
+ * `space-schema-tab.component.spec.ts` still covers the service's own behaviour end to end. That is the
+ * characterization net proving this extraction changed nothing; this file pins the rules themselves.
+ */
+import { describe, it, expect } from 'vitest';
+import { emptyTypeSchemaState, type TypeSchemaState } from './space-settings-state.service';
+import { addProp, removeProp, addEnumVal, removeEnumVal, canAddProp } from './type-schema-edits';
+
+const state = (over: Partial<TypeSchemaState> = {}): TypeSchemaState => emptyTypeSchemaState(over);
+const prop = (key: string, s = {}) => ({ key, s, _enumInput: '' });
+
+describe('adding a property', () => {
+  it('adds the pending key and returns it', () => {
+    const s = state({ _newPropInput: 'tier' });
+    expect(addProp(s)).toBe('tier');
+    expect(s.propertySchemas.map(p => p.key)).toEqual(['tier']);
+  });
+
+  it('clears the input even when the key is refused', () => {
+    // A rejected duplicate left sitting in the box reads as "the button did nothing", which is the bug
+    // report we would get instead of the duplicate we prevented.
+    const s = state({ _newPropInput: 'tier', propertySchemas: [prop('tier')] });
+    expect(addProp(s)).toBeNull();
+    expect(s._newPropInput).toBe('');
+    expect(s.propertySchemas).toHaveLength(1);
+  });
+
+  it('refuses blank and whitespace-only keys', () => {
+    for (const input of ['', '   ', '\t']) {
+      const s = state({ _newPropInput: input });
+      expect(addProp(s)).toBeNull();
+      expect(s.propertySchemas).toHaveLength(0);
+    }
+  });
+
+  it('trims the key it stores', () => {
+    const s = state({ _newPropInput: '  tier  ' });
+    expect(addProp(s)).toBe('tier');
+    expect(s.propertySchemas[0]!.key).toBe('tier');
+  });
+
+  it('canAddProp answers without mutating, so a template can disable the button', () => {
+    const s = state({ _newPropInput: 'tier', propertySchemas: [prop('tier')] });
+    expect(canAddProp(s)).toBeNull();
+    expect(s._newPropInput).toBe('tier');
+  });
+
+  it('returning the key is what lets a caller expand the new row', () => {
+    // The settings tab expands the row it just created. It cannot do that for a key that was never added,
+    // which is why this returns the key rather than a boolean.
+    const s = state({ _newPropInput: 'repo' });
+    const key = addProp(s);
+    expect(key).not.toBeNull();
+    expect(s.propertySchemas.some(p => p.key === key)).toBe(true);
+  });
+});
+
+describe('removing a property', () => {
+  it('removes only the named key', () => {
+    const s = state({ propertySchemas: [prop('a'), prop('b')] });
+    removeProp(s, 'a');
+    expect(s.propertySchemas.map(p => p.key)).toEqual(['b']);
+  });
+
+  it('removing a key that is not there is a no-op, not a throw', () => {
+    const s = state({ propertySchemas: [prop('a')] });
+    expect(() => removeProp(s, 'nope')).not.toThrow();
+    expect(s.propertySchemas).toHaveLength(1);
+  });
+});
+
+describe('enum values', () => {
+  it('adds the pending value and clears the input', () => {
+    const s = state({ propertySchemas: [{ key: 'tier', s: {}, _enumInput: 'gold' }] });
+    addEnumVal(s, 'tier');
+    expect(s.propertySchemas[0]!.s.enum).toEqual(['gold']);
+    expect(s.propertySchemas[0]!._enumInput).toBe('');
+  });
+
+  it('a typed "4" does not duplicate a stored 4', () => {
+    // The input is text and the stored value may be a number. Comparing strictly would grow a list with two
+    // entries that LOOK identical and that no record could satisfy twice.
+    const s = state({ propertySchemas: [{ key: 'n', s: { enum: [4] }, _enumInput: '4' }] });
+    addEnumVal(s, 'n');
+    expect(s.propertySchemas[0]!.s.enum).toEqual([4]);
+  });
+
+  it('ignores a blank value rather than storing an empty option', () => {
+    const s = state({ propertySchemas: [{ key: 'tier', s: {}, _enumInput: '   ' }] });
+    addEnumVal(s, 'tier');
+    expect(s.propertySchemas[0]!.s.enum).toBeUndefined();
+  });
+
+  it('does nothing for a property that does not exist', () => {
+    const s = state({ propertySchemas: [prop('a')] });
+    expect(() => addEnumVal(s, 'nope')).not.toThrow();
+  });
+
+  it('removes a value, leaving the rest', () => {
+    const s = state({ propertySchemas: [{ key: 'tier', s: { enum: ['gold', 'silver'] }, _enumInput: '' }] });
+    removeEnumVal(s, 'tier', 'gold');
+    expect(s.propertySchemas[0]!.s.enum).toEqual(['silver']);
+  });
+
+  it('replaces the schema object rather than mutating it in place', () => {
+    // The entry's `s` is handed to a template. Replacing it is what makes the change visible; mutating the
+    // same object would leave an OnPush view showing the old list.
+    const original = { enum: ['gold', 'silver'] };
+    const s = state({ propertySchemas: [{ key: 'tier', s: original, _enumInput: '' }] });
+    removeEnumVal(s, 'tier', 'gold');
+    expect(s.propertySchemas[0]!.s).not.toBe(original);
+    expect(original.enum).toEqual(['gold', 'silver']);
+  });
+});

--- a/client/src/app/pages/settings/type-schema-edits.ts
+++ b/client/src/app/pages/settings/type-schema-edits.ts
@@ -1,0 +1,84 @@
+/**
+ * The per-type schema edits, as pure operations over one `TypeSchemaState`.
+ *
+ * ## Why they left the service
+ *
+ * These lived on `SpaceSettingsState` and reached into its own `schTypeSchemas` map to find the type they
+ * were editing. That made them unusable anywhere else — and "anywhere else" is now a real requirement: the
+ * Brain Overview's data-model panel opens the SAME per-type editor in place, rather than sending an operator
+ * off to Space Settings to make a one-field change.
+ *
+ * `SpaceSettingsState` is `@Injectable()` with no `providedIn`, so it is provided by the settings page and
+ * the Brain page cannot inject it. Making it root-provided would turn per-space editing state into a
+ * cross-page singleton, which is a worse problem than the one being solved.
+ *
+ * So the editing logic operates on a state object it is handed. The service keeps its map and delegates;
+ * the dialog keeps a draft and delegates to the same functions. One implementation, two callers, and no
+ * service dragged across the app.
+ *
+ * ## What is deliberately NOT here
+ *
+ * **Persistence.** The two callers save differently and must keep doing so: Space Settings is STAGED — edit
+ * several types, then Save — while the Overview panel is IMMEDIATE, editing one type and writing it now.
+ * Pushing a save into these functions would force one of those hosts to adopt the other's model.
+ *
+ * **Expansion state.** Which property rows are open is a property of a VIEW, not of the schema, and the two
+ * hosts disagree about it: the settings tab keeps a set across every type it has open, and a modal editing
+ * one type does not need one at all. The service keeps its own set and calls these for the data half.
+ */
+import type { PropertySchema } from '../../core/api.types';
+import type { TypeSchemaState } from './space-settings-state.service';
+
+/** A property key that is blank, or already taken, is not an edit — it is a typo. */
+export function canAddProp(state: TypeSchemaState): string | null {
+  const key = (state._newPropInput ?? '').trim();
+  if (!key) return null;
+  if (state.propertySchemas.some(e => e.key === key)) return null;
+  return key;
+}
+
+/**
+ * Append the pending property.
+ *
+ * Returns the key that was added, or `null` when nothing was — the caller needs to know, because the
+ * settings tab also expands the new row and cannot do that for a key that was never created.
+ *
+ * Mutates in place because the callers hold this object directly and Angular's change detection here is
+ * driven by the containing signal, not by identity of this leaf.
+ */
+export function addProp(state: TypeSchemaState): string | null {
+  const key = canAddProp(state);
+  // The input is cleared either way. Leaving a rejected duplicate sitting in the box reads as "the button
+  // did nothing", which is the report we would get.
+  state._newPropInput = '';
+  if (!key) return null;
+  state.propertySchemas = [...state.propertySchemas, { key, s: {}, _enumInput: '' }];
+  return key;
+}
+
+export function removeProp(state: TypeSchemaState, propKey: string): void {
+  state.propertySchemas = state.propertySchemas.filter(e => e.key !== propKey);
+}
+
+/**
+ * Add the pending enum value to one property.
+ *
+ * Compared by `String(v)` rather than by value: the input is text, and a stored `4` and a typed `"4"` are
+ * the same allowed value to anyone reading the list. Comparing strictly would let the list grow a visually
+ * duplicated entry that no record could ever satisfy twice.
+ */
+export function addEnumVal(state: TypeSchemaState, propKey: string): void {
+  const entry = state.propertySchemas.find(e => e.key === propKey);
+  if (!entry) return;
+  const val = (entry._enumInput ?? '').trim();
+  if (!val) return;
+  const curr: NonNullable<PropertySchema['enum']> = entry.s.enum ?? [];
+  if (!curr.some(v => String(v) === val)) entry.s = { ...entry.s, enum: [...curr, val] };
+  entry._enumInput = '';
+}
+
+export function removeEnumVal(state: TypeSchemaState, propKey: string, val: string | number | boolean): void {
+  const entry = state.propertySchemas.find(e => e.key === propKey);
+  if (!entry) return;
+  entry.s = { ...entry.s, enum: (entry.s.enum ?? []).filter(v => v !== val) };
+}


### PR DESCRIPTION
refactor(settings): the per-type schema edits become pure, so a second host can use them

Slice 2a of the inferred ER diagram. No behaviour change -- this is the move
that makes the shared editor possible, done on its own so the diff that follows
is about the dialog rather than about untangling this.

The blocker it removes
-----------------------

`addProp`, `removeProp`, `addEnumVal` and `removeEnumVal` lived on
`SpaceSettingsState` and reached into its own `schTypeSchemas` map to find the
type being edited. That made them unusable anywhere else, and "anywhere else" is
now a requirement: the Brain Overview's data-model panel opens the SAME per-type
editor in place, rather than sending an operator to Space Settings for a
one-field change.

`SpaceSettingsState` is `@Injectable()` with no `providedIn`, so it is provided
by the settings page and the Brain page cannot inject it. Making it
root-provided would turn per-space editing state into a cross-page singleton --
a worse problem than the one being solved.

So the edits are now plain functions over a `TypeSchemaState` they are handed.
The service keeps its map and delegates; the dialog will keep a draft and
delegate to the same functions. One implementation, two callers.

What deliberately did NOT move
-------------------------------

Persistence. The two hosts save differently and must keep doing so: Space
Settings is STAGED (edit several types, then Save) and the Overview panel is
IMMEDIATE (edit one type, write it now). A save inside these functions would
force one host to adopt the other's model.

Expansion state. Which property rows are open is a property of a VIEW, and the
two hosts disagree: the settings tab keeps a set across every type it has open,
and a modal editing one type has no use for one. The service keeps its set and
calls these for the data half -- which is why `addProp` returns the key it added
rather than a boolean, since the caller cannot expand a row for a key that was
never created.

How this is known to be safe
-----------------------------

`space-schema-tab.component.spec.ts` already exists as a characterization net --
it was written before an earlier redesign for exactly this purpose. The full
client suite is green (958 -> 972 tests), which is the evidence that delegating
changed nothing observable.

The 14 new tests are what the extraction buys: these rules previously needed a
settings-page TestBed to assert that a duplicate property key is refused. Two of
them pin behaviour that is easy to lose in a rewrite --

  - the pending input is cleared even when the key is REFUSED, because a
    rejected duplicate left in the box reads as "the button did nothing";
  - a typed "4" does not duplicate a stored 4, because the input is text and the
    stored value may be a number, and a strict compare would grow a list with
    two entries that look identical and that no record could satisfy twice.

preflight green.
