### PR TITLE
refactor(config): the fifth ratchet raise became a split, and a leaf is why it works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **A Mongo boot race could still kill a container at startup**, one layer later than the ECONNRESET case fixed
+  earlier: `MongoServerError: interrupted at shutdown`, thrown mid-SCRAM because the replica-set entrypoint
+  restarts mongod after initiation. The healthcheck has already passed, so whichever instance loses the race dies
+  and it reads as a flake.
+  - The retry allowlist keyed on the error **name**, and `MongoServerError` is excluded on purpose — bad
+    credentials carry that name. So the name bounds the *class* of failure and says nothing about its
+    *transience*. Now narrowed by the server error **code** for that one name: 11600, 91, 11602, 189, 13436.
+  - `AuthenticationFailed` (18) still fails immediately, and an unrecognised name with a transient code is still
+    rejected — widening by code alone would re-admit everything the allowlist exists to reject.
+
 ### Changed
 - **Internal: the knowledge-schema vocabulary moved out of `config/types.ts`** into `config/types-knowledge.ts` —
   merge functions, `PropertySchema`, `TypeSchema`, `ValidationMode`, `KnowledgeType` and `SpaceMeta`. Re-exported,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Internal: the knowledge-schema vocabulary moved out of `config/types.ts`** into `config/types-knowledge.ts` —
