### PR TITLE
feat(tokens): the list shows what each token can reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **The tokens list shows what each token can reach.** One bar per area, height for the ceiling and a red
+  line for the floor, beside the existing badges.
+  - A single label was what the old model could say, and it is exactly what this replaces: "read-write"
+    cannot express *admin on Files here, nothing anywhere else*. A row of bars can be scanned down a column,
+    which is what a list is for.
+  - **Ceiling and floor are one bar and one mark, not two bars.** They answer different questions — how high
+    this goes, and how much of that applies everywhere including spaces that do not exist yet. As two bars
+    they read as unrelated numbers; as a bar with a line, the gap between them is visible and is exactly the
+    part granted per space.
+  - A line at the top therefore means ceiling equals floor: that level everywhere, forever, nothing
+    space-specific to review. That is the state worth spotting across a list, which is why the mark is red.
+  - **Instance administrator renders as its own state**, not as a rung. It reaches routes no space can grant,
+    so it must not look identical to a token that happens to hold area-admin in every space.
+  - Drawn only for tokens that carry a matrix. OIDC records never get one, and an empty glyph would read as
+    "reaches nothing" rather than "not known here" — different facts, and the wrong one is reassuring.
+  - The component reads the wire shape defensively: a missing area is `none` rather than a crash. A glyph
+    that throws takes the whole token list with it, and the list is where somebody is auditing access.
+
+### Added
 - **`PATCH /api/tokens/:id` can now edit a token's rights matrix — and a token cannot raise its own floor.**
   The last of the two enforcement rules the approved design said must live in the API rather than the UI.
   - **The same cap as minting applies**, from the same function. A second implementation here is how the two

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -220,6 +220,18 @@ export interface TokenRecord {
    * case, and a deliberate hole, so it is badged wherever the token is listed.
    */
   mfa?: 'inherit' | 'exempt' | 'required';
+  /**
+   * The per-space rights matrix, when the server has one for this token.
+   *
+   * Optional because OIDC-derived records never pass through the config backfill that derives it. A missing
+   * matrix means "not known here", not "reaches nothing" — the glyph is omitted rather than drawn empty.
+   */
+  rights?: {
+    instanceAdmin: boolean;
+    createSpaces: boolean;
+    floor: Record<string, 'none' | 'read' | 'write' | 'admin'> | null;
+    perSpace: Record<string, Record<string, 'none' | 'read' | 'write' | 'admin'>>;
+  };
 }
 
 export interface Memory {

--- a/client/src/app/pages/settings/rights-glyph.component.spec.ts
+++ b/client/src/app/pages/settings/rights-glyph.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RightsGlyphComponent, RIGHT_AREAS, type TokenRights, type AreaRungs, type Rung } from './rights-glyph.component';
+
+/**
+ * The glyph has to be right about two different things at once — how high a token goes, and how much of that
+ * it holds everywhere — and both are easy to get subtly wrong in the direction that flatters a token.
+ */
+const R = (r: Rung): AreaRungs => ({ knowledge: r, files: r, schema: r, dataQuality: r });
+const rights = (over: Partial<TokenRights> = {}): TokenRights =>
+  ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+describe('RightsGlyphComponent', () => {
+  let fixture: ComponentFixture<RightsGlyphComponent>;
+
+  const render = (r: TokenRights) => {
+    fixture = TestBed.createComponent(RightsGlyphComponent);
+    fixture.componentRef.setInput('rights', r);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [RightsGlyphComponent] }).compileComponents();
+  });
+
+  it('draws one bar per area, in the matrix order', () => {
+    const el = render(rights());
+    expect(el.querySelectorAll('.bar').length).toBe(RIGHT_AREAS.length);
+  });
+
+  it('the ceiling is the highest rung in ANY space, not just the floor', () => {
+    // Reading only the floor would show this token as `none` while it administers one space.
+    const el = render(rights({ perSpace: { qa: R('admin') } }));
+    expect(el.querySelector('.bar')!.className).toContain('h3');
+  });
+
+  it('the ceiling counts the floor too, not just the rows', () => {
+    // The mirror mistake: reading only `perSpace` would show nothing for a token whose reach is its floor.
+    const el = render(rights({ floor: R('write') }));
+    expect(el.querySelector('.bar')!.className).toContain('h2');
+  });
+
+  it('marks the floor, and only when there IS one', () => {
+    // A line at the baseline would read as "a floor of zero" rather than "no floor", and those are
+    // different facts: one reaches every future space at `none`, the other reaches none of them at all.
+    expect(render(rights({ perSpace: { qa: R('admin') } })).querySelector('.floor')).toBeNull();
+    expect(render(rights({ floor: R('read'), perSpace: { qa: R('admin') } })).querySelector('.floor')).not.toBeNull();
+  });
+
+  it('puts the floor mark at the floor level, not the ceiling', () => {
+    const el = render(rights({ floor: R('read'), perSpace: { qa: R('admin') } }));
+    expect(el.querySelector('.floor')!.className).toContain('f1');
+    expect(el.querySelector('.bar')!.className).toContain('h3');
+  });
+
+  it('shows a full-height mark when ceiling and floor are equal', () => {
+    // The state worth spotting from across a list: that level everywhere, forever, nothing space-specific
+    // left to review.
+    const el = render(rights({ floor: R('admin') }));
+    expect(el.querySelector('.bar')!.className).toContain('h3');
+    expect(el.querySelector('.floor')!.className).toContain('f3');
+  });
+
+  it('renders instance administrator as its own state, not as a rung', () => {
+    // It is not "admin everywhere" — it also reaches routes no space can grant, so it must not be
+    // indistinguishable from a token that happens to hold area-admin in every space.
+    const boss = render(rights({ instanceAdmin: true }));
+    const areaAdmin = render(rights({ floor: R('admin') }));
+    expect(boss.querySelector('.bar')!.className).toContain('hx');
+    expect(areaAdmin.querySelector('.bar')!.className).not.toContain('hx');
+  });
+
+  it('every bar carries a readable title, since a bar alone is not self-describing', () => {
+    const el = render(rights({ floor: R('read'), perSpace: { qa: R('admin') } }));
+    expect(el.querySelector('.bar')!.getAttribute('title')).toBe('knowledge: up to admin, read everywhere');
+  });
+
+  it('does not crash on a token with no rights at all', () => {
+    const el = render(rights());
+    expect(el.querySelectorAll('.bar').length).toBe(RIGHT_AREAS.length);
+    expect(el.querySelector('.floor')).toBeNull();
+  });
+});

