### PR TITLE
feat(tokens): create a token with the per-space rights matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **A token can be created with the per-space rights matrix from the UI.** The create dialog offers it behind
+  a switch; the four areas, the all-spaces floor, and one row per space.
+  - **It is a switch, not an extra panel.** The matrix and the legacy permission/space controls are mutually
+    exclusive on the wire — the server refuses a body carrying both rather than silently preferring one — so
+    opening it changes which field the request sends.
+  - **The floor row is a minimum, not a bulk button.** Every space is at least that, and so is every space
+    created after the token was minted. Rungs beneath it are clamped in each cell rather than removed, so the
+    reason a cell will not go lower is visible where the click happens.
+  - **A cell shows the higher of its own row and the floor.** Showing the stored row alone would display
+    `none` for a space the token actually reaches — the screen saying one thing while enforcement does
+    another, in the direction that under-states access.
+  - Each cell is an escalation rather than four checkboxes: rungs contain the ones below, so "write but not
+    read" cannot be expressed. Clicking the rung you are on steps down one — a control that can only climb
+    reads as resisting being narrowed.
+
+### Added
 - **The tokens list shows what each token can reach.** One bar per area, height for the ceiling and a red
   line for the floor, beside the existing badges.
   - A single label was what the old model could say, and it is exactly what this replaces: "read-write"

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1828,5 +1828,8 @@
   "brain.overview.er.declareSchema": "Schema deklarieren für",
   "brain.overview.er.truncated": "Dieser Raum ist größer als ein Lesevorgang: Der {{scan}}-Scan endete bei {{limit}} Datensätzen, das Diagramm ist daher unvollständig.",
   "brain.overview.er.dangling": "{{n}} Kanten verweisen auf eine Entität, die nicht mehr existiert.",
-  "brain.overview.er.proxy": "Ein Proxy-Raum hat kein einzelnes Datenmodell — öffnen Sie einen Mitgliedsraum."
+  "brain.overview.er.proxy": "Ein Proxy-Raum hat kein einzelnes Datenmodell — öffnen Sie einen Mitgliedsraum.",
+  "tokens.matrix.show": "Matrix pro Space verwenden",
+  "tokens.matrix.hide": "Einfache Berechtigung verwenden",
+  "tokens.matrix.help": "Pro Bereich und Space eine Stufe setzen. Ersetzt die Auswahl oben — ein Token nutzt entweder das eine oder das andere, nie beides."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1828,5 +1828,8 @@
   "brain.overview.er.declareSchema": "Declare a schema for",
   "brain.overview.er.truncated": "This space is larger than one read: the {{scan}} scan stopped at {{limit}} records, so the diagram is partial.",
   "brain.overview.er.dangling": "{{n}} edges point at an entity that no longer exists.",
-  "brain.overview.er.proxy": "A proxy space has no single data model — open a member space to see one."
+  "brain.overview.er.proxy": "A proxy space has no single data model — open a member space to see one.",
+  "tokens.matrix.show": "Use the per-space matrix",
+  "tokens.matrix.hide": "Use the simple permission",
+  "tokens.matrix.help": "Set a level per area per space. Replaces the permission and space choices above — a token uses one or the other, never both."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1828,5 +1828,8 @@
   "brain.overview.er.declareSchema": "Zadeklaruj schemat dla",
   "brain.overview.er.truncated": "Ta przestrzeń jest większa niż jeden odczyt: skanowanie {{scan}} zatrzymało się na {{limit}} rekordach, więc diagram jest częściowy.",
   "brain.overview.er.dangling": "{{n}} krawędzi wskazuje na encję, która już nie istnieje.",
-  "brain.overview.er.proxy": "Przestrzeń proxy nie ma jednego modelu danych — otwórz przestrzeń członkowską."
+  "brain.overview.er.proxy": "Przestrzeń proxy nie ma jednego modelu danych — otwórz przestrzeń członkowską.",
+  "tokens.matrix.show": "Użyj macierzy per przestrzeń",
+  "tokens.matrix.hide": "Użyj prostych uprawnień",
+  "tokens.matrix.help": "Ustaw poziom dla obszaru w każdej przestrzeni. Zastępuje wybory powyżej — token używa jednego albo drugiego, nigdy obu."
 }

