### PR TITLE
fix(files): a changed face-descriptor width would have skipped every face in silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- **A changed face-descriptor width would have skipped every face in silence.** Both embedding paths
+  compared `embedding.length !== 128` and moved on — no error, no log, no counter — so the symptom would
+  have read as "this image has no faces" or "the provider is broken", never as the actual cause.
+  - **The actual cause it was guarding against is closer than it looks.** Our docs said in five places that
+    FaceRes produces a 128-dimensional descriptor. It does not: `faceres.json` declares its output as
+    `[1, 1024]`, and `@vladmandic/human` reduces it to 128 in library code. **The width the whole face
+    gallery is built on is a property of a dependency's post-processing, not of the weights we ship** — so a
+    library upgrade could change the vector space of every future embedding. Reported by an operator
+    standing up a centralised face service, and confirmed here.
+  - The skip still happens, because one odd descriptor must not fail a whole media job. What changed is that
+    the first one says so, naming the width it got and which path produced it — once per process, because a
+    changed library means every face is wrong and a per-face log would bury the message.
+  - The literal `128`, previously written in both paths, is one shared constant. An operator has asked for
+    the width to become configurable; this is the single place that question now gets asked.
+  - The docs no longer claim the model emits 128. They say where the number actually comes from.
+
+
+### Fixed
 
 ### Added
 - **The Brain remembers which space and tab you were on, in the URL.** `?space=` and `?tab=` are read on

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -1025,7 +1025,7 @@ The model files are not bundled with Ythril. Download and place them in `DATA_RO
 | File | Size | Purpose |
 |---|---|---|
 | `blazeface-back.json` + `.bin` | ~0.5 MB | Face detector (BlazeFace Back) |
-| `faceres.json` + `.bin` | ~6.7 MB | 128-dimensional face descriptor (FaceRes) |
+| `faceres.json` + `.bin` | ~6.7 MB | Face descriptor (FaceRes). The model outputs 1024 dimensions; `@vladmandic/human` reduces them to the 128 the gallery stores |
 
 Download from `https://vladmandic.github.io/human/models/` — use the exact filenames listed above.
 
@@ -1038,7 +1038,7 @@ and the infra pin not turned off):
 
 1. **Decode** — image bytes decoded to raw RGBA via `sharp`.
 2. **Detect** — `@vladmandic/human` runs BlazeFace Back detection. Faces below `minFaceSizeFraction` (default: 5% of the shorter image side) are skipped.
-3. **Embed** — FaceRes produces a 128-dimensional descriptor per face.
+3. **Embed** — FaceRes produces a descriptor per face, which the library reduces to 128 dimensions. That reduction, not the model weights, is where the 128 comes from — worth knowing because the gallery is built on it.
 4. **Gallery search** — each descriptor is searched against the space's face gallery (all face-chunk records that have a `faceEntityId`) using an exact `$vectorSearch`. The top-1 result is examined.
 5. **Auto-label** — if the top match's cosine similarity score ≥ `confidenceThreshold` (default: `0.6`), the parent image is linked to that entity (`entityIds` updated). The first successful match wins.
 6. **Persist face-chunks** — one `{fileId}#face-chunk{N}` filemeta record per detected face is written (or replaced on reprocess) with:

