### PR TITLE
refactor(api): nine more proxy fan-outs narrow to what the caller may see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- **Internal: nine more proxy fan-outs narrowed to the members the caller may see** — `api/spaces.ts` (4),
+  `api/brain/file-meta.ts` (3), `api/brain/entities.ts` and `api/files.ts`. Every HTTP-side fan-out with a request in
+  scope is now converted: **16 narrowed, 12 pending**, and the gate's conserved total still reads 28.
+  - Still a **provable no-op**: the guard requires a token to reach every member, so the narrowed list equals the
+    full one for any caller that gets this far.
+  - What remains is the work that needs more than a mechanical swap — `brain/write-validation.ts` is a shared helper
+    whose signature has to change, and the MCP tools carry a call context rather than a request.
+
+### Changed
 - **Internal: recall's seven proxy fan-outs now narrow to the members the caller may see.** `api/brain/search.ts`
   calls `memberSpacesForRequest` instead of `resolveMemberSpaces` — recall, stats, activity, traverse, the ER model,
   reindex and reindex-status.

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -15,6 +15,7 @@ import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
 import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
 import { validateEntity } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError, dupeCheckOptsFromBody, ifMatchFromRequest, preconditionFailedBody } from './_shared.js';
 import { classifyEntityUpsert, classifyUpdateViolations } from '../../brain/write-validation.js';
