### PR TITLE
feat(brain): a way back from suppressEmbeddings, and the sweep that was only ever a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`POST /api/spaces/:id/reembed` — the way back from `suppressEmbeddings`.** Queues an embedding job for every
+  record in a space that has no vector. Owner: *"there should be a way to backfill"*.
+  - **A record still suppressed at any tier is skipped**, using the same resolver the write path uses, so a
+    backfill cannot re-index what an operator asked to keep out of recall. Running it while suppression is on is
+    not an error — every candidate comes back under `skippedSuppressed`, which says the setting is still on.
+  - **It queues rather than embeds.** A large space would time out mid-way through inline work with no record of
+    where it stopped. Idempotent per record, so a repeated call converges.
+  - **Nothing is truncated silently:** `remaining` is counted over the space rather than the page, and
+    `truncated` says a further call is needed.
+  - Filters on `embedding: {$exists: false}`, not `null` — suppression `$unset`s the field, and a `null` filter
+    would match nothing and report a clean sweep over an entirely unindexed space.
+
+### Fixed
+- **A comment promised a repair mechanism that had never been built.** `enqueueEmbedJob` swallows its error
+  rather than failing the caller's write, justified by "the periodic backfill sweep will find it" — **there was
+  no such sweep**. A swallowed enqueue meant a record silently missing from recall forever, with no error, no
+  metric and nothing to grep for. The repair now exists, and the comment states that it is on demand rather than
+  periodic, because "it will be picked up" and "an operator can pick it up" are different promises.
+
 - **`suppressEmbeddings` — skip embedding records that are state rather than prose.** Now wired end to end, on
   three tiers resolving **record > schema > space**, the same order `retention` uses.
   - `TypeSchema.suppressEmbeddings` suppresses one type; `SpaceMeta.suppressEmbeddings` suppresses a whole space.

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -171,6 +171,63 @@ The rename atomically:
 
 ---
 
+### Re-embed backfill
+
+```http
+POST /api/spaces/:id/reembed
+Authorization: Bearer <admin-token>
+```
+
+Queues an embedding job for every record in the space that **has no vector**. This is the way back from
+`suppressEmbeddings`: suppression leaves records unembedded, and nothing revisits them on its own, so recall stays
+blind to whatever was written while it was on.
+
+It is also the repair for an embedding that never got queued — an enqueue failure is deliberately swallowed rather
+than failing the write, which leaves exactly this state.
+
+**Body — all fields optional.** An empty body sweeps every record kind at the default limit.
+
+| Field | Description |
+|-------|-------------|
+| `kinds` | Narrow the sweep: any of `memory`, `entity`, `edge`, `chrono`, `file`. Omitted means all five. |
+| `limit` | Maximum records to queue in one call. Default 5000, maximum 50000. |
+
+An unknown field is a `400` rather than being ignored — a caller who meant to narrow the sweep and silently got
+all of it would be worse off than one who got an error.
+
+**Response** `200`:
+
+```json
+{
+  "spaceId": "research",
+  "enqueued": 1284,
+  "skippedSuppressed": 0,
+  "byKind": { "memory": 900, "entity": 384 },
+  "remaining": 0,
+  "truncated": false
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `enqueued` | Records a job was queued for. Embedding happens in the background afterwards. |
+| `skippedSuppressed` | Candidates skipped because suppression **still applies**. See the note below. |
+| `byKind` | Where the gap was, per record kind. |
+| `remaining` | Candidates left after `limit`. Counted over the whole space, not over this page. |
+| `truncated` | `true` when `remaining > 0` — call again to continue. |
+
+> **Turn suppression off first.** A record that is still suppressed at any tier is skipped, so that a backfill
+> cannot re-index what an operator asked to keep out of recall. Running this while suppression is on is not an
+> error: every candidate comes back under `skippedSuppressed`, which tells you the setting is still on.
+
+**It queues rather than embeds.** A large space would time out mid-way through inline embedding, having done
+partial work with no record of where it stopped. Queuing is idempotent per record, so repeating the call over the
+same space converges instead of duplicating work.
+
+**Nothing is truncated silently** — when more candidates remain than `limit` allowed, `remaining` says how many.
+
+---
+
 ### Update a Space
 
 ```http
