### PR TITLE
feat(ui): one timestamp treatment for data tables — date over local time, with seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`<app-timestamp>` — one absolute-time treatment for data tables:** the date on one line, the local time with
+  **seconds** below it. Nothing uses it yet; the 23 call sites follow.
+  - Replaces five different formats measured across the client (`dd.MM.yyyy HH:mm` ×11, `yyyy-MM-dd HH:mm:ss` ×5,
+    `dd.MM.yyyy` ×4, `dd.MM.yy` ×2, `mediumDate` ×1), so it is a drift fix as much as a feature.
+  - **Rendering only — storage stays UTC.** The `datetime` attribute carries the original UTC ISO string, so anything
+    reading the DOM gets UTC rather than a localised string.
+  - It exposes `sortKey()` in epoch-ms, because sorting the rendered text is the specific way this goes wrong:
+    `01.02.2026` sorts before `02.01.2025` as a string, and that ordering looks plausible enough to survive review.
+  - 24-hour clock pinned regardless of locale — left to the locale, one row reads `11:59:03 PM` and the next
+    `23:59:03`, and a column mixing both cannot be scanned.
+  - Absent values render a dash, not an empty cell, and an unparseable value renders the dash rather than
+    `Invalid Date`.
+  - **First two tables converted:** the Memories and Entities `Created` columns, which showed `dd.MM.yyyy` and no time
+    at all. 21 usages remain.
+
 ### Changed
 - **A schema-library entry refusing `retention` now explains why.** `.strict()` alone answered
   `Unrecognized key(s) in object: 'retention'`, which tells a direct API caller that a field valid on an inline type

