### PR TITLE
feat(auth): the token-rights migration, as a pure function that cannot widen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: the migration from today's token model to the per-space matrix, as a pure function.** Nothing
+  consumes it yet; no behaviour changes.
+  - This is the step where silent widening would happen. A token that gains an area nobody chose keeps
+    working, reports success, and is indistinguishable from one configured that way on purpose — no error,
+    no log line, no counter. So the mapping takes a record and returns a value, with no database, config or
+    clock, and every token shape is a test rather than a deployment.
+  - **The rule is "never a superset."** Where the old model is ambiguous the mapping takes the narrower
+    reading: a token that loses an access it should have had produces a 403 somebody reports on day one; one
+    that gains an access produces nothing at all.
+  - Two traps are pinned by name. A `schemaLibrary` token carries `readOnly: true` and stores `spaces: []`,
+    so reading `readOnly` first — or treating an empty list as "unscoped" — turns the narrowest token on the
+    instance into the widest. And an unscoped token maps to a FLOOR, because it reaches spaces created
+    tomorrow, while a scoped one must not.
+  - The property is asserted twice: per shape, and across 108 generated combinations, because a fixture test
+    can only speak about shapes somebody thought of. The widening detector is itself mutation-checked — a
+    predicate that always returns false would look identical to a clean run.
+
 - **Internal: every space-scoped route is now classified into an area, and a gate fails the build on one
   that is not.** Groundwork for the per-space rights matrix; no behaviour changes yet.
   - The matrix can only govern routes it knows about. An unclassified route does not warn — it keeps working