@@ -765,7 +822,7 @@ What the schema enforces:
 | `typeSchemas` | Per-type schema definitions (see above). **The PATCH merge is exactly two levels deep, and the second one REPLACES.** A knowledge type you do not mention is preserved; a *type name* you do not mention inside one is preserved; but a type name you **do** mention has its definition object **replaced wholesale**, not merged. So `PATCH {"meta":{"typeSchemas":{"chrono":{"event":{"retention":{"days":90}}}}}}` leaves `entity` and every other chrono type untouched — and wipes `event`'s own `propertySchemas`, `namingPattern` and `tagSuggestions`. **Read the type first and send it back complete.** Deleting a type needs `PUT /:id/schema` (full replace), because under merge semantics an absent type is indistinguishable from a removed one. |
 | `tagSuggestions` | **Retired.** A space-wide list of non-enforced tag hints. It is still accepted and stored (so an existing list is preserved untouched, and the change is reversible) but nothing reads it: it no longer feeds tag autocomplete in the Brain record forms, and no longer appears in the schema guidance returned to MCP clients. It was one list, editable in a single place, applied to every type and every form in the space — easy to set once and forget while quietly steering what got tagged. Autocomplete now comes from the tags actually in use, which maintains itself. **The per-type `typeSchemas.<kind>.<type>.tagSuggestions` is retired on exactly the same terms** — stored, returned, read by nothing, no editor. An earlier revision of this line said it was "unaffected", which contradicted the `typeSchemas` section above and left an integrator unable to tell which sentence was current; both lists are dead, and clearing either is safe. `null` is **rejected** with a 400 on a meta write; `[]` empties the list and is the way to clear one. There is no route that removes a top-level `meta` key, so the field itself stays present and empty — which is what makes the retirement reversible. |
 | `strictLinkage` | When `true`, all reference fields (`from`/`to`, `entityIds`, `memoryIds`) must be valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. **Default: `true`** — and an absent value also resolves to `true`. Turning it off is a deliberate per-space choice to accept dangling references (the case it exists for is bulk import, where targets are resolved in a later pass); you do not get that by saying nothing. |
-| `suppressEmbeddings` | When `true`, records in this space are **not embedded**, so they never appear in semantic recall. **Default: `false`** — suppression is opt-in. This is the LOWEST of three tiers: a per-record `excludeFromVectorSearch` wins, then a type's own `suppressEmbeddings`, then this. A type schema that says nothing falls through to this value rather than overriding it with `false`. Intended for records that are **state rather than prose** — a row whose text never changes but whose numbers are patched constantly, which would otherwise re-embed identical text on every write. **Switching it off does not backfill:** records written while it was on have no vector and nothing revisits them, so recall stays blind to them until each is written again. There is no bulk re-embed endpoint; re-saving a record re-embeds that record. |
+| `suppressEmbeddings` | When `true`, records in this space are **not embedded**, so they never appear in semantic recall. **Default: `false`** — suppression is opt-in. This is the LOWEST of three tiers: a per-record `excludeFromVectorSearch` wins, then a type's own `suppressEmbeddings`, then this. A type schema that says nothing falls through to this value rather than overriding it with `false`. Intended for records that are **state rather than prose** — a row whose text never changes but whose numbers are patched constantly, which would otherwise re-embed identical text on every write. **Switching it off does not backfill on its own** — records written while it was on have no vector and nothing revisits them. Run [`POST /api/spaces/:id/reembed`](#re-embed-backfill) afterwards to queue the missing ones. |
 | `purpose` | Short description of the space (max 4000 chars). Returned by `get_space_meta`. |
 | `usageNotes` | Extended Markdown-formatted guidance for LLM clients (max 50 000 chars — the settings form shows a live count and accepts the same limit). Returned by `get_space_meta`. |
 

