### PR TITLE
feat(files): the face descriptor width comes from the space's index, not a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **The face descriptor width is now read from each space's own index instead of a built-in constant.**
+  Groundwork for making the width configurable, and the half that has to land first.
+  - The number that has to agree was never "what does this instance prefer" — it is "what are this space's
+    stored vectors, and what is its index expecting". Those two were created together at `initSpace`, so
+    reading the index makes a space **self-consistent by construction**: a gallery built at 128 keeps
+    rejecting 512-wide descriptors even after the configured default changes, because its stored vectors are
+    still 128 wide. That is the correct answer, not a limitation.
+  - One `listSearchIndexes` round trip per space, cached for the process — face embedding runs per image in
+    a background job, so an uncached read would sit in front of every one. A space whose index cannot be
+    read right now falls back to the built-in default and is **deliberately not cached**: pinning a guess
+    for the life of the process would be wrong for exactly the spaces this exists to serve.
+  - The per-face-chunk `sizeBytes` follows the same width, so a record's reported size matches the vector it
+    actually holds.
+  - **Not yet configurable.** Every space is still created at 128; what changed is that nothing downstream
+    assumes it. The setting that lets a space be created at another width is the next step.
+
 ### Fixed
 - **`POST /api/tokens` accepted a mis-spelled scope field and minted an UNSCOPED token, reporting success.**
   `allowedSpaces`, `scope`, `spaceIds` and `denySpaces` were all taken with a **201** and silently dropped;

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -1047,6 +1047,10 @@ and the infra pin not turned off):
 1. **Decode** — image bytes decoded to raw RGBA via `sharp`.
 2. **Detect** — `@vladmandic/human` runs BlazeFace Back detection. Faces below `minFaceSizeFraction` (default: 5% of the shorter image side) are skipped.
 3. **Embed** — FaceRes produces a descriptor per face, which the library reduces to 128 dimensions. That reduction, not the model weights, is where the 128 comes from — worth knowing because the gallery is built on it.
+   - **The width is read from the space's own face index**, not from an instance-wide constant, so a space
+     is judged against the vectors it actually holds. Every space is still created at 128 today; what
+     changed is that nothing downstream assumes it. A gallery built at one width keeps rejecting another
+     even if the default changes later — its stored vectors have not moved.
    - **A descriptor of any other width is skipped, and the first one is logged as a warning** naming the width received and which path produced it (in-process or external). One odd descriptor must not fail a whole media job, so the skip itself is not an error; the log is once per process, because a changed width means every face is affected and a per-face log would bury the message. If face recognition appears to find nothing, check for this warning before concluding the images have no faces — that is the symptom a width mismatch produces.
 4. **Gallery search** — each descriptor is searched against the space's face gallery (all face-chunk records that have a `faceEntityId`) using an exact `$vectorSearch`. The top-1 result is examined.
 5. **Auto-label** — if the top match's cosine similarity score ≥ `confidenceThreshold` (default: `0.6`), the parent image is linked to that entity (`entityIds` updated). The first successful match wins.

--- a/server/src/files/media/face-descriptor.ts
+++ b/server/src/files/media/face-descriptor.ts
@@ -48,14 +48,25 @@ let warned = false;
  * in-process path changing width means the library's reduction moved, and an external provider changing
  * width means someone pointed the hook at a different model.
  */
