### PR TITLE
fix(ui): every checkbox in the app was the browser's blue, not the accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **Every checkbox and radio in the app rendered the browser's default blue instead of the accent.** `--accent` is
+  lime; the platform default is blue, and nothing set `accent-color` globally.
+  - The graph toolbar had already fixed it **locally**, for its own toggles only — so the product had two answers to
+    "what colour is a ticked box", and the wrong one was the default everywhere else: settings, space dialogs,
+    network wizards, the schema editor.
+  - Checkboxes are deliberately NOT in the shared text-input selector list, and should not be: they take neither
+    height nor padding the way a text input does. What they needed was the one property that list cannot give them.
+  - **Found by screenshot**, which is the third time on this file. The comment above the input rule records the same
+    lesson and says the drift sweep missed its case because the tool and the CSS shared one blind spot — a sweep
+    enumerating `input[type="text"]` cannot report a checkbox it never looks at.
+
 ### Changed
 - **The network types moved out of `config/types.ts`** into `config/types-networks.ts` — `NetworkType`,
   `SyncDirection`, `VoteValue`, `VoteRoundType`, `NetworkMember`, `VoteCast`, `VoteRound`, `NetworkConfig`.

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -269,6 +269,28 @@ select {
   appearance: none;
 }
 
+/*
+ * Checkboxes and radios: the accent, not the browser's blue.
+ *
+ * They are NOT in the selector list above and should not be — they take neither height nor padding the way a text
+ * input does, so folding them in would set five properties that do nothing and one that breaks them. What they do
+ * need is the one property that list cannot give them.
+ *
+ * Without this every checkbox in the app rendered the platform default blue, while `--accent` is lime. The graph
+ * toolbar had already fixed it locally (`graph.styles.ts`), for its own toggles only — so the product had two
+ * answers to "what colour is a ticked box", and the wrong one was the default everywhere else.
+ *
+ * Found by SCREENSHOT, which is the whole point and is the third time on this file: the comment above the input
+ * rule records the same lesson, and it says the drift sweep missed its case because the tool and the CSS shared one
+ * blind spot. A sweep that enumerates `input[type="text"]` cannot report a checkbox it never looks at.
+ */
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+
 /* Same list as the base rule above — a type styled but not focus-styled loses its focus ring, which is an
    accessibility regression rather than a cosmetic one. */
 input[type="text"]:focus,


### PR DESCRIPTION
## What the screenshot was for

**Q-9** was the debt I flagged on #777: that PR shipped the Danger Zone embeddings block **without a visual check**.
So I booted an isolated instance and looked at it.

**The block itself is correct** — the warning alert appears while the box is ticked, Backfill is disabled with its
reason line beneath it, the description and buttons sit where they should, no console errors.

## What the screenshot found next to it

The checkbox was the platform default **blue**. `--accent` is lime.

**Not a regression from #777.** *Every* checkbox in the app was blue, because nothing set `accent-color` globally:
settings, the space dialogs, the network wizards, the schema editor. The graph toolbar had fixed it **locally** in
`graph.styles.ts`, for its own toggles only — so the product had two answers to "what colour is a ticked box", and
the wrong one was the default everywhere except one page.

## Why a separate rule and not the shared input list

Checkboxes and radios are deliberately **not** in the shared text-input selector list, and should not be: they take
neither height nor padding the way a text input does, so folding them in would set five properties that do nothing
and one that breaks them. What they needed was the one property that list cannot give them.

## Third time on this file

The comment directly above the input rule records the same lesson from #659 — an incomplete selector list that
failed silently and was only visible in a screenshot — and it notes the drift sweep missed its case because *the
tool and the CSS shared one blind spot*.

That is exactly what happened again. A sweep enumerating `input[type="text"]` cannot report a checkbox it never
looks at.

## Verification — the way the rule actually requires

Booted an isolated instance on `:3260` against a throwaway Mongo, drove Edge to a space's Danger Zone, and **read
the PNG** before and after.

| | checkbox |
|---|---|
| before | browser blue |
| after | `--accent` lime |

Nothing else moved; no console errors either run. Preflight green.

Closes Q-9.

🤖 Generated with Claude Code