--- a/server/src/api/spaces-reembed.ts
+++ b/server/src/api/spaces-reembed.ts
@@ -1,0 +1,66 @@
+/**
+ * `POST /api/spaces/:id/reembed` — its own module, because `api/spaces.ts` is a frozen god-file.
+ *
+ * Adding this route inline took that file from 847 to 875 code lines, one PR after it was raised from 844 for
+ * `suppressEmbeddings`. Two raises in two PRs is the pattern the ratchet exists to report, and `config/types.ts`
+ * is the cautionary tale: four individually-correct raises in two days, each one answered by raising it again.
+ *
+ * A route is the easiest thing in that file to move, since nothing else references it. The sweep, the suppression
+ * check and the bounding live one layer further out again in `brain/reembed.ts` — this module is only the HTTP
+ * shape: validate, delegate, report.
+ */
+
+import type { Router } from 'express';
+import { z } from 'zod';
+import { globalRateLimit } from '../rate-limit/middleware.js';
+import { requireAdminMfaScoped } from '../auth/middleware.js';
+import { getConfig } from '../config/loader.js';
+import { reembedSpace, REEMBED_MAX_LIMIT } from '../brain/reembed.js';
+import { log } from '../util/log.js';
+
+/**
+ * Body for the re-embed backfill. Every field optional — `POST` with no body sweeps everything at the default
+ * limit, which is the common case.
+ *
+ * `.strict()` so a misspelled `kind` is a 400 rather than a silent full sweep. A caller who meant to narrow and
+ * got everything would be told they had narrowed it, which is the failure mode worth a rejection.
+ */
+const ReembedBody = z.object({
+  kinds: z.array(z.enum(['memory', 'entity', 'edge', 'chrono', 'file'])).min(1).optional(),
+  limit: z.number().int().positive().max(REEMBED_MAX_LIMIT).optional(),
+}).strict();
+
+/** Mounted from `api/spaces.ts` so the route path stays `/api/spaces/:id/reembed`. */
+export function registerReembedRoute(spacesRouter: Router): void {
+  // POST /api/spaces/:id/reembed — queue embeddings for records that have none.
+  //
+  // The way back from `suppressEmbeddings`. Kept thin on purpose: the sweep, the suppression check and the
+  // bounding all live in `brain/reembed.ts`, because `api/spaces.ts` is already a frozen god-file and a route
+  // body is the wrong place for a rule the write path also has to agree with.
+  spacesRouter.post('/:id/reembed', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+    const spaceId = req.params['id'] as string;
+    if (!getConfig().spaces.some(s => s.id === spaceId)) {
+      res.status(404).json({ error: `Space '${spaceId}' not found` });
+      return;
+    }
+    const parsed = ReembedBody.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid body' });
+      return;
+    }
+    try {
+      // Awaited, unlike `rebuild-indexes`: this only ENQUEUES, so it returns in the time it takes to scan, and
+      // the counts it reports are the point. A fire-and-forget version could not tell the operator whether
+      // anything was found — which is the one question they are asking.
+      const out = await reembedSpace(spaceId, {
+        ...(parsed.data.kinds !== undefined ? { kinds: parsed.data.kinds } : {}),
+        ...(parsed.data.limit !== undefined ? { limit: parsed.data.limit } : {}),
+      });
+      res.json(out);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`POST /api/spaces/${spaceId}/reembed: ${err}`);
+      res.status(500).json({ error: msg });
+    }
+  });
+}

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { registerReembedRoute } from './spaces-reembed.js';
 import path from 'path';
 import { requireAuth, requireAdmin, requireAdminMfa, requireAdminMfaScoped } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
@@ -343,6 +344,8 @@ spacesRouter.post('/:id/rebuild-indexes', globalRateLimit, requireAdminMfaScoped
     res.status(500).json({ error: msg });
   }
 });
