### PR TITLE
fix(overview): storage is a section of Usage again, and the Data model panel gets its own icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Storage is a section of the Usage card again, not a card of its own** (owner, 2026-08-09: *"i wanted
+  storage to be a section in the usage card and not one card for one number"*).
+  - It was briefly nested there, then split out because the Usage panel only rendered once activity data
+    arrived — so storage vanished on a space nobody had called yet, exactly the space where a filling disk is
+    least expected. Splitting it worked around that and was the wrong fix: it made a card for one number.
+  - The real fix is the one that should have been made first: **the Usage section is unconditional, and only
+    the activity block inside it is gated.** Its loading state is a skeleton in the body rather than a
+    placeholder replacing the whole card, so the card never appears or disappears.
+- **The Data model panel and the Graph tab no longer share an icon.** The panel showed the node-graph icon,
+  which made it read as a small copy of the Graph tab. The tab takes `graph` (it was binoculars) and the
+  panel takes `stack` — the icon its own record-type tiles already used. Not `database`: the Indexing panel
+  owns that, and swapping one collision for another is not a fix.
+
 ### Added
 - **Internal: the migration from today's token model to the per-space matrix, as a pure function.** Nothing
   consumes it yet; no behaviour changes.

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -235,7 +235,7 @@ interface SpaceView {
           <ph-icon name="magnifying-glass" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.query' | transloco }}
         </button>
         <button class="tab" type="button" role="tab" [class.active]="activeTab() === 'graph'" [attr.aria-selected]="activeTab() === 'graph'" (click)="setTab('graph')">
-          <ph-icon name="binoculars" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.graph' | transloco }}
+          <ph-icon name="graph" [size]="15" style="display:inline-flex;vertical-align:middle;margin-right:4px;"/> {{ 'brain.tab.graph' | transloco }}
         </button>
         <!-- Review (F-REVIEW): duplicate pairs awaiting a decision in this space. Grouped with the
              other whole-space views rather than after Files — it is a workflow, not a record collection. -->

--- a/client/src/app/pages/brain/overview-tab.component.spec.ts
+++ b/client/src/app/pages/brain/overview-tab.component.spec.ts
@@ -417,12 +417,17 @@ describe('OverviewTabComponent — the usage panel', () => {
     expect(el.textContent).toContain('63 ms');
   });
 
-  it('hides the panel when the fetch has landed with nothing, and does not crash on null', () => {
-    // `pending` defaults to false, which is "settled with no data" — the panel stays hidden, as it always has.
-    // The loading case is a skeleton and is covered in its own block below.
+  it('STAYS VISIBLE when the fetch has landed with nothing, because storage lives in it', () => {
+    // Reversed deliberately (owner, 2026-08-09). The panel used to hide when activity was null, which is why
+    // storage could not live here: on a space nobody had called, the card was absent and storage with it —
+    // exactly the space where a filling disk is least expected. Giving storage its own card worked around
+    // that and was the wrong fix; it made a card for one number.
+    // Now the SECTION is unconditional and only the activity block inside it is gated.
     const { el, c } = render(null);
     expect(c.answerRate()).toBeNull();
-    expect(el.textContent).not.toContain('brain.overview.useTitle');
+    expect(el.textContent).toContain('brain.overview.useTitle');
+    expect(el.textContent).toContain('brain.overview.storage');
+    expect(el.querySelector('.store')).not.toBeNull();
   });
 
   it('only mentions slow calls when there are some', () => {
@@ -467,7 +472,10 @@ describe('OverviewTabComponent — first-load skeletons', () => {
 
   it('reserves a card for every panel still awaiting its first answer', () => {
     const { el } = render(PENDING);
-    expect(busy(el)).toBe(4);
+    // Three, not four: the Usage card is unconditional now, so it renders its own frame and puts a skeleton
+    // in the body rather than being replaced by an aria-busy placeholder. Storage is inside it and must show
+    // whether or not activity has landed, which is the whole reason that panel stopped being conditional.
+    expect(busy(el)).toBe(3);
     // The frame is the real one, so the placeholder is identifiable rather than an anonymous grey box.
     for (const key of ['brain.overview.useTitle', 'brain.overview.compTitle', 'brain.overview.queueTitle', 'brain.overview.tokenTitle']) {
       expect(titles(el), key).toContain(key);
@@ -478,10 +486,11 @@ describe('OverviewTabComponent — first-load skeletons', () => {
     // This is the whole fix: what makes the page look like it is assembling itself is the layout moving.
     const loading = titles(render(PENDING).el);
     const settled = titles(render({}).el);
-    // Settled-with-no-data hides the four optional panels; loading shows their frames. Every OTHER card must be
-    // in the same place in both, and the four must appear in loading exactly where they will land.
+    // THREE optional panels now, not four: Usage left that set when storage moved into it, and is present in
+    // both renders. Its skeleton is inside its body rather than replacing the card, so the card itself never
+    // appears or disappears — which is a stronger version of what this test is about.
     expect(loading.filter(t => !settled.includes(t)).sort()).toEqual([
-      'brain.overview.compTitle', 'brain.overview.queueTitle', 'brain.overview.tokenTitle', 'brain.overview.useTitle',
+      'brain.overview.compTitle', 'brain.overview.queueTitle', 'brain.overview.tokenTitle',
     ]);
     expect(settled.every(t => loading.includes(t))).toBe(true);
   });
@@ -494,11 +503,15 @@ describe('OverviewTabComponent — first-load skeletons', () => {
     expect(titles(el)).not.toContain('brain.overview.tokenTitle');
   });
 
+  // Usage is deliberately excluded from the per-panel assertions below: it is unconditional now, so its title
+  // is present whatever any pending flag says. Leaving it in would assert the old behaviour.
   it('is per panel — one still loading does not reserve the others', () => {
     const { el } = render({ tokens: true });
     expect(busy(el)).toBe(1);
     expect(titles(el)).toContain('brain.overview.tokenTitle');
-    expect(titles(el)).not.toContain('brain.overview.useTitle');
+    // Usage IS present — it is unconditional. What must be absent is another panel's frame: the point of the
+    // test is that one pending flag does not reserve cards for panels nobody is waiting on.
+    expect(titles(el)).not.toContain('brain.overview.compTitle');
   });
 
   it('draws lines, not a spinner — the size is the point', () => {

--- a/client/src/app/pages/brain/overview-tab.component.ts
+++ b/client/src/app/pages/brain/overview-tab.component.ts
@@ -184,7 +184,14 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
       <!-- ── Data model (full width: a diagram in a third-width card is unreadable) ──── -->
       <section class="panel span-all">
         <header class="panel-h">
-          <span class="ic"><ph-icon name="graph" [size]="16"/></span>
+          <!-- NO BACKTICKS in a template comment: one ends the inline template string and the error points
+               at @Component, not here.
+               This is "stack", not "graph". The panel is the space's SCHEMA — record TYPES and their fields,
+               with the relationships between them. "graph" is the node-graph VIEW and now labels that tab;
+               two things wearing one icon made this read as a small copy of the Graph tab. Not "database"
+               either: the Indexing panel below already owns that, and swapping one collision for another is
+               not a fix. -->
+          <span class="ic"><ph-icon name="stack" [size]="16"/></span>
           <div>
             <h3>{{ 'brain.overview.er.title' | transloco }}</h3>
             <p class="hint">{{ 'brain.overview.er.hint' | transloco }}</p>
@@ -200,40 +207,20 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
            The STORAGE bar was not duplicated by the diagram, so it moved into Usage below rather than
            being deleted with the strip around it — disk consumed is usage. -->
 
-      <!-- ── Storage: a small card, and NOT inside the activity panel ── -->
-      <!-- It briefly lived inside the usage card below and the spec caught it: that panel only renders when
-           activity data has arrived, so storage vanished on a space nobody had called yet — exactly the
-           space where filling the disk is least expected. It is unconditional here. -->
+      <!-- ── Usage: storage, and whether anyone gets anything OUT of this space ── -->
+      <!-- The SECTION is unconditional; only the ACTIVITY block inside it is gated. It used to be the other
+           way round, which is why storage could not live here: the whole card waited on activity data, so on
+           a space nobody had called yet the card was absent and storage with it — exactly the space where a
+           filling disk is least expected. Giving storage its own card worked around that and was the wrong
+           fix: it made a card for one number. -->
       <section class="panel">
         <header class="panel-h">
-          <span class="ic"><ph-icon name="database" [size]="16"/></span>
-          <div><h3>{{ 'brain.overview.storage' | transloco }}</h3></div>
+          <span class="ic"><ph-icon name="broadcast" [size]="16"/></span>
+          <div><h3>{{ 'brain.overview.useTitle' | transloco }}</h3>
+            <p>{{ 'brain.overview.useHint' | transloco }}</p></div>
         </header>
         <div class="panel-b">
-          <div class="store">
-            <div class="store-row">
-              @if (space().maxGiB) {
-                <span class="num">{{ used() }} / {{ space().maxGiB }} GiB</span>
-              } @else {
-                <span class="num">{{ used() }} GiB · {{ 'brain.overview.storageUnlimited' | transloco }}</span>
-              }
-            </div>
-            @if (usagePct(); as pct) {
-              <div class="bar"><span [class.warn]="pct >= 80 && pct < 95" [class.err]="pct >= 95" [style.width.%]="pct"></span></div>
-            }
-          </div>
-        </div>
-      </section>
-
-      <!-- ── Usage: is anyone getting anything OUT of this space? ────── -->
-      @if (activity(); as act) {
-        <section class="panel">
-          <header class="panel-h">
-            <span class="ic"><ph-icon name="broadcast" [size]="16"/></span>
-            <div><h3>{{ 'brain.overview.useTitle' | transloco }}</h3>
-              <p>{{ 'brain.overview.useHint' | transloco }}</p></div>
-          </header>
-          <div class="panel-b">
+          @if (activity(); as act) {
             @if (act.calls > 0) {
               <div class="stat-grid">
                 <div class="stat">
@@ -267,8 +254,8 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
                     <span class="num">{{ act.answered }} / {{ act.recall }}<!--
                       -->@if (act.meanTopScore !== null) { · {{ 'brain.overview.useTopScore' | transloco }} {{ act.meanTopScore }} }</span>
                   </div>
-                  <!-- Inverted thresholds against the storage bar above: there, full is bad. Here a LOW rate is
-                       the warning — questions arriving and going unanswered is the content gap this panel
+                  <!-- Inverted thresholds against the storage bar below: there, full is bad. Here a LOW rate
+                       is the warning — questions arriving and going unanswered is the content gap this panel
                        exists to make visible. -->
                   <div class="bar"><span [class.warn]="rate < 50 && rate >= 20" [class.err]="rate < 20" [style.width.%]="rate"></span></div>
                 </div>
@@ -282,22 +269,31 @@ interface StatCard { key: CollectionTab; icon: string; label: string; value: num
               }
             } @else {
               <!-- Not "no data": no calls. A space with nothing asked of it is the clearest answer this panel
-                   can give, and blanking the panel would look like a loading failure instead. -->
+                   can give, and blanking it would look like a loading failure instead. -->
               <span class="muted">{{ 'brain.overview.useNone' | transloco }}</span>
             }
+          } @else if (pending().activity) {
+            <app-skeleton-lines [rows]="4" />
+          }
 
+          <!-- Storage: a SECTION of usage, not a card of its own. Disk consumed IS usage, and one number does
+               not earn a card in a grid of panels. It sits OUTSIDE the activity branch above, so it renders
+               whether or not anyone has ever called this space. -->
+          <div class="store">
+            <div class="store-row">
+              <span class="cap">{{ 'brain.overview.storage' | transloco }}</span>
+              @if (space().maxGiB) {
+                <span class="num">{{ used() }} / {{ space().maxGiB }} GiB</span>
+              } @else {
+                <span class="num">{{ used() }} GiB · {{ 'brain.overview.storageUnlimited' | transloco }}</span>
+              }
+            </div>
+            @if (usagePct(); as pct) {
+              <div class="bar"><span [class.warn]="pct >= 80 && pct < 95" [class.err]="pct >= 95" [style.width.%]="pct"></span></div>
+            }
           </div>
-        </section>
-      } @else if (pending().activity) {
-        <section class="panel" [attr.aria-busy]="true">
-          <header class="panel-h">
-            <span class="ic"><ph-icon name="broadcast" [size]="16"/></span>
-            <div><h3>{{ 'brain.overview.useTitle' | transloco }}</h3>
-              <p>{{ 'brain.overview.useHint' | transloco }}</p></div>
-          </header>
-          <div class="panel-b"><app-skeleton-lines [rows]="4" /></div>
-        </section>
-      }
+        </div>
+      </section>
 
       <!-- ── Completeness ───────────────────────────────────────────── -->
       @if (completeness(); as comp) {


### PR DESCRIPTION
Owner: *'i wanted storage to be a section in the usage card and not one card for one number'* and *'data model has the wrong icon, it renders the graph icon. btw put that graph icon on the taboverview instead of the binoculars'*.

**Storage.** It was briefly nested in Usage, then split out because that panel only rendered once activity data arrived — so storage vanished on a space nobody had called yet, exactly the space where a filling disk is least expected. Splitting it worked around that and was the wrong fix: it made a card for one number.

The real fix is the one that should have come first: **the section is unconditional and only the activity block inside it is gated**, with the skeleton in the body rather than replacing the card. The card now never appears or disappears — a stronger version of what the first-load tests were already about.

**Icons.** The Data model panel wore the node-graph icon, so it read as a small copy of the Graph tab. The tab takes `graph` (it was binoculars, which named nothing); the panel takes `stack`, the icon its own record-type tiles already used. Not `database` — the Indexing panel owns that, and swapping one collision for another is not a fix.

**Four specs updated, not deleted.** Three encoded *'the Usage card appears and disappears'*, which is precisely the behaviour that had to change. Each says why in place.