### PR TITLE
refactor(config): the network types move out, and this is the move that failed the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **The network types moved out of `config/types.ts`** into `config/types-networks.ts` — `NetworkType`,
+  `SyncDirection`, `VoteValue`, `VoteRoundType`, `NetworkMember`, `VoteCast`, `VoteRound`, `NetworkConfig`.
+  Re-exported, so **no importer changes and no behaviour change**. Ratchet lowered 645 → 578.
+  - Completes the Q-3 split: **677 → 645 → 578** across two slices. The gate's own comment said a fifth raise of
+    this file should be a split instead, and this is the second half of it.
+  - **This is the move that failed the first time.** `NetworkConfig` references `SpaceMeta`, so before the
+    knowledge-schema leaf existed it created a module cycle and TypeScript degraded `NetworkConfig` to `any` — a
+    caller losing its types while every file in the diff compiled clean. It imports `SpaceMeta` from the leaf now.
+  - Verified with `grep -c "TS7006"` on a full build (0), not on a green compile of the moved files.
+
 ### Added
 - **The space-wide `suppressEmbeddings` toggle, in the space Danger Zone** — completing the feature. Alongside it,
   the backfill from #776 is now a button rather than API-only.

--- a/server/src/config/types-networks.ts
+++ b/server/src/config/types-networks.ts
@@ -1,0 +1,157 @@
+/**
+ * Network and sync types: topology, membership, and the vote rounds that govern a shared space.
+ *
+ * ## Why this is a separate file
+ *
+ * Q-3, slice 2. `types.ts` is the config contract for every subsystem — spaces, networks, media, embedding, auth,
+ * sync — and it took FOUR god-file ratchet raises in two days, each individually correct and each one line of
+ * honest type. The gate's own comment said a fifth should be a split instead.
+ *
+ * ## Why the leaf had to come first
+ *
+ * This exact move was attempted before slice 1 and **reverted**. `NetworkConfig` references `SpaceMeta`, which
+ * belongs to spaces. With `types.ts` re-exporting this file and this file importing `SpaceMeta` back from
+ * `types.ts`, that is a module cycle — TypeScript resolved it by degrading `NetworkConfig` to `any`, and
+ * `api/invite.ts` silently lost the types on three `members` callbacks while every file in the diff compiled
+ * clean.
+ *
+ * So `SpaceMeta` moved to `types-knowledge.ts` first (slice 1, #774), a leaf that imports nothing. This file
+ * imports it **from the leaf**, never from `types.ts`. That is the whole reason the two slices are in this order,
+ * and the reason to check `grep -c "TS7006"` on a full build rather than trusting a green compile of the moved
+ * files.
+ *
+ * Re-exported from `types.ts`, so no importer changes.
+ */
+import type { SpaceMeta } from './types-knowledge.js';
+
+// ── Network types ──────────────────────────────────────────────────────────
+
+export type NetworkType = 'closed' | 'democratic' | 'club' | 'braintree' | 'pubsub';
+export type SyncDirection = 'both' | 'push' | 'pull';
+export type VoteValue = 'yes' | 'veto';
+export type VoteRoundType = 'join' | 'remove' | 'space_deletion' | 'meta_change';
+
+export interface NetworkMember {
+  instanceId: string;
+  label: string;
+  url: string;
+  tokenHash: string;         // bcrypt of the token this instance uses to auth inbound from peer
+  direction: SyncDirection;
+  lastSyncAt?: string;       // ISO8601 — set only on successful sync
+  lastSeqReceived?: Record<string, number>;  // spaceId → last seq ingested from this peer
+  lastSeqPushed?: Record<string, number>;    // spaceId → last seq we confirmed pushed to this peer
+  /** spaceId → the newest `deletedAt` among FILE tombstones this peer has answered 200 to on a push.
+   *  File tombstones carry no `seq`, so their retention floor is built from acknowledgement rather than from a
+   *  served position (see `sync/file-tombstone-ack.ts`). Only a 200 may advance it: a direction-blocked peer
+   *  that 403s has NOT taken the deletion, and pruning on a rejected push is how a deleted file comes back. */
+  lastFileTombstoneAckedAt?: Record<string, string>;
+  /** spaceId → the highest `sinceSeq` this peer has pulled OUR tombstones from, i.e. the position it has
+   *  confirmed applying. The mirror of the two above: they are our position in the peer's data, this is the
+   *  peer's position in ours, and without it a tombstone can never be safely dropped (see
+   *  `sync/served-watermark.ts`). Monotonic; absent means "never pulled", which blocks pruning. */
+  lastSeqServed?: Record<string, number>;
+  consecutiveFailures?: number;  // incremented on each failed sync; reset to 0 on success
+  parentInstanceId?: string; // braintree only
+  /** Set during a temporary reparent; stores the original parent so it can be restored. */
+  originalParentInstanceId?: string;
+  children?: string[];       // instanceIds of direct children (braintree)
+  skipTlsVerify?: boolean;   // non-default; UI shows security warning when true
+  /** Ed25519 public key (SPKI PEM) used to verify this member's signed vote casts.
+   *  Trust-on-first-use: pinned the first time we learn it via member gossip / invite;
+   *  a later attempt to change it to a different key is rejected. */
+  signingPublicKey?: string;
+}
+
+export interface VoteCast {
+  instanceId: string;
+  vote: VoteValue;
+  castAt: string;            // ISO8601
+  /** Base64 Ed25519 signature by `instanceId` over the canonical vote message
+   *  (see util/signing.ts). Present on casts created by signing-capable brains;
+   *  absent on legacy/unsigned casts (accepted only via the own-cast path). */
+  sig?: string;
+}
+
+export interface VoteRound {
+  roundId: string;
+  type: VoteRoundType;
+  subjectInstanceId: string;
+  subjectLabel: string;
+  subjectUrl: string;
+  deadline: string;          // ISO8601
+  openedAt: string;          // ISO8601
+  votes: VoteCast[];
+  inviteKeyHash?: string;    // bcrypt of invite key (join rounds only)
+  concluded?: boolean;
+  passed?: boolean;          // true if concluded and the motion carried; false if vetoed/expired
+  pendingMember?: NetworkMember;  // stored on join rounds; added to members when vote passes
+  spaceId?: string;              // populated for space_deletion and meta_change rounds
+  pendingMeta?: SpaceMeta;       // stored on meta_change rounds; applied when vote passes
+  /**
+   * Top-level `meta` fields the proposer changed (meta_change rounds).
+   *
+   * Conclusion applies only these, re-merged into whatever the meta says at that moment, so two rounds
+   * that touch different fields no longer overwrite each other — `pendingMeta` is a full snapshot of the
+   * meta as it stood when the round opened, and applying it wholesale silently reverts anything that
+   * concluded in between. See `sync/meta-round-merge.ts`.
+   */
+  metaChangedFields?: string[];
+  /**
+   * The space's `meta.version` the proposal was computed against (meta_change rounds).
+   *
+   * Rounds gossip, so this is absent on any round proposed by a peer predating field-merge — and that
+   * absence is the compatibility switch: such a round applies wholesale, exactly as before. It cannot
+   * field-merge, because the changed-field list it never recorded would merge nothing at all.
+   */
+  baseMetaVersion?: number;
+  requiredVoters?: string[];     // braintree only: instanceIds that must ALL vote yes
+}
+
+export interface NetworkConfig {
+  id: string;
+  label: string;
+  type: NetworkType;
+  spaces: string[];          // space IDs scoped to this network
+  /**
+   * Which token established each membership — `spaceId` -> token id.
+   *
+   * A PARALLEL map rather than a field on the membership, because `spaces` is a plain `string[]` on every
+   * instance in the field. Turning it into objects would be a breaking migration of live config for a value
+   * that is absent on every existing row anyway.
+   *
+   * **Absent means unknown, and unknown FAILS CLOSED.** Memberships that predate this field cannot prove
+   * whose they are, so leaving one requires the Networks admin rung rather than the write rung. That is the
+   * safe direction: a token that cannot dismantle somebody else's topology asks for help, while one that can
+   * does it silently. See `mayLeaveNetwork` in `auth/network-membership.ts`.
+   */
+  spaceOrigins?: Record<string, string>;
+  /** Maps remote (peer-side) space IDs to local space IDs.
+   *  Used when a local space was renamed after joining, or when the joiner chose
+   *  a different local ID to avoid a collision.  The sync engine uses this to
+   *  translate between peer space IDs on the wire and local collection/file IDs.
+   *  Key = remote space ID, Value = local space ID. */
+  spaceMap?: Record<string, string>;
+  votingDeadlineHours: number;
+  merkle?: boolean;
+  /** When true, governance vote casts must carry a valid Ed25519 signature from
+   *  the voting member (verified against its pinned signingPublicKey). Enable
+   *  once every member has published a signing key. Default (false/undefined)
+   *  runs in compatibility mode: signed casts are verified and relay-safe, while
+   *  unsigned casts are accepted only directly from the voter (never relayed). */
+  requireSignedVotes?: boolean;
+  members: NetworkMember[];
+  pendingRounds: VoteRound[];
+  syncSchedule?: string;     // cron expression; omit = manual only
+  inviteKeyHash?: string;    // bcrypt of current active invite key
+  createdAt: string;
+  /** Braintree only: this instance's parent instanceId in the network tree.
+   *  When unset this instance is treated as the root. */
+  myParentInstanceId?: string;
+  /** Set on THIS instance when it has been temporarily re-parented in a braintree.
+   *  Cleared when the reparent is made permanent (`adopt`) or reverted. */
+  temporaryReparent?: {
+    newParentInstanceId: string;      // grandparent that adopted us
+    originalParentInstanceId: string; // offline intermediate we bypassed
+    reparentedAt: string;             // ISO8601
+  };
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -760,136 +760,16 @@ export interface FaceRecognitionConfig {
 }
 
 // ── Network types ──────────────────────────────────────────────────────────
+//
+// Moved to `types-networks.ts`. It imports `SpaceMeta` from the `types-knowledge.ts` LEAF rather than from
+// here — importing it back from this file would be a cycle, which is what made the first attempt at this split
+// degrade `NetworkConfig` to `any` in `api/invite.ts`. See that file for the full account.
+//
+// Imported as well as re-exported: `export ... from` does not bring a name into local scope, and types below
+// this line are built from these.
+import type { NetworkType, SyncDirection, VoteValue, VoteRoundType, NetworkMember, VoteCast, VoteRound, NetworkConfig } from './types-networks.js';
+export type { NetworkType, SyncDirection, VoteValue, VoteRoundType, NetworkMember, VoteCast, VoteRound, NetworkConfig };
 
-export type NetworkType = 'closed' | 'democratic' | 'club' | 'braintree' | 'pubsub';
-export type SyncDirection = 'both' | 'push' | 'pull';
-export type VoteValue = 'yes' | 'veto';
-export type VoteRoundType = 'join' | 'remove' | 'space_deletion' | 'meta_change';
-
-export interface NetworkMember {
-  instanceId: string;
-  label: string;
-  url: string;
-  tokenHash: string;         // bcrypt of the token this instance uses to auth inbound from peer
-  direction: SyncDirection;
-  lastSyncAt?: string;       // ISO8601 — set only on successful sync
-  lastSeqReceived?: Record<string, number>;  // spaceId → last seq ingested from this peer
-  lastSeqPushed?: Record<string, number>;    // spaceId → last seq we confirmed pushed to this peer
-  /** spaceId → the newest `deletedAt` among FILE tombstones this peer has answered 200 to on a push.
-   *  File tombstones carry no `seq`, so their retention floor is built from acknowledgement rather than from a
-   *  served position (see `sync/file-tombstone-ack.ts`). Only a 200 may advance it: a direction-blocked peer
-   *  that 403s has NOT taken the deletion, and pruning on a rejected push is how a deleted file comes back. */
-  lastFileTombstoneAckedAt?: Record<string, string>;
-  /** spaceId → the highest `sinceSeq` this peer has pulled OUR tombstones from, i.e. the position it has
-   *  confirmed applying. The mirror of the two above: they are our position in the peer's data, this is the
-   *  peer's position in ours, and without it a tombstone can never be safely dropped (see
-   *  `sync/served-watermark.ts`). Monotonic; absent means "never pulled", which blocks pruning. */
-  lastSeqServed?: Record<string, number>;
-  consecutiveFailures?: number;  // incremented on each failed sync; reset to 0 on success
-  parentInstanceId?: string; // braintree only
-  /** Set during a temporary reparent; stores the original parent so it can be restored. */
-  originalParentInstanceId?: string;
-  children?: string[];       // instanceIds of direct children (braintree)
-  skipTlsVerify?: boolean;   // non-default; UI shows security warning when true
-  /** Ed25519 public key (SPKI PEM) used to verify this member's signed vote casts.
-   *  Trust-on-first-use: pinned the first time we learn it via member gossip / invite;
-   *  a later attempt to change it to a different key is rejected. */
-  signingPublicKey?: string;
-}
-
-export interface VoteCast {
-  instanceId: string;
-  vote: VoteValue;
-  castAt: string;            // ISO8601
-  /** Base64 Ed25519 signature by `instanceId` over the canonical vote message
-   *  (see util/signing.ts). Present on casts created by signing-capable brains;
-   *  absent on legacy/unsigned casts (accepted only via the own-cast path). */
-  sig?: string;
-}
-
-export interface VoteRound {
-  roundId: string;
-  type: VoteRoundType;
-  subjectInstanceId: string;
-  subjectLabel: string;
-  subjectUrl: string;
-  deadline: string;          // ISO8601
-  openedAt: string;          // ISO8601
-  votes: VoteCast[];
-  inviteKeyHash?: string;    // bcrypt of invite key (join rounds only)
-  concluded?: boolean;
-  passed?: boolean;          // true if concluded and the motion carried; false if vetoed/expired
-  pendingMember?: NetworkMember;  // stored on join rounds; added to members when vote passes
-  spaceId?: string;              // populated for space_deletion and meta_change rounds
-  pendingMeta?: SpaceMeta;       // stored on meta_change rounds; applied when vote passes
-  /**
-   * Top-level `meta` fields the proposer changed (meta_change rounds).
-   *
-   * Conclusion applies only these, re-merged into whatever the meta says at that moment, so two rounds
-   * that touch different fields no longer overwrite each other — `pendingMeta` is a full snapshot of the
-   * meta as it stood when the round opened, and applying it wholesale silently reverts anything that
-   * concluded in between. See `sync/meta-round-merge.ts`.
-   */
-  metaChangedFields?: string[];
-  /**
-   * The space's `meta.version` the proposal was computed against (meta_change rounds).
-   *
-   * Rounds gossip, so this is absent on any round proposed by a peer predating field-merge — and that
-   * absence is the compatibility switch: such a round applies wholesale, exactly as before. It cannot
-   * field-merge, because the changed-field list it never recorded would merge nothing at all.
-   */
-  baseMetaVersion?: number;
-  requiredVoters?: string[];     // braintree only: instanceIds that must ALL vote yes
-}
-
-export interface NetworkConfig {
-  id: string;
-  label: string;
-  type: NetworkType;
-  spaces: string[];          // space IDs scoped to this network
-  /**
-   * Which token established each membership — `spaceId` -> token id.
-   *
-   * A PARALLEL map rather than a field on the membership, because `spaces` is a plain `string[]` on every
-   * instance in the field. Turning it into objects would be a breaking migration of live config for a value
-   * that is absent on every existing row anyway.
-   *
-   * **Absent means unknown, and unknown FAILS CLOSED.** Memberships that predate this field cannot prove
-   * whose they are, so leaving one requires the Networks admin rung rather than the write rung. That is the
-   * safe direction: a token that cannot dismantle somebody else's topology asks for help, while one that can
-   * does it silently. See `mayLeaveNetwork` in `auth/network-membership.ts`.
-   */
-  spaceOrigins?: Record<string, string>;
-  /** Maps remote (peer-side) space IDs to local space IDs.
-   *  Used when a local space was renamed after joining, or when the joiner chose
-   *  a different local ID to avoid a collision.  The sync engine uses this to
-   *  translate between peer space IDs on the wire and local collection/file IDs.
-   *  Key = remote space ID, Value = local space ID. */
-  spaceMap?: Record<string, string>;
-  votingDeadlineHours: number;
-  merkle?: boolean;
-  /** When true, governance vote casts must carry a valid Ed25519 signature from
-   *  the voting member (verified against its pinned signingPublicKey). Enable
-   *  once every member has published a signing key. Default (false/undefined)
-   *  runs in compatibility mode: signed casts are verified and relay-safe, while
-   *  unsigned casts are accepted only directly from the voter (never relayed). */
-  requireSignedVotes?: boolean;
-  members: NetworkMember[];
-  pendingRounds: VoteRound[];
-  syncSchedule?: string;     // cron expression; omit = manual only
-  inviteKeyHash?: string;    // bcrypt of current active invite key
-  createdAt: string;
-  /** Braintree only: this instance's parent instanceId in the network tree.
-   *  When unset this instance is treated as the root. */
-  myParentInstanceId?: string;
-  /** Set on THIS instance when it has been temporarily re-parented in a braintree.
-   *  Cleared when the reparent is made permanent (`adopt`) or reverted. */
-  temporaryReparent?: {
-    newParentInstanceId: string;      // grandparent that adopted us
-    originalParentInstanceId: string; // offline intermediate we bypassed
-    reparentedAt: string;             // ISO8601
-  };
-}
 
 // ── OIDC types ─────────────────────────────────────────────────────────────
 

--- a/testing/standalone/config-key-docs-coverage.test.js
+++ b/testing/standalone/config-key-docs-coverage.test.js
@@ -87,9 +87,27 @@ const FREE_FORM = new Set([
   'entity', 'memory', 'edge', 'chrono',
 ]);
 
+/**
+ * Every file the config contract is spread across.
+ *
+ * **Derived, not listed.** Q-3 split `config/types.ts` by domain — the knowledge-schema vocabulary to
+ * `types-knowledge.ts`, the network types to `types-networks.ts` — and a hand-written list meant this gate stopped
+ * seeing `NetworkConfig`'s fields the moment they moved. It then reported `members` and `direction` as
+ * undocumented keys: a **false positive**, which is the better failure of the two, but only by luck. Had the split
+ * gone the other way the gate would have quietly checked less and still passed.
+ *
+ * So the sources are enumerated from the directory. Any further slice is covered without touching this file.
+ */
+function typeSources() {
+  const dir = join(ROOT, 'server', 'src', 'config');
+  return readdirSync(dir)
+    .filter((f) => /^types.*\.ts$/.test(f) && !f.endsWith('.d.ts'))
+    .map((f) => join(dir, f));
+}
+
 function declaredFields() {
   const out = new Set();
-  const sources = [TYPES, join(ROOT, 'server', 'src', 'db', 'backup-config.ts')].filter(existsSync);
+  const sources = [...typeSources(), join(ROOT, 'server', 'src', 'db', 'backup-config.ts')].filter(existsSync);
   for (const f of sources) {
     const src = readFileSync(f, 'utf8');
     // Anywhere, not line-anchored — see the header note on inline object literals.

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -134,7 +134,11 @@ const FROZEN = {
   // that imports nothing. This entry took FOUR raises in two days and the comment below said the fifth should
   // be a split instead; that is this. The number matters less than where the growth now goes: per-type schema
   // fields land in the leaf, so Q-2's `suppressEmbeddings` is not a fifth raise of this file.
-  'server/src/config/types.ts': 645,
+  // LOWERED 645 -> 578 (Q-3, slice 2). The network types moved to `config/types-networks.ts`, which imports
+  // `SpaceMeta` from the slice-1 leaf rather than back from `types.ts`. 677 -> 645 -> 578 across the two slices,
+  // and the first attempt at this move — before the leaf existed — reached 609 while silently degrading
+  // `NetworkConfig` to `any` in a caller. The number was never the point; where the growth goes is.
+  'server/src/config/types.ts': 578,
   'client/src/app/pages/settings/data.component.ts': 644,
   'server/src/api/files.ts': 646,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate


### PR DESCRIPTION
## What

**Q-3, slice 2 — and the last of it.** `NetworkType`, `SyncDirection`, `VoteValue`, `VoteRoundType`,
`NetworkMember`, `VoteCast`, `VoteRound` and `NetworkConfig` move to `config/types-networks.ts`, re-exported from
`types.ts` so **no importer changes and no behaviour change**. Ratchet lowered **645 → 578**.

`config/types.ts` across the whole of Q-3: **677 → 645 → 578**. The gate's own comment said a fifth raise of that
file should be a split instead; this is the second half of it.

## This is the move that failed the first time

`NetworkConfig` references `SpaceMeta`, which belongs to spaces. With `types.ts` re-exporting the new file and the
new file importing `SpaceMeta` **back** from `types.ts`, that is a module cycle — and TypeScript resolved it by
degrading `NetworkConfig` to `any`. `api/invite.ts` picked up three `TS7006` implicit-anys on its `members`
callbacks **while every file in the diff compiled clean**.

It even reached a *smaller* 609 lines, which is exactly why the line count was never the thing to optimise.

So `SpaceMeta` went to `types-knowledge.ts` first (#774) — a leaf that imports nothing, and therefore cannot be
half of a cycle. This file imports it **from the leaf**. That ordering is the entire content of the two-slice plan.

## Verified on the callers

```bash
npm --prefix server run build 2>&1 | grep -c "TS7006"    # 0
```

Which is what the first attempt did not do. The exported names are also read off the moved block rather than
hand-listed, because a hand list is how a re-export quietly drops a type.

## One gate failed, and it was the better of the two possible failures

`config-key-docs-coverage` collects declared config fields from a **hand-written list** of source files. When
`NetworkConfig`'s fields moved it stopped seeing them and reported `members` and `direction` as undocumented keys in
the networks guide.

That is a false positive — annoying, but the safe direction. **Had the split gone the other way it would have
checked less and still passed**, which is the vacuous-gate shape this repo keeps finding.

Fixed by **deriving** the sources from the config directory (`types*.ts`) rather than listing them, so any further
slice is covered without touching the gate.

Mutation-tested: narrowing the filter back to `types.ts` alone fails (1 fail).

🤖 Generated with Claude Code
