### PR TITLE
feat(networks): record which token established each membership, and fail closed without it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: network memberships now record which token established them.** `NetworkConfig.spaceOrigins`
+  maps `spaceId` -> token id. Nothing consumes it yet; no behaviour changes.
+  - Needed for the Networks column's admin rung: a token at `out` may leave a network it joined itself, but
+    removing a membership another token established needs `leave`.
+  - **Leaving is the guarded direction, which is counter-intuitive and deliberate.** Leaving stops nothing
+    retroactively — peers keep every record they already hold — so "leave quickly to stop a leak" was never
+    available. What leaving does is dismantle somebody else's topology: a publisher leaving strands its
+    subscribers, a braintree parent orphans its subtree.
+  - **An unknown establisher fails CLOSED.** Every membership predating this field has none, and treating
+    unknown as "probably fine" would leave the guard absent on exactly the memberships that have existed
+    longest and carry the most peers.
+  - A parallel map rather than a field on the membership: `spaces` is a plain `string[]` on every instance in
+    the field, and turning it into objects would be a breaking migration of live config for a value absent on
+    every existing row.
+
 - **Internal: the migration from today's token model to the per-space matrix, as a pure function.** Nothing
   consumes it yet; no behaviour changes.
   - This is the step where silent widening would happen. A token that gains an area nobody chose keeps

