### PR TITLE
refactor(tokens): the create dialog becomes its own component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Internal: the create-token dialog is its own component.** No behaviour change — the same request body,
+  the same fields, the same flow.
+  - `tokens.component.ts` had crossed the god-file ceiling at 676 code lines and was frozen with a note
+    saying the number should go **down**. It is 502 now, under the ceiling, and the dialog it lost is 207.
+  - **It stays on the frozen list on purpose.** An entry there is a ratchet; removing it would hand the file
+    back the 148 lines of headroom the extraction just removed.
+  - **The nine characterization tests were written and proven green BEFORE the move**, against the
+    pre-extraction code. The refactor changed the host they reach for and **not one assertion**. That was the
+    point of writing them first: the move is judged by them rather than by reading the diff.
+  - One harness became two, because the pills belong to the table and the create fields to the dialog. A
+    single harness serving both was only possible while they shared a file.
+
 ### Added
 - **A token can be created with the per-space rights matrix from the UI.** The create dialog offers it behind
   a switch; the four areas, the all-spaces floor, and one row per space.

--- a/client/src/app/pages/settings/token-create-dialog.component.ts
+++ b/client/src/app/pages/settings/token-create-dialog.component.ts
@@ -1,0 +1,249 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ModalDirective } from '../../shared/modal.directive';
+import { AuthApi } from '../../core/auth-api.service';
+import { RightsMatrixComponent } from './rights-matrix.component';
+import type { TokenRights } from './rights-glyph.component';
+import type { Space, TokenRecord } from '../../core/api.types';
+
+/**
+ * The create-token dialog.
+ *
+ * ## Why it is its own component
+ *
+ * It was over a quarter of `tokens.component.ts` and pushed that file past the god-file ceiling. It is also
+ * a self-contained flow: thirteen pieces of state that exist only while the dialog is open, and one decision
+ * — legacy permission fields or the per-space matrix — that the rest of the page has no opinion about.
+ *
+ * ## The contract this must not change
+ *
+ * The REQUEST BODY. It is what the server's mint cap and the audit log see, and
+ * `tokens.component.spec.ts` characterizes it: legacy fields and `rights` are mutually exclusive, `mfa` is
+ * omitted when `inherit`, `spaces` only when some are selected. Those tests were written and proven green
+ * against the pre-extraction code precisely so this move could be judged by them rather than by the diff.
+ */
+@Component({
+  selector: 'app-token-create-dialog',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent],
+  template: `
+      <div class="dialog-backdrop">
+        <div class="dialog" [appModal]="'tokens.create.title' | transloco" (dismiss)="close.emit()" (click)="$event.stopPropagation()">
+          <div class="dialog-header">
+            <div class="card-title">{{ 'tokens.create.title' | transloco }}</div>
+            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="close.emit()"><ph-icon name="x" [size]="14"/></button>
+          </div>
+
+          @if (createError()) {
+            <div class="alert alert-error" style="margin-bottom:16px;">{{ createError() }}</div>
+          }
+
+          <form (ngSubmit)="createToken()" #f="ngForm">
+            <div class="form-grid">
+              <div class="field" style="margin-bottom:0;">
+                <label>{{ 'tokens.create.label' | transloco }}</label>
+                <input type="text" [(ngModel)]="newName" name="name" [placeholder]="'tokens.create.labelPlaceholder' | transloco" maxlength="200" required />
+              </div>
+              <div class="field" style="margin-bottom:0;">
+                <label>{{ 'tokens.create.expires' | transloco }}</label>
+                <input type="date" class="styled-input" [(ngModel)]="newExpiry" name="expiry" />
+              </div>
+            </div>
+
+            <div class="field" style="margin-top:12px; margin-bottom:0;">
+              <label>{{ 'tokens.create.spaces' | transloco }}</label>
+              @if (spacesLoadFailed()) {
+                <div class="alert alert-error" style="margin-bottom:6px; font-size:12px;">{{ 'tokens.create.spacesLoadFailed' | transloco }}</div>
+                <input type="text" [(ngModel)]="newSpacesFallback" name="spaces" [placeholder]="'tokens.create.spacesFallbackPlaceholder' | transloco" />
+              } @else if (availableSpaces().length === 0) {
+                <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'tokens.create.loadingSpaces' | transloco }}</div>
+              } @else {
+                <div class="table-wrapper" hscrollTop style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
+                  <table style="margin:0;">
+                    <thead>
+                      <tr>
+                        <th style="width:40px; text-align:center;">
+                          <input type="checkbox" [checked]="newSelectedSpaces.length === 0" (change)="selectAllSpaces()" [attr.title]="'tokens.create.allSpacesTitle' | transloco" />
+                        </th>
+                        <th>{{ 'auditLog.filter.space' | transloco }} <span style="font-size:10px; color:var(--text-muted); font-weight:400;">— {{ 'tokens.create.spacesCheckNoneHint' | transloco }}</span></th>
+                        <th>{{ 'spaces.table.column.id' | transloco }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (s of availableSpaces(); track s.id) {
+                        <tr style="cursor:pointer;" (click)="toggleSpace(s.id)">
+                          <td style="text-align:center;">
+                            <input type="checkbox" [checked]="isSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleSpace(s.id)" />
+                          </td>
+                          <td>{{ s.label }}</td>
+                          <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              }
+              <div class="scope-hint">{{ 'tokens.create.spacesHint' | transloco }}</div>
+            </div>
+
+            <!-- Second factor, per token. The instance-wide switch is all-or-nothing, which is what makes
+                 MFA mutually exclusive with automation — a scheduler cannot type a code. Inherit is the
+                 default and means exactly what it means today. -->
+            <div class="field" style="margin-top:12px; margin-bottom:0;">
+              <label for="tokenMfa">{{ 'tokens.create.mfa' | transloco }}</label>
+              <select id="tokenMfa" [(ngModel)]="newMfa" name="mfa">
+                <option value="inherit">{{ 'tokens.mfa.inherit' | transloco }}</option>
+                <option value="exempt">{{ 'tokens.mfa.exempt' | transloco }}</option>
+                <option value="required">{{ 'tokens.mfa.required' | transloco }}</option>
+              </select>
+              <p class="permission-help">
+                <ph-icon name="info" [size]="14" />
+                <span>{{ ('tokens.mfa.' + newMfa + '.desc') | transloco }}</span>
+              </p>
+            </div>
+
+            <div class="field" style="margin-top:12px; margin-bottom:0;">
+              <label>{{ 'tokens.create.permission' | transloco }}</label>
+              <div class="permission-radio-group">
+                <label class="permission-radio-item">
+                  <input type="radio" name="permission" value="readOnly" [(ngModel)]="newPermission" />
+                  {{ 'tokens.permission.readOnly' | transloco }}
+                </label>
+                <label class="permission-radio-item">
+                  <input type="radio" name="permission" value="standard" [(ngModel)]="newPermission" />
+                  {{ 'tokens.permission.standard' | transloco }}
+                </label>
+                @if (callerIsAdmin()) {
+                  <label class="permission-radio-item">
+                    <input type="radio" name="permission" value="admin" [(ngModel)]="newPermission" />
+                    {{ 'tokens.permission.admin' | transloco }}
+                  </label>
+                }
+              </div>
+              <p class="permission-help">
+                <ph-icon name="info" [size]="14" />
+                <span>{{ ('tokens.permission.' + newPermission + '.desc') | transloco }}</span>
+              </p>
+            </div>
+
+            <!-- The per-space matrix, shown only when the operator asks for it. Collapsed by default because
+                 the legacy permission control above already answers the common case, and the two are
+                 mutually exclusive on the wire: the server refuses a body carrying both rather than
+                 silently preferring one. Opening this is therefore a deliberate switch, not an extra. -->
+            <div style="margin-top:14px;">
+              <button class="btn-secondary btn btn-sm" type="button" (click)="useMatrix.set(!useMatrix())">
+                {{ useMatrix() ? ('tokens.matrix.hide' | transloco) : ('tokens.matrix.show' | transloco) }}
+              </button>
+              @if (useMatrix()) {
+                <p class="permission-help" style="margin-top:8px;">
+                  <ph-icon name="info" [size]="14" />
+                  <span>{{ 'tokens.matrix.help' | transloco }}</span>
+                </p>
+                <app-rights-matrix
+                  [rights]="draftRights()"
+                  [spaces]="spaceIds()"
+                  (changed)="draftRights.set($event)"/>
+              }
+            </div>
+
+            <div class="form-grid-bottom" style="margin-top:12px;">
+              <button class="btn-secondary btn" type="button" (click)="close.emit()">{{ 'common.cancel' | transloco }}</button>
+              <button class="btn-primary btn" type="submit" style="margin-left:auto;" [disabled]="creating() || !newName.trim()">
+                @if (creating()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
+                {{ 'tokens.create.submitButton' | transloco }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+  `,
+})
+export class TokenCreateDialogComponent {
+  private authApi = inject(AuthApi);
+  private transloco = inject(TranslocoService);
+
+  availableSpaces = input<Space[]>([]);
+  spacesLoadFailed = input(false);
+  /** Whether the CALLER is an admin — only an admin may offer the admin permission. Passed in rather than
+   *  re-fetched: two components asking `getMe()` is two answers that can disagree mid-dialog. */
+  callerIsAdmin = input(false);
+  close = output<void>();
+  created = output<{ token: TokenRecord; plaintext: string }>();
+
+  creating = signal(false);
+  createError = signal('');
+  /** Just the ids: the matrix keys rows by id and does not need the rest of a space. */
+  spaceIds = computed(() => this.availableSpaces().map(s => s.id));
+  useMatrix = signal(false);
+  draftRights = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
+  newName = '';
+  newExpiry = '';
+  newPermission: 'readOnly' | 'standard' | 'admin' = 'standard';
+  newMfa: 'inherit' | 'exempt' | 'required' = 'inherit';
+  newSelectedSpaces: string[] = [];
+  newSpacesFallback = '';
+
+  /** Empty selection means "all spaces" in this form, matching what the server does with an absent list. */
+  selectAllSpaces(): void { this.newSelectedSpaces = []; }
+
+  isSpaceSelected(id: string): boolean { return this.newSelectedSpaces.includes(id); }
+
+  toggleSpace(id: string): void {
+    this.newSelectedSpaces = this.isSpaceSelected(id)
+      ? this.newSelectedSpaces.filter(s => s !== id)
+      : [...this.newSelectedSpaces, id];
+  }
+
+  createToken(): void {
+    if (!this.newName.trim()) return;
+    this.creating.set(true);
+    this.createError.set('');
+
+    const body: {
+      name: string; expiresAt?: string; admin?: boolean; readOnly?: boolean; spaces?: string[];
+      mfa?: 'exempt' | 'required'; rights?: TokenRights;
+    } = { name: this.newName.trim() };
+    // Sent only when it says something — `inherit` is the absent state on the server too.
+    if (this.newMfa !== 'inherit') body.mfa = this.newMfa;
+    if (this.newExpiry) body.expiresAt = new Date(this.newExpiry).toISOString();
+
+    if (this.useMatrix()) {
+      // EITHER the matrix OR the legacy fields, never both. The server refuses a body carrying both rather
+      // than silently preferring one, so sending the permission radio alongside would turn a deliberate
+      // choice into a 400 the operator did not make.
+      body.rights = this.draftRights();
+    } else {
+      if (this.newPermission === 'admin') body.admin = true;
+      if (this.newPermission === 'readOnly') body.readOnly = true;
+
+      let spaceIds: string[];
+      if (this.spacesLoadFailed()) {
+        spaceIds = this.newSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
+      } else {
+        spaceIds = [...this.newSelectedSpaces];
+      }
+      if (spaceIds.length) body.spaces = spaceIds;
+    }
+
+    this.authApi.createToken(body).subscribe({
+      next: ({ token, plaintext }) => {
+        this.creating.set(false);
+        this.close.emit();
+        this.created.emit({ token, plaintext });
+        this.newName = '';
+        this.newExpiry = '';
+        this.newPermission = 'standard';
+        this.newSelectedSpaces = [];
+        this.newSpacesFallback = '';
+      },
+      error: (err) => {
+        this.creating.set(false);
+        this.createError.set(err.error?.error ?? this.transloco.translate('tokens.error.createFailed'));
+      },
+    });
+  }
+}

