### PR TITLE
feat(auth): the guard checks the area and level a request needs, not only reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **The space guard now checks the AREA and LEVEL a request needs, not only whether the token reaches the
+  space.** This is the change that makes the rights columns bite.
+  - **Staged deliberately.** A route the inventory cannot resolve at runtime falls through to the reach check
+    with a warning naming the key that missed. So this layer can only ever be **stricter** than before, never
+    looser — there is no input for which it grants something reach denied.
+  - Turning those misses into refusals is the follow-up, once the warning has shown the log is clean. Doing
+    it now would `403` real traffic on any route whose key was reconstructed wrongly, and there is no runtime
+    evidence either way yet.
+  - **Iterating routes are not gated on the call.** Data quality's endpoints take no space and walk the
+    token's reachable ones; refusing the call would block a token that legitimately reaches some of the
+    spaces behind it. Their loop is the enforcement point and is a separate step.
+  - Refusals name the area and the level. "Forbidden" across four areas and four levels is unactionable.
+
 ### Added
 - **Internal: the route inventory can now answer "what rung does this request need".** Nothing calls it yet;
   the guard still checks reach only.

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
+import { log } from '../util/log.js';
 import { findMatchingToken, touchToken } from './tokens.js';
 import { consumeSseTicket } from './sse-ticket.js';
 import { isMfaEnabled, verifyMfaCode } from './totp.js';
@@ -7,6 +8,8 @@ import type { TokenRecord } from '../config/types.js';
 import type { OidcTokenRecord } from './oidc.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
 import { reachesSpace } from './space-reach.js';
+import { requiredRung, satisfies } from './required-rung.js';
+import { effectiveRung } from './mint-cap.js';
 import { authAttemptsTotal } from '../metrics/registry.js';
 import { logAuthFailure } from '../audit/middleware.js';
 import { mcpResourceMetadataUrl } from '../mcp/oauth.js';
@@ -261,6 +264,57 @@ function enforceMfa(
  * Writes 403 and returns false when the token lacks access. Unrestricted tokens
  * (no `spaces` allowlist) always pass.
  */
+/**
+ * The AREA check, layered on top of reach — and deliberately staged.
+ *
+ * A route the inventory does not resolve at RUNTIME falls through to the reach check alone, with a warning.
+ * That is not the permissive default this feature exists to remove: reach is still enforced, so this can
+ * only ever be stricter than yesterday, never looser. What it cannot yet be is COMPLETE, because
+ * `req.baseUrl + req.route.path` is the only way to reconstruct the inventory key at runtime and nested
+ * routers can make that disagree with the registered path.
+ *
+ * The warning is the point. It names the key that missed, so the log says exactly which routes still need
+ * the mapping before misses can be turned into refusals — which is the follow-up. Flipping to refuse now
+ * would 403 real traffic on any route whose key I reconstructed wrongly, and I have no runtime evidence yet
+ * that I did not.
+ */
+/** The spaces a request actually touches: a proxy's members, or the space itself. Shared so the reach check
+ *  and the area check can never disagree about WHAT they are checking. */
+function spaceTargets(spaceId: string | undefined): string[] {
+  if (!spaceId) return [];
+  const memberIds = resolveMemberSpaces(spaceId);
+  return memberIds.length > 0 ? memberIds : [spaceId];
+}
+
+function enforceAreaRung(
+  res: Response,
+  record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
+  req: Request,
+  targets: string[],
+): boolean {
+  const rights = (record as { rights?: Parameters<typeof effectiveRung>[0] }).rights;
+  if (!rights) return true;                    // OIDC records: reach already answered for them
+
+  const routePath = `${req.baseUrl ?? ''}${(req.route as { path?: string } | undefined)?.path ?? ''}`;
+  const need = requiredRung(req.method, routePath);
+  if (!need) {
+    log.warn(`Space rights: no inventory entry for '${req.method} ${routePath}' — reach enforced, area not. `
+      + 'Add it to ROUTE_RIGHTS; misses become refusals once the log is clean.');
+    return true;
+  }
+  if (need.scope !== 'path') return true;      // iterating routes gate their LOOP, not the call
+
+  for (const sid of targets) {
+    if (!satisfies(effectiveRung(rights, sid, need.area), need.needs)) {
+      res.status(403).json({
+        error: `Token needs '${need.needs}' on ${need.area} in space '${sid}'`,
+      });
+      return false;
+    }
+  }
+  return true;
+}
+
 function enforceSpaceScope(
   res: Response,
   record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
@@ -398,6 +452,7 @@ export async function requireSpaceAuth(
 
   const spaceId = req.params['spaceId'] as string | undefined;
   if (!enforceSpaceScope(res, record, spaceId)) return;
+  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId))) return;
 
   authAttemptsTotal.inc({ result: 'success' });
   attachToken(req, record, bearer);
@@ -426,6 +481,7 @@ export function requireAdminMfaScoped(paramName: string) {
     // Tokens without a spaces allowlist (unrestricted admin) are always allowed.
     const spaceId = req.params[paramName] as string | undefined;
     if (!enforceSpaceScope(res, record, spaceId)) return;
+  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId))) return;
 
     attachToken(req, record, bearer);
     next();

