### PR TITLE
feat(auth): a minted token can never exceed the token that minted it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: the mint cap — a minted token can never exceed the token that minted it.** Nothing calls it
+  yet; rights are not settable on mint.
+  - Minting is delegated in the approved design: a space admin may issue tokens for their own spaces.
+    Uncapped that is an escalation ladder — mint a token holding more than you do, then authenticate as it —
+    and nothing about the result looks wrong afterwards.
+  - **It refuses rather than silently trimming.** A quietly narrowed token works, looks configured, and is
+    not what the operator asked for; they find out when something they granted does not work, with the grid
+    saying one thing and the behaviour another. The refusal names every excess at once so one edit fixes it.
+  - Two comparisons that are easy to get subtly wrong, both pinned: the minter's reach in a space is its
+    floor **or** its row, whichever is higher; and a **floor may only come from a floor**, never from a row,
+    because a floor reaches spaces that do not exist yet and a row does not.
+
+### Added
 - **Internal: every token now carries a derived per-space rights object.** Computed at config load from the
   existing `admin` / `readOnly` / `spaces` fields. **Enforcement still reads the legacy fields** — nothing
   about access changes.

--- a/server/src/auth/mint-cap.ts
+++ b/server/src/auth/mint-cap.ts
@@ -1,0 +1,101 @@
+/**
+ * A minted token can never exceed the token that minted it.
+ *
+ * ## Why this is the rule that has to live in the API
+ *
+ * The rights matrix delegates minting: a space admin may issue tokens for their own spaces. Without a cap
+ * that is an escalation ladder — mint a token with more rights than you hold, then authenticate as it. The
+ * UI can grey out the controls, and that is worth doing, but the grid is one API call away from being
+ * bypassed and the API is exactly where a token would be used to widen itself.
+ *
+ * ## Refuse, do not silently trim
+ *
+ * `capRights` reports what it would have cut rather than quietly returning a narrowed object. Silently
+ * trimming produces a token that works, looks configured, and is not what the operator asked for — and they
+ * find out when something they granted does not work, at which point the grid says one thing and the
+ * behaviour says another. A refusal naming the excess costs one call to fix.
+ *
+ * ## Two rules, and only one of them is about the matrix
+ *
+ *  - **Never above the minter**, per area per space, including the floor.
+ *  - **Never the instance-administrator switch**, and never `createSpaces`, from a non-administrator. Those
+ *    are not areas and do not cap — they are held or they are not.
+ */
+import type { TokenRights, AreaRungs, Rung, SpaceArea } from '../config/rights-shape.js';
+
+const ORDER: readonly Rung[] = ['none', 'read', 'write', 'admin'];
+const AREAS: readonly SpaceArea[] = ['knowledge', 'files', 'schema', 'dataQuality'];
+
+const rank = (r: Rung): number => ORDER.indexOf(r);
+
+/** One excess grant, named precisely enough to fix without a second request. */
+export interface Excess {
+  /** `'*'` for the floor, otherwise the space id. */
+  space: string;
+  area: SpaceArea | 'instanceAdmin' | 'createSpaces';
+  requested: string;
+  allowed: string;
+}
+
+/**
+ * What the minter actually holds in a given space: the higher of its floor and its explicit row.
+ *
+ * Both, not either. A token with a `read` floor and a `write` row on `qa` holds write there, and a token
+ * with a `write` floor and no row still holds write everywhere — reading only one of them under-reports the
+ * minter and refuses grants it was entitled to make.
+ */
+export function effectiveRung(rights: TokenRights, space: string, area: SpaceArea): Rung {
+  const floor = rights.floor?.[area] ?? 'none';
+  const row = rights.perSpace[space]?.[area] ?? 'none';
+  return rank(row) > rank(floor) ? row : floor;
+}
+
+/**
+ * Check a requested rights object against the minter's.
+ *
+ * Returns every excess rather than the first, so one refusal can name everything wrong with the request.
+ * Stopping at the first turns a five-line fix into five round trips.
+ */
+export function capRights(minter: TokenRights, requested: TokenRights): Excess[] {
+  const excess: Excess[] = [];
+
+  if (requested.instanceAdmin && !minter.instanceAdmin) {
+    excess.push({ space: '*', area: 'instanceAdmin', requested: 'true', allowed: 'false' });
+  }
+  if (requested.createSpaces && !minter.createSpaces) {
+    excess.push({ space: '*', area: 'createSpaces', requested: 'true', allowed: 'false' });
+  }
+
+  // The floor is compared against the minter's FLOOR alone, not its effective rung anywhere.
+  // A minter with no floor and a `write` row on one space may grant that row — it may not grant a floor,
+  // because a floor reaches every space including ones created later, which the minter cannot do.
+  if (requested.floor) {
+    for (const area of AREAS) {
+      const want = requested.floor[area];
+      const have = minter.floor?.[area] ?? 'none';
+      if (rank(want) > rank(have)) {
+        excess.push({ space: '*', area, requested: want, allowed: have });
+      }
+    }
+  }
+
+  for (const [space, rungs] of Object.entries(requested.perSpace)) {
+    for (const area of AREAS) {
+      const want = (rungs as AreaRungs)[area];
+      const have = effectiveRung(minter, space, area);
+      if (rank(want) > rank(have)) {
+        excess.push({ space, area, requested: want, allowed: have });
+      }
+    }
+  }
+
+  return excess;
+}
+
+/** A refusal message that names every excess, in a stable order, short enough to read in a response body. */
+export function describeExcess(excess: Excess[]): string {
+  return excess
+    .map(e => `${e.space === '*' ? 'floor' : e.space}.${e.area}: asked ${e.requested}, you hold ${e.allowed}`)
+    .sort()
+    .join('; ');
+}

