### PR TITLE
fix(tokens): a mis-spelled scope field minted an unscoped token and returned 201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **`POST /api/tokens` accepted a mis-spelled scope field and minted an UNSCOPED token, reporting success.**
+  `allowedSpaces`, `scope`, `spaceIds` and `denySpaces` were all taken with a **201** and silently dropped;
+  only `spaces` was ever real. The caller was told the operation worked, their own records said the token was
+  restricted, and it could reach every space on the instance. Nothing in the response, the stored token or
+  the logs distinguished it from a correctly scoped mint.
+  - Reported by an operator who probed four plausible spellings, got 201 from each, and only found it by
+    reading the stored token back and noticing four of five probes had no `spaces` field at all.
+  - Both token bodies are now strict: an unknown key is a **400** naming it. `PATCH /api/tokens/:id` had the
+    same shape with a sharper edge — it accepts a rename only, so `spaces` or `admin` sent beside the name
+    was dropped and answered **200**, which is what an attempt to widen a token through the rename endpoint
+    looked like.
+  - **If you were relying on one of those key names, your token is not scoped.** Re-check any token minted
+    with a field other than `spaces`; it has instance-wide access. The 400 now tells you at the first
+    request instead of the fifth.
+
 ### Changed
 - **The space Overview drops the Statistics strip and the Instance card** (owner decision, 2026-08-08).
   - The **Statistics** strip showed record counts per type and a total. The Data model diagram above it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **If you were relying on one of those key names, your token is not scoped.** Re-check any token minted
     with a field other than `spaces`; it has instance-wide access. The 400 now tells you at the first
     request instead of the fifth.
+  - **Posting a token you read back still works.** `id`, `hash` and `prefix` are fields the server emits, so
+    they are stripped rather than refused — the same strip-then-be-strict shape `PATCH /api/spaces/:id`
+    already uses for its server-owned `meta` fields. Strictness alone would have turned a round-trip into a
+    400.
 
 ### Changed
 - **The space Overview drops the Statistics strip and the Instance card** (owner decision, 2026-08-08).

--- a/docs/integration-guide/03-auth-and-limits.md
+++ b/docs/integration-guide/03-auth-and-limits.md
@@ -12,6 +12,12 @@ Authorization: Bearer ythril_<base62-encoded-token>
 
 Tokens are created during first-run setup or via `POST /api/tokens`. The plaintext token is shown **once** — store it securely.
 
