### PR TITLE
fix(mcp): the space guard read the legacy allowlist while HTTP read the rights matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **MCP decided which spaces a token could see from the legacy `spaces` allowlist, while the HTTP guard used the
+  per-space rights matrix.** MCP now consults `reachesSpace` too, at both transports.
+  - **Not exploitable today, and that is worth stating plainly:** the migration derives `rights` *from* `spaces`, and a
+    test proves the two agree across 50 comparisons. Every config-loaded token got the same answer from both surfaces.
+  - The defect is that they can now **diverge**. A token edited directly through the rights-matrix editor has a
+    `spaces` array that no longer describes it, and MCP was still reading the array — so this was not "MCP is more
+    permissive", it was "MCP is answering from stale data", with no fixed direction of error.
+  - The legacy branch survives for records with no rights: OIDC tokens are built per request and the config backfill
+    never sees them, so removing it would refuse every OIDC caller rather than tighten anything.
+  - **It also unblocks Q-6's MCP half**, which cannot narrow a proxy to a token's reachable members while the surface
+    has no access to the rights that define them.
+
 ### Changed
 - **`locateForUpdate`'s first parameter is now called `writeTarget`, not `spaceId`** — a rename with a point. All four
   callers pass `wt.target` from `resolveWriteTarget`, which is always a real space: a non-proxy resolves to itself, and

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -10,6 +10,8 @@ import { createHash } from 'node:crypto';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
+import { reachesSpace } from '../auth/space-reach.js';
+import type { TokenRights } from '../config/rights-shape.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
 import { ALL_TOOLS, TOOLS_BY_NAME, type ToolSchemas } from './tools/index.js';
 import { SchemaViolationError } from '../brain/write-validation.js';
@@ -55,10 +57,44 @@ function sessionTag(sessionId: string): string {
  *   because the SSE transport builds the server once per CONNECTION and then serves many tool calls
  *   over it — there is no `req` in scope at dispatch time, only the one that opened the stream.
  */
+/**
+ * The rights off a token record, or `undefined` for one that has none.
+ *
+ * A cast because `OidcTokenRecord` has no `rights` field: those tokens are built per request from the identity
+ * provider and the config backfill never sees them. `undefined` here is the signal to fall back to the legacy
+ * allowlist, which is the same answer that path has always given — not a weaker one.
+ *
+ * The same cast appears at every other rights call site (`middleware.ts`, the three `accessibleSpaces` helpers). It is
+ * a narrowing the union cannot express, and writing it once here keeps this file from repeating it per transport.
+ */
+function tokenRights(record: unknown): TokenRights | undefined {
+  return (record as { rights?: TokenRights } | undefined)?.rights;
+}
+
 function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdmin?: boolean, tokenId?: string, tokenLabel?: string,
-  audit?: { ip: string; authMethod: 'pat' | 'oidc' | null; oidcSubject: string | null; transport: 'sse' | 'http' }): Server {
+  audit?: { ip: string; authMethod: 'pat' | 'oidc' | null; oidcSubject: string | null; transport: 'sse' | 'http' },
+  rights?: TokenRights): Server {
   const cfg = getConfig();
-  const accessibleSpaces = cfg.spaces.filter(s => !tokenSpaces || tokenSpaces.includes(s.id));
+  // The rights matrix decides this, with `tokenSpaces` as the fallback for records that carry no rights.
+  //
+  // Until now MCP answered from `tokenSpaces` ALONE while the HTTP guard used `reachesSpace`. Two surfaces, one rule,
+  // one of them weaker — the shape of the four defects fixed on 2026-08-05. It was not exploitable, because the
+  // migration derives `rights` FROM `spaces` and a test proves they agree across 50 comparisons. The problem was that
+  // they can now DIVERGE: a token edited through the rights-matrix editor has a `spaces` array that no longer
+  // describes it, and MCP was still reading the array. The error had no fixed direction either — the matrix can be
+  // narrower than the legacy list as well as wider, so this was not "MCP is more permissive", it was "MCP is
+  // answering from stale data".
+  //
+  // A `&&` of the two would be worse than either: the matrix can be wider, so combining them would silently refuse
+  // access the matrix grants.
+  //
+  // NOTE the parameter count. Seven positionals is past the point where a caller can get the order right by reading
+  // the call, and this change made it worse rather than better; it wants to be one `caller` object. Filed rather than
+  // done here, because rewriting the signature and every use of the five it replaces is a bigger diff than the
+  // correctness fix it would be hiding inside.
+  const accessibleSpaces = cfg.spaces.filter(s => (
+    rights ? reachesSpace(rights, s.id) : !tokenSpaces || tokenSpaces.includes(s.id)
+  ));
   const accessibleSpaceIds = accessibleSpaces.map(s => s.id);
   const spacesLine = accessibleSpaces.length > 0
     ? accessibleSpaces.map(s => s.id + (s.label ? ` ("${s.label.replace(/[\x00-\x1f]/g, '').slice(0, 200)}")` : '')).join(', ')
@@ -268,7 +304,7 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
   });
 
   const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
