### PR TITLE
feat(auth): a proxy space becomes a lens over what a token may already see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **A proxy space can now be granted to a scoped token — it becomes a lens over what that token may already see.**
+  `enforceSpaceScope` and the MCP guard accept a proxy when the token reaches **at least one** member instead of
+  requiring every member, and the read paths serve only the members it reaches.
+  - Asked for by an integrator with probes: a proxy space could not be granted to a non-admin token at all — listing it
+    in `spaces` did nothing and every call `403`'d. Building a filtered proxy by hand is not the answer, because it is a
+    second list to keep in step with the space set: every new space must be added or it silently drops out of recall.
+  - **This is the only behaviour change of the ten PRs in this work.** All 29 read fan-outs were narrowed first;
+    flipping the guard earlier would have served records from every member of the proxy — well-formed, `200`, nothing
+    to notice, and with a wildcard proxy that is every space on the instance.
+  - **Unchanged for a non-proxy space:** a real space resolves to one member, so "reaches at least one of one" is the
+    same predicate as "reaches all of one". That guarantee rests on the single-space fallback rather than the
+    predicate, and has its own test — without it an unknown space would produce an empty target list that passes
+    vacuously.
+  - The legacy allowlist branch now tests `spaces === undefined` rather than truthiness: under the old rule an empty
+    allowlist passed, and under the new one it must refuse.
+
 ### Changed
 - **Every proxy read fan-out is now narrowed to what the caller may see — all 29 sites.** The last one was
   `resolveFindSimilarScope` in `mcp/tools/search.ts`, which takes the resolver as a **parameter**, so this was a

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -322,26 +322,37 @@ function enforceSpaceScope(
 ): boolean {
   if (!spaceId) return true;
 
-  // For proxy spaces, the token must have access to ALL member spaces.
-  // If the space doesn't exist in config, resolveMemberSpaces returns [].
-  // Fall back to [spaceId] so the scope check still rejects tokens that
-  // don't reach this space — returning 403 instead of leaking a 404.
+  // A proxy is a LENS over what the caller may already see: it is usable when the token reaches AT LEAST ONE
+  // member, and the read paths then serve only the members it reaches.
+  //
+  // This used to require ALL members, which meant a proxy could not be granted to a scoped token at all — listing it
+  // in `spaces` did nothing and every call 403'd. aigents proved it was not specific to one proxy by building their
+  // own over 15 spaces and getting the same refusal (Q-6).
+  //
+  // **This is the ONLY behaviour change in Q-6**, and it is safe now because all 29 read fan-outs were narrowed
+  // first — `proxy-fanout-inventory.test.js` asserts `PENDING` is empty. Flipping this beforehand would have handed
+  // a token records from every member of the proxy, well-formed and with nothing to notice.
+  //
+  // For a NON-PROXY space nothing changes, and that deserves precision rather than trust: a real space resolves to
+  // `[spaceId]`, so "reaches at least one of one" is the same predicate as "reaches all of one".
+  //
+  // A space missing from the config resolves to `[]`, and the fallback to `[spaceId]` keeps the answer a 403 for a
+  // token that cannot reach it, rather than a 404 that would confirm the space does not exist.
   const memberIds = resolveMemberSpaces(spaceId);
   const targets = memberIds.length > 0 ? memberIds : [spaceId];
 
-  // The rights matrix answers this now. It is derived from `spaces`/`admin`/`readOnly` at config load, and
-  // `rights-reach-matches-legacy.test.js` proves the two agree for every token shape on listed, unlisted and
-  // not-yet-created spaces — which is why this swap changes no behaviour.
+  // The legacy branch survives for records that carry no rights: OIDC-derived tokens are built per request rather
+  // than read from config, so the backfill never sees them. Falling through to `spaces` there is the same answer,
+  // not a weaker one; removing it would refuse every OIDC caller instead.
   //
-  // The legacy branch survives for records that carry no rights: OIDC-derived tokens are built per request
-  // rather than read from config, so the backfill never sees them. Falling through to `spaces` there is the
-  // same answer, not a weaker one; removing it would refuse every OIDC caller instead.
+  // `record.spaces === undefined` is unrestricted and reaches everything — NOT `.length === 0`. An empty allowlist
+  // reaches nothing, and reading empty as absent would turn the narrowest token into the widest.
   const rights = (record as { rights?: Parameters<typeof reachesSpace>[0] }).rights;
-  const missing = rights
-    ? targets.filter(sid => !reachesSpace(rights, sid))
-    : record.spaces ? targets.filter(sid => !record.spaces!.includes(sid)) : [];
+  const reachable = rights
+    ? targets.filter(sid => reachesSpace(rights, sid))
+    : record.spaces === undefined ? targets : targets.filter(sid => record.spaces!.includes(sid));
 
-  if (missing.length > 0) {
+  if (reachable.length === 0) {
     res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });
     return false;
   }

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -12,7 +12,7 @@ import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { reachesSpace } from '../auth/space-reach.js';
 import type { TokenRights } from '../config/rights-shape.js';
-import { resolveMemberSpaces } from '../spaces/proxy.js';
+import { memberSpacesWithin } from '../spaces/proxy-scoped.js';
 import { ALL_TOOLS, TOOLS_BY_NAME, type ToolSchemas } from './tools/index.js';
 import { SchemaViolationError } from '../brain/write-validation.js';
 import { makeArgsValidator } from './validate-args.js';
@@ -200,18 +200,21 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
       if (tokenSpaces && !tokenSpaces.includes(rawSpace)) {
         return { content: [{ type: 'text' as const, text: `Error: token does not have access to space '${rawSpace}'` }], isError: true };
       }
-      // Proxy fan-out scope check: a proxy space aggregates reads across (and
-      // routes writes to) its member spaces. The token must hold EVERY member
-      // space — mirroring requireSpaceAuth on the REST layer — otherwise a token
-      // scoped only to the proxy (especially a `proxyFor: ['*']` wildcard) could
-      // read/write member spaces it was never granted. For a non-proxy space
-      // resolveMemberSpaces returns [rawSpace], so this is a no-op there.
-      if (tokenSpaces) {
-        const members = resolveMemberSpaces(rawSpace);
-        const missing = members.filter(m => !tokenSpaces.includes(m));
-        if (missing.length > 0) {
-          return { content: [{ type: 'text' as const, text: `Error: token does not have access to member space(s) of '${rawSpace}': ${missing.join(', ')}` }], isError: true };
-        }
+      // Proxy scope check, mirroring `enforceSpaceScope` on the REST layer — and it has to keep mirroring it, or the
+      // two surfaces answer one question differently, which is the defect #786 fixed one layer up.
+      //
+      // A proxy is usable when the connection reaches AT LEAST ONE member; the tools then read only the members it
+      // reaches, via `memberSpacesWithin`. It used to require EVERY member, which is why a scoped token could not be
+      // given a proxy at all (Q-6).
+      //
+      // Safe now only because every MCP fan-out was narrowed first. With the wide fan-outs still in place, a token
+      // reaching one member of a `proxyFor: ['*']` wildcard would have read every space on the instance.
+      //
+      // For a non-proxy space `resolveMemberSpaces` returns `[rawSpace]`, so "at least one of one" is the same
+      // predicate as "all of one" and nothing changes there.
+      const members = memberSpacesWithin(rawSpace, accessibleSpaceIds);
+      if (members.length === 0) {
+        return { content: [{ type: 'text' as const, text: `Error: token does not have access to '${rawSpace}' or any of its member spaces` }], isError: true };
       }
     }
     const callSpace = rawSpace;

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -92,7 +92,12 @@ const TOTAL = 29;
 
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,
-  'server/src/mcp/router.ts': 1,
+  // `mcp/router.ts` used to be here. Its guard is FLIPPED: it calls `memberSpacesWithin` and refuses only when the
+  // connection reaches no member, so it is counted by `narrowedCalls()` now rather than as an un-flipped guard.
+  // Leaving it in both places would double-count it, which the conserved total caught immediately (30 !== 29).
+  //
+  // `auth/middleware.ts` stays: its predicate is flipped, but it still resolves the member list with
+  // `resolveMemberSpaces` — it needs the FULL list to decide reachability, which is exactly what a guard does.
 };
 
 const NARROWED = new Set([

--- a/testing/standalone/space-guard-reads-rights.test.js
+++ b/testing/standalone/space-guard-reads-rights.test.js
@@ -56,13 +56,29 @@ describe('the space guard', () => {
       'the fallback is gone; every OIDC caller would be refused, and no unit test stands one up');
   });
 
-  it('still applies the proxy rule — ALL member spaces, not any', () => {
+  it('applies the proxy rule — AT LEAST ONE member, since Q-6', () => {
     const body = guardBody();
     assert.match(body, /resolveMemberSpaces\(/, 'proxy members are no longer resolved');
-    // `filter(... !reaches)` then `length > 0` is "every target must pass". A `.some()` here would mean one
-    // reachable member unlocked a proxy over spaces the token cannot see — the widening this rule prevents.
-    assert.match(body, /missing\.length > 0/, 'the all-members rule is gone');
-    assert.doesNotMatch(body, /targets\.some\(/, 'ANY-member access would unlock a proxy over unreachable spaces');
+
+    // This assertion used to demand the opposite: `missing.length > 0`, i.e. EVERY member must be reachable. That
+    // rule meant a proxy could not be granted to a scoped token at all, which is what aigents reported. It is now
+    // deliberately "at least one", and the read paths serve only the members the caller reaches.
+    //
+    // The old comment here argued that ANY-member access "would unlock a proxy over spaces the token cannot see".
+    // That was true when the fan-outs were wide, and it is exactly why the flip came LAST: all 29 read fan-outs were
+    // narrowed first, and `proxy-fanout-inventory.test.js` asserts none is left.
+    assert.match(body, /reachable\.length === 0/, 'the at-least-one rule is gone');
+    assert.doesNotMatch(body, /missing\.length > 0/, 'the old all-members rule is back');
+  });
+
+  it('is UNCHANGED for a non-proxy space, which is the safety property', () => {
+    // A real space resolves to `[spaceId]`, so "reaches at least one of one" is the same predicate as "reaches all
+    // of one". Pinned because it is the claim that makes the flip safe, and it rests on the fallback below rather
+    // than on the predicate: without `memberIds.length > 0 ? … : [spaceId]` an unknown space would resolve to `[]`
+    // and an empty target list would pass a `.some()`-shaped check vacuously.
+    const body = guardBody();
+    assert.match(body, /memberIds\.length > 0 \? memberIds : \[spaceId\]/,
+      'the single-space fallback is gone; an unknown space would produce an empty target list');
   });
 
   it('refuses rather than falling through when a space is unreachable', () => {


### PR DESCRIPTION
## Q-6, done

`enforceSpaceScope` and the MCP guard now accept a proxy when the token reaches **at least one** member, instead of
requiring every member. **This is the one behaviour change in the whole of Q-6.**

## The ask

From aigents, with probes. A proxy space could not be granted to a non-admin token at all: listing it in `spaces` did
nothing and every call `403`'d. They proved it was not specific to one proxy by building their own over 15 spaces,
getting the same refusal, and deleting it.

They *can* build a filtered proxy by hand — the reason that is not the answer is that it is a **second list** to keep
in step with the space set, so every new project space must be added or silently drop out of everyone's recall.

## Safe now, and not before

All **29** read fan-outs were narrowed first, across nine PRs, with `proxy-fanout-inventory.test.js` asserting
`PENDING` is empty.

Flipping this earlier would have handed a token records from every member of the proxy — well-formed, `200`, nothing
to notice. With a `proxyFor: ['*']` wildcard that is *every space on the instance*.

## Nothing changes for a non-proxy space

A real space resolves to `[spaceId]`, so "reaches at least one of one" is the same predicate as "reaches all of one".

But the property actually rests on the `memberIds.length > 0 ? memberIds : [spaceId]` **fallback**, not on the
predicate: without it an unknown space resolves to `[]`, and an empty target list would pass an at-least-one check
**vacuously**. Pinned by its own test for that reason.

## The empty-allowlist trap, at exactly the point it would have bitten

The legacy branch now checks `record.spaces === undefined` rather than truthiness.

Under all-members, an empty allowlist produced an empty `missing` list and **passed**. Under at-least-one it must
produce an empty `reachable` list and **refuse**. Same trap this repo has hit in three separate files, and the flip is
precisely where it would have returned.

## Two tests failed against the new behaviour, both correctly

- **`space-guard-reads-rights`** asserted the all-members rule directly, with a comment arguing that ANY-member access
  *"would unlock a proxy over spaces the token cannot see"*. That was **true when the fan-outs were wide** — and it is
  exactly why the flip came last. Updated to pin the new rule, plus a second test for the non-proxy equivalence that
  makes it safe.
- **The conserved total** caught the MCP guard being counted twice — once as a guard, once as a narrowed call, since a
  flipped guard uses `memberSpacesWithin`. `30 !== 29`, immediately.

`auth/middleware.ts` stays classified as a guard: its predicate is flipped but it still resolves the **full** member
list, because deciding reachability is what a guard does.

## Verification

Inventory gate 10 green with `PENDING` empty and the total conserved at 29; guard tests 7 green; server build clean;
preflight green.

🤖 Generated with Claude Code