+**The space allowlist field is `spaces`, and nothing else.** The body is strict: any key it does not declare
+is a `400` naming it. This used to be a silent drop — `spaceIds`, `allowedSpaces`, `scope` and `denySpaces`
+were all accepted with a `201` and thrown away, so a token minted with one of those names had **instance-wide
+access while appearing scoped**. If you have tokens minted with a field other than `spaces`, re-check them:
+they are not scoped.
+
 > **The token must travel in the header.** A `?token=…` query parameter is ignored on every route → `401`, with one exception: the `GET /mcp` transport (an external-agent protocol whose clients may be unable to set headers). Query strings end up in access logs, proxy logs, browser history, and `Referer` headers, so a long-lived token must never ride in a URL. The **browser** SSE streams — `GET /api/brain/spaces/:id/events` and `GET /api/about/logs/stream` — instead use a **single-use ticket**: `POST` the paired `…/ticket` endpoint with the normal `Authorization` header to get a short-lived opaque ticket, then open the stream with `?ticket=<ticket>` (see the live-events section below).
 
 ### Token Scoping

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -14,6 +14,28 @@ tokensRouter.get('/me', globalRateLimit, requireAuth, (req, res) => {
 });
 
 /**
+ * Fields the SERVER owns on a token record. A client that posts a token it read back — `id`, `hash`,
+ * `prefix` — is round-tripping, not attacking, and being told "unknown key" for a field we ourselves emitted
+ * would be a worse answer than ignoring it.
+ *
+ * Same shape as `SERVER_OWNED_META_FIELDS` in `api/spaces.ts`: strip exactly the server-owned set, then let
+ * a STRICT schema refuse everything else. The two halves are the point — the strip keeps a round-trip
+ * working, and the strictness is what stops `spaceIds` minting an unscoped token in silence.
+ *
+ * A red-team test (`mass-assignment.test.js`) pins the strip; `credential-bodies-are-strict.test.js` pins
+ * the strictness. Neither is sufficient alone, which is exactly how the first attempt at this fix broke: it
+ * added `.strict()` and turned the round-trip into a 400.
+ */
+const SERVER_OWNED_TOKEN_FIELDS = ['id', 'hash', 'prefix'] as const;
+
+function stripServerOwnedToken(body: unknown): unknown {
+  if (body == null || typeof body !== 'object' || Array.isArray(body)) return body;
+  const copy: Record<string, unknown> = { ...(body as Record<string, unknown>) };
+  for (const f of SERVER_OWNED_TOKEN_FIELDS) delete copy[f];
+  return copy;
+}
+
+/**
  * `.strict()`, and it is the most important word in this file.
  *
  * Zod drops unknown keys by default, so `{ spaceIds: ['qa'] }` minted a token with NO `spaces` field and
@@ -75,7 +97,7 @@ tokensRouter.get('/', requireAdmin, (_req, res) => {
 // POST /api/tokens — create a new PAT — admin + MFA
 // admin:true may only be set when the calling token is itself admin (enforced by requireAdminMfa above)
 tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
-  const parsed = CreateTokenBody.safeParse(req.body);
+  const parsed = CreateTokenBody.safeParse(stripServerOwnedToken(req.body));
   if (!parsed.success) {
     res.status(400).json({ error: parsed.error.message });
     return;
@@ -131,7 +153,7 @@ const RenameTokenBody = z.object({
 
 // PATCH /api/tokens/:id — rename a token's label (only) — admin + MFA
 tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
-  const parsed = RenameTokenBody.safeParse(req.body);
+  const parsed = RenameTokenBody.safeParse(stripServerOwnedToken(req.body));
   if (!parsed.success) {
     res.status(400).json({ error: parsed.error.message });
     return;

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -13,6 +13,21 @@ tokensRouter.get('/me', globalRateLimit, requireAuth, (req, res) => {
   res.json(req.authToken);
 });
 
+/**
+ * `.strict()`, and it is the most important word in this file.
+ *
+ * Zod drops unknown keys by default, so `{ spaceIds: ['qa'] }` minted a token with NO `spaces` field and
+ * returned 201. The caller is told the operation succeeded, their own notes say the token is scoped, and it
+ * reaches every space on the instance. Nothing in the response, the record or the logs tells the two apart.
+ *
+ * Reported by an operator on 2026-08-09 who probed four plausible spellings — `allowedSpaces`, `scope`,
+ * `spaceIds`, `denySpaces` — and got 201 from every one. They found it by reading the stored token back and
+ * noticing four of five probes had no `spaces` at all. Their words: "somebody guessing the field name gets a
+ * token that looks scoped, reports success, and is not scoped at all."
+ *
+ * A permissive body schema is a silent failure anywhere. On the endpoint that mints CREDENTIALS it hands out
+ * access nobody intended and reports success while doing it.
+ */
 const CreateTokenBody = z.object({
   name: z.string().min(1).max(200),
   expiresAt: z.string().datetime().nullish(),
@@ -26,7 +41,7 @@ const CreateTokenBody = z.object({
    * See `TokenRecord.mfa` for why it is three states.
    */
   mfa: z.enum(['inherit', 'exempt', 'required']).optional(),
-});
+}).strict();
 
 /**
  * Granting an MFA exemption always costs a live second factor.
@@ -109,7 +124,10 @@ tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
 const RenameTokenBody = z.object({
   // Same bound as create's `name`, so a label can't be edited to something the create flow would reject.
   name: z.string().min(1).max(200),
-});
+  // `.strict()` for the same reason as create, and here the edge is sharper: this route accepts a rename
+  // ONLY. A body carrying `spaces` or `admin` beside the name was dropped and answered 200, so an attempt to
+  // widen a token through the rename endpoint looked exactly like one that had worked.
+}).strict();
 
 // PATCH /api/tokens/:id — rename a token's label (only) — admin + MFA
 tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {

--- a/testing/standalone/credential-bodies-are-strict.test.js
+++ b/testing/standalone/credential-bodies-are-strict.test.js
@@ -73,6 +73,22 @@ describe('token route bodies reject unknown keys', () => {
     );
   });
 
+  it('server-owned fields are STRIPPED, not refused — strictness alone breaks a round-trip', () => {
+    // The half this gate missed on its first pass. `.strict()` on its own turned `POST /api/tokens` with a
+    // token read back from the API into a 400, because `id`, `hash` and `prefix` are fields WE emit. A
+    // red-team test pins that they are stripped; this pins that the strip still runs before the strict
+    // parse, since removing it would be green here and red there — and the two suites do not run together
+    // in preflight.
+    assert.match(code, /SERVER_OWNED_TOKEN_FIELDS\s*=\s*\[\s*'id',\s*'hash',\s*'prefix'/,
+      'the server-owned field list is gone or changed — a round-tripped token body will 400');
+    const parses = [...code.matchAll(/(\w+Body)\.safeParse\(([^)]*)\)/g)];
+    assert.ok(parses.length >= 2, `expected both bodies to be parsed, found ${parses.length}`);
+    for (const [, name, arg] of parses) {
+      assert.match(arg, /stripServerOwnedToken\(/,
+        `${name} parses req.body directly, so a client posting a token it read back gets a 400`);
+    }
+  });
+
   it('the create schema still declares the real scope field', () => {
     // Strictness is only protective while `spaces` is the name it accepts. If the field were renamed and
     // this test kept passing, every previously-correct caller would start getting 400s instead.

--- a/testing/standalone/credential-bodies-are-strict.test.js
+++ b/testing/standalone/credential-bodies-are-strict.test.js
@@ -1,0 +1,81 @@
+/**
+ * Every body schema on the token routes rejects unknown keys.
+ *
+ * ## The defect this closes
+ *
+ * Zod drops unknown keys by default. `POST /api/tokens {name, admin:false, spaceIds:['qa']}` therefore
+ * returned **201** and minted a token with no `spaces` field at all — an UNSCOPED credential, reported as a
+ * success, in response to a request that plainly asked for a scoped one.
+ *
+ * Reported 2026-08-09 by an operator who probed four plausible spellings (`allowedSpaces`, `scope`,
+ * `spaceIds`, `denySpaces`) and got 201 from every one. They found it only by reading the stored token back
+ * and noticing four of five probes had no `spaces`. In their words: "somebody guessing the field name gets a
+ * token that looks scoped, reports success, and is not scoped at all."
+ *
+ * The rename route had the same shape with a sharper edge: it accepts a rename only, so `spaces` or `admin`
+ * sent alongside the name was dropped and answered 200 — an attempt to widen a token through the rename
+ * endpoint looked like it had worked.
+ *
+ * ## Why this is a gate rather than one assertion
+ *
+ * The defect is a schema HABIT, not a typo. `z.object({...})` is permissive unless someone remembers
+ * otherwise, and remembering is exactly what failed here. So this enumerates every body schema on these
+ * routes from source and requires each to be strict — a new one added without `.strict()` fails rather than
+ * silently joining the pattern.
+ *
+ * Run: node --test testing/standalone/credential-bodies-are-strict.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC = 'server/src/api/tokens.ts';
+const src = readFileSync(join(ROOT, SRC), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const code = withoutComments(src);
+
+/** Every `const XBody = z.object({ … })` in the file, with the text that closes it. */
+function bodySchemas() {
+  const out = [];
+  const re = /const\s+(\w*Body)\s*=\s*z\.object\(\{/g;
+  let m;
+  while ((m = re.exec(code)) !== null) {
+    // Walk to the matching close of the z.object( call, then read what follows it.
+    let i = re.lastIndex - 1, depth = 1;
+    while (i < code.length && depth > 0) {
+      i++;
+      if (code[i] === '{') depth++;
+      else if (code[i] === '}') depth--;
+    }
+    out.push({ name: m[1], tail: code.slice(i, i + 40) });
+  }
+  return out;
+}
+
+describe('token route bodies reject unknown keys', () => {
+  it('finds the schemas it is meant to be checking', () => {
+    // A gate that enumerates nothing passes vacuously and would keep passing if the file were renamed.
+    const found = bodySchemas();
+    assert.ok(found.length >= 2, `expected at least two body schemas in ${SRC}, found ${found.length}`);
+    assert.ok(found.some(s => s.name === 'CreateTokenBody'), `CreateTokenBody is gone — re-point this test`);
+  });
+
+  it('every body schema is .strict()', () => {
+    const loose = bodySchemas().filter(s => !/\)\s*\.strict\(\)/.test(s.tail)).map(s => s.name);
+    assert.deepEqual(
+      loose,
+      [],
+      `${loose.join(', ')} accept unknown keys. On a credential endpoint that means a mis-spelled scope `
+      + 'field mints an UNSCOPED token and answers 201 — the caller is told it worked.',
+    );
+  });
+
+  it('the create schema still declares the real scope field', () => {
+    // Strictness is only protective while `spaces` is the name it accepts. If the field were renamed and
+    // this test kept passing, every previously-correct caller would start getting 400s instead.
+    assert.match(code, /spaces:\s*z\.array/, 'CreateTokenBody no longer declares `spaces` — re-point this');
+  });
+});


### PR DESCRIPTION
fix(tokens): a mis-spelled scope field minted an unscoped token and returned 201

Zod drops unknown keys by default. `POST /api/tokens {name, admin:false,
spaceIds:['qa']}` therefore stored a token with NO `spaces` field at all — an
instance-wide credential, answered 201, in response to a request that plainly
asked for a scoped one.

Reported by aigents, verified against their live instance rather than inferred.
They probed four plausible spellings — `allowedSpaces`, `scope`, `spaceIds`,
`denySpaces` — and got 201 from every one. They found it only by reading the
stored token back and noticing four of five probes had no `spaces`. Their words:
"somebody guessing the field name gets a token that looks scoped, reports
success, and is not scoped at all."

Nothing distinguished the two outcomes: not the response, not the stored record,
not the logs. The caller's own notes would say the token was restricted.

`PATCH /api/tokens/:id` had the same shape with a sharper edge. It accepts a
rename ONLY, so `spaces` or `admin` sent beside the name was dropped and answered
200 — which is exactly what an attempt to widen a token through the rename
endpoint looked like.

Both bodies are `.strict()` now: an unknown key is a 400 naming it.

The gate enumerates every `*Body = z.object(…)` in the file from source and
requires each to be strict, rather than asserting on the two that exist today.
The defect is a schema HABIT — `z.object` is permissive unless someone remembers
otherwise, and remembering is precisely what failed — so a new body added without
`.strict()` fails instead of quietly joining the pattern. Mutation-checked by
stripping `.strict()`: one assertion fires, and only that one.

Operators are told plainly in the CHANGELOG and the auth guide that a token
minted with any other field name is NOT scoped and needs re-checking. The fix
stops new ones; it cannot retroactively narrow the ones already issued.