--- a/client/src/app/pages/settings/rights-matrix.component.spec.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RightsMatrixComponent } from './rights-matrix.component';
+import type { TokenRights } from './rights-glyph.component';
+
+const rights = (over: Partial<TokenRights> = {}): TokenRights =>
+  ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+describe('RightsMatrixComponent', () => {
+  let fixture: ComponentFixture<RightsMatrixComponent>;
+  let emitted: TokenRights[];
+
+  const render = (r: TokenRights, spaces = ['qa', 'research']) => {
+    fixture = TestBed.createComponent(RightsMatrixComponent);
+    fixture.componentRef.setInput('rights', r);
+    fixture.componentRef.setInput('spaces', spaces);
+    emitted = [];
+    fixture.componentInstance.changed.subscribe(v => emitted.push(v));
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [RightsMatrixComponent] }).compileComponents();
+  });
+
+  it('puts the floor row FIRST, then one row per space', () => {
+    const el = render(rights());
+    const rows = [...el.querySelectorAll('tbody tr')];
+    expect(rows.length).toBe(3);
+    expect(rows[0]!.className).toContain('floor');
+    expect(rows[0]!.querySelector('td.l')!.textContent).toContain('All spaces');
+    expect(rows[1]!.querySelector('td.l')!.textContent).toContain('qa');
+  });
+
+  it('a cell shows the FLOOR when the floor is higher than its own row', () => {
+    // Showing the stored row alone would display `none` for a space the token reaches through the floor —
+    // the cell saying one thing while enforcement does another, in the direction that under-states access.
+    const el = render(rights({ floor: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' } }));
+    const firstCell = el.querySelectorAll('tbody tr')[1]!.querySelectorAll('app-rung-picker')[0]!;
+    const filled = [...firstCell.querySelectorAll('button')].filter(b => b.className.includes('on'));
+    expect(filled.length).toBe(2);   // none + read
+  });
+
+  it('a row above the floor keeps its own higher level', () => {
+    const el = render(rights({
+      floor: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' },
+      perSpace: { qa: { knowledge: 'admin', files: 'none', schema: 'none', dataQuality: 'none' } },
+    }));
+    const cell = el.querySelectorAll('tbody tr')[1]!.querySelectorAll('app-rung-picker')[0]!;
+    expect([...cell.querySelectorAll('button')].filter(b => b.className.includes('on')).length).toBe(4);
+  });
+
+  it('emits a WHOLE matrix, not a patch', () => {
+    // The parent holds one draft and saves it as one thing. Emitting deltas would mean the parent
+    // reassembles the object — a second place the shape is known, and the shape is what the server caps.
+    const el = render(rights());
+    el.querySelectorAll('tbody tr')[1]!.querySelectorAll('button')[1]!.click();
+    expect(emitted.length).toBe(1);
+    expect(emitted[0]).toHaveProperty('instanceAdmin');
+    expect(emitted[0]).toHaveProperty('floor');
+    expect(emitted[0]!.perSpace['qa']!['knowledge']).toBe('read');
+  });
+
+  it('editing one space leaves the others untouched', () => {
+    const el = render(rights({ perSpace: { research: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } }));
+    el.querySelectorAll('tbody tr')[1]!.querySelectorAll('button')[1]!.click();
+    expect(emitted[0]!.perSpace['research']!['knowledge']).toBe('write');
+  });
+
+  it('the floor row edits the floor, not a space', () => {
+    const el = render(rights());
+    el.querySelectorAll('tbody tr')[0]!.querySelectorAll('button')[1]!.click();
+    expect(emitted[0]!.floor!['knowledge']).toBe('read');
+    expect(Object.keys(emitted[0]!.perSpace)).toEqual([]);
+  });
+
+  it('clamps space cells beneath the floor rather than hiding the rung', () => {
+    const el = render(rights({ floor: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } }));
+    const cell = el.querySelectorAll('tbody tr')[1]!.querySelectorAll('app-rung-picker')[0]!;
+    const bs = [...cell.querySelectorAll('button')];
+    expect(bs[0]!.disabled).toBe(true);
+    expect(bs[1]!.disabled).toBe(true);
+    expect(bs[2]!.disabled).toBe(false);
+  });
+
+  it('renders with no spaces without collapsing the floor row', () => {
+    const el = render(rights(), []);
+    expect(el.querySelectorAll('tbody tr').length).toBe(1);
+    expect(el.querySelector('tbody tr')!.className).toContain('floor');
+  });
+});

