### PR TITLE
feat(auth): the rule for narrowing a proxy space to what a token may see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Internal: the rule for narrowing a proxy space to the members a token may see.** Nothing consults it yet — the
+  guard change and the read-path narrowing must land together, and this is the rule on its own.
+  - Asked for by aigents with probes: today a proxy space cannot be granted to a non-admin token at all, because
+    the guard requires the token to reach **every** member. They proved it was not specific to one proxy by
+    building their own over 15 spaces and getting the same 403.
+  - **The result can only ever narrow.** `narrowsOnly()` asserts that independently, because the failure it guards
+    is silent — one unreachable member in the set leaks that space's records through the proxy while every response
+    still looks well-formed.
+  - **An empty `spaces` array is not unrestricted.** The check is on `undefined` alone; the
+    `!spaces || spaces.length === 0` reading has already been a defect in three separate files.
+  - **An empty proxy is refused, not answered with an empty body** — a caller cannot tell that from a space they
+    are not allowed to see into.
+
 ### Fixed
 - **Every checkbox and radio in the app rendered the browser's default blue instead of the accent.** `--accent` is
   lime; the platform default is blue, and nothing set `accent-color` globally.

--- a/server/src/auth/proxy-reach.ts
+++ b/server/src/auth/proxy-reach.ts
@@ -1,0 +1,90 @@
+/**
+ * A proxy space, narrowed to the members a given token may actually see.
+ *
+ * ## The ask
+ *
+ * From aigents (2026-08-09), with probes: today a proxy space cannot be granted to a non-admin token at all.
+ * Listing the proxy in `spaces` does nothing and every call `403`s, because `enforceSpaceScope` requires the token
+ * to reach **every** member. They proved it was not specific to one proxy by building their own over 15 spaces and
+ * getting the same refusal.
+ *
+ * What they asked for is the intersection: **expand the proxy through the TOKEN's scope, not through the proxy's
+ * full member list.** A token holding `['qa','team']` used against an all-spaces proxy recalls across `qa` and
+ * `team` and nothing else. The proxy becomes a lens over what you may already see.
+ *
+ * They can already build a filtered proxy by hand — the reason that is not the answer is that it is a SECOND list
+ * to keep in step with the space set: every new project space must be added to it or silently drop out of
+ * everyone's recall. One list beats two, and it is the list they already maintain.
+ *
+ * ## Why this is a module of its own, doing nothing yet
+ *
+ * **Nothing calls this.** Allowing a token onto a proxy is only half the change: the read paths fan out over
+ * `resolveMemberSpaces` in 17 files, and letting a token through the guard **without** narrowing every one of those
+ * would hand it records from spaces it cannot see. That is a data leak, not a partial feature.
+ *
+ * So the rule lands first, on its own, with the property that matters asserted independently — exactly the shape
+ * the per-space rights series used: eight zero-behaviour PRs and an equivalence proof before any guard moved.
+ *
+ * ## The property that must never break
+ *
+ * The result is **always a subset** of `resolveMemberSpaces(proxyId)`, and always a subset of what the token
+ * reaches. It can only ever narrow. A bug that widens it is the leak above, so `narrowsOnly()` exists to be
+ * asserted directly rather than inferred from the implementation reading correctly.
+ */
+
+import { reachesSpace } from './space-reach.js';
+import type { TokenRights } from '../config/rights-shape.js';
+
+/**
+ * The members of `proxyId` that this token reaches.
+ *
+ * `allMembers` is passed in rather than resolved here so this stays pure and testable without a loaded config —
+ * the caller already has it, and taking it as an argument is what lets the subset property be checked against the
+ * same list the read path will fan out over.
+ *
+ * **Legacy fallback matches `enforceSpaceScope` exactly.** A record with no `rights` is an OIDC-derived token,
+ * built per request and never seen by the config backfill, so it is filtered by its `spaces` allowlist instead.
+ * A record with neither is unrestricted and reaches everything — the same answer both other call sites give, and
+ * the reason this is a `?? undefined` check rather than a truthiness one: `spaces: []` must not read as unscoped.
+ */
+export function memberSpacesForToken(
+  rights: TokenRights | undefined,
+  legacySpaces: string[] | undefined,
+  allMembers: string[],
+): string[] {
+  if (rights) return allMembers.filter(id => reachesSpace(rights, id));
+  if (legacySpaces === undefined) return [...allMembers];
+  return allMembers.filter(id => legacySpaces.includes(id));
+}
+
+/**
+ * Whether a narrowed set is a legitimate narrowing of the full member list.
+ *
+ * Asserted on its own rather than trusted from reading `memberSpacesForToken`, because the failure it guards
+ * against is silent: a set containing one id the token cannot reach leaks that space's records through the proxy,
+ * and every response still looks well-formed. A count is not enough either — the same size with a substituted id
+ * would pass a length check.
+ */
+export function narrowsOnly(narrowed: string[], allMembers: string[]): boolean {
+  const all = new Set(allMembers);
+  return narrowed.every(id => all.has(id)) && new Set(narrowed).size === narrowed.length;
+}
+
+/**
+ * Whether the token may use this proxy at all.
+ *
+ * Reaching **one** member is enough — that is the whole point of the change, and it is why this cannot be folded
+ * into `memberSpacesForToken`: "may I use it" and "what do I see" are different questions, and a caller that
+ * conflates them ends up treating an empty result as an error on a non-proxy space.
+ *
+ * An empty proxy — a `proxyFor` list whose members have all been deleted — reaches nothing and is refused. That is
+ * the correct answer rather than an edge case to smooth over: a lens over nothing should not answer `200` with an
+ * empty body, because the caller cannot tell that from a space they simply cannot see into.
+ */
+export function mayUseProxy(
+  rights: TokenRights | undefined,
+  legacySpaces: string[] | undefined,
+  allMembers: string[],
+): boolean {
+  return memberSpacesForToken(rights, legacySpaces, allMembers).length > 0;
+}

