### PR TITLE
refactor(files): the face index and the embedders share one width constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **The face vector index and the embedders now share one width.** The number was written three times — in
+  the index built at `initSpace`, and in each of the two embedding paths. They MUST agree: an index built at
+  one width with vectors written at another gives a cosine search that ranks nothing correctly **and reports
+  no error at all**. One constant now, gated so it stays one.
+  - This is the groundwork for making the width configurable, which an operator has asked for because every
+    top-tier open face recogniser emits 512 dimensions while the contract admits only 128 — so the hook that
+    exists for bringing a better model currently accepts only models in the bundled one's weight class.
+    Asking that question in three places would have been the problem; there is one place now.
+  - The remaining `128`s in comments claimed FaceRes emits that width. It emits 1024, and the library reduces
+    it. Corrected where they sat.
+
 
 - **A changed face-descriptor width would have skipped every face in silence.** Both embedding paths
   compared `embedding.length !== 128` and moved on — no error, no log, no counter — so the symptom would

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -3,12 +3,14 @@
  *
  * Uses @vladmandic/human with the CPU backend (pure JavaScript, no GPU, no
  * native TensorFlow bindings, no WASM file path configuration).
- * Model: BlazeFace Back (detection) + FaceRes (128d face descriptor).
+ * Model: BlazeFace Back (detection) + FaceRes (descriptor). FaceRes itself outputs 1024 dimensions;
  *
  * Pipeline per image:
+ * @vladmandic/human reduces them to the 128 the gallery stores — see face-descriptor.ts.
+ *
  *  1. Decode image bytes via sharp → raw RGBA pixel data + dimensions
  *  2. Create tf.Tensor3D via human.tf (bundled TF.js) from pixel data
- *  3. human.detect() → per-face {embedding (128d), boxRaw (normalised bbox)}
+ *  3. human.detect() → per-face {embedding (reduced to FACE_DESCRIPTOR_DIMS), boxRaw (normalised bbox)}
  *  4. For each detected face with a valid embedding:
  *     a. Gallery search: $vectorSearch (exact) on faceEmbedding index, post-
  *        match for faceEntityId, top-1
@@ -19,7 +21,7 @@
  *
  * Model files (NOT bundled — must be placed manually):
  *   DATA_ROOT/<modelPath>/blazeface-back.json + .bin  (~0.5 MB, detection)
- *   DATA_ROOT/<modelPath>/faceres.json + .bin          (~6.7 MB, 128d embed)
+ *   DATA_ROOT/<modelPath>/faceres.json + .bin          (~6.7 MB, 1024-wide, reduced to 128 by the library)
  *
  * Download from:
  *   https://vladmandic.github.io/human/models/blazeface-back.json

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -7,6 +7,7 @@
  * lifecycle; spaces.ts calls in, not the other way round.
  */
 import { getDb, asDoc } from '../db/mongo.js';
+import { FACE_DESCRIPTOR_DIMS } from '../files/media/face-descriptor.js';
 import { getConfig, mutateConfig, getEmbeddingConfig, getFaceRecognitionConfig } from '../config/loader.js';
 import { resolveMetaRefs } from './schema-validation.js';
 import { log } from '../util/log.js';
@@ -475,7 +476,11 @@ export async function buildSpaceVectorIndexes(
   }
   const faceCfg = getFaceRecognitionConfig();
   if (faceCfg.enabled) {
-    await ensureVectorSearchIndex(spaceId, 'files', 128, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady, undefined, opts);
+    // The width comes from the same constant the embedders check against. It was a literal here and a
+    // literal in each embedding path — three copies of a number that MUST agree, because an index built at
+    // one width and vectors written at another produce a cosine search that silently ranks nothing
+    // correctly. One copy now, which is also the precondition for making it configurable.
+    await ensureVectorSearchIndex(spaceId, 'files', FACE_DESCRIPTOR_DIMS, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady, undefined, opts);
   }
 }
 

--- a/testing/standalone/face-external.test.js
+++ b/testing/standalone/face-external.test.js
@@ -84,6 +84,17 @@ describe('the source enforces its own guarantees', () => {
     assert.ok(src.includes('Number.isFinite'), 'NaN/Infinity must be rejected');
   });
 
+  it('the vector index is built at the width the embedders check against', () => {
+    // Three copies of this number used to exist: the index, and each embedding path. They MUST agree — an
+    // index built at one width with vectors written at another gives a cosine search that ranks nothing
+    // correctly and reports no error at all. One constant now, and this is what keeps it one.
+    const idx = readFileSync(new URL('../../server/src/spaces/vector-index.ts', import.meta.url), 'utf8');
+    assert.match(idx, /'faceEmbedding'/, 'the face index is gone from vector-index.ts — re-point this');
+    assert.ok(idx.includes('FACE_DESCRIPTOR_DIMS'),
+      'the face index writes its own width instead of reading the constant the embedders enforce');
+    assert.ok(!idx.includes("'files', 128,"), 'the face index width is a literal again');
+  });
+
   it('caps how many faces a provider can return', () => {
     assert.ok(src.includes('MAX_FACES'), 'an unbounded provider response must be capped');
   });


### PR DESCRIPTION
Groundwork for queue item 4 (make the face-descriptor width configurable), done as its own step because the precondition is worth landing on its own.

The width was written **three times**: the index built at `initSpace`, and each of the two embedding paths. They must agree — an index built at one width with vectors written at another gives a cosine search that ranks nothing correctly **and reports no error at all**. That is the same silent-failure family as the descriptor skip fixed in #744.

One constant now, and a gate keeps it one. Mutation-checked: restoring the literal in `vector-index.ts` fails by name.

Why this comes before the configurability itself: the operator's case is that every top-tier open recogniser emits 512 dimensions while our contract admits only 128, so the hook that exists for bringing a better model accepts only models in the bundled one's weight class. Making that width a question the system asks **once** is the precondition; asking it in three places would have been the bug.

The remaining `128`s in comments claimed FaceRes emits that width. It emits 1024 and `@vladmandic/human` reduces it — corrected where they sat.

preflight green.