### PR TITLE
refactor(mcp): the remaining tool fan-outs narrow to what the connection may see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **The remaining MCP proxy fan-outs narrow to what the connection may see** — `mcp/tools/spaces.ts` (3),
+  `file.ts` (2), `edge.ts` and `chrono.ts`. **One site left of 29:** the by-reference pass in `mcp/tools/search.ts`.
+  - `accessibleSpaceIds` was already on the tool `ctx` and only `chrono.ts` ever destructured it — so the narrowed
+    list was there the whole time and the other tools simply did not ask for it. Since #786 it comes from the rights
+    matrix, so intersecting with it gives the answer the HTTP side gets without threading rights into every tool.
+  - Still a provable no-op: the guards continue to require a token to reach every member.
+
 ### Fixed
 - **The proxy fan-out sweep was blind to a by-reference pass, and did not strip comments.** Two defects in the gate
   itself, found while converting `mcp/tools/search.ts`.

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -6,6 +6,7 @@ import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '
 import { getConfig } from '../../config/loader.js';
 import { checkQuota } from '../../quota/quota.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
+import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { getAllowedChronoTypes, resolveMetaRefs, validateChrono } from '../../spaces/schema-validation.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
@@ -324,7 +325,7 @@ export const list_chronoTool: ToolHandler = {
     const limit = typeof a['limit'] === 'number' ? Math.min(a['limit'], 100) : 20;
     const skip = typeof a['skip'] === 'number' ? Math.max(a['skip'], 0) : 0;
 
-    const memberIds = callSpace ? resolveMemberSpaces(callSpace) : accessibleSpaceIds;
+    const memberIds = callSpace ? memberSpacesWithin(callSpace, accessibleSpaceIds) : accessibleSpaceIds;
     // Fetch skip+limit from each member so the combined list has enough entries
     // after global sort/slice. For large skip values this over-fetches slightly,
     // but chrono lists are expected to be small in practice.

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -6,6 +6,7 @@ import { deleteEdge, getEdgeById, traverseGraph, updateEdgeById, upsertEdge } fr
 import { assertUpdateAllowed, classifyEdgeUpsert, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
 import { getConfig } from '../../config/loader.js';
 import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers } from '../../spaces/proxy.js';
+import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { assertRefsResolve } from '../../brain/entity-refs.js';
 import { resolveMetaRefs, validateEdge } from '../../spaces/schema-validation.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
@@ -205,7 +206,7 @@ export const traverseTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace } = ctx;
+    const { args: a, callSpace , accessibleSpaceIds } = ctx;
     const startId = String(a['startId'] ?? '').trim();
     if (!startId) throw new Error('startId must not be empty');
     const directionRaw = typeof a['direction'] === 'string' ? a['direction'] : 'outbound';