+
+registerReembedRoute(spacesRouter);
 
 // PATCH /api/spaces/:id/rename
 spacesRouter.patch('/:id/rename', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -91,6 +91,10 @@ const ROUTE_RULES: RouteRule[] = [
   // Rebuilding vector indexes leaves recall returning empty until the build finishes, so it is an
   // availability-affecting admin action and belongs in the trail alongside rename and wipe.
   { method: 'POST',   pattern: /^\/api\/spaces\/([^/]+)\/rebuild-indexes$/,        operation: 'space.indexes.rebuild', spaceGroup: 1 },
+  // Audited even though it only queues work: it changes what a space is findable BY, which is the same class of
+  // change as a rebuild, and it is the action an operator takes after turning suppression off. "Who un-suppressed
+  // this space and when" is answerable from the meta write; "who then backfilled it" needs this row.
+  { method: 'POST',   pattern: /^\/api\/spaces\/([^/]+)\/reembed$/,                 operation: 'space.embeddings.reembed', spaceGroup: 1 },
   { method: 'PATCH',  pattern: /^\/api\/spaces\/([^/]+)$/,                         operation: 'space.update',   spaceGroup: 1 },
   // There was no PUT rule in the entire table, so every schema write was unaudited.
   { method: 'PUT',    pattern: /^\/api\/spaces\/([^/]+)\/schema$/,                 operation: 'space.schema.update', spaceGroup: 1 },

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -99,9 +99,17 @@ export async function ensureEmbedJobIndexes(spaceId: string): Promise<void> {
  * exhausted its attempts on the OLD content must not inherit that verdict. This is what makes rewriting
  * a record the operator's escape hatch from a permanently failed job.
  *
- * Never throws into the caller's write path. An enqueue that fails leaves a record whose vector is
- * missing — exactly the state this queue exists to repair — and the periodic backfill sweep will find
- * it. Failing the write instead would trade a delayed search hit for lost data.
+ * Never throws into the caller's write path. An enqueue that fails leaves a record whose vector is missing,
+ * and failing the write instead would trade a delayed search hit for lost data.
+ *
+ * **This used to claim "the periodic backfill sweep will find it". There was no such sweep** — the comment
+ * described a repair mechanism that had never been built, which is worse than saying nothing: it is exactly the
+ * kind of reassurance that stops anyone checking. A swallowed enqueue error meant a record silently missing from
+ * recall forever, with no error, no metric and nothing to grep for.
+ *
+ * The repair now exists and is `POST /api/spaces/:id/reembed` (`brain/reembed.ts`), which queues a job for every
+ * record with no vector. It is **on demand, not periodic** — say that precisely, because "it will be picked up"
+ * and "an operator can pick it up" are different promises, and only one of them is true here.
  */
 export async function enqueueEmbedJob(
   spaceId: string,

--- a/server/src/brain/embed-record.ts
+++ b/server/src/brain/embed-record.ts
@@ -27,7 +27,9 @@ import type {
 } from '../config/types.js';
 
 /** Collection suffix per record type — the same mapping recall uses. */
-const COLLECTION: Record<BrainEmbedRecordType, string> = {
+/** Exported so the re-embed backfill scans the same collections this function writes. A second copy of this
+ *  map is how a backfill quietly misses a record kind. */
+export const COLLECTION: Record<BrainEmbedRecordType, string> = {
   memory: 'memories', entity: 'entities', edge: 'edges', chrono: 'chrono', file: 'files',
 };
 

--- a/server/src/brain/reembed.ts
+++ b/server/src/brain/reembed.ts
@@ -1,0 +1,132 @@
+/**
+ * Backfill missing embeddings for a space.
+ *
+ * ## Why this exists
+ *
+ * `suppressEmbeddings` shipped without a way back. Records written while suppression was on have no vector, and
+ * nothing revisited them — so turning the setting off left the space permanently half-indexed, with recall blind
+ * to everything written during the suppressed period and no symptom beyond worse results. The owner's call was
+ * blunt: *"there should be a way to backfill"*.
+ *
+ * It is not only for suppression. The same gap opens whenever an enqueue fails: `enqueueEmbedJob` deliberately
+ * swallows its error rather than failing the caller's write, and its comment claimed "the periodic backfill sweep
+ * will find it". **There was no such sweep** — the comment described a repair mechanism that had never been
+ * built, which is exactly the kind of reassurance that stops anyone looking. This is that sweep, on demand.
+ *
+ * ## It ENQUEUES, and does not embed
+ *
+ * A space can hold a million records and the model is the slow part. Embedding inline would time out the request
+ * somewhere in the middle, having done partial work with no record of where it stopped. Enqueuing is idempotent
+ * per record (`enqueueEmbedJob` upserts by job id), so a repeated call over the same space converges instead of
+ * duplicating.
+ *
+ * ## A backfill must not fight the setting
+ *
+ * A record that is STILL suppressed is skipped, and the same `embeddingSuppressed` resolver the write path uses
+ * decides it. Re-deriving the rule here would let a backfill re-index exactly what an operator asked to keep out
+ * of recall — the resolver is imported for that reason, not for convenience.
+ *
+ * So the operator's sequence is: turn suppression off, then backfill. Running it while still suppressed is not an
+ * error and reports honestly — every candidate comes back under `skippedSuppressed`, which tells the operator the
+ * setting is still on rather than leaving them to wonder why nothing happened.
+ *
+ * ## Nothing is capped silently
+ *
+ * `limit` bounds one call. When more candidates remain, `remaining` says how many and `truncated` is `true`. A
+ * backfill that quietly stopped at a round number would read as "the space is fully indexed now", which is the
+ * same class of lie as the missing sweep this replaces.
+ */
+
+import { col, asFilter } from '../db/mongo.js';
+import { COLLECTION, } from './embed-record.js';
+import { enqueueEmbedJob } from './embed-queue.js';
+import { embeddingSuppressed, schemaKeyFor } from './suppress-embeddings.js';
+import { getSpaceMeta } from '../spaces/schema-validation.js';
+import type { KnowledgeType } from '../config/types-knowledge.js';
+import type { BrainEmbedRecordType } from '../config/types.js';
+
+/** Every record kind that carries a vector. Derived from `COLLECTION` so a new kind cannot be missed here. */
+export const REEMBED_KINDS = Object.keys(COLLECTION) as BrainEmbedRecordType[];
+
+/** Default and ceiling for one call. The ceiling exists so a single request cannot enqueue unbounded work. */
+export const REEMBED_DEFAULT_LIMIT = 5_000;
+export const REEMBED_MAX_LIMIT = 50_000;
+
+export interface ReembedResult {
+  spaceId: string;
+  /** Records with no vector that are not suppressed — the ones a job was queued for. */
+  enqueued: number;
+  /** Candidates skipped because suppression still applies at some tier. */
+  skippedSuppressed: number;
+  /** Per-kind breakdown of what was enqueued, so an operator can see WHERE the gap was. */
+  byKind: Record<string, number>;
+  /** Candidates left over after `limit`. Zero when the space is fully swept. */
+  remaining: number;
+  /** True when `remaining > 0` — call again to continue. */
+  truncated: boolean;
+}
+
+/**
+ * Whether this stored document is still suppressed.
+ *
+ * Mirrors `embedStoredRecord` exactly, including the file asymmetry: a file has no type and therefore no type
+ * schema, so it skips the middle tier. Narrowed rather than cast — a cast would index `typeSchemas` with
+ * `'file'` and miss every time, which here would mean re-embedding files an operator had suppressed.
+ */
+function stillSuppressed(spaceId: string, kind: BrainEmbedRecordType, doc: Record<string, unknown>): boolean {
+  const meta = getSpaceMeta(spaceId);
+  const knowledgeType: KnowledgeType | undefined = kind === 'file' ? undefined : kind;
+  const schemaKey = knowledgeType === undefined ? undefined : schemaKeyFor(knowledgeType, doc);
+  return embeddingSuppressed({
+    record: doc['excludeFromVectorSearch'] === true ? true : undefined,
+    schema: knowledgeType === undefined || schemaKey === undefined
+      ? undefined
+      : meta?.typeSchemas?.[knowledgeType]?.[schemaKey],
+    space: meta?.suppressEmbeddings === true,
+  });
+}
+
+/**
+ * Queue an embedding job for every record in the space that has no vector and is not suppressed.
+ *
+ * `kinds` narrows the sweep; omitted means all of them. `limit` bounds one call — see the class comment on why
+ * the remainder is reported rather than hidden.
+ */
+export async function reembedSpace(
+  spaceId: string,
+  { kinds = REEMBED_KINDS, limit = REEMBED_DEFAULT_LIMIT }: { kinds?: BrainEmbedRecordType[]; limit?: number } = {},
+): Promise<ReembedResult> {
+  const cap = Math.min(Math.max(1, Math.floor(limit)), REEMBED_MAX_LIMIT);
+  const result: ReembedResult = {
+    spaceId, enqueued: 0, skippedSuppressed: 0, byKind: {}, remaining: 0, truncated: false,
+  };
+
+  for (const kind of kinds) {
+    // `$exists: false` on `embedding`, NOT a null check: the suppressed path `$unset`s the field, so a record
+    // that was suppressed and later released has no key at all rather than a null one. A `null` filter would
+    // find nothing and report a clean sweep over a space that is entirely unindexed.
+    const filter = asFilter({ embedding: { $exists: false } });
+    const collName = `${spaceId}_${COLLECTION[kind]}`;
+
+    // Counted before the cap is applied, so `remaining` is the truth about the space rather than about this
+    // page. Without this a truncated sweep could not tell an operator that more work is left.
+    const total = await col(collName).countDocuments(filter);
+
+    const budget = cap - result.enqueued - result.skippedSuppressed;
+    if (budget <= 0) { result.remaining += total; continue; }
+
+    const docs = await col(collName).find(filter).limit(budget).toArray() as Array<Record<string, unknown>>;
+    for (const doc of docs) {
+      const id = doc['_id'];
+      if (typeof id !== 'string') continue;
+      if (stillSuppressed(spaceId, kind, doc)) { result.skippedSuppressed++; continue; }
+      await enqueueEmbedJob(spaceId, kind, id);
+      result.enqueued++;
+      result.byKind[kind] = (result.byKind[kind] ?? 0) + 1;
+    }
+    if (total > docs.length) result.remaining += total - docs.length;
+  }
+
+  result.truncated = result.remaining > 0;
+  return result;
+}

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -96,7 +96,11 @@ const FROZEN = {
   // ignored — there is no "put it beside this file" for a field the API must accept. Raised rather than split
   // because this is its FIRST raise; `config/types.ts` is the cautionary case, and the rule stands: a fourth
   // raise of one file is the signal to split it instead of raising a fifth time.
-  'server/src/api/spaces.ts': 847,
+  // RAISED 847 -> 849 for the re-embed route: an import and a registration call, nothing else. Inline it was
+  // +28 (route body plus its Zod schema), which would have been the SECOND double-digit raise of this file in two
+  // PRs — so the route moved to `api/spaces-reembed.ts` instead and only its mount point stayed. That is what the
+  // ratchet is for: not to forbid growth, but to make the second raise in two PRs visible enough to answer.
+  'server/src/api/spaces.ts': 849,
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.

--- a/testing/standalone/reembed-backfill.test.js
+++ b/testing/standalone/reembed-backfill.test.js
@@ -1,0 +1,149 @@
+/**
+ * The re-embed backfill: the way back from `suppressEmbeddings`.
+ *
+ * ## What is worth asserting here
+ *
+ * The sweep itself is a Mongo query and a loop. The three things that make it correct or useless are none of
+ * that, and all three are visible without a database:
+ *
+ *  - **It filters on `$exists: false`, not on `null`.** The suppressed path `$unset`s the vector, so a released
+ *    record has no key at all. A `null` filter would find nothing and report a clean sweep over a space that is
+ *    entirely unindexed — a backfill that says "all done" having done nothing.
+ *  - **It reuses the write path's suppression resolver.** Re-deriving the rule would let a backfill re-index
+ *    exactly what an operator asked to keep out of recall.
+ *  - **It never truncates silently.** `remaining` is counted before the cap, so it describes the space and not
+ *    the page.
+ *
+ * Run: node --test testing/standalone/reembed-backfill.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), 'utf8');
+const strip = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const SRC = read('../../server/src/brain/reembed.ts');
+const CODE = strip(SRC);
+
+describe('the candidate query', () => {
+  it('filters on $exists: false, never on null', () => {
+    // The trap. Suppression `$unset`s the field, so the key is ABSENT rather than null.
+    assert.match(CODE, /embedding:\s*\{\s*\$exists:\s*false\s*\}/);
+    assert.ok(!/embedding:\s*null/.test(CODE), 'a null filter would match nothing and report a clean sweep');
+  });
+
+  it('derives the record kinds from the collection map rather than listing them again', () => {
+    // A second list is how a new record kind gets silently left out of every backfill.
+    assert.match(CODE, /Object\.keys\(COLLECTION\)/);
+  });
+
+  it('uses the same collection map the embed path writes through', () => {
+    assert.match(CODE, /from '\.\/embed-record\.js'/);
+    assert.match(CODE, /COLLECTION\[kind\]/);
+  });
+});
+
+describe('it does not fight the suppression setting', () => {
+  it('imports the shared resolver instead of re-deriving the rule', () => {
+    assert.match(CODE, /embeddingSuppressed/);
+    assert.match(CODE, /from '\.\/suppress-embeddings\.js'/);
+  });
+
+  it('skips a still-suppressed record and REPORTS it', () => {
+    // Reporting matters as much as skipping: running the backfill before turning suppression off must tell the
+    // operator the setting is still on, not look like a no-op.
+    assert.match(CODE, /skippedSuppressed\+\+/);
+    assert.match(CODE, /skippedSuppressed: number/);
+  });
+
+  it('applies the file asymmetry, narrowed rather than cast', () => {
+    // A cast would index `typeSchemas` with `'file'` and miss — here that means re-embedding suppressed files.
+    assert.match(CODE, /kind === 'file' \? undefined : kind/);
+    assert.ok(!/kind as KnowledgeType/.test(CODE), 'the kind is cast rather than narrowed');
+  });
+
+  it('passes the record flag as undefined when absent, never false', () => {
+    assert.match(CODE, /record:\s*doc\['excludeFromVectorSearch'\]\s*===\s*true\s*\?\s*true\s*:\s*undefined/);
+  });
+});
+
+describe('it enqueues rather than embedding inline', () => {
+  it('calls the queue, not the embedder', () => {
+    // A million-record space would time out mid-way, having done partial work with no record of where.
+    assert.match(CODE, /enqueueEmbedJob\(spaceId, kind, id\)/);
+    assert.ok(!/embedStoredRecord/.test(CODE), 'embedding inline would time out on a large space');
+  });
+});
+
+describe('nothing is capped silently', () => {
+  it('counts the total BEFORE applying the cap', () => {
+    // Otherwise `remaining` describes the page rather than the space, and a truncated sweep reads as complete.
+    const countAt = CODE.indexOf('countDocuments');
+    const limitAt = CODE.indexOf('.limit(budget)');
+    assert.ok(countAt > 0 && limitAt > 0, 'expected both a count and a limited find');
+    assert.ok(countAt < limitAt, 'the total must be counted before the page is fetched');
+  });
+
+  it('reports the remainder and flags truncation', () => {
+    assert.match(CODE, /truncated = result\.remaining > 0/);
+  });
+
+  it('clamps the limit to a ceiling rather than trusting the caller', () => {
+    assert.match(CODE, /Math\.min\(Math\.max\(1, Math\.floor\(limit\)\), REEMBED_MAX_LIMIT\)/);
+  });
+
+  it('still counts a kind it had no budget left for', () => {
+    // Skipping the count would under-report `remaining` for every kind after the budget ran out, which is the
+    // silent-truncation failure wearing a different hat.
+    assert.match(CODE, /if \(budget <= 0\) \{ result\.remaining \+= total; continue; \}/);
+  });
+});
+
+describe('the route stays thin, and out of the god-file', () => {
+  // It lives in its own module: inline it was +28 code lines on `api/spaces.ts`, which would have been the second
+  // double-digit raise of that file in two PRs. Extracted, only the mount point stays (+2).
+  const ROUTE = read('../../server/src/api/spaces-reembed.ts');
+  const SPACES = read('../../server/src/api/spaces.ts');
+
+  it('delegates to the module instead of inlining the sweep', () => {
+    assert.match(ROUTE, /reembedSpace\(spaceId, \{/);
+    assert.ok(!/\$exists: false/.test(ROUTE), 'the query belongs in brain/reembed.ts, not in the route');
+  });
+
+  it('is admin-gated and scoped to the space in the path', () => {
+    assert.match(ROUTE, /post\('\/:id\/reembed', globalRateLimit, requireAdminMfaScoped\('id'\)/);
+  });
+
+  it('rejects an unknown body key rather than silently sweeping everything', () => {
+    // A caller who meant to narrow and got a full sweep would be told they had narrowed it.
+    assert.match(ROUTE, /const ReembedBody = z\.object\(\{[\s\S]*?\}\)\.strict\(\)/);
+  });
+
+  it('spaces.ts only MOUNTS it — the body did not come back', () => {
+    // The whole point of the extraction. If a later edit inlines the handler again, this fails rather than the
+    // ratchet quietly absorbing another raise.
+    assert.match(SPACES, /registerReembedRoute\(spacesRouter\);/);
+    assert.ok(!/reembedSpace\(/.test(SPACES), 'the handler is back inside the god-file');
+  });
+
+  it('is audited, because it changes what a space is findable by', () => {
+    const AUDIT = read('../../server/src/audit/middleware.ts');
+    assert.match(AUDIT, /reembed\$\/[\s\S]{0,80}space\.embeddings\.reembed/);
+  });
+});
+
+describe('the comment that promised a sweep that never existed', () => {
+  it('states the correction and names the real repair', () => {
+    // The old comment justified swallowing the enqueue error with "the periodic backfill sweep will find it".
+    // There was no sweep, so a swallowed error meant a record silently missing from recall forever.
+    //
+    // Asserted POSITIVELY, and that is the lesson rather than a detail: the first version of this test searched
+    // for the absence of the old phrase and failed against correct code, because the phrase is quoted inside the
+    // comment that corrects it. A gate that reads source has to survive the source explaining itself.
+    const QUEUE = read('../../server/src/brain/embed-queue.ts');
+    assert.match(QUEUE, /There was no such sweep/);
+    assert.match(QUEUE, /reembed/);
+    assert.match(QUEUE, /on demand, not periodic/);
+  });
+});


### PR DESCRIPTION
## Why

`suppressEmbeddings` shipped in #775 **without a way back**. Records written while suppression was on have no
vector and nothing revisited them, so turning the setting off left a space permanently half-indexed — recall blind
to everything written during the suppressed period, with no symptom beyond worse results.

Owner: *"there should be a way to backfill"*.

## What

`POST /api/spaces/:id/reembed` queues an embedding job for every record in a space that has no vector.
Optional `kinds` narrows it; optional `limit` bounds one call. Admin-gated and scoped to the space in the path.

## The more interesting half: a sweep that was only ever a comment

`enqueueEmbedJob` deliberately swallows its error rather than failing the caller's write, justified by this:

> An enqueue that fails leaves a record whose vector is missing — exactly the state this queue exists to repair —
> and **the periodic backfill sweep will find it**.

**There was no such sweep.** Nothing in the codebase queried for a missing embedding. I checked *before* building,
because if a sweep had existed then the docs claim in #775 would have been the thing that was wrong.

So for as long as that comment has been there, a swallowed enqueue meant a record silently and permanently missing
from recall: no error, no metric, nothing to grep for. A false reassurance is worse than silence — it is precisely
what stops anyone checking.

The comment now names the real repair and says it is **on demand, not periodic**. "It will be picked up" and "an
operator can pick it up" are different promises, and only the second is true.

## Design

- **A backfill must not fight the setting.** A record still suppressed at any tier is skipped, decided by the
  **same** `embeddingSuppressed` resolver the write path uses. Re-deriving the rule would let a backfill re-index
  exactly what an operator asked to keep out of recall. Running it while suppression is on is not an error: every
  candidate returns under `skippedSuppressed`, which tells the operator the setting is on rather than looking like
  a no-op.
- **It enqueues rather than embeds.** A large space would time out mid-way through inline work, having done part
  of it with no record of where it stopped. Queuing is idempotent per record, so a repeated call converges.
- **`$exists: false`, never `null`.** Suppression `$unset`s the field, so a released record has no key at all. A
  `null` filter would match nothing and report a clean sweep over an entirely unindexed space — a backfill whose
  failure mode is announcing success.
- **Nothing is truncated silently.** `remaining` is counted over the whole space *before* the cap, not over the
  page, and a kind the budget ran out on is still counted. `truncated` says another call is needed.
- **The file asymmetry again:** a file has no type and therefore no type schema, so it skips the middle tier.
  Narrowed, not cast — a cast would index `typeSchemas` with `'file'` and miss, which here means re-embedding
  files someone had suppressed.

## Two gates fired and shaped the result

| Gate | What it caught | Resolution |
|---|---|---|
| `audit-route-coverage` | a new mutating route with no audit rule | Added as `space.embeddings.reembed`. "Who un-suppressed this space" is answerable from the meta write; "who then backfilled it" needs this row. |
| `no-new-god-files` | inline, the route took `api/spaces.ts` 847 → **875** — a second double-digit raise in two PRs | The route moved to `api/spaces-reembed.ts`; only the mount point stayed, so the raise is **+2 instead of +28**. A test asserts the handler has not come back, so a later edit cannot quietly re-inline it. |

## One test of mine failed against correct code

It searched for the **absence** of the old "periodic backfill sweep" phrase — which appears inside the comment
that corrects it. A gate reading source has to survive the source explaining itself, so the assertion is positive
now. Recorded in the test rather than quietly fixed.

## Verification

18 tests: the `$exists` filter, resolver reuse, the skip-and-report path, the file narrowing, enqueue-not-embed,
remainder counting before the cap, the route's thinness, `spaces.ts` mounting only, and the audit rule.
Full server build clean; preflight green.

🤖 Generated with Claude Code
