### PR TITLE
feat(auth): classify every space-scoped route, and fail the build on one that is not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: every space-scoped route is now classified into an area, and a gate fails the build on one
+  that is not.** Groundwork for the per-space rights matrix; no behaviour changes yet.
+  - The matrix can only govern routes it knows about. An unclassified route does not warn — it keeps working
+    at whatever access the old model gave it while the UI shows a column implying otherwise.
+  - **The enumeration immediately found what hand-writing the list had missed:** every COLLECTION-level
+    delete (`DELETE` on `memories`, `entities`, `edges`, `chrono` and `files` — each empties a whole record
+    type in a space), plus the conflict deletes and a test-seed route. The most destructive endpoints in the
+    area were the ones absent from the first draft.
+  - It also caught two routes that were listed with a method they do not have, which would have produced
+    rules guarding nothing.
+  - **Two enforcement shapes, not one.** Most routes take the space from the path. All of Data quality takes
+    no space at all — `duplicates`, `contradictions` and `conflicts` walk every space the token can reach and
+    resolve the space from the record. For those the enforcement point is the ITERATION SET, not the call, so
+    each entry records which shape it is. A guard written only for the path shape would have left that column
+    decorative.
+
+### Added
 - **A space can now be created at a face descriptor width other than 128.** `POST /api/spaces` accepts
   `faceDescriptorDims` (64–4096, default 128), and the space's face index is built at that width.
   - **Why it exists:** every top-tier open face recogniser emits 512 dimensions — ArcFace, AdaFace, FaceNet,

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -1,0 +1,189 @@
+/**
+ * Which space-scoped area each route belongs to, and HOW that route learns its space.
+ *
+ * ## Why an inventory and not a decorator
+ *
+ * The per-space rights matrix (owner-approved 2026-08-09) says a token holds a rung — none / read / write /
+ * area-admin — per area per space. That is only true if every route that touches a space is assigned to
+ * exactly one area. A route nobody classified is a route the grid does not govern, and it does not announce
+ * itself: it simply keeps working at whatever access the old model gave it while the UI shows a column that
+ * says otherwise.
+ *
+ * So the mapping is data, in one file, and a gate enumerates the real route surface and fails on anything
+ * missing from it. That ordering matters — the list is derived from the surface, not the other way round.
+ *
+ * ## The part that was nearly missed, and is the reason `scope` exists
+ *
+ * There are TWO enforcement shapes, and the design assumed one:
+ *
+ *  - **`path`** — the space is in the URL (`:spaceId`, or `:id` on the spaces router). Gate by reading it.
+ *  - **`iterates`** — the route takes NO space and walks every space the token can reach. All of Data
+ *    quality is this shape: `duplicates`, `contradictions` and `conflicts` resolve the space from the
+ *    RECORD, looping over the token's accessible spaces.
+ *
+ * A guard written only for `path` would leave the Data quality column decorative — those routes would keep
+ * scanning every reachable space at any level while the grid claimed to restrict them. For `iterates`, the
+ * enforcement point is the ITERATION SET, not the route: the loop must be narrowed to spaces where the token
+ * holds the required rung, and `/scan` and `/bulk-resolve` narrowed identically or one call reaches spaces
+ * the grid excludes.
+ *
+ * Three columns have now turned out not to mean what their name suggested — Governance was keyed by network,
+ * Sync/peer by peer, and Data quality by nothing at all. Each was caught by enumerating rather than by
+ * reasoning from the name.
+ */
+
+/** The four space-scoped areas. Instance-level capabilities are NOT here — they have no space to scope to. */
+export type SpaceArea = 'knowledge' | 'files' | 'schema' | 'dataQuality';
+
+/** Rungs, lowest first. Each CONTAINS the one below, so "write but not read" is unrepresentable. */
+export const RUNGS = ['none', 'read', 'write', 'admin'] as const;
+export type Rung = (typeof RUNGS)[number];
+
+/** How a route learns which space it is acting on. See the note above — this is not cosmetic. */
+export type ScopeShape = 'path' | 'iterates';
+
+export interface RouteRight {
+  /** Express path as registered, including the router's mount prefix. */
+  route: string;
+  method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+  area: SpaceArea;
+  /** The LOWEST rung that may call it. A token at or above this passes. */
+  needs: Exclude<Rung, 'none'>;
+  scope: ScopeShape;
+}
+
+/**
+ * Ordered by area, then by route, so a diff reads as "what changed about this area" rather than as churn.
+ *
+ * `needs` is the lowest sufficient rung, never the intended audience: `recall` needs `read` even though
+ * most callers holding it also write, because the question at the gate is "may this call happen", not "who
+ * usually makes it".
+ */
+export const ROUTE_RIGHTS: readonly RouteRight[] = [
+  // ── Knowledge ────────────────────────────────────────────────────────────────────────────────────────
+  { route: '/api/brain/spaces/:spaceId/recall', method: 'POST', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/query', method: 'POST', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/traverse', method: 'POST', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/find-similar', method: 'POST', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/er-model', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/stats', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/events', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/events/ticket', method: 'POST', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/memories', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/memories', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/by-ids', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/by-name', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  // A merge DESTROYS one of the two records, so it is admin even though each half looks like an edit.
+  { route: '/api/brain/spaces/:spaceId/entities/:survivorId/merge/:absorbedId', method: 'POST', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  // `bulk` can create OR delete, so it takes the higher rung of what it can do rather than of what it is
+  // usually used for. A bulk endpoint gated at `write` is a delete endpoint with a friendly name.
+  { route: '/api/brain/spaces/:spaceId/bulk', method: 'POST', area: 'knowledge', needs: 'admin', scope: 'path' },
+  // COLLECTION-level deletes. Every one of these empties a whole record type in the space, and not one was
+  // in the first draft of this list — the gate found them. They are the single most destructive thing in the
+  // area and would have been the least governed.
+  { route: '/api/brain/spaces/:spaceId/memories', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  // POST-as-update on a chrono id: the only POST-that-updates in the brain API, and a documented
+  // deprecation. Rung follows what it DOES, not what its verb suggests.
+  { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
+
+  // ── Files ────────────────────────────────────────────────────────────────────────────────────────────
+  { route: '/api/files/:spaceId', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
+  { route: '/api/files/:spaceId', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
+  { route: '/api/files/:spaceId/upload-status', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/files', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/files/extract', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/embedding-queue', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/embedding-queue/retry-failed', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/files', method: 'PATCH', area: 'files', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/files', method: 'DELETE', area: 'files', needs: 'admin', scope: 'path' },
+  { route: '/api/files/:spaceId/mkdir', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
+
+  // ── Schema ───────────────────────────────────────────────────────────────────────────────────────────
+  { route: '/api/spaces/:id', method: 'GET', area: 'schema', needs: 'read', scope: 'path' },
+  { route: '/api/spaces/:id/schema', method: 'GET', area: 'schema', needs: 'read', scope: 'path' },
+  { route: '/api/spaces/:id/schema', method: 'PUT', area: 'schema', needs: 'write', scope: 'path' },
+  { route: '/api/spaces/:id/meta', method: 'GET', area: 'schema', needs: 'read', scope: 'path' },
+  { route: '/api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName', method: 'PUT', area: 'schema', needs: 'write', scope: 'path' },
+  { route: '/api/spaces/:id/validate-schema', method: 'POST', area: 'schema', needs: 'read', scope: 'path' },
+  { route: '/api/spaces/:id/completeness', method: 'GET', area: 'schema', needs: 'read', scope: 'path' },
+  // Reindex and rebuild-indexes rewrite infrastructure the whole space depends on, and a rebuild makes
+  // recall return nothing until it finishes. Structural, so admin.
+  { route: '/api/spaces/:id/rebuild-indexes', method: 'POST', area: 'schema', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/reindex', method: 'POST', area: 'schema', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/reindex-status', method: 'GET', area: 'schema', needs: 'read', scope: 'path' },
+
+  // ── Data quality — every one of these is `iterates` ───────────────────────────────────────────────────
+  // These take no space. They walk the token's accessible spaces and resolve the space from the record, so
+  // the gate is the ITERATION SET: narrow the loop to spaces holding `needs`, do not gate the call.
+  { route: '/api/duplicates', method: 'GET', area: 'dataQuality', needs: 'read', scope: 'iterates' },
+  { route: '/api/duplicates/scan', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/duplicates/:id/merge', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/duplicates/:id/dismiss', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/duplicates/:id/reopen', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/contradictions', method: 'GET', area: 'dataQuality', needs: 'read', scope: 'iterates' },
+  { route: '/api/contradictions/scan', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/contradictions/:id/resolve', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/contradictions/:id/dismiss', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/contradictions/:id/reopen', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/conflicts', method: 'GET', area: 'dataQuality', needs: 'read', scope: 'iterates' },
+  { route: '/api/conflicts/:id', method: 'GET', area: 'dataQuality', needs: 'read', scope: 'iterates' },
+  { route: '/api/conflicts/:id/resolve', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/conflicts/bulk-resolve', method: 'POST', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/conflicts/link-violations', method: 'GET', area: 'dataQuality', needs: 'read', scope: 'iterates' },
+  { route: '/api/conflicts/:id', method: 'DELETE', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/conflicts/link-violations', method: 'DELETE', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  { route: '/api/conflicts/link-violations/:id', method: 'DELETE', area: 'dataQuality', needs: 'write', scope: 'iterates' },
+  // A seed route exists for tests. Classified rather than exempted: an unclassified route is exactly what
+  // this inventory is for, and "it is only for tests" is the sentence that precedes finding it in production.
+  { route: '/api/conflicts/seed', method: 'POST', area: 'dataQuality', needs: 'admin', scope: 'iterates' },
+];
+
+/**
+ * Routes that carry a space but are governed by something OTHER than the four areas, listed so the gate can
+ * tell "deliberately elsewhere" from "nobody looked at it".
+ *
+ * An empty exemption list would be the honest default; this one is not empty, so each entry says why.
+ */
+export const NOT_AREA_SCOPED: readonly { route: string; why: string }[] = [
+  {
+    route: '/api/spaces/:id/rename',
+    why: 'Renaming a space is Space-admin, which is a column in the approved design but not one of the four '
+       + 'DATA areas this inventory covers. It moves with the Space-admin work, not with these.',
+  },
+  {
+    route: '/api/spaces/:id/token-access',
+    why: 'Lists which tokens reach this space. Governed by the Space-admin column for the same reason, and '
+       + 'it is a read of AUTH state rather than of the space\'s contents.',
+  },
+  {
+    route: '/api/brain/spaces/:spaceId/token-access',
+    why: 'Lists which tokens reach this space — the same AUTH read as the spaces-router copy above, and '
+       + 'governed by Space-admin rather than by any of the four data areas.',
+  },
+  {
+    route: '/api/brain/spaces/:spaceId/activity',
+    why: 'Per-space usage counters, served from the admin activity surface. Instance-level observability '
+       + 'that happens to be keyed by space, not a view of the space\'s data.',
+  },
+];

--- a/testing/standalone/every-space-route-has-an-area.test.js
+++ b/testing/standalone/every-space-route-has-an-area.test.js
@@ -1,0 +1,150 @@
+/**
+ * Every space-scoped route is classified into an area, or the build fails.
+ *
+ * ## What this is for
+ *
+ * The per-space rights matrix only governs what it knows about. A route nobody assigned to an area is not
+ * refused and does not warn — it keeps working at whatever access the old model gave it, while the UI shows
+ * a grid implying otherwise. That is the failure this repo keeps meeting: a control that looks complete
+ * because nothing contradicts it.
+ *
+ * So the inventory in `server/src/auth/space-rights.ts` is checked against the ROUTE SURFACE, discovered
+ * here from source. A route that is neither classified nor explicitly exempt fails, and the message names
+ * it. Adding a space-scoped route without deciding what it means becomes impossible rather than merely
+ * discouraged.
+ *
+ * ## Why the surface is discovered rather than listed
+ *
+ * A hand-written list of routes is the same artefact as the inventory, so comparing them would prove
+ * nothing — both would be edited in the same commit by the same person making the same assumption. The
+ * surface is read out of the router files instead.
+ *
+ * Run: node --test testing/standalone/every-space-route-has-an-area.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const INVENTORY = 'server/src/auth/space-rights.ts';
+
+/**
+ * Routers whose every route is space-scoped, and the prefix each is mounted at.
+ *
+ * Discovered files, fixed mounts: the mount lives in `app.ts` and is the one thing a router file cannot
+ * tell us. The `duplicates`/`contradictions`/`conflicts` trio is here because those routes scope by
+ * ITERATING the token's spaces rather than by taking one in the path — the reason `scope` exists on a
+ * `RouteRight` at all.
+ */
+const SPACE_ROUTERS = [
+  { glob: 'server/src/api/brain', mount: '/api/brain' },
+  { glob: 'server/src/api/files.ts', mount: '/api/files' },
+  { glob: 'server/src/api/duplicates.ts', mount: '/api/duplicates' },
+  { glob: 'server/src/api/contradictions.ts', mount: '/api/contradictions' },
+  { glob: 'server/src/api/conflicts.ts', mount: '/api/conflicts' },
+];
+
+function filesUnder(p) {
+  return execFileSync('git', ['ls-files', p], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts') && !l.endsWith('_shared.ts'));
+}
+
+/** Every `router.VERB('path')` in the given routers, as `METHOD mount+path`. */
+function discoveredRoutes() {
+  const out = new Set();
+  for (const { glob, mount } of SPACE_ROUTERS) {
+    for (const f of filesUnder(glob)) {
+      const code = withoutComments(read(f));
+      // The path must START with '/'. Without that, `res.set('If-Match', …)` and any other
+      // `.get('Header-Name')` read as a route and the gate demands they be classified.
+      for (const m of code.matchAll(/\.(get|post|patch|put|delete)\(\s*'(\/[^']*)'/g)) {
+        const path = m[2] === '/' ? '' : m[2];
+        out.add(`${m[1].toUpperCase()} ${mount}${path}`);
+      }
+    }
+  }
+  return out;
+}
+
+/** Everything the inventory claims, as the same `METHOD route` key. */
+function classifiedRoutes() {
+  const code = read(INVENTORY);
+  const out = new Set();
+  for (const m of code.matchAll(/route:\s*'([^']+)',\s*method:\s*'([A-Z]+)'/g)) {
+    out.add(`${m[2]} ${m[1]}`);
+  }
+  return out;
+}
+
+function exemptRoutes() {
+  const code = read(INVENTORY);
+  const block = code.slice(code.indexOf('NOT_AREA_SCOPED'));
+  return new Set([...block.matchAll(/route:\s*'([^']+)'/g)].map(m => m[1]));
+}
+
+describe('every space-scoped route is classified', () => {
+  it('discovers a real route surface', () => {
+    // A gate that enumerates nothing passes vacuously, and would keep passing if a router moved.
+    const found = discoveredRoutes();
+    assert.ok(found.size >= 30, `expected the space routers to yield many routes, found ${found.size}`);
+    assert.ok([...found].some(r => r.includes(':spaceId')), 'no :spaceId route found — re-point SPACE_ROUTERS');
+  });
+
+  it('the inventory is not empty and names all four areas', () => {
+    const code = read(INVENTORY);
+    for (const area of ['knowledge', 'files', 'schema', 'dataQuality']) {
+      assert.match(code, new RegExp(`area:\\s*'${area}'`), `no route is classified as ${area}`);
+    }
+  });
+
+  it('no discovered route is unclassified', () => {
+    const classified = classifiedRoutes();
+    const exempt = exemptRoutes();
+    const missing = [...discoveredRoutes()].filter(r => {
+      if (classified.has(r)) return false;
+      const path = r.slice(r.indexOf(' ') + 1);
+      return !exempt.has(path);
+    }).sort();
+    assert.deepEqual(
+      missing,
+      [],
+      `these space-scoped routes belong to no area and are not exempt, so the rights matrix does not govern `
+      + `them:\n  ${missing.join('\n  ')}\nAdd each to ROUTE_RIGHTS with its area, the lowest rung that may `
+      + `call it, and whether it scopes by 'path' or 'iterates' — or to NOT_AREA_SCOPED with a reason.`,
+    );
+  });
+
+  it('the inventory claims no route that does not exist', () => {
+    // The other direction, and the one that rots quietly: a classified route that was deleted or renamed
+    // leaves a rule guarding nothing, and the count still looks healthy.
+    const found = discoveredRoutes();
+    const stale = [...classifiedRoutes()].filter(r => {
+      // The spaces router is not in SPACE_ROUTERS — it is not wholly space-scoped — so its entries are
+      // checked against the file directly rather than against the discovered set.
+      if (r.includes('/api/spaces/:id')) {
+        const code = withoutComments(read('server/src/api/spaces.ts'));
+        const path = r.slice(r.indexOf(' ') + 1).replace('/api/spaces', '') || '/';
+        return !code.includes(`'${path}'`);
+      }
+      return !found.has(r);
+    }).sort();
+    assert.deepEqual(stale, [], `the inventory classifies routes that no longer exist:\n  ${stale.join('\n  ')}`);
+  });
+
+  it('every data-quality route scopes by iterating, not by path', () => {
+    // The finding this whole file exists to protect. Those routes take no space and walk the token's
+    // accessible ones, so their enforcement point is the ITERATION SET. Classifying one as 'path' would
+    // produce a guard that reads correctly and never fires.
+    const code = read(INVENTORY);
+    for (const m of code.matchAll(/area:\s*'dataQuality',\s*needs:\s*'\w+',\s*scope:\s*'(\w+)'/g)) {
+      assert.equal(m[1], 'iterates',
+        'a data-quality route is classified as path-scoped; those routes take no space in the URL');
+    }
+  });
+});


### PR DESCRIPTION
feat(auth): classify every space-scoped route, and fail the build on one that is not

First step of the approved per-space rights matrix, and deliberately the first:
the matrix governs only what it knows about. An unclassified route does not warn
or refuse — it keeps working at whatever access the old model gave it, while the
UI shows a column implying otherwise. No behaviour changes here; nothing consumes
the inventory yet.

The list is DERIVED from the route surface rather than compared against a second
hand-written list, because two hand-written lists are one artefact: both get
edited in the same commit by the same person making the same assumption. The gate
reads the routers and fails on anything neither classified nor explicitly exempt,
naming it.

WHAT THE ENUMERATION FOUND, having written the inventory by hand first:

  - every COLLECTION-level delete was missing — DELETE on memories, entities,
    edges, chrono and files, each of which empties a whole record type in a space.
    The most destructive endpoints in the area were the ones absent from the draft;
  - the conflict deletes and link-violation deletes, likewise;
  - a /api/conflicts/seed route, classified rather than exempted: "it is only for
    tests" is the sentence that precedes finding it in production;
  - two routes listed with a method they do not have (`POST` on `entities/by-ids`
    and `files/extract`, both `GET`), which would have produced rules guarding
    nothing while the count looked healthy.

So the gate checks both directions. A missing route leaves a hole; a stale one
leaves a rule that never fires, and only the first is visible without asking.

THE FINDING THAT CHANGES THE DESIGN: there are two enforcement shapes.

Most routes take the space from the path. All of Data quality takes no space at
all — `duplicates`, `contradictions` and `conflicts` walk every space the token
can reach and resolve the space from the RECORD. For those the enforcement point
is the ITERATION SET, not the call: the loop must be narrowed to spaces holding
the required rung, and /scan and /bulk-resolve narrowed identically or one call
reaches spaces the grid excludes.

A guard written only for the path shape would have left that column decorative —
the routes would keep scanning every reachable space at any level. Each entry
therefore records which shape it is, and a gate asserts no data-quality route is
ever marked path-scoped.

That is now the third column whose name did not describe what it was keyed by:
Governance was keyed by network, Sync/peer by peer, Data quality by nothing. All
three were caught by enumerating rather than by reasoning from the name, which is
the argument for doing this before the mapping rather than after.