--- a/server/src/auth/rights-migration.ts
+++ b/server/src/auth/rights-migration.ts
@@ -1,0 +1,130 @@
+/**
+ * What every EXISTING token becomes under the per-space rights matrix.
+ *
+ * ## Why this is a pure function in its own file
+ *
+ * This is the step where silent widening happens. Every token on every instance is re-expressed here, and a
+ * mistake does not fail — it grants. A token that gains an area nobody chose keeps working, reports success,
+ * and looks exactly like one that was configured that way on purpose. There is no error to notice.
+ *
+ * So it takes a record and returns a value, with no database, no config and no clock. Every shape a token can
+ * have is a test case rather than a deployment.
+ *
+ * ## The rule, and it is the only one
+ *
+ * **Never a superset.** Where the old model is ambiguous, the mapping takes the NARROWER reading. A token
+ * that loses an access it should have had produces a 403 that somebody reports on the first day; a token
+ * that gains one produces nothing at all, for as long as nobody looks.
+ */
+import type { SpaceArea, Rung } from './space-rights.js';
+
+/** The four areas, in the order the UI shows them. */
+export const AREAS: readonly SpaceArea[] = ['knowledge', 'files', 'schema', 'dataQuality'];
+
+export type AreaRungs = Record<SpaceArea, Rung>;
+
+export interface MigratedRights {
+  /** The instance-administrator switch — the danger zone, not an area. */
+  instanceAdmin: boolean;
+  /** May create spaces. Separate from instance admin by owner decision. */
+  createSpaces: boolean;
+  /**
+   * The MINIMUM held in every space, including ones created later. `null` means no floor: this token
+   * reaches only the spaces named in `perSpace`.
+   */
+  floor: AreaRungs | null;
+  /** Explicit per-space rows, for a token that was scoped to a list. */
+  perSpace: Record<string, AreaRungs>;
+}
+
+/** The subset of a token record this mapping reads. Deliberately narrow — anything else is not an input. */
+export interface LegacyToken {
+  admin?: boolean;
+  readOnly?: boolean;
+  spaces?: string[];
+  schemaLibrary?: boolean;
+  peerInstanceId?: string;
+}
+
+const rungs = (r: Rung): AreaRungs =>
+  ({ knowledge: r, files: r, schema: r, dataQuality: r });
+
+const NONE = (): AreaRungs => rungs('none');
+
+/**
+ * Map one legacy token to its rights.
+ *
+ * The order of the branches is the order of precedence in the old model, and it matters:
+ *
+ *  1. `schemaLibrary` — has NO space access by construction (the create route rejects it alongside `admin`
+ *     or any `spaces`), so it maps to nothing rather than to a floor. Checked first because such a token may
+ *     also carry `readOnly: true`, which would otherwise read as "read everywhere".
+ *  2. `admin` — reaches everything, so every area at `admin`, as a FLOOR. An admin token today also reaches
+ *     spaces created tomorrow, and a floor is the only construct that preserves that.
+ *  3. `readOnly` — every area at `read`, scoped as below.
+ *  4. otherwise — `write`, scoped as below.
+ *
+ * `admin` at the area level is NOT the instance switch: it is the destructive rung within an area. The
+ * instance switch is set separately from `admin` on the same record, which is why both appear here.
+ */
+export function migrateToken(t: LegacyToken): MigratedRights {
+  // A schema-library token is not a space token at all. Mapping it to a read floor would hand it every
+  // space on the instance — the widest possible widening, from the narrowest possible token.
+  if (t.schemaLibrary) {
+    return { instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} };
+  }
+
+  const level: Rung = t.admin ? 'admin' : t.readOnly ? 'read' : 'write';
+
+  // `spaces` absent means "all spaces" in the old model, including future ones. That is exactly a floor.
+  // `spaces: []` is NOT the same as absent — an empty allowlist reaches nothing, and the create route can
+  // produce one (a schemaLibrary token stores `[]`). Treating empty as absent would turn the narrowest
+  // token into the widest, so the check is on `undefined`, never on length.
+  if (t.spaces === undefined) {
+    return {
+      instanceAdmin: t.admin === true,
+      // Creating spaces was an admin-only act, so only an admin token carries it forward. A non-admin token
+      // never had it and must not acquire it.
+      createSpaces: t.admin === true,
+      floor: rungs(level),
+      perSpace: {},
+    };
+  }
+
+  const perSpace: Record<string, AreaRungs> = {};
+  for (const id of t.spaces) perSpace[id] = rungs(level);
+  return {
+    instanceAdmin: t.admin === true,
+    createSpaces: t.admin === true,
+    // A space-scoped token reaches only what it was given, and must NOT inherit spaces created later — it
+    // could not reach them before. No floor is the whole point of the distinction.
+    floor: null,
+    perSpace,
+  };
+}
+
+/**
+ * Does the mapping grant anything the legacy token did not?
+ *
+ * Exported as its own predicate so the property can be asserted directly rather than inferred from a fixture
+ * comparison: "never a superset" is the requirement, and a test that only checks known shapes cannot say
+ * anything about one nobody thought of.
+ */
+export function grantsMoreThan(t: LegacyToken, r: MigratedRights): boolean {
+  const legacyReachesAllSpaces = !t.schemaLibrary && t.spaces === undefined;
+  if (r.floor && !legacyReachesAllSpaces) return true;                   // a floor where there was no reach
+  if (r.instanceAdmin && t.admin !== true) return true;                  // admin from a non-admin token
+  if (r.createSpaces && t.admin !== true) return true;                   // ditto
+  if (t.schemaLibrary && (r.floor || Object.keys(r.perSpace).length)) return true;
+
+  const allowed = new Set(t.spaces ?? []);
+  for (const id of Object.keys(r.perSpace)) {
+    if (!legacyReachesAllSpaces && !allowed.has(id)) return true;        // a space it never had
+  }
+
+  const ceiling: Rung = t.admin ? 'admin' : t.readOnly ? 'read' : 'write';
+  const order: Rung[] = ['none', 'read', 'write', 'admin'];
+  const tooHigh = (a: AreaRungs) => AREAS.some(k => order.indexOf(a[k]) > order.indexOf(ceiling));
+  if (r.floor && tooHigh(r.floor)) return true;
+  return Object.values(r.perSpace).some(tooHigh);
+}

