### PR TITLE
feat(brain): the suppressEmbeddings tier resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Internal: the `suppressEmbeddings` tier resolver.** Nothing consults it yet; the schema field, the
+  space-wide setting and the wiring into `embedStoredRecord` follow.
+  - Asked for by an operator with records that are **state rather than prose**: a queue row whose name and
+    description never change, whose weight is PATCHed every tick, and which nobody will ever search for by
+    meaning. Each write re-embedded byte-identical text ~4,800 times a day to produce a vector that already
+    existed.
+  - Resolves **record > schema > space**, matching `retention` exactly rather than inventing an order. Two
+    tiered settings that resolve differently is the kind of thing nobody discovers until it is wrong.
+  - **"Not stated" falls through; it is not `false`.** If an absent schema flag read as "do not suppress",
+    the space-wide switch would do nothing for any type that had a schema at all — which is every type worth
+    suppressing.
+  - **An edge finds its schema by `label`, not `type`.** `EdgeDoc` carries both, so reading `type` finds a
+    schema that is never there and looks like it worked — suppression would silently never apply to edges,
+    the record kind this was explicitly widened to cover.
+
+### Added
 - **An existing token's rights can be edited from the tokens list.** A pencil beside the glyph opens the
   matrix; saving sends it to `PATCH /api/tokens/:id`, where the server caps it and refuses a self floor-raise.
   - **The server's refusals are shown verbatim.** Two guards can reject the save and they are different

--- a/server/src/brain/suppress-embeddings.ts
+++ b/server/src/brain/suppress-embeddings.ts
@@ -1,0 +1,59 @@
+import { TYPE_FIELD } from './ttl.js';
+import type { KnowledgeType } from '../config/types.js';
+
+/**
+ * Should this record be embedded at all?
+ *
+ * ## Why the tiers, and why THIS order
+ *
+ * Asked by an operator for records that are **state rather than prose**: a queue row whose name and
+ * description never change, whose weight is PATCHed every tick, and which nobody will ever search for by
+ * meaning. Each of those writes re-embedded text byte-identical to the last, ~4,800 times a day, producing a
+ * vector that already existed.
+ *
+ * `record > schema > space`, matching `retention` exactly (owner decision). Two tiered settings that resolve
+ * differently is the kind of thing nobody discovers until it is wrong, and there is no reason for this one to
+ * be novel.
+ *
+ * ## Suppresses the WRITE, not the read
+ *
+ * The operator was explicit: excluding from search while still computing the vector saves nothing, because
+ * the cost is the embedding call. So this is consulted where a vector is WRITTEN.
+ *
+ * ## The edge trap
+ *
+ * A schema is looked up by the record's type field, and **edges key on `label` while everything else keys on
+ * `type`**. `EdgeDoc` carries both, so reading `type` for an edge finds a schema that is never there and
+ * looks like it worked — the suppression would silently never apply to the one record kind the owner
+ * specifically widened this to cover. `TYPE_FIELD` already encodes that and is reused rather than re-derived.
+ */
+export interface SuppressInputs {
+  /** The per-record flag, if the record carries one. `undefined` means "not stated". */
+  record?: boolean | undefined;
+  /** The type schema for this record's type, if any. */
+  schema?: { suppressEmbeddings?: boolean } | undefined;
+  /** The space-wide setting from the Danger Zone. */
+  space?: boolean | undefined;
+}
+
+/** `record > schema > space`, with "not stated" falling through rather than counting as `false`. */
+export function embeddingSuppressed(i: SuppressInputs): boolean {
+  if (i.record !== undefined) return i.record;
+  if (i.schema?.suppressEmbeddings !== undefined) return i.schema.suppressEmbeddings;
+  return i.space === true;
+}
+
+/**
+ * The type name to look a schema up by, for a given record.
+ *
+ * Exported because the caller has the document and this file has the rule. Returning `undefined` rather than
+ * guessing keeps an untyped record out of the schema tier instead of matching some other type's schema.
+ */
+export function schemaKeyFor(
+  kind: KnowledgeType,
+  doc: Record<string, unknown> | undefined,
+): string | undefined {
+  const field = TYPE_FIELD[kind];
+  const v = doc?.[field];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}

