### PR TITLE
feat(tokens): POST /api/tokens accepts a rights matrix, capped at the minter's own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`POST /api/tokens` accepts a `rights` matrix, capped at the minter's own.** The first point where the
+  per-space rights model is settable rather than only derived.
+  - **A token can never mint above itself.** Enforced on the endpoint, not only in the UI: the grid is one
+    API call away from being bypassed, and the API is exactly where a token would be used to widen itself.
+    The refusal is a `403` naming every excess at once, so one edit fixes it.
+  - **`rights` and the legacy `spaces`/`admin`/`readOnly` cannot be sent together** — a `400`. A body
+    carrying both describes the same access twice, and any precedence rule makes one of them silent: the
+    caller states an access, the server ignores it, and both believe the request succeeded.
+  - The nested `rights` object is itself strict, so a mis-spelled area is a `400` rather than a token minted
+    with less than was asked for while reporting success.
+  - When the minting token carries no matrix — OIDC records never pass through the load-time backfill — its
+    matrix is derived from the same legacy fields rather than treated as unrestricted.
+
 ### Changed
 - **The space guard now decides access from the rights matrix instead of the `spaces` allowlist.** Access is
   unchanged: the rights are derived from `spaces`/`admin`/`readOnly` at config load, and the two predicates

--- a/docs/integration-guide/03-auth-and-limits.md
+++ b/docs/integration-guide/03-auth-and-limits.md
@@ -12,6 +12,14 @@ Authorization: Bearer ythril_<base62-encoded-token>
 
 Tokens are created during first-run setup or via `POST /api/tokens`. The plaintext token is shown **once** — store it securely.
 
+**A token may instead be minted with a `rights` matrix** — per-space, per-area levels (`none` / `read` /
+`write` / `admin`) plus a `floor` that applies to every space including ones created later. Two rules:
+
+- **`rights` and `spaces`/`admin`/`readOnly` cannot be sent together** — `400`. A body carrying both
+  describes the same access twice, and whichever lost would be applied silently.
+- **A token can never mint above itself** — `403`, naming every level that exceeded the minter. This is
+  enforced on the endpoint, not only in the UI, so it holds for the API too.
+
 **The space allowlist field is `spaces`, and nothing else.** The body is strict: any key it does not declare
 is a `400` naming it. This used to be a silent drop — `spaceIds`, `allowedSpaces`, `scope` and `denySpaces`
 were all accepted with a `201` and thrown away, so a token minted with one of those names had **instance-wide

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -5,6 +5,8 @@ import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { createToken, listTokens, revokeToken, regenerateToken, renameToken } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
+import { capRights, describeExcess } from '../auth/mint-cap.js';
+import { migrateToken } from '../auth/rights-migration.js';
 
 export const tokensRouter = Router();
 