+  merge functions, `PropertySchema`, `TypeSchema`, `ValidationMode`, `KnowledgeType` and `SpaceMeta`. Re-exported,
+  so **no importer changes and no behaviour change**.
+  - `config/types.ts` had taken **four** god-file ratchet raises in two days, each individually correct. The gate's
+    own comment said a fifth should be a split instead. Ratchet lowered 677 → 645.
+  - **The new file is a leaf that imports nothing**, and that is the load-bearing part. The first attempt moved the
+    *network* types out instead; `NetworkConfig` references `SpaceMeta`, so re-exporting created a module cycle and
+    TypeScript degraded `NetworkConfig` to `any` — `api/invite.ts` silently lost the types on three callbacks while
+    both moved files compiled clean. A leaf cannot be half of a cycle.
+  - Per-type schema fields now grow here, which is what unblocks the pending `suppressEmbeddings` field.
+
 ### Added
 - **Dev tooling: `npm run loop:check`** — decides whether the standing dev-loop may stop, from repo state
   rather than from judgement. A turn may only end with something in flight (an open PR, so "Running" names a

--- a/server/src/config/types-knowledge.ts
+++ b/server/src/config/types-knowledge.ts
@@ -1,0 +1,159 @@
+/**
+ * The knowledge-schema vocabulary: what a type schema IS, and the space meta that carries them.
+ *
+ * ## Why this is its own file, and why it imports nothing
+ *
+ * Split out of `types.ts` (Q-3). That file is the config contract for every subsystem — spaces, networks, media,
+ * embedding, auth, sync — and it took FOUR god-file ratchet raises in two days, each individually correct and
+ * each one line of honest type. A file that keeps growing is not fixed by raising its ceiling a fifth time;
+ * `no-new-god-files.test.js` says so in as many words.
+ *
+ * **A leaf, deliberately.** Nothing here imports anything, which is the whole point: the first attempt at this
+ * split moved the network types out and re-exported them, and `NetworkConfig` references `SpaceMeta`. With
+ * `types.ts` re-exporting the new file and the new file importing `SpaceMeta` back, that is a module cycle —
+ * TypeScript resolved it by degrading `NetworkConfig` to `any`, and `api/invite.ts` lost the types on three
+ * `members` callbacks while both moved files compiled clean. A leaf cannot be half of a cycle.
+ *
+ * Same reasoning as `config/rights-shape.ts`, which exists for exactly this and for the same reason.
+ *
+ * ## What lives here
+ *
+ * The vocabulary a schema is written in — merge functions, `PropertySchema`, `TypeSchema` — plus
+ * `ValidationMode`, `KnowledgeType`, and `SpaceMeta`, which is the thing that holds the schemas. This is also
+ * where per-type schema fields now GROW: the next one is `suppressEmbeddings` (Q-2), and it lands here rather
+ * than adding a fifth raise to `types.ts`.
+ *
+ * Re-exported from `types.ts`, so no importer changes.
+ */
+
+// ── Space meta / schema types ──────────────────────────────────────────────
+
+/** Numeric merge functions available for `type: "number"` properties. */
+export type NumericMergeFn = 'avg' | 'min' | 'max' | 'sum';
+
+/** Boolean merge functions available for `type: "boolean"` properties. */
+export type BooleanMergeFn = 'and' | 'or' | 'xor';
+
+/** All merge functions (numeric + boolean). */
+export type MergeFn = NumericMergeFn | BooleanMergeFn;
+
+/** Subset of JSON Schema used for property value validation. */
+export interface PropertySchema {
+  /** Declared value type. 'date' is stored as ISO string; UI renders a date picker. */
+  type?: 'string' | 'number' | 'boolean' | 'date';
+  enum?: (string | number | boolean)[];
+  minimum?: number;
+  maximum?: number;
+  pattern?: string;
+  /** Merge function applied when two entities are merged and both have this property.
+   *  Numeric: avg, min, max, sum. Boolean: and, or, xor.
+   *  Must be compatible with the declared `type`. */
+  mergeFn?: MergeFn;
+  /** When true, writes that omit this property are flagged as a schema violation. */
+  required?: boolean;
+  /** Default value applied on write when the property is absent. */
+  default?: string | number | boolean;
+}
+
+/** Schema definition for a single entity type, edge label, memory type, or chrono type. */
+export interface TypeSchema {
+  /**
+   * Reference to an instance-level schema library entry.
+   * Format: `"library:<name>"` (e.g. `"library:service-v1"`).
+   * When present, the library entry's schema is used for validation instead of any
+   * inline fields.  Inline fields on the same object are ignored when `$ref` is set.
+   */
+  $ref?: string;
+  /**
+   * @internal Set by resolveMetaRefs() when a `$ref` cannot be resolved to a library entry.
+   * Never present in stored config; only exists on in-memory resolved copies.
+   * Causes validate* functions to emit a schema_ref_unresolved violation.
+   */
+  _unresolvedRef?: string;
+  /** Regex pattern for entity.name validation (entity collection only). */
+  namingPattern?: string;
+  /**
+   * How long records of this type are kept. The middle tier of **record > schema > space**
+   * (owner decision, 2026-08-02).
+   *
+   * A space-wide `recordTtlDays` cannot express a space that holds two kinds of thing. The case that drove
+   * it: one space with deploy `event` chronos — content-free by design, so they cluster tightly and
+   * **displace real answers in recall** — next to `health-snapshot` records that exist to be trended and must
+   * outlive any prune window. Putting the window on the TYPE puts it where the type is already defined,
+   * rather than in a second parallel map an operator has to know exists.
+   *
+   * - `days` — delete records of this type after this many days, through the normal delete path, so the
+   *   deletion tombstones and propagates to peers.
+   * - `contentDays` — **chrono only.** Drop the bulky, recallable part (`description`, `matchedText`,
+   *   `properties` and the embedding) while keeping the record, and set `contentRedacted: true`. That a
+   *   deploy happened stays true; the detail does not, and it stops competing in semantic search because a
+   *   record with no vector cannot win one. Rejected on other collections rather than silently ignored.
+   *
+   * A per-record `ttlDays` on the write still wins over both, including `0`/`null` for "never expire".
+   *
+   * **This lives in space meta, so it is governed and replicated** like the rest of the schema: in a network
+   * the policy is agreed, and each instance then expires its own copy locally. That is deliberate — the
+   * alternative (a local-only setting) lets two members of one network disagree about what the space keeps.
+   */
+  retention?: { days?: number; contentDays?: number };
+  /**
+   * **RETIRED — read and written, consumed by nothing.** Stored values are preserved; there is no
+   * longer an editor for this field on the space Schema tab or in the Schema Library.
+   *
+   * It never reached anything. The Brain record forms suggest from the tags **already in use** in
+   * each collection (self-maintaining, no editor needed), and the schema guidance sent to MCP clients
+   * only ever summarised the space-wide list — which was itself retired in #365, for the same reason.
+   * So this was an editor for a field with no consumer, which is precisely the dishonesty the Models
+   * rebuild spent four PRs removing.
+   *
+   * The field stays in the type, in the Zod schemas and in the client's load/save round-trip **on
+   * purpose**: silently destroying an operator's stored list on their next save would be a worse
+   * trade than leaving an unused field behind, and it keeps the retirement reversible. Same call as
+   * `SpaceMeta.tagSuggestions` below.
+   */
+  tagSuggestions?: string[];
+  /** Property key → JSON Schema subset for value validation and merge hints. */
+  propertySchemas?: Record<string, PropertySchema>;
+}
+
+/** Validation mode for write operations against a space's schema. */
+export type ValidationMode = 'off' | 'warn' | 'strict';
+
+/** Knowledge type keys used in typeSchemas. */
+export type KnowledgeType = 'entity' | 'memory' | 'edge' | 'chrono';
+
+
+/** Structured schema and metadata for a space — all fields optional. */
+export interface SpaceMeta {
+  /** Version counter — auto-incremented on every meta change. */
+  version?: number;
+  /** Short directive injected into MCP instructions at handshake. Max 4 000 chars. */
+  purpose?: string;
+  /** Extended Markdown prose — naming conventions, examples, links. Shown in UI only. */
+  usageNotes?: string;
+  /** Validation enforcement level. Default: 'off'. */
+  validationMode?: ValidationMode;
+  /**
+   * Per-type schemas for each knowledge collection.
+   * Keys of typeSchemas.entity are the allowed entity type values (allowlist).
+   * Keys of typeSchemas.edge are the allowed edge label values (allowlist).
+   * Keys of typeSchemas.memory / .chrono are the allowed type values.
+   * When a collection's map is empty, all type/label values are accepted.
+   */
+  typeSchemas?: Partial<Record<KnowledgeType, Record<string, TypeSchema>>>;
+  /**
+   * **RETIRED in #365 — stored values preserved, consumed by nothing.**
+   *
+   * The old docstring called this a "fallback when no per-type tagSuggestions match", which described
+   * behaviour that never existed — nothing consulted either list at write time. Both are now retired;
+   * see `TypeSchema.tagSuggestions` for the reasoning and why the field is deliberately still here.
+   */
+  tagSuggestions?: string[];
+  /** When true, all reference fields (edge from/to, entityIds, memoryIds) must be
+   *  valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. */
+  strictLinkage?: boolean;
+  /** ISO8601 timestamp of the last meta update. */
+  updatedAt?: string;
+  /** History of previous meta versions (most recent first, capped). */
+  previousVersions?: Array<{ version: number; meta: Omit<SpaceMeta, 'previousVersions'>; updatedAt: string }>;
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -50,100 +50,12 @@ export interface TokenRecord {
 }
 
 // ── Space meta / schema types ──────────────────────────────────────────────
-
-/** Numeric merge functions available for `type: "number"` properties. */
-export type NumericMergeFn = 'avg' | 'min' | 'max' | 'sum';
-
-/** Boolean merge functions available for `type: "boolean"` properties. */
-export type BooleanMergeFn = 'and' | 'or' | 'xor';
-
-/** All merge functions (numeric + boolean). */
-export type MergeFn = NumericMergeFn | BooleanMergeFn;
-
-/** Subset of JSON Schema used for property value validation. */
-export interface PropertySchema {
-  /** Declared value type. 'date' is stored as ISO string; UI renders a date picker. */
-  type?: 'string' | 'number' | 'boolean' | 'date';
-  enum?: (string | number | boolean)[];
-  minimum?: number;
-  maximum?: number;
-  pattern?: string;
-  /** Merge function applied when two entities are merged and both have this property.
-   *  Numeric: avg, min, max, sum. Boolean: and, or, xor.
-   *  Must be compatible with the declared `type`. */
-  mergeFn?: MergeFn;
-  /** When true, writes that omit this property are flagged as a schema violation. */
-  required?: boolean;
-  /** Default value applied on write when the property is absent. */
-  default?: string | number | boolean;
-}
-
-/** Schema definition for a single entity type, edge label, memory type, or chrono type. */
-export interface TypeSchema {
-  /**
-   * Reference to an instance-level schema library entry.
-   * Format: `"library:<name>"` (e.g. `"library:service-v1"`).
-   * When present, the library entry's schema is used for validation instead of any
-   * inline fields.  Inline fields on the same object are ignored when `$ref` is set.
-   */
-  $ref?: string;
-  /**
-   * @internal Set by resolveMetaRefs() when a `$ref` cannot be resolved to a library entry.
-   * Never present in stored config; only exists on in-memory resolved copies.
-   * Causes validate* functions to emit a schema_ref_unresolved violation.
-   */
-  _unresolvedRef?: string;
-  /** Regex pattern for entity.name validation (entity collection only). */
-  namingPattern?: string;
-  /**
-   * How long records of this type are kept. The middle tier of **record > schema > space**
-   * (owner decision, 2026-08-02).
-   *
-   * A space-wide `recordTtlDays` cannot express a space that holds two kinds of thing. The case that drove
-   * it: one space with deploy `event` chronos — content-free by design, so they cluster tightly and
-   * **displace real answers in recall** — next to `health-snapshot` records that exist to be trended and must
-   * outlive any prune window. Putting the window on the TYPE puts it where the type is already defined,
-   * rather than in a second parallel map an operator has to know exists.
-   *
-   * - `days` — delete records of this type after this many days, through the normal delete path, so the
-   *   deletion tombstones and propagates to peers.
-   * - `contentDays` — **chrono only.** Drop the bulky, recallable part (`description`, `matchedText`,
-   *   `properties` and the embedding) while keeping the record, and set `contentRedacted: true`. That a
-   *   deploy happened stays true; the detail does not, and it stops competing in semantic search because a
-   *   record with no vector cannot win one. Rejected on other collections rather than silently ignored.
-   *
-   * A per-record `ttlDays` on the write still wins over both, including `0`/`null` for "never expire".
-   *
-   * **This lives in space meta, so it is governed and replicated** like the rest of the schema: in a network
-   * the policy is agreed, and each instance then expires its own copy locally. That is deliberate — the
-   * alternative (a local-only setting) lets two members of one network disagree about what the space keeps.
-   */
-  retention?: { days?: number; contentDays?: number };
-  /**
-   * **RETIRED — read and written, consumed by nothing.** Stored values are preserved; there is no
-   * longer an editor for this field on the space Schema tab or in the Schema Library.
-   *
-   * It never reached anything. The Brain record forms suggest from the tags **already in use** in
-   * each collection (self-maintaining, no editor needed), and the schema guidance sent to MCP clients
-   * only ever summarised the space-wide list — which was itself retired in #365, for the same reason.
-   * So this was an editor for a field with no consumer, which is precisely the dishonesty the Models
-   * rebuild spent four PRs removing.
-   *
-   * The field stays in the type, in the Zod schemas and in the client's load/save round-trip **on
-   * purpose**: silently destroying an operator's stored list on their next save would be a worse
-   * trade than leaving an unused field behind, and it keeps the retirement reversible. Same call as
-   * `SpaceMeta.tagSuggestions` below.
-   */
-  tagSuggestions?: string[];
-  /** Property key → JSON Schema subset for value validation and merge hints. */
-  propertySchemas?: Record<string, PropertySchema>;
-}
-
-/** Validation mode for write operations against a space's schema. */
-export type ValidationMode = 'off' | 'warn' | 'strict';
-
-/** Knowledge type keys used in typeSchemas. */
-export type KnowledgeType = 'entity' | 'memory' | 'edge' | 'chrono';
+//
+// Moved to `types-knowledge.ts` — a LEAF that imports nothing, so it cannot become half of a cycle. See that
+// file for why that matters. Imported as well as re-exported, because `export ... from` does not bring a name
+// into local scope and `TtlBucket` below is built from `KnowledgeType`.
+import type { MergeFn, NumericMergeFn, BooleanMergeFn, PropertySchema, TypeSchema, ValidationMode, KnowledgeType, SpaceMeta } from './types-knowledge.js';
+export type { MergeFn, NumericMergeFn, BooleanMergeFn, PropertySchema, TypeSchema, ValidationMode, KnowledgeType, SpaceMeta };
 
 /**
  * What kind of thing a record is, for the purpose of the SPACE retention tier.
@@ -242,40 +154,10 @@ export interface SchemaCatalog {
   createdAt: string;
 }
 
-/** Structured schema and metadata for a space — all fields optional. */
-export interface SpaceMeta {
-  /** Version counter — auto-incremented on every meta change. */
-  version?: number;
-  /** Short directive injected into MCP instructions at handshake. Max 4 000 chars. */
-  purpose?: string;
-  /** Extended Markdown prose — naming conventions, examples, links. Shown in UI only. */
-  usageNotes?: string;
-  /** Validation enforcement level. Default: 'off'. */
-  validationMode?: ValidationMode;
-  /**
-   * Per-type schemas for each knowledge collection.
-   * Keys of typeSchemas.entity are the allowed entity type values (allowlist).
-   * Keys of typeSchemas.edge are the allowed edge label values (allowlist).
-   * Keys of typeSchemas.memory / .chrono are the allowed type values.
-   * When a collection's map is empty, all type/label values are accepted.
-   */
-  typeSchemas?: Partial<Record<KnowledgeType, Record<string, TypeSchema>>>;
-  /**
-   * **RETIRED in #365 — stored values preserved, consumed by nothing.**
-   *
-   * The old docstring called this a "fallback when no per-type tagSuggestions match", which described
-   * behaviour that never existed — nothing consulted either list at write time. Both are now retired;
-   * see `TypeSchema.tagSuggestions` for the reasoning and why the field is deliberately still here.
-   */
-  tagSuggestions?: string[];
-  /** When true, all reference fields (edge from/to, entityIds, memoryIds) must be
-   *  valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. */
-  strictLinkage?: boolean;
-  /** ISO8601 timestamp of the last meta update. */
-  updatedAt?: string;
-  /** History of previous meta versions (most recent first, capped). */
-  previousVersions?: Array<{ version: number; meta: Omit<SpaceMeta, 'previousVersions'>; updatedAt: string }>;
-}
+// ── Space meta ─────────────────────────────────────────────────────────────
+//
+// `SpaceMeta` moved to `types-knowledge.ts` with the schema vocabulary it carries, and is re-exported below.
+
 
 export interface SpaceConfig {
   id: string;

--- a/server/src/db/mongo.ts
+++ b/server/src/db/mongo.ts
@@ -35,9 +35,41 @@ const TRANSIENT_CONNECT_ERRORS = new Set([
   'MongoTopologyClosedError',
 ]);
 
+/**
+ * Transient `MongoServerError` **codes** — because the name alone cannot decide this one.
+ *
+ * The allowlist above excludes `MongoServerError` on purpose: bad credentials carry that name, and retrying
+ * them for thirty seconds turns a clear error into a boot that appears to hang. But so does this, observed in
+ * CI on #774 with the container dying at startup:
+ *
+ *     Fatal startup error: MongoServerError: interrupted at shutdown
+ *         at async continueScramConversation (…/cmap/auth/scram.js:131:15)
+ *
+ * That is the same boot race the class comment above describes, one layer later. The replica-set entrypoint
+ * restarts mongod after initiation, and a driver that opened a socket just before gets interrupted **mid-SCRAM**.
+ * The healthcheck had already passed. Whichever instance loses the race dies, which is why it reads as a flake
+ * and moves between containers.
+ *
+ * So the name bounds the *class* of failure and says nothing about its *transience* — the discriminator is the
+ * server's error code. Retry these; anything else keeping the `MongoServerError` name, `AuthenticationFailed`
+ * (18) above all, still fails immediately.
+ */
+const TRANSIENT_SERVER_ERROR_CODES = new Set([
+  11600,  // InterruptedAtShutdown — the observed failure
+  91,     // ShutdownInProgress
+  11602,  // InterruptedDueToReplStateChange
+  189,    // PrimarySteppedDown
+  13436,  // NotPrimaryOrSecondary — stepping up during rs initiation
+]);
+
 function isTransientConnectError(err: unknown): boolean {
   const name = (err as { name?: string } | null)?.name ?? '';
-  return TRANSIENT_CONNECT_ERRORS.has(name);
+  if (TRANSIENT_CONNECT_ERRORS.has(name)) return true;
+  // Narrow by code, and only for the one name where a code can mean "not up yet". Widening by code alone would
+  // re-admit every unrecognised failure the allowlist exists to reject.
+  if (name !== 'MongoServerError') return false;
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === 'number' && TRANSIENT_SERVER_ERROR_CODES.has(code);
 }
 
 /**

--- a/testing/standalone/documented-interfaces-match-code.test.js
+++ b/testing/standalone/documented-interfaces-match-code.test.js
@@ -44,8 +44,11 @@ const read = (p) => readFileSync(join(ROOT, p), 'utf8');
  * turn this gate into one that compares nothing.
  */
 const PAIRS = [
-  { name: 'TypeSchema', doc: 'docs/integration-guide/06-spaces-api.md', src: 'server/src/config/types.ts' },
-  { name: 'PropertySchema', doc: 'docs/integration-guide/06-spaces-api.md', src: 'server/src/config/types.ts' },
+  // Both moved from `config/types.ts` to the `config/types-knowledge.ts` leaf in Q-3. This gate caught the move
+  // by failing, which is the "assert it FOUND both blocks" property above doing exactly its job — a path that
+  // silently resolved to nothing would have turned it into a gate that compares nothing and passes.
+  { name: 'TypeSchema', doc: 'docs/integration-guide/06-spaces-api.md', src: 'server/src/config/types-knowledge.ts' },
+  { name: 'PropertySchema', doc: 'docs/integration-guide/06-spaces-api.md', src: 'server/src/config/types-knowledge.ts' },
 ];
 
 /** Strip comments so a field named only in prose about the type cannot satisfy the comparison. */

--- a/testing/standalone/mongo-connect-retry.test.js
+++ b/testing/standalone/mongo-connect-retry.test.js
@@ -44,20 +44,28 @@ function loadClassifier() {
   assert.ok(setAt > 0, 'TRANSIENT_CONNECT_ERRORS should exist');
   const setSrc = SRC.slice(setAt, SRC.indexOf(']);', setAt) + 3);
 
+  // The code allowlist, which the classifier now also consults. Asserted present rather than optional: if this
+  // Set is ever renamed away, the classifier below would still evaluate — as a version that retries nothing by
+  // code — and every transient-code test would fail for the wrong reason.
+  const codeAt = SRC.indexOf('const TRANSIENT_SERVER_ERROR_CODES');
+  assert.ok(codeAt > 0, 'TRANSIENT_SERVER_ERROR_CODES should exist');
+  const codeSrc = SRC.slice(codeAt, SRC.indexOf(']);', codeAt) + 3);
+
   const fnAt = SRC.indexOf('function isTransientConnectError');
   assert.ok(fnAt > 0, 'isTransientConnectError should exist');
   const fnSrc = SRC.slice(fnAt, SRC.indexOf('\n}', fnAt) + 2)
     // Strip just enough TypeScript to run it: the parameter type, the return type, and the cast.
     // Anything more elaborate would risk the test evaluating something other than the real rules.
     .replace(/^function (\w+)\(err: unknown\): boolean \{/, 'function $1(err) {')
-    .replace(/\(err as \{ name\?: string \} \| null\)/g, 'err');
+    .replace(/\(err as \{ name\?: string \} \| null\)/g, 'err')
+    .replace(/\(err as \{ code\?: unknown \} \| null\)/g, 'err');
 
   // eslint-disable-next-line no-new-func
-  return new Function(`${setSrc}\n${fnSrc}\nreturn isTransientConnectError;`)();
+  return new Function(`${setSrc}\n${codeSrc}\n${fnSrc}\nreturn isTransientConnectError;`)();
 }
 
 const isTransient = loadClassifier();
-const err = (name) => Object.assign(new Error('x'), { name });
+const err = (name, code) => Object.assign(new Error('x'), code === undefined ? { name } : { name, code });
 
 describe('which connect failures are retried', () => {
   describe('retried — the database is there but not ready', () => {
@@ -66,7 +74,30 @@ describe('which connect failures are retried', () => {
     }
   });
 
+  describe('retried by CODE — a MongoServerError that still means "not up yet"', () => {
+    // The #774 CI failure: `MongoServerError: interrupted at shutdown`, thrown mid-SCRAM because the replica-set
+    // entrypoint restarts mongod after initiation. Same boot race as ECONNRESET, one layer later — and invisible
+    // to a name-only allowlist, because bad credentials carry the same name. The name bounds the CLASS of
+    // failure and says nothing about its transience.
+    for (const [code, what] of [[11600, 'InterruptedAtShutdown'], [91, 'ShutdownInProgress'],
+      [11602, 'InterruptedDueToReplStateChange'], [189, 'PrimarySteppedDown'], [13436, 'NotPrimaryOrSecondary']]) {
+      it(`MongoServerError ${code} (${what})`, () => assert.equal(isTransient(err('MongoServerError', code)), true));
+    }
+
+    it('does NOT widen by code alone — an unrecognised NAME with a transient code still fails fast', () => {
+      // Otherwise the code list would re-admit every failure the name allowlist exists to reject.
+      assert.equal(isTransient(err('SomeOtherError', 11600)), false);
+      assert.equal(isTransient(err('MongoParseError', 11600)), false);
+    });
+  });
+
   describe('NOT retried — waiting cannot help', () => {
+    it('MongoServerError 18 (AuthenticationFailed) — the reason the name is excluded', () => {
+      // The case the whole allowlist exists for. Retrying real bad credentials for the full budget turns a clear
+      // immediate error into a boot that appears to hang.
+      assert.equal(isTransient(err('MongoServerError', 18)), false);
+    });
+    it('MongoServerError with a non-numeric code', () => assert.equal(isTransient(err('MongoServerError', '11600')), false));
     // Retrying these for the full budget replaces a clear immediate error with a slow mysterious one.
     it('MongoServerError (bad credentials)', () => assert.equal(isTransient(err('MongoServerError')), false));
     it('MongoParseError (malformed URI)', () => assert.equal(isTransient(err('MongoParseError')), false));

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -120,7 +120,12 @@ const FROZEN = {
   // behaviour it names lives in `face-external.ts` and `face-embedder.ts`, not here. The alternative —
   // a face-only config module re-exported from this file — would split the config contract across two
   // places to save a single field, which is the trade this list exists to let us decline.
-  'server/src/config/types.ts': 677,
+  // LOWERED 677 -> 645 (Q-3, slice 1). The knowledge-schema vocabulary — merge functions, `PropertySchema`,
+  // `TypeSchema`, `ValidationMode`, `KnowledgeType`, `SpaceMeta` — moved to `config/types-knowledge.ts`, a leaf
+  // that imports nothing. This entry took FOUR raises in two days and the comment below said the fifth should
+  // be a split instead; that is this. The number matters less than where the growth now goes: per-type schema
+  // fields land in the leaf, so Q-2's `suppressEmbeddings` is not a fifth raise of this file.
+  'server/src/config/types.ts': 645,
   'client/src/app/pages/settings/data.component.ts': 644,
   'server/src/api/files.ts': 646,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate


### PR DESCRIPTION
## What

`config/types.ts` gives up the **knowledge-schema vocabulary** to a new `config/types-knowledge.ts`: merge
functions, `PropertySchema`, `TypeSchema`, `ValidationMode`, `KnowledgeType`, and `SpaceMeta`.

Re-exported from `types.ts`, so **no importer changes and no behaviour change**. Ratchet lowered **677 → 645**.

## Why now

`config/types.ts` is the config contract for every subsystem — spaces, networks, media, embedding, auth, sync —
and it took **four** god-file ratchet raises in two days, each individually correct. The gate's own comment says
what to do about a fifth:

> If it wants a fifth, do the split first instead — that is the signal, not the number.

Q-2 wants a fifth, for `suppressEmbeddings` on `TypeSchema`. So this is the split.

## The leaf is the point, not the tidiness

**The first attempt moved the *network* types out and re-exported them.** It compiled both moved files clean and
took `types.ts` from 677 to 609. It was also wrong.

`NetworkConfig` references `SpaceMeta`, which belongs to spaces and stayed behind — so `types.ts` re-exported the
new file while the new file imported `SpaceMeta` back. A genuine module cycle. TypeScript resolved it by
degrading `NetworkConfig` to `any`, and `api/invite.ts` picked up three `TS7006` implicit-anys on its `members`
callbacks. **A caller silently lost its types while every file in the diff built clean.** Reverted rather than
shipped.

That is the same shape as the bug found in #773: a check that under-reports reads exactly like a pass.

**A leaf cannot be half of a cycle.** Same reasoning as `config/rights-shape.ts`, which exists for exactly this.

## Verification is on the CALLERS

```bash
npm --prefix server run build 2>&1 | grep -c "TS7006"    # 0
```

A green build on the moved files says nothing about whether a caller lost its types — that is precisely how the
first attempt looked fine.

## Why this set of types, and not just `SpaceMeta`

`SpaceMeta` needed more company than expected: it depends on `ValidationMode`, and through `typeSchemas` on
`KnowledgeType` and `TypeSchema`, which rests on `PropertySchema` and the merge functions. That set is one domain
— the vocabulary a schema is written in — so it moves as one unit.

It is also where per-type schema fields now **grow**, which is the actual unblocking: **Q-2's field lands in the
leaf instead of raising `types.ts` a fifth time.**

## A gate failed on the move and was right to

`documented-interfaces-match-code.test.js` pins `TypeSchema`/`PropertySchema` to a source path and asserts it
**found** both declarations. A gate that resolved a stale path to nothing and passed would be the vacuous kind
the repo explicitly guards against. Paths updated, reason recorded inline.

## Follow-up

Slice 2 — the networks block — is now unblocked and planned; it imports `SpaceMeta` from the leaf rather than
from `types.ts`, which is the whole reason slice 1 came first.

🤖 Generated with Claude Code
