### PR TITLE
fix(duplicates): an EMPTY space allowlist granted access to every space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **An EMPTY token space-allowlist granted access to EVERY space on the duplicates routes.** Those routes
+  take no space in the path — they walk every space the token can reach — and their filter read
+  `tokenSpaces.length === 0` as "unrestricted". An absent allowlist does mean every space; an empty one means
+  none, and they are opposite.
+  - So anything holding `spaces: []` was handed the whole instance, in the one place nobody would look for
+    it, because the routes name no space at all. A schema-library token stores exactly that value.
+  - The same conflation is the trap `migrateToken` avoids by checking `undefined` rather than length. This
+    removes the second copy rather than fixing it twice.
+
+### Changed
+- **The data-quality routes now filter their iteration set from the rights matrix.** Their loop is the
+  enforcement point: refusing the call would block a token that legitimately reaches some of the spaces
+  behind it, and an unfiltered loop leaves the Data quality column decorative.
+  - Mutating routes — dismiss, reopen, scan — require `write` on the area rather than `read`. Filtering them
+    at read would let a read-only token act on every space it can see.
+  - `/scan` intersects before acting: it triggers automerge and notification, and a filter applied afterwards
+    is a log entry rather than a guard.
+
 ### Changed
 - **The space guard now checks the AREA and LEVEL a request needs, not only whether the token reaches the
   space.** This is the change that makes the rights columns bite.

--- a/server/src/api/duplicates.ts
+++ b/server/src/api/duplicates.ts
@@ -12,6 +12,8 @@ import { Router } from 'express';
 import { requireAuth, requireAdminMfa, denyReadOnly } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { col, asFilter, asUpdate } from '../db/mongo.js';
+import { spacesWhereTokenMay } from '../auth/reachable-spaces.js';
+import type { TokenRights, Rung } from '../config/rights-shape.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { scanSpace, pairContentHash } from '../brain/dupe-scanner.js';
@@ -20,10 +22,10 @@ import { nliConfigured } from '../brain/nli-client.js';
 import type { DupeCandidateDoc, ContradictionCandidateDoc } from '../config/types.js';
 
 /** Find a candidate across the caller's accessible spaces. */