@@ -63,6 +65,18 @@ const CreateTokenBody = z.object({
    * See `TokenRecord.mfa` for why it is three states.
    */
   mfa: z.enum(['inherit', 'exempt', 'required']).optional(),
+  /**
+   * The per-space rights matrix for the new token.
+   *
+   * Mutually exclusive with `spaces` / `admin` / `readOnly` — see the refusal below. Accepting both would
+   * put two descriptions of the same thing in one request, and the loser would be silent.
+   */
+  rights: z.object({
+    instanceAdmin: z.boolean(),
+    createSpaces: z.boolean(),
+    floor: z.record(z.string(), z.enum(['none', 'read', 'write', 'admin'])).nullable(),
+    perSpace: z.record(z.string(), z.record(z.string(), z.enum(['none', 'read', 'write', 'admin']))),
+  }).strict().optional(),
 }).strict();
 
 /**
@@ -102,7 +116,34 @@ tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
     res.status(400).json({ error: parsed.error.message });
     return;
   }
-  const { name, expiresAt, spaces, admin, readOnly, peerInstanceId, schemaLibrary, mfa } = parsed.data;
+  const { name, expiresAt, spaces, admin, readOnly, peerInstanceId, schemaLibrary, mfa, rights } = parsed.data;
+
+  // One description of access per request. A body carrying both `rights` and a legacy field describes the
+  // same thing twice, and whichever lost would do so silently — which is the failure this whole area keeps
+  // producing. Refusing costs one call; guessing costs an access nobody chose.
+  if (rights && (spaces !== undefined || admin !== undefined || readOnly !== undefined)) {
+    res.status(400).json({
+      error: 'Specify either `rights` or the legacy `spaces`/`admin`/`readOnly` fields, not both',
+    });
+    return;
+  }
+
+  // A token may never mint above itself. Enforced HERE and not only in the UI: the grid is one API call away
+  // from being bypassed, and the API is exactly where a token would be used to widen itself.
+  if (rights) {
+    // OIDC records carry no `rights` — they are built per request and never pass through the config
+    // backfill — so the minter's matrix is derived on the spot from the same legacy fields. Deriving is the
+    // same answer, not a weaker one; treating a missing matrix as "unrestricted" would be the widening.
+    const held = (req.authToken as { rights?: unknown } | undefined)?.rights;
+    const minter = held ?? migrateToken(req.authToken ?? {});
+    const excess = capRights(minter as never, rights as never);
+    if (excess.length > 0) {
+      res.status(403).json({
+        error: `A token cannot mint rights it does not hold — ${describeExcess(excess)}`,
+      });
+      return;
+    }
+  }
   if (!exemptionNeedsLiveCode(req, res, mfa)) return;
   if (admin && readOnly) {
     res.status(400).json({ error: 'A token cannot be both admin and readOnly' });
@@ -137,7 +178,7 @@ tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
   // schemaLibrary tokens are always read-only and have no space access
   const effectiveReadOnly = schemaLibrary ? true : (readOnly ?? false);
   const effectiveSpaces = schemaLibrary ? [] : spaces;
-  const { record, plaintext } = await createToken({ name, expiresAt: expiresAt ?? null, spaces: effectiveSpaces, admin, readOnly: effectiveReadOnly, peerInstanceId, schemaLibrary, mfa });
+  const { record, plaintext } = await createToken({ name, expiresAt: expiresAt ?? null, spaces: effectiveSpaces, admin, readOnly: effectiveReadOnly, peerInstanceId, schemaLibrary, mfa, rights: rights as never });
   // Return plaintext only on creation — never retrievable again
   const { hash: _h, ...safeRecord } = record;
   res.status(201).json({ token: safeRecord, plaintext });

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -175,6 +175,14 @@ export async function createToken(opts: {
   schemaLibrary?: boolean;
   /** `inherit` (default), `exempt`, or `required` — see `TokenRecord.mfa`. */
   mfa?: 'inherit' | 'exempt' | 'required';