--- a/testing/standalone/suppress-embeddings-tiers.test.js
+++ b/testing/standalone/suppress-embeddings-tiers.test.js
@@ -1,0 +1,80 @@
+/**
+ * `suppressEmbeddings` resolves record > schema > space, and an edge finds its schema by `label`.
+ *
+ * ## Why the order is asserted rather than assumed
+ *
+ * `retention` already resolves in this order, by owner decision. Two tiered settings that resolve differently
+ * is the kind of thing nobody discovers until it is wrong — and "wrong" here means either embedding records
+ * somebody paid to suppress, or silently not embedding records somebody expects to find by meaning. The
+ * second is worse: recall simply stops covering something, and nothing reports it.
+ *
+ * ## The distinction that carries the whole thing
+ *
+ * "Not stated" must fall THROUGH, not count as `false`. A schema saying nothing has to let the space setting
+ * apply; if absent read as "do not suppress", the space-wide switch in the Danger Zone would do nothing for
+ * any type that had a schema at all — which is every type worth suppressing.
+ *
+ * Run: node --test testing/standalone/suppress-embeddings-tiers.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let embeddingSuppressed, schemaKeyFor;
+before(async () => {
+  ({ embeddingSuppressed, schemaKeyFor } = await import('../../server/dist/brain/suppress-embeddings.js'));
+});
+
+describe('the tiers', () => {
+  it('the record wins over both lower tiers, in both directions', () => {
+    assert.equal(embeddingSuppressed({ record: true, schema: { suppressEmbeddings: false }, space: false }), true);
+    assert.equal(embeddingSuppressed({ record: false, schema: { suppressEmbeddings: true }, space: true }), false);
+  });
+
+  it('the schema wins over the space when the record says nothing', () => {
+    assert.equal(embeddingSuppressed({ schema: { suppressEmbeddings: true }, space: false }), true);
+    assert.equal(embeddingSuppressed({ schema: { suppressEmbeddings: false }, space: true }), false);
+  });
+
+  it('the space applies when neither higher tier states anything', () => {
+    assert.equal(embeddingSuppressed({ space: true }), true);
+    assert.equal(embeddingSuppressed({ space: false }), false);
+  });
+
+  it('NOT STATED falls through — it is not `false`', () => {
+    // The distinction the whole thing rests on. If an absent schema flag read as "do not suppress", the
+    // space-wide switch would do nothing for any type that had a schema at all.
+    assert.equal(embeddingSuppressed({ schema: {}, space: true }), true);
+    assert.equal(embeddingSuppressed({ schema: undefined, space: true }), true);
+    assert.equal(embeddingSuppressed({ record: undefined, schema: {}, space: true }), true);
+  });
+
+  it('defaults to embedding when nothing anywhere says otherwise', () => {
+    // Suppression is opt-in. The failure direction of getting this wrong is records silently absent from
+    // recall, which nobody reports because there is nothing to see.
+    assert.equal(embeddingSuppressed({}), false);
+  });
+});
+
+describe('the schema key', () => {
+  it('an EDGE keys on `label`, not `type`', () => {
+    // The trap. EdgeDoc carries both, so reading `type` finds a schema that is never there and looks like it
+    // worked — suppression would silently never apply to edges, the record kind this was widened to cover.
+    assert.equal(schemaKeyFor('edge', { label: 'depends-on', type: 'relation' }), 'depends-on');
+  });
+
+  it('everything else keys on `type`', () => {
+    for (const kind of ['entity', 'memory', 'chrono']) {
+      assert.equal(schemaKeyFor(kind, { type: 'task', label: 'nope' }), 'task', `${kind} used the wrong field`);
+    }
+  });
+
+  it('returns undefined rather than guessing on an untyped record', () => {
+    // Guessing would match some other type's schema and apply its suppression to a record that never
+    // declared one.
+    assert.equal(schemaKeyFor('entity', {}), undefined);
+    assert.equal(schemaKeyFor('entity', undefined), undefined);
+    assert.equal(schemaKeyFor('entity', { type: '' }), undefined);
+    assert.equal(schemaKeyFor('entity', { type: 42 }), undefined);
+  });
+});


### PR DESCRIPTION
feat(brain): the suppressEmbeddings tier resolver

Nothing consults it yet - the schema field, the space-wide setting and the wiring into embedStoredRecord follow. Q-2.

Asked for by an operator with records that are STATE rather than prose: a queue row whose name and description never change, whose weight is PATCHed every tick, and which nobody will ever search for by meaning. Each write re-embedded byte-identical text about 4,800 times a day to produce a vector that already existed.

Resolves record > schema > space, matching retention EXACTLY rather than inventing an order. Two tiered settings that resolve differently is the kind of thing nobody discovers until it is wrong, and there is no reason for this one to be novel.

'Not stated' falls THROUGH; it is not false. If an absent schema flag read as 'do not suppress', the space-wide switch in the Danger Zone would do nothing for any type that had a schema at all - which is every type worth suppressing.

An edge finds its schema by LABEL, not type. EdgeDoc carries both, so reading type finds a schema that is never there and looks like it worked - suppression would silently never apply to edges, the record kind the owner explicitly widened this to cover. TYPE_FIELD already encodes that trap and is reused rather than re-derived.

Also corrected the trackers: the token-rights item is complete and retired, but its proxy-space rider is NOT. enforceSpaceScope still requires reach on EVERY proxy member rather than intersecting them with what the token reaches, which is the pre-matrix rule. Found by reading the guard rather than assuming the matrix carried it, and refiled as Q-6.

