### PR TITLE
feat(auth): prove the rights-based space reach matches the legacy allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: the rights-based space-reach check, proved equivalent to the legacy allowlist.** The guard
+  still uses the old rule; nothing about access changes.
+  - Swapping `enforceSpaceScope` from `record.spaces` to the rights matrix is the one change in this feature
+    where a mistake is **silent widening** — a token reaching a space it never could, with no error, nothing
+    in the response and nothing in the logs. The token works and looks configured.
+  - So the replacement lands first as a pure function beside a test that compares it against a written-out
+    statement of the legacy rule, across every token shape and on listed, unlisted and not-yet-created
+    spaces. **If that test cannot be made green, the switch is not ready** — which is the point of writing it
+    before the switch rather than after.
+  - Deliberately space-level, not area-level. Area granularity comes from the route inventory and is a later
+    step: wiring both at once means a defect in either reads as a defect in the other.
+
+### Added
 - **Internal: the mint cap — a minted token can never exceed the token that minted it.** Nothing calls it
   yet; rights are not settable on mint.
   - Minting is delegated in the approved design: a space admin may issue tokens for their own spaces.

--- a/server/src/auth/space-reach.ts
+++ b/server/src/auth/space-reach.ts
@@ -1,0 +1,36 @@
+/**
+ * Does this token reach a space at all?
+ *
+ * ## Why this exists before the guard uses it
+ *
+ * `enforceSpaceScope` currently answers the question from the legacy `spaces` allowlist. The rights matrix
+ * answers it from `floor` and `perSpace`. Switching the guard from one to the other is the single change in
+ * this feature where a mistake is SILENT WIDENING — a token reaching a space it never could, with no error
+ * and nothing in the response to say so.
+ *
+ * So the replacement lands first, as a pure function, next to a test that asserts it agrees with the legacy
+ * rule for every token shape. Only once the two provably answer the same question does the guard move onto
+ * it. Behaviour changes when the guard changes; nothing here changes anything.
+ *
+ * ## Space-level, not area-level, and deliberately so
+ *
+ * The guard's question is "may this token touch this space at all". Area granularity comes from the route
+ * inventory (`space-rights.ts`) and is a LATER step: wiring both at once means a defect in either reads as a
+ * defect in the other, and the failure mode of the pair is the one nobody sees.
+ */
+import type { TokenRights, SpaceArea } from '../config/rights-shape.js';
+
+const AREAS: readonly SpaceArea[] = ['knowledge', 'files', 'schema', 'dataQuality'];
+
+/**
+ * True when the token holds ANY rung above `none` in this space — via its floor or its explicit row.
+ *
+ * Both are consulted. A floor reaches spaces with no row at all, which is exactly how an unscoped token is
+ * represented, and a row can raise a space above the floor.
+ */
+export function reachesSpace(rights: TokenRights, spaceId: string): boolean {
+  const row = rights.perSpace[spaceId];
+  if (row && AREAS.some(a => row[a] !== 'none')) return true;
+  const floor = rights.floor;
+  return !!floor && AREAS.some(a => floor[a] !== 'none');
+}

