### PR TITLE
feat(tokens): rights are editable, and a token cannot raise its own floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`PATCH /api/tokens/:id` can now edit a token's rights matrix — and a token cannot raise its own floor.**
+  The last of the two enforcement rules the approved design said must live in the API rather than the UI.
+  - **The same cap as minting applies**, from the same function. A second implementation here is how the two
+    would come to disagree about what "above" means.
+  - **A token may not raise its OWN floor.** The mint cap stops handing more than you hold to a *new* token;
+    without this the same escalation is available by a shorter route — edit yourself, then use yourself — and
+    nothing about the result looks unusual afterwards.
+  - **Lowering your own floor is always allowed.** Refusing it would mean a token cannot reduce its own blast
+    radius, which is the one self-modification worth encouraging.
+  - Compared **per area**, not as one unit: a raise on `schema` must not pass because `knowledge` went down
+    in the same edit, and gaining a floor from none is the widest version of the move rather than an
+    exemption from it.
+  - `name` is now optional on that route and an empty body is a `400` rather than a silent no-op reported as
+    success.
+
 ### Fixed
 - **The same empty-allowlist bug existed in `contradictions` and `conflicts` too — three copies, not one.**
   Both carried a byte-identical filter reading `tokenSpaces.length === 0` as "unrestricted", and both are

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -2,10 +2,11 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth, requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
-import { createToken, listTokens, revokeToken, regenerateToken, renameToken } from '../auth/tokens.js';
+import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
 import { capRights, describeExcess } from '../auth/mint-cap.js';
+import { refuseSelfFloorRaise } from '../auth/floor-guard.js';
 import { migrateToken } from '../auth/rights-migration.js';
 
 export const tokensRouter = Router();
@@ -186,11 +187,22 @@ tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
 
 const RenameTokenBody = z.object({
   // Same bound as create's `name`, so a label can't be edited to something the create flow would reject.
-  name: z.string().min(1).max(200),
-  // `.strict()` for the same reason as create, and here the edge is sharper: this route accepts a rename
-  // ONLY. A body carrying `spaces` or `admin` beside the name was dropped and answered 200, so an attempt to
-  // widen a token through the rename endpoint looked exactly like one that had worked.
-}).strict();
+  name: z.string().min(1).max(200).optional(),
+  // `.strict()` for the same reason as create, and here the edge is sharper: this route once accepted a
+  // rename ONLY. A body carrying `spaces` or `admin` beside the name was dropped and answered 200, so an
+  // attempt to widen a token through it looked exactly like one that had worked.
+  //
+  // `rights` is now a legitimate field, and `name` is optional so an edit can change either or both. The
+  // refine below keeps an empty body from being a silent no-op reported as success.
+  rights: z.object({
+    instanceAdmin: z.boolean(),
+    createSpaces: z.boolean(),
+    floor: z.record(z.string(), z.enum(['none', 'read', 'write', 'admin'])).nullable(),
+    perSpace: z.record(z.string(), z.record(z.string(), z.enum(['none', 'read', 'write', 'admin']))),
+  }).strict().optional(),
+}).strict().refine(d => d.name !== undefined || d.rights !== undefined, {
+  message: 'Provide `name`, `rights`, or both',
+});
 
 // PATCH /api/tokens/:id — rename a token's label (only) — admin + MFA
 tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
@@ -200,17 +212,55 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
     return;
   }
   const id = req.params['id'] as string;
-  // Only the name. The record also holds `hash` and `prefix`; handing the whole thing over would be safe
-  // (the allowlist reads `name` and nothing else), but naming the two fields keeps the intent legible at
-  // the call site rather than resting entirely on a list in another file.
+  const { name, rights } = parsed.data;
   const previous = listTokens().find(t => t.id === id);