--- a/client/src/app/pages/settings/rights-matrix.component.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.ts
@@ -1,0 +1,107 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { RungPickerComponent } from './rung-picker.component';
+import { RIGHT_AREAS, type Rung, type TokenRights, type WireRungs } from './rights-glyph.component';
+
+const EMPTY = (): WireRungs => ({ knowledge: 'none', files: 'none', schema: 'none', dataQuality: 'none' });
+
+/**
+ * The rights matrix: an all-spaces FLOOR on top, then one row per space.
+ *
+ * ## The floor is a minimum, not a bulk button
+ *
+ * Whatever it says, every space below is at least that — and so is every space created after this token was
+ * minted. That is the whole reason the separate `spaces` allowlist could be dropped: a token reaches a
+ * future space only if somebody said so here, deliberately, in advance.
+ *
+ * Rungs under the floor are therefore clamped in each cell rather than removed, so the reason a cell will
+ * not go lower is visible where the click happens rather than inferred from a row above.
+ *
+ * ## Emits a whole matrix, never a patch
+ *
+ * The parent holds a draft and saves it as one thing. Emitting per-cell deltas would mean the parent
+ * reassembles the object, which is a second place the shape is known — and the shape is what the server
+ * caps and audits.
+ */
+@Component({
+  selector: 'app-rights-matrix',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RungPickerComponent],
+  styles: [`
+    :host { display: block; overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    th, td { border-bottom: 1px solid var(--border-muted); padding: 8px 10px; text-align: center; }
+    th.l, td.l { text-align: left; white-space: nowrap; font-weight: 600; }
+    thead th { background: var(--bg-elevated); font-size: 11.5px; color: var(--text-secondary); font-weight: 620; }
+    tr.floor td { background: color-mix(in srgb, var(--accent) 6%, transparent); }
+    tr.floor { border-bottom: 2px solid var(--accent); }
+    tr.floor td.l { color: var(--accent); }
+    td.l small { display: block; font-weight: 400; font-size: 11px; color: var(--text-muted); }
+  `],
+  template: `
+    <table>
+      <thead>
+        <tr>
+          <th class="l">Space</th>
+          @for (a of areas; track a) { <th>{{ a }}</th> }
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="floor">
+          <td class="l">All spaces<small>minimum, incl. future</small></td>
+          @for (a of areas; track a) {
+            <td>
+              <app-rung-picker [value]="floorOf(a)" (changed)="setFloor(a, $event)"/>
+            </td>
+          }
+        </tr>
+        @for (s of spaces(); track s) {
+          <tr>
+            <td class="l">{{ s }}</td>
+            @for (a of areas; track a) {
+              <td>
+                <app-rung-picker [value]="cellOf(s, a)" [floor]="floorOf(a)" (changed)="setCell(s, a, $event)"/>
+              </td>
+            }
+          </tr>
+        }
+      </tbody>
+    </table>
+  `,
+})
+export class RightsMatrixComponent {
+  rights = input.required<TokenRights>();
+  spaces = input.required<string[]>();
+  changed = output<TokenRights>();
+
+  readonly areas = RIGHT_AREAS;
+
+  floorOf = (area: string): Rung => this.rights().floor?.[area] ?? 'none';
+
+  /**
+   * A cell shows the higher of its own row and the floor.
+   *
+   * Showing the stored row alone would display `none` for a space the token can in fact reach through the
+   * floor — the cell would say one thing and the enforcement do another, in the direction that under-states
+   * access. That is the direction that matters most on a screen somebody is auditing.
+   */
+  cellOf = (space: string, area: string): Rung => {
+    const row = this.rights().perSpace[space]?.[area] ?? 'none';
+    const floor = this.floorOf(area);
+    return rank(row) > rank(floor) ? row : floor;
+  };
+
+  setFloor(area: string, rung: Rung): void {
+    const r = this.rights();
+    this.changed.emit({ ...r, floor: { ...(r.floor ?? EMPTY()), [area]: rung } });
+  }
+
+  setCell(space: string, area: string, rung: Rung): void {
+    const r = this.rights();
+    const row = { ...(r.perSpace[space] ?? EMPTY()), [area]: rung };
+    this.changed.emit({ ...r, perSpace: { ...r.perSpace, [space]: row } });
+  }
+}
+
+const ORDER: Rung[] = ['none', 'read', 'write', 'admin'];
+const rank = (r: Rung): number => ORDER.indexOf(r);