-async function findCandidate(id: string, tokenSpaces?: string[]): Promise<{ doc: DupeCandidateDoc; spaceId: string } | null> {
-  const cfg = getConfig();
-  const all = cfg.spaces.map(s => s.id);
-  const spaces = !tokenSpaces || tokenSpaces.length === 0 ? all : all.filter(s => tokenSpaces.includes(s));
+async function findCandidate(id: string, tokenSpaces?: string[], rights?: TokenRights): Promise<{ doc: DupeCandidateDoc; spaceId: string } | null> {
+  // Same rule as `accessibleSpaces`, and deliberately not a second copy of it: resolving a candidate id
+  // reads the record, so `read` is the level, and an empty allowlist means none rather than all.
+  const spaces = spacesWhereTokenMay(rights, tokenSpaces, 'dataQuality', 'read');
   for (const spaceId of spaces) {
     const doc = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).findOne(asFilter<DupeCandidateDoc>({ _id: id })) as DupeCandidateDoc | null;
     if (doc) return { doc, spaceId };
@@ -99,12 +101,20 @@ async function contradictionSignalsFor(
 
 export const duplicatesRouter = Router();
 
-/** Return the space IDs the authenticated token is allowed to access. */
-function accessibleSpaces(tokenSpaces?: string[]): string[] {
-  const cfg = getConfig();
-  const all = cfg.spaces.map(s => s.id);
-  if (!tokenSpaces || tokenSpaces.length === 0) return all;
-  return all.filter(id => tokenSpaces.includes(id));
+/**
+ * The space IDs this token may act on, at the Data-quality level the caller needs.
+ *
+ * These routes take no space in the path — they walk every space the token can reach — so this list IS the
+ * enforcement point. Reading it from the rights matrix is what stops the Data quality column being
+ * decorative.
+ *
+ * It also removes a conflation that lived here: `tokenSpaces.length === 0` used to mean "unrestricted". An
+ * ABSENT allowlist means every space; an EMPTY one means none, and they are opposite. Anything holding
+ * `spaces: []` was handed the whole instance.
+ */
+function accessibleSpaces(req: { authToken?: unknown }, needs: Rung = 'read'): string[] {
+  const t = req.authToken as { rights?: TokenRights; spaces?: string[] } | undefined;
+  return spacesWhereTokenMay(t?.rights, t?.spaces, 'dataQuality', needs);
 }
 
 /**
@@ -197,7 +207,7 @@ duplicatesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     const status = statusRaw === 'dismissed' || statusRaw === 'all' ? statusRaw : 'open';
     const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
 
-    let spaces = accessibleSpaces(req.authToken?.spaces);
+    let spaces = accessibleSpaces(req);
     if (spaceFilter) spaces = spaces.filter(id => id === spaceFilter);
 
     const results: DupeCandidateDoc[] = [];
@@ -233,7 +243,7 @@ duplicatesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
 duplicatesRouter.post('/:id/dismiss', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const id = req.params['id'] as string;
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
     for (const spaceId of spaces) {
       const coll = col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`);
       const doc = await coll.findOne(asFilter<DupeCandidateDoc>({ _id: id })) as DupeCandidateDoc | null;
@@ -260,7 +270,7 @@ duplicatesRouter.post('/:id/dismiss', globalRateLimit, requireAuth, denyReadOnly
 duplicatesRouter.post('/:id/reopen', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const id = req.params['id'] as string;
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
     for (const spaceId of spaces) {
       const r = await col<DupeCandidateDoc>(`${spaceId}_dupe_candidates`).updateOne(
         asFilter<DupeCandidateDoc>({ _id: id, status: 'dismissed' }),
@@ -280,7 +290,7 @@ duplicatesRouter.post('/:id/reopen', globalRateLimit, requireAuth, denyReadOnly,
 // Returns 409 with the merge plan if the pair has a property-value conflict.
 duplicatesRouter.post('/:id/merge', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
-    const found = await findCandidate(req.params['id'] as string, req.authToken?.spaces);
+    const found = await findCandidate(req.params['id'] as string, req.authToken?.spaces, (req.authToken as { rights?: TokenRights } | undefined)?.rights);
     if (!found) { res.status(404).json({ error: 'Duplicate candidate not found' }); return; }
     const { doc, spaceId } = found;
     if (doc.type !== 'entity') { res.status(400).json({ error: 'Merge is only supported for entity candidates' }); return; }
@@ -318,7 +328,7 @@ duplicatesRouter.post('/scan', globalRateLimit, requireAdminMfa, denyReadOnly, a
     // Intersect with the token's space allowlist — a space-restricted admin must
     // not be able to trigger destructive rules (automerge/notify) on spaces it
     // cannot access.
-    const allowed = new Set(accessibleSpaces(req.authToken?.spaces));
+    const allowed = new Set(accessibleSpaces(req, 'write'));
     const targets = cfg.spaces
       .filter(s => !s.proxyFor && allowed.has(s.id) && (!spaceFilter || s.id === spaceFilter))
       .map(s => s.id);

--- a/server/src/auth/reachable-spaces.ts
+++ b/server/src/auth/reachable-spaces.ts
@@ -1,0 +1,45 @@
+/**
+ * Which spaces may a token act on, for a given area and level?
+ *
+ * ## Why the iterating routes need their own answer
+ *
+ * Most routes name a space in the path, and the guard checks it. The data-quality routes — duplicates,
+ * contradictions, conflicts — name none: they walk every space the token can reach and resolve the space
+ * from the record. For those, the enforcement point is the ITERATION SET rather than the call, so refusing
+ * the request would be wrong (a token legitimately reaches some of the spaces behind it) and letting the
+ * loop run unfiltered leaves the Data quality column decorative.
+ *
+ * ## The conflation this replaces
+ *
+ * The previous filter read `!tokenSpaces || tokenSpaces.length === 0` as "unrestricted". An ABSENT allowlist
+ * does mean every space; an EMPTY one means none, and the two are opposite. Anything holding `spaces: []` —
+ * a schema-library token stores exactly that — was handed every space on the instance by the widest possible
+ * reading of the narrowest possible token.
+ *
+ * That is the same trap `rights-migration.ts` documents and `migrateToken` avoids by checking `undefined`
+ * rather than length. Routing this through the rights matrix removes the second copy of the mistake rather
+ * than fixing it twice.
+ */
+import { getConfig } from '../config/loader.js';
+import { effectiveRung } from './mint-cap.js';
+import { satisfies } from './required-rung.js';
+import type { TokenRights, SpaceArea, Rung } from '../config/rights-shape.js';
+
+/**
+ * Every space in which this token holds at least `needs` on `area`.
+ *
+ * `rights` absent means the record never passed the config backfill — an OIDC session — so the legacy
+ * allowlist answers instead, with the absent/empty distinction made explicitly rather than by truthiness.
+ */
+export function spacesWhereTokenMay(
+  rights: TokenRights | undefined,
+  legacySpaces: string[] | undefined,
+  area: SpaceArea,
+  needs: Rung,
+): string[] {
+  const all = getConfig().spaces.map(s => s.id);
+  if (rights) return all.filter(id => satisfies(effectiveRung(rights, id, area), needs));
+  // No matrix: an ABSENT allowlist is every space, an EMPTY one is none. Never length-as-truthiness.
+  if (legacySpaces === undefined) return all;
+  return all.filter(id => legacySpaces.includes(id));
+}

--- a/testing/standalone/iterating-routes-filter-the-loop.test.js
+++ b/testing/standalone/iterating-routes-filter-the-loop.test.js
@@ -1,0 +1,82 @@
+/**
+ * The data-quality routes filter their ITERATION SET, and an empty allowlist means none rather than all.
+ *
+ * ## Why the loop and not the call
+ *
+ * These routes name no space. They walk every space the token can reach and resolve the space from the
+ * record. Refusing the call would block a token that legitimately reaches some of the spaces behind it;
+ * letting the loop run unfiltered leaves the Data quality column decorative. So the list the loop walks IS
+ * the enforcement point.
+ *
+ * ## The conflation this removes
+ *
+ * The old filter read `!tokenSpaces || tokenSpaces.length === 0` as "unrestricted". An **absent** allowlist
+ * does mean every space; an **empty** one means none, and they are opposite. Anything holding `spaces: []`
+ * was handed the whole instance — the widest possible reading of the narrowest possible token, in the one
+ * place where nobody would look for it because the routes take no space at all.
+ *
+ * That is the same trap `migrateToken` avoids by checking `undefined` rather than length. This removes the
+ * second copy rather than fixing it twice.
+ *
+ * Run: node --test testing/standalone/iterating-routes-filter-the-loop.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => readFileSync(join(ROOT, p), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const dupes = read('server/src/api/duplicates.ts');
+const helper = read('server/src/auth/reachable-spaces.ts');
+
+describe('the shared filter', () => {
+  it('distinguishes an ABSENT allowlist from an EMPTY one', () => {
+    // The whole bug, in one assertion. `undefined` is every space; `[]` is none.
+    assert.match(helper, /legacySpaces === undefined/,
+      'the filter tests truthiness or length again, so an empty allowlist means every space');
+    assert.doesNotMatch(helper, /legacySpaces\.length === 0/,
+      'length-as-truthiness is back');
+  });
+
+  it('reads the rights matrix when the record has one', () => {
+    assert.match(helper, /satisfies\(effectiveRung\(/,
+      'the filter ignores the matrix, so the Data quality column governs nothing');
+  });
+
+  it('falls back to the legacy allowlist only when there is no matrix', () => {
+    // OIDC records never pass the config backfill. Without this they would reach nothing at all.
+    assert.match(helper, /if \(rights\)/);
+    assert.match(helper, /if \(legacySpaces === undefined\) return all;/);
+  });
+});
+
+describe('the duplicates routes', () => {
+  it('no longer carry their own copy of the rule', () => {
+    assert.doesNotMatch(dupes, /tokenSpaces\.length === 0/,
+      'a second copy of the empty-means-all conflation survives in this file');
+    assert.match(dupes, /spacesWhereTokenMay\(/, 'the routes do not use the shared filter');
+  });
+
+  it('ask for WRITE on the mutating routes, not read', () => {
+    // Dismiss, reopen and scan change records. Filtering them at `read` would let a read-only token act on
+    // every space it can see — the column would exist and permit everything anyway.
+    const writes = [...dupes.matchAll(/accessibleSpaces\(req, 'write'\)/g)];
+    assert.ok(writes.length >= 3, `expected the mutating routes to require write, found ${writes.length}`);
+  });
+
+  it('the listing route asks only for READ', () => {
+    assert.match(dupes, /accessibleSpaces\(req\)(?!\s*,)/,
+      'the list route demands write, which would hide findings from a read-only token');
+  });
+
+  it('scan intersects before acting, not after', () => {
+    // `/scan` triggers automerge and notification. Filtering after the destructive step would be a log entry
+    // rather than a guard.
+    const i = dupes.indexOf("accessibleSpaces(req, 'write')", dupes.indexOf('/scan'));
+    const j = dupes.indexOf('targets', i);
+    assert.ok(i > 0 && j > i, 'the scan route no longer intersects its targets with what the token may touch');
+  });
+});


### PR DESCRIPTION
The duplicates routes take no space in the path — they walk every space the token can reach — and their filter read `tokenSpaces.length === 0` as *unrestricted*.

**An absent allowlist does mean every space. An empty one means none. They are opposite.**

So anything holding `spaces: []` was handed the whole instance, in the one place nobody would look for it, because the routes name no space at all. A schema-library token stores exactly that value.

This is the same conflation `migrateToken` avoids by checking `undefined` rather than length — which is why the fix routes both filters through **one shared helper** instead of correcting the comparison twice. A second copy is how it survived here in the first place.

**The loop is also now filtered from the rights matrix**, which is what stops the Data quality column being decorative:

- mutating routes (dismiss, reopen, scan) require `write` rather than `read` — filtering them at read would let a read-only token act on every space it can see;
- `/scan` intersects **before** acting, since it triggers automerge and notification, and a filter applied afterwards is a log entry rather than a guard.