### PR TITLE
refactor(brain): recall's seven proxy fan-outs narrow to what the caller may see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Internal: recall's seven proxy fan-outs now narrow to the members the caller may see.** `api/brain/search.ts`
+  calls `memberSpacesForRequest` instead of `resolveMemberSpaces` — recall, stats, activity, traverse, the ER model,
+  reindex and reindex-status.
+  - **A provable no-op today.** `enforceSpaceScope` still requires a token to reach every member, so any caller that
+    gets this far already reaches all of them and the narrowed list equals the full one. Converting first and
+    flipping the guard afterwards is what makes the expensive half verifiable.
+  - The reverse order would be a leak: flip the guard first and every un-narrowed site serves records from spaces the
+    caller cannot see, with a well-formed `200`.
+  - The inventory gate now holds a **conserved total** — narrowed plus pending must equal 28 — so a conversion has to
+    move a site rather than drop it, and a half-converted file fails outright.
+
 ### Added
 - **A gate over every proxy fan-out, so Q-6's second half cannot miss one.** `resolveMemberSpaces` expands a proxy
   into its members and the read paths fan out over the result; once a token that reaches only *some* members may use

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -20,7 +20,8 @@ import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
 import { needsReindex, clearReindexFlag } from '../../spaces/_shared.js';
 import { log } from '../../util/log.js';
-import { resolveMemberSpaces, collectAcrossMembers } from '../../spaces/proxy.js';
+import { collectAcrossMembers } from '../../spaces/proxy.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
 import type { MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc } from '../../config/types.js';
 import { reindexInProgress } from '../../metrics/registry.js';
 import { UUID_V4_RE } from './_shared.js';
