### PR TITLE
fix(conflicts,contradictions): the same empty-allowlist bug, in two more copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **The same empty-allowlist bug existed in `contradictions` and `conflicts` too — three copies, not one.**
+  Both carried a byte-identical filter reading `tokenSpaces.length === 0` as "unrestricted", and both are
+  converted to the shared one. Fixing the reported copy and stopping is how it survived in the other two, so
+  the gate now asserts across all three routers rather than the file that was reported.
+  - Their mutating routes — resolve, dismiss, reopen, scan, bulk-resolve — require `write` on the area
+    rather than `read`, chosen per route from its HTTP method rather than assumed.
+
 - **An EMPTY token space-allowlist granted access to EVERY space on the duplicates routes.** Those routes
   take no space in the path — they walk every space the token can reach — and their filter read
   `tokenSpaces.length === 0` as "unrestricted". An absent allowlist does mean every space; an empty one means

--- a/server/src/api/conflicts.ts
+++ b/server/src/api/conflicts.ts
@@ -1,3 +1,5 @@
+import { spacesWhereTokenMay } from '../auth/reachable-spaces.js';
+import type { TokenRights, Rung } from '../config/rights-shape.js';
 import { Router } from 'express';
 import fs from 'fs/promises';
 import path from 'path';
@@ -15,11 +17,17 @@ const VALID_ACTIONS = ['keep-local', 'keep-incoming', 'keep-both', 'save-to-spac
 type ResolveAction = typeof VALID_ACTIONS[number];
 
 /** Return the space IDs the authenticated token is allowed to access. */
-function accessibleSpaces(tokenSpaces?: string[]): string[] {
-  const cfg = getConfig();
-  const all = cfg.spaces.map(s => s.id);
-  if (!tokenSpaces || tokenSpaces.length === 0) return all;
-  return all.filter(id => tokenSpaces.includes(id));
+/**
+ * The space IDs this token may act on at the given Data-quality level.
+ *
+ * These routes take no space in the path — they walk every space the token can reach — so this list IS the
+ * enforcement point. It also removes the copy of a conflation that lived here: `tokenSpaces.length === 0`
+ * used to mean "unrestricted". An ABSENT allowlist means every space; an EMPTY one means none. Anything
+ * holding `spaces: []` was handed the whole instance.
+ */
+function accessibleSpaces(req: { authToken?: unknown }, needs: Rung = 'read'): string[] {
+  const t = req.authToken as { rights?: TokenRights; spaces?: string[] } | undefined;
+  return spacesWhereTokenMay(t?.rights, t?.spaces, 'dataQuality', needs);
 }
 
 /** Find a conflict document across accessible spaces. Returns doc + spaceId, or null. */
@@ -103,7 +111,7 @@ const MAX_TOTAL = 2000;
 // GET /api/conflicts — list unresolved conflicts for all accessible spaces
 conflictsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
   try {
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'read');
     const results: ConflictDoc[] = [];
     let truncated = false;
     for (const spaceId of spaces) {
@@ -144,7 +152,7 @@ conflictsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
 // GET /api/conflicts/link-violations — list all link violations
 conflictsRouter.get('/link-violations', globalRateLimit, requireAuth, async (_req, res) => {
   try {
-    const spaces = accessibleSpaces(_req.authToken?.spaces);
+    const spaces = accessibleSpaces(_req, 'read');
     const results: LinkViolationDoc[] = [];
     let truncated = false;
     for (const spaceId of spaces) {
@@ -169,7 +177,7 @@ conflictsRouter.get('/link-violations', globalRateLimit, requireAuth, async (_re
 // DELETE /api/conflicts/link-violations/:id — dismiss a single link violation
 conflictsRouter.delete('/link-violations/:id', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
     for (const spaceId of spaces) {
       const result = await col<LinkViolationDoc>(`${spaceId}_link_violations`)
         .deleteOne(asFilter<LinkViolationDoc>({ _id: req.params['id'] }));
@@ -188,7 +196,7 @@ conflictsRouter.delete('/link-violations/:id', globalRateLimit, requireAuth, den
 // DELETE /api/conflicts/link-violations — dismiss all link violations for accessible spaces
 conflictsRouter.delete('/link-violations', globalRateLimit, requireAuth, denyReadOnly, async (_req, res) => {
   try {
-    const spaces = accessibleSpaces(_req.authToken?.spaces);
+    const spaces = accessibleSpaces(_req, 'write');
     let total = 0;
     for (const spaceId of spaces) {
       const result = await col<LinkViolationDoc>(`${spaceId}_link_violations`).deleteMany({});
@@ -204,7 +212,7 @@ conflictsRouter.delete('/link-violations', globalRateLimit, requireAuth, denyRea
 // GET /api/conflicts/:id — get a single conflict record
 conflictsRouter.get('/:id', globalRateLimit, requireAuth, async (req, res) => {
   try {
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'read');
     for (const spaceId of spaces) {
       const doc = await col<ConflictDoc>(`${spaceId}_conflicts`)
         .findOne(asFilter<ConflictDoc>({ _id: req.params['id'] })) as ConflictDoc | null;
@@ -231,7 +239,7 @@ conflictsRouter.get('/:id', globalRateLimit, requireAuth, async (req, res) => {
 // DELETE /api/conflicts/:id — dismiss (resolve) a conflict record
 conflictsRouter.delete('/:id', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
     for (const spaceId of spaces) {
       const result = await col<ConflictDoc>(`${spaceId}_conflicts`)
         .deleteOne(asFilter<ConflictDoc>({ _id: req.params['id'] }));
@@ -263,7 +271,7 @@ conflictsRouter.post('/bulk-resolve', globalRateLimit, requireAuth, denyReadOnly
       res.status(400).json({ error: 'targetSpaceId is required for save-to-space action' });
       return;
     }
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
     if (action === 'save-to-space' && !spaces.includes(targetSpaceId)) {
       res.status(403).json({ error: 'Token does not have access to target space' });
       return;
@@ -307,7 +315,7 @@ conflictsRouter.post('/seed', globalRateLimit, requireAdmin, denyReadOnly, async
       res.status(400).json({ error: 'Missing required fields: _id, spaceId, originalPath, conflictPath' });
       return;
     }
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
     if (!spaces.includes(spaceId)) {
       res.status(403).json({ error: 'Token does not have access to this space' });
       return;
@@ -344,7 +352,7 @@ conflictsRouter.post('/:id/resolve', globalRateLimit, requireAuth, denyReadOnly,
       return;
     }
 
-    const spaces = accessibleSpaces(req.authToken?.spaces);
+    const spaces = accessibleSpaces(req, 'write');
 
     // Validate target space access for save-to-space
     if (action === 'save-to-space' && !spaces.includes(targetSpaceId)) {

--- a/server/src/api/contradictions.ts
+++ b/server/src/api/contradictions.ts
@@ -1,3 +1,5 @@
+import { spacesWhereTokenMay } from '../auth/reachable-spaces.js';
+import type { TokenRights, Rung } from '../config/rights-shape.js';
 /**
  * Contradiction review API (F-REVIEW slice 4) — the Review tab's Contradictions sub-view.
  *
@@ -42,10 +44,17 @@ export const SUPERSEDES_LABEL = 'supersedes';
 const collectionFor = (spaceId: string) => col<ContradictionCandidateDoc>(`${spaceId}_contradiction_candidates`);
 
 /** Space IDs the authenticated token may access (empty/absent allow-list = all spaces). */
-function accessibleSpaces(tokenSpaces?: string[]): string[] {
-  const all = getConfig().spaces.map(s => s.id);
-  if (!tokenSpaces || tokenSpaces.length === 0) return all;
-  return all.filter(id => tokenSpaces.includes(id));
+/**
+ * The space IDs this token may act on at the given Data-quality level.
+ *
+ * These routes take no space in the path — they walk every space the token can reach — so this list IS the
+ * enforcement point. It also removes the copy of a conflation that lived here: `tokenSpaces.length === 0`
+ * used to mean "unrestricted". An ABSENT allowlist means every space; an EMPTY one means none. Anything
+ * holding `spaces: []` was handed the whole instance.
+ */
+function accessibleSpaces(req: { authToken?: unknown }, needs: Rung = 'read'): string[] {
+  const t = req.authToken as { rights?: TokenRights; spaces?: string[] } | undefined;
+  return spacesWhereTokenMay(t?.rights, t?.spaces, 'dataQuality', needs);
 }
 
 function toRecord(c: ContradictionCandidateDoc) {
@@ -84,7 +93,7 @@ contradictionsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => 
     const status = statusRaw === 'dismissed' || statusRaw === 'resolved' || statusRaw === 'all' ? statusRaw : 'open';
     const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
 
-    let spaces = accessibleSpaces(req.authToken?.spaces);
+    let spaces = accessibleSpaces(req, 'read');
     if (spaceFilter) spaces = spaces.filter(id => id === spaceFilter);
 
     const results: ContradictionCandidateDoc[] = [];
@@ -127,7 +136,7 @@ contradictionsRouter.get('/', globalRateLimit, requireAuth, async (req, res) => 
 contradictionsRouter.post('/:id/dismiss', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const id = req.params['id'] as string;
-    for (const spaceId of accessibleSpaces(req.authToken?.spaces)) {
+    for (const spaceId of accessibleSpaces(req, 'write')) {
       const coll = collectionFor(spaceId);
       const doc = await coll.findOne(asFilter<ContradictionCandidateDoc>({ _id: id })) as ContradictionCandidateDoc | null;
       if (!doc) continue;
@@ -151,7 +160,7 @@ contradictionsRouter.post('/:id/dismiss', globalRateLimit, requireAuth, denyRead
 contradictionsRouter.post('/:id/reopen', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const id = req.params['id'] as string;
-    for (const spaceId of accessibleSpaces(req.authToken?.spaces)) {
+    for (const spaceId of accessibleSpaces(req, 'write')) {
       const r = await collectionFor(spaceId).updateOne(
         asFilter<ContradictionCandidateDoc>({ _id: id, status: 'dismissed' }),
         asUpdate<ContradictionCandidateDoc>({ $set: { status: 'open', updatedAt: new Date().toISOString() }, $unset: { dismissedContentHash: '' } }),
@@ -201,7 +210,7 @@ contradictionsRouter.post('/:id/resolve', globalRateLimit, requireAuth, denyRead
       return;
     }
 
-    for (const spaceId of accessibleSpaces(req.authToken?.spaces)) {
+    for (const spaceId of accessibleSpaces(req, 'write')) {
       const coll = collectionFor(spaceId);
       const doc = await coll.findOne(asFilter<ContradictionCandidateDoc>({ _id: id })) as ContradictionCandidateDoc | null;
       if (!doc) continue;
@@ -261,7 +270,7 @@ contradictionsRouter.post('/:id/resolve', globalRateLimit, requireAuth, denyRead
 contradictionsRouter.post('/scan', globalRateLimit, requireAdminMfa, denyReadOnly, async (req, res) => {
   try {
     const spaceFilter = typeof req.query['space'] === 'string' ? req.query['space'] : undefined;
-    const spaces = accessibleSpaces(req.authToken?.spaces).filter(id => !spaceFilter || id === spaceFilter);
+    const spaces = accessibleSpaces(req, 'write').filter(id => !spaceFilter || id === spaceFilter);
     let scanned = 0, found = 0, nliStalled = false, judgedPairs = 0, modelCalls = 0, budgetExhausted = false;
     for (const spaceId of spaces) {
       const r = await scanSpace(spaceId);

--- a/testing/standalone/iterating-routes-filter-the-loop.test.js
+++ b/testing/standalone/iterating-routes-filter-the-loop.test.js
@@ -29,6 +29,7 @@ const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8')
   .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
+const ITERATING = ['duplicates', 'contradictions', 'conflicts'];
 const dupes = read('server/src/api/duplicates.ts');
 const helper = read('server/src/auth/reachable-spaces.ts');
 
@@ -50,6 +51,29 @@ describe('the shared filter', () => {
     // OIDC records never pass the config backfill. Without this they would reach nothing at all.
     assert.match(helper, /if \(rights\)/);
     assert.match(helper, /if \(legacySpaces === undefined\) return all;/);
+  });
+});
+
+describe('every iterating router', () => {
+  it('carries no copy of the empty-means-all conflation', () => {
+    // Three copies of one rule existed. Fixing the reported one and stopping is how it survived in the other
+    // two, so this asserts across the set rather than the file that was reported.
+    for (const name of ITERATING) {
+      const src = read(`server/src/api/${name}.ts`);
+      assert.doesNotMatch(src, /tokenSpaces\.length === 0/,
+        `${name}.ts still reads an empty allowlist as unrestricted`);
+      assert.match(src, /spacesWhereTokenMay\(/, `${name}.ts does not use the shared filter`);
+    }
+  });
+
+  it('none of them declares its own space filter any more', () => {
+    // A local copy is what drifts. The helper takes the request, not a raw allowlist, so a caller cannot
+    // hand it the wrong thing.
+    for (const name of ITERATING) {
+      const src = read(`server/src/api/${name}.ts`);
+      assert.doesNotMatch(src, /function accessibleSpaces\(tokenSpaces/,
+        `${name}.ts still has the old signature, which takes a raw allowlist`);
+    }
   });
 });
 


### PR DESCRIPTION
Both carried a **byte-identical** filter reading `tokenSpaces.length === 0` as *unrestricted*, so a token holding `spaces: []` reached every space on the instance there too. Three copies of one rule existed; the previous PR fixed the reported one.

**Fixing what was reported and stopping is exactly how it survived in the other two.** So the gate now asserts across all three iterating routers rather than the file that was reported — and asserts that none of them declares its own space filter any more. A local copy is what drifts, and the shared helper takes the *request* rather than a raw allowlist, so a caller cannot hand it the wrong thing.

Their mutating routes — resolve, dismiss, reopen, scan, bulk-resolve — require `write` on the area rather than `read`. The level is chosen per route from its HTTP method rather than assumed, because a `GET` and a `POST` on the same router are not the same permission.