### PR TITLE
refactor(mcp): the last proxy fan-out narrows, and PENDING is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- **Every proxy read fan-out is now narrowed to what the caller may see — all 29 sites.** The last one was
+  `resolveFindSimilarScope` in `mcp/tools/search.ts`, which takes the resolver as a **parameter**, so this was a
+  one-line call-site change rather than the signature rewrite the plan predicted.
+  - The inventory gate now asserts `PENDING` is empty, so a new un-narrowed fan-out fails twice over.
+  - **Still no behaviour change.** The three guards continue to require a token to reach every member of a proxy,
+    which is what has made the whole sweep a provable no-op. Flipping them to accept a non-empty intersection is the
+    single remaining change — now a small diff against fully-narrowed read paths rather than a leap of faith.
+
+### Changed
 - **The remaining MCP proxy fan-outs narrow to what the connection may see** — `mcp/tools/spaces.ts` (3),
   `file.ts` (2), `edge.ts` and `chrono.ts`. **One site left of 29:** the by-reference pass in `mcp/tools/search.ts`.
   - `accessibleSpaceIds` was already on the tool `ctx` and only `chrono.ts` ever destructured it — so the narrowed

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -13,7 +13,7 @@ import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
 import { queryBrain } from '../../brain/query.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal, rankOf, mergeRecallResults } from '../../brain/recall.js';
-import { collectAcrossMembers, resolveMemberSpaces } from '../../spaces/proxy.js';
+import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { NotFoundError } from '../../util/errors.js';
 
@@ -31,6 +31,13 @@ export function resolveFindSimilarScope(
   callSpace: string | undefined,
   crossSpace: boolean,
   accessibleSpaceIds: string[],
+  /**
+   * Expand a space to its members, ALREADY narrowed to what the caller may see.
+   *
+   * Injected rather than imported so this stays testable without a config — and that injection is what made the Q-6
+   * narrowing a one-line change here instead of a signature rewrite. It is also why the parameter is documented: a
+   * caller passing the raw `resolveMemberSpaces` would compile, run, and quietly widen a proxy back to every member.
+   */
   resolveMembers: (space: string) => string[],
 ): { candidateBases: string[]; searchIds: string[] | undefined } {
   if (callSpace && !crossSpace) {
@@ -288,7 +295,10 @@ export const find_similarTool: ToolHandler = {
 
     // Locate the source entry: with a space, use it; without, try each accessible space (first match
     // wins — the lookup fails fast before any search, so misses are cheap).
-    const { candidateBases, searchIds } = resolveFindSimilarScope(callSpace || undefined, crossSpace, accessibleSpaceIds, resolveMemberSpaces);
+    // The resolver is NARROWED. `resolveFindSimilarScope` takes it as a parameter, so this is the whole fix — no
+    // signature change was needed, which is the opposite of what the plan for this site predicted.
+    const { candidateBases, searchIds } = resolveFindSimilarScope(
+      callSpace || undefined, crossSpace, accessibleSpaceIds, sp => memberSpacesWithin(sp, accessibleSpaceIds));
     let result: Awaited<ReturnType<typeof findSimilar>> | undefined;
     let usedBase: string | undefined;
     for (const base of candidateBases) {

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -99,6 +99,7 @@ const NARROWED = new Set([
   // Converted to memberSpacesForRequest. A no-op while the guard still requires all members, which is what makes
   // the conversion provable rather than a behaviour change taken on trust.
   'server/src/api/brain/search.ts',
+  'server/src/mcp/tools/search.ts',
   'server/src/mcp/tools/spaces.ts',
   'server/src/mcp/tools/file.ts',
   'server/src/mcp/tools/edge.ts',
@@ -110,7 +111,6 @@ const NARROWED = new Set([
 ]);
 
 const PENDING = {
-  'server/src/mcp/tools/search.ts': 1,
 };
 
 // 28 read fan-outs across 13 files, plus 5 write-target sites. Those numbers came out of this gate, and the first
@@ -237,6 +237,18 @@ describe('a NARROWED file is really narrowed', () => {
     // Otherwise a file could be moved to NARROWED by deleting its fan-outs rather than converting them.
     const byFile = new Set(narrowedCalls().map(c => c.file));
     assert.deepEqual([...NARROWED].filter(f => !byFile.has(f)), []);
+  });
+});
+
+describe('the narrowing half is COMPLETE', () => {
+  it('PENDING is empty — every read fan-out is narrowed', () => {
+    // The definition of done for Q-6's expensive half, and now a regression guard: a new un-narrowed fan-out puts a
+    // file back into PENDING and fails here as well as in the classification test.
+    //
+    // What is left is NOT a fan-out. The three GUARDS still require a token to reach every member of a proxy, which
+    // is why all of this has been a provable no-op so far. Flipping them to accept a non-empty intersection is the
+    // one behaviour change, and it is now a small diff against fully-narrowed read paths instead of a leap of faith.
+    assert.deepEqual(PENDING, {});
   });
 });
 


### PR DESCRIPTION
## All 29 narrowed

The last read fan-out was `resolveFindSimilarScope` in `mcp/tools/search.ts`.

It takes the member resolver as a **parameter**, so the fix was passing a narrowed closure at the call site — one
line, not the signature rewrite the plan predicted.

## Second consecutive pessimistic estimate, for the same reason

I inferred difficulty from the *shape* of the problem instead of reading the function:

| I said | reality |
|---|---|
| the MCP tools need rights threaded through five files | `accessibleSpaceIds` was already on their `ctx`, unused |
| this one needs a shared-helper signature change | already parameterised |

Worth stating because the pattern is the same both times, and it cost a plan revision each time.

## The injected parameter is now documented

Injection is a loaded gun here: a caller passing the raw `resolveMemberSpaces` would compile, run, and **quietly
widen a proxy back to every member**. The type cannot tell the two apart — both are `(space: string) => string[]`.

## `PENDING` is asserted empty

Not a milestone note but a regression guard: a new un-narrowed fan-out now fails both the classification test and
this one.

## Still no behaviour change

The three guards continue to require a token to reach every member of a proxy — which is exactly what made the whole
sweep **provable** rather than hopeful: the narrowed list equals the full one for any caller that gets this far.

Flipping them to accept a non-empty intersection is the single remaining change, and it is now a small diff against
fully-narrowed read paths rather than a leap of faith.

## Verification

Inventory gate green at 10 tests with `PENDING` empty and the conserved total intact at 29; server build clean;
preflight green.

🤖 Generated with Claude Code