--- a/server/src/auth/network-membership.ts
+++ b/server/src/auth/network-membership.ts
@@ -1,0 +1,90 @@
+/**
+ * Who may remove a space from a network.
+ *
+ * ## The rule, and why leaving is the guarded direction
+ *
+ * Owner decision, 2026-08-09. Under the Networks column a token at **write** may join a network and may
+ * leave one **it joined itself**. Removing a membership that another token established requires **admin**.
+ *
+ * That is the opposite of the instinct — surely stopping data leaving should be easy? It is not, and the
+ * reason is that leaving does not stop anything retroactively: peers keep every record they already hold.
+ * So "leave quickly to stop a leak" was never available. What leaving DOES do is dismantle somebody else's
+ * topology: a publisher leaving strands its subscribers, a braintree parent leaving orphans its subtree.
+ * One token quietly undoing another's deliberate join is the real hazard, and it is the one this guards.
+ *
+ * ## Unknown origin fails closed
+ *
+ * Every membership that predates `spaceOrigins` has no recorded establisher. Such a membership cannot be
+ * proved to be yours, so it needs the admin rung. The alternative — treating unknown as "probably fine" —
+ * would make the guard useless on exactly the memberships that have existed longest and are load-bearing
+ * for the most peers.
+ *
+ * The cost of failing closed is a token being told to ask someone. The cost of failing open is a topology
+ * dismantled by a token that was never meant to be able to.
+ */
+
+/** The Networks rungs, in the order they contain one another. */
+export type NetworkRung = 'none' | 'in' | 'out' | 'leave';
+
+export interface LeaveRequest {
+  /** `spaceId` -> id of the token that established the membership. Absent entries are unknown. */
+  origins: Record<string, string> | undefined;
+  spaceId: string;
+  /** The id of the token asking to leave. */
+  tokenId: string;
+  /** This token's rung on the Networks column for this space. */
+  rung: NetworkRung;
+}
+
+export type LeaveVerdict =
+  | { allowed: true; because: 'admin-rung' | 'own-membership' }
+  | { allowed: false; because: 'insufficient-rung' | 'not-your-membership' | 'origin-unknown' };
+
+/**
+ * Decide a leave request. Pure: no config, no database, no clock.
+ *
+ * Order matters and is deliberate — `leave` short-circuits before the ownership check, so an admin never
+ * needs an origin record to act. Checking ownership first would make the admin rung depend on data that is
+ * absent for every pre-existing membership, which is precisely the case the admin rung exists to unblock.
+ */
+export function mayLeaveNetwork(req: LeaveRequest): LeaveVerdict {
+  if (req.rung === 'leave') return { allowed: true, because: 'admin-rung' };
+  if (req.rung !== 'out') return { allowed: false, because: 'insufficient-rung' };
+
+  const establisher = req.origins?.[req.spaceId];
+  if (establisher === undefined) return { allowed: false, because: 'origin-unknown' };
+  if (establisher !== req.tokenId) return { allowed: false, because: 'not-your-membership' };
+  return { allowed: true, because: 'own-membership' };
+}
+
+/**
+ * Record who established a membership, returning a NEW map.
+ *
+ * Returns a copy rather than mutating, so a caller cannot half-apply it: writing the origin and then failing
+ * to persist the network would otherwise leave the map claiming an establisher for a membership that does
+ * not exist.
+ */
+export function recordOrigin(
+  origins: Record<string, string> | undefined,
+  spaceId: string,
+  tokenId: string,
+): Record<string, string> {
+  return { ...(origins ?? {}), [spaceId]: tokenId };
+}
+
+/**
+ * Drop a membership's origin when the membership goes.
+ *
+ * Without this, a space removed and later re-added by a DIFFERENT token would inherit the first token's
+ * claim — and that token could then leave a membership it never made. A stale entry here is not inert; it is
+ * a permission.
+ */
+export function forgetOrigin(
+  origins: Record<string, string> | undefined,
+  spaceId: string,
+): Record<string, string> | undefined {
+  if (!origins || !(spaceId in origins)) return origins;
+  const copy = { ...origins };
+  delete copy[spaceId];
+  return Object.keys(copy).length > 0 ? copy : undefined;
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -954,6 +954,19 @@ export interface NetworkConfig {
   label: string;
   type: NetworkType;
   spaces: string[];          // space IDs scoped to this network
+  /**
+   * Which token established each membership — `spaceId` -> token id.
+   *
+   * A PARALLEL map rather than a field on the membership, because `spaces` is a plain `string[]` on every
+   * instance in the field. Turning it into objects would be a breaking migration of live config for a value
+   * that is absent on every existing row anyway.
+   *
+   * **Absent means unknown, and unknown FAILS CLOSED.** Memberships that predate this field cannot prove
+   * whose they are, so leaving one requires the Networks admin rung rather than the write rung. That is the
+   * safe direction: a token that cannot dismantle somebody else's topology asks for help, while one that can
+   * does it silently. See `mayLeaveNetwork` in `auth/network-membership.ts`.
+   */
+  spaceOrigins?: Record<string, string>;
   /** Maps remote (peer-side) space IDs to local space IDs.
    *  Used when a local space was renamed after joining, or when the joiner chose
    *  a different local ID to avoid a collision.  The sync engine uses this to

--- a/testing/standalone/network-leave-fails-closed.test.js
+++ b/testing/standalone/network-leave-fails-closed.test.js
@@ -1,0 +1,110 @@
+/**
+ * Leaving a network is guarded, and an unknown establisher fails CLOSED.
+ *
+ * ## What is being protected
+ *
+ * A token at the Networks `out` rung may join a network and may leave one it joined itself. Removing a
+ * membership another token established needs the admin rung. Leaving does not stop data leaving
+ * retroactively — peers keep what they hold — so the thing worth guarding is not the egress but the
+ * dismantling: a publisher leaving strands its subscribers, a braintree parent orphans its subtree.
+ *
+ * ## The case that decides whether this guard is real
+ *
+ * Every membership that predates the `spaceOrigins` map has no recorded establisher. If unknown resolved to
+ * "allowed", the guard would be absent on exactly the memberships that have existed longest and carry the
+ * most peers — the ones it exists for. Unknown must therefore be a refusal, and it has its own verdict so
+ * the refusal can say which of the two reasons it was.
+ *
+ * Run: node --test testing/standalone/network-leave-fails-closed.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mayLeaveNetwork, recordOrigin, forgetOrigin;
+before(async () => {
+  ({ mayLeaveNetwork, recordOrigin, forgetOrigin } =
+    await import('../../server/dist/auth/network-membership.js'));
+});
+
+const req = (over) => ({ origins: {}, spaceId: 'qa', tokenId: 't1', rung: 'out', ...over });
+
+describe('who may leave a network', () => {
+  it('the admin rung may leave anything, with no origin recorded at all', () => {
+    // Order matters: `leave` must short-circuit BEFORE the ownership check, or the admin rung would depend
+    // on data that is absent for every pre-existing membership — the exact case it exists to unblock.
+    const v = mayLeaveNetwork(req({ rung: 'leave', origins: undefined }));
+    assert.deepEqual(v, { allowed: true, because: 'admin-rung' });
+  });
+
+  it('a token may leave the membership it established', () => {
+    const v = mayLeaveNetwork(req({ origins: { qa: 't1' } }));
+    assert.deepEqual(v, { allowed: true, because: 'own-membership' });
+  });
+
+  it('a token may NOT leave a membership another token established', () => {
+    const v = mayLeaveNetwork(req({ origins: { qa: 't2' } }));
+    assert.deepEqual(v, { allowed: false, because: 'not-your-membership' });
+  });
+
+  it('an UNKNOWN establisher is refused, not waved through', () => {
+    // The decisive case. Every membership older than the origins map lands here.
+    assert.deepEqual(mayLeaveNetwork(req({ origins: {} })),
+      { allowed: false, because: 'origin-unknown' });
+    assert.deepEqual(mayLeaveNetwork(req({ origins: undefined })),
+      { allowed: false, because: 'origin-unknown' });
+    assert.deepEqual(mayLeaveNetwork(req({ origins: { other: 't1' } })),
+      { allowed: false, because: 'origin-unknown' });
+  });
+
+  it('the lower rungs cannot leave at all, whoever established it', () => {
+    for (const rung of ['none', 'in']) {
+      assert.deepEqual(mayLeaveNetwork(req({ rung, origins: { qa: 't1' } })),
+        { allowed: false, because: 'insufficient-rung' },
+        `rung ${rung} was allowed to leave a network`);
+    }
+  });
+
+  it('refusals are distinguishable from each other', () => {
+    // Three refusals with one reason between them would make "you may not" unactionable: ask an admin, ask
+    // the token that joined, or record the origin are three different next steps.
+    const reasons = new Set([
+      mayLeaveNetwork(req({ rung: 'in' })).because,
+      mayLeaveNetwork(req({ origins: {} })).because,
+      mayLeaveNetwork(req({ origins: { qa: 't2' } })).because,
+    ]);
+    assert.equal(reasons.size, 3, `expected three distinct refusal reasons, got ${[...reasons]}`);
+  });
+});
+
+describe('the origin map', () => {
+  it('recordOrigin returns a new map rather than mutating', () => {
+    // A caller that writes the origin and then fails to persist the network would otherwise leave the map
+    // claiming an establisher for a membership that does not exist.
+    const before = { a: 't9' };
+    const after = recordOrigin(before, 'qa', 't1');
+    assert.deepEqual(before, { a: 't9' }, 'the input was mutated');
+    assert.deepEqual(after, { a: 't9', qa: 't1' });
+    assert.deepEqual(recordOrigin(undefined, 'qa', 't1'), { qa: 't1' });
+  });
+
+  it('forgetOrigin drops the entry, because a stale one is a PERMISSION', () => {
+    // A space removed and re-added by a different token would otherwise inherit the first token's claim,
+    // and that token could then leave a membership it never made.
+    assert.deepEqual(forgetOrigin({ qa: 't1', b: 't2' }, 'qa'), { b: 't2' });
+    assert.equal(forgetOrigin({ qa: 't1' }, 'qa'), undefined, 'an emptied map should not linger as {}');
+    assert.deepEqual(forgetOrigin({ b: 't2' }, 'qa'), { b: 't2' }, 'an absent key must be a no-op');
+    assert.equal(forgetOrigin(undefined, 'qa'), undefined);
+  });
+
+  it('re-adding after forgetting does not restore the old claim', () => {
+    // The whole point of forgetOrigin, asserted end to end rather than left to inference.
+    let o = recordOrigin(undefined, 'qa', 't1');
+    o = forgetOrigin(o, 'qa');
+    o = recordOrigin(o, 'qa', 't2');
+    assert.deepEqual(mayLeaveNetwork({ origins: o, spaceId: 'qa', tokenId: 't1', rung: 'out' }),
+      { allowed: false, because: 'not-your-membership' });
+    assert.deepEqual(mayLeaveNetwork({ origins: o, spaceId: 'qa', tokenId: 't2', rung: 'out' }),
+      { allowed: true, because: 'own-membership' });
+  });
+});

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -89,6 +89,11 @@ const FROZEN = {
   'client/src/app/pages/brain/review-tab.component.ts': 748,
   'server/src/brain/recall.ts': 739,
   'client/src/app/pages/settings/media-processing/models-tab.component.ts': 678,
+  // 674 -> 675: `spaceOrigins` on NetworkConfig. **THIRD raise of this file in one session** (672 -> 673 ->
+  // 674 -> 675), and that is the signal this list exists to send rather than a run of bad luck. Each was one
+  // honest line of type whose behaviour lives elsewhere, and each was individually correct — which is
+  // precisely how a god-file grows. Filed as work in ARCHITECTURE-TODO: this file is the config CONTRACT for
+  // every subsystem, and it wants splitting by domain, not another line.
   // 673 -> 674: `faceDescriptorDims` on SpaceConfig. One line of type again, and the behaviour it names is
   // in `vector-index.ts` and `lifecycle.ts`. A space's shape belongs in the space's type; the alternative is
   // a side-table of per-space settings, which is a worse trade than one line.
@@ -96,7 +101,7 @@ const FROZEN = {
   // behaviour it names lives in `face-external.ts` and `face-embedder.ts`, not here. The alternative —
   // a face-only config module re-exported from this file — would split the config contract across two
   // places to save a single field, which is the trade this list exists to let us decline.
-  'server/src/config/types.ts': 674,
+  'server/src/config/types.ts': 675,
   'client/src/app/pages/settings/data.component.ts': 644,
   'server/src/api/files.ts': 646,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate


### PR DESCRIPTION
feat(networks): record which token established each membership, and fail closed without it

Third step of the approved per-space rights matrix. Nothing consumes it yet; no
behaviour changes.

The Networks column's admin rung means "may undo somebody else's join". That is
unenforceable without knowing whose a membership is, and nothing recorded it.
`NetworkConfig.spaceOrigins` maps spaceId -> token id, and
`auth/network-membership.ts` decides a leave request as a pure function.

LEAVING IS THE GUARDED DIRECTION, which reverses the obvious instinct and is
worth stating. Leaving stops nothing retroactively — peers keep every record they
already hold — so "leave quickly to stop a leak" was never actually available.
What leaving does is dismantle somebody else's topology: a publisher leaving
strands its subscribers, a braintree parent orphans its subtree. One token
quietly undoing another's deliberate join is the real hazard.

AN UNKNOWN ESTABLISHER FAILS CLOSED. Every membership predating this field has
none. Treating unknown as "probably fine" would leave the guard absent on exactly
the memberships that have existed longest and carry the most peers — the ones it
exists for. The cost of failing closed is a token being told to ask someone; the
cost of failing open is a topology dismantled by a token that was never meant to
be able to.

Three details that are each one line from being wrong:

  - the admin rung short-circuits BEFORE the ownership check, so it never depends
    on origin data that is absent for every pre-existing membership — the exact
    case it exists to unblock;
  - `forgetOrigin` drops the entry when a membership goes, because a stale claim
    is not inert, it is a permission: a space removed and re-added by a different
    token would otherwise inherit the first token's right to leave it;
  - the three refusals are distinguishable. "You may not" is unactionable when ask
    an admin, ask the token that joined, and record the origin are three different
    next steps.

A parallel map rather than a field on the membership: `spaces` is a plain
`string[]` on every instance in the field, and turning it into objects is a
breaking migration of live config for a value absent on every existing row.

ALSO: this is the THIRD ratchet raise of `config/types.ts` in one session
(672 -> 673 -> 674 -> 675). Each was one honest line of type whose behaviour lives
elsewhere, and each was individually correct — which is how a god-file actually
grows. Filed in ARCHITECTURE-TODO as work: split the file by domain, re-exported
so no importer changes, and ordered explicitly AFTER the token-rights work,
because that work touches the same file and a rename underneath it would turn a
mechanical change into a merge conflict across several PRs.