--- a/client/src/app/pages/brain/entities-tab.component.ts
+++ b/client/src/app/pages/brain/entities-tab.component.ts
@@ -19,6 +19,7 @@ import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { TimestampComponent } from '../../shared/timestamp.component';
 
 /**
  * The Entities record tab, extracted from BrainComponent (A17.9b-6e) following the memories pattern.
@@ -36,7 +37,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
   selector: 'app-entities-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, SortableHeaderComponent, HscrollTopDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, SortableHeaderComponent, HscrollTopDirective, TimestampComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -199,7 +200,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                         @if (!(ent.tags?.length)) { <span style="color:var(--text-muted)">—</span> }
                       </td>
                       <td><app-properties-view [properties]="ent.properties" [schema]="store.entitySchema(ent.type)" /></td>
-                      <td style="color:var(--text-muted)">{{ ent.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td><app-timestamp [value]="ent.createdAt"/></td>
                       <td style="white-space:nowrap;">
                         <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('entity', ent)"><ph-icon name="eye" [size]="16"/></button>
                         <button class="icon-btn" [attr.title]="'common.viewInGraph' | transloco" [attr.aria-label]="'common.viewInGraph' | transloco" (click)="viewInGraph.emit(ent._id)"><ph-icon name="graph" [size]="16"/></button>

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -20,6 +20,7 @@ import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { TimestampComponent } from '../../shared/timestamp.component';
 
 /**
  * The Memories record tab, extracted from BrainComponent (A17.9b-6d) — the first of the five record
@@ -41,7 +42,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
   selector: 'app-memories-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntityRefFieldComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective, TimestampComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -188,7 +189,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                         } @else { <span style="color:var(--text-muted)">—</span> }
                       </td>
                       <td><app-properties-view [properties]="mem.properties" [schema]="store.memorySchema()" /></td>
-                      <td style="color:var(--text-muted)">{{ mem.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td><app-timestamp [value]="mem.createdAt"/></td>
                       <td style="white-space:nowrap;">
                         <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('memory', mem)"><ph-icon name="eye" [size]="16"/></button>
                         @if (recordList.confirmDeleteId() === mem._id) {

--- a/client/src/app/shared/timestamp.component.spec.ts
+++ b/client/src/app/shared/timestamp.component.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TimestampComponent, formatTimestampParts, toEpochMs } from './timestamp.component';
+
+/**
+ * The absolute-time treatment for data tables.
+ *
+ * Every test pins `timeZone` and `locale`. Without that these assertions pass in one office and fail in the next,
+ * which is the specific way a local-rendering test is worthless — and this component exists precisely because
+ * rendering is local while storage is not.
+ */
+describe('formatTimestampParts', () => {
+  const UTC_NOON = '2026-08-10T12:00:03.000Z';
+
+  it('renders the date and the time SEPARATELY', () => {
+    const p = formatTimestampParts(UTC_NOON, 'de-DE', 'UTC')!;
+    expect(p.date).toBe('10.08.2026');
+    expect(p.time).toBe('12:00:03');
+  });
+
+  it('includes SECONDS, which the format it replaces dropped', () => {
+    // `HH:mm` was the majority format. An audit log where two entries share a minute is unreadable without these.
+    expect(formatTimestampParts(UTC_NOON, 'en-GB', 'UTC')!.time).toBe('12:00:03');
+  });
+
+  it('converts to the given zone — the whole point of "render local"', () => {
+    const p = formatTimestampParts(UTC_NOON, 'de-DE', 'Europe/Berlin')!;
+    expect(p.time).toBe('14:00:03');   // CEST, UTC+2 in August
+    expect(p.date).toBe('10.08.2026');
+  });
+
+  it('crosses the DATE line when the zone says so', () => {
+    // A late-evening UTC timestamp is the next day in Berlin. If only the time were converted, the two lines would
+    // disagree with each other and the row would be wrong in a way nobody would question.
+    const p = formatTimestampParts('2026-08-10T23:30:00.000Z', 'de-DE', 'Europe/Berlin')!;
+    expect(p.date).toBe('11.08.2026');
+    expect(p.time).toBe('01:30:00');
+  });
+
+  it('keeps the ISO as UTC, never the localised string', () => {
+    // The DOM must stay UTC: `datetime` is what a test, a scraper or a copy-paste reads. This is the assertion that
+    // holds the owner's "we save utc, render local" line at the boundary.
+    expect(formatTimestampParts(UTC_NOON, 'de-DE', 'Europe/Berlin')!.iso).toBe(UTC_NOON);
+  });
+
+  it('uses a 24-hour clock regardless of locale', () => {
+    // Left to the locale, `en-US` gives `11:59:03 PM` while `de-DE` gives `23:59:03` — a column mixing both cannot
+    // be scanned, which is the drift this component exists to end.
+    expect(formatTimestampParts('2026-08-10T23:59:03.000Z', 'en-US', 'UTC')!.time).toBe('23:59:03');
+  });
+
+  it('accepts an ISO string, epoch-ms and a Date alike', () => {
+    const ms = Date.parse(UTC_NOON);
+    for (const v of [UTC_NOON, ms, new Date(ms)]) {
+      expect(formatTimestampParts(v, 'de-DE', 'UTC')!.time).toBe('12:00:03');
+    }
+  });
+
+  it('returns null for absent or unparseable input rather than a plausible date', () => {
+    // `new Date(undefined)` is Invalid Date and `Intl` would render "Invalid Date" into the cell. Returning null lets
+    // the component show a dash instead of a string that looks like a bug in the data.
+    for (const v of [null, undefined, '', 'not a date', NaN]) {
+      expect(formatTimestampParts(v as never, 'de-DE', 'UTC')).toBe(null);
+    }
+  });
+});
+
+describe('toEpochMs, which exists so nobody sorts the rendered text', () => {
+  it('orders two timestamps the way a string comparison would NOT', () => {
+    // `01.02.2026` vs `02.01.2025`: as strings the 2026 date sorts first, which is wrong and looks plausible.
+    const later = toEpochMs('2026-02-01T00:00:00Z')!;
+    const earlier = toEpochMs('2025-01-02T00:00:00Z')!;
+    expect(earlier).toBeLessThan(later);
+    expect('01.02.2026' < '02.01.2025').toBe(true);   // the trap, asserted so it is not theoretical
+  });
+
+  it('is null for unparseable input, so a bad row does not sort as epoch 0', () => {
+    expect(toEpochMs('nonsense')).toBe(null);
+  });
+});
+
+describe('TimestampComponent', () => {
+  const render = (value: unknown, over: Record<string, unknown> = {}) => {
+    const f = TestBed.createComponent(TimestampComponent);
+    f.componentRef.setInput('value', value);
+    f.componentRef.setInput('locale', 'de-DE');
+    f.componentRef.setInput('timeZone', 'UTC');
+    for (const [k, v] of Object.entries(over)) f.componentRef.setInput(k, v);
+    f.detectChanges();
+    return f;
+  };
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({ imports: [TimestampComponent] }).compileComponents();
+  });
+
+  it('renders two lines inside a machine-readable <time>', () => {
+    const el = render('2026-08-10T12:00:03.000Z').nativeElement as HTMLElement;
+    expect(el.querySelector('.d')!.textContent).toBe('10.08.2026');
+    expect(el.querySelector('.t')!.textContent).toBe('12:00:03');
+    expect(el.querySelector('time')!.getAttribute('datetime')).toBe('2026-08-10T12:00:03.000Z');
+  });
+
+  it('shows a dash for an absent value, not an empty cell', () => {
+    // An empty cell reads as a layout bug and invites someone to "fix" the component.
+    const el = render(null).nativeElement as HTMLElement;
+    expect(el.textContent!.trim()).toBe('—');
+    expect(el.querySelector('time')).toBe(null);
+  });
+
+  it('exposes epoch-ms as a sort key', () => {
+    const f = render('2026-08-10T12:00:03.000Z');
+    expect(f.componentInstance.sortKey()).toBe(Date.parse('2026-08-10T12:00:03.000Z'));
+  });
+
+  it('sortKey is null when the value is unusable, rather than 0', () => {
+    // Zero would sort a broken row to 1970 and look like real data.
+    expect(render('nonsense').componentInstance.sortKey()).toBe(null);
+  });
+});