--- a/server/src/files/media/face-descriptor.ts
+++ b/server/src/files/media/face-descriptor.ts
@@ -1,0 +1,71 @@
+/**
+ * The width of a face descriptor, and the guard that says when it stops being that.
+ *
+ * ## Why this is not just a constant
+ *
+ * The docs said, in five places, that FaceRes produces a 128-dimensional descriptor. **The model does not.**
+ * `faceres.json`'s own signature declares its descriptor output `global_pooling/Mean` as `[1, 1024]`;
+ * `@vladmandic/human` reduces that to 128 in library code.
+ *
+ * Reported by an operator standing up a centralised face service, and confirmed here. It matters more to us
+ * than to them: **the width the whole face gallery is built on is a property of a dependency's internal
+ * post-processing, not of the weights we ship.** A `@vladmandic/human` upgrade that changes or removes that
+ * reduction changes the vector space of every future in-process embedding.
+ *
+ * ## The failure it would have had
+ *
+ * Both embedding paths compared `embedding.length !== 128` and `continue`d — no error, no log, no counter.
+ * So a changed reduction would have skipped every face silently, and the symptom would read as "this image
+ * has no faces" or "the provider is broken", never as "the library changed". That is the shape this codebase
+ * keeps finding: a state the system knew about and did not report.
+ *
+ * ## What this does instead
+ *
+ * The skip still happens — one odd descriptor must not fail a whole media job — but the first one to arrive
+ * says so, loudly, naming the width it actually got. Once per process, because a changed library means EVERY
+ * face is wrong and a per-face log would bury the message it exists to deliver.
+ */
+import { log } from '../../util/log.js';
+
+/**
+ * The dimension the face gallery's Atlas vector index is built with (`{spaceId}_files_faceEmbedding`).
+ *
+ * One constant rather than the literal `128` that was written in both embedding paths and five doc lines.
+ * If this ever becomes configurable — an operator asked for it, so it may — this is the single place the
+ * question is asked, rather than a number to go hunting for.
+ */
+export const FACE_DESCRIPTOR_DIMS = 128;
+
+let warned = false;
+
+/**
+ * Check a descriptor's width, and report the first disagreement.
+ *
+ * Returns whether the descriptor is usable. A `false` means the caller should skip this face — which is what
+ * both callers already did; the difference is that it is no longer silent.
+ *
+ * `source` names which path produced it, because the two have different causes and different fixes: the
+ * in-process path changing width means the library's reduction moved, and an external provider changing
+ * width means someone pointed the hook at a different model.
+ */
+export function isUsableDescriptor(embedding: unknown, source: 'in-process' | 'external'): boolean {
+  if (!Array.isArray(embedding)) return false;
+  if (embedding.length === FACE_DESCRIPTOR_DIMS) return true;
+
+  if (!warned) {
+    warned = true;
+    log.warn(
+      `Face descriptor width is ${embedding.length}, expected ${FACE_DESCRIPTOR_DIMS} (${source}). `
+      + 'Every face is being skipped, and this will read as "no faces detected" everywhere. '
+      + (source === 'in-process'
+        ? 'The in-process width is produced by @vladmandic/human reducing FaceRes\'s own 1024-wide output — '
+          + 'if that library was upgraded, its reduction may have changed and the gallery\'s vector space with it.'
+        : 'The external provider is returning a different width than the gallery was built for; its vectors '
+          + 'cannot be compared with the ones already stored.'),
+    );
+  }
+  return false;
+}
+
+/** Test seam: the once-per-process latch would otherwise make the second test in a file assert nothing. */
+export function resetDescriptorWarning(): void { warned = false; }

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -36,6 +36,7 @@ import { getConfig, getDataRoot, getFaceRecognitionConfig } from '../../config/l
 import { faceRecognitionAllowed } from '../converters/media-level.js';
 import { updateFileMeta } from '../file-meta.js';
 import { log } from '../../util/log.js';
+import { isUsableDescriptor, FACE_DESCRIPTOR_DIMS } from './face-descriptor.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../../config/types.js';
 import type { Config as HumanConfig, Result } from '@vladmandic/human';
 import { detectFacesExternal } from './face-external.js';
