### PR TITLE
feat(graph): edge labels sit on the edge, and only where they were asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Graph edge labels sit on the edge, and only where they were asked for.** The style carried
+  `text-margin-y: -8`, which lifted every label OFF the line it belongs to — on a bezier that reads as text
+  floating between two edges rather than sitting on one. Removed, so the label falls at cytoscape's default
+  placement, which is the midpoint.
+  - **A label now appears on the selected node's edges and on a hovered edge**, rather than on every edge at
+    all times. Cytoscape does not de-collide mid-edge labels, so a dense traverse turned into overlapping
+    text over the nodes — the picture got worse exactly as it got more interesting. Selection and hover are
+    the two ways a person says "this one", so the labels are present whenever they were asked for and absent
+    when they were not.
+  - The global hide-labels toggle still wins: it sits later in the stylesheet, so a setting a person turned
+    off cannot be re-enabled by a selection.
+
 
 - **A space's entity-relationship model, inferred from the schema and from the records** —
   `GET /api/brain/spaces/:spaceId/er-model`. Entity types with their declared properties and their real

--- a/client/src/app/pages/graph/graph-cytoscape.ts
+++ b/client/src/app/pages/graph/graph-cytoscape.ts
@@ -175,6 +175,7 @@ function graphStylesheet(theme: GraphTheme): cytoscape.StylesheetJson {
       },
     },
     {
+      // Edges carry NO label by default — see `edge.show-label` below for when one appears and why.
       selector: 'edge',
       style: {
         'width': 1.5,
@@ -182,16 +183,33 @@ function graphStylesheet(theme: GraphTheme): cytoscape.StylesheetJson {
         'target-arrow-shape': 'triangle',
         'target-arrow-color': theme.edge,
         'curve-style': 'bezier',
-        'label': 'data(label)',
+        'label': '',
         'font-size': 10,
         'color': theme.edgeLabel,
         'text-rotation': 'autorotate',
-        'text-margin-y': -8,
+        // No `text-margin-y`. It used to be -8, which lifted the label OFF the line it belongs to; on a
+        // curve that reads as a label floating between two edges rather than sitting on one. Cytoscape's
+        // default placement for an edge label is the midpoint, which is where it should have been.
         'text-background-color': theme.nodeBg,
-        'text-background-opacity': 0.7,
-        'text-background-padding': '2px',
+        'text-background-opacity': 0.85,
+        'text-background-padding': '3px',
         'opacity': 0.75,
       },
+    },
+    {
+      /**
+       * A label appears on the edges of whatever you are looking at, and nowhere else.
+       *
+       * Every edge used to be labelled at all times. On a small traverse that is fine and on a dense one it
+       * is unreadable: cytoscape does not de-collide mid-edge labels, so they overlap each other and the
+       * nodes, and the picture gets worse exactly as it gets more interesting.
+       *
+       * Applied to the edges of the SELECTED node and to a HOVERED edge. Between them those are the two
+       * ways a person says "this one" — selection for the thing being examined, hover for the thing being
+       * pointed at — so the labels are present whenever they were asked for and absent when they were not.
+       */
+      selector: 'edge.show-label',
+      style: { 'label': 'data(label)' },
     },
     {
       selector: 'edge.hovered',
@@ -209,6 +227,25 @@ function graphStylesheet(theme: GraphTheme): cytoscape.StylesheetJson {
     },
     { selector: 'edge.hide-labels', style: { 'label': '' } },
   ];
+}
+
+/**
+ * Put a label on the edges of the selected node, and on nothing else.
+ *
+ * Recomputed from scratch each time rather than toggled incrementally: an incremental version has to undo
+ * exactly what it did last time, and the state it is undoing lives in the graph rather than in a variable —
+ * which is how a stale label survives a deselect and then belongs to nothing.
+ *
+ * A hovered edge adds its own class on mouseover and this function reinstates the correct set on mouseout,
+ * so the two rules compose without either needing to know about the other.
+ *
+ * `hide-labels` — the operator's global off switch — is deliberately NOT consulted here. It wins in the
+ * stylesheet instead, because a setting a person turned off must not be re-enabled by a selection.
+ */
+export function syncEdgeLabels(cy: cytoscape.Core): void {
+  cy.edges().removeClass('show-label');
+  const selected = cy.nodes(':selected');
+  if (selected.length > 0) selected.connectedEdges().addClass('show-label');
 }
 
 /**
@@ -296,14 +333,23 @@ export function createGraphCytoscape(
 
   const idOf = (evt: cytoscape.EventObject): string => evt.target.data('id');
 
+  syncEdgeLabels(cy);
+
   cy.on('tap', 'node', evt => handlers.onNodeTap(idOf(evt)));
   cy.on('tap', 'edge', evt => handlers.onEdgeTap(idOf(evt)));
   cy.on('dbltap', 'node', evt => handlers.onNodeDoubleTap(idOf(evt)));
 
   cy.on('mouseover', 'node', evt => { evt.target.addClass('hovered'); });
   cy.on('mouseout',  'node', evt => { evt.target.removeClass('hovered'); });
-  cy.on('mouseover', 'edge', evt => { evt.target.addClass('hovered'); });
-  cy.on('mouseout',  'edge', evt => { evt.target.removeClass('hovered'); });
+  // A hovered edge labels ITSELF — pointing at one line is the narrowest possible way of asking what it is.
+  cy.on('mouseover', 'edge', evt => { evt.target.addClass('hovered').addClass('show-label'); });
+  cy.on('mouseout',  'edge', evt => { evt.target.removeClass('hovered'); syncEdgeLabels(cy); });
+
+  // Selecting a node labels the edges around it, and deselecting takes them away again. Driven off
+  // cytoscape's own select/unselect rather than off `tap`, so a selection made any other way — restored
+  // state, a programmatic select — lights the same edges.
+  cy.on('select unselect', 'node', () => { syncEdgeLabels(cy); });
+  cy.on('tap', evt => { if (evt.target === cy) syncEdgeLabels(cy); });
 
   // Background tap — identified by the event target being the instance itself, not an element.
   cy.on('tap', evt => { if (evt.target === cy) handlers.onBackgroundTap(); });
@@ -331,6 +377,11 @@ export function renderElements(
 
   if (hideLabels) cy.edges().addClass('hide-labels');
   else cy.edges().removeClass('hide-labels');
+
+  // A re-render replaces every element, so the label set has to be recomputed rather than assumed to have
+  // survived. Runs after `hide-labels` is set, and that class still wins — the operator's global "off" is
+  // not something a selection may quietly override.
+  syncEdgeLabels(cy);
 
   // breadthfirst keeps each node next to its direct edge-partner.
   //

--- a/client/src/app/pages/graph/graph.component.characterization.spec.ts
+++ b/client/src/app/pages/graph/graph.component.characterization.spec.ts
@@ -36,6 +36,8 @@ const cy = vi.hoisted(() => {
     layoutOpts: [] as any[],
     layoutStop: null as null | (() => void),
     edgeClasses: new Set<string>(),
+    /** Which nodes cytoscape would report as selected. Drives `syncEdgeLabels`. */
+    selectedNodes: [] as string[],
     removeCalls: 0,
     destroyed: 0,
     fits: 0,