--- a/client/src/app/shared/timestamp.component.ts
+++ b/client/src/app/shared/timestamp.component.ts
@@ -1,0 +1,117 @@
+/**
+ * Timestamp — one absolute-time treatment for every data table.
+ *
+ * Date on the first line, local time with SECONDS on the second. Owner request, 2026-08-10: *"in data tables
+ * timestamps should also show the time rendered in local time below the date with precision: seconds"*.
+ *
+ * ## What it replaces
+ *
+ * Measured before writing it: **23 `| date:` usages in five different formats** — `dd.MM.yyyy HH:mm` ×11,
+ * `yyyy-MM-dd HH:mm:ss` ×5, `dd.MM.yyyy` ×4, `dd.MM.yy` ×2, `mediumDate` ×1. Five formats exist because each table
+ * formatted its own, so this is a drift fix as much as a feature, and a sixth spelling of the same idea is how it
+ * recurs.
+ *
+ * The two-line stack is the treatment the owner already approved for the tokens table — *"last used and expires
+ * should be date and below time"* — generalised. The complaint behind it was `expires tomorrow`, which "makes me
+ * wonder when tomorrow": a relative label needs the absolute one AVAILABLE, not replaced. So this does not compete
+ * with `RelativeTime`; use that where "3 minutes ago" is the useful answer and this where the exact moment is.
+ *
+ * ## RENDERING ONLY
+ *
+ * Owner, 2026-08-10: *"dont change the 'we save utc' stance. just for rendering local"*. Storage, the wire format,
+ * the API, sync and the audit log all stay UTC ISO strings. The local time exists in the DOM and nowhere else.
+ *
+ * That boundary is the one most likely to be crossed by accident, so this component is built to make crossing it
+ * hard rather than to trust nobody will:
+ *
+ *  - it takes the **UTC value** and converts at render time, never the other way round;
+ *  - `datetime` on the `<time>` element carries the **original UTC ISO string**, so anything reading the DOM
+ *    programmatically — a test, a scraper, a copy-paste — gets UTC, not a localised string;
+ *  - it exposes `sortKey()` returning epoch-ms, because a table that sorts on the RENDERED TEXT is the specific way
+ *    this goes wrong. `01.02.2026` sorts before `02.01.2025` as a string. A timezone bug in stored data is invisible
+ *    until someone in another offset reads it, and a sort bug is invisible until the rows happen to disagree.
+ *
+ * ## Seconds are the point
+ *
+ * `HH:mm` is the current majority format and drops them. An audit log where two entries share a minute is unreadable
+ * without seconds, which is exactly where an operator looks hardest.
+ */
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+export type TimestampValue = string | number | Date | null | undefined;
+
+/** Epoch-ms from an ISO string / epoch-ms / Date, or null when unparseable. Exported for testing and sorting. */
+export function toEpochMs(value: TimestampValue): number | null {
+  if (value == null) return null;
+  const t = value instanceof Date ? value.getTime() : typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(t) ? t : null;
+}
+
+/**
+ * The two lines, in the VIEWER's timezone.
+ *
+ * `Intl` rather than manual padding: it honours the locale's date order, which is the whole reason five hand-rolled
+ * formats existed. `hourCycle: 'h23'` is pinned because a table with `11:59:03 PM` in one row and `23:59:03` in
+ * another — which is what happens when the locale decides — cannot be scanned down a column.
+ *
+ * Pure, and `locale`/`timeZone` are parameters so a test is not at the mercy of the machine it runs on. That is not
+ * hypothetical care: a test asserting a local rendering without pinning the zone passes in one office and fails in
+ * the next.
+ */
+export function formatTimestampParts(
+  value: TimestampValue,
+  locale?: string,
+  timeZone?: string,
+): { date: string; time: string; iso: string } | null {
+  const t = toEpochMs(value);
+  if (t === null) return null;
+  const d = new Date(t);
+  const opts: Intl.DateTimeFormatOptions = timeZone ? { timeZone } : {};
+  return {
+    date: new Intl.DateTimeFormat(locale, { ...opts, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d),
+    time: new Intl.DateTimeFormat(locale, { ...opts, hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23' }).format(d),
+    // The ORIGINAL instant, in UTC. Never the localised string — see the class comment on why the DOM must stay UTC.
+    iso: d.toISOString(),
+  };
+}
+
+@Component({
+  selector: 'app-timestamp',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    :host { display: inline-block; font-variant-numeric: tabular-nums; line-height: 1.25; }
+    .d { display: block; }
+    /* The time is secondary: an operator scans dates first and reads the time on the row they stopped at. Dimmed
+       rather than smaller alone, because two lines of identical weight read as two separate values. */
+    .t { display: block; font-size: .85em; color: var(--text-muted); }
+    .empty { color: var(--text-muted); }
+  `],
+  template: `
+    @if (parts(); as p) {
+      <time [attr.datetime]="p.iso" [attr.title]="p.iso">
+        <span class="d">{{ p.date }}</span><span class="t">{{ p.time }}</span>
+      </time>
+    } @else {
+      <span class="empty">{{ empty() }}</span>
+    }
+  `,
+})
+export class TimestampComponent {
+  value = input.required<TimestampValue>();
+  /** What to show when there is no timestamp. A dash, not an empty cell — an empty cell reads as a layout bug. */
+  empty = input<string>('—');
+  /** Overridable for tests and for a future per-user preference; undefined means the viewer's own. */
+  locale = input<string | undefined>(undefined);
+  timeZone = input<string | undefined>(undefined);
+
+  readonly parts = computed(() => formatTimestampParts(this.value(), this.locale(), this.timeZone()));
+
+  /**
+   * Epoch-ms, for a caller that sorts a column of these.
+   *
+   * Exposed so nobody sorts the rendered text. `01.02.2026` before `02.01.2025` is a real ordering a string
+   * comparison produces, and it looks plausible enough to survive review.
+   */
+  readonly sortKey = computed(() => toEpochMs(this.value()));
+}


### PR DESCRIPTION
## What

`<app-timestamp>` — the date on one line, the local time with **seconds** below it. Owner request: *"in data tables
timestamps should also show the time rendered in local time below the date with precision: seconds"*.

First two call sites: the **Memories** and **Entities** `Created` columns, which showed `dd.MM.yyyy` and no time at all.

## Measured, not estimated

**23 `| date:` usages in five different formats** across the client:

| count | format |
|---|---|
| 11 | `dd.MM.yyyy HH:mm` |
| 5 | `yyyy-MM-dd HH:mm:ss` |
| 4 | `dd.MM.yyyy` |
| 2 | `dd.MM.yy` |
| 1 | `mediumDate` |

Five formats exist because each table formatted its own — so this is a drift fix as much as a feature, and a sixth
spelling of the same idea is how it comes back. **21 remain.**

## Rendering only — the "we save UTC" stance does not change

Storage, the wire format, the API, sync and the audit log stay UTC ISO strings. That boundary is the one most likely
to be crossed by accident, so the component is built to make crossing it hard rather than to trust nobody will:

- it takes the UTC value and converts **at render time**, never the reverse;
- `datetime` carries the **original UTC ISO string**, so a test, a scraper or a copy-paste reads UTC and not a
  localised string;
- it exposes **`sortKey()` in epoch-ms**, because sorting the *rendered text* is the specific way this goes wrong.
  `01.02.2026` sorts before `02.01.2025` as a string, and that ordering is plausible enough to survive review. The
  test asserts the trap directly rather than describing it.

## Two smaller calls, with their reasons

- **24-hour clock pinned regardless of locale.** Left to the locale, one row reads `11:59:03 PM` and the next
  `23:59:03` — a column mixing both cannot be scanned, which is the drift this is meant to end.
- **An unparseable value renders the dash, not `Invalid Date`.** `Intl` will happily print that into a cell, where it
  looks like bad *data* rather than bad *code*.

## Every test pins locale and timeZone

A local-rendering assertion without that passes in one office and fails in the next — and this component exists
precisely because rendering is local while storage is not. 14 tests, including a date-line crossing case
(`23:30 UTC` → `11.08. 01:30` in Berlin), because converting only the time would leave the two lines disagreeing with
each other in a way nobody would question.

## Why two call sites are in this PR

The reachability gate refused the component while nothing rendered it — **the third time that gate has correctly
caught me shipping a component ahead of its use.** So the conversions are here rather than "next".

Preflight green; 1035 client tests pass.

🤖 Generated with Claude Code