--- a/client/src/app/pages/settings/rung-picker.component.spec.ts
+++ b/client/src/app/pages/settings/rung-picker.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RungPickerComponent } from './rung-picker.component';
+import type { Rung } from './rights-glyph.component';
+
+/**
+ * The cell control. Two of its behaviours are the whole reason it is a component rather than four
+ * checkboxes, and both are easy to lose in a refactor: clicking the current rung steps DOWN, and rungs
+ * below the floor are visibly clamped rather than silently ignored.
+ */
+describe('RungPickerComponent', () => {
+  let fixture: ComponentFixture<RungPickerComponent>;
+  let emitted: Rung[];
+
+  const render = (value: Rung, floor: Rung = 'none') => {
+    fixture = TestBed.createComponent(RungPickerComponent);
+    fixture.componentRef.setInput('value', value);
+    fixture.componentRef.setInput('floor', floor);
+    emitted = [];
+    fixture.componentInstance.changed.subscribe(r => emitted.push(r));
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  };
+  const buttons = (el: HTMLElement) => [...el.querySelectorAll('button')] as HTMLButtonElement[];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [RungPickerComponent] }).compileComponents();
+  });
+
+  it('renders one segment per rung', () => {
+    expect(buttons(render('none')).map(b => b.textContent?.trim())).toEqual(['—', 'R', 'W', 'A']);
+  });
+
+  it('fills every segment up to the held rung, because rungs CONTAIN the ones below', () => {
+    // Not "the selected one is highlighted": write includes read, and the control has to show that or it
+    // reads as four independent choices.
+    const el = render('write');
+    expect(buttons(el).map(b => b.className.includes('on'))).toEqual([true, true, true, false]);
+  });
+
+  it('emits the rung that was clicked', () => {
+    const el = render('none');
+    buttons(el)[2]!.click();
+    expect(emitted).toEqual(['write']);
+  });
+
+  it('clicking the CURRENT rung steps down one', () => {
+    // A control that can only climb reads as resisting being narrowed — the direction anyone auditing wants.
+    const el = render('write');
+    buttons(el)[2]!.click();
+    expect(emitted).toEqual(['read']);
+  });
+
+  it('stepping down stops at the floor rather than going under it', () => {
+    const el = render('write', 'write');
+    buttons(el)[2]!.click();
+    expect(emitted).toEqual([]);
+  });
+
+  it('clamps the rungs below the floor, and says why', () => {
+    // Dimmed and titled, not hidden: the floor is set on a different row, so a cell that silently refuses
+    // to go lower with no visible reason looks broken rather than governed.
+    const el = render('write', 'read');
+    const bs = buttons(el);
+    expect(bs[0]!.disabled).toBe(true);
+    expect(bs[0]!.className).toContain('clamped');
+    expect(bs[0]!.getAttribute('title')).toContain('floor');
+    expect(bs[1]!.disabled).toBe(false);
+  });
+
+  it('emits nothing for a clamped rung', () => {
+    const el = render('write', 'read');
+    buttons(el)[0]!.click();
+    expect(emitted).toEqual([]);
+  });
+
+  it('emits nothing when the value would not change', () => {
+    // An event per click regardless of effect would make a parent mark itself dirty for nothing, and a diff
+    // on save would show an edit nobody made.
+    const el = render('read');
+    buttons(el)[1]!.click();          // clicking `read` while on `read` steps to `none`
+    expect(emitted).toEqual(['none']);
+    const el2 = render('none');
+    buttons(el2)[0]!.click();         // already at the bottom
+    expect(emitted).toEqual([]);
+  });
+
+  it('exposes pressed state for assistive tech', () => {
+    const el = render('read');
+    expect(buttons(el).map(b => b.getAttribute('aria-pressed'))).toEqual(['true', 'true', 'false', 'false']);
+  });
+});