-    { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'sse' });
+    { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'sse' }, tokenRights(req.authToken));
   log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
 });
@@ -300,7 +336,7 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
 mcpRouter.post('/', globalRateLimit, async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
   const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
-    { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'http' });
+    { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'http' }, tokenRights(req.authToken));
   // Register cleanup before handling the request so it fires regardless of outcome.
   res.on('close', () => {
     transport.close();

--- a/testing/standalone/mcp-reads-rights-matrix.test.js
+++ b/testing/standalone/mcp-reads-rights-matrix.test.js
@@ -1,0 +1,74 @@
+/**
+ * MCP and HTTP must answer "which spaces may this token see" the same way.
+ *
+ * ## The defect this pins
+ *
+ * `mcp/router.ts` built its accessible-space list from `tokenSpaces` — the legacy allowlist — while
+ * `auth/middleware.ts` answered the same question with `reachesSpace` and the per-space rights matrix. Two surfaces,
+ * one rule, one of them weaker: the shape of the four defects fixed on 2026-08-05.
+ *
+ * It was **not exploitable**, and that is worth stating rather than implying, because it changes what this test is
+ * for. The migration derives `rights` FROM `spaces`, and `rights-reach-matches-legacy.test.js` proves the two agree
+ * across 50 comparisons — so for any config-loaded token both surfaces gave the same answer.
+ *
+ * The problem was that they can now **diverge**. A token edited directly through the rights-matrix editor has a
+ * `spaces` array that no longer describes it, and MCP was still reading the array. The error had no fixed direction
+ * either: the matrix can be narrower than the legacy list as well as wider, so this was not "MCP is more permissive"
+ * — it was "MCP is answering from stale data".
+ *
+ * ## Why the assertions are on source
+ *
+ * `createGlobalMcpServer` is a private factory that builds an SDK `Server` over a live config and a transport. What
+ * is worth guarding is not its output but two structural facts: that it consults `reachesSpace` when rights exist,
+ * and that the legacy branch survives for records that have none. Both are visible without standing up a session,
+ * and a test that needed a session would not have been written.
+ *
+ * Run: node --test testing/standalone/mcp-reads-rights-matrix.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync(new URL('../../server/src/mcp/router.ts', import.meta.url), 'utf8');
+/** Comments must not satisfy any of this — several of them describe the very defect being pinned. */
+const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('the rights matrix decides', () => {
+  it('consults reachesSpace, not the allowlist alone', () => {
+    assert.match(CODE, /reachesSpace\(rights, s\.id\)/);
+    assert.match(CODE, /from '\.\.\/auth\/space-reach\.js'/);
+  });
+
+  it('receives the rights from the request at BOTH transports', () => {
+    // SSE and streamable-HTTP each build their own server. Threading it through one and not the other would leave a
+    // whole transport on the old answer — and it is the less-used transport that would go unnoticed.
+    assert.equal((CODE.match(/tokenRights\(req\.authToken\)/g) ?? []).length, 2);
+  });
+
+  it('keeps the legacy branch for records with no rights', () => {
+    // OIDC tokens are built per request, so the config backfill never sees them. Removing this branch would refuse
+    // every OIDC caller rather than tighten anything.
+    assert.match(CODE, /rights \?\s*reachesSpace\(rights, s\.id\)\s*:\s*!tokenSpaces \|\| tokenSpaces\.includes\(s\.id\)/);
+  });
+
+  it('does not read `spaces` when rights are present', () => {
+    // The whole defect. A belt-and-braces `&&` of the two would re-admit the stale array as a second gate, and the
+    // matrix can be WIDER than the legacy list — so an `&&` would silently refuse access the matrix grants.
+    const filter = CODE.slice(CODE.indexOf('const accessibleSpaces'), CODE.indexOf('const accessibleSpaceIds'));
+    assert.ok(!/tokenSpaces\.includes\(s\.id\)\s*&&/.test(filter), 'the legacy list is still gating alongside rights');
+    assert.ok(!/&&\s*!?tokenSpaces/.test(filter), 'the legacy list is still gating alongside rights');
+  });
+});
+
+describe('the cast is written once', () => {
+  it('has a named helper rather than an inline cast per call site', () => {
+    // `OidcTokenRecord` has no `rights`, so the union needs a narrowing it cannot express. Two inline copies is how
+    // one of them later gets a different fallback.
+    assert.match(CODE, /function tokenRights\(record: unknown\): TokenRights \| undefined/);
+    assert.ok(!/\(req\.authToken as \{ rights/.test(CODE), 'an inline cast crept back in');
+  });
+
+  it('returns undefined rather than throwing on an absent record', () => {
+    assert.match(CODE, /\(record as \{ rights\?: TokenRights \} \| undefined\)\?\.rights/);
+  });
+});


### PR DESCRIPTION
## The inconsistency

`mcp/router.ts` built its accessible-space list as `!tokenSpaces || tokenSpaces.includes(s.id)`.
`auth/middleware.ts` answers the same question with `reachesSpace` and the per-space rights matrix.

Two surfaces, one rule, one of them weaker — the shape of the four defects fixed on 2026-08-05.

## Not exploitable today, and that matters more than filing it dramatically

The migration derives `rights` **from** `spaces`, and `rights-reach-matches-legacy.test.js` proves the two agree
across 50 comparisons. Every config-loaded token got the same answer from both surfaces.

The defect is that they can now **diverge**: a token edited directly through the rights-matrix editor has a `spaces`
array that no longer describes it, and MCP was still reading the array.

So this was never *"MCP is more permissive"* — it was **"MCP is answering from stale data"**, and the error has no
fixed direction, because the matrix can be narrower than the legacy list as well as wider.

A `&&` of the two would be worse than either alone: the matrix can be wider, so combining them would silently refuse
access the matrix grants. There is a test for that specifically.

## The legacy branch survives, deliberately

OIDC tokens are built per request from the identity provider and the config backfill never sees them. Removing the
fallback would refuse every OIDC caller rather than tighten anything.

The cast it needs — `OidcTokenRecord` has no `rights` field — is a named `tokenRights` helper rather than two inline
copies, because two copies is how one of them later gets a different fallback.

## Why it jumped the queue: it unblocks Q-6's MCP half

Narrowing a proxy to a token's reachable members is impossible on a surface with no access to the rights that define
them — `createGlobalMcpServer` received `req.authToken?.spaces` and nothing else.

Converting the 8 MCP fan-outs before this would have narrowed them off the **stale array**: correct today by
coincidence, wrong the moment a token is edited.

## Two things I would rather state than have found

- **The parameter count is now seven positionals, and this made it worse.** It wants to be one `caller` object. Filed
  rather than done here: rewriting the signature and every use of the five it replaces is a bigger diff than the
  correctness fix it would be hiding inside.
- **I lost this work once and redid it.** Mutation-testing the rights branch confirmed the kill (2 fail), then
  `git checkout` to undo the planted change discarded the uncommitted fix with it. Second time this session, against
  a rule I have written down: commit before mutation testing.

## Verification

6 tests: `reachesSpace` is consulted, the rights are threaded through **both** transports (SSE and streamable-HTTP —
threading one and not the other would leave a whole transport on the old answer), the legacy branch survives, the
legacy list does not gate alongside rights, and the cast is written once.

Mutation-tested: reverting the filter to the allowlist alone fails 2. Server build clean; preflight green.

🤖 Generated with Claude Code
