### PR TITLE
feat(ui): five more table cells get the timestamp treatment, with the format pinned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Five more data-table cells use `<app-timestamp>`** — the chrono Starts/Ends/Created columns, the edges Created
+  column, and the file-manager Modified column. Each gains the local time with seconds; two of them showed no time at
+  all before.
+  - **The date format is pinned to `dd.MM.yyyy`, not taken from the browser.** The instruction was to render the local
+    *time* — the zone. Taking the viewer's locale for the date too would make the field order vary by browser
+    (`15.01.2026` here, `01/15/2026` there) for the same row on the same instance, which would undo the point of a
+    scannable column. The zone is the viewer's; the format is fixed.
+  - The chrono Ends column loses its `? … : '—'` ternary: the component renders its own dash, and a second copy of
+    that decision is one more place for the two to disagree about what "no timestamp" looks like.
+  - 16 usages remain, and they are deliberately **not** all in scope: the rest are inline in sentences, in detail
+    drawers, or inside a `title` attribute, where a two-line stack would break the line.
+
 ### Added
 - **`<app-timestamp>` — one absolute-time treatment for data tables:** the date on one line, the local time with
   **seconds** below it. Nothing uses it yet; the 23 call sites follow.

--- a/client/src/app/pages/brain/chrono-tab.component.ts
+++ b/client/src/app/pages/brain/chrono-tab.component.ts
@@ -20,6 +20,7 @@ import { fmtApiError, toLocalDatetime } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { TimestampComponent } from '../../shared/timestamp.component';
 
 /**
  * The Chrono record tab, extracted from BrainComponent (A17.9b-6g) following the memories/edges pattern.
@@ -36,7 +37,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
   selector: 'app-chrono-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, PropertiesEditorComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective, TimestampComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -222,8 +223,8 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                       </td>
                       <td><span class="badge badge-blue">{{ entry.type }}</span></td>
                       <td><span class="badge" [class.badge-purple]="entry.status === 'upcoming'" [class.badge-blue]="entry.status === 'active'">{{ entry.status }}</span></td>
-                      <td style="color:var(--text-muted); font-size:12px">{{ entry.startsAt | date:'dd.MM.yyyy HH:mm' }}</td>
-                      <td style="color:var(--text-muted); font-size:12px">{{ entry.endsAt ? (entry.endsAt | date:'dd.MM.yyyy HH:mm') : '—' }}</td>
+                      <td><app-timestamp [value]="entry.startsAt"/></td>
+                      <td><app-timestamp [value]="entry.endsAt"/></td>
                       <td>
                         @for (tag of entry.tags; track tag) { <span class="tag">{{ tag }}</span> }
                       </td>
@@ -236,7 +237,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                           </div>
                         } @else { <span style="color:var(--text-muted)">—</span> }
                       </td>
-                      <td style="color:var(--text-muted)">{{ entry.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td><app-timestamp [value]="entry.createdAt"/></td>
                       <td style="white-space:nowrap;">
                         <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('chrono', entry)"><ph-icon name="eye" [size]="16"/></button>
                         @if (recordList.confirmDeleteId() === entry._id) {

--- a/client/src/app/pages/brain/edges-tab.component.ts
+++ b/client/src/app/pages/brain/edges-tab.component.ts
@@ -20,6 +20,7 @@ import { fmtApiError } from './brain-format';
 import { BRAIN_CHIP_STYLES } from './brain-form.styles';
 import { BRAIN_RECORD_TABLE_STYLES } from './brain-table.styles';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
+import { TimestampComponent } from '../../shared/timestamp.component';
 
 /**
  * The Edges record tab, extracted from BrainComponent (A17.9b-6f) following the memories pattern.
@@ -34,7 +35,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
   selector: 'app-edges-tab',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective],
+  imports: [CommonModule, FormsModule, TranslocoPipe, TagInputComponent, PropertiesViewComponent, PropertiesEditorComponent, EntitySearchComponent, PhIconComponent, ErrorStateComponent, RecordSearchBarComponent, SortableHeaderComponent, HscrollTopDirective, TimestampComponent],
   styles: [BRAIN_CHIP_STYLES, BRAIN_RECORD_TABLE_STYLES],
   template: `
 
@@ -213,7 +214,7 @@ import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
                         {{ edge.description || '—' }}
                       </td>
                       <td><app-properties-view [properties]="edge.properties" [schema]="store.edgeSchema(edge.label)" /></td>
-                      <td style="color:var(--text-muted); white-space:nowrap;">{{ edge.createdAt | date:'dd.MM.yyyy' }}</td>
+                      <td><app-timestamp [value]="edge.createdAt"/></td>
                       <td style="white-space:nowrap;">
                         <button class="icon-btn" [attr.title]="'common.viewInGraph' | transloco" [attr.aria-label]="'common.viewInGraph' | transloco" (click)="viewInGraph.emit(edge.from)"><ph-icon name="graph" [size]="16"/></button>
                         <button class="icon-btn" [attr.title]="'common.viewDetails' | transloco" [attr.aria-label]="'common.viewDetails' | transloco" (click)="drawerState.open('edge', edge)"><ph-icon name="eye" [size]="16"/></button>

--- a/client/src/app/pages/files/file-manager.component.ts
+++ b/client/src/app/pages/files/file-manager.component.ts
@@ -39,6 +39,7 @@ import bash from 'highlight.js/lib/languages/bash';
 import plaintext from 'highlight.js/lib/languages/plaintext';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 import { ModalDirective } from '../../shared/modal.directive';
+import { TimestampComponent } from '../../shared/timestamp.component';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('typescript', typescript);
@@ -143,7 +144,7 @@ function xlsxCellText(v: unknown): string {
   // regardless of zone. Text fields (`newFolderName`, `renameValue`) are ngModel two-way bindings
   // whose input events mark the view dirty. So OnPush re-checks exactly when state changes.
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent, HscrollTopDirective, ModalDirective],
+  imports: [CommonModule, FormsModule, PhIconComponent, TranslocoPipe, ErrorStateComponent, TagInputComponent, EntityRefFieldComponent, MemoryRefFieldComponent, ChronoRefFieldComponent, SortableHeaderComponent, StepProgressBarComponent, HscrollTopDirective, ModalDirective, TimestampComponent],
   styles: [`
     /* A background refresh, as a 2px indeterminate hairline above the table. Deliberately NOT a spinner and
        deliberately not an overlay: the whole point is that nothing on screen moves or disappears while a poll
@@ -710,7 +711,7 @@ function xlsxCellText(v: unknown): string {
                     <td style="color:var(--text-muted)">
                       {{ formatSize(entry.size) }}
                     </td>
-                    <td style="color:var(--text-muted)">{{ entry.modified | date:'dd.MM.yyyy HH:mm' }}</td>
+                    <td><app-timestamp [value]="entry.modified"/></td>
                     <td style="display:flex; gap:6px; align-items:center;">
                       @if (entry.isFile) {
                         <button

--- a/client/src/app/shared/timestamp.component.ts
+++ b/client/src/app/shared/timestamp.component.ts
@@ -66,10 +66,21 @@ export function formatTimestampParts(
   const t = toEpochMs(value);
   if (t === null) return null;
   const d = new Date(t);
+  // `de-DE` by default, and that is deliberate rather than an oversight.
+  //
+  // The instruction was to render the local TIME — the zone. Taking the viewer's locale for the date as well would
+  // make the field ORDER vary by browser: `15.01.2026` here, `01/15/2026` there, for the same row on the same
+  // instance. This app has an explicit `dd.MM.yyyy` convention in eleven places, and a spec asserting it caught the
+  // switch immediately. Varying the format by browser would also undo the point of the component, which is that a
+  // column can be scanned.
+  //
+  // So the ZONE is the viewer's and the FORMAT is fixed. `locale` stays an input for tests and for a future explicit
+  // per-user preference — a deliberate setting rather than whatever the browser happens to be.
   const opts: Intl.DateTimeFormatOptions = timeZone ? { timeZone } : {};
+  const fmt = locale ?? 'de-DE';
   return {
-    date: new Intl.DateTimeFormat(locale, { ...opts, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d),
-    time: new Intl.DateTimeFormat(locale, { ...opts, hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23' }).format(d),
+    date: new Intl.DateTimeFormat(fmt, { ...opts, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d),
+    time: new Intl.DateTimeFormat(fmt, { ...opts, hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23' }).format(d),
     // The ORIGINAL instant, in UTC. Never the localised string — see the class comment on why the DOM must stay UTC.
     iso: d.toISOString(),
   };
@@ -101,7 +112,10 @@ export class TimestampComponent {
   value = input.required<TimestampValue>();
   /** What to show when there is no timestamp. A dash, not an empty cell — an empty cell reads as a layout bug. */
   empty = input<string>('—');