+  /**
+   * An explicit rights matrix, already capped against the minter by the route.
+   *
+   * Threaded through rather than derived here: the caller has the minter's record and this function does
+   * not, so deriving at this depth would mean re-reading auth state from a place that has no business
+   * knowing about it. Absent means the load-time backfill will derive one from the legacy fields.
+   */
+  rights?: TokenRecord['rights'];
 }): Promise<{ record: TokenRecord; plaintext: string }> {
   const plaintext = generateToken();
   const hash = await hashToken(plaintext);
@@ -194,6 +202,9 @@ export async function createToken(opts: {
     // Stored only when it says something. `inherit` IS the absent state, so writing it would put a field on
     // every future token that means exactly what its absence already means.
     ...(opts.mfa && opts.mfa !== 'inherit' ? { mfa: opts.mfa } : {}),
+    // Stored when given. Omitted otherwise so the backfill derives it — writing an empty matrix here would
+    // mint a token that reaches nothing while its legacy fields say otherwise.
+    ...(opts.rights ? { rights: opts.rights } : {}),
   };
   const config = getConfig();
   config.tokens.push(record);

--- a/testing/standalone/mint-accepts-rights-capped.test.js
+++ b/testing/standalone/mint-accepts-rights-capped.test.js
@@ -1,0 +1,81 @@
+/**
+ * `POST /api/tokens` accepts a rights matrix, refuses one above the minter, and refuses both descriptions
+ * of access in one request.
+ *
+ * ## Why "both" is a refusal rather than a precedence rule
+ *
+ * A body carrying `rights` AND `spaces`/`admin`/`readOnly` describes the same thing twice. Any precedence
+ * rule makes one of them silent — the caller states an access, the server ignores it, and both parties
+ * believe the request succeeded. That is the failure this whole area keeps producing. Refusing costs one
+ * call; guessing costs an access nobody chose.
+ *
+ * ## Why the cap is asserted on the ROUTE and not only on `capRights`
+ *
+ * `mint-cannot-exceed-minter.test.js` proves the rule. This proves the route applies it — and that it reads
+ * the minter's own matrix rather than trusting the request. A correct rule nobody calls is indistinguishable
+ * from no rule, and on this endpoint the difference is an escalation ladder.
+ *
+ * Run: node --test testing/standalone/mint-accepts-rights-capped.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC = 'server/src/api/tokens.ts';
+const src = readFileSync(join(ROOT, SRC), 'utf8');
+const withoutComments = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const code = withoutComments(src);
+
+describe('minting with a rights matrix', () => {
+  it('the create body accepts `rights`', () => {
+    assert.match(code, /rights:\s*z\.object\(/, 'a rights matrix cannot be set on mint, so nothing can use it');
+  });
+
+  it('the rights object is itself strict', () => {
+    // The same defect the body had: an unknown key inside `rights` would be dropped, and a mis-spelled area
+    // would mint a token with less than asked for while reporting success.
+    const i = code.indexOf('rights: z.object(');
+    assert.match(code.slice(i, i + 600), /\}\)\.strict\(\)/, 'the nested rights object drops unknown keys');
+  });
+
+  it('refuses `rights` together with the legacy fields', () => {
+    assert.match(code, /Specify either `rights` or the legacy/,
+      'both descriptions are accepted, so one of them is applied silently');
+  });
+
+  it('calls the cap, and refuses rather than trimming', () => {
+    assert.match(code, /capRights\(/, 'the mint cap is not applied on the route');
+    assert.match(code, /status\(403\)/);
+    assert.match(code, /cannot mint rights it does not hold/);
+    assert.match(code, /describeExcess\(/, 'the refusal must name what was over the line');
+  });
+
+  it('derives the minter matrix when the record carries none', () => {
+    // OIDC records never pass through the config backfill. Treating a missing matrix as "unrestricted"
+    // would be the widening this endpoint exists to prevent, so it is derived from the legacy fields.
+    assert.match(code, /migrateToken\(req\.authToken/,
+      'a token with no rights would mint unchecked');
+  });
+
+  it('the accepted rights actually REACH the stored token', () => {
+    // The defect this endpoint already had once: a field accepted, validated, and then dropped on the way to
+    // storage. The caller is told 201, the token is minted, and the matrix they asked for is nowhere. Here
+    // the drop would be worse than in #750 — the token would fall back to the legacy fields it was meant to
+    // replace, so it would work, and work WRONGLY.
+    assert.match(code, /createToken\(\{[^}]*rights/,
+      'createToken is called without `rights`, so an accepted matrix is silently discarded');
+    const store = readFileSync(join(ROOT, 'server/src/auth/tokens.ts'), 'utf8');
+    assert.match(withoutComments(store), /opts\.rights \? \{ rights: opts\.rights \}/,
+      'createToken does not persist the matrix it was handed');
+  });
+
+  it('the cap runs BEFORE anything is created', () => {
+    const capAt = code.indexOf('capRights(');
+    const createAt = code.indexOf('createToken(');
+    assert.ok(capAt > 0 && createAt > 0, 'expected both calls to exist');
+    assert.ok(capAt < createAt, 'the token is minted before the cap is checked, so the refusal is too late');
+  });
+});


### PR DESCRIPTION
The first point where the per-space rights model is **settable** rather than only derived.

**A token can never mint above itself** — enforced on the endpoint, not only in the UI. The grid is one API call away from being bypassed, and the API is exactly where a token would be used to widen itself. The `403` names every excess at once, because stopping at the first turns one edit into several round trips.

**`rights` and the legacy `spaces`/`admin`/`readOnly` cannot be sent together** — `400`. A body carrying both describes the same access twice, and any precedence rule makes one of them silent: the caller states an access, the server ignores it, and both parties believe the request succeeded. That is the failure this endpoint already had once.

Which is also why the nested `rights` object is itself strict, and why a test asserts the accepted matrix **reaches storage**. A field accepted, validated and then dropped is the #750 defect again — and here it would be worse, because the token would silently fall back to the legacy fields it was meant to replace. It would work, and work *wrongly*.

When the minting token carries no matrix — OIDC records never pass through the load-time backfill — its matrix is derived from the same legacy fields rather than treated as unrestricted.