-  req.auditSnapshots = { before: { name: previous?.name }, after: { name: parsed.data.name.trim() } };
-
-  const ok = renameToken(id, parsed.data.name.trim());
-  if (!ok) {
+  if (!previous) {
     res.status(404).json({ error: 'Token not found' });
     return;
   }
+
+  if (rights) {
+    // A token may never GRANT above itself, edit or mint. Same rule, same function — a second
+    // implementation here is how the two would come to disagree about what "above" means.
+    const editorRights = (req.authToken as { rights?: unknown } | undefined)?.rights
+      ?? migrateToken(req.authToken ?? {});
+    const excess = capRights(editorRights as never, rights as never);
+    if (excess.length > 0) {
+      res.status(403).json({ error: `A token cannot grant rights it does not hold — ${describeExcess(excess)}` });
+      return;
+    }
+
+    // And it may never raise its OWN floor. The mint cap stops handing more to a NEW token; without this
+    // the same escalation is available by a shorter route — edit yourself, then use yourself — and nothing
+    // about the result looks unusual afterwards.
+    const raised = refuseSelfFloorRaise(
+      (req.authToken as { id?: string } | undefined)?.id,
+      editorRights as never,
+      id,
+      rights as never,
+    );
+    if (raised.length > 0) {
+      res.status(403).json({
+        error: `A token cannot raise its own floor — ${raised.join(', ')}. Ask another administrator.`,
+      });
+      return;
+    }
+  }
+
+  req.auditSnapshots = {
+    before: { name: previous.name, rights: previous.rights },
+    after: { name: name?.trim() ?? previous.name, rights: rights ?? previous.rights },
+  };
+
+  if (name !== undefined && !renameToken(id, name.trim())) {
+    res.status(404).json({ error: 'Token not found' });
+    return;
+  }
+  if (rights && !setTokenRights(id, rights as never)) {
+    res.status(404).json({ error: 'Token not found' });
+    return;
+  }
+
   const updated = listTokens().find(t => t.id === id);
   res.json({ token: updated });
 });

--- a/server/src/audit/audit-changes.ts
+++ b/server/src/audit/audit-changes.ts
@@ -60,7 +60,10 @@ export const AUDIT_CHANGE_FIELDS: Readonly<Record<string, readonly string[]>> = 
   // Token metadata ONLY, and only what this route can actually change: `PATCH /api/tokens/:id` renames.
   // Never `hash` or `prefix`; `token.create` and `token.regenerate` are absent entirely, because the
   // interesting value there IS the secret.
-  'token.update': ['name'],
+  // `rights` joined `name` when PATCH gained the ability to edit the matrix. Without it a rights change —
+  // the single most security-relevant edit this route can make — would be applied and leave no trace in the
+  // audit log, while a rename beside it did.
+  'token.update': ['name', 'rights'],
   // Media levels and extraction mode: the settings that decide what gets processed and what leaves the
   // instance. The provider blocks in the same payload carry API keys and are NOT listed.
   'config.media.update': ['levels.images', 'levels.audio', 'levels.video', 'levels.text', 'documentProcessing.mode'],

--- a/server/src/auth/floor-guard.ts
+++ b/server/src/auth/floor-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * A token cannot raise its own floor.
+ *
+ * ## Why this rule and not "a token cannot edit itself"
+ *
+ * Editing your own token is ordinary — renaming it, narrowing it, setting an expiry. What must not happen is
+ * a token WIDENING itself, and the floor is the only part of the matrix that can do so invisibly: it applies
+ * to every space, including ones that do not exist yet, so raising it grants access to spaces nobody has
+ * created and nobody will review.
+ *
+ * The mint cap already stops a token handing more than it holds to a NEW token. Without this, the same
+ * escalation is available by a shorter route: edit yourself, then use yourself. Nothing about the result
+ * looks unusual afterwards — the token's rights simply say what they say.
+ *
+ * ## Lowering is always allowed
+ *
+ * Narrowing your own floor cannot escalate anything, and refusing it would mean a token could not reduce its
+ * own blast radius — the one self-modification worth encouraging.
+ *
+ * ## Per area, not "the floor as a whole"
+ *
+ * A floor is four independent levels. Comparing them as one unit would let a raise on `schema` pass because
+ * `knowledge` went down in the same edit, which is a widening with a decoy attached.
+ */
+import type { TokenRights, AreaRungs, SpaceArea, Rung } from '../config/rights-shape.js';
+
+const ORDER: readonly Rung[] = ['none', 'read', 'write', 'admin'];
+const AREAS: readonly SpaceArea[] = ['knowledge', 'files', 'schema', 'dataQuality'];
+const rank = (r: Rung): number => ORDER.indexOf(r);
+
+/** Areas whose floor level would go UP. Empty means the edit raises nothing. */
+export function floorRaises(current: AreaRungs | null, next: AreaRungs | null): SpaceArea[] {
+  if (!next) return [];                                   // removing the floor cannot widen
+  // A token with NO floor gaining one is a raise in every area the new floor grants — that is the widest
+  // version of this move, not an exemption from it.
+  const from = current ?? ({ knowledge: 'none', files: 'none', schema: 'none', dataQuality: 'none' } as AreaRungs);
+  return AREAS.filter(a => rank(next[a]) > rank(from[a]));
+}
+
+/**
+ * May `editor` apply `next` to the token identified by `targetId`?
+ *
+ * Returns the areas that would be raised, or an empty array when the edit is allowed. Self-edits are
+ * identified by id: a token holding the same rights as another is still a different token, and the rule is
+ * about acting on yourself rather than about equivalence.
+ */
+export function refuseSelfFloorRaise(
+  editorId: string | undefined,
+  editorRights: TokenRights | undefined,
+  targetId: string,
+  next: TokenRights,
+): SpaceArea[] {
+  if (!editorId || editorId !== targetId) return [];
+  return floorRaises(editorRights?.floor ?? null, next.floor);
+}

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -290,6 +290,20 @@ export function updateTokenSpaces(id: string, spaces: string[] | undefined): boo
 }
 
 /** Rename a token — updates only its human-readable label (`name`); the secret and scope are untouched. */