-export function isUsableDescriptor(embedding: unknown, source: 'in-process' | 'external'): boolean {
+export function isUsableDescriptor(
+  embedding: unknown,
+  source: 'in-process' | 'external',
+  /**
+   * The width THIS SPACE's gallery was built at, from `faceDescriptorDimsFor()`.
+   *
+   * Defaults to the built-in only so a caller that genuinely has no space in hand still gets the old
+   * behaviour rather than silently accepting anything. Every real caller passes the resolved value: the
+   * number that has to agree is the one on the space's own index, not this instance's preference.
+   */
+  expectedDims: number = FACE_DESCRIPTOR_DIMS,
+): boolean {
   if (!Array.isArray(embedding)) return false;
-  if (embedding.length === FACE_DESCRIPTOR_DIMS) return true;
+  if (embedding.length === expectedDims) return true;
 
   if (!warned) {
     warned = true;
     log.warn(
-      `Face descriptor width is ${embedding.length}, expected ${FACE_DESCRIPTOR_DIMS} (${source}). `
+      `Face descriptor width is ${embedding.length}, expected ${expectedDims} (${source}). `
       + 'Every face is being skipped, and this will read as "no faces detected" everywhere. '
       + (source === 'in-process'
         ? 'The in-process width is produced by @vladmandic/human reducing FaceRes\'s own 1024-wide output — '

--- a/server/src/files/media/face-embedder.ts
+++ b/server/src/files/media/face-embedder.ts
@@ -39,6 +39,7 @@ import { faceRecognitionAllowed } from '../converters/media-level.js';
 import { updateFileMeta } from '../file-meta.js';
 import { log } from '../../util/log.js';
 import { isUsableDescriptor, FACE_DESCRIPTOR_DIMS } from './face-descriptor.js';
+import { faceDescriptorDimsFor } from '../../spaces/vector-index.js';
 import type { FileMetaDoc, AuthorRef, EntityDoc } from '../../config/types.js';
 import type { Config as HumanConfig, Result } from '@vladmandic/human';
 import { detectFacesExternal, externalFaceReady, inProcessFallbackAllowed } from './face-external.js';
@@ -271,8 +272,12 @@ export async function embedFaces(
   // An external provider gets first refusal, when one is configured AND its host is acknowledged. It
   // returns null on ANY failure. Both paths yield the same `{ embedding, boxRaw }` shape, so everything
   // below is shared.
+  // Resolved once per image from THIS space's index, then used by both paths and by the chunk's sizeBytes.
+  // Reading it per face would put a mongot round trip inside the per-face loop.
+  const expectedDims = await faceDescriptorDimsFor(spaceId);
+
   let faces: Array<{ embedding?: number[]; boxRaw?: number[] }> | undefined =
-    (await detectFacesExternal(imageBytes)) ?? undefined;
+    (await detectFacesExternal(imageBytes, expectedDims)) ?? undefined;
 
   // A configured provider that failed does NOT hand off to the bundled model unless the operator asked
   // for that. The two embedders emit the same width, so mixing them corrupts the gallery in a way no
@@ -338,7 +343,7 @@ export async function embedFaces(
     const embedding: number[] | undefined = face.embedding;
     // Absent means FaceRes did not run for this face — routine, and not what the width guard is about.
     // Present-but-wrong-width is the case that must not stay quiet, so it goes through the shared guard.
-    if (!embedding || !isUsableDescriptor(embedding, 'in-process')) continue;
+    if (!embedding || !isUsableDescriptor(embedding, 'in-process', expectedDims)) continue;
 
     // Filter by minimum face size (fraction of shorter image side)
     const boxRaw = face.boxRaw; // [x, y, w, h] normalised 0–1
@@ -373,7 +378,7 @@ export async function embedFaces(
       tags: [],
       createdAt: now,
       updatedAt: now,
-      sizeBytes: FACE_DESCRIPTOR_DIMS * 4, // float32 each
+      sizeBytes: expectedDims * 4, // float32 each — the space's own width, not the built-in default
       author,
       parentFileId: fileId,
       chunkIndex: i,

--- a/server/src/files/media/face-external.ts
+++ b/server/src/files/media/face-external.ts
@@ -80,7 +80,7 @@ export function inProcessFallbackAllowed(): boolean {
  * follow a redirect into link-local metadata. Validating the URL at write time is not enough on its own —
  * DNS can change between the save and the call.
  */
-export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalFace[] | null> {
+export async function detectFacesExternal(imageBytes: Buffer, expectedDims: number): Promise<ExternalFace[] | null> {
   if (!externalFaceReady()) return null;
   const ext = getConfig().mediaEmbedding?.faceRecognition?.externalModel;
   const baseUrl = ext?.baseUrl?.trim();
@@ -122,7 +122,7 @@ export async function detectFacesExternal(imageBytes: Buffer): Promise<ExternalF
       // Exactly as many floats as the gallery's index was built with. A provider returning a different width
       // would corrupt gallery similarity scores rather than fail loudly, so the wrong shape is dropped here,
       // not downstream.
-      if (!isUsableDescriptor(f?.embedding, 'external')) continue;
+      if (!isUsableDescriptor(f?.embedding, 'external', expectedDims)) continue;
       // `isUsableDescriptor` has already established this is an array of the right LENGTH; the values are
       // still a provider's word for it, so they are checked before anything stores them.
       const emb = f.embedding as unknown[];

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -565,3 +565,58 @@ export async function finalizeSpaceIndexReady(
   // the opposite about two of them.
   return ok;
 }
+
+// ── Face descriptor width, resolved per space ────────────────────────────────────────────────────────────
+
+/**
+ * The width a given space's face gallery was built at.
+ *
+ * ## Why this is read from the INDEX rather than from config
+ *
+ * The number that matters is not "what does this instance prefer" but "what are this space's stored vectors,
+ * and what is its index expecting" — and those two were created together at `initSpace`. Reading the index
+ * makes a space self-consistent by construction: a gallery built at 128 keeps rejecting 512 descriptors even
+ * after an operator changes the configured default, which is the correct answer, because its stored vectors
+ * are still 128 wide.
+ *
+ * This is the shape the requesting operator asked for: *"the number exists as configuration in one place and
+ * the validator could read it instead of a literal."* The alternative they offered — a second
+ * `externalModel.dimensions` setting — is a second place to write the width down, and the two would drift.
+ *
+ * ## The cache, and why a miss is not cached
+ *
+ * One `listSearchIndexes` round trip per space, held for the process. Face embedding runs per image in a
+ * background job, so an uncached read would put a mongot call in front of every one.
+ *
+ * A space whose index cannot be read right now — mid-creation, mongot lagging, a transient error — falls back
+ * to `FACE_DESCRIPTOR_DIMS` and is **deliberately not cached**. Caching a fallback would pin a guess for the
+ * life of the process, and the guess is wrong precisely for the spaces this feature exists to serve: the ones
+ * built at a different width.
+ */
+const faceDimsBySpace = new Map<string, number>();
+
+export function resetFaceDimsCache(): void { faceDimsBySpace.clear(); }
+
+export async function faceDescriptorDimsFor(spaceId: string): Promise<number> {
+  const hit = faceDimsBySpace.get(spaceId);
+  if (hit !== undefined) return hit;
+
+  const indexName = `${spaceId}_files_faceEmbedding`;
+  try {
+    const coll = getDb().collection(`${spaceId}_files`);
+    const indexes = await coll.listSearchIndexes().toArray() as Array<{
+      name?: string; latestDefinition?: { fields?: SearchIndexField[] };
+    }>;
+    const fields = indexes.find(i => i.name === indexName)?.latestDefinition?.fields ?? [];
+    const dims = fields.find(f => f.type === 'vector')?.numDimensions ?? fields[0]?.numDimensions;
+    if (typeof dims === 'number' && dims > 0) {
+      faceDimsBySpace.set(spaceId, dims);
+      return dims;
+    }
+    log.debug(`Face index ${indexName} reports no dimension; using the built-in default this call only`);
+  } catch (err) {
+    log.debug(`Could not read ${indexName} (${err instanceof Error ? err.message : String(err)}); `
+      + 'using the built-in default this call only');
+  }
+  return FACE_DESCRIPTOR_DIMS;
+}

--- a/testing/standalone/face-external.test.js
+++ b/testing/standalone/face-external.test.js
@@ -71,7 +71,7 @@ describe('the source enforces its own guarantees', () => {
     assert.ok(!/[^f]\bfetch\(/.test(src.replace(/ssrfSafeFetch\(/g, '')), 'no bare fetch(');
   });
 
-  it('rejects any descriptor that is not exactly 128 floats', () => {
+  it('rejects any descriptor that is not the width THIS SPACE was built at', () => {
     // The width check moved into `face-descriptor.ts` so the first unexpected width is REPORTED rather than
     // skipped in silence. This asserts both halves for THIS path: that the file still defers to the helper,
     // and that the helper still enforces the width — checking only the call would pass against a helper that
@@ -83,9 +83,15 @@ describe('the source enforces its own guarantees', () => {
     // in `face-width-is-never-a-literal.test.js`, which discovers the paths instead of naming them.
     assert.ok(src.includes('isUsableDescriptor('), 'the width check must still happen');
     const guard = readFileSync(new URL('../../server/src/files/media/face-descriptor.ts', import.meta.url), 'utf8');
-    assert.match(guard, /embedding\.length === FACE_DESCRIPTOR_DIMS/,
+    assert.match(guard, /embedding\.length === expectedDims/,
       'face-descriptor.ts no longer compares the width, so nothing does');
-    assert.match(guard, /FACE_DESCRIPTOR_DIMS = 128/, 'the gallery index is built at 128');
+    // The width is per SPACE now, resolved from that space's own index, so the guard must take it as an
+    // argument rather than reading a module constant. `FACE_DESCRIPTOR_DIMS` survives only as the default
+    // for a caller with no space in hand — asserting on it here would pin the old fixed-width rule.
+    assert.match(guard, /expectedDims: number = FACE_DESCRIPTOR_DIMS/,
+      'the guard no longer accepts a per-space width; a space built at 512 would be judged against 128');
+    assert.match(src, /isUsableDescriptor\([^)]*expectedDims/,
+      'face-external.ts calls the guard without the resolved width');
     assert.ok(src.includes('Number.isFinite'), 'NaN/Infinity must be rejected');
   });
 

--- a/testing/standalone/face-width-is-never-a-literal.test.js
+++ b/testing/standalone/face-width-is-never-a-literal.test.js
@@ -83,7 +83,7 @@ describe('face descriptor width is never a literal', () => {
   it('both descriptor sources are named, so neither can be quietly dropped', () => {
     const sources = mediaSources()
       .filter((f) => f !== GUARD)
-      .flatMap((f) => [...withoutComments(read(f)).matchAll(/isUsableDescriptor\s*\([^)]*?['"]([a-z-]+)['"]\s*\)/g)]
+      .flatMap((f) => [...withoutComments(read(f)).matchAll(/isUsableDescriptor\s*\([^)]*?['"]([a-z-]+)['"]/g)]
         .map((m) => m[1]));
     // Build the regex fresh per use; a shared /g regex advances lastIndex between assertions.
     assert.ok(sources.includes('in-process'), `no in-process width check found, got: ${sources.join(', ') || '(none)'}`);


### PR DESCRIPTION
feat(files): the face descriptor width comes from the space's index, not a constant

Groundwork for making the width configurable, and the half that has to land
first. Nothing is configurable yet: every space is still created at 128. What
changed is that nothing downstream assumes it any more.

The number that has to agree was never "what does this instance prefer". It is
"what are this space's stored vectors, and what is its index expecting" — and
those two were created together at initSpace. So the validator reads the index.

That makes a space self-consistent by construction, and gives the right answer to
the case that would otherwise be a trap: a gallery built at 128 keeps rejecting
512-wide descriptors even after an operator changes the configured default,
because its stored vectors are still 128 wide. Refusing there is correct, not a
limitation.

This is the shape the requesting operator asked for — "the number exists as
configuration in one place and the validator could read it instead of a literal".
Their fallback option, an `externalModel.dimensions` setting, is declined for the
reason they gave themselves: a second place to write the width down, and the two
would drift.

Caching: one listSearchIndexes round trip per space, held for the process,
because face embedding runs per image in a background job and an uncached read
would sit in front of every one. A space whose index cannot be read right now —
mid-creation, mongot lagging, a transient error — falls back to the built-in
default and is DELIBERATELY NOT CACHED. Pinning a guess for the life of the
process would be wrong for precisely the spaces this feature exists to serve.

Also corrected: a face chunk's `sizeBytes` was computed from the constant, so on
a space of any other width the stored record would have misreported the size of
the vector it holds.

Two gates were re-pointed rather than left passing on the old rule. `face-external`
asserted `embedding.length === FACE_DESCRIPTOR_DIMS` and `FACE_DESCRIPTOR_DIMS =
128`; both would have gone green while describing a fixed width that no longer
exists. They now assert the guard takes a per-space width and that the callers
pass it.