--- a/client/src/app/pages/settings/tokens.component.spec.ts
+++ b/client/src/app/pages/settings/tokens.component.spec.ts
@@ -10,15 +10,24 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { TokensComponent } from './tokens.component';
+import { TokenCreateDialogComponent } from './token-create-dialog.component';
 import { AuthApi } from '../../core/auth-api.service';
 import { SpacesApi } from '../../core/spaces-api.service';
 import { ToastService } from '../../core/toast.service';
 import { ConfirmDialogService } from '../../core/confirm-dialog.service';
 
+/**
+ * The create flow moved into `TokenCreateDialogComponent` (Q-5). The HOST changed; not one assertion below
+ * did. That is the result these tests were written to produce: they were proven green against the
+ * pre-extraction code, and the only edit the refactor required was where they reach for `createToken`.
+ *
+ * If a future change to this file needs an assertion edited rather than a subject re-pointed, that is the
+ * refactor altering behaviour and the edit is the thing to question.
+ */
 function make(createSpy = vi.fn().mockReturnValue(of({ token: 'tok_x' }))) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
-    imports: [TokensComponent, getTranslocoModule()],
+    imports: [TokenCreateDialogComponent, getTranslocoModule()],
     providers: [
       { provide: AuthApi, useValue: {
         getMe: () => of({ admin: true }),
@@ -30,7 +39,7 @@ function make(createSpy = vi.fn().mockReturnValue(of({ token: 'tok_x' }))) {
       { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(true) } },
     ],
   });