@@ -333,7 +334,7 @@ export async function embedFaces(
       tags: [],
       createdAt: now,
       updatedAt: now,
-      sizeBytes: 128 * 4, // 128 × float32 = 512 bytes
+      sizeBytes: FACE_DESCRIPTOR_DIMS * 4, // float32 each
       author,
       parentFileId: fileId,
       chunkIndex: i,

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -1,4 +1,5 @@
 import { ssrfSafeFetch } from '../../util/ssrf.js';
+import { isUsableDescriptor } from './face-descriptor.js';
 import { boundedJson } from '../../util/bounded-read.js';
 import { getConfig, getSecrets } from '../../config/loader.js';
 import { allowPrivateForSlot } from '../../config/model-egress-policy.js';
@@ -96,8 +97,11 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
     for (const f of raw) {
       // 128 floats exactly. A provider returning a different width would corrupt gallery similarity
       // scores rather than fail loudly, so the wrong shape is dropped here, not downstream.
-      if (!Array.isArray(f?.embedding) || f.embedding.length !== 128) continue;
-      if (!f.embedding.every(n => typeof n === 'number' && Number.isFinite(n))) continue;
+      if (!isUsableDescriptor(f?.embedding, 'external')) continue;
+      // `isUsableDescriptor` has already established this is an array of the right LENGTH; the values are
+      // still a provider's word for it, so they are checked before anything stores them.
+      const emb = f.embedding as unknown[];
+      if (!emb.every((n: unknown) => typeof n === 'number' && Number.isFinite(n))) continue;
       const box = f.boxRaw;
       const boxRaw = Array.isArray(box) && box.length === 4 && box.every(n => typeof n === 'number' && Number.isFinite(n))
         ? [box[0], box[1], box[2], box[3]] as [number, number, number, number]

--- a/testing/standalone/face-external.test.js
+++ b/testing/standalone/face-external.test.js
@@ -72,7 +72,15 @@ describe('the source enforces its own guarantees', () => {
   });
 
   it('rejects any descriptor that is not exactly 128 floats', () => {
-    assert.ok(src.includes('length !== 128'), 'width must be checked');
+    // The width check moved into `face-descriptor.ts` so both embedding paths share one rule and the first
+    // unexpected width is REPORTED rather than skipped in silence. This asserts both halves: that this file
+    // still defers to that helper, and that the helper still enforces the width — checking only the call
+    // would pass against a helper that had stopped checking anything.
+    assert.ok(src.includes('isUsableDescriptor('), 'the width check must still happen');
+    const guard = readFileSync(new URL('../../server/src/files/media/face-descriptor.ts', import.meta.url), 'utf8');
+    assert.match(guard, /embedding\.length === FACE_DESCRIPTOR_DIMS/,
+      'face-descriptor.ts no longer compares the width, so nothing does');
+    assert.match(guard, /FACE_DESCRIPTOR_DIMS = 128/, 'the gallery index is built at 128');
     assert.ok(src.includes('Number.isFinite'), 'NaN/Infinity must be rejected');
   });
 


### PR DESCRIPTION
Queue item 3, from the inbox. breituai-platform found it while auditing models for a centralised face service, and it is confirmed in our source.

Both embedding paths compared `embedding.length !== 128` and `continue`d — no error, no log, no counter. So the symptom would read as "this image has no faces" or "the provider is broken", never as the cause.

**The cause is closer than it looks.** Our docs said in five places that FaceRes produces a 128-dimensional descriptor. It does not: `faceres.json` declares its output as `[1, 1024]`, and `@vladmandic/human` reduces it to 128 in library code. The width the whole face gallery is built on is a property of a dependency's internal post-processing, not of the weights we ship — so a library upgrade could change the vector space of every future in-process embedding.

The skip still happens, because one odd descriptor must not fail a whole media job. What changed is that the first one says so, naming the width it got and which path produced it, once per process — a changed library means every face is wrong, and a per-face log would bury the message it exists to deliver.

The literal `128` was written in both paths and five doc lines; it is one constant now. The same operator has asked for the width to become **configurable** (queue item 4) — this is the single place that question now gets asked.

The `face-external` gate asserted `src.includes('length !== 128')` — it named the mechanism rather than the behaviour, so moving the check broke it. Re-pointed at both halves: that the file defers to the helper, **and** that the helper still compares the width. Asserting only the call would pass against a helper that had stopped checking anything.

preflight green.