--- a/testing/standalone/area-rung-is-staged.test.js
+++ b/testing/standalone/area-rung-is-staged.test.js
@@ -1,0 +1,81 @@
+/**
+ * The area check is layered on reach, and a route it cannot resolve stays enforced rather than open.
+ *
+ * ## Why this ships staged, and why that is not a compromise
+ *
+ * Reach ("may this token touch this space at all") is already enforced from the rights matrix. The area
+ * check adds "and at what level, for what kind of operation". It needs the inventory key, which at runtime
+ * can only be reconstructed as `req.baseUrl + req.route.path` — and nested routers can make that disagree
+ * with the registered path.
+ *
+ * So a miss **warns and falls through to reach**, which is yesterday's enforcement. This layer can therefore
+ * only ever be stricter than before, never looser: there is no input for which it grants something reach
+ * denied. Turning misses into refusals is the follow-up, once the warning has proved the log is clean —
+ * flipping now would `403` real traffic on any route whose key was reconstructed wrongly, with no runtime
+ * evidence either way.
+ *
+ * ## What must not drift
+ *
+ * The two checks have to agree about WHICH spaces they are checking. A proxy resolves to its members, and if
+ * reach checked the members while the area check checked the proxy id, a proxy would be governed at one
+ * level and its contents at another. They share `spaceTargets` for exactly that reason.
+ *
+ * Run: node --test testing/standalone/area-rung-is-staged.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC = 'server/src/auth/middleware.ts';
+const code = readFileSync(join(ROOT, SRC), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const body = (fn) => {
+  const i = code.indexOf(`function ${fn}`);
+  return i < 0 ? null : code.slice(i, code.indexOf('\n}', i));
+};
+
+describe('the area check', () => {
+  it('exists and runs after reach, not instead of it', () => {
+    assert.ok(body('enforceAreaRung'), 'enforceAreaRung is gone — re-point this test');
+    const reachAt = code.indexOf('enforceSpaceScope(res, record, spaceId)');
+    const areaAt = code.indexOf('enforceAreaRung(res, record, req');
+    assert.ok(reachAt > 0 && areaAt > 0, 'both checks must be called');
+    assert.ok(reachAt < areaAt, 'the area check runs before reach, so an unreachable space is judged on level');
+  });
+
+  it('an unresolved route falls through to reach, and says so', () => {
+    const b = body('enforceAreaRung');
+    assert.match(b, /if \(!need\)/, 'a miss is not handled at all');
+    assert.match(b, /log\.warn/, 'a miss is silent, so nothing would ever reveal the gap');
+    assert.match(b, /return true;/, 'a miss must fall through to reach, not refuse');
+  });
+
+  it('iterating routes are NOT gated on the call', () => {
+    // Data quality takes no space and walks the token's reachable ones. Gating the call would refuse the
+    // whole endpoint for a token that legitimately reaches some of the spaces behind it.
+    assert.match(body('enforceAreaRung'), /need\.scope !== 'path'/,
+      'an iterating route would be judged as though it named one space');
+  });
+
+  it('records with no rights are left to reach alone', () => {
+    // OIDC tokens never pass the config backfill. Refusing them here would be a lockout.
+    assert.match(body('enforceAreaRung'), /if \(!rights\) return true;/);
+  });
+
+  it('both checks resolve the target spaces the SAME way', () => {
+    // If reach checked a proxy's members while the area check checked the proxy id, the container and its
+    // contents would be governed at different levels — and the weaker one would win silently.
+    assert.ok(body('spaceTargets'), 'the shared resolver is gone; the two checks can now drift');
+    assert.match(body('spaceTargets'), /resolveMemberSpaces\(/);
+    assert.match(code, /enforceAreaRung\(res, record, req, spaceTargets\(spaceId\)\)/,
+      'the area check no longer uses the shared target resolution');
+  });
+
+  it('refuses with the area and the level, not a bare 403', () => {
+    // "Forbidden" on a matrix of four areas and four levels is unactionable.
+    assert.match(body('enforceAreaRung'), /needs '\$\{need\.needs\}' on \$\{need\.area\}/);
+  });
+});


### PR DESCRIPTION
The change that makes the rights columns bite. Shipped **staged**, and the staging is the design rather than a compromise.

A route the inventory cannot resolve at runtime falls through to the reach check, with a warning naming the key that missed. **This layer can therefore only ever be stricter than before, never looser** — there is no input for which it grants something reach denied.

Turning those misses into refusals is the follow-up, once the warning has shown the log is clean. `req.baseUrl + req.route.path` is the only runtime reconstruction of the inventory key available, and nested routers can make it disagree with the registered path. Flipping now would `403` real traffic on any route I reconstructed wrongly, and there is no runtime evidence either way yet — guessing in the refusing direction breaks working callers.

**Iterating routes are not gated on the call.** Data quality's endpoints take no space and walk the token's reachable ones; refusing the call would block a token that legitimately reaches some of the spaces behind it. Their loop is the enforcement point, and its own step.

**Both checks resolve target spaces through one shared helper.** If reach checked a proxy's members while the area check checked the proxy id, the container and its contents would be governed at different levels — and the weaker one would win silently.

Refusals name the area and the level. *Forbidden* across four areas and four levels is unactionable.