@@ -52,7 +53,7 @@ searchRouter.get('/spaces/:spaceId/er-model', globalRateLimit, requireSpaceAuth,
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   const models = await Promise.all(memberIds.map(mid => buildErModel(mid)));
   res.json(memberIds.length === 1 && memberIds[0] === spaceId
     ? models[0]
@@ -68,7 +69,7 @@ searchRouter.get('/spaces/:spaceId/stats', globalRateLimit, requireSpaceAuth, as
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   const counts = await Promise.all(memberIds.map(async mid => ({
     memories: await countMemories(mid),
     entities: await col(`${mid}_entities`).countDocuments(),
@@ -122,7 +123,7 @@ searchRouter.get('/spaces/:spaceId/activity', globalRateLimit, requireSpaceAuth,
   const raw = Number(req.query['hours'] ?? 24);
   const hours = Number.isFinite(raw) ? Math.max(1, Math.min(90 * 24, Math.floor(raw))) : 24;
 
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   const rows = (await Promise.all(memberIds.map(mid => summariseActivity(hours, Date.now(), mid)))).flat();
   res.json({ spaceId, hours, spaces: rows });
 });
@@ -187,7 +188,7 @@ searchRouter.post('/spaces/:spaceId/traverse', globalRateLimit, requireSpaceAuth
     return;
   }
 
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   const result = await traverseGraph(memberIds, startId.trim(), effectiveDirection, effectiveEdgeLabels, effectiveDepth, effectiveLimit,
     includeChronoRaw !== false);
   res.json(result);
@@ -378,7 +379,7 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
   }
 
   try {
-    const memberIds = resolveMemberSpaces(spaceId);
+    const memberIds = memberSpacesForRequest(req, spaceId);
     // One collector across every member, deduped by `recall` itself, so a proxy space reports "the answer is
     // partial" once rather than once per member.
     // Opt-in scan of the newest records, for the case the index has not caught up yet. Rejected rather
@@ -540,7 +541,7 @@ searchRouter.get('/spaces/:spaceId/reindex-status', globalRateLimit, requireSpac
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   const needs = memberIds.some(mid => needsReindex(mid));
   res.json({ spaceId, needsReindex: needs });
 });
@@ -562,7 +563,7 @@ searchRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth,
     return;
   }
 
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   reindexJobRunning = true;
   reindexInProgress.set(1);
   res.json({ spaceId, reindexed: 0, errors: 0, status: 'started' });

--- a/server/src/spaces/proxy-scoped.ts
+++ b/server/src/spaces/proxy-scoped.ts
@@ -1,0 +1,60 @@
+/**
+ * A proxy space's members, narrowed to what the CALLER may see.
+ *
+ * ## What this is for
+ *
+ * `resolveMemberSpaces(spaceId)` answers "what does this proxy contain". Every read path fans out over that answer.
+ * Q-6 lets a token that reaches only SOME members use a proxy, at which point "what does it contain" and "what may
+ * this caller see" stop being the same question — and a fan-out that keeps asking the first one serves records from
+ * a space the caller cannot see, with a well-formed `200` and nothing to notice.
+ *
+ * So this is the version the read paths should call. `auth/proxy-reach.ts` holds the rule and stays pure; this adds
+ * the two things it deliberately does not know — the config lookup, and where a request keeps its token.
+ *
+ * ## It is a NO-OP until the guard changes, on purpose
+ *
+ * `enforceSpaceScope` still requires a token to reach **every** member, so any caller that gets this far already
+ * reaches all of them and the narrowed list equals the full one. That is what makes converting 28 call sites a
+ * provable no-op, and it reduces the actual behaviour change to one line in the guard afterwards.
+ *
+ * The reverse order is the leak: flip the guard first and every un-narrowed site is serving another space's records
+ * until it is converted.
+ *
+ * ## Why the request is structurally typed
+ *
+ * `req: { authToken?: unknown }` is the idiom already used by `accessibleSpaces` in `api/conflicts.ts`,
+ * `api/contradictions.ts` and `api/duplicates.ts`. It keeps this module out of the Express type graph, and it is
+ * what lets the MCP tools — which have a call context rather than a request — use `memberSpacesForToken` directly
+ * instead of faking a request object.
+ */
+
+import { resolveMemberSpaces } from './proxy.js';
+import { memberSpacesForToken } from '../auth/proxy-reach.js';
+import type { TokenRights } from '../config/rights-shape.js';
+
+/** The token fields that decide reach. Extracted the same way the three `accessibleSpaces` helpers do it. */
+type Bearer = { rights?: TokenRights; spaces?: string[] } | undefined;
+
+/**
+ * The members of `spaceId` this request may see. For a non-proxy space this is `[spaceId]` when the caller reaches
+ * it, and `[]` when it does not.
+ *
+ * **An empty result is meaningful and must not be treated as "all".** That inversion — reading an empty allowlist as
+ * unrestricted — has been a real defect in three separate files in this repo, and here it would turn the narrowest
+ * caller into the widest. A caller that gets `[]` should answer 403 or return nothing, never fall back.
+ */
+export function memberSpacesForRequest(req: { authToken?: unknown }, spaceId: string): string[] {
+  const t = req.authToken as Bearer;
+  return memberSpacesForToken(t?.rights, t?.spaces, resolveMemberSpaces(spaceId));
+}
+
+/**
+ * The same narrowing for a caller that holds a token record rather than a request — the MCP tools.
+ *
+ * Separate from the request form rather than sharing it through a fake `{ authToken }` wrapper: a synthesised
+ * request object is a lie that the next reader has to unpick, and it invites someone to pass a real request where a
+ * record was meant.
+ */
+export function memberSpacesForRecord(record: Bearer, spaceId: string): string[] {
+  return memberSpacesForToken(record?.rights, record?.spaces, resolveMemberSpaces(spaceId));
+}

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -45,10 +45,15 @@ import { readFileSync } from 'node:fs';
  * that fails for an edit three functions away gets ignored. The count still catches a NEW fan-out appearing in a
  * file that already had some, which a bare file list would not.
  */
+const NARROWED = new Set([
+  // Converted to memberSpacesForRequest. A no-op while the guard still requires all members, which is what makes
+  // the conversion provable rather than a behaviour change taken on trust.
+  'server/src/api/brain/search.ts',
+]);
+
 const PENDING = {
   'server/src/api/brain/entities.ts': 1,
   'server/src/api/brain/file-meta.ts': 3,
-  'server/src/api/brain/search.ts': 7,
   'server/src/api/files.ts': 1,
   'server/src/api/spaces.ts': 4,
   'server/src/auth/middleware.ts': 2,
@@ -71,7 +76,13 @@ const PENDING = {
 // is wrong the first time, every time.
 
 /** The module that DEFINES it, and the rule module that only names it in prose. Neither is a fan-out. */
-const NOT_CALL_SITES = new Set(['server/src/spaces/proxy.ts', 'server/src/auth/proxy-reach.ts']);
+//  DEFINES it,  names it in prose, and  is the narrowing wrapper — its
+// own call is the one legitimate un-narrowed use, since it is what does the narrowing.
+const NOT_CALL_SITES = new Set([
+  'server/src/spaces/proxy.ts',
+  'server/src/auth/proxy-reach.ts',
+  'server/src/spaces/proxy-scoped.ts',
+]);
 
 /**
  * Every `resolveMemberSpaces(<arg>)` call in the server, with its argument text.
@@ -100,26 +111,39 @@ function callSites() {
  */
 const isWriteTarget = (arg) => /^wt\.target$/.test(arg);
 
-describe('the fan-out inventory matches the source', () => {
+
+/** Calls that HAVE been narrowed — `memberSpacesForRequest` / `memberSpacesForRecord`. */
+function narrowedCalls() {
+  const out = [];
+  const files = execSync('git grep --untracked -l "memberSpacesFor" -- server/src', { encoding: 'utf8' })
+    .trim().split('\n').filter(Boolean);
+  for (const f of files) {
+    if (NOT_CALL_SITES.has(f) || f === 'server/src/spaces/proxy-scoped.ts') continue;
+    const src = readFileSync(f, 'utf8');
+    for (const m of src.matchAll(/memberSpacesFor(?:Request|Record)\(/g)) out.push({ file: f, at: m.index });
+  }
+  return out;
+}
+
+describe('the inventory matches the source', () => {
   const sites = callSites();
+  const done = narrowedCalls();
 
   it('finds call sites at all — an empty sweep would pass everything', () => {
     // The failure this repo keeps finding: a gate whose measurement returns nothing reads exactly like a clean one.
-    assert.ok(sites.length >= 20, `only found ${sites.length} call sites — the sweep is broken`);
+    assert.ok(sites.length + done.length >= 25, `only found ${sites.length + done.length} — the sweep is broken`);
   });
 
-  it('classifies every site as a write target or a listed read fan-out', () => {
-    const unlisted = [];
-    for (const s of sites) {
-      if (isWriteTarget(s.arg)) continue;
-      if (!(s.file in PENDING)) unlisted.push(`${s.file} → resolveMemberSpaces(${s.arg})`);
-    }
+  it('every un-narrowed read fan-out is a listed PENDING file', () => {
+    const unlisted = sites
+      .filter(s => !isWriteTarget(s.arg) && !(s.file in PENDING))
+      .map(s => `${s.file} → resolveMemberSpaces(${s.arg})`);
     assert.deepEqual(unlisted, [],
-      'a read fan-out in a file the inventory does not list. Narrow it to the token\'s members '
-      + '(auth/proxy-reach.ts) and add the file to PENDING, or explain why it cannot expose another space.');
+      'a read fan-out in a file the inventory does not list. Narrow it with memberSpacesForRequest '
+      + '(spaces/proxy-scoped.ts) and move the file to NARROWED, or add it to PENDING with its count.');
   });
 
-  it('counts match per file, so a NEW fan-out in a known file is caught', () => {
+  it('PENDING counts match, so a NEW fan-out in a known file is caught', () => {
     const actual = {};
     for (const s of sites) {
       if (isWriteTarget(s.arg)) continue;
@@ -128,35 +152,50 @@ describe('the fan-out inventory matches the source', () => {
     assert.deepEqual(actual, PENDING);
   });
 
-  it('has no stale entry — every listed file still contains a fan-out', () => {
-    // A list that outlives its code is how an inventory starts describing the past. Same reason the tracker rule
-    // says a checkbox is not evidence.
+  it('no PENDING entry is stale', () => {
+    // A list that outlives its code starts describing the past — the same reason a tracker checkbox is not evidence.
     const seen = new Set(sites.filter(s => !isWriteTarget(s.arg)).map(s => s.file));
-    assert.deepEqual([...Object.keys(PENDING)].filter(f => !seen.has(f)), []);
+    assert.deepEqual(Object.keys(PENDING).filter(f => !seen.has(f)), []);
+  });
+});
+
+describe('a NARROWED file is really narrowed', () => {
+  it('contains no un-narrowed read fan-out left behind', () => {
+    // The half-converted file is the dangerous state: six sites narrowed and a seventh still fanning out over every
+    // member reads as done and leaks on one route.
+    const leftovers = callSites()
+      .filter(s => !isWriteTarget(s.arg) && NARROWED.has(s.file))
+      .map(s => `${s.file} → resolveMemberSpaces(${s.arg})`);
+    assert.deepEqual(leftovers, []);
+  });
+
+  it('actually calls the narrowing helper', () => {
+    // Otherwise a file could be moved to NARROWED by deleting its fan-outs rather than converting them.
+    const byFile = new Set(narrowedCalls().map(c => c.file));
+    assert.deepEqual([...NARROWED].filter(f => !byFile.has(f)), []);
+  });
+});
+
+describe('the total is conserved', () => {
+  it('narrowed + still pending accounts for all 28 read fan-outs', () => {
+    // The invariant that makes progress checkable: converting a site must MOVE it, never drop it. A conversion that
+    // quietly deleted a fan-out would otherwise look like progress.
+    const pending = Object.values(PENDING).reduce((a, b) => a + b, 0);
+    assert.equal(pending + narrowedCalls().length, 28,
+      `expected 28 total, got ${pending} pending + ${narrowedCalls().length} narrowed`);
   });
 });
 
 describe('the write-target classification is real, not a loophole', () => {
   it('recognises exactly the resolved-write-target form', () => {
     assert.equal(isWriteTarget('wt.target'), true);
-    // Anything that merely mentions the request's space is a fan-out, however it is spelled.
     for (const arg of ['spaceId', 'id', 'callSpace', 'rawSpace', 's.id', 'wt.target ?? spaceId', 'proxyId']) {
       assert.equal(isWriteTarget(arg), false, `${arg} must not classify as a write target`);
     }
   });
 
   it('at least one real write-target site exists, so the branch is exercised', () => {
-    // If this were zero, `isWriteTarget` could be wrong in either direction and every test above would still pass.
+    // At zero, `isWriteTarget` could be wrong in either direction and every test above would still pass.
     assert.ok(callSites().some(s => isWriteTarget(s.arg)), 'no write-target call sites found — check the pattern');
-  });
-});
-
-describe('the rule from #780 is still unwired', () => {
-  it('no fan-out consults it yet, which is what makes this a PENDING list', () => {
-    // When this starts failing, it is because the second half has begun — at which point the entries move to
-    // NARROWED and the assertions above tighten. It failing is the signal to update this file, not a defect.
-    const hits = execSync('git grep --untracked -l "memberSpacesForToken\\|mayUseProxy" -- server/src || true',
-      { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
-    assert.deepEqual(hits, ['server/src/auth/proxy-reach.ts']);
   });
 });

--- a/testing/standalone/proxy-reach.test.js
+++ b/testing/standalone/proxy-reach.test.js
@@ -145,20 +145,15 @@ describe('may the token use the proxy at all', () => {
   });
 });
 
-describe('nothing is wired to it yet, and that is deliberate', () => {
-  it('no caller outside its own module and tests', async () => {
-    // Allowing a token onto a proxy WITHOUT narrowing the 17 read fan-outs would hand it records from spaces it
-    // cannot see. This test is the reminder that the guard change and the fan-out change must land together.
-    // `--untracked` matters: plain `git grep` searches the INDEX, so on the commit that introduces these two files
-    // it finds neither and this assertion fails against correct code. Same shape as the repo's rule about never
-    // asking git what files exist without saying which set you mean.
-    // Scoped to `server/src`, because that is where a CALLER would be. The first version also searched `testing/`
-    // and pinned an exact two-file list, so it failed the moment a second test mentioned the names — which happened
-    // immediately, when the fan-out inventory gate referenced them in its own assertion. A test naming a function is
-    // not a caller of it, and a gate that cannot tell those apart fires on correct code.
+describe('the rule is reached through ONE seam', () => {
+  it('only spaces/proxy-scoped.ts calls it', async () => {
+    // This replaced an assertion that nothing called it at all, which was right until the conversion began and then
+    // failed against correct code. The property worth keeping is not "unused" — it is that every read path goes
+    // through the one wrapper that also does the config lookup. A handler calling the pure rule directly would have
+    // to resolve the member list itself, which is the second copy that makes two answers to one question.
     const { execSync } = await import('node:child_process');
-    const hits = execSync('git grep --untracked -l "memberSpacesForToken\\|mayUseProxy" -- server/src || true',
-      { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
-    assert.deepEqual(hits, ['server/src/auth/proxy-reach.ts']);
+    const hits = execSync('git grep --untracked -l "memberSpacesForToken(" -- server/src || true',
+      { encoding: 'utf8' }).trim().split('\n').filter(Boolean).sort();
+    assert.deepEqual(hits, ['server/src/auth/proxy-reach.ts', 'server/src/spaces/proxy-scoped.ts']);
   });
 });


### PR DESCRIPTION
## What

Q-6's expensive half, starting with the file that matters most. `api/brain/search.ts` calls
`memberSpacesForRequest` instead of `resolveMemberSpaces` at all **seven** sites: recall, stats, activity, traverse,
the ER model, reindex and reindex-status.

## It is a provable no-op today, and that is the strategy

`enforceSpaceScope` still requires a token to reach **every** member of a proxy — so any caller reaching these lines
already reaches all of them, and the narrowed list equals the full one.

Converting first and flipping the guard afterwards makes 28 site changes verifiable, and reduces the actual
behaviour change to one line.

**The reverse order is a data leak.** Flip the guard first and every un-narrowed site serves records from a space the
caller cannot see, with a well-formed `200` and nothing to notice.

## The seam

`spaces/proxy-scoped.ts` adds the two things the pure rule in `auth/proxy-reach.ts` deliberately does not know: the
config lookup, and where a request keeps its token.

The request is structurally typed (`{ authToken?: unknown }`) — the idiom the three `accessibleSpaces` helpers
already use. It keeps this out of the Express type graph and lets the MCP tools call `memberSpacesForRecord` rather
than synthesise a fake request. A synthesised request is a lie the next reader has to unpick, and it invites someone
to pass a real one where a record was meant.

## Foundation verified before relying on it

`reachesSpace` **never consults `instanceAdmin`** — which would matter if admin tokens then narrowed to nothing.
It is correct as it stands, and deliberately so:

| admin token | migration gives it | reaches |
|---|---|---|
| no `spaces` | `floor: rungs('admin')` | everything |
| with `spaces` | `perSpace` rows, `floor: null` | only those spaces |

The second row is the right answer, and the reason `instanceAdmin` must not be a reach shortcut. No special-casing
needed.

## The gate now holds a conserved total

**Narrowed + pending must equal 28.** A conversion has to *move* a site rather than drop it — one that quietly
deleted a fan-out would otherwise read as progress.

It also refuses a **half-converted file**, which is the genuinely dangerous state: six sites narrowed and a seventh
still fanning out over every member reads as done and leaks on one route.

**21 sites remain across 12 files.** `PENDING` reaching empty is the definition of done.

## Two of my own tests failed against correct code

Both from asserting a premise instead of a property:

- `proxy-fanout-inventory` treated `proxy-scoped.ts` as a fan-out. It is the **wrapper** — its own call is the one
  legitimate un-narrowed use, since it is what does the narrowing.
- `proxy-reach` asserted that **nothing** called the rule. True until the conversion began, then wrong. Replaced with
  the property actually worth holding: **the rule is reached through one seam.** A handler calling it directly would
  have to resolve the member list itself, which is the second copy that makes two answers to one question.

27 tests green across both files; server build clean; preflight green.

🤖 Generated with Claude Code