--- a/testing/standalone/mint-cannot-exceed-minter.test.js
+++ b/testing/standalone/mint-cannot-exceed-minter.test.js
@@ -1,0 +1,97 @@
+/**
+ * A minted token can never exceed the token that minted it.
+ *
+ * ## What breaks without this
+ *
+ * Minting is delegated: a space admin may issue tokens for their own spaces. Uncapped, that is an escalation
+ * ladder — mint a token holding more than you do, then authenticate as it. Nothing about the result looks
+ * wrong afterwards; the token is valid, and its rights read as though somebody granted them.
+ *
+ * ## The two properties that are easy to get subtly wrong
+ *
+ *  1. **The minter's reach is floor OR row, whichever is higher.** Reading only the row under-reports a
+ *     minter with a broad floor and refuses grants it was entitled to make; reading only the floor
+ *     under-reports one with a specific row. Either way the bug is a refusal, which gets reported — but the
+ *     inverse of that mistake in the floor comparison is a GRANT, which does not.
+ *  2. **A floor may only come from a floor.** A minter with no floor and `write` on one space may pass that
+ *     row on. It may not grant a FLOOR, because a floor reaches every space including ones created later —
+ *     which the minter itself cannot reach. That is the case where "highest rung anywhere" would be exactly
+ *     the wrong comparison.
+ *
+ * Run: node --test testing/standalone/mint-cannot-exceed-minter.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let capRights, effectiveRung, describeExcess;
+before(async () => {
+  ({ capRights, effectiveRung, describeExcess } = await import('../../server/dist/auth/mint-cap.js'));
+});
+
+const R = (r) => ({ knowledge: r, files: r, schema: r, dataQuality: r });
+const rights = (over = {}) => ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+describe('the cap', () => {
+  it('allows a grant equal to the minter', () => {
+    const m = rights({ perSpace: { qa: R('write') } });
+    assert.deepEqual(capRights(m, rights({ perSpace: { qa: R('write') } })), []);
+  });
+
+  it('refuses a rung above the minter, and names it', () => {
+    const m = rights({ perSpace: { qa: R('write') } });
+    const e = capRights(m, rights({ perSpace: { qa: R('admin') } }));
+    assert.equal(e.length, 4, 'every area over the line should be reported, not just the first');
+    assert.match(describeExcess(e), /qa\.knowledge: asked admin, you hold write/);
+  });
+
+  it('refuses a space the minter cannot reach at all', () => {
+    const m = rights({ perSpace: { qa: R('admin') } });
+    const e = capRights(m, rights({ perSpace: { other: R('read') } }));
+    assert.equal(e.length, 4);
+    assert.match(describeExcess(e), /other\.knowledge: asked read, you hold none/);
+  });
+
+  it('counts the minter as floor OR row, whichever is higher', () => {
+    // A `read` floor plus a `write` row on qa means the minter holds write there, and may pass it on.
+    const m = rights({ floor: R('read'), perSpace: { qa: R('write') } });
+    assert.equal(effectiveRung(m, 'qa', 'knowledge'), 'write');
+    assert.equal(effectiveRung(m, 'elsewhere', 'knowledge'), 'read', 'the floor must apply to unlisted spaces');
+    assert.deepEqual(capRights(m, rights({ perSpace: { qa: R('write'), elsewhere: R('read') } })), []);
+  });
+
+  it('a FLOOR may only come from a floor, never from a row', () => {
+    // The case where "highest rung anywhere" is the wrong comparison. A floor reaches every space including
+    // ones created later; a minter with only a row on qa cannot reach those, so it cannot grant one.
+    const m = rights({ perSpace: { qa: R('admin') } });
+    const e = capRights(m, rights({ floor: R('read') }));
+    assert.equal(e.length, 4, 'granting a floor from a row must be refused for every area');
+    assert.match(describeExcess(e), /floor\.knowledge: asked read, you hold none/);
+  });
+
+  it('a minter WITH a floor may grant up to it', () => {
+    const m = rights({ floor: R('write') });
+    assert.deepEqual(capRights(m, rights({ floor: R('read') })), []);
+    assert.deepEqual(capRights(m, rights({ floor: R('write') })), []);
+    assert.equal(capRights(m, rights({ floor: R('admin') })).length, 4);
+  });
+
+  it('instance admin and createSpaces are held or not — they do not cap', () => {
+    const plain = rights({ floor: R('admin') });
+    assert.equal(capRights(plain, rights({ instanceAdmin: true })).length, 1,
+      'area admin everywhere must NOT imply the instance switch');
+    assert.equal(capRights(plain, rights({ createSpaces: true })).length, 1);
+    const boss = rights({ instanceAdmin: true, createSpaces: true, floor: R('admin') });
+    assert.deepEqual(capRights(boss, rights({ instanceAdmin: true, createSpaces: true })), []);
+  });
+
+  it('reports EVERY excess, so one refusal can be fixed in one edit', () => {
+    const m = rights({ perSpace: { qa: R('read') } });
+    const e = capRights(m, rights({ instanceAdmin: true, perSpace: { qa: R('admin'), nope: R('read') } }));
+    assert.equal(e.length, 1 + 4 + 4, 'stopping at the first excess turns one fix into several round trips');
+  });
+
+  it('an empty request is always allowed', () => {
+    assert.deepEqual(capRights(rights(), rights()), []);
+  });
+});


### PR DESCRIPTION
Step 5 of the approved per-space rights matrix. Nothing calls it yet — rights are not settable on mint — so no behaviour changes.

Minting is delegated by design: a space admin may issue tokens for their own spaces. Uncapped, that is an escalation ladder — mint a token holding more than you do, then authenticate as it — and **nothing about the result looks wrong afterwards**. The token is valid and its rights read as though somebody granted them.

**It refuses rather than silently trimming.** A quietly narrowed token works, looks configured, and is not what the operator asked for; they find out when something they granted does not work, with the grid saying one thing and the behaviour another. The refusal names every excess at once, because stopping at the first turns one edit into several round trips.

**Two comparisons that are easy to get subtly wrong, both pinned:**

- the minter's reach in a space is its **floor OR its row, whichever is higher** — reading either alone under-reports it;
- a **floor may only come from a floor**, never from a row. A floor reaches every space including ones created later, which a minter holding a single row cannot do. This is the case where *highest rung anywhere* would be exactly the wrong comparison, and its failure direction is a **grant**, not a refusal.