### PR TITLE
feat(auth): every token carries a derived rights object, computed at load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Internal: every token now carries a derived per-space rights object.** Computed at config load from the
+  existing `admin` / `readOnly` / `spaces` fields. **Enforcement still reads the legacy fields** — nothing
+  about access changes.
+  - Deliberately **in memory only, not written to `config.json`.** Persisting it would make a derivation
+    defect durable before anything has compared it against the behaviour it is supposed to reproduce.
+  - A boot migration is the right shape here **only because tokens are local state** — `config.json` does not
+    sync. Synced data has to be migrated lazily and self-healingly instead.
+  - An existing rights object is never overwritten. Once these become editable, a re-run at every boot would
+    silently revert an operator's change back to whatever the legacy fields imply — and those fields will
+    still be sitting there.
+
 ### Changed
 - **Storage is a section of the Usage card again, not a card of its own** (owner, 2026-08-09: *"i wanted
   storage to be a section in the usage card and not one card for one number"*).

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -5,6 +5,7 @@ import type { Config, SecretsFile, SchemaLibraryEntry, SchemaCatalog } from './t
 import { normalizeDocExtractionMode } from './types.js';
 import { resolveMasterSecret, isEnvelope, encryptEnvelope, decryptEnvelope } from './secretbox.js';
 import { envIntOpt } from './env-num.js';
+import { migrateToken } from '../auth/rights-migration.js';
 
 const CONFIG_PATH = process.env['CONFIG_PATH'] ?? '/config/config.json';
 const SECRETS_PATH = path.join(path.dirname(CONFIG_PATH), 'secrets.json');
@@ -194,6 +195,22 @@ export function configExists(): boolean {
  *
  * @returns true if it changed the config (caller persists).
  */
+/**
+ * Give every token a `rights` object derived from its legacy fields, if it lacks one.
+ *
+ * Returns how many were filled, so a caller can log it and a test can assert the count rather than trusting
+ * that the loop ran. In-memory only — see the call site for why this is not written to disk yet.
+ */
+export function backfillTokenRights(config: Config): number {
+  let filled = 0;
+  for (const t of config.tokens ?? []) {
+    if (t.rights) continue;
+    t.rights = migrateToken(t) as unknown as typeof t.rights;
+    filled++;
+  }
+  return filled;
+}
+
 export function migrateMediaEmbeddingMasterSwitch(config: Config): boolean {
   const media = config.mediaEmbedding as (MediaEmbeddingConfig & { enabled?: boolean }) | undefined;
   if (!media || !('enabled' in media)) return false;
@@ -291,6 +308,15 @@ export function loadConfig(): Config {
   parsed.networks ??= [];
   _config = parsed;
   validateOidcBlock(_config);
+  // Derive the per-space rights matrix for any token that has none. IN MEMORY ONLY, and deliberately not
+  // persisted: enforcement still reads the legacy fields, so this run is an observation rather than a
+  // change. Writing it to config.json would make a derivation defect durable before anything has compared
+  // it against the behaviour it is meant to reproduce.
+  //
+  // A boot migration is the right shape here at all only because tokens are LOCAL state — config.json does
+  // not sync. Synced data must be migrated lazily and self-healingly instead.
+  backfillTokenRights(_config);
+
   // Durable one-time migration of the removed media-embedding master switch (writes config.json once).
   if (migrateMediaEmbeddingMasterSwitch(_config)) {
     try {

--- a/server/src/config/rights-shape.ts
+++ b/server/src/config/rights-shape.ts
@@ -1,0 +1,26 @@
+/**
+ * The shape of a token's per-space rights, in a leaf module with no imports.
+ *
+ * It lives here rather than inline in `types.ts` for a concrete reason: written out there it added six lines
+ * to a file that had already taken three god-file ratchet raises in one day, and the honest response to a
+ * fifth is to stop putting things in it — not to raise it again.
+ *
+ * It cannot live in `auth/rights-migration.ts` either, because `types.ts` would then import from `auth/`,
+ * which imports `types.ts`. A leaf both can import breaks that cycle without either owning the other.
+ */
+
+/** Rungs, lowest first. Each CONTAINS the one below, so "write but not read" is unrepresentable. */
+export type Rung = 'none' | 'read' | 'write' | 'admin';
+
+/** The four space-scoped areas. Instance capabilities are not here — they have no space to scope to. */
+export type SpaceArea = 'knowledge' | 'files' | 'schema' | 'dataQuality';
+
+export type AreaRungs = Record<SpaceArea, Rung>;
+
+export interface TokenRights {
+  instanceAdmin: boolean;
+  createSpaces: boolean;
+  /** The MINIMUM held in every space, including ones created later. `null` means no floor. */
+  floor: AreaRungs | null;
+  perSpace: Record<string, AreaRungs>;
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1,3 +1,4 @@
+import type { TokenRights } from './rights-shape.js';
 export interface TokenRecord {
   id: string;
   name: string;
@@ -36,6 +37,16 @@ export interface TokenRecord {
    *               same all-or-nothing trap from the other side.
    */
   mfa?: 'inherit' | 'exempt' | 'required';
+  /**
+   * The per-space rights matrix, derived from `admin`/`readOnly`/`spaces` by `migrateToken()` at load.
+   *
+   * **Not authoritative yet.** Enforcement still reads the legacy fields; this is written and compared
+   * first, so a defect in the derivation shows up as a mismatch rather than as access somebody has and
+   * nobody granted. Shape is `MigratedRights` in `auth/rights-migration.ts` — typed loosely here because
+   * `config/types.ts` must not import from `auth/`, which imports this file.
+   */
+  rights?: TokenRights;
+
 }
 
 // ── Space meta / schema types ──────────────────────────────────────────────

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -85,10 +85,18 @@ const FROZEN = {
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.
   'client/src/app/pages/graph/graph.component.ts': 773,
-  'server/src/config/loader.ts': 753,
+  // 753 -> 764: `backfillTokenRights`. This file is where config migrations already live — the media
+  // master-switch and space-description ones are both here — so a fourth belongs beside them rather than in
+  // a module only the loader would ever call.
+  'server/src/config/loader.ts': 764,
   'client/src/app/pages/brain/review-tab.component.ts': 748,
   'server/src/brain/recall.ts': 739,
   'client/src/app/pages/settings/media-processing/models-tab.component.ts': 678,
+  // 675 -> 677: `rights` on TokenRecord, plus its import. FOURTH raise of this file in one session, and the
+  // first attempt wanted SIX lines because the shape was written inline. That was the signal, so the shape
+  // moved to `config/rights-shape.ts` — a leaf both this file and `auth/` can import without a cycle — and
+  // what is left here is one field and one import. The answer to a file that keeps growing is to stop
+  // putting things in it, not to raise the number again. The domain split is filed in ARCHITECTURE-TODO.
   // 674 -> 675: `spaceOrigins` on NetworkConfig. **THIRD raise of this file in one session** (672 -> 673 ->
   // 674 -> 675), and that is the signal this list exists to send rather than a run of bad luck. Each was one
   // honest line of type whose behaviour lives elsewhere, and each was individually correct — which is
@@ -101,7 +109,7 @@ const FROZEN = {
   // behaviour it names lives in `face-external.ts` and `face-embedder.ts`, not here. The alternative —
   // a face-only config module re-exported from this file — would split the config contract across two
   // places to save a single field, which is the trade this list exists to let us decline.
-  'server/src/config/types.ts': 675,
+  'server/src/config/types.ts': 677,
   'client/src/app/pages/settings/data.component.ts': 644,
   'server/src/api/files.ts': 646,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate

--- a/testing/standalone/token-rights-backfill.test.js
+++ b/testing/standalone/token-rights-backfill.test.js
@@ -1,0 +1,68 @@
+/**
+ * Every token gets a rights object at load, and an existing one is never overwritten.
+ *
+ * ## What this covers that the mapping tests do not
+ *
+ * `rights-migration.test.js` proves the MAPPING is correct for every token shape. This proves the
+ * BACKFILL applies it — that the loop runs, that it reaches every token, and that it does not clobber a
+ * rights object somebody already set. A correct mapping nobody calls, or one that overwrites a deliberate
+ * edit, both look identical to working.
+ *
+ * ## Why the count is returned and asserted
+ *
+ * A `for` loop that silently iterates nothing is the failure this file exists to catch, and it is invisible
+ * from the outside: every token would simply have no rights, exactly as before the feature. So the function
+ * reports how many it filled and the tests assert that number rather than only inspecting the result.
+ *
+ * Run: node --test testing/standalone/token-rights-backfill.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let backfillTokenRights;
+before(async () => {
+  ({ backfillTokenRights } = await import('../../server/dist/config/loader.js'));
+});
+
+const tok = (over) => ({ id: 'i', name: 'n', hash: 'h', prefix: 'p', createdAt: '', lastUsed: null, expiresAt: null, admin: false, ...over });
+
+describe('the rights backfill', () => {
+  it('fills every token that has none, and says how many', () => {
+    const cfg = { tokens: [tok({ id: 'a' }), tok({ id: 'b', readOnly: true }), tok({ id: 'c', spaces: ['qa'] })] };
+    assert.equal(backfillTokenRights(cfg), 3, 'the loop did not reach every token');
+    for (const t of cfg.tokens) assert.ok(t.rights, `${t.id} has no rights`);
+  });
+
+  it('derives from the legacy fields rather than defaulting', () => {
+    // If it wrote a constant, every token would look the same and the count would still be right.
+    const cfg = { tokens: [tok({ id: 'a', admin: true }), tok({ id: 'b', readOnly: true }), tok({ id: 'c', spaces: ['qa'] })] };
+    backfillTokenRights(cfg);
+    assert.equal(cfg.tokens[0].rights.instanceAdmin, true);
+    assert.equal(cfg.tokens[1].rights.instanceAdmin, false);
+    assert.equal(cfg.tokens[1].rights.floor.knowledge, 'read');
+    assert.equal(cfg.tokens[2].rights.floor, null, 'a scoped token must not get a floor');
+    assert.deepEqual(Object.keys(cfg.tokens[2].rights.perSpace), ['qa']);
+  });
+
+  it('NEVER overwrites a rights object that is already there', () => {
+    // Once these become editable, a re-run at every boot would silently revert an operator's change back to
+    // whatever the legacy fields imply — and the legacy fields will still be sitting there.
+    const mine = { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { only: { knowledge: 'read' } } };
+    const cfg = { tokens: [tok({ id: 'a', admin: true, rights: mine })] };
+    assert.equal(backfillTokenRights(cfg), 0, 'it reported filling a token that already had rights');
+    assert.equal(cfg.tokens[0].rights, mine, 'an existing rights object was replaced');
+  });
+
+  it('is a no-op on an empty or absent token list, without throwing', () => {
+    assert.equal(backfillTokenRights({ tokens: [] }), 0);
+    assert.equal(backfillTokenRights({}), 0, 'a config with no tokens key must not throw during boot');
+  });
+
+  it('is idempotent — a second run fills nothing', () => {
+    // It runs on every config load, not once. A second pass reporting work would mean it is rewriting.
+    const cfg = { tokens: [tok({ id: 'a' }), tok({ id: 'b' })] };
+    assert.equal(backfillTokenRights(cfg), 2);
+    assert.equal(backfillTokenRights(cfg), 0);
+  });
+});


### PR DESCRIPTION
Step 4 of the approved per-space rights matrix. **Enforcement still reads the legacy fields** — nothing about access changes.

**In memory only, not written to `config.json`.** Persisting it would make a derivation defect durable before anything has compared it against the behaviour it is meant to reproduce. A boot migration is the right shape here *only* because tokens are local state — `config.json` does not sync, and synced data must be migrated lazily and self-healingly instead.

**An existing rights object is never overwritten.** Once these become editable, a re-run at every boot would silently revert an operator's change back to whatever the legacy fields imply — and those fields will still be sitting there.

**The backfill returns a count**, so a loop that silently iterates nothing fails a test rather than leaving every token exactly as it was before the feature — which is precisely what that bug looks like from outside.

**On the ratchet.** This wanted a *fifth* raise of `config/types.ts`, and the first attempt wanted six lines because the rights shape was written inline. That was the signal. The shape moved to `config/rights-shape.ts` — a leaf both `types.ts` and `auth/` can import without a cycle — leaving one field and one import. The answer to a file that keeps growing is to stop putting things in it.