### PR TITLE
fix(spaces): the face gallery's index can no longer be silently re-dimensioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **The face gallery's vector index can no longer be silently re-dimensioned.** A change to the face
+  descriptor width was treated like any other index definition change and rebuilt the index — in place, or
+  by drop-and-recreate.
+  - For a text index that is correct: the records are re-embedded and the vectors catch up. **The face
+    gallery has no such path.** Its vectors live on already-stored face-chunk records and nothing re-derives
+    them, so a rebuild would leave 128-wide vectors indexed as if they were 512-wide — every similarity
+    score wrong, and **no error reported anywhere**.
+  - Ythril now refuses the width change, keeps the existing width, and logs both numbers with what to do
+    about it. Moving a populated gallery to a new width means re-embedding its faces first; that is a
+    decision about the data, not a config edit.
+  - A refused width change still lets a **filter-field** change through, at the existing width — freezing
+    the index against legitimate edits would break filtered recall for the space.
+  - Text indexes are deliberately unaffected. The asymmetry is the point: if every index refused, an
+    embedding-model change could never be applied.
+
 ### Changed
 - **BREAKING for operators using an external face model: the in-process fallback is now OFF by default.**
   When a configured and consented external face provider fails, Ythril no longer embeds the image with the

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -1078,6 +1078,8 @@ Set `reprocessSyncedImages: false` to restrict gallery building to images upload
 
 Face recognition requires a dedicated Atlas vector search index per space. Name: `{spaceId}_files_faceEmbedding`, field: `faceEmbedding`, dimensions: `128`, similarity: `cosine`. This is distinct from the text embedding index used by `recall`.
 