+/**
+ * Replace a token's rights matrix. Separate from `renameToken` because the two are different decisions with
+ * different guards, and one function taking an optional second thing would let a caller change rights while
+ * believing it renamed.
+ */
+export function setTokenRights(id: string, rights: TokenRecord['rights']): boolean {
+  const config = getConfig();
+  const idx = config.tokens.findIndex(t => t.id === id);
+  if (idx < 0) return false;
+  config.tokens[idx]!.rights = rights;
+  saveConfig(config);
+  return true;
+}
+
 export function renameToken(id: string, name: string): boolean {
   const config = getConfig();
   const idx = config.tokens.findIndex(t => t.id === id);

--- a/testing/standalone/audit-changes.test.js
+++ b/testing/standalone/audit-changes.test.js
@@ -107,9 +107,17 @@ describe('audit changes — every allowlist is actually reachable', () => {
     // The second half of the same mistake: `token.update` was allowlisted as label/level/expiresAt when
     // the record field is `name` and the route changes nothing else. Entries that can never match are
     // silent forever, so nothing would have reported it.
-    assert.deepEqual(AUDIT_CHANGE_FIELDS['token.update'], ['name']);
-    assert.ok(read('server/src/api/tokens.ts').includes('name: parsed.data.name.trim()'),
-      'the token route should snapshot the same field the allowlist names');
+    // `rights` joined `name` when PATCH gained the ability to edit the matrix. Both are asserted against the
+    // route's own snapshot, not against each other: an allowlisted field the route never snapshots is silent
+    // forever, and a snapshotted field the allowlist omits is an edit that leaves no audit trace — and the
+    // second is worse here, because the field is the token's permissions.
+    assert.deepEqual(AUDIT_CHANGE_FIELDS['token.update'], ['name', 'rights']);
+    // Substring, not a regex: the snapshot spans two lines and a pattern that assumed one was the reason
+    // this assertion first failed against code that was actually correct.
+    const tokenSrc = read('server/src/api/tokens.ts');
+    assert.ok(tokenSrc.includes('name: previous.name'), 'the route does not snapshot `name`');
+    assert.ok(tokenSrc.includes('rights: previous.rights'),
+      'the route does not snapshot `rights`, so a permissions edit would leave no audit trace');
   });
 
   it('network.update names exactly the three fields its PATCH can change', () => {

--- a/testing/standalone/floor-cannot-be-self-raised.test.js
+++ b/testing/standalone/floor-cannot-be-self-raised.test.js
@@ -1,0 +1,93 @@
+/**
+ * A token cannot raise its own floor.
+ *
+ * ## Why the floor specifically, and not "cannot edit itself"
+ *
+ * Editing your own token is ordinary — renaming it, narrowing it, setting an expiry. What must not happen is
+ * a token WIDENING itself, and the floor is the only part of the matrix that does so invisibly: it applies
+ * to every space including ones that do not exist yet, so raising it grants access to spaces nobody has
+ * created and nobody will review.
+ *
+ * The mint cap stops a token handing more than it holds to a NEW token. Without this rule the same
+ * escalation is available by a shorter route: edit yourself, then use yourself. Nothing about the result
+ * looks unusual afterwards — the token's rights simply say what they say.
+ *
+ * ## The two ways to get this subtly wrong
+ *
+ *  1. **Comparing the floor as one unit.** It is four independent levels. A raise on `schema` would pass
+ *     because `knowledge` went down in the same edit — a widening with a decoy attached.
+ *  2. **Treating "had no floor" as exempt.** Gaining a floor from nothing is the WIDEST version of this
+ *     move, not an exception to it.
+ *
+ * Run: node --test testing/standalone/floor-cannot-be-self-raised.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let floorRaises, refuseSelfFloorRaise;
+before(async () => {
+  ({ floorRaises, refuseSelfFloorRaise } = await import('../../server/dist/auth/floor-guard.js'));
+});
+
+const F = (over = {}) => ({ knowledge: 'none', files: 'none', schema: 'none', dataQuality: 'none', ...over });
+const rights = (floor) => ({ instanceAdmin: false, createSpaces: false, floor, perSpace: {} });
+
+describe('floorRaises', () => {
+  it('reports nothing when the floor is unchanged or lowered', () => {
+    assert.deepEqual(floorRaises(F({ knowledge: 'write' }), F({ knowledge: 'write' })), []);
+    assert.deepEqual(floorRaises(F({ knowledge: 'admin' }), F({ knowledge: 'read' })), []);
+    assert.deepEqual(floorRaises(F({ knowledge: 'read' }), null), [], 'removing the floor cannot widen');
+  });
+
+  it('reports the area that went up', () => {
+    assert.deepEqual(floorRaises(F({ knowledge: 'read' }), F({ knowledge: 'write' })), ['knowledge']);
+  });
+
+  it('is per area — a decoy lowering elsewhere does not excuse a raise', () => {
+    // The failure this exists for: comparing the floor as one unit lets `schema` climb because `knowledge`
+    // dropped in the same edit.
+    const from = F({ knowledge: 'admin', schema: 'none' });
+    const to = F({ knowledge: 'none', schema: 'admin' });
+    assert.deepEqual(floorRaises(from, to), ['schema']);
+  });
+
+  it('treats gaining a floor from NONE as a raise, not an exemption', () => {
+    // The widest version of the move. A token with no floor reaches only the spaces it names; one with a
+    // floor reaches every space that will ever exist.
+    assert.deepEqual(floorRaises(null, F({ knowledge: 'read' })), ['knowledge']);
+  });
+});
+
+describe('the self-edit rule', () => {
+  it('refuses a token raising its OWN floor', () => {
+    const r = refuseSelfFloorRaise('t1', rights(F({ knowledge: 'read' })), 't1', rights(F({ knowledge: 'admin' })));
+    assert.deepEqual(r, ['knowledge']);
+  });
+
+  it('allows a token LOWERING its own floor', () => {
+    // Refusing this would mean a token cannot reduce its own blast radius — the one self-modification worth
+    // encouraging.
+    assert.deepEqual(refuseSelfFloorRaise('t1', rights(F({ knowledge: 'admin' })), 't1', rights(F({ knowledge: 'read' }))), []);
+  });
+
+  it('does not apply when editing a DIFFERENT token', () => {
+    // Granting to someone else is the mint cap's job, not this rule's. Conflating them would refuse an
+    // administrator legitimately widening a colleague's token.
+    assert.deepEqual(refuseSelfFloorRaise('t1', rights(null), 't2', rights(F({ knowledge: 'admin' }))), []);
+  });
+
+  it('identifies self by ID, not by equal rights', () => {
+    // Two tokens can hold identical rights and still be different tokens. The rule is about acting on
+    // yourself, not about equivalence.
+    const same = rights(F({ knowledge: 'read' }));
+    assert.deepEqual(refuseSelfFloorRaise('t1', same, 't2', rights(F({ knowledge: 'admin' }))), []);
+    assert.deepEqual(refuseSelfFloorRaise('t1', same, 't1', rights(F({ knowledge: 'admin' }))), ['knowledge']);
+  });
+
+  it('does not crash when the editor is anonymous', () => {
+    // An unauthenticated caller never reaches this route, but a rule that throws on a missing id would turn
+    // a 401 into a 500 and hide which one it was.
+    assert.deepEqual(refuseSelfFloorRaise(undefined, undefined, 't1', rights(F({ knowledge: 'admin' }))), []);
+  });
+});


### PR DESCRIPTION
The last of the two enforcement rules the approved design said must live in the API rather than the UI.

**The same cap as minting applies, from the same function.** A second implementation here is how the two would come to disagree about what *above* means.

**A token may never raise its own floor.** The mint cap stops handing more than you hold to a *new* token; without this the same escalation is available by a shorter route — edit yourself, then use yourself — and nothing about the result looks unusual afterwards. Lowering your own floor stays allowed: refusing it would mean a token cannot reduce its own blast radius, the one self-modification worth encouraging.

Compared **per area**, not as one unit — a raise on `schema` must not pass because `knowledge` went down in the same edit, which is a widening with a decoy attached. Gaining a floor from none counts as a raise in every area it grants: that is the widest version of the move, not an exemption from it.

**The audit gate caught what I would otherwise have shipped.** `token.update` allowlisted only `name`, so editing a token's *permissions* would have applied and left no trace in the audit log while a rename beside it did. Both fields are allowlisted now, and the gate asserts the route snapshots each.