-  const fixture = TestBed.createComponent(TokensComponent);
+  const fixture = TestBed.createComponent(TokenCreateDialogComponent);
   fixture.detectChanges();
   return { fixture, c: fixture.componentInstance, createSpy };
 }
@@ -57,6 +66,30 @@ describe('TokensComponent — permission → create payload', () => {
   });
 });
 
+/**
+ * The LIST page. Separate harness from `make()` since Q-5: the pills belong to the table and the create
+ * fields belong to the dialog, and one harness serving both was only possible while they shared a file.
+ */
+function makeList(tokens: unknown[] = []) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [TokensComponent, getTranslocoModule()],
+    providers: [
+      { provide: AuthApi, useValue: {
+        getMe: () => of({ admin: true }),
+        listTokens: () => of({ tokens }),
+        createToken: vi.fn().mockReturnValue(of({ token: 'tok_x' })),
+      } },
+      { provide: SpacesApi, useValue: { listSpaces: () => of({ spaces: [] }) } },
+      { provide: ToastService, useValue: { show: () => {}, error: () => {}, success: () => {} } },
+      { provide: ConfirmDialogService, useValue: { confirm: () => Promise.resolve(true) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(TokensComponent);
+  fixture.detectChanges();
+  return { fixture, c: fixture.componentInstance };
+}
+
 describe('TokensComponent — permission pill colour semantics (UI-BUNDLE-1)', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
@@ -70,7 +103,7 @@ describe('TokensComponent — permission pill colour semantics (UI-BUNDLE-1)', (
       { tok: { id: 't4', schemaLibrary: true }, variant: 'pending' },
     ] as const;
     for (const { tok, variant } of cases) {
-      const { fixture, c } = make();
+      const { fixture, c } = makeList();
       c.tokens.set([{ spaces: [], ...tok } as never]);
       fixture.detectChanges();
       const pill = fixture.nativeElement.querySelector('tbody tr td:nth-child(2) .pill');
@@ -88,7 +121,6 @@ describe('TokensComponent — permission capability help (U6)', () => {
   // the transloco pipe's async key resolution is awkward to pin deterministically in a unit test).
   it('renders the permission capability-help line in the open create dialog', () => {
     const { fixture } = make();
-    fixture.componentInstance.showCreateDialog.set(true);
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.permission-help')).not.toBeNull();
     expect(fixture.nativeElement.querySelector('.permission-help > span')).not.toBeNull();

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -16,7 +16,7 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
 import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 import { RightsGlyphComponent, type TokenRights } from './rights-glyph.component';
-import { RightsMatrixComponent } from './rights-matrix.component';
+import { TokenCreateDialogComponent } from './token-create-dialog.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 
@@ -25,7 +25,7 @@ import { httpErrorReason } from '../../core/http-error';
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
             SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective,
-            ErrorStateComponent, RightsGlyphComponent, RightsMatrixComponent],
+            ErrorStateComponent, RightsGlyphComponent, TokenCreateDialogComponent],
   styles: [`
     .new-token-banner {
       background: var(--success-dim);
@@ -258,137 +258,16 @@ import { httpErrorReason } from '../../core/http-error';
       </div>
     }
 
-    <!-- Create token form (dialog) -->
+    <!-- The create dialog lives in TokenCreateDialogComponent. It was over a quarter of this file and
+         is a self-contained flow with thirteen pieces of its own state; leaving it here is what kept
+         this component over the god-file ceiling. -->
     @if (showCreateDialog()) {
-      <div class="dialog-backdrop">
-        <div class="dialog" [appModal]="'tokens.create.title' | transloco" (dismiss)="showCreateDialog.set(false)" (click)="$event.stopPropagation()">
-          <div class="dialog-header">
-            <div class="card-title">{{ 'tokens.create.title' | transloco }}</div>
-            <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="showCreateDialog.set(false)"><ph-icon name="x" [size]="14"/></button>
-          </div>
-
-          @if (createError()) {
-            <div class="alert alert-error" style="margin-bottom:16px;">{{ createError() }}</div>
-          }
-
-          <form (ngSubmit)="createToken()" #f="ngForm">
-            <div class="form-grid">
-              <div class="field" style="margin-bottom:0;">
-                <label>{{ 'tokens.create.label' | transloco }}</label>
-                <input type="text" [(ngModel)]="newName" name="name" [placeholder]="'tokens.create.labelPlaceholder' | transloco" maxlength="200" required />
-              </div>
-              <div class="field" style="margin-bottom:0;">
-                <label>{{ 'tokens.create.expires' | transloco }}</label>
-                <input type="date" class="styled-input" [(ngModel)]="newExpiry" name="expiry" />
-              </div>
-            </div>
-
-            <div class="field" style="margin-top:12px; margin-bottom:0;">
-              <label>{{ 'tokens.create.spaces' | transloco }}</label>
-              @if (spacesLoadFailed()) {
-                <div class="alert alert-error" style="margin-bottom:6px; font-size:12px;">{{ 'tokens.create.spacesLoadFailed' | transloco }}</div>
-                <input type="text" [(ngModel)]="newSpacesFallback" name="spaces" [placeholder]="'tokens.create.spacesFallbackPlaceholder' | transloco" />
-              } @else if (availableSpaces().length === 0) {
-                <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'tokens.create.loadingSpaces' | transloco }}</div>
-              } @else {
-                <div class="table-wrapper" hscrollTop style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
-                  <table style="margin:0;">
-                    <thead>
-                      <tr>
-                        <th style="width:40px; text-align:center;">
-                          <input type="checkbox" [checked]="newSelectedSpaces.length === 0" (change)="selectAllSpaces()" [attr.title]="'tokens.create.allSpacesTitle' | transloco" />
-                        </th>
-                        <th>{{ 'auditLog.filter.space' | transloco }} <span style="font-size:10px; color:var(--text-muted); font-weight:400;">— {{ 'tokens.create.spacesCheckNoneHint' | transloco }}</span></th>
-                        <th>{{ 'spaces.table.column.id' | transloco }}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      @for (s of availableSpaces(); track s.id) {
-                        <tr style="cursor:pointer;" (click)="toggleSpace(s.id)">
-                          <td style="text-align:center;">
-                            <input type="checkbox" [checked]="isSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleSpace(s.id)" />
-                          </td>
-                          <td>{{ s.label }}</td>
-                          <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
-                        </tr>
-                      }
-                    </tbody>
-                  </table>
-                </div>
-              }
-              <div class="scope-hint">{{ 'tokens.create.spacesHint' | transloco }}</div>
-            </div>
-
-            <!-- Second factor, per token. The instance-wide switch is all-or-nothing, which is what makes
-                 MFA mutually exclusive with automation — a scheduler cannot type a code. Inherit is the
-                 default and means exactly what it means today. -->
-            <div class="field" style="margin-top:12px; margin-bottom:0;">
-              <label for="tokenMfa">{{ 'tokens.create.mfa' | transloco }}</label>
-              <select id="tokenMfa" [(ngModel)]="newMfa" name="mfa">
-                <option value="inherit">{{ 'tokens.mfa.inherit' | transloco }}</option>
-                <option value="exempt">{{ 'tokens.mfa.exempt' | transloco }}</option>
-                <option value="required">{{ 'tokens.mfa.required' | transloco }}</option>
-              </select>
-              <p class="permission-help">
-                <ph-icon name="info" [size]="14" />
-                <span>{{ ('tokens.mfa.' + newMfa + '.desc') | transloco }}</span>
-              </p>
-            </div>
-
-            <div class="field" style="margin-top:12px; margin-bottom:0;">
-              <label>{{ 'tokens.create.permission' | transloco }}</label>
-              <div class="permission-radio-group">
-                <label class="permission-radio-item">
-                  <input type="radio" name="permission" value="readOnly" [(ngModel)]="newPermission" />
-                  {{ 'tokens.permission.readOnly' | transloco }}
-                </label>
-                <label class="permission-radio-item">
-                  <input type="radio" name="permission" value="standard" [(ngModel)]="newPermission" />
-                  {{ 'tokens.permission.standard' | transloco }}
-                </label>
-                @if (selfToken()?.admin) {
-                  <label class="permission-radio-item">
-                    <input type="radio" name="permission" value="admin" [(ngModel)]="newPermission" />
-                    {{ 'tokens.permission.admin' | transloco }}
-                  </label>
-                }
-              </div>
-              <p class="permission-help">
-                <ph-icon name="info" [size]="14" />
-                <span>{{ ('tokens.permission.' + newPermission + '.desc') | transloco }}</span>
-              </p>
-            </div>
-
-            <!-- The per-space matrix, shown only when the operator asks for it. Collapsed by default because
-                 the legacy permission control above already answers the common case, and the two are
-                 mutually exclusive on the wire: the server refuses a body carrying both rather than
-                 silently preferring one. Opening this is therefore a deliberate switch, not an extra. -->
-            <div style="margin-top:14px;">
-              <button class="btn-secondary btn btn-sm" type="button" (click)="useMatrix.set(!useMatrix())">
-                {{ useMatrix() ? ('tokens.matrix.hide' | transloco) : ('tokens.matrix.show' | transloco) }}
-              </button>
-              @if (useMatrix()) {
-                <p class="permission-help" style="margin-top:8px;">
-                  <ph-icon name="info" [size]="14" />
-                  <span>{{ 'tokens.matrix.help' | transloco }}</span>
-                </p>
-                <app-rights-matrix
-                  [rights]="draftRights()"
-                  [spaces]="spaceIds()"
-                  (changed)="draftRights.set($event)"/>
-              }
-            </div>
-
-            <div class="form-grid-bottom" style="margin-top:12px;">
-              <button class="btn-secondary btn" type="button" (click)="showCreateDialog.set(false)">{{ 'common.cancel' | transloco }}</button>
-              <button class="btn-primary btn" type="submit" style="margin-left:auto;" [disabled]="creating() || !newName.trim()">
-                @if (creating()) { <span class="spinner" style="width:12px;height:12px;border-width:2px;"></span> }
-                {{ 'tokens.create.submitButton' | transloco }}
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
+      <app-token-create-dialog
+        [availableSpaces]="availableSpaces()"
+        [spacesLoadFailed]="spacesLoadFailed()"
+        [callerIsAdmin]="!!selfToken()?.admin"
+        (close)="showCreateDialog.set(false)"
+        (created)="onTokenCreated($event)"/>
     }
 
     <!-- Operator summary -->
@@ -520,8 +399,6 @@ export class TokensComponent implements OnInit {
   loading = signal(true);
   /** Null until the last load failed — checked before the empty state, so a failure never reads as "no tokens". */
   loadError = signal<string | null>(null);
-  creating = signal(false);
-  createError = signal('');
   showCreateDialog = signal(false);
 
   /**
@@ -531,17 +408,8 @@ export class TokensComponent implements OnInit {
    * both rather than silently preferring one. So this decides WHICH field the create request sends.
    */
   /** Just the ids, because the matrix keys rows by id and does not need the rest of a space. */
-  spaceIds = computed(() => this.availableSpaces().map(s => s.id));
 
-  useMatrix = signal(false);
-  draftRights = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
-  newName = '';
-  newExpiry = '';
-  newPermission: 'readOnly' | 'standard' | 'admin' = 'standard';
   /** Second factor for the token being created. `inherit` is today's behaviour for every existing token. */
-  newMfa: 'inherit' | 'exempt' | 'required' = 'inherit';
-  newSelectedSpaces: string[] = [];
-  newSpacesFallback = '';
   spacesLoadFailed = signal(false);
   newToken = signal('');
   copied = signal(false);
@@ -569,71 +437,16 @@ export class TokensComponent implements OnInit {
     });
   }
 
-  createToken(): void {
-    if (!this.newName.trim()) return;
-    this.creating.set(true);
-    this.createError.set('');
 
-    const body: {
-      name: string; expiresAt?: string; admin?: boolean; readOnly?: boolean; spaces?: string[];
-      mfa?: 'exempt' | 'required'; rights?: TokenRights;
-    } = { name: this.newName.trim() };
-    // Sent only when it says something — `inherit` is the absent state on the server too.
-    if (this.newMfa !== 'inherit') body.mfa = this.newMfa;
-    if (this.newExpiry) body.expiresAt = new Date(this.newExpiry).toISOString();
-
-    if (this.useMatrix()) {
-      // EITHER the matrix OR the legacy fields, never both. The server refuses a body carrying both rather
-      // than silently preferring one, so sending the permission radio alongside would turn a deliberate
-      // choice into a 400 the operator did not make.
-      body.rights = this.draftRights();
-    } else {
-      if (this.newPermission === 'admin') body.admin = true;
-      if (this.newPermission === 'readOnly') body.readOnly = true;
-
-      let spaceIds: string[];
-      if (this.spacesLoadFailed()) {
-        spaceIds = this.newSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
-      } else {
-        spaceIds = [...this.newSelectedSpaces];
-      }
-      if (spaceIds.length) body.spaces = spaceIds;
-    }
-
-    this.authApi.createToken(body).subscribe({
-      next: ({ token, plaintext }) => {
-        this.creating.set(false);
-        this.showCreateDialog.set(false);
-        this.tokens.update(list => [token, ...list]);
-        this.newToken.set(plaintext);
-        this.newName = '';
-        this.newExpiry = '';
-        this.newPermission = 'standard';
-        this.newSelectedSpaces = [];
-        this.newSpacesFallback = '';
-      },
-      error: (err) => {
-        this.creating.set(false);
-        this.createError.set(err.error?.error ?? this.transloco.translate('tokens.error.createFailed'));
-      },
-    });
+  /** The dialog owns the create flow; the page owns the list and the one-time plaintext reveal. */
+  onTokenCreated(e: { token: TokenRecord; plaintext: string }): void {
+    this.showCreateDialog.set(false);
+    this.tokens.update(list => [e.token, ...list]);
+    this.newToken.set(e.plaintext);
   }
 
-  isSpaceSelected(id: string): boolean {
-    return this.newSelectedSpaces.includes(id);
-  }
 
-  toggleSpace(id: string): void {
-    if (this.newSelectedSpaces.includes(id)) {
-      this.newSelectedSpaces = this.newSelectedSpaces.filter(s => s !== id);
-    } else {
-      this.newSelectedSpaces = [...this.newSelectedSpaces, id];
-    }
-  }
 
-  selectAllSpaces(): void {
-    this.newSelectedSpaces = [];
-  }
 
   async regenerate(t: TokenRecord): Promise<void> {
     const ok = await this.confirmDialog.confirm({

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -67,14 +67,13 @@ const CEILING = 650;
  * file shrinks; raising one is a decision to make deliberately and to say why in the commit.
  */
 const FROZEN = {
-  // NEW ENTRANT 2026-08-10, at 676 — it crossed the 650 ceiling when the rights matrix was wired into the
-  // create dialog. Frozen rather than split because the split is real work and doing it inside a feature PR
-  // would mix a refactor with a behaviour change; filed in ARCHITECTURE-TODO as the extraction it needs.
+  // 676 -> 502. It crossed the 650 ceiling when the rights matrix was wired in, was frozen with a note
+  // saying the number should go DOWN rather than up again, and the create dialog came out (Q-5).
   //
-  // The honest reading: this file is a page, a create dialog, a permission editor and a token list in one
-  // component, and the create dialog alone is over half of it. It is the next thing to come out, and this
-  // number should go DOWN when it does rather than up again.
-  'client/src/app/pages/settings/tokens.component.ts': 676,
+  // It is now UNDER the ceiling and stays on this list on purpose: an entry here is a ratchet, and removing
+  // it would hand the file back the 148 lines of headroom the extraction just removed. The dialog it lost
+  // lives in `token-create-dialog.component.ts` at 207.
+  'client/src/app/pages/settings/tokens.component.ts': 502,
   'client/src/app/pages/files/file-manager.component.ts': 1617,
   'client/src/app/pages/schema-library/schema-library.component.ts': 1112,
   'server/src/sync/engine.ts': 966,


### PR DESCRIPTION
No behaviour change: the same request body, the same fields, the same flow. **Q-5.**

`tokens.component.ts` had crossed the god-file ceiling at 676 code lines and was frozen with a note saying the number should go **down** rather than up again. It is **502** now, under the ceiling, and the dialog it lost is 207.

**It stays on the frozen list deliberately.** An entry there is a ratchet; removing it because the file is now under the ceiling would hand back the 148 lines of headroom this extraction just removed.

**The nine characterization tests were written and proven green before the move**, against the pre-extraction code. The refactor changed the *host* they reach for and **not one assertion**. That was the point of writing them first: this move is judged by whether they pass, not by reading a 200-line diff of moved template. Had an assertion needed editing, that would have been the refactor altering behaviour — and the edit would have been the thing to question.

One harness became two, because the permission pills belong to the table and the create fields to the dialog. A single harness serving both was only possible while they shared a file — which is itself part of what made the file worth splitting.