+**This index is never re-dimensioned automatically, and that is deliberate.** Ythril rebuilds other vector indexes when their definition changes, because re-embedding the records makes the vectors catch up. Face vectors live on already-stored face-chunk records and nothing re-derives them, so a rebuild at a new width would leave the stored vectors indexed as if they were the new width — every similarity score wrong, with no error reported. If the configured width ever differs from an existing space's index, Ythril **refuses the change, keeps the existing width, and logs both numbers**. To move a populated gallery, re-embed its faces at the new width first. A filter-field change still applies, at the existing width.
+
 When the face recognition feature is first enabled, any existing `initSpace` call will create the required index. If you add the feature after spaces already exist, re-run `initSpace` for each space or create the index manually via the Atlas UI / MongoDB admin API.
 
 #### Configuration Reference

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -163,7 +163,7 @@ export async function ensureVectorSearchIndex(
   indexSuffix: string = 'embedding',
   waitForReady: boolean = true,
   filterFields: string[] = [],
-  opts: { force?: boolean } = {},
+  opts: { force?: boolean; refuseWidthChange?: boolean } = {},
 ): Promise<void> {
   const db = getDb();
   const coll = db.collection(`${spaceId}_${collectionSuffix}`);
@@ -213,6 +213,35 @@ export async function ensureVectorSearchIndex(
     if (dimsMatch && filtersMatch && !opts.force) {
       log.debug(`Vector search index ${indexName} already up to date`);
       return;
+    }
+
+    // Some indexes must NOT be silently re-dimensioned, and the face gallery is the one that exists today.
+    //
+    // Rebuilding a TEXT index at a new width is recoverable: the records are re-embedded and the vectors
+    // catch up. The face gallery has no such path. Its vectors live on `faceEmbedding` in already-stored
+    // face-chunk records, and nothing re-derives them — so widening the index leaves 128-wide vectors
+    // indexed as if they were 512-wide. Cosine search then ranks nothing correctly **and reports no error
+    // at all**, which is precisely the failure the shared width constant and its guards exist to prevent.
+    // Reintroducing it through the feature meant to make the width configurable would be the worst version
+    // of it, because the operator would have just been told the width is theirs to choose.
+    //
+    // So this refuses and keeps the existing width. Moving a POPULATED gallery to a new width means
+    // re-embedding every face, which is a decision about the data, not a config edit.
+    if (existing && !dimsMatch && opts.refuseWidthChange) {
+      log.error(
+        `REFUSING to change ${indexName} from ${existingDims} to ${numDimensions} dimensions. `
+        + `The vectors already stored in this space are ${existingDims}-wide and nothing re-derives them, `
+        + `so rebuilding the index at ${numDimensions} would leave every similarity score wrong with no `
+        + `error reported. The index keeps its current width. To move a populated gallery, re-embed its `
+        + `records at the new width first; to build a new space at ${numDimensions}, create it fresh.`,
+      );
+      if (filtersMatch) return;
+      // Filter fields may still legitimately need updating. Re-issue the definition at the width the
+      // index ALREADY has, so the filter change lands without touching the part that would destroy data.
+      definition.fields = [
+        { type: 'vector', path: vectorPath, numDimensions: existingDims as number, similarity },
+        ...filterFields.map(path => ({ type: 'filter', path })),
+      ];
     }
 
     // Definition changed (dimensions or filter fields). Prefer an in-place update — Atlas keeps
@@ -480,7 +509,9 @@ export async function buildSpaceVectorIndexes(
     // literal in each embedding path — three copies of a number that MUST agree, because an index built at
     // one width and vectors written at another produce a cosine search that silently ranks nothing
     // correctly. One copy now, which is also the precondition for making it configurable.
-    await ensureVectorSearchIndex(spaceId, 'files', FACE_DESCRIPTOR_DIMS, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady, undefined, opts);
+    // `refuseWidthChange`: the face gallery is the one index whose vectors nothing re-derives, so a width
+    // change must never be applied silently to an existing space. See the guard in ensureVectorSearchIndex.
+    await ensureVectorSearchIndex(spaceId, 'files', FACE_DESCRIPTOR_DIMS, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady, undefined, { ...opts, refuseWidthChange: true });
   }
 }
 

--- a/testing/standalone/face-index-width-is-never-rebuilt.test.js
+++ b/testing/standalone/face-index-width-is-never-rebuilt.test.js
@@ -1,0 +1,86 @@
+/**
+ * The face gallery's index is never silently re-dimensioned.
+ *
+ * ## Why this index is different from every other one
+ *
+ * `ensureVectorSearchIndex` treats a dimension change as a definition change and rebuilds — in place if
+ * Atlas allows it, otherwise drop-and-recreate. For a TEXT index that is correct and recoverable: the
+ * records get re-embedded and the vectors catch up.
+ *
+ * The face gallery has no such path. Its vectors sit on `faceEmbedding` in already-stored face-chunk
+ * records and **nothing re-derives them**. Rebuilding that index at a new width leaves 128-wide vectors
+ * indexed as though they were 512-wide, so every cosine score is wrong and **no error is reported** — the
+ * exact silent-corruption failure the shared width constant, `isUsableDescriptor`, and the in-process guard
+ * were all added to prevent.
+ *
+ * That matters most precisely when the width becomes configurable, because the operator will have just been
+ * told the number is theirs to choose. A config edit must not be able to invalidate a populated gallery.
+ *
+ * ## Why the ORDER is asserted, not just the presence
+ *
+ * A refusal placed after `updateSearchIndex` would read correctly and do nothing — the destructive call
+ * would already have happened. Presence alone cannot tell those apart, so the position is pinned too.
+ *
+ * Run: node --test testing/standalone/face-index-width-is-never-rebuilt.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC = 'server/src/spaces/vector-index.ts';
+const src = readFileSync(join(ROOT, SRC), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const code = withoutComments(src);
+
+describe('the face index refuses a width change', () => {
+  it('the face index asks for the refusal', () => {
+    // Located by the index path rather than a line number: this call has moved before.
+    const line = code.split('\n').find((l) => l.includes("'faceEmbedding'") && l.includes('ensureVectorSearchIndex'));
+    assert.ok(line, "no ensureVectorSearchIndex call for 'faceEmbedding' — re-point this test");
+    assert.match(
+      line,
+      /refuseWidthChange:\s*true/,
+      'the face index is built without refuseWidthChange, so a width change would silently rebuild it and '
+      + 'orphan every stored face vector',
+    );
+  });
+
+  it('the guard exists and keeps the existing width', () => {
+    assert.match(code, /opts\.refuseWidthChange/, 'ensureVectorSearchIndex does not implement the refusal');
+    assert.match(code, /REFUSING to change/, 'the refusal must be logged — a silent refusal is its own defect');
+  });
+
+  it('the refusal is reached BEFORE anything rebuilds the index', () => {
+    const guard = code.indexOf('opts.refuseWidthChange');
+    const update = code.indexOf('updateSearchIndex(');
+    const drop = code.indexOf('dropSearchIndex(');
+    assert.ok(guard > 0 && update > 0, 'expected both the guard and the update call to exist');
+    assert.ok(
+      guard < update,
+      'the refusal sits AFTER updateSearchIndex, so the rebuild it exists to prevent has already happened',
+    );
+    assert.ok(guard < drop, 'the refusal sits AFTER dropSearchIndex, which is the destructive path');
+  });
+
+  it('refuses on a width change specifically, not on any definition change', () => {
+    // Filter-field changes must still apply — refusing those would freeze the index against legitimate
+    // edits and quietly break filtered recall for the space.
+    const i = code.indexOf('opts.refuseWidthChange');
+    const stmt = code.slice(Math.max(0, i - 120), i + 40);
+    assert.match(stmt, /!\s*dimsMatch/, 'the refusal must be conditioned on the WIDTH differing');
+    assert.match(code.slice(i, i + 1400), /filtersMatch/,
+      'a refused width change must still let a filter-field change through, at the existing width');
+  });
+
+  it('the text indexes are NOT refused, because re-embedding recovers them', () => {
+    // The asymmetry is the point. If every index refused, a legitimate embedding-model change could never
+    // be applied, and the fix would be worse than the problem.
+    const faceLines = code.split('\n').filter((l) => l.includes('refuseWidthChange: true'));
+    assert.equal(faceLines.length, 1,
+      `expected exactly one index to refuse width changes, found ${faceLines.length} — if a second index `
+      + 'genuinely needs it, say why here rather than letting the count drift');
+  });
+});


### PR DESCRIPTION
fix(spaces): the face gallery's index can no longer be silently re-dimensioned

`ensureVectorSearchIndex` treats a dimension change as a definition change and
rebuilds — in place if Atlas allows it, otherwise drop-and-recreate. For a text
index that is correct and recoverable: the records get re-embedded and the
vectors catch up.

The face gallery has no such path. Its vectors sit on `faceEmbedding` in
already-stored face-chunk records and nothing re-derives them. Rebuilding that
index at a new width leaves 128-wide vectors indexed as though they were
512-wide: every cosine score wrong, and no error reported anywhere — the exact
silent corruption that the shared width constant, `isUsableDescriptor` and the
in-process guard were all added to prevent.

This is groundwork for making the width configurable, and it is the half that
has to land first. The operator is about to be told the number is theirs to
choose; a config edit must not be able to invalidate a populated gallery as a
side effect of that.

So the face index refuses: it keeps its existing width and logs both numbers
with what to do about it. Moving a populated gallery means re-embedding its
faces first, which is a decision about the data.

Two deliberate limits on the refusal:

- a refused WIDTH change still lets a FILTER-FIELD change through, at the
  existing width. Freezing the index against legitimate edits would break
  filtered recall for the space, which is a different failure, not a smaller one;
- text indexes are not refused. The asymmetry is the point — if every index
  refused, an embedding-model change could never be applied, and the fix would
  be worse than the problem. The gate asserts exactly one index opts in.

The gate pins the ORDER as well as the presence: a refusal placed after
`updateSearchIndex` would read correctly and do nothing, and presence alone
cannot tell those two apart. Mutation-checked by dropping the flag at the call
site — two assertions fail, from two directions.
