### PR TITLE
feat(files): a failing face provider no longer substitutes a different embedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING for operators using an external face model: the in-process fallback is now OFF by default.**
+  When a configured and consented external face provider fails, Ythril no longer embeds the image with the
+  bundled model. It skips the image, logs once, and lets the media job retry.
+  - **Why the old behaviour was worse than a failure.** Both embedders emit the same descriptor width, so a
+    fallback wrote a *different embedder's* vectors into the same gallery and nothing could tell. The vectors
+    were the right shape and the wrong vector space; every similarity score computed against them was wrong,
+    silently and permanently. A skipped image is recoverable — a poisoned gallery entry is not.
+  - **If you do not use an external provider, nothing changes.** In-process is your only path, not a
+    fallback, and it keeps running exactly as before. The switch is gated on an external provider being
+    configured AND consented, specifically so a single-model install cannot lose face recognition to it.
+  - To keep the old behaviour, set `mediaEmbedding.faceRecognition.externalModel.allowInProcessFallback` to
+    `true`. The flag is read as a strict boolean, so a `"false"` string in a hand-edited config stays off.
+  - **What you will see if this bites you:** faces stop being added to the gallery while the provider is
+    down, and a single warning names the reason. Previously you would have seen nothing at all, and the
+    gallery would have been quietly accumulating incomparable vectors.
+  - **Two log lines changed text.** Both provider-failure warnings ended in *"falling back to in-process
+    recognition"*, which is now the opposite of what happens on a default configuration. They end in
+    *"no descriptors from this provider"* and no longer claim to know what happens next — that is the
+    caller's decision. If you alert on the old string, re-point it.
+
 ### Fixed
 - **The face vector index and the embedders now share one width.** The number was written three times — in
   the index built at `initSpace`, and in each of the two embedding paths. They MUST agree: an index built at

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -631,14 +631,22 @@ data leaves the instance. You can optionally point at an external recogniser und
 | `model` | Optional model name, passed through in the request body. |
 | `apiKey` | Sent as `Authorization: Bearer`. Stored in `secrets.json`, masked on read, never echoed back. |
 | `acknowledgedHost` | The host you consented to. **Must equal `baseUrl`'s host or the endpoint is not used at all.** |
+| `allowInProcessFallback` | Whether a failing provider may hand off to the bundled model. **Default `false`.** Read as a strict boolean — a `"false"` string stays off. |
 
 Three properties worth knowing before enabling it:
 
 - **Consent is mandatory and host-scoped.** Face crops are biometric data. The API rejects a save whose
   `acknowledgedHost` does not match, and the runtime re-checks it — so a config edited on disk cannot
   egress faces either. Re-pointing `baseUrl` at a different host revokes consent by construction.
