### PR TITLE
feat(spaces): a space can be created at a face descriptor width other than 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **A space can now be created at a face descriptor width other than 128.** `POST /api/spaces` accepts
+  `faceDescriptorDims` (64–4096, default 128), and the space's face index is built at that width.
+  - **Why it exists:** every top-tier open face recogniser emits 512 dimensions — ArcFace, AdaFace, FaceNet,
+    EdgeFace — while the bundled model emits 128. The external-provider hook exists so an operator can bring
+    a better model, and a hard 128 admitted only models in the bundled one's weight class. Requested by an
+    operator who had chosen a 512-d model and was holding their whole face rollout on it.
+  - **Create-only, and permanently so.** The gallery's vectors are written at this width and nothing
+    re-derives them, so changing it later would leave stored vectors indexed as a different size — a cosine
+    search that ranks nothing correctly and reports no error. The field is absent from `PATCH /api/spaces/:id`
+    so the API never offers the change, and the index build refuses it independently for a width that reaches
+    an existing space some other way.
+  - Bounds rather than an enum: 128 and 512 are today's answers, and an enum would make the next model a
+    code change.
+  - Absent means the built-in default and is **stored as absent**, so an existing space and a new
+    default-width one are the same shape on disk — a stored `128` would read as a choice nobody made.
+
 ### Changed
 - **The face descriptor width is now read from each space's own index instead of a built-in constant.**
   Groundwork for making the width configurable, and the half that has to land first.

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -73,6 +73,17 @@ Authorization: Bearer <admin-token>
 | `description` | no | **Deprecated** — writes `meta.purpose`. Max 4000 chars. Removal in 3.0. |
 | `folders` | no | Pre-create these directories on disk at space creation time. |
 | `maxGiB` | no | Maximum storage quota for the space (positive number in GiB). |
+| `faceDescriptorDims` | no | Width of this space's face descriptors (integer, 64–4096, default 128). **Create-only** — see below. |
+
+**`faceDescriptorDims` cannot be changed after creation, and that is deliberate.** The space's face gallery
+stores vectors at this width and nothing re-derives them, so re-dimensioning the index later would leave the
+stored vectors indexed as a different size — every similarity score wrong, with no error reported anywhere.
+The field is therefore absent from `PATCH /api/spaces/:id`, and the index build refuses a width change
+independently. Set it at creation or accept 128. To move a populated gallery, create a new space at the new
+width and re-process its images.
+
+Use it when you point `faceRecognition.externalModel` at a recogniser that does not emit 128 dimensions —
+most current open models emit 512.
 
 **Response** `201`: the created space object, wrapped in a `space` field:
 

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -159,6 +159,11 @@ const CreateSpaceBody = z.object({
   description: z.string().max(SPACE_PURPOSE_MAX).optional(),
   folders: z.array(z.string()).optional(),
   maxGiB: z.number().positive().optional(),
+  // Create-only, and deliberately absent from the update body: a populated gallery cannot be re-dimensioned,
+  // so offering the field on PATCH would be offering a change the index build then refuses.
+  // Bounds rather than an enum — 128 (MobileFaceNet class) and 512 (ArcFace, AdaFace, FaceNet, EdgeFace) are
+  // today's answers, and pinning an enum would make the next model a code change.
+  faceDescriptorDims: z.number().int().min(64).max(4096).optional(),
   proxyFor: ProxyForZ.optional(),
   meta: SpaceMetaBody.optional(),
 });
@@ -492,7 +497,7 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
     res.status(400).json({ error: parsed.error.message });
     return;
   }
-  const { id: rawId, label, description, folders, maxGiB, proxyFor, meta } = parsed.data;
+  const { id: rawId, label, description, folders, maxGiB, proxyFor, meta, faceDescriptorDims } = parsed.data;
   const id = rawId ?? slugify(label);
 
   // Validate proxy members exist and are not themselves proxies
