### PR TITLE
feat(auth): the route inventory answers what rung a request needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: the route inventory can now answer "what rung does this request need".** Nothing calls it yet;
+  the guard still checks reach only.
+  - A miss returns `null`, and **`null` means refuse, never "no requirement"**. An unclassified route is one
+    nobody decided about, and defaulting it to permissive reproduces exactly the situation this feature
+    exists to end — access that works because nothing said otherwise. The build-time gate makes a miss
+    unreachable in practice; the lookup assumes it happens anyway.
+  - Keyed by method **and** path: `GET`, `POST` and `DELETE` on the same collection are three different
+    permissions, and a path-only lookup would call them one.
+  - Carries the scope shape through, because Data quality's routes take no space and iterate the token's
+    reachable ones — a caller that ignored it would gate the call instead of the loop, leaving that column
+    decorative.
+
+### Added
 - **`POST /api/tokens` accepts a `rights` matrix, capped at the minter's own.** The first point where the
   per-space rights model is settable rather than only derived.
   - **A token can never mint above itself.** Enforced on the endpoint, not only in the UI: the grid is one

--- a/server/src/auth/required-rung.ts
+++ b/server/src/auth/required-rung.ts
@@ -1,0 +1,53 @@
+/**
+ * What rung a request needs, from the route inventory.
+ *
+ * ## Why a lookup and not a decorator on each route
+ *
+ * The inventory in `space-rights.ts` is the single list a gate can check against the real route surface.
+ * Scattering the requirement across the handlers would put it back where the gate cannot see it, and the
+ * gate is the only reason an unclassified route fails the build rather than quietly ungoverned.
+ *
+ * ## Matching, and the one thing that must never happen
+ *
+ * Express gives the registered pattern (`/spaces/:spaceId/entities/:id`), not the concrete URL, so matching
+ * is on the pattern and is exact. **A miss returns `null`, and a `null` must be treated by the caller as
+ * REFUSE, never as allow.** That is the whole safety property: an unclassified route is one nobody decided
+ * about, and defaulting it to permissive reproduces the situation this feature exists to end — access that
+ * works because nothing said otherwise.
+ *
+ * The build-time gate makes a miss unreachable in practice. This function assumes it will happen anyway,
+ * because "unreachable in practice" is how the last three silent failures in this codebase described
+ * themselves.
+ */
+import { ROUTE_RIGHTS, type SpaceArea } from './space-rights.js';
+import type { Rung } from '../config/rights-shape.js';
+
+export interface RungRequirement {
+  area: SpaceArea;
+  needs: Rung;
+  scope: 'path' | 'iterates';
+}
+
+/** Normalise a mount + route pair into the key the inventory stores. */
+function key(method: string, routePath: string): string {
+  return `${method.toUpperCase()} ${routePath.replace(/\/+$/, '') || '/'}`;
+}
+
+const BY_KEY: ReadonlyMap<string, RungRequirement> = new Map(
+  ROUTE_RIGHTS.map(r => [key(r.method, r.route), { area: r.area, needs: r.needs, scope: r.scope }]),
+);
+
+/**
+ * The requirement for a route, or `null` when the inventory does not classify it.
+ *
+ * `null` is not "no requirement". See the note above: the caller must refuse.
+ */
+export function requiredRung(method: string, fullPath: string): RungRequirement | null {
+  return BY_KEY.get(key(method, fullPath)) ?? null;
+}
+
+/** Does a held rung satisfy a required one? Rungs contain the ones below them. */
+export function satisfies(held: Rung, needs: Rung): boolean {
+  const order: Rung[] = ['none', 'read', 'write', 'admin'];
+  return order.indexOf(held) >= order.indexOf(needs);
+}