-- **In-process stays the fallback.** An unreachable, erroring or malformed provider falls back to local
-  recognition rather than dropping faces silently.
+- **A failing provider does NOT fall back to the bundled model unless you ask it to.** This changed: the
+  fallback used to be unconditional. Both embedders emit the same descriptor width, so falling back wrote a
+  *different embedder's* vectors into the same gallery and nothing could detect it — the vectors were the
+  right shape and the wrong vector space, and every similarity score computed against them was wrong.
+  Ythril now skips the image, logs once, and lets the media job retry; set `allowInProcessFallback: true`
+  to restore the old behaviour.
+  - **If you have no external provider configured, none of this applies to you.** In-process is your only
+    path rather than a fallback, and it runs exactly as before. The switch is gated on a provider being
+    configured *and* consented, precisely so a single-model install cannot lose face recognition to it.
 - **A provider's answer is not trusted.** Descriptors that are not exactly 128 finite floats are
   discarded (a wrong width would corrupt gallery similarity rather than fail loudly), and the number of
   faces accepted from one response is capped.

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -807,6 +807,23 @@ export interface FaceRecognitionConfig {
     apiKey?: string;
     /** Host the operator acknowledged for biometric egress. Must match `baseUrl`'s host to be usable. */
     acknowledgedHost?: string;
+    /**
+     * Whether a configured-but-failing external provider may fall back to the bundled in-process model.
+     *
+     * **Defaults to `false`, and that is a deliberate behaviour change** (owner decision 2026-08-08:
+     * *"disable by default and enable consciously. its a silent pollution."*). The fallback used to be
+     * unconditional, so an unreachable or malformed endpoint quietly wrote a DIFFERENT embedder's vectors
+     * into the same gallery. Both models emit the same width today, so nothing detects the mixture — the
+     * vectors are simply wrong, and every similarity score computed against them is wrong with them.
+     *
+     * Skipping is the better failure: the media job retries later and the faces get embedded by the model
+     * the operator chose, instead of being permanently embedded by one they did not.
+     *
+     * **This only applies when an external provider is configured AND consented.** An instance with no
+     * external provider is not falling back to anything — in-process is its only path — and it keeps
+     * running exactly as before regardless of this flag.
+     */
+    allowInProcessFallback?: boolean;
   };
   /**
    * Directory (relative to DATA_ROOT) where the @vladmandic/human WASM model

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -4,9 +4,9 @@
  * Uses @vladmandic/human with the CPU backend (pure JavaScript, no GPU, no
  * native TensorFlow bindings, no WASM file path configuration).
  * Model: BlazeFace Back (detection) + FaceRes (descriptor). FaceRes itself outputs 1024 dimensions;
+ * @vladmandic/human reduces them to the 128 the gallery stores — see face-descriptor.ts.
  *
  * Pipeline per image:
- * @vladmandic/human reduces them to the 128 the gallery stores — see face-descriptor.ts.
  *
  *  1. Decode image bytes via sharp → raw RGBA pixel data + dimensions
  *  2. Create tf.Tensor3D via human.tf (bundled TF.js) from pixel data
@@ -41,7 +41,7 @@ import { log } from '../../util/log.js';
 import { isUsableDescriptor, FACE_DESCRIPTOR_DIMS } from './face-descriptor.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../../config/types.js';
 import type { Config as HumanConfig, Result } from '@vladmandic/human';
-import { detectFacesExternal } from './face-external.js';
+import { detectFacesExternal, externalFaceReady, inProcessFallbackAllowed } from './face-external.js';
 
 // ── Singleton Human instance (lazy init) ──────────────────────────────────
 
@@ -54,6 +54,17 @@ type HumanInstance = {
 let _human: HumanInstance | null = null;
 // serialise concurrent initialisations — only one load() runs at a time
 let _humanLoading: Promise<HumanInstance> | null = null;
+
+/**
+ * Once-per-process latch for the "fallback is disabled, so this image was skipped" warning.
+ *
+ * A provider that is down is down for every image in the backlog, so a per-image log would emit
+ * thousands of identical lines and bury the one an operator needs to read.
+ */
+let warnedFallbackDisabled = false;
+
+/** Test seam: the latch would otherwise make the second test in a file assert nothing. */
+export function resetFallbackWarning(): void { warnedFallbackDisabled = false; }
 
 async function getHuman(): Promise<HumanInstance> {
   if (_human) return _human;
@@ -258,11 +269,33 @@ export async function embedFaces(
 
   // ── 2. Detect + embed ────────────────────────────────────────────────────
   // An external provider gets first refusal, when one is configured AND its host is acknowledged. It
-  // returns null on ANY failure, so an unreachable or malformed endpoint falls through to in-process
-  // recognition rather than dropping faces — degrading, never silently doing nothing. Both paths yield
-  // the same `{ embedding, boxRaw }` shape, so everything below is shared.
+  // returns null on ANY failure. Both paths yield the same `{ embedding, boxRaw }` shape, so everything
+  // below is shared.
   let faces: Array<{ embedding?: number[]; boxRaw?: number[] }> | undefined =
     (await detectFacesExternal(imageBytes)) ?? undefined;
+
+  // A configured provider that failed does NOT hand off to the bundled model unless the operator asked
+  // for that. The two embedders emit the same width, so mixing them corrupts the gallery in a way no
+  // check can see: the vectors are the right shape, they are simply from a different vector space, and
+  // every similarity score computed against them is wrong. Returning here leaves the job to retry, which
+  // is recoverable; writing one wrong vector is not.
+  //
+  // `externalFaceReady()` and not `!faces` is the whole point. An instance with NO external provider is
+  // not falling back — in-process is its only path — and gating on `!faces` alone would silently switch
+  // face recognition off for every single-model install.
+  if (!faces && externalFaceReady() && !inProcessFallbackAllowed()) {
+    if (!warnedFallbackDisabled) {
+      warnedFallbackDisabled = true;
+      log.warn(
+        'Face recogniser: the external provider did not answer and the in-process fallback is disabled, '
+        + 'so this image was skipped rather than embedded with the bundled model. The media job will retry. '
+        + 'Set mediaEmbedding.faceRecognition.externalModel.allowInProcessFallback=true to accept vectors '
+        + 'from a different embedder in the same gallery. Logged once per process.',
+      );
+    }
+    log.debug(`Face recogniser: skipped ${spaceId}/${fileId} — external provider unavailable, fallback disabled`);
+    return;
+  }
 
   if (!faces) {
     // The local model is only loaded when no external provider answered — initialising it otherwise

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -48,11 +48,33 @@ export function externalFaceReady(): boolean {
 }
 
 /**
+ * May a configured-but-failing external provider hand off to the bundled in-process model?
+ *
+ * Defaults to `false` — see `allowInProcessFallback` in the config type for why a skip beats a silent
+ * substitution. Exported so the embedder asks this question in one place rather than reading config inline.
+ *
+ * Deliberately NOT combined with `externalFaceReady()`. They answer different questions and the caller
+ * needs both separately: an instance with no external provider must keep running in-process, so the
+ * fallback flag has to be irrelevant there rather than switching recognition off.
+ */
+export function fallbackAllowedIn(ext?: { allowInProcessFallback?: boolean }): boolean {
+  // `=== true` and not a truthy read: a config hand-edited on disk can carry the STRING "false", which is
+  // truthy, and would turn the operator's explicit refusal into an enable.
+  return ext?.allowInProcessFallback === true;
+}
+
+/** `fallbackAllowedIn` against the live config. Split so the rule itself is testable without it. */
+export function inProcessFallbackAllowed(): boolean {
+  return fallbackAllowedIn(getConfig().mediaEmbedding?.faceRecognition?.externalModel);
+}
+
+/**
  * Detect + embed faces via the configured external provider.
  *
- * Returns `null` on ANY failure — unconfigured, unacknowledged, unreachable, malformed. The caller then
- * runs the in-process recogniser, so a broken endpoint degrades to local processing instead of dropping
- * faces silently. That fallback is the whole reason this returns null rather than throwing.
+ * Returns `null` on ANY failure — unconfigured, unacknowledged, unreachable, malformed. Returning rather
+ * than throwing is what lets the caller decide: an instance with no provider runs in-process, and an
+ * instance whose provider failed skips the image unless `allowInProcessFallback` says otherwise. This
+ * function deliberately does not know which of those applies — it reports the failure and nothing more.
  *
  * `ssrfSafeFetch` rather than `fetch`: the URL is admin-settable through the API, and a plain fetch would
  * follow a redirect into link-local metadata. Validating the URL at write time is not enough on its own —
@@ -87,7 +109,9 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
       allowPrivate: allowPrivateForSlot('faceExternal'),
     });
     if (!res.ok) {
-      log.warn(`External face model: HTTP ${res.status} — falling back to in-process recognition`);
+      // Deliberately does not say what happens next: that is the caller's decision and it depends on
+      // `allowInProcessFallback`. Claiming a fallback here would be wrong on the default configuration.
+      log.warn(`External face model: HTTP ${res.status} — no descriptors from this provider`);
       return null;
     }
     const body = await boundedJson<ExternalFaceResponse>(res, 'external face provider');
@@ -111,7 +135,7 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
     }
     return faces;
   } catch (err) {
-    log.warn(`External face model unreachable (${err instanceof Error ? err.message : String(err)}) — falling back to in-process recognition`);
+    log.warn(`External face model unreachable (${err instanceof Error ? err.message : String(err)}) — no descriptors from this provider`);
     return null;
   }
 }

--- a/testing/integration/embed-properties.test.js
+++ b/testing/integration/embed-properties.test.js
@@ -59,13 +59,28 @@ const COLLECTION_PATH = { memory: 'memories', entity: 'entities', edge: 'edges',
 
 async function embedTextOf(kind, id, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
+  let last = null;
+  let polls = 0;
   while (Date.now() < deadline) {
     const r = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/${COLLECTION_PATH[kind]}/${id}`);
+    polls++;
+    last = r;
     if (r.status === 200 && r.body?.matchedText != null) return r.body;
     await new Promise(res => setTimeout(res, 250));
   }
+  // Carry the reason out with the failure. A bare `null` cannot tell "the record was never written" from
+  // "the record is there and the embed job never ran" from "the read itself was failing" — and those have
+  // three different causes. This timed out once on 2026-08-08 (edge only, three siblings green in ~0.5 s)
+  // and the log said nothing beyond the assertion message, so the diagnosis had to be reconstructed from
+  // the outside. Whatever the next occurrence is, it should be readable from the failure itself.
+  lastProbe = `after ${polls} polls over ${timeoutMs}ms: HTTP ${last?.status}, `
+    + `record ${last?.status === 200 ? 'EXISTS' : 'NOT READABLE'}, `
+    + `matchedText ${last?.body?.matchedText === undefined ? 'absent' : JSON.stringify(last?.body?.matchedText)}`;
   return null;
 }
+
+/** Set by the last `embedTextOf` that timed out, so the assertion can say why rather than just "falsy". */
+let lastProbe = '(no probe recorded)';
 
 describe('Property keys are embedded (B4)', () => {
   before(async () => {
@@ -96,7 +111,7 @@ describe('Property keys are embedded (B4)', () => {
     assert.match(r.body.matchedText ?? '', /occupation pilot/,
       `memory create must fold "key value" into matchedText: ${r.body.matchedText}`);
     const hit = await embedTextOf('memory', r.body._id);
-    assert.ok(hit, 'memory should have its embed text stored');
+    assert.ok(hit, `memory should have its embed text stored — ${lastProbe}`);
     assert.match(hit.matchedText ?? '', /occupation/,
       `memory embed text must include the property key: ${hit.matchedText}`);
   });
@@ -107,7 +122,7 @@ describe('Property keys are embedded (B4)', () => {
       { name: `EntPropKey-${RUN}`, type: 'concept', properties: { occupation: 'engineer' } });
     assert.equal(r.status, 201, JSON.stringify(r.body));
     const hit = await embedTextOf('entity', r.body._id);
-    assert.ok(hit, 'entity should have its embed text stored');
+    assert.ok(hit, `entity should have its embed text stored — ${lastProbe}`);
     assert.match(hit.matchedText ?? '', /occupation/,
       `entity embed text must include the property key: ${hit.matchedText}`);
   });
@@ -120,7 +135,7 @@ describe('Property keys are embedded (B4)', () => {
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
     const hit = await embedTextOf('chrono', r.body._id);
-    assert.ok(hit, 'chrono should have its embed text stored');
+    assert.ok(hit, `chrono should have its embed text stored — ${lastProbe}`);
     assert.match(hit.matchedText ?? '', /venue/,
       `chrono embed text must include the property key: ${hit.matchedText}`);
   });
@@ -136,7 +151,7 @@ describe('Property keys are embedded (B4)', () => {
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
     const hit = await embedTextOf('edge', r.body._id);
-    assert.ok(hit, 'edge should have its embed text stored');
+    assert.ok(hit, `edge should have its embed text stored — ${lastProbe}`);
     assert.match(hit.matchedText ?? '', /medium/,
       `edge embed text must include the property key: ${hit.matchedText}`);
   });

--- a/testing/standalone/face-fallback-off-by-default.test.js
+++ b/testing/standalone/face-fallback-off-by-default.test.js
@@ -1,0 +1,107 @@
+/**
+ * A configured-but-failing external face provider does NOT quietly hand off to the bundled model.
+ *
+ * ## What this protects
+ *
+ * The two embedders emit the same descriptor width, so mixing their output corrupts a gallery in a way
+ * nothing can detect: the vectors are the right shape, they are simply from a different vector space, and
+ * every similarity score computed against them is wrong. Owner decision 2026-08-08 — *"disable by default
+ * and enable consciously. its a silent pollution."*
+ *
+ * ## The trap this file exists for
+ *
+ * "Disabled by default" must mean **no fallback when an external provider was configured and failed**, NOT
+ * **no in-process recognition**. An instance with no external provider has in-process as its only path; that
+ * is not a fallback. Gating on `!faces` alone — the obvious reading — would silently switch face recognition
+ * off for every existing single-model install, which is a far worse outcome than the one being fixed and
+ * would look identical to "the images have no faces".
+ *
+ * So the condition must consult `externalFaceReady()`. That is the assertion that matters here, and it is
+ * the one a plausible-looking implementation gets wrong.
+ *
+ * Run: node --test testing/standalone/face-fallback-off-by-default.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(new URL('../../server/src/files/media/face-embedder.ts', import.meta.url), 'utf8');
+const ext = readFileSync(new URL('../../server/src/files/media/face-external.ts', import.meta.url), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+let fallbackAllowedIn;
+before(async () => {
+  ({ fallbackAllowedIn } = await import('../../server/dist/files/media/face-external.js'));
+});
+
+describe('the in-process fallback is off unless asked for', () => {
+  it('defaults to false when nothing is configured', () => {
+    // The default IS the decision. A flag that defaults on would ship the old behaviour under a new name.
+    assert.equal(fallbackAllowedIn(undefined), false);
+    assert.equal(fallbackAllowedIn({}), false);
+  });
+
+  it('is true only for the boolean, never for a truthy lookalike', () => {
+    assert.equal(fallbackAllowedIn({ allowInProcessFallback: true }), true);
+    assert.equal(fallbackAllowedIn({ allowInProcessFallback: false }), false);
+    // A config hand-edited on disk carries strings. "false" is truthy, so a truthy read would invert the
+    // operator's explicit refusal — which is the one direction this flag must never fail in.
+    assert.equal(fallbackAllowedIn({ allowInProcessFallback: 'false' }), false);
+    assert.equal(fallbackAllowedIn({ allowInProcessFallback: 'true' }), false);
+    assert.equal(fallbackAllowedIn({ allowInProcessFallback: 1 }), false);
+  });
+});
+
+describe('the skip is gated on an external provider being configured', () => {
+  const code = withoutComments(src);
+  // The guard is the `if` that returns early when the fallback is refused. Located by its condition rather
+  // than by line number so a reordering does not silently re-point this at nothing. Matched line-wise
+  // because the condition contains call parentheses, which a bracket-counting regex cannot span.
+  const lines = code.split('\n');
+  const guardIdx = lines.findIndex((l) => /\bif\s*\(/.test(l) && l.includes('inProcessFallbackAllowed()'));
+  const guard = guardIdx >= 0 ? [lines[guardIdx]] : null;
+
+  it('has a guard at all', () => {
+    assert.ok(guard, 'no guard consulting inProcessFallbackAllowed() — the unconditional fallback is back');
+  });
+
+  it('consults externalFaceReady, not merely the absence of faces', () => {
+    // THE assertion. Without this term, a single-model install loses face recognition entirely and the
+    // symptom reads as "no faces detected" — the exact silent failure this whole area keeps producing.
+    assert.match(
+      guard[0],
+      /externalFaceReady\(\)/,
+      'the guard does not check whether an external provider was configured, so an instance with no '
+      + 'provider would stop embedding faces altogether',
+    );
+  });
+
+  it('refuses the fallback only when the flag is off', () => {
+    assert.match(guard[0], /!\s*inProcessFallbackAllowed\(\)/, 'the flag must be negated in the refusal path');
+  });
+
+  it('returns without writing anything, leaving the job to retry', () => {
+    const after = lines.slice(guardIdx).join('\n');
+    const body = after.slice(0, after.indexOf('\n  }') + 4);
+    assert.match(body, /return;/, 'the guard must return — a partial write is what it exists to prevent');
+    assert.doesNotMatch(body, /replaceOne|updateOne|insertOne/, 'nothing may be persisted on the skip path');
+  });
+
+  it('no provider-failure log promises a fallback that will not happen', () => {
+    // These two lines said "falling back to in-process recognition" on every provider failure. With the
+    // fallback off by default that is the OPPOSITE of what happens, and a log that misreports the outcome
+    // is worse than no log — an operator would stop looking for the reason their gallery went quiet.
+    const extCode = withoutComments(ext);
+    const logs = [...extCode.matchAll(/log\.(?:warn|info|error)\(([^\n]*)/g)].map((m) => m[1]);
+    const liars = logs.filter((l) => /falling back|fall back/i.test(l));
+    assert.deepEqual(liars, [], 'a provider-failure log claims a fallback the default configuration refuses');
+  });
+
+  it('warns once rather than per image', () => {
+    // A provider that is down is down for the whole backlog; a per-image log buries the one line that matters.
+    assert.match(code, /warnedFallbackDisabled/, 'the warning must be latched');
+    assert.match(src, /Logged once per process/, 'the message must tell the operator it is deduplicated');
+  });
+});

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -86,7 +86,11 @@ const FROZEN = {
   'client/src/app/pages/brain/review-tab.component.ts': 748,
   'server/src/brain/recall.ts': 739,
   'client/src/app/pages/settings/media-processing/models-tab.component.ts': 678,
-  'server/src/config/types.ts': 672,
+  // 672 -> 673: `allowInProcessFallback` on `faceRecognition.externalModel`. ONE line of type, and the
+  // behaviour it names lives in `face-external.ts` and `face-embedder.ts`, not here. The alternative —
+  // a face-only config module re-exported from this file — would split the config contract across two
+  // places to save a single field, which is the trade this list exists to let us decline.
+  'server/src/config/types.ts': 673,
   'client/src/app/pages/settings/data.component.ts': 644,
   'server/src/api/files.ts': 646,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate


### PR DESCRIPTION
feat(files): a failing face provider no longer substitutes a different embedder

Owner decision 2026-08-08: "disable by default and enable consciously. its a
silent pollution."

A configured and consented external face provider that failed used to fall
through to the bundled model. Both embedders emit the same descriptor width, so
that wrote another embedder's vectors into the same gallery with nothing able to
detect it — right shape, wrong vector space, and every similarity score computed
against them wrong from then on. A skipped image is recoverable; a poisoned
gallery entry is not.

Now: skip, warn once, let the media job retry. Opt back in with
`mediaEmbedding.faceRecognition.externalModel.allowInProcessFallback` (default
false, read as a strict boolean so a hand-edited "false" string cannot invert the
refusal).

The trap, and the reason the test file is named for it: "disabled by default"
must mean no fallback when a provider was configured and FAILED, not no
in-process recognition. An instance with no external provider is not falling back
— in-process is its only path. Gating on `!faces` alone would have switched face
recognition off for every single-model install, and the symptom would have read
as "these images have no faces". The condition is therefore
`externalFaceReady() && !inProcessFallbackAllowed()`.

Mutation-checked: dropping the `externalFaceReady()` term fails exactly one
assertion, the one written for it, and nothing else.

Also carries a `_DEPRECATIONS.md` entry, because the operator this reaches is one
whose gallery quietly stops growing — they have no reason to read a release note
about a flag they never set — and because the old behaviour looks like the more
forgiving default and must not be "restored" at 3.0.
