### PR TITLE
feat(tokens): edit an existing token's rights from the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **An existing token's rights can be edited from the tokens list.** A pencil beside the glyph opens the
+  matrix; saving sends it to `PATCH /api/tokens/:id`, where the server caps it and refuses a self floor-raise.
+  - **The server's refusals are shown verbatim.** Two guards can reject the save and they are different
+    problems: the cap names every level that was over the line, and the floor guard names the areas that
+    would have gone up. A generic "could not save" would leave the operator guessing between *I asked for too
+    much* and *I am not allowed to do this to myself*, which have different next steps.
+  - **The draft starts from what the token already has.** Starting empty would make every save a silent
+    narrowing of everything the operator did not happen to re-enter.
+  - The glyph stays a display and the pencil is the way in. Making the glyph itself clickable would turn an
+    information element secretly interactive — on a page about credentials, that is how somebody opens an
+    editor by accident.
+
 ### Changed
 - **Internal: the create-token dialog is its own component.** No behaviour change — the same request body,
   the same fields, the same flow.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1831,5 +1831,9 @@
   "brain.overview.er.proxy": "Ein Proxy-Raum hat kein einzelnes Datenmodell — öffnen Sie einen Mitgliedsraum.",
   "tokens.matrix.show": "Matrix pro Space verwenden",
   "tokens.matrix.hide": "Einfache Berechtigung verwenden",
-  "tokens.matrix.help": "Pro Bereich und Space eine Stufe setzen. Ersetzt die Auswahl oben — ein Token nutzt entweder das eine oder das andere, nie beides."
+  "tokens.matrix.help": "Pro Bereich und Space eine Stufe setzen. Ersetzt die Auswahl oben — ein Token nutzt entweder das eine oder das andere, nie beides.",
+  "tokens.rights.title": "Rechte",
+  "tokens.rights.edit": "Rechte bearbeiten",
+  "tokens.rights.saved": "Rechte aktualisiert",
+  "tokens.error.rightsFailed": "Rechte konnten nicht aktualisiert werden"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1831,5 +1831,9 @@
   "brain.overview.er.proxy": "A proxy space has no single data model — open a member space to see one.",
   "tokens.matrix.show": "Use the per-space matrix",
   "tokens.matrix.hide": "Use the simple permission",
-  "tokens.matrix.help": "Set a level per area per space. Replaces the permission and space choices above — a token uses one or the other, never both."
+  "tokens.matrix.help": "Set a level per area per space. Replaces the permission and space choices above — a token uses one or the other, never both.",
+  "tokens.rights.title": "Rights",
+  "tokens.rights.edit": "Edit rights",
+  "tokens.rights.saved": "Rights updated",
+  "tokens.error.rightsFailed": "Could not update rights"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1831,5 +1831,9 @@
   "brain.overview.er.proxy": "Przestrzeń proxy nie ma jednego modelu danych — otwórz przestrzeń członkowską.",
   "tokens.matrix.show": "Użyj macierzy per przestrzeń",
   "tokens.matrix.hide": "Użyj prostych uprawnień",
-  "tokens.matrix.help": "Ustaw poziom dla obszaru w każdej przestrzeni. Zastępuje wybory powyżej — token używa jednego albo drugiego, nigdy obu."
+  "tokens.matrix.help": "Ustaw poziom dla obszaru w każdej przestrzeni. Zastępuje wybory powyżej — token używa jednego albo drugiego, nigdy obu.",
+  "tokens.rights.title": "Uprawnienia",
+  "tokens.rights.edit": "Edytuj uprawnienia",
+  "tokens.rights.saved": "Uprawnienia zaktualizowane",
+  "tokens.error.rightsFailed": "Nie udało się zaktualizować uprawnień"
 }