--- a/testing/standalone/proxy-reach.test.js
+++ b/testing/standalone/proxy-reach.test.js
@@ -1,0 +1,160 @@
+/**
+ * A proxy space narrowed to the members a token may see.
+ *
+ * ## The direction that matters
+ *
+ * This exists to LET a scoped token onto a proxy, which means the dangerous mistake is not refusing too much — it
+ * is returning one member the token cannot reach. That leaks records from another space through the proxy, and
+ * every response still looks well-formed. So most of what follows asserts the subset property from several angles
+ * rather than checking a happy path once.
+ *
+ * A count is deliberately not trusted anywhere: the same size with a substituted id would pass a length check.
+ *
+ * Run: node --test testing/standalone/proxy-reach.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let memberSpacesForToken, narrowsOnly, mayUseProxy;
+before(async () => {
+  ({ memberSpacesForToken, narrowsOnly, mayUseProxy } = await import('../../server/dist/auth/proxy-reach.js'));
+});
+
+const ALL = ['qa', 'team', 'research', 'ops'];
+
+/** Rights reaching exactly the named spaces: a row per space, floor absent. */
+const rightsFor = (...spaces) => ({
+  instanceAdmin: false,
+  createSpaces: false,
+  floor: null,
+  perSpace: Object.fromEntries(spaces.map(s => [s, { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' }])),
+});
+
+/** A floor reaches every space, including ones created later — that is what a floor IS. */
+const withFloor = () => ({
+  instanceAdmin: false,
+  createSpaces: false,
+  floor: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' },
+  perSpace: {},
+});
+
+describe('narrowing by rights', () => {
+  it('returns the INTERSECTION, not the full member list', () => {
+    // The ask. A token holding qa+team against an all-spaces proxy sees qa and team, not research or ops.
+    assert.deepEqual(memberSpacesForToken(rightsFor('qa', 'team'), undefined, ALL), ['qa', 'team']);
+  });
+
+  it('preserves the member list ORDER rather than the token\'s', () => {
+    // The read path fans out over this; a reordering would make paging and any first-match lookup depend on how a
+    // token happened to be written.
+    assert.deepEqual(memberSpacesForToken(rightsFor('ops', 'qa'), undefined, ALL), ['qa', 'ops']);
+  });
+
+  it('drops a space the token holds that is NOT a member of this proxy', () => {
+    // Otherwise a token could reach a space through a proxy that does not contain it.
+    assert.deepEqual(memberSpacesForToken(rightsFor('qa', 'elsewhere'), undefined, ALL), ['qa']);
+  });
+
+  it('returns everything when the token has a FLOOR', () => {
+    // A floor is a minimum across all spaces including future ones, so it reaches every member by definition.
+    assert.deepEqual(memberSpacesForToken(withFloor(), undefined, ALL), ALL);
+  });
+
+  it('returns nothing when the token reaches no member', () => {
+    assert.deepEqual(memberSpacesForToken(rightsFor('elsewhere'), undefined, ALL), []);
+  });
+});
+
+describe('the legacy fallback, for OIDC records with no rights', () => {
+  it('filters by the spaces allowlist', () => {
+    assert.deepEqual(memberSpacesForToken(undefined, ['team', 'ops'], ALL), ['team', 'ops']);
+  });
+
+  it('UNDEFINED spaces means unrestricted — every member', () => {
+    assert.deepEqual(memberSpacesForToken(undefined, undefined, ALL), ALL);
+  });
+
+  it('an EMPTY array is not unrestricted', () => {
+    // The trap this repo has hit in three separate files: `!spaces || spaces.length === 0` reading as "all".
+    // The check must be on `undefined` alone.
+    assert.deepEqual(memberSpacesForToken(undefined, [], ALL), []);
+  });
+
+  it('does not return a member the allowlist omits', () => {
+    assert.deepEqual(memberSpacesForToken(undefined, ['qa'], ALL), ['qa']);
+  });
+});
+
+describe('it can only ever NARROW', () => {
+  it('never returns a member that is not in the full list', () => {
+    // The leak, asserted directly rather than inferred from the implementation reading correctly.
+    for (const r of [rightsFor('qa'), rightsFor('qa', 'team'), withFloor(), rightsFor()]) {
+      const out = memberSpacesForToken(r, undefined, ALL);
+      assert.ok(narrowsOnly(out, ALL), `${JSON.stringify(out)} is not a subset of the members`);
+    }
+  });
+
+  it('narrowsOnly REJECTS a foreign id, so the check is not vacuous', () => {
+    // A predicate that returns true for everything would pass every test above.
+    assert.equal(narrowsOnly(['qa', 'secret'], ALL), false);
+    assert.equal(narrowsOnly(['secret'], ALL), false);
+  });
+
+  it('narrowsOnly rejects a DUPLICATE, which a subset check alone would allow', () => {
+    // A duplicated member would make a read path visit one space twice and double its results — a wrong answer
+    // that is not a permission failure, so nothing else here would catch it.
+    assert.equal(narrowsOnly(['qa', 'qa'], ALL), false);
+  });
+
+  it('accepts the empty set and the whole set', () => {
+    assert.equal(narrowsOnly([], ALL), true);
+    assert.equal(narrowsOnly([...ALL], ALL), true);
+  });
+});
+
+describe('may the token use the proxy at all', () => {
+  it('ONE reachable member is enough', () => {
+    // The entire point of the change: today the answer is "only if you reach every member", which is why a scoped
+    // token gets 403 on an all-spaces proxy.
+    assert.equal(mayUseProxy(rightsFor('qa'), undefined, ALL), true);
+  });
+
+  it('no reachable member is a refusal', () => {
+    assert.equal(mayUseProxy(rightsFor('elsewhere'), undefined, ALL), false);
+    assert.equal(mayUseProxy(undefined, [], ALL), false);
+  });
+
+  it('an EMPTY proxy is refused, not answered with nothing', () => {
+    // A proxy whose members were all deleted. Answering 200 with an empty body would be indistinguishable from a
+    // space the caller cannot see into, which is the worse of the two failures.
+    assert.equal(mayUseProxy(withFloor(), undefined, []), false);
+    assert.equal(mayUseProxy(undefined, undefined, []), false);
+  });
+
+  it('agrees with memberSpacesForToken in every case', () => {
+    // Two functions answering one question is how they drift. Pinned so a later change to either is caught.
+    for (const [r, legacy] of [[rightsFor('qa'), undefined], [rightsFor('elsewhere'), undefined],
+      [withFloor(), undefined], [undefined, ['ops']], [undefined, []], [undefined, undefined]]) {
+      assert.equal(
+        mayUseProxy(r, legacy, ALL),
+        memberSpacesForToken(r, legacy, ALL).length > 0,
+        `disagreement for ${JSON.stringify({ r, legacy })}`,
+      );
+    }
+  });
+});
+
+describe('nothing is wired to it yet, and that is deliberate', () => {
+  it('no caller outside its own module and tests', async () => {
+    // Allowing a token onto a proxy WITHOUT narrowing the 17 read fan-outs would hand it records from spaces it
+    // cannot see. This test is the reminder that the guard change and the fan-out change must land together.
+    // `--untracked` matters: plain `git grep` searches the INDEX, so on the commit that introduces these two files
+    // it finds neither and this assertion fails against correct code. Same shape as the repo's rule about never
+    // asking git what files exist without saying which set you mean.
+    const { execSync } = await import('node:child_process');
+    const hits = execSync('git grep --untracked -l "memberSpacesForToken\\|mayUseProxy" -- server/src testing || true',
+      { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
+    assert.deepEqual(hits.sort(), ['server/src/auth/proxy-reach.ts', 'testing/standalone/proxy-reach.test.js']);
+  });
+});


### PR DESCRIPTION
## The ask

From **aigents**, 2026-08-09, with probes. Today a proxy space **cannot be granted to a non-admin token at all**:
`enforceSpaceScope` requires the token to reach *every* member, so listing the proxy in `spaces` does nothing and
every call `403`s. They proved it was not specific to one proxy by building their own over 15 spaces, getting the
same refusal, and deleting it.

What they asked for is the **intersection**: expand the proxy through the *token's* scope rather than the proxy's
full member list. A token holding `['qa','team']` against an all-spaces proxy recalls across `qa` and `team` and
nothing else. The proxy becomes a lens over what you may already see.

They *can* already build a filtered proxy by hand. The reason that is not the answer: it is a **second list** to
keep in step with the space set — every new project space must be added to it or silently drop out of everyone's
recall. One list beats two, and it is the list they already maintain.

## Nothing calls this, and that is why it ships alone

`resolveMemberSpaces` is called from **17 files**, and each one is a read fan-out. Letting a token past the guard
**without** narrowing every one of them would hand it records from spaces it cannot see.

That is a data leak, not a partial feature. So the guard flip and the 17 call sites have to land as **one** change,
and the rule lands first by itself — the same shape the per-space rights series used: eight zero-behaviour PRs and
an equivalence proof before any guard moved.

A test asserts the absence of callers, so the two halves cannot drift apart unnoticed.

## Three functions, split deliberately

| | |
|---|---|
| `memberSpacesForToken` | The intersection, preserving the **member** list's order, not the token's — the read path fans out over this, so reordering would make paging and first-match lookups depend on how a token happened to be written. |
| `mayUseProxy` | One reachable member is enough. Separate because *"may I use it"* and *"what do I see"* are different questions; a caller that conflates them treats an empty result as an error on a non-proxy space. |
| `narrowsOnly` | The subset property, asserted **independently** rather than inferred from the implementation reading correctly. |

`narrowsOnly` also rejects a **duplicate**, which a plain subset check would allow — a duplicated member makes a read
path visit one space twice and double its results. That is a wrong answer rather than a permission failure, so
nothing else here would catch it.

## Two traps this repo has already paid for

- **An empty `spaces` array is not unrestricted.** The check is on `undefined` alone; the
  `!spaces || spaces.length === 0` reading has already been a defect in three separate files.
- **An empty proxy is refused, not answered with an empty body.** A caller cannot distinguish an empty body from a
  space they are not allowed to see into, which is the worse of the two failures.

## One test failed against correct code

It asserted the absence of callers with `git grep` — which searches the **index**, and both files are untracked on
the commit that introduces them. Fixed with `--untracked`. Same lesson as never asking git what files exist without
saying which set you mean.

## Verification

18 tests: the intersection, member-order preservation, floor reaching everything, the legacy OIDC fallback including
the empty-array case, the subset property from four angles, `narrowsOnly` rejecting a foreign id *and* a duplicate
(so it is not vacuous), the empty-proxy refusal, and agreement between `mayUseProxy` and `memberSpacesForToken`
across six shapes. Preflight green.

🤖 Generated with Claude Code
