### PR TITLE
feat(auth): the space guard decides from the rights matrix, not the spaces allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **The space guard now decides access from the rights matrix instead of the `spaces` allowlist.** Access is
+  unchanged: the rights are derived from `spaces`/`admin`/`readOnly` at config load, and the two predicates
+  are proved equivalent for every token shape on listed, unlisted and not-yet-created spaces.
+  - This is the first change in the rights work that alters how a decision is MADE rather than only adding
+    machinery. It went last on purpose, behind the proof, because its failure mode is a token reaching a
+    space it never could — with no error, nothing in the response and nothing in the logs.
+  - **The legacy branch survives, and is not decoration.** OIDC-derived tokens are built per request rather
+    than read from config, so the load-time backfill never sees them and they carry no rights. Without the
+    fallback the guard would refuse every OIDC caller — a lockout, not a widening, but one that would reach
+    production because no unit test stands up an OIDC session.
+  - The proxy rule is untouched: a proxy space still requires access to **every** member, never any one of
+    them.
+
 ### Added
 - **Internal: the rights-based space-reach check, proved equivalent to the legacy allowlist.** The guard
   still uses the old rule; nothing about access changes.

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -6,6 +6,7 @@ import { validateOidcJwt, getOidcConfig } from './oidc.js';
 import type { TokenRecord } from '../config/types.js';
 import type { OidcTokenRecord } from './oidc.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
+import { reachesSpace } from './space-reach.js';
 import { authAttemptsTotal } from '../metrics/registry.js';
 import { logAuthFailure } from '../audit/middleware.js';
 import { mcpResourceMetadataUrl } from '../mcp/oauth.js';
@@ -265,18 +266,30 @@ function enforceSpaceScope(
   record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
   spaceId: string | undefined,
 ): boolean {
-  if (record.spaces && spaceId) {
-    // For proxy spaces, the token must have access to all member spaces.
-    // If the space doesn't exist in config, resolveMemberSpaces returns [].
-    // Fall back to [spaceId] so the scope check still rejects tokens that
-    // don't list this space — returning 403 instead of leaking a 404.
-    const memberIds = resolveMemberSpaces(spaceId);
-    const targets = memberIds.length > 0 ? memberIds : [spaceId];
-    const missing = targets.filter(sid => !record.spaces!.includes(sid));
-    if (missing.length > 0) {
-      res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });
-      return false;
-    }
+  if (!spaceId) return true;
+
+  // For proxy spaces, the token must have access to ALL member spaces.
+  // If the space doesn't exist in config, resolveMemberSpaces returns [].
+  // Fall back to [spaceId] so the scope check still rejects tokens that
+  // don't reach this space — returning 403 instead of leaking a 404.
+  const memberIds = resolveMemberSpaces(spaceId);
+  const targets = memberIds.length > 0 ? memberIds : [spaceId];
+
+  // The rights matrix answers this now. It is derived from `spaces`/`admin`/`readOnly` at config load, and
+  // `rights-reach-matches-legacy.test.js` proves the two agree for every token shape on listed, unlisted and
+  // not-yet-created spaces — which is why this swap changes no behaviour.
+  //
+  // The legacy branch survives for records that carry no rights: OIDC-derived tokens are built per request
+  // rather than read from config, so the backfill never sees them. Falling through to `spaces` there is the
+  // same answer, not a weaker one; removing it would refuse every OIDC caller instead.
+  const rights = (record as { rights?: Parameters<typeof reachesSpace>[0] }).rights;
+  const missing = rights
+    ? targets.filter(sid => !reachesSpace(rights, sid))
+    : record.spaces ? targets.filter(sid => !record.spaces!.includes(sid)) : [];
+
+  if (missing.length > 0) {
+    res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });
+    return false;
   }
   return true;
 }