@@ -545,7 +550,7 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
     : { validationMode: 'strict', strictLinkage: true, ...(requestMeta ?? {}) };
 
   try {
-    const space = await createSpace({ id, label, description, folders, maxGiB, proxyFor, meta: seededMeta });
+    const space = await createSpace({ id, label, description, folders, maxGiB, proxyFor, meta: seededMeta, faceDescriptorDims });
     res.status(201).json({ space: spaceResponse(space) });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -272,6 +272,18 @@ export interface SpaceConfig {
   builtIn: boolean;
   folders: string[];
   maxGiB?: number;
+  /**
+   * The width of this space's face descriptors, fixed when the space is created.
+   *
+   * Absent means the built-in default. **Create-only**: the face gallery's vectors are written at this width
+   * and nothing re-derives them, so changing it later would leave stored vectors indexed as if they were a
+   * different size — a cosine search that ranks nothing correctly and reports no error. The index build
+   * refuses such a change; this field simply never offers it.
+   *
+   * Exists because every top-tier open face recogniser emits 512 dimensions while the bundled one emits 128,
+   * so the external-provider hook admitted only models in the bundled model's weight class.
+   */
+  faceDescriptorDims?: number;
   flex?: number;
   /**
    * @deprecated Say `meta.purpose`. This is the legacy spelling of the same thing: it was the field

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -311,6 +311,8 @@ export async function createSpace(opts: {
   maxGiB?: number;
   proxyFor?: string[];
   meta?: SpaceMeta;
+  /** Face descriptor width for this space. Create-only — see `SpaceConfig.faceDescriptorDims`. */
+  faceDescriptorDims?: number;
 }): Promise<SpaceConfig> {
   const cfg = getConfig();
   if (cfg.spaces.some(s => s.id === opts.id)) {
@@ -327,6 +329,9 @@ export async function createSpace(opts: {
     builtIn: false,
     folders: opts.folders ?? [],
     maxGiB: opts.maxGiB,
+    // Omitted rather than defaulted when absent, so an existing space and a new one at the built-in width
+    // are the same shape on disk — a stored `128` would read as a deliberate choice nobody made.
+    ...(opts.faceDescriptorDims ? { faceDescriptorDims: opts.faceDescriptorDims } : {}),
     ...(opts.proxyFor ? { proxyFor: opts.proxyFor } : {}),
     // `description` on the create body is the deprecated spelling of `meta.purpose`; it seeds the
     // one store rather than a second one, so a space cannot be born with the two disagreeing.

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -511,7 +511,11 @@ export async function buildSpaceVectorIndexes(
     // correctly. One copy now, which is also the precondition for making it configurable.
     // `refuseWidthChange`: the face gallery is the one index whose vectors nothing re-derives, so a width
     // change must never be applied silently to an existing space. See the guard in ensureVectorSearchIndex.
-    await ensureVectorSearchIndex(spaceId, 'files', FACE_DESCRIPTOR_DIMS, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady, undefined, { ...opts, refuseWidthChange: true });
+    // The space's own width, chosen at creation. `refuseWidthChange` then makes it permanent: an existing
+    // gallery is never re-dimensioned, because nothing re-derives the vectors already stored in it.
+    const configuredDims = getConfig().spaces.find(s => s.id === spaceId)?.faceDescriptorDims
+      ?? FACE_DESCRIPTOR_DIMS;
+    await ensureVectorSearchIndex(spaceId, 'files', configuredDims, 'cosine', 'faceEmbedding', 'faceEmbedding', waitForReady, undefined, { ...opts, refuseWidthChange: true });
   }
 }
 

--- a/testing/standalone/face-width-is-create-only.test.js
+++ b/testing/standalone/face-width-is-create-only.test.js
@@ -1,0 +1,86 @@
+/**
+ * A space's face descriptor width is chosen once, at creation, and can never be edited.
+ *
+ * ## Why create-only is the whole design
+ *
+ * The face gallery's vectors live on stored face-chunk records and **nothing re-derives them**. Changing a
+ * populated space's width would leave 128-wide vectors indexed as though they were 512 — a cosine search
+ * that ranks nothing correctly and reports no error at all.
+ *
+ * Two independent things have to hold, and each covers a different way of getting it wrong:
+ *
+ *  1. the field is on the CREATE body and NOT on the update body, so the API never offers the change;
+ *  2. the index build passes `refuseWidthChange`, so a width that reached an existing space some other way
+ *     — a hand-edited `config.json`, a restore, a future code path — is refused rather than applied.
+ *
+ * Only the second is a real guard. The first is what stops an operator being told "yes" and then discovering
+ * their gallery is silently unsearchable. Asserting one and not the other is how this feature would look
+ * finished while being dangerous.
+ *
+ * Run: node --test testing/standalone/face-width-is-create-only.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const api = withoutComments(read('server/src/api/spaces.ts'));
+const idx = withoutComments(read('server/src/spaces/vector-index.ts'));
+const life = withoutComments(read('server/src/spaces/lifecycle.ts'));
+
+/** The body schema named by `constName`, sliced to its own closing paren. */
+function schemaBody(code, constName) {
+  const start = code.indexOf(`const ${constName}`);
+  if (start < 0) return null;
+  let i = code.indexOf('z.object({', start);
+  if (i < 0) return null;
+  let depth = 1;
+  i += 'z.object({'.length - 1;
+  while (i < code.length && depth > 0) {
+    i++;
+    if (code[i] === '{') depth++;
+    else if (code[i] === '}') depth--;
+  }
+  return code.slice(start, i);
+}
+
+describe('the face descriptor width is create-only', () => {
+  it('finds the two body schemas it is comparing', () => {
+    // Without this the next two tests pass vacuously on a renamed constant.
+    assert.ok(schemaBody(api, 'CreateSpaceBody'), 'CreateSpaceBody not found — re-point this test');
+    assert.ok(schemaBody(api, 'UpdateSpaceBody'), 'UpdateSpaceBody not found — re-point this test');
+  });
+
+  it('the CREATE body accepts it', () => {
+    assert.match(schemaBody(api, 'CreateSpaceBody'), /faceDescriptorDims/,
+      'a space can no longer be created at a chosen width, which is the whole feature');
+  });
+
+  it('the UPDATE body does NOT accept it', () => {
+    assert.doesNotMatch(schemaBody(api, 'UpdateSpaceBody'), /faceDescriptorDims/,
+      'PATCH offers a width change that the index build then refuses — the operator is told yes and gets no');
+  });
+
+  it('the index is sized from the space, not from the built-in constant', () => {
+    assert.match(idx, /faceDescriptorDims/,
+      'buildSpaceVectorIndexes ignores the space setting, so every space is still built at the default');
+  });
+
+  it('and it still refuses to re-dimension an existing index', () => {
+    // The guard that makes create-only enforceable rather than merely polite.
+    assert.match(idx, /refuseWidthChange:\s*true/,
+      'the face index would be rebuilt at a new width, orphaning every stored vector');
+  });
+
+  it('an absent width is omitted from the stored space, not defaulted to a number', () => {
+    // A stored `128` reads as a deliberate choice. Absent reads as "nobody chose", which is the truth and
+    // keeps an existing space and a new default-width space the same shape on disk.
+    assert.match(life, /opts\.faceDescriptorDims\s*\?\s*\{\s*faceDescriptorDims/,
+      'createSpace writes a width unconditionally; absent and default become indistinguishable');
+  });
+});

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -77,7 +77,10 @@ const FROZEN = {
   // 839 -> 843: `typeSchemasMode` on the update body and the replace branch in `mergeSpaceMeta`. Both are
   // small and belong beside the merge they qualify — splitting a two-branch decision across files would
   // make the contract harder to read, not easier.
-  'server/src/api/spaces.ts': 843,
+  // 843 -> 844: one Zod line accepting `faceDescriptorDims` on the CREATE body. Deliberately NOT added to
+  // the update body — see `face-width-is-create-only.test.js` — so this is the single line that admits the
+  // field at all, and there is nowhere smaller to put it.
+  'server/src/api/spaces.ts': 844,
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.
@@ -86,11 +89,14 @@ const FROZEN = {
   'client/src/app/pages/brain/review-tab.component.ts': 748,
   'server/src/brain/recall.ts': 739,
   'client/src/app/pages/settings/media-processing/models-tab.component.ts': 678,
+  // 673 -> 674: `faceDescriptorDims` on SpaceConfig. One line of type again, and the behaviour it names is
+  // in `vector-index.ts` and `lifecycle.ts`. A space's shape belongs in the space's type; the alternative is
+  // a side-table of per-space settings, which is a worse trade than one line.
   // 672 -> 673: `allowInProcessFallback` on `faceRecognition.externalModel`. ONE line of type, and the
   // behaviour it names lives in `face-external.ts` and `face-embedder.ts`, not here. The alternative —
   // a face-only config module re-exported from this file — would split the config contract across two
   // places to save a single field, which is the trade this list exists to let us decline.
-  'server/src/config/types.ts': 673,
+  'server/src/config/types.ts': 674,
   'client/src/app/pages/settings/data.component.ts': 644,
   'server/src/api/files.ts': 646,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate


### PR DESCRIPTION
feat(spaces): a space can be created at a face descriptor width other than 128

`POST /api/spaces` takes `faceDescriptorDims` (64-4096, default 128) and the
space's face index is built at that width. This completes the item: the previous
PR made every reader take the width from the space's own index, and this one
lets the space be created at a width worth reading.

Why it exists: every top-tier open face recogniser emits 512 dimensions —
ArcFace, AdaFace, InceptionResnetV1, EdgeFace — while the bundled model emits
128. The external-provider hook exists precisely so an operator can bring a
better model, and a hard 128 admitted only models in the bundled one's weight
class. The operator who reported it had already chosen a 512-d model and was
holding their entire face rollout on the answer.

CREATE-ONLY, and that is the design rather than a shortcut. The gallery's vectors
are written at this width and nothing re-derives them, so changing it later leaves
stored vectors indexed as a different size: every similarity score wrong, no error
anywhere. Two independent things enforce it, and each covers a different failure:

  - the field is absent from the UPDATE body, so the API never offers the change
    and nobody is told "yes" and then quietly loses their gallery;
  - the index build still passes `refuseWidthChange`, so a width that reaches an
    existing space some other way — a hand-edited config.json, a restore, a future
    code path — is refused rather than applied.

Only the second is a guard. Asserting one and not the other is how this would look
finished while being dangerous, so the gate asserts both.

Bounds rather than an enum. 128 and 512 are today's answers; pinning an enum makes
the next model a code change for no safety gained, since the index and the
validator already have to agree and now do so through the space itself.

An absent width is stored as absent, not defaulted to 128, so an existing space
and a new default-width space are the same shape on disk. A stored 128 would read
as a deliberate choice nobody made.

Two ratchet entries raised by one line each, with the reason inline: the field on
`SpaceConfig`, and the Zod line that admits it on create. Both are type/schema
lines whose behaviour lives elsewhere.