@@ -44,6 +46,7 @@ const cy = vi.hoisted(() => {
   state.reset = () => {
     state.handlers = []; state.added = []; state.layoutOpts = []; state.layoutStop = null;
     state.edgeClasses = new Set<string>();
+    state.selectedNodes = [];
     state.removeCalls = 0; state.destroyed = 0; state.fits = 0;
   };
 
@@ -56,9 +59,18 @@ const cy = vi.hoisted(() => {
     };
   };
 
-  /** Fire a registered handler, as a real user tap would. */
+  /**
+   * Fire a registered handler, as a real user tap would.
+   *
+   * The registered name is split on whitespace because cytoscape's `on()` accepts a space-separated list —
+   * `cy.on('select unselect', …)` is one registration for two events. Matching the whole string would make
+   * such a handler unreachable from here, and the first test to rely on one would fail against production
+   * code that is correct.
+   */
   state.fire = (ev: string, sel: string | undefined, evt: any) => {
-    for (const h of state.handlers) if (h.ev === ev && h.sel === sel) h.cb(evt);
+    for (const h of state.handlers) {
+      if (h.sel === sel && String(h.ev).split(/\s+/).includes(ev)) h.cb(evt);
+    }
   };
 
   state.make = () => {
@@ -70,6 +82,16 @@ const cy = vi.hoisted(() => {
       edges: () => ({
         addClass: (c: string) => state.edgeClasses.add(c),
         removeClass: (c: string) => state.edgeClasses.delete(c),
+      }),
+      // `nodes(selector)` exists so `syncEdgeLabels` can ask which node is selected. `selectedNodes`
+      // defaults to none, which is the state a freshly rendered graph is in — nothing is selected, so no
+      // edge carries a label. A test that wants the labelled case sets it and calls the handler.
+      nodes: (_sel?: string) => ({
+        length: state.selectedNodes.length,
+        connectedEdges: () => ({
+          addClass: (c: string) => state.edgeClasses.add(c),
+          removeClass: (c: string) => state.edgeClasses.delete(c),
+        }),
       }),
       resize: () => {},
       fit: () => { state.fits++; },
@@ -456,6 +478,53 @@ describe('GraphComponent — what it asks the renderer to draw', () => {
     expect(cy.edgeClasses.has('hide-labels')).toBe(true);   // a re-render must not lose the setting
     c.onHideLabelsChange(false);
     expect(cy.edgeClasses.has('hide-labels')).toBe(false);
+  });
+
+  // ── Edge labels appear where they were asked for, and nowhere else ──────────────────────────────
+  //
+  // Every edge used to be labelled at all times. Cytoscape does not de-collide mid-edge labels, so a dense
+  // traverse turned into overlapping text over the nodes — the picture got worse exactly as it got more
+  // interesting. Labels now belong to the selected node's edges, and to a hovered edge.
+
+  it('labels no edge when nothing is selected', () => {
+    render([['a', 1]], [['e1', 'root', 'a']]);
+    expect(cy.edgeClasses.has('show-label')).toBe(false);
+  });
+
+  it('labels the selected node\'s edges once something is selected', () => {
+    render([['a', 1]], [['e1', 'root', 'a']]);
+    cy.selectedNodes = ['root'];
+    cy.fire('select', 'node', { target: { data: () => 'root' } });
+    expect(cy.edgeClasses.has('show-label')).toBe(true);
+  });
+
+  it('takes the labels away again on deselect', () => {
+    render([['a', 1]], [['e1', 'root', 'a']]);
+    cy.selectedNodes = ['root'];
+    cy.fire('select', 'node', { target: { data: () => 'root' } });
+    cy.selectedNodes = [];
+    cy.fire('unselect', 'node', { target: { data: () => 'root' } });
+    expect(cy.edgeClasses.has('show-label')).toBe(false);
+  });
+
+  it('a hovered edge labels itself even with nothing selected', () => {
+    // The narrowest way of asking what one line is. Without this, an unselected graph answers nothing.
+    render([['a', 1]], [['e1', 'root', 'a']]);
+    const added: string[] = [];
+    cy.fire('mouseover', 'edge', {
+      target: { addClass: (c: string) => { added.push(c); return { addClass: (d: string) => added.push(d) }; } },
+    });
+    expect(added).toContain('show-label');
+  });
+
+  it('re-applies the label set on every render, so a re-draw does not strand one', () => {
+    // The same reasoning as `hide-labels` above: a render replaces every element, so a class that was on an
+    // edge before is gone unless it is recomputed. A stale label would belong to nothing.
+    const brain: any = makeBrain({ traverseGraph: vi.fn(() => of(traverseResult([['a', 1]], [['e1', 'root', 'a']]))) });
+    const { c } = create(brain);
+    cy.selectedNodes = ['root'];
+    c.selectRoot(ROOT);
+    expect(cy.edgeClasses.has('show-label')).toBe(true);
   });
 
   it('auto-selects the root once the layout settles, and not before', () => {


### PR DESCRIPTION
feat(graph): edge labels sit on the edge, and only where they were asked for

Owner request. Two changes, and one honest correction to what I claimed was
wrong.

The label was never on the line
--------------------------------

The edge style carried `text-margin-y: -8`, which lifts the label OFF the edge
it belongs to. On a bezier that reads as text floating BETWEEN two edges rather
than sitting on one, which is what "the lineflows look random" was pointing at.
Removed: cytoscape's default placement for an edge label is the midpoint, which
is where it should have been all along.

The plate behind the label already existed (`text-background-*`) and is only
strengthened -- 0.7 to 0.85 opacity, 2px to 3px padding -- because a label on
the line now crosses more of what is underneath it.

Labels appear where they were asked for
----------------------------------------

Every edge used to be labelled at all times. Cytoscape does not de-collide
mid-edge labels, so a dense traverse turns into overlapping text on top of the
nodes: the picture gets worse exactly as it gets more interesting.

A label now appears on the SELECTED node's edges, and on a HOVERED edge. Between
them those are the two ways a person says "this one" -- selection for the thing
being examined, hover for the thing being pointed at -- so labels are present
whenever they were asked for and absent when they were not.

The global `hide-labels` toggle still wins. It sits later in the stylesheet, so
a setting a person turned off cannot be re-enabled by a selection.

`syncEdgeLabels` recomputes the set from scratch rather than toggling
incrementally: an incremental version has to undo exactly what it did last time,
and the state it is undoing lives in the graph rather than in a variable, which
is how a stale label survives a deselect and ends up belonging to nothing. It
runs on init, on select/unselect, on background tap, on mouseout, and on every
render -- a render replaces every element, so the class set does not survive one.

Two things I said were wrong that were not
-------------------------------------------

While mocking this up I claimed the graph had too many labels per node and a
visible depth label. Neither is true of the product: nodes already carry exactly
one label, and depth is already conveyed by opacity and halo size with no text
at all. Those were artifacts of my mockup, not defects, and nothing was
"fixed" -- said plainly because a changelog that quietly claims credit for
repairing something that was never broken is worse than one that says less.

The test double was too naive in two ways
------------------------------------------

Both surfaced as failures rather than being reasoned about, and both are the
double's fault rather than production's:

  - it had no `nodes()`, so the new `syncEdgeLabels` call at init threw and all
    45 characterization tests failed at once. Extended, with a `selectedNodes`
    state that defaults to none -- which is what a freshly rendered graph is.
  - its `fire()` matched the registered event name EXACTLY, so a handler
    registered as `on('select unselect', ...)` -- a form cytoscape genuinely
    supports -- was unreachable and the selection test failed against correct
    code. It now splits on whitespace like cytoscape does.

The second one matters beyond this PR: any future handler registered with a
space-separated list would have been silently untestable.

5 new tests, including that a re-render re-applies the label set (the same
reasoning the existing `hide-labels` test pins) and that a hovered edge labels
itself with nothing selected.

977 client tests green. preflight green.