--- a/testing/standalone/rights-migration-never-widens.test.js
+++ b/testing/standalone/rights-migration-never-widens.test.js
@@ -1,0 +1,136 @@
+/**
+ * Every existing token shape maps to exactly what it grants today, and never more.
+ *
+ * ## Why this file is the one that matters
+ *
+ * The rest of the rights work can be wrong and fail loudly. This step cannot: a token that gains an area
+ * nobody chose keeps working, reports success, and is indistinguishable from one configured that way on
+ * purpose. There is no error, no log line and no counter — only access somebody has that nobody granted.
+ *
+ * So every shape a token can have is a case here, and the "never a superset" property is asserted twice: once
+ * per shape against the expected mapping, and once as a PROPERTY across generated combinations, because a
+ * fixture test can only speak about shapes somebody thought of.
+ *
+ * Run: node --test testing/standalone/rights-migration-never-widens.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let migrateToken, grantsMoreThan, AREAS;
+before(async () => {
+  ({ migrateToken, grantsMoreThan, AREAS } = await import('../../server/dist/auth/rights-migration.js'));
+});
+
+
+describe('the shapes that exist today', () => {
+  it('admin — every area at admin, as a FLOOR, plus the instance switch', () => {
+    const r = migrateToken({ admin: true });
+    assert.equal(r.instanceAdmin, true);
+    assert.equal(r.createSpaces, true);
+    assert.ok(r.floor, 'an admin token reaches spaces created tomorrow; only a floor preserves that');
+    for (const a of AREAS) assert.equal(r.floor[a], 'admin');
+    assert.deepEqual(r.perSpace, {});
+  });
+
+  it('read-only, unscoped — read everywhere, no instance switch', () => {
+    const r = migrateToken({ readOnly: true });
+    assert.equal(r.instanceAdmin, false);
+    assert.equal(r.createSpaces, false, 'creating spaces was admin-only; a read-only token never had it');
+    for (const a of AREAS) assert.equal(r.floor[a], 'read');
+  });
+
+  it('ordinary, unscoped — write everywhere', () => {
+    const r = migrateToken({});
+    assert.equal(r.instanceAdmin, false);
+    for (const a of AREAS) assert.equal(r.floor[a], 'write');
+  });
+
+  it('space-scoped — rows, and NO floor', () => {
+    const r = migrateToken({ spaces: ['qa', 'tasks'] });
+    assert.equal(r.floor, null,
+      'a scoped token could not reach spaces created later; a floor would hand it every future space');
+    assert.deepEqual(Object.keys(r.perSpace).sort(), ['qa', 'tasks']);
+    for (const a of AREAS) assert.equal(r.perSpace['qa'][a], 'write');
+  });
+
+  it('space-scoped AND read-only — rows at read', () => {
+    const r = migrateToken({ readOnly: true, spaces: ['qa'] });
+    assert.equal(r.floor, null);
+    for (const a of AREAS) assert.equal(r.perSpace['qa'][a], 'read');
+  });
+
+  it('space-scoped AND admin — rows at admin, instance switch still on', () => {
+    // Both halves are real: the token IS an instance admin, and its space reach was still a list.
+    const r = migrateToken({ admin: true, spaces: ['qa'] });
+    assert.equal(r.instanceAdmin, true);
+    assert.equal(r.floor, null);
+    for (const a of AREAS) assert.equal(r.perSpace['qa'][a], 'admin');
+  });
+
+  it('schemaLibrary — NOTHING, even though it carries readOnly', () => {
+    // The trap. A schemaLibrary token is read-only and stores `spaces: []`. Reading `readOnly` first, or
+    // treating an empty list as "unscoped", turns the narrowest token on the instance into the widest.
+    const r = migrateToken({ schemaLibrary: true, readOnly: true, spaces: [] });
+    assert.equal(r.floor, null, 'a schemaLibrary token would reach EVERY space on the instance');
+    assert.deepEqual(r.perSpace, {});
+    assert.equal(r.instanceAdmin, false);
+  });
+
+  it('an EMPTY spaces list is not the same as an absent one', () => {
+    // `spaces: []` reaches nothing; `spaces` absent reaches everything. A length check collapses them.
+    assert.equal(migrateToken({ spaces: [] }).floor, null);
+    assert.deepEqual(migrateToken({ spaces: [] }).perSpace, {});
+    assert.ok(migrateToken({}).floor, 'an absent list must still mean all spaces');
+  });
+
+  it('a peer token maps by its other fields, not by being a peer', () => {
+    // `peerInstanceId` is a label on how the token is used, not a permission. It must not add or remove one.
+    const withPeer = migrateToken({ peerInstanceId: 'i-1', spaces: ['fleet'] });
+    const without = migrateToken({ spaces: ['fleet'] });
+    assert.deepEqual(withPeer, without);
+  });
+});
+
+describe('the property, across shapes nobody listed', () => {
+  it('never grants more than the legacy token did', () => {
+    // A fixture test can only speak about shapes somebody thought of. This walks the combinations.
+    const bools = [undefined, true, false];
+    const spaceSets = [undefined, [], ['a'], ['a', 'b']];
+    let checked = 0;
+    for (const admin of bools) {
+      for (const readOnly of bools) {
+        for (const schemaLibrary of bools) {
+          for (const spaces of spaceSets) {
+            const t = { admin, readOnly, schemaLibrary, spaces };
+            const r = migrateToken(t);
+            assert.equal(grantsMoreThan(t, r), false,
+              `widened: ${JSON.stringify(t)} -> ${JSON.stringify(r)}`);
+            checked++;
+          }
+        }
+      }
+    }
+    // The count is asserted so a loop that silently stops iterating cannot pass as thoroughness.
+    assert.equal(checked, 108, `expected 108 combinations, walked ${checked}`);
+  });
+
+  it('the widening detector actually detects widening', () => {
+    // Mutation-check on the checker itself: a property test whose predicate always returns false proves
+    // nothing, and would look identical to a clean run.
+    const t = { spaces: ['a'] };
+    assert.equal(grantsMoreThan(t, { instanceAdmin: true, createSpaces: false, floor: null, perSpace: {} }), true);
+    assert.equal(grantsMoreThan(t, {
+      instanceAdmin: false, createSpaces: false,
+      floor: { knowledge: 'read', files: 'read', schema: 'read', dataQuality: 'read' }, perSpace: {},
+    }), true, 'a floor where the token had a fixed list is a grant of every future space');
+    assert.equal(grantsMoreThan(t, {
+      instanceAdmin: false, createSpaces: false, floor: null,
+      perSpace: { b: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' } },
+    }), true, 'a space the token never had');
+    assert.equal(grantsMoreThan({ readOnly: true }, {
+      instanceAdmin: false, createSpaces: false,
+      floor: { knowledge: 'write', files: 'read', schema: 'read', dataQuality: 'read' }, perSpace: {},
+    }), true, 'write from a read-only token');
+  });
+});


### PR DESCRIPTION
feat(auth): the token-rights migration, as a pure function that cannot widen

Second step of the approved per-space rights matrix. Nothing consumes it yet and
no behaviour changes.

This is the step where silent widening happens. Every token on every instance is
re-expressed here, and a mistake does not fail — it grants. A token that gains an
area nobody chose keeps working, reports success, and is indistinguishable from
one configured that way on purpose. There is no error, no log line and no counter
to notice.

So it takes a record and returns a value: no database, no config, no clock. Every
shape a token can have is a test case rather than a deployment.

THE RULE IS "NEVER A SUPERSET", and where the old model is ambiguous the mapping
takes the narrower reading. A token that loses an access it should have had
produces a 403 somebody reports on the first day. One that gains an access
produces nothing at all, for as long as nobody looks.

Two traps, both pinned by name because both are one line away:

  - a `schemaLibrary` token carries `readOnly: true` AND stores `spaces: []`.
    Reading `readOnly` first, or treating an empty list as "unscoped", turns the
    narrowest token on the instance into the widest. The check is on `undefined`,
    never on length;
  - an unscoped token maps to a FLOOR, because it reaches spaces created tomorrow
    and a floor is the only construct that preserves that. A scoped token maps to
    rows with NO floor, because it could not reach them.

`createSpaces` follows `admin` and nothing else: creating a space was an
admin-only act, so a non-admin token must not acquire it in translation.

The property is asserted twice. Once per known shape, and once across 108
generated combinations — a fixture test can only speak about shapes somebody
thought of, and this mapping will meet tokens nobody listed. The combination count
is asserted too, so a loop that silently stops iterating cannot pass as
thoroughness.

`grantsMoreThan` is itself mutation-checked with four hand-built widenings. A
property test whose predicate always returns false proves nothing and looks
exactly like a clean run.