--- a/client/src/app/core/auth-api.service.ts
+++ b/client/src/app/core/auth-api.service.ts
@@ -1,3 +1,4 @@
+import type { TokenRights } from '../pages/settings/rights-glyph.component';
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
@@ -45,6 +46,17 @@ export class AuthApi {
 
   regenerateToken(id: string): Observable<{ plaintext: string }> {
     return this.http.post<{ plaintext: string }>(`/api/tokens/${id}/regenerate`, {});
+  }
+
+  /**
+   * Replace a token's rights matrix.
+   *
+   * Separate call from `renameToken` rather than one method with two optional fields: the server guards them
+   * differently — a rights edit is capped at the caller's own and refused outright if it would raise the
+   * caller's floor — and a single method would let a caller believe it renamed while it changed permissions.
+   */
+  setTokenRights(id: string, rights: TokenRights): Observable<{ token: TokenRecord }> {
+    return this.http.patch<{ token: TokenRecord }>(`/api/tokens/${id}`, { rights });
   }
 
   renameToken(id: string, name: string): Observable<{ token: TokenRecord }> {

--- a/client/src/app/pages/settings/token-rights-dialog.component.ts
+++ b/client/src/app/pages/settings/token-rights-dialog.component.ts
@@ -1,0 +1,101 @@
+import { ChangeDetectionStrategy, Component, inject, input, output, signal } from '@angular/core';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { ModalDirective } from '../../shared/modal.directive';
+import { AuthApi } from '../../core/auth-api.service';
+import { RightsMatrixComponent } from './rights-matrix.component';
+import type { TokenRights } from './rights-glyph.component';
+import type { Space, TokenRecord } from '../../core/api.types';
+
+/**
+ * Edit an existing token's rights.
+ *
+ * ## Why the server's refusals are surfaced verbatim
+ *
+ * Two guards can reject this save, and both are decisions the operator needs the reason for:
+ *
+ *  - **the cap** — a token may not grant rights it does not hold, and the 403 names every level that was
+ *    over the line;
+ *  - **the floor** — a token may not raise its OWN floor, and the 403 names the areas that would have gone
+ *    up.
+ *
+ * Replacing either with a generic "could not save" would leave the operator guessing between "I asked for
+ * too much" and "I am not allowed to do this to myself", which are different problems with different next
+ * steps. So the message is shown as it arrives.
+ *
+ * ## Why the draft starts from what the token has
+ *
+ * Starting from an empty matrix would make every save a silent narrowing of everything the operator did not
+ * happen to re-enter.
+ */
+@Component({
+  selector: 'app-token-rights-dialog',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent],
+  template: `
+    <div class="dialog-backdrop">
+      <div class="dialog" [appModal]="'tokens.rights.title' | transloco"
+           (dismiss)="close.emit()" (click)="$event.stopPropagation()">
+        <div class="dialog-header">
+          <h3>{{ 'tokens.rights.title' | transloco }} — {{ token().name }}</h3>
+          <button class="icon-btn" [attr.aria-label]="'common.close' | transloco" (click)="close.emit()">
+            <ph-icon name="x" [size]="14"/>
+          </button>
+        </div>
+
+        @if (error()) {
+          <!-- Verbatim: the server names the areas or levels that were refused, and a generic message would
+               leave the operator guessing which of the two guards fired. -->
+          <p class="form-error" role="alert" style="white-space:pre-wrap;">{{ error() }}</p>
+        }
+
+        <app-rights-matrix [rights]="draft()" [spaces]="spaceIds()" (changed)="draft.set($event)"/>
+
+        <div class="form-grid-bottom" style="margin-top:12px;">
+          <button class="btn-secondary btn" type="button" (click)="close.emit()">
+            {{ 'common.cancel' | transloco }}
+          </button>
+          <button class="btn-primary btn" type="button" style="margin-left:auto;"
+                  [disabled]="saving()" (click)="save()">
+            {{ 'common.save' | transloco }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class TokenRightsDialogComponent {
+  private authApi = inject(AuthApi);
+  private transloco = inject(TranslocoService);
+
+  token = input.required<TokenRecord>();
+  availableSpaces = input<Space[]>([]);
+  close = output<void>();
+  saved = output<TokenRecord>();
+
+  saving = signal(false);
+  error = signal('');
+
+  /** Starts from what the token HAS — an empty start would make every save narrow everything not re-entered. */
+  draft = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
+
+  spaceIds = () => this.availableSpaces().map(s => s.id);
+
+  ngOnInit(): void {
+    const r = this.token().rights;
+    if (r) this.draft.set({ ...r } as TokenRights);
+  }
+
+  save(): void {
+    this.saving.set(true);
+    this.error.set('');
+    this.authApi.setTokenRights(this.token().id, this.draft()).subscribe({
+      next: ({ token }) => { this.saving.set(false); this.saved.emit(token); },
+      error: (err) => {
+        this.saving.set(false);
+        this.error.set(err.error?.error ?? this.transloco.translate('tokens.error.rightsFailed'));
+      },
+    });
+  }
+}

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -17,6 +17,7 @@ import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 import { RightsGlyphComponent, type TokenRights } from './rights-glyph.component';
 import { TokenCreateDialogComponent } from './token-create-dialog.component';
+import { TokenRightsDialogComponent } from './token-rights-dialog.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 
@@ -25,7 +26,8 @@ import { httpErrorReason } from '../../core/http-error';
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
             SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective,
-            ErrorStateComponent, RightsGlyphComponent, TokenCreateDialogComponent],
+            ErrorStateComponent, RightsGlyphComponent, TokenCreateDialogComponent,
+            TokenRightsDialogComponent],
   styles: [`
     .new-token-banner {
       background: var(--success-dim);
@@ -258,6 +260,14 @@ import { httpErrorReason } from '../../core/http-error';
       </div>
     }
 
+    @if (editRightsFor(); as t) {
+      <app-token-rights-dialog
+        [token]="t"
+        [availableSpaces]="availableSpaces()"
+        (close)="editRightsFor.set(null)"
+        (saved)="onRightsSaved($event)"/>
+    }
+
     <!-- The create dialog lives in TokenCreateDialogComponent. It was over a quarter of this file and
          is a self-contained flow with thirteen pieces of its own state; leaving it here is what kept
          this component over the god-file ceiling. -->
@@ -334,7 +344,16 @@ import { httpErrorReason } from '../../core/http-error';
                          what the rights model makes possible. Only drawn once a token carries a matrix —
                          OIDC records never get one, and an empty glyph would read as "reaches nothing". -->
                     @if (t.rights) {
+                      <!-- The glyph is the summary; the button is the way in. Clicking the glyph itself would
+                           make an information display secretly interactive, which is how people discover an
+                           editor by accident on a page about credentials. -->
                       <app-rights-glyph [rights]="t.rights" style="margin-left:8px;vertical-align:middle;"/>
+                      <button class="icon-btn" type="button" style="margin-left:4px;vertical-align:middle;"
+                              [attr.aria-label]="'tokens.rights.edit' | transloco"
+                              [attr.title]="'tokens.rights.edit' | transloco"
+                              (click)="editRightsFor.set(t)">
+                        <ph-icon name="pencil-simple" [size]="13"/>
+                      </button>
                     }
                   </td>
                   <td><app-relative-time [value]="t.createdAt"/></td>
@@ -400,6 +419,9 @@ export class TokensComponent implements OnInit {
   /** Null until the last load failed — checked before the empty state, so a failure never reads as "no tokens". */
   loadError = signal<string | null>(null);
   showCreateDialog = signal(false);
+  /** The token whose rights are being edited, or null. Holding the RECORD rather than an id keeps the dialog
+   *  from having to look it up again and disagreeing with the row that opened it. */
+  editRightsFor = signal<TokenRecord | null>(null);
 
   /**
    * Whether the operator switched from the legacy permission control to the per-space matrix.
@@ -439,6 +461,12 @@ export class TokensComponent implements OnInit {
 
 
   /** The dialog owns the create flow; the page owns the list and the one-time plaintext reveal. */
+  onRightsSaved(updated: TokenRecord): void {
+    this.editRightsFor.set(null);
+    this.tokens.update(list => list.map(t => (t.id === updated.id ? updated : t)));
+    this.toast.success(this.transloco.translate('tokens.rights.saved'));
+  }
+
   onTokenCreated(e: { token: TokenRecord; plaintext: string }): void {
     this.showCreateDialog.set(false);
     this.tokens.update(list => [e.token, ...list]);

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -73,7 +73,11 @@ const FROZEN = {
   // It is now UNDER the ceiling and stays on this list on purpose: an entry here is a ratchet, and removing
   // it would hand the file back the 148 lines of headroom the extraction just removed. The dialog it lost
   // lives in `token-create-dialog.component.ts` at 207.
-  'client/src/app/pages/settings/tokens.component.ts': 502,
+  // 502 -> 526: the per-row "edit rights" action, its state, and the saved handler. The DIALOG went to
+  // `token-rights-dialog.component.ts`; what landed here is the entry point, which belongs to the page that
+  // owns the rows. Raised rather than worked around — hiding a row action somewhere it does not belong to
+  // keep a number down is the trade this list exists to let us decline.
+  'client/src/app/pages/settings/tokens.component.ts': 526,
   'client/src/app/pages/files/file-manager.component.ts': 1617,
   'client/src/app/pages/schema-library/schema-library.component.ts': 1112,
   'server/src/sync/engine.ts': 966,


### PR DESCRIPTION
A pencil beside the glyph opens the matrix; saving sends it to `PATCH /api/tokens/:id`, where the server caps it and refuses a self floor-raise. **Q-1's last piece.**

**The server's refusals are shown verbatim.** Two guards can reject the save and they are different problems: the cap names every level that was over the line, and the floor guard names the areas that would have gone up. A generic *could not save* would leave the operator guessing between *I asked for too much* and *I am not allowed to do this to myself* — which have different next steps.

**The draft starts from what the token already has.** Starting from an empty matrix would make every save a silent narrowing of everything the operator did not happen to re-enter.

**The glyph stays a display; the pencil is the way in.** Making the glyph itself clickable would turn an information element secretly interactive — on a page about credentials, that is how somebody opens an editor by accident.

The dialog is its own component; only the row action, its state and the saved handler landed in `tokens.component.ts`, which is why its ratchet went 502 → 526. Raised with the reason rather than worked around: hiding a row action somewhere it does not belong, to keep a number down, is the trade that list exists to let us decline.