--- a/testing/standalone/rights-reach-matches-legacy.test.js
+++ b/testing/standalone/rights-reach-matches-legacy.test.js
@@ -1,0 +1,81 @@
+/**
+ * The rights-based reach check answers the SAME question as the legacy `spaces` allowlist.
+ *
+ * ## Why this test has to exist before the guard changes
+ *
+ * `enforceSpaceScope` decides "may this token touch this space" from `record.spaces`. The rights matrix
+ * decides it from `floor` and `perSpace`. Swapping one for the other is the single change in this feature
+ * where a mistake is **silent widening**: a token reaching a space it never could, with no error, nothing in
+ * the response, and nothing in the logs. The token works. It looks configured.
+ *
+ * So the two are proved equivalent here, across every token shape, before anything is switched. If this file
+ * cannot be made green, the switch is not ready — that is the whole point of writing it first.
+ *
+ * ## The legacy rule, stated exactly
+ *
+ * `record.spaces` absent → reaches every space, including ones created later.
+ * `record.spaces` present → reaches exactly the listed ids, and an empty list reaches nothing.
+ *
+ * Run: node --test testing/standalone/rights-reach-matches-legacy.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let reachesSpace, migrateToken;
+before(async () => {
+  ({ reachesSpace } = await import('../../server/dist/auth/space-reach.js'));
+  ({ migrateToken } = await import('../../server/dist/auth/rights-migration.js'));
+});
+
+/** The legacy rule, written out so the comparison is against a statement of it rather than against itself. */
+const legacyReaches = (t, spaceId) => (t.schemaLibrary ? false : t.spaces === undefined || t.spaces.includes(spaceId));
+
+describe('rights-based reach agrees with the legacy allowlist', () => {
+  it('agrees for every token shape, on listed, unlisted and future spaces', () => {
+    const shapes = [
+      {}, { admin: true }, { readOnly: true },
+      { spaces: [] }, { spaces: ['qa'] }, { spaces: ['qa', 'tasks'] },
+      { admin: true, spaces: ['qa'] }, { readOnly: true, spaces: ['qa'] },
+      { schemaLibrary: true, readOnly: true, spaces: [] },
+      { peerInstanceId: 'i-1', spaces: ['fleet'] },
+    ];
+    // 'created-later' is in nobody's list: it stands for a space that did not exist when the token was
+    // minted, which is the case the floor exists to express and the one an allowlist answers by omission.
+    const spaces = ['qa', 'tasks', 'fleet', 'other', 'created-later'];
+    let compared = 0;
+    for (const t of shapes) {
+      const rights = migrateToken(t);
+      for (const s of spaces) {
+        assert.equal(
+          reachesSpace(rights, s), legacyReaches(t, s),
+          `disagreement on ${JSON.stringify(t)} / '${s}' — rights say ${reachesSpace(rights, s)}, legacy says ${legacyReaches(t, s)}`,
+        );
+        compared++;
+      }
+    }
+    // Asserted so a loop that silently stops iterating cannot pass as agreement.
+    assert.equal(compared, shapes.length * spaces.length, `expected 50 comparisons, made ${compared}`);
+  });
+
+  it('an unscoped token reaches a space created after it was minted', () => {
+    // The property an allowlist expresses by ABSENCE and the matrix expresses by a floor. Getting this wrong
+    // is the one direction that widens rather than refuses, so it is asserted on its own as well.
+    assert.equal(reachesSpace(migrateToken({}), 'invented-tomorrow'), true);
+    assert.equal(reachesSpace(migrateToken({ spaces: ['qa'] }), 'invented-tomorrow'), false);
+  });
+
+  it('a schemaLibrary token reaches nothing, despite carrying readOnly', () => {
+    assert.equal(reachesSpace(migrateToken({ schemaLibrary: true, readOnly: true, spaces: [] }), 'qa'), false);
+  });
+
+  it('the comparison would NOTICE a widening', () => {
+    // Mutation-check on the test itself: if `reachesSpace` returned true unconditionally, the assertions
+    // above must fail. A green run here would otherwise prove only that both functions were called.
+    const alwaysTrue = { floor: { knowledge: 'read', files: 'read', schema: 'read', dataQuality: 'read' }, perSpace: {} };
+    assert.equal(reachesSpace(alwaysTrue, 'anything'), true);
+    const neverReaches = { floor: null, perSpace: {} };
+    assert.equal(reachesSpace(neverReaches, 'anything'), false,
+      'a token with no floor and no rows must reach nothing — otherwise the check cannot refuse at all');
+  });
+});


### PR DESCRIPTION
The guard still uses the old rule. **Nothing about access changes.**

Swapping `enforceSpaceScope` from `record.spaces` to the rights matrix is the one change in this feature where a mistake is **silent widening**: a token reaching a space it never could, with no error, nothing in the response and nothing in the logs. The token works and looks configured. There is no symptom to notice.

So the replacement lands first as a pure function, beside a test that compares it against a **written-out statement of the legacy rule** rather than against itself — across every token shape, on listed, unlisted and not-yet-created spaces, with the comparison count asserted so a loop that stops iterating cannot pass as agreement.

**If that test cannot be made green, the switch is not ready.** That is the point of writing it before the switch rather than after.

Deliberately space-level, not area-level. Area granularity comes from the route inventory and is a later step: wiring both at once means a defect in either reads as a defect in the other, and the failure mode of the pair is the one nobody sees.