@@ -219,7 +220,7 @@ export const traverseTool: ToolHandler = {
     const maxDepth = typeof a['maxDepth'] === 'number' ? Math.min(Math.max(1, a['maxDepth']), 10) : 3;
     const limit = typeof a['limit'] === 'number' ? Math.min(Math.max(1, a['limit']), 1000) : 100;
 
-    const memberIds = resolveMemberSpaces(callSpace);
+    const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
     // Same default and same opt-out as REST — a rule that reaches one door and not the other is the defect
     // four brain-API fixes were about.
     const result = await traverseGraph(memberIds, startId, direction, edgeLabels, maxDepth, limit,

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -9,6 +9,7 @@ import { writeFileTombstones } from '../../files/tombstones.js';
 import { deleteFileCascade } from '../../files/delete-cascade.js';
 import { QuotaError, checkQuota } from '../../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget } from '../../spaces/proxy.js';
+import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { emitWebhookEvent } from '../../webhooks/dispatcher.js';
 import { log } from '../../util/log.js';
 
@@ -26,10 +27,10 @@ export const read_fileTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace } = ctx;
+    const { args: a, callSpace , accessibleSpaceIds } = ctx;
     const filePath = String(a['path'] ?? '');
     if (!filePath.trim()) throw new Error('path must not be empty');
-    const memberIds = resolveMemberSpaces(callSpace);
+    const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
     let content: string | null = null;
     for (const mid of memberIds) {
       try { content = await readFile(mid, filePath); break; } catch { /* try next */ }
@@ -124,9 +125,9 @@ export const list_dirTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace, name } = ctx;
+    const { args: a, callSpace, name , accessibleSpaceIds } = ctx;
     const dirPath = String(a['path'] ?? '');
-    const memberIds = resolveMemberSpaces(callSpace);
+    const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
     const seen = new Set<string>();
     const allEntries: { name: string; type: 'file' | 'dir'; size?: number }[] = [];
     for (const mid of memberIds) {

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -2,6 +2,7 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { getConfig } from '../../config/loader.js';
 import { col } from '../../db/mongo.js';
 import { resolveMemberSpaces } from '../../spaces/proxy.js';
+import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { WIPE_COLLECTION_TYPES, type WipeCollectionType, wipeSpace } from '../../spaces/lifecycle.js';
 import { updateSpace, spacePurpose } from '../../spaces/spaces.js';
 import { SPACE_PURPOSE_MAX } from '../../spaces/_shared.js';
@@ -11,10 +12,10 @@ export const list_spacesTool: ToolHandler = {
   description: 'List all accessible spaces with their IDs, labels, purposes, and entry counts (memories, entities, edges, chrono). Use counts to decide which spaces are populated and worth querying.',
   inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [], additionalProperties: false }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { accessibleSpaces } = ctx;
+    const { accessibleSpaces , accessibleSpaceIds } = ctx;
     const spaceCountResults = await Promise.allSettled(
       accessibleSpaces.map(async s => {
-        const memberIds = resolveMemberSpaces(s.id);
+        const memberIds = memberSpacesWithin(s.id, accessibleSpaceIds);
         const perMember = await Promise.all(memberIds.map(async mid => ({
           memories: await col(`${mid}_memories`).countDocuments(),
           entities: await col(`${mid}_entities`).countDocuments(),
@@ -64,8 +65,8 @@ export const get_statsTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { callSpace } = ctx;
-    const memberIds = resolveMemberSpaces(callSpace);
+    const { callSpace , accessibleSpaceIds } = ctx;
+    const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
     const counts = await Promise.all(memberIds.map(async mid => ({
       memories: await col(`${mid}_memories`).countDocuments(),
       entities: await col(`${mid}_entities`).countDocuments(),
@@ -103,7 +104,7 @@ export const get_space_metaTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { callSpace } = ctx;
+    const { callSpace , accessibleSpaceIds } = ctx;
     const metaCfg = getConfig();
     const metaSpace = metaCfg.spaces.find(s => s.id === callSpace);
     // Always resolve library `$ref` types so the agent sees the effective schema (propertySchemas from
@@ -111,7 +112,7 @@ export const get_space_metaTool: ToolHandler = {
     // GET /api/spaces/:id/meta?resolve=1.
     const { resolveMetaRefs } = await import('../../spaces/schema-validation.js');
     const metaBlock = resolveMetaRefs(metaSpace?.meta ?? {});
-    const metaMemberIds = resolveMemberSpaces(callSpace);
+    const metaMemberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
     const metaCounts = await Promise.all(metaMemberIds.map(async mid => ({
       memories: await col(`${mid}_memories`).countDocuments(),
       entities: await col(`${mid}_entities`).countDocuments(),

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -99,6 +99,10 @@ const NARROWED = new Set([
   // Converted to memberSpacesForRequest. A no-op while the guard still requires all members, which is what makes
   // the conversion provable rather than a behaviour change taken on trust.
   'server/src/api/brain/search.ts',
+  'server/src/mcp/tools/spaces.ts',
+  'server/src/mcp/tools/file.ts',
+  'server/src/mcp/tools/edge.ts',
+  'server/src/mcp/tools/chrono.ts',
   'server/src/api/spaces.ts',
   'server/src/api/brain/file-meta.ts',
   'server/src/api/brain/entities.ts',
@@ -106,11 +110,7 @@ const NARROWED = new Set([
 ]);
 
 const PENDING = {
-  'server/src/mcp/tools/chrono.ts': 1,
-  'server/src/mcp/tools/edge.ts': 1,
-  'server/src/mcp/tools/file.ts': 2,
   'server/src/mcp/tools/search.ts': 1,
-  'server/src/mcp/tools/spaces.ts': 3,
 };
 
 // 28 read fan-outs across 13 files, plus 5 write-target sites. Those numbers came out of this gate, and the first


### PR DESCRIPTION
## What

`mcp/tools/spaces.ts` (3), `file.ts` (2), `edge.ts` (1) and `chrono.ts` (1) now use `memberSpacesWithin`.

**One site left of 29** — the by-reference pass in `mcp/tools/search.ts`, which needs `resolveFindSimilarScope` to
take the narrowed resolver rather than the wide one.

## It was much cheaper than planned, and why that is worth recording

`accessibleSpaceIds` was **already on the tool `ctx`**, and only `chrono.ts` ever destructured it. The narrowed list
had been in reach of every tool the whole time; the others simply did not ask for it.

Since #786 that list is built from the rights matrix, so intersecting with it gives the same answer the HTTP side gets
from `memberSpacesForRequest` — with no need to thread rights down into each tool.

**The earlier plan said this would need a signature change across five files. It did not.** That estimate came from
checking 90 lines above each call site and finding no `accessibleSpaceIds` — which was true, and told me nothing,
because the *destructure* that would have had it was the thing missing, not the value.

A scope check that looks for a **name** cannot distinguish "not available here" from "available and unused".

## Still a provable no-op

The three guards continue to require a token to reach every member, so the narrowed list equals the full one for any
caller that gets this far. The behaviour change is the guard flip, and it remains the last step.

## Verification

`8 → 1` pending on the inventory gate, conserved total intact at 29; server build clean; preflight green.

🤖 Generated with Claude Code
