### PR TITLE
fix(files): the in-process face path never got the fix its own file documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The face vector index and the embedders now share one width.** The number was written three times — in
   the index built at `initSpace`, and in each of the two embedding paths. They MUST agree: an index built at
   one width with vectors written at another gives a cosine search that ranks nothing correctly **and reports
-  no error at all**. One constant now, gated so it stays one.
+  no error at all**. One constant now, gated so it stays one — see the entry below for the copy this first
+  pass left behind, which is why the gate now discovers the paths rather than naming them.
   - This is the groundwork for making the width configurable, which an operator has asked for because every
     top-tier open face recogniser emits 512 dimensions while the contract admits only 128 — so the hook that
     exists for bringing a better model currently accepts only models in the bundled one's weight class.
@@ -31,9 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The skip still happens, because one odd descriptor must not fail a whole media job. What changed is that
     the first one says so, naming the width it got and which path produced it — once per process, because a
     changed library means every face is wrong and a per-face log would bury the message.
-  - The literal `128`, previously written in both paths, is one shared constant. An operator has asked for
-    the width to become configurable; this is the single place that question now gets asked.
+  - The literal `128` becomes one shared constant. An operator has asked for the width to become configurable;
+    this is the single place that question now gets asked. **Only the external path was actually converted —
+    the entry below finishes it.**
   - The docs no longer claim the model emits 128. They say where the number actually comes from.
+
+
+- **The in-process face path kept skipping wrong-width descriptors in silence.** The change above was
+  believed to cover both embedding paths, and said so. It covered one. The in-process path — the one that
+  runs on every default install, because the external provider is opt-in — kept its own
+  `embedding.length !== 128` and kept dropping faces with no error, no log and no counter. It now goes
+  through the same guard, so the first unexpected width is reported and names which path produced it.
+  - Two comments still told operators that FaceRes emits a 128-wide descriptor. It emits 1024 and the
+    library reduces it; a reader trusting those comments would look for a width change in the wrong place.
+  - **Nothing disagreed with the incomplete fix**, which is the part worth recording. The file's own
+    documentation said both paths were converted, and the test asserting it read a single file — it stated a
+    two-path property while checking one, so it went green on exactly the half that was done. The
+    replacement discovers every face-vector writer from `git ls-files` and requires each to consult the
+    guard, so a path that is added or missed fails rather than going unmentioned.
 
 
 ### Fixed

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -1039,6 +1039,7 @@ and the infra pin not turned off):
 1. **Decode** — image bytes decoded to raw RGBA via `sharp`.
 2. **Detect** — `@vladmandic/human` runs BlazeFace Back detection. Faces below `minFaceSizeFraction` (default: 5% of the shorter image side) are skipped.
 3. **Embed** — FaceRes produces a descriptor per face, which the library reduces to 128 dimensions. That reduction, not the model weights, is where the 128 comes from — worth knowing because the gallery is built on it.