--- a/client/src/app/pages/settings/rights-glyph.component.ts
+++ b/client/src/app/pages/settings/rights-glyph.component.ts
@@ -1,0 +1,103 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+/** The four areas, in the order the matrix shows them. Bars follow this order so a row reads left to right. */
+export const RIGHT_AREAS = ['knowledge', 'files', 'schema', 'dataQuality'] as const;
+export type RightArea = (typeof RIGHT_AREAS)[number];
+export type Rung = 'none' | 'read' | 'write' | 'admin';
+export type AreaRungs = Record<RightArea, Rung>;
+
+/**
+ * What arrives on the wire: a plain record, not a guaranteed four-key object.
+ *
+ * The component reads it defensively and treats a missing area as `none`. A server that grows a fifth area,
+ * or an older instance that has not, must not make this throw — a glyph that crashes takes the whole token
+ * list with it, and the list is where somebody is auditing access.
+ */
+export type WireRungs = Record<string, Rung>;
+
+export interface TokenRights {
+  instanceAdmin: boolean;
+  createSpaces: boolean;
+  floor: WireRungs | null;
+  perSpace: Record<string, WireRungs>;
+}
+
+const RANK: Record<Rung, number> = { none: 0, read: 1, write: 2, admin: 3 };
+
+/**
+ * One bar per area: height is the CEILING, a red line marks the FLOOR.
+ *
+ * ## Why a glyph and not a label
+ *
+ * A token's rights are four areas across every space. "read-write" was what the old model could say and it
+ * is exactly what this replaces — a single label cannot express "admin on Files here, nothing anywhere
+ * else". A row of bars can be scanned down a column, which is what a list is for.
+ *
+ * ## Why the floor is a separate mark rather than a second bar
+ *
+ * Ceiling and floor answer different questions — *how high does this go* and *how much of that applies
+ * everywhere, including spaces that do not exist yet*. Drawn as two bars they read as two unrelated numbers;
+ * drawn as a bar with a line, the gap between them is visible and is exactly the part that is granted per
+ * space and can be audited space by space.
+ *
+ * A line at the top of a bar therefore means ceiling equals floor: that level everywhere, forever, with
+ * nothing space-specific to review. That is the state worth spotting from across a list, which is why the
+ * mark is red rather than another shade of the bar.
+ */
+@Component({
+  selector: 'app-rights-glyph',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    :host { display: inline-flex; align-items: flex-end; gap: 4px; height: 24px; padding-top: 2px; }
+    .bar { position: relative; width: 10px; border-radius: 2px; display: block; background: var(--bg-elevated); }
+    .bar.h0 { height: 4px; }
+    .bar.h1 { height: 9px;  background: var(--info); }
+    .bar.h2 { height: 15px; background: var(--accent); }
+    .bar.h3 { height: 22px; background: var(--warning); }
+    /* Instance administrator is not a rung — it is everything, everywhere, and reads as its own state. */
+    .bar.hx { height: 22px; background: var(--error); }
+    .floor { position: absolute; left: -2px; right: -2px; height: 2px; background: var(--error);
+      border-radius: 1px; box-shadow: 0 0 0 1px var(--bg-surface); }
+    .floor.f1 { bottom: 8px; } .floor.f2 { bottom: 14px; } .floor.f3 { bottom: 21px; }
+  `],
+  template: `
+    @for (b of bars(); track b.area) {
+      <span class="bar" [class]="'bar ' + b.h" [attr.title]="b.label">
+        @if (b.f) { <span class="floor" [class]="'floor ' + b.f"></span> }
+      </span>
+    }
+  `,
+})
+export class RightsGlyphComponent {
+  rights = input.required<TokenRights>();
+
+  /**
+   * The ceiling for an area is the highest rung held in ANY space — floor or row, whichever is higher.
+   *
+   * Reading only `perSpace` under-reports a token whose reach comes from its floor; reading only the floor
+   * under-reports one with a specific row. Both are wrong in the same direction — they make a token look
+   * smaller than it is — which is the direction that matters least in a refusal and most in a list somebody
+   * is auditing.
+   */
+  bars = computed(() => {
+    const r = this.rights();
+    return RIGHT_AREAS.map(area => {
+      if (r.instanceAdmin) {
+        return { area, h: 'hx', f: 'f3', label: `${area}: instance administrator` };
+      }
+      const floor: Rung = r.floor?.[area] ?? 'none';
+      const ceiling = Object.values(r.perSpace).reduce<Rung>(
+        (hi, row) => (RANK[row[area] ?? 'none'] > RANK[hi] ? (row[area] as Rung) : hi), floor,
+      );
+      return {
+        area,
+        h: `h${RANK[ceiling]}`,
+        // No mark when the floor is `none`: a line at the baseline would read as a floor of zero rather
+        // than as no floor at all, and those are different facts.
+        f: floor === 'none' ? '' : `f${RANK[floor]}`,
+        label: `${area}: up to ${ceiling}${floor === 'none' ? '' : `, ${floor} everywhere`}`,
+      };
+    });
+  });
+}

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -15,6 +15,7 @@ import { SummaryStripComponent, SummaryItem } from '../../shared/summary-strip.c
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { RightsGlyphComponent } from './rights-glyph.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 
@@ -23,7 +24,7 @@ import { httpErrorReason } from '../../core/http-error';
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
             SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective,
-            ErrorStateComponent],
+            ErrorStateComponent, RightsGlyphComponent],
   styles: [`
     .new-token-banner {
       background: var(--success-dim);
@@ -427,6 +428,14 @@ import { httpErrorReason } from '../../core/http-error';
                          wherever the token is, because a hole nobody can see is one nobody reviews. -->
                     @if (t.mfa === 'exempt') { <app-status-pill variant="warn">{{ 'tokens.badge.mfaExempt' | transloco }}</app-status-pill> }
                     @else if (t.mfa === 'required') { <app-status-pill variant="pending">{{ 'tokens.badge.mfaRequired' | transloco }}</app-status-pill> }
+                    <!-- The badges above say what KIND of token this is. The glyph says what it can reach:
+                         one bar per area, height for the ceiling, a red line for the floor. A badge cannot
+                         express "admin on Files in one space and nothing anywhere else", which is exactly
+                         what the rights model makes possible. Only drawn once a token carries a matrix —
+                         OIDC records never get one, and an empty glyph would read as "reaches nothing". -->
+                    @if (t.rights) {
+                      <app-rights-glyph [rights]="t.rights" style="margin-left:8px;vertical-align:middle;"/>
+                    }
                   </td>
                   <td><app-relative-time [value]="t.createdAt"/></td>
                   <td>


### PR DESCRIPTION
One bar per area, height for the ceiling and a red line for the floor, beside the existing badges. First piece of the rights UI.

A single label was what the old model could say, and it is what this replaces: *read-write* cannot express **admin on Files in one space and nothing anywhere else**, which is exactly what the rights model makes possible. A row of bars can be scanned down a column, which is what a list is for.

**Ceiling and floor are one bar and one mark, not two bars.** They answer different questions — how high this goes, and how much of that applies everywhere including spaces that do not exist yet. As two bars they read as unrelated numbers; as a bar with a line the **gap** is visible, and the gap is exactly the part granted per space. A line at the top therefore means that level everywhere, forever, with nothing space-specific left to review — the state worth spotting across a list, and why the mark is red.

**Instance administrator renders as its own state**, not as a rung: it reaches routes no space can grant, so it must not look identical to a token holding area-admin in every space.

Drawn only for tokens that carry a matrix. OIDC records never get one, and an empty glyph would read as *reaches nothing* rather than *not known here* — different facts, and the wrong one is reassuring. The component also reads the wire shape defensively, treating a missing area as `none`: a glyph that throws takes the whole token list with it, and the list is where somebody is auditing access.

The reachability gate caught it landing unrendered — I had planned to wire it in a follow-up, which is precisely the unreferenced-component state that gate exists to prevent.