### PR TITLE
fix(test): the fan-out sweep could not see a by-reference pass, and did not strip comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **The proxy fan-out sweep was blind to a by-reference pass, and did not strip comments.** Two defects in the gate
+  itself, found while converting `mcp/tools/search.ts`.
+  - `resolveFindSimilarScope(..., resolveMemberSpaces)` hands the resolver to a helper that expands a proxy inside it.
+    The sweep matched only `resolveMemberSpaces(` — so **the indirection that makes a fan-out hardest to follow was
+    exactly what it could not see.** Found by accident: removing the import for a conversion broke the build on a line
+    the gate had never counted.
+  - Widening it then reported a by-reference fan-out in a file that had none, because it was matching the name inside
+    a **comment**. Comments are stripped now — the standing rule that prose describing a thing must not satisfy a
+    check for the thing.
+  - **The true total is 29, not 28.** Raised rather than left, because a conserved total that conserves the wrong
+    number is worse than none. The original figure was an undercount produced by a call-only sweep.
+
+### Fixed
 - **MCP decided which spaces a token could see from the legacy `spaces` allowlist, while the HTTP guard used the
   per-space rights matrix.** MCP now consults `reachesSpace` too, at both transports.
   - **Not exploitable today, and that is worth stating plainly:** the migration derives `rights` *from* `spaces`, and a

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -13,7 +13,8 @@ import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
 import { queryBrain } from '../../brain/query.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal, rankOf, mergeRecallResults } from '../../brain/recall.js';
-import { resolveMemberSpaces, collectAcrossMembers } from '../../spaces/proxy.js';
+import { collectAcrossMembers, resolveMemberSpaces } from '../../spaces/proxy.js';
+import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { NotFoundError } from '../../util/errors.js';
 
 /**
@@ -181,7 +182,10 @@ export const recallTool: ToolHandler = {
     let seeds: RecallResult[];
     let traverseSpaces: string[];
     if (callSpace) {
-      const memberIds = resolveMemberSpaces(callSpace);
+      // Narrowed to what this connection may see, not every member of the proxy. `accessibleSpaceIds` is built
+      // once per connection from the rights matrix (#786), so intersecting with it is the same answer the HTTP side
+      // gets from `memberSpacesForRequest` — without threading rights down into every tool.
+      const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
       const all = (await Promise.all(memberIds.map(mid => recall(mid, query, topK, tags, types, minPerType, minScore, filter, { maxPerType, maxTimeMS: recallMaxTimeMS, degraded, includeFreshWrites: a['includeFreshWrites'] === true })))).flat();
       // Same rule as everywhere else: rankOf, not `.score`. See the note on the REST recall route.
       all.sort((x, y) => rankOf(y) - rankOf(x));

--- a/server/src/spaces/proxy-scoped.ts
+++ b/server/src/spaces/proxy-scoped.ts
@@ -58,3 +58,19 @@ export function memberSpacesForRequest(req: { authToken?: unknown }, spaceId: st
 export function memberSpacesForRecord(record: Bearer, spaceId: string): string[] {
   return memberSpacesForToken(record?.rights, record?.spaces, resolveMemberSpaces(spaceId));
 }
+
+/**
+ * The members of `spaceId` that appear in an already-narrowed accessible list.
+ *
+ * For the MCP tools, which hold no request and no token record — they are handed an `accessibleSpaceIds` list built
+ * once per connection. Since #786 that list comes from the rights matrix, so intersecting with it gives the same
+ * answer `memberSpacesForRequest` would, without threading rights down to every tool.
+ *
+ * **`accessible` must already be the narrowed set.** If a caller passes every space in the config, this narrows
+ * nothing and the name lies. It is not defensive about that on purpose: a check here could only compare the list
+ * against itself, and the honest place to be sure is the one line in `mcp/router.ts` that builds it.
+ */
+export function memberSpacesWithin(spaceId: string, accessible: readonly string[]): string[] {
+  const allowed = new Set(accessible);
+  return resolveMemberSpaces(spaceId).filter(id => allowed.has(id));
+}

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -77,6 +77,19 @@ import { readFileSync } from 'node:fs';
  */
 const RECLASSIFIED = 1;
 
+/**
+ * The true total, and why it is 29 rather than the 28 first measured.
+ *
+ * 28 counted only `resolveMemberSpaces(...)` CALLS. Widening the sweep to catch a by-reference pass —
+ * `resolveFindSimilarScope(..., resolveMemberSpaces)` in `mcp/tools/search.ts`, which hands the resolver to a helper
+ * that expands a proxy inside it — revealed one more site that had always been there.
+ *
+ * Raised rather than left at 28, because the alternative is a conserved total that conserves the wrong number. The
+ * original figure was not wrong through carelessness: it was an undercount produced by a sweep that matched calls,
+ * and the indirection it missed is exactly the kind that makes a fan-out hard to follow.
+ */
+const TOTAL = 29;
+
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,
   'server/src/mcp/router.ts': 1,
@@ -130,9 +143,24 @@ function callSites() {
     .trim().split('\n').filter(Boolean);
   for (const f of files) {
     if (NOT_CALL_SITES.has(f)) continue;
-    const src = readFileSync(f, 'utf8');
+    // Comments STRIPPED first. Without this the sweep matched `resolveMemberSpaces` inside a comment explaining what
+    // a handler does, and reported a by-reference fan-out in a file that had none. That is the standing rule about
+    // source-reading gates: the prose describing a thing must not satisfy a check for the thing.
+    const src = readFileSync(f, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
     for (const m of src.matchAll(/resolveMemberSpaces\(([^)]*)\)/g)) {
       out.push({ file: f, arg: m[1].trim() });
+    }
+    // A BY-REFERENCE pass is a fan-out the call regex above cannot see: `resolveFindSimilarScope(..., crossSpace,
+    // accessibleSpaceIds, resolveMemberSpaces)` hands the function itself to a helper that then expands a proxy
+    // inside. Found by accident — removing the import for a conversion broke the build on a line the gate had never
+    // counted. A sweep that only matches calls is blind to exactly the indirection that makes a fan-out hard to
+    // follow, which is the wrong way round.
+    for (const m of src.matchAll(/(?<![.\w])resolveMemberSpaces(?!\s*\()/g)) {
+      const before = src.slice(Math.max(0, m.index - 200), m.index);
+      if (/import\s*\{[^}]*$/.test(before)) continue;   // the import statement itself is not a use
+      out.push({ file: f, arg: 'BY-REFERENCE' });
     }
   }
   return out;
@@ -149,12 +177,12 @@ const isWriteTarget = (arg) => /^(wt\.target|writeTarget)$/.test(arg);
 /** Calls that HAVE been narrowed — `memberSpacesForRequest` / `memberSpacesForRecord`. */
 function narrowedCalls() {
   const out = [];
-  const files = execSync('git grep --untracked -l "memberSpacesFor" -- server/src', { encoding: 'utf8' })
+  const files = execSync('git grep --untracked -l "memberSpaces" -- server/src', { encoding: 'utf8' })
     .trim().split('\n').filter(Boolean);
   for (const f of files) {
     if (NOT_CALL_SITES.has(f) || f === 'server/src/spaces/proxy-scoped.ts') continue;
     const src = readFileSync(f, 'utf8');
-    for (const m of src.matchAll(/memberSpacesFor(?:Request|Record)\(/g)) out.push({ file: f, at: m.index });
+    for (const m of src.matchAll(/memberSpaces(?:ForRequest|ForRecord|Within)\(/g)) out.push({ file: f, at: m.index });
   }
   return out;
 }
@@ -219,8 +247,8 @@ describe('the total is conserved', () => {
     const pending = Object.values(PENDING).reduce((a, b) => a + b, 0);
     const guards = Object.values(GUARDS).reduce((a, b) => a + b, 0);
     const narrowed = narrowedCalls().length;
-    assert.equal(pending + guards + narrowed + RECLASSIFIED, 28,
-      `expected 28, got ${pending} pending + ${guards} guards + ${narrowed} narrowed + ${RECLASSIFIED} reclassified`);
+    assert.equal(pending + guards + narrowed + RECLASSIFIED, TOTAL,
+      `expected ${TOTAL}, got ${pending} pending + ${guards} guards + ${narrowed} narrowed + ${RECLASSIFIED} reclassified`);
   });
 });
 


### PR DESCRIPTION
## Two defects in the gate itself

Both found while converting the MCP recall fan-out, not by looking for them.

### It matched only calls

`mcp/tools/search.ts` passes the resolver **by reference**:

```ts
resolveFindSimilarScope(callSpace, crossSpace, accessibleSpaceIds, resolveMemberSpaces)
```

That helper expands a proxy inside itself. The sweep matched only `resolveMemberSpaces(` — so it was blind to
**precisely the indirection that makes a fan-out hardest to follow**, which is the wrong way round for a gate whose
entire job is not missing one.

Found by accident, and worth saying so: removing the now-unused import during a conversion broke the build on a line
the gate had never counted. Nothing in the gate's own output would have revealed it.

### Widening it produced a false positive

It reported a by-reference fan-out in `api/brain/file-meta.ts`, which has none — it was matching the name inside a
**comment** describing what a handler does.

Comments are stripped now. That is the standing rule about source-reading gates, and this file broke it while being
the file that enforces the rest.

## The true total is 29, not 28

Raised, with the reasoning at the constant. **A conserved total that conserves the wrong number is worse than not
having one.** The original 28 was not carelessness — it was an undercount produced by a call-only sweep, and the extra
site had always been there.

Now: `8 pending + 3 guards + 17 narrowed + 1 reclassified = 29`.

## The conversion that came out of it

`mcp/tools/search.ts` recall uses `memberSpacesWithin(callSpace, accessibleSpaceIds)`.

The MCP tools hold no request and no token record — they get an `accessibleSpaceIds` list built once per connection —
and since #786 that list comes from the rights matrix. So intersecting with it gives the same answer the HTTP side
gets, **without threading rights down into every tool.**

Its by-reference pass is still pending, and the file correctly stays in `PENDING`: `resolveFindSimilarScope` should
receive the *narrowed* resolver, which is a signature change on a shared helper rather than a one-line swap.

## The matcher missed the new helper twice

Once because the git-grep pattern used `\|` inside a JS string — the escape collapses to a literal pipe, which BRE
treats as a character, so it matched nothing. Once because the alternation was anchored on `memberSpacesFor` rather
than `memberSpaces`.

**Both surfaced as the conserved total refusing to add up**, which is that assertion earning its place.

## Verification

Inventory gate green at 9 tests; server build clean; preflight green.

🤖 Generated with Claude Code