+   - **A descriptor of any other width is skipped, and the first one is logged as a warning** naming the width received and which path produced it (in-process or external). One odd descriptor must not fail a whole media job, so the skip itself is not an error; the log is once per process, because a changed width means every face is affected and a per-face log would bury the message. If face recognition appears to find nothing, check for this warning before concluding the images have no faces — that is the symptom a width mismatch produces.
 4. **Gallery search** — each descriptor is searched against the space's face gallery (all face-chunk records that have a `faceEntityId`) using an exact `$vectorSearch`. The top-1 result is examined.
 5. **Auto-label** — if the top match's cosine similarity score ≥ `confidenceThreshold` (default: `0.6`), the parent image is linked to that entity (`entityIds` updated). The first successful match wins.
 6. **Persist face-chunks** — one `{fileId}#face-chunk{N}` filemeta record per detected face is written (or replaced on reprocess) with:

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -94,7 +94,9 @@ async function getHuman(): Promise<HumanInstance> {
         iris: { enabled: false },
         description: {
           enabled: true,
-          modelPath: 'faceres.json', // FaceRes — 128d descriptor; age/gender computed here too
+          // FaceRes emits a 1024-wide descriptor; the library reduces it to FACE_DESCRIPTOR_DIMS before we
+          // ever see it. Age/gender are computed here too.
+          modelPath: 'faceres.json',
           minConfidence: 0.0,
           skipFrames: 0,
         },
@@ -151,7 +153,7 @@ export async function labelStillResolves(spaceId: string, entityId: string): Pro
 
 /**
  * Search the face gallery (labeled face-chunk records in the space) for the
- * closest match to the given 128d descriptor.
+ * closest match to the given descriptor, which is FACE_DESCRIPTOR_DIMS wide.
  *
  * Uses exact-mode $vectorSearch so all gallery entries are considered, then
  * a post-match filter for faceEntityId to restrict to labeled faces only.
@@ -301,7 +303,9 @@ export async function embedFaces(
     const face = faces[i]!;
 
     const embedding: number[] | undefined = face.embedding;
-    if (!embedding || embedding.length !== 128) continue; // FaceRes not run / failed
+    // Absent means FaceRes did not run for this face — routine, and not what the width guard is about.
+    // Present-but-wrong-width is the case that must not stay quiet, so it goes through the shared guard.
+    if (!embedding || !isUsableDescriptor(embedding, 'in-process')) continue;
 
     // Filter by minimum face size (fraction of shorter image side)
     const boxRaw = face.boxRaw; // [x, y, w, h] normalised 0–1

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -7,7 +7,7 @@ import { log } from '../../util/log.js';
 
 /** One detected face, in exactly the shape the in-process recogniser produces. */
 export interface ExternalFace {
-  /** 128-d descriptor. Anything else is rejected — the gallery's cosine search assumes this width. */
+  /** FACE_DESCRIPTOR_DIMS wide. Anything else is rejected — the gallery's cosine search assumes this width. */
   embedding: number[];
   /** `[x, y, w, h]`, normalised 0–1, like `human`'s `boxRaw`. Optional: only used for the size filter. */
   boxRaw?: [number, number, number, number];
@@ -95,8 +95,9 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
 
     const faces: ExternalFace[] = [];
     for (const f of raw) {
-      // 128 floats exactly. A provider returning a different width would corrupt gallery similarity
-      // scores rather than fail loudly, so the wrong shape is dropped here, not downstream.
+      // Exactly as many floats as the gallery's index was built with. A provider returning a different width
+      // would corrupt gallery similarity scores rather than fail loudly, so the wrong shape is dropped here,
+      // not downstream.
       if (!isUsableDescriptor(f?.embedding, 'external')) continue;
       // `isUsableDescriptor` has already established this is an array of the right LENGTH; the values are
       // still a provider's word for it, so they are checked before anything stores them.

--- a/testing/standalone/face-external.test.js
+++ b/testing/standalone/face-external.test.js
@@ -72,10 +72,15 @@ describe('the source enforces its own guarantees', () => {
   });
 
   it('rejects any descriptor that is not exactly 128 floats', () => {
-    // The width check moved into `face-descriptor.ts` so both embedding paths share one rule and the first
-    // unexpected width is REPORTED rather than skipped in silence. This asserts both halves: that this file
-    // still defers to that helper, and that the helper still enforces the width — checking only the call
-    // would pass against a helper that had stopped checking anything.
+    // The width check moved into `face-descriptor.ts` so the first unexpected width is REPORTED rather than
+    // skipped in silence. This asserts both halves for THIS path: that the file still defers to the helper,
+    // and that the helper still enforces the width — checking only the call would pass against a helper that
+    // had stopped checking anything.
+    //
+    // Scope, because this comment used to overstate it: these assertions cover the EXTERNAL path only. They
+    // once claimed "both embedding paths share one rule" while reading a single file, and the in-process path
+    // kept its own `!== 128` literal underneath that claim for a full release. The cross-path property lives
+    // in `face-width-is-never-a-literal.test.js`, which discovers the paths instead of naming them.
     assert.ok(src.includes('isUsableDescriptor('), 'the width check must still happen');
     const guard = readFileSync(new URL('../../server/src/files/media/face-descriptor.ts', import.meta.url), 'utf8');
     assert.match(guard, /embedding\.length === FACE_DESCRIPTOR_DIMS/,
@@ -87,7 +92,9 @@ describe('the source enforces its own guarantees', () => {
   it('the vector index is built at the width the embedders check against', () => {
     // Three copies of this number used to exist: the index, and each embedding path. They MUST agree — an
     // index built at one width with vectors written at another gives a cosine search that ranks nothing
-    // correctly and reports no error at all. One constant now, and this is what keeps it one.
+    // correctly and reports no error at all. This keeps the INDEX copy honest; the two embedding copies are
+    // kept honest by `face-width-is-never-a-literal.test.js`. Splitting that out is deliberate — asserting
+    // the three-way property here, where only the index is read, is how the third copy survived unnoticed.
     const idx = readFileSync(new URL('../../server/src/spaces/vector-index.ts', import.meta.url), 'utf8');
     assert.match(idx, /'faceEmbedding'/, 'the face index is gone from vector-index.ts — re-point this');
     assert.ok(idx.includes('FACE_DESCRIPTOR_DIMS'),

--- a/testing/standalone/face-width-is-never-a-literal.test.js
+++ b/testing/standalone/face-width-is-never-a-literal.test.js
@@ -1,0 +1,119 @@
+/**
+ * Every face-descriptor width decision goes through the shared guard — no path compares against a literal.
+ *
+ * ## The defect this closes
+ *
+ * `face-descriptor.ts` was added to end a silent skip: both embedding paths compared `embedding.length !== 128`
+ * and `continue`d with no error, no log and no counter, so a changed descriptor width would read as "this image
+ * has no faces" forever. It introduced `FACE_DESCRIPTOR_DIMS` and `isUsableDescriptor`, and its own doc says the
+ * constant replaced "the literal `128` that was written in both embedding paths".
+ *
+ * **Only one path was converted.** The external one got `isUsableDescriptor`; the in-process one kept
+ * `embedding.length !== 128` and kept skipping silently — in the same file that imports the guard, under a
+ * comment describing the fix. The half that was left behind is the half that runs on every default install,
+ * because the external provider is opt-in.
+ *
+ * That is why this is a gate and not a single assertion. The first fix was believed complete, the file's own
+ * documentation asserted it was complete, and nothing disagreed.
+ *
+ * ## Why it is asserted on the source
+ *
+ * The runtime behaviour — a wrong-width descriptor is skipped AND announced — is covered by the guard's own
+ * unit tests. What cannot be observed at runtime is a *third* path appearing that never consults the guard at
+ * all: it would simply behave like the code did before, which is to say it would look like nothing is wrong.
+ * So the property pinned here is structural: anything that stores a face vector must reference the guard, and
+ * nothing may re-derive the width from a number.
+ *
+ * Comments are stripped first, in both directions. The width is discussed in prose all over these files, so an
+ * assertion that reads comments would fail on the explanation of the fix — and, worse, a "must mention the
+ * guard" check would PASS on a comment merely naming it.
+ *
+ * Run: node --test testing/standalone/face-width-is-never-a-literal.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/** The one file allowed to write the number down. */
+const GUARD = 'server/src/files/media/face-descriptor.ts';
+
+/**
+ * Discovered, not listed. A hand-written list of embedding paths is exactly what failed here: the list had two
+ * entries, one was fixed, and the file's documentation counted it as both.
+ */
+function mediaSources() {
+  return execFileSync('git', ['ls-files', 'server/src/files/media'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.endsWith('.ts') && !l.endsWith('.spec.ts'));
+}
+
+describe('face descriptor width is never a literal', () => {
+  it('finds the media sources it is meant to be checking', () => {
+    const files = mediaSources();
+    // A gate that enumerates nothing passes vacuously, and would keep passing if the directory were renamed.
+    assert.ok(files.length >= 3, `expected several media sources, found ${files.length}: ${files.join(', ')}`);
+    assert.ok(files.includes(GUARD), `the guard itself must be among the enumerated sources, got ${files.join(', ')}`);
+  });
+
+  it('every path that stores a face vector consults the guard', () => {
+    const writers = mediaSources().filter((f) => {
+      const code = withoutComments(read(f));
+      return f !== GUARD && /faceEmbedding\s*:/.test(code);
+    });
+    assert.ok(writers.length > 0, 'no face-vector writer found — the property this gate exists for is unchecked');
+
+    for (const f of writers) {
+      const code = withoutComments(read(f));
+      assert.match(
+        code,
+        /isUsableDescriptor\s*\(/,
+        `${f} stores a face vector without ever calling isUsableDescriptor — this is the silent-skip defect returning`,
+      );
+    }
+  });
+
+  it('both descriptor sources are named, so neither can be quietly dropped', () => {
+    const sources = mediaSources()
+      .filter((f) => f !== GUARD)
+      .flatMap((f) => [...withoutComments(read(f)).matchAll(/isUsableDescriptor\s*\([^)]*?['"]([a-z-]+)['"]\s*\)/g)]
+        .map((m) => m[1]));
+    // Build the regex fresh per use; a shared /g regex advances lastIndex between assertions.
+    assert.ok(sources.includes('in-process'), `no in-process width check found, got: ${sources.join(', ') || '(none)'}`);
+    assert.ok(sources.includes('external'), `no external width check found, got: ${sources.join(', ') || '(none)'}`);
+  });
+
+  it('no media source re-derives the width from a number', () => {
+    for (const f of mediaSources()) {
+      if (f === GUARD) continue;
+      const code = withoutComments(read(f));
+      // Scoped to descriptor identifiers on purpose. An emptiness check (`faces.length === 0`) and a shape
+      // check (`box.length === 4`) are structural and correct; the defect is specifically a WIDTH re-derived
+      // from a number, which is the one comparison that has to agree with the vector index to mean anything.
+      const bad = [...code.matchAll(/\b(?:embedding|descriptor|emb)\w*\.length\s*(?:!==?|===?)\s*(\d+)/gi)]
+        .map((m) => m[0]);
+      assert.deepEqual(
+        bad,
+        [],
+        `${f} compares a length against a literal: ${bad.join(', ')} — use isUsableDescriptor / FACE_DESCRIPTOR_DIMS`,
+      );
+    }
+  });
+
+  it('the vector index is built from the same constant the embedders check against', () => {
+    const code = withoutComments(read('server/src/spaces/vector-index.ts'));
+    assert.match(code, /FACE_DESCRIPTOR_DIMS/, 'the face index must be sized from the shared constant');
+    assert.doesNotMatch(
+      code,
+      /'faceEmbedding'[^)]*\b128\b/,
+      'the face index is sized from a literal — an index and an embedder that disagree give a cosine search that ranks nothing correctly and reports no error',
+    );
+  });
+});


### PR DESCRIPTION
fix(files): the in-process face path never got the fix its own file documents

#745 introduced `face-descriptor.ts` to end a silent skip: both embedding paths
compared `embedding.length !== 128` and `continue`d with no error, no log and no
counter, so a changed descriptor width reads as "this image has no faces"
forever. It converted the external path and stopped.

The in-process path kept the literal, kept skipping silently, and does so in the
same file that imports the guard — `face-embedder.ts` imported
`isUsableDescriptor` and never called it. That is the half running on every
default install, since the external provider is opt-in.

Why nothing caught it:

- `face-descriptor.ts` states the constant replaced "the literal 128 that was
  written in both embedding paths";
- `face-external.test.js` asserted "both embedding paths share one rule" while
  reading a single file. It stated the two-path property and checked one path,
  so it went green on exactly the half that was done;
- the CHANGELOG entry said the same thing, in the same words.

Three independent statements of the property, all written in the same pass, all
describing the intent rather than the result. The comments in that test are
corrected to say what they actually cover.

The replacement gate discovers face-vector writers from `git ls-files` instead
of naming them, and requires each to consult the guard. Mutation-checked against
the pre-fix line: three of its five assertions fail, from three angles.

Also corrected: two comments still told operators FaceRes emits a 128-wide
descriptor. It emits 1024 and the library reduces it, so a reader trusting them
would look for a width change in the wrong place. #745's entry claimed these had
been corrected "where they sat"; these two sat elsewhere.

Docs: the media-embedding walkthrough now says a wrong-width descriptor is
skipped AND logged, and that the warning is what to look for before concluding
an image has no faces.