-  /** Overridable for tests and for a future per-user preference; undefined means the viewer's own. */
+  /**
+   * Overridable for tests and for a future per-user preference. Undefined means the app's fixed `dd.MM.yyyy`, NOT the
+   * browser's locale — see `formatTimestampParts` on why the field order must not vary by viewer.
+   */
   locale = input<string | undefined>(undefined);
   timeZone = input<string | undefined>(undefined);
 

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -78,7 +78,11 @@ const FROZEN = {
   // owns the rows. Raised rather than worked around — hiding a row action somewhere it does not belong to
   // keep a number down is the trade this list exists to let us decline.
   'client/src/app/pages/settings/tokens.component.ts': 526,
-  'client/src/app/pages/files/file-manager.component.ts': 1617,
+  // RAISED 1617 -> 1618 by one line: the Q-10 timestamp swap replaced a `| date:` cell with `<app-timestamp>` and
+  // needed an import, gaining an import line while losing none. At 1618 code lines this file is by far the largest
+  // here and wants splitting on its own terms — but not inside a one-cell rendering change, where the split would be
+  // the diff and the fix would be a footnote.
+  'client/src/app/pages/files/file-manager.component.ts': 1618,
   'client/src/app/pages/schema-library/schema-library.component.ts': 1112,
   'server/src/sync/engine.ts': 966,
   // 958 -> 684: the per-type editor body moved into `schema-type-editor.component` so the Brain Overview


### PR DESCRIPTION
## What

Five more table cells use `<app-timestamp>`: the chrono **Starts / Ends / Created** columns, the edges **Created**
column, and the file-manager **Modified** column. Each gains the local time with seconds; two showed no time at all.

## An existing spec forced a design question, and it was right to

`chrono-tab.component.spec.ts` asserts the row contains `15.01.2026`. It **failed** — because the first version of the
component took the viewer's locale for the *date* as well as the zone.

Reading that failure instead of fixing it: **the instruction was to render the local *time*, which means the zone.**
Taking the locale for the date too would make the field order vary by browser — `15.01.2026` here, `01/15/2026` there,
for the same row on the same instance. That undoes the point of the component (a column you can scan) and silently
changes eleven places that had deliberately chosen `dd.MM.yyyy`.

**So the zone is the viewer's and the format is fixed.** `locale` stays an input for tests and for a future explicit
per-user preference — a setting, rather than whatever the browser happens to be.

## A ternary removed

The chrono Ends column loses `? … : '—'`. The component renders its own dash, and a second copy of that decision is
one more place for the two to disagree about what "no timestamp" looks like.

## 16 remain, and deliberately not all in scope

The request was about **data tables**. What is left is inline in sentences (*"Expires: …"*), in detail drawers, in a
`<dd>`, or inside a `title` attribute — places where a two-line stack breaks the line it sits in.

Converting them would be over-applying the instruction, so the remainder is recorded with that reasoning rather than
left looking unfinished.

## One ratchet raise, and what it says

`file-manager.component.ts` 1617 → 1618, for the import. At 1618 code lines it is by far the largest frozen file and
wants splitting on its own terms — **but not inside a one-cell rendering change**, where the split would be the diff
and the fix would be a footnote.

## Verification

1035 client tests pass, including the chrono spec that caught the locale question; preflight green.

🤖 Generated with Claude Code