@@ -193,7 +194,7 @@ entitiesRouter.get('/spaces/:spaceId/entities/:id', globalRateLimit, requireSpac
 entitiesRouter.delete('/spaces/:spaceId/entities/:id', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const id = req.params['id'] as string;
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
   for (const mid of memberIds) {
     const entity = await getEntityById(mid, id);
     if (!entity) continue;

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -24,6 +24,7 @@ import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { fetchJobProgress, getMediaJobCounts, FAILED_SAMPLE_LIMIT, FAILED_REASON_LIMIT, type MediaJobCounts } from '../../files/media/job-queue.js';
 import { tagContains } from '../../brain/tag-filter.js';
@@ -157,7 +158,7 @@ fileMetaRouter.get('/spaces/:spaceId/files/extract', globalRateLimit, requireSpa
   // member collection as their parent, and querying another member's would silently return nothing.
   let member: string | null = null;
   let parent: FileMetaDoc | null = null;
-  for (const mid of resolveMemberSpaces(spaceId)) {
+  for (const mid of memberSpacesForRequest(req, spaceId)) {
     const found = await getFileMeta(mid, parentId);
     if (found) { member = mid; parent = found; break; }
   }
@@ -264,7 +265,7 @@ fileMetaRouter.get('/spaces/:spaceId/embedding-queue', globalRateLimit, requireS
   // Reasons are summed across member spaces before truncating, so a proxy space's grouping is the grouping of
   // its whole fleet rather than of whichever member was iterated first.
   const reasons = new Map<string | null, number>();
-  for (const mid of resolveMemberSpaces(spaceId)) {
+  for (const mid of memberSpacesForRequest(req, spaceId)) {
     const c = await getMediaJobCounts(mid);
     total.pending += c.pending; total.processing += c.processing; total.complete += c.complete; total.failed += c.failed;
     total.failedSample.push(...c.failedSample);
@@ -289,7 +290,7 @@ fileMetaRouter.post('/spaces/:spaceId/embedding-queue/retry-failed', globalRateL
   }
   const { retryFailedJobs } = await import('../../files/media/job-queue.js');
   let retried = 0;
-  for (const mid of resolveMemberSpaces(spaceId)) {
+  for (const mid of memberSpacesForRequest(req, spaceId)) {
     retried += await retryFailedJobs(mid);
   }
   res.status(202).json({ retried });

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -49,7 +49,8 @@ import type { FileMetaDoc } from '../config/types.js';
 import { upsertFileMeta, deleteFileMeta, deleteFileMetaByPrefix, renameFileMeta, renameFileMetaByPrefix, markFileMetaDeleted, markFileMetaDeletedByPrefix } from '../files/file-meta.js';
 import { writeFileTombstones } from '../files/tombstones.js';
 import { deleteFileCascade } from '../files/delete-cascade.js';
-import { resolveMemberSpaces, resolveWriteTarget } from '../spaces/proxy.js';
+import { resolveWriteTarget } from '../spaces/proxy.js';
+import { memberSpacesForRequest } from '../spaces/proxy-scoped.js';
 import { emitWebhookEvent } from '../webhooks/dispatcher.js';
 import { deleteConversionArtifacts, deleteConversionArtifactsByPrefix, isMediaFormat } from '../files/converters/pipeline.js';
 import type { InputFormat } from '../files/converters/pipeline.js';
@@ -295,7 +296,7 @@ fileStoreRouter.get('/:spaceId', globalRateLimit, requireSpaceAuth, async (req, 
 
   const filePath = req.query['path'];
   const normalised = typeof filePath === 'string' && filePath.trim() ? filePath : '.';
-  const memberIds = resolveMemberSpaces(spaceId);
+  const memberIds = memberSpacesForRequest(req, spaceId);
 
   // Directory listing — aggregate across all member spaces
   // Try to find the first member where the path resolves successfully

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -14,7 +14,7 @@ import { gatherCompletenessFacts, scoreCompleteness } from '../spaces/completene
 import { ensureTtlIndex } from '../brain/ttl.js';
 import { measureUsage, dirSizeBytes } from '../quota/quota.js';
 import { col } from '../db/mongo.js';
-import { resolveMemberSpaces } from '../spaces/proxy.js';
+import { memberSpacesForRequest } from '../spaces/proxy-scoped.js';
 import { isNetworkSyncing } from '../sync/engine.js';
 import { spaceNetworkInfo } from '../spaces/network-status.js';
 import { z } from 'zod';
@@ -422,7 +422,7 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
   if (includeCounts) {
     const countResults = await Promise.allSettled(
       visibleSpaces.map(async s => {
-        const memberIds = resolveMemberSpaces(s.id);
+        const memberIds = memberSpacesForRequest(req, s.id);
         const perMember = await Promise.all(memberIds.map(async mid => ({
           memories: await col(`${mid}_memories`).countDocuments(),
           entities: await col(`${mid}_entities`).countDocuments(),
@@ -874,7 +874,7 @@ spacesRouter.get('/:id/meta', globalRateLimit, requireAuth, async (req, res) => 
   const meta = resolveRefs
     ? (await import('../spaces/schema-validation.js')).resolveMetaRefs(rawMeta)
     : rawMeta;
-  const memberIds = resolveMemberSpaces(id);
+  const memberIds = memberSpacesForRequest(req, id);
   const counts = await Promise.all(memberIds.map(async mid => ({
     memories: await col(`${mid}_memories`).countDocuments(),
     entities: await col(`${mid}_entities`).countDocuments(),
@@ -915,7 +915,7 @@ spacesRouter.get('/:id/completeness', globalRateLimit, requireAuth, async (req, 
     res.status(404).json({ error: `Space '${id}' not found` });
     return;
   }
-  const facts = await gatherCompletenessFacts(resolveMemberSpaces(id));
+  const facts = await gatherCompletenessFacts(memberSpacesForRequest(req, id));
   res.json(scoreCompleteness(id, space.meta ?? {}, facts));
 });
 
@@ -1118,7 +1118,7 @@ spacesRouter.post('/:id/validate-schema', globalRateLimit, requireAdminMfaScoped
   const resolvedMeta = resolveMetaRefs(dryMeta);
 
   const violations: Array<{ collection: string; _id: string; violations: Array<{ field: string; value: unknown; reason: string }> }> = [];
-  const memberIds = resolveMemberSpaces(id);
+  const memberIds = memberSpacesForRequest(req, id);
   const SCAN_LIMIT = 10_000;
 
   for (const mid of memberIds) {

--- a/testing/standalone/extract-view.test.js
+++ b/testing/standalone/extract-view.test.js
@@ -93,7 +93,10 @@ describe('the extract route', () => {
     // On a proxy space the derived records live in the same member collection as their parent. Looking
     // them up in another member's collection returns nothing, with no error — the failure mode that made
     // `pipeline-status` report every index missing on a working instance.
-    assert.match(handler, /for \(const mid of resolveMemberSpaces\(spaceId\)\)/);
+    // Q-6 narrowed this fan-out: the members are now the ones the CALLER may see, not every member of the proxy.
+    // The property this test is about is unchanged — it iterates members and keeps the one it found the record in —
+    // and pinning the narrowed form keeps it honest, since reverting to the unnarrowed call would fail here too.
+    assert.match(handler, /for \(const mid of memberSpacesForRequest\(req, spaceId\)\)/);
     assert.match(handler, /member = mid/);
     assert.match(handler, /col<FileMetaDoc>\(`\$\{member\}_files`\)/);
   });

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -140,7 +140,11 @@ const FROZEN = {
   // `NetworkConfig` to `any` in a caller. The number was never the point; where the growth goes is.
   'server/src/config/types.ts': 578,
   'client/src/app/pages/settings/data.component.ts': 644,
-  'server/src/api/files.ts': 646,
+  // RAISED 646 -> 647 by ONE line: the Q-6 narrowing swapped `resolveMemberSpaces` for `memberSpacesForRequest`,
+  // and this file no longer needed the old import, so it gained an import line and lost none. Not growth in any
+  // meaningful sense — but the ratchet cannot tell a net line from a meaningful one, and quietly special-casing
+  // "it was only an import" is how a ceiling stops meaning anything.
+  'server/src/api/files.ts': 647,
   // 645 -> 660: the data-model panel’s mount and its card header. The panel ITSELF is a separate
   // component (er-model-panel) and its geometry a separate module (er-layout) — which is what this
   // ratchet asks for. What landed here is the 13 lines that place it in the grid, plus the two inputs

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -49,13 +49,13 @@ const NARROWED = new Set([
   // Converted to memberSpacesForRequest. A no-op while the guard still requires all members, which is what makes
   // the conversion provable rather than a behaviour change taken on trust.
   'server/src/api/brain/search.ts',
+  'server/src/api/spaces.ts',
+  'server/src/api/brain/file-meta.ts',
+  'server/src/api/brain/entities.ts',
+  'server/src/api/files.ts',
 ]);
 
 const PENDING = {
-  'server/src/api/brain/entities.ts': 1,
-  'server/src/api/brain/file-meta.ts': 3,
-  'server/src/api/files.ts': 1,
-  'server/src/api/spaces.ts': 4,
   'server/src/auth/middleware.ts': 2,
   'server/src/brain/write-validation.ts': 1,
   'server/src/mcp/router.ts': 1,


### PR DESCRIPTION
## What

Q-6 continued. `api/spaces.ts` (4), `api/brain/file-meta.ts` (3), `api/brain/entities.ts` (1) and `api/files.ts` (1)
now call `memberSpacesForRequest`.

**Every HTTP-side fan-out with a request in scope is converted: 16 narrowed, 12 pending** — and the gate's conserved
total still reads 28, which is what proves nothing was dropped rather than moved.

Still a **provable no-op**: `enforceSpaceScope` requires a token to reach every member, so the narrowed list equals
the full one for any caller that reaches these lines. The behaviour change is the guard flip at the end.

## Stopped at the boundary where the swap stops being mechanical

- **`brain/write-validation.ts` (1)** — inside `locateForUpdate`, a shared helper with no request. Its signature has
  to take the member list and every caller has to pass it. A different kind of change, and not one to bury in a batch
  of one-line swaps.
- **The MCP side (11)** — holds a token record and an `accessibleSpaceIds` list rather than a request, so it uses
  `memberSpacesForRecord`. Worth checking whether `accessibleSpaceIds` already narrows first: some may be no-ops
  where only the gate entry changes. **Verify rather than assume.**

## Two gates fired, both correctly

**`extract-view`** pins the file-meta handler's fan-out by *source text*, so the swap failed it. The property it
guards is unchanged — iterate the members and keep the one the record was found in, because on a proxy the derived
records live in the same member collection as their parent, and looking in another member's collection returns
nothing with no error. That was the failure mode which made `pipeline-status` report every index missing on a working
instance.

The assertion now pins the **narrowed** form, which keeps it honest: reverting to the unnarrowed call fails here too.

**`no-new-god-files`** on `api/files.ts`, 646 → 647, by exactly one line — the file gained an import and lost none,
because the old import was still needed elsewhere in one file and not in this one.

Not growth in any meaningful sense. But the ratchet cannot tell a net line from a meaningful one, and special-casing
*"it was only an import"* is how a ceiling stops meaning anything. Raised with the reason recorded instead.

## Verification

Server build clean; the inventory gate green with 16 + 12 = 28; preflight green.

🤖 Generated with Claude Code