--- a/testing/standalone/required-rung-lookup.test.js
+++ b/testing/standalone/required-rung-lookup.test.js
@@ -1,0 +1,85 @@
+/**
+ * The route inventory answers "what rung does this request need", and a miss means REFUSE.
+ *
+ * ## The property that carries the whole feature
+ *
+ * `requiredRung()` returns `null` for a route the inventory does not classify. That `null` must be treated
+ * as a refusal, never as "no requirement". An unclassified route is one nobody decided about, and defaulting
+ * it to permissive reproduces exactly the situation this feature exists to end: access that works because
+ * nothing said otherwise.
+ *
+ * The build-time gate makes a miss unreachable in practice. This file assumes it happens anyway, because
+ * "unreachable in practice" is how the last three silent failures in this codebase described themselves.
+ *
+ * Run: node --test testing/standalone/required-rung-lookup.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let requiredRung, satisfies, ROUTE_RIGHTS;
+before(async () => {
+  ({ requiredRung, satisfies } = await import('../../server/dist/auth/required-rung.js'));
+  ({ ROUTE_RIGHTS } = await import('../../server/dist/auth/space-rights.js'));
+});
+
+describe('the lookup', () => {
+  it('answers for a classified route', () => {
+    const r = requiredRung('POST', '/api/brain/spaces/:spaceId/recall');
+    assert.deepEqual(r, { area: 'knowledge', needs: 'read', scope: 'path' });
+  });
+
+  it('distinguishes methods on the same path', () => {
+    // GET and DELETE on a collection are not the same permission, and a path-only lookup would say they are.
+    assert.equal(requiredRung('GET', '/api/brain/spaces/:spaceId/memories').needs, 'read');
+    assert.equal(requiredRung('POST', '/api/brain/spaces/:spaceId/memories').needs, 'write');
+    assert.equal(requiredRung('DELETE', '/api/brain/spaces/:spaceId/memories').needs, 'admin');
+  });
+
+  it('returns null for an unclassified route, NOT a permissive default', () => {
+    assert.equal(requiredRung('GET', '/api/brain/spaces/:spaceId/invented'), null);
+    assert.equal(requiredRung('PUT', '/api/brain/spaces/:spaceId/recall'), null,
+      'a method the inventory does not list must miss, not inherit the path');
+  });
+
+  it('carries the scope shape through, because Data quality needs it', () => {
+    // Those routes take no space and iterate the token's reachable ones. A caller that ignores `scope` would
+    // gate the call instead of the loop, leaving that column decorative.
+    assert.equal(requiredRung('GET', '/api/duplicates').scope, 'iterates');
+    assert.equal(requiredRung('POST', '/api/brain/spaces/:spaceId/recall').scope, 'path');
+  });
+
+  it('every inventory entry is findable — the map has no dropped rows', () => {
+    // A Map built from a list can silently lose duplicates. Asserting the count catches a key collision,
+    // which would leave one route unclassified while the inventory looks complete.
+    let found = 0;
+    for (const r of ROUTE_RIGHTS) {
+      const got = requiredRung(r.method, r.route);
+      assert.ok(got, `${r.method} ${r.route} is in the inventory but not findable`);
+      assert.equal(got.needs, r.needs);
+      found++;
+    }
+    assert.equal(found, ROUTE_RIGHTS.length);
+  });
+
+  it('a trailing slash does not change the answer', () => {
+    assert.deepEqual(requiredRung('POST', '/api/brain/spaces/:spaceId/recall/'),
+      requiredRung('POST', '/api/brain/spaces/:spaceId/recall'));
+  });
+});
+
+describe('rung containment', () => {
+  it('a higher rung satisfies a lower requirement', () => {
+    assert.equal(satisfies('admin', 'read'), true);
+    assert.equal(satisfies('write', 'write'), true);
+    assert.equal(satisfies('read', 'write'), false);
+    assert.equal(satisfies('none', 'read'), false);
+  });
+
+  it('none satisfies nothing, including none', () => {
+    // `needs` is never 'none' in the inventory, but if it ever were, "you may call it holding nothing" would
+    // be a route with no requirement at all — which is what an exemption is for, not a rung.
+    assert.equal(satisfies('none', 'read'), false);
+    assert.equal(satisfies('read', 'none'), true);
+  });
+});


### PR DESCRIPTION
Nothing calls it yet — the guard still checks reach only — so no behaviour changes.

**A miss returns `null`, and `null` means refuse**, never *no requirement*. An unclassified route is one nobody decided about, and defaulting it to permissive reproduces exactly the situation this feature exists to end: access that works because nothing said otherwise. The build-time gate makes a miss unreachable in practice; this assumes it happens anyway, because *unreachable in practice* is how the last three silent failures in this codebase described themselves.

**Keyed by method and path.** `GET`, `POST` and `DELETE` on the same collection are three different permissions, and a path-only lookup would call them one — the shape of an accident that reads as a simplification.

**Carries the scope shape through**, because Data quality's routes take no space and iterate the token's reachable ones. A caller that ignored it would gate the call instead of the loop, leaving that column decorative.

The tests assert **every** inventory row is findable, not a sample: a `Map` built from a list silently loses a duplicate key, which would leave one route unclassified while the inventory still looked complete.