### PR TITLE
fix(preflight): run the CHANGELOG gate locally, and let it see uncommitted work

### DIFF
--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -50,7 +50,18 @@ const SHIPPED = [/^server\/src\//, /^client\/src\//, /^client\/public\//];
 
 let changed;
 try {
-  changed = git('diff', '--name-only', `${base}...HEAD`).split('\n').map(s => s.trim()).filter(Boolean);
+  // Committed work UNION the working tree, and the union is the point.
+  //
+  // `${base}...HEAD` alone is committed-only, which is correct in CI and useless in a local pre-push run: the usual
+  // order is `git add` → preflight → commit → push, so the change being checked is not committed yet and the gate
+  // sees nothing. It would then report "nothing to require" and pass — vacuously, on exactly the push it exists to
+  // stop. That is how this was missed on the one PR in eleven that had no entry.
+  //
+  // `git diff --name-only ${base}` compares the working tree to the base, so it catches uncommitted and staged files.
+  // In CI the two produce the same set, because there is nothing uncommitted there.
+  const committed = git('diff', '--name-only', `${base}...HEAD`).split('\n');
+  const working = git('diff', '--name-only', base).split('\n');
+  changed = [...new Set([...committed, ...working].map(s => s.trim()).filter(Boolean))];
 } catch (err) {
   // A diff that cannot run must NOT look like a pass. In CI that is an environment fault worth stopping for — a
   // shallow clone with no merge base would otherwise turn this check into a no-op that reports success, which is

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -215,6 +215,17 @@ try { run('npm run todo:check'); } catch {
   failures.push({ name: 'todo:check', why: 'a tracker holds closed work, or an open item the ordered list never references' });
 }
 
+// CI has run this since it was written; preflight never did. So eleven PRs in a row passed locally with an entry, and
+// the twelfth — the only one in that run to change access rules — got as far as a red CI job before anyone noticed the
+// CHANGELOG had no line for it. A gate that only exists after the push is a gate that teaches you to push and see.
+//
+// It works locally for the same reason CI can run it: the comparison is against `origin/main`, which is already
+// fetched. Nothing about it needed the runner.
+console.log('\n── CHANGELOG entry for shipped changes ──');
+try { run('node ./scripts/check-changelog.mjs'); } catch {
+  failures.push({ name: 'check-changelog', why: 'a file that changes what ships, with no [Unreleased] line' });
+}
+
 console.log('\n── client unit tests (includes i18n key coverage) ──');
 try { run('npm run test:client'); } catch {
   failures.push({ name: 'test:client', why: 'component behaviour, and translation keys missing from de/pl' });


### PR DESCRIPTION
## Two defects that made this a push-and-see check

### Preflight never ran it

CI has run `check-changelog` since it was written; the local gate list did not include it.

So **eleven PRs in a row** passed preflight with an entry, and the twelfth — the only one in that run to change access
rules — got as far as a red CI job before anyone noticed the CHANGELOG had no line for it.

A gate that only exists after the push teaches you to push and see. Nothing about it needed the runner: it compares
against `origin/main`, which is already fetched locally.

### And it would have been vacuous there anyway

It diffed `origin/main...HEAD` — **committed only**. The usual local order is `git add` → preflight → commit → push,
so the change being checked is not committed when preflight runs.

The gate would have seen **zero** shipped files and reported *"nothing to require"*. Passing, on exactly the push it
exists to stop.

## The fix

The changed set is now the committed diff **union** the working-tree diff (`git diff --name-only ${base}`), so staged
and unstaged files count. In CI the two sets are identical, because nothing is uncommitted there.

## Verified by planting a line, not by reading the logic

```
$ printf '\n// probe\n' >> server/src/util/log.ts
$ node ./scripts/check-changelog.mjs
check-changelog: FAILED
These files change what ships, and CHANGELOG.md gained no line under [Unreleased]:
```

Without that step this would have been a second gate that looked wired and reported nothing — the same mistake, one
level up.

Preflight green.

🤖 Generated with Claude Code