--- a/client/src/app/pages/settings/rung-picker.component.ts
+++ b/client/src/app/pages/settings/rung-picker.component.ts
@@ -1,0 +1,87 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import type { Rung } from './rights-glyph.component';
+
+export const RUNGS: readonly Rung[] = ['none', 'read', 'write', 'admin'];
+const RANK: Record<Rung, number> = { none: 0, read: 1, write: 2, admin: 3 };
+
+/** What each rung is called in the grid. Short, because a matrix cell has no room for a sentence. */
+const LABEL: Record<Rung, string> = { none: '—', read: 'R', write: 'W', admin: 'A' };
+
+/**
+ * One cell of the rights matrix: an escalation, not four checkboxes.
+ *
+ * ## Why an escalation
+ *
+ * Each rung CONTAINS the one below it, so "write but not read" is not a thing that can be expressed. Four
+ * checkboxes would let somebody save it, and the server would then have to decide what it meant — which is
+ * a decision nobody should be making at read time.
+ *
+ * ## Two behaviours that are easy to get wrong
+ *
+ *  - **Clicking the current rung steps DOWN one.** Without it, a cell can only ever go up by clicking and
+ *    down by clicking a specific lower segment, which reads as "the control resists being narrowed".
+ *  - **Rungs below the floor are clamped, not hidden.** The floor is set on another row entirely, so a cell
+ *    that silently refuses to go lower with no visible reason looks broken. Dimmed-and-titled says why.
+ */
+@Component({
+  selector: 'app-rung-picker',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    :host { display: inline-flex; border: 1px solid var(--border); border-radius: 7px; overflow: hidden; }
+    button { font-family: var(--font-mono, monospace); font-size: 10.5px; font-weight: 600; padding: 5px 8px;
+      color: var(--text-muted); background: var(--bg-surface); border: 0;
+      border-right: 1px solid var(--border-muted); cursor: pointer; }
+    button:last-child { border-right: 0; }
+    button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+    button.on.r0 { background: var(--text-muted); color: var(--bg-primary); }
+    button.on.r1 { background: var(--info);    color: var(--bg-primary); }
+    button.on.r2 { background: var(--accent);  color: var(--text-on-accent); }
+    button.on.r3 { background: var(--warning); color: var(--bg-primary); }
+    button.clamped { opacity: .35; cursor: not-allowed; }
+  `],
+  template: `
+    @for (s of segments(); track s.rung) {
+      <button type="button"
+              [class]="s.classes"
+              [disabled]="s.clamped"
+              [attr.aria-pressed]="s.filled"
+              [attr.title]="s.title"
+              (click)="pick(s.rung)">{{ s.label }}</button>
+    }
+  `,
+})
+export class RungPickerComponent {
+  value = input.required<Rung>();
+  /** The floor for this area. A cell may never sit below it — see the class comment. */
+  floor = input<Rung>('none');
+  changed = output<Rung>();
+
+  segments = computed(() => {
+    const held = RANK[this.value()];
+    const min = RANK[this.floor()];
+    return RUNGS.map((rung, i) => {
+      const clamped = i < min;
+      const filled = i <= held;
+      return {
+        rung, label: LABEL[rung], clamped, filled,
+        // The colour comes from the SELECTED rung, not from each segment's own level, so a filled bar reads
+        // as one block at one level rather than a gradient nobody asked for.
+        classes: `${filled ? `on r${held}` : ''}${clamped ? ' clamped' : ''}`,
+        title: clamped
+          ? `Held at ${this.floor()} by the all-spaces floor`
+          : `Set ${rung}${rung === this.value() ? ' — click again to step down' : ''}`,
+      };
+    });
+  });
+
+  pick(rung: Rung): void {
+    if (RANK[rung] < RANK[this.floor()]) return;
+    // Clicking the rung you are already on steps down one, never below the floor. A control that can only
+    // climb reads as resisting being narrowed, which is the direction anyone auditing wants to move.
+    const next: Rung = rung === this.value()
+      ? (RUNGS[Math.max(RANK[this.floor()], RANK[rung] - 1)] as Rung)
+      : rung;
+    if (next !== this.value()) this.changed.emit(next);
+  }
+}

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -15,7 +15,8 @@ import { SummaryStripComponent, SummaryItem } from '../../shared/summary-strip.c
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
-import { RightsGlyphComponent } from './rights-glyph.component';
+import { RightsGlyphComponent, type TokenRights } from './rights-glyph.component';
+import { RightsMatrixComponent } from './rights-matrix.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 
@@ -24,7 +25,7 @@ import { httpErrorReason } from '../../core/http-error';
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
             SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective,
-            ErrorStateComponent, RightsGlyphComponent],
+            ErrorStateComponent, RightsGlyphComponent, RightsMatrixComponent],
   styles: [`
     .new-token-banner {
       background: var(--success-dim);
@@ -358,6 +359,26 @@ import { httpErrorReason } from '../../core/http-error';
               </p>
             </div>
 
+            <!-- The per-space matrix, shown only when the operator asks for it. Collapsed by default because
+                 the legacy permission control above already answers the common case, and the two are
+                 mutually exclusive on the wire: the server refuses a body carrying both rather than
+                 silently preferring one. Opening this is therefore a deliberate switch, not an extra. -->
+            <div style="margin-top:14px;">
+              <button class="btn-secondary btn btn-sm" type="button" (click)="useMatrix.set(!useMatrix())">
+                {{ useMatrix() ? ('tokens.matrix.hide' | transloco) : ('tokens.matrix.show' | transloco) }}
+              </button>
+              @if (useMatrix()) {
+                <p class="permission-help" style="margin-top:8px;">
+                  <ph-icon name="info" [size]="14" />
+                  <span>{{ 'tokens.matrix.help' | transloco }}</span>
+                </p>
+                <app-rights-matrix
+                  [rights]="draftRights()"
+                  [spaces]="spaceIds()"
+                  (changed)="draftRights.set($event)"/>
+              }
+            </div>
+
             <div class="form-grid-bottom" style="margin-top:12px;">
               <button class="btn-secondary btn" type="button" (click)="showCreateDialog.set(false)">{{ 'common.cancel' | transloco }}</button>
               <button class="btn-primary btn" type="submit" style="margin-left:auto;" [disabled]="creating() || !newName.trim()">
@@ -502,6 +523,18 @@ export class TokensComponent implements OnInit {
   creating = signal(false);
   createError = signal('');
   showCreateDialog = signal(false);
+
+  /**
+   * Whether the operator switched from the legacy permission control to the per-space matrix.
+   *
+   * Not a view toggle — the two are mutually exclusive on the wire, and the server refuses a body carrying
+   * both rather than silently preferring one. So this decides WHICH field the create request sends.
+   */
+  /** Just the ids, because the matrix keys rows by id and does not need the rest of a space. */
+  spaceIds = computed(() => this.availableSpaces().map(s => s.id));
+
+  useMatrix = signal(false);
+  draftRights = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
   newName = '';
   newExpiry = '';
   newPermission: 'readOnly' | 'standard' | 'admin' = 'standard';
@@ -541,20 +574,31 @@ export class TokensComponent implements OnInit {
     this.creating.set(true);
     this.createError.set('');
 
-    const body: { name: string; expiresAt?: string; admin?: boolean; readOnly?: boolean; spaces?: string[]; mfa?: 'exempt' | 'required' } = { name: this.newName.trim() };
+    const body: {
+      name: string; expiresAt?: string; admin?: boolean; readOnly?: boolean; spaces?: string[];
+      mfa?: 'exempt' | 'required'; rights?: TokenRights;
+    } = { name: this.newName.trim() };
     // Sent only when it says something — `inherit` is the absent state on the server too.
     if (this.newMfa !== 'inherit') body.mfa = this.newMfa;
     if (this.newExpiry) body.expiresAt = new Date(this.newExpiry).toISOString();
-    if (this.newPermission === 'admin') body.admin = true;
-    if (this.newPermission === 'readOnly') body.readOnly = true;
 
-    let spaceIds: string[];
-    if (this.spacesLoadFailed()) {
-      spaceIds = this.newSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
+    if (this.useMatrix()) {
+      // EITHER the matrix OR the legacy fields, never both. The server refuses a body carrying both rather
+      // than silently preferring one, so sending the permission radio alongside would turn a deliberate
+      // choice into a 400 the operator did not make.
+      body.rights = this.draftRights();
     } else {
-      spaceIds = [...this.newSelectedSpaces];
+      if (this.newPermission === 'admin') body.admin = true;
+      if (this.newPermission === 'readOnly') body.readOnly = true;
+
+      let spaceIds: string[];
+      if (this.spacesLoadFailed()) {
+        spaceIds = this.newSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
+      } else {
+        spaceIds = [...this.newSelectedSpaces];
+      }
+      if (spaceIds.length) body.spaces = spaceIds;
     }
-    if (spaceIds.length) body.spaces = spaceIds;
 
     this.authApi.createToken(body).subscribe({
       next: ({ token, plaintext }) => {

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -67,6 +67,14 @@ const CEILING = 650;
  * file shrinks; raising one is a decision to make deliberately and to say why in the commit.
  */
 const FROZEN = {
+  // NEW ENTRANT 2026-08-10, at 676 — it crossed the 650 ceiling when the rights matrix was wired into the
+  // create dialog. Frozen rather than split because the split is real work and doing it inside a feature PR
+  // would mix a refactor with a behaviour change; filed in ARCHITECTURE-TODO as the extraction it needs.
+  //
+  // The honest reading: this file is a page, a create dialog, a permission editor and a token list in one
+  // component, and the create dialog alone is over half of it. It is the next thing to come out, and this
+  // number should go DOWN when it does rather than up again.
+  'client/src/app/pages/settings/tokens.component.ts': 676,
   'client/src/app/pages/files/file-manager.component.ts': 1617,
   'client/src/app/pages/schema-library/schema-library.component.ts': 1112,
   'server/src/sync/engine.ts': 966,


### PR DESCRIPTION
The create dialog offers the matrix behind a switch: four areas, the all-spaces floor, one row per space.

**It is a switch, not an extra panel.** The matrix and the legacy permission/space controls are mutually exclusive on the wire — the server refuses a body carrying both rather than silently preferring one — so opening it changes *which field the request sends*. Sending both would turn a deliberate choice into a `400` the operator did not make.

**The floor row is a minimum, not a bulk button.** Every space is at least that, and so is every space created after the token was minted. Rungs beneath it are clamped in each cell rather than removed, so the reason a cell will not go lower is visible where the click happens instead of inferred from a row above.

**A cell shows the higher of its own row and the floor.** Showing the stored row alone would display `none` for a space the token actually reaches through the floor — the screen saying one thing while enforcement does another, in the direction that *under-states* access. That is the direction that matters most on a screen somebody is auditing.

Each cell is an **escalation**, not four checkboxes: rungs contain the ones below, so *write but not read* cannot be expressed at all. Clicking the rung you are already on steps down one, because a control that can only climb reads as resisting being narrowed.

`tokens.component.ts` crossed the god-file ceiling at 676 doing this. **Frozen rather than split**, because the split is real work and doing it inside a feature PR mixes a refactor with a behaviour change — filed as Q-5. That file is a page, a create dialog, a permission editor and a token list in one component, and the dialog alone is over half of it. The frozen number should go **down** when it comes out.