### PR TITLE
tooling(loop): the loop kept stopping, so the rule became a gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Dev tooling: `npm run loop:check`** — decides whether the standing dev-loop may stop, from repo state
+  rather than from judgement. A turn may only end with something in flight (an open PR, so "Running" names a
+  number) or with the queue drained (the release boundary). Otherwise it refuses and prints the next row.
+  - Turned into a gate because the rule was broken five times in one session while being perfectly clear.
+    Every other rule here with that history became a gate — the god-file ratchet, the reachability check,
+    `todo:check`, the audit-route allowlist.
+  - **A tracker edit does not count as work in progress**, which is the specific failure it catches: a reply
+    whose newest work is bookkeeping, with nothing running and no PR open.
+  - Not wired into preflight — preflight guards a *push*, and this guards a *turn ending*.
 - **Internal: the `suppressEmbeddings` tier resolver.** Nothing consults it yet; the schema field, the
   space-wide setting and the wiring into `embedStoredRecord` follow.
   - Asked for by an operator with records that are **state rather than prose**: a queue row whose name and

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:all": "node testing/_init/run-test-all-with-cleanup.mjs",
     "test:client": "npm run test --workspace=client",
     "release:gate": "node ./scripts/release-gate.mjs",
-    "todo:check": "node ./scripts/todo-consistency.mjs"
+    "todo:check": "node ./scripts/todo-consistency.mjs",
+    "loop:check": "node ./scripts/loop-check.mjs"
   },
   "overrides": {
     "protobufjs": "^7.5.5"

--- a/scripts/loop-check.mjs
+++ b/scripts/loop-check.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * `npm run loop:check` — may the turn end here?
+ *
+ * ## Why this exists
+ *
+ * The dev-loop in `todo/_THE_LOOP.md` is a discipline, and it kept failing in the same way: I would finish a
+ * unit of *bookkeeping* — a tracker updated, a blocker recorded, a revert explained — and write the reply. A
+ * reply ends the turn. So the loop did not stop because the work ran out; it stopped because something felt
+ * like a finished thought.
+ *
+ * The owner corrected this five separate times in one session ("are you still in the loop?", "why did you leave
+ * the loop again?", "your loop is buggy"). Five corrections of one behaviour means the rule was never the
+ * problem. Every other rule here that kept being broken became a gate — the god-file ratchet, the reachability
+ * check, `todo:check`, the audit-route allowlist. This is that, for the loop itself.
+ *
+ * ## What it decides
+ *
+ * One question, answered from repo state rather than from how finished I feel: **is something in flight, or is
+ * the queue drained?** Those are the only two states in which a turn may end.
+ *
+ *  - **In flight** — an open PR I authored. Then "Running" is a fact with a number attached, which is what the
+ *    reply format's last slot is supposed to carry.
+ *  - **Drained** — no open `Q-` rows. That is the release boundary the loop is designed to stop at.
+ *
+ * Anything else means work is available and nothing is executing, so the turn must continue. It prints the next
+ * row, so the verdict is "keep going, on this" rather than just "keep going".
+ *
+ * ## The three excuses it refuses by construction
+ *
+ *  - **"I recorded the blocker, so that item is handled."** A blocker on item N is not a stopping condition; it
+ *    is item N being replaced by item N+1 in the same turn. The script sees no PR and open rows, not my reasoning.
+ *  - **"Context is low."** Not a state this reads. Deliberately.
+ *  - **"This is a natural stopping point."** Neither.
+ *
+ * A genuine stop — an owner decision, a live-cluster change, something outward-facing, an external failure — is
+ * still a stop. `--reason "<which>"` puts that claim on the record instead of leaving it implied.
+ *
+ * ## Why it is not wired into preflight
+ *
+ * Preflight guards a *push*. This guards a *turn ending*, which is not an event any hook can observe — so it is
+ * run at the point of writing a reply, and exits non-zero so it reads like every other gate. `todo/` is
+ * gitignored, so like `todo:check` this only ever runs locally; with the folder absent it exits 0 rather than
+ * inventing a verdict.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const ORDERED = 'todo/_TODO-ORDERED.md';
+const C = { red: '\x1b[31m', green: '\x1b[32m', yellow: '\x1b[33m', dim: '\x1b[2m', bold: '\x1b[1m', off: '\x1b[0m' };
+const reason = process.argv.includes('--reason') ? process.argv[process.argv.indexOf('--reason') + 1] : null;
+
+const sh = (cmd) => {
+  // NOT trimmed. `git status --porcelain` puts a meaningful SPACE in column 1 for an unstaged change, and
+  // trimming the aggregate output eats it on the first line only — which is how this once reported `ackage.json`.
+  try { return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }); }
+  catch { return null; }
+};
+
+/**
+ * Open rows in the ordered queue.
+ *
+ * The file is a table, one task per line (owner, 2026-08-09), so a row is a `|`-delimited line whose first cell
+ * is an ID like `Q-2`. Anything else — headers, the `|---|` separator, prose between tables — is not a task.
+ *
+ * Only the `Q-` tier counts. `W-` (watching) and `P-` (parked) rows are exactly why the file can be drained
+ * while still listing things; counting them would make "the queue is empty" unreachable, which is the defect the
+ * retired *behind the tag* tier had. A row whose status says it shipped is not open either — the queue is what
+ * is left, not what was listed.
+ */
+export function parseRows(text) {
+  const rows = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim().startsWith('|')) continue;
+    const cells = line.split('|').map((c) => c.trim()).filter((_, i, a) => i > 0 && i < a.length - 1);
+    const id = cells[0];
+    if (!id || !/^[A-Z]-\d+$/.test(id)) continue;
+    if (!id.startsWith('Q-')) continue;
+    if (/\b(done|shipped|merged)\b/.test((cells[3] ?? '').toLowerCase())) continue;
+    rows.push({ id, what: cells[1] ?? '', status: cells[3] ?? '' });
+  }
+  return rows;
+}
+
+function openRows() {
+  if (!existsSync(ORDERED)) return null;
+  return parseRows(readFileSync(ORDERED, 'utf8'));
+}
+
+/** An open PR authored by me is the only thing that makes "Running" a fact rather than an intention. */
+function openPr() {
+  const out = sh('gh pr list --author @me --state open --json number,title,headRefName --limit 5');
+  if (!out) return null;
+  try { return JSON.parse(out); } catch { return null; }
+}
+
+/**
+ * `XY <path>` lines to paths.
+ *
+ * Anchored on the separating whitespace rather than a fixed width, and accepting one OR two status columns. A
+ * fixed `slice(3)` breaks the moment anything upstream trims the output, and it fails by returning a filename
+ * with its first letter missing — which then matches no extension and reads as a clean tree. A gate that
+ * under-reports is worse than no gate.
+ *
+ * A rename reports `old -> new`; the new path is the one that exists. `todo/` is excluded on purpose: a tracker
+ * edit is precisely what must not count as work in progress.
+ */
+export function sourceFiles(porcelain) {
+  return porcelain.split('\n')
+    .map((l) => l.replace(/^[A-Z?! ]{1,2}\s+/, '').replace(/^.* -> /, '').trim())
+    .filter((f) => f && !f.startsWith('todo/') && /\.(ts|js|mjs|html|css|json|yml|md)$/.test(f));
+}
+
+/** Uncommitted source changes mean a task is half-done in the tree, which is never a place to stop. */
+function dirtySource() {
+  const out = sh('git status --porcelain');
+  return out ? sourceFiles(out) : [];
+}
+
+// Only the CLI renders a verdict; the test imports the two pure helpers above.
+if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('scripts/loop-check.mjs')) main();
+
+function main() {
+  const rows = openRows();
+  const prs = openPr();
+  const dirty = dirtySource();
+
+  console.log(`${C.bold}loop:check${C.off} ${C.dim}— may this turn end?${C.off}\n`);
+
+  if (rows === null) {
+    console.log(`${C.dim}todo/ is absent — nothing to check.${C.off}`);
+    process.exit(0);
+  }
+
+  const inFlight = prs !== null && prs.length > 0;
+  console.log(`  open Q- rows in ${ORDERED}: ${rows.length}`);
+  console.log(`  open PRs authored by me:    ${prs === null ? '(gh unavailable)' : prs.length}` +
+    (inFlight ? ` ${C.dim}-> #${prs.map((p) => p.number).join(', #')}${C.off}` : ''));
+  console.log(`  uncommitted source files:   ${dirty.length}` +
+    (dirty.length ? ` ${C.dim}-> ${dirty.slice(0, 3).join(', ')}${C.off}` : ''));
+  console.log('');
+
+  if (reason) {
+    // Naming a stop puts the claim on the record. The script cannot verify it, but an unnamed stop and a named
+    // one should not look identical afterwards.
+    console.log(`${C.yellow}STOP CLAIMED${C.off} — ${reason}`);
+    console.log(`${C.dim}The genuine stops: an owner decision, a live-cluster change, something${C.off}`);
+    console.log(`${C.dim}outward-facing, or an external failure. Nothing else.${C.off}`);
+    process.exit(0);
+  }
+
+  if (dirty.length) {
+    console.log(`${C.red}DO NOT STOP${C.off} — ${dirty.length} source file(s) are uncommitted.`);
+    console.log('A half-applied change in the tree is a task in progress, not a finished one.');
+    process.exit(1);
+  }
+
+  if (rows.length === 0) {
+    console.log(`${C.green}MAY STOP${C.off} — the queue is drained.`);
+    console.log('That is the release boundary: cut the tag, then open the next audit lens.');
+    process.exit(0);
+  }
+
+  if (inFlight) {
+    console.log(`${C.green}MAY STOP${C.off} — #${prs[0].number} is in flight.`);
+    console.log(`${C.dim}"Running" must name it. Prepare the next PR locally while the Monitor waits on green.${C.off}`);
+    process.exit(0);
+  }
+
+  console.log(`${C.red}DO NOT STOP${C.off} — nothing is in flight and ${rows.length} row(s) are open.`);
+  console.log(`${C.bold}Next: ${rows[0].id} — ${rows[0].what}${C.off}` +
+    (rows[0].status ? ` ${C.dim}(${rows[0].status})${C.off}` : ''));
+  console.log('');
+  console.log(`${C.dim}"Running" with no PR number is the failure signature. So is a reply whose newest${C.off}`);
+  console.log(`${C.dim}work is a tracker edit. Go build ${rows[0].id}, then come back to this.${C.off}`);
+  process.exit(1);
+}

--- a/testing/standalone/loop-check.test.js
+++ b/testing/standalone/loop-check.test.js
@@ -1,0 +1,108 @@
+/**
+ * `loop:check` must fire on the state that actually happened.
+ *
+ * The gate exists because the loop kept stopping with work available and nothing in flight. So the one case
+ * that matters is the one it was written for: **rows open, no PR** must be a refusal. A gate for a repeated
+ * mistake that does not fire on that exact mistake is decoration.
+ *
+ * The two parsing helpers are tested rather than the CLI, because the verdict is trivial once they are right
+ * and both of them have already been wrong once — the status-prefix strip ate the first letter of `package.json`
+ * on its first run.
+ *
+ * Run: node --test testing/standalone/loop-check.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRows, sourceFiles } from '../../scripts/loop-check.mjs';
+
+const TABLE = `# Ordered queue
+
+| # | What | Home | Status | Remark |
+|---|------|------|--------|--------|
+| Q-2 | suppressEmbeddings per type | QA | in progress | tier resolver merged |
+| Q-3 | Split config/types.ts | ARCH | open | |
+| Q-4 | Authenticate CI compose pull | ARCH | open | measure first |
+
+## Watching
+
+| # | What | Home | Status | Remark |
+|---|------|------|--------|--------|
+| W-1 | Mongo boot race | QA | watching | |
+
+## Parked
+
+| # | What | Home | Status | Remark |
+|---|------|------|--------|--------|
+| P-1 | F11-b assist model | FEAT | parked | owner decision |
+`;
+
+describe('the queue rows', () => {
+  it('counts the Q- tier and nothing else', () => {
+    // W- and P- rows are why the file can be "drained" while still listing things. Counting them would make
+    // the queue permanently non-empty, and "cut the tag when the queue is empty" unreachable — the same defect
+    // the retired `behind the tag` tier had.
+    assert.deepEqual(parseRows(TABLE).map((r) => r.id), ['Q-2', 'Q-3', 'Q-4']);
+  });
+
+  it('keeps what the next row IS, so the refusal can name it', () => {
+    const first = parseRows(TABLE)[0];
+    assert.equal(first.what, 'suppressEmbeddings per type');
+    assert.equal(first.status, 'in progress');
+  });
+
+  it('does not read the header or the separator as tasks', () => {
+    assert.equal(parseRows('| # | What | Home | Status |\n|---|---|---|---|\n').length, 0);
+  });
+
+  it('a row marked done is not open', () => {
+    // The queue is what is left, not what was listed. `todo/` is supposed to hold open items only, but a status
+    // cell is the one place a shipped row can linger before the tracker reconcile catches it.
+    const done = TABLE.replace('| Q-3 | Split config/types.ts | ARCH | open |', '| Q-3 | Split config/types.ts | ARCH | shipped |');
+    assert.deepEqual(parseRows(done).map((r) => r.id), ['Q-2', 'Q-4']);
+  });
+
+  it('an empty file is a drained queue, not a parse failure', () => {
+    assert.deepEqual(parseRows(''), []);
+    assert.deepEqual(parseRows('# Ordered queue\n\nNothing open.\n'), []);
+  });
+});
+
+describe('the dirty-tree read', () => {
+  it('strips the status prefix for every column combination', () => {
+    // The bug this test is here for: a fixed `slice(3)` reported `ackage.json`, because git pads a
+    // single-column status differently depending on which slot is set.
+    assert.deepEqual(
+      sourceFiles('M  package.json\n M server/src/a.ts\n?? scripts/b.mjs\nMM client/src/c.html'),
+      ['package.json', 'server/src/a.ts', 'scripts/b.mjs', 'client/src/c.html'],
+    );
+  });
+
+  it('survives a caller that trimmed the whole output', () => {
+    // The actual bug, and the reason the first version of this test passed while the script was broken: the
+    // helper feeding it ran `.trim()` on the aggregate `git status` output, which eats the leading space of the
+    // FIRST line only. So line one arrives with one status column and every later line with two — the script
+    // reported `ackage.json` while a test fed well-formed porcelain and saw nothing wrong.
+    assert.deepEqual(
+      sourceFiles('M package.json\n?? scripts/b.mjs'),
+      ['package.json', 'scripts/b.mjs'],
+    );
+  });
+
+  it('takes the NEW path of a rename', () => {
+    assert.deepEqual(sourceFiles('R  old/a.ts -> new/a.ts'), ['new/a.ts']);
+  });
+
+  it('ignores todo/, because the trackers are gitignored bookkeeping', () => {
+    // A tracker edit is precisely what must NOT count as work in progress — treating it as such would let the
+    // gate pass on the exact state it exists to refuse.
+    assert.deepEqual(sourceFiles('M  todo/_TODO-ORDERED.md'), []);
+  });
+
+  it('ignores files that are not source', () => {
+    assert.deepEqual(sourceFiles('?? notes.txt\n?? shot.png'), []);
+  });
+
+  it('reports nothing for a clean tree', () => {
+    assert.deepEqual(sourceFiles(''), []);
+  });
+});


### PR DESCRIPTION
## What

`npm run loop:check` — a gate that decides whether the standing dev-loop may stop, from repo state rather than
from judgement.

A turn may end in exactly two states:

- **Something in flight** — an open PR I authored. Then "Running" is a fact with a number attached, which is
  what the reply format's last slot is supposed to carry.
- **The queue is drained** — no open `Q-` rows in `todo/_TODO-ORDERED.md`. That is the release boundary the
  loop is designed to stop at.

Anything else means work is available and nothing is executing, so it exits non-zero and prints the next row.

## Why a gate and not a rule

The rule already existed, in `todo/_THE_LOOP.md`, and was clear. It was broken **five times in one session**,
always with the same shape: finish a unit of *bookkeeping* — a tracker updated, a blocker recorded, a revert
explained — and write the reply. A reply ends the turn. The loop did not stop because work ran out; it stopped
because something felt like a finished thought.

The owner's fifth correction named the fix: *"you are not working and there is no open pr. your loop is buggy.
fix your loop first so you dont stop all the time."*

Every other rule in this repo with that history became a gate — the god-file ratchet, the reachability check,
`todo:check`, the audit-route allowlist. Five corrections of one behaviour is evidence the rule was never the
problem.

The case that prompted it: `Q-3` was attempted, hit a type-only import cycle, was reverted, and the blocker was
filed — then reported as **"Next step — Running"** with nothing running and no PR open.

## Three excuses it refuses by construction

- *"I recorded the blocker, so that item is handled."* A blocker on item N is item N+1 **in the same turn**,
  not a stop. The script sees no PR and open rows; it does not see reasoning.
- *"Context is low."* Not a state it reads. Deliberately.
- *"This is a natural stopping point."* Neither.

A genuine stop — an owner decision, a live-cluster change, something outward-facing, a real external failure —
is still a stop. `--reason "<which>"` puts that claim on the record instead of leaving it implied.

## Two things deliberately NOT counted as work in progress

- **An edit under `todo/`.** This is the exact failure being caught: bookkeeping reading as progress. Letting
  it count would make the gate pass on the very state it exists to refuse.
- **A `W-` or `P-` row.** They are why the file can be drained while still listing things. Counting parked rows
  would make "the queue is empty" unreachable — the defect the retired *behind the tag* tier had.

## Two bugs found while testing it, both of the class it exists to catch

A check that **under-reports** is worse than no check:

1. The porcelain reader used `slice(3)`, and the helper feeding it ran `.trim()` on the aggregate `git status`
   output. Trimming eats the leading status space of the **first line only**, so line one arrived with one
   status column and every later line with two. It reported `ackage.json` — which matches no extension and
   therefore reads as *a clean tree*. Fixed at both ends: `sh()` no longer trims, and the strip anchors on the
   separating whitespace rather than a fixed width.
2. **The first version of the test passed while the script was broken**, because it fed well-formed porcelain.
   The trimmed-first-line case is now asserted explicitly, since that is the input that actually occurs.

## Verification

11 tests over the two pure helpers, and mutation-tested against the committed state:

| Mutation | Result |
|---|---|
| `slice(3)` instead of the shape-anchored strip | **killed** (1 fail — the trimmed-first-line test) |
| count every tier, not just `Q-` | **killed** (2 fail) |
| let a `todo/` edit count as work in progress | **killed** (1 fail) |

The first mutation initially read as SURVIVED — the `sed` had never applied, and `grep -c "slice(3)"` matched
the *doc comment* explaining the fix. Re-run against a verified needle, it dies. That is
`shared-global-regex-poisons-the-sweep` again: verify the harness before believing a survivor.

Not wired into preflight — preflight guards a *push*, this guards a *turn ending*, which is not an event a hook
can observe. `todo/` is gitignored, so like `todo:check` it exits 0 when the folder is absent.

🤖 Generated with Claude Code
