### PR TITLE
fix: the loop gate refuses a manufactured owner decision, and Q-8 explains its refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **A schema-library entry refusing `retention` now explains why.** `.strict()` alone answered
+  `Unrecognized key(s) in object: 'retention'`, which tells a direct API caller that a field valid on an inline type
+  schema is invalid here and nothing about the reason — inviting them to report it as a bug.
+  - The refusal itself is unchanged and deliberate: one library entry is referenced by any number of spaces, and a
+    delete window belongs to a type *in* a space rather than to the shape. The message now says that, and names both
+    ways out (resolve the `$ref` to an inline definition, or use the space-wide `recordTtlDays`).
+  - `.strict()` still handles everything else, so an ordinary typo keeps the generic answer.
+
 ### Added
 - **A proxy space can now be granted to a scoped token — it becomes a lens over what that token may already see.**
   `enforceSpaceScope` and the MCP guard accept a proxy when the token reaches **at least one** member instead of

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -86,9 +86,18 @@ if (shipped.length === 0) {
 
 /** Line numbers added to CHANGELOG.md in this diff. */
 function addedChangelogLines() {
+  // `${base}` and NOT `${base}...HEAD`, to match how the changed-FILE list is built above.
+  //
+  // The two were inconsistent for exactly one commit: the file list was widened to include the working tree, and this
+  // was left committed-only. So an uncommitted change to shipped code was SEEN while the uncommitted CHANGELOG entry
+  // answering it was not — and the gate failed on correct code, on its own first real use. Half-widening a comparison
+  // is worse than not widening it, because the halves disagree in the direction that reports a defect.
+  //
+  // Line numbers here are compared against the CURRENT file (`unreleasedRange` reads it from disk), so a working-tree
+  // diff is the consistent choice rather than a convenience.
   let patch;
   try {
-    patch = git('diff', '-U0', `${base}...HEAD`, '--', 'CHANGELOG.md');
+    patch = git('diff', '-U0', base, '--', 'CHANGELOG.md');
   } catch {
     return [];
   }

--- a/scripts/loop-check.mjs
+++ b/scripts/loop-check.mjs
@@ -47,6 +47,8 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 
 const ORDERED = 'todo/_TODO-ORDERED.md';
+/** The authority for what is parked. A tier in the ordered file is bookkeeping; this is what the owner reads. */
+const PARKED = 'todo/_PARKED-DECISIONS.md';
 const C = { red: '\x1b[31m', green: '\x1b[32m', yellow: '\x1b[33m', dim: '\x1b[2m', bold: '\x1b[1m', off: '\x1b[0m' };
 const reason = process.argv.includes('--reason') ? process.argv[process.argv.indexOf('--reason') + 1] : null;
 
@@ -141,8 +143,32 @@ function main() {
   console.log('');
 
   if (reason) {
-    // Naming a stop puts the claim on the record. The script cannot verify it, but an unnamed stop and a named
-    // one should not look identical afterwards.
+    // A claimed OWNER DECISION is checkable, and it is the one that has been abused.
+    //
+    // Twice now a turn ended on "Your move" while the ordered queue held work — once on an item that was already
+    // decided and documented, once on a phantom: a row sitting in the ordered file's parked tier while
+    // `_PARKED-DECISIONS.md` said "Nothing open". A decision nobody is actually waiting on is not a stop, it is a
+    // manufactured one, and it is the same failure as claiming "Running" with nothing running.
+    //
+    // Two facts settle it. **Parked never blocks** while other work exists (owner, 2026-08-10: "if its in parked you
+    // dont wait for me if there are other things in ordered"). And `_PARKED-DECISIONS.md` is the authority for what
+    // is parked — a tier in the ordered file is bookkeeping, not a queue the owner reads for decisions.
+    if (/owner|decision|your move|sign.?off|approval/i.test(reason)) {
+      const parkedOpen = existsSync(PARKED) && !/^\s*##\s+Nothing open\s*$/mi.test(readFileSync(PARKED, 'utf8'));
+      if (rows.length > 0) {
+        console.log(`${C.red}NOT A STOP${C.off} — an owner decision is claimed, but ${rows.length} Q- row(s) are open.`);
+        console.log('Parked never blocks while other work exists. Go build the next row and batch the decision.');
+        console.log(`${C.bold}Next: ${rows[0].id} — ${rows[0].what}${C.off}`);
+        process.exit(1);
+      }
+      if (!parkedOpen) {
+        console.log(`${C.red}NOT A STOP${C.off} — an owner decision is claimed, but ${PARKED} says nothing is open.`);
+        console.log('Either file it there with a recommended default, or decide it yourself (the TINA rule).');
+        process.exit(1);
+      }
+    }
+    // Naming a stop puts the claim on the record. The script cannot verify the other kinds, but an unnamed stop and
+    // a named one should not look identical afterwards.
     console.log(`${C.yellow}STOP CLAIMED${C.off} — ${reason}`);
     console.log(`${C.dim}The genuine stops: an owner decision, a live-cluster change, something${C.off}`);
     console.log(`${C.dim}outward-facing, or an external failure. Nothing else.${C.off}`);

--- a/server/src/api/schema-library.ts
+++ b/server/src/api/schema-library.ts
@@ -88,16 +88,38 @@ const PropertySchemaZ = z.object({
   message: 'mergeFn is incompatible with the declared type (numeric fns require type "number", boolean fns require type "boolean")',
 });
 
-/** Zod schema for the inline TypeSchema stored in library entries.
- *  `$ref` is not permitted inside a library entry (no recursive references). */
+/**
+ * Zod schema for the inline TypeSchema stored in library entries.
+ *
+ * `$ref` is not permitted inside a library entry (no recursive references).
+ *
+ * ## `retention` is refused ON PURPOSE, and now says so
+ *
+ * A library entry is referenced by any number of spaces, and a delete policy is not a property of a shape — so a
+ * window belongs to a type IN a space, never to the library definition. That decision predates this comment and is
+ * already documented in `04-brain-api.md`; the client strips the field before saving to the library
+ * (`typeSchemaFromState(..., { withRetention: false })`).
+ *
+ * What was missing was the explanation at the point of refusal. `.strict()` alone answers `Unrecognized key(s) in
+ * object: 'retention'`, which tells a direct API caller that a field valid one place is invalid here and nothing
+ * about why. Declaring the key with a message that fails is uglier than omitting it, and worth it: the alternative
+ * is a caller reading the Zod error and concluding it is a bug.
+ *
+ * Anything else unrecognised still falls through to `.strict()`, because a generic rejection is the right answer for
+ * a genuine typo — this is only for the one field whose absence is a design decision rather than an oversight.
+ */
 const LibraryTypeSchemaZ = z.object({
   namingPattern: z.string().max(500).optional(),
   tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
   propertySchemas: z.record(z.string().min(1).max(200), PropertySchemaZ).optional(),
-  // Kept in step with `TypeSchemaZ` in `api/spaces.ts` deliberately: a library entry that cannot express a field
-  // the inline schema can is a surface that silently drops it on `.strict()`. `retention` is already in exactly
-  // that state here and is filed as its own item rather than widened in a feature PR.
+  // Kept in step with `TypeSchemaZ` in `api/spaces.ts` deliberately: a library entry that cannot express a field the
+  // inline schema can is a surface that silently drops it.
   suppressEmbeddings: z.boolean().optional(),
+  retention: z.never({
+    message: 'retention cannot be set on a schema-library entry: one entry is referenced by any number of spaces, '
+      + 'and a delete window belongs to a type in a space rather than to the shape. Set it on the type after '
+      + 'resolving the $ref to an inline definition, or use the space-wide recordTtlDays.',
+  }).optional(),
 }).strict();
 
 /** Name must be URL-safe and reasonably short. Allows uppercase, dots, dashes, underscores. */

--- a/testing/standalone/library-retention-refusal.test.js
+++ b/testing/standalone/library-retention-refusal.test.js
@@ -1,0 +1,85 @@
+/**
+ * A schema-library entry refuses `retention`, and the refusal explains itself.
+ *
+ * ## What was actually wrong, having read the code
+ *
+ * This was filed as "two surfaces, one weaker: the library cannot express a field the inline schema can". Two thirds
+ * of that dissolved on reading:
+ *
+ *  - the client already strips it — `typeSchemaFromState(..., { withRetention: false })`;
+ *  - the docs already state it AND give the reason, in `04-brain-api.md`.
+ *
+ * So the omission was never an oversight. A library entry is referenced by any number of spaces, and a delete policy
+ * is not a property of a shape. What was missing was the explanation at the **point of refusal**: `.strict()` alone
+ * answers `Unrecognized key(s) in object: 'retention'`, which tells a direct API caller that a field valid one place
+ * is invalid here, and nothing about why — inviting them to report it as a bug.
+ *
+ * That is the whole change, and this test pins the two things that make it worth having: the field is still refused,
+ * and the message says why.
+ *
+ * Run: node --test testing/standalone/library-retention-refusal.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync(new URL('../../server/src/api/schema-library.ts', import.meta.url), 'utf8');
+/** Comments must not satisfy any of this — the block above the schema describes the very rule being checked. */
+const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/**
+ * The `retention` declaration only.
+ *
+ * Sliced from the key FORWARD, not between the key and the first `}).strict()` — that was the first version, and this
+ * file has an earlier `.strict()` schema, so the end index came out BEFORE the start and every slice was empty. Two
+ * assertions then passed vacuously against an empty string while looking specific.
+ */
+const RETENTION_DECL = (() => {
+  const a = CODE.indexOf('retention: z.never(');
+  return a < 0 ? '' : CODE.slice(a, CODE.indexOf('}).optional(),', a));
+})();
+
+describe('the refusal', () => {
+  it('still refuses retention — the field is not quietly accepted', () => {
+    // The one thing that must not change. Widening the library to hold a window would give a linked type a delete
+    // policy inherited from the library, which is new behaviour nobody asked for.
+    assert.match(CODE, /retention: z\.never\(/);
+  });
+
+  it('keeps .strict(), so an ordinary typo is still rejected', () => {
+    // The explicit key is for the ONE field whose absence is a design decision. A genuine misspelling should still
+    // get the generic answer rather than silently landing in the entry.
+    assert.match(CODE, /\}\)\.strict\(\)/);
+  });
+
+  it('explains why, naming the reason rather than the rule', () => {
+    // "Not allowed" is what `.strict()` already said. The message has to carry the design reason, or the caller has
+    // no way to tell a deliberate refusal from a bug.
+    assert.ok(RETENTION_DECL.length > 0, 'the declaration was not found — the slice is broken, not the code');
+    assert.match(RETENTION_DECL, /referenced by any number of spaces/);
+    assert.match(RETENTION_DECL, /belongs to a type in a space/);
+  });
+
+  it('tells the caller what to do instead', () => {
+    // An error that only says no leaves the caller stuck. Both routes out are named.
+    assert.ok(RETENTION_DECL.length > 0, 'the declaration was not found — the slice is broken, not the code');
+    assert.match(RETENTION_DECL, /inline definition/);
+    assert.match(RETENTION_DECL, /recordTtlDays/);
+  });
+});
+
+describe('the two surfaces are otherwise in step', () => {
+  it('the library accepts suppressEmbeddings, as the inline schema does', () => {
+    // The field that WAS a real gap of this shape, closed when it shipped. Pinned so the library does not fall behind
+    // again the next time a per-type field is added.
+    assert.match(CODE, /suppressEmbeddings: z\.boolean\(\)\.optional\(\)/);
+  });
+
+  it('the client strips retention rather than relying on the 400', () => {
+    // Belt and braces, and the belt is the client: a UI that posted a field it knew would be refused would surface
+    // the error to an operator who did nothing wrong.
+    const tab = readFileSync(new URL('../../client/src/app/pages/settings/space-schema-tab.component.ts', import.meta.url), 'utf8');
+    assert.match(tab, /withRetention: false/);
+  });
+});

--- a/testing/standalone/type-schema-editable.test.js
+++ b/testing/standalone/type-schema-editable.test.js
@@ -119,9 +119,14 @@ describe('a space type schema is editable in the UI', () => {
     const start = lib.indexOf('const LibraryTypeSchemaZ =');
     assert.ok(start > 0, `LibraryTypeSchemaZ not found in ${LIB}`);
     const block = lib.slice(start, lib.indexOf('}).strict()', start));
-    assert.ok(!/retention:/.test(block), 'LibraryTypeSchemaZ now accepts `retention`, but nothing resolves a '
+    // ACCEPTS, not mentions. The field may be declared as `z.never(...)` — that refuses it while giving the caller
+    // the reason instead of a bare `Unrecognized key(s)`, which is strictly better than omitting it. A substring
+    // check on `retention:` could not tell those apart and failed on the version that improved the error.
+    const declared = /retention:\s*z\.(\w+)/.exec(block);
+    assert.ok(!declared || declared[1] === 'never',
+      `LibraryTypeSchemaZ declares retention as z.${declared?.[1]}, which ACCEPTS it — but nothing resolves a `
       + '$ref when retention is read (see chrono-retention.ts / ttl.ts, which use the RAW space meta). Either '
-      + 'resolve refs there first, or keep the field out of the library — and update the UI copy either way: '
+      + 'resolve refs there first, or keep the field refused — and update the UI copy either way: '
       + 'the Schema tab tells the operator a saved-to-library type loses its window.');
   });
 


### PR DESCRIPTION
## The behaviour that needed fixing

Three turns in a row ended on **"Your move"** while the ordered queue held work.

The owner's correction: *"if its in ordered its not parked, if its in parked you dont wait for me if there are other
things in ordered"*, then *"either way something is wrong with your behaviour"*.

Both right, and it is **one** behaviour: manufacturing a decision point to end a turn on. The same failure the loop
gate was built for, in a new disguise — instead of "Running" with nothing running, "Your move" with nobody waiting.

## `loop:check` now checks the claim

A `--reason` mentioning an owner decision is **refused** when:

- any `Q-` row is open — parked never blocks while other work exists; or
- `_PARKED-DECISIONS.md` says nothing is open.

That file is the authority. A tier in `_TODO-ORDERED.md` is bookkeeping, not a queue the owner reads for decisions.

## P-3 was a phantom, and there are no open decisions

The `plaintext`/`token` response rename is answered in `_REFERENCE.md` **A-L7-3: NO**, with the reasoning and an
explicit *"do not re-open by pointing at the incident"*.

It sat in the ordered file's parked tier as a row for a decision made weeks ago, and I used it **three times** as a
reason to hand back.

## Q-8 was the same mistake one layer down

I filed it as needing an owner call without reading the docs that answered it. Two thirds dissolved on reading:

- the client already strips the field (`withRetention: false`);
- `04-brain-api.md` already states the rule **and its reason**.

What was actually missing was the explanation at the point of refusal. `.strict()` answers
`Unrecognized key(s) in object: 'retention'` — which tells a direct API caller that a field valid on an inline schema
is invalid here, and nothing about why.

`retention` is now `z.never` with a message naming the reason (one entry is referenced by many spaces; a window
belongs to a type *in* a space) and both ways out. `.strict()` still handles genuine typos.

## Two gates fired on correct code, and both were mine

| gate | what was wrong |
|---|---|
| `check-changelog` (from my #791) | I widened the changed-**file** list to the working tree and left the CHANGELOG **line count** on `${base}...HEAD`. An uncommitted shipped file was seen while the uncommitted entry answering it was not. **Half-widening a comparison is worse than not widening it** — the halves disagree in the direction that reports a defect. Verified both ways this time: removing the entry fails, restoring it passes. |
| `type-schema-editable` | Asserted the library schema does not *mention* `retention`, by substring. It cannot tell "declared to refuse" from "declared to accept", so it failed on the version that improved the error. Now checks the declared type and permits `z.never` only. |

## Verification

6 new tests on the refusal (including that the message names the reason *and* the way out, and that `.strict()`
survives), 11 on `loop:check`, 6 on the tightened editable gate; preflight green.

🤖 Generated with Claude Code