--- a/testing/standalone/space-guard-reads-rights.test.js
+++ b/testing/standalone/space-guard-reads-rights.test.js
@@ -1,0 +1,78 @@
+/**
+ * The space guard asks the rights matrix, and still refuses everything it refused before.
+ *
+ * ## What changed, and what must not have
+ *
+ * `enforceSpaceScope` decided access from `record.spaces`. It now asks `reachesSpace()` on the token's
+ * rights, which are derived from the same legacy fields at config load. Behaviour is unchanged BY
+ * CONSTRUCTION — but "by construction" is exactly the claim that needs a test, because the failure mode of
+ * getting it wrong is a token reaching a space it never could, with nothing to notice.
+ *
+ * `rights-reach-matches-legacy.test.js` proves the two predicates agree. This proves the GUARD uses the new
+ * one, keeps the proxy rule, and keeps the fallback that OIDC callers depend on.
+ *
+ * ## The fallback is not decoration
+ *
+ * OIDC-derived tokens are built per request, not read from config, so the backfill never sees them and they
+ * carry no `rights`. Without the legacy branch the guard would refuse every OIDC caller — a lockout, not a
+ * widening, but a lockout that would reach production because no unit test stands up an OIDC session.
+ *
+ * Run: node --test testing/standalone/space-guard-reads-rights.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC = 'server/src/auth/middleware.ts';
+const src = readFileSync(join(ROOT, SRC), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const code = withoutComments(src);
+
+/** The body of `enforceSpaceScope`, sliced to its own closing brace rather than by a character count. */
+function guardBody() {
+  const i = code.indexOf('function enforceSpaceScope');
+  if (i < 0) return null;
+  const j = code.indexOf('\n}', i);
+  return j < 0 ? null : code.slice(i, j);
+}
+
+describe('the space guard', () => {
+  it('is still there to be checked', () => {
+    // A gate that cannot find its subject passes vacuously and would keep passing after a rename.
+    assert.ok(guardBody(), `enforceSpaceScope is gone from ${SRC} — re-point this test`);
+  });
+
+  it('asks the rights matrix', () => {
+    assert.match(guardBody(), /reachesSpace\(/,
+      'the guard no longer consults the rights matrix, so the grid governs nothing');
+  });
+
+  it('keeps the legacy branch for records with no rights', () => {
+    // OIDC tokens are built per request and never reach the config backfill. Removing this refuses them all.
+    assert.match(guardBody(), /record\.spaces/,
+      'the fallback is gone; every OIDC caller would be refused, and no unit test stands one up');
+  });
+
+  it('still applies the proxy rule — ALL member spaces, not any', () => {
+    const body = guardBody();
+    assert.match(body, /resolveMemberSpaces\(/, 'proxy members are no longer resolved');
+    // `filter(... !reaches)` then `length > 0` is "every target must pass". A `.some()` here would mean one
+    // reachable member unlocked a proxy over spaces the token cannot see — the widening this rule prevents.
+    assert.match(body, /missing\.length > 0/, 'the all-members rule is gone');
+    assert.doesNotMatch(body, /targets\.some\(/, 'ANY-member access would unlock a proxy over unreachable spaces');
+  });
+
+  it('refuses rather than falling through when a space is unreachable', () => {
+    const body = guardBody();
+    assert.match(body, /status\(403\)/, 'an unreachable space must be refused, not allowed');
+    assert.match(body, /return false/);
+  });
+
+  it('still answers true when there is no space to check', () => {
+    // Routes with no :spaceId must not be refused by a space guard.
+    assert.match(guardBody(), /if \(!spaceId\) return true;/);
+  });
+});


### PR DESCRIPTION
**Access is unchanged.** The rights are derived from `spaces`/`admin`/`readOnly` at config load, and `rights-reach-matches-legacy.test.js` proves the two predicates agree for every token shape on listed, unlisted and not-yet-created spaces.

This is the first change in the rights work that alters how a decision is **made** rather than only adding machinery. It went last on purpose, behind the proof, because its failure mode is a token reaching a space it never could — with no error, nothing in the response and nothing in the logs.

**The legacy branch survives, and is not decoration.** OIDC-derived tokens are built per request rather than read from config, so the load-time backfill never sees them and they carry no rights. Without the fallback the guard would refuse every OIDC caller — a lockout rather than a widening, but one that would reach production, because no unit test stands up an OIDC session.

**The proxy rule is untouched:** a proxy space still requires access to *every* member, never any one of them. The gate asserts that explicitly, including that a `.some()` has not crept in — any-member access would unlock a proxy over spaces